### PR TITLE
[Impeller] Dispose thread local caches on each frame when using GPUSurfaceVulkanImpeller with a delegate

### DIFF
--- a/engine/src/flutter/BUILD.gn
+++ b/engine/src/flutter/BUILD.gn
@@ -215,6 +215,7 @@ group("unittests") {
       "//flutter/runtime:runtime_unittests",
       "//flutter/shell/common:shell_unittests",
       "//flutter/shell/geometry:geometry_unittests",
+      "//flutter/shell/gpu:gpu_surface_unittests",
       "//flutter/shell/platform/embedder:embedder_a11y_unittests",
       "//flutter/shell/platform/embedder:embedder_proctable_unittests",
       "//flutter/shell/platform/embedder:embedder_unittests",
@@ -246,7 +247,6 @@ group("unittests") {
     if (is_mac) {
       public_deps += [
         "//flutter/impeller/golden_tests:impeller_golden_tests",
-        "//flutter/shell/gpu:gpu_surface_metal_unittests",
         "//flutter/shell/platform/darwin/common:availability_version_check_unittests",
         "//flutter/shell/platform/darwin/common:framework_common_swift_unittests",
         "//flutter/shell/platform/darwin/common:framework_common_unittests",
@@ -260,10 +260,6 @@ group("unittests") {
         "//flutter/shell/platform/android/jni:jni_unittests",
         "//flutter/shell/platform/android/platform_view_android_delegate:platform_view_android_delegate_unittests",
       ]
-    }
-
-    if (test_enable_vulkan) {
-      public_deps += [ "//flutter/shell/gpu:gpu_surface_vulkan_unittests" ]
     }
 
     # Unit tests for desktop embeddings should only be built if the desktop

--- a/engine/src/flutter/BUILD.gn
+++ b/engine/src/flutter/BUILD.gn
@@ -5,6 +5,7 @@
 import("//build/toolchain/clang.gni")
 import("//flutter/common/config.gni")
 import("//flutter/examples/examples.gni")
+import("//flutter/shell/config.gni")
 import("//flutter/shell/platform/config.gni")
 import("//flutter/shell/platform/glfw/config.gni")
 import("//flutter/testing/testing.gni")
@@ -239,7 +240,6 @@ group("unittests") {
         "//flutter/impeller:impeller_dart_unittests",
         "//flutter/impeller:impeller_unittests",
         "//flutter/impeller/toolkit/interop:example",
-        "//flutter/shell/gpu:gpu_surface_vulkan_unittests",
       ]
     }
 
@@ -260,6 +260,10 @@ group("unittests") {
         "//flutter/shell/platform/android/jni:jni_unittests",
         "//flutter/shell/platform/android/platform_view_android_delegate:platform_view_android_delegate_unittests",
       ]
+    }
+
+    if (test_enable_vulkan) {
+      public_deps += [ "//flutter/shell/gpu:gpu_surface_vulkan_unittests" ]
     }
 
     # Unit tests for desktop embeddings should only be built if the desktop

--- a/engine/src/flutter/BUILD.gn
+++ b/engine/src/flutter/BUILD.gn
@@ -239,6 +239,7 @@ group("unittests") {
         "//flutter/impeller:impeller_dart_unittests",
         "//flutter/impeller:impeller_unittests",
         "//flutter/impeller/toolkit/interop:example",
+        "//flutter/shell/gpu:gpu_surface_vulkan_unittests",
       ]
     }
 

--- a/engine/src/flutter/shell/gpu/BUILD.gn
+++ b/engine/src/flutter/shell/gpu/BUILD.gn
@@ -74,7 +74,7 @@ source_set("gpu_surface_vulkan") {
   }
 }
 
-if (impeller_enable_vulkan) {
+if (test_enable_vulkan) {
   impeller_component("gpu_surface_vulkan_unittests") {
     testonly = true
 

--- a/engine/src/flutter/shell/gpu/BUILD.gn
+++ b/engine/src/flutter/shell/gpu/BUILD.gn
@@ -78,7 +78,6 @@ if (test_enable_vulkan) {
   impeller_component("gpu_surface_vulkan_unittests") {
     testonly = true
 
-    target_type = "executable"
     sources = [ "gpu_surface_vulkan_impeller_unittests.cc" ]
 
     deps = [
@@ -127,7 +126,6 @@ if (is_mac) {
     cflags_objc = flutter_cflags_objc
     cflags_objcc = flutter_cflags_objcc
 
-    target_type = "executable"
     sources = [
       "gpu_surface_metal_impeller_unittests.mm",
       "gpu_surface_noop_unittests.mm",
@@ -146,5 +144,23 @@ if (is_mac) {
              "//flutter/runtime:libdart",
              "//flutter/testing",
            ] + gpu_common_deps
+  }
+}
+
+impeller_component("gpu_surface_unittests") {
+  testonly = true
+  target_type = "executable"
+
+  sources = [ "gpu_surface_unittests.cc" ]
+  deps = [
+    "//flutter/impeller/fixtures",
+    "//flutter/testing",
+  ]
+
+  if (is_mac) {
+    deps += [ ":gpu_surface_metal_unittests" ]
+  }
+  if (test_enable_vulkan) {
+    deps += [ ":gpu_surface_vulkan_unittests" ]
   }
 }

--- a/engine/src/flutter/shell/gpu/BUILD.gn
+++ b/engine/src/flutter/shell/gpu/BUILD.gn
@@ -74,6 +74,26 @@ source_set("gpu_surface_vulkan") {
   }
 }
 
+if (impeller_enable_vulkan) {
+  impeller_component("gpu_surface_vulkan_unittests") {
+    testonly = true
+
+    target_type = "executable"
+    sources = [ "gpu_surface_vulkan_impeller_unittests.cc" ]
+
+    deps = [
+             ":gpu_surface_vulkan",
+             "//flutter/fml",
+             "//flutter/impeller/fixtures",
+             "//flutter/runtime",
+             "//flutter/runtime:libdart",
+             "//flutter/testing",
+             "//flutter/testing:vulkan",
+             "//flutter/third_party/swiftshader/src/Vulkan:swiftshader_libvulkan_static",
+           ] + gpu_common_deps
+  }
+}
+
 if (shell_enable_metal) {
   source_set("gpu_surface_metal") {
     cflags_objc = flutter_cflags_objc

--- a/engine/src/flutter/shell/gpu/gpu_surface_unittests.cc
+++ b/engine/src/flutter/shell/gpu/gpu_surface_unittests.cc
@@ -1,0 +1,15 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "gtest/gtest.h"
+
+namespace flutter {
+namespace testing {
+
+// An empty test added to make this binary buildable on platforms that do not
+// have any GPU surface test cases.
+TEST(GPUSurface, Empty) {}
+
+}  // namespace testing
+}  // namespace flutter

--- a/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller.cc
+++ b/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller.cc
@@ -155,6 +155,11 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkanImpeller::AcquireFrame(
       return nullptr;
     }
 
+    impeller::ContextVK& context_vk =
+        impeller::ContextVK::Cast(*impeller_context_);
+
+    context_vk.DisposeThreadLocalCachedResources();
+
     impeller::vk::Image vk_image =
         impeller::vk::Image(reinterpret_cast<VkImage>(flutter_image.image));
 
@@ -165,9 +170,6 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkanImpeller::AcquireFrame(
     desc.mip_count = 1;
     desc.compression_type = impeller::CompressionType::kLossless;
     desc.usage = impeller::TextureUsage::kRenderTarget;
-
-    impeller::ContextVK& context_vk =
-        impeller::ContextVK::Cast(*impeller_context_);
 
     impeller::vk::ImageViewCreateInfo view_info = {};
     view_info.viewType = impeller::vk::ImageViewType::e2D;

--- a/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller_unittests.cc
+++ b/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller_unittests.cc
@@ -1,0 +1,80 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <vulkan/vulkan.h>
+
+#include "flutter/shell/gpu/gpu_surface_vulkan_delegate.h"
+#include "flutter/shell/gpu/gpu_surface_vulkan_impeller.h"
+#include "flutter/testing/test_vulkan_context.h"
+#include "flutter/testing/test_vulkan_surface.h"
+#include "gtest/gtest.h"
+#include "impeller/entity/vk/entity_shaders_vk.h"
+#include "impeller/entity/vk/framebuffer_blend_shaders_vk.h"
+#include "impeller/entity/vk/modern_shaders_vk.h"
+#include "impeller/renderer/backend/vulkan/context_vk.h"
+
+namespace flutter {
+namespace testing {
+
+std::vector<std::shared_ptr<fml::Mapping>> ShaderLibraryMappings() {
+  return {
+      std::make_shared<fml::NonOwnedMapping>(impeller_entity_shaders_vk_data,
+                                             impeller_entity_shaders_vk_length),
+      std::make_shared<fml::NonOwnedMapping>(impeller_modern_shaders_vk_data,
+                                             impeller_modern_shaders_vk_length),
+      std::make_shared<fml::NonOwnedMapping>(
+          impeller_framebuffer_blend_shaders_vk_data,
+          impeller_framebuffer_blend_shaders_vk_length),
+  };
+}
+
+class TestGPUSurfaceVulkanDelegate : public GPUSurfaceVulkanDelegate {
+ public:
+  TestGPUSurfaceVulkanDelegate()
+      : vk_(fml::MakeRefCounted<vulkan::VulkanProcTable>(
+            vkGetInstanceProcAddr)),
+        test_context_(fml::MakeRefCounted<TestVulkanContext>()),
+        test_surface_(TestVulkanSurface::Create(*test_context_, {100, 100})) {}
+
+  const vulkan::VulkanProcTable& vk() override { return *vk_; }
+
+  FlutterVulkanImage AcquireImage(const DlISize& size) override {
+    return {
+        .struct_size = sizeof(FlutterVulkanImage),
+        .image = reinterpret_cast<uint64_t>(test_surface_->GetImage()),
+        .format = VK_FORMAT_R8G8B8A8_UNORM,
+    };
+  }
+
+  bool PresentImage(VkImage image, VkFormat format) override { return true; }
+
+ private:
+  fml::RefPtr<vulkan::VulkanProcTable> vk_;
+  fml::RefPtr<TestVulkanContext> test_context_;
+  std::unique_ptr<TestVulkanSurface> test_surface_;
+};
+
+TEST(GPUSurfaceVulkanImpeller, DisposesThreadLocalResources) {
+  impeller::ContextVK::Settings context_settings;
+  context_settings.proc_address_callback = vkGetInstanceProcAddr;
+  context_settings.shader_libraries_data = ShaderLibraryMappings();
+  auto context = impeller::ContextVK::Create(std::move(context_settings));
+
+  TestGPUSurfaceVulkanDelegate delegate;
+
+  std::unique_ptr<Surface> surface =
+      std::make_unique<GPUSurfaceVulkanImpeller>(&delegate, context);
+
+  // Add a command pool to the global map.
+  auto pool = context->GetCommandPoolRecycler()->Get();
+  EXPECT_EQ(impeller::CommandPoolRecyclerVK::GetGlobalPoolCount(*context), 1);
+
+  // Check that AcquireFrame disposes thread local resources and removes
+  // the pool from the global map.
+  auto frame = surface->AcquireFrame(DlISize(100, 100));
+  EXPECT_EQ(impeller::CommandPoolRecyclerVK::GetGlobalPoolCount(*context), 0);
+}
+
+}  // namespace testing
+}  // namespace flutter

--- a/engine/src/flutter/testing/run_tests.py
+++ b/engine/src/flutter/testing/run_tests.py
@@ -468,6 +468,7 @@ def run_cc_tests(
       make_test('embedder_unittests'),
       make_test('fml_unittests'),
       make_test('geometry_unittests'),
+      make_test('gpu_surface_unittests'),
       make_test('no_dart_plugin_registrant_unittests'),
       make_test('runtime_unittests'),
       make_test('testing_unittests'),
@@ -503,7 +504,6 @@ def run_cc_tests(
         make_test('framework_common_swift_unittests'),
         make_test('framework_common_unittests'),
         make_test('spring_animation_unittests'),
-        make_test('gpu_surface_metal_unittests'),
     ]
 
   if is_linux():
@@ -516,7 +516,6 @@ def run_cc_tests(
         make_test('flow_unittests', flags=repeat_flags + ['--'] + flow_flags),
         make_test('flutter_glfw_unittests'),
         make_test('flutter_linux_unittests', extra_env={'G_DEBUG': 'fatal-criticals'}),
-        make_test('gpu_surface_vulkan_unittests'),
         # https://github.com/flutter/flutter/issues/36296
         make_test('txt_unittests', flags=repeat_flags + ['--'] + icu_flags),
     ]

--- a/engine/src/flutter/testing/run_tests.py
+++ b/engine/src/flutter/testing/run_tests.py
@@ -516,6 +516,7 @@ def run_cc_tests(
         make_test('flow_unittests', flags=repeat_flags + ['--'] + flow_flags),
         make_test('flutter_glfw_unittests'),
         make_test('flutter_linux_unittests', extra_env={'G_DEBUG': 'fatal-criticals'}),
+        make_test('gpu_surface_vulkan_unittests'),
         # https://github.com/flutter/flutter/issues/36296
         make_test('txt_unittests', flags=repeat_flags + ['--'] + icu_flags),
     ]


### PR DESCRIPTION
The Impeller Vulkan back end caches command pools in thread-local storage.  These caches can grow unbounded unless the embedder calls ContextVK::DisposeThreadLocalCachedResources()

If the GPUSurfaceVulkanImpeller does not have a delegate, then AcquireFrame will invoke DisposeThreadLocalCachedResources through its call to SurfaceContextVK::AcquireNextSurface.

With a delegate, AcquireFrame follows a different code path that must explicitly call DisposeThreadLocalCachedResources.