### PR TITLE
Disable multithread opengles, enables remaining fragment shader tests

### DIFF
--- a/engine/src/flutter/testing/dart/fragment_shader_test.dart
+++ b/engine/src/flutter/testing/dart/fragment_shader_test.dart
@@ -1177,18 +1177,14 @@ void main() async {
     });
   });
 
-  test(
-    'FragmentProgram getImageSampler',
-    () async {
-      final FragmentProgram program = await FragmentProgram.fromAsset('uniform_ordering.frag.iplr');
-      final FragmentShader shader = program.fragmentShader();
-      final Image blueGreenImage = await _createBlueGreenImage();
-      final ImageSamplerSlot slot = shader.getImageSampler('u_texture');
-      slot.set(blueGreenImage);
-      expect(slot.shaderIndex, equals(0));
-    },
-    skip: Platform.executableArguments.contains('--impeller-backend=opengles'),
-  );
+  test('FragmentProgram getImageSampler', () async {
+    final FragmentProgram program = await FragmentProgram.fromAsset('uniform_ordering.frag.iplr');
+    final FragmentShader shader = program.fragmentShader();
+    final Image blueGreenImage = await _createBlueGreenImage();
+    final ImageSamplerSlot slot = shader.getImageSampler('u_texture');
+    slot.set(blueGreenImage);
+    expect(slot.shaderIndex, equals(0));
+  });
 
   test('FragmentProgram getImageSampler unknown', () async {
     final FragmentProgram program = await FragmentProgram.fromAsset('uniform_ordering.frag.iplr');
@@ -1201,27 +1197,21 @@ void main() async {
     }
   });
 
-  test(
-    'FragmentShader setSampler throws with out-of-bounds index',
-    () async {
-      final FragmentProgram program = await FragmentProgram.fromAsset(
-        'blue_green_sampler.frag.iplr',
-      );
-      final Image blueGreenImage = await _createBlueGreenImage();
-      final FragmentShader fragmentShader = program.fragmentShader();
+  test('FragmentShader setSampler throws with out-of-bounds index', () async {
+    final FragmentProgram program = await FragmentProgram.fromAsset('blue_green_sampler.frag.iplr');
+    final Image blueGreenImage = await _createBlueGreenImage();
+    final FragmentShader fragmentShader = program.fragmentShader();
 
-      try {
-        fragmentShader.setImageSampler(1, blueGreenImage);
-        fail('Unreachable');
-      } catch (e) {
-        expect(e, contains('Sampler index out of bounds'));
-      } finally {
-        fragmentShader.dispose();
-        blueGreenImage.dispose();
-      }
-    },
-    skip: Platform.executableArguments.contains('--impeller-backend=opengles'),
-  );
+    try {
+      fragmentShader.setImageSampler(1, blueGreenImage);
+      fail('Unreachable');
+    } catch (e) {
+      expect(e, contains('Sampler index out of bounds'));
+    } finally {
+      fragmentShader.dispose();
+      blueGreenImage.dispose();
+    }
+  });
 
   test(
     'FragmentShader with sampler asserts if sampler is missing when assigned to paint',
@@ -1242,62 +1232,50 @@ void main() async {
     },
   );
 
-  test(
-    'FragmentShader setImageSampler asserts if image is disposed',
-    () async {
-      final FragmentProgram program = await FragmentProgram.fromAsset(
-        'blue_green_sampler.frag.iplr',
-      );
-      final Image blueGreenImage = await _createBlueGreenImage();
-      final FragmentShader fragmentShader = program.fragmentShader();
+  test('FragmentShader setImageSampler asserts if image is disposed', () async {
+    final FragmentProgram program = await FragmentProgram.fromAsset('blue_green_sampler.frag.iplr');
+    final Image blueGreenImage = await _createBlueGreenImage();
+    final FragmentShader fragmentShader = program.fragmentShader();
 
-      try {
-        blueGreenImage.dispose();
-        expect(
-          () {
-            fragmentShader.setImageSampler(0, blueGreenImage);
-          },
-          throwsA(
-            isA<AssertionError>().having(
-              (AssertionError e) => e.message,
-              'message',
-              contains('Image has been disposed'),
-            ),
-          ),
-        );
-      } finally {
-        fragmentShader.dispose();
-      }
-    },
-    skip: Platform.executableArguments.contains('--impeller-backend=opengles'),
-  );
-
-  test(
-    'Disposed FragmentShader on Paint',
-    () async {
-      final FragmentProgram program = await FragmentProgram.fromAsset(
-        'blue_green_sampler.frag.iplr',
-      );
-      final Image blueGreenImage = await _createBlueGreenImage();
-
-      final FragmentShader shader = program.fragmentShader()..setImageSampler(0, blueGreenImage);
-      shader.dispose();
+    try {
+      blueGreenImage.dispose();
       expect(
         () {
-          Paint().shader = shader;
+          fragmentShader.setImageSampler(0, blueGreenImage);
         },
         throwsA(
           isA<AssertionError>().having(
             (AssertionError e) => e.message,
             'message',
-            contains('Attempted to set a disposed shader'),
+            contains('Image has been disposed'),
           ),
         ),
       );
-      blueGreenImage.dispose();
-    },
-    skip: Platform.executableArguments.contains('--impeller-backend=opengles'),
-  );
+    } finally {
+      fragmentShader.dispose();
+    }
+  });
+
+  test('Disposed FragmentShader on Paint', () async {
+    final FragmentProgram program = await FragmentProgram.fromAsset('blue_green_sampler.frag.iplr');
+    final Image blueGreenImage = await _createBlueGreenImage();
+
+    final FragmentShader shader = program.fragmentShader()..setImageSampler(0, blueGreenImage);
+    shader.dispose();
+    expect(
+      () {
+        Paint().shader = shader;
+      },
+      throwsA(
+        isA<AssertionError>().having(
+          (AssertionError e) => e.message,
+          'message',
+          contains('Attempted to set a disposed shader'),
+        ),
+      ),
+    );
+    blueGreenImage.dispose();
+  });
 
   test('Disposed FragmentShader setFloat', () async {
     final FragmentProgram program = await FragmentProgram.fromAsset('uniforms.frag.iplr');
@@ -1318,32 +1296,26 @@ void main() async {
     );
   });
 
-  test(
-    'Disposed FragmentShader setImageSampler',
-    () async {
-      final FragmentProgram program = await FragmentProgram.fromAsset(
-        'blue_green_sampler.frag.iplr',
-      );
-      final Image blueGreenImage = await _createBlueGreenImage();
+  test('Disposed FragmentShader setImageSampler', () async {
+    final FragmentProgram program = await FragmentProgram.fromAsset('blue_green_sampler.frag.iplr');
+    final Image blueGreenImage = await _createBlueGreenImage();
 
-      final FragmentShader shader = program.fragmentShader()..setImageSampler(0, blueGreenImage);
-      shader.dispose();
-      expect(
-        () {
-          shader.setImageSampler(0, blueGreenImage);
-        },
-        throwsA(
-          isA<AssertionError>().having(
-            (AssertionError e) => e.message,
-            'message',
-            contains('Tried to access uniforms on a disposed Shader'),
-          ),
+    final FragmentShader shader = program.fragmentShader()..setImageSampler(0, blueGreenImage);
+    shader.dispose();
+    expect(
+      () {
+        shader.setImageSampler(0, blueGreenImage);
+      },
+      throwsA(
+        isA<AssertionError>().having(
+          (AssertionError e) => e.message,
+          'message',
+          contains('Tried to access uniforms on a disposed Shader'),
         ),
-      );
-      blueGreenImage.dispose();
-    },
-    skip: Platform.executableArguments.contains('--impeller-backend=opengles'),
-  );
+      ),
+    );
+    blueGreenImage.dispose();
+  });
 
   test('Disposed FragmentShader dispose', () async {
     final FragmentProgram program = await FragmentProgram.fromAsset('uniforms.frag.iplr');

--- a/engine/src/flutter/testing/run_tests.py
+++ b/engine/src/flutter/testing/run_tests.py
@@ -968,6 +968,11 @@ def gather_dart_tests(
         continue
 
       for multithreaded in [False, True]:
+        # An opengles implementation that is multithreaded would require the
+        # raster thread and the io thread to have their own contexts in a share
+        # group. This isn't currently supported by swangle.
+        if impeller == 'opengles' and multithreaded:
+          continue
         yield gather_dart_test(
             build_dir, dart_test_file,
             FlutterTesterOptions(


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/180764

test exempt: is test

Opengles requires a separate context for the raster and io threads that have a share group.  Swangle doesn't seem to have support for that so we'll just run the opengles tests in a single threaded environment.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
