### PR TITLE
[macOS] Add move timer runloop mode to common modes

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowController.h
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowController.h
@@ -18,7 +18,7 @@
 
 - (void)closeAllWindows;
 
-- (void)fixMoveRunLoopMode;
+- (void)fixMoveRunLoopModeIfNeeded;
 
 @end
 

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowController.h
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowController.h
@@ -18,6 +18,8 @@
 
 - (void)closeAllWindows;
 
+- (void)fixMoveRunLoopMode;
+
 @end
 
 struct FlutterWindowRect {

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowController.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowController.mm
@@ -312,7 +312,7 @@ static void FlipRect(NSRect& rect, const NSRect& globalScreenFrame) {
   [window orderFront:nil];
   [window zoom:nil];
   [window close];
-  NSArray* modes = (__bridge NSArray*)CFRunLoopCopyAllModes(CFRunLoopGetCurrent());
+  NSArray* modes = (__bridge_transfer NSArray*)CFRunLoopCopyAllModes(CFRunLoopGetCurrent());
   for (NSString* mode in modes) {
     if ([mode hasSuffix:@"MoveTimerRunLoopMode"]) {
       CFRunLoopAddCommonMode(CFRunLoopGetCurrent(), (__bridge CFStringRef)mode);

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowController.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowController.mm
@@ -69,6 +69,7 @@
 
 @interface FlutterWindowController () {
   NSMutableArray<FlutterWindowOwner*>* _windows;
+  BOOL _runLoopModeFixApplied;
 }
 
 - (void)windowDidResignKey:(FlutterWindowOwner*)window;
@@ -263,6 +264,20 @@ static void FlipRect(NSRect& rect, const NSRect& globalScreenFrame) {
 
 @end
 
+@interface _FlutterRunLoopModeFixWindowDelegate : NSObject <NSWindowDelegate>
+@end
+
+@implementation _FlutterRunLoopModeFixWindowDelegate
+
+- (NSRect)windowWillUseStandardFrame:(NSWindow*)window defaultFrame:(NSRect)newFrame {
+  // Small frame difference (100px to 110px) to trigger the animation but make it fast.
+  newFrame.size.width = 110;
+  newFrame.size.height = 110;
+  return newFrame;
+}
+
+@end
+
 @implementation FlutterWindowController
 
 - (instancetype)init {
@@ -271,6 +286,39 @@ static void FlipRect(NSRect& rect, const NSRect& globalScreenFrame) {
     _windows = [NSMutableArray array];
   }
   return self;
+}
+
+- (void)fixMoveRunLoopMode {
+  if (_runLoopModeFixApplied) {
+    return;
+  }
+  // When modal sheet is presented, for the duration of the animation the run loop
+  // is running in _NSMoveTimerRunLoopMode. This prevents Flutter content from
+  // being rendered. The solution is to add _NSMoveTimerRunLoopMode to common
+  // run loop modes, but referencing it directly may be flagged as SPI usage.
+  // Instead as a workaround a very short window zoom animation is triggered, which
+  // runs in _NSMoveTimerRunLoopMode adding the mode to CFRunLoop all modes list.
+  // After that it can be queried and added to common modes.
+  NSWindow* window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 100, 100)
+                                                 styleMask:NSWindowStyleMaskResizable
+                                                   backing:NSBackingStoreNonretained
+                                                     defer:NO];
+  _FlutterRunLoopModeFixWindowDelegate* delegate =
+      [[_FlutterRunLoopModeFixWindowDelegate alloc] init];
+  window.releasedWhenClosed = NO;
+  window.delegate = delegate;
+  window.ignoresMouseEvents = YES;
+  window.alphaValue = 0;
+  [window orderFront:nil];
+  [window zoom:nil];
+  [window close];
+  NSArray* modes = (__bridge NSArray*)CFRunLoopCopyAllModes(CFRunLoopGetCurrent());
+  for (NSString* mode in modes) {
+    if ([mode hasSuffix:@"MoveTimerRunLoopMode"]) {
+      CFRunLoopAddCommonMode(CFRunLoopGetCurrent(), (__bridge CFStringRef)mode);
+    }
+  }
+  _runLoopModeFixApplied = YES;
 }
 
 - (FlutterViewIdentifier)createDialogWindow:(const FlutterWindowCreationRequest*)request {
@@ -316,6 +364,7 @@ static void FlipRect(NSRect& rect, const NSRect& globalScreenFrame) {
 
   if (parent != nil) {
     dispatch_async(dispatch_get_main_queue(), ^{
+      [self fixMoveRunLoopMode];
       // beginCriticalSheet blocks with nested run loop until the
       // sheet animation is finished.
       [parent beginCriticalSheet:window

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowController.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowController.mm
@@ -288,7 +288,7 @@ static void FlipRect(NSRect& rect, const NSRect& globalScreenFrame) {
   return self;
 }
 
-- (void)fixMoveRunLoopMode {
+- (void)fixMoveRunLoopModeIfNeeded {
   if (_runLoopModeFixApplied) {
     return;
   }
@@ -364,7 +364,7 @@ static void FlipRect(NSRect& rect, const NSRect& globalScreenFrame) {
 
   if (parent != nil) {
     dispatch_async(dispatch_get_main_queue(), ^{
-      [self fixMoveRunLoopMode];
+      [self fixMoveRunLoopModeIfNeeded];
       // beginCriticalSheet blocks with nested run loop until the
       // sheet animation is finished.
       [parent beginCriticalSheet:window

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowControllerTest.mm
@@ -57,6 +57,20 @@ class FlutterWindowControllerTest : public FlutterEngineTest {
 
 class FlutterWindowControllerRetainTest : public ::testing::Test {};
 
+TEST_F(FlutterWindowControllerTest, FixMoveRunLoopMode) {
+  FlutterEngine* engine = GetFlutterEngine();
+  [engine.windowController fixMoveRunLoopMode];
+
+  // Make sure that after fixMoveRunLoopMode _NSMoveTimerRunLoopMode becomes
+  // common run loop mode.
+  __block BOOL signalled = NO;
+  CFRunLoopPerformBlock(CFRunLoopGetCurrent(), kCFRunLoopCommonModes, ^{
+    signalled = YES;
+  });
+  CFRunLoopRunInMode(CFSTR("_NSMoveTimerRunLoopMode"), 1.0, YES);
+  EXPECT_TRUE(signalled);
+}
+
 TEST_F(FlutterWindowControllerTest, CreateRegularWindow) {
   FlutterWindowCreationRequest request{
       .has_size = true,

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowControllerTest.mm
@@ -59,7 +59,7 @@ class FlutterWindowControllerRetainTest : public ::testing::Test {};
 
 TEST_F(FlutterWindowControllerTest, FixMoveRunLoopMode) {
   FlutterEngine* engine = GetFlutterEngine();
-  [engine.windowController fixMoveRunLoopMode];
+  [engine.windowController fixMoveRunLoopModeIfNeeded];
 
   // Make sure that after fixMoveRunLoopMode _NSMoveTimerRunLoopMode becomes
   // common run loop mode.


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/182294 by adding `_NSMoveTimerRunLoopMode` to common run loop modes. This ensures that Flutter messages are processed during sheet animation.

This PR avoids referencing `_NSMoveTimerRunLoopMode` in code directly to avoid the possibility of being flagged an SPI. Instead it runs a very brief (~10ms) hidden animation and then gets the run loop mode through `CFRunLoopCopyAllModes`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
