### PR TITLE
Support linux-arm64 host for Android gen_snapshot artifact download

### DIFF
--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -600,9 +600,8 @@ class CachedArtifacts implements Artifacts {
       case Artifact.genSnapshotX64:
         assert(mode != BuildMode.debug, 'Artifact $artifact only available in non-debug mode.');
 
-        // TODO(cbracken): Build Android gen_snapshot as Arm64 binary to run
-        // natively on Apple Silicon. See:
-        // https://github.com/flutter/flutter/issues/152281
+        // macOS gen_snapshot ships as a universal binary under the darwin-x64
+        // directory name, so remap darwin-arm64 to darwin-x64 for path resolution.
         HostPlatform hostPlatform = getCurrentHostPlatform();
         if (hostPlatform == HostPlatform.darwin_arm64) {
           hostPlatform = HostPlatform.darwin_x64;

--- a/packages/flutter_tools/lib/src/flutter_cache.dart
+++ b/packages/flutter_tools/lib/src/flutter_cache.dart
@@ -365,10 +365,11 @@ class AndroidGenSnapshotArtifacts extends EngineCachedArtifact {
 
   @override
   List<List<String>> getBinaryDirs() {
+    final String linuxArch = cache.getHostPlatformArchName();
     return <List<String>>[
       if (cache.includeAllPlatforms) ...<List<String>>[
         ..._osxBinaryDirs,
-        ..._linuxBinaryDirs,
+        ..._linuxBinaryDirs(linuxArch),
         ..._windowsBinaryDirs,
         ..._dartSdks,
       ] else if (_platform.isWindows)
@@ -376,7 +377,7 @@ class AndroidGenSnapshotArtifacts extends EngineCachedArtifact {
       else if (_platform.isMacOS)
         ..._osxBinaryDirs
       else if (_platform.isLinux)
-        ..._linuxBinaryDirs,
+        ..._linuxBinaryDirs(linuxArch),
     ];
   }
 
@@ -866,13 +867,13 @@ const _osxBinaryDirs = <List<String>>[
   <String>['android-x64-release/darwin-x64', 'android-x64-release/darwin-x64.zip'],
 ];
 
-const _linuxBinaryDirs = <List<String>>[
-  <String>['android-arm-profile/linux-x64', 'android-arm-profile/linux-x64.zip'],
-  <String>['android-arm-release/linux-x64', 'android-arm-release/linux-x64.zip'],
-  <String>['android-arm64-profile/linux-x64', 'android-arm64-profile/linux-x64.zip'],
-  <String>['android-arm64-release/linux-x64', 'android-arm64-release/linux-x64.zip'],
-  <String>['android-x64-profile/linux-x64', 'android-x64-profile/linux-x64.zip'],
-  <String>['android-x64-release/linux-x64', 'android-x64-release/linux-x64.zip'],
+List<List<String>> _linuxBinaryDirs(String arch) => <List<String>>[
+  <String>['android-arm-profile/linux-$arch', 'android-arm-profile/linux-$arch.zip'],
+  <String>['android-arm-release/linux-$arch', 'android-arm-release/linux-$arch.zip'],
+  <String>['android-arm64-profile/linux-$arch', 'android-arm64-profile/linux-$arch.zip'],
+  <String>['android-arm64-release/linux-$arch', 'android-arm64-release/linux-$arch.zip'],
+  <String>['android-x64-profile/linux-$arch', 'android-x64-profile/linux-$arch.zip'],
+  <String>['android-x64-release/linux-$arch', 'android-x64-release/linux-$arch.zip'],
 ];
 
 const _windowsBinaryDirs = <List<String>>[

--- a/packages/flutter_tools/test/general.shard/artifacts_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifacts_test.dart
@@ -6,6 +6,7 @@ import 'package:file/memory.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
@@ -161,6 +162,52 @@ void main() {
           'bin',
           'snapshots',
           'frontend_server_aot.dart.snapshot',
+        ),
+      );
+    });
+
+    testWithoutContext('getArtifactPath resolves gen_snapshot to linux-x64 on x64 Linux host', () {
+      expect(
+        artifacts.getArtifactPath(
+          Artifact.genSnapshot,
+          platform: TargetPlatform.android_arm64,
+          mode: BuildMode.release,
+        ),
+        fileSystem.path.join(
+          'root',
+          'bin',
+          'cache',
+          'artifacts',
+          'engine',
+          'android-arm64-release',
+          'linux-x64',
+          'gen_snapshot',
+        ),
+      );
+    });
+
+    testWithoutContext('getArtifactPath resolves gen_snapshot to linux-arm64 on arm64 Linux host', () {
+      final arm64Artifacts = CachedArtifacts(
+        fileSystem: fileSystem,
+        cache: cache,
+        platform: platform,
+        operatingSystemUtils: FakeOperatingSystemUtils(hostPlatform: HostPlatform.linux_arm64),
+      );
+      expect(
+        arm64Artifacts.getArtifactPath(
+          Artifact.genSnapshot,
+          platform: TargetPlatform.android_arm64,
+          mode: BuildMode.release,
+        ),
+        fileSystem.path.join(
+          'root',
+          'bin',
+          'cache',
+          'artifacts',
+          'engine',
+          'android-arm64-release',
+          'linux-arm64',
+          'gen_snapshot',
         ),
       );
     });

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -773,6 +773,38 @@ void main() {
     ]);
   });
 
+  testWithoutContext('Android gen_snapshot artifacts on x64 linux host include linux-x64 archives', () {
+    fakeProcessManager.addCommand(unameCommandForX64);
+
+    final Cache cache = createCache(FakePlatform());
+    final artifacts = AndroidGenSnapshotArtifacts(cache, platform: FakePlatform());
+
+    expect(artifacts.getBinaryDirs(), <List<String>>[
+      <String>['android-arm-profile/linux-x64', 'android-arm-profile/linux-x64.zip'],
+      <String>['android-arm-release/linux-x64', 'android-arm-release/linux-x64.zip'],
+      <String>['android-arm64-profile/linux-x64', 'android-arm64-profile/linux-x64.zip'],
+      <String>['android-arm64-release/linux-x64', 'android-arm64-release/linux-x64.zip'],
+      <String>['android-x64-profile/linux-x64', 'android-x64-profile/linux-x64.zip'],
+      <String>['android-x64-release/linux-x64', 'android-x64-release/linux-x64.zip'],
+    ]);
+  });
+
+  testWithoutContext('Android gen_snapshot artifacts on arm64 linux host include linux-arm64 archives', () {
+    fakeProcessManager.addCommand(unameCommandForArm64);
+
+    final Cache cache = createCache(FakePlatform());
+    final artifacts = AndroidGenSnapshotArtifacts(cache, platform: FakePlatform());
+
+    expect(artifacts.getBinaryDirs(), <List<String>>[
+      <String>['android-arm-profile/linux-arm64', 'android-arm-profile/linux-arm64.zip'],
+      <String>['android-arm-release/linux-arm64', 'android-arm-release/linux-arm64.zip'],
+      <String>['android-arm64-profile/linux-arm64', 'android-arm64-profile/linux-arm64.zip'],
+      <String>['android-arm64-release/linux-arm64', 'android-arm64-release/linux-arm64.zip'],
+      <String>['android-x64-profile/linux-arm64', 'android-x64-profile/linux-arm64.zip'],
+      <String>['android-x64-release/linux-arm64', 'android-x64-release/linux-arm64.zip'],
+    ]);
+  });
+
   testWithoutContext('Cache can delete stampfiles of artifacts', () {
     final FileSystem fileSystem = MemoryFileSystem.test();
     final artifactSet = FakeIosUsbArtifacts();


### PR DESCRIPTION
## Summary

- Convert `_linuxBinaryDirs` from a hardcoded `linux-x64` const list to a function parameterized by host architecture, following the existing `LinuxEngineArtifacts` pattern using `cache.getHostPlatformArchName()`
- Clean up stale TODO comment in `artifacts.dart`
- Add tests for both x64 and arm64 host artifact resolution

On ARM64 Linux hosts, `flutter build apk --release` fails because the tool tries to find `gen_snapshot` at `linux-arm64/gen_snapshot` but only `linux-x64` artifacts are downloaded. This change makes the artifact download host-architecture-aware.

Depends on https://github.com/flutter/flutter/pull/182275 (engine-side changes that produce `linux-arm64.zip` archives).

Related https://github.com/flutter/flutter/issues/75864
Related https://github.com/flutter/flutter/issues/168980

## Test plan

- [ ] `AndroidGenSnapshotArtifacts.getBinaryDirs()` returns `linux-x64` entries on x64 hosts
- [ ] `AndroidGenSnapshotArtifacts.getBinaryDirs()` returns `linux-arm64` entries on arm64 hosts
- [ ] `getArtifactPath` resolves `gen_snapshot` to `linux-x64/gen_snapshot` on x64 Linux
- [ ] `getArtifactPath` resolves `gen_snapshot` to `linux-arm64/gen_snapshot` on arm64 Linux
- [ ] Existing macOS and Windows artifact resolution is unaffected