### PR TITLE
[AGP 9] Added Warning Against Updating to AGP 9

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -663,9 +663,9 @@ final missingNdkSourcePropertiesFile = GradleHandledError(
 
 // TODO(jesswon): Remove this constant and its usages once AGP 9 is supported in the ecosystem: https://github.com/flutter/flutter/issues/181383
 const String _kAgp9WarningAndMigrationPrompt = '''
-    Please do not upgrade your Flutter app on Android to AGP 9 as migrating plugins to AGP 9
-    and Flutter apps on AGP 9 using plugins is not yet supported. For more details, see https://github.com/flutter/flutter/issues/181383.
-    \nIf you would still like to migrate to AGP 9:
+Please do not upgrade your Flutter app on Android to AGP 9 as migrating plugins to AGP 9
+and Flutter apps on AGP 9 using plugins is not yet supported. For more details, see https://github.com/flutter/flutter/issues/181383.
+\nTo proceed with the AGP 9 migration despite this warning:
     ''';
 
 /// Handler when applying the kotlin-android plugin results in a build failure. This failure occurs when

--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -675,7 +675,10 @@ final applyingKotlinAndroidPluginErrorHandler = GradleHandledError(
         final File appGradleFile = project.android.appGradleFile;
         globals.printBox(
           '''
-${globals.logger.terminal.warningMark} Starting AGP 9+, the default has become built-in Kotlin. This results in a build failure when applying the kotlin-android plugin at ${appGradleFile.path}.
+${globals.logger.terminal.warningMark} Please do not upgrade your Flutter app on Android to AGP 9 as migrating plugins to AGP 9
+and Flutter apps on AGP 9 using plugins is not yet supported. For more details, see https://github.com/flutter/flutter/issues/181383.
+\nIf you would still like to migrate to AGP 9:
+Starting AGP 9+, the default has become built-in Kotlin. This results in a build failure when applying the kotlin-android plugin at ${appGradleFile.path}.
 \nTo resolve this, migrate to built-in Kotlin. For instructions on how to migrate, see: https://docs.flutter.dev/release/breaking-changes/migrate-to-agp-9''',
           title: _boxTitle,
         );
@@ -699,7 +702,10 @@ final useNewAgpDslErrorHandler = GradleHandledError(
         final File appGradleFile = project.android.appGradleFile;
         globals.printBox(
           '''
-${globals.logger.terminal.warningMark} Starting AGP 9+, only the new DSL interface will be read. This results in a build failure when applying the Flutter Gradle plugin at ${appGradleFile.path}.
+${globals.logger.terminal.warningMark} Please do not upgrade your Flutter app on Android to AGP 9 as migrating plugins to AGP 9
+and Flutter apps on AGP 9 using plugins is not yet supported. For more details, see https://github.com/flutter/flutter/issues/181383.
+\nIf you would still like to migrate to AGP 9:
+Starting AGP 9+, only the new DSL interface will be read. This results in a build failure when applying the Flutter Gradle plugin at ${appGradleFile.path}.
 \nTo resolve this update flutter or opt out of `android.newDsl`. For instructions on how to opt out, see: https://docs.flutter.dev/release/breaking-changes/migrate-to-agp-9
 \nIf you are not upgrading to AGP 9+, run `flutter analyze --suggestions` to check for incompatible dependencies.''',
           title: _boxTitle,

--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -661,6 +661,13 @@ final missingNdkSourcePropertiesFile = GradleHandledError(
   eventLabel: 'ndk-missing-source-properties-file',
 );
 
+// TODO(jesswon): Remove this constant and its usages once AGP 9 is supported in the ecosystem: https://github.com/flutter/flutter/issues/181383
+const String _kAgp9WarningAndMigrationPrompt = '''
+    Please do not upgrade your Flutter app on Android to AGP 9 as migrating plugins to AGP 9
+    and Flutter apps on AGP 9 using plugins is not yet supported. For more details, see https://github.com/flutter/flutter/issues/181383.
+    \nIf you would still like to migrate to AGP 9:
+    ''';
+
 /// Handler when applying the kotlin-android plugin results in a build failure. This failure occurs when
 /// using AGP 9+ because built-in Kotlin has become the default behavior.
 @visibleForTesting
@@ -675,9 +682,7 @@ final applyingKotlinAndroidPluginErrorHandler = GradleHandledError(
         final File appGradleFile = project.android.appGradleFile;
         globals.printBox(
           '''
-${globals.logger.terminal.warningMark} Please do not upgrade your Flutter app on Android to AGP 9 as migrating plugins to AGP 9
-and Flutter apps on AGP 9 using plugins is not yet supported. For more details, see https://github.com/flutter/flutter/issues/181383.
-\nIf you would still like to migrate to AGP 9:
+${globals.logger.terminal.warningMark} $_kAgp9WarningAndMigrationPrompt
 Starting AGP 9+, the default has become built-in Kotlin. This results in a build failure when applying the kotlin-android plugin at ${appGradleFile.path}.
 \nTo resolve this, migrate to built-in Kotlin. For instructions on how to migrate, see: https://docs.flutter.dev/release/breaking-changes/migrate-to-agp-9''',
           title: _boxTitle,
@@ -702,9 +707,7 @@ final useNewAgpDslErrorHandler = GradleHandledError(
         final File appGradleFile = project.android.appGradleFile;
         globals.printBox(
           '''
-${globals.logger.terminal.warningMark} Please do not upgrade your Flutter app on Android to AGP 9 as migrating plugins to AGP 9
-and Flutter apps on AGP 9 using plugins is not yet supported. For more details, see https://github.com/flutter/flutter/issues/181383.
-\nIf you would still like to migrate to AGP 9:
+${globals.logger.terminal.warningMark} $_kAgp9WarningAndMigrationPrompt
 Starting AGP 9+, only the new DSL interface will be read. This results in a build failure when applying the Flutter Gradle plugin at ${appGradleFile.path}.
 \nTo resolve this update flutter or opt out of `android.newDsl`. For instructions on how to opt out, see: https://docs.flutter.dev/release/breaking-changes/migrate-to-agp-9
 \nIf you are not upgrading to AGP 9+, run `flutter analyze --suggestions` to check for incompatible dependencies.''',

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -1652,10 +1652,17 @@ An exception occurred applying plugin request [id: 'kotlin-android']
 
       expect(
         testLogger.statusText,
-        contains('Starting AGP 9+, the default has become built-in Kotlin.'),
+        contains('Please do not upgrade your Flutter app on Android to AGP 9'),
       );
-      expect(testLogger.statusText, contains('This results in a build failure'));
-      expect(testLogger.statusText, contains('when applying the kotlin-android plugin'));
+      expect(
+        testLogger.statusText,
+        contains('If you would still like to migrate to AGP 9:'),
+      );
+      expect(
+        testLogger.statusText,
+        contains('Starting AGP 9+, the default has become built-in Kotlin. This results in a build failure when'),
+      );
+      expect(testLogger.statusText, contains('applying the kotlin-android plugin'));
     },
     overrides: <Type, Generator>{
       GradleUtils: () => FakeGradleUtils(),
@@ -1687,14 +1694,22 @@ An exception occurred applying plugin request [id: 'dev.flutter.flutter-gradle-p
         usesAndroidX: true,
       );
 
+
+      expect(
+        testLogger.statusText,
+        contains('Please do not upgrade your Flutter app on Android to AGP 9'),
+      );
+      expect(
+        testLogger.statusText,
+        contains('If you would still like to migrate to AGP 9:'),
+      );
       expect(
         testLogger.statusText,
         contains('Starting AGP 9+, only the new DSL interface will be read.'),
       );
-      expect(testLogger.statusText, contains('This results in a build failure'));
-      expect(testLogger.statusText, contains('when applying the Flutter Gradle plugin'));
-      expect(testLogger.statusText, contains('If you are not upgrading to AGP 9+'));
-      expect(testLogger.statusText, contains('run `flutter analyze --suggestions`'));
+      expect(testLogger.statusText, contains('This results in a build failure when'));
+      expect(testLogger.statusText, contains('applying the Flutter Gradle plugin'));
+      expect(testLogger.statusText, contains('If you are not upgrading to AGP 9+, run `flutter analyze --suggestions`'));
     },
     overrides: <Type, Generator>{
       GradleUtils: () => FakeGradleUtils(),

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -1654,7 +1654,10 @@ An exception occurred applying plugin request [id: 'kotlin-android']
         testLogger.statusText,
         contains('Please do not upgrade your Flutter app on Android to AGP 9'),
       );
-      expect(testLogger.statusText, contains('If you would still like to migrate to AGP 9:'));
+      expect(
+        testLogger.statusText,
+        contains('To proceed with the AGP 9 migration despite this warning:'),
+      );
       expect(
         testLogger.statusText,
         contains(
@@ -1697,7 +1700,10 @@ An exception occurred applying plugin request [id: 'dev.flutter.flutter-gradle-p
         testLogger.statusText,
         contains('Please do not upgrade your Flutter app on Android to AGP 9'),
       );
-      expect(testLogger.statusText, contains('If you would still like to migrate to AGP 9:'));
+      expect(
+        testLogger.statusText,
+        contains('To proceed with the AGP 9 migration despite this warning:'),
+      );
       expect(
         testLogger.statusText,
         contains('Starting AGP 9+, only the new DSL interface will be read.'),

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -1654,13 +1654,12 @@ An exception occurred applying plugin request [id: 'kotlin-android']
         testLogger.statusText,
         contains('Please do not upgrade your Flutter app on Android to AGP 9'),
       );
+      expect(testLogger.statusText, contains('If you would still like to migrate to AGP 9:'));
       expect(
         testLogger.statusText,
-        contains('If you would still like to migrate to AGP 9:'),
-      );
-      expect(
-        testLogger.statusText,
-        contains('Starting AGP 9+, the default has become built-in Kotlin. This results in a build failure when'),
+        contains(
+          'Starting AGP 9+, the default has become built-in Kotlin. This results in a build failure when',
+        ),
       );
       expect(testLogger.statusText, contains('applying the kotlin-android plugin'));
     },
@@ -1694,22 +1693,21 @@ An exception occurred applying plugin request [id: 'dev.flutter.flutter-gradle-p
         usesAndroidX: true,
       );
 
-
       expect(
         testLogger.statusText,
         contains('Please do not upgrade your Flutter app on Android to AGP 9'),
       );
-      expect(
-        testLogger.statusText,
-        contains('If you would still like to migrate to AGP 9:'),
-      );
+      expect(testLogger.statusText, contains('If you would still like to migrate to AGP 9:'));
       expect(
         testLogger.statusText,
         contains('Starting AGP 9+, only the new DSL interface will be read.'),
       );
       expect(testLogger.statusText, contains('This results in a build failure when'));
       expect(testLogger.statusText, contains('applying the Flutter Gradle plugin'));
-      expect(testLogger.statusText, contains('If you are not upgrading to AGP 9+, run `flutter analyze --suggestions`'));
+      expect(
+        testLogger.statusText,
+        contains('If you are not upgrading to AGP 9+, run `flutter analyze --suggestions`'),
+      );
     },
     overrides: <Type, Generator>{
       GradleUtils: () => FakeGradleUtils(),


### PR DESCRIPTION
Developers should not update to AGP 9 because plugins and Flutter apps using plugins currently do not support AGP 9. Added the warning to the existing Flutter errors that guide developers to an AGP 9 migration guide. 

Should developers still choose to migrate to AGP 9, they can just follow the guide.

This warning will be removed when AGP 9 is supported for the ecosystem.

Related to https://github.com/flutter/flutter/issues/181557
## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
