### PR TITLE
fix: disable NavigationDestination tooltip when message is empty

### DIFF
--- a/packages/flutter/lib/src/material/navigation_bar.dart
+++ b/packages/flutter/lib/src/material/navigation_bar.dart
@@ -613,14 +613,13 @@ class _NavigationDestinationBuilderState extends State<_NavigationDestinationBui
       ),
     );
 
-    if (_effectiveTooltip != null && _effectiveTooltip!.isNotEmpty) {
-      child = _NavigationBarDestinationTooltip(message: _effectiveTooltip!, child: child);
+    final String tooltip = widget.tooltip ?? widget.label;
+    if (tooltip.isNotEmpty) {
+      child = _NavigationBarDestinationTooltip(message: tooltip, child: child);
     }
 
     return _NavigationBarDestinationSemantics(enabled: widget.enabled, child: child);
   }
-
-  String? get _effectiveTooltip => widget.tooltip ?? widget.label;
 }
 
 class _IndicatorInkWell extends InkResponse {

--- a/packages/flutter/lib/src/material/navigation_bar.dart
+++ b/packages/flutter/lib/src/material/navigation_bar.dart
@@ -593,32 +593,34 @@ class _NavigationDestinationBuilderState extends State<_NavigationDestinationBui
     final NavigationBarThemeData navigationBarTheme = NavigationBarTheme.of(context);
     final NavigationBarThemeData defaults = _defaultsFor(context);
 
-    return _NavigationBarDestinationSemantics(
-      enabled: widget.enabled,
-      child: _NavigationBarDestinationTooltip(
-        message: widget.tooltip ?? widget.label,
-        child: _IndicatorInkWell(
-          iconKey: iconKey,
-          labelBehavior: info.labelBehavior,
-          customBorder:
-              info.indicatorShape ?? navigationBarTheme.indicatorShape ?? defaults.indicatorShape,
-          overlayColor: info.overlayColor ?? navigationBarTheme.overlayColor,
-          onTap: widget.enabled ? info.onTap : null,
-          child: Row(
-            children: <Widget>[
-              Expanded(
-                child: _NavigationBarDestinationLayout(
-                  icon: widget.buildIcon(context),
-                  iconKey: iconKey,
-                  label: widget.buildLabel(context),
-                ),
-              ),
-            ],
+    Widget child = _IndicatorInkWell(
+      iconKey: iconKey,
+      labelBehavior: info.labelBehavior,
+      customBorder:
+          info.indicatorShape ?? navigationBarTheme.indicatorShape ?? defaults.indicatorShape,
+      overlayColor: info.overlayColor ?? navigationBarTheme.overlayColor,
+      onTap: widget.enabled ? info.onTap : null,
+      child: Row(
+        children: <Widget>[
+          Expanded(
+            child: _NavigationBarDestinationLayout(
+              icon: widget.buildIcon(context),
+              iconKey: iconKey,
+              label: widget.buildLabel(context),
+            ),
           ),
-        ),
+        ],
       ),
     );
+
+    if (_effectiveTooltip != null && _effectiveTooltip!.isNotEmpty) {
+      child = _NavigationBarDestinationTooltip(message: _effectiveTooltip!, child: child);
+    }
+
+    return _NavigationBarDestinationSemantics(enabled: widget.enabled, child: child);
   }
+
+  String? get _effectiveTooltip => widget.tooltip ?? widget.label;
 }
 
 class _IndicatorInkWell extends InkResponse {

--- a/packages/flutter/test/material/navigation_bar_test.dart
+++ b/packages/flutter/test/material/navigation_bar_test.dart
@@ -1760,6 +1760,31 @@ void main() {
     );
     expect(tester.getSize(find.byType(NavigationBar)), Size.zero);
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/182495.
+  testWidgets('NavigationDestination ignores empty tooltip', (WidgetTester tester) async {
+    const emptyTooltip = '';
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          bottomNavigationBar: NavigationBar(
+            destinations: const <NavigationDestination>[
+              NavigationDestination(label: 'A', tooltip: emptyTooltip, icon: Icon(Icons.ac_unit)),
+              NavigationDestination(label: 'B', icon: Icon(Icons.battery_alert)),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('A'), findsOneWidget);
+    await tester.longPress(find.text('A'));
+    expect(find.byTooltip(emptyTooltip), findsNothing);
+
+    await tester.longPress(find.text('B'));
+    expect(find.text('B'), findsNWidgets(2));
+  });
 }
 
 Widget _buildWidget(Widget child, {bool? useMaterial3}) {

--- a/packages/flutter/test/material/navigation_bar_test.dart
+++ b/packages/flutter/test/material/navigation_bar_test.dart
@@ -1783,7 +1783,7 @@ void main() {
     expect(find.byTooltip(emptyTooltip), findsNothing);
 
     await tester.longPress(find.text('B'));
-    expect(find.text('B'), findsNWidgets(2));
+    expect(find.byTooltip('B'), findsOneWidget);
   });
 }
 


### PR DESCRIPTION
Aligns the behavior with the documented. An empty string now disables the tooltip rather than falling back to the label. The label fallback is preserved only when the tooltip is null.

Fixes https://github.com/flutter/flutter/issues/182495

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
