### PR TITLE
Manual roll Skia from 7bbdc51ab0aa to ce5854495a3a

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -15,7 +15,7 @@ vars = {
   'flutter_git': 'https://flutter.googlesource.com',
   'skia_git': 'https://skia.googlesource.com',
   'llvm_git': 'https://llvm.googlesource.com',
-  'skia_revision': '7bbdc51ab0aac2d26c919ce00f2b4b2344599338',
+  'skia_revision': 'ce5854495a3a1e0bbac6c77d81f1e863f1a809a3',
 
   # WARNING: DO NOT EDIT canvaskit_cipd_instance MANUALLY
   # See `lib/web_ui/README.md` for how to roll CanvasKit to a new version.

--- a/engine/src/flutter/lib/web_ui/test/ui/codecs_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/ui/codecs_test.dart
@@ -143,6 +143,10 @@ Future<void> testMain() async {
         // https://github.com/flutter/flutter/issues/152709
         continue;
       }
+      if (testFile == 'rgb24prof.bmp' && isSafari) {
+        // This file causes Safari to crash with `EncodingError`.
+        continue;
+      }
       if (testFile == 'b464333052.jpg') {
         // This is an undecodable image used to test a Skia failure code path.
         continue;


### PR DESCRIPTION
Includes a workaround for a Skia BMP test image that is not compatible with Safari.