### PR TITLE
Eliminate rebuilds for Scaffold FAB animation

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -997,14 +997,14 @@ class _ScaffoldLayout extends MultiChildLayoutDelegate {
     // for floating action button
     required this.previousFloatingActionButtonLocation,
     required this.currentFloatingActionButtonLocation,
-    required this.floatingActionButtonMoveAnimationProgress,
+    required this.floatingActionButtonMoveAnimation,
     required this.floatingActionButtonMotionAnimator,
     required this.isSnackBarFloating,
     required this.snackBarWidth,
     required this.extendBody,
     required this.extendBodyBehindAppBar,
     required this.extendBodyBehindMaterialBanner,
-  });
+  }) : super(relayout: floatingActionButtonMoveAnimation);
 
   final bool extendBody;
   final bool extendBodyBehindAppBar;
@@ -1015,7 +1015,7 @@ class _ScaffoldLayout extends MultiChildLayoutDelegate {
 
   final FloatingActionButtonLocation previousFloatingActionButtonLocation;
   final FloatingActionButtonLocation currentFloatingActionButtonLocation;
-  final double floatingActionButtonMoveAnimationProgress;
+  final ValueListenable<double> floatingActionButtonMoveAnimation;
   final FloatingActionButtonAnimator floatingActionButtonMotionAnimator;
 
   final bool isSnackBarFloating;
@@ -1185,7 +1185,7 @@ class _ScaffoldLayout extends MultiChildLayoutDelegate {
       final Offset fabOffset = floatingActionButtonMotionAnimator.getOffset(
         begin: previousFabOffset,
         end: currentFabOffset,
-        progress: floatingActionButtonMoveAnimationProgress,
+        progress: floatingActionButtonMoveAnimation.value,
       );
       positionChild(_ScaffoldSlot.floatingActionButton, fabOffset);
       floatingActionButtonRect = fabOffset & fabSize;
@@ -1300,8 +1300,6 @@ class _ScaffoldLayout extends MultiChildLayoutDelegate {
     return oldDelegate.minInsets != minInsets ||
         oldDelegate.minViewPadding != minViewPadding ||
         oldDelegate.textDirection != textDirection ||
-        oldDelegate.floatingActionButtonMoveAnimationProgress !=
-            floatingActionButtonMoveAnimationProgress ||
         oldDelegate.previousFloatingActionButtonLocation != previousFloatingActionButtonLocation ||
         oldDelegate.currentFloatingActionButtonLocation != currentFloatingActionButtonLocation ||
         oldDelegate.extendBody != extendBody ||
@@ -3237,9 +3235,8 @@ class ScaffoldState extends State<Scaffold>
       child: ScrollNotificationObserver(
         child: Material(
           color: widget.backgroundColor ?? themeData.scaffoldBackgroundColor,
-          child: AnimatedBuilder(
-            animation: _floatingActionButtonMoveController,
-            builder: (BuildContext context, Widget? child) {
+          child: Builder(
+            builder: (BuildContext context) {
               return Actions(
                 actions: <Type, Action<Intent>>{DismissIntent: _DismissDrawerAction(context)},
                 child: CustomMultiChildLayout(
@@ -3249,8 +3246,7 @@ class ScaffoldState extends State<Scaffold>
                     minInsets: minInsets,
                     minViewPadding: minViewPadding,
                     currentFloatingActionButtonLocation: _floatingActionButtonLocation!,
-                    floatingActionButtonMoveAnimationProgress:
-                        _floatingActionButtonMoveController.value,
+                    floatingActionButtonMoveAnimation: _floatingActionButtonMoveController,
                     floatingActionButtonMotionAnimator: _floatingActionButtonAnimator,
                     geometryNotifier: _geometryNotifier,
                     previousFloatingActionButtonLocation: _previousFloatingActionButtonLocation!,

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -3684,6 +3684,55 @@ void main() {
     expect(find.byType(FloatingActionButton), findsNothing);
   });
 
+  testWidgets('Scaffold FAB animates without rebuilding', (WidgetTester tester) async {
+    bool? dirty;
+    bool? checkDirty() {
+      final Finder finder = find.descendant(
+        of: find.byType(ScrollNotificationObserver),
+        matching: find.ancestor(
+          of: find.byType(CustomMultiChildLayout),
+          matching: find.byWidgetPredicate((widget) {
+            return widget is AnimatedBuilder || widget is Builder;
+          }),
+        ),
+      );
+      return finder.tryEvaluate() ? tester.element(finder).dirty : null;
+    }
+
+    final fabLocation = ValueNotifier<FloatingActionButtonLocation>(.centerDocked);
+    const builderKey = Key('Builder');
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ValueListenableBuilder(
+          key: builderKey,
+          valueListenable: fabLocation,
+          builder: (context, location, child) {
+            dirty = checkDirty();
+
+            return Scaffold(
+              body: const SizedBox.expand(),
+              floatingActionButton: FloatingActionButton(onPressed: () {}),
+              floatingActionButtonLocation: location,
+            );
+          },
+        ),
+      ),
+    );
+
+    // Switch the FAB location to trigger the animation.
+    fabLocation.value = .endFloat;
+    await tester.pump(Durations.short1);
+
+    // Trigger a rebuild to update the "dirty" value.
+    tester.element(find.byKey(builderKey)).markNeedsBuild();
+    await tester.pump(Durations.short1);
+
+    // The element that builds the Scaffold's CustomMultiChildLayout should not be dirty.
+    expect(dirty, isFalse);
+
+    fabLocation.dispose();
+  });
+
   testWidgets('Scaffold background color defaults to ColorScheme.surface', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION
This PR contains a tweak to the Scaffold widget's internal logic, reducing the amount of work that needs to be performed each time the FAB animation updates.

resolves #182330