### PR TITLE
Enable SafeArea on Scaffold bottomSheet

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -3084,7 +3084,7 @@ class ScaffoldState extends State<Scaffold>
         removeLeftPadding: false,
         removeTopPadding: true,
         removeRightPadding: false,
-        removeBottomPadding: _resizeToAvoidBottomInset,
+        removeBottomPadding: false,
       );
     }
 


### PR DESCRIPTION
As explained in https://github.com/flutter/flutter/issues/69676 , for a long time, it hasn't been possible to use `SafeArea` with `BottomSheet` displayed by `Scaffold`.

The issue here is that we remove the bottom padding from `MediaQuery`, which is what `SafeArea` widget uses to understand when to apply padding and of how much.

I can't think of a good reason to disable such option for bottom sheets.

As a note, this _doesn't_ add padding by default, but rather users must still wrap their widgets in a `SafeArea`, hence this should be a backward compatible change.
