### PR TITLE
feat: add few required properties to test widgets app

### DIFF
--- a/packages/flutter/test/widgets/widgets_app_tester.dart
+++ b/packages/flutter/test/widgets/widgets_app_tester.dart
@@ -56,9 +56,14 @@ class TestWidgetsApp extends StatelessWidget {
     super.key,
     this.navigatorKey,
     this.home,
+    this.initialRoute,
     this.routes = const <String, WidgetBuilder>{},
     this.color = const Color(0xFFFFFFFF),
     this.pageRouteBuilder = _defaultPageRouteBuilder,
+    this.builder,
+    this.shortcuts,
+    this.actions,
+    this.restorationScopeId,
   });
 
   /// A key to use when building the [Navigator].
@@ -90,6 +95,15 @@ class TestWidgetsApp extends StatelessWidget {
   ///
   ///  * [WidgetsApp.home], the equivalent property in [WidgetsApp].
   final Widget? home;
+
+  /// The name of the first route to show when the app launches.
+  ///
+  /// Defaults to [Navigator.defaultRouteName] (typically `/`).
+  ///
+  /// See also:
+  ///
+  ///  * [WidgetsApp.initialRoute], the equivalent property in [WidgetsApp].
+  final String? initialRoute;
 
   /// The application's top-level routing table.
   ///
@@ -148,6 +162,44 @@ class TestWidgetsApp extends StatelessWidget {
   ///  * [WidgetsApp.pageRouteBuilder], the equivalent property in [WidgetsApp].
   final PageRouteFactory pageRouteBuilder;
 
+  /// A builder for inserting widgets above the [Navigator].
+  ///
+  /// See also:
+  ///
+  ///  * [WidgetsApp.builder], the equivalent property in [WidgetsApp].
+  final TransitionBuilder? builder;
+
+  /// The application's keyboard shortcut map.
+  ///
+  /// In tests, this allows registering custom keyboard shortcuts to verify
+  /// that key combinations trigger the expected [Intent]s.
+  ///
+  /// When null, [WidgetsApp.defaultShortcuts] are used.
+  ///
+  /// See also:
+  ///
+  ///  * [WidgetsApp.shortcuts], the equivalent property in [WidgetsApp].
+  final Map<ShortcutActivator, Intent>? shortcuts;
+
+  /// The application's action map.
+  ///
+  /// In tests, this allows registering custom [Action]s that respond to
+  /// [Intent]s dispatched by [Shortcuts] or programmatic invocation.
+  ///
+  /// When null, [WidgetsApp.defaultActions] are used.
+  ///
+  /// See also:
+  ///
+  ///  * [WidgetsApp.actions], the equivalent property in [WidgetsApp].
+  final Map<Type, Action<Intent>>? actions;
+
+  /// The identifier to use for state restoration of the app's [Navigator].
+  ///
+  /// See also:
+  ///
+  ///  * [WidgetsApp.restorationScopeId], the equivalent property in [WidgetsApp].
+  final String? restorationScopeId;
+
   static PageRoute<T> _defaultPageRouteBuilder<T>(RouteSettings settings, WidgetBuilder builder) {
     return PageRouteBuilder<T>(
       settings: settings,
@@ -173,8 +225,13 @@ class TestWidgetsApp extends StatelessWidget {
       color: color,
       navigatorKey: navigatorKey,
       home: home,
+      initialRoute: initialRoute,
       routes: routes,
       pageRouteBuilder: pageRouteBuilder,
+      builder: builder,
+      shortcuts: shortcuts,
+      actions: actions,
+      restorationScopeId: restorationScopeId,
     );
   }
 }


### PR DESCRIPTION
This PR add new properties like initialRoute, builder, shortcuts, actions and restorationScopeId.

part of: https://github.com/flutter/flutter/issues/177415

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.