### PR TITLE
Add plugin dependencies to Add to App FlutterPluginRegistrant

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_swift_package.dart
+++ b/packages/flutter_tools/lib/src/commands/build_swift_package.dart
@@ -490,10 +490,7 @@ class FlutterPluginSwiftDependencies {
       // Example: https://github.com/firebase/flutterfire/blob/198aef8db6c96a08f57d750f1fa756da5e4a68a5/packages/firebase_core/firebase_core/ios/firebase_core/Package.swift#L21-L26
       final Directory pluginDestination = pluginsDirectory.childDirectory(plugin.name)
         ..createSync(recursive: true);
-      copyDirectory(
-        _utils.fileSystem.directory(plugin.path),
-        pluginDestination,
-      );
+      copyDirectory(_utils.fileSystem.directory(plugin.path), pluginDestination);
 
       final String? swiftPackagePath = plugin.pluginSwiftPackagePath(
         _utils.fileSystem,
@@ -571,20 +568,18 @@ class FlutterPluginSwiftDependencies {
     if (!manifestContents.contains('platforms')) {
       return null;
     }
-    // First attempt to parse with regex, which is fast
-    // e.g. \.iOS\(([\.v\d"\s]*)\) matches .iOS("13.0") or .iOS(.v13) or .iOS(.v10_15)
+    // First, attempt to parse with regex, which is fast
+    // e.g. \.iOS\([\s"]*([\._v\d]*)[\s"]*\) matches .iOS("13.0") or .iOS(.v13) or .iOS(.v10_15)
     final pattern = RegExp(
-      '\\${_targetPlatform.swiftPackagePlatform.displayName}\\(([_v\\.\\d\\s"]*)\\)',
+      r'\'
+      '${_targetPlatform.swiftPackagePlatform.displayName}'
+      r'\([\s"]*([\._v\d]*)[\s"]*\)',
     );
     final Iterable<RegExpMatch> matches = pattern.allMatches(manifestContents);
     if (matches.length == 1) {
       final String? match = matches.first.group(1);
       if (match != null) {
-        final String normalizedVersionString = match
-            .replaceAll('"', '')
-            .replaceAll(' ', '')
-            .replaceAll('.v', '')
-            .replaceAll('_', '.');
+        final String normalizedVersionString = match.replaceAll('.v', '').replaceAll('_', '.');
         final Version? parsedVersion = Version.parse(normalizedVersionString);
         if (parsedVersion != null) {
           return parsedVersion;
@@ -608,8 +603,7 @@ class FlutterPluginSwiftDependencies {
     }
     throwToolExit(
       'Unable to parse ${_targetPlatform.name} supported platform version from '
-      '${swiftPackageManifest.path}. $_kFileAnIssue and include the contents of the aforementioned '
-      'file.',
+      '${swiftPackageManifest.path}. $_kFileAnIssue and include the contents of this file.',
     );
   }
 
@@ -624,8 +618,8 @@ class FlutterPluginSwiftDependencies {
       return json.decode(parsedManifest.stdout.toString()) as Map<String, Object?>;
     } on Exception catch (e, stackTrace) {
       throwToolExit(
-        'Failed to decode ${swiftPackageManifest.path}. $_kFileAnIssue and include aforementioned '
-        'file and the following stack trace: \n$e\n$stackTrace',
+        'Failed to decode ${swiftPackageManifest.path}. $_kFileAnIssue and include this file '
+        'and the following stack trace: \n$e\n$stackTrace',
       );
     }
   }

--- a/packages/flutter_tools/lib/src/commands/build_swift_package.dart
+++ b/packages/flutter_tools/lib/src/commands/build_swift_package.dart
@@ -428,14 +428,16 @@ class FlutterPluginSwiftDependencies {
 
   /// The highest [SwiftPackageSupportedPlatform] among all of the Flutter SwiftPM plugins.
   /// Defaults to the Flutter framework's [SwiftPackageSupportedPlatform].
-  late SwiftPackageSupportedPlatform highestSupportedVersion =
+  SwiftPackageSupportedPlatform get highestSupportedVersion => _highestSupportedVersion;
+  late SwiftPackageSupportedPlatform _highestSupportedVersion =
       _targetPlatform.supportedPackagePlatform;
 
   @visibleForTesting
   /// A list of [Plugin]s copied and path to the copied Swift package.
   final List<(Plugin, String)> copiedPlugins = [];
 
-  /// Copy plugins from pubcache to [pluginsDirectory] and determines [highestSupportedVersion].
+  /// Copy plugins from pubcache to [pluginsDirectory] and sets [highestSupportedVersion] to later
+  /// be used when creating the FlutterPluginRegistrant.
   Future<void> processPlugins({
     required Directory cacheDirectory,
     required List<Plugin> plugins,
@@ -448,9 +450,14 @@ class FlutterPluginSwiftDependencies {
         plugins: plugins,
         pluginsDirectory: pluginsDirectory,
       );
-      skipped = await determineHighestSupportedVersion(
+      final Version parsedHighestVersion;
+      (parsedHighestVersion, skipped) = await determineHighestSupportedVersion(
         cacheDirectory: cacheDirectory,
         manifests: manifests,
+      );
+      _highestSupportedVersion = SwiftPackageSupportedPlatform(
+        platform: _targetPlatform.swiftPackagePlatform,
+        version: parsedHighestVersion,
       );
     } finally {
       status.stop();
@@ -478,15 +485,14 @@ class FlutterPluginSwiftDependencies {
         continue;
       }
 
-      // The entire plugin is copied (excluding the example app) instead of just the Swift package
-      // to maintain any relative links within the plugin.
+      // The entire plugin is copied instead of just the Swift package to maintain any relative
+      // links within the plugin.
       // Example: https://github.com/firebase/flutterfire/blob/198aef8db6c96a08f57d750f1fa756da5e4a68a5/packages/firebase_core/firebase_core/ios/firebase_core/Package.swift#L21-L26
       final Directory pluginDestination = pluginsDirectory.childDirectory(plugin.name)
         ..createSync(recursive: true);
       copyDirectory(
         _utils.fileSystem.directory(plugin.path),
         pluginDestination,
-        shouldCopyDirectory: (Directory dir) => dir.basename != 'example',
       );
 
       final String? swiftPackagePath = plugin.pluginSwiftPackagePath(
@@ -503,14 +509,13 @@ class FlutterPluginSwiftDependencies {
     return manifests;
   }
 
-  /// Determines the highest [SwiftPackageSupportedPlatform] version among the plugins and saves
-  /// the value to [highestSupportedVersion] to later be used when creating the
-  /// FlutterPluginRegistrant.
+  /// Returns the highest [SwiftPackageSupportedPlatform.version] among the plugins and `true` if
+  /// it was able to get the version from the cache.
   ///
   /// Saves the value to a file in [cacheDirectory] for quicker lookup when the list of Swift
   /// package manifests has not changed.
   @visibleForTesting
-  Future<bool> determineHighestSupportedVersion({
+  Future<(Version, bool)> determineHighestSupportedVersion({
     required List<File> manifests,
     required Directory cacheDirectory,
   }) async {
@@ -538,32 +543,25 @@ class FlutterPluginSwiftDependencies {
     if (fingerprinter.doesFingerprintMatch() && savedHighestVersionFile.existsSync()) {
       // Use saved version if possible
       final String versionAsString = savedHighestVersionFile.readAsStringSync();
-      final Version? parsedVersion = Version.parse(versionAsString);
-      if (parsedVersion != null) {
-        highestSupportedVersion = SwiftPackageSupportedPlatform(
-          platform: _targetPlatform.swiftPackagePlatform,
-          version: parsedVersion,
-        );
-        return true;
+      final Version? savedVersion = Version.parse(versionAsString);
+      if (savedVersion != null) {
+        return (savedVersion, true);
       }
     }
+    Version parsedHighestVersion = _highestSupportedVersion.version;
     for (final manifest in manifests) {
       // Parse the plugins for the minimum deployment target.
       // The FlutterPluginRegistrant needs to match the highest version. Otherwise, it will error.
       final Version? pluginSupportedVersion = await _parseSwiftPackageSupportedPlatform(manifest);
-      if (pluginSupportedVersion != null &&
-          (highestSupportedVersion.version < pluginSupportedVersion)) {
-        highestSupportedVersion = SwiftPackageSupportedPlatform(
-          platform: _targetPlatform.swiftPackagePlatform,
-          version: pluginSupportedVersion,
-        );
+      if (pluginSupportedVersion != null && (parsedHighestVersion < pluginSupportedVersion)) {
+        parsedHighestVersion = pluginSupportedVersion;
       }
     }
     savedHighestVersionFile
       ..createSync(recursive: true)
-      ..writeAsStringSync(highestSupportedVersion.version.toString());
+      ..writeAsStringSync(parsedHighestVersion.toString());
     fingerprinter.writeFingerprint();
-    return false;
+    return (parsedHighestVersion, false);
   }
 
   /// Parses the [SwiftPackageSupportedPlatform] from the Package.swift using either regex or
@@ -574,8 +572,10 @@ class FlutterPluginSwiftDependencies {
       return null;
     }
     // First attempt to parse with regex, which is fast
-    // e.g. \.iOS\((.*)\) matches .iOS("13.0") or .iOS(.v13) or .macOS(.v10_15)
-    final pattern = RegExp('\\${_targetPlatform.swiftPackagePlatform.displayName}\\((.*)\\)');
+    // e.g. \.iOS\(([\.v\d"\s]*)\) matches .iOS("13.0") or .iOS(.v13) or .iOS(.v10_15)
+    final pattern = RegExp(
+      '\\${_targetPlatform.swiftPackagePlatform.displayName}\\(([_v\\.\\d\\s"]*)\\)',
+    );
     final Iterable<RegExpMatch> matches = pattern.allMatches(manifestContents);
     if (matches.length == 1) {
       final String? match = matches.first.group(1);
@@ -595,15 +595,16 @@ class FlutterPluginSwiftDependencies {
     // If regex matching fails, convert the manifest to json and then parse
     final Map<String, Object?> manifestAsJson = await _parseSwiftPackage(swiftPackageManifest);
     if (manifestAsJson case {'platforms': final List<Object?> platformsData}) {
-      final Iterable<SwiftPackageSupportedPlatform?> parsedPlatforms = platformsData
-          .whereType<Map<String, Object?>>()
-          .map((platformData) => SwiftPackageSupportedPlatform.fromJson(platformData))
-          .where(
-            (parsedPlatform) =>
-                parsedPlatform != null &&
-                parsedPlatform.platform == _targetPlatform.swiftPackagePlatform,
-          );
-      return parsedPlatforms.firstOrNull?.version;
+      for (final Map<String, Object?> platformData
+          in platformsData.whereType<Map<String, Object?>>()) {
+        final SwiftPackageSupportedPlatform? parsedPlatform =
+            SwiftPackageSupportedPlatform.fromJson(platformData);
+        if (parsedPlatform != null &&
+            parsedPlatform.platform == _targetPlatform.swiftPackagePlatform) {
+          return parsedPlatform.version;
+        }
+      }
+      return null;
     }
     throwToolExit(
       'Unable to parse ${_targetPlatform.name} supported platform version from '

--- a/packages/flutter_tools/lib/src/commands/build_swift_package.dart
+++ b/packages/flutter_tools/lib/src/commands/build_swift_package.dart
@@ -10,6 +10,8 @@ import '../artifacts.dart';
 import '../base/common.dart';
 import '../base/error_handling_io.dart';
 import '../base/file_system.dart';
+import '../base/fingerprint.dart';
+import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/platform.dart';
 import '../base/template.dart';
@@ -17,6 +19,7 @@ import '../base/version.dart';
 import '../build_info.dart';
 import '../build_system/build_system.dart';
 import '../cache.dart';
+import '../convert.dart';
 import '../darwin/darwin.dart';
 import '../features.dart';
 import '../flutter_plugins.dart';
@@ -28,6 +31,10 @@ import '../runner/flutter_command.dart';
 import '../version.dart';
 import 'build.dart';
 
+const String _kFileAnIssue =
+    'Please file an issue at https://github.com/flutter/flutter/issues/new/choose';
+const String _kPackages = 'Packages';
+const String _kPlugins = 'Plugins';
 const String kPluginSwiftPackageName = 'FlutterPluginRegistrant';
 const String _kSources = 'Sources';
 const List<String> _kSupportedPlatforms = ['ios', 'macos'];
@@ -191,6 +198,7 @@ class BuildSwiftPackage extends BuildSubCommand {
     buildSystem: _buildSystem,
     cache: _cache,
     fileSystem: _fileSystem,
+    flutterRoot: Cache.flutterRoot!,
     flutterVersion: _flutterVersion,
     logger: logger,
     platform: _platform,
@@ -200,6 +208,10 @@ class BuildSwiftPackage extends BuildSubCommand {
     xcode: _xcode!,
   );
   late final pluginRegistrant = FlutterPluginRegistrantSwiftPackage(
+    targetPlatform: _targetPlatform,
+    utils: utils,
+  );
+  late final pluginSwiftDependencies = FlutterPluginSwiftDependencies(
     targetPlatform: _targetPlatform,
     utils: utils,
   );
@@ -222,10 +234,12 @@ class BuildSwiftPackage extends BuildSubCommand {
     final Directory outputDirectory = _fileSystem.directory(
       _fileSystem.path.absolute(_fileSystem.path.normalize(outputArgument)),
     );
+    final Directory cacheDirectory = outputDirectory.childDirectory('.cache')
+      ..createSync(recursive: true);
     final Directory pluginRegistrantSwiftPackage = outputDirectory.childDirectory(
       kPluginSwiftPackageName,
-    );
-    pluginRegistrantSwiftPackage.createSync(recursive: true);
+    )..createSync(recursive: true);
+    final Directory pluginsDirectory = pluginRegistrantSwiftPackage.childDirectory(_kPlugins);
 
     await project.regeneratePlatformSpecificTooling(releaseMode: false);
 
@@ -236,6 +250,11 @@ class BuildSwiftPackage extends BuildSubCommand {
 
     final List<Plugin> plugins = await findPlugins(project);
     plugins.sort((Plugin left, Plugin right) => left.name.compareTo(right.name));
+    await pluginSwiftDependencies.processPlugins(
+      cacheDirectory: cacheDirectory,
+      plugins: plugins,
+      pluginsDirectory: pluginsDirectory,
+    );
 
     for (final buildInfo in buildInfos) {
       final String xcodeBuildConfiguration = buildInfo.mode.uppercaseName;
@@ -262,6 +281,7 @@ class BuildSwiftPackage extends BuildSubCommand {
         pluginRegistrantSwiftPackage: pluginRegistrantSwiftPackage,
         plugins: plugins,
         xcodeBuildConfiguration: xcodeBuildConfiguration,
+        pluginSwiftDependencies: pluginSwiftDependencies,
       );
     } finally {
       status.stop();
@@ -307,9 +327,21 @@ class FlutterPluginRegistrantSwiftPackage {
     required Directory pluginRegistrantSwiftPackage,
     required List<Plugin> plugins,
     required String xcodeBuildConfiguration,
+    required FlutterPluginSwiftDependencies pluginSwiftDependencies,
   }) async {
-    final List<SwiftPackageTargetDependency> targetDependencies = [];
-    final List<SwiftPackagePackageDependency> packageDependencies = [];
+    final Directory packagesForConfiguration = pluginRegistrantSwiftPackage
+        .childDirectory(xcodeBuildConfiguration)
+        .childDirectory(_kPackages);
+
+    final (
+      List<SwiftPackagePackageDependency> pluginPackageDependencies,
+      List<SwiftPackageTargetDependency> pluginTargetDependencies,
+    ) = pluginSwiftDependencies.generateDependencies(
+      packagesForConfiguration: packagesForConfiguration,
+    );
+
+    final targetDependencies = <SwiftPackageTargetDependency>[...pluginTargetDependencies];
+    final packageDependencies = <SwiftPackagePackageDependency>[...pluginPackageDependencies];
 
     const String swiftPackageName = kPluginSwiftPackageName;
     final File manifestFile = pluginRegistrantSwiftPackage
@@ -329,7 +361,7 @@ class FlutterPluginRegistrantSwiftPackage {
     final pluginsPackage = SwiftPackage(
       manifest: manifestFile,
       name: swiftPackageName,
-      platforms: <SwiftPackageSupportedPlatform>[],
+      platforms: <SwiftPackageSupportedPlatform>[pluginSwiftDependencies.highestSupportedVersion],
       products: <SwiftPackageProduct>[product],
       dependencies: packageDependencies,
       targets: targets,
@@ -381,6 +413,259 @@ class FlutterPluginRegistrantSwiftPackage {
   }
 }
 
+/// Class that encapsulates logic needed to copy Flutter plugins that support SwiftPM and generate
+/// dependencies for the FlutterPluginRegistrant swift package.
+@visibleForTesting
+class FlutterPluginSwiftDependencies {
+  FlutterPluginSwiftDependencies({
+    required FlutterDarwinPlatform targetPlatform,
+    required BuildSwiftPackageUtils utils,
+  }) : _targetPlatform = targetPlatform,
+       _utils = utils;
+
+  final FlutterDarwinPlatform _targetPlatform;
+  final BuildSwiftPackageUtils _utils;
+
+  /// The highest [SwiftPackageSupportedPlatform] among all of the Flutter SwiftPM plugins.
+  /// Defaults to the Flutter framework's [SwiftPackageSupportedPlatform].
+  late SwiftPackageSupportedPlatform highestSupportedVersion =
+      _targetPlatform.supportedPackagePlatform;
+
+  @visibleForTesting
+  /// A list of [Plugin]s copied and path to the copied Swift package.
+  final List<(Plugin, String)> copiedPlugins = [];
+
+  /// Copy plugins from pubcache to [pluginsDirectory] and determines [highestSupportedVersion].
+  Future<void> processPlugins({
+    required Directory cacheDirectory,
+    required List<Plugin> plugins,
+    required Directory pluginsDirectory,
+  }) async {
+    final Status status = _utils.logger.startProgress('   ├─Processing plugins...');
+    var skipped = false;
+    try {
+      final List<File> manifests = await _copyPlugins(
+        plugins: plugins,
+        pluginsDirectory: pluginsDirectory,
+      );
+      skipped = await determineHighestSupportedVersion(
+        cacheDirectory: cacheDirectory,
+        manifests: manifests,
+      );
+    } finally {
+      status.stop();
+      if (skipped) {
+        _utils.logger.printStatus('   │   └── Skipping processing plugins. No change detected.');
+      }
+    }
+  }
+
+  /// Copies SwiftPM plugins from pubcache to [pluginsDirectory].
+  Future<List<File>> _copyPlugins({
+    required List<Plugin> plugins,
+    required Directory pluginsDirectory,
+  }) async {
+    final List<File> manifests = [];
+    try {
+      ErrorHandlingFileSystem.deleteIfExists(pluginsDirectory, recursive: true);
+    } on FileSystemException catch (e, stackTrace) {
+      // Delete may fail due to Xcode writing hidden files to the directory at the same time.
+      _utils.logger.printTrace('Failed to delete ${pluginsDirectory.path}: $e\n$stackTrace');
+    }
+    for (final plugin in plugins) {
+      // If plugin does not support the platform, skip it.
+      if (!plugin.supportSwiftPackageManagerForPlatform(_utils.fileSystem, _targetPlatform.name)) {
+        continue;
+      }
+
+      // The entire plugin is copied (excluding the example app) instead of just the Swift package
+      // to maintain any relative links within the plugin.
+      // Example: https://github.com/firebase/flutterfire/blob/198aef8db6c96a08f57d750f1fa756da5e4a68a5/packages/firebase_core/firebase_core/ios/firebase_core/Package.swift#L21-L26
+      final Directory pluginDestination = pluginsDirectory.childDirectory(plugin.name)
+        ..createSync(recursive: true);
+      copyDirectory(
+        _utils.fileSystem.directory(plugin.path),
+        pluginDestination,
+        shouldCopyDirectory: (Directory dir) => dir.basename != 'example',
+      );
+
+      final String? swiftPackagePath = plugin.pluginSwiftPackagePath(
+        _utils.fileSystem,
+        _targetPlatform.name,
+        overridePath: pluginDestination.path,
+      );
+      if (swiftPackagePath == null) {
+        throwToolExit("Failed to find copied ${plugin.name}'s Package.swift. $_kFileAnIssue");
+      }
+      copiedPlugins.add((plugin, swiftPackagePath));
+      manifests.add(_utils.fileSystem.directory(swiftPackagePath).childFile('Package.swift'));
+    }
+    return manifests;
+  }
+
+  /// Determines the highest [SwiftPackageSupportedPlatform] version among the plugins and saves
+  /// the value to [highestSupportedVersion] to later be used when creating the
+  /// FlutterPluginRegistrant.
+  ///
+  /// Saves the value to a file in [cacheDirectory] for quicker lookup when the list of Swift
+  /// package manifests has not changed.
+  @visibleForTesting
+  Future<bool> determineHighestSupportedVersion({
+    required List<File> manifests,
+    required Directory cacheDirectory,
+  }) async {
+    final File savedHighestVersionFile = cacheDirectory.childFile(
+      '${_targetPlatform.name}.version',
+    );
+    final fingerprinter = Fingerprinter(
+      fileSystem: _utils.fileSystem,
+      fingerprintPath: cacheDirectory.childFile('flutter_swift_pm_plugins.fingerprint').path,
+      paths: [
+        ...manifests.map((manifest) => manifest.path),
+        savedHighestVersionFile.path,
+        _utils.fileSystem.path.join(
+          _utils.flutterRoot,
+          'packages',
+          'flutter_tools',
+          'lib',
+          'src',
+          'commands',
+          'build_swift_package.dart',
+        ),
+      ],
+      logger: _utils.logger,
+    );
+    if (fingerprinter.doesFingerprintMatch() && savedHighestVersionFile.existsSync()) {
+      // Use saved version if possible
+      final String versionAsString = savedHighestVersionFile.readAsStringSync();
+      final Version? parsedVersion = Version.parse(versionAsString);
+      if (parsedVersion != null) {
+        highestSupportedVersion = SwiftPackageSupportedPlatform(
+          platform: _targetPlatform.swiftPackagePlatform,
+          version: parsedVersion,
+        );
+        return true;
+      }
+    }
+    for (final manifest in manifests) {
+      // Parse the plugins for the minimum deployment target.
+      // The FlutterPluginRegistrant needs to match the highest version. Otherwise, it will error.
+      final Version? pluginSupportedVersion = await _parseSwiftPackageSupportedPlatform(manifest);
+      if (pluginSupportedVersion != null &&
+          (highestSupportedVersion.version < pluginSupportedVersion)) {
+        highestSupportedVersion = SwiftPackageSupportedPlatform(
+          platform: _targetPlatform.swiftPackagePlatform,
+          version: pluginSupportedVersion,
+        );
+      }
+    }
+    savedHighestVersionFile
+      ..createSync(recursive: true)
+      ..writeAsStringSync(highestSupportedVersion.version.toString());
+    fingerprinter.writeFingerprint();
+    return false;
+  }
+
+  /// Parses the [SwiftPackageSupportedPlatform] from the Package.swift using either regex or
+  /// `swift` command line tool.
+  Future<Version?> _parseSwiftPackageSupportedPlatform(File swiftPackageManifest) async {
+    final String manifestContents = swiftPackageManifest.readAsStringSync();
+    if (!manifestContents.contains('platforms')) {
+      return null;
+    }
+    // First attempt to parse with regex, which is fast
+    // e.g. \.iOS\((.*)\) matches .iOS("13.0") or .iOS(.v13) or .macOS(.v10_15)
+    final pattern = RegExp('\\${_targetPlatform.swiftPackagePlatform.displayName}\\((.*)\\)');
+    final Iterable<RegExpMatch> matches = pattern.allMatches(manifestContents);
+    if (matches.length == 1) {
+      final String? match = matches.first.group(1);
+      if (match != null) {
+        final String normalizedVersionString = match
+            .replaceAll('"', '')
+            .replaceAll(' ', '')
+            .replaceAll('.v', '')
+            .replaceAll('_', '.');
+        final Version? parsedVersion = Version.parse(normalizedVersionString);
+        if (parsedVersion != null) {
+          return parsedVersion;
+        }
+      }
+    }
+
+    // If regex matching fails, convert the manifest to json and then parse
+    final Map<String, Object?> manifestAsJson = await _parseSwiftPackage(swiftPackageManifest);
+    if (manifestAsJson case {'platforms': final List<Object?> platformsData}) {
+      final Iterable<SwiftPackageSupportedPlatform?> parsedPlatforms = platformsData
+          .whereType<Map<String, Object?>>()
+          .map((platformData) => SwiftPackageSupportedPlatform.fromJson(platformData))
+          .where(
+            (parsedPlatform) =>
+                parsedPlatform != null &&
+                parsedPlatform.platform == _targetPlatform.swiftPackagePlatform,
+          );
+      return parsedPlatforms.firstOrNull?.version;
+    }
+    throwToolExit(
+      'Unable to parse ${_targetPlatform.name} supported platform version from '
+      '${swiftPackageManifest.path}. $_kFileAnIssue and include the contents of the aforementioned '
+      'file.',
+    );
+  }
+
+  /// Uses `swift` command line tool to convert Package.swift to json.
+  Future<Map<String, Object?>> _parseSwiftPackage(File swiftPackageManifest) async {
+    try {
+      final ProcessResult parsedManifest = await _utils.processManager.run([
+        'swift',
+        'package',
+        'dump-package',
+      ], workingDirectory: swiftPackageManifest.parent.path);
+      return json.decode(parsedManifest.stdout.toString()) as Map<String, Object?>;
+    } on Exception catch (e, stackTrace) {
+      throwToolExit(
+        'Failed to decode ${swiftPackageManifest.path}. $_kFileAnIssue and include aforementioned '
+        'file and the following stack trace: \n$e\n$stackTrace',
+      );
+    }
+  }
+
+  /// Returns dependencies from the SwiftPM-supported plugins for the FlutterPluginRegistrant.
+  ///
+  /// Also creates the symlinks to the Swift package within [packagesForConfiguration].
+  (List<SwiftPackagePackageDependency>, List<SwiftPackageTargetDependency>) generateDependencies({
+    required Directory packagesForConfiguration,
+  }) {
+    final List<SwiftPackagePackageDependency> packageDependencies = [];
+    final List<SwiftPackageTargetDependency> targetDependencies = [];
+    for (final (plugin, swiftPackagePath) in copiedPlugins) {
+      // Symlink the swift package inside the packagesForConfiguration directory
+      final Link symlink = packagesForConfiguration.childLink(plugin.name);
+      if (symlink.existsSync()) {
+        continue;
+      }
+      symlink.createSync(
+        _utils.fileSystem.path.relative(swiftPackagePath, from: symlink.parent.path),
+        recursive: true,
+      );
+
+      packageDependencies.add(
+        SwiftPackagePackageDependency(
+          name: plugin.name,
+          path: '$_kSources/$_kPackages/${plugin.name}',
+        ),
+      );
+      targetDependencies.add(
+        SwiftPackageTargetDependency.product(
+          name: plugin.name.replaceAll('_', '-'),
+          packageName: plugin.name,
+        ),
+      );
+    }
+
+    return (packageDependencies, targetDependencies);
+  }
+}
+
 /// Helper class that bundles global context variables for easy passing with less boilerplate.
 @visibleForTesting
 class BuildSwiftPackageUtils {
@@ -390,6 +675,7 @@ class BuildSwiftPackageUtils {
     required this.buildSystem,
     required this.cache,
     required this.fileSystem,
+    required this.flutterRoot,
     required this.flutterVersion,
     required this.logger,
     required this.platform,
@@ -404,6 +690,7 @@ class BuildSwiftPackageUtils {
   final BuildSystem buildSystem;
   final Cache cache;
   final FileSystem fileSystem;
+  final String flutterRoot;
   final FlutterVersion flutterVersion;
   final Logger logger;
   final Platform platform;

--- a/packages/flutter_tools/lib/src/commands/build_swift_package.dart
+++ b/packages/flutter_tools/lib/src/commands/build_swift_package.dart
@@ -640,13 +640,15 @@ class FlutterPluginSwiftDependencies {
     for (final (plugin, swiftPackagePath) in copiedPlugins) {
       // Symlink the swift package inside the packagesForConfiguration directory
       final Link symlink = packagesForConfiguration.childLink(plugin.name);
-      if (symlink.existsSync()) {
-        continue;
-      }
-      symlink.createSync(
-        _utils.fileSystem.path.relative(swiftPackagePath, from: symlink.parent.path),
-        recursive: true,
+      final String target = _utils.fileSystem.path.relative(
+        swiftPackagePath,
+        from: symlink.parent.path,
       );
+      if (symlink.existsSync()) {
+        symlink.updateSync(target);
+      } else {
+        symlink.createSync(target, recursive: true);
+      }
 
       packageDependencies.add(
         SwiftPackagePackageDependency(

--- a/packages/flutter_tools/lib/src/macos/swift_packages.dart
+++ b/packages/flutter_tools/lib/src/macos/swift_packages.dart
@@ -178,14 +178,14 @@ class SwiftPackage {
 }
 
 enum SwiftPackagePlatform {
-  ios(name: '.iOS'),
-  macos(name: '.macOS'),
-  tvos(name: '.tvOS'),
-  watchos(name: '.watchOS');
+  ios(displayName: '.iOS'),
+  macos(displayName: '.macOS'),
+  tvos(displayName: '.tvOS'),
+  watchos(displayName: '.watchOS');
 
-  const SwiftPackagePlatform({required this.name});
+  const SwiftPackagePlatform({required this.displayName});
 
-  final String name;
+  final String displayName;
 }
 
 /// A platform that the Swift package supports.
@@ -203,7 +203,30 @@ class SwiftPackageSupportedPlatform {
     //     .macOS("10.15"),
     //     .iOS("13.0"),
     // ],
-    return '${platform.name}("$version")';
+    return '${platform.displayName}("$version")';
+  }
+
+  static SwiftPackageSupportedPlatform? fromJson(Map<String, Object?> json) {
+    if (json case {
+      'platformName': final String platformName,
+      'version': final String versionString,
+    }) {
+      final Version? parsedVersion = Version.parse(versionString);
+      if (parsedVersion != null) {
+        if (platformName == SwiftPackagePlatform.ios.name) {
+          return SwiftPackageSupportedPlatform(
+            platform: SwiftPackagePlatform.ios,
+            version: parsedVersion,
+          );
+        } else if (platformName == SwiftPackagePlatform.macos.name) {
+          return SwiftPackageSupportedPlatform(
+            platform: SwiftPackagePlatform.macos,
+            version: parsedVersion,
+          );
+        }
+      }
+    }
+    return null;
   }
 }
 

--- a/packages/flutter_tools/lib/src/macos/swift_packages.dart
+++ b/packages/flutter_tools/lib/src/macos/swift_packages.dart
@@ -213,16 +213,11 @@ class SwiftPackageSupportedPlatform {
     }) {
       final Version? parsedVersion = Version.parse(versionString);
       if (parsedVersion != null) {
-        if (platformName == SwiftPackagePlatform.ios.name) {
-          return SwiftPackageSupportedPlatform(
-            platform: SwiftPackagePlatform.ios,
-            version: parsedVersion,
-          );
-        } else if (platformName == SwiftPackagePlatform.macos.name) {
-          return SwiftPackageSupportedPlatform(
-            platform: SwiftPackagePlatform.macos,
-            version: parsedVersion,
-          );
+        switch (platformName) {
+          case 'ios':
+            return SwiftPackageSupportedPlatform(platform: .ios, version: parsedVersion);
+          case 'macos':
+            return SwiftPackageSupportedPlatform(platform: .macos, version: parsedVersion);
         }
       }
     }

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -447,10 +447,15 @@ class Plugin {
   ///
   /// Returns null if the plugin does not support the [platform] or the
   /// [platform] is not iOS or macOS.
-  String? pluginSwiftPackagePath(FileSystem fileSystem, String platform) {
+  ///
+  /// If [overridePath] is provided, returns `[overridePath]/[platform]/[package_name]`.
+  String? pluginSwiftPackagePath(FileSystem fileSystem, String platform, {String? overridePath}) {
     final String? platformDirectoryName = _darwinPluginDirectoryName(platform);
     if (platformDirectoryName == null) {
       return null;
+    }
+    if (overridePath != null) {
+      return fileSystem.path.join(overridePath, platformDirectoryName, name);
     }
     return fileSystem.path.join(path, platformDirectoryName, name);
   }
@@ -463,6 +468,14 @@ class Plugin {
       return null;
     }
     return fileSystem.path.join(packagePath, 'Package.swift');
+  }
+
+  /// Returns true if a Package.swift is found.
+  bool supportSwiftPackageManagerForPlatform(FileSystem fileSystem, String platform) {
+    final String? manifestPath = pluginSwiftPackageManifestPath(fileSystem, platform);
+    return platforms[platform] != null &&
+        manifestPath != null &&
+        fileSystem.file(manifestPath).existsSync();
   }
 
   /// Expected path to the plugin's podspec. Returns null if the plugin does

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_swift_package_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_swift_package_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/base/version.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/cache.dart';
@@ -15,6 +16,7 @@ import 'package:flutter_tools/src/commands/build_swift_package.dart';
 import 'package:flutter_tools/src/darwin/darwin.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/isolated/mustache_template.dart';
+import 'package:flutter_tools/src/macos/swift_packages.dart';
 import 'package:flutter_tools/src/macos/xcode.dart';
 import 'package:flutter_tools/src/platform_plugins.dart';
 import 'package:flutter_tools/src/plugins.dart';
@@ -27,7 +29,12 @@ import '../../src/common.dart';
 import '../../src/context.dart';
 
 void main() {
+  const flutterRoot = '/path/to/flutter';
+  const commandFilePath =
+      '/path/to/flutter/packages/flutter_tools/lib/src/commands/build_swift_package.dart';
   const pluginRegistrantSwiftPackagePath = 'output/FlutterPluginRegistrant';
+  const cacheDirectoryPath = 'output/.cache';
+  const pluginsDirectoryPath = '$pluginRegistrantSwiftPackagePath/Plugins';
   const engineArtifactPath = '/flutter/bin/cache/artifacts/engine/ios/Flutter.xcframework';
 
   group('BuildSwiftPackage', () {
@@ -73,12 +80,14 @@ void main() {
         final fs = MemoryFileSystem.test();
         final logger = BufferLogger.test();
         final processManager = FakeProcessManager.list([]);
+        const FlutterDarwinPlatform targetPlatform = .ios;
         final testUtils = BuildSwiftPackageUtils(
           analytics: FakeAnalytics(),
           artifacts: FakeArtifacts(engineArtifactPath),
           buildSystem: FakeBuildSystem(),
           cache: FakeCache(),
           fileSystem: fs,
+          flutterRoot: flutterRoot,
           flutterVersion: FakeFlutterVersion(),
           logger: logger,
           platform: FakePlatform(),
@@ -88,16 +97,22 @@ void main() {
           xcode: FakeXcode(),
         );
         final package = FlutterPluginRegistrantSwiftPackage(
-          targetPlatform: FlutterDarwinPlatform.ios,
+          targetPlatform: targetPlatform,
+          utils: testUtils,
+        );
+        final pluginSwiftDependencies = FlutterPluginSwiftDependencies(
+          targetPlatform: targetPlatform,
           utils: testUtils,
         );
         final Directory swiftPackageOutput = fs.directory(pluginRegistrantSwiftPackagePath);
-        final pluginA = FakePlugin(name: 'PluginA', darwinPlatform: FlutterDarwinPlatform.ios);
+        final pluginA = FakePlugin(name: 'PluginA', darwinPlatform: targetPlatform);
+        pluginSwiftDependencies.copiedPlugins.add((pluginA, '$pluginsDirectoryPath/PluginA'));
 
         await package.generateSwiftPackage(
           pluginRegistrantSwiftPackage: swiftPackageOutput,
           plugins: [pluginA],
           xcodeBuildConfiguration: 'Debug',
+          pluginSwiftDependencies: pluginSwiftDependencies,
         );
 
         expect(logger.traceText, isEmpty);
@@ -119,13 +134,21 @@ import PackageDescription
 
 let package = Package(
     name: "FlutterPluginRegistrant",
+    platforms: [
+        .iOS("13.0")
+    ],
     products: [
         .library(name: "FlutterPluginRegistrant", type: .static, targets: ["FlutterPluginRegistrant"])
     ],
-    dependencies: [\n        \n    ],
+    dependencies: [
+        .package(name: "PluginA", path: "Sources/Packages/PluginA")
+    ],
     targets: [
         .target(
-            name: "FlutterPluginRegistrant"
+            name: "FlutterPluginRegistrant",
+            dependencies: [
+                .product(name: "PluginA", package: "PluginA")
+            ]
         )
     ]
 )
@@ -154,6 +177,270 @@ import PluginA
 ''');
       });
     });
+
+    group('FlutterPluginDependencies', () {
+      testWithoutContext('processPlugins', () async {
+        final fs = MemoryFileSystem.test();
+        final logger = BufferLogger.test();
+        final processManager = FakeProcessManager.list([]);
+        const FlutterDarwinPlatform targetPlatform = .ios;
+        final testUtils = BuildSwiftPackageUtils(
+          analytics: FakeAnalytics(),
+          artifacts: FakeArtifacts(engineArtifactPath),
+          buildSystem: FakeBuildSystem(),
+          cache: FakeCache(),
+          fileSystem: fs,
+          flutterRoot: flutterRoot,
+          flutterVersion: FakeFlutterVersion(),
+          logger: logger,
+          platform: FakePlatform(),
+          processManager: processManager,
+          project: FakeFlutterProject(),
+          templateRenderer: const MustacheTemplateRenderer(),
+          xcode: FakeXcode(),
+        );
+        final pluginSwiftDependencies = FlutterPluginSwiftDependencies(
+          targetPlatform: targetPlatform,
+          utils: testUtils,
+        );
+        final pluginA = FakePlugin(name: 'PluginA', darwinPlatform: targetPlatform);
+        fs.file(
+            fs.path.join(pluginA.pluginSwiftPackagePath(fs, targetPlatform.name)!, 'Package.swift'),
+          )
+          ..createSync(recursive: true)
+          ..writeAsStringSync(_pluginManifest(pluginName: 'PluginA', platforms: '.iOS("15.0")'));
+        final pluginB = FakePlugin(
+          name: 'PluginB',
+          darwinPlatform: targetPlatform,
+          supportsSwiftPM: false,
+        );
+        final pluginC = FakePlugin(name: 'PluginC', darwinPlatform: targetPlatform);
+        fs.file(
+            fs.path.join(pluginC.pluginSwiftPackagePath(fs, targetPlatform.name)!, 'Package.swift'),
+          )
+          ..createSync(recursive: true)
+          ..writeAsStringSync(_pluginManifest(pluginName: 'PluginC'));
+
+        final Directory pluginsDirectory = fs.directory(pluginsDirectoryPath);
+        await pluginSwiftDependencies.processPlugins(
+          cacheDirectory: fs.directory(cacheDirectoryPath),
+          plugins: [pluginA, pluginB, pluginC],
+          pluginsDirectory: pluginsDirectory,
+        );
+        expect(pluginsDirectory.listSync().length, 2);
+        expect(pluginSwiftDependencies.highestSupportedVersion.version, Version(15, 0, 0));
+      });
+
+      testWithoutContext('determineHighestSupportedVersion matches using regex', () async {
+        final fs = MemoryFileSystem.test();
+        final logger = BufferLogger.test();
+        final processManager = FakeProcessManager.list([]);
+        const FlutterDarwinPlatform targetPlatform = .ios;
+        final testUtils = BuildSwiftPackageUtils(
+          analytics: FakeAnalytics(),
+          artifacts: FakeArtifacts(engineArtifactPath),
+          buildSystem: FakeBuildSystem(),
+          cache: FakeCache(),
+          fileSystem: fs,
+          flutterRoot: flutterRoot,
+          flutterVersion: FakeFlutterVersion(),
+          logger: logger,
+          platform: FakePlatform(),
+          processManager: processManager,
+          project: FakeFlutterProject(),
+          templateRenderer: const MustacheTemplateRenderer(),
+          xcode: FakeXcode(),
+        );
+        final pluginSwiftDependencies = FlutterPluginSwiftDependencies(
+          targetPlatform: targetPlatform,
+          utils: testUtils,
+        );
+        final Directory cacheDirectory = fs.directory(cacheDirectoryPath);
+        final List<File> manifests = [
+          fs.file('PluginA/Package.swift')
+            ..createSync(recursive: true)
+            ..writeAsStringSync(_pluginManifest(pluginName: 'PluginA', platforms: '.iOS("15.0")')),
+        ];
+        expect(
+          pluginSwiftDependencies.highestSupportedVersion.platform,
+          targetPlatform.swiftPackagePlatform,
+        );
+        expect(pluginSwiftDependencies.highestSupportedVersion.version, Version(13, 0, 0));
+        await pluginSwiftDependencies.determineHighestSupportedVersion(
+          manifests: manifests,
+          cacheDirectory: cacheDirectory,
+        );
+        expect(
+          pluginSwiftDependencies.highestSupportedVersion.platform,
+          targetPlatform.swiftPackagePlatform,
+        );
+        expect(pluginSwiftDependencies.highestSupportedVersion.version, Version(15, 0, 0));
+
+        manifests.add(
+          fs.file('PluginB/Package.swift')
+            ..createSync(recursive: true)
+            ..writeAsStringSync(
+              _pluginManifest(pluginName: 'PluginB', platforms: '.iOS( .v16 ),\n .macOS("26.0")'),
+            ),
+        );
+        await pluginSwiftDependencies.determineHighestSupportedVersion(
+          manifests: manifests,
+          cacheDirectory: cacheDirectory,
+        );
+        expect(
+          pluginSwiftDependencies.highestSupportedVersion.platform,
+          targetPlatform.swiftPackagePlatform,
+        );
+        expect(pluginSwiftDependencies.highestSupportedVersion.version, Version(16, 0, 0));
+      });
+
+      testWithoutContext('determineHighestSupportedVersion matches using swift', () async {
+        final fs = MemoryFileSystem.test();
+        final logger = BufferLogger.test();
+        fs.file(commandFilePath).createSync(recursive: true);
+        final processManager = FakeProcessManager.list([
+          const FakeCommand(
+            command: ['swift', 'package', 'dump-package'],
+            workingDirectory: 'PluginA',
+            stdout: '''
+{
+  "name" : "PluginA",
+  "platforms" : [
+    {
+      "options" : [
+
+      ],
+      "platformName" : "ios",
+      "version" : "15.0"
+    },
+    {
+      "options" : [
+
+      ],
+      "platformName" : "macos",
+      "version" : "26.0"
+    }
+  ]
+}
+''',
+          ),
+        ]);
+        const FlutterDarwinPlatform targetPlatform = .ios;
+        final testUtils = BuildSwiftPackageUtils(
+          analytics: FakeAnalytics(),
+          artifacts: FakeArtifacts(engineArtifactPath),
+          buildSystem: FakeBuildSystem(),
+          cache: FakeCache(),
+          fileSystem: fs,
+          flutterRoot: flutterRoot,
+          flutterVersion: FakeFlutterVersion(),
+          logger: logger,
+          platform: FakePlatform(),
+          processManager: processManager,
+          project: FakeFlutterProject(),
+          templateRenderer: const MustacheTemplateRenderer(),
+          xcode: FakeXcode(),
+        );
+        final pluginSwiftDependencies = FlutterPluginSwiftDependencies(
+          targetPlatform: targetPlatform,
+          utils: testUtils,
+        );
+        final Directory cacheDirectory = fs.directory(cacheDirectoryPath);
+        final List<File> manifests = [
+          fs.file('PluginA/Package.swift')
+            ..createSync(recursive: true)
+            ..writeAsStringSync(_pluginManifest(pluginName: 'PluginA', platforms: 'someVar')),
+        ];
+        expect(
+          pluginSwiftDependencies.highestSupportedVersion.platform,
+          targetPlatform.swiftPackagePlatform,
+        );
+        expect(pluginSwiftDependencies.highestSupportedVersion.version, Version(13, 0, 0));
+        await pluginSwiftDependencies.determineHighestSupportedVersion(
+          manifests: manifests,
+          cacheDirectory: cacheDirectory,
+        );
+        expect(
+          pluginSwiftDependencies.highestSupportedVersion.platform,
+          targetPlatform.swiftPackagePlatform,
+        );
+        expect(pluginSwiftDependencies.highestSupportedVersion.version, Version(15, 0, 0));
+        expect(processManager.hasRemainingExpectations, isFalse);
+
+        // Verify it uses cache next time it runs (process is not called again)
+        await pluginSwiftDependencies.determineHighestSupportedVersion(
+          manifests: manifests,
+          cacheDirectory: cacheDirectory,
+        );
+        expect(
+          pluginSwiftDependencies.highestSupportedVersion.platform,
+          targetPlatform.swiftPackagePlatform,
+        );
+        expect(pluginSwiftDependencies.highestSupportedVersion.version, Version(15, 0, 0));
+      });
+
+      testWithoutContext('generateDependencies', () {
+        final fs = MemoryFileSystem.test();
+        final logger = BufferLogger.test();
+        final processManager = FakeProcessManager.list([]);
+        const FlutterDarwinPlatform targetPlatform = .ios;
+        final testUtils = BuildSwiftPackageUtils(
+          analytics: FakeAnalytics(),
+          artifacts: FakeArtifacts(engineArtifactPath),
+          buildSystem: FakeBuildSystem(),
+          cache: FakeCache(),
+          fileSystem: fs,
+          flutterRoot: flutterRoot,
+          flutterVersion: FakeFlutterVersion(),
+          logger: logger,
+          platform: FakePlatform(),
+          processManager: processManager,
+          project: FakeFlutterProject(),
+          templateRenderer: const MustacheTemplateRenderer(),
+          xcode: FakeXcode(),
+        );
+        final pluginSwiftDependencies = FlutterPluginSwiftDependencies(
+          targetPlatform: targetPlatform,
+          utils: testUtils,
+        );
+        final pluginA = FakePlugin(name: 'plugin_a', darwinPlatform: targetPlatform);
+        fs.file(
+            fs.path.join(pluginA.pluginSwiftPackagePath(fs, targetPlatform.name)!, 'Package.swift'),
+          )
+          ..createSync(recursive: true)
+          ..writeAsStringSync(_pluginManifest(pluginName: 'plugin_a'));
+        pluginSwiftDependencies.copiedPlugins.add((pluginA, '$pluginsDirectoryPath/plugin_a'));
+
+        final Directory packagesForConfiguration = fs.directory(
+          '$pluginRegistrantSwiftPackagePath/Release/Packages',
+        );
+
+        final (
+          List<SwiftPackagePackageDependency> pluginPackageDependencies,
+          List<SwiftPackageTargetDependency> pluginTargetDependencies,
+        ) = pluginSwiftDependencies.generateDependencies(
+          packagesForConfiguration: fs.directory(
+            '$pluginRegistrantSwiftPackagePath/Release/Packages',
+          ),
+        );
+        expect(
+          packagesForConfiguration.childLink(pluginA.name).targetSync(),
+          '../../Plugins/plugin_a',
+        );
+        expect(
+          pluginPackageDependencies.first.format().endsWith(
+            '.package(name: "plugin_a", path: "Sources/Packages/plugin_a")',
+          ),
+          isTrue,
+        );
+        expect(
+          pluginTargetDependencies.first.format().endsWith(
+            '.product(name: "plugin-a", package: "plugin_a")',
+          ),
+          isTrue,
+        );
+      });
+    });
   });
 
   group('macos', () {
@@ -162,12 +449,14 @@ import PluginA
         final fs = MemoryFileSystem.test();
         final logger = BufferLogger.test();
         final processManager = FakeProcessManager.list([]);
+        const FlutterDarwinPlatform targetPlatform = .macos;
         final testUtils = BuildSwiftPackageUtils(
           analytics: FakeAnalytics(),
           artifacts: FakeArtifacts(engineArtifactPath),
           buildSystem: FakeBuildSystem(),
           cache: FakeCache(),
           fileSystem: fs,
+          flutterRoot: flutterRoot,
           flutterVersion: FakeFlutterVersion(),
           logger: logger,
           platform: FakePlatform(),
@@ -177,16 +466,22 @@ import PluginA
           xcode: FakeXcode(),
         );
         final package = FlutterPluginRegistrantSwiftPackage(
-          targetPlatform: FlutterDarwinPlatform.macos,
+          targetPlatform: targetPlatform,
+          utils: testUtils,
+        );
+        final pluginSwiftDependencies = FlutterPluginSwiftDependencies(
+          targetPlatform: targetPlatform,
           utils: testUtils,
         );
         final Directory swiftPackageOutput = fs.directory(pluginRegistrantSwiftPackagePath);
-        final pluginA = FakePlugin(name: 'PluginA', darwinPlatform: FlutterDarwinPlatform.macos);
+        final pluginA = FakePlugin(name: 'PluginA', darwinPlatform: targetPlatform);
+        pluginSwiftDependencies.copiedPlugins.add((pluginA, '$pluginsDirectoryPath/PluginA'));
 
         await package.generateSwiftPackage(
           pluginRegistrantSwiftPackage: swiftPackageOutput,
           plugins: [pluginA],
           xcodeBuildConfiguration: 'Debug',
+          pluginSwiftDependencies: pluginSwiftDependencies,
         );
 
         expect(logger.traceText, isEmpty);
@@ -208,13 +503,21 @@ import PackageDescription
 
 let package = Package(
     name: "FlutterPluginRegistrant",
+    platforms: [
+        .macOS("10.15")
+    ],
     products: [
         .library(name: "FlutterPluginRegistrant", type: .static, targets: ["FlutterPluginRegistrant"])
     ],
-    dependencies: [\n        \n    ],
+    dependencies: [
+        .package(name: "PluginA", path: "Sources/Packages/PluginA")
+    ],
     targets: [
         .target(
-            name: "FlutterPluginRegistrant"
+            name: "FlutterPluginRegistrant",
+            dependencies: [
+                .product(name: "PluginA", package: "PluginA")
+            ]
         )
     ]
 )
@@ -240,7 +543,305 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
 ''');
       });
     });
+
+    group('FlutterPluginDependencies', () {
+      testWithoutContext('processPlugins', () async {
+        final fs = MemoryFileSystem.test();
+        final logger = BufferLogger.test();
+        final processManager = FakeProcessManager.list([]);
+        const FlutterDarwinPlatform targetPlatform = .macos;
+        final testUtils = BuildSwiftPackageUtils(
+          analytics: FakeAnalytics(),
+          artifacts: FakeArtifacts(engineArtifactPath),
+          buildSystem: FakeBuildSystem(),
+          cache: FakeCache(),
+          fileSystem: fs,
+          flutterRoot: flutterRoot,
+          flutterVersion: FakeFlutterVersion(),
+          logger: logger,
+          platform: FakePlatform(),
+          processManager: processManager,
+          project: FakeFlutterProject(),
+          templateRenderer: const MustacheTemplateRenderer(),
+          xcode: FakeXcode(),
+        );
+        final pluginSwiftDependencies = FlutterPluginSwiftDependencies(
+          targetPlatform: targetPlatform,
+          utils: testUtils,
+        );
+        final pluginA = FakePlugin(name: 'PluginA', darwinPlatform: targetPlatform);
+        fs.file(
+            fs.path.join(pluginA.pluginSwiftPackagePath(fs, targetPlatform.name)!, 'Package.swift'),
+          )
+          ..createSync(recursive: true)
+          ..writeAsStringSync(_pluginManifest(pluginName: 'PluginA', platforms: '.macOS("11")'));
+        final pluginB = FakePlugin(
+          name: 'PluginB',
+          darwinPlatform: targetPlatform,
+          supportsSwiftPM: false,
+        );
+        final pluginC = FakePlugin(name: 'PluginC', darwinPlatform: targetPlatform);
+        fs.file(
+            fs.path.join(pluginC.pluginSwiftPackagePath(fs, targetPlatform.name)!, 'Package.swift'),
+          )
+          ..createSync(recursive: true)
+          ..writeAsStringSync(_pluginManifest(pluginName: 'PluginC'));
+
+        final Directory pluginsDirectory = fs.directory(pluginsDirectoryPath);
+        await pluginSwiftDependencies.processPlugins(
+          cacheDirectory: fs.directory(cacheDirectoryPath),
+          plugins: [pluginA, pluginB, pluginC],
+          pluginsDirectory: pluginsDirectory,
+        );
+        expect(pluginsDirectory.listSync().length, 2);
+        expect(pluginSwiftDependencies.highestSupportedVersion.version, Version(11, 0, 0));
+      });
+
+      testWithoutContext('determineHighestSupportedVersion matches using regex', () async {
+        final fs = MemoryFileSystem.test();
+        final logger = BufferLogger.test();
+        final processManager = FakeProcessManager.list([]);
+        const FlutterDarwinPlatform targetPlatform = .macos;
+        final testUtils = BuildSwiftPackageUtils(
+          analytics: FakeAnalytics(),
+          artifacts: FakeArtifacts(engineArtifactPath),
+          buildSystem: FakeBuildSystem(),
+          cache: FakeCache(),
+          fileSystem: fs,
+          flutterRoot: flutterRoot,
+          flutterVersion: FakeFlutterVersion(),
+          logger: logger,
+          platform: FakePlatform(),
+          processManager: processManager,
+          project: FakeFlutterProject(),
+          templateRenderer: const MustacheTemplateRenderer(),
+          xcode: FakeXcode(),
+        );
+        final pluginSwiftDependencies = FlutterPluginSwiftDependencies(
+          targetPlatform: targetPlatform,
+          utils: testUtils,
+        );
+        final Directory cacheDirectory = fs.directory(cacheDirectoryPath);
+        final List<File> manifests = [
+          fs.file('PluginA/Package.swift')
+            ..createSync(recursive: true)
+            ..writeAsStringSync(
+              _pluginManifest(pluginName: 'PluginA', platforms: '.macOS("10.16")'),
+            ),
+        ];
+        expect(
+          pluginSwiftDependencies.highestSupportedVersion.platform,
+          targetPlatform.swiftPackagePlatform,
+        );
+        expect(pluginSwiftDependencies.highestSupportedVersion.version, Version(10, 15, 0));
+        await pluginSwiftDependencies.determineHighestSupportedVersion(
+          manifests: manifests,
+          cacheDirectory: cacheDirectory,
+        );
+        expect(
+          pluginSwiftDependencies.highestSupportedVersion.platform,
+          targetPlatform.swiftPackagePlatform,
+        );
+        expect(pluginSwiftDependencies.highestSupportedVersion.version, Version(10, 16, 0));
+
+        manifests.add(
+          fs.file('PluginB/Package.swift')
+            ..createSync(recursive: true)
+            ..writeAsStringSync(
+              _pluginManifest(
+                pluginName: 'PluginB',
+                platforms: '.iOS( .v16 ),\n .macOS( .v11_15 )',
+              ),
+            ),
+        );
+        await pluginSwiftDependencies.determineHighestSupportedVersion(
+          manifests: manifests,
+          cacheDirectory: cacheDirectory,
+        );
+        expect(
+          pluginSwiftDependencies.highestSupportedVersion.platform,
+          targetPlatform.swiftPackagePlatform,
+        );
+        expect(pluginSwiftDependencies.highestSupportedVersion.version, Version(11, 15, 0));
+      });
+
+      testWithoutContext('determineHighestSupportedVersion matches using swift', () async {
+        final fs = MemoryFileSystem.test();
+        final logger = BufferLogger.test();
+        fs.file(commandFilePath).createSync(recursive: true);
+        final processManager = FakeProcessManager.list([
+          const FakeCommand(
+            command: ['swift', 'package', 'dump-package'],
+            workingDirectory: 'PluginA',
+            stdout: '''
+{
+  "name" : "PluginA",
+  "platforms" : [
+    {
+      "options" : [
+
+      ],
+      "platformName" : "ios",
+      "version" : "15.0"
+    },
+    {
+      "options" : [
+
+      ],
+      "platformName" : "macos",
+      "version" : "26.0"
+    }
+  ]
+}
+''',
+          ),
+        ]);
+        const FlutterDarwinPlatform targetPlatform = .macos;
+        final testUtils = BuildSwiftPackageUtils(
+          analytics: FakeAnalytics(),
+          artifacts: FakeArtifacts(engineArtifactPath),
+          buildSystem: FakeBuildSystem(),
+          cache: FakeCache(),
+          fileSystem: fs,
+          flutterRoot: flutterRoot,
+          flutterVersion: FakeFlutterVersion(),
+          logger: logger,
+          platform: FakePlatform(),
+          processManager: processManager,
+          project: FakeFlutterProject(),
+          templateRenderer: const MustacheTemplateRenderer(),
+          xcode: FakeXcode(),
+        );
+        final pluginSwiftDependencies = FlutterPluginSwiftDependencies(
+          targetPlatform: targetPlatform,
+          utils: testUtils,
+        );
+        final Directory cacheDirectory = fs.directory(cacheDirectoryPath);
+        final List<File> manifests = [
+          fs.file('PluginA/Package.swift')
+            ..createSync(recursive: true)
+            ..writeAsStringSync(_pluginManifest(pluginName: 'PluginA', platforms: 'someVar')),
+        ];
+        expect(
+          pluginSwiftDependencies.highestSupportedVersion.platform,
+          targetPlatform.swiftPackagePlatform,
+        );
+        expect(pluginSwiftDependencies.highestSupportedVersion.version, Version(10, 15, 0));
+        await pluginSwiftDependencies.determineHighestSupportedVersion(
+          manifests: manifests,
+          cacheDirectory: cacheDirectory,
+        );
+        expect(
+          pluginSwiftDependencies.highestSupportedVersion.platform,
+          targetPlatform.swiftPackagePlatform,
+        );
+        expect(pluginSwiftDependencies.highestSupportedVersion.version, Version(26, 0, 0));
+        expect(processManager.hasRemainingExpectations, isFalse);
+
+        // Verify it uses cache next time it runs (process is not called again)
+        await pluginSwiftDependencies.determineHighestSupportedVersion(
+          manifests: manifests,
+          cacheDirectory: cacheDirectory,
+        );
+        expect(
+          pluginSwiftDependencies.highestSupportedVersion.platform,
+          targetPlatform.swiftPackagePlatform,
+        );
+        expect(pluginSwiftDependencies.highestSupportedVersion.version, Version(26, 0, 0));
+      });
+
+      testWithoutContext('generateDependencies', () {
+        final fs = MemoryFileSystem.test();
+        final logger = BufferLogger.test();
+        final processManager = FakeProcessManager.list([]);
+        const FlutterDarwinPlatform targetPlatform = .macos;
+        final testUtils = BuildSwiftPackageUtils(
+          analytics: FakeAnalytics(),
+          artifacts: FakeArtifacts(engineArtifactPath),
+          buildSystem: FakeBuildSystem(),
+          cache: FakeCache(),
+          fileSystem: fs,
+          flutterRoot: flutterRoot,
+          flutterVersion: FakeFlutterVersion(),
+          logger: logger,
+          platform: FakePlatform(),
+          processManager: processManager,
+          project: FakeFlutterProject(),
+          templateRenderer: const MustacheTemplateRenderer(),
+          xcode: FakeXcode(),
+        );
+        final pluginSwiftDependencies = FlutterPluginSwiftDependencies(
+          targetPlatform: targetPlatform,
+          utils: testUtils,
+        );
+        final pluginA = FakePlugin(name: 'plugin_a', darwinPlatform: targetPlatform);
+        fs.file(
+            fs.path.join(pluginA.pluginSwiftPackagePath(fs, targetPlatform.name)!, 'Package.swift'),
+          )
+          ..createSync(recursive: true)
+          ..writeAsStringSync(_pluginManifest(pluginName: 'plugin_a'));
+        pluginSwiftDependencies.copiedPlugins.add((pluginA, '$pluginsDirectoryPath/plugin_a'));
+
+        final Directory packagesForConfiguration = fs.directory(
+          '$pluginRegistrantSwiftPackagePath/Release/Packages',
+        );
+
+        final (
+          List<SwiftPackagePackageDependency> pluginPackageDependencies,
+          List<SwiftPackageTargetDependency> pluginTargetDependencies,
+        ) = pluginSwiftDependencies.generateDependencies(
+          packagesForConfiguration: fs.directory(
+            '$pluginRegistrantSwiftPackagePath/Release/Packages',
+          ),
+        );
+        expect(
+          packagesForConfiguration.childLink(pluginA.name).targetSync(),
+          '../../Plugins/plugin_a',
+        );
+        expect(
+          pluginPackageDependencies.first.format().endsWith(
+            '.package(name: "plugin_a", path: "Sources/Packages/plugin_a")',
+          ),
+          isTrue,
+        );
+        expect(
+          pluginTargetDependencies.first.format().endsWith(
+            '.product(name: "plugin-a", package: "plugin_a")',
+          ),
+          isTrue,
+        );
+      });
+    });
   });
+}
+
+String _pluginManifest({required String pluginName, String platforms = ''}) {
+  if (platforms.isNotEmpty) {
+    platforms =
+        '''
+    platforms: [
+        $platforms
+    ],
+''';
+  }
+  return '''
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "$pluginName",$platforms
+    products: [
+        .library(name: "${pluginName.replaceAll('_', '-')}", targets: ["$pluginName"])
+    ],
+    targets: [
+        .target(
+            name: "$pluginName",
+        )
+    ]
+)
+''';
 }
 
 class FakeAnalytics extends Fake implements Analytics {}
@@ -274,12 +875,13 @@ class FakeFlutterProject extends Fake implements FlutterProject {
 }
 
 class FakePlugin extends Fake implements Plugin {
-  FakePlugin({required this.name, required this.darwinPlatform});
+  FakePlugin({required this.name, required this.darwinPlatform, this.supportsSwiftPM = true});
 
   @override
   final String name;
 
   final FlutterDarwinPlatform darwinPlatform;
+  final bool supportsSwiftPM;
 
   @override
   String get path => '/path/to/$name';
@@ -290,6 +892,16 @@ class FakePlugin extends Fake implements Plugin {
         ? MacOSPlugin(name: name, pluginClass: '${name}Plugin')
         : IOSPlugin(name: name, classPrefix: '', pluginClass: '${name}Plugin'),
   };
+
+  @override
+  String? pluginSwiftPackagePath(FileSystem fileSystem, String platform, {String? overridePath}) {
+    return fileSystem.path.join(path, platform, name);
+  }
+
+  @override
+  bool supportSwiftPackageManagerForPlatform(FileSystem fileSystem, String platform) {
+    return supportsSwiftPM;
+  }
 }
 
 class FakeFeatureFlags extends Fake implements FeatureFlags {}

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_swift_package_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_swift_package_test.dart
@@ -261,20 +261,10 @@ import PluginA
             ..createSync(recursive: true)
             ..writeAsStringSync(_pluginManifest(pluginName: 'PluginA', platforms: '.iOS("15.0")')),
         ];
-        expect(
-          pluginSwiftDependencies.highestSupportedVersion.platform,
-          targetPlatform.swiftPackagePlatform,
-        );
-        expect(pluginSwiftDependencies.highestSupportedVersion.version, Version(13, 0, 0));
-        await pluginSwiftDependencies.determineHighestSupportedVersion(
-          manifests: manifests,
-          cacheDirectory: cacheDirectory,
-        );
-        expect(
-          pluginSwiftDependencies.highestSupportedVersion.platform,
-          targetPlatform.swiftPackagePlatform,
-        );
-        expect(pluginSwiftDependencies.highestSupportedVersion.version, Version(15, 0, 0));
+        final (Version highestVersion, bool skipped) = await pluginSwiftDependencies
+            .determineHighestSupportedVersion(manifests: manifests, cacheDirectory: cacheDirectory);
+        expect(highestVersion, Version(15, 0, 0));
+        expect(skipped, isFalse);
 
         manifests.add(
           fs.file('PluginB/Package.swift')
@@ -283,15 +273,10 @@ import PluginA
               _pluginManifest(pluginName: 'PluginB', platforms: '.iOS( .v16 ),\n .macOS("26.0")'),
             ),
         );
-        await pluginSwiftDependencies.determineHighestSupportedVersion(
-          manifests: manifests,
-          cacheDirectory: cacheDirectory,
-        );
-        expect(
-          pluginSwiftDependencies.highestSupportedVersion.platform,
-          targetPlatform.swiftPackagePlatform,
-        );
-        expect(pluginSwiftDependencies.highestSupportedVersion.version, Version(16, 0, 0));
+        final (Version retryHighestVersion, bool retrySkipped) = await pluginSwiftDependencies
+            .determineHighestSupportedVersion(manifests: manifests, cacheDirectory: cacheDirectory);
+        expect(retryHighestVersion, Version(16, 0, 0));
+        expect(retrySkipped, isFalse);
       });
 
       testWithoutContext('determineHighestSupportedVersion matches using swift', () async {
@@ -351,32 +336,16 @@ import PluginA
             ..createSync(recursive: true)
             ..writeAsStringSync(_pluginManifest(pluginName: 'PluginA', platforms: 'someVar')),
         ];
-        expect(
-          pluginSwiftDependencies.highestSupportedVersion.platform,
-          targetPlatform.swiftPackagePlatform,
-        );
-        expect(pluginSwiftDependencies.highestSupportedVersion.version, Version(13, 0, 0));
-        await pluginSwiftDependencies.determineHighestSupportedVersion(
-          manifests: manifests,
-          cacheDirectory: cacheDirectory,
-        );
-        expect(
-          pluginSwiftDependencies.highestSupportedVersion.platform,
-          targetPlatform.swiftPackagePlatform,
-        );
-        expect(pluginSwiftDependencies.highestSupportedVersion.version, Version(15, 0, 0));
-        expect(processManager.hasRemainingExpectations, isFalse);
+        final (Version highestVersion, bool skipped) = await pluginSwiftDependencies
+            .determineHighestSupportedVersion(manifests: manifests, cacheDirectory: cacheDirectory);
+        expect(highestVersion, Version(15, 0, 0));
+        expect(skipped, isFalse);
 
         // Verify it uses cache next time it runs (process is not called again)
-        await pluginSwiftDependencies.determineHighestSupportedVersion(
-          manifests: manifests,
-          cacheDirectory: cacheDirectory,
-        );
-        expect(
-          pluginSwiftDependencies.highestSupportedVersion.platform,
-          targetPlatform.swiftPackagePlatform,
-        );
-        expect(pluginSwiftDependencies.highestSupportedVersion.version, Version(15, 0, 0));
+        final (Version retryHighestVersion, bool retrySkipped) = await pluginSwiftDependencies
+            .determineHighestSupportedVersion(manifests: manifests, cacheDirectory: cacheDirectory);
+        expect(retryHighestVersion, Version(15, 0, 0));
+        expect(retrySkipped, isTrue);
       });
 
       testWithoutContext('generateDependencies', () {
@@ -629,20 +598,10 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
               _pluginManifest(pluginName: 'PluginA', platforms: '.macOS("10.16")'),
             ),
         ];
-        expect(
-          pluginSwiftDependencies.highestSupportedVersion.platform,
-          targetPlatform.swiftPackagePlatform,
-        );
-        expect(pluginSwiftDependencies.highestSupportedVersion.version, Version(10, 15, 0));
-        await pluginSwiftDependencies.determineHighestSupportedVersion(
-          manifests: manifests,
-          cacheDirectory: cacheDirectory,
-        );
-        expect(
-          pluginSwiftDependencies.highestSupportedVersion.platform,
-          targetPlatform.swiftPackagePlatform,
-        );
-        expect(pluginSwiftDependencies.highestSupportedVersion.version, Version(10, 16, 0));
+        final (Version highestVersion, bool skipped) = await pluginSwiftDependencies
+            .determineHighestSupportedVersion(manifests: manifests, cacheDirectory: cacheDirectory);
+        expect(highestVersion, Version(10, 16, 0));
+        expect(skipped, isFalse);
 
         manifests.add(
           fs.file('PluginB/Package.swift')
@@ -654,15 +613,10 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
               ),
             ),
         );
-        await pluginSwiftDependencies.determineHighestSupportedVersion(
-          manifests: manifests,
-          cacheDirectory: cacheDirectory,
-        );
-        expect(
-          pluginSwiftDependencies.highestSupportedVersion.platform,
-          targetPlatform.swiftPackagePlatform,
-        );
-        expect(pluginSwiftDependencies.highestSupportedVersion.version, Version(11, 15, 0));
+        final (Version retryHighestVersion, bool retrySkipped) = await pluginSwiftDependencies
+            .determineHighestSupportedVersion(manifests: manifests, cacheDirectory: cacheDirectory);
+        expect(retryHighestVersion, Version(11, 15, 0));
+        expect(retrySkipped, isFalse);
       });
 
       testWithoutContext('determineHighestSupportedVersion matches using swift', () async {
@@ -722,32 +676,16 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
             ..createSync(recursive: true)
             ..writeAsStringSync(_pluginManifest(pluginName: 'PluginA', platforms: 'someVar')),
         ];
-        expect(
-          pluginSwiftDependencies.highestSupportedVersion.platform,
-          targetPlatform.swiftPackagePlatform,
-        );
-        expect(pluginSwiftDependencies.highestSupportedVersion.version, Version(10, 15, 0));
-        await pluginSwiftDependencies.determineHighestSupportedVersion(
-          manifests: manifests,
-          cacheDirectory: cacheDirectory,
-        );
-        expect(
-          pluginSwiftDependencies.highestSupportedVersion.platform,
-          targetPlatform.swiftPackagePlatform,
-        );
-        expect(pluginSwiftDependencies.highestSupportedVersion.version, Version(26, 0, 0));
-        expect(processManager.hasRemainingExpectations, isFalse);
+        final (Version highestVersion, bool skipped) = await pluginSwiftDependencies
+            .determineHighestSupportedVersion(manifests: manifests, cacheDirectory: cacheDirectory);
+        expect(highestVersion, Version(26, 0, 0));
+        expect(skipped, isFalse);
 
         // Verify it uses cache next time it runs (process is not called again)
-        await pluginSwiftDependencies.determineHighestSupportedVersion(
-          manifests: manifests,
-          cacheDirectory: cacheDirectory,
-        );
-        expect(
-          pluginSwiftDependencies.highestSupportedVersion.platform,
-          targetPlatform.swiftPackagePlatform,
-        );
-        expect(pluginSwiftDependencies.highestSupportedVersion.version, Version(26, 0, 0));
+        final (Version retryHighestVersion, bool retrySkipped) = await pluginSwiftDependencies
+            .determineHighestSupportedVersion(manifests: manifests, cacheDirectory: cacheDirectory);
+        expect(retryHighestVersion, Version(26, 0, 0));
+        expect(retrySkipped, isTrue);
       });
 
       testWithoutContext('generateDependencies', () {

--- a/packages/flutter_tools/test/general.shard/macos/swift_package_manager_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/swift_package_manager_test.dart
@@ -631,7 +631,7 @@ class FakePlugin extends Fake implements Plugin {
   final Map<String, PluginPlatform> platforms;
 
   @override
-  String? pluginSwiftPackagePath(FileSystem fileSystem, String platform) {
+  String? pluginSwiftPackagePath(FileSystem fileSystem, String platform, {String? overridePath}) {
     return _pluginSwiftPackagePath;
   }
 

--- a/packages/flutter_tools/test/general.shard/macos/swift_packages_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/swift_packages_test.dart
@@ -348,6 +348,42 @@ let package = Package(
     expect(supportedPlatform.format(), '.iOS("17.0")');
   });
 
+  testWithoutContext('SwiftPackageSupportedPlatform.fromJson parsed iOS', () {
+    final SwiftPackageSupportedPlatform? supportedPlatform = SwiftPackageSupportedPlatform.fromJson(
+      {'platformName': 'ios', 'version': '13.0'},
+    );
+    expect(supportedPlatform, isNotNull);
+    expect(supportedPlatform?.format(), '.iOS("13.0")');
+  });
+
+  testWithoutContext('SwiftPackageSupportedPlatform.fromJson parsed macOS', () {
+    final SwiftPackageSupportedPlatform? supportedPlatform = SwiftPackageSupportedPlatform.fromJson(
+      {'platformName': 'macos', 'version': '10.15'},
+    );
+    expect(supportedPlatform, isNotNull);
+    expect(supportedPlatform?.format(), '.macOS("10.15")');
+  });
+
+  testWithoutContext('SwiftPackageSupportedPlatform.fromJson returns null when invalid', () {
+    final SwiftPackageSupportedPlatform? invalidVersion = SwiftPackageSupportedPlatform.fromJson({
+      'platformName': 'ios',
+      'version': 'v15',
+    });
+    expect(invalidVersion, isNull);
+
+    final SwiftPackageSupportedPlatform? invalidPlatform = SwiftPackageSupportedPlatform.fromJson({
+      'platformName': 'asdf',
+      'version': '13.0',
+    });
+    expect(invalidPlatform, isNull);
+
+    final SwiftPackageSupportedPlatform? invalidJson = SwiftPackageSupportedPlatform.fromJson({
+      'name': 'ios',
+      'version': '13.0',
+    });
+    expect(invalidJson, isNull);
+  });
+
   group('Format SwiftPackageProduct', () {
     testWithoutContext('without targets and libraryType', () {
       final product = SwiftPackageProduct(name: 'ProductName', targets: <String>[]);

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -2030,6 +2030,14 @@ flutter:
           '/path/to/test/macos/test',
         );
         expect(
+          plugin.pluginSwiftPackagePath(fs, IOSPlugin.kConfigKey, overridePath: '/override'),
+          '/override/ios/test',
+        );
+        expect(
+          plugin.pluginSwiftPackagePath(fs, MacOSPlugin.kConfigKey, overridePath: '/override'),
+          '/override/macos/test',
+        );
+        expect(
           plugin.pluginSwiftPackageManifestPath(fs, IOSPlugin.kConfigKey),
           '/path/to/test/ios/test/Package.swift',
         );
@@ -2076,6 +2084,14 @@ flutter:
           '/path/to/test/darwin/test',
         );
         expect(
+          plugin.pluginSwiftPackagePath(fs, IOSPlugin.kConfigKey, overridePath: '/override'),
+          '/override/darwin/test',
+        );
+        expect(
+          plugin.pluginSwiftPackagePath(fs, MacOSPlugin.kConfigKey, overridePath: '/override'),
+          '/override/darwin/test',
+        );
+        expect(
           plugin.pluginSwiftPackageManifestPath(fs, IOSPlugin.kConfigKey),
           '/path/to/test/darwin/test/Package.swift',
         );
@@ -2117,6 +2133,75 @@ flutter:
         expect(plugin.pluginPodspecPath(fs, IOSPlugin.kConfigKey), isNull);
         expect(plugin.pluginPodspecPath(fs, MacOSPlugin.kConfigKey), isNull);
         expect(plugin.pluginPodspecPath(fs, WindowsPlugin.kConfigKey), isNull);
+      });
+
+      testWithoutContext('supportSwiftPackageManagerForPlatform if manifest exists', () {
+        final fs = MemoryFileSystem.test();
+        final plugin = Plugin(
+          name: 'test',
+          path: '/path/to/test/',
+          defaultPackagePlatforms: const <String, String>{},
+          pluginDartClassPlatforms: const <String, DartPluginClassAndFilePair>{},
+          platforms: const <String, PluginPlatform>{
+            IOSPlugin.kConfigKey: IOSPlugin(name: 'test', classPrefix: ''),
+            MacOSPlugin.kConfigKey: MacOSPlugin(name: 'test'),
+          },
+          dependencies: <String>[],
+          isDirectDependency: true,
+          isDevDependency: false,
+        );
+        expect(plugin.supportSwiftPackageManagerForPlatform(fs, IOSPlugin.kConfigKey), isFalse);
+        expect(plugin.supportSwiftPackageManagerForPlatform(fs, MacOSPlugin.kConfigKey), isFalse);
+
+        fs
+            .file(fs.path.join(plugin.path, 'ios', plugin.name, 'Package.swift'))
+            .createSync(recursive: true);
+        expect(plugin.supportSwiftPackageManagerForPlatform(fs, IOSPlugin.kConfigKey), isTrue);
+        expect(plugin.supportSwiftPackageManagerForPlatform(fs, MacOSPlugin.kConfigKey), isFalse);
+
+        fs
+            .file(fs.path.join(plugin.path, 'macos', plugin.name, 'Package.swift'))
+            .createSync(recursive: true);
+        expect(plugin.supportSwiftPackageManagerForPlatform(fs, IOSPlugin.kConfigKey), isTrue);
+        expect(plugin.supportSwiftPackageManagerForPlatform(fs, MacOSPlugin.kConfigKey), isTrue);
+
+        final darwinPlugin = Plugin(
+          name: 'test',
+          path: '/path/to/test/',
+          defaultPackagePlatforms: const <String, String>{},
+          pluginDartClassPlatforms: const <String, DartPluginClassAndFilePair>{},
+          platforms: const <String, PluginPlatform>{
+            IOSPlugin.kConfigKey: IOSPlugin(
+              name: 'test',
+              classPrefix: '',
+              sharedDarwinSource: true,
+            ),
+            MacOSPlugin.kConfigKey: MacOSPlugin(name: 'test', sharedDarwinSource: true),
+          },
+          dependencies: <String>[],
+          isDirectDependency: true,
+          isDevDependency: false,
+        );
+        expect(
+          darwinPlugin.supportSwiftPackageManagerForPlatform(fs, IOSPlugin.kConfigKey),
+          isFalse,
+        );
+        expect(
+          darwinPlugin.supportSwiftPackageManagerForPlatform(fs, MacOSPlugin.kConfigKey),
+          isFalse,
+        );
+
+        fs
+            .file(fs.path.join(darwinPlugin.path, 'darwin', darwinPlugin.name, 'Package.swift'))
+            .createSync(recursive: true);
+        expect(
+          darwinPlugin.supportSwiftPackageManagerForPlatform(fs, IOSPlugin.kConfigKey),
+          isTrue,
+        );
+        expect(
+          darwinPlugin.supportSwiftPackageManagerForPlatform(fs, MacOSPlugin.kConfigKey),
+          isTrue,
+        );
       });
     });
 


### PR DESCRIPTION
This PR copies Flutter plugins that support SwiftPM into the FlutterPluginRegistrant directory and adds them as dependencies in the FlutterPluginRegistrant Package.swift. It also parses the [SupportedPlatform](https://developer.apple.com/documentation/packagedescription/supportedplatform) out of the Package.swift for each plugin and finds the highest one. It then makes that value the SupportedPlatform for the FlutterPluginRegistrant.

Fixes https://github.com/flutter/flutter/issues/181207.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
