### PR TITLE
Changelog entry for 3.38.10 stable hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ docs/releases/Hotfix-Documentation-Best-Practices.md
 
 ## Flutter 3.38 Changes
 
+### [3.38.10](https://github.com/flutter/flutter/releases/tag/3.38.10)
+
+- [flutter/181607](https://github.com/flutter/flutter/pull/181607) When using an ffi plugin on macOS, generated frameworks have the wrong structure.
+
 ### [3.38.9](https://github.com/flutter/flutter/releases/tag/3.38.9)
 
 - [flutter/181568](https://github.com/flutter/flutter/pull/181568) Update Dart to 3.10.8.


### PR DESCRIPTION
Now that it's been released, merging the changelog updates to master from https://github.com/flutter/flutter/pull/182037.