### PR TITLE
flutter_tools: Use a super-parameter in several missed cases

### DIFF
--- a/packages/flutter_tools/lib/src/android/deferred_components_gen_snapshot_validator.dart
+++ b/packages/flutter_tools/lib/src/android/deferred_components_gen_snapshot_validator.dart
@@ -25,8 +25,8 @@ class DeferredComponentsGenSnapshotValidator extends DeferredComponentsValidator
   /// When [exitOnFail] is set to true, the [handleResults] and [attemptToolExit]
   /// methods will exit the tool when this validator detects a recommended
   /// change. This defaults to true.
-  DeferredComponentsGenSnapshotValidator(this.env, {bool exitOnFail = true, String? title})
-    : super(env.projectDir, env.logger, env.platform, exitOnFail: exitOnFail, title: title);
+  DeferredComponentsGenSnapshotValidator(this.env, {super.exitOnFail = true, super.title})
+    : super(env.projectDir, env.logger, env.platform);
 
   /// The build environment that should be used to find the input files to run
   /// checks against.

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -98,11 +98,11 @@ class ResidentWebRunner extends ResidentRunner {
   ResidentWebRunner(
     FlutterDevice device, {
     String? target,
-    bool stayResident = true,
-    bool machine = false,
-    String? projectRootPath,
+    super.stayResident = true,
+    super.machine = false,
+    super.projectRootPath,
     required this.flutterProject,
-    required DebuggingOptions debuggingOptions,
+    required super.debuggingOptions,
     required FileSystem fileSystem,
     required Logger logger,
     required Terminal terminal,
@@ -122,9 +122,6 @@ class ResidentWebRunner extends ResidentRunner {
        super(
          <FlutterDevice>[device],
          target: target ?? fileSystem.path.join('lib', 'main.dart'),
-         debuggingOptions: debuggingOptions,
-         stayResident: stayResident,
-         machine: machine,
          commandHelp: CommandHelp(
            logger: logger,
            terminal: terminal,
@@ -132,7 +129,6 @@ class ResidentWebRunner extends ResidentRunner {
            outputPreferences: outputPreferences,
          ),
          dartBuilder: hookRunner,
-         projectRootPath: projectRootPath,
        );
 
   final FileSystem _fileSystem;

--- a/packages/flutter_tools/lib/src/linux/linux_device.dart
+++ b/packages/flutter_tools/lib/src/linux/linux_device.dart
@@ -20,21 +20,13 @@ import 'linux_workflow.dart';
 /// A device that represents a desktop Linux target.
 class LinuxDevice extends DesktopDevice {
   LinuxDevice({
-    required ProcessManager processManager,
-    required Logger logger,
-    required FileSystem fileSystem,
-    required OperatingSystemUtils operatingSystemUtils,
+    required super.processManager,
+    required super.logger,
+    required super.fileSystem,
+    required super.operatingSystemUtils,
   }) : _operatingSystemUtils = operatingSystemUtils,
        _logger = logger,
-       super(
-         'linux',
-         platformType: PlatformType.linux,
-         ephemeral: false,
-         logger: logger,
-         processManager: processManager,
-         fileSystem: fileSystem,
-         operatingSystemUtils: operatingSystemUtils,
-       );
+       super('linux', platformType: PlatformType.linux, ephemeral: false);
 
   final OperatingSystemUtils _operatingSystemUtils;
   final Logger _logger;

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -20,22 +20,14 @@ import 'macos_workflow.dart';
 /// A device that represents a desktop MacOS target.
 class MacOSDevice extends DesktopDevice {
   MacOSDevice({
-    required ProcessManager processManager,
-    required Logger logger,
-    required FileSystem fileSystem,
-    required OperatingSystemUtils operatingSystemUtils,
+    required super.processManager,
+    required super.logger,
+    required super.fileSystem,
+    required super.operatingSystemUtils,
   }) : _processManager = processManager,
        _logger = logger,
        _operatingSystemUtils = operatingSystemUtils,
-       super(
-         'macos',
-         platformType: PlatformType.macos,
-         ephemeral: false,
-         processManager: processManager,
-         logger: logger,
-         fileSystem: fileSystem,
-         operatingSystemUtils: operatingSystemUtils,
-       );
+       super('macos', platformType: PlatformType.macos, ephemeral: false);
 
   final ProcessManager _processManager;
   final Logger _logger;

--- a/packages/flutter_tools/lib/src/macos/macos_ipad_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_ipad_device.dart
@@ -23,20 +23,12 @@ import '../project.dart';
 /// https://developer.apple.com/documentation/apple-silicon/running-your-ios-apps-on-macos
 class MacOSDesignedForIPadDevice extends DesktopDevice {
   MacOSDesignedForIPadDevice({
-    required ProcessManager processManager,
-    required Logger logger,
-    required FileSystem fileSystem,
-    required OperatingSystemUtils operatingSystemUtils,
+    required super.processManager,
+    required super.logger,
+    required super.fileSystem,
+    required super.operatingSystemUtils,
   }) : _operatingSystemUtils = operatingSystemUtils,
-       super(
-         'mac-designed-for-ipad',
-         platformType: PlatformType.macos,
-         ephemeral: false,
-         processManager: processManager,
-         logger: logger,
-         fileSystem: fileSystem,
-         operatingSystemUtils: operatingSystemUtils,
-       );
+       super('mac-designed-for-ipad', platformType: PlatformType.macos, ephemeral: false);
 
   final OperatingSystemUtils _operatingSystemUtils;
 

--- a/packages/flutter_tools/lib/src/proxied_devices/devices.dart
+++ b/packages/flutter_tools/lib/src/proxied_devices/devices.dart
@@ -174,10 +174,10 @@ class ProxiedDevice extends Device {
     String id, {
     bool deltaFileTransfer = true,
     bool enableDdsProxy = false,
-    required Category? category,
-    required PlatformType? platformType,
+    required super.category,
+    required super.platformType,
     required TargetPlatform targetPlatform,
-    required bool ephemeral,
+    required super.ephemeral,
     required this.isConnected,
     required this.connectionInterface,
     required this.name,
@@ -200,7 +200,7 @@ class ProxiedDevice extends Device {
        _targetPlatform = targetPlatform,
        _logger = logger,
        _fileTransfer = fileTransfer,
-       super(id, category: category, platformType: platformType, ephemeral: ephemeral);
+       super(id);
 
   /// [DaemonConnection] used to communicate with the daemon.
   final DaemonConnection connection;

--- a/packages/flutter_tools/lib/src/reporting/events.dart
+++ b/packages/flutter_tools/lib/src/reporting/events.dart
@@ -145,7 +145,7 @@ class BuildEvent extends UsageEvent {
     String? command,
     String? settings,
     String? eventError,
-    required Usage flutterUsage,
+    required super.flutterUsage,
     required String type,
   }) : _command = command,
        _settings = settings,
@@ -156,7 +156,6 @@ class BuildEvent extends UsageEvent {
          // parameter
          type,
          label: label,
-         flutterUsage: flutterUsage,
        );
 
   final String? _command;
@@ -211,8 +210,8 @@ class AnalyticsConfigEvent extends UsageEvent {
 
 /// An event that reports when the code size measurement is run via `--analyze-size`.
 class CodeSizeEvent extends UsageEvent {
-  CodeSizeEvent(String platform, {required Usage flutterUsage})
-    : super('code-size-analysis', platform, flutterUsage: flutterUsage);
+  CodeSizeEvent(String platform, {required super.flutterUsage})
+    : super('code-size-analysis', platform);
 }
 
 /// An event for tracking the usage of specific error handling fallbacks.

--- a/packages/flutter_tools/lib/src/windows/windows_device.dart
+++ b/packages/flutter_tools/lib/src/windows/windows_device.dart
@@ -20,20 +20,12 @@ import 'windows_workflow.dart';
 /// A device that represents a desktop Windows target.
 class WindowsDevice extends DesktopDevice {
   WindowsDevice({
-    required ProcessManager processManager,
-    required Logger logger,
-    required FileSystem fileSystem,
-    required OperatingSystemUtils operatingSystemUtils,
+    required super.processManager,
+    required super.logger,
+    required super.fileSystem,
+    required super.operatingSystemUtils,
   }) : _operatingSystemUtils = operatingSystemUtils,
-       super(
-         'windows',
-         platformType: PlatformType.windows,
-         ephemeral: false,
-         processManager: processManager,
-         logger: logger,
-         fileSystem: fileSystem,
-         operatingSystemUtils: operatingSystemUtils,
-       );
+       super('windows', platformType: PlatformType.windows, ephemeral: false);
 
   final OperatingSystemUtils _operatingSystemUtils;
 

--- a/packages/flutter_tools/test/general.shard/dap/mocks.dart
+++ b/packages/flutter_tools/test/general.shard/dap/mocks.dart
@@ -236,9 +236,9 @@ class FakeFlutterTestDebugAdapter extends FlutterTestDebugAdapter {
     this.stdin,
     this.stdout,
     ByteStreamServerChannel channel, {
-    required FileSystem fileSystem,
-    required Platform platform,
-  }) : super(channel, fileSystem: fileSystem, platform: platform);
+    required super.fileSystem,
+    required super.platform,
+  }) : super(channel);
 
   final StreamSink<List<int>> stdin;
   final Stream<List<int>> stdout;

--- a/packages/flutter_tools/test/general.shard/desktop_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/desktop_device_test.dart
@@ -450,20 +450,12 @@ FakeDesktopDevice setUpDesktopDevice({
 /// A trivial subclass of DesktopDevice for testing the shared functionality.
 class FakeDesktopDevice extends DesktopDevice {
   FakeDesktopDevice({
-    required ProcessManager processManager,
-    required Logger logger,
-    required FileSystem fileSystem,
-    required OperatingSystemUtils operatingSystemUtils,
+    required super.processManager,
+    required super.logger,
+    required super.fileSystem,
+    required super.operatingSystemUtils,
     this.nullExecutablePathForDevice = false,
-  }) : super(
-         'dummy',
-         platformType: PlatformType.linux,
-         ephemeral: false,
-         processManager: processManager,
-         logger: logger,
-         fileSystem: fileSystem,
-         operatingSystemUtils: operatingSystemUtils,
-       );
+  }) : super('dummy', platformType: PlatformType.linux, ephemeral: false);
 
   /// The `mainPath` last passed to [buildForDevice].
   String? lastBuiltMainPath;

--- a/packages/flutter_tools/test/src/fake_devices.dart
+++ b/packages/flutter_tools/test/src/fake_devices.dart
@@ -112,7 +112,7 @@ class FakeDevice extends Device {
   FakeDevice(
     this.name,
     String id, {
-    bool ephemeral = true,
+    super.ephemeral = true,
     bool isSupported = true,
     bool isSupportedForProject = true,
     this.isConnected = true,
@@ -125,13 +125,7 @@ class FakeDevice extends Device {
        _isSupportedForProject = isSupportedForProject,
        _launchResult = launchResult ?? LaunchResult.succeeded(),
        _supportsFlavors = supportsFlavors,
-       super(
-         id,
-         platformType: type,
-         category: Category.mobile,
-         ephemeral: ephemeral,
-         logger: FakeLogger(),
-       );
+       super(id, platformType: type, category: Category.mobile, logger: FakeLogger());
 
   final bool _isSupported;
   final bool _isSupportedForProject;


### PR DESCRIPTION
Work towards https://github.com/dart-lang/sdk/issues/58729

The lint rule will suggest using a super-parameter for a named parameter even if the positional parameters cannot be super-parameters.