### PR TITLE
Clean up include paths for Fuchsia in the flutter engine

### DIFF
--- a/engine/src/flutter/shell/platform/fuchsia/dart-pkg/fuchsia/BUILD.gn
+++ b/engine/src/flutter/shell/platform/fuchsia/dart-pkg/fuchsia/BUILD.gn
@@ -4,10 +4,6 @@
 
 import("//flutter/tools/fuchsia/gn-sdk/src/gn_configs.gni")
 
-config("sdk_ext_config") {
-  include_dirs = [ "../.." ]
-}
-
 group("fuchsia") {
   public_deps = [ ":sdk_ext" ]
 }
@@ -26,6 +22,4 @@ source_set("sdk_ext") {
   ]
 
   public_deps = [ "${fuchsia_sdk}/pkg/zx" ]
-
-  public_configs = [ ":sdk_ext_config" ]
 }

--- a/engine/src/flutter/shell/platform/fuchsia/dart-pkg/fuchsia/sdk_ext/fuchsia.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/dart-pkg/fuchsia/sdk_ext/fuchsia.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "dart-pkg/fuchsia/sdk_ext/fuchsia.h"
+#include "flutter/shell/platform/fuchsia/dart-pkg/fuchsia/sdk_ext/fuchsia.h"
 
 #include <zircon/syscalls.h>
 
@@ -11,9 +11,9 @@
 #include <memory>
 #include <vector>
 
-#include "dart-pkg/zircon/sdk_ext/handle.h"
-#include "dart-pkg/zircon/sdk_ext/natives.h"
-#include "dart-pkg/zircon/sdk_ext/system.h"
+#include "flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle.h"
+#include "flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/natives.h"
+#include "flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/system.h"
 #include "third_party/dart/runtime/include/dart_api.h"
 #include "third_party/tonic/dart_binding_macros.h"
 #include "third_party/tonic/dart_class_library.h"

--- a/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon/BUILD.gn
+++ b/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon/BUILD.gn
@@ -8,13 +8,7 @@ import("//flutter/tools/fuchsia/flutter/flutter_component.gni")
 import("//flutter/tools/fuchsia/gn-sdk/src/gn_configs.gni")
 import("//flutter/tools/fuchsia/gn-sdk/src/package.gni")
 
-config("zircon_config") {
-  include_dirs = [ "." ]
-}
-
 source_set("zircon") {
-  public_configs = [ ":zircon_config" ]
-
   sources = [
     "sdk_ext/handle.cc",
     "sdk_ext/handle.h",

--- a/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "handle.h"
+#include "flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle.h"
 
 #include <algorithm>
 

--- a/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle.h
+++ b/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle.h
@@ -11,7 +11,7 @@
 #include <vector>
 
 #include "flutter/fml/memory/ref_counted.h"
-#include "handle_waiter.h"
+#include "flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle_waiter.h"
 #include "third_party/dart/runtime/include/dart_api.h"
 #include "third_party/tonic/dart_library_natives.h"
 #include "third_party/tonic/dart_wrappable.h"

--- a/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle_disposition.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle_disposition.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "handle_disposition.h"
+#include "flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle_disposition.h"
 
 #include <algorithm>
 

--- a/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle_disposition.h
+++ b/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle_disposition.h
@@ -10,7 +10,7 @@
 #include <vector>
 
 #include "flutter/fml/memory/ref_counted.h"
-#include "handle.h"
+#include "flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle.h"
 #include "third_party/dart/runtime/include/dart_api.h"
 #include "third_party/tonic/dart_library_natives.h"
 #include "third_party/tonic/dart_wrappable.h"

--- a/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle_waiter.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle_waiter.cc
@@ -2,11 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "handle_waiter.h"
+#include "flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle_waiter.h"
 
 #include <lib/async/default.h>
 
-#include "handle.h"
+#include "flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle.h"
 #include "third_party/tonic/converter/dart_converter.h"
 #include "third_party/tonic/dart_args.h"
 #include "third_party/tonic/dart_binding_macros.h"

--- a/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/natives.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/natives.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "natives.h"
+#include "flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/natives.h"
 
 #include <zircon/syscalls.h>
 
@@ -10,10 +10,10 @@
 #include <memory>
 #include <vector>
 
-#include "handle.h"
-#include "handle_disposition.h"
-#include "handle_waiter.h"
-#include "system.h"
+#include "flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle.h"
+#include "flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle_disposition.h"
+#include "flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle_waiter.h"
+#include "flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/system.h"
 #include "third_party/dart/runtime/include/dart_api.h"
 #include "third_party/tonic/dart_binding_macros.h"
 #include "third_party/tonic/dart_class_library.h"

--- a/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/system.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/system.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "system.h"
+#include "flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/system.h"
 
 #include <array>
 

--- a/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/system.h
+++ b/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/system.h
@@ -7,8 +7,8 @@
 
 #include <zircon/syscalls.h>
 
-#include "handle.h"
-#include "handle_disposition.h"
+#include "flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle.h"
+#include "flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle_disposition.h"
 #include "third_party/dart/runtime/include/dart_api.h"
 #include "third_party/tonic/dart_library_natives.h"
 #include "third_party/tonic/dart_wrappable.h"

--- a/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/BUILD.gn
+++ b/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/BUILD.gn
@@ -4,13 +4,7 @@
 
 import("//flutter/tools/fuchsia/gn-sdk/src/gn_configs.gni")
 
-config("zircon_ffi_config") {
-  include_dirs = [ "." ]
-}
-
 shared_library("zircon_ffi") {
-  public_configs = [ ":zircon_ffi_config" ]
-
   sources = [
     "basic_types.cc",
     "basic_types.h",

--- a/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/basic_types.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/basic_types.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "basic_types.h"
+#include "flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/basic_types.h"
 
 #include <cstdint>
 #include <cstdlib>

--- a/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/basic_types.h
+++ b/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/basic_types.h
@@ -5,7 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_FUCHSIA_DART_PKG_ZIRCON_FFI_BASIC_TYPES_H_
 #define FLUTTER_SHELL_PLATFORM_FUCHSIA_DART_PKG_ZIRCON_FFI_BASIC_TYPES_H_
 
-#include "macros.h"
+#include "flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/macros.h"
 
 #include <stdint.h>
 

--- a/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/channel.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/channel.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "channel.h"
+#include "flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/channel.h"
 
 #include "flutter/fml/logging.h"
 #include "flutter/fml/macros.h"

--- a/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/channel.h
+++ b/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/channel.h
@@ -5,9 +5,9 @@
 #ifndef FLUTTER_SHELL_PLATFORM_FUCHSIA_DART_PKG_ZIRCON_FFI_CHANNEL_H_
 #define FLUTTER_SHELL_PLATFORM_FUCHSIA_DART_PKG_ZIRCON_FFI_CHANNEL_H_
 
-#include "basic_types.h"
-#include "handle.h"
-#include "macros.h"
+#include "flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/basic_types.h"
+#include "flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/handle.h"
+#include "flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/macros.h"
 
 #include <stdint.h>
 

--- a/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/clock.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/clock.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "clock.h"
+#include "flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/clock.h"
 
 #include <zircon/syscalls.h>
 

--- a/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/clock.h
+++ b/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/clock.h
@@ -5,7 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_FUCHSIA_DART_PKG_ZIRCON_FFI_CLOCK_H_
 #define FLUTTER_SHELL_PLATFORM_FUCHSIA_DART_PKG_ZIRCON_FFI_CLOCK_H_
 
-#include "macros.h"
+#include "flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/macros.h"
 
 #include <stdint.h>
 

--- a/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/dart_dl.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/dart_dl.cc
@@ -1,7 +1,7 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-#include "dart_dl.h"
+#include "flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/dart_dl.h"
 
 #include "flutter/fml/logging.h"
 #include "include/dart_api_dl.h"

--- a/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/dart_dl.h
+++ b/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/dart_dl.h
@@ -4,7 +4,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_FUCHSIA_DART_PKG_ZIRCON_FFI_DART_DL_H_
 #define FLUTTER_SHELL_PLATFORM_FUCHSIA_DART_PKG_ZIRCON_FFI_DART_DL_H_
 
-#include "macros.h"
+#include "flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/macros.h"
 
 #include <stdint.h>
 

--- a/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/handle.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/handle.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "handle.h"
+#include "flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/handle.h"
 
 #include "flutter/fml/logging.h"
 

--- a/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/handle.h
+++ b/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/handle.h
@@ -5,7 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_FUCHSIA_DART_PKG_ZIRCON_FFI_HANDLE_H_
 #define FLUTTER_SHELL_PLATFORM_FUCHSIA_DART_PKG_ZIRCON_FFI_HANDLE_H_
 
-#include "macros.h"
+#include "flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/macros.h"
 
 #include "include/dart_api_dl.h"
 

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/builtin_libraries.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/builtin_libraries.cc
@@ -2,23 +2,21 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "builtin_libraries.h"
+#include "flutter/shell/platform/fuchsia/dart_runner/builtin_libraries.h"
 
 #include <lib/fdio/namespace.h>
 #include <lib/zx/channel.h>
 
 #include <optional>
 
-#include "dart-pkg/fuchsia/sdk_ext/fuchsia.h"
 #include "flutter/fml/logging.h"
-#include "runtime/dart/utils/inlines.h"
+#include "flutter/shell/platform/fuchsia/dart-pkg/fuchsia/sdk_ext/fuchsia.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/inlines.h"
 #include "third_party/dart/runtime/bin/io_natives.h"
 #include "third_party/dart/runtime/include/dart_api.h"
 #include "third_party/tonic/converter/dart_converter.h"
 #include "third_party/tonic/dart_microtask_queue.h"
 #include "third_party/tonic/logging/dart_error.h"
-
-#include "logging.h"
 
 using tonic::ToDart;
 

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/builtin_libraries.h
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/builtin_libraries.h
@@ -8,7 +8,6 @@
 #include <lib/fdio/namespace.h>
 #include <lib/zx/channel.h>
 
-#include <memory>
 #include <string>
 
 namespace dart_runner {

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/dart_component_controller.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/dart_component_controller.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "dart_component_controller.h"
+#include "flutter/shell/platform/fuchsia/dart_runner/dart_component_controller.h"
 
 #include <fcntl.h>
 #include <lib/async-loop/loop.h>
@@ -27,9 +27,9 @@
 
 #include "dart_api.h"
 #include "flutter/fml/logging.h"
-#include "runtime/dart/utils/files.h"
-#include "runtime/dart/utils/handle_exception.h"
-#include "runtime/dart/utils/tempfs.h"
+#include "flutter/shell/platform/fuchsia/dart_runner/builtin_libraries.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/handle_exception.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/tempfs.h"
 #include "third_party/dart/runtime/include/dart_tools_api.h"
 #include "third_party/tonic/converter/dart_converter.h"
 #include "third_party/tonic/dart_message_handler.h"
@@ -37,8 +37,6 @@
 #include "third_party/tonic/dart_state.h"
 #include "third_party/tonic/logging/dart_error.h"
 #include "third_party/tonic/logging/dart_invoke.h"
-
-#include "builtin_libraries.h"
 
 using tonic::ToDart;
 

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/dart_component_controller.h
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/dart_component_controller.h
@@ -20,7 +20,7 @@
 
 #include <memory>
 
-#include "runtime/dart/utils/mapped_resource.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/mapped_resource.h"
 #include "third_party/dart/runtime/include/dart_api.h"
 
 namespace dart_runner {

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/dart_runner.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/dart_runner.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "dart_runner.h"
+#include "flutter/shell/platform/fuchsia/dart_runner/dart_runner.h"
 
 #include <lib/async-loop/loop.h>
 #include <lib/async/default.h>
@@ -16,13 +16,13 @@
 #include <thread>
 #include <utility>
 
-#include "dart_component_controller.h"
 #include "flutter/fml/command_line.h"
 #include "flutter/fml/logging.h"
 #include "flutter/fml/trace_event.h"
-#include "runtime/dart/utils/inlines.h"
-#include "runtime/dart/utils/vmservice_object.h"
-#include "service_isolate.h"
+#include "flutter/shell/platform/fuchsia/dart_runner/dart_component_controller.h"
+#include "flutter/shell/platform/fuchsia/dart_runner/service_isolate.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/inlines.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/vmservice_object.h"
 #include "third_party/dart/runtime/include/bin/dart_io_api.h"
 #include "third_party/tonic/dart_microtask_queue.h"
 #include "third_party/tonic/dart_state.h"

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/dart_runner.h
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/dart_runner.h
@@ -9,8 +9,8 @@
 #include <lib/fidl/cpp/binding_set.h>
 #include <lib/sys/cpp/component_context.h>
 
-#include "dart_test_component_controller.h"
-#include "runtime/dart/utils/mapped_resource.h"
+#include "flutter/shell/platform/fuchsia/dart_runner/dart_test_component_controller.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/mapped_resource.h"
 
 namespace dart_runner {
 

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/dart_test_component_controller.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/dart_test_component_controller.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "dart_test_component_controller.h"
+#include "flutter/shell/platform/fuchsia/dart_runner/dart_test_component_controller.h"
 
 #include <fcntl.h>
 #include <fuchsia/test/cpp/fidl.h>
@@ -26,10 +26,9 @@
 #include <utility>
 
 #include "flutter/fml/logging.h"
-#include "runtime/dart/utils/files.h"
-#include "runtime/dart/utils/handle_exception.h"
-#include "runtime/dart/utils/inlines.h"
-#include "runtime/dart/utils/tempfs.h"
+#include "flutter/shell/platform/fuchsia/dart_runner/builtin_libraries.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/handle_exception.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/tempfs.h"
 #include "third_party/dart/runtime/include/dart_tools_api.h"
 #include "third_party/tonic/converter/dart_converter.h"
 #include "third_party/tonic/dart_message_handler.h"
@@ -37,8 +36,6 @@
 #include "third_party/tonic/dart_state.h"
 #include "third_party/tonic/logging/dart_error.h"
 #include "third_party/tonic/logging/dart_invoke.h"
-
-#include "builtin_libraries.h"
 
 using tonic::ToDart;
 

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/dart_test_component_controller.h
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/dart_test_component_controller.h
@@ -13,13 +13,13 @@
 #include <lib/async/cpp/executor.h>
 #include <lib/async/cpp/wait.h>
 #include <lib/fdio/namespace.h>
+#include <lib/fidl/cpp/binding.h>
+#include <lib/fidl/cpp/binding_set.h>
 #include <lib/sys/cpp/component_context.h>
 #include <lib/sys/cpp/service_directory.h>
 #include <lib/zx/timer.h>
 
-#include <lib/fidl/cpp/binding_set.h>
-#include "lib/fidl/cpp/binding.h"
-#include "runtime/dart/utils/mapped_resource.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/mapped_resource.h"
 #include "third_party/dart/runtime/include/dart_api.h"
 
 namespace dart_runner {

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/embedder/snapshot.cc.tmpl
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/embedder/snapshot.cc.tmpl
@@ -5,7 +5,7 @@
 // This file is linked into the dart executable when it has a snapshot
 // linked into it.
 
-#include "embedder/snapshot.h"
+#include "flutter/shell/platform/fuchsia/dart_runner/embedder/snapshot.h"
 
 namespace dart_runner {
 

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/main.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/main.cc
@@ -9,15 +9,13 @@
 #include <lib/trace-provider/provider.h>
 #include <lib/trace/event.h>
 
-#include "dart_runner.h"
 #include "flutter/fml/logging.h"
-#include "flutter/fml/trace_event.h"
-#include "logging.h"
+#include "flutter/shell/platform/fuchsia/dart_runner/dart_runner.h"
+#include "flutter/shell/platform/fuchsia/dart_runner/logging.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/build_info.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/files.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/root_inspect_node.h"
 #include "platform/utils.h"
-#include "runtime/dart/utils/build_info.h"
-#include "runtime/dart/utils/files.h"
-#include "runtime/dart/utils/root_inspect_node.h"
-#include "runtime/dart/utils/tempfs.h"
 #include "third_party/dart/runtime/include/dart_api.h"
 
 #if !defined(DART_PRODUCT)

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/service_isolate.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/service_isolate.cc
@@ -2,18 +2,17 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "service_isolate.h"
+#include "flutter/shell/platform/fuchsia/dart_runner/service_isolate.h"
 
 #include "flutter/fml/logging.h"
+#include "flutter/shell/platform/fuchsia/dart_runner/builtin_libraries.h"
+#include "flutter/shell/platform/fuchsia/dart_runner/dart_component_controller.h"
 #include "third_party/dart/runtime/include/bin/dart_io_api.h"
 #include "third_party/tonic/converter/dart_converter.h"
 #include "third_party/tonic/dart_library_natives.h"
 #include "third_party/tonic/dart_microtask_queue.h"
 #include "third_party/tonic/dart_state.h"
 #include "third_party/tonic/typed_data/typed_list.h"
-
-#include "builtin_libraries.h"
-#include "dart_component_controller.h"
 
 namespace dart_runner {
 namespace {

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/tests/suite_impl_unittests.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/tests/suite_impl_unittests.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "dart_runner/dart_test_component_controller.h"
+#include "flutter/shell/platform/fuchsia/dart_runner/dart_test_component_controller.h"
 
 #include "gtest/gtest.h"
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/accessibility_bridge.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/accessibility_bridge.cc
@@ -15,7 +15,7 @@
 #include "flutter/fml/logging.h"
 #include "flutter/lib/ui/semantics/semantics_node.h"
 
-#include "../runtime/dart/utils/root_inspect_node.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/root_inspect_node.h"
 
 namespace flutter_runner {
 namespace {

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/accessibility_bridge_unittest.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/accessibility_bridge_unittest.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "accessibility_bridge.h"
+#include "flutter/shell/platform/fuchsia/flutter/accessibility_bridge.h"
 
 #include <fuchsia/ui/views/cpp/fidl.h>
 #include <lib/async-loop/cpp/loop.h>
@@ -23,7 +23,7 @@
 #include "flutter/lib/ui/semantics/semantics_node.h"
 #include "gtest/gtest.h"
 
-#include "flutter_runner_fakes.h"
+#include "flutter/shell/platform/fuchsia/flutter/flutter_runner_fakes.h"
 
 namespace flutter_runner_test {
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/component_v2.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/component_v2.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "component_v2.h"
+#include "flutter/shell/platform/fuchsia/flutter/component_v2.h"
 
 #include <dlfcn.h>
 #include <fuchsia/mem/cpp/fidl.h>
@@ -25,7 +25,6 @@
 #include <regex>
 #include <sstream>
 
-#include "file_in_namespace_buffer.h"
 #include "flutter/fml/command_line.h"
 #include "flutter/fml/mapping.h"
 #include "flutter/fml/platform/fuchsia/task_observers.h"
@@ -33,11 +32,12 @@
 #include "flutter/fml/unique_fd.h"
 #include "flutter/runtime/dart_vm_lifecycle.h"
 #include "flutter/shell/common/switches.h"
-#include "runtime/dart/utils/files.h"
-#include "runtime/dart/utils/handle_exception.h"
-#include "runtime/dart/utils/mapped_resource.h"
-#include "runtime/dart/utils/tempfs.h"
-#include "runtime/dart/utils/vmo.h"
+#include "flutter/shell/platform/fuchsia/flutter/file_in_namespace_buffer.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/files.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/handle_exception.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/mapped_resource.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/tempfs.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/vmo.h"
 
 namespace flutter_runner {
 namespace {

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/component_v2.h
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/component_v2.h
@@ -24,10 +24,10 @@
 #include "flutter/common/settings.h"
 #include "flutter/fml/macros.h"
 
-#include "engine.h"
-#include "flutter_runner_product_configuration.h"
-#include "program_metadata.h"
-#include "unique_fdio_ns.h"
+#include "flutter/shell/platform/fuchsia/flutter/engine.h"
+#include "flutter/shell/platform/fuchsia/flutter/flutter_runner_product_configuration.h"
+#include "flutter/shell/platform/fuchsia/flutter/program_metadata.h"
+#include "flutter/shell/platform/fuchsia/flutter/unique_fdio_ns.h"
 
 namespace flutter_runner {
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/component_v2_unittest.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/component_v2_unittest.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "component_v2.h"
+#include "flutter/shell/platform/fuchsia/flutter/component_v2.h"
 
 #include <gtest/gtest.h>
 #include <optional>

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/engine.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/engine.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "engine.h"
+#include "flutter/shell/platform/fuchsia/flutter/engine.h"
 
 #include <fuchsia/accessibility/semantics/cpp/fidl.h>
 #include <fuchsia/media/cpp/fidl.h>
@@ -30,15 +30,15 @@
 #include "third_party/skia/include/gpu/ganesh/GrTypes.h"
 #include "third_party/skia/include/ports/SkFontMgr_fuchsia.h"
 
-#include "../runtime/dart/utils/files.h"
-#include "../runtime/dart/utils/root_inspect_node.h"
-#include "focus_delegate.h"
-#include "fuchsia_intl.h"
-#include "platform_view.h"
-#include "software_surface_producer.h"
-#include "surface.h"
-#include "vsync_waiter.h"
-#include "vulkan_surface_producer.h"
+#include "flutter/shell/platform/fuchsia/flutter/focus_delegate.h"
+#include "flutter/shell/platform/fuchsia/flutter/fuchsia_intl.h"
+#include "flutter/shell/platform/fuchsia/flutter/platform_view.h"
+#include "flutter/shell/platform/fuchsia/flutter/software_surface_producer.h"
+#include "flutter/shell/platform/fuchsia/flutter/surface.h"
+#include "flutter/shell/platform/fuchsia/flutter/vsync_waiter.h"
+#include "flutter/shell/platform/fuchsia/flutter/vulkan_surface_producer.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/files.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/root_inspect_node.h"
 
 namespace flutter_runner {
 namespace {

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/engine.h
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/engine.h
@@ -22,11 +22,11 @@
 #include "flutter/shell/common/thread_host.h"
 #include "flutter/shell/platform/fuchsia/flutter/accessibility_bridge.h"
 
-#include "external_view_embedder.h"
-#include "flatland_connection.h"
-#include "flutter_runner_product_configuration.h"
-#include "isolate_configurator.h"
-#include "surface_producer.h"
+#include "flutter/shell/platform/fuchsia/flutter/external_view_embedder.h"
+#include "flutter/shell/platform/fuchsia/flutter/flatland_connection.h"
+#include "flutter/shell/platform/fuchsia/flutter/flutter_runner_product_configuration.h"
+#include "flutter/shell/platform/fuchsia/flutter/isolate_configurator.h"
+#include "flutter/shell/platform/fuchsia/flutter/surface_producer.h"
 
 namespace flutter_runner {
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/external_view_embedder.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/external_view_embedder.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "external_view_embedder.h"
+#include "flutter/shell/platform/fuchsia/flutter/external_view_embedder.h"
 
 #include <algorithm>
 #include <cstdint>

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/external_view_embedder.h
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/external_view_embedder.h
@@ -26,8 +26,8 @@
 #include "third_party/skia/include/core/SkSize.h"
 #include "third_party/skia/include/gpu/ganesh/GrDirectContext.h"
 
-#include "flatland_connection.h"
-#include "surface_producer.h"
+#include "flutter/shell/platform/fuchsia/flutter/flatland_connection.h"
+#include "flutter/shell/platform/fuchsia/flutter/surface_producer.h"
 
 namespace flutter_runner {
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/file_in_namespace_buffer.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/file_in_namespace_buffer.cc
@@ -2,18 +2,18 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "file_in_namespace_buffer.h"
+#include "flutter/shell/platform/fuchsia/flutter/file_in_namespace_buffer.h"
 
 #include <fuchsia/io/cpp/fidl.h>
 #include <lib/fdio/directory.h>
 #include <zircon/status.h>
 
 #include "flutter/fml/trace_event.h"
-#include "runtime/dart/utils/files.h"
-#include "runtime/dart/utils/handle_exception.h"
-#include "runtime/dart/utils/mapped_resource.h"
-#include "runtime/dart/utils/tempfs.h"
-#include "runtime/dart/utils/vmo.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/files.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/handle_exception.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/mapped_resource.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/tempfs.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/vmo.h"
 
 namespace flutter_runner {
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/file_in_namespace_buffer.h
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/file_in_namespace_buffer.h
@@ -4,6 +4,8 @@
 #ifndef FLUTTER_SHELL_PLATFORM_FUCHSIA_FLUTTER_FILE_IN_NAMESPACE_BUFFER_H_
 #define FLUTTER_SHELL_PLATFORM_FUCHSIA_FLUTTER_FILE_IN_NAMESPACE_BUFFER_H_
 
+#include <cstddef>
+
 #include "flutter/fml/mapping.h"
 
 namespace flutter_runner {

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/flatland_connection.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/flatland_connection.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flatland_connection.h"
+#include "flutter/shell/platform/fuchsia/flutter/flatland_connection.h"
 
 #include <lib/async/cpp/task.h>
 #include <lib/async/default.h>

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/flatland_connection.h
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/flatland_connection.h
@@ -15,8 +15,7 @@
 #include "flutter/fml/macros.h"
 #include "flutter/fml/time/time_delta.h"
 #include "flutter/fml/time/time_point.h"
-
-#include "vsync_waiter.h"
+#include "flutter/shell/platform/fuchsia/flutter/vsync_waiter.h"
 
 #include <cstdint>
 #include <mutex>

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/flutter_runner_product_configuration.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/flutter_runner_product_configuration.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter_runner_product_configuration.h"
+#include "flutter/shell/platform/fuchsia/flutter/flutter_runner_product_configuration.h"
 
 #include <zircon/assert.h>
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/focus_delegate.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/focus_delegate.cc
@@ -4,7 +4,7 @@
 
 #include <ostream>
 
-#include "focus_delegate.h"
+#include "flutter/shell/platform/fuchsia/flutter/focus_delegate.h"
 
 namespace flutter_runner {
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/focus_delegate_unittests.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/focus_delegate_unittests.cc
@@ -9,10 +9,10 @@
 #include <lib/fidl/cpp/binding_set.h>
 #include <lib/zx/eventpair.h>
 
-#include "focus_delegate.h"
-#include "tests/fakes/focuser.h"
-#include "tests/fakes/platform_message.h"
-#include "tests/fakes/view_ref_focused.h"
+#include "flutter/shell/platform/fuchsia/flutter/focus_delegate.h"
+#include "flutter/shell/platform/fuchsia/flutter/tests/fakes/focuser.h"
+#include "flutter/shell/platform/fuchsia/flutter/tests/fakes/platform_message.h"
+#include "flutter/shell/platform/fuchsia/flutter/tests/fakes/view_ref_focused.h"
 #include "third_party/rapidjson/include/rapidjson/document.h"
 
 rapidjson::Value ParsePlatformMessage(std::string json) {

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/fuchsia_intl.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/fuchsia_intl.cc
@@ -2,23 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "fuchsia_intl.h"
+#include "flutter/shell/platform/fuchsia/flutter/fuchsia_intl.h"
 
-#include <sstream>
 #include <string>
 #include <vector>
 
 #include "rapidjson/document.h"
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h"
-#include "runner.h"
-#include "runtime/dart/utils/tempfs.h"
-#include "third_party/icu/source/common/unicode/bytestream.h"
-#include "third_party/icu/source/common/unicode/errorcode.h"
 #include "third_party/icu/source/common/unicode/locid.h"
-#include "third_party/icu/source/common/unicode/strenum.h"
 #include "third_party/icu/source/common/unicode/stringpiece.h"
-#include "third_party/icu/source/common/unicode/uloc.h"
 
 using icu::Locale;
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/fuchsia_intl_unittest.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/fuchsia_intl_unittest.cc
@@ -7,7 +7,7 @@
 #include "flutter/fml/icu_util.h"
 #include "gtest/gtest.h"
 
-#include "fuchsia_intl.h"
+#include "flutter/shell/platform/fuchsia/flutter/fuchsia_intl.h"
 
 using fuchsia::intl::CalendarId;
 using fuchsia::intl::LocaleId;

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/isolate_configurator.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/isolate_configurator.cc
@@ -2,10 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "isolate_configurator.h"
+#include "flutter/shell/platform/fuchsia/flutter/isolate_configurator.h"
 
-#include "dart-pkg/fuchsia/sdk_ext/fuchsia.h"
-#include "dart-pkg/zircon/sdk_ext/handle.h"
+#include "flutter/shell/platform/fuchsia/dart-pkg/fuchsia/sdk_ext/fuchsia.h"
+#include "flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle.h"
 #include "third_party/dart/runtime/include/dart_api.h"
 #include "third_party/tonic/converter/dart_converter.h"
 #include "third_party/tonic/dart_state.h"

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/isolate_configurator.h
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/isolate_configurator.h
@@ -8,7 +8,7 @@
 #include <lib/zx/channel.h>
 #include <lib/zx/eventpair.h>
 #include "flutter/fml/macros.h"
-#include "unique_fdio_ns.h"
+#include "flutter/shell/platform/fuchsia/flutter/unique_fdio_ns.h"
 
 namespace flutter_runner {
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/main.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/main.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include <lib/async-loop/cpp/loop.h>
+#include <lib/async/default.h>
 #include <lib/inspect/component/cpp/component.h>
 #include <lib/syslog/cpp/log_settings.h>
 #include <lib/trace-provider/provider.h>
@@ -10,14 +11,12 @@
 
 #include <cstdlib>
 
-#include "fml/message_loop.h"
-#include "lib/async/default.h"
-#include "logging.h"
+#include "flutter/fml/message_loop.h"
+#include "flutter/shell/platform/fuchsia/flutter/logging.h"
+#include "flutter/shell/platform/fuchsia/flutter/runner.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/build_info.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/root_inspect_node.h"
 #include "platform/utils.h"
-#include "runner.h"
-#include "runtime/dart/utils/build_info.h"
-#include "runtime/dart/utils/root_inspect_node.h"
-#include "runtime/dart/utils/tempfs.h"
 
 int main(int argc, char const* argv[]) {
   fml::MessageLoop::EnsureInitializedForCurrentThread();

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/platform_view.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/platform_view.cc
@@ -4,7 +4,7 @@
 
 #define RAPIDJSON_HAS_STDSTRING 1
 
-#include "platform_view.h"
+#include "flutter/shell/platform/fuchsia/flutter/platform_view.h"
 
 #include <fuchsia/ui/app/cpp/fidl.h>
 #include <zircon/status.h>
@@ -24,11 +24,10 @@
 #include "third_party/rapidjson/include/rapidjson/writer.h"
 
 #include "flutter/fml/make_copyable.h"
-#include "logging.h"
-#include "pointer_injector_delegate.h"
-#include "runtime/dart/utils/inlines.h"
-#include "text_delegate.h"
-#include "vsync_waiter.h"
+#include "flutter/shell/platform/fuchsia/flutter/pointer_injector_delegate.h"
+#include "flutter/shell/platform/fuchsia/flutter/text_delegate.h"
+#include "flutter/shell/platform/fuchsia/flutter/vsync_waiter.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/inlines.h"
 
 namespace {
 // Helper to extract a given member with a given type from a rapidjson object.

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/platform_view.h
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/platform_view.h
@@ -30,12 +30,12 @@
 #include "flutter/fml/memory/weak_ptr.h"
 #include "flutter/fml/time/time_delta.h"
 #include "flutter/shell/common/platform_view.h"
+#include "flutter/shell/platform/fuchsia/flutter/focus_delegate.h"
 #include "flutter/shell/platform/fuchsia/flutter/keyboard.h"
+#include "flutter/shell/platform/fuchsia/flutter/pointer_delegate.h"
+#include "flutter/shell/platform/fuchsia/flutter/pointer_injector_delegate.h"
+#include "flutter/shell/platform/fuchsia/flutter/text_delegate.h"
 #include "flutter/shell/platform/fuchsia/flutter/vsync_waiter.h"
-#include "focus_delegate.h"
-#include "pointer_delegate.h"
-#include "pointer_injector_delegate.h"
-#include "text_delegate.h"
 
 namespace flutter_runner {
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/pointer_delegate.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/pointer_delegate.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "pointer_delegate.h"
+#include "flutter/shell/platform/fuchsia/flutter/pointer_delegate.h"
 
 #include <lib/trace/event.h>
 #include <zircon/status.h>

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/pointer_delegate_unittests.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/pointer_delegate_unittests.cc
@@ -14,10 +14,10 @@
 
 #include "flutter/fml/logging.h"
 #include "flutter/fml/macros.h"
-#include "pointer_delegate.h"
-#include "tests/fakes/mouse_source.h"
-#include "tests/fakes/touch_source.h"
-#include "tests/pointer_event_utility.h"
+#include "flutter/shell/platform/fuchsia/flutter/pointer_delegate.h"
+#include "flutter/shell/platform/fuchsia/flutter/tests/fakes/mouse_source.h"
+#include "flutter/shell/platform/fuchsia/flutter/tests/fakes/touch_source.h"
+#include "flutter/shell/platform/fuchsia/flutter/tests/pointer_event_utility.h"
 
 namespace flutter_runner::testing {
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/pointer_injector_delegate.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/pointer_injector_delegate.cc
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "pointer_injector_delegate.h"
+#include "flutter/shell/platform/fuchsia/flutter/pointer_injector_delegate.h"
+
 #include "flutter/fml/logging.h"
 
 namespace flutter_runner {

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/pointer_injector_delegate_unittest.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/pointer_injector_delegate_unittest.cc
@@ -13,9 +13,9 @@
 
 #include <lib/fidl/cpp/binding_set.h>
 
-#include "pointer_injector_delegate.h"
-#include "tests/fakes/mock_injector_registry.h"
-#include "tests/fakes/platform_message.h"
+#include "flutter/shell/platform/fuchsia/flutter/pointer_injector_delegate.h"
+#include "flutter/shell/platform/fuchsia/flutter/tests/fakes/mock_injector_registry.h"
+#include "flutter/shell/platform/fuchsia/flutter/tests/fakes/platform_message.h"
 
 namespace flutter_runner::testing {
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/runner.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/runner.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "runner.h"
+#include "flutter/shell/platform/fuchsia/flutter/runner.h"
 
 #include <fcntl.h>
 #include <fuchsia/mem/cpp/fidl.h>
@@ -22,10 +22,10 @@
 #include "flutter/fml/make_copyable.h"
 #include "flutter/lib/ui/text/font_collection.h"
 #include "flutter/runtime/dart_vm.h"
-#include "runtime/dart/utils/files.h"
-#include "runtime/dart/utils/root_inspect_node.h"
-#include "runtime/dart/utils/vmo.h"
-#include "runtime/dart/utils/vmservice_object.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/files.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/root_inspect_node.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/vmo.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/vmservice_object.h"
 #include "third_party/icu/source/common/unicode/udata.h"
 #include "third_party/skia/include/core/SkGraphics.h"
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/runner.h
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/runner.h
@@ -10,16 +10,16 @@
 
 #include <fuchsia/component/runner/cpp/fidl.h>
 #include <lib/async-loop/cpp/loop.h>
+#include <lib/fidl/cpp/binding_set.h>
 #include <lib/sys/cpp/component_context.h>
 #include <lib/trace-engine/instrumentation.h>
 #include <lib/trace/observer.h>
 
-#include "component_v2.h"
 #include "flutter/fml/macros.h"
-#include "fml/memory/ref_ptr.h"
-#include "fml/task_runner.h"
-#include "lib/fidl/cpp/binding_set.h"
-#include "runtime/dart/utils/vmservice_object.h"
+#include "flutter/fml/memory/ref_ptr.h"
+#include "flutter/fml/task_runner.h"
+#include "flutter/shell/platform/fuchsia/flutter/component_v2.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/vmservice_object.h"
 
 namespace flutter_runner {
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/runner_tzdata_missing_unittest.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/runner_tzdata_missing_unittest.cc
@@ -4,7 +4,7 @@
 
 #include <gtest/gtest.h>
 
-#include "runner.h"
+#include "flutter/shell/platform/fuchsia/flutter/runner.h"
 #include "third_party/icu/source/i18n/unicode/timezone.h"
 
 namespace flutter_runner {

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/runner_tzdata_unittest.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/runner_tzdata_unittest.cc
@@ -6,7 +6,7 @@
 
 #include <cstdlib>
 
-#include "runner.h"
+#include "flutter/shell/platform/fuchsia/flutter/runner.h"
 #include "third_party/icu/source/i18n/unicode/timezone.h"
 
 namespace flutter_runner {

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/software_surface.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/software_surface.cc
@@ -2,8 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "software_surface.h"
+#include "flutter/shell/platform/fuchsia/flutter/software_surface.h"
 
+#include <fuchsia/sysmem/cpp/fidl.h>
 #include <lib/async/default.h>
 #include <zircon/rights.h>
 #include <zircon/status.h>
@@ -13,14 +14,13 @@
 
 #include "flutter/fml/logging.h"
 #include "flutter/fml/trace_event.h"
-#include "fuchsia/sysmem/cpp/fidl.h"
 #include "include/core/SkImageInfo.h"
 
 #include "third_party/skia/include/core/SkColorSpace.h"
 #include "third_party/skia/include/core/SkImageInfo.h"
 #include "third_party/skia/include/core/SkSurface.h"
 
-#include "../runtime/dart/utils/inlines.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/inlines.h"
 
 namespace flutter_runner {
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/software_surface.h
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/software_surface.h
@@ -16,10 +16,9 @@
 #include <memory>
 
 #include "flutter/fml/macros.h"
+#include "flutter/shell/platform/fuchsia/flutter/surface_producer.h"
 #include "third_party/skia/include/core/SkSize.h"
 #include "third_party/skia/include/core/SkSurface.h"
-
-#include "surface_producer.h"
 
 namespace flutter_runner {
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/software_surface_producer.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/software_surface_producer.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "software_surface_producer.h"
+#include "flutter/shell/platform/fuchsia/flutter/software_surface_producer.h"
 
 #include <lib/fdio/directory.h>
 #include <lib/zx/process.h>

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/software_surface_producer.h
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/software_surface_producer.h
@@ -11,8 +11,7 @@
 #include <unordered_map>
 
 #include "flutter/fml/macros.h"
-
-#include "software_surface.h"
+#include "flutter/shell/platform/fuchsia/flutter/software_surface.h"
 
 namespace flutter_runner {
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/surface.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/surface.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "surface.h"
+#include "flutter/shell/platform/fuchsia/flutter/surface.h"
 
 #include <fcntl.h>
 #include <lib/fdio/watcher.h>

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/task_runner_adapter.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/task_runner_adapter.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "task_runner_adapter.h"
+#include "flutter/shell/platform/fuchsia/flutter/task_runner_adapter.h"
 
 #include <lib/async/cpp/task.h>
 #include <lib/async/default.h>

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/external_view_embedder_unittests.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/external_view_embedder_unittests.cc
@@ -27,9 +27,9 @@
 #include "third_party/skia/include/core/SkSize.h"
 #include "third_party/skia/include/core/SkSurface.h"
 
-#include "fakes/scenic/fake_flatland.h"
-#include "fakes/scenic/fake_flatland_types.h"
 #include "flutter/shell/platform/fuchsia/flutter/surface_producer.h"
+#include "flutter/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland.h"
+#include "flutter/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland_types.h"
 
 #include "gmock/gmock.h"  // For EXPECT_THAT and matchers
 #include "gtest/gtest.h"

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/fake_flatland_unittests.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/fake_flatland_unittests.cc
@@ -2,15 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "fakes/scenic/fake_flatland.h"
+#include "flutter/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland.h"
 
+#include <fuchsia/ui/composition/cpp/fidl.h>
 #include <lib/async-testing/test_loop.h>
 #include <lib/async/dispatcher.h>
 
 #include <string>
 
 #include "flutter/fml/logging.h"
-#include "fuchsia/ui/composition/cpp/fidl.h"
 #include "gtest/gtest.h"
 
 namespace flutter_runner::testing {

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "fake_flatland.h"
+#include "flutter/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland.h"
 
 #include <zircon/types.h>
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland.h
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland.h
@@ -24,7 +24,7 @@
 #include "flutter/fml/logging.h"
 #include "flutter/fml/macros.h"
 
-#include "fake_flatland_types.h"
+#include "flutter/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland_types.h"
 
 namespace flutter_runner::testing {
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland_types.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland_types.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "fake_flatland_types.h"
+#include "flutter/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland_types.h"
 
 #include <lib/fidl/cpp/clone.h>
 #include <lib/zx/channel.h>

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/flatland_connection_unittests.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/flatland_connection_unittests.cc
@@ -19,7 +19,7 @@
 #include "flutter/fml/time/time_point.h"
 #include "gtest/gtest.h"
 
-#include "fakes/scenic/fake_flatland.h"
+#include "flutter/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland.h"
 
 namespace flutter_runner::testing {
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/mouse-input/mouse-input-test.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/mouse-input/mouse-input-test.cc
@@ -20,6 +20,7 @@
 #include <fuchsia/web/cpp/fidl.h>
 #include <lib/async/cpp/task.h>
 #include <lib/fidl/cpp/binding_set.h>
+#include <lib/fidl/cpp/interface_ptr.h>
 #include <lib/sys/component/cpp/testing/realm_builder.h>
 #include <lib/sys/component/cpp/testing/realm_builder_types.h>
 #include <zircon/status.h>
@@ -41,7 +42,6 @@
 
 #include "flutter/fml/logging.h"
 #include "flutter/shell/platform/fuchsia/flutter/tests/integration/utils/portable_ui_test.h"
-#include "lib/fidl/cpp/interface_ptr.h"
 
 namespace mouse_input_test::testing {
 namespace {

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/utils/check_view.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/utils/check_view.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "check_view.h"
+#include "flutter/shell/platform/fuchsia/flutter/tests/integration/utils/check_view.h"
 
 #include "flutter/fml/logging.h"
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/utils/portable_ui_test.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/utils/portable_ui_test.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "portable_ui_test.h"
+#include "flutter/shell/platform/fuchsia/flutter/tests/integration/utils/portable_ui_test.h"
 
 #include <fuchsia/inspect/cpp/fidl.h>
 #include <fuchsia/logger/cpp/fidl.h>
@@ -14,8 +14,8 @@
 #include <lib/sys/component/cpp/testing/realm_builder.h>
 #include <lib/sys/component/cpp/testing/realm_builder_types.h>
 
-#include "check_view.h"
 #include "flutter/fml/logging.h"
+#include "flutter/shell/platform/fuchsia/flutter/tests/integration/utils/check_view.h"
 
 namespace fuchsia_test_utils {
 namespace {

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/utils/screenshot.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/utils/screenshot.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "screenshot.h"
+#include "flutter/shell/platform/fuchsia/flutter/tests/integration/utils/screenshot.h"
 
 #include <lib/zx/vmar.h>
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/platform_view_unittest.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/platform_view_unittest.cc
@@ -28,14 +28,14 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-#include "fakes/focuser.h"
-#include "fakes/platform_message.h"
-#include "fakes/touch_source.h"
-#include "fakes/view_ref_focused.h"
 #include "flutter/shell/platform/fuchsia/flutter/surface.h"
 #include "flutter/shell/platform/fuchsia/flutter/task_runner_adapter.h"
+#include "flutter/shell/platform/fuchsia/flutter/tests/fakes/focuser.h"
+#include "flutter/shell/platform/fuchsia/flutter/tests/fakes/platform_message.h"
+#include "flutter/shell/platform/fuchsia/flutter/tests/fakes/touch_source.h"
+#include "flutter/shell/platform/fuchsia/flutter/tests/fakes/view_ref_focused.h"
+#include "flutter/shell/platform/fuchsia/flutter/tests/pointer_event_utility.h"
 #include "platform/assert.h"
-#include "pointer_event_utility.h"
 
 namespace flutter_runner::testing {
 namespace {

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/pointer_event_utility.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/pointer_event_utility.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "pointer_event_utility.h"
+#include "flutter/shell/platform/fuchsia/flutter/tests/pointer_event_utility.h"
 
 namespace flutter_runner::testing {
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/text_delegate.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/text_delegate.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "text_delegate.h"
+#include "flutter/shell/platform/fuchsia/flutter/text_delegate.h"
 
 #include <fuchsia/ui/input/cpp/fidl.h>
 #include <fuchsia/ui/input3/cpp/fidl.h>
@@ -17,8 +17,6 @@
 #include "third_party/rapidjson/include/rapidjson/document.h"
 #include "third_party/rapidjson/include/rapidjson/stringbuffer.h"
 #include "third_party/rapidjson/include/rapidjson/writer.h"
-
-#include "logging.h"
 
 namespace flutter_runner {
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/text_delegate.h
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/text_delegate.h
@@ -19,8 +19,6 @@
 #include "flutter/shell/common/platform_view.h"
 #include "flutter/shell/platform/fuchsia/flutter/keyboard.h"
 
-#include "logging.h"
-
 namespace flutter_runner {
 
 /// The channel name used for text editing platofrm messages.

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/text_delegate_unittests.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/text_delegate_unittests.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "text_delegate.h"
+#include "flutter/shell/platform/fuchsia/flutter/text_delegate.h"
 
 #include <fuchsia/ui/input/cpp/fidl.h>
 #include <fuchsia/ui/input3/cpp/fidl.h>
@@ -14,11 +14,10 @@
 #include <lib/fidl/cpp/binding_set.h>
 #include <lib/zx/eventpair.h>
 
-#include "tests/fakes/platform_message.h"
+#include <memory>
 
 #include "flutter/lib/ui/window/platform_message.h"
-
-#include <memory>
+#include "flutter/shell/platform/fuchsia/flutter/tests/fakes/platform_message.h"
 
 namespace flutter_runner::testing {
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/unique_fdio_ns.h
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/unique_fdio_ns.h
@@ -5,9 +5,10 @@
 #ifndef FLUTTER_SHELL_PLATFORM_FUCHSIA_FLUTTER_UNIQUE_FDIO_NS_H_
 #define FLUTTER_SHELL_PLATFORM_FUCHSIA_FLUTTER_UNIQUE_FDIO_NS_H_
 
+#include <lib/fdio/namespace.h>
+
 #include "flutter/fml/logging.h"
 #include "flutter/fml/unique_object.h"
-#include "lib/fdio/namespace.h"
 
 namespace flutter_runner {
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/vsync_waiter.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/vsync_waiter.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "vsync_waiter.h"
+#include "flutter/shell/platform/fuchsia/flutter/vsync_waiter.h"
 
 #include <cstdint>
 
@@ -14,7 +14,7 @@
 #include "flutter/fml/time/time_delta.h"
 #include "flutter/fml/trace_event.h"
 
-#include "flutter_runner_product_configuration.h"
+#include "flutter/shell/platform/fuchsia/flutter/flutter_runner_product_configuration.h"
 
 namespace flutter_runner {
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/vsync_waiter.h
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/vsync_waiter.h
@@ -12,7 +12,7 @@
 #include "flutter/fml/time/time_delta.h"
 #include "flutter/fml/time/time_point.h"
 #include "flutter/shell/common/vsync_waiter.h"
-#include "flutter_runner_product_configuration.h"
+#include "flutter/shell/platform/fuchsia/flutter/flutter_runner_product_configuration.h"
 
 namespace flutter_runner {
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/vsync_waiter_unittest.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/vsync_waiter_unittest.cc
@@ -6,14 +6,14 @@
 
 #include <string>
 
+#include "flutter/fml/make_copyable.h"
+#include "flutter/fml/message_loop.h"
+#include "flutter/fml/synchronization/waitable_event.h"
 #include "flutter/fml/task_runner.h"
+#include "flutter/fml/time/time_delta.h"
+#include "flutter/fml/time/time_point.h"
 #include "flutter/shell/common/thread_host.h"
-#include "fml/make_copyable.h"
-#include "fml/message_loop.h"
-#include "fml/synchronization/waitable_event.h"
-#include "fml/time/time_delta.h"
-#include "fml/time/time_point.h"
-#include "vsync_waiter.h"
+#include "flutter/shell/platform/fuchsia/flutter/vsync_waiter.h"
 
 namespace flutter_runner {
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/vulkan_surface.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/vulkan_surface.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "vulkan_surface.h"
+#include "flutter/shell/platform/fuchsia/flutter/vulkan_surface.h"
 
 #include <fuchsia/sysmem/cpp/fidl.h>
 #include <lib/async/default.h>
@@ -11,7 +11,7 @@
 
 #include "flutter/fml/logging.h"
 #include "flutter/fml/trace_event.h"
-#include "runtime/dart/utils/inlines.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/inlines.h"
 #include "third_party/skia/include/core/SkCanvas.h"
 #include "third_party/skia/include/core/SkColorSpace.h"
 #include "third_party/skia/include/core/SkSurfaceProps.h"

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/vulkan_surface.h
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/vulkan_surface.h
@@ -24,7 +24,7 @@
 #include "third_party/skia/include/core/SkSize.h"
 #include "third_party/skia/include/core/SkSurface.h"
 
-#include "surface_producer.h"
+#include "flutter/shell/platform/fuchsia/flutter/surface_producer.h"
 
 namespace flutter_runner {
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/vulkan_surface_pool.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/vulkan_surface_pool.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "vulkan_surface_pool.h"
+#include "flutter/shell/platform/fuchsia/flutter/vulkan_surface_pool.h"
 
 #include <lib/fdio/directory.h>
 #include <lib/zx/process.h>

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/vulkan_surface_pool.h
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/vulkan_surface_pool.h
@@ -11,7 +11,7 @@
 #include <vector>
 
 #include "flutter/fml/macros.h"
-#include "vulkan_surface.h"
+#include "flutter/shell/platform/fuchsia/flutter/vulkan_surface.h"
 
 namespace flutter_runner {
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/vulkan_surface_producer.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/vulkan_surface_producer.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "vulkan_surface_producer.h"
+#include "flutter/shell/platform/fuchsia/flutter/vulkan_surface_producer.h"
 
 #include <lib/async/cpp/task.h>
 #include <lib/async/default.h>

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/vulkan_surface_producer.h
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/vulkan_surface_producer.h
@@ -11,15 +11,13 @@
 #include "flutter/flutter_vma/flutter_skia_vma.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/memory/weak_ptr.h"
+#include "flutter/shell/platform/fuchsia/flutter/vulkan_surface.h"
+#include "flutter/shell/platform/fuchsia/flutter/vulkan_surface_pool.h"
 #include "flutter/vulkan/procs/vulkan_proc_table.h"
 #include "flutter/vulkan/vulkan_application.h"
 #include "flutter/vulkan/vulkan_device.h"
 #include "flutter/vulkan/vulkan_provider.h"
 #include "third_party/skia/include/gpu/ganesh/GrDirectContext.h"
-
-#include "logging.h"
-#include "vulkan_surface.h"
-#include "vulkan_surface_pool.h"
 
 namespace flutter_runner {
 

--- a/engine/src/flutter/shell/platform/fuchsia/runtime/dart/utils/BUILD.gn
+++ b/engine/src/flutter/shell/platform/fuchsia/runtime/dart/utils/BUILD.gn
@@ -9,10 +9,6 @@ import("//flutter/shell/version/version.gni")
 import("//flutter/testing/testing.gni")
 import("//flutter/tools/fuchsia/gn-sdk/src/gn_configs.gni")
 
-config("utils_config") {
-  include_dirs = [ "../../.." ]
-}
-
 template("make_utils") {
   source_set(target_name) {
     sources = [
@@ -52,8 +48,6 @@ template("make_utils") {
              "//flutter/fml",
              "//flutter/third_party/tonic",
            ]
-
-    public_configs = [ ":utils_config" ]
   }
 }
 

--- a/engine/src/flutter/shell/platform/fuchsia/runtime/dart/utils/build_info.h
+++ b/engine/src/flutter/shell/platform/fuchsia/runtime/dart/utils/build_info.h
@@ -5,7 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_FUCHSIA_RUNTIME_DART_UTILS_BUILD_INFO_H_
 #define FLUTTER_SHELL_PLATFORM_FUCHSIA_RUNTIME_DART_UTILS_BUILD_INFO_H_
 
-#include "root_inspect_node.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/root_inspect_node.h"
 
 namespace dart_utils {
 

--- a/engine/src/flutter/shell/platform/fuchsia/runtime/dart/utils/build_info_in.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/runtime/dart/utils/build_info_in.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "runtime/dart/utils/build_info.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/build_info.h"
 
 namespace dart_utils {
 

--- a/engine/src/flutter/shell/platform/fuchsia/runtime/dart/utils/build_info_unittests.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/runtime/dart/utils/build_info_unittests.cc
@@ -2,13 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "build_info.h"
-
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <lib/async-loop/cpp/loop.h>
 #include <lib/async-loop/default.h>
 #include <lib/inspect/cpp/reader.h>
+
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/build_info.h"
 
 const std::string& inspect_node_name = "build_info_unittests";
 

--- a/engine/src/flutter/shell/platform/fuchsia/runtime/dart/utils/files.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/runtime/dart/utils/files.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "files.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/files.h"
 
 #include <fcntl.h>
 #include <unistd.h>

--- a/engine/src/flutter/shell/platform/fuchsia/runtime/dart/utils/handle_exception.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/runtime/dart/utils/handle_exception.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "handle_exception.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/handle_exception.h"
 
 #include <fuchsia/feedback/cpp/fidl.h>
 #include <fuchsia/mem/cpp/fidl.h>

--- a/engine/src/flutter/shell/platform/fuchsia/runtime/dart/utils/mapped_resource.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/runtime/dart/utils/mapped_resource.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "mapped_resource.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/mapped_resource.h"
 
 #include <dlfcn.h>
 #include <fcntl.h>
@@ -18,10 +18,9 @@
 #include <zircon/status.h>
 
 #include "flutter/fml/logging.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/inlines.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/vmo.h"
 #include "third_party/dart/runtime/include/dart_api.h"
-
-#include "inlines.h"
-#include "vmo.h"
 
 namespace dart_utils {
 

--- a/engine/src/flutter/shell/platform/fuchsia/runtime/dart/utils/root_inspect_node.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/runtime/dart/utils/root_inspect_node.cc
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "root_inspect_node.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/root_inspect_node.h"
+
 #include <lib/async/default.h>
 
 namespace dart_utils {

--- a/engine/src/flutter/shell/platform/fuchsia/runtime/dart/utils/tempfs.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/runtime/dart/utils/tempfs.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "tempfs.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/tempfs.h"
 
 #include <string_view>
 

--- a/engine/src/flutter/shell/platform/fuchsia/runtime/dart/utils/vmo.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/runtime/dart/utils/vmo.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "vmo.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/vmo.h"
 
 #include <fcntl.h>
 #include <sys/stat.h>

--- a/engine/src/flutter/shell/platform/fuchsia/runtime/dart/utils/vmservice_object.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/runtime/dart/utils/vmservice_object.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "vmservice_object.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/vmservice_object.h"
 
 #include <dirent.h>
 #include <fuchsia/io/cpp/fidl.h>


### PR DESCRIPTION
This rewrites many of the include paths in Fuchsia engine code to use the full path of the file. For example:

```diff
-#include "runtime/dart/utils/inlines.h"
+#include "flutter/shell/platform/fuchsia/runtime/dart/utils/inlines.h"
```

I also cleaned up a few unused includes and convered the includes for the Fuchsia SDK to using angle backets.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.