### PR TITLE
Improve non rect platform view rendering 

### DIFF
--- a/engine/src/flutter/flow/view_slicer.cc
+++ b/engine/src/flutter/flow/view_slicer.cc
@@ -16,7 +16,7 @@ std::unordered_map<int64_t, DlRect> SliceViews(
     const std::unordered_map<int64_t, std::unique_ptr<EmbedderViewSlice>>&
         slices,
     const std::unordered_map<int64_t, DlRect>& view_rects,
-    const std::unordered_set<int64_t>* preserve_underlay_for_views) {
+    const std::unordered_set<int64_t>& preserve_underlay_for_views) {
   std::unordered_map<int64_t, DlRect> overlay_layers;
 
   auto current_frame_view_count = composition_order.size();
@@ -112,9 +112,8 @@ std::unordered_map<int64_t, DlRect> SliceViews(
       overlay_layers.insert({view_id, full_joined_rect});
 
       const bool preserve_underlay =
-          preserve_underlay_for_views &&
-          preserve_underlay_for_views->find(view_id) !=
-              preserve_underlay_for_views->end();
+          preserve_underlay_for_views.find(view_id) !=
+          preserve_underlay_for_views.end();
       if (!preserve_underlay) {
         // Clip the background canvas, so it doesn't contain any of the pixels
         // drawn on the overlay layer.

--- a/engine/src/flutter/flow/view_slicer.cc
+++ b/engine/src/flutter/flow/view_slicer.cc
@@ -16,7 +16,7 @@ std::unordered_map<int64_t, DlRect> SliceViews(
     const std::unordered_map<int64_t, std::unique_ptr<EmbedderViewSlice>>&
         slices,
     const std::unordered_map<int64_t, DlRect>& view_rects,
-    const std::unordered_set<int64_t>& preserve_underlay_for_views) {
+    const std::unordered_set<int64_t>& views_with_underlay_preserved) {
   std::unordered_map<int64_t, DlRect> overlay_layers;
 
   auto current_frame_view_count = composition_order.size();
@@ -111,9 +111,12 @@ std::unordered_map<int64_t, DlRect> SliceViews(
     if (!full_joined_rect.IsEmpty()) {
       overlay_layers.insert({view_id, full_joined_rect});
 
+      // If overlay has a non-rect clip, we need to preserve the underlay in
+      // that area to show correctly after overlay is clipped behind the
+      // platform view
       const bool preserve_underlay =
-          preserve_underlay_for_views.find(view_id) !=
-          preserve_underlay_for_views.end();
+          views_with_underlay_preserved.find(view_id) !=
+          views_with_underlay_preserved.end();
       if (!preserve_underlay) {
         // Clip the background canvas, so it doesn't contain any of the pixels
         // drawn on the overlay layer.

--- a/engine/src/flutter/flow/view_slicer.h
+++ b/engine/src/flutter/flow/view_slicer.h
@@ -22,7 +22,7 @@ std::unordered_map<int64_t, DlRect> SliceViews(
     const std::unordered_map<int64_t, std::unique_ptr<EmbedderViewSlice>>&
         slices,
     const std::unordered_map<int64_t, DlRect>& view_rects,
-    const std::unordered_set<int64_t>* preserve_underlay_for_views = nullptr);
+    const std::unordered_set<int64_t>& preserve_underlay_for_views);
 
 }  // namespace flutter
 

--- a/engine/src/flutter/flow/view_slicer.h
+++ b/engine/src/flutter/flow/view_slicer.h
@@ -6,6 +6,7 @@
 #define FLUTTER_FLOW_VIEW_SLICER_H_
 
 #include <unordered_map>
+#include <unordered_set>
 #include "display_list/dl_canvas.h"
 #include "flow/embedded_views.h"
 
@@ -13,12 +14,15 @@ namespace flutter {
 
 /// @brief Compute the required overlay layers and clip the view slices
 ///        according to the size and position of the platform views.
+/// @param preserve_underlay_for_views The platform view IDs for which we
+///        should not subtract the overlap from the background canvas.
 std::unordered_map<int64_t, DlRect> SliceViews(
     DlCanvas* background_canvas,
     const std::vector<int64_t>& composition_order,
     const std::unordered_map<int64_t, std::unique_ptr<EmbedderViewSlice>>&
         slices,
-    const std::unordered_map<int64_t, DlRect>& view_rects);
+    const std::unordered_map<int64_t, DlRect>& view_rects,
+    const std::unordered_set<int64_t>* preserve_underlay_for_views = nullptr);
 
 }  // namespace flutter
 

--- a/engine/src/flutter/flow/view_slicer.h
+++ b/engine/src/flutter/flow/view_slicer.h
@@ -14,7 +14,7 @@ namespace flutter {
 
 /// @brief Compute the required overlay layers and clip the view slices
 ///        according to the size and position of the platform views.
-/// @param preserve_underlay_for_views The platform view IDs for which we
+/// @param views_with_underlay_preserved The platform view IDs for which we
 ///        should not subtract the overlap from the background canvas.
 std::unordered_map<int64_t, DlRect> SliceViews(
     DlCanvas* background_canvas,
@@ -22,7 +22,7 @@ std::unordered_map<int64_t, DlRect> SliceViews(
     const std::unordered_map<int64_t, std::unique_ptr<EmbedderViewSlice>>&
         slices,
     const std::unordered_map<int64_t, DlRect>& view_rects,
-    const std::unordered_set<int64_t>& preserve_underlay_for_views);
+    const std::unordered_set<int64_t>& views_with_underlay_preserved);
 
 }  // namespace flutter
 

--- a/engine/src/flutter/flow/view_slicer_unittests.cc
+++ b/engine/src/flutter/flow/view_slicer_unittests.cc
@@ -43,7 +43,7 @@ TEST(ViewSlicerTest, CanSlicerNonOverlappingViews) {
       {1, DlRect::MakeLTRB(50, 50, 60, 60)}};
 
   auto computed_overlays =
-      SliceViews(&builder, composition_order, slices, view_rects);
+      SliceViews(&builder, composition_order, slices, view_rects, {});
 
   EXPECT_TRUE(computed_overlays.empty());
 }
@@ -59,7 +59,7 @@ TEST(ViewSlicerTest, IgnoresFractionalOverlaps) {
       {1, DlRect::MakeLTRB(50.5, 50.5, 100, 100)}};
 
   auto computed_overlays =
-      SliceViews(&builder, composition_order, slices, view_rects);
+      SliceViews(&builder, composition_order, slices, view_rects, {});
 
   EXPECT_TRUE(computed_overlays.empty());
 }
@@ -75,7 +75,7 @@ TEST(ViewSlicerTest, ComputesOverlapWith1PV) {
       {1, DlRect::MakeLTRB(0, 0, 100, 100)}};
 
   auto computed_overlays =
-      SliceViews(&builder, composition_order, slices, view_rects);
+      SliceViews(&builder, composition_order, slices, view_rects, {});
 
   EXPECT_EQ(computed_overlays.size(), 1u);
   auto overlay = computed_overlays.find(1);
@@ -98,7 +98,7 @@ TEST(ViewSlicerTest, ComputesOverlapWith2PV) {
   };
 
   auto computed_overlays =
-      SliceViews(&builder, composition_order, slices, view_rects);
+      SliceViews(&builder, composition_order, slices, view_rects, {});
 
   EXPECT_EQ(computed_overlays.size(), 2u);
 
@@ -132,7 +132,7 @@ TEST(ViewSlicerTest, OverlappingTwoPVs) {
   };
 
   auto computed_overlays =
-      SliceViews(&builder, composition_order, slices, view_rects);
+      SliceViews(&builder, composition_order, slices, view_rects, {});
 
   EXPECT_EQ(computed_overlays.size(), 1u);
 
@@ -153,7 +153,7 @@ TEST(ViewSlicerTest, PreservesUnderlayForSelectedViews) {
   AddSliceOfSize(baseline_slices, 1, DlRect::MakeLTRB(0, 0, 50, 50));
   DisplayListBuilder baseline_builder(DlRect::MakeLTRB(0, 0, 100, 100));
   auto baseline_overlays = SliceViews(&baseline_builder, composition_order,
-                                      baseline_slices, view_rects);
+                                      baseline_slices, view_rects, {});
   EXPECT_EQ(baseline_overlays.size(), 1u);
   auto baseline_dl = baseline_builder.Build();
   EXPECT_TRUE(ContainsClipDifferenceRect(baseline_dl));
@@ -165,7 +165,7 @@ TEST(ViewSlicerTest, PreservesUnderlayForSelectedViews) {
   DisplayListBuilder preserve_builder(DlRect::MakeLTRB(0, 0, 100, 100));
   auto preserve_overlays =
       SliceViews(&preserve_builder, composition_order, preserve_slices,
-                 view_rects, &preserve_underlay_for_views);
+                 view_rects, preserve_underlay_for_views);
   EXPECT_EQ(preserve_overlays.size(), 1u);
   auto preserve_dl = preserve_builder.Build();
   EXPECT_FALSE(ContainsClipDifferenceRect(preserve_dl));

--- a/engine/src/flutter/flow/view_slicer_unittests.cc
+++ b/engine/src/flutter/flow/view_slicer_unittests.cc
@@ -161,11 +161,11 @@ TEST(ViewSlicerTest, PreservesUnderlayForSelectedViews) {
   std::unordered_map<int64_t, std::unique_ptr<EmbedderViewSlice>>
       preserve_slices;
   AddSliceOfSize(preserve_slices, 1, DlRect::MakeLTRB(0, 0, 50, 50));
-  std::unordered_set<int64_t> preserve_underlay_for_views = {1};
+  std::unordered_set<int64_t> views_with_underlay_preserved = {1};
   DisplayListBuilder preserve_builder(DlRect::MakeLTRB(0, 0, 100, 100));
   auto preserve_overlays =
       SliceViews(&preserve_builder, composition_order, preserve_slices,
-                 view_rects, preserve_underlay_for_views);
+                 view_rects, views_with_underlay_preserved);
   EXPECT_EQ(preserve_overlays.size(), 1u);
   auto preserve_dl = preserve_builder.Build();
   EXPECT_FALSE(ContainsClipDifferenceRect(preserve_dl));

--- a/engine/src/flutter/shell/platform/android/external_view_embedder/external_view_embedder.cc
+++ b/engine/src/flutter/shell/platform/android/external_view_embedder/external_view_embedder.cc
@@ -86,7 +86,8 @@ void AndroidExternalViewEmbedder::SubmitFlutterView(
       SliceViews(frame->Canvas(),     //
                  composition_order_,  //
                  slices_,             //
-                 view_rects           //
+                 view_rects,          //
+                 {}                   //
       );
 
   // Submit the background canvas frame before switching the GL context to

--- a/engine/src/flutter/shell/platform/android/external_view_embedder/external_view_embedder_2.cc
+++ b/engine/src/flutter/shell/platform/android/external_view_embedder/external_view_embedder_2.cc
@@ -99,7 +99,8 @@ void AndroidExternalViewEmbedder2::SubmitFlutterView(
       SliceViews(frame->Canvas(),     //
                  composition_order_,  //
                  slices_,             //
-                 view_rects           //
+                 view_rects,          //
+                 {}                   //
       );
 
   // If there is no overlay Surface, initialize one on the platform thread. This

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
@@ -110,7 +110,7 @@ static bool HasNonRectClipForUnderlayCutout(const flutter::EmbeddedViewParams& p
 // Overlay canvas needs to be clipped to the shape of platform view to ensure
 // underlay shows up correctly, so that when there's backdrop filter, the region outside of platform
 // view's shape is blurred. See: https://github.com/flutter/flutter/issues/150660
-static void ApplyComplexClipToOverlayCanvas(flutter::DlCanvas* overlay_canvas,
+static void ApplyNonRectClipToOverlayCanvas(flutter::DlCanvas* overlay_canvas,
                                             const flutter::EmbeddedViewParams& params) {
   flutter::DlMatrix transform;
   auto iter = params.mutatorsStack().Begin();
@@ -845,19 +845,19 @@ static void ApplyComplexClipToOverlayCanvas(flutter::DlCanvas* overlay_canvas,
   std::vector<std::unique_ptr<flutter::SurfaceFrame>> surfaceFrames;
   surfaceFrames.reserve(self.compositionOrder.size());
   std::unordered_map<int64_t, DlRect> viewRects;
-  std::unordered_set<int64_t> preserveUnderlayForViews;
+  std::unordered_set<int64_t> viewsWithUnderlayPreserved;
 
   for (int64_t viewId : self.compositionOrder) {
     const flutter::EmbeddedViewParams& params = self.currentCompositionParams[viewId];
     viewRects[viewId] = params.finalBoundingRect();
     if (HasNonRectClipForUnderlayCutout(params)) {
-      preserveUnderlayForViews.insert(viewId);
+      viewsWithUnderlayPreserved.insert(viewId);
     }
   }
 
   std::unordered_map<int64_t, DlRect> overlayLayers =
       SliceViews(background_frame->Canvas(), self.compositionOrder, self.slices, viewRects,
-                 preserveUnderlayForViews);
+                 viewsWithUnderlayPreserved);
 
   size_t requiredOverlayLayers = 0;
   for (int64_t viewId : self.compositionOrder) {
@@ -893,7 +893,7 @@ static void ApplyComplexClipToOverlayCanvas(flutter::DlCanvas* overlay_canvas,
     int restoreCount = overlayCanvas->GetSaveCount();
     overlayCanvas->Save();
     overlayCanvas->ClipRect(overlay->second);
-    if (preserveUnderlayForViews.find(viewId) != preserveUnderlayForViews.end()) {
+    if (viewsWithUnderlayPreserved.find(viewId) != viewsWithUnderlayPreserved.end()) {
       ApplyComplexClipToOverlayCanvas(overlayCanvas, self.currentCompositionParams[viewId]);
     }
     overlayCanvas->Clear(flutter::DlColor::kTransparent());

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
@@ -91,7 +91,7 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
                     clipDlRect.GetHeight());
 }
 
-static bool HasComplexClipForUnderlayCutout(const flutter::EmbeddedViewParams& params) {
+static bool HasNonRectClipForUnderlayCutout(const flutter::EmbeddedViewParams& params) {
   auto iter = params.mutatorsStack().Begin();
   while (iter != params.mutatorsStack().End()) {
     switch ((*iter)->GetType()) {
@@ -108,7 +108,8 @@ static bool HasComplexClipForUnderlayCutout(const flutter::EmbeddedViewParams& p
 }
 
 // Overlay canvas needs to be clipped to the shape of platform view to ensure
-// underlay shows up correctly
+// underlay shows up correctly, so that when there's backdrop filter, the region outside of platform
+// view's shape is blurred. See: https://github.com/flutter/flutter/issues/150660
 static void ApplyComplexClipToOverlayCanvas(flutter::DlCanvas* overlay_canvas,
                                             const flutter::EmbeddedViewParams& params) {
   flutter::DlMatrix transform;
@@ -849,7 +850,7 @@ static void ApplyComplexClipToOverlayCanvas(flutter::DlCanvas* overlay_canvas,
   for (int64_t viewId : self.compositionOrder) {
     const flutter::EmbeddedViewParams& params = self.currentCompositionParams[viewId];
     viewRects[viewId] = params.finalBoundingRect();
-    if (HasComplexClipForUnderlayCutout(params)) {
+    if (HasNonRectClipForUnderlayCutout(params)) {
       preserveUnderlayForViews.insert(viewId);
     }
   }

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
@@ -120,7 +120,7 @@ static void ApplyComplexClipToOverlayCanvas(flutter::DlCanvas* overlay_canvas,
         break;
       case flutter::MutatorType::kClipRRect: {
         if (transform.IsIdentity()) {
-          overlay_canvas->ClipRoundRect((*iter)->GetRRect(), flutter::DlClipOp::kIntersect, / true);
+          overlay_canvas->ClipRoundRect((*iter)->GetRRect(), flutter::DlClipOp::kIntersect, true);
         } else {
           auto path = flutter::DlPath::MakeRoundRect((*iter)->GetRRect());
           auto transformed_path =

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
@@ -4,6 +4,7 @@
 
 #import "shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.h"
 #include "display_list/geometry/dl_geometry_types.h"
+#include "flutter/display_list/geometry/dl_geometry_conversions.h"
 #include "impeller/geometry/rounding_radii.h"
 
 #include "flutter/display_list/effects/image_filters/dl_blur_image_filter.h"
@@ -88,6 +89,73 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
                     clipDlRect.GetTop(),    //
                     clipDlRect.GetWidth(),  //
                     clipDlRect.GetHeight());
+}
+
+static bool HasComplexClipForUnderlayCutout(const flutter::EmbeddedViewParams& params) {
+  auto iter = params.mutatorsStack().Begin();
+  while (iter != params.mutatorsStack().End()) {
+    switch ((*iter)->GetType()) {
+      case flutter::MutatorType::kClipRRect:
+      case flutter::MutatorType::kClipRSE:
+      case flutter::MutatorType::kClipPath:
+        return true;
+      default:
+        break;
+    }
+    ++iter;
+  }
+  return false;
+}
+
+// Overlay canvas needs to be clipped to the shape of platform view to ensure
+// underlay shows up correctly
+static void ApplyComplexClipToOverlayCanvas(flutter::DlCanvas* overlay_canvas,
+                                            const flutter::EmbeddedViewParams& params) {
+  flutter::DlMatrix transform;
+  auto iter = params.mutatorsStack().Begin();
+  while (iter != params.mutatorsStack().End()) {
+    switch ((*iter)->GetType()) {
+      case flutter::MutatorType::kTransform:
+        transform = transform * (*iter)->GetMatrix();
+        break;
+      case flutter::MutatorType::kClipRRect: {
+        if (transform.IsIdentity()) {
+          overlay_canvas->ClipRoundRect((*iter)->GetRRect(), flutter::DlClipOp::kIntersect, / true);
+        } else {
+          auto path = flutter::DlPath::MakeRoundRect((*iter)->GetRRect());
+          auto transformed_path =
+              flutter::DlPath(path.GetSkPath().makeTransform(flutter::ToSkMatrix(transform)));
+          overlay_canvas->ClipPath(transformed_path, flutter::DlClipOp::kIntersect, true);
+        }
+        break;
+      }
+      case flutter::MutatorType::kClipRSE: {
+        if (transform.IsIdentity()) {
+          overlay_canvas->ClipRoundSuperellipse((*iter)->GetRSE(), flutter::DlClipOp::kIntersect,
+                                                true);
+        } else {
+          auto path = flutter::DlPath::MakeRoundSuperellipse((*iter)->GetRSE());
+          auto transformed_path =
+              flutter::DlPath(path.GetSkPath().makeTransform(flutter::ToSkMatrix(transform)));
+          overlay_canvas->ClipPath(transformed_path, flutter::DlClipOp::kIntersect, true);
+        }
+        break;
+      }
+      case flutter::MutatorType::kClipPath: {
+        if (transform.IsIdentity()) {
+          overlay_canvas->ClipPath((*iter)->GetPath(), flutter::DlClipOp::kIntersect, true);
+        } else {
+          auto transformed_path = flutter::DlPath(
+              (*iter)->GetPath().GetSkPath().makeTransform(flutter::ToSkMatrix(transform)));
+          overlay_canvas->ClipPath(transformed_path, flutter::DlClipOp::kIntersect, true);
+        }
+        break;
+      }
+      default:
+        break;
+    }
+    ++iter;
+  }
 }
 
 @interface FlutterPlatformViewsController ()
@@ -776,13 +844,19 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
   std::vector<std::unique_ptr<flutter::SurfaceFrame>> surfaceFrames;
   surfaceFrames.reserve(self.compositionOrder.size());
   std::unordered_map<int64_t, DlRect> viewRects;
+  std::unordered_set<int64_t> preserveUnderlayForViews;
 
   for (int64_t viewId : self.compositionOrder) {
-    viewRects[viewId] = self.currentCompositionParams[viewId].finalBoundingRect();
+    const flutter::EmbeddedViewParams& params = self.currentCompositionParams[viewId];
+    viewRects[viewId] = params.finalBoundingRect();
+    if (HasComplexClipForUnderlayCutout(params)) {
+      preserveUnderlayForViews.insert(viewId);
+    }
   }
 
   std::unordered_map<int64_t, DlRect> overlayLayers =
-      SliceViews(background_frame->Canvas(), self.compositionOrder, self.slices, viewRects);
+      SliceViews(background_frame->Canvas(), self.compositionOrder, self.slices, viewRects,
+                 &preserveUnderlayForViews);
 
   size_t requiredOverlayLayers = 0;
   for (int64_t viewId : self.compositionOrder) {
@@ -818,6 +892,9 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
     int restoreCount = overlayCanvas->GetSaveCount();
     overlayCanvas->Save();
     overlayCanvas->ClipRect(overlay->second);
+    if (preserveUnderlayForViews.find(viewId) != preserveUnderlayForViews.end()) {
+      ApplyComplexClipToOverlayCanvas(overlayCanvas, self.currentCompositionParams[viewId]);
+    }
     overlayCanvas->Clear(flutter::DlColor::kTransparent());
     self.slices[viewId]->render_into(overlayCanvas);
     overlayCanvas->RestoreToCount(restoreCount);

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
@@ -894,7 +894,7 @@ static void ApplyNonRectClipToOverlayCanvas(flutter::DlCanvas* overlay_canvas,
     overlayCanvas->Save();
     overlayCanvas->ClipRect(overlay->second);
     if (viewsWithUnderlayPreserved.find(viewId) != viewsWithUnderlayPreserved.end()) {
-      ApplyComplexClipToOverlayCanvas(overlayCanvas, self.currentCompositionParams[viewId]);
+      ApplyNonRectClipToOverlayCanvas(overlayCanvas, self.currentCompositionParams[viewId]);
     }
     overlayCanvas->Clear(flutter::DlColor::kTransparent());
     self.slices[viewId]->render_into(overlayCanvas);

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
@@ -4,10 +4,10 @@
 
 #import "shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.h"
 #include "display_list/geometry/dl_geometry_types.h"
-#include "flutter/display_list/geometry/dl_geometry_conversions.h"
 #include "impeller/geometry/rounding_radii.h"
 
 #include "flutter/display_list/effects/image_filters/dl_blur_image_filter.h"
+#include "flutter/display_list/geometry/dl_geometry_conversions.h"
 #include "flutter/display_list/utils/dl_matrix_clip_tracker.h"
 #include "flutter/flow/surface_frame.h"
 #include "flutter/flow/view_slicer.h"
@@ -856,7 +856,7 @@ static void ApplyComplexClipToOverlayCanvas(flutter::DlCanvas* overlay_canvas,
 
   std::unordered_map<int64_t, DlRect> overlayLayers =
       SliceViews(background_frame->Canvas(), self.compositionOrder, self.slices, viewRects,
-                 &preserveUnderlayForViews);
+                 preserveUnderlayForViews);
 
   size_t requiredOverlayLayers = 0;
   for (int64_t viewId : self.compositionOrder) {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

Test setup:
```dart
return Stack(
      children: [
        Container(color: Colors.blue), // Flutter content behind
        const Text('Some random text'),
        ClipRRect(
          borderRadius: BorderRadius.circular(250),
          child: const PlatformViewWidget(), // platform view on top - red background with black text on it
        ),
        BackdropFilter(
          filter: ImageFilter.blur(sigmaX: 5, sigmaY: 5),
          child: Center( 
            child: Container(
              height: 100,
              width: 100,
              color: Colors.blueAccent,
            ),
          ), // Flutter content infront of the blur
        )
      ],
    );
```

<p>
Before<br/>
<img height="600" alt="image" src="https://github.com/user-attachments/assets/2ea8d99a-73a5-415f-ad63-292f3b9cc12c" />

After<br/>
<img height="600" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-20 at 19 03 15" src="https://github.com/user-attachments/assets/ae515106-6238-474f-9aea-c6589da79bff" />
</p>


- Currently the underlay is always clipped by platform view in a rectangular shape. This isn't correct because the platform view can have clips on it such as a rounded rect or a custom path even
- The overlay was also always drawn in a rectangular shape
- Blurred text can only be part of the underlay because there's no background information in overlay.
- When a blured text was in the corner of a backdrop filter containing a platform view, the underlay which contains the blurred text got sliced away and overlay had unblurred text
- This PR makes this flow clip aware and handles different clips correctly

Definitions:
- Underlay: This is the flutter layer drawn below a platform view. When rendering we cut out holes in this layer for where the platform view will be rendered to save on compute
- [Overlay](https://docs.google.com/document/d/1V7Jc_RGaknrBBPPBBKB8lT7f3PKhYr8sin35MSMFAf4): This is the flutter layer drawn on top of the area occupied by the platform view.

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*
Fixes #150660 

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
