### PR TITLE
[cupertino/dialog.dart] CupertinoPopupSurface: remove bounded parameter from ImageFilterConfig.blur

### DIFF
--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -679,6 +679,8 @@ class CupertinoPopupSurface extends StatelessWidget {
   /// Defaults to true.
   static bool debugIsVibrancePainted = true;
 
+  // TODO(davidhicks980): Set `bounded` to true on ImageFilterConfig.blur after
+  // https://github.com/flutter/flutter/issues/182066 is resolved.
   ImageFilterConfig? _buildFilter(Brightness? brightness) {
     var isVibrancePainted = true;
     assert(() {
@@ -689,7 +691,7 @@ class CupertinoPopupSurface extends StatelessWidget {
       if (blurSigma == 0) {
         return null;
       }
-      return ImageFilterConfig.blur(sigmaX: blurSigma, sigmaY: blurSigma, bounded: true);
+      return ImageFilterConfig.blur(sigmaX: blurSigma, sigmaY: blurSigma);
     }
 
     final colorFilter = ImageFilterConfig(switch (brightness) {
@@ -703,10 +705,10 @@ class CupertinoPopupSurface extends StatelessWidget {
 
     return ImageFilterConfig.compose(
       inner: colorFilter,
-      outer: ImageFilterConfig.blur(sigmaX: blurSigma, sigmaY: blurSigma, bounded: true),
+      outer: ImageFilterConfig.blur(sigmaX: blurSigma, sigmaY: blurSigma),
     );
   }
-
+  
   @override
   Widget build(BuildContext context) {
     final ImageFilterConfig? filter = _buildFilter(CupertinoTheme.maybeBrightnessOf(context));


### PR DESCRIPTION
Removed 'bounded: true' from ImageFilterConfig.blur until https://github.com/flutter/flutter/issues/182066 is resolved. This should unblock https://github.com/flutter/flutter/pull/182036.

See comment: https://github.com/flutter/flutter/issues/182066#issuecomment-3881321273

@dkwingsmt 

Before:
<img width="600" alt="Before" src="https://github.com/user-attachments/assets/29573ca2-eef7-4443-947c-58a7d30d060d" />

After:
<img width="600"  alt="After" src="https://github.com/user-attachments/assets/abae388a-ff40-494e-8137-13083e05ea81" />





## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt]. 
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing. // Goldens will need to be updated.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
