### PR TITLE
Increase timeout for tracing_test.dart's "Canvas.saveLayer emits tracing"

### DIFF
--- a/engine/src/flutter/testing/dart/vm_service/tracing_test.dart
+++ b/engine/src/flutter/testing/dart/vm_service/tracing_test.dart
@@ -110,7 +110,7 @@ void main() {
     await _testChromeFormatTrace(vmService);
     await _testPerfettoFormatTrace(vmService);
     await vmService.dispose();
-  });
+  }, timeout: const Timeout(Duration(seconds: 60)));
 
   test('Frame request pending begin/end pairs are matched', () async {
     final developer.ServiceProtocolInfo info = await developer.Service.getInfo();

--- a/engine/src/flutter/testing/dart/vm_service/tracing_test.dart
+++ b/engine/src/flutter/testing/dart/vm_service/tracing_test.dart
@@ -68,49 +68,55 @@ Future<void> _testPerfettoFormatTrace(vms.VmService vmService) async {
 }
 
 void main() {
-  test('Canvas.saveLayer emits tracing', () async {
-    final developer.ServiceProtocolInfo info = await developer.Service.getInfo();
+  test(
+    'Canvas.saveLayer emits tracing',
+    () async {
+      final developer.ServiceProtocolInfo info = await developer.Service.getInfo();
 
-    if (info.serverUri == null) {
-      fail('This test must not be run with --disable-vm-service.');
-    }
+      if (info.serverUri == null) {
+        fail('This test must not be run with --disable-vm-service.');
+      }
 
-    final vms.VmService vmService = await vmServiceConnectUri(
-      'ws://localhost:${info.serverUri!.port}${info.serverUri!.path}ws',
-    );
-    await vmService.clearVMTimeline();
+      final vms.VmService vmService = await vmServiceConnectUri(
+        'ws://localhost:${info.serverUri!.port}${info.serverUri!.path}ws',
+      );
+      await vmService.clearVMTimeline();
 
-    final completer = Completer<void>();
-    PlatformDispatcher.instance.onBeginFrame = (Duration timeStamp) async {
-      final recorder = PictureRecorder();
-      final canvas = Canvas(recorder);
-      canvas.drawColor(const Color(0xff0000ff), BlendMode.srcOut);
-      // Will saveLayer implicitly for Skia, but not Impeller.
-      canvas.drawPaint(Paint()..imageFilter = ImageFilter.blur(sigmaX: 2, sigmaY: 3));
-      canvas.saveLayer(null, Paint());
-      canvas.drawRect(const Rect.fromLTRB(10, 10, 20, 20), Paint());
-      canvas.saveLayer(const Rect.fromLTWH(0, 0, 100, 100), Paint());
-      canvas.drawRect(const Rect.fromLTRB(10, 10, 20, 20), Paint());
-      canvas.drawRect(const Rect.fromLTRB(15, 15, 25, 25), Paint());
-      canvas.restore();
-      canvas.restore();
-      final Picture picture = recorder.endRecording();
+      final completer = Completer<void>();
+      PlatformDispatcher.instance.onBeginFrame = (Duration timeStamp) async {
+        final recorder = PictureRecorder();
+        final canvas = Canvas(recorder);
+        canvas.drawColor(const Color(0xff0000ff), BlendMode.srcOut);
+        // Will saveLayer implicitly for Skia, but not Impeller.
+        canvas.drawPaint(Paint()..imageFilter = ImageFilter.blur(sigmaX: 2, sigmaY: 3));
+        canvas.saveLayer(null, Paint());
+        canvas.drawRect(const Rect.fromLTRB(10, 10, 20, 20), Paint());
+        canvas.saveLayer(const Rect.fromLTWH(0, 0, 100, 100), Paint());
+        canvas.drawRect(const Rect.fromLTRB(10, 10, 20, 20), Paint());
+        canvas.drawRect(const Rect.fromLTRB(15, 15, 25, 25), Paint());
+        canvas.restore();
+        canvas.restore();
+        final Picture picture = recorder.endRecording();
 
-      final builder = SceneBuilder();
-      builder.addPicture(Offset.zero, picture);
-      final Scene scene = builder.build();
+        final builder = SceneBuilder();
+        builder.addPicture(Offset.zero, picture);
+        final Scene scene = builder.build();
 
-      await scene.toImage(100, 100);
-      scene.dispose();
-      completer.complete();
-    };
-    PlatformDispatcher.instance.scheduleFrame();
-    await completer.future;
+        await scene.toImage(100, 100);
+        scene.dispose();
+        completer.complete();
+      };
+      PlatformDispatcher.instance.scheduleFrame();
+      await completer.future;
 
-    await _testChromeFormatTrace(vmService);
-    await _testPerfettoFormatTrace(vmService);
-    await vmService.dispose();
-  }, timeout: const Timeout(Duration(seconds: 60)));
+      await _testChromeFormatTrace(vmService);
+      await _testPerfettoFormatTrace(vmService);
+      await vmService.dispose();
+    },
+    // Test times out with the default 30 second timeout:
+    // https://github.com/flutter/flutter/issues/182150
+    timeout: const Timeout(Duration(seconds: 60)),
+  );
 
   test('Frame request pending begin/end pairs are matched', () async {
     final developer.ServiceProtocolInfo info = await developer.Service.getInfo();


### PR DESCRIPTION
Potentially addresses #182150.

From https://github.com/flutter/flutter/issues/182150#issuecomment-3886099639:

From looking at the newly non-quiet failures, the issue is that the "Canvas.saveLayer emits tracing" test in tracing_tests.dart is timing out after 30 seconds.

Looking at a sample of this test when it passes (from https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8690171468694972273/+/u/test:_test:_Host_Tests_for_host_debug_unopt/stdout), it took 20, 19, 29, 25, 21, and 23 seconds for 6 different variations (multithreading enabled/disabled, skia/vulkan/opengles backends). So it definitely could be running up against the default 30 second test timeout if a run happens to take a little bit slower.

We can try increasing the timeout for this test.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
