### PR TITLE
[gn] fix --stripped being disabled for all targets

### DIFF
--- a/engine/src/flutter/tools/gn
+++ b/engine/src/flutter/tools/gn
@@ -1207,7 +1207,9 @@ def parse_args(args):
   parser.add_argument(
       '--stripped',
       action='store_true',
-      help='Strip debug symbols from the output. This defaults to true and has no effect on iOS.'
+      default=None,
+      help='Strip debug symbols from the output. This defaults to true for all targets '
+      'except android, and has no effect on iOS.'
   )
   parser.add_argument('--no-stripped', dest='stripped', action='store_false')
 


### PR DESCRIPTION
#161546 changed the stripped option with the intent to be true for android, and false for all other targets, but the check never worked as intended because parser store_true action default value is False so the final else was never used.

This fixes the build size increase that was noticed on flutter 3.32 for linux targets

Fixes #181983

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.
