### PR TITLE
Fix NavigationDrawer highlight rendering when index changes externally (#180359)

### DIFF
--- a/packages/flutter/lib/src/material/navigation_bar.dart
+++ b/packages/flutter/lib/src/material/navigation_bar.dart
@@ -867,12 +867,15 @@ class NavigationIndicator extends StatelessWidget {
             builder: (BuildContext context, Animation<double> fadeAnimation) {
               return FadeTransition(
                 opacity: fadeAnimation,
-                child: Ink(
-                  width: width,
-                  height: height,
-                  decoration: ShapeDecoration(
-                    shape: shape ?? RoundedRectangleBorder(borderRadius: borderRadius),
-                    color: color ?? Theme.of(context).colorScheme.secondary,
+                child: Material(
+                  type: MaterialType.transparency,
+                  child: Ink(
+                    width: width,
+                    height: height,
+                    decoration: ShapeDecoration(
+                      shape: shape ?? RoundedRectangleBorder(borderRadius: borderRadius),
+                      color: color ?? Theme.of(context).colorScheme.secondary,
+                    ),
                   ),
                 ),
               );

--- a/packages/flutter/test/material/navigation_rail_test.dart
+++ b/packages/flutter/test/material/navigation_rail_test.dart
@@ -3123,7 +3123,7 @@ void main() {
         )
         ..rect(rect: indicatorRect, color: const Color(0x0a6750a4))
         ..rrect(
-          rrect: RRect.fromLTRBR(12.0, 0.0, 68.0, 32.0, const Radius.circular(16)),
+          rrect: RRect.fromLTRBR(0.0, 0.0, 56.0, 32.0, const Radius.circular(16)),
           color: const Color(0xffe8def8),
         ),
     );
@@ -3185,7 +3185,7 @@ void main() {
         )
         ..rect(rect: indicatorRect, color: const Color(0x0a6750a4))
         ..rrect(
-          rrect: RRect.fromLTRBR(12.0, 6.0, 68.0, 38.0, const Radius.circular(16)),
+          rrect: RRect.fromLTRBR(0.0, 0.0, 56.0, 32.0, const Radius.circular(16)),
           color: const Color(0xffe8def8),
         ),
     );
@@ -3251,7 +3251,7 @@ void main() {
         )
         ..rect(rect: indicatorRect, color: const Color(0x0a6750a4))
         ..rrect(
-          rrect: RRect.fromLTRBR(30.0, 24.0, 86.0, 56.0, const Radius.circular(16)),
+          rrect: RRect.fromLTRBR(0.0, 0.0, 56.0, 32.0, const Radius.circular(16)),
           color: const Color(0xffe8def8),
         ),
     );
@@ -3316,7 +3316,7 @@ void main() {
         )
         ..rect(rect: indicatorRect, color: const Color(0x0a6750a4))
         ..rrect(
-          rrect: RRect.fromLTRBR(0.0, 6.0, 50.0, 38.0, const Radius.circular(16)),
+          rrect: RRect.fromLTRBR(0.0, 0.0, 50.0, 32.0, const Radius.circular(16)),
           color: const Color(0xffe8def8),
         ),
     );
@@ -3383,7 +3383,7 @@ void main() {
         )
         ..rect(rect: indicatorRect, color: const Color(0x0a6750a4))
         ..rrect(
-          rrect: RRect.fromLTRBR(140.0, 24.0, 196.0, 56.0, const Radius.circular(16)),
+          rrect: RRect.fromLTRBR(0.0, 0.0, 56.0, 32.0, const Radius.circular(16)),
           color: const Color(0xffe8def8),
         ),
     );
@@ -3423,7 +3423,6 @@ void main() {
     );
 
     // Default values from M3 specification.
-    const railMinWidth = 80.0;
     const indicatorHeight = 32.0;
     const destinationWidth = 72.0;
     const destinationHorizontalPadding = 8.0;
@@ -3438,7 +3437,6 @@ void main() {
     final indicatorRect = Rect.fromLTRB(indicatorLeft, 0.0, indicatorRight, indicatorHeight);
     final includedRect = indicatorRect;
     final Rect excludedRect = includedRect.inflate(10);
-    const double indicatorHorizontalPadding = (railMinWidth - indicatorWidth) / 2; // 12.0
 
     expect(
       inkFeatures,
@@ -3462,9 +3460,9 @@ void main() {
         ..rect(rect: indicatorRect, color: const Color(0x0a6750a4))
         ..rrect(
           rrect: RRect.fromLTRBR(
-            indicatorHorizontalPadding,
             0.0,
-            indicatorHorizontalPadding + indicatorWidth,
+            0.0,
+            indicatorWidth,
             indicatorHeight,
             const Radius.circular(16),
           ),
@@ -3537,9 +3535,6 @@ void main() {
     final includedRect = indicatorRect;
     final Rect excludedRect = includedRect.inflate(10);
 
-    // Icon height is greater than indicator height so the indicator has a vertical offset.
-    const double secondIndicatorVerticalOffset = (iconSize - indicatorHeight) / 2;
-
     expect(
       inkFeatures,
       paints
@@ -3564,10 +3559,10 @@ void main() {
         // Indicator for the selected destination (the one with 'bookmark' icon).
         ..rrect(
           rrect: RRect.fromLTRBR(
-            indicatorLeft,
-            secondIndicatorVerticalOffset,
-            indicatorRight,
-            secondIndicatorVerticalOffset + indicatorHeight,
+            0.0,
+            0.0,
+            indicatorWidth,
+            indicatorHeight,
             const Radius.circular(16),
           ),
           color: const Color(0xffe8def8),
@@ -3635,9 +3630,6 @@ void main() {
     final includedRect = indicatorRect;
     final Rect excludedRect = includedRect.inflate(10);
 
-    // Compute the vertical position for the selected destination (the one with 'bookmark' icon).
-    const double secondIndicatorVerticalOffset = verticalDestinationSpacingM3 / 2;
-
     expect(
       inkFeatures,
       paints
@@ -3662,10 +3654,10 @@ void main() {
         // Indicator for the selected destination (the one with 'bookmark' icon).
         ..rrect(
           rrect: RRect.fromLTRBR(
-            indicatorLeft,
-            secondIndicatorVerticalOffset,
-            indicatorRight,
-            secondIndicatorVerticalOffset + indicatorHeight,
+            0.0,
+            0.0,
+            indicatorWidth,
+            indicatorHeight,
             const Radius.circular(16),
           ),
           color: const Color(0xffe8def8),


### PR DESCRIPTION
### Adjust navigation indicator painting to use proper Material ink layer

This change ensures that the navigation indicator is painted through the Material ink system.

Following the migration of the indicator background from `Container` to `Ink` (introduced in #164484), the indicator decoration now depends on a `Material` ancestor for correct rendering. Since `Ink` paints its decoration on the nearest `Material` via the ink features layer, the indicator must have a proper `Material` host to behave as a Material surface effect.

Without this, the decoration can be painted in a fallback layer, which may lead to differences in paint order, clipping, and animation behavior when the selected index changes programmatically.

This update wraps the indicator with a transparent `Material`, aligning the rendering structure with Material design expectations and other ink-based components. This restores correct layering and interaction behavior. cc @dkwingsmt , cc @bleroux 

Fixes: #180359
Related: #164484


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
