### PR TITLE
Turns on most of fragment_shader_test.dart for opengles

### DIFF
--- a/engine/src/flutter/impeller/compiler/code_gen_template.h
+++ b/engine/src/flutter/impeller/compiler/code_gen_template.h
@@ -233,12 +233,13 @@ ShaderMetadata Shader::kMetadata{{camel_case(buffer.name)}} = {
   std::vector<ShaderStructMemberMetadata> {
     {% for member in buffer.type.members %}
       ShaderStructMemberMetadata {
-        {{ member.base_type }},      // type
-        "{{ member.name }}",         // name
-        {{ member.offset }},         // offset
-        {{ member.size }},           // size
-        {{ member.byte_length }},    // byte_length
-        {{ member.array_elements }}, // array_elements
+        /*type=*/{{ member.base_type }},
+        /*name=*/"{{ member.name }}",
+        /*offset=*/{{ member.offset }},
+        /*size=*/{{ member.size }},
+        /*byte_length=*/{{ member.byte_length }},
+        /*array_elements=*/{{ member.array_elements }},
+        /*float_type=*/{{ member.float_type }},
       },
     {% endfor %}
   } // members

--- a/engine/src/flutter/impeller/compiler/reflector.cc
+++ b/engine/src/flutter/impeller/compiler/reflector.cc
@@ -754,6 +754,11 @@ std::optional<nlohmann::json::object_t> Reflector::ReflectType(
       } else {
         member["array_elements"] = "std::nullopt";
       }
+      if (struct_member.float_type.has_value()) {
+        member["float_type"] = struct_member.float_type.value();
+      } else {
+        member["float_type"] = "std::nullopt";
+      }
       members.emplace_back(std::move(member));
     }
   }
@@ -931,6 +936,7 @@ std::vector<StructMember> Reflector::ReadStructMembers(
           /*p_byte_length=*/total_length,
           /*p_array_elements=*/count,
           /*p_element_padding=*/8,
+          /*p_float_type=*/"ShaderFloatType::kMat2",
       });
       current_byte_offset += total_length;
       continue;
@@ -954,6 +960,7 @@ std::vector<StructMember> Reflector::ReadStructMembers(
           /*p_byte_length=*/total_length,
           /*p_array_elements=*/count,
           /*p_element_padding=*/4,
+          /*p_float_type=*/"ShaderFloatType::kMat3",
       });
       current_byte_offset += total_length;
       continue;
@@ -977,6 +984,7 @@ std::vector<StructMember> Reflector::ReadStructMembers(
           /*p_byte_length=*/stride * array_elements.value_or(1),
           /*p_array_elements=*/array_elements,
           /*p_element_padding=*/element_padding,
+          /*p_float_type=*/"ShaderFloatType::kMat4",
       });
       current_byte_offset += stride * array_elements.value_or(1);
       continue;
@@ -1045,6 +1053,7 @@ std::vector<StructMember> Reflector::ReadStructMembers(
           /*p_byte_length=*/stride * array_elements.value_or(1),
           /*p_array_elements=*/array_elements,
           /*p_element_padding=*/element_padding,
+          /*p_float_type=*/"ShaderFloatType::kVec2",
       });
       current_byte_offset += stride * array_elements.value_or(1);
       continue;
@@ -1067,6 +1076,7 @@ std::vector<StructMember> Reflector::ReadStructMembers(
           /*p_byte_length=*/stride * array_elements.value_or(1),
           /*p_array_elements=*/array_elements,
           /*p_element_padding=*/element_padding,
+          /*p_float_type=*/"ShaderFloatType::kVec3",
       });
       current_byte_offset += stride * array_elements.value_or(1);
       continue;
@@ -1089,6 +1099,7 @@ std::vector<StructMember> Reflector::ReadStructMembers(
           /*p_byte_length=*/stride * array_elements.value_or(1),
           /*p_array_elements=*/array_elements,
           /*p_element_padding=*/element_padding,
+          /*p_float_type=*/"ShaderFloatType::kVec4",
       });
       current_byte_offset += stride * array_elements.value_or(1);
       continue;
@@ -1174,7 +1185,12 @@ std::vector<StructMember> Reflector::ReadStructMembers(
         if (stride == 0) {
           stride = maybe_known_type.value().byte_size;
         }
+        std::optional<std::string> float_type = std::nullopt;
+        if (member.basetype == spirv_cross::SPIRType::BaseType::Float) {
+          float_type = "ShaderFloatType::kFloat";
+        }
         uint32_t element_padding = stride - maybe_known_type.value().byte_size;
+
         // Add the type directly.
         result.emplace_back(StructMember{
             /*p_type=*/maybe_known_type.value().name,
@@ -1185,6 +1201,7 @@ std::vector<StructMember> Reflector::ReadStructMembers(
             /*p_byte_length=*/stride * array_elements.value_or(1),
             /*p_array_elements=*/array_elements,
             /*p_element_padding=*/element_padding,
+            /*p_float_type=*/float_type,
         });
         current_byte_offset += stride * array_elements.value_or(1);
         continue;
@@ -1280,6 +1297,11 @@ nlohmann::json::object_t Reflector::EmitStructDefinition(
       member["array_elements"] = "std::nullopt";
     }
     member["element_padding"] = struct_member.element_padding;
+    if (struct_member.float_type.has_value()) {
+      member["float_type"] = struct_member.float_type.value();
+    } else {
+      member["float_type"] = "std::nullopt";
+    }
   }
   return result;
 }

--- a/engine/src/flutter/impeller/compiler/reflector.h
+++ b/engine/src/flutter/impeller/compiler/reflector.h
@@ -39,6 +39,7 @@ struct StructMember {
   size_t byte_length = 0u;
   std::optional<size_t> array_elements = std::nullopt;
   size_t element_padding = 0u;
+  std::optional<std::string> float_type = std::nullopt;
   UnderlyingType underlying_type = UnderlyingType::kOther;
 
   static std::string BaseTypeToString(spirv_cross::SPIRType::BaseType type) {
@@ -135,6 +136,7 @@ struct StructMember {
   /// treated as arrays of columns, this includes the column count.
   /// @param p_element_padding The padding in bytes after each array
   /// element to satisfy alignment requirements (stride - size).
+  /// @param p_float_type The float type of the member.
   /// @param p_underlying_type The underlying type category, used for
   /// runtime validation.
   StructMember(std::string p_type,
@@ -145,6 +147,7 @@ struct StructMember {
                size_t p_byte_length,
                std::optional<size_t> p_array_elements,
                size_t p_element_padding,
+               std::optional<std::string> p_float_type = std::nullopt,
                UnderlyingType p_underlying_type = UnderlyingType::kOther)
       : type(std::move(p_type)),
         base_type(p_base_type),
@@ -154,6 +157,7 @@ struct StructMember {
         byte_length(p_byte_length),
         array_elements(p_array_elements),
         element_padding(p_element_padding),
+        float_type(std::move(p_float_type)),
         underlying_type(DetermineUnderlyingType(p_base_type)) {}
 };
 

--- a/engine/src/flutter/impeller/core/shader_types.h
+++ b/engine/src/flutter/impeller/core/shader_types.h
@@ -60,6 +60,16 @@ enum class ShaderType {
   kSampler,
 };
 
+enum class ShaderFloatType {
+  kFloat,
+  kVec2,
+  kVec3,
+  kVec4,
+  kMat2,
+  kMat3,
+  kMat4,
+};
+
 struct ShaderStructMemberMetadata {
   ShaderType type;
   std::string name;
@@ -67,6 +77,7 @@ struct ShaderStructMemberMetadata {
   size_t size;
   size_t byte_length;
   std::optional<size_t> array_elements;
+  std::optional<ShaderFloatType> float_type;
 };
 
 struct ShaderMetadata {

--- a/engine/src/flutter/impeller/core/shader_types.h
+++ b/engine/src/flutter/impeller/core/shader_types.h
@@ -60,6 +60,8 @@ enum class ShaderType {
   kSampler,
 };
 
+// This is a separate type from ShaderType because ShaderType is used for
+// OpenGLES's attrib type which doesn't map to things like vec4.
 enum class ShaderFloatType {
   kFloat,
   kVec2,

--- a/engine/src/flutter/impeller/entity/contents/runtime_effect_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/runtime_effect_contents.cc
@@ -108,11 +108,46 @@ static std::unique_ptr<ShaderMetadata> MakeShaderMetadata(
 
   size_t member_size = uniform.dimensions.rows * uniform.dimensions.cols *
                        (uniform.bit_width / 8u);
+
+  ShaderType shader_type = GetShaderType(uniform.type);
+  std::optional<ShaderFloatType> float_type;
+  if (shader_type == ShaderType::kFloat) {
+    if (uniform.dimensions.cols == 1) {
+      switch (uniform.dimensions.rows) {
+        case 1:
+          float_type = ShaderFloatType::kFloat;
+          break;
+        case 2:
+          float_type = ShaderFloatType::kVec2;
+          break;
+        case 3:
+          float_type = ShaderFloatType::kVec3;
+          break;
+        case 4:
+          float_type = ShaderFloatType::kVec4;
+          break;
+      }
+    } else if (uniform.dimensions.rows == uniform.dimensions.cols) {
+      switch (uniform.dimensions.rows) {
+        case 2:
+          float_type = ShaderFloatType::kMat2;
+          break;
+        case 3:
+          float_type = ShaderFloatType::kMat3;
+          break;
+        case 4:
+          float_type = ShaderFloatType::kMat4;
+          break;
+      }
+    }
+  }
+
   metadata->members.emplace_back(ShaderStructMemberMetadata{
-      .type = GetShaderType(uniform.type),                      //
+      .type = shader_type,                                      //
       .size = member_size,                                      //
       .byte_length = member_size * array_elements.value_or(1),  //
-      .array_elements = array_elements                          //
+      .array_elements = array_elements,                         //
+      .float_type = float_type,                                 //
   });
 
   return metadata;

--- a/engine/src/flutter/impeller/fixtures/BUILD.gn
+++ b/engine/src/flutter/impeller/fixtures/BUILD.gn
@@ -107,6 +107,7 @@ impellerc("runtime_stages") {
   shader_target_flags = [
     "--runtime-stage-metal",
     "--runtime-stage-gles",
+    "--runtime-stage-gles3",
     "--runtime-stage-vulkan",
   ]
 

--- a/engine/src/flutter/impeller/fixtures/texture.frag
+++ b/engine/src/flutter/impeller/fixtures/texture.frag
@@ -9,5 +9,9 @@ out vec4 frag_color;
 uniform sampler2D texture_contents;
 
 void main() {
-  frag_color = texture(texture_contents, interpolated_texture_coordinates);
+  vec2 tex_coords = interpolated_texture_coordinates;
+#ifdef IMPELLER_TARGET_OPENGLES
+  tex_coords.y = 1.0 - tex_coords.y;
+#endif
+  frag_color = texture(texture_contents, tex_coords);
 }

--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -402,41 +402,30 @@ bool BufferBindingsGLES::BindUniformBufferV2(
       return false;
     }
 
-    switch (member.size) {
-      case sizeof(Matrix):
-        gl.UniformMatrix4fv(location,       // location
-                            element_count,  // count
-                            GL_FALSE,       // normalize
-                            buffer_data     // data
-        );
-        continue;
-      case sizeof(Vector4):
-        gl.Uniform4fv(location,       // location
-                      element_count,  // count
-                      buffer_data     // data
-        );
-        continue;
-      case sizeof(Vector3):
-        gl.Uniform3fv(location,       // location
-                      element_count,  // count
-                      buffer_data     // data
-        );
-        continue;
-      case sizeof(Vector2):
-        gl.Uniform2fv(location,       // location
-                      element_count,  // count
-                      buffer_data     // data
-        );
-        continue;
-      case sizeof(Scalar):
-        gl.Uniform1fv(location,       // location
-                      element_count,  // count
-                      buffer_data     // data
-        );
-        continue;
-      default:
-        VALIDATION_LOG << "Invalid member size binding: " << member.size;
-        return false;
+    FML_DCHECK(member.float_type.has_value());
+
+    switch (member.float_type.value()) {
+      case ShaderFloatType::kFloat:
+        gl.Uniform1fv(location, element_count, buffer_data);
+        break;
+      case ShaderFloatType::kVec2:
+        gl.Uniform2fv(location, element_count, buffer_data);
+        break;
+      case ShaderFloatType::kVec3:
+        gl.Uniform3fv(location, element_count, buffer_data);
+        break;
+      case ShaderFloatType::kVec4:
+        gl.Uniform4fv(location, element_count, buffer_data);
+        break;
+      case ShaderFloatType::kMat2:
+        gl.UniformMatrix2fv(location, element_count, GL_FALSE, buffer_data);
+        break;
+      case ShaderFloatType::kMat3:
+        gl.UniformMatrix3fv(location, element_count, GL_FALSE, buffer_data);
+        break;
+      case ShaderFloatType::kMat4:
+        gl.UniformMatrix4fv(location, element_count, GL_FALSE, buffer_data);
+        break;
     }
   }
   return true;

--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -402,7 +402,10 @@ bool BufferBindingsGLES::BindUniformBufferV2(
       return false;
     }
 
-    FML_DCHECK(member.float_type.has_value());
+    if (!member.float_type.has_value()) {
+      VALIDATION_LOG << "Float uniform should have a float type.";
+      return false;
+    }
 
     switch (member.float_type.value()) {
       case ShaderFloatType::kFloat:

--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.h
@@ -19,6 +19,7 @@ namespace impeller {
 namespace testing {
 FML_TEST_CLASS(BufferBindingsGLESTest, BindUniformData);
 FML_TEST_CLASS(BufferBindingsGLESTest, BindArrayData);
+FML_TEST_CLASS(BufferBindingsGLESTest, BindUniformDataWithNewTypes);
 }  // namespace testing
 
 //------------------------------------------------------------------------------
@@ -53,6 +54,7 @@ class BufferBindingsGLES {
  private:
   FML_FRIEND_TEST(testing::BufferBindingsGLESTest, BindUniformData);
   FML_FRIEND_TEST(testing::BufferBindingsGLESTest, BindArrayData);
+  FML_FRIEND_TEST(testing::BufferBindingsGLESTest, BindUniformDataWithNewTypes);
   //----------------------------------------------------------------------------
   /// @brief      The arguments to glVertexAttribPointer.
   ///

--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.h
@@ -19,7 +19,7 @@ namespace impeller {
 namespace testing {
 FML_TEST_CLASS(BufferBindingsGLESTest, BindUniformData);
 FML_TEST_CLASS(BufferBindingsGLESTest, BindArrayData);
-FML_TEST_CLASS(BufferBindingsGLESTest, BindUniformDataWithNewTypes);
+FML_TEST_CLASS(BufferBindingsGLESTest, BindUniformDataVerticesAndMatrices);
 }  // namespace testing
 
 //------------------------------------------------------------------------------
@@ -54,7 +54,8 @@ class BufferBindingsGLES {
  private:
   FML_FRIEND_TEST(testing::BufferBindingsGLESTest, BindUniformData);
   FML_FRIEND_TEST(testing::BufferBindingsGLESTest, BindArrayData);
-  FML_FRIEND_TEST(testing::BufferBindingsGLESTest, BindUniformDataWithNewTypes);
+  FML_FRIEND_TEST(testing::BufferBindingsGLESTest,
+                  BindUniformDataVerticesAndMatrices);
   //----------------------------------------------------------------------------
   /// @brief      The arguments to glVertexAttribPointer.
   ///

--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles_unittests.cc
@@ -4,6 +4,7 @@
 
 #include "flutter/testing/testing.h"  // IWYU pragma: keep
 #include "gtest/gtest.h"
+#include "impeller/core/shader_types.h"
 #include "impeller/renderer/backend/gles/buffer_bindings_gles.h"
 #include "impeller/renderer/backend/gles/device_buffer_gles.h"
 #include "impeller/renderer/backend/gles/test/mock_gles.h"
@@ -29,12 +30,14 @@ TEST(BufferBindingsGLESTest, BindUniformData) {
 
   ShaderMetadata shader_metadata = {
       .name = "shader_metadata",
-      .members = {ShaderStructMemberMetadata{.type = ShaderType::kFloat,
-                                             .name = "foobar",
-                                             .offset = 0,
-                                             .size = sizeof(float),
-                                             .byte_length = sizeof(float),
-                                             .array_elements = std::nullopt}}};
+      .members = {
+          ShaderStructMemberMetadata{.type = ShaderType::kFloat,
+                                     .name = "foobar",
+                                     .offset = 0,
+                                     .size = sizeof(float),
+                                     .byte_length = sizeof(float),
+                                     .array_elements = std::nullopt,
+                                     .float_type = ShaderFloatType::kFloat}}};
   std::shared_ptr<ReactorGLES> reactor;
   std::shared_ptr<Allocation> backing_store = std::make_shared<Allocation>();
   ASSERT_TRUE(backing_store->Truncate(Bytes{sizeof(float)}));
@@ -63,12 +66,14 @@ TEST(BufferBindingsGLESTest, BindArrayData) {
 
   ShaderMetadata shader_metadata = {
       .name = "shader_metadata",
-      .members = {ShaderStructMemberMetadata{.type = ShaderType::kFloat,
-                                             .name = "foobar",
-                                             .offset = 0,
-                                             .size = sizeof(float),
-                                             .byte_length = sizeof(float) * 4,
-                                             .array_elements = 4}}};
+      .members = {
+          ShaderStructMemberMetadata{.type = ShaderType::kFloat,
+                                     .name = "foobar",
+                                     .offset = 0,
+                                     .size = sizeof(float),
+                                     .byte_length = sizeof(float) * 4,
+                                     .array_elements = 4,
+                                     .float_type = ShaderFloatType::kFloat}}};
   std::shared_ptr<ReactorGLES> reactor;
   std::shared_ptr<Allocation> backing_store = std::make_shared<Allocation>();
   ASSERT_TRUE(backing_store->Truncate(Bytes{sizeof(float) * 4}));
@@ -76,6 +81,67 @@ TEST(BufferBindingsGLESTest, BindArrayData) {
       DeviceBufferDescriptor{.size = sizeof(float) * 4}, reactor,
       backing_store);
   BufferView buffer_view(&device_buffer, Range(0, sizeof(float)));
+  bound_buffers.push_back(BufferResource(&shader_metadata, buffer_view));
+
+  EXPECT_TRUE(bindings.BindUniformData(mock_gl->GetProcTable(), bound_textures,
+                                       bound_buffers, Range{0, 0},
+                                       Range{0, 1}));
+}
+
+TEST(BufferBindingsGLESTest, BindUniformDataWithNewTypes) {
+  BufferBindingsGLES bindings;
+  absl::flat_hash_map<std::string, GLint> uniform_bindings;
+  uniform_bindings["SHADERMETADATA.VEC2"] = 1;
+  uniform_bindings["SHADERMETADATA.VEC3"] = 2;
+  uniform_bindings["SHADERMETADATA.VEC4"] = 3;
+  uniform_bindings["SHADERMETADATA.MAT2"] = 4;
+  uniform_bindings["SHADERMETADATA.MAT3"] = 5;
+  uniform_bindings["SHADERMETADATA.MAT4"] = 6;
+  bindings.SetUniformBindings(std::move(uniform_bindings));
+  auto mock_gles_impl = std::make_unique<MockGLESImpl>();
+
+  EXPECT_CALL(*mock_gles_impl, Uniform2fv(1, 1, _)).Times(1);
+  EXPECT_CALL(*mock_gles_impl, Uniform3fv(2, 1, _)).Times(1);
+  EXPECT_CALL(*mock_gles_impl, Uniform4fv(3, 1, _)).Times(1);
+  EXPECT_CALL(*mock_gles_impl, UniformMatrix2fv(4, 1, GL_FALSE, _)).Times(1);
+  EXPECT_CALL(*mock_gles_impl, UniformMatrix3fv(5, 1, GL_FALSE, _)).Times(1);
+  EXPECT_CALL(*mock_gles_impl, UniformMatrix4fv(6, 1, GL_FALSE, _)).Times(1);
+
+  std::shared_ptr<MockGLES> mock_gl = MockGLES::Init(std::move(mock_gles_impl));
+  std::vector<BufferResource> bound_buffers;
+  std::vector<TextureAndSampler> bound_textures;
+
+  auto make_metadata = [](ShaderFloatType float_type, const char* name,
+                          size_t size) {
+    return ShaderStructMemberMetadata{.type = ShaderType::kFloat,
+                                      .name = name,
+                                      .offset = 0,
+                                      .size = size,
+                                      .byte_length = size,
+                                      .array_elements = std::nullopt,
+                                      .float_type = float_type};
+  };
+
+  ShaderMetadata shader_metadata = {
+      .name = "shader_metadata",
+      .members = {
+          make_metadata(ShaderFloatType::kVec2, "vec2", sizeof(Vector2)),
+          make_metadata(ShaderFloatType::kVec3, "vec3", sizeof(Vector3)),
+          make_metadata(ShaderFloatType::kVec4, "vec4", sizeof(Vector4)),
+          make_metadata(
+              ShaderFloatType::kMat2, "mat2",
+              sizeof(Matrix)),  // Simplification: Render logic usually passes
+                                // full matrix size or appropriate data
+          make_metadata(ShaderFloatType::kMat3, "mat3", sizeof(Matrix)),
+          make_metadata(ShaderFloatType::kMat4, "mat4", sizeof(Matrix)),
+      }};
+
+  std::shared_ptr<ReactorGLES> reactor;
+  std::shared_ptr<Allocation> backing_store = std::make_shared<Allocation>();
+  ASSERT_TRUE(backing_store->Truncate(Bytes{1024}));  // Plenty of space
+  DeviceBufferGLES device_buffer(DeviceBufferDescriptor{.size = 1024}, reactor,
+                                 backing_store);
+  BufferView buffer_view(&device_buffer, Range(0, 1024));
   bound_buffers.push_back(BufferResource(&shader_metadata, buffer_view));
 
   EXPECT_TRUE(bindings.BindUniformData(mock_gl->GetProcTable(), bound_textures,

--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles_unittests.cc
@@ -128,11 +128,8 @@ TEST(BufferBindingsGLESTest, BindUniformDataVerticesAndMatrices) {
           make_metadata(ShaderFloatType::kVec2, "vec2", sizeof(Vector2)),
           make_metadata(ShaderFloatType::kVec3, "vec3", sizeof(Vector3)),
           make_metadata(ShaderFloatType::kVec4, "vec4", sizeof(Vector4)),
-          make_metadata(
-              ShaderFloatType::kMat2, "mat2",
-              sizeof(Matrix)),  // Simplification: Render logic usually passes
-                                // full matrix size or appropriate data
-          make_metadata(ShaderFloatType::kMat3, "mat3", sizeof(Matrix)),
+          make_metadata(ShaderFloatType::kMat2, "mat2", sizeof(float) * 4),
+          make_metadata(ShaderFloatType::kMat3, "mat3", sizeof(float) * 9),
           make_metadata(ShaderFloatType::kMat4, "mat4", sizeof(Matrix)),
       }};
 

--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles_unittests.cc
@@ -88,7 +88,7 @@ TEST(BufferBindingsGLESTest, BindArrayData) {
                                        Range{0, 1}));
 }
 
-TEST(BufferBindingsGLESTest, BindUniformDataWithNewTypes) {
+TEST(BufferBindingsGLESTest, BindUniformDataVerticesAndMatrices) {
   BufferBindingsGLES bindings;
   absl::flat_hash_map<std::string, GLint> uniform_bindings;
   uniform_bindings["SHADERMETADATA.VEC2"] = 1;

--- a/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
@@ -231,6 +231,8 @@ struct GLProc {
   PROC(Uniform2fv);                          \
   PROC(Uniform3fv);                          \
   PROC(Uniform4fv);                          \
+  PROC(UniformMatrix2fv);                    \
+  PROC(UniformMatrix3fv);                    \
   PROC(UniformMatrix4fv);                    \
   PROC(UseProgram);                          \
   PROC(VertexAttribPointer);                 \

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.cc
@@ -180,8 +180,54 @@ static_assert(CheckSameSignature<decltype(mockDeleteQueriesEXT),  //
 void mockUniform1fv(GLint location, GLsizei count, const GLfloat* value) {
   CallMockMethod(&IMockGLESImpl::Uniform1fv, location, count, value);
 }
-static_assert(CheckSameSignature<decltype(mockUniform1fv),  //
-                                 decltype(glUniform1fv)>::value);
+// Uniform1fv is already here, adding others
+void mockUniform2fv(GLint location, GLsizei count, const GLfloat* value) {
+  CallMockMethod(&IMockGLESImpl::Uniform2fv, location, count, value);
+}
+static_assert(CheckSameSignature<decltype(mockUniform2fv),  //
+                                 decltype(glUniform2fv)>::value);
+
+void mockUniform3fv(GLint location, GLsizei count, const GLfloat* value) {
+  CallMockMethod(&IMockGLESImpl::Uniform3fv, location, count, value);
+}
+static_assert(CheckSameSignature<decltype(mockUniform3fv),  //
+                                 decltype(glUniform3fv)>::value);
+
+void mockUniform4fv(GLint location, GLsizei count, const GLfloat* value) {
+  CallMockMethod(&IMockGLESImpl::Uniform4fv, location, count, value);
+}
+static_assert(CheckSameSignature<decltype(mockUniform4fv),  //
+                                 decltype(glUniform4fv)>::value);
+
+void mockUniformMatrix2fv(GLint location,
+                          GLsizei count,
+                          GLboolean transpose,
+                          const GLfloat* value) {
+  CallMockMethod(&IMockGLESImpl::UniformMatrix2fv, location, count, transpose,
+                 value);
+}
+static_assert(CheckSameSignature<decltype(mockUniformMatrix2fv),  //
+                                 decltype(glUniformMatrix2fv)>::value);
+
+void mockUniformMatrix3fv(GLint location,
+                          GLsizei count,
+                          GLboolean transpose,
+                          const GLfloat* value) {
+  CallMockMethod(&IMockGLESImpl::UniformMatrix3fv, location, count, transpose,
+                 value);
+}
+static_assert(CheckSameSignature<decltype(mockUniformMatrix3fv),  //
+                                 decltype(glUniformMatrix3fv)>::value);
+
+void mockUniformMatrix4fv(GLint location,
+                          GLsizei count,
+                          GLboolean transpose,
+                          const GLfloat* value) {
+  CallMockMethod(&IMockGLESImpl::UniformMatrix4fv, location, count, transpose,
+                 value);
+}
+static_assert(CheckSameSignature<decltype(mockUniformMatrix4fv),  //
+                                 decltype(glUniformMatrix4fv)>::value);
 
 void mockGenTextures(GLsizei n, GLuint* textures) {
   CallMockMethod(&IMockGLESImpl::GenTextures, n, textures);
@@ -313,6 +359,18 @@ const ProcTableGLES::Resolver kMockResolverGLES = [](const char* name) {
     return reinterpret_cast<void*>(mockGetQueryObjectuivEXT);
   } else if (strcmp(name, "glUniform1fv") == 0) {
     return reinterpret_cast<void*>(mockUniform1fv);
+  } else if (strcmp(name, "glUniform2fv") == 0) {
+    return reinterpret_cast<void*>(mockUniform2fv);
+  } else if (strcmp(name, "glUniform3fv") == 0) {
+    return reinterpret_cast<void*>(mockUniform3fv);
+  } else if (strcmp(name, "glUniform4fv") == 0) {
+    return reinterpret_cast<void*>(mockUniform4fv);
+  } else if (strcmp(name, "glUniformMatrix2fv") == 0) {
+    return reinterpret_cast<void*>(mockUniformMatrix2fv);
+  } else if (strcmp(name, "glUniformMatrix3fv") == 0) {
+    return reinterpret_cast<void*>(mockUniformMatrix3fv);
+  } else if (strcmp(name, "glUniformMatrix4fv") == 0) {
+    return reinterpret_cast<void*>(mockUniformMatrix4fv);
   } else if (strcmp(name, "glGenTextures") == 0) {
     return reinterpret_cast<void*>(mockGenTextures);
   } else if (strcmp(name, "glObjectLabelKHR") == 0) {

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.h
@@ -55,6 +55,24 @@ class IMockGLESImpl {
                               const GLchar* label) {}
   virtual void Uniform1fv(GLint location, GLsizei count, const GLfloat* value) {
   }
+  virtual void Uniform2fv(GLint location, GLsizei count, const GLfloat* value) {
+  }
+  virtual void Uniform3fv(GLint location, GLsizei count, const GLfloat* value) {
+  }
+  virtual void Uniform4fv(GLint location, GLsizei count, const GLfloat* value) {
+  }
+  virtual void UniformMatrix2fv(GLint location,
+                                GLsizei count,
+                                GLboolean transpose,
+                                const GLfloat* value) {}
+  virtual void UniformMatrix3fv(GLint location,
+                                GLsizei count,
+                                GLboolean transpose,
+                                const GLfloat* value) {}
+  virtual void UniformMatrix4fv(GLint location,
+                                GLsizei count,
+                                GLboolean transpose,
+                                const GLfloat* value) {}
   virtual void GenQueriesEXT(GLsizei n, GLuint* ids) {}
   virtual void BeginQueryEXT(GLenum target, GLuint id) {}
   virtual void EndQueryEXT(GLuint id) {}
@@ -131,6 +149,39 @@ class MockGLESImpl : public IMockGLESImpl {
   MOCK_METHOD(void,
               Uniform1fv,
               (GLint location, GLsizei count, const GLfloat* value),
+              (override));
+  MOCK_METHOD(void,
+              Uniform2fv,
+              (GLint location, GLsizei count, const GLfloat* value),
+              (override));
+  MOCK_METHOD(void,
+              Uniform3fv,
+              (GLint location, GLsizei count, const GLfloat* value),
+              (override));
+  MOCK_METHOD(void,
+              Uniform4fv,
+              (GLint location, GLsizei count, const GLfloat* value),
+              (override));
+  MOCK_METHOD(void,
+              UniformMatrix2fv,
+              (GLint location,
+               GLsizei count,
+               GLboolean transpose,
+               const GLfloat* value),
+              (override));
+  MOCK_METHOD(void,
+              UniformMatrix3fv,
+              (GLint location,
+               GLsizei count,
+               GLboolean transpose,
+               const GLfloat* value),
+              (override));
+  MOCK_METHOD(void,
+              UniformMatrix4fv,
+              (GLint location,
+               GLsizei count,
+               GLboolean transpose,
+               const GLfloat* value),
               (override));
   MOCK_METHOD(void, GenQueriesEXT, (GLsizei n, GLuint* ids), (override));
   MOCK_METHOD(void, BeginQueryEXT, (GLenum target, GLuint id), (override));

--- a/engine/src/flutter/lib/ui/fixtures/shaders/BUILD.gn
+++ b/engine/src/flutter/lib/ui/fixtures/shaders/BUILD.gn
@@ -23,6 +23,7 @@ if (enable_unittests) {
       "--sksl",
       "--runtime-stage-metal",
       "--runtime-stage-gles",
+      "--runtime-stage-gles3",
       "--runtime-stage-vulkan",
     ]
     intermediates_subdir = "iplr"

--- a/engine/src/flutter/lib/ui/fixtures/shaders/general_shaders/BUILD.gn
+++ b/engine/src/flutter/lib/ui/fixtures/shaders/general_shaders/BUILD.gn
@@ -44,6 +44,7 @@ if (enable_unittests) {
       "--sksl",
       "--runtime-stage-metal",
       "--runtime-stage-gles",
+      "--runtime-stage-gles3",
       "--runtime-stage-vulkan",
     ]
     intermediates_subdir = "iplr"

--- a/engine/src/flutter/lib/ui/fixtures/shaders/general_shaders/texture.frag
+++ b/engine/src/flutter/lib/ui/fixtures/shaders/general_shaders/texture.frag
@@ -13,5 +13,9 @@ uniform sampler2D u_texture;
 out vec4 frag_color;
 
 void main() {
-  frag_color = texture(u_texture, FlutterFragCoord().xy / u_size);
+  vec2 tex_coords = FlutterFragCoord().xy / u_size;
+#ifdef IMPELLER_TARGET_OPENGLES
+  tex_coords.y = 1.0 - tex_coords.y;
+#endif
+  frag_color = texture(u_texture, tex_coords);
 }

--- a/engine/src/flutter/lib/ui/fixtures/shaders/uniforms/BUILD.gn
+++ b/engine/src/flutter/lib/ui/fixtures/shaders/uniforms/BUILD.gn
@@ -37,6 +37,7 @@ if (enable_unittests) {
       "--sksl",
       "--runtime-stage-metal",
       "--runtime-stage-gles",
+      "--runtime-stage-gles3",
       "--runtime-stage-vulkan",
     ]
     intermediates_subdir = "iplr"

--- a/engine/src/flutter/shell/testing/tester_context_gles_factory.cc
+++ b/engine/src/flutter/shell/testing/tester_context_gles_factory.cc
@@ -22,9 +22,9 @@
 #include "flutter/shell/gpu/gpu_surface_gl_impeller.h"
 #include "flutter/testing/test_swangle_utils.h"
 #include "flutter/testing/test_swiftshader_utils.h"
-#include "impeller/entity/gles/entity_shaders_gles.h"
-#include "impeller/entity/gles/framebuffer_blend_shaders_gles.h"
-#include "impeller/entity/gles/modern_shaders_gles.h"
+#include "impeller/entity/gles3/entity_shaders_gles.h"
+#include "impeller/entity/gles3/framebuffer_blend_shaders_gles.h"
+#include "impeller/entity/gles3/modern_shaders_gles.h"
 #include "impeller/renderer/backend/gles/context_gles.h"
 #include "impeller/renderer/backend/gles/proc_table_gles.h"
 #include "third_party/abseil-cpp/absl/status/statusor.h"
@@ -93,7 +93,7 @@ class TesterGLESDelegate : public GPUSurfaceGLDelegate {
       return absl::InternalError("Could not choose EGL config.");
     }
 
-    const EGLint context_attributes[] = {EGL_CONTEXT_CLIENT_VERSION, 2,
+    const EGLint context_attributes[] = {EGL_CONTEXT_CLIENT_VERSION, 3,
                                          EGL_NONE};
 
     EGLContext context =
@@ -249,14 +249,14 @@ class TesterContextGLES : public TesterContext {
 
     std::vector<std::shared_ptr<fml::Mapping>> shader_mappings = {
         std::make_shared<fml::NonOwnedMapping>(
-            impeller_entity_shaders_gles_data,
-            impeller_entity_shaders_gles_length),
+            impeller_entity_shaders_gles3_data,
+            impeller_entity_shaders_gles3_length),
         std::make_shared<fml::NonOwnedMapping>(
-            impeller_modern_shaders_gles_data,
-            impeller_modern_shaders_gles_length),
+            impeller_modern_shaders_gles3_data,
+            impeller_modern_shaders_gles3_length),
         std::make_shared<fml::NonOwnedMapping>(
-            impeller_framebuffer_blend_shaders_gles_data,
-            impeller_framebuffer_blend_shaders_gles_length),
+            impeller_framebuffer_blend_shaders_gles3_data,
+            impeller_framebuffer_blend_shaders_gles3_length),
     };
     context_ = impeller::ContextGLES::Create(impeller::Flags{}, std::move(gl),
                                              shader_mappings, false);

--- a/engine/src/flutter/testing/run_tests.py
+++ b/engine/src/flutter/testing/run_tests.py
@@ -940,7 +940,6 @@ def gather_dart_tests(
       'codec_test.dart',
       'decode_image_from_pixels_sync_test.dart',
       'encoding_test.dart',
-      #'fragment_shader_test.dart',
       'gpu_test.dart',
       'high_bitrate_texture_test.dart',
       'image_dispose_test.dart',

--- a/engine/src/flutter/testing/run_tests.py
+++ b/engine/src/flutter/testing/run_tests.py
@@ -940,7 +940,7 @@ def gather_dart_tests(
       'codec_test.dart',
       'decode_image_from_pixels_sync_test.dart',
       'encoding_test.dart',
-      'fragment_shader_test.dart',
+      #'fragment_shader_test.dart',
       'gpu_test.dart',
       'high_bitrate_texture_test.dart',
       'image_dispose_test.dart',


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/182106

Changes:
- started running the tests against opengles 3, which matches the version of the test shaders
- fixed binging uniforms on opengles so it's based on it's type, not it's size (since vec4 and mat2 have the same size for instance)
  - fixed for builtin shaders
  - fixed for runtime shaders
- expands our opengles mocking to include more uniform setters
- skips the handful of tests that still don't work

Now builtin shader headers look something like this.  You can see this information didn't exist and was not derivable based on the existing information in all cases:

```c++
ShaderMetadata Shader::kMetadataFrameInfo = {
  "FrameInfo",    // name
  std::vector<ShaderStructMemberMetadata> {
      ShaderStructMemberMetadata {
        /*type=*/ShaderType::kFloat,
        /*name=*/"mvp",
        /*offset=*/0,
        /*size=*/64,
        /*byte_length=*/64,
        /*array_elements=*/std::nullopt,
        /*float_type=*/ShaderFloatType::kMat4, // <-- new
      },
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
