### PR TITLE
Correct PerformanceOverlay optionsMask checks and add tests

### DIFF
--- a/packages/flutter/lib/src/rendering/performance_overlay.dart
+++ b/packages/flutter/lib/src/rendering/performance_overlay.dart
@@ -94,21 +94,24 @@ class RenderPerformanceOverlay extends RenderBox {
     return 0.0;
   }
 
-      double get _intrinsicHeight {
-        const kDefaultGraphHeight = 80.0;
-        var result = 0.0;
-        final int rasterizerBits = (1 << PerformanceOverlayOption.displayRasterizerStatistics.index) |
-            (1 << PerformanceOverlayOption.visualizeRasterizerStatistics.index);
-        if ((optionsMask & rasterizerBits) != 0) {
-          result += kDefaultGraphHeight;
-        }
-        final int engineBits = (1 << PerformanceOverlayOption.displayEngineStatistics.index) |
-            (1 << PerformanceOverlayOption.visualizeEngineStatistics.index);
-        if ((optionsMask & engineBits) != 0) {
-          result += kDefaultGraphHeight;
-        }
-        return result;
-      }
+  double get _intrinsicHeight {
+    const kDefaultGraphHeight = 80.0;
+    var result = 0.0;
+    final int rasterizerBits =
+        (1 << PerformanceOverlayOption.displayRasterizerStatistics.index) |
+        (1 << PerformanceOverlayOption.visualizeRasterizerStatistics.index);
+    if ((optionsMask & rasterizerBits) != 0) {
+      result += kDefaultGraphHeight;
+    }
+    final int engineBits =
+        (1 << PerformanceOverlayOption.displayEngineStatistics.index) |
+        (1 << PerformanceOverlayOption.visualizeEngineStatistics.index);
+    if ((optionsMask & engineBits) != 0) {
+      result += kDefaultGraphHeight;
+    }
+    return result;
+  }
+
   @override
   double computeMinIntrinsicHeight(double width) {
     return _intrinsicHeight;

--- a/packages/flutter/lib/src/rendering/performance_overlay.dart
+++ b/packages/flutter/lib/src/rendering/performance_overlay.dart
@@ -66,6 +66,13 @@ class RenderPerformanceOverlay extends RenderBox {
   /// Creates a performance overlay render object.
   RenderPerformanceOverlay({int optionsMask = 0}) : _optionsMask = optionsMask;
 
+  static final int _rasterizerMask =
+      (1 << PerformanceOverlayOption.displayRasterizerStatistics.index) |
+      (1 << PerformanceOverlayOption.visualizeRasterizerStatistics.index);
+  static final int _engineMask =
+      (1 << PerformanceOverlayOption.displayEngineStatistics.index) |
+      (1 << PerformanceOverlayOption.visualizeEngineStatistics.index);
+
   /// The mask is created by shifting 1 by the index of the specific
   /// [PerformanceOverlayOption] to enable.
   int get optionsMask => _optionsMask;
@@ -95,18 +102,12 @@ class RenderPerformanceOverlay extends RenderBox {
   }
 
   double get _intrinsicHeight {
-    const kDefaultGraphHeight = 80.0;
-    var result = 0.0;
-    final int rasterizerBits =
-        (1 << PerformanceOverlayOption.displayRasterizerStatistics.index) |
-        (1 << PerformanceOverlayOption.visualizeRasterizerStatistics.index);
-    if ((optionsMask & rasterizerBits) != 0) {
+    const double kDefaultGraphHeight = 80.0;
+    double result = 0.0;
+    if ((optionsMask & _rasterizerMask) != 0) {
       result += kDefaultGraphHeight;
     }
-    final int engineBits =
-        (1 << PerformanceOverlayOption.displayEngineStatistics.index) |
-        (1 << PerformanceOverlayOption.visualizeEngineStatistics.index);
-    if ((optionsMask & engineBits) != 0) {
+    if ((optionsMask & _engineMask) != 0) {
       result += kDefaultGraphHeight;
     }
     return result;

--- a/packages/flutter/lib/src/rendering/performance_overlay.dart
+++ b/packages/flutter/lib/src/rendering/performance_overlay.dart
@@ -102,8 +102,8 @@ class RenderPerformanceOverlay extends RenderBox {
   }
 
   double get _intrinsicHeight {
-    const double kDefaultGraphHeight = 80.0;
-    double result = 0.0;
+    const kDefaultGraphHeight = 80.0;
+    var result = 0.0;
     if ((optionsMask & _rasterizerMask) != 0) {
       result += kDefaultGraphHeight;
     }

--- a/packages/flutter/lib/src/rendering/performance_overlay.dart
+++ b/packages/flutter/lib/src/rendering/performance_overlay.dart
@@ -94,20 +94,21 @@ class RenderPerformanceOverlay extends RenderBox {
     return 0.0;
   }
 
-  double get _intrinsicHeight {
-    const kDefaultGraphHeight = 80.0;
-    var result = 0.0;
-    if ((optionsMask | (1 << PerformanceOverlayOption.displayRasterizerStatistics.index) > 0) ||
-        (optionsMask | (1 << PerformanceOverlayOption.visualizeRasterizerStatistics.index) > 0)) {
-      result += kDefaultGraphHeight;
-    }
-    if ((optionsMask | (1 << PerformanceOverlayOption.displayEngineStatistics.index) > 0) ||
-        (optionsMask | (1 << PerformanceOverlayOption.visualizeEngineStatistics.index) > 0)) {
-      result += kDefaultGraphHeight;
-    }
-    return result;
-  }
-
+      double get _intrinsicHeight {
+        const kDefaultGraphHeight = 80.0;
+        var result = 0.0;
+        final int rasterizerBits = (1 << PerformanceOverlayOption.displayRasterizerStatistics.index) |
+            (1 << PerformanceOverlayOption.visualizeRasterizerStatistics.index);
+        if ((optionsMask & rasterizerBits) != 0) {
+          result += kDefaultGraphHeight;
+        }
+        final int engineBits = (1 << PerformanceOverlayOption.displayEngineStatistics.index) |
+            (1 << PerformanceOverlayOption.visualizeEngineStatistics.index);
+        if ((optionsMask & engineBits) != 0) {
+          result += kDefaultGraphHeight;
+        }
+        return result;
+      }
   @override
   double computeMinIntrinsicHeight(double width) {
     return _intrinsicHeight;

--- a/packages/flutter/test/rendering/performance_overlay_test.dart
+++ b/packages/flutter/test/rendering/performance_overlay_test.dart
@@ -1,0 +1,28 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('RenderPerformanceOverlay intrinsic height respects optionsMask', () {
+    const kGraph = 80.0; // Matches implementation default graph height.
+    final r = RenderPerformanceOverlay();
+    expect(r.computeMinIntrinsicHeight(100.0), 0.0);
+
+    // One engine stat enabled.
+    final int engineMask = 1 << PerformanceOverlayOption.displayEngineStatistics.index;
+    r.optionsMask = engineMask;
+    expect(r.computeMinIntrinsicHeight(100.0), kGraph);
+
+    // One rasterizer stat enabled.
+    final int rasterMask = 1 << PerformanceOverlayOption.displayRasterizerStatistics.index;
+    r.optionsMask = rasterMask;
+    expect(r.computeMinIntrinsicHeight(100.0), kGraph);
+
+    // Both engine and rasterizer graphs.
+    r.optionsMask = engineMask | rasterMask;
+    expect(r.computeMinIntrinsicHeight(100.0), 2 * kGraph);
+  });
+}

--- a/packages/flutter/test/rendering/performance_overlay_test.dart
+++ b/packages/flutter/test/rendering/performance_overlay_test.dart
@@ -24,5 +24,27 @@ void main() {
     // Both engine and rasterizer graphs.
     r.optionsMask = engineMask | rasterMask;
     expect(r.computeMinIntrinsicHeight(100.0), 2 * kGraph);
+
+    // One visualize engine stat enabled.
+    final int visualizeEngineMask = 1 << PerformanceOverlayOption.visualizeEngineStatistics.index;
+    r.optionsMask = visualizeEngineMask;
+    expect(r.computeMinIntrinsicHeight(100.0), kGraph);
+
+    // One visualize rasterizer stat enabled.
+    final int visualizeRasterMask = 1 << PerformanceOverlayOption.visualizeRasterizerStatistics.index;
+    r.optionsMask = visualizeRasterMask;
+    expect(r.computeMinIntrinsicHeight(100.0), kGraph);
+
+    // Both display and visualize engine stats enabled.
+    r.optionsMask = engineMask | visualizeEngineMask;
+    expect(r.computeMinIntrinsicHeight(100.0), kGraph);
+
+    // Both display and visualize rasterizer stats enabled.
+    r.optionsMask = rasterMask | visualizeRasterMask;
+    expect(r.computeMinIntrinsicHeight(100.0), kGraph);
+
+    // All options enabled.
+    r.optionsMask = engineMask | visualizeEngineMask | rasterMask | visualizeRasterMask;
+    expect(r.computeMinIntrinsicHeight(100.0), 2 * kGraph);
   });
 }

--- a/packages/flutter/test/rendering/performance_overlay_test.dart
+++ b/packages/flutter/test/rendering/performance_overlay_test.dart
@@ -31,7 +31,8 @@ void main() {
     expect(r.computeMinIntrinsicHeight(100.0), kGraph);
 
     // One visualize rasterizer stat enabled.
-    final int visualizeRasterMask = 1 << PerformanceOverlayOption.visualizeRasterizerStatistics.index;
+    final int visualizeRasterMask =
+        1 << PerformanceOverlayOption.visualizeRasterizerStatistics.index;
     r.optionsMask = visualizeRasterMask;
     expect(r.computeMinIntrinsicHeight(100.0), kGraph);
 


### PR DESCRIPTION
This re-stages the changes from https://github.com/flutter/flutter/pull/174814
That PR had some outstanding feedback to resolve, this is now done and we can get this change in, with thanks to @jihanurrahman33 !

From the original PR: 

> Fix bitmask checks in RenderPerformanceOverlay._intrinsicHeight:
> 
> Use bitwise AND (&) and compare against 0 instead of bitwise OR (|).
> This ensures the intrinsic height is 0 when no options are enabled, 80.0 for one graph,
> and 160.0 when both rasterizer and engine graphs are enabled.
> Add tests in rendering/performance_overlay_test.dart to verify intrinsic height for
> various masks.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
