### PR TITLE
[Impeller] libImpeller: Dispose thread local caches on each Vulkan frame

### DIFF
--- a/engine/src/flutter/impeller/toolkit/interop/backend/vulkan/swapchain_vk.cc
+++ b/engine/src/flutter/impeller/toolkit/interop/backend/vulkan/swapchain_vk.cc
@@ -47,6 +47,9 @@ ScopedObject<SurfaceVK> SwapchainVK::AcquireNextSurface() {
     return nullptr;
   }
 
+  auto& context_vk = impeller::ContextVK::Cast(*context_->GetContext());
+  context_vk.DisposeThreadLocalCachedResources();
+
   auto impeller_surface = swapchain_->AcquireNextDrawable();
   if (!impeller_surface) {
     VALIDATION_LOG << "Could not acquire next drawable.";


### PR DESCRIPTION
The Impeller Vulkan back end caches command pools in thread-local storage. These caches can grow unbounded unless the embedder calls ContextVK::DisposeThreadLocalCachedResources()

This PR ensures that libImpeller Vulkan apps do this on each frame by calling DisposeThreadLocalCachedResources inside the ImpellerVulkanSwapchainAcquireNextSurfaceNew API.