### PR TITLE
Remove iOS build configuration check when building with flavors

### DIFF
--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -212,45 +212,6 @@ Future<XcodeBuildResult> buildXcodeProject({
     projectInfo.reportFlavorNotFoundAndExit();
   }
   final String? configuration = projectInfo.buildConfigurationFor(buildInfo, scheme);
-  if (configuration == null) {
-    globals.printError('');
-    globals.printError(
-      'The Xcode project defines build configurations: ${projectInfo.buildConfigurations.join(', ')}',
-    );
-    globals.printError(
-      'Flutter expects a build configuration named ${XcodeProjectInfo.expectedBuildConfigurationFor(buildInfo, scheme)} or similar.',
-    );
-    globals.printError('Open Xcode to fix the problem:');
-    globals.printError('  open ios/Runner.xcworkspace');
-    globals.printError('1. Click on "Runner" in the project navigator.');
-    globals.printError('2. Ensure the Runner PROJECT is selected, not the Runner TARGET.');
-    if (buildInfo.isDebug) {
-      globals.printError(
-        '3. Click the Editor->Add Configuration->Duplicate "Debug" Configuration.',
-      );
-    } else {
-      globals.printError(
-        '3. Click the Editor->Add Configuration->Duplicate "Release" Configuration.',
-      );
-    }
-    globals.printError('');
-    globals.printError(
-      '   If this option is disabled, it is likely you have the target selected instead',
-    );
-    globals.printError('   of the project; see:');
-    globals.printError(
-      '   https://stackoverflow.com/questions/19842746/adding-a-build-configuration-in-xcode',
-    );
-    globals.printError('');
-    globals.printError('   If you have created a completely custom set of build configurations,');
-    globals.printError('   you can set the FLUTTER_BUILD_MODE=${buildInfo.modeName.toLowerCase()}');
-    globals.printError('   in the .xcconfig file for that configuration and run from Xcode.');
-    globals.printError('');
-    globals.printError(
-      '4. If you are not using completely custom build configurations, name the newly created configuration ${buildInfo.modeName}.',
-    );
-    return XcodeBuildResult(success: false);
-  }
 
   final FlutterManifest manifest = app.project.parent.manifest;
   final String? buildName = parsedBuildName(manifest: manifest, buildInfo: buildInfo);
@@ -292,8 +253,7 @@ Future<XcodeBuildResult> buildXcodeProject({
   final buildCommands = <String>[
     ...globals.xcode!.xcrunCommand(),
     'xcodebuild',
-    '-configuration',
-    configuration,
+    if (configuration != null) ...<String>['-configuration', configuration],
   ];
 
   // Check the public headers before checking Xcode version so headers fingerprinter is created
@@ -618,7 +578,11 @@ Future<XcodeBuildResult> buildXcodeProject({
       if (globals.fs.directory(expectedOutputDirectory).existsSync()) {
         // Copy app folder to a place where other tools can find it without knowing
         // the BuildInfo.
-        outputDir = targetBuildDir.replaceFirst('/$configuration-', '/');
+        outputDir = targetBuildDir;
+        if (configuration != null) {
+          outputDir = outputDir.replaceFirst('/$configuration-', '/');
+        }
+
         globals.fs.directory(outputDir).createSync(recursive: true);
 
         // rsync instead of copy to maintain timestamps to support incremental

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -578,10 +578,9 @@ Future<XcodeBuildResult> buildXcodeProject({
       if (globals.fs.directory(expectedOutputDirectory).existsSync()) {
         // Copy app folder to a place where other tools can find it without knowing
         // the BuildInfo.
-        outputDir = targetBuildDir;
-        if (configuration != null) {
-          outputDir = outputDir.replaceFirst('/$configuration-', '/');
-        }
+        outputDir = configuration != null
+            ? targetBuildDir.replaceFirst('/$configuration-', '/')
+            : targetBuildDir;
 
         globals.fs.directory(outputDir).createSync(recursive: true);
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ios_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ios_test.dart
@@ -38,6 +38,7 @@ class FakeXcodeProjectInterpreterWithBuildSettings extends FakeXcodeProjectInter
   FakeXcodeProjectInterpreterWithBuildSettings({
     this.productBundleIdentifier,
     this.developmentTeam = 'abc',
+    this.buildConfigurations = const <String>['Debug', 'Release'],
   });
 
   @override
@@ -58,6 +59,18 @@ class FakeXcodeProjectInterpreterWithBuildSettings extends FakeXcodeProjectInter
   final String? productBundleIdentifier;
 
   final String? developmentTeam;
+
+  final List<String> buildConfigurations;
+
+  @override
+  Future<XcodeProjectInfo> getInfo(String projectPath, {String? projectFilename}) async {
+    return XcodeProjectInfo(
+      <String>['Runner'],
+      buildConfigurations,
+      <String>['Runner'],
+      BufferLogger.test(),
+    );
+  }
 }
 
 final Platform macosPlatform = FakePlatform(
@@ -114,15 +127,18 @@ void main() {
     command: <String>['xattr', '-r', '-d', 'com.apple.provenance', '/'],
   );
 
-  FakeCommand setUpRsyncCommand({void Function(List<String> command)? onRun}) {
+  FakeCommand setUpRsyncCommand({
+    String destination = 'build/ios/iphoneos',
+    void Function(List<String> command)? onRun,
+  }) {
     return FakeCommand(
-      command: const <String>[
+      command: <String>[
         'rsync',
         '-8',
         '-av',
         '--delete',
         'build/ios/Release-iphoneos/Runner.app',
-        'build/ios/iphoneos',
+        destination,
       ],
       onRun: onRun,
     );
@@ -155,6 +171,7 @@ void main() {
     bool simulator = false,
     bool customNaming = false,
     bool disablePortPublication = false,
+    bool includeConfiguration = true,
     String? deviceId,
     int exitCode = 0,
     String? stdout,
@@ -164,8 +181,10 @@ void main() {
       command: <String>[
         'xcrun',
         'xcodebuild',
-        '-configuration',
-        if (simulator) 'Debug' else 'Release',
+        if (includeConfiguration) ...<String>[
+          '-configuration',
+          if (simulator) 'Debug' else 'Release',
+        ],
         if (verbose) 'VERBOSE_SCRIPT_LOGGING=YES' else '-quiet',
         '-allowProvisioningUpdates',
         '-allowProvisioningDeviceRegistration',
@@ -360,6 +379,46 @@ void main() {
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
+    },
+  );
+
+  testUsingContext(
+    'ios build omits -configuration when no matching build configuration exists',
+    () async {
+      final command = BuildCommand(
+        androidSdk: FakeAndroidSdk(),
+        buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+        fileSystem: fileSystem,
+        logger: logger,
+        osUtils: FakeOperatingSystemUtils(),
+      );
+      createMinimalMockProjectFiles();
+
+      processManager.addCommands(<FakeCommand>[
+        xattrCommand,
+        setUpFakeXcodeBuildHandler(
+          includeConfiguration: false,
+          onRun: (_) {
+            fileSystem
+                .directory('build/ios/Release-iphoneos/Runner.app')
+                .createSync(recursive: true);
+          },
+        ),
+        setUpRsyncCommand(destination: 'build/ios/Release-iphoneos'),
+      ]);
+
+      await createTestCommandRunner(command).run(const <String>['build', 'ios', '--no-pub']);
+      expect(testLogger.statusText, contains('build/ios/Release-iphoneos/Runner.app'));
+    },
+    overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      ProcessManager: () => processManager,
+      Pub: ThrowingPub.new,
+      Platform: () => macosPlatform,
+      XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(
+        buildConfigurations: const <String>['Debug-F'],
+      ),
       Artifacts: () => Artifacts.test(),
     },
   );


### PR DESCRIPTION
This PR removes the check that disallows an iOS build if the Xcode project does not contain a build configuration with a name corresponding to BuildMode-Flavor (Debug-apple, Release-banana). 

Instead it allows the build to fallback to the build configuration that is defined in the scheme for each of the modes (Run, Test, Analyze, Profile, Archive).

Fixes https://github.com/flutter/flutter/issues/182368

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

