### PR TITLE
Add `dtdUri` to `MDNSObservation` and `running-apps` machine output when `wsUri` is HTTP.

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -957,7 +957,7 @@ class ResidentWebRunner extends ResidentRunner {
                 vmServiceUri: debugConnection.ddsUri != null
                     ? Uri.parse(debugConnection.ddsUri!)
                     : _vmService.httpAddress,
-                dtdUri: debugConnection.dtdUri,
+                dtdUri: debugConnection.dtdUri?.toUri(),
               ),
             );
           }

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -38,8 +38,8 @@ import '../project.dart';
 import '../reporting/reporting.dart';
 import '../resident_runner.dart';
 import '../run_hot.dart';
-import '../vmservice.dart';
 import '../version.dart';
+import '../vmservice.dart';
 import '../web/chrome.dart';
 import '../web/compile.dart';
 import '../web/devfs_config.dart';
@@ -51,16 +51,17 @@ import 'devfs_web.dart';
 import 'web_expression_compiler.dart';
 
 /// Factory for creating an [MDNSDeviceDiscovery] instance.
-typedef MDNSDeviceDiscoveryFactory = MDNSDeviceDiscovery Function({
-  required Device device,
-  required vmservice.VmService vmService,
-  required DebuggingOptions debuggingOptions,
-  required Logger logger,
-  required Platform platform,
-  required FlutterVersion flutterVersion,
-  required SystemClock systemClock,
-  required BotDetector botDetector,
-});
+typedef MDNSDeviceDiscoveryFactory =
+    MDNSDeviceDiscovery Function({
+      required Device device,
+      required vmservice.VmService vmService,
+      required DebuggingOptions debuggingOptions,
+      required Logger logger,
+      required Platform platform,
+      required FlutterVersion flutterVersion,
+      required SystemClock systemClock,
+      required BotDetector botDetector,
+    });
 
 /// Injectable factory to create a [ResidentWebRunner].
 class DwdsWebRunnerFactory extends WebRunnerFactory {

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -920,23 +920,26 @@ class ResidentWebRunner extends ResidentRunner {
           );
 
           // Start mDNS server
-          final discovery = MDNSDeviceDiscovery(
-            device: flutterDevice!.device!,
-            vmService: _vmService.service,
-            debuggingOptions: debuggingOptions,
-            logger: logger,
-            platform: _platform,
-            flutterVersion: globals.flutterVersion,
-            systemClock: _systemClock,
-            botDetector: globals.botDetector,
-          );
-          _mdnsDiscoveries.add(discovery);
-          unawaited(
-            discovery.advertise(
-              appName: flutterProject.manifest.appName,
-              vmServiceUri: _vmService.httpAddress,
-            ),
-          );
+          if (debuggingOptions.enableLocalDiscovery) {
+            final discovery = MDNSDeviceDiscovery(
+              device: flutterDevice!.device!,
+              vmService: _vmService.service,
+              debuggingOptions: debuggingOptions,
+              logger: logger,
+              platform: _platform,
+              flutterVersion: globals.flutterVersion,
+              systemClock: _systemClock,
+              botDetector: globals.botDetector,
+            );
+            _mdnsDiscoveries.add(discovery);
+            unawaited(
+              discovery.advertise(
+                appName: flutterProject.manifest.appName,
+                vmServiceUri: _vmService.httpAddress,
+                dtdUri: debugConnection.dtdUri,
+              ),
+            );
+          }
 
           final Uri websocketUri = Uri.parse(debugConnection.uri);
           flutterDevice!.vmService = _vmService;

--- a/packages/flutter_tools/lib/src/mdns_device_discovery.dart
+++ b/packages/flutter_tools/lib/src/mdns_device_discovery.dart
@@ -65,7 +65,7 @@ class MDNSDeviceDiscovery {
   Future<void> advertise({
     required String appName,
     required Uri? vmServiceUri,
-    required String? dtdUri,
+    required Uri? dtdUri,
   }) async {
     try {
       if (_servers.isNotEmpty) {
@@ -107,7 +107,7 @@ class MDNSDeviceDiscovery {
         flutterVersion: frameworkVersion,
         dartVersion: dartVersion,
         pid: pid,
-        dtdUri: dtdUri,
+        dtdUri: dtdUri?.toString(),
       );
 
       final List<String> txt = observation.toTxtRecord();
@@ -191,7 +191,7 @@ class MDNSObservation {
   static const String _kTargetPlatform = 'target_platform';
   static const String _kMode = 'mode';
   static const String _kWsUri = 'ws_uri';
-  static const String _kDtdUri = 'dtdUri';
+  static const String _kDtdUri = 'dtd_uri';
   static const String _kEpoch = 'epoch';
   static const String _kPid = 'pid';
   static const String _kFlutterVersion = 'flutter_version';
@@ -281,10 +281,7 @@ class MDNSObservation {
     return txt;
   }
 
-  /// The DTD URI for the VM Service, derived from [wsUri].
-  ///
-  /// If [wsUri] uses HTTP/HTTPS, this converts it to WS/WSS.
-  /// This getter ensures the URI does not end with a trailing slash.
+  /// Converts the observation to a JSON map.
   Map<String, String> toJson() {
     return <String, String>{
       _kHostname: hostname,

--- a/packages/flutter_tools/lib/src/mdns_device_discovery.dart
+++ b/packages/flutter_tools/lib/src/mdns_device_discovery.dart
@@ -15,7 +15,6 @@ import 'base/logger.dart';
 import 'base/platform.dart';
 import 'base/time.dart';
 import 'build_info.dart';
-import 'convert.dart';
 import 'device.dart';
 import 'version.dart';
 
@@ -63,7 +62,11 @@ class MDNSDeviceDiscovery {
   /// Advertises the Flutter application via mDNS.
   ///
   /// The advertisement includes metadata about the application, device, and environment.
-  Future<void> advertise({required String appName, required Uri? vmServiceUri}) async {
+  Future<void> advertise({
+    required String appName,
+    required Uri? vmServiceUri,
+    required String? dtdUri,
+  }) async {
     try {
       if (_servers.isNotEmpty) {
         throw StateError(
@@ -104,6 +107,7 @@ class MDNSDeviceDiscovery {
         flutterVersion: frameworkVersion,
         dartVersion: dartVersion,
         pid: pid,
+        dtdUri: dtdUri,
       );
 
       final List<String> txt = observation.toTxtRecord();
@@ -178,6 +182,7 @@ class MDNSObservation {
     required this.pid,
     required this.flutterVersion,
     required this.dartVersion,
+    this.dtdUri,
   });
 
   static const String _kProjectName = 'project_name';
@@ -186,6 +191,7 @@ class MDNSObservation {
   static const String _kTargetPlatform = 'target_platform';
   static const String _kMode = 'mode';
   static const String _kWsUri = 'ws_uri';
+  static const String _kDtdUri = 'dtdUri';
   static const String _kEpoch = 'epoch';
   static const String _kPid = 'pid';
   static const String _kFlutterVersion = 'flutter_version';
@@ -203,23 +209,24 @@ class MDNSObservation {
   final int pid;
   final String flutterVersion;
   final String dartVersion;
+  final String? dtdUri;
 
-  /// Parses a raw TXT record string into an [MDNSObservation].
+  /// Parses a TXT record string into an [MDNSObservation].
   ///
-  /// Returns `null` if the record is empty or invalid.
+  /// Returns null if the TXT record is invalid or missing required fields.
   static MDNSObservation? parse(String txtRecord) {
-    final metadata = <String, String>{};
-    // The multicast_dns package joins the strings of a TXT record with newlines.
-    final Iterable<String> parts = LineSplitter.split(txtRecord);
-    for (final part in parts) {
-      final int equalsIndex = part.indexOf('=');
-      if (equalsIndex != -1) {
-        // Trim to remove any whitespace that may be around the delimiters.
-        metadata[part.substring(0, equalsIndex).trim()] = part.substring(equalsIndex + 1).trim();
-      }
-    }
-    if (metadata.isEmpty) {
+    if (txtRecord.isEmpty) {
       return null;
+    }
+    final metadata = <String, String>{};
+    for (final String line in txtRecord.split('\n')) {
+      final int equalsIndex = line.indexOf('=');
+      if (equalsIndex < 0) {
+        continue;
+      }
+      final String key = line.substring(0, equalsIndex).trim();
+      final String value = line.substring(equalsIndex + 1).trim();
+      metadata[key] = value;
     }
 
     final int? epoch = int.tryParse(metadata[_kEpoch] ?? '');
@@ -248,6 +255,7 @@ class MDNSObservation {
         pid: pid,
         flutterVersion: flutterVersion,
         dartVersion: dartVersion,
+        dtdUri: metadata[_kDtdUri],
       );
     }
 
@@ -256,21 +264,29 @@ class MDNSObservation {
 
   /// Converts the observation to a list of strings for mDNS TXT record.
   List<String> toTxtRecord() {
-    return <String>[
+    final txt = <String>[
       '$_kHostname=$hostname',
-      '$_kWsUri=$wsUri',
-      '$_kPid=$pid',
-      '$_kTargetPlatform=$targetPlatform',
-      '$_kMode=$mode',
-      '$_kEpoch=$epoch',
       '$_kProjectName=$projectName',
       '$_kDeviceName=$deviceName',
       '$_kDeviceId=$deviceId',
+      '$_kTargetPlatform=$targetPlatform',
+      '$_kMode=$mode',
+      '$_kWsUri=$wsUri',
+      '$_kEpoch=$epoch',
+      '$_kPid=$pid',
       '$_kFlutterVersion=$flutterVersion',
       '$_kDartVersion=$dartVersion',
     ];
+    if (dtdUri != null) {
+      txt.add('$_kDtdUri=$dtdUri');
+    }
+    return txt;
   }
 
+  /// The DTD URI for the VM Service, derived from [wsUri].
+  ///
+  /// If [wsUri] uses HTTP/HTTPS, this converts it to WS/WSS.
+  /// This getter ensures the URI does not end with a trailing slash.
   Map<String, String> toJson() {
     return <String, String>{
       _kHostname: hostname,
@@ -280,6 +296,7 @@ class MDNSObservation {
       _kTargetPlatform: targetPlatform,
       _kMode: mode,
       _kWsUri: wsUri,
+      if (dtdUri != null) _kDtdUri: dtdUri!,
       _kEpoch: epoch.toString(),
       _kPid: pid.toString(),
       _kFlutterVersion: flutterVersion,

--- a/packages/flutter_tools/lib/src/mdns_device_discovery.dart
+++ b/packages/flutter_tools/lib/src/mdns_device_discovery.dart
@@ -276,10 +276,8 @@ class MDNSObservation {
       '$_kPid=$pid',
       '$_kFlutterVersion=$flutterVersion',
       '$_kDartVersion=$dartVersion',
+      if (dtdUri != null) '$_kDtdUri=$dtdUri',
     ];
-    if (dtdUri != null) {
-      txt.add('$_kDtdUri=$dtdUri');
-    }
     return txt;
   }
 

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1288,6 +1288,7 @@ abstract class ResidentRunner extends ResidentHandlers {
         await mdnsDeviceDiscovery.advertise(
           appName: appName,
           vmServiceUri: device.vmService!.httpAddress,
+          dtdUri: device.device!.dds.dtdUri?.toString(),
         );
       }
 

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1288,7 +1288,7 @@ abstract class ResidentRunner extends ResidentHandlers {
         await mdnsDeviceDiscovery.advertise(
           appName: appName,
           vmServiceUri: device.vmService!.httpAddress,
-          dtdUri: device.device!.dds.dtdUri?.toString(),
+          dtdUri: device.device!.dds.dtdUri,
         );
       }
 

--- a/packages/flutter_tools/test/general.shard/mdns_device_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/mdns_device_discovery_test.dart
@@ -23,11 +23,11 @@ void main() {
       await discovery.advertise(
         appName: 'app',
         vmServiceUri: Uri.parse('ws://localhost:1234'),
-        dtdUri: 'ws://localhost:4321',
+        dtdUri: Uri.parse('ws://localhost:4321'),
       );
 
       expect(discovery.advertised, isTrue);
-      expect(discovery.advertisedDtdUri, 'ws://localhost:4321');
+      expect(discovery.advertisedDtdUri, Uri.parse('ws://localhost:4321'));
     });
 
     test('does not advertise when running on bot', () async {
@@ -38,7 +38,7 @@ void main() {
       await discovery.advertise(
         appName: 'app',
         vmServiceUri: Uri.parse('ws://localhost:1234'),
-        dtdUri: 'ws://localhost:4321',
+        dtdUri: Uri.parse('ws://localhost:4321'),
       );
 
       expect(discovery.advertised, isFalse);
@@ -55,7 +55,7 @@ void main() {
       await discovery.advertise(
         appName: 'app',
         vmServiceUri: Uri.parse('ws://localhost:1234'),
-        dtdUri: 'ws://localhost:4321',
+        dtdUri: Uri.parse('ws://localhost:4321'),
       );
 
       expect(discovery.advertised, isTrue);
@@ -71,7 +71,7 @@ void main() {
       await discovery.advertise(
         appName: 'app',
         vmServiceUri: Uri.parse('ws://localhost:1234'),
-        dtdUri: 'ws://localhost:4321',
+        dtdUri: Uri.parse('ws://localhost:4321'),
       );
     });
   });
@@ -133,7 +133,7 @@ void main() {
         dtdUri: 'ws://127.0.0.1:4321/auth/ws',
       );
 
-      expect(observation.toJson()['dtdUri'], 'ws://127.0.0.1:4321/auth/ws');
+      expect(observation.toJson()['dtd_uri'], 'ws://127.0.0.1:4321/auth/ws');
     });
 
     test('toJson excludes dtdUri if null', () {
@@ -151,7 +151,7 @@ void main() {
         dartVersion: '2.0.0',
       );
 
-      expect(observation.toJson().containsKey('dtdUri'), isFalse);
+      expect(observation.toJson().containsKey('dtd_uri'), isFalse);
     });
 
     test('parse correctly handles dtdUri', () {
@@ -167,7 +167,7 @@ epoch=0
 pid=1
 flutter_version=1.0.0
 dart_version=2.0.0
-dtdUri=http://127.0.0.1:4321/auth/
+dtd_uri=http://127.0.0.1:4321/auth/
 ''';
       final MDNSObservation? observation = MDNSObservation.parse(txt);
       expect(observation, isNotNull);
@@ -209,14 +209,10 @@ class FakeMDNSDeviceDiscovery extends MDNSDeviceDiscovery {
   });
 
   bool advertised = false;
-  String? advertisedDtdUri;
+  Uri? advertisedDtdUri;
 
   @override
-  Future<void> advertise({
-    required String appName,
-    required Uri? vmServiceUri,
-    String? dtdUri,
-  }) async {
+  Future<void> advertise({required String appName, required Uri? vmServiceUri, Uri? dtdUri}) async {
     // We override advertise to check if the base implementation would have proceeded.
     // However, the base implementation calls `MDNSService.create` and `server.start()` which we can't easily mock
     // without more refactoring or proper dependency injection of the mDNS client.

--- a/packages/flutter_tools/test/general.shard/mdns_device_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/mdns_device_discovery_test.dart
@@ -20,9 +20,14 @@ void main() {
       final botDetector = FakeBotDetector(false);
       final FakeMDNSDeviceDiscovery discovery = createDiscovery(botDetector);
 
-      await discovery.advertise(appName: 'app', vmServiceUri: Uri.parse('ws://localhost:1234'));
+      await discovery.advertise(
+        appName: 'app',
+        vmServiceUri: Uri.parse('ws://localhost:1234'),
+        dtdUri: 'ws://localhost:4321',
+      );
 
       expect(discovery.advertised, isTrue);
+      expect(discovery.advertisedDtdUri, 'ws://localhost:4321');
     });
 
     test('does not advertise when running on bot', () async {
@@ -30,7 +35,11 @@ void main() {
       final FakeMDNSDeviceDiscovery discovery = createDiscovery(botDetector);
 
       // Advertise attempts to start mDNS, but should respect the bot detector.
-      await discovery.advertise(appName: 'app', vmServiceUri: Uri.parse('ws://localhost:1234'));
+      await discovery.advertise(
+        appName: 'app',
+        vmServiceUri: Uri.parse('ws://localhost:1234'),
+        dtdUri: 'ws://localhost:4321',
+      );
 
       expect(discovery.advertised, isFalse);
     });
@@ -43,7 +52,11 @@ void main() {
         platform: fakePlatform,
       );
 
-      await discovery.advertise(appName: 'app', vmServiceUri: Uri.parse('ws://localhost:1234'));
+      await discovery.advertise(
+        appName: 'app',
+        vmServiceUri: Uri.parse('ws://localhost:1234'),
+        dtdUri: 'ws://localhost:4321',
+      );
 
       expect(discovery.advertised, isTrue);
     });
@@ -55,9 +68,110 @@ void main() {
         enableLocalDiscovery: false,
       );
 
-      await discovery.advertise(appName: 'app', vmServiceUri: Uri.parse('ws://localhost:1234'));
+      await discovery.advertise(
+        appName: 'app',
+        vmServiceUri: Uri.parse('ws://localhost:1234'),
+        dtdUri: 'ws://localhost:4321',
+      );
+    });
+  });
 
-      expect(discovery.advertised, isFalse);
+  group('MDNSObservation', () {
+    test('stores dtdUri and wsUri as provided', () {
+      final observation = MDNSObservation(
+        hostname: 'host',
+        projectName: 'project',
+        deviceName: 'device',
+        deviceId: 'device_id',
+        targetPlatform: 'android',
+        mode: 'debug',
+        wsUri: 'http://127.0.0.1:1234/auth/',
+        epoch: 0,
+        pid: 1,
+        flutterVersion: '1.0.0',
+        dartVersion: '2.0.0',
+        dtdUri: 'http://127.0.0.1:4321/auth/',
+      );
+
+      // We no longer convert inside the class, it expects what is passed.
+      // But let's check what we passed.
+      expect(observation.wsUri, 'http://127.0.0.1:1234/auth/');
+      expect(observation.dtdUri, 'http://127.0.0.1:4321/auth/');
+    });
+
+    test('dtdUri is optional', () {
+      final observation = MDNSObservation(
+        hostname: 'host',
+        projectName: 'project',
+        deviceName: 'device',
+        deviceId: 'device_id',
+        targetPlatform: 'android',
+        mode: 'debug',
+        wsUri: 'https://127.0.0.1:1234/auth/',
+        epoch: 0,
+        pid: 1,
+        flutterVersion: '1.0.0',
+        dartVersion: '2.0.0',
+      );
+
+      expect(observation.dtdUri, null);
+    });
+
+    test('toJson includes dtdUri if present', () {
+      final observation = MDNSObservation(
+        hostname: 'host',
+        projectName: 'project',
+        deviceName: 'device',
+        deviceId: 'device_id',
+        targetPlatform: 'android',
+        mode: 'debug',
+        wsUri: 'ws://127.0.0.1:1234/auth/ws',
+        epoch: 0,
+        pid: 1,
+        flutterVersion: '1.0.0',
+        dartVersion: '2.0.0',
+        dtdUri: 'ws://127.0.0.1:4321/auth/ws',
+      );
+
+      expect(observation.toJson()['dtdUri'], 'ws://127.0.0.1:4321/auth/ws');
+    });
+
+    test('toJson excludes dtdUri if null', () {
+      final observation = MDNSObservation(
+        hostname: 'host',
+        projectName: 'project',
+        deviceName: 'device',
+        deviceId: 'device_id',
+        targetPlatform: 'android',
+        mode: 'debug',
+        wsUri: 'http://127.0.0.1:1234/auth',
+        epoch: 0,
+        pid: 1,
+        flutterVersion: '1.0.0',
+        dartVersion: '2.0.0',
+      );
+
+      expect(observation.toJson().containsKey('dtdUri'), isFalse);
+    });
+
+    test('parse correctly handles dtdUri', () {
+      const txt = '''
+hostname=host
+project_name=project
+device_name=device
+device_id=device_id
+target_platform=android
+mode=debug
+ws_uri=http://127.0.0.1:1234/auth/
+epoch=0
+pid=1
+flutter_version=1.0.0
+dart_version=2.0.0
+dtdUri=http://127.0.0.1:4321/auth/
+''';
+      final MDNSObservation? observation = MDNSObservation.parse(txt);
+      expect(observation, isNotNull);
+      expect(observation!.dtdUri, 'http://127.0.0.1:4321/auth/');
     });
   });
 }
@@ -95,9 +209,14 @@ class FakeMDNSDeviceDiscovery extends MDNSDeviceDiscovery {
   });
 
   bool advertised = false;
+  String? advertisedDtdUri;
 
   @override
-  Future<void> advertise({required String appName, required Uri? vmServiceUri}) async {
+  Future<void> advertise({
+    required String appName,
+    required Uri? vmServiceUri,
+    String? dtdUri,
+  }) async {
     // We override advertise to check if the base implementation would have proceeded.
     // However, the base implementation calls `MDNSService.create` and `server.start()` which we can't easily mock
     // without more refactoring or proper dependency injection of the mDNS client.
@@ -110,7 +229,7 @@ class FakeMDNSDeviceDiscovery extends MDNSDeviceDiscovery {
     // We can check the logger.
 
     try {
-      await super.advertise(appName: appName, vmServiceUri: vmServiceUri);
+      await super.advertise(appName: appName, vmServiceUri: vmServiceUri, dtdUri: dtdUri);
     } on Object {
       // Ignore errors from starting mDNS
     }
@@ -126,6 +245,7 @@ class FakeMDNSDeviceDiscovery extends MDNSDeviceDiscovery {
       advertised = false;
     } else {
       advertised = true;
+      advertisedDtdUri = dtdUri;
     }
   }
 }

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -34,9 +34,7 @@ import 'package:flutter_tools/src/resident_runner.dart';
 import 'package:flutter_tools/src/version.dart';
 import 'package:flutter_tools/src/vmservice.dart';
 import 'package:flutter_tools/src/web/chrome.dart';
-import 'package:flutter_tools/src/web/compile.dart';
 import 'package:flutter_tools/src/web/devfs_config.dart';
-import 'package:flutter_tools/src/web/web_runner.dart';
 import 'package:flutter_tools/src/web/web_device.dart';
 import 'package:package_config/package_config.dart';
 import 'package:package_config/package_config_types.dart';
@@ -283,22 +281,20 @@ name: my_app
       final ResidentRunner residentWebRunner = setUpResidentRunner(
         flutterDevice,
         logger: logger,
-        debuggingOptions: DebuggingOptions.enabled(
-          BuildInfo.debug,
-          enableLocalDiscovery: true,
-        ),
-        mdnsDeviceDiscoveryFactory: ({
-          required Device device,
-          required vm_service.VmService vmService,
-          required DebuggingOptions debuggingOptions,
-          required Logger logger,
-          required Platform platform,
-          required FlutterVersion flutterVersion,
-          required SystemClock systemClock,
-          required BotDetector botDetector,
-        }) {
-          return fakeMDNSDeviceDiscovery;
-        },
+        debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug, enableLocalDiscovery: true),
+        mdnsDeviceDiscoveryFactory:
+            ({
+              required Device device,
+              required vm_service.VmService vmService,
+              required DebuggingOptions debuggingOptions,
+              required Logger logger,
+              required Platform platform,
+              required FlutterVersion flutterVersion,
+              required SystemClock systemClock,
+              required BotDetector botDetector,
+            }) {
+              return fakeMDNSDeviceDiscovery;
+            },
       );
       fakeVmServiceHost = FakeVmServiceHost(requests: kAttachExpectations.toList());
       setupMocks();
@@ -2423,6 +2419,7 @@ class FakeShaderCompiler implements DevelopmentShaderCompiler {
     throw UnimplementedError();
   }
 }
+
 class FakeMDNSDeviceDiscovery extends Fake implements MDNSDeviceDiscovery {
   Uri? advertisedVmServiceUri;
   String? advertisedDtdUri;

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -10,6 +10,7 @@ import 'package:dwds/dwds.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/application_package.dart';
 import 'package:flutter_tools/src/asset.dart';
+import 'package:flutter_tools/src/base/bot_detector.dart';
 import 'package:flutter_tools/src/base/dds.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
@@ -27,11 +28,15 @@ import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/isolated/devfs_web.dart';
 import 'package:flutter_tools/src/isolated/resident_web_runner.dart';
+import 'package:flutter_tools/src/mdns_device_discovery.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/resident_runner.dart';
+import 'package:flutter_tools/src/version.dart';
 import 'package:flutter_tools/src/vmservice.dart';
 import 'package:flutter_tools/src/web/chrome.dart';
+import 'package:flutter_tools/src/web/compile.dart';
 import 'package:flutter_tools/src/web/devfs_config.dart';
+import 'package:flutter_tools/src/web/web_runner.dart';
 import 'package:flutter_tools/src/web/web_device.dart';
 import 'package:package_config/package_config.dart';
 import 'package:package_config/package_config_types.dart';
@@ -262,6 +267,53 @@ name: my_app
       expect(logger.statusText, contains('Debug service listening on ws://127.0.0.1/abcd/'));
       expect(debugConnectionInfo.wsUri.toString(), 'ws://127.0.0.1/abcd/');
       expect(debugConnectionInfo.dtdUri.toString(), 'ws://127.0.0.1/efgh/');
+    },
+    overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      ProcessManager: () => processManager,
+      Pub: ThrowingPub.new,
+    },
+  );
+
+  testUsingContext(
+    'ResidentWebRunner uses DDS URI for mDNS advertisement when available',
+    () async {
+      final logger = BufferLogger.test();
+      final fakeMDNSDeviceDiscovery = FakeMDNSDeviceDiscovery();
+      final ResidentRunner residentWebRunner = setUpResidentRunner(
+        flutterDevice,
+        logger: logger,
+        debuggingOptions: DebuggingOptions.enabled(
+          BuildInfo.debug,
+          enableLocalDiscovery: true,
+        ),
+        mdnsDeviceDiscoveryFactory: ({
+          required Device device,
+          required vm_service.VmService vmService,
+          required DebuggingOptions debuggingOptions,
+          required Logger logger,
+          required Platform platform,
+          required FlutterVersion flutterVersion,
+          required SystemClock systemClock,
+          required BotDetector botDetector,
+        }) {
+          return fakeMDNSDeviceDiscovery;
+        },
+      );
+      fakeVmServiceHost = FakeVmServiceHost(requests: kAttachExpectations.toList());
+      setupMocks();
+
+      // Setup DDS URI
+      debugConnection.ddsUri = 'http://127.0.0.1:1234/dds/';
+
+      final connectionInfoCompleter = Completer<DebugConnectionInfo>();
+      unawaited(residentWebRunner.run(connectionInfoCompleter: connectionInfoCompleter));
+      await connectionInfoCompleter.future;
+
+      expect(
+        fakeMDNSDeviceDiscovery.advertisedVmServiceUri,
+        Uri.parse('http://127.0.0.1:1234/dds/'),
+      );
     },
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
@@ -1971,6 +2023,7 @@ ResidentRunner setUpResidentRunner(
   Logger? logger,
   SystemClock? systemClock,
   DebuggingOptions? debuggingOptions,
+  MDNSDeviceDiscoveryFactory? mdnsDeviceDiscoveryFactory,
 }) {
   return ResidentWebRunner(
     flutterDevice,
@@ -1983,6 +2036,7 @@ ResidentRunner setUpResidentRunner(
     terminal: Terminal.test(),
     platform: FakePlatform(),
     outputPreferences: OutputPreferences.test(),
+    mdnsDeviceDiscoveryFactory: mdnsDeviceDiscoveryFactory,
   );
 }
 
@@ -2057,6 +2111,9 @@ class FakeDebugConnection extends Fake implements DebugConnection {
 
   @override
   late String dtdUri;
+
+  @override
+  String? ddsUri;
 
   final completer = Completer<void>();
   bool didClose = false;
@@ -2365,4 +2422,21 @@ class FakeShaderCompiler implements DevelopmentShaderCompiler {
   Future<DevFSContent> recompileShader(DevFSContent inputShader) {
     throw UnimplementedError();
   }
+}
+class FakeMDNSDeviceDiscovery extends Fake implements MDNSDeviceDiscovery {
+  Uri? advertisedVmServiceUri;
+  String? advertisedDtdUri;
+
+  @override
+  Future<void> advertise({
+    required String appName,
+    required Uri? vmServiceUri,
+    required String? dtdUri,
+  }) async {
+    advertisedVmServiceUri = vmServiceUri;
+    advertisedDtdUri = dtdUri;
+  }
+
+  @override
+  Future<void> stop() async {}
 }

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -2422,13 +2422,13 @@ class FakeShaderCompiler implements DevelopmentShaderCompiler {
 
 class FakeMDNSDeviceDiscovery extends Fake implements MDNSDeviceDiscovery {
   Uri? advertisedVmServiceUri;
-  String? advertisedDtdUri;
+  Uri? advertisedDtdUri;
 
   @override
   Future<void> advertise({
     required String appName,
     required Uri? vmServiceUri,
-    required String? dtdUri,
+    required Uri? dtdUri,
   }) async {
     advertisedVmServiceUri = vmServiceUri;
     advertisedDtdUri = dtdUri;


### PR DESCRIPTION
This PR addresses two main improvements to how running Flutter apps are discovered by external tools (like IDEs and DevTools) via mDNS:

1. Fixes mDNS broadcasting for Web targets (Fixes [#182389](https://github.com/flutter/flutter/issues/182389)). Previously, ResidentWebRunner was always advertising the direct VM Service URI over mDNS. This was an issue because external tools relying on mDNS discovery would connect directly to the VM Service, entirely bypassing the Dart Development Service (DDS). We now correctly prioritize and advertise the DDS URI when it is available, ensuring tools connect through the proper DDS layer.

2. Adds support for reporting the DTD URI. This PR also adds the Dart Tooling Daemon (dtdUri) to the mDNS TXT records (MDNSObservation),  https://github.com/flutter/flutter/issues/182322. This allows external tools and IDEs to automatically discover and connect to the DTD for a running application.
