### PR TITLE
Update linux_unopt CI: Increase timeout and remove --quiet flag

### DIFF
--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -412,7 +412,6 @@ targets:
     timeout: 120
     properties:
       config_name: linux_unopt
-      test_timeout_secs: "7200"
 
   - name: Linux mac_android_aot_engine
     recipe: engine_v2/engine_v2

--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -412,6 +412,7 @@ targets:
     timeout: 120
     properties:
       config_name: linux_unopt
+      test_timeout_secs: "7200"
 
   - name: Linux mac_android_aot_engine
     recipe: engine_v2/engine_v2

--- a/engine/src/flutter/ci/builders/linux_unopt.json
+++ b/engine/src/flutter/ci/builders/linux_unopt.json
@@ -101,7 +101,8 @@
                     "language": "python3",
                     "script": "flutter/tools/gn_test.py"
                 }
-            ]
+            ],
+            "timeout": 120
         },
         {
             "archives": [],

--- a/engine/src/flutter/ci/builders/linux_unopt.json
+++ b/engine/src/flutter/ci/builders/linux_unopt.json
@@ -60,7 +60,6 @@
                     "name": "test: Host_Tests_for_host_debug_unopt",
                     "script": "flutter/testing/run_tests.py",
                     "parameters": [
-                        "--quiet",
                         "--logs-dir",
                         "${FLUTTER_LOGS_DIR}",
                         "--variant",


### PR DESCRIPTION
Increasing the timeout should let reruns complete if the initial run fails. Right now reruns make the workflow time out, so reruns don't have time to complete.

Removing the --quiet flag should help debug what's going wrong.

Helps to deflake/debug #182150

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
