### PR TITLE
Ship gen_snapshot for linux-arm64 hosts targeting Android

### DIFF
--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -302,6 +302,25 @@ targets:
       # at https://github.com/flutter/flutter/issues/152186.
       cores: "8"
 
+  - name: Linux linux_arm64_android_aot_engine
+    recipe: engine_v2/engine_v2
+    timeout: 120
+    properties:
+      add_recipes_cq: "true"
+      release_build: "true"
+      config_name: linux_arm64_android_aot_engine
+    # Do not remove(https://github.com/flutter/flutter/issues/144644)
+    # Scheduler will fail to get the platform
+    drone_dimensions:
+      - os=Linux
+      - cpu=arm64
+    dimensions:
+      # This is needed so that orchestrators that only spawn subbuilds are not
+      # assigned to the large 32 core workers when doing release builds.
+      # For more details see the issue
+      # at https://github.com/flutter/flutter/issues/152186.
+      cores: "8"
+
   - name: Linux linux_android_aot_engine_ddm
     recipe: engine_v2/engine_v2
     timeout: 120

--- a/engine/src/flutter/ci/builders/linux_arm64_android_aot_engine.json
+++ b/engine/src/flutter/ci/builders/linux_arm64_android_aot_engine.json
@@ -1,0 +1,357 @@
+{
+    "_comment": [
+        "The builds defined in this file should not contain tests, ",
+        "and the file should not contain builds that are essentially tests. ",
+        "The only builds in this file should be the builds necessary to produce ",
+        "release artifacts. ",
+        "Tests to run on linux hosts should go in one of the other linux_ build ",
+        "definition files."
+    ],
+    "luci_flags": {
+      "upload_content_hash": true
+    },
+    "builds": [
+        {
+            "archives": [
+                {
+                    "base_path": "out/ci/android_profile/zip_archives/",
+                    "type": "gcs",
+                    "include_paths": [
+                        "out/ci/android_profile/zip_archives/android-arm-profile/linux-arm64.zip"
+                    ],
+                    "name": "ci/android_profile",
+                    "realm": "production"
+                }
+            ],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux",
+                "cpu=arm64"
+            ],
+            "gclient_variables": {
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
+                "ci/android_profile",
+                "--runtime-mode",
+                "profile",
+                "--android",
+                "--android-cpu",
+                "arm",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/android_profile",
+            "description": "Produces profile mode artifacts to target 32-bit arm Android from an ARM64 Linux host.",
+            "ninja": {
+                "config": "ci/android_profile",
+                "targets": [
+                    "flutter/lib/snapshot",
+                    "flutter/shell/platform/android:gen_snapshot"
+                ]
+            }
+        },
+        {
+            "archives": [
+                {
+                    "base_path": "out/ci/android_release/zip_archives/",
+                    "type": "gcs",
+                    "include_paths": [
+                        "out/ci/android_release/zip_archives/android-arm-release/linux-arm64.zip"
+                    ],
+                    "name": "ci/android_release",
+                    "realm": "production"
+                }
+            ],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux",
+                "cpu=arm64"
+            ],
+            "gclient_variables": {
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
+                "ci/android_release",
+                "--runtime-mode",
+                "release",
+                "--android",
+                "--android-cpu",
+                "arm",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/android_release",
+            "description": "Produces release mode artifacts to target 32-bit arm Android from an ARM64 Linux host.",
+            "ninja": {
+                "config": "ci/android_release",
+                "targets": [
+                    "flutter/lib/snapshot",
+                    "flutter/shell/platform/android:gen_snapshot"
+                ]
+            }
+        },
+        {
+            "archives": [
+                {
+                    "base_path": "out/ci/android_profile_arm64/zip_archives/",
+                    "type": "gcs",
+                    "include_paths": [
+                        "out/ci/android_profile_arm64/zip_archives/android-arm64-profile/linux-arm64.zip",
+                        "out/ci/android_profile_arm64/zip_archives/android-arm64-profile/analyze-snapshot-linux-arm64.zip"
+                    ],
+                    "name": "ci/android_profile_arm64",
+                    "realm": "production"
+                }
+            ],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux",
+                "cpu=arm64"
+            ],
+            "gclient_variables": {
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
+                "ci/android_profile_arm64",
+                "--runtime-mode",
+                "profile",
+                "--android",
+                "--android-cpu",
+                "arm64",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/android_profile_arm64",
+            "description": "Produces profile mode artifacts to target 64-bit arm Android from an ARM64 Linux host.",
+            "ninja": {
+                "config": "ci/android_profile_arm64",
+                "targets": [
+                    "flutter/lib/snapshot",
+                    "flutter/shell/platform/android:gen_snapshot",
+                    "flutter/shell/platform/android:analyze_snapshot"
+                ]
+            }
+        },
+        {
+            "archives": [
+                {
+                    "base_path": "out/ci/android_release_arm64/zip_archives/",
+                    "type": "gcs",
+                    "include_paths": [
+                        "out/ci/android_release_arm64/zip_archives/android-arm64-release/linux-arm64.zip",
+                        "out/ci/android_release_arm64/zip_archives/android-arm64-release/analyze-snapshot-linux-arm64.zip"
+                    ],
+                    "name": "ci/android_release_arm64",
+                    "realm": "production"
+                }
+            ],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux",
+                "cpu=arm64"
+            ],
+            "gclient_variables": {
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
+                "ci/android_release_arm64",
+                "--runtime-mode",
+                "release",
+                "--android",
+                "--android-cpu",
+                "arm64",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/android_release_arm64",
+            "description": "Produces release mode artifacts to target 64-bit arm Android from an ARM64 Linux host.",
+            "ninja": {
+                "config": "ci/android_release_arm64",
+                "targets": [
+                    "flutter/lib/snapshot",
+                    "flutter/shell/platform/android:gen_snapshot",
+                    "flutter/shell/platform/android:analyze_snapshot"
+                ]
+            }
+        },
+        {
+            "archives": [
+                {
+                    "base_path": "out/ci/android_profile_x64/zip_archives/",
+                    "type": "gcs",
+                    "include_paths": [
+                        "out/ci/android_profile_x64/zip_archives/android-x64-profile/linux-arm64.zip",
+                        "out/ci/android_profile_x64/zip_archives/android-x64-profile/analyze-snapshot-linux-arm64.zip"
+                    ],
+                    "name": "ci/android_profile_x64",
+                    "realm": "production"
+                }
+            ],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux",
+                "cpu=arm64"
+            ],
+            "gclient_variables": {
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
+                "ci/android_profile_x64",
+                "--runtime-mode",
+                "profile",
+                "--android",
+                "--android-cpu",
+                "x64",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/android_profile_x64",
+            "description": "Produces profile mode artifacts to target x64 Android from an ARM64 Linux host.",
+            "ninja": {
+                "config": "ci/android_profile_x64",
+                "targets": [
+                    "flutter/lib/snapshot",
+                    "flutter/shell/platform/android:gen_snapshot",
+                    "flutter/shell/platform/android:analyze_snapshot"
+                ]
+            }
+        },
+        {
+            "archives": [
+                {
+                    "base_path": "out/ci/android_release_x64/zip_archives/",
+                    "type": "gcs",
+                    "include_paths": [
+                        "out/ci/android_release_x64/zip_archives/android-x64-release/linux-arm64.zip",
+                        "out/ci/android_release_x64/zip_archives/android-x64-release/analyze-snapshot-linux-arm64.zip"
+                    ],
+                    "name": "ci/android_release_x64",
+                    "realm": "production"
+                }
+            ],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux",
+                "cpu=arm64"
+            ],
+            "gclient_variables": {
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
+                "ci/android_release_x64",
+                "--runtime-mode",
+                "release",
+                "--android",
+                "--android-cpu",
+                "x64",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/android_release_x64",
+            "description": "Produces release mode artifacts to target x64 Android from an ARM64 Linux host.",
+            "ninja": {
+                "config": "ci/android_release_x64",
+                "targets": [
+                    "flutter/lib/snapshot",
+                    "flutter/shell/platform/android:gen_snapshot",
+                    "flutter/shell/platform/android:analyze_snapshot"
+                ]
+            }
+        },
+        {
+            "archives": [
+                {
+                    "base_path": "out/ci/android_profile_riscv64/zip_archives/",
+                    "type": "gcs",
+                    "include_paths": [
+                        "out/ci/android_profile_riscv64/zip_archives/android-riscv64-profile/linux-arm64.zip",
+                        "out/ci/android_profile_riscv64/zip_archives/android-riscv64-profile/analyze-snapshot-linux-arm64.zip"
+                    ],
+                    "name": "ci/android_profile_riscv64",
+                    "realm": "production"
+                }
+            ],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux",
+                "cpu=arm64"
+            ],
+            "gclient_variables": {
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
+                "ci/android_profile_riscv64",
+                "--runtime-mode",
+                "profile",
+                "--android",
+                "--android-cpu",
+                "riscv64",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/android_profile_riscv64",
+            "description": "Produces profile mode artifacts to target riscv64 Android from an ARM64 Linux host.",
+            "ninja": {
+                "config": "ci/android_profile_riscv64",
+                "targets": [
+                    "flutter/lib/snapshot",
+                    "flutter/shell/platform/android:gen_snapshot",
+                    "flutter/shell/platform/android:analyze_snapshot"
+                ]
+            }
+        },
+        {
+            "archives": [
+                {
+                    "base_path": "out/ci/android_release_riscv64/zip_archives/",
+                    "type": "gcs",
+                    "include_paths": [
+                        "out/ci/android_release_riscv64/zip_archives/android-riscv64-release/linux-arm64.zip",
+                        "out/ci/android_release_riscv64/zip_archives/android-riscv64-release/analyze-snapshot-linux-arm64.zip"
+                    ],
+                    "name": "ci/android_release_riscv64",
+                    "realm": "production"
+                }
+            ],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux",
+                "cpu=arm64"
+            ],
+            "gclient_variables": {
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
+                "ci/android_release_riscv64",
+                "--runtime-mode",
+                "release",
+                "--android",
+                "--android-cpu",
+                "riscv64",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/android_release_riscv64",
+            "description": "Produces release mode artifacts to target riscv64 Android from an ARM64 Linux host.",
+            "ninja": {
+                "config": "ci/android_release_riscv64",
+                "targets": [
+                    "flutter/lib/snapshot",
+                    "flutter/shell/platform/android:gen_snapshot",
+                    "flutter/shell/platform/android:analyze_snapshot"
+                ]
+            }
+        }
+    ],
+    "generators": {},
+    "archives": []
+}

--- a/engine/src/flutter/shell/platform/android/BUILD.gn
+++ b/engine/src/flutter/shell/platform/android/BUILD.gn
@@ -780,7 +780,9 @@ if (target_cpu != "x86") {
       gen_snapshot_dest = "gen_snapshot.exe"
     }
 
-    if (host_os == "linux") {
+    if (host_os == "linux" && host_cpu == "arm64") {
+      output = "$android_zip_archive_dir/linux-arm64.zip"
+    } else if (host_os == "linux") {
       output = "$android_zip_archive_dir/linux-x64.zip"
     } else if (host_os == "mac") {
       output = "$android_zip_archive_dir/darwin-x64.zip"
@@ -822,7 +824,9 @@ if (host_os == "linux" &&
     analyze_snapshot_path =
         rebase_path("$analyze_snapshot_out_dir/$analyze_snapshot_bin")
 
-    if (host_os == "linux") {
+    if (host_os == "linux" && host_cpu == "arm64") {
+      output = "$android_zip_archive_dir/analyze-snapshot-linux-arm64.zip"
+    } else if (host_os == "linux") {
       output = "$android_zip_archive_dir/analyze-snapshot-linux-x64.zip"
     } else if (host_os == "mac") {
       output = "$android_zip_archive_dir/analyze-snapshot-darwin-x64.zip"


### PR DESCRIPTION
## Summary

- Make `gen_snapshot` and `analyze_snapshot` zip output names in `BUILD.gn` host-architecture-aware (`linux-arm64.zip` vs `linux-x64.zip`)
- Add `linux_arm64_android_aot_engine.json` CI builder config following the secondary builder pattern (matching `mac_android_aot_engine.json`)
- Add `.ci.yaml` entry for the new ARM64 Linux builder

The ARM64 builder only produces host-specific archives (`linux-arm64.zip` and `analyze-snapshot-linux-arm64.zip`). Shared artifacts (`artifacts.zip`, `symbols.zip`, embedding/abi jars) continue to be produced by the existing x64 Linux builder.

This enables Android **profile** and **release** builds on ARM64 Linux machines (AWS Graviton, GCP Tau T2A, self-hosted ARM64 runners, etc.), which currently fail because `gen_snapshot` is only shipped for `linux-x64` hosts.

Fixes https://github.com/flutter/flutter/issues/75864
Fixes https://github.com/flutter/flutter/issues/168980

## Test plan

- [ ] CI builder produces `linux-arm64.zip` archives for all Android target CPUs (arm, arm64, x64, riscv64) in both profile and release modes
- [ ] Archive paths are unique across all builder configs (verified locally via `check.dart` logic)
- [ ] Existing `linux-x64` builds are unaffected — `BUILD.gn` change still produces `linux-x64.zip` on x64 hosts
- [ ] Companion framework PR lands after this to enable artifact download on arm64 hosts