### PR TITLE
Implements `ClipRSuperellipse` on backdrop filter on platform view

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -95,13 +95,13 @@ static BOOL _preparedOnce = NO;
 - (instancetype)initWithFrame:(CGRect)frame
                    blurRadius:(CGFloat)blurRadius
                  cornerRadius:(CGFloat)cornerRadius
-                        isRSE:(BOOL)isRSE
+        isRoundedSuperellipse:(BOOL)isRoundedSuperellipse
              visualEffectView:(UIVisualEffectView*)visualEffectView {
   if (self = [super init]) {
     _frame = frame;
     _blurRadius = blurRadius;
     _cornerRadius = cornerRadius;
-    _isRSE = isRSE;
+    _isRoundedSuperellipse = isRoundedSuperellipse;
     [PlatformViewFilter prepareOnce:visualEffectView];
     if (![PlatformViewFilter isUIVisualEffectViewImplementationValid]) {
       FML_DLOG(ERROR) << "Apple's API for UIVisualEffectView changed. Update the implementation to "
@@ -169,7 +169,8 @@ static BOOL _preparedOnce = NO;
 
   visualEffectView.layer.cornerRadius = _cornerRadius;
   if (@available(iOS 13.0, *)) {
-    visualEffectView.layer.cornerCurve = _isRSE ? kCACornerCurveContinuous : kCACornerCurveCircular;
+    visualEffectView.layer.cornerCurve =
+        _isRoundedSuperellipse ? kCACornerCurveContinuous : kCACornerCurveCircular;
   }
   visualEffectView.clipsToBounds = YES;
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -95,11 +95,13 @@ static BOOL _preparedOnce = NO;
 - (instancetype)initWithFrame:(CGRect)frame
                    blurRadius:(CGFloat)blurRadius
                  cornerRadius:(CGFloat)cornerRadius
+                        isRSE:(BOOL)isRSE
              visualEffectView:(UIVisualEffectView*)visualEffectView {
   if (self = [super init]) {
     _frame = frame;
     _blurRadius = blurRadius;
     _cornerRadius = cornerRadius;
+    _isRSE = isRSE;
     [PlatformViewFilter prepareOnce:visualEffectView];
     if (![PlatformViewFilter isUIVisualEffectViewImplementationValid]) {
       FML_DLOG(ERROR) << "Apple's API for UIVisualEffectView changed. Update the implementation to "
@@ -166,6 +168,9 @@ static BOOL _preparedOnce = NO;
   visualEffectView.frame = _frame;
 
   visualEffectView.layer.cornerRadius = _cornerRadius;
+  if (_isRSE) {
+    visualEffectView.layer.cornerCurve = kCACornerCurveContinuous;
+  }
   visualEffectView.clipsToBounds = YES;
 
   self.backdropFilterView = visualEffectView;

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -168,8 +168,8 @@ static BOOL _preparedOnce = NO;
   visualEffectView.frame = _frame;
 
   visualEffectView.layer.cornerRadius = _cornerRadius;
-  if (_isRSE) {
-    visualEffectView.layer.cornerCurve = kCACornerCurveContinuous;
+  if (@available(iOS 13.0, *)) {
+    visualEffectView.layer.cornerCurve = _isRSE ? kCACornerCurveContinuous : kCACornerCurveCircular;
   }
   visualEffectView.clipsToBounds = YES;
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
@@ -583,25 +583,25 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
 
         // TODO(https://github.com/flutter/flutter/issues/179126)
         CGFloat cornerRadius = 0.0;
-        BOOL isRSE = NO;
+        BOOL isRoundedSuperellipse = NO;
         // If there's multiple clips, this uses the innermost to decide if its
         // rse or not. The assumption being the innermost will be the tightest
         if ([pendingClipRRects count] > 0) {
           cornerRadius = pendingClipRRects.lastObject.topLeftRadius;
-          isRSE = pendingClipRRects.lastObject.isRSE;
+          isRoundedSuperellipse = pendingClipRRects.lastObject.isRoundedSuperellipse;
           [pendingClipRRects removeAllObjects];
         }
         visualEffectView.layer.cornerRadius = cornerRadius;
         if (@available(iOS 13.0, *)) {
           visualEffectView.layer.cornerCurve =
-              isRSE ? kCACornerCurveContinuous : kCACornerCurveCircular;
+              isRoundedSuperellipse ? kCACornerCurveContinuous : kCACornerCurveCircular;
         }
         visualEffectView.clipsToBounds = YES;
 
         PlatformViewFilter* filter = [[PlatformViewFilter alloc] initWithFrame:frameInClipView
                                                                     blurRadius:blurRadius
                                                                   cornerRadius:cornerRadius
-                                                                         isRSE:isRSE
+                                                         isRoundedSuperellipse:isRoundedSuperellipse
                                                               visualEffectView:visualEffectView];
         if (!filter) {
           self.canApplyBlurBackdrop = NO;
@@ -638,7 +638,7 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
         clip.topRightRadius = radii.top_right.width;
         clip.bottomLeftRadius = radii.bottom_left.width;
         clip.bottomRightRadius = radii.bottom_right.width;
-        clip.isRSE = YES;
+        clip.isRoundedSuperellipse = YES;
         [pendingClipRRects addObject:clip];
         break;
       }

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
@@ -593,7 +593,8 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
         }
         visualEffectView.layer.cornerRadius = cornerRadius;
         if (@available(iOS 13.0, *)) {
-          visualEffectView.layer.cornerCurve = isRSE ? kCACornerCurveContinuous : kCACornerCurveCircular;
+          visualEffectView.layer.cornerCurve =
+              isRSE ? kCACornerCurveContinuous : kCACornerCurveCircular;
         }
         visualEffectView.clipsToBounds = YES;
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
@@ -592,8 +592,8 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
           [pendingClipRRects removeAllObjects];
         }
         visualEffectView.layer.cornerRadius = cornerRadius;
-        if (isRSE) {
-          visualEffectView.layer.cornerCurve = kCACornerCurveContinuous;
+        if (@available(iOS 13.0, *)) {
+          visualEffectView.layer.cornerCurve = isRSE ? kCACornerCurveContinuous : kCACornerCurveCircular;
         }
         visualEffectView.clipsToBounds = YES;
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -457,6 +457,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
         [[PlatformViewFilter alloc] initWithFrame:CGRectMake(0, 0, 10, 10)
                                        blurRadius:5
                                      cornerRadius:0
+                                            isRSE:NO
                                  visualEffectView:visualEffectView1];
 
     [clippingView applyBlurBackdropFilters:@[ platformViewFilter1 ]];
@@ -469,6 +470,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
         [[PlatformViewFilter alloc] initWithFrame:CGRectMake(0, 0, 10, 10)
                                        blurRadius:5
                                      cornerRadius:0
+                                            isRSE:NO
                                  visualEffectView:visualEffectView2];
     [clippingView applyBlurBackdropFilters:@[ platformViewFilter2 ]];
 
@@ -1721,6 +1723,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
         [[PlatformViewFilter alloc] initWithFrame:CGRectMake(0, 0, 10, 10)
                                        blurRadius:5
                                      cornerRadius:0
+                                            isRSE:NO
                                  visualEffectView:visualEffectView];
     CGColorRef visualEffectSubviewBackgroundColor = nil;
     for (UIView* view in [platformViewFilter backdropFilterView].subviews) {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -457,7 +457,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
         [[PlatformViewFilter alloc] initWithFrame:CGRectMake(0, 0, 10, 10)
                                        blurRadius:5
                                      cornerRadius:0
-                                            isRSE:NO
+                            isRoundedSuperellipse:NO
                                  visualEffectView:visualEffectView1];
 
     [clippingView applyBlurBackdropFilters:@[ platformViewFilter1 ]];
@@ -470,7 +470,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
         [[PlatformViewFilter alloc] initWithFrame:CGRectMake(0, 0, 10, 10)
                                        blurRadius:5
                                      cornerRadius:0
-                                            isRSE:NO
+                            isRoundedSuperellipse:NO
                                  visualEffectView:visualEffectView2];
     [clippingView applyBlurBackdropFilters:@[ platformViewFilter2 ]];
 
@@ -1567,7 +1567,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       [[PlatformViewFilter alloc] initWithFrame:CGRectMake(0, 0, 10, 10)
                                      blurRadius:5
                                    cornerRadius:0
-                                          isRSE:NO
+                          isRoundedSuperellipse:NO
                                visualEffectView:visualEffectView];
   XCTAssertNotNil(platformViewFilter);
 }
@@ -1579,7 +1579,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       [[PlatformViewFilter alloc] initWithFrame:CGRectMake(0, 0, 10, 10)
                                      blurRadius:5
                                    cornerRadius:0
-                                          isRSE:NO
+                          isRoundedSuperellipse:NO
                                visualEffectView:visualEffectView];
   XCTAssertNil(platformViewFilter);
 }
@@ -1604,7 +1604,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       [[PlatformViewFilter alloc] initWithFrame:CGRectMake(0, 0, 10, 10)
                                      blurRadius:5
                                    cornerRadius:0
-                                          isRSE:NO
+                          isRoundedSuperellipse:NO
                                visualEffectView:editedUIVisualEffectView];
   XCTAssertNil(platformViewFilter);
 }
@@ -1630,7 +1630,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       [[PlatformViewFilter alloc] initWithFrame:CGRectMake(0, 0, 10, 10)
                                      blurRadius:5
                                    cornerRadius:0
-                                          isRSE:NO
+                          isRoundedSuperellipse:NO
                                visualEffectView:editedUIVisualEffectView];
   XCTAssertNil(platformViewFilter);
 }
@@ -1810,7 +1810,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
         [[PlatformViewFilter alloc] initWithFrame:CGRectMake(0, 0, 10, 10)
                                        blurRadius:5
                                      cornerRadius:0
-                                            isRSE:NO
+                            isRoundedSuperellipse:NO
                                  visualEffectView:visualEffectView];
     CGColorRef visualEffectSubviewBackgroundColor = nil;
     for (UIView* view in [platformViewFilter backdropFilterView].subviews) {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -97,6 +97,9 @@
 // Determines the corner radius of the backdrop filter view.
 @property(nonatomic, readonly) CGFloat cornerRadius;
 
+// Whether the clip shape is a rounded superellipse (continuous corner curve).
+@property(nonatomic, readonly) BOOL isRSE;
+
 // For testing only.
 + (void)resetPreparation;
 
@@ -115,6 +118,7 @@
 - (instancetype)initWithFrame:(CGRect)frame
                    blurRadius:(CGFloat)blurRadius
                  cornerRadius:(CGFloat)cornerRadius
+                        isRSE:(BOOL)isRSE
              visualEffectView:(UIVisualEffectView*)visualEffectView NS_DESIGNATED_INITIALIZER;
 
 @end
@@ -204,6 +208,7 @@
 @property(nonatomic) CGFloat topRightRadius;
 @property(nonatomic) CGFloat bottomRightRadius;
 @property(nonatomic) CGFloat bottomLeftRadius;
+@property(nonatomic) BOOL isRSE;
 @end
 
 #endif  // FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERPLATFORMVIEWS_INTERNAL_H_

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -98,7 +98,7 @@
 @property(nonatomic, readonly) CGFloat cornerRadius;
 
 // Whether the clip shape is a rounded superellipse (continuous corner curve).
-@property(nonatomic, readonly) BOOL isRSE;
+@property(nonatomic, readonly) BOOL isRoundedSuperellipse;
 
 // For testing only.
 + (void)resetPreparation;
@@ -118,7 +118,7 @@
 - (instancetype)initWithFrame:(CGRect)frame
                    blurRadius:(CGFloat)blurRadius
                  cornerRadius:(CGFloat)cornerRadius
-                        isRSE:(BOOL)isRSE
+        isRoundedSuperellipse:(BOOL)isRoundedSuperellipse
              visualEffectView:(UIVisualEffectView*)visualEffectView NS_DESIGNATED_INITIALIZER;
 
 @end
@@ -208,7 +208,7 @@
 @property(nonatomic) CGFloat topRightRadius;
 @property(nonatomic) CGFloat bottomRightRadius;
 @property(nonatomic) CGFloat bottomLeftRadius;
-@property(nonatomic) BOOL isRSE;
+@property(nonatomic) BOOL isRoundedSuperellipse;
 @end
 
 #endif  // FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERPLATFORMVIEWS_INTERNAL_H_


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

- Implements `ClipRSuperellipse` on backdrop filter on platform view 

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*
Fixes #179125 


*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
