### PR TITLE
Remove `FML_DCHECK` around `CanReactOnCurrentThread()` in `ReactorGLES::CreateUntrackedHandle()

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/gles/reactor_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/reactor_gles.cc
@@ -201,7 +201,7 @@ bool ReactorGLES::RegisterCleanupCallback(const HandleGLES& handle,
 }
 
 HandleGLES ReactorGLES::CreateUntrackedHandle(HandleType type) const {
-  bool can_react = CanReactOnCurrentThread();
+  [[maybe_unused]] bool can_react = CanReactOnCurrentThread();
   FML_DCHECK(can_react);
   auto new_handle = HandleGLES::Create(type);
   std::optional<ReactorGLES::GLStorage> gl_handle =

--- a/engine/src/flutter/impeller/renderer/backend/gles/reactor_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/reactor_gles.cc
@@ -201,7 +201,8 @@ bool ReactorGLES::RegisterCleanupCallback(const HandleGLES& handle,
 }
 
 HandleGLES ReactorGLES::CreateUntrackedHandle(HandleType type) const {
-  FML_DCHECK(CanReactOnCurrentThread());
+  bool can_react = CanReactOnCurrentThread();
+  FML_DCHECK(can_react);
   auto new_handle = HandleGLES::Create(type);
   std::optional<ReactorGLES::GLStorage> gl_handle =
       CreateGLHandle(GetProcTable(), type);

--- a/engine/src/flutter/testing/run_tests.py
+++ b/engine/src/flutter/testing/run_tests.py
@@ -937,6 +937,7 @@ def gather_dart_tests(
   dart_tests = glob.glob(f'{dart_tests_dir}/*_test.dart')
 
   opengles_skipped_tests = [
+      'codec_test.dart',
       'gpu_test.dart',
       'high_bitrate_texture_test.dart',
   ]

--- a/engine/src/flutter/testing/run_tests.py
+++ b/engine/src/flutter/testing/run_tests.py
@@ -937,13 +937,8 @@ def gather_dart_tests(
   dart_tests = glob.glob(f'{dart_tests_dir}/*_test.dart')
 
   opengles_skipped_tests = [
-      'codec_test.dart',
-      'decode_image_from_pixels_sync_test.dart',
-      'encoding_test.dart',
       'gpu_test.dart',
       'high_bitrate_texture_test.dart',
-      'image_dispose_test.dart',
-      'image_resize_test.dart',
   ]
 
   impeller_backends = ['', 'vulkan', 'opengles']


### PR DESCRIPTION
`ReactorGLES::CreateUntrackedHandle()` requires the current thread to have the current opengles context. In environments that use `SwitchableGLContext`, calling `CanReactOnCurrentThread()` has the side effect of setting the current opengles context. So it must be called. Having it inside `FML_DCHECK` made the call only happen in unopt builds, resulting in https://github.com/flutter/flutter/issues/182105.

Makes progress on https://github.com/flutter/flutter/issues/182105. The `GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT ` issues no longer happen. Newly passing tests:
```
decode_image_from_pixels_sync_test.dart
encoding_test.dart
image_dispose_test.dart
image_resize_test.dart
```

`codec_test.dart` no longer has the `GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT ` error, but still fails. It passes on mac, but on linux it fails with:
```
[ERROR:flutter/impeller/renderer/backend/gles/blit_command_gles.cc(343)] Break on 'ImpellerValidationBreak' to inspect point of failure: Only textures with pixel format RGBA are supported yet.
[FATAL:flutter/impeller/renderer/backend/gles/blit_pass_gles.cc(88)] Check failed: result. Must be able to encode GL commands without error.
```

I have a pending fix for this which I will send out afterwards.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
