### PR TITLE
Fix/ios codesign xattr for Building in Xcode 26

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -914,8 +914,10 @@ Future<void> _createStubAppFramework(
 }
 
 Future<void> _signFramework(Environment environment, File binary, BuildMode buildMode) async {
+  // Strip xattrs from the entire .framework directory, not just the binary.
+  // codesign validates the whole bundle. See https://github.com/flutter/flutter/issues/181103
   await removeExtendedAttributes(
-    binary,
+    binary.parent,
     ProcessUtils(processManager: environment.processManager, logger: environment.logger),
     environment.logger,
   );

--- a/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets_host.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets_host.dart
@@ -13,6 +13,7 @@ import '../../../base/process.dart';
 import '../../../build_info.dart';
 import '../../../build_system/targets/darwin.dart';
 import '../../../globals.dart' as globals;
+import '../../../ios/mac.dart';
 import '../native_assets.dart';
 
 /// Create an `Info.plist` in [target] for a framework with a single dylib.
@@ -179,8 +180,8 @@ Future<void> codesignDylib(
     codesignIdentity = '-';
   }
   // Strip extended attributes (com.apple.provenance, etc.) that cause codesign
-  // failures on macOS 26+. See https://github.com/flutter/flutter/issues/181103
-  await globals.processUtils.run(<String>['xattr', '-cr', target.path]);
+  // failures on macOS 14+. See https://github.com/flutter/flutter/issues/181103
+  await removeExtendedAttributes(target, globals.processUtils, globals.logger);
   final codesignCommand = <String>[
     'xcrun',
     'codesign',

--- a/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets_host.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets_host.dart
@@ -178,6 +178,9 @@ Future<void> codesignDylib(
   if (codesignIdentity == null || codesignIdentity.isEmpty) {
     codesignIdentity = '-';
   }
+  // Strip extended attributes (com.apple.provenance, etc.) that cause codesign
+  // failures on macOS 26+. See https://github.com/flutter/flutter/issues/181103
+  await globals.processManager.run(<String>['xattr', '-cr', target.path]);
   final codesignCommand = <String>[
     'xcrun',
     'codesign',

--- a/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets_host.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets_host.dart
@@ -180,7 +180,7 @@ Future<void> codesignDylib(
   }
   // Strip extended attributes (com.apple.provenance, etc.) that cause codesign
   // failures on macOS 26+. See https://github.com/flutter/flutter/issues/181103
-  await globals.processManager.run(<String>['xattr', '-cr', target.path]);
+  await globals.processUtils.run(<String>['xattr', '-cr', target.path]);
   final codesignCommand = <String>[
     'xcrun',
     'codesign',

--- a/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
@@ -98,10 +98,9 @@ void main() {
     () async {
       environment.defines[kIosArchs] = 'x86_64';
       environment.defines[kSdkRoot] = 'path/to/iPhoneSimulator.sdk';
-      final String appFrameworkPath = environment.buildDir
-          .childDirectory('App.framework')
-          .childFile('App')
-          .path;
+      final Directory appFrameworkDir = environment.buildDir
+          .childDirectory('App.framework');
+      final String appFrameworkPath = appFrameworkDir.childFile('App').path;
       processManager.addCommands(<FakeCommand>[
         FakeCommand(
           command: <String>[
@@ -134,10 +133,10 @@ void main() {
           ],
         ),
         FakeCommand(
-          command: <String>['xattr', '-r', '-d', 'com.apple.FinderInfo', appFrameworkPath],
+          command: <String>['xattr', '-r', '-d', 'com.apple.FinderInfo', appFrameworkDir.path],
         ),
         FakeCommand(
-          command: <String>['xattr', '-r', '-d', 'com.apple.provenance', appFrameworkPath],
+          command: <String>['xattr', '-r', '-d', 'com.apple.provenance', appFrameworkDir.path],
         ),
         FakeCommand(
           command: <String>[
@@ -166,10 +165,9 @@ void main() {
     () async {
       environment.defines[kIosArchs] = 'arm64';
       environment.defines[kSdkRoot] = 'path/to/iPhoneOS.sdk';
-      final String appFrameworkPath = environment.buildDir
-          .childDirectory('App.framework')
-          .childFile('App')
-          .path;
+      final Directory appFrameworkDir = environment.buildDir
+          .childDirectory('App.framework');
+      final String appFrameworkPath = appFrameworkDir.childFile('App').path;
       processManager.addCommands(<FakeCommand>[
         FakeCommand(
           command: <String>[
@@ -189,10 +187,10 @@ void main() {
           ],
         ),
         FakeCommand(
-          command: <String>['xattr', '-r', '-d', 'com.apple.FinderInfo', appFrameworkPath],
+          command: <String>['xattr', '-r', '-d', 'com.apple.FinderInfo', appFrameworkDir.path],
         ),
         FakeCommand(
-          command: <String>['xattr', '-r', '-d', 'com.apple.provenance', appFrameworkPath],
+          command: <String>['xattr', '-r', '-d', 'com.apple.provenance', appFrameworkDir.path],
         ),
         FakeCommand(
           command: <String>[
@@ -262,10 +260,10 @@ void main() {
         ),
 
         FakeCommand(
-          command: <String>['xattr', '-r', '-d', 'com.apple.FinderInfo', frameworkBinary.path],
+          command: <String>['xattr', '-r', '-d', 'com.apple.FinderInfo', frameworkBinary.parent.path],
         ),
         FakeCommand(
-          command: <String>['xattr', '-r', '-d', 'com.apple.provenance', frameworkBinary.path],
+          command: <String>['xattr', '-r', '-d', 'com.apple.provenance', frameworkBinary.parent.path],
         ),
         FakeCommand(
           command: <String>[
@@ -337,7 +335,7 @@ void main() {
             '-r',
             '-d',
             'com.apple.FinderInfo',
-            frameworkDirectoryBinary.path,
+            frameworkDirectory.path,
           ],
         ),
         FakeCommand(
@@ -346,7 +344,7 @@ void main() {
             '-r',
             '-d',
             'com.apple.provenance',
-            frameworkDirectoryBinary.path,
+            frameworkDirectory.path,
           ],
         ),
         FakeCommand(
@@ -438,7 +436,7 @@ void main() {
             '-r',
             '-d',
             'com.apple.FinderInfo',
-            frameworkDirectoryBinary.path,
+            frameworkDirectory.path,
           ],
         ),
         FakeCommand(
@@ -447,7 +445,7 @@ void main() {
             '-r',
             '-d',
             'com.apple.provenance',
-            frameworkDirectoryBinary.path,
+            frameworkDirectory.path,
           ],
         ),
         FakeCommand(
@@ -549,7 +547,7 @@ void main() {
             '-r',
             '-d',
             'com.apple.FinderInfo',
-            frameworkDirectoryBinary.path,
+            frameworkDirectory.path,
           ],
         ),
         FakeCommand(
@@ -558,7 +556,7 @@ void main() {
             '-r',
             '-d',
             'com.apple.provenance',
-            frameworkDirectoryBinary.path,
+            frameworkDirectory.path,
           ],
         ),
         FakeCommand(
@@ -634,7 +632,7 @@ void main() {
             '-r',
             '-d',
             'com.apple.FinderInfo',
-            frameworkDirectoryBinary.path,
+            frameworkDirectory.path,
           ],
         ),
         FakeCommand(
@@ -643,7 +641,7 @@ void main() {
             '-r',
             '-d',
             'com.apple.provenance',
-            frameworkDirectoryBinary.path,
+            frameworkDirectory.path,
           ],
         ),
         FakeCommand(
@@ -713,7 +711,7 @@ void main() {
             '-r',
             '-d',
             'com.apple.FinderInfo',
-            frameworkDirectoryBinary.path,
+            frameworkDirectory.path,
           ],
         ),
         FakeCommand(
@@ -722,7 +720,7 @@ void main() {
             '-r',
             '-d',
             'com.apple.provenance',
-            frameworkDirectoryBinary.path,
+            frameworkDirectory.path,
           ],
         ),
         FakeCommand(
@@ -907,7 +905,7 @@ void main() {
       );
 
       xattrCommand = FakeCommand(
-        command: <String>['xattr', '-r', '-d', 'com.apple.FinderInfo', binary.path],
+        command: <String>['xattr', '-r', '-d', 'com.apple.FinderInfo', binary.parent.path],
       );
 
       adHocCodesignCommand = FakeCommand(

--- a/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
@@ -98,8 +98,7 @@ void main() {
     () async {
       environment.defines[kIosArchs] = 'x86_64';
       environment.defines[kSdkRoot] = 'path/to/iPhoneSimulator.sdk';
-      final Directory appFrameworkDir = environment.buildDir
-          .childDirectory('App.framework');
+      final Directory appFrameworkDir = environment.buildDir.childDirectory('App.framework');
       final String appFrameworkPath = appFrameworkDir.childFile('App').path;
       processManager.addCommands(<FakeCommand>[
         FakeCommand(
@@ -165,8 +164,7 @@ void main() {
     () async {
       environment.defines[kIosArchs] = 'arm64';
       environment.defines[kSdkRoot] = 'path/to/iPhoneOS.sdk';
-      final Directory appFrameworkDir = environment.buildDir
-          .childDirectory('App.framework');
+      final Directory appFrameworkDir = environment.buildDir.childDirectory('App.framework');
       final String appFrameworkPath = appFrameworkDir.childFile('App').path;
       processManager.addCommands(<FakeCommand>[
         FakeCommand(
@@ -260,10 +258,22 @@ void main() {
         ),
 
         FakeCommand(
-          command: <String>['xattr', '-r', '-d', 'com.apple.FinderInfo', frameworkBinary.parent.path],
+          command: <String>[
+            'xattr',
+            '-r',
+            '-d',
+            'com.apple.FinderInfo',
+            frameworkBinary.parent.path,
+          ],
         ),
         FakeCommand(
-          command: <String>['xattr', '-r', '-d', 'com.apple.provenance', frameworkBinary.parent.path],
+          command: <String>[
+            'xattr',
+            '-r',
+            '-d',
+            'com.apple.provenance',
+            frameworkBinary.parent.path,
+          ],
         ),
         FakeCommand(
           command: <String>[
@@ -330,22 +340,10 @@ void main() {
       processManager.addCommands(<FakeCommand>[
         createPlutilFakeCommand(infoPlist),
         FakeCommand(
-          command: <String>[
-            'xattr',
-            '-r',
-            '-d',
-            'com.apple.FinderInfo',
-            frameworkDirectory.path,
-          ],
+          command: <String>['xattr', '-r', '-d', 'com.apple.FinderInfo', frameworkDirectory.path],
         ),
         FakeCommand(
-          command: <String>[
-            'xattr',
-            '-r',
-            '-d',
-            'com.apple.provenance',
-            frameworkDirectory.path,
-          ],
+          command: <String>['xattr', '-r', '-d', 'com.apple.provenance', frameworkDirectory.path],
         ),
         FakeCommand(
           command: <String>[
@@ -431,22 +429,10 @@ void main() {
       processManager.addCommands(<FakeCommand>[
         createPlutilFakeCommand(infoPlist),
         FakeCommand(
-          command: <String>[
-            'xattr',
-            '-r',
-            '-d',
-            'com.apple.FinderInfo',
-            frameworkDirectory.path,
-          ],
+          command: <String>['xattr', '-r', '-d', 'com.apple.FinderInfo', frameworkDirectory.path],
         ),
         FakeCommand(
-          command: <String>[
-            'xattr',
-            '-r',
-            '-d',
-            'com.apple.provenance',
-            frameworkDirectory.path,
-          ],
+          command: <String>['xattr', '-r', '-d', 'com.apple.provenance', frameworkDirectory.path],
         ),
         FakeCommand(
           command: <String>[
@@ -542,22 +528,10 @@ void main() {
         ),
         createPlutilFakeCommand(infoPlist),
         FakeCommand(
-          command: <String>[
-            'xattr',
-            '-r',
-            '-d',
-            'com.apple.FinderInfo',
-            frameworkDirectory.path,
-          ],
+          command: <String>['xattr', '-r', '-d', 'com.apple.FinderInfo', frameworkDirectory.path],
         ),
         FakeCommand(
-          command: <String>[
-            'xattr',
-            '-r',
-            '-d',
-            'com.apple.provenance',
-            frameworkDirectory.path,
-          ],
+          command: <String>['xattr', '-r', '-d', 'com.apple.provenance', frameworkDirectory.path],
         ),
         FakeCommand(
           command: <String>[
@@ -627,22 +601,10 @@ void main() {
       processManager.addCommands(<FakeCommand>[
         createPlutilFakeCommand(infoPlist),
         FakeCommand(
-          command: <String>[
-            'xattr',
-            '-r',
-            '-d',
-            'com.apple.FinderInfo',
-            frameworkDirectory.path,
-          ],
+          command: <String>['xattr', '-r', '-d', 'com.apple.FinderInfo', frameworkDirectory.path],
         ),
         FakeCommand(
-          command: <String>[
-            'xattr',
-            '-r',
-            '-d',
-            'com.apple.provenance',
-            frameworkDirectory.path,
-          ],
+          command: <String>['xattr', '-r', '-d', 'com.apple.provenance', frameworkDirectory.path],
         ),
         FakeCommand(
           command: <String>[
@@ -706,22 +668,10 @@ void main() {
       processManager.addCommands(<FakeCommand>[
         createPlutilFakeCommand(infoPlist),
         FakeCommand(
-          command: <String>[
-            'xattr',
-            '-r',
-            '-d',
-            'com.apple.FinderInfo',
-            frameworkDirectory.path,
-          ],
+          command: <String>['xattr', '-r', '-d', 'com.apple.FinderInfo', frameworkDirectory.path],
         ),
         FakeCommand(
-          command: <String>[
-            'xattr',
-            '-r',
-            '-d',
-            'com.apple.provenance',
-            frameworkDirectory.path,
-          ],
+          command: <String>['xattr', '-r', '-d', 'com.apple.provenance', frameworkDirectory.path],
         ),
         FakeCommand(
           command: <String>['codesign', '--force', '--sign', '-', frameworkDirectoryBinary.path],

--- a/packages/flutter_tools/test/general.shard/isolated/macos/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/macos/native_assets_test.dart
@@ -150,7 +150,10 @@ void main() {
                 ],
               ),
               FakeCommand(
-                command: <Pattern>['xattr', '-cr', signPathBar],
+                command: <Pattern>['xattr', '-r', '-d', 'com.apple.FinderInfo', signPathBar],
+              ),
+              FakeCommand(
+                command: <Pattern>['xattr', '-r', '-d', 'com.apple.provenance', signPathBar],
               ),
               FakeCommand(
                 command: <Pattern>[
@@ -179,7 +182,10 @@ void main() {
                 ],
               ),
               FakeCommand(
-                command: <Pattern>['xattr', '-cr', signPathBuz],
+                command: <Pattern>['xattr', '-r', '-d', 'com.apple.FinderInfo', signPathBuz],
+              ),
+              FakeCommand(
+                command: <Pattern>['xattr', '-r', '-d', 'com.apple.provenance', signPathBuz],
               ),
               FakeCommand(
                 command: <Pattern>[

--- a/packages/flutter_tools/test/general.shard/isolated/macos/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/macos/native_assets_test.dart
@@ -150,6 +150,9 @@ void main() {
                 ],
               ),
               FakeCommand(
+                command: <Pattern>['xattr', '-cr', signPathBar],
+              ),
+              FakeCommand(
                 command: <Pattern>[
                   'xcrun',
                   'codesign',
@@ -174,6 +177,9 @@ void main() {
                   signPathBuz,
                   signPathBuz,
                 ],
+              ),
+              FakeCommand(
+                command: <Pattern>['xattr', '-cr', signPathBuz],
               ),
               FakeCommand(
                 command: <Pattern>[


### PR DESCRIPTION
## Fix iOS/macOS codesign failure caused by extended attributes

Fixes #181103

### Problem

On macOS Sequoia (15.x) with Xcode 26, iOS and macOS builds fail during codesigning with:

```
resource fork, Finder information, or similar detritus not allowed
```

The root cause is the `com.apple.provenance` extended attribute, which newer macOS versions automatically add to files during copy operations. The existing `removeFinderExtendedAttributes` function only stripped `com.apple.FinderInfo`, leaving `com.apple.provenance` behind — which `codesign` rejects.

### Changes

**1. Renamed and expanded xattr removal (`ios/mac.dart`)**

Renamed `removeFinderExtendedAttributes` → `removeExtendedAttributes` to reflect its broader scope. The function now removes both `com.apple.FinderInfo` and `com.apple.provenance`, while intentionally preserving other attributes like `com.apple.xcode.CreatedByBuildSystem` that Xcode relies on.

**2. Fixed xattr target scope for iOS frameworks (`ios.dart`)**

Changed `_signFramework` to strip xattrs from the entire `.framework` directory (`binary.parent`) rather than just the binary file. `codesign` validates the whole bundle, so attributes on any file within the framework can cause failures.

**3. Added xattr stripping to macOS native asset codesigning (`native_assets_host.dart`)**

The `codesignDylib` function had no xattr removal at all. Added a call to the shared `removeExtendedAttributes()` helper before codesigning, ensuring consistent behavior across both iOS and macOS native asset paths.

**4. Updated all tests**

- Updated `ios_test.dart` to expect xattr commands targeting the `.framework` directory instead of the binary
- Updated `native_assets_test.dart` to expect the two targeted `xattr -r -d` commands (one per attribute) before each codesign invocation

### Why targeted removal instead of `xattr -cr`

The issue description suggests `xattr -cr` (clear all attributes) as an alternative. This PR intentionally removes only specific known-problematic attributes because:

- `com.apple.xcode.CreatedByBuildSystem` is used by Xcode to manage build directories — clearing it could cause subtle build system issues
- Targeted removal is the existing pattern in this codebase and makes the intent explicit
- New problematic attributes can be added to the set in `removeExtendedAttributes()` as needed

### Future refactoring

`removeExtendedAttributes()` currently lives in `ios/mac.dart` but is now used by both iOS and macOS code paths (including `native_assets/macos/native_assets_host.dart` and `macos/xcdevice.dart`). A future cleanup should move it to a shared location (e.g., `base/` or `build_system/targets/darwin.dart`) to better reflect its cross-platform usage and avoid the `ios/` → `macos/` import direction.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md