### PR TITLE
Replaces some deprecation iOS API usages

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
@@ -50,7 +50,13 @@ using namespace flutter;
 static void SetStatusBarHiddenForSharedApplication(BOOL hidden) {
   UIApplication* flutterApplication = FlutterSharedApplication.application;
   if (flutterApplication) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    // -[UIApplication setStatusBarHidden] is deprecated in iOS9 in favor of
+    // delegating to the view controller. There's no UIScene equivalent for
+    // setting the value per UIScene.
     flutterApplication.statusBarHidden = hidden;
+#pragma clang diagnostic pop
   } else {
     [FlutterLogger logWarning:@"Application based status bar styling is not available in app "
                                "extension."];
@@ -60,9 +66,13 @@ static void SetStatusBarHiddenForSharedApplication(BOOL hidden) {
 static void SetStatusBarStyleForSharedApplication(UIStatusBarStyle style) {
   UIApplication* flutterApplication = FlutterSharedApplication.application;
   if (flutterApplication) {
-    // Note: -[UIApplication setStatusBarStyle] is deprecated in iOS9
-    // in favor of delegating to the view controller.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    // -[UIApplication setStatusBarStyle] is deprecated in iOS9 in favor of
+    // delegating to the view controller. There's no UIScene equivalent for
+    // setting the value per UIScene.
     [flutterApplication setStatusBarStyle:style];
+#pragma clang diagnostic pop
   } else {
     [FlutterLogger logWarning:@"Application based status bar styling is not available in app "
                                "extension."];
@@ -197,7 +207,7 @@ static void SetStatusBarStyleForSharedApplication(UIStatusBarStyle style) {
       [[UIActivityViewController alloc] initWithActivityItems:itemsToShare
                                         applicationActivities:nil];
 
-  if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+  if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
     // On iPad, the share screen is presented in a popover view, and requires a
     // sourceView and sourceRect
     FlutterTextInputPlugin* _textInputPlugin = [self.engine textInputPlugin];

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/TextInputSemanticsObject.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/TextInputSemanticsObject.mm
@@ -124,13 +124,13 @@ static const UIAccessibilityTraits kUIAccessibilityTraitUndocumentedEmptyLine = 
   return nil;
 }
 
-- (UITextWritingDirection)baseWritingDirectionForPosition:(UITextPosition*)position
+- (NSWritingDirection)baseWritingDirectionForPosition:(UITextPosition*)position
                                               inDirection:(UITextStorageDirection)direction {
   // Not editable. Does not apply.
-  return UITextWritingDirectionNatural;
+  return NSWritingDirectionNatural;
 }
 
-- (void)setBaseWritingDirection:(UITextWritingDirection)writingDirection
+- (void)setBaseWritingDirection:(NSWritingDirection)writingDirection
                        forRange:(UITextRange*)range {
   // Not editable. Does not apply.
 }
@@ -422,12 +422,12 @@ static const UIAccessibilityTraits kUIAccessibilityTraitUndocumentedEmptyLine = 
                                                           inDirection:direction];
 }
 
-- (UITextWritingDirection)baseWritingDirectionForPosition:(UITextPosition*)position
+- (NSWritingDirection)baseWritingDirectionForPosition:(UITextPosition*)position
                                               inDirection:(UITextStorageDirection)direction {
   return [[self textInputSurrogate] baseWritingDirectionForPosition:position inDirection:direction];
 }
 
-- (void)setBaseWritingDirection:(UITextWritingDirection)writingDirection
+- (void)setBaseWritingDirection:(NSWritingDirection)writingDirection
                        forRange:(UITextRange*)range {
   [[self textInputSurrogate] setBaseWritingDirection:writingDirection forRange:range];
 }


### PR DESCRIPTION
Replaces a few deprecated iOS API usages. 

The `-[UIApplication setStatusBar*:]` methods have long been deprecated (since iOS 9) and don't have alternatives. On the [StatusBarManager](https://developer.apple.com/documentation/uikit/uistatusbarmanager?language=objc) interface these properties are readonly. Keeping Not sure if these should be removed altogether.

No semantic changes so no tests. I didn't turn on `-Wdeprecated-declarations` for the target because there are still deprecated APIs being used in "flutter_framework_source".

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
