### PR TITLE
Remove Material dependency from rotated_box_test.dart

### DIFF
--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -230,7 +230,6 @@ class TestsCrossImportChecker {
     'packages/flutter/test/widgets/baseline_test.dart',
     'packages/flutter/test/widgets/selection_container_test.dart',
     'packages/flutter/test/widgets/scrollable_semantics_test.dart',
-    'packages/flutter/test/widgets/rotated_box_test.dart',
     'packages/flutter/test/widgets/single_child_scroll_view_test.dart',
     'packages/flutter/test/widgets/pinned_header_sliver_test.dart',
     'packages/flutter/test/widgets/raw_radio_test.dart',

--- a/packages/flutter/test/widgets/rotated_box_test.dart
+++ b/packages/flutter/test/widgets/rotated_box_test.dart
@@ -2,8 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+const Color _kTestColor = Color(0xFF2196F3);
 
 void main() {
   testWidgets('Rotated box control test', (WidgetTester tester) async {
@@ -23,13 +25,13 @@ void main() {
                 onTap: () {
                   log.add('left');
                 },
-                child: Container(width: 100.0, height: 40.0, color: Colors.blue[500]),
+                child: Container(width: 100.0, height: 40.0, color: _kTestColor),
               ),
               GestureDetector(
                 onTap: () {
                   log.add('right');
                 },
-                child: Container(width: 75.0, height: 65.0, color: Colors.blue[500]),
+                child: Container(width: 75.0, height: 65.0, color: _kTestColor),
               ),
             ],
           ),


### PR DESCRIPTION
  PR Description:                                                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                            
  Remove Material dependency from rotated_box_test.dart                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                            
  Replace `Colors.blue[500]` with `const Color(0xFF2196F3)` to remove the Material library dependency from this widgets test.                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                            
  Part of #177414                                                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                            
  ## Pre-launch Checklist                                                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                                            
  - [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.                                                                                                                                                                                                                                                                          
  - [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.                                                                                                                                                                                                                                                                                            
  - [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].                                                                                                                                                                                                                                                            
  - [x] I signed the [CLA].                                                                                                                                                                                                                                                                                                                                                 
  - [x] I listed at least one issue that this PR fixes in the description above.                                                                                                                                                                                                                                                                                            
  - [x] I updated/added relevant documentation (doc comments with `///`).                                                                                                                                                                                                                                                                                                   
  - [x] I added new tests to check the change I am making, or this PR is [test-exempt].                                                                                                                                                                                                                                                                                     
  - [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.                                                                                                                                                                                                                                                                              
  - [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
