### PR TITLE
Fix incorrect rendering from drawImageNine when running on impeller with opengles

### DIFF
--- a/engine/src/flutter/impeller/entity/contents/texture_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/texture_contents.cc
@@ -186,9 +186,9 @@ bool TextureContents::Render(const ContentContext& renderer,
     FSStrict::FragInfo frag_info;
     if (texture_->GetYCoordScale() < 0.0) {
       frag_info.source_rect = Vector4(strict_texture_coords.GetLeft(),
-                                      1.0 - strict_texture_coords.GetBottom(),
+                                      1.0f - strict_texture_coords.GetBottom(),
                                       strict_texture_coords.GetRight(),
-                                      1.0 - strict_texture_coords.GetTop());
+                                      1.0f - strict_texture_coords.GetTop());
     } else {
       frag_info.source_rect = Vector4(strict_texture_coords.GetLTRB());
     }

--- a/engine/src/flutter/impeller/entity/contents/texture_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/texture_contents.cc
@@ -184,7 +184,14 @@ bool TextureContents::Render(const ContentContext& renderer,
         Rect::MakeSize(texture_->GetSize()).Project(source_rect_.Expand(-0.5));
 
     FSStrict::FragInfo frag_info;
-    frag_info.source_rect = Vector4(strict_texture_coords.GetLTRB());
+    if (texture_->GetYCoordScale() < 0.0) {
+      frag_info.source_rect = Vector4(strict_texture_coords.GetLeft(),
+                                      1.0 - strict_texture_coords.GetBottom(),
+                                      strict_texture_coords.GetRight(),
+                                      1.0 - strict_texture_coords.GetTop());
+    } else {
+      frag_info.source_rect = Vector4(strict_texture_coords.GetLTRB());
+    }
     frag_info.alpha = GetOpacity();
     FSStrict::BindFragInfo(pass, data_host_buffer.EmplaceUniform((frag_info)));
     FSStrict::BindTextureSampler(

--- a/engine/src/flutter/impeller/entity/contents/texture_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/texture_contents.cc
@@ -8,6 +8,7 @@
 #include <optional>
 #include <utility>
 
+#include "fml/logging.h"
 #include "impeller/core/formats.h"
 #include "impeller/entity/contents/content_context.h"
 #include "impeller/entity/entity.h"
@@ -185,6 +186,7 @@ bool TextureContents::Render(const ContentContext& renderer,
 
     FSStrict::FragInfo frag_info;
     if (texture_->GetYCoordScale() < 0.0) {
+      FML_DCHECK(texture_->GetYCoordScale() == -1.0f);
       frag_info.source_rect = Vector4(strict_texture_coords.GetLeft(),
                                       1.0f - strict_texture_coords.GetBottom(),
                                       strict_texture_coords.GetRight(),


### PR DESCRIPTION
The `frag_info.source_rect` passed into https://github.com/flutter/flutter/blob/98977409b2ac8209be9e918abb0bbb9c37a23d0f/engine/src/flutter/impeller/entity/shaders/texture_fill_strict_src.frag from [texture_contents.cc](https://github.com/flutter/flutter/blob/98977409b2ac8209be9e918abb0bbb9c37a23d0f/engine/src/flutter/impeller/entity/contents/texture_contents.cc#L187) did not account for an inverted y scale (used with an opengles impeller backend).

This ends up causing the coordinates used to sample the texture in the fragment shader to be incorrectly clamped. A lot of the y coordinates end up incorrectly being considered outside of the source_rect, so we end up with lots of incorrect y values and vertical smearing caused by the clamping.

The texture_fill_strict_src.frag shader is used primarily by calls to drawImageNIne. NinePatchConverter calls DrawImageRect with SourceRectConstraint::kStrict, which uses texture_fill_strict_src.frag.

https://github.com/flutter/flutter/issues/182101 shows a repro case for this. The golden test issue discussed in https://github.com/flutter/flutter/pull/181933#issuecomment-3873204657 is also caused by this.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
