### PR TITLE
Don't compile shaders to SkSL unless --sksl arg is present

### DIFF
--- a/engine/src/flutter/impeller/compiler/compiler.cc
+++ b/engine/src/flutter/impeller/compiler/compiler.cc
@@ -242,7 +242,6 @@ static CompilerBackend CreateCompiler(const spirv_cross::ParsedIR& ir,
     case TargetPlatform::kRuntimeStageVulkan:
       compiler = CreateVulkanCompiler(ir, source_options);
       break;
-    case TargetPlatform::kUnknown:
     case TargetPlatform::kOpenGLES:
     case TargetPlatform::kOpenGLDesktop:
     case TargetPlatform::kRuntimeStageGLES:
@@ -251,6 +250,9 @@ static CompilerBackend CreateCompiler(const spirv_cross::ParsedIR& ir,
       break;
     case TargetPlatform::kSkSL:
       compiler = CreateSkSLCompiler(ir, source_options);
+      break;
+    case TargetPlatform::kUnknown:
+      FML_UNREACHABLE();
   }
   if (!compiler) {
     return {};

--- a/engine/src/flutter/impeller/compiler/compiler_test.cc
+++ b/engine/src/flutter/impeller/compiler/compiler_test.cc
@@ -142,53 +142,50 @@ bool CompilerTestBase::CanCompileAndReflect(
     return false;
   }
 
-  if (TargetPlatformNeedsReflection(GetParam())) {
-    auto reflector = compiler.GetReflector();
-    if (!reflector) {
-      VALIDATION_LOG
-          << "No reflector was found for target platform SL compiler.";
-      return false;
-    }
+  auto reflector = compiler.GetReflector();
+  if (!reflector) {
+    VALIDATION_LOG << "No reflector was found for target platform SL compiler.";
+    return false;
+  }
 
-    auto reflection_json = reflector->GetReflectionJSON();
-    auto reflection_header = reflector->GetReflectionHeader();
-    auto reflection_source = reflector->GetReflectionCC();
+  auto reflection_json = reflector->GetReflectionJSON();
+  auto reflection_header = reflector->GetReflectionHeader();
+  auto reflection_source = reflector->GetReflectionCC();
 
-    if (!reflection_json) {
-      VALIDATION_LOG << "Reflection JSON was not found.";
-      return false;
-    }
+  if (!reflection_json) {
+    VALIDATION_LOG << "Reflection JSON was not found.";
+    return false;
+  }
 
-    if (!reflection_header) {
-      VALIDATION_LOG << "Reflection header was not found.";
-      return false;
-    }
+  if (!reflection_header) {
+    VALIDATION_LOG << "Reflection header was not found.";
+    return false;
+  }
 
-    if (!reflection_source) {
-      VALIDATION_LOG << "Reflection source was not found.";
-      return false;
-    }
+  if (!reflection_source) {
+    VALIDATION_LOG << "Reflection source was not found.";
+    return false;
+  }
 
-    if (!fml::WriteAtomically(intermediates_directory_,
-                              ReflectionHeaderName(fixture_name).c_str(),
-                              *reflection_header)) {
-      VALIDATION_LOG << "Could not write reflection header intermediates.";
-      return false;
-    }
+  if (!fml::WriteAtomically(intermediates_directory_,
+                            ReflectionHeaderName(fixture_name).c_str(),
+                            *reflection_header)) {
+    VALIDATION_LOG << "Could not write reflection header intermediates.";
+    return false;
+  }
 
-    if (!fml::WriteAtomically(intermediates_directory_,
-                              ReflectionCCName(fixture_name).c_str(),
-                              *reflection_source)) {
-      VALIDATION_LOG << "Could not write reflection CC intermediates.";
-      return false;
-    }
+  if (!fml::WriteAtomically(intermediates_directory_,
+                            ReflectionCCName(fixture_name).c_str(),
+                            *reflection_source)) {
+    VALIDATION_LOG << "Could not write reflection CC intermediates.";
+    return false;
+  }
 
-    if (!fml::WriteAtomically(intermediates_directory_,
-                              ReflectionJSONName(fixture_name).c_str(),
-                              *reflection_json)) {
-      VALIDATION_LOG << "Could not write reflection json intermediates.";
-      return false;
-    }
+  if (!fml::WriteAtomically(intermediates_directory_,
+                            ReflectionJSONName(fixture_name).c_str(),
+                            *reflection_json)) {
+    VALIDATION_LOG << "Could not write reflection json intermediates.";
+    return false;
   }
   return true;
 }

--- a/engine/src/flutter/impeller/compiler/compiler_test.h
+++ b/engine/src/flutter/impeller/compiler/compiler_test.h
@@ -45,9 +45,11 @@ class CompilerTestBase : public ::testing::TestWithParam<TargetPlatform> {
 
 class CompilerTest : public CompilerTestBase {};
 
+class CompilerTestRuntime : public CompilerTestBase {};
+
 class CompilerTestSkSL : public CompilerTestBase {};
 
-class CompilerTestRuntime : public CompilerTestBase {};
+class CompilerTestUnknownPlatform : public CompilerTestBase {};
 
 }  // namespace testing
 }  // namespace compiler

--- a/engine/src/flutter/impeller/compiler/compiler_unittests.cc
+++ b/engine/src/flutter/impeller/compiler/compiler_unittests.cc
@@ -15,6 +15,52 @@ namespace impeller {
 namespace compiler {
 namespace testing {
 
+#define INSTANTIATE_TARGET_PLATFORM_TEST_SUITE_P(suite_name)                 \
+  INSTANTIATE_TEST_SUITE_P(                                                  \
+      suite_name, CompilerTest,                                              \
+      ::testing::Values(TargetPlatform::kOpenGLES,                           \
+                        TargetPlatform::kOpenGLDesktop,                      \
+                        TargetPlatform::kMetalDesktop,                       \
+                        TargetPlatform::kMetalIOS, TargetPlatform::kVulkan), \
+      [](const ::testing::TestParamInfo<CompilerTest::ParamType>& info) {    \
+        return TargetPlatformToString(info.param);                           \
+      });
+
+INSTANTIATE_TARGET_PLATFORM_TEST_SUITE_P(CompilerSuite);
+
+#define INSTANTIATE_RUNTIME_TARGET_PLATFORM_TEST_SUITE_P(suite_name)      \
+  INSTANTIATE_TEST_SUITE_P(                                               \
+      suite_name, CompilerTestRuntime,                                    \
+      ::testing::Values(TargetPlatform::kRuntimeStageMetal,               \
+                        TargetPlatform::kRuntimeStageGLES,                \
+                        TargetPlatform::kRuntimeStageGLES3,               \
+                        TargetPlatform::kRuntimeStageVulkan,              \
+                        TargetPlatform::kSkSL),                           \
+      [](const ::testing::TestParamInfo<CompilerTest::ParamType>& info) { \
+        return TargetPlatformToString(info.param);                        \
+      });
+
+INSTANTIATE_RUNTIME_TARGET_PLATFORM_TEST_SUITE_P(CompilerSuite);
+
+#define INSTANTIATE_SKSL_TARGET_PLATFORM_TEST_SUITE_P(suite_name)             \
+  INSTANTIATE_TEST_SUITE_P(                                                   \
+      suite_name, CompilerTestSkSL, ::testing::Values(TargetPlatform::kSkSL), \
+      [](const ::testing::TestParamInfo<CompilerTest::ParamType>& info) {     \
+        return TargetPlatformToString(info.param);                            \
+      });
+
+INSTANTIATE_SKSL_TARGET_PLATFORM_TEST_SUITE_P(CompilerSuite);
+
+#define INSTANTIATE_UNKNOWN_TARGET_PLATFORM_TEST_SUITE_P(suite_name)      \
+  INSTANTIATE_TEST_SUITE_P(                                               \
+      suite_name, CompilerTestUnknownPlatform,                            \
+      ::testing::Values(TargetPlatform::kUnknown),                        \
+      [](const ::testing::TestParamInfo<CompilerTest::ParamType>& info) { \
+        return TargetPlatformToString(info.param);                        \
+      });
+
+INSTANTIATE_UNKNOWN_TARGET_PLATFORM_TEST_SUITE_P(CompilerSuite);
+
 TEST(CompilerTest, Defines) {
   std::shared_ptr<const fml::Mapping> fixture =
       flutter::testing::OpenFixtureAsMapping("check_gles_definition.frag");
@@ -48,9 +94,6 @@ TEST(CompilerTest, ShaderKindMatchingIsSuccessful) {
 }
 
 TEST_P(CompilerTest, CanCompile) {
-  if (GetParam() == TargetPlatform::kSkSL) {
-    GTEST_SKIP() << "Not supported with SkSL";
-  }
   ASSERT_TRUE(CanCompileAndReflect("sample.vert"));
   ASSERT_TRUE(CanCompileAndReflect("sample.vert", SourceType::kVertexShader));
   ASSERT_TRUE(CanCompileAndReflect("sample.vert", SourceType::kVertexShader,
@@ -58,17 +101,11 @@ TEST_P(CompilerTest, CanCompile) {
 }
 
 TEST_P(CompilerTest, CanCompileHLSL) {
-  if (GetParam() == TargetPlatform::kSkSL) {
-    GTEST_SKIP() << "Not supported with SkSL";
-  }
   ASSERT_TRUE(CanCompileAndReflect(
       "simple.vert.hlsl", SourceType::kVertexShader, SourceLanguage::kHLSL));
 }
 
 TEST_P(CompilerTest, CanCompileHLSLWithMultipleStages) {
-  if (GetParam() == TargetPlatform::kSkSL) {
-    GTEST_SKIP() << "Not supported with SkSL";
-  }
   ASSERT_TRUE(CanCompileAndReflect("multiple_stages.hlsl",
                                    SourceType::kVertexShader,
                                    SourceLanguage::kHLSL, "VertexShader"));
@@ -87,18 +124,12 @@ TEST_P(CompilerTest, CanCompileComputeShader) {
 }
 
 TEST_P(CompilerTest, MustFailDueToExceedingResourcesLimit) {
-  if (GetParam() == TargetPlatform::kSkSL) {
-    GTEST_SKIP() << "Not supported with SkSL";
-  }
   ScopedValidationDisable disable_validation;
   ASSERT_FALSE(
       CanCompileAndReflect("resources_limit.vert", SourceType::kVertexShader));
 }
 
 TEST_P(CompilerTest, MustFailDueToMultipleLocationPerStructMember) {
-  if (GetParam() == TargetPlatform::kSkSL) {
-    GTEST_SKIP() << "Not supported with SkSL";
-  }
   ScopedValidationDisable disable_validation;
   ASSERT_FALSE(CanCompileAndReflect("struct_def_bug.vert"));
 }
@@ -202,6 +233,13 @@ inline std::ostream& operator<<(std::ostream& out, const UniformInfo& info) {
 }  // namespace
 
 TEST_P(CompilerTestRuntime, UniformsAppearInJson) {
+  if (GetParam() == TargetPlatform::kSkSL) {
+    GTEST_SKIP() << "Not supported with SkSL";
+  }
+  if (GetParam() == TargetPlatform::kRuntimeStageVulkan) {
+    GTEST_SKIP() << "Not supported with Vulkan";
+  }
+
   ASSERT_TRUE(CanCompileAndReflect("sample_with_uniforms.frag",
                                    SourceType::kFragmentShader,
                                    SourceLanguage::kGLSL));
@@ -248,6 +286,13 @@ TEST_P(CompilerTestRuntime, UniformsAppearInJson) {
 }
 
 TEST_P(CompilerTestRuntime, PositionedUniformsAppearInJson) {
+  if (GetParam() == TargetPlatform::kSkSL) {
+    GTEST_SKIP() << "Not supported with SkSL";
+  }
+  if (GetParam() == TargetPlatform::kRuntimeStageVulkan) {
+    GTEST_SKIP() << "Not supported with Vulkan";
+  }
+
   ASSERT_TRUE(CanCompileAndReflect("sample_with_positioned_uniforms.frag",
                                    SourceType::kFragmentShader,
                                    SourceLanguage::kGLSL));
@@ -377,39 +422,11 @@ TEST_P(CompilerTestSkSL, CompilesWithValidArrayInitialization) {
                            SourceType::kFragmentShader));
 }
 
-#define INSTANTIATE_TARGET_PLATFORM_TEST_SUITE_P(suite_name)               \
-  INSTANTIATE_TEST_SUITE_P(                                                \
-      suite_name, CompilerTest,                                            \
-      ::testing::Values(TargetPlatform::kOpenGLES,                         \
-                        TargetPlatform::kOpenGLDesktop,                    \
-                        TargetPlatform::kMetalDesktop,                     \
-                        TargetPlatform::kMetalIOS, TargetPlatform::kSkSL), \
-      [](const ::testing::TestParamInfo<CompilerTest::ParamType>& info) {  \
-        return TargetPlatformToString(info.param);                         \
-      });
-
-INSTANTIATE_TARGET_PLATFORM_TEST_SUITE_P(CompilerSuite);
-
-#define INSTANTIATE_RUNTIME_TARGET_PLATFORM_TEST_SUITE_P(suite_name)      \
-  INSTANTIATE_TEST_SUITE_P(                                               \
-      suite_name, CompilerTestRuntime,                                    \
-      ::testing::Values(TargetPlatform::kRuntimeStageMetal),              \
-      [](const ::testing::TestParamInfo<CompilerTest::ParamType>& info) { \
-        return TargetPlatformToString(info.param);                        \
-      });
-
-INSTANTIATE_RUNTIME_TARGET_PLATFORM_TEST_SUITE_P(CompilerSuite);
-
-#define INSTANTIATE_SKSL_TARGET_PLATFORM_TEST_SUITE_P(suite_name)             \
-  INSTANTIATE_TEST_SUITE_P(                                                   \
-      suite_name, CompilerTestSkSL, ::testing::Values(TargetPlatform::kSkSL), \
-      [](const ::testing::TestParamInfo<CompilerTest::ParamType>& info) {     \
-        return TargetPlatformToString(info.param);                            \
-      });
-
-INSTANTIATE_SKSL_TARGET_PLATFORM_TEST_SUITE_P(CompilerSuite);
-
 TEST_P(CompilerTestRuntime, Mat2Reflection) {
+  if (GetParam() == TargetPlatform::kSkSL) {
+    GTEST_SKIP() << "Not supported with SkSL";
+  }
+
   ASSERT_TRUE(CanCompileAndReflect(
       "mat2_test.frag", SourceType::kFragmentShader, SourceLanguage::kGLSL));
 
@@ -446,6 +463,11 @@ TEST_P(CompilerTestRuntime, Mat2Reflection) {
 
   // Offset 0
   EXPECT_EQ(mat2Member["offset"], 0u);
+}
+
+TEST_P(CompilerTestUnknownPlatform, MustFailDueToUnknownPlatform) {
+  ASSERT_FALSE(
+      CanCompileAndReflect("sample.frag", SourceType::kFragmentShader));
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/compiler/compiler_unittests.cc
+++ b/engine/src/flutter/impeller/compiler/compiler_unittests.cc
@@ -15,51 +15,45 @@ namespace impeller {
 namespace compiler {
 namespace testing {
 
-#define INSTANTIATE_TARGET_PLATFORM_TEST_SUITE_P(suite_name)                 \
-  INSTANTIATE_TEST_SUITE_P(                                                  \
-      suite_name, CompilerTest,                                              \
-      ::testing::Values(TargetPlatform::kOpenGLES,                           \
-                        TargetPlatform::kOpenGLDesktop,                      \
-                        TargetPlatform::kMetalDesktop,                       \
-                        TargetPlatform::kMetalIOS, TargetPlatform::kVulkan), \
-      [](const ::testing::TestParamInfo<CompilerTest::ParamType>& info) {    \
-        return TargetPlatformToString(info.param);                           \
-      });
+INSTANTIATE_TEST_SUITE_P(
+    CompilerSuite,
+    CompilerTest,
+    ::testing::Values(TargetPlatform::kOpenGLES,
+                      TargetPlatform::kOpenGLDesktop,
+                      TargetPlatform::kMetalDesktop,
+                      TargetPlatform::kMetalIOS,
+                      TargetPlatform::kVulkan),
+    [](const ::testing::TestParamInfo<CompilerTest::ParamType>& info) {
+      return TargetPlatformToString(info.param);
+    });
 
-INSTANTIATE_TARGET_PLATFORM_TEST_SUITE_P(CompilerSuite);
+INSTANTIATE_TEST_SUITE_P(
+    CompilerSuite,
+    CompilerTestRuntime,
+    ::testing::Values(TargetPlatform::kRuntimeStageMetal,
+                      TargetPlatform::kRuntimeStageGLES,
+                      TargetPlatform::kRuntimeStageGLES3,
+                      TargetPlatform::kRuntimeStageVulkan,
+                      TargetPlatform::kSkSL),
+    [](const ::testing::TestParamInfo<CompilerTest::ParamType>& info) {
+      return TargetPlatformToString(info.param);
+    });
 
-#define INSTANTIATE_RUNTIME_TARGET_PLATFORM_TEST_SUITE_P(suite_name)      \
-  INSTANTIATE_TEST_SUITE_P(                                               \
-      suite_name, CompilerTestRuntime,                                    \
-      ::testing::Values(TargetPlatform::kRuntimeStageMetal,               \
-                        TargetPlatform::kRuntimeStageGLES,                \
-                        TargetPlatform::kRuntimeStageGLES3,               \
-                        TargetPlatform::kRuntimeStageVulkan,              \
-                        TargetPlatform::kSkSL),                           \
-      [](const ::testing::TestParamInfo<CompilerTest::ParamType>& info) { \
-        return TargetPlatformToString(info.param);                        \
-      });
+INSTANTIATE_TEST_SUITE_P(
+    CompilerSuite,
+    CompilerTestSkSL,
+    ::testing::Values(TargetPlatform::kSkSL),
+    [](const ::testing::TestParamInfo<CompilerTest::ParamType>& info) {
+      return TargetPlatformToString(info.param);
+    });
 
-INSTANTIATE_RUNTIME_TARGET_PLATFORM_TEST_SUITE_P(CompilerSuite);
-
-#define INSTANTIATE_SKSL_TARGET_PLATFORM_TEST_SUITE_P(suite_name)             \
-  INSTANTIATE_TEST_SUITE_P(                                                   \
-      suite_name, CompilerTestSkSL, ::testing::Values(TargetPlatform::kSkSL), \
-      [](const ::testing::TestParamInfo<CompilerTest::ParamType>& info) {     \
-        return TargetPlatformToString(info.param);                            \
-      });
-
-INSTANTIATE_SKSL_TARGET_PLATFORM_TEST_SUITE_P(CompilerSuite);
-
-#define INSTANTIATE_UNKNOWN_TARGET_PLATFORM_TEST_SUITE_P(suite_name)      \
-  INSTANTIATE_TEST_SUITE_P(                                               \
-      suite_name, CompilerTestUnknownPlatform,                            \
-      ::testing::Values(TargetPlatform::kUnknown),                        \
-      [](const ::testing::TestParamInfo<CompilerTest::ParamType>& info) { \
-        return TargetPlatformToString(info.param);                        \
-      });
-
-INSTANTIATE_UNKNOWN_TARGET_PLATFORM_TEST_SUITE_P(CompilerSuite);
+INSTANTIATE_TEST_SUITE_P(
+    CompilerSuite,
+    CompilerTestUnknownPlatform,
+    ::testing::Values(TargetPlatform::kUnknown),
+    [](const ::testing::TestParamInfo<CompilerTest::ParamType>& info) {
+      return TargetPlatformToString(info.param);
+    });
 
 TEST(CompilerTest, Defines) {
   std::shared_ptr<const fml::Mapping> fixture =
@@ -233,10 +227,9 @@ inline std::ostream& operator<<(std::ostream& out, const UniformInfo& info) {
 }  // namespace
 
 TEST_P(CompilerTestRuntime, UniformsAppearInJson) {
-  if (GetParam() == TargetPlatform::kSkSL) {
-    GTEST_SKIP() << "Not supported with SkSL";
-  }
   if (GetParam() == TargetPlatform::kRuntimeStageVulkan) {
+    // TODO: Investigate why does not pass:
+    // https://github.com/flutter/flutter/issues/182578
     GTEST_SKIP() << "Not supported with Vulkan";
   }
 
@@ -286,10 +279,9 @@ TEST_P(CompilerTestRuntime, UniformsAppearInJson) {
 }
 
 TEST_P(CompilerTestRuntime, PositionedUniformsAppearInJson) {
-  if (GetParam() == TargetPlatform::kSkSL) {
-    GTEST_SKIP() << "Not supported with SkSL";
-  }
   if (GetParam() == TargetPlatform::kRuntimeStageVulkan) {
+    // TODO: Investigate why does not pass:
+    // https://github.com/flutter/flutter/issues/182578
     GTEST_SKIP() << "Not supported with Vulkan";
   }
 

--- a/engine/src/flutter/impeller/compiler/compiler_unittests.cc
+++ b/engine/src/flutter/impeller/compiler/compiler_unittests.cc
@@ -228,8 +228,8 @@ inline std::ostream& operator<<(std::ostream& out, const UniformInfo& info) {
 
 TEST_P(CompilerTestRuntime, UniformsAppearInJson) {
   if (GetParam() == TargetPlatform::kRuntimeStageVulkan) {
-    // TODO: Investigate why does not pass:
-    // https://github.com/flutter/flutter/issues/182578
+    // TODO(https://github.com/flutter/flutter/issues/182578): Investigate why
+    // this does not pass.
     GTEST_SKIP() << "Not supported with Vulkan";
   }
 
@@ -280,8 +280,8 @@ TEST_P(CompilerTestRuntime, UniformsAppearInJson) {
 
 TEST_P(CompilerTestRuntime, PositionedUniformsAppearInJson) {
   if (GetParam() == TargetPlatform::kRuntimeStageVulkan) {
-    // TODO: Investigate why does not pass:
-    // https://github.com/flutter/flutter/issues/182578
+    // TODO(https://github.com/flutter/flutter/issues/182578): Investigate why
+    // this does not pass.
     GTEST_SKIP() << "Not supported with Vulkan";
   }
 

--- a/engine/src/flutter/impeller/compiler/impellerc_main.cc
+++ b/engine/src/flutter/impeller/compiler/impellerc_main.cc
@@ -116,43 +116,40 @@ static bool OutputReflectionData(const Compiler& compiler,
   ///    May include a JSON file, a C++ header, and/or a C++ TU.
   ///
 
-  if (TargetPlatformNeedsReflection(options.target_platform)) {
-    if (!switches.reflection_json_name.empty()) {
-      auto reflection_json_name = std::filesystem::absolute(
-          std::filesystem::current_path() / switches.reflection_json_name);
-      if (!fml::WriteAtomically(
-              *switches.working_directory,
-              Utf8FromPath(reflection_json_name).c_str(),
-              *compiler.GetReflector()->GetReflectionJSON())) {
-        std::cerr << "Could not write reflection json to "
-                  << switches.reflection_json_name << std::endl;
-        return false;
-      }
+  if (!switches.reflection_json_name.empty()) {
+    auto reflection_json_name = std::filesystem::absolute(
+        std::filesystem::current_path() / switches.reflection_json_name);
+    if (!fml::WriteAtomically(*switches.working_directory,
+                              Utf8FromPath(reflection_json_name).c_str(),
+                              *compiler.GetReflector()->GetReflectionJSON())) {
+      std::cerr << "Could not write reflection json to "
+                << switches.reflection_json_name << std::endl;
+      return false;
     }
+  }
 
-    if (!switches.reflection_header_name.empty()) {
-      auto reflection_header_name = std::filesystem::absolute(
-          std::filesystem::current_path() / switches.reflection_header_name);
-      if (!fml::WriteAtomically(
-              *switches.working_directory,
-              Utf8FromPath(reflection_header_name).c_str(),
-              *compiler.GetReflector()->GetReflectionHeader())) {
-        std::cerr << "Could not write reflection header to "
-                  << switches.reflection_header_name << std::endl;
-        return false;
-      }
+  if (!switches.reflection_header_name.empty()) {
+    auto reflection_header_name = std::filesystem::absolute(
+        std::filesystem::current_path() / switches.reflection_header_name);
+    if (!fml::WriteAtomically(
+            *switches.working_directory,
+            Utf8FromPath(reflection_header_name).c_str(),
+            *compiler.GetReflector()->GetReflectionHeader())) {
+      std::cerr << "Could not write reflection header to "
+                << switches.reflection_header_name << std::endl;
+      return false;
     }
+  }
 
-    if (!switches.reflection_cc_name.empty()) {
-      auto reflection_cc_name = std::filesystem::absolute(
-          std::filesystem::current_path() / switches.reflection_cc_name);
-      if (!fml::WriteAtomically(*switches.working_directory,
-                                Utf8FromPath(reflection_cc_name).c_str(),
-                                *compiler.GetReflector()->GetReflectionCC())) {
-        std::cerr << "Could not write reflection CC to "
-                  << switches.reflection_cc_name << std::endl;
-        return false;
-      }
+  if (!switches.reflection_cc_name.empty()) {
+    auto reflection_cc_name = std::filesystem::absolute(
+        std::filesystem::current_path() / switches.reflection_cc_name);
+    if (!fml::WriteAtomically(*switches.working_directory,
+                              Utf8FromPath(reflection_cc_name).c_str(),
+                              *compiler.GetReflector()->GetReflectionCC())) {
+      std::cerr << "Could not write reflection CC to "
+                << switches.reflection_cc_name << std::endl;
+      return false;
     }
   }
   return true;

--- a/engine/src/flutter/impeller/compiler/impellerc_main.cc
+++ b/engine/src/flutter/impeller/compiler/impellerc_main.cc
@@ -32,47 +32,13 @@ static Reflector::Options CreateReflectorOptions(const SourceOptions& options,
   return reflector_options;
 }
 
-/// Run the shader compiler to geneate SkSL reflection data.
-/// If there is an error, prints error text and returns `nullptr`.
-static std::shared_ptr<RuntimeStageData::Shader> CompileSkSL(
-    std::shared_ptr<fml::Mapping> source_file_mapping,
-    const Switches& switches) {
-  auto options = switches.CreateSourceOptions(TargetPlatform::kSkSL);
-
-  Reflector::Options sksl_reflector_options =
-      CreateReflectorOptions(options, switches);
-  sksl_reflector_options.target_platform = TargetPlatform::kSkSL;
-
-  Compiler sksl_compiler =
-      Compiler(std::move(source_file_mapping), options, sksl_reflector_options);
-  if (!sksl_compiler.IsValid()) {
-    std::cerr << "Compilation to SkSL failed." << std::endl;
-    std::cerr << sksl_compiler.GetErrorMessages() << std::endl;
-    return nullptr;
-  }
-  return sksl_compiler.GetReflector()->GetRuntimeStageShaderData();
-}
-
 static bool OutputIPLR(
     const Switches& switches,
     const std::shared_ptr<fml::Mapping>& source_file_mapping) {
   FML_DCHECK(switches.iplr);
 
   RuntimeStageData stages;
-  std::shared_ptr<RuntimeStageData::Shader> sksl_shader;
-  if (TargetPlatformBundlesSkSL(switches.SelectDefaultTargetPlatform())) {
-    sksl_shader = CompileSkSL(source_file_mapping, switches);
-    if (!sksl_shader) {
-      return false;
-    }
-    stages.AddShader(sksl_shader);
-  }
-
   for (const auto& platform : switches.PlatformsToCompile()) {
-    if (platform == TargetPlatform::kSkSL) {
-      // Already handled above.
-      continue;
-    }
     SourceOptions options = switches.CreateSourceOptions(platform);
 
     // Invoke the compiler and generate reflection data for a single shader.
@@ -81,7 +47,8 @@ static bool OutputIPLR(
         CreateReflectorOptions(options, switches);
     Compiler compiler(source_file_mapping, options, reflector_options);
     if (!compiler.IsValid()) {
-      std::cerr << "Compilation failed." << std::endl;
+      std::cerr << "Compilation failed for target: "
+                << TargetPlatformToString(platform) << std::endl;
       std::cerr << compiler.GetErrorMessages() << std::endl;
       return false;
     }
@@ -197,24 +164,7 @@ static bool OutputDepfile(const Compiler& compiler, const Switches& switches) {
   ///
 
   if (!switches.depfile_path.empty()) {
-    std::string result_file;
-    switch (switches.SelectDefaultTargetPlatform()) {
-      case TargetPlatform::kMetalDesktop:
-      case TargetPlatform::kMetalIOS:
-      case TargetPlatform::kOpenGLES:
-      case TargetPlatform::kOpenGLDesktop:
-      case TargetPlatform::kRuntimeStageMetal:
-      case TargetPlatform::kRuntimeStageGLES:
-      case TargetPlatform::kRuntimeStageGLES3:
-      case TargetPlatform::kRuntimeStageVulkan:
-      case TargetPlatform::kSkSL:
-      case TargetPlatform::kVulkan:
-        result_file = Utf8FromPath(switches.sl_file_name);
-        break;
-      case TargetPlatform::kUnknown:
-        result_file = Utf8FromPath(switches.spirv_file_name);
-        break;
-    }
+    std::string result_file = Utf8FromPath(switches.sl_file_name);
     auto depfile_path = std::filesystem::absolute(
         std::filesystem::current_path() / switches.depfile_path);
     if (!fml::WriteAtomically(*switches.working_directory,
@@ -263,7 +213,8 @@ bool Main(const fml::CommandLine& command_line) {
   // Create at least one compiler to output the SL file, reflection data, and a
   // depfile.
 
-  SourceOptions options = switches.CreateSourceOptions();
+  SourceOptions options =
+      switches.CreateSourceOptions(switches.PlatformsToCompile().front());
 
   // Invoke the compiler and generate reflection data for a single shader.
 

--- a/engine/src/flutter/impeller/compiler/impellerc_main.cc
+++ b/engine/src/flutter/impeller/compiler/impellerc_main.cc
@@ -39,7 +39,8 @@ static bool OutputIPLR(
 
   RuntimeStageData stages;
   for (const auto& platform : switches.PlatformsToCompile()) {
-    SourceOptions options = switches.CreateSourceOptions(platform);
+    SourceOptions options = switches.CreateSourceOptions();
+    options.target_platform = platform;
 
     // Invoke the compiler and generate reflection data for a single shader.
 
@@ -210,8 +211,12 @@ bool Main(const fml::CommandLine& command_line) {
   // Create at least one compiler to output the SL file, reflection data, and a
   // depfile.
 
-  SourceOptions options =
-      switches.CreateSourceOptions(switches.PlatformsToCompile().front());
+  SourceOptions options = switches.CreateSourceOptions();
+  // If there are multiple platform compile targets, the specific target
+  // platform that is used does not matter because the output files won't depend
+  // on the target platform. Arbitrarily choose the first one from
+  // PlatformsToCompile().
+  options.target_platform = switches.PlatformsToCompile().front();
 
   // Invoke the compiler and generate reflection data for a single shader.
 

--- a/engine/src/flutter/impeller/compiler/shader_bundle.cc
+++ b/engine/src/flutter/impeller/compiler/shader_bundle.cc
@@ -215,11 +215,7 @@ bool GenerateShaderBundle(Switches& switches) {
   ///
 
   auto shader_bundle = GenerateShaderBundleFlatbuffer(
-      switches.shader_bundle,
-      switches.CreateSourceOptions(
-          // This TargetPlatform does not matter because it is overridden by
-          // GenerateShaderBackendFB().
-          TargetPlatform::kUnknown));
+      switches.shader_bundle, switches.CreateSourceOptions());
   if (!shader_bundle.has_value()) {
     // Specific error messages are already handled by
     // GenerateShaderBundleFlatbuffer.

--- a/engine/src/flutter/impeller/compiler/shader_bundle.cc
+++ b/engine/src/flutter/impeller/compiler/shader_bundle.cc
@@ -215,7 +215,11 @@ bool GenerateShaderBundle(Switches& switches) {
   ///
 
   auto shader_bundle = GenerateShaderBundleFlatbuffer(
-      switches.shader_bundle, switches.CreateSourceOptions());
+      switches.shader_bundle,
+      switches.CreateSourceOptions(
+          // This TargetPlatform does not matter because it is overridden by
+          // GenerateShaderBackendFB().
+          TargetPlatform::kUnknown));
   if (!shader_bundle.has_value()) {
     // Specific error messages are already handled by
     // GenerateShaderBundleFlatbuffer.

--- a/engine/src/flutter/impeller/compiler/switches.cc
+++ b/engine/src/flutter/impeller/compiler/switches.cc
@@ -25,12 +25,13 @@ static const std::map<std::string, TargetPlatform> kKnownPlatforms = {
     {"opengl-desktop", TargetPlatform::kOpenGLDesktop},
 };
 
-static const std::map<std::string, TargetPlatform> kKnownRuntimeStages = {
-    {"sksl", TargetPlatform::kSkSL},
-    {"runtime-stage-metal", TargetPlatform::kRuntimeStageMetal},
-    {"runtime-stage-gles", TargetPlatform::kRuntimeStageGLES},
-    {"runtime-stage-gles3", TargetPlatform::kRuntimeStageGLES3},
-    {"runtime-stage-vulkan", TargetPlatform::kRuntimeStageVulkan},
+static const std::vector<std::pair<std::string, TargetPlatform>>
+    kKnownRuntimeStages = {
+        {"sksl", TargetPlatform::kSkSL},
+        {"runtime-stage-metal", TargetPlatform::kRuntimeStageMetal},
+        {"runtime-stage-gles", TargetPlatform::kRuntimeStageGLES},
+        {"runtime-stage-gles3", TargetPlatform::kRuntimeStageGLES3},
+        {"runtime-stage-vulkan", TargetPlatform::kRuntimeStageVulkan},
 };
 
 static const std::map<std::string, SourceType> kKnownSourceTypes = {
@@ -309,19 +310,10 @@ std::vector<TargetPlatform> Switches::PlatformsToCompile() const {
   return {target_platform_};
 }
 
-TargetPlatform Switches::SelectDefaultTargetPlatform() const {
-  if (target_platform_ == TargetPlatform::kUnknown &&
-      !runtime_stages_.empty()) {
-    return runtime_stages_.front();
-  }
-  return target_platform_;
-}
-
 SourceOptions Switches::CreateSourceOptions(
-    std::optional<TargetPlatform> target_platform) const {
+    TargetPlatform target_platform) const {
   SourceOptions options;
-  options.target_platform =
-      target_platform.value_or(SelectDefaultTargetPlatform());
+  options.target_platform = target_platform;
   options.source_language = source_language;
   if (input_type == SourceType::kUnknown) {
     options.type = SourceTypeFromFileName(source_file_name);

--- a/engine/src/flutter/impeller/compiler/switches.cc
+++ b/engine/src/flutter/impeller/compiler/switches.cc
@@ -310,10 +310,8 @@ std::vector<TargetPlatform> Switches::PlatformsToCompile() const {
   return {target_platform_};
 }
 
-SourceOptions Switches::CreateSourceOptions(
-    TargetPlatform target_platform) const {
+SourceOptions Switches::CreateSourceOptions() const {
   SourceOptions options;
-  options.target_platform = target_platform;
   options.source_language = source_language;
   if (input_type == SourceType::kUnknown) {
     options.type = SourceTypeFromFileName(source_file_name);

--- a/engine/src/flutter/impeller/compiler/switches.h
+++ b/engine/src/flutter/impeller/compiler/switches.h
@@ -57,10 +57,10 @@ class Switches {
   /// A vector containing at least one valid platform.
   std::vector<TargetPlatform> PlatformsToCompile() const;
 
-  // Creates source options from these switches. The returned options does not
-  // have a set TargetPlatform because that cannot be determined based purely
-  // on the switches. Clients must set a valid TargetPlatform on the returned
-  // options before before it is used.
+  /// Creates source options from these switches. The returned options does not
+  /// have a set TargetPlatform because that cannot be determined based purely
+  /// on the switches. Clients must set a valid TargetPlatform on the returned
+  /// options before before it is used.
   SourceOptions CreateSourceOptions() const;
 
   static void PrintHelp(std::ostream& stream);

--- a/engine/src/flutter/impeller/compiler/switches.h
+++ b/engine/src/flutter/impeller/compiler/switches.h
@@ -57,9 +57,11 @@ class Switches {
   /// A vector containing at least one valid platform.
   std::vector<TargetPlatform> PlatformsToCompile() const;
 
-  // Creates source options from these switches for the specified
-  // TargetPlatform.
-  SourceOptions CreateSourceOptions(TargetPlatform target_platform) const;
+  // Creates source options from these switches. The returned options does not
+  // have a set TargetPlatform because that cannot be determined based purely
+  // on the switches. Clients must set a valid TargetPlatform on the returned
+  // options before before it is used.
+  SourceOptions CreateSourceOptions() const;
 
   static void PrintHelp(std::ostream& stream);
 

--- a/engine/src/flutter/impeller/compiler/switches.h
+++ b/engine/src/flutter/impeller/compiler/switches.h
@@ -56,12 +56,10 @@ class Switches {
 
   /// A vector containing at least one valid platform.
   std::vector<TargetPlatform> PlatformsToCompile() const;
-  TargetPlatform SelectDefaultTargetPlatform() const;
 
   // Creates source options from these switches for the specified
-  // TargetPlatform. Uses SelectDefaultTargetPlatform if not specified.
-  SourceOptions CreateSourceOptions(
-      std::optional<TargetPlatform> target_platform = std::nullopt) const;
+  // TargetPlatform.
+  SourceOptions CreateSourceOptions(TargetPlatform target_platform) const;
 
   static void PrintHelp(std::ostream& stream);
 

--- a/engine/src/flutter/impeller/compiler/switches_unittests.cc
+++ b/engine/src/flutter/impeller/compiler/switches_unittests.cc
@@ -102,7 +102,7 @@ TEST(SwitchesTest, EntryPointPrefixIsApplied) {
   EXPECT_EQ(switches.entry_point_prefix, "my_prefix_");
 
   switches.source_file_name = "test.frag";
-  auto options = switches.CreateSourceOptions(TargetPlatform::kUnknown);
+  auto options = switches.CreateSourceOptions();
   EXPECT_EQ(options.entry_point_name, "my_prefix_test_fragment_main");
 }
 

--- a/engine/src/flutter/impeller/compiler/switches_unittests.cc
+++ b/engine/src/flutter/impeller/compiler/switches_unittests.cc
@@ -10,6 +10,7 @@
 #include "flutter/fml/string_conversion.h"
 #include "flutter/testing/testing.h"
 #include "impeller/compiler/switches.h"
+#include "impeller/compiler/types.h"
 #include "impeller/compiler/utilities.h"
 
 namespace impeller {
@@ -101,7 +102,7 @@ TEST(SwitchesTest, EntryPointPrefixIsApplied) {
   EXPECT_EQ(switches.entry_point_prefix, "my_prefix_");
 
   switches.source_file_name = "test.frag";
-  auto options = switches.CreateSourceOptions();
+  auto options = switches.CreateSourceOptions(TargetPlatform::kUnknown);
   EXPECT_EQ(options.entry_point_name, "my_prefix_test_fragment_main");
 }
 

--- a/engine/src/flutter/impeller/compiler/types.cc
+++ b/engine/src/flutter/impeller/compiler/types.cc
@@ -312,24 +312,5 @@ bool TargetPlatformIsVulkan(TargetPlatform platform) {
   FML_UNREACHABLE();
 }
 
-bool TargetPlatformBundlesSkSL(TargetPlatform platform) {
-  switch (platform) {
-    case TargetPlatform::kSkSL:
-    case TargetPlatform::kRuntimeStageMetal:
-    case TargetPlatform::kRuntimeStageGLES:
-    case TargetPlatform::kRuntimeStageGLES3:
-    case TargetPlatform::kRuntimeStageVulkan:
-      return true;
-    case TargetPlatform::kMetalDesktop:
-    case TargetPlatform::kMetalIOS:
-    case TargetPlatform::kUnknown:
-    case TargetPlatform::kOpenGLES:
-    case TargetPlatform::kOpenGLDesktop:
-    case TargetPlatform::kVulkan:
-      return false;
-  }
-  FML_UNREACHABLE();
-}
-
 }  // namespace compiler
 }  // namespace impeller

--- a/engine/src/flutter/impeller/compiler/types.cc
+++ b/engine/src/flutter/impeller/compiler/types.cc
@@ -127,25 +127,6 @@ std::string EntryPointFunctionNameFromSourceName(
   return stream.str();
 }
 
-bool TargetPlatformNeedsReflection(TargetPlatform platform) {
-  switch (platform) {
-    case TargetPlatform::kMetalIOS:
-    case TargetPlatform::kMetalDesktop:
-    case TargetPlatform::kOpenGLES:
-    case TargetPlatform::kOpenGLDesktop:
-    case TargetPlatform::kRuntimeStageMetal:
-    case TargetPlatform::kRuntimeStageGLES:
-    case TargetPlatform::kRuntimeStageGLES3:
-    case TargetPlatform::kRuntimeStageVulkan:
-    case TargetPlatform::kVulkan:
-      return true;
-    case TargetPlatform::kUnknown:
-    case TargetPlatform::kSkSL:
-      return false;
-  }
-  FML_UNREACHABLE();
-}
-
 std::string ShaderCErrorToString(shaderc_compilation_status status) {
   using Status = shaderc_compilation_status;
   switch (status) {

--- a/engine/src/flutter/impeller/compiler/types.h
+++ b/engine/src/flutter/impeller/compiler/types.h
@@ -124,8 +124,6 @@ std::string EntryPointFunctionNameFromSourceName(
 
 bool TargetPlatformNeedsReflection(TargetPlatform platform);
 
-bool TargetPlatformBundlesSkSL(TargetPlatform platform);
-
 std::string ShaderCErrorToString(shaderc_compilation_status status);
 
 shaderc_shader_kind ToShaderCShaderKind(SourceType type);

--- a/engine/src/flutter/impeller/compiler/types.h
+++ b/engine/src/flutter/impeller/compiler/types.h
@@ -122,8 +122,6 @@ std::string EntryPointFunctionNameFromSourceName(
     SourceLanguage source_language,
     const std::string& entry_point_name);
 
-bool TargetPlatformNeedsReflection(TargetPlatform platform);
-
 std::string ShaderCErrorToString(shaderc_compilation_status status);
 
 shaderc_shader_kind ToShaderCShaderKind(SourceType type);

--- a/engine/src/flutter/impeller/fixtures/BUILD.gn
+++ b/engine/src/flutter/impeller/fixtures/BUILD.gn
@@ -105,6 +105,22 @@ impellerc("runtime_stages") {
   sl_file_extension = "iplr"
 
   shader_target_flags = [
+    "--sksl",
+    "--runtime-stage-metal",
+    "--runtime-stage-gles",
+    "--runtime-stage-gles3",
+    "--runtime-stage-vulkan",
+  ]
+
+  iplr = true
+}
+
+impellerc("runtime_stages_non_sksl") {
+  mnemonic = "IMPELLERC_IPLR"
+  shaders = [ "runtime_stage_simple_no_sksl.frag" ]
+  sl_file_extension = "iplr"
+
+  shader_target_flags = [
     "--runtime-stage-metal",
     "--runtime-stage-gles",
     "--runtime-stage-gles3",
@@ -172,7 +188,12 @@ test_fixtures("file_fixtures") {
   }
   fixtures +=
       filter_include(get_target_outputs(":runtime_stages"), [ "*.iplr" ])
-  deps = [ ":runtime_stages" ]
+  fixtures += filter_include(get_target_outputs(":runtime_stages_non_sksl"),
+                             [ "*.iplr" ])
+  deps = [
+    ":runtime_stages",
+    ":runtime_stages_non_sksl",
+  ]
 }
 
 impellerc("flutter_gpu_shaders") {

--- a/engine/src/flutter/impeller/fixtures/runtime_stage_simple_no_sksl.frag
+++ b/engine/src/flutter/impeller/fixtures/runtime_stage_simple_no_sksl.frag
@@ -1,0 +1,9 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+out vec4 frag_color;
+
+void main() {
+  frag_color = vec4(1.0, 0.0, 0.0, 1.0);
+}

--- a/engine/src/flutter/impeller/runtime_stage/runtime_stage_unittests.cc
+++ b/engine/src/flutter/impeller/runtime_stage/runtime_stage_unittests.cc
@@ -471,12 +471,18 @@ TEST_P(RuntimeStageTest, ContainsExpectedShaderTypes) {
   auto stages_result = OpenAssetAsRuntimeStage("ink_sparkle.frag.iplr");
   ABSL_ASSERT_OK(stages_result);
   auto stages = stages_result.value();
-  // Right now, SkSL gets implicitly bundled regardless of what the build rule
-  // for this test requested. After
-  // https://github.com/flutter/flutter/issues/138919, this may require a build
-  // rule change or a new test.
   EXPECT_TRUE(stages[RuntimeStageBackend::kSkSL]);
+  EXPECT_TRUE(stages[RuntimeStageBackend::kOpenGLES]);
+  EXPECT_TRUE(stages[RuntimeStageBackend::kMetal]);
+  EXPECT_TRUE(stages[RuntimeStageBackend::kVulkan]);
+}
 
+TEST_P(RuntimeStageTest, ContainsExpectedShaderTypesNoSksl) {
+  auto stages_result =
+      OpenAssetAsRuntimeStage("runtime_stage_simple_no_sksl.frag.iplr");
+  ABSL_ASSERT_OK(stages_result);
+  auto stages = stages_result.value();
+  EXPECT_FALSE(stages[RuntimeStageBackend::kSkSL]);
   EXPECT_TRUE(stages[RuntimeStageBackend::kOpenGLES]);
   EXPECT_TRUE(stages[RuntimeStageBackend::kMetal]);
   EXPECT_TRUE(stages[RuntimeStageBackend::kVulkan]);

--- a/engine/src/flutter/impeller/tools/compiler.gni
+++ b/engine/src/flutter/impeller/tools/compiler.gni
@@ -75,10 +75,6 @@ template("impellerc") {
     shader_target_flags = []
   }
 
-  sksl = false
-  foreach(shader_target_flag, shader_target_flags) {
-    sksl = shader_target_flag == "--sksl"
-  }
   iplr = false
   if (defined(invoker.iplr) && invoker.iplr) {
     iplr = invoker.iplr
@@ -91,7 +87,6 @@ template("impellerc") {
   # Not needed on every path.
   not_needed([
                "iplr",
-               "sksl",
                "shader_bundle",
                "shader_bundle_output",
              ])
@@ -181,11 +176,7 @@ template("impellerc") {
       ]
 
       outputs = [ sl_output ]
-    } else if (sksl) {
-      # When SkSL is selected as a `shader_target_flags`, don't generate
-      # C++ reflection state. Nothing needs to use it and it's likely invalid
-      # given the special cases when generating SkSL.
-      # Note that this configuration is orthogonal to the "--iplr" flag
+    } else {
       sl_output =
           "$generated_dir/{{source_file_part}}.${invoker.sl_file_extension}"
       sl_output_path = rebase_path(sl_output, root_build_dir)
@@ -198,40 +189,39 @@ template("impellerc") {
       ]
 
       outputs = [ sl_output ]
-    } else {
-      # The default branch. Here we just generate one shader along with all of
-      # its C++ reflection state.
 
-      sl_output =
-          "$generated_dir/{{source_file_part}}.${invoker.sl_file_extension}"
-      sl_output_path = rebase_path(sl_output, root_build_dir)
+      # Generate reflection state only if a non-runtime target is provided.
+      if (filter_include(shader_target_flags,
+                         [
+                           "--metal-ios",
+                           "--metal-desktop",
+                           "--opengl-es",
+                           "--opengl-desktop",
+                           "--vulkan",
+                         ]) != []) {
+        reflection_json_intermediate =
+            "$generated_dir/{{source_file_part}}.json"
+        reflection_header_intermediate = "$generated_dir/{{source_file_part}}.h"
+        reflection_cc_intermediate = "$generated_dir/{{source_file_part}}.cc"
 
-      reflection_json_intermediate = "$generated_dir/{{source_file_part}}.json"
-      reflection_header_intermediate = "$generated_dir/{{source_file_part}}.h"
-      reflection_cc_intermediate = "$generated_dir/{{source_file_part}}.cc"
+        reflection_json_path =
+            rebase_path(reflection_json_intermediate, root_build_dir)
+        reflection_header_path =
+            rebase_path(reflection_header_intermediate, root_build_dir)
+        reflection_cc_path =
+            rebase_path(reflection_cc_intermediate, root_build_dir)
 
-      spirv_intermediate = "$generated_dir/{{source_file_part}}.spirv"
-      spirv_intermediate_path = rebase_path(spirv_intermediate, root_build_dir)
-      reflection_json_path =
-          rebase_path(reflection_json_intermediate, root_build_dir)
-      reflection_header_path =
-          rebase_path(reflection_header_intermediate, root_build_dir)
-      reflection_cc_path =
-          rebase_path(reflection_cc_intermediate, root_build_dir)
+        args += [
+          "--reflection-json=$reflection_json_path",
+          "--reflection-header=$reflection_header_path",
+          "--reflection-cc=$reflection_cc_path",
+        ]
 
-      args += [
-        "--sl=$sl_output_path",
-        "--spirv=$spirv_intermediate_path",
-        "--reflection-json=$reflection_json_path",
-        "--reflection-header=$reflection_header_path",
-        "--reflection-cc=$reflection_cc_path",
-      ]
-
-      outputs = [
-        sl_output,
-        reflection_header_intermediate,
-        reflection_cc_intermediate,
-      ]
+        outputs += [
+          reflection_header_intermediate,
+          reflection_cc_intermediate,
+        ]
+      }
     }
 
     if (defined(invoker.defines)) {


### PR DESCRIPTION
The main change of this PR is to make `impellerc_main` no longer use `TargetPlatformBundlesSkSL(switches.SelectDefaultTargetPlatform())` to determine whether to compile to SkSL.

Addresses the "sksl unexpectedly compiling when building for ios" mentioned in #182400.

`TargetPlatformBundlesSkSL()` returned `true` when running impellerc targeting *any* runtime shaders. So even though https://github.com/flutter/flutter/pull/163144/changes changed iOS runtime shaders to no longer call impellerc with the `--sksl` runtime target, it would still compile to SkSL because of the `--runtime-stage-metal` runtime target.

After this PR, impellerc will only compile to SkSL if `--sksl` is explicitly provided when calling impellerc.

The rest of the changes in this PR are related changes to improve code organization and to update tests.

- `impellerc_main.cc`:
  - `OutputIPLR()`: Remove the custom logic for compiling to SkSL. SkSL is now treated the same as all the other compile targets in the `for (const auto& platform : switches.PlatformsToCompile())` loop. This is the only change with a behavioral difference in the PR. We no longer use `TargetPlatformBundlesSkSL(switches.SelectDefaultTargetPlatform())` to determine whether to compile to SkSL. Instead, it's treated the same as any other compilation target and will only be targeted when it is specified as an arg to the executable.
  - Remove the `CompileSkSL()` helper function. This had the exact same logic as what is used for all the other compilation targets in the `for (const auto& platform : switches.PlatformsToCompile())` loop. So it is not needed.
  - `OutputDepfile()`: Remove the switch/case. The `TargetPlatform::kUnknown` case is unreachable, so this used the other case 100% of the time.
  - `Main()`: `switches.CreateSourceOptions()` no longer has a default platform target parameter. It doesn't matter which target it's called with here. Arbitrarily call it with `switches.PlatformsToCompile().front()`.

- `types.h/cc`:
  - Remove the `TargetPlatformBundlesSkSL()` function. The only place this was used was for `impellerc_main.cc`'s special case logic for SkSL, which was removed as described above.

- `switches.h/cc`:
  - Remove the optional/default parameter for `CreateSourceOptions()`. This used to fall back to calling `SelectDefaultTargetPlatform()` to determine the default value. I found this to be very unclear behavior. The only place this was actually called with the default parameter is in one function in `shader_bundle.cc` where the selected target platform does not actually matter, so it doesn't even need this somewhat-convoluted logic to select a platform with `SelectDefaultTargetPlatform()`. I changed `CreateSourceOptions()` to require an explicit parameter, which I think makes the function's behavior clearer by removing the confusing default parameter.
  - Remove the `SelectDefaultTargetPlatform()` function. I think it was a little unclear/nonobvious what this was actually returning. It was only used in 3 places, all of which were kind of confusing/unneeded:
    1. In this same file, to pick the default target platform in `switches.CreateSourceOptions()`. As described above, this seems entirely unnecessary.
    1. In `impeller_main.cc`, used in `TargetPlatformBundlesSkSL(switches.SelectDefaultTargetPlatform())` to determine whether to compile to SkSL. As described above, we don't want this behavior. I think it was also kind of confusing.
    1. In `impeller_main.cc`, used for the switch/case in `OutputDepfile()`. As described above, this switch/case is entirely unnecessary.
  - Change the `kKnownRuntimeStages` map to be a vector of pairs. This is iterated through to populate the returned `runtime_stages_` list of `Switches::PlatformsToCompile()`. Making it a vector makes the `runtime_stages_` list maintain the ordering of `kKnownRuntimeStages` (previously, iterating through the map would iterate in alphabetical order of the keys).
    - `impellerc_main.cc`'s `OutputIPLR()` now compiles to targets based on `Switches::PlatformsToCompile()`, without special case logic to always compile to "sksl" first. Changing this to a vector with "sksl" as the first value preserves the original behavior of compiling to "sksl" before any other targets. We do this because certain tests that perform a failed shader compilation check specifically for an SkSL-based error message (e.g. [this one](https://github.com/flutter/flutter/blob/64866862f623ceeb45fd8be4782e8db8b58910c0/packages/flutter_tools/test/integration.shard/shader_compiler_test.dart#L150-L170)). So for these tests, we need to try/fail with the SkSL compiler first, before trying/failing with other compilers which would produce a different error message.

- `shader_bundle.cc`
  - As described above, change the usage of `switches.CreateSourceOptions()` to require an explicit target platform parameter. This particular usage doesn't matter, so use `TargetPlatform::kUnknown` and add an explanatory comment.

- `compiler.cc`
  - In `CreateCompiler()`, Add an `FML_UNREACHABLE` for the `TargetPlatform::kUnknown` case, instead of falling back to using a vulkan compiler. It doesn't make sense to call `CreateCompiler()` with `TargetPlatform::kUnknown`. And currently, it can't happen: The only use of `CreateCompiler()` is in the `Compiler` constructor on [line 432](https://github.com/flutter/flutter/blob/24ce716cfddfef201027c1a5fa2299a8aeffb03e/engine/src/flutter/impeller/compiler/compiler.cc#L432), and there is a check preventing `TargetPlatform::kUnknown` earlier on [line 292](https://github.com/flutter/flutter/blob/24ce716cfddfef201027c1a5fa2299a8aeffb03e/engine/src/flutter/impeller/compiler/compiler.cc#L292).

- `compiler_unittests.cc`, `compiler_test.h`
  - The `INSTANTIATE_{TARGET|RUNTIME_TARGET|SKSL_TARGET}_PLATFORM_TEST_SUITE_P` defines were oddly located in the file in the middle of the tests. Move them to the top of the file.
  - `INSTANTIATE_TARGET_PLATFORM_TEST_SUITE_P`
    - Remove the `kSkSL` target. These tests seem to be specifically for non-runtime targets, so SkSL doesn't belong here. All of these tests had a filter to skip for SkSL, so none of them actually ran for SkSL. These skips are now removed.
    - Add the `kVulkan` target, so all non-runtime platform targets are covered: opengles, openglesdesktop, metaldesktop, metalios, vulkan.
  - `INSTANTIATE_RUNTIME_TARGET_PLATFORM_TEST_SUITE_P`
    - This used to only test with `kRuntimeStageMetal`. For better coverage, I added all other runtime stages to this. It now tests on the metal, gles, gles3, vulkan, and sksl runtime targets.
    - Two tests, `UniformsAppearInJson` and `PositionedUniformsAppearInJson` fail when running with vulkan and with sksl. I added skips for these. I haven't dug deeper, but the failures seem unexpected to me. It's possible that this is revealing a bug with the vulkan and sksl compilers.
  - `INSTANTIATE_UNKNOWN_TARGET_PLATFORM_TEST_SUITE_P`
    - Added this new define for running tests with `TargetPlatform::kUnknown`.
    - Added a `MustFailDueToUnknownPlatform` test for this case. 

- `fixtures/BUILD.gn`, `runtime_stage_unittests.cc`
  - For the `impellerc("runtime_stages")` build target, add `--sksl` to the impellerc flags. This preserves the existing behavior of these targets being compiled for SkSL. They used to compile for SkSL because other runtime targets are specified. But now impellerc only compiles to SkSL when `--sksl` is explicitly specified.
  - Create a new `impellerc("runtime_stages_non_sksl")` target that runs impellerc without `--sksl`. Use this for a new `ContainsExpectedShaderTypesNoSksl` test in the unit test file. That test is the same as the existing `ContainsExpectedShaderTypes` test, but using the non-sksl output from `impellerc("runtime_stages_non_sksl")`.

### Update for commit 2 of the PR:
The original PR had an issue that failed CI because a build rule expected an impellerc output to include C++ reflection data, but the reflection data was not output. I added a sizable commit to address this:

- Fix compiler.gni logic around when to generate reflection state.
  - This used to incorrectly generate reflection state whenever the last shader_target_flags is not "--sksl".
  - Instead, generate reflection state when any non-runtime target is in shader_target_flags.
  - Consolidate some of the if/else logic to reduce duplicate code.
- Remove the TargetPlatformNeedsReflection check in impeller_main.cc.
  - Instead, whether reflection state is generated depends only on the presence or absense of "reflection_{json|header|cc}_name" flags.
  - The logic of whether to include these flags is already in compiler.gni. So it's redundant to also have logic for whether to generate the reflection state here.
  - The TargetPlatformNeedsReflection method had faulty logic.
    - It returned true for everything except SkSL, even though reflection state isn't needed for runtime targets.
    - It was called on the target from Switches::SelectDefaultTargetPlatform. When impellerc is used with multiple runtime targets, this would return the runtime target that is first alphabetically by flag name. So if --sksl is provided along with any other --runtime-stage-* target, SelectDefaultTargetPlatform returns the non-sksl runtime target. Effectively this meant that TargetPlatformNeedsReflection returns true except for when --sksl is the only provided runtime target.
  - Removes the TargetPlatformNeedsReflection function entirely.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
