### PR TITLE
flutter analyze: suggest running dart fix --apply when issues are found

### DIFF
--- a/packages/flutter_tools/lib/src/commands/analyze_base.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze_base.dart
@@ -108,23 +108,29 @@ abstract class AnalyzeBase {
     final errorsMessage = StringBuffer(
       issueCount > 0 ? '$issueCount ${pluralize('issue', issueCount)} found.' : 'No issues found!',
     );
-
-    // Only [AnalyzeContinuously] has issueDiff message.
-    if (issueDiff != null) {
-      if (issueDiff > 0) {
-        errorsMessage.write(' ($issueDiff new)');
-      } else if (issueDiff < 0) {
-        errorsMessage.write(' (${-issueDiff} fixed)');
-      }
-    }
-
-    // Only [AnalyzeContinuously] has files message.
-    if (files != null) {
-      errorsMessage.write(' • analyzed $files ${pluralize('file', files)}');
-    }
-    errorsMessage.write(' (ran in ${seconds}s)');
-    return errorsMessage.toString();
+// Only [AnalyzeContinuously] has issueDiff message.
+if (issueDiff != null) {
+  if (issueDiff > 0) {
+    errorsMessage.write(' ($issueDiff new)');
+  } else if (issueDiff < 0) {
+    errorsMessage.write(' (${-issueDiff} fixed)');
   }
+}
+
+// Only [AnalyzeContinuously] has files message.
+if (files != null) {
+  errorsMessage.write(' • analyzed $files ${pluralize('file', files)}');
+}
+
+errorsMessage.write(' (ran in ${seconds}s)');
+
+if (issueCount > 0) {
+  errorsMessage.write(
+    '\nRun `dart fix --apply` to automatically fix some issues.',
+  );
+}
+
+return errorsMessage.toString();
 }
 
 class PackageDependency {

--- a/packages/flutter_tools/lib/src/commands/analyze_once.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze_once.dart
@@ -145,10 +145,14 @@ class AnalyzeOnce extends AnalyzeBase {
       seconds: seconds,
     );
 
-    if (errorCount > 0) {
+   if (errorCount > 0) {
       logger.printStatus('');
-      throwToolExit(errorsMessage, exitCode: _isFatal(errors) ? 1 : 0);
-    }
+      throwToolExit(
+      errorsMessage,
+      exitCode: _isFatal(errors) ? 1 : 0,
+     );
+   }
+
 
     if (argResults['congratulate'] as bool) {
       logger.printStatus(errorsMessage);

--- a/packages/flutter_tools/test/commands.shard/hermetic/analyze_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/analyze_test.dart
@@ -34,7 +34,8 @@ void main() {
 
     expect(
       AnalyzeBase.generateErrorsMessage(issueCount: 3, issueDiff: 2, files: 1, seconds: '0.1'),
-      '3 issues found. (2 new) • analyzed 1 file (ran in 0.1s)',
+      '3 issues found. (2 new) • analyzed 1 file (ran in 0.1s)\n\n'
+      'Run `dart fix --apply` to automatically fix some issues.',
     );
   });
 


### PR DESCRIPTION
## Description

When `flutter analyze` reports issues, users may not realize that some of
those issues can be automatically fixed using `dart fix --apply`.

This change appends a suggestion to run `dart fix --apply` when analysis
errors are detected in `AnalyzeOnce`.

The suggestion is only shown when issues are present and does not affect
the success case output.

## Example

Before:
10 issues found. (ran in 1.2s)

After:
10 issues found. (ran in 1.2s)

Run `dart fix --apply` to automatically fix some issues.

## Testing

The change modifies the error output path of `flutter analyze` when
issues are present. Existing tests should validate updated output behavior.

Fixes #182063
