### PR TITLE
Delete the last remaining skia only fragment shader tests

### DIFF
--- a/engine/src/flutter/lib/ui/painting.dart
+++ b/engine/src/flutter/lib/ui/painting.dart
@@ -5524,12 +5524,7 @@ base class FragmentProgram extends NativeFieldWrapperClass1 {
     }
 
     if (!found) {
-      bool didFindFloat = false;
-      try {
-        _getUniformFloatInfo(name);
-        didFindFloat = true;
-      } catch (_) {}
-      if (didFindFloat) {
+      if (_hasUniform(name)) {
         throw ArgumentError('Uniform "$name" is not an image sampler.');
       } else {
         throw ArgumentError('No uniform named "$name".');

--- a/engine/src/flutter/lib/ui/painting.dart
+++ b/engine/src/flutter/lib/ui/painting.dart
@@ -5524,7 +5524,16 @@ base class FragmentProgram extends NativeFieldWrapperClass1 {
     }
 
     if (!found) {
-      throw ArgumentError('No uniform named "$name".');
+      bool didFindFloat = false;
+      try {
+        _getUniformFloatInfo(name);
+        didFindFloat = true;
+      } catch (_) {}
+      if (didFindFloat) {
+        throw ArgumentError('Uniform "$name" is not an image sampler.');
+      } else {
+        throw ArgumentError('No uniform named "$name".');
+      }
     }
     return index;
   }

--- a/engine/src/flutter/testing/dart/fragment_shader_test.dart
+++ b/engine/src/flutter/testing/dart/fragment_shader_test.dart
@@ -787,7 +787,7 @@ void main() async {
     shader.dispose();
   });
 
-  _runSkiaTest('FragmentProgram getImageSampler wrong type', () async {
+  test('FragmentProgram getImageSampler wrong type', () async {
     final FragmentProgram program = await FragmentProgram.fromAsset('uniform_ordering.frag.iplr');
     final FragmentShader shader = program.fragmentShader();
     try {
@@ -978,16 +978,6 @@ void main() async {
 ////////////////////////////////////////////////////////////////////////////////
 // Helper Functions ////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
-
-void _runSkiaTest(String name, Future<void> Function() callback) {
-  test(name, () async {
-    if (impellerEnabled) {
-      print('Skipped for Impeller.');
-      return;
-    }
-    await callback();
-  });
-}
 
 void _runImpellerTest(String name, Future<void> Function() callback, {Object? skip}) {
   test(name, () async {

--- a/engine/src/flutter/testing/dart/fragment_shader_test.dart
+++ b/engine/src/flutter/testing/dart/fragment_shader_test.dart
@@ -61,7 +61,7 @@ void main() async {
       shader = program.fragmentShader();
     });
 
-    _runSkiaTest('FragmentProgram uniform info', () async {
+    test('FragmentProgram uniform info', () async {
       final List<UniformFloatSlot> slots = [
         shader.getUniformFloat('iFloatUniform'),
         shader.getUniformFloat('iVec2Uniform', 0),


### PR DESCRIPTION
issue https://github.com/flutter/flutter/issues/180764

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
