### PR TITLE
`AnimationStyle` methods

### DIFF
--- a/packages/flutter/lib/src/animation/animation_style.dart
+++ b/packages/flutter/lib/src/animation/animation_style.dart
@@ -71,11 +71,39 @@ class AnimationStyle with Diagnosticable {
       return a;
     }
     return AnimationStyle(
-      curve: t < 0.5 ? a?.curve : b?.curve,
-      duration: t < 0.5 ? a?.duration : b?.duration,
-      reverseCurve: t < 0.5 ? a?.reverseCurve : b?.reverseCurve,
-      reverseDuration: t < 0.5 ? a?.reverseDuration : b?.reverseDuration,
+      curve: _lerpCurve(a?.curve, b?.curve, t),
+      duration: _lerpDuration(a?.duration, b?.duration, t),
+      reverseCurve: _lerpCurve(a?.reverseCurve, b?.reverseCurve, t),
+      reverseDuration: _lerpDuration(a?.reverseDuration, b?.reverseDuration, t),
     );
+  }
+  
+  static Duration? _lerpDuration(Duration? a, Duration? b, double t) {
+    if (t == 0.0) {
+      return a;
+    }
+    if (t == 1.0) {
+      return b;
+    }
+    if (a == null || b == null) {
+      return a ?? b;
+    }
+    return Duration(
+      microseconds: (a.inMicroseconds * (1.0 - t) + b.inMicroseconds * t).round(),
+    );
+  }
+
+  static Curve? _lerpCurve(Curve? a, Curve? b, double t) {
+    if (t == 0.0) {
+      return a;
+    }
+    if (t == 1.0) {
+      return b;
+    }
+    if (a == null || b == null) {
+      return a ?? b;
+    }
+    return _LerpedCurve(a, b, t);
   }
 
   @override
@@ -106,4 +134,31 @@ class AnimationStyle with Diagnosticable {
       DiagnosticsProperty<Duration>('reverseDuration', reverseDuration, defaultValue: null),
     );
   }
+}
+
+class _LerpedCurve extends Curve {
+  const _LerpedCurve(this.first, this.second, this._t);
+
+  final Curve first;
+  final Curve second;
+  final double _t;
+
+  @override
+  double transform(double t) {
+    final double a = first.transform(t);
+    final double b = second.transform(t);
+
+    return a * (1.0 - _t) + b * _t;
+  }
+
+  @override
+  bool operator==(Object other) {
+    return other is _LerpedCurve
+        && other.first == first
+        && other.second == second
+        && other._t == _t;
+  }
+
+  @override
+  int get hashCode => Object.hash(first, second, _t);
 }

--- a/packages/flutter/lib/src/animation/animation_style.dart
+++ b/packages/flutter/lib/src/animation/animation_style.dart
@@ -65,6 +65,22 @@ class AnimationStyle with Diagnosticable {
     );
   }
 
+  /// Returns a modified version of the `other` style, where its `null` properties
+  /// are filled in with the non-null properties of this style, where applicable.
+  ///
+  /// If a `null` argument is passed, returns this animation style.
+  AnimationStyle merge(AnimationStyle? other) {
+    if (other == null) {
+      return this;
+    }
+    return copyWith(
+      curve: other.curve,
+      duration: other.duration,
+      reverseCurve: other.reverseCurve,
+      reverseDuration: other.reverseDuration,
+    );
+  }
+
   /// Linearly interpolate between two animation styles.
   static AnimationStyle? lerp(AnimationStyle? a, AnimationStyle? b, double t) {
     if (identical(a, b)) {

--- a/packages/flutter/lib/src/animation/animation_style.dart
+++ b/packages/flutter/lib/src/animation/animation_style.dart
@@ -87,29 +87,18 @@ class AnimationStyle with Diagnosticable {
       return a;
     }
     return AnimationStyle(
-      curve: _lerpCurve(a?.curve, b?.curve, t),
-      duration: _lerpDuration(a?.duration, b?.duration, t),
-      reverseCurve: _lerpCurve(a?.reverseCurve, b?.reverseCurve, t),
-      reverseDuration: _lerpDuration(a?.reverseDuration, b?.reverseDuration, t),
-    );
-  }
-  
-  static Duration? _lerpDuration(Duration? a, Duration? b, double t) {
-    if (t == 0.0) {
-      return a;
-    }
-    if (t == 1.0) {
-      return b;
-    }
-    if (a == null || b == null) {
-      return a ?? b;
-    }
-    return Duration(
-      microseconds: (a.inMicroseconds * (1.0 - t) + b.inMicroseconds * t).round(),
+      curve: _lerp(a?.curve, b?.curve, t, _LerpedCurve.new),
+      duration: _lerp(a?.duration, b?.duration, t, _lerpDuration),
+      reverseCurve: _lerp(a?.reverseCurve, b?.reverseCurve, t, _LerpedCurve.new),
+      reverseDuration: _lerp(a?.reverseDuration, b?.reverseDuration, t, _lerpDuration),
     );
   }
 
-  static Curve? _lerpCurve(Curve? a, Curve? b, double t) {
+  @optionalTypeArgs
+  static T? _lerp<T extends Object>(T? a, T? b, double t, T Function(T a, T b, double t) lerp) {
+    if (identical(a, b)) {
+      return a;
+    }
     if (t == 0.0) {
       return a;
     }
@@ -119,7 +108,13 @@ class AnimationStyle with Diagnosticable {
     if (a == null || b == null) {
       return a ?? b;
     }
-    return _LerpedCurve(a, b, t);
+    return lerp(a, b, t);
+  }
+
+  static Duration _lerpDuration(Duration a, Duration b, double t) {
+    return Duration(
+      microseconds: (a.inMicroseconds * (1.0 - t) + b.inMicroseconds * t).round(),
+    );
   }
 
   @override

--- a/packages/flutter/lib/src/animation/animation_style.dart
+++ b/packages/flutter/lib/src/animation/animation_style.dart
@@ -64,13 +64,13 @@ class AnimationStyle with Diagnosticable {
     );
   }
 
-  /// Creates a new animation style that is a combination of this animation style
+  /// Creates a new [AnimationStyle] that is a combination of this animation style
   /// and the given `other` animation style.
   ///
   /// If `other` is non-null, its non-null properties are used to override the
   /// corresponding properties of this style.
   ///
-  /// If a `null` argument is passed, returns this animation style.
+  /// Returns this animation style if `other` is null.
   AnimationStyle merge(AnimationStyle? other) {
     if (other == null) {
       return this;
@@ -172,5 +172,5 @@ class _LerpedCurve extends Curve {
   int get hashCode => Object.hash(first, second, _t);
 
   @override
-  String toString() => 'interpolated curve ($first, $second, t: $_t)';
+  String toString() => '_LerpedCurve($first, $second, t: $_t)';
 }

--- a/packages/flutter/lib/src/animation/animation_style.dart
+++ b/packages/flutter/lib/src/animation/animation_style.dart
@@ -98,10 +98,7 @@ class AnimationStyle with Diagnosticable {
 
   @optionalTypeArgs
   static T? _lerp<T extends Object>(T? a, T? b, double t, T Function(T? a, T? b, double t) lerp) {
-    if (identical(a, b)) {
-      return a;
-    }
-    if (t == 0.0) {
+    if (a == b || t == 0.0) {
       return a;
     }
     if (t == 1.0) {

--- a/packages/flutter/lib/src/animation/animation_style.dart
+++ b/packages/flutter/lib/src/animation/animation_style.dart
@@ -8,7 +8,6 @@ library;
 import 'package:flutter/foundation.dart';
 
 import 'curves.dart';
-import 'tween.dart';
 
 /// Used to override the default parameters of an animation.
 ///
@@ -65,8 +64,11 @@ class AnimationStyle with Diagnosticable {
     );
   }
 
-  /// Returns a modified version of the `other` style, where its `null` properties
-  /// are filled in with the non-null properties of this style, where applicable.
+  /// Creates a new animation style that is a combination of this animation style
+  /// and the given `other` animation style.
+  ///
+  /// If `other` is non-null, its non-null properties are used to override the
+  /// corresponding properties of this style.
   ///
   /// If a `null` argument is passed, returns this animation style.
   AnimationStyle merge(AnimationStyle? other) {
@@ -95,7 +97,7 @@ class AnimationStyle with Diagnosticable {
   }
 
   @optionalTypeArgs
-  static T? _lerp<T extends Object>(T? a, T? b, double t, T Function(T a, T b, double t) lerp) {
+  static T? _lerp<T extends Object>(T? a, T? b, double t, T Function(T? a, T? b, double t) lerp) {
     if (identical(a, b)) {
       return a;
     }
@@ -105,15 +107,12 @@ class AnimationStyle with Diagnosticable {
     if (t == 1.0) {
       return b;
     }
-    if (a == null || b == null) {
-      return a ?? b;
-    }
     return lerp(a, b, t);
   }
 
-  static Duration _lerpDuration(Duration a, Duration b, double t) {
+  static Duration _lerpDuration(Duration? a, Duration? b, double t) {
     return Duration(
-      microseconds: (a.inMicroseconds * (1.0 - t) + b.inMicroseconds * t).round(),
+      microseconds: ((a?.inMicroseconds ?? 0) * (1.0 - t) + (b?.inMicroseconds ?? 0) * t).round(),
     );
   }
 
@@ -148,7 +147,9 @@ class AnimationStyle with Diagnosticable {
 }
 
 class _LerpedCurve extends Curve {
-  const _LerpedCurve(this.first, this.second, this._t);
+  const _LerpedCurve(Curve? a, Curve? b, this._t)
+    : first = a ?? Curves.linear,
+      second = b ?? Curves.linear;
 
   final Curve first;
   final Curve second;
@@ -163,11 +164,11 @@ class _LerpedCurve extends Curve {
   }
 
   @override
-  bool operator==(Object other) {
-    return other is _LerpedCurve
-        && other.first == first
-        && other.second == second
-        && other._t == _t;
+  bool operator ==(Object other) {
+    return other is _LerpedCurve &&
+        other.first == first &&
+        other.second == second &&
+        other._t == _t;
   }
 
   @override

--- a/packages/flutter/lib/src/animation/animation_style.dart
+++ b/packages/flutter/lib/src/animation/animation_style.dart
@@ -173,4 +173,7 @@ class _LerpedCurve extends Curve {
 
   @override
   int get hashCode => Object.hash(first, second, _t);
+
+  @override
+  String toString() => 'interpolated curve ($first, $second, t: $_t)';
 }

--- a/packages/flutter/test/animation/animation_style_test.dart
+++ b/packages/flutter/test/animation/animation_style_test.dart
@@ -33,6 +33,24 @@ void main() {
     expect(copy.reverseDuration, const Duration(seconds: 2));
   });
 
+  testWidgets('AnimationStyle.merge() fills in null properties', (WidgetTester tester) async {
+    final AnimationStyle original = AnimationStyle(
+      curve: Curves.ease,
+      duration: const Duration(seconds: 1),
+      reverseCurve: Curves.ease,
+      reverseDuration: const Duration(seconds: 1),
+    );
+    final AnimationStyle other = AnimationStyle(
+      curve: Curves.linear,
+      duration: const Duration(seconds: 2),
+    );
+    final AnimationStyle merged = original.merge(other);
+    expect(merged.curve, Curves.linear);
+    expect(merged.duration, const Duration(seconds: 2));
+    expect(merged.reverseCurve, Curves.ease);
+    expect(merged.reverseDuration, const Duration(seconds: 1));
+  });
+
   test('AnimationStyle.lerp identical a,b', () {
     expect(AnimationStyle.lerp(null, null, 0), null);
     const data = AnimationStyle();

--- a/packages/flutter/test/animation/animation_style_test.dart
+++ b/packages/flutter/test/animation/animation_style_test.dart
@@ -34,16 +34,13 @@ void main() {
   });
 
   testWidgets('AnimationStyle.merge() fills in null properties', (WidgetTester tester) async {
-    final AnimationStyle original = AnimationStyle(
+    const original = AnimationStyle(
       curve: Curves.ease,
-      duration: const Duration(seconds: 1),
+      duration: Duration(seconds: 1),
       reverseCurve: Curves.ease,
-      reverseDuration: const Duration(seconds: 1),
+      reverseDuration: Duration(seconds: 1),
     );
-    final AnimationStyle other = AnimationStyle(
-      curve: Curves.linear,
-      duration: const Duration(seconds: 2),
-    );
+    const other = AnimationStyle(curve: Curves.linear, duration: Duration(seconds: 2));
     final AnimationStyle merged = original.merge(other);
     expect(merged.curve, Curves.linear);
     expect(merged.duration, const Duration(seconds: 2));
@@ -78,9 +75,9 @@ void main() {
     expect(AnimationStyle.lerp(a, b, 0), a);
     expect(AnimationStyle.lerp(a, b, 1.0), b);
 
-    const int styleSteps = 5;
-    const int curveSteps = 5;
-    for (int styleStep = 0; styleStep < styleSteps; styleStep += 1) {
+    const styleSteps = 5;
+    const curveSteps = 5;
+    for (var styleStep = 0; styleStep < styleSteps; styleStep += 1) {
       final double styleTransition = (styleStep + 1) / (styleSteps + 1);
       final AnimationStyle? lerpedStyle = AnimationStyle.lerp(a, b, styleTransition);
 
@@ -93,7 +90,7 @@ void main() {
         ui.lerpDouble(aReverse, bReverse, styleTransition)?.round(),
       );
 
-      for (int curveStep = 0; curveStep < curveSteps; curveStep += 1) {
+      for (var curveStep = 0; curveStep < curveSteps; curveStep += 1) {
         final double t = (curveStep + 1) / (curveSteps + 1);
         final double aResult = Curves.ease.transform(t);
         final double bResult = Curves.linear.transform(t);

--- a/packages/flutter/test/animation/animation_style_test.dart
+++ b/packages/flutter/test/animation/animation_style_test.dart
@@ -14,7 +14,7 @@ void main() {
     expect(const AnimationStyle().hashCode, const AnimationStyle().copyWith().hashCode);
   });
 
-  testWidgets('AnimationStyle.copyWith() overrides all properties', (WidgetTester tester) async {
+  test('AnimationStyle.copyWith() overrides all properties', () {
     const original = AnimationStyle(
       curve: Curves.ease,
       duration: Duration(seconds: 1),
@@ -33,7 +33,7 @@ void main() {
     expect(copy.reverseDuration, const Duration(seconds: 2));
   });
 
-  testWidgets('AnimationStyle.merge() fills in null properties', (WidgetTester tester) async {
+  test('AnimationStyle.merge() fills in null properties', () {
     const original = AnimationStyle(
       curve: Curves.ease,
       duration: Duration(seconds: 1),
@@ -54,7 +54,7 @@ void main() {
     expect(identical(AnimationStyle.lerp(data, data, 0.5), data), true);
   });
 
-  testWidgets('AnimationStyle.lerp smoothly transitions all values', (WidgetTester tester) async {
+  test('AnimationStyle.lerp smoothly transitions all values', () {
     const a = AnimationStyle(
       curve: Curves.ease,
       duration: Duration(seconds: 1),
@@ -101,7 +101,16 @@ void main() {
     }
   });
 
-  testWidgets('default AnimationStyle debugFillProperties', (WidgetTester tester) async {
+  test('AnimationStyle.lerp with null property', () {
+    const a = AnimationStyle(duration: Duration(seconds: 2));
+    const b = AnimationStyle();
+
+    // Assuming null is treated as Duration.zero for interpolation.
+    expect(AnimationStyle.lerp(a, b, 1 / 2)?.duration, const Duration(seconds: 1));
+    expect(AnimationStyle.lerp(a, b, 1 / 4)?.duration, const Duration(milliseconds: 1500));
+  });
+
+  test('default AnimationStyle debugFillProperties', () {
     final builder = DiagnosticPropertiesBuilder();
 
     const AnimationStyle().debugFillProperties(builder);
@@ -114,7 +123,7 @@ void main() {
     expect(description, <String>[]);
   });
 
-  testWidgets('AnimationStyle implements debugFillProperties', (WidgetTester tester) async {
+  test('AnimationStyle implements debugFillProperties', () {
     final builder = DiagnosticPropertiesBuilder();
 
     const AnimationStyle(

--- a/packages/flutter/test/animation/animation_style_test.dart
+++ b/packages/flutter/test/animation/animation_style_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui' as ui show lerpDouble;
+
 import 'package:flutter/animation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -37,7 +39,7 @@ void main() {
     expect(identical(AnimationStyle.lerp(data, data, 0.5), data), true);
   });
 
-  testWidgets('default AnimationStyle debugFillProperties', (WidgetTester tester) async {
+  testWidgets('AnimationStyle.lerp smoothly transitions all values', (WidgetTester tester) async {
     const a = AnimationStyle(
       curve: Curves.ease,
       duration: Duration(seconds: 1),
@@ -50,10 +52,38 @@ void main() {
       reverseCurve: Curves.linear,
       reverseDuration: Duration(seconds: 2),
     );
+    final int aForward = a.duration!.inMicroseconds;
+    final int aReverse = a.reverseDuration!.inMicroseconds;
+    final int bForward = b.duration!.inMicroseconds;
+    final int bReverse = b.reverseDuration!.inMicroseconds;
 
     expect(AnimationStyle.lerp(a, b, 0), a);
-    expect(AnimationStyle.lerp(a, b, 0.5), b);
     expect(AnimationStyle.lerp(a, b, 1.0), b);
+
+    const int styleSteps = 5;
+    const int curveSteps = 5;
+    for (int styleStep = 0; styleStep < styleSteps; styleStep += 1) {
+      final double styleTransition = (styleStep + 1) / (styleSteps + 1);
+      final AnimationStyle? lerpedStyle = AnimationStyle.lerp(a, b, styleTransition);
+
+      expect(
+        lerpedStyle?.duration?.inMicroseconds,
+        ui.lerpDouble(aForward, bForward, styleTransition)?.round(),
+      );
+      expect(
+        lerpedStyle?.reverseDuration?.inMicroseconds,
+        ui.lerpDouble(aReverse, bReverse, styleTransition)?.round(),
+      );
+
+      for (int curveStep = 0; curveStep < curveSteps; curveStep += 1) {
+        final double t = (curveStep + 1) / (curveSteps + 1);
+        final double aResult = Curves.ease.transform(t);
+        final double bResult = Curves.linear.transform(t);
+        final double? lerpResult = lerpedStyle?.curve?.transform(t);
+
+        expect(lerpResult, ui.lerpDouble(aResult, bResult, styleTransition));
+      }
+    }
   });
 
   testWidgets('default AnimationStyle debugFillProperties', (WidgetTester tester) async {


### PR DESCRIPTION
This pull request adds an `AnimationStyle.merge()` method (for parity with similar APIs) and updates `AnimationStyle.lerp()` so that it performs an accurate interpolation.

<br>

closes #160563