### PR TITLE
[A11y][Web] Support isAccessibilityFocusBlocked flag on web

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -890,9 +890,9 @@ abstract class SemanticRole {
 
     if (semanticsObject.isFlagsDirty) {
       if (semanticsObject.flags.isAccessibilityFocusBlocked) {
-        element.setAttribute('aria-hidden', 'true');
+        setAttribute('aria-hidden', 'true');
       } else {
-        element.removeAttribute('aria-hidden');
+        removeAttribute('aria-hidden');
       }
     }
 

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -888,6 +888,14 @@ abstract class SemanticRole {
       updateValidationResult();
     }
 
+    if (semanticsObject.isFlagsDirty) {
+      if (semanticsObject.flags.isAccessibilityFocusBlocked) {
+        element.setAttribute('aria-hidden', 'true');
+      } else {
+        element.removeAttribute('aria-hidden');
+      }
+    }
+
     final List<SemanticBehavior>? behaviors = _behaviors;
     if (behaviors != null) {
       for (final SemanticBehavior behavior in behaviors) {

--- a/engine/src/flutter/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -166,6 +166,9 @@ void runSemanticsTests() {
   group('loadingSpinner', () {
     _testLoadingSpinner();
   });
+  group('AccessibilityFocusBlocked', () {
+    _testAccessibilityFocusBlocked();
+  });
 }
 
 void _testSemanticRole() {
@@ -6411,4 +6414,34 @@ Future<void> createPlatformView(int id, String viewType) {
     (dynamic _) => completer.complete(),
   );
   return completer.future;
+}
+
+void _testAccessibilityFocusBlocked() {
+  test('sets and removes aria-hidden for isAccessibilityFocusBlocked', () async {
+    semantics()
+      ..debugOverrideTimestampFunction(() => _testTime)
+      ..semanticsEnabled = true;
+
+    // Create a node with isAccessibilityFocusBlocked = true
+    {
+      final builder = ui.SemanticsUpdateBuilder();
+      updateNode(
+        builder,
+        flags: const ui.SemanticsFlags(isAccessibilityFocusBlocked: true),
+        rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
+      );
+      owner().updateSemantics(builder.build());
+      expectSemanticsTree(owner(), '<sem aria-hidden="true"></sem>');
+    }
+
+    // Update to isAccessibilityFocusBlocked = false
+    {
+      final builder = ui.SemanticsUpdateBuilder();
+      updateNode(builder, rect: const ui.Rect.fromLTRB(0, 0, 100, 50));
+      owner().updateSemantics(builder.build());
+      expectSemanticsTree(owner(), '<sem></sem>');
+    }
+
+    semantics().semanticsEnabled = false;
+  });
 }


### PR DESCRIPTION
... using aria-hidden. 


## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
