### PR TITLE
Add alwaysSizeToContent argument to Overlay.

### DIFF
--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -489,6 +489,7 @@ class Overlay extends StatefulWidget {
     super.key,
     this.initialEntries = const <OverlayEntry>[],
     this.clipBehavior = Clip.hardEdge,
+    this.alwaysSizeToContent = false,
   });
 
   /// Wrap the provided `child` in an [Overlay] to allow other visual elements
@@ -497,8 +498,18 @@ class Overlay extends StatefulWidget {
   /// This is a convenience method over the regular [Overlay] constructor: It
   /// creates an [Overlay] and puts the provided `child` in an [OverlayEntry]
   /// at the bottom of that newly created Overlay.
-  static Widget wrap({Key? key, Clip clipBehavior = Clip.hardEdge, required Widget child}) {
-    return _WrappingOverlay(key: key, clipBehavior: clipBehavior, child: child);
+  static Widget wrap({
+    Key? key,
+    Clip clipBehavior = Clip.hardEdge,
+    bool alwaysSizeToContent = false,
+    required Widget child,
+  }) {
+    return _WrappingOverlay(
+      key: key,
+      clipBehavior: clipBehavior,
+      alwaysSizeToContent: alwaysSizeToContent,
+      child: child,
+    );
   }
 
   /// The entries to include in the overlay initially.
@@ -520,6 +531,17 @@ class Overlay extends StatefulWidget {
   ///
   /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;
+
+  /// Determines that the overlay should always size itself to content.
+  ///
+  /// Normally overlay will only size itself to content if the the incoming
+  /// constraints are infinite and there is a [OverlayEntry] that can size
+  /// the overlay. Setting this to `true` will force this behavior even for
+  /// finite (but possibly loose) constraints.
+  ///
+  /// Setting this to true requires an [OverlayEntry] that can size the overlay
+  /// based on itself.
+  final bool alwaysSizeToContent;
 
   /// The [OverlayState] from the closest instance of [Overlay] that encloses
   /// the given context within the closest [LookupBoundary], and, in debug mode,
@@ -889,6 +911,7 @@ class OverlayState extends State<Overlay> with TickerProviderStateMixin {
     return _Theater(
       skipCount: children.length - onstageCount,
       clipBehavior: widget.clipBehavior,
+      alwaysSizeToContent: widget.alwaysSizeToContent,
       children: children.reversed.toList(growable: false),
     );
   }
@@ -904,9 +927,15 @@ class OverlayState extends State<Overlay> with TickerProviderStateMixin {
 }
 
 class _WrappingOverlay extends StatefulWidget {
-  const _WrappingOverlay({super.key, this.clipBehavior = Clip.hardEdge, required this.child});
+  const _WrappingOverlay({
+    super.key,
+    this.clipBehavior = Clip.hardEdge,
+    required this.alwaysSizeToContent,
+    required this.child,
+  });
 
   final Clip clipBehavior;
+  final bool alwaysSizeToContent;
   final Widget child;
 
   @override
@@ -938,7 +967,11 @@ class _WrappingOverlayState extends State<_WrappingOverlay> {
 
   @override
   Widget build(BuildContext context) {
-    return Overlay(clipBehavior: widget.clipBehavior, initialEntries: <OverlayEntry>[_entry]);
+    return Overlay(
+      clipBehavior: widget.clipBehavior,
+      alwaysSizeToContent: widget.alwaysSizeToContent,
+      initialEntries: <OverlayEntry>[_entry],
+    );
   }
 }
 
@@ -950,6 +983,7 @@ class _Theater extends MultiChildRenderObjectWidget {
   const _Theater({
     this.skipCount = 0,
     this.clipBehavior = Clip.hardEdge,
+    required this.alwaysSizeToContent,
     required List<_OverlayEntryWidget> super.children,
   }) : assert(skipCount >= 0),
        assert(children.length >= skipCount);
@@ -957,6 +991,8 @@ class _Theater extends MultiChildRenderObjectWidget {
   final int skipCount;
 
   final Clip clipBehavior;
+
+  final bool alwaysSizeToContent;
 
   @override
   _TheaterElement createElement() => _TheaterElement(this);
@@ -967,6 +1003,7 @@ class _Theater extends MultiChildRenderObjectWidget {
       skipCount: skipCount,
       textDirection: Directionality.of(context),
       clipBehavior: clipBehavior,
+      alwaysSizeToContent: alwaysSizeToContent,
     );
   }
 
@@ -975,7 +1012,8 @@ class _Theater extends MultiChildRenderObjectWidget {
     renderObject
       ..skipCount = skipCount
       ..textDirection = Directionality.of(context)
-      ..clipBehavior = clipBehavior;
+      ..clipBehavior = clipBehavior
+      ..alwaysSizeToContent = alwaysSizeToContent;
   }
 
   @override
@@ -1159,10 +1197,12 @@ class _RenderTheater extends RenderBox
     required TextDirection textDirection,
     int skipCount = 0,
     Clip clipBehavior = Clip.hardEdge,
+    required bool alwaysSizeToContent,
   }) : assert(skipCount >= 0),
        _textDirection = textDirection,
        _skipCount = skipCount,
-       _clipBehavior = clipBehavior {
+       _clipBehavior = clipBehavior,
+       _alwaysSizeToContent = alwaysSizeToContent {
     addAll(children);
   }
 
@@ -1248,6 +1288,16 @@ class _RenderTheater extends RenderBox
       markNeedsSemanticsUpdate();
     }
   }
+
+  bool get alwaysSizeToContent => _alwaysSizeToContent;
+  set alwaysSizeToContent(bool value) {
+    if (_alwaysSizeToContent != value) {
+      _alwaysSizeToContent = value;
+      markNeedsLayout();
+    }
+  }
+
+  bool _alwaysSizeToContent;
 
   // Adding/removing deferred child does not affect the layout of other children,
   // or that of the Overlay, so there's no need to invalidate the layout of the
@@ -1338,7 +1388,7 @@ class _RenderTheater extends RenderBox
 
   @override
   double? computeDryBaseline(BoxConstraints constraints, TextBaseline baseline) {
-    final Size size = constraints.biggest.isFinite
+    final Size size = !alwaysSizeToContent && constraints.biggest.isFinite
         ? constraints.biggest
         : _findSizeDeterminingChild().getDryLayout(constraints);
     final nonPositionedChildConstraints = BoxConstraints.tight(size);
@@ -1363,7 +1413,7 @@ class _RenderTheater extends RenderBox
 
   @override
   Size computeDryLayout(BoxConstraints constraints) {
-    if (constraints.biggest.isFinite) {
+    if (!alwaysSizeToContent && constraints.biggest.isFinite) {
       return constraints.biggest;
     }
     return _findSizeDeterminingChild().getDryLayout(constraints);
@@ -1413,7 +1463,7 @@ class _RenderTheater extends RenderBox
   @override
   void performLayout() {
     RenderBox? sizeDeterminingChild;
-    if (constraints.biggest.isFinite) {
+    if (!alwaysSizeToContent && constraints.biggest.isFinite) {
       size = constraints.biggest;
     } else {
       sizeDeterminingChild = _findSizeDeterminingChild();
@@ -1441,6 +1491,20 @@ class _RenderTheater extends RenderBox
         return child;
       }
       child = childParentData.previousSibling;
+    }
+    if (alwaysSizeToContent) {
+      throw FlutterError.fromParts(<DiagnosticsNode>[
+        ErrorSummary(
+          'Overlay was asked to size itself to content but does not have a suitable child.',
+        ),
+        ErrorDescription(
+          'When created with alwaysSizeToContent=true the Overlay requires at least one '
+          'non-positioned OverlayEntry with canSizeOverlay set to true',
+        ),
+        ErrorHint(
+          'Try removing alwaysSizeToContent=true or provide a suitable child that can size the Overlay',
+        ),
+      ]);
     }
     throw FlutterError.fromParts(<DiagnosticsNode>[
       ErrorSummary(

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -534,13 +534,14 @@ class Overlay extends StatefulWidget {
 
   /// Determines that the overlay should always size itself to content.
   ///
-  /// Normally overlay will only size itself to content if the the incoming
+  /// Normally overlay will only size itself to content if the incoming
   /// constraints are infinite and there is a [OverlayEntry] that can size
   /// the overlay. Setting this to `true` will force this behavior even for
   /// finite (but possibly loose) constraints.
   ///
   /// Setting this to true requires an [OverlayEntry] that can size the overlay
-  /// based on itself.
+  /// based on itself ([OverlayEntry.canSizeOverlay] set to true). If not provided
+  /// an exception is thrown.
   final bool alwaysSizeToContent;
 
   /// The [OverlayState] from the closest instance of [Overlay] that encloses
@@ -1498,8 +1499,8 @@ class _RenderTheater extends RenderBox
           'Overlay was asked to size itself to content but does not have a suitable child.',
         ),
         ErrorDescription(
-          'When created with alwaysSizeToContent=true the Overlay requires at least one '
-          'non-positioned OverlayEntry with canSizeOverlay set to true',
+          'When `alwaysSizeToContent` is true, the Overlay requires at least one '
+          'non-positioned `OverlayEntry` with `canSizeOverlay` set to true to determine its size.',
         ),
         ErrorHint(
           'Try removing alwaysSizeToContent=true or provide a suitable child that can size the Overlay',

--- a/packages/flutter/test/widgets/overlay_test.dart
+++ b/packages/flutter/test/widgets/overlay_test.dart
@@ -1927,6 +1927,54 @@ void main() {
     );
   });
 
+  testWidgets(
+    'Overlay.wrap with alwaysSizeToContent is sized by child in loose constraint environment',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: UnconstrainedBox(
+            child: ConstrainedBox(
+              constraints: BoxConstraints.loose(const Size(800, 600)),
+              child: Overlay.wrap(
+                alwaysSizeToContent: true,
+                child: const SizedBox(width: 123, height: 456),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(tester.getSize(find.byType(Overlay)), const Size(123, 456));
+    },
+  );
+
+  testWidgets('Overlay with alwaysSizeToContent throws without sizing child', (
+    WidgetTester tester,
+  ) async {
+    final errors = <FlutterErrorDetails>[];
+    final FlutterExceptionHandler? oldHandler = FlutterError.onError;
+    FlutterError.onError = errors.add;
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: UnconstrainedBox(
+          child: ConstrainedBox(
+            constraints: BoxConstraints.loose(const Size(800, 600)),
+            child: const Overlay(alwaysSizeToContent: true),
+          ),
+        ),
+      ),
+    );
+    FlutterError.onError = oldHandler;
+
+    expect(
+      errors.first.toString().replaceAll('\n', ' '),
+      contains('Overlay was asked to size itself to content but does not have a suitable child.'),
+    );
+  });
+
   testWidgets('Overlay is not visible from sub-views', (WidgetTester tester) async {
     OverlayState? outsideView;
     OverlayState? insideView;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/182008.

This PR introduces `alwaysSizeToContent` argument to `Overlay`. When set to true, this ensures the Overlay
is always sized to content, even if the constraints are finite.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
