### PR TITLE
Give guided error message when CocoaPod and SwiftPM dependency conflicts

### DIFF
--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -1093,10 +1093,7 @@ Future<bool> _handleIssues(
         'looking at your "ios/Podfile.lock" dependency tree and requesting the '
         'author add Swift Package Manager compatibility. See https://stackoverflow.com/a/27955017 '
         'to learn more about understanding Podlock dependency tree. \n\n'
-        'You can also disable Swift Package Manager for the project by adding the '
-        'following in the project\'s pubspec.yaml under the "flutter" section:\n'
-        '  config:'
-        '    enable-swift-package-manager: false\n',
+        '$kDisableSwiftPMInstructions',
       );
     }
   } else if (missingModules.isNotEmpty) {

--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -387,7 +387,7 @@ class CocoaPods {
       return;
     }
     if (stdout.contains('Unable to find a specification for')) {
-      // Example: Unable to find a specification for `plguin_a` depended upon by `plugin_b`
+      // Example: Unable to find a specification for `plugin_a` depended upon by `plugin_b`
       final pattern = RegExp(r'Unable to find a specification for `(.*)` depended upon by `(.*)`');
       final Iterable<RegExpMatch> matches = pattern.allMatches(stdout);
       for (final match in matches) {

--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -386,35 +386,10 @@ class CocoaPods {
     if (stdout is! String || stderr is! String) {
       return;
     }
-    if (stdout.contains('Unable to find a specification for')) {
-      // Example: Unable to find a specification for `plugin_a` depended upon by `plugin_b`
-      final pattern = RegExp(r'Unable to find a specification for `(.*)` depended upon by `(.*)`');
-      final Iterable<RegExpMatch> matches = pattern.allMatches(stdout);
-      for (final match in matches) {
-        final String? missingPlugin = match.group(1);
-        final String? requiringPlugin = match.group(2);
-        if (missingPlugin != null && requiringPlugin != null) {
-          final List<Plugin> plugins = await findPlugins(xcodeProject.parent);
-          final bool missingPluginSupportsSwiftPM = plugins.any(
-            (plugin) =>
-                plugin.name == missingPlugin &&
-                plugin.supportSwiftPackageManagerForPlatform(
-                  _fileSystem,
-                  xcodeProject.pluginConfigKey,
-                ),
-          );
-          if (missingPluginSupportsSwiftPM) {
-            _logger.printError(
-              'Error: A dependency conflict has occurred because $requiringPlugin uses CocoaPods while '
-              '$missingPlugin uses Swift Package Manager. Please contact the $requiringPlugin '
-              'maintainers to request Swift Package Manager adoption.\n\n'
-              '$kDisableSwiftPMInstructions',
-              emphasis: true,
-            );
-            return;
-          }
-        }
-      }
+    final String? conflict = await _pluginDependencyManagerConflictError(stdout, xcodeProject);
+    if (conflict != null) {
+      _logger.printError(conflict, emphasis: true);
+      return;
     }
     if (stdout.contains('out-of-date source repos')) {
       _logger.printError(
@@ -520,6 +495,47 @@ class CocoaPods {
         emphasis: true,
       );
     }
+  }
+
+  /// Returns a guided error message when a CocoaPod plugin has a dependency on a SwiftPM plugin
+  /// and SwiftPM is enabled. Otherwise returns `null`.
+  Future<String?> _pluginDependencyManagerConflictError(
+    String stdout,
+    XcodeBasedProject xcodeProject,
+  ) async {
+    if (!xcodeProject.usesSwiftPackageManager) {
+      return null;
+    }
+    final pattern = RegExp(
+      r'Unable to find a specification for `([^`]*)` depended upon by `([^`]*)`',
+    );
+    // Example: Unable to find a specification for `plugin_a` depended upon by `plugin_b`
+    final Iterable<RegExpMatch> matches = pattern.allMatches(stdout);
+    if (matches.isEmpty) {
+      return null;
+    }
+    final List<Plugin> plugins = await findPlugins(xcodeProject.parent);
+    for (final match in matches) {
+      final String? missingPlugin = match.group(1);
+      final String? requiringPlugin = match.group(2);
+      if (missingPlugin != null && requiringPlugin != null) {
+        final bool missingPluginSupportsSwiftPM = plugins.any(
+          (plugin) =>
+              plugin.name == missingPlugin &&
+              plugin.supportSwiftPackageManagerForPlatform(
+                _fileSystem,
+                xcodeProject.pluginConfigKey,
+              ),
+        );
+        if (missingPluginSupportsSwiftPM) {
+          return 'Error: A dependency conflict has occurred because $requiringPlugin uses CocoaPods while '
+              '$missingPlugin uses Swift Package Manager. Please contact the $requiringPlugin '
+              'maintainers to request Swift Package Manager adoption.\n\n'
+              '$kDisableSwiftPMInstructions';
+        }
+      }
+    }
+    return null;
   }
 
   ({String failingPod, String sourcePlugin, String podPluginSubdir})?

--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -18,10 +18,13 @@ import '../base/project_migrator.dart';
 import '../base/version.dart';
 import '../build_info.dart';
 import '../cache.dart';
+import '../flutter_plugins.dart';
 import '../ios/xcodeproj.dart';
 import '../migrations/cocoapods_script_symlink.dart';
 import '../migrations/cocoapods_toolchain_directory_migration.dart';
+import '../plugins.dart';
 import '../project.dart';
+import 'swift_package_manager.dart';
 
 const noCocoaPodsConsequence = '''
   CocoaPods is a package manager for iOS or macOS platform code.
@@ -362,7 +365,7 @@ class CocoaPods {
 
     if (result.exitCode != 0) {
       invalidatePodInstallOutput(xcodeProject);
-      _diagnosePodInstallFailure(result, xcodeProject);
+      await _diagnosePodInstallFailure(result, xcodeProject);
       throwToolExit('Error running pod install');
     } else if (xcodeProject.podfileLock.existsSync()) {
       // Even if the Podfile.lock didn't change, update its modified date to now
@@ -374,11 +377,44 @@ class CocoaPods {
     }
   }
 
-  void _diagnosePodInstallFailure(ProcessResult result, XcodeBasedProject xcodeProject) {
+  Future<void> _diagnosePodInstallFailure(
+    ProcessResult result,
+    XcodeBasedProject xcodeProject,
+  ) async {
     final Object? stdout = result.stdout;
     final Object? stderr = result.stderr;
     if (stdout is! String || stderr is! String) {
       return;
+    }
+    if (stdout.contains('Unable to find a specification for')) {
+      // Example: Unable to find a specification for `plguin_a` depended upon by `plugin_b`
+      final pattern = RegExp(r'Unable to find a specification for `(.*)` depended upon by `(.*)`');
+      final Iterable<RegExpMatch> matches = pattern.allMatches(stdout);
+      for (final match in matches) {
+        final String? missingPlugin = match.group(1);
+        final String? requiringPlugin = match.group(2);
+        if (missingPlugin != null && requiringPlugin != null) {
+          final List<Plugin> plugins = await findPlugins(xcodeProject.parent);
+          final bool missingPluginSupportsSwiftPM = plugins.any(
+            (plugin) =>
+                plugin.name == missingPlugin &&
+                plugin.supportSwiftPackageManagerForPlatform(
+                  _fileSystem,
+                  xcodeProject.pluginConfigKey,
+                ),
+          );
+          if (missingPluginSupportsSwiftPM) {
+            _logger.printError(
+              'Error: A dependency conflict has occurred because $requiringPlugin uses CocoaPods while '
+              '$missingPlugin uses Swift Package Manager. Please contact the $requiringPlugin '
+              'maintainers to request Swift Package Manager adoption.\n\n'
+              '$kDisableSwiftPMInstructions',
+              emphasis: true,
+            );
+            return;
+          }
+        }
+      }
     }
     if (stdout.contains('out-of-date source repos')) {
       _logger.printError(

--- a/packages/flutter_tools/lib/src/macos/swift_package_manager.dart
+++ b/packages/flutter_tools/lib/src/macos/swift_package_manager.dart
@@ -21,6 +21,11 @@ const kFlutterGeneratedPluginSwiftPackageName = 'FlutterGeneratedPluginSwiftPack
 /// a dependency on the Flutter/FlutterMacOS framework.
 const kFlutterGeneratedFrameworkSwiftPackageTargetName = 'FlutterFramework';
 
+const kDisableSwiftPMInstructions =
+    'You can also disable Swift Package Manager for the project by following these instructions:\n'
+    '  https://docs.flutter.dev/packages-and-plugins/swift-package-manager/for-app-developers#how-to-turn-off-swift-package-manager\n'
+    'Disabling Swift Package Manager will not be allowed in a future version of Flutter.\n';
+
 /// Swift Package Manager is a dependency management solution for iOS and macOS
 /// applications.
 ///

--- a/packages/flutter_tools/lib/src/migrations/swift_package_manager_integration_migration.dart
+++ b/packages/flutter_tools/lib/src/migrations/swift_package_manager_integration_migration.dart
@@ -223,13 +223,7 @@ class SwiftPackageManagerIntegrationMigration extends ProjectMigrator {
         '(or the scheme for the flavor used)\n\n'
         'To add Swift Package Manager integration manually, please use the following instructions:\n'
         'https://docs.flutter.dev/to/add-swift-package-manager-manually\n\n'
-        'Alternatively, to avoid this failure, disable Flutter Swift Package Manager integration for the project\n'
-        'by adding the following in the project\'s pubspec.yaml under the "flutter" section:\n'
-        '  config:\n'
-        '    enable-swift-package-manager: false\n'
-        'Or disable Flutter Swift Package Manager integration globally with the\n'
-        'following command:\n'
-        '  "flutter config --no-enable-swift-package-manager"\n',
+        '$kDisableSwiftPMInstructions',
       );
     } finally {
       ErrorHandlingFileSystem.deleteIfExists(backupProjectSettings);

--- a/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
@@ -1709,14 +1709,3 @@ class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterprete
   @override
   Version? version;
 }
-
-class FakeFlutterManifest extends Fake implements FlutterManifest {
-  @override
-  late final dependencies = <String>{};
-
-  @override
-  String get appName => 'my_app';
-
-  @override
-  YamlMap toYaml() => YamlMap.wrap(<String, String>{});
-}

--- a/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
@@ -12,14 +12,12 @@ import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/features.dart';
-import 'package:flutter_tools/src/flutter_manifest.dart';
 import 'package:flutter_tools/src/flutter_plugins.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
 import 'package:flutter_tools/src/macos/cocoapods.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:test/fake.dart';
 import 'package:unified_analytics/unified_analytics.dart';
-import 'package:yaml/yaml.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';

--- a/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
@@ -1595,6 +1595,7 @@ end''');
       overrides: <Type, Generator>{
         FileSystem: () => fileSystem,
         ProcessManager: () => FakeProcessManager.any(),
+        FeatureFlags: () => TestFeatureFlags(isSwiftPackageManagerEnabled: true),
       },
     );
   });

--- a/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
@@ -9,14 +9,17 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/version.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/features.dart';
+import 'package:flutter_tools/src/flutter_manifest.dart';
 import 'package:flutter_tools/src/flutter_plugins.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
 import 'package:flutter_tools/src/macos/cocoapods.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:test/fake.dart';
 import 'package:unified_analytics/unified_analytics.dart';
+import 'package:yaml/yaml.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
@@ -1551,6 +1554,51 @@ end''');
       );
       expect(projectUnderTest.ios.podManifestLock.existsSync(), isFalse);
     });
+
+    testUsingContext(
+      'throws, if unable to find a specification',
+      () async {
+        final FlutterProject projectUnderTest = setupProjectUnderTest();
+        pretendPodIsInstalled();
+        pretendPodVersionIs('100.0.0');
+        projectUnderTest.ios.podfile.createSync(recursive: true);
+        final pluginNames = <String>['plugin_1_name', 'plugin_2_name'];
+        createFakePlugins(projectUnderTest, fileSystem, pluginNames);
+        fileSystem.systemTempDirectory
+            .childFile('/.tmp_rand0/fake_pub_cache/plugin_1_name/ios/plugin_1_name/Package.swift')
+            .createSync(recursive: true);
+
+        fakeProcessManager.addCommand(
+          const FakeCommand(
+            command: <String>['pod', 'install', '--verbose'],
+            workingDirectory: 'project/ios',
+            environment: <String, String>{'COCOAPODS_DISABLE_STATS': 'true', 'LANG': 'en_US.UTF-8'},
+            exitCode: 1,
+            // This output is the output that a real CocoaPods install would generate.
+            stdout: '''
+    [!] Unable to find a specification for `plugin_1_name` depended upon by `plugin_2_name`
+
+    You have either:
+     * out-of-date source repos which you can update with `pod repo update` or with `pod install --repo-update`.
+     * mistyped the name or version.
+     * not added the source repo that hosts the Podspec to your Podfile.''',
+          ),
+        );
+
+        await expectLater(
+          cocoaPodsUnderTest.processPods(
+            xcodeProject: projectUnderTest.ios,
+            buildMode: BuildMode.debug,
+          ),
+          throwsToolExit(),
+        );
+        expect(logger.errorText, contains('Error: A dependency conflict has occurred because'));
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => FakeProcessManager.any(),
+      },
+    );
   });
 }
 
@@ -1608,6 +1656,50 @@ Resolving dependencies of `Podfile`
 Specs satisfying the `$fakePluginName (from `Flutter/ephemeral/.symlinks/plugins/$fakePluginName/$subdir`)` dependency were found, but they required a higher minimum deployment target.''';
 }
 
+void createFakePlugins(
+  FlutterProject flutterProject,
+  FileSystem fileSystem,
+  List<String> pluginNames,
+) {
+  const pluginYamlTemplate = '''
+  flutter:
+    plugin:
+      platforms:
+        ios:
+          pluginClass: PLUGIN_CLASS
+        macos:
+          pluginClass: PLUGIN_CLASS
+  ''';
+
+  final Directory fakePubCache = fileSystem.systemTempDirectory.childDirectory('fake_pub_cache');
+
+  writePackageConfigFiles(
+    directory: flutterProject.directory,
+    mainLibName: 'my_app',
+    packages: <String, String>{
+      for (final String name in pluginNames) name: fakePubCache.childDirectory(name).path,
+    },
+  );
+
+  for (final name in pluginNames) {
+    final Directory pluginDirectory = fakePubCache.childDirectory(name);
+    pluginDirectory.childFile('pubspec.yaml')
+      ..createSync(recursive: true)
+      ..writeAsStringSync(pluginYamlTemplate.replaceAll('PLUGIN_CLASS', name));
+  }
+
+  final File graph = flutterProject.dartTool.childFile('package_graph.json')
+    ..createSync(recursive: true);
+
+  final packages = <Map<String, Object>>[
+    <String, Object>{'name': 'my_app', 'dependencies': pluginNames, 'devDependencies': <String>[]},
+    for (final String name in pluginNames)
+      <String, Object>{'name': name, 'dependencies': <String>[], 'devDependencies': <String>[]},
+  ];
+
+  graph.writeAsStringSync(jsonEncode(<String, Object>{'configVersion': 1, 'packages': packages}));
+}
+
 class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterpreter {
   FakeXcodeProjectInterpreter({this.isInstalled = true, this.version});
 
@@ -1616,4 +1708,15 @@ class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterprete
 
   @override
   Version? version;
+}
+
+class FakeFlutterManifest extends Fake implements FlutterManifest {
+  @override
+  late final dependencies = <String>{};
+
+  @override
+  String get appName => 'my_app';
+
+  @override
+  YamlMap toYaml() => YamlMap.wrap(<String, String>{});
 }


### PR DESCRIPTION
Gives a guided message when a CocoaPod plugin has a pod-level dependency on a plugin that supports SwiftPM.

Fixes https://github.com/flutter/flutter/issues/181303

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
