### PR TITLE
Call dart::bin::Platform::Initialize during Dart VM startup

### DIFF
--- a/engine/src/flutter/runtime/dart_vm.cc
+++ b/engine/src/flutter/runtime/dart_vm.cc
@@ -19,6 +19,7 @@
 #include "flutter/runtime/dart_isolate.h"
 #include "flutter/runtime/dart_vm_initializer.h"
 #include "flutter/runtime/ptrace_check.h"
+#include "third_party/dart/runtime/bin/platform.h"
 #include "third_party/dart/runtime/include/bin/dart_io_api.h"
 #include "third_party/skia/include/core/SkExecutor.h"
 #include "third_party/tonic/converter/dart_converter.h"
@@ -294,6 +295,10 @@ DartVM::DartVM(const std::shared_ptr<const DartVMData>& vm_data,
   FML_DCHECK(vm_data_);
   FML_DCHECK(isolate_name_server_);
   FML_DCHECK(service_protocol_);
+
+  if (!dart::bin::Platform::Initialize(false)) {
+    FML_LOG(FATAL) << "Dart platform-specific initialization failed";
+  }
 
   {
     TRACE_EVENT0("flutter", "dart::bin::BootstrapDartIo");

--- a/engine/src/flutter/testing/dart/BUILD.gn
+++ b/engine/src/flutter/testing/dart/BUILD.gn
@@ -45,6 +45,7 @@ tests = [
   "platform_isolate_test.dart",
   "platform_isolate_shutdown_test.dart",
   "plugin_utilities_test.dart",
+  "process_test.dart",
   "semantics_test.dart",
   "serial_gc_test.dart",
   "spawn_helper.dart",

--- a/engine/src/flutter/testing/dart/process_test.dart
+++ b/engine/src/flutter/testing/dart/process_test.dart
@@ -9,7 +9,7 @@ import 'package:test/test.dart';
 
 void main() {
   test('start process with missing executable', () async {
-    Future<Process> proc = Process.start('nonexistent-executable', []);
-    expect(() async => await proc, throwsA(isA<ProcessException>()));
+    final Future<Process> proc = Process.start('nonexistent-executable', []);
+    expect(proc, throwsA(isA<ProcessException>()));
   });
 }

--- a/engine/src/flutter/testing/dart/process_test.dart
+++ b/engine/src/flutter/testing/dart/process_test.dart
@@ -1,0 +1,15 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+void main() {
+  test('start process with missing executable', () async {
+    Future<Process> proc = Process.start('nonexistent-executable', []);
+    expect(() async => await proc, throwsA(isA<ProcessException>()));
+  });
+}


### PR DESCRIPTION
This does platform-specific setup for Dart (such as configuring signal handlers)

Fixes https://github.com/flutter/flutter/issues/182436
See https://github.com/dart-lang/sdk/issues/62679
See https://github.com/dart-lang/sdk/pull/62680