### PR TITLE
feat: Add --no-uninstall flag to flutter test for integration tests

### DIFF
--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -295,6 +295,13 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
             'and this flag can be used to override the default. To disable this for the '
             'skwasm renderer, use "--no-cross-origin-isolation".',
         hide: !verboseHelp,
+      )
+      ..addFlag(
+        'uninstall',
+        defaultsTo: true,
+        help:
+            'Whether to uninstall the app after running integration tests. '
+            'Set "--no-uninstall" to keep the app installed on the device. ',
       );
 
     addDdsOptions(verboseHelp: verboseHelp);
@@ -477,6 +484,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
           : null,
       printDtd: boolArg(FlutterGlobalOptions.kPrintDtd, global: true),
       webUseWasm: useWasm,
+      uninstallApp: boolArg('uninstall'),
     );
 
     final Uri? nativeAssetsJson = _isIntegrationTest

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -301,7 +301,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
         defaultsTo: true,
         help:
             'Whether to uninstall the app after running integration tests. '
-            'Set "--no-uninstall" to keep the app installed on the device. ',
+            'Set "--no-uninstall" to keep the app installed on the device.',
       );
 
     addDdsOptions(verboseHelp: verboseHelp);

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -1165,10 +1165,10 @@ class DebuggingOptions {
   /// This is not implemented for every platform.
   final bool uninstallFirst;
 
-  /// Whether the tool should uninstall the app after running integration tests.
+  /// Whether the tool should uninstall the app after running.
   ///
-  /// Defaults to true. Set to false via `--no-uninstall` to keep the app
-  /// installed on the device after tests complete.
+  /// This is currently only implemented for integration tests.
+  /// Defaults to true.
   final bool uninstallApp;
 
   /// Whether to run the browser in headless mode.

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -982,6 +982,7 @@ class DebuggingOptions {
     this.enableFlutterGpu = false,
     this.enableVulkanValidation = false,
     this.uninstallFirst = false,
+    this.uninstallApp = true,
     this.enableDartProfiling = true,
     this.profileStartup = false,
     this.enableEmbedderApi = false,
@@ -1016,6 +1017,7 @@ class DebuggingOptions {
     this.enableFlutterGpu = false,
     this.enableVulkanValidation = false,
     this.uninstallFirst = false,
+    this.uninstallApp = true,
     this.enableDartProfiling = true,
     this.profileStartup = false,
     this.enableEmbedderApi = false,
@@ -1099,6 +1101,7 @@ class DebuggingOptions {
     required this.enableFlutterGpu,
     required this.enableVulkanValidation,
     required this.uninstallFirst,
+    required this.uninstallApp,
     required this.enableDartProfiling,
     required this.profileStartup,
     required this.enableEmbedderApi,
@@ -1161,6 +1164,12 @@ class DebuggingOptions {
   ///
   /// This is not implemented for every platform.
   final bool uninstallFirst;
+
+  /// Whether the tool should uninstall the app after running integration tests.
+  ///
+  /// Defaults to true. Set to false via `--no-uninstall` to keep the app
+  /// installed on the device after tests complete.
+  final bool uninstallApp;
 
   /// Whether to run the browser in headless mode.
   ///
@@ -1295,6 +1304,7 @@ class DebuggingOptions {
     'enableImpeller': enableImpeller.asBool,
     'enableFlutterGpu': enableFlutterGpu,
     'enableVulkanValidation': enableVulkanValidation,
+    'uninstallApp': uninstallApp,
     'enableDartProfiling': enableDartProfiling,
     'profileStartup': profileStartup,
     'enableEmbedderApi': enableEmbedderApi,
@@ -1364,6 +1374,7 @@ class DebuggingOptions {
         enableFlutterGpu: json['enableFlutterGpu']! as bool,
         enableVulkanValidation: (json['enableVulkanValidation'] as bool?) ?? false,
         uninstallFirst: (json['uninstallFirst'] as bool?) ?? false,
+        uninstallApp: (json['uninstallApp'] as bool?) ?? true,
         enableDartProfiling: (json['enableDartProfiling'] as bool?) ?? true,
         profileStartup: (json['profileStartup'] as bool?) ?? false,
         enableEmbedderApi: (json['enableEmbedderApi'] as bool?) ?? false,

--- a/packages/flutter_tools/lib/src/test/integration_test_device.dart
+++ b/packages/flutter_tools/lib/src/test/integration_test_device.dart
@@ -141,8 +141,10 @@ class IntegrationTestTestDevice implements TestDevice {
       if (!await device.stopApp(applicationPackage, userIdentifier: userIdentifier)) {
         globals.printTrace('Could not stop the Integration Test app.');
       }
-      if (!await device.uninstallApp(applicationPackage, userIdentifier: userIdentifier)) {
-        globals.printTrace('Could not uninstall the Integration Test app.');
+      if (debuggingOptions.uninstallApp) {
+        if (!await device.uninstallApp(applicationPackage, userIdentifier: userIdentifier)) {
+          globals.printTrace('Could not uninstall the Integration Test app.');
+        }
       }
     }
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
@@ -1523,6 +1523,40 @@ dev_dependencies:
     );
 
     testUsingContext(
+      'uninstallApp defaults to true',
+      () async {
+        final testRunner = FakeFlutterTestRunner(0);
+
+        final testCommand = TestCommand(testRunner: testRunner);
+        final CommandRunner<void> commandRunner = createTestCommandRunner(testCommand);
+
+        await commandRunner.run(const <String>['test', '--no-pub']);
+        expect(testRunner.lastDebuggingOptionsValue.uninstallApp, true);
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager.any(),
+      },
+    );
+
+    testUsingContext(
+      '--no-uninstall sets uninstallApp to false',
+      () async {
+        final testRunner = FakeFlutterTestRunner(0);
+
+        final testCommand = TestCommand(testRunner: testRunner);
+        final CommandRunner<void> commandRunner = createTestCommandRunner(testCommand);
+
+        await commandRunner.run(const <String>['test', '--no-pub', '--no-uninstall']);
+        expect(testRunner.lastDebuggingOptionsValue.uninstallApp, false);
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager.any(),
+      },
+    );
+
+    testUsingContext(
       'Passes web renderer into debugging options',
       () async {
         final testRunner = FakeFlutterTestRunner(0);


### PR DESCRIPTION
## Description

Add `--no-uninstall` flag to `flutter test` to skip app uninstallation after integration tests complete.

When running integration tests on Android (`flutter test integration_test/`), the `IntegrationTestTestDevice.kill()` method always calls `device.uninstallApp()` after tests finish. For Device Policy Manager (DPM) apps, Android prevents uninstallation, causing the error:

```bash
adb uninstall failed: Failure [DELETE_FAILED_DEVICE_POLICY_MANAGER]
```

This PR adds a `--uninstall` flag (defaulting to true) to `flutter test`, so users can pass `--no-uninstall` to skip the post-test uninstallation step:

```bash
flutter test integration_test/ --no-uninstall
```

Fixes #166709 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
