### PR TITLE
[pv]add integration test for original untappable web view link behind context menu bug

### DIFF
--- a/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
+++ b/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
@@ -95,4 +95,32 @@ static const CGFloat kStandardTimeOut = 60.0;
   }
 }
 
+- (void)testPlatformViewWebViewLinkTappableForContextMenuScenario {
+  XCUIElement *entranceButton = self.app.buttons[@"web view behind context menu test"];
+  XCTAssertTrue([entranceButton waitForExistenceWithTimeout:kStandardTimeOut]);
+  [entranceButton tap];
+
+  XCUIElement *platformView = self.app.webViews[@"platform_view[0]"];
+  XCTAssertTrue([platformView waitForExistenceWithTimeout:kStandardTimeOut]);
+
+  // expand the context menu.
+  XCUIElement *showMenuButton = self.app.buttons[@"Show menu"];
+  XCTAssertTrue([showMenuButton waitForExistenceWithTimeout:kStandardTimeOut]);
+  [showMenuButton tap];
+
+  // tap to dismiss the context menu.
+  XCUIElement *menuItem = self.app.buttons[@"menu button 1"];
+  XCTAssertTrue([menuItem waitForExistenceWithTimeout:kStandardTimeOut]);
+  XCUICoordinate *center = [self.app coordinateWithNormalizedOffset:CGVectorMake(0.5, 0.5)];
+  [center tap];
+  XCTAssertTrue([menuItem waitForNonExistenceWithTimeout:kStandardTimeOut]);
+
+  // Verify that the web view link is still tappable.
+  XCUIElement *link = self.app.links[@"Target Link"];
+  XCTAssertTrue([link waitForExistenceWithTimeout:kStandardTimeOut]);
+  [link tap];
+  XCUIElement *successText = self.app.staticTexts[@"Navigation Successful"];
+  XCTAssertTrue([successText waitForExistenceWithTimeout:60]);
+}
+
 @end

--- a/dev/integration_tests/ios_platform_view_tests/ios/Runner.xcodeproj/project.pbxproj
+++ b/dev/integration_tests/ios_platform_view_tests/ios/Runner.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		E0440002299C782300D02513 /* ButtonFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = E0440001299C782300D02513 /* ButtonFactory.m */; };
+		E09007712F3A6FE400B349AE /* WebViewFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = E09007702F3A6FE400B349AE /* WebViewFactory.m */; };
 		E09898DE2853DBE800064317 /* ViewFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = E09898DD2853DBE800064317 /* ViewFactory.m */; };
 		E09898E12853DC3C00064317 /* TextFieldFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = E09898E02853DC3C00064317 /* TextFieldFactory.m */; };
 		E09898E92853E9F000064317 /* PlatformViewUITests.m in Sources */ = {isa = PBXBuildFile; fileRef = E09898E82853E9F000064317 /* PlatformViewUITests.m */; };
@@ -60,6 +61,8 @@
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E0440000299C782300D02513 /* ButtonFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ButtonFactory.h; sourceTree = "<group>"; };
 		E0440001299C782300D02513 /* ButtonFactory.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ButtonFactory.m; sourceTree = "<group>"; };
+		E090076F2F3A6FE400B349AE /* WebViewFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebViewFactory.h; sourceTree = "<group>"; };
+		E09007702F3A6FE400B349AE /* WebViewFactory.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WebViewFactory.m; sourceTree = "<group>"; };
 		E09898DC2853DBE800064317 /* ViewFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewFactory.h; sourceTree = "<group>"; };
 		E09898DD2853DBE800064317 /* ViewFactory.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewFactory.m; sourceTree = "<group>"; };
 		E09898DF2853DC3C00064317 /* TextFieldFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TextFieldFactory.h; sourceTree = "<group>"; };
@@ -127,6 +130,8 @@
 				E0440001299C782300D02513 /* ButtonFactory.m */,
 				E09898DC2853DBE800064317 /* ViewFactory.h */,
 				E09898DD2853DBE800064317 /* ViewFactory.m */,
+				E090076F2F3A6FE400B349AE /* WebViewFactory.h */,
+				E09007702F3A6FE400B349AE /* WebViewFactory.m */,
 				97C146FA1CF9000F007C117D /* Main.storyboard */,
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
@@ -292,6 +297,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E09007712F3A6FE400B349AE /* WebViewFactory.m in Sources */,
 				978B8F6F1D3862AE00F588F7 /* AppDelegate.m in Sources */,
 				97C146F31CF9000F007C117D /* main.m in Sources */,
 				E0440002299C782300D02513 /* ButtonFactory.m in Sources */,

--- a/dev/integration_tests/ios_platform_view_tests/ios/Runner/AppDelegate.m
+++ b/dev/integration_tests/ios_platform_view_tests/ios/Runner/AppDelegate.m
@@ -7,6 +7,7 @@
 #import "ViewFactory.h"
 #import "TextFieldFactory.h"
 #import "ButtonFactory.h"
+#import "WebViewFactory.h"
 
 @implementation AppDelegate
 
@@ -18,6 +19,7 @@
   [registrar registerViewFactory:[[ViewFactory alloc] init] withId:@"platform_view"];
   [registrar registerViewFactory:[[TextFieldFactory alloc] init] withId:@"platform_text_field"];
   [registrar registerViewFactory:[[ButtonFactory alloc] init] withId:@"platform_button"];
+  [registrar registerViewFactory:[[WebViewFactory alloc] init] withId:@"platform_web_view"];
   return [super application:application didFinishLaunchingWithOptions:launchOptions];
 }
 

--- a/dev/integration_tests/ios_platform_view_tests/ios/Runner/WebViewFactory.h
+++ b/dev/integration_tests/ios_platform_view_tests/ios/Runner/WebViewFactory.h
@@ -1,0 +1,14 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Flutter/Flutter.h>
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface WebViewFactory: NSObject<FlutterPlatformViewFactory>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/dev/integration_tests/ios_platform_view_tests/ios/Runner/WebViewFactory.m
+++ b/dev/integration_tests/ios_platform_view_tests/ios/Runner/WebViewFactory.m
@@ -1,0 +1,67 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "WebViewFactory.h"
+#import <WebKit/WebKit.h>
+
+@interface WebViewPlatformView: NSObject<FlutterPlatformView, WKNavigationDelegate>
+@property (strong, nonatomic) WKWebView *platformView;
+@end
+
+@implementation WebViewPlatformView
+
+- (instancetype)init
+{
+  self = [super init];
+  if (self) {
+    _platformView = [[WKWebView alloc] init];
+    // Event listener is required to reproduce the non-tappable web view link issue (https://github.com/flutter/flutter/issues/175099).
+    NSString *html = @"<html>"
+      "  <head>"
+      "    <title>Initial</title>"
+      "    <script>"
+      "      document.addEventListener('touchstart', () => console.log('touchstart on document'));"
+      "    </script>"
+      "  </head>"
+      "  <body>"
+      "    <a style='font-size: 50px;' href='custom://page2'>Target Link</a>"
+      "  </body>"
+      "</html>";
+    [_platformView loadHTMLString:html baseURL:nil];
+    _platformView.navigationDelegate = self;
+  }
+  return self;
+}
+
+- (UIView *)view {
+  return self.platformView;
+}
+
+- (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
+  if ([navigationAction.request.URL.scheme isEqualToString:@"custom"]) {
+    NSString *html = @"<html>"
+      "  <head>"
+      "    <title>Page 2</title>"
+      "  </head>"
+      "  <body>"
+      "    <h1 style='font-size: 50px;'>Navigation Successful</h1>"
+      "  </body>"
+      "</html>";
+    [webView loadHTMLString:html baseURL:nil];
+    decisionHandler(WKNavigationActionPolicyCancel);
+    return;
+  }
+  decisionHandler(WKNavigationActionPolicyAllow);
+}
+
+@end
+
+
+@implementation WebViewFactory
+
+- (NSObject<FlutterPlatformView> *)createWithFrame:(CGRect)frame viewIdentifier:(int64_t)viewId arguments:(id)args {
+  return [[WebViewPlatformView alloc] init];
+}
+
+@end

--- a/dev/integration_tests/ios_platform_view_tests/lib/main.dart
+++ b/dev/integration_tests/ios_platform_view_tests/lib/main.dart
@@ -90,6 +90,18 @@ class _MyHomePageState extends State<MyHomePage> {
               );
             },
           ),
+          TextButton(
+            key: const ValueKey<String>('web_view_behind_context_menu_test'),
+            child: const Text('web view behind context menu test'),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute<WebViewBehindContextMenuTestPage>(
+                  builder: (BuildContext context) => const WebViewBehindContextMenuTestPage(),
+                ),
+              );
+            },
+          ),
         ],
       ),
     );
@@ -210,6 +222,51 @@ class _ZOrderTestPageState extends State<ZOrderTestPage> {
               child: const Text('Show Alert'),
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+/// A page to test a web view link is still tappable after dismissing a context menu.
+/// See [this issue](https://github.com/flutter/flutter/issues/175099).
+class WebViewBehindContextMenuTestPage extends StatefulWidget {
+  const WebViewBehindContextMenuTestPage({super.key});
+
+  @override
+  State<WebViewBehindContextMenuTestPage> createState() => _WebViewBehindContextMenuTestPageState();
+}
+
+class _WebViewBehindContextMenuTestPageState extends State<WebViewBehindContextMenuTestPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Web view behind context menu test'),
+        actions: <Widget>[
+          PopupMenuButton<String>(
+            icon: const Icon(Icons.more_vert),
+            onSelected: (String value) {},
+            itemBuilder: (BuildContext context) {
+              return <PopupMenuEntry<String>>[
+                const PopupMenuItem<String>(value: 'button 1', child: Text('menu button 1')),
+                const PopupMenuItem<String>(value: 'button 2', child: Text('menu button 2')),
+                const PopupMenuItem<String>(value: 'button 3', child: Text('menu button 3')),
+                const PopupMenuItem<String>(value: 'button 4', child: Text('menu button 4')),
+                const PopupMenuItem<String>(value: 'button 5', child: Text('menu button 5')),
+              ];
+            },
+          ),
+        ],
+      ),
+      body: const Center(
+        child: SizedBox(
+          width: 500,
+          height: 500,
+          child: UiKitView(
+            viewType: 'platform_web_view',
+            creationParamsCodec: StandardMessageCodec(),
+          ),
         ),
       ),
     );


### PR DESCRIPTION
This PR adds an integration test that reproduces the bug in https://github.com/flutter/flutter/issues/175099. 

I have verified that this test would fail if remove [the hacky workaround](https://github.com/flutter/flutter/pull/179908). 

The next todo item would be to add test for admob banners in a scrollabe list.

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

Related to https://github.com/flutter/flutter/issues/175099
And solve part of https://github.com/flutter/flutter/issues/156753


*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
