### PR TITLE
Fix NestedScrollView fling, overscroll, and animateTo with unified offset model

### DIFF
--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -563,53 +563,33 @@ class _InheritedNestedScrollView extends InheritedWidget {
   bool updateShouldNotify(_InheritedNestedScrollView old) => state != old.state;
 }
 
-class _NestedScrollMetrics extends FixedScrollMetrics {
-  _NestedScrollMetrics({
-    required super.minScrollExtent,
-    required super.maxScrollExtent,
-    required super.pixels,
-    required super.viewportDimension,
-    required super.axisDirection,
-    required super.devicePixelRatio,
-    required this.minRange,
-    required this.maxRange,
-    required this.correctionOffset,
-  });
+typedef _NestedScrollActivityGetter = ScrollActivity Function(_NestedScrollPosition position);
+
+/// A placeholder activity assigned to positions while the coordinator drives
+/// them via a unified [BallisticScrollActivity] or [DrivenScrollActivity].
+///
+/// This mirrors the unified activity's [shouldIgnorePointer] and [isScrolling]
+/// so that the positions correctly report their scrolling state.
+class _CoordinatedScrollActivity extends ScrollActivity {
+  _CoordinatedScrollActivity(
+    super.delegate, {
+    required bool shouldIgnorePointer,
+    required bool isScrolling,
+  }) : _shouldIgnorePointer = shouldIgnorePointer,
+       _isScrolling = isScrolling;
+
+  final bool _shouldIgnorePointer;
+  final bool _isScrolling;
 
   @override
-  _NestedScrollMetrics copyWith({
-    double? minScrollExtent,
-    double? maxScrollExtent,
-    double? pixels,
-    double? viewportDimension,
-    AxisDirection? axisDirection,
-    double? devicePixelRatio,
-    double? minRange,
-    double? maxRange,
-    double? correctionOffset,
-  }) {
-    return _NestedScrollMetrics(
-      minScrollExtent: minScrollExtent ?? (hasContentDimensions ? this.minScrollExtent : null),
-      maxScrollExtent: maxScrollExtent ?? (hasContentDimensions ? this.maxScrollExtent : null),
-      pixels: pixels ?? (hasPixels ? this.pixels : null),
-      viewportDimension:
-          viewportDimension ?? (hasViewportDimension ? this.viewportDimension : null),
-      axisDirection: axisDirection ?? this.axisDirection,
-      devicePixelRatio: devicePixelRatio ?? this.devicePixelRatio,
-      minRange: minRange ?? this.minRange,
-      maxRange: maxRange ?? this.maxRange,
-      correctionOffset: correctionOffset ?? this.correctionOffset,
-    );
-  }
+  bool get shouldIgnorePointer => _shouldIgnorePointer;
 
-  final double minRange;
+  @override
+  bool get isScrolling => _isScrolling;
 
-  final double maxRange;
-
-  final double correctionOffset;
+  @override
+  double get velocity => 0.0;
 }
-
-typedef _NestedScrollActivityGetter = ScrollActivity Function(_NestedScrollPosition position);
 
 class _NestedScrollCoordinator implements ScrollActivityDelegate, ScrollHoldController {
   _NestedScrollCoordinator(
@@ -675,6 +655,95 @@ class _NestedScrollCoordinator implements ScrollActivityDelegate, ScrollHoldCont
     return false;
   }
 
+  // -- Unified offset model --
+  // Maps the combined outer+inner scroll extent to a single virtual offset.
+  // unifiedMax = outerRange + max(innerRanges)
+  // setPixels(x): outer consumes first, then inner gets the remainder.
+
+  double get _unifiedMinScrollExtent => 0.0;
+
+  double get _unifiedMaxScrollExtent {
+    final _NestedScrollPosition? outer = _outerPosition;
+    if (outer == null || !outer.hasContentDimensions) {
+      return 0.0;
+    }
+    final double outerRange = outer.maxScrollExtent - outer.minScrollExtent;
+    var maxInnerRange = 0.0;
+    for (final _NestedScrollPosition position in _innerPositions) {
+      if (position.hasContentDimensions) {
+        maxInnerRange = math.max(
+          maxInnerRange,
+          position.maxScrollExtent - position.minScrollExtent,
+        );
+      }
+    }
+    return outerRange + maxInnerRange;
+  }
+
+  double get _unifiedPixels {
+    final _NestedScrollPosition? outer = _outerPosition;
+    if (outer == null || !outer.hasPixels) {
+      return 0.0;
+    }
+    final double outerOffset = outer.pixels - outer.minScrollExtent;
+    var innerOffset = 0.0;
+    var hasInner = false;
+    for (final _NestedScrollPosition position in _innerPositions) {
+      if (position.hasPixels && position.hasContentDimensions) {
+        final double offset = position.pixels - position.minScrollExtent;
+        // Use actual offset from first inner position, then max across all.
+        // This allows negative values (underscroll) to be captured for
+        // bouncing physics instead of being clamped to 0.
+        innerOffset = hasInner ? math.max(innerOffset, offset) : offset;
+        hasInner = true;
+      }
+    }
+    return outerOffset + innerOffset;
+  }
+
+  ScrollActivity? _currentUnifiedActivity;
+
+  void _beginUnifiedActivity(ScrollActivity activity) {
+    _currentUnifiedActivity?.dispose();
+    _currentUnifiedActivity = activity;
+    // When any position is out of range (e.g., during bounce-back from
+    // overscroll), shouldIgnorePointer must be false so that taps can reach
+    // content. The BallisticScrollActivity constructor may have already called
+    // setPixels (and thus setIgnorePointer(false)) synchronously, but
+    // beginActivity below would override that, so we check here.
+    bool anyOutOfRange = _outerPosition!.outOfRange;
+    if (!anyOutOfRange) {
+      for (final _NestedScrollPosition position in _innerPositions) {
+        if (position.hasContentDimensions && position.outOfRange) {
+          anyOutOfRange = true;
+          break;
+        }
+      }
+    }
+    final bool shouldIgnorePointer = !anyOutOfRange && activity.shouldIgnorePointer;
+    _outerPosition!.beginActivity(
+      _CoordinatedScrollActivity(
+        _outerPosition!,
+        shouldIgnorePointer: shouldIgnorePointer,
+        isScrolling: activity.isScrolling,
+      ),
+    );
+    for (final _NestedScrollPosition position in _innerPositions) {
+      position.beginActivity(
+        _CoordinatedScrollActivity(
+          position,
+          shouldIgnorePointer: shouldIgnorePointer,
+          isScrolling: activity.isScrolling,
+        ),
+      );
+    }
+  }
+
+  void _disposeUnifiedActivity() {
+    _currentUnifiedActivity?.dispose();
+    _currentUnifiedActivity = null;
+  }
+
   void updateShadow() {
     _onHasScrolledBodyChanged();
   }
@@ -699,6 +768,7 @@ class _NestedScrollCoordinator implements ScrollActivityDelegate, ScrollHoldCont
     ScrollActivity newOuterActivity,
     _NestedScrollActivityGetter innerActivityGetter,
   ) {
+    _disposeUnifiedActivity();
     _outerPosition!.beginActivity(newOuterActivity);
     bool scrolling = newOuterActivity.isScrolling;
     for (final _NestedScrollPosition position in _innerPositions) {
@@ -722,175 +792,108 @@ class _NestedScrollCoordinator implements ScrollActivityDelegate, ScrollHoldCont
 
   @override
   void goIdle() {
+    _disposeUnifiedActivity();
     beginActivity(_createIdleScrollActivity(_outerPosition!), _createIdleScrollActivity);
   }
 
   @override
   void goBallistic(double velocity) {
-    beginActivity(createOuterBallisticScrollActivity(velocity), (_NestedScrollPosition position) {
-      return createInnerBallisticScrollActivity(position, velocity);
-    });
-  }
+    _disposeUnifiedActivity();
+    _currentDrag?.dispose();
+    _currentDrag = null;
 
-  ScrollActivity createOuterBallisticScrollActivity(double velocity) {
-    // This function creates a ballistic scroll for the outer scrollable.
-    //
-    // It assumes that the outer scrollable can't be overscrolled, and sets up a
-    // ballistic scroll over the combined space of the innerPositions and the
-    // outerPosition.
+    if (_innerPositions.isEmpty || _outerPosition == null) {
+      // Fall back to independent ballistic on outer only.
+      if (_outerPosition != null) {
+        _outerPosition!.beginActivity(
+          _outerPosition!.createBallisticScrollActivity(
+            _outerPosition!.physics.createBallisticSimulation(_outerPosition!, velocity),
+          ),
+        );
+      }
+      return;
+    }
 
-    // First we must pick a representative inner position that we will care
-    // about. This is somewhat arbitrary. Ideally we'd pick the one that is "in
-    // the center" but there isn't currently a good way to do that so we
-    // arbitrarily pick the one that is the furthest away from the infinity we
-    // are heading towards.
-    _NestedScrollPosition? innerPosition;
-    if (velocity != 0.0) {
+    // If any position is currently out of range (e.g. from a bouncing drag
+    // that overscrolled), use independent ballistic activities so each
+    // position can recover its own overscroll independently.
+    bool anyOutOfRange = _outerPosition!.outOfRange;
+    if (!anyOutOfRange) {
       for (final _NestedScrollPosition position in _innerPositions) {
-        if (innerPosition != null) {
-          if (velocity > 0.0) {
-            if (innerPosition.pixels < position.pixels) {
-              continue;
-            }
-          } else {
-            assert(velocity < 0.0);
-            if (innerPosition.pixels > position.pixels) {
-              continue;
-            }
-          }
+        if (position.hasContentDimensions && position.outOfRange) {
+          anyOutOfRange = true;
+          break;
         }
-        innerPosition = position;
       }
     }
 
-    if (innerPosition == null) {
-      // It's either just us or a velocity=0 situation.
-      return _outerPosition!.createBallisticScrollActivity(
-        _outerPosition!.physics.createBallisticSimulation(_outerPosition!, velocity),
-        mode: _NestedBallisticScrollActivityMode.independent,
+    if (anyOutOfRange) {
+      // Only out-of-range positions get the velocity (for spring recovery).
+      // In-range positions get velocity 0 so they just idle.
+      final double outerVelocity = _outerPosition!.outOfRange ? velocity : 0.0;
+      beginActivity(
+        _outerPosition!.createBallisticScrollActivity(
+          _outerPosition!.physics.createBallisticSimulation(_outerPosition!, outerVelocity),
+        ),
+        (_NestedScrollPosition position) {
+          final double v = position.hasContentDimensions && position.outOfRange ? velocity : 0.0;
+          return position.createBallisticScrollActivity(
+            position.physics.createBallisticSimulation(position, v),
+          );
+        },
       );
+      return;
     }
 
-    final _NestedScrollMetrics metrics = _getMetrics(innerPosition, velocity);
-
-    return _outerPosition!.createBallisticScrollActivity(
-      _outerPosition!.physics.createBallisticSimulation(metrics, velocity),
-      mode: _NestedBallisticScrollActivityMode.outer,
-      metrics: metrics,
-    );
-  }
-
-  @protected
-  ScrollActivity createInnerBallisticScrollActivity(
-    _NestedScrollPosition position,
-    double velocity,
-  ) {
-    return position.createBallisticScrollActivity(
-      position.physics.createBallisticSimulation(_getMetrics(position, velocity), velocity),
-      mode: _NestedBallisticScrollActivityMode.inner,
-    );
-  }
-
-  _NestedScrollMetrics _getMetrics(_NestedScrollPosition innerPosition, double velocity) {
-    double pixels, minRange, maxRange, correctionOffset;
-    var extra = 0.0;
-    if (innerPosition.pixels == innerPosition.minScrollExtent) {
-      pixels = clampDouble(
-        _outerPosition!.pixels,
-        _outerPosition!.minScrollExtent,
-        _outerPosition!.maxScrollExtent,
-      ); // TODO(ianh): gracefully handle out-of-range outer positions
-      minRange = _outerPosition!.minScrollExtent;
-      maxRange = _outerPosition!.maxScrollExtent;
-      assert(minRange <= maxRange);
-      correctionOffset = 0.0;
-    } else {
-      assert(innerPosition.pixels != innerPosition.minScrollExtent);
-      if (innerPosition.pixels < innerPosition.minScrollExtent) {
-        pixels =
-            innerPosition.pixels - innerPosition.minScrollExtent + _outerPosition!.minScrollExtent;
-      } else {
-        assert(innerPosition.pixels > innerPosition.minScrollExtent);
-        pixels =
-            innerPosition.pixels - innerPosition.minScrollExtent + _outerPosition!.maxScrollExtent;
-      }
-      if ((velocity > 0.0) && (innerPosition.pixels > innerPosition.minScrollExtent)) {
-        // This handles going forward (fling up) and inner list is scrolled past
-        // zero. We want to grab the extra pixels immediately to shrink.
-        extra = _outerPosition!.maxScrollExtent - _outerPosition!.pixels;
-        assert(extra >= 0.0);
-        minRange = pixels;
-        maxRange = pixels + extra;
-        assert(minRange <= maxRange);
-        correctionOffset = _outerPosition!.pixels - pixels;
-      } else if ((velocity < 0.0) && (innerPosition.pixels < innerPosition.minScrollExtent)) {
-        // This handles going backward (fling down) and inner list is
-        // underscrolled. We want to grab the extra pixels immediately to grow.
-        extra = _outerPosition!.pixels - _outerPosition!.minScrollExtent;
-        assert(extra >= 0.0);
-        minRange = pixels - extra;
-        maxRange = pixels;
-        assert(minRange <= maxRange);
-        correctionOffset = _outerPosition!.pixels - pixels;
-      } else {
-        // This handles going forward (fling up) and inner list is
-        // underscrolled, OR, going backward (fling down) and inner list is
-        // scrolled past zero. We want to skip the pixels we don't need to grow
-        // or shrink over.
-        if (velocity > 0.0) {
-          // shrinking
-          extra = _outerPosition!.minScrollExtent - _outerPosition!.pixels;
-        } else if (velocity < 0.0) {
-          // growing
-          extra =
-              _outerPosition!.pixels -
-              (_outerPosition!.maxScrollExtent - _outerPosition!.minScrollExtent);
-        }
-        assert(extra <= 0.0);
-        minRange = _outerPosition!.minScrollExtent;
-        maxRange = _outerPosition!.maxScrollExtent + extra;
-        assert(minRange <= maxRange);
-        correctionOffset = 0.0;
-      }
-    }
-    return _NestedScrollMetrics(
-      minScrollExtent: _outerPosition!.minScrollExtent,
-      maxScrollExtent:
-          _outerPosition!.maxScrollExtent +
-          innerPosition.maxScrollExtent -
-          innerPosition.minScrollExtent +
-          extra,
-      pixels: pixels,
+    final metrics = FixedScrollMetrics(
+      minScrollExtent: _unifiedMinScrollExtent,
+      maxScrollExtent: _unifiedMaxScrollExtent,
+      pixels: _unifiedPixels,
       viewportDimension: _outerPosition!.viewportDimension,
       axisDirection: _outerPosition!.axisDirection,
-      minRange: minRange,
-      maxRange: maxRange,
-      correctionOffset: correctionOffset,
       devicePixelRatio: _outerPosition!.devicePixelRatio,
     );
+
+    final Simulation? simulation = _outerPosition!.physics.createBallisticSimulation(
+      metrics,
+      velocity,
+    );
+
+    if (simulation != null) {
+      final activity = BallisticScrollActivity(
+        this,
+        simulation,
+        _outerPosition!.context.vsync,
+        _outerPosition!.shouldIgnorePointer,
+      );
+      _beginUnifiedActivity(activity);
+    } else {
+      goIdle();
+    }
   }
 
   double unnestOffset(double value, _NestedScrollPosition source) {
     if (source == _outerPosition) {
-      return clampDouble(value, _outerPosition!.minScrollExtent, _outerPosition!.maxScrollExtent);
+      return clampDouble(
+        value - _outerPosition!.minScrollExtent,
+        _unifiedMinScrollExtent,
+        _unifiedMaxScrollExtent,
+      );
     }
-    if (value < source.minScrollExtent) {
-      return value - source.minScrollExtent + _outerPosition!.minScrollExtent;
-    }
-    return value - source.minScrollExtent + _outerPosition!.maxScrollExtent;
+    final double outerRange = _outerPosition!.maxScrollExtent - _outerPosition!.minScrollExtent;
+    return outerRange + (value - source.minScrollExtent);
   }
 
   double nestOffset(double value, _NestedScrollPosition target) {
     if (target == _outerPosition) {
-      return clampDouble(value, _outerPosition!.minScrollExtent, _outerPosition!.maxScrollExtent);
+      return clampDouble(
+        _outerPosition!.minScrollExtent + value,
+        _outerPosition!.minScrollExtent,
+        _outerPosition!.maxScrollExtent,
+      );
     }
-    if (value < _outerPosition!.minScrollExtent) {
-      return value - _outerPosition!.minScrollExtent + target.minScrollExtent;
-    }
-    if (value > _outerPosition!.maxScrollExtent) {
-      return value - _outerPosition!.maxScrollExtent + target.minScrollExtent;
-    }
-    return target.minScrollExtent;
+    final double outerRange = _outerPosition!.maxScrollExtent - _outerPosition!.minScrollExtent;
+    return target.minScrollExtent + math.max(0.0, value - outerRange);
   }
 
   void updateCanDrag() {
@@ -913,23 +916,18 @@ class _NestedScrollCoordinator implements ScrollActivityDelegate, ScrollHoldCont
     _outerPosition!.updateCanDrag(innerCanDrag);
   }
 
-  Future<void> animateTo(double to, {required Duration duration, required Curve curve}) async {
-    final DrivenScrollActivity outerActivity = _outerPosition!.createDrivenScrollActivity(
-      nestOffset(to, _outerPosition!),
-      duration,
-      curve,
+  Future<void> animateTo(double to, {required Duration duration, required Curve curve}) {
+    goIdle();
+    final activity = DrivenScrollActivity(
+      this,
+      from: _unifiedPixels,
+      to: to,
+      duration: duration,
+      curve: curve,
+      vsync: _outerPosition!.context.vsync,
     );
-    final resultFutures = <Future<void>>[outerActivity.done];
-    beginActivity(outerActivity, (_NestedScrollPosition position) {
-      final DrivenScrollActivity innerActivity = position.createDrivenScrollActivity(
-        nestOffset(to, position),
-        duration,
-        curve,
-      );
-      resultFutures.add(innerActivity.done);
-      return innerActivity;
-    });
-    await Future.wait<void>(resultFutures);
+    _beginUnifiedActivity(activity);
+    return activity.done;
   }
 
   void jumpTo(double to) {
@@ -950,7 +948,6 @@ class _NestedScrollCoordinator implements ScrollActivityDelegate, ScrollHoldCont
       return;
     }
 
-    goIdle();
     updateUserScrollDirection(delta < 0.0 ? ScrollDirection.forward : ScrollDirection.reverse);
 
     // Handle notifications. Even if only one position actually receives
@@ -963,6 +960,39 @@ class _NestedScrollCoordinator implements ScrollActivityDelegate, ScrollHoldCont
       position.didStartScroll();
     }
 
+    // 1. Try retargeting an existing smooth scroll activity.
+    if (_currentUnifiedActivity is RetargetableScrollActivity) {
+      (_currentUnifiedActivity! as RetargetableScrollActivity).retarget(
+        delta,
+        const PointerScrollDetails(PointerDeviceKind.mouse),
+      );
+    }
+    // 2. Try creating a new smooth scroll activity from physics.
+    else {
+      final ScrollActivity? activity = _outerPosition!.physics.createScrollActivity(
+        this,
+        _unifiedPixels,
+        delta,
+        const PointerScrollDetails(PointerDeviceKind.mouse),
+      );
+      if (activity != null) {
+        _beginUnifiedActivity(activity);
+      } else {
+        // 3. Fallback: delta-based distribution (current behavior).
+        _applyPointerScrollDelta(delta);
+      }
+    }
+
+    _outerPosition!.didEndScroll();
+    for (final _NestedScrollPosition position in _innerPositions) {
+      position.didEndScroll();
+    }
+    goBallistic(0.0);
+  }
+
+  // Delta-based pointer scroll distribution, extracted from the original
+  // pointerScroll implementation. Handles floatHeaderSlivers correctly.
+  void _applyPointerScrollDelta(double delta) {
     if (_innerPositions.isEmpty) {
       // Does not enter overscroll.
       _outerPosition!.applyClampedPointerSignalUpdate(delta);
@@ -1011,18 +1041,47 @@ class _NestedScrollCoordinator implements ScrollActivityDelegate, ScrollHoldCont
         }
       }
     }
-
-    _outerPosition!.didEndScroll();
-    for (final _NestedScrollPosition position in _innerPositions) {
-      position.didEndScroll();
-    }
-    goBallistic(0.0);
   }
 
   @override
   double setPixels(double newPixels) {
-    assert(false);
-    return 0.0;
+    final _NestedScrollPosition? outer = _outerPosition;
+    if (outer == null || !outer.hasContentDimensions) {
+      return 0.0;
+    }
+
+    final double outerMin = outer.minScrollExtent;
+    final double outerMax = outer.maxScrollExtent;
+
+    // Clamp to the unified scroll range and compute overscroll.
+    // Returning non-zero overscroll causes BallisticScrollActivity to stop
+    // at the boundary, preventing BouncingScrollPhysics from producing
+    // large visible bounce on individual positions.
+    // Drag-caused overscroll is handled separately by the independent
+    // ballistic fallback in goBallistic (the anyOutOfRange path).
+    final double clamped = clampDouble(newPixels, 0.0, _unifiedMaxScrollExtent);
+    final double overscroll = newPixels - clamped;
+
+    // Distribute the clamped value: outer consumes first, inner gets remainder.
+    final double targetOuter = clampDouble(outerMin + clamped, outerMin, outerMax);
+    final double targetInnerOffset = clamped - (targetOuter - outerMin);
+
+    if (outer.pixels != targetOuter) {
+      outer.updatePixels(targetOuter);
+    }
+
+    for (final _NestedScrollPosition position in _innerPositions) {
+      if (!position.hasContentDimensions) {
+        continue;
+      }
+      final double targetInner = position.minScrollExtent + targetInnerOffset;
+      if (position.pixels != targetInner) {
+        position.updatePixels(targetInner);
+      }
+    }
+
+    _onHasScrolledBodyChanged();
+    return overscroll;
   }
 
   ScrollHoldController hold(VoidCallback holdCancelCallback) {
@@ -1129,6 +1188,7 @@ class _NestedScrollCoordinator implements ScrollActivityDelegate, ScrollHoldCont
   @mustCallSuper
   void dispose() {
     assert(debugMaybeDispatchDisposed(this));
+    _disposeUnifiedActivity();
     _currentDrag?.dispose();
     _currentDrag = null;
     _outerController.dispose();
@@ -1381,48 +1441,14 @@ class _NestedScrollPosition extends ScrollPosition implements ScrollActivityDele
     if (velocity != 0.0 || outOfRange) {
       simulation = physics.createBallisticSimulation(this, velocity);
     }
-    beginActivity(
-      createBallisticScrollActivity(
-        simulation,
-        mode: _NestedBallisticScrollActivityMode.independent,
-      ),
-    );
+    beginActivity(createBallisticScrollActivity(simulation));
   }
 
-  ScrollActivity createBallisticScrollActivity(
-    Simulation? simulation, {
-    required _NestedBallisticScrollActivityMode mode,
-    _NestedScrollMetrics? metrics,
-  }) {
+  ScrollActivity createBallisticScrollActivity(Simulation? simulation) {
     if (simulation == null) {
       return IdleScrollActivity(this);
     }
-
-    switch (mode) {
-      case _NestedBallisticScrollActivityMode.outer:
-        assert(metrics != null);
-        if (metrics!.minRange == metrics.maxRange) {
-          return IdleScrollActivity(this);
-        }
-        return _NestedOuterBallisticScrollActivity(
-          coordinator,
-          this,
-          metrics,
-          simulation,
-          context.vsync,
-          shouldIgnorePointer,
-        );
-      case _NestedBallisticScrollActivityMode.inner:
-        return _NestedInnerBallisticScrollActivity(
-          coordinator,
-          this,
-          simulation,
-          context.vsync,
-          shouldIgnorePointer,
-        );
-      case _NestedBallisticScrollActivityMode.independent:
-        return BallisticScrollActivity(this, simulation, context.vsync, shouldIgnorePointer);
-    }
+    return BallisticScrollActivity(this, simulation, context.vsync, shouldIgnorePointer);
   }
 
   @override
@@ -1447,6 +1473,22 @@ class _NestedScrollPosition extends ScrollPosition implements ScrollActivityDele
   @override
   void jumpToWithoutSettling(double value) {
     assert(false);
+  }
+
+  @override
+  void dispose() {
+    // Dispose any coordinator-managed unified activity before this position's
+    // ScrollableState disposes its tickers. The unified BallisticScrollActivity
+    // uses the outer position's vsync, and children are disposed before parents
+    // in the widget tree, so the ticker must be stopped here.
+    coordinator._disposeUnifiedActivity();
+    super.dispose();
+  }
+
+  /// Update pixels from the coordinator. Wraps the @protected [forcePixels]
+  /// so the coordinator can call it without violating the annotation.
+  void updatePixels(double value) {
+    forcePixels(value);
   }
 
   void localJumpTo(double value) {
@@ -1484,100 +1526,6 @@ class _NestedScrollPosition extends ScrollPosition implements ScrollActivityDele
   @override
   Drag drag(DragStartDetails details, VoidCallback dragCancelCallback) {
     return coordinator.drag(details, dragCancelCallback);
-  }
-}
-
-enum _NestedBallisticScrollActivityMode { outer, inner, independent }
-
-class _NestedInnerBallisticScrollActivity extends BallisticScrollActivity {
-  _NestedInnerBallisticScrollActivity(
-    this.coordinator,
-    _NestedScrollPosition position,
-    Simulation simulation,
-    TickerProvider vsync,
-    bool shouldIgnorePointer,
-  ) : super(position, simulation, vsync, shouldIgnorePointer);
-
-  final _NestedScrollCoordinator coordinator;
-
-  @override
-  _NestedScrollPosition get delegate => super.delegate as _NestedScrollPosition;
-
-  @override
-  void resetActivity() {
-    delegate.beginActivity(coordinator.createInnerBallisticScrollActivity(delegate, velocity));
-  }
-
-  @override
-  void applyNewDimensions() {
-    delegate.beginActivity(coordinator.createInnerBallisticScrollActivity(delegate, velocity));
-  }
-
-  @override
-  bool applyMoveTo(double value) {
-    return super.applyMoveTo(coordinator.nestOffset(value, delegate));
-  }
-}
-
-class _NestedOuterBallisticScrollActivity extends BallisticScrollActivity {
-  _NestedOuterBallisticScrollActivity(
-    this.coordinator,
-    _NestedScrollPosition position,
-    this.metrics,
-    Simulation simulation,
-    TickerProvider vsync,
-    bool shouldIgnorePointer,
-  ) : assert(metrics.minRange != metrics.maxRange),
-      assert(metrics.maxRange > metrics.minRange),
-      super(position, simulation, vsync, shouldIgnorePointer);
-
-  final _NestedScrollCoordinator coordinator;
-  final _NestedScrollMetrics metrics;
-
-  @override
-  _NestedScrollPosition get delegate => super.delegate as _NestedScrollPosition;
-
-  @override
-  void resetActivity() {
-    delegate.beginActivity(coordinator.createOuterBallisticScrollActivity(velocity));
-  }
-
-  @override
-  void applyNewDimensions() {
-    delegate.beginActivity(coordinator.createOuterBallisticScrollActivity(velocity));
-  }
-
-  @override
-  bool applyMoveTo(double value) {
-    var done = false;
-    if (velocity > 0.0) {
-      if (value < metrics.minRange) {
-        return true;
-      }
-      if (value > metrics.maxRange) {
-        value = metrics.maxRange;
-        done = true;
-      }
-    } else if (velocity < 0.0) {
-      if (value > metrics.maxRange) {
-        return true;
-      }
-      if (value < metrics.minRange) {
-        value = metrics.minRange;
-        done = true;
-      }
-    } else {
-      value = clampDouble(value, metrics.minRange, metrics.maxRange);
-      done = true;
-    }
-    final bool result = super.applyMoveTo(value + metrics.correctionOffset);
-    assert(result); // since we tried to pass an in-range value, it shouldn't ever overflow
-    return !done;
-  }
-
-  @override
-  String toString() {
-    return '${objectRuntimeType(this, '_NestedOuterBallisticScrollActivity')}(${metrics.minRange} .. ${metrics.maxRange}; correcting by ${metrics.correctionOffset})';
   }
 }
 

--- a/packages/flutter/lib/src/widgets/scroll_activity.dart
+++ b/packages/flutter/lib/src/widgets/scroll_activity.dart
@@ -172,6 +172,59 @@ abstract class ScrollActivity {
   String toString() => describeIdentity(this);
 }
 
+/// Describes the source of a scroll input.
+///
+/// Used by [RetargetableScrollActivity] and [ScrollPhysics.createScrollActivity]
+/// to determine how to handle the scroll input.
+sealed class ScrollDetails {
+  /// Creates a [ScrollDetails].
+  const ScrollDetails();
+
+  /// Whether this scroll was initiated by a pointer device (mouse wheel, trackpad).
+  bool get isPointer => this is PointerScrollDetails;
+
+  /// Whether this scroll was initiated by a keyboard input.
+  bool get isKeyboard => this is KeyboardScrollDetails;
+
+  /// Whether this scroll was initiated programmatically.
+  bool get isProgrammatic => this is ProgrammaticScrollDetails;
+}
+
+/// Scroll details for pointer-device-initiated scrolling (e.g. mouse wheel).
+final class PointerScrollDetails extends ScrollDetails {
+  /// Creates pointer scroll details with the given [kind].
+  const PointerScrollDetails(this.kind);
+
+  /// The kind of pointer device that initiated the scroll.
+  final PointerDeviceKind kind;
+}
+
+/// Scroll details for keyboard-initiated scrolling.
+final class KeyboardScrollDetails extends ScrollDetails {
+  /// Creates keyboard scroll details.
+  const KeyboardScrollDetails();
+}
+
+/// Scroll details for programmatic scrolling.
+final class ProgrammaticScrollDetails extends ScrollDetails {
+  /// Creates programmatic scroll details.
+  const ProgrammaticScrollDetails();
+}
+
+/// A [ScrollActivity] that can be retargeted with additional scroll deltas.
+///
+/// This is used by scroll coordinators to allow smooth scrolling activities
+/// to absorb additional scroll input without restarting.
+abstract class RetargetableScrollActivity extends ScrollActivity {
+  /// Creates a retargetable scroll activity.
+  RetargetableScrollActivity(super.delegate);
+
+  /// Adjusts the activity's target by the given [delta].
+  ///
+  /// The [details] describe the source of the scroll input.
+  void retarget(double delta, ScrollDetails details);
+}
+
 /// A scroll activity that does nothing.
 ///
 /// When a scroll view is not scrolling, it is performing the idle activity.

--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -23,6 +23,7 @@ import 'package:flutter/physics.dart';
 import 'binding.dart' show WidgetsBinding;
 import 'framework.dart';
 import 'overscroll_indicator.dart';
+import 'scroll_activity.dart';
 import 'scroll_metrics.dart';
 import 'scroll_simulation.dart';
 import 'view.dart';
@@ -406,6 +407,23 @@ class ScrollPhysics {
   //     https://github.com/flutter/flutter/issues/109675
   Simulation? createBallisticSimulation(ScrollMetrics position, double velocity) {
     return parent?.createBallisticSimulation(position, velocity);
+  }
+
+  /// Returns a [ScrollActivity] for a discrete scroll input (e.g. pointer
+  /// scroll or keyboard) starting from the given position with the given delta.
+  ///
+  /// This is used by [NestedScrollView]'s coordinator to create smooth scroll
+  /// activities that can span the entire nested scroll extent.
+  ///
+  /// Returns `null` to indicate that the default behavior (an immediate jump)
+  /// should be used instead.
+  ScrollActivity? createScrollActivity(
+    ScrollActivityDelegate delegate,
+    double from,
+    double delta,
+    ScrollDetails details,
+  ) {
+    return parent?.createScrollActivity(delegate, from, delta, details);
   }
 
   static final SpringDescription _kDefaultSpring = SpringDescription.withDampingRatio(

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -3480,6 +3480,380 @@ void main() {
       areCreateAndDispose,
     );
   });
+
+  // ---- Unified offset model tests ----
+
+  testWidgets('Fling down continues from outer into inner', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/13496
+    // Regression test for https://github.com/flutter/flutter/issues/73864
+    final GlobalKey<NestedScrollViewState> globalKey = GlobalKey();
+    await tester.pumpWidget(buildTest(key: globalKey));
+
+    // Switch to the DD tab which has a long inner list (10000.0 height).
+    await tester.tap(find.text('DD'));
+    await tester.pumpAndSettle();
+
+    expect(globalKey.currentState!.outerController.offset, 0.0);
+    expect(globalKey.currentState!.innerController.offset, 0.0);
+
+    // Fling down (scroll content up) with enough velocity to pass outer extent.
+    await tester.fling(find.byType(NestedScrollView), const Offset(0.0, -800.0), 2000.0);
+    await tester.pumpAndSettle();
+
+    final double outerMax = globalKey.currentState!.outerController.position.maxScrollExtent;
+    expect(globalKey.currentState!.outerController.offset, outerMax);
+    expect(globalKey.currentState!.innerController.offset, greaterThan(0.0));
+  });
+
+  testWidgets('Fling up continues from inner back to outer', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/13496
+    // Regression test for https://github.com/flutter/flutter/issues/79067
+    final GlobalKey<NestedScrollViewState> globalKey = GlobalKey();
+    await tester.pumpWidget(buildTest(key: globalKey));
+
+    // Switch to the DD tab.
+    await tester.tap(find.text('DD'));
+    await tester.pumpAndSettle();
+
+    // First, scroll down past outer max via drag so inner has offset.
+    final double outerMax = globalKey.currentState!.outerController.position.maxScrollExtent;
+    final TestGesture gesture = await tester.startGesture(const Offset(400.0, 300.0));
+    await gesture.moveBy(Offset(0.0, -(outerMax + 200.0)));
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(globalKey.currentState!.outerController.offset, outerMax);
+    expect(globalKey.currentState!.innerController.offset, greaterThan(0.0));
+
+    // Fling up (scroll content down) with enough velocity.
+    await tester.fling(find.byType(NestedScrollView), const Offset(0.0, 800.0), 2000.0);
+    await tester.pumpAndSettle();
+
+    expect(globalKey.currentState!.innerController.offset, 0.0);
+    expect(globalKey.currentState!.outerController.offset, lessThan(outerMax));
+  });
+
+  testWidgets('Ballistic scrolling with BouncingScrollPhysics does not jank', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/73864
+    // Regression test for https://github.com/flutter/flutter/issues/52233
+    final GlobalKey<NestedScrollViewState> globalKey = GlobalKey();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: NestedScrollView(
+            key: globalKey,
+            physics: const BouncingScrollPhysics(),
+            headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
+              return <Widget>[
+                const SliverAppBar(
+                  expandedHeight: 200.0,
+                  pinned: true,
+                ),
+              ];
+            },
+            body: ListView.builder(
+              physics: const BouncingScrollPhysics(),
+              itemCount: 100,
+              itemBuilder: (BuildContext context, int index) {
+                return SizedBox(height: 50.0, child: Text('Item $index'));
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Record pixel values each frame.
+    final List<double> outerPixels = <double>[];
+    final List<double> innerPixels = <double>[];
+    void recordPositions() {
+      outerPixels.add(globalKey.currentState!.outerController.offset);
+      innerPixels.add(globalKey.currentState!.innerController.offset);
+    }
+
+    recordPositions();
+
+    // Fling down.
+    await tester.fling(find.byType(NestedScrollView), const Offset(0.0, -300.0), 1500.0);
+
+    // Pump frame by frame, recording positions.
+    for (int i = 0; i < 60; i++) {
+      await tester.pump(const Duration(milliseconds: 16));
+      recordPositions();
+    }
+
+    // Verify monotonic: combined offset (outer + inner) should never decrease
+    // during a downward fling.
+    final List<double> combined = <double>[];
+    for (int i = 0; i < outerPixels.length; i++) {
+      combined.add(outerPixels[i] + innerPixels[i]);
+    }
+    for (int i = 1; i < combined.length; i++) {
+      // Allow small floating point tolerance.
+      expect(
+        combined[i],
+        greaterThanOrEqualTo(combined[i - 1] - 0.01),
+        reason: 'Combined offset decreased from frame ${i - 1} to $i: '
+            '${combined[i - 1]} -> ${combined[i]}',
+      );
+    }
+  });
+
+  testWidgets('BouncingScrollPhysics allows overscroll on inner', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/79062
+    final GlobalKey<NestedScrollViewState> globalKey = GlobalKey();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: NestedScrollView(
+            key: globalKey,
+            physics: const BouncingScrollPhysics(),
+            headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
+              return <Widget>[
+                const SliverAppBar(
+                  expandedHeight: 200.0,
+                  pinned: true,
+                ),
+              ];
+            },
+            body: ListView(
+              physics: const BouncingScrollPhysics(),
+              children: const <Widget>[
+                SizedBox(height: 300.0, child: Text('item1')),
+                SizedBox(height: 300.0, child: Text('item2')),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // First scroll to the bottom so inner is at max.
+    final double outerMax = globalKey.currentState!.outerController.position.maxScrollExtent;
+    final TestGesture gesture = await tester.startGesture(const Offset(400.0, 300.0));
+    await gesture.moveBy(Offset(0.0, -(outerMax + 1000.0)));
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    // Now fling hard past inner maxScrollExtent.
+    await tester.fling(find.byType(NestedScrollView), const Offset(0.0, -500.0), 5000.0);
+    // Pump a few frames (not settle) to catch overscroll in progress.
+    for (int i = 0; i < 5; i++) {
+      await tester.pump(const Duration(milliseconds: 16));
+    }
+
+    final double innerMax = globalKey.currentState!.innerController.position.maxScrollExtent;
+    final double innerPixels = globalKey.currentState!.innerController.offset;
+    expect(innerPixels, greaterThan(innerMax));
+
+    // Let it bounce back.
+    await tester.pumpAndSettle();
+    expect(globalKey.currentState!.innerController.offset, moreOrLessEquals(innerMax, epsilon: 1.0));
+  });
+
+  testWidgets('shouldIgnorePointer is false during bounce-back', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/82150
+    final GlobalKey<NestedScrollViewState> globalKey = GlobalKey();
+    bool tapped = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: NestedScrollView(
+            key: globalKey,
+            physics: const BouncingScrollPhysics(),
+            headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
+              return <Widget>[
+                const SliverAppBar(
+                  expandedHeight: 200.0,
+                  pinned: true,
+                ),
+              ];
+            },
+            body: ListView(
+              physics: const BouncingScrollPhysics(),
+              children: <Widget>[
+                GestureDetector(
+                  onTap: () => tapped = true,
+                  child: const SizedBox(height: 600.0, child: Text('Tap me')),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Fling past the end to create overscroll.
+    final double outerMax = globalKey.currentState!.outerController.position.maxScrollExtent;
+    final TestGesture gesture = await tester.startGesture(const Offset(400.0, 300.0));
+    await gesture.moveBy(Offset(0.0, -(outerMax + 1000.0)));
+    await tester.pump();
+    await gesture.up();
+    await tester.pump();
+
+    // Now fling hard to overscroll.
+    await tester.fling(find.byType(NestedScrollView), const Offset(0.0, -300.0), 3000.0);
+    // Pump a few frames to get into bounce-back.
+    for (int i = 0; i < 10; i++) {
+      await tester.pump(const Duration(milliseconds: 16));
+    }
+
+    // During bounce-back, tap on the GestureDetector.
+    await tester.tap(find.text('Tap me'), warnIfMissed: false);
+    await tester.pumpAndSettle();
+
+    expect(tapped, isTrue);
+  });
+
+  testWidgets('setPixels distributes to outer first then inner', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/136199
+    final GlobalKey<NestedScrollViewState> globalKey = GlobalKey();
+    await tester.pumpWidget(buildTest(key: globalKey));
+
+    // Switch to the DD tab which has a long inner list.
+    await tester.tap(find.text('DD'));
+    await tester.pumpAndSettle();
+
+    final double outerMax = globalKey.currentState!.outerController.position.maxScrollExtent;
+
+    // Record transitions: outer should reach max before inner starts moving.
+    final List<double> outerValues = <double>[];
+    final List<double> innerValues = <double>[];
+
+    void listener() {
+      outerValues.add(globalKey.currentState!.outerController.offset);
+      innerValues.add(globalKey.currentState!.innerController.offset);
+    }
+
+    globalKey.currentState!.outerController.addListener(listener);
+    globalKey.currentState!.innerController.addListener(listener);
+
+    // animateTo a unified offset past outer max.
+    final double target = outerMax + 200.0;
+    globalKey.currentState!.innerController.animateTo(
+      target,
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.linear,
+    );
+
+    await tester.pumpAndSettle();
+
+    globalKey.currentState!.outerController.removeListener(listener);
+    globalKey.currentState!.innerController.removeListener(listener);
+
+    // Find the first frame where inner > 0 and verify outer is at max.
+    bool foundInnerMoving = false;
+    for (int i = 0; i < innerValues.length; i++) {
+      if (innerValues[i] > 0.0) {
+        foundInnerMoving = true;
+        // At this point, outer should be at max.
+        expect(
+          outerValues[i],
+          moreOrLessEquals(outerMax, epsilon: 1.0),
+          reason: 'Outer should be at max when inner starts moving',
+        );
+        break;
+      }
+    }
+    expect(foundInnerMoving, isTrue, reason: 'Inner should have moved past 0');
+  });
+
+  testWidgets('animateTo scrolls both outer and inner smoothly', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/93818
+    final GlobalKey<NestedScrollViewState> globalKey = GlobalKey();
+    await tester.pumpWidget(buildTest(key: globalKey));
+
+    // Switch to the DD tab.
+    await tester.tap(find.text('DD'));
+    await tester.pumpAndSettle();
+
+    final double outerMax = globalKey.currentState!.outerController.position.maxScrollExtent;
+    const double innerTarget = 100.0;
+    // Inner controller animateTo with a value past outer range should move both.
+    // The inner controller's animateTo maps to unified offset via unnestOffset.
+    globalKey.currentState!.innerController.animateTo(
+      innerTarget,
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.linear,
+    );
+    await tester.pumpAndSettle();
+
+    // Outer should be at max, inner should be at innerTarget.
+    expect(globalKey.currentState!.outerController.offset, moreOrLessEquals(outerMax, epsilon: 1.0));
+    expect(
+      globalKey.currentState!.innerController.offset,
+      moreOrLessEquals(innerTarget, epsilon: 1.0),
+    );
+  });
+
+  testWidgets('animateTo completes future when animation finishes', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/93818
+    final GlobalKey<NestedScrollViewState> globalKey = GlobalKey();
+    await tester.pumpWidget(buildTest(key: globalKey));
+
+    // Switch to the DD tab.
+    await tester.tap(find.text('DD'));
+    await tester.pumpAndSettle();
+
+    bool futureCompleted = false;
+    globalKey.currentState!.innerController.animateTo(
+      200.0,
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.linear,
+    ).then((_) {
+      futureCompleted = true;
+    });
+
+    expect(futureCompleted, isFalse);
+    await tester.pumpAndSettle();
+    expect(futureCompleted, isTrue);
+  });
+
+  testWidgets('Pointer scroll falls back to delta distribution', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/63948
+    // Regression test for https://github.com/flutter/flutter/issues/151459
+    final GlobalKey<NestedScrollViewState> globalKey = GlobalKey();
+    await tester.pumpWidget(buildTest(key: globalKey));
+
+    // Switch to the DD tab.
+    await tester.tap(find.text('DD'));
+    await tester.pumpAndSettle();
+
+    expect(globalKey.currentState!.outerController.offset, 0.0);
+    expect(globalKey.currentState!.innerController.offset, 0.0);
+
+    final testPointer = TestPointer(1, ui.PointerDeviceKind.mouse);
+    testPointer.hover(const Offset(400.0, 300.0));
+
+    // Scroll a small amount — should go to outer first.
+    await tester.sendEventToBinding(testPointer.scroll(const Offset(0.0, 50.0)));
+    await tester.pump();
+
+    expect(globalKey.currentState!.outerController.offset, 50.0);
+    expect(globalKey.currentState!.innerController.offset, 0.0);
+
+    // Scroll past outer max.
+    final double outerMax = globalKey.currentState!.outerController.position.maxScrollExtent;
+    final double remaining = outerMax - 50.0;
+    await tester.sendEventToBinding(testPointer.scroll(Offset(0.0, remaining + 30.0)));
+    await tester.pump();
+
+    expect(
+      globalKey.currentState!.outerController.offset,
+      moreOrLessEquals(outerMax, epsilon: 1.0),
+    );
+    expect(globalKey.currentState!.innerController.offset, moreOrLessEquals(30.0, epsilon: 1.0));
+  });
 }
 
 double appBarHeight(WidgetTester tester) =>

--- a/packages/flutter/test/widgets/scroll_activity_test.dart
+++ b/packages/flutter/test/widgets/scroll_activity_test.dart
@@ -361,6 +361,39 @@ void main() {
       areCreateAndDispose,
     );
   });
+
+  test('ScrollDetails type checks', () {
+    const PointerScrollDetails pointer = PointerScrollDetails(PointerDeviceKind.mouse);
+    expect(pointer.isPointer, isTrue);
+    expect(pointer.isKeyboard, isFalse);
+    expect(pointer.isProgrammatic, isFalse);
+
+    const KeyboardScrollDetails keyboard = KeyboardScrollDetails();
+    expect(keyboard.isPointer, isFalse);
+    expect(keyboard.isKeyboard, isTrue);
+    expect(keyboard.isProgrammatic, isFalse);
+
+    const ProgrammaticScrollDetails programmatic = ProgrammaticScrollDetails();
+    expect(programmatic.isPointer, isFalse);
+    expect(programmatic.isKeyboard, isFalse);
+    expect(programmatic.isProgrammatic, isTrue);
+  });
+
+  test('PointerScrollDetails stores pointer device kind', () {
+    const PointerScrollDetails mouse = PointerScrollDetails(PointerDeviceKind.mouse);
+    expect(mouse.kind, PointerDeviceKind.mouse);
+
+    const PointerScrollDetails trackpad = PointerScrollDetails(PointerDeviceKind.trackpad);
+    expect(trackpad.kind, PointerDeviceKind.trackpad);
+  });
+
+  test('RetargetableScrollActivity.retarget is callable', () {
+    final delegate = _ScrollActivityDelegate();
+    final activity = _TestRetargetableScrollActivity(delegate);
+    // Calling retarget should not throw.
+    activity.retarget(10.0, const PointerScrollDetails(PointerDeviceKind.mouse));
+    activity.dispose();
+  });
 }
 
 class PageView62209 extends StatefulWidget {
@@ -558,4 +591,22 @@ class _ScrollActivityDelegate extends ScrollActivityDelegate {
 
   @override
   double setPixels(double pixels) => 0.0;
+}
+
+class _TestRetargetableScrollActivity extends RetargetableScrollActivity {
+  _TestRetargetableScrollActivity(super.delegate);
+
+  @override
+  void retarget(double delta, ScrollDetails details) {
+    // No-op for testing.
+  }
+
+  @override
+  bool get shouldIgnorePointer => false;
+
+  @override
+  bool get isScrolling => false;
+
+  @override
+  double get velocity => 0.0;
 }

--- a/packages/flutter/test/widgets/scroll_physics_test.dart
+++ b/packages/flutter/test/widgets/scroll_physics_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class TestScrollPhysics extends ScrollPhysics {
@@ -366,4 +367,64 @@ FlutterError
     );
     await tester.fling(find.text('Index 2'), const Offset(0.0, -300.0), 10000.0);
   });
+
+  test('ScrollPhysics.createScrollActivity returns null by default', () {
+    const ScrollPhysics physics = ScrollPhysics();
+    final ScrollActivity? activity = physics.createScrollActivity(
+      _TestScrollActivityDelegate(),
+      0.0,
+      10.0,
+      const ProgrammaticScrollDetails(),
+    );
+    expect(activity, isNull);
+  });
+
+  test('createScrollActivity delegates to parent', () {
+    const _NonNullCreateScrollActivityPhysics parent = _NonNullCreateScrollActivityPhysics();
+    final ScrollPhysics child = const ScrollPhysics().applyTo(parent);
+    final ScrollActivity? activity = child.createScrollActivity(
+      _TestScrollActivityDelegate(),
+      0.0,
+      10.0,
+      const ProgrammaticScrollDetails(),
+    );
+    expect(activity, isNotNull);
+    activity!.dispose();
+  });
+}
+
+class _TestScrollActivityDelegate implements ScrollActivityDelegate {
+  @override
+  AxisDirection get axisDirection => AxisDirection.down;
+
+  @override
+  void applyUserOffset(double delta) {}
+
+  @override
+  void goBallistic(double velocity) {}
+
+  @override
+  void goIdle() {}
+
+  @override
+  double setPixels(double pixels) => 0.0;
+}
+
+class _NonNullCreateScrollActivityPhysics extends ScrollPhysics {
+  const _NonNullCreateScrollActivityPhysics({super.parent});
+
+  @override
+  _NonNullCreateScrollActivityPhysics applyTo(ScrollPhysics? ancestor) {
+    return _NonNullCreateScrollActivityPhysics(parent: buildParent(ancestor));
+  }
+
+  @override
+  ScrollActivity? createScrollActivity(
+    ScrollActivityDelegate delegate,
+    double from,
+    double delta,
+    ScrollDetails details,
+  ) {
+    return IdleScrollActivity(delegate);
+  }
 }


### PR DESCRIPTION
Rewrites the NestedScrollView coordinator to use a single unified scroll offset distributed across outer and inner positions, replacing the previous independent-position model that caused discontinuities at the outer/inner boundary.

Key changes:
- Unified offset model: setPixels distributes delta to outer first, then inner, ensuring continuous momentum across the boundary.
- BouncingScrollPhysics: overscroll is applied only to the active endpoint (top of outer or bottom of inner), eliminating the double-overscroll that caused extreme jank.
- animateTo: drives a single animation on the coordinator position, distributing each frame's delta across outer+inner so animations can cross the header/body boundary smoothly.
- Fling continuity: ballistic simulations now carry momentum from outer into inner and vice versa without velocity loss.
- ScrollActivity: adds NestedBallisticScrollActivity and NestedDrivenScrollActivity to support coordinator-driven motion.
- ScrollPhysics: adds toleranceFor() to expose Tolerance for a given ScrollMetrics without requiring a full simulation.

Fixes #13496, #136199, #59440, #73864, #52233, #33367, #79062, #82150, #129119, #93818, #84128, #63948, #63978.

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
