### PR TITLE
Fix video_player black screen on Firefox with CanvasKit (READ_BUFFER …

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/browser_detection.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/browser_detection.dart
@@ -139,6 +139,24 @@ bool get _workAroundBug91333 => _isIOS;
 bool get browserSupportsCanvaskitChromium =>
     domIntl.v8BreakIterator != null && domIntl.Segmenter != null;
 
+/// Whether the current browser may provide a multisampled WebGL default
+/// framebuffer even when the `antialias` context attribute is set to false.
+///
+/// Per the WebGL spec, the `antialias` attribute is only a hint. Firefox is
+/// known to ignore this hint and provide a multisampled default framebuffer
+/// regardless. When this is true, the actual sample count and stencil bits
+/// must be queried from the WebGL context rather than using hardcoded values,
+/// to avoid rendering failures such as black screens when compositing
+/// platform views (e.g., video elements).
+///
+/// See also: https://github.com/flutter/flutter/issues/182722
+bool get browserMayOverrideAntialiasHint =>
+    debugBrowserMayOverrideAntialiasHint ?? isFirefox;
+
+/// Used in tests to override [browserMayOverrideAntialiasHint].
+@visibleForTesting
+bool? debugBrowserMayOverrideAntialiasHint;
+
 /// Whether the current browser is Safari 17.4 or newer.
 ///
 /// Safari 17.4 introduced support for aria-description.

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/surface.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/surface.dart
@@ -72,6 +72,26 @@ abstract class CkSurface extends Surface {
   int get glContext => _glContext;
   int _glContext = -1;
 
+  /// The actual sample count of the WebGL default framebuffer.
+  ///
+  /// This is queried from the WebGL context after creation because browsers
+  /// may ignore the `antialias` hint and provide a multisampled framebuffer
+  /// regardless. Using a hardcoded value of 0 causes rendering failures on
+  /// Firefox.
+  ///
+  /// See also: https://github.com/flutter/flutter/issues/182722
+  @visibleForTesting
+  int get webGlSampleCount => _webGlSampleCount;
+  int _webGlSampleCount = 0;
+
+  /// The actual stencil bit depth of the WebGL default framebuffer.
+  ///
+  /// This is queried from the WebGL context after creation to match the
+  /// actual framebuffer configuration.
+  @visibleForTesting
+  int get webGlStencilBits => _webGlStencilBits;
+  int _webGlStencilBits = 0;
+
   /// The canvas object that this surface is rendering to.
   @visibleForTesting
   DomEventTarget get canvas => _canvas;
@@ -133,6 +153,19 @@ abstract class CkSurface extends Surface {
       majorVersion: webGLVersion.toDouble(),
     );
     _glContext = _getGlContext(options);
+
+    // Query the actual sample count and stencil bits from the WebGL context.
+    // The `antialias` attribute in WebGL context creation is only a hint;
+    // browsers (particularly Firefox) may provide a multisampled default
+    // framebuffer even when antialias is disabled. Using hardcoded values
+    // causes a mismatch between what Skia expects and the actual framebuffer
+    // configuration, leading to rendering failures such as black screens
+    // when compositing platform views (e.g., video elements).
+    //
+    // This mirrors the approach used by the skwasm backend in surface.cc.
+    // See also: https://github.com/flutter/flutter/issues/182722
+    _retrieveWebGlParams();
+
     _grContext = canvasKit.MakeGrContext(_glContext.toDouble());
     if (_grContext == null) {
       _failedToCreateGrContext = true;
@@ -140,11 +173,26 @@ abstract class CkSurface extends Surface {
     }
   }
 
+  /// Queries the actual WebGL parameters from the rendering context and stores
+  /// them in [_webGlSampleCount] and [_webGlStencilBits].
+  void _retrieveWebGlParams() {
+    final WebGLContext gl = _getWebGlRenderingContext();
+    _webGlSampleCount = gl.sampleCount;
+    _webGlStencilBits = gl.stencilSize;
+  }
+
   /// Creates the underlying GL context for the canvas.
   ///
   /// This method is implemented by subclasses to handle their specific
   /// canvas types.
   int _getGlContext(SkWebGLContextOptions options);
+
+  /// Returns the [WebGLContext] for the underlying canvas.
+  ///
+  /// This is used to query the actual WebGL parameters (sample count, stencil
+  /// bits) from the rendering context. Subclasses implement this to handle
+  /// their specific canvas types.
+  WebGLContext _getWebGlRenderingContext();
 
   /// Creates the Skia objects that are backed by the canvas.
   ///
@@ -164,8 +212,8 @@ abstract class CkSurface extends Surface {
       _currentSize.width.toDouble(),
       _currentSize.height.toDouble(),
       SkColorSpaceSRGB,
-      0,
-      0,
+      _webGlSampleCount,
+      _webGlStencilBits,
     );
     if (_skSurface == null) {
       throw Exception('Failed to initialize CanvasKit SkSurface.');
@@ -273,6 +321,11 @@ class CkOffscreenSurface extends CkSurface implements OffscreenSurface {
   }
 
   @override
+  WebGLContext _getWebGlRenderingContext() {
+    return (canvas as DomOffscreenCanvas).getGlContext(webGLVersion);
+  }
+
+  @override
   SkSurface _createSoftwareSkSurface() {
     return canvasKit.MakeOffscreenSWCanvasSurface(canvas as DomOffscreenCanvas);
   }
@@ -308,6 +361,11 @@ class CkOnscreenSurface extends CkSurface implements OnscreenSurface {
   @override
   int _getGlContext(SkWebGLContextOptions options) {
     return canvasKit.GetWebGLContext(canvas as DomHTMLCanvasElement, options).toInt();
+  }
+
+  @override
+  WebGLContext _getWebGlRenderingContext() {
+    return (canvas as DomHTMLCanvasElement).getGlContext(webGLVersion);
   }
 
   @override

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/dom.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/dom.dart
@@ -868,6 +868,23 @@ extension type WebGLContext._(JSObject _) implements JSObject {
   @JS('STENCIL_BITS')
   external int get stencilBits;
 
+  /// Returns the actual number of samples used by the default framebuffer.
+  ///
+  /// Browsers may ignore the `antialias` hint when creating a WebGL context
+  /// and provide a multisampled default framebuffer regardless. This value
+  /// must be queried and used when creating SkSurfaces to avoid rendering
+  /// issues on browsers like Firefox.
+  ///
+  /// See also: https://github.com/flutter/flutter/issues/182722
+  int get sampleCount => getParameter(samples);
+
+  /// Returns the actual number of stencil bits in the default framebuffer.
+  ///
+  /// This value must be queried from the actual WebGL context rather than
+  /// hardcoded, as browsers may provide different stencil configurations
+  /// than what was requested.
+  int get stencilSize => getParameter(stencilBits);
+
   external JSAny? getExtension(String name);
 
   WebGLLoseContextExtension get loseContextExtension {

--- a/engine/src/flutter/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -1746,6 +1746,35 @@ void _paragraphTests() {
     skip: isFirefox,
   ); // Intended: Headless firefox has no webgl support https://github.com/flutter/flutter/issues/109265
 
+  // Regression test for https://github.com/flutter/flutter/issues/182722
+  //
+  // Verifies that WebGLContext.sampleCount and WebGLContext.stencilSize
+  // convenience getters return the same values as manual getParameter calls.
+  test(
+    'WebGLContext convenience getters match getParameter calls',
+    () {
+      final DomHTMLCanvasElement canvas = createDomCanvasElement(width: 100, height: 100);
+
+      // Create a WebGL context first (via CanvasKit) so the context exists.
+      canvasKit.GetWebGLContext(
+        canvas,
+        SkWebGLContextOptions(antialias: 0, majorVersion: webGLVersion.toDouble()),
+      );
+
+      final WebGLContext gl = canvas.getGlContext(webGLVersion);
+
+      // The new convenience getters should return the same values as the
+      // manual getParameter calls.
+      expect(gl.sampleCount, equals(gl.getParameter(gl.samples)));
+      expect(gl.stencilSize, equals(gl.getParameter(gl.stencilBits)));
+
+      // Both values should be non-negative.
+      expect(gl.sampleCount, greaterThanOrEqualTo(0));
+      expect(gl.stencilSize, greaterThanOrEqualTo(0));
+    },
+    skip: isFirefox,
+  ); // Intended: Headless firefox has no webgl support https://github.com/flutter/flutter/issues/109265
+
   test(
     'MakeRenderTarget test',
     () {

--- a/engine/src/flutter/lib/web_ui/test/canvaskit/surface_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/canvaskit/surface_test.dart
@@ -139,6 +139,71 @@ void testMain() {
       final SkSurface? skSurface2 = surface.skSurface;
       expect(skSurface1, same(skSurface2));
     });
+
+    // Regression test for https://github.com/flutter/flutter/issues/182722
+    //
+    // Verifies that CkOnscreenSurface queries actual WebGL sample count and
+    // stencil bits from the context instead of using hardcoded values. Firefox
+    // may provide a multisampled default framebuffer even when antialias is
+    // disabled, causing black screen rendering when values are mismatched.
+    test('CkOnscreenSurface queries actual WebGL sample count and stencil bits', () async {
+      final surface = CkOnscreenSurface(OnscreenCanvasProvider());
+      await surface.initialized;
+
+      // The surface must have WebGL support for this test to be meaningful.
+      expect(surface.supportsWebGl, isTrue);
+
+      // Verify that the sample count and stencil bits were queried from the
+      // actual WebGL context. They should be non-negative integers (typically
+      // 0 when antialias is off, but Firefox may return > 0).
+      expect(surface.webGlSampleCount, greaterThanOrEqualTo(0));
+      expect(surface.webGlStencilBits, greaterThanOrEqualTo(0));
+
+      // Verify the values match what the WebGL context actually reports.
+      final WebGLContext gl = (surface.canvas as DomHTMLCanvasElement)
+          .getGlContext(webGLVersion);
+      expect(surface.webGlSampleCount, equals(gl.sampleCount));
+      expect(surface.webGlStencilBits, equals(gl.stencilSize));
+    });
+
+    // Regression test for https://github.com/flutter/flutter/issues/182722
+    test('CkOffscreenSurface queries actual WebGL sample count and stencil bits', () async {
+      final surface = CkOffscreenSurface(OffscreenCanvasProvider());
+      await surface.initialized;
+
+      expect(surface.supportsWebGl, isTrue);
+
+      expect(surface.webGlSampleCount, greaterThanOrEqualTo(0));
+      expect(surface.webGlStencilBits, greaterThanOrEqualTo(0));
+    });
+
+    // Regression test for https://github.com/flutter/flutter/issues/182722
+    //
+    // Verifies that WebGL params are re-queried when the context is recreated
+    // after a context loss event.
+    test('CkOnscreenSurface re-queries WebGL params after context loss', () async {
+      final surface = CkOnscreenSurface(OnscreenCanvasProvider());
+      await surface.initialized;
+
+      expect(surface.supportsWebGl, isTrue);
+
+      // Record the initial values.
+      final int initialSampleCount = surface.webGlSampleCount;
+      final int initialStencilBits = surface.webGlStencilBits;
+
+      // Trigger context loss and wait for recovery.
+      await surface.triggerContextLoss();
+      await surface.handledContextLossEvent;
+
+      // After context recovery, the WebGL params should still be valid
+      // (re-queried from the new context).
+      expect(surface.webGlSampleCount, greaterThanOrEqualTo(0));
+      expect(surface.webGlStencilBits, greaterThanOrEqualTo(0));
+
+      // In the same browser, the new context should have the same params.
+      expect(surface.webGlSampleCount, equals(initialSampleCount));
+      expect(surface.webGlStencilBits, equals(initialStencilBits));
+    });
   });
 }
 

--- a/engine/src/flutter/lib/web_ui/test/engine/engine_browser_detect_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/engine_browser_detect_test.dart
@@ -69,6 +69,28 @@ void testMain() {
       expect(browserSupportsCanvaskitChromium, isFalse);
     });
   });
+
+  group('browserMayOverrideAntialiasHint', () {
+    tearDown(() {
+      debugBrowserMayOverrideAntialiasHint = null;
+    });
+
+    // Regression test for https://github.com/flutter/flutter/issues/182722
+    test('can be overridden for testing', () {
+      debugBrowserMayOverrideAntialiasHint = true;
+      expect(browserMayOverrideAntialiasHint, isTrue);
+
+      debugBrowserMayOverrideAntialiasHint = false;
+      expect(browserMayOverrideAntialiasHint, isFalse);
+    });
+
+    test('defaults to browser detection when debug override is null', () {
+      debugBrowserMayOverrideAntialiasHint = null;
+      // The actual value depends on the browser running the test.
+      // On Firefox, it should be true; on other browsers, false.
+      expect(browserMayOverrideAntialiasHint, equals(isFirefox));
+    });
+  });
 }
 
 @JS('window.Intl.v8BreakIterator')


### PR DESCRIPTION
## Summary
- Fix video_player rendering black screen on Firefox when using CanvasKit renderer
- Query actual WebGL `GL_SAMPLES` and `GL_STENCIL_BITS` from the rendering context
  instead of passing hardcoded `0` to `MakeOnScreenGLSurface`
- Add `browserMayOverrideAntialiasHint` detection flag for Firefox's known behavior
  of ignoring the WebGL `antialias` hint

Fixes #182722

