### PR TITLE
[win32] Fix overflow in TaskRunnerWindow.

### DIFF
--- a/engine/src/flutter/shell/platform/windows/task_runner.cc
+++ b/engine/src/flutter/shell/platform/windows/task_runner.cc
@@ -63,10 +63,11 @@ std::chrono::nanoseconds TaskRunner::ProcessTasks() {
   // Calculate duration to sleep for on next iteration.
   {
     std::lock_guard<std::mutex> lock(task_queue_mutex_);
-    const auto next_wake = task_queue_.empty() ? TaskTimePoint::max()
-                                               : task_queue_.top().fire_time;
-
-    return std::min(next_wake - now, std::chrono::nanoseconds::max());
+    if (task_queue_.empty()) {
+      return std::chrono::nanoseconds::max();
+    } else {
+      return task_queue_.top().fire_time - now;
+    }
   }
 }
 

--- a/engine/src/flutter/shell/platform/windows/task_runner.cc
+++ b/engine/src/flutter/shell/platform/windows/task_runner.cc
@@ -64,6 +64,9 @@ std::chrono::nanoseconds TaskRunner::ProcessTasks() {
   {
     std::lock_guard<std::mutex> lock(task_queue_mutex_);
     if (task_queue_.empty()) {
+      // TaskRunnerWindow::SetTimer() has special handling for
+      // std::chrono::nanoseconds::max() to avoid overflow when calculating the
+      // absolute timer fire time.
       return std::chrono::nanoseconds::max();
     } else {
       return task_queue_.top().fire_time - now;

--- a/engine/src/flutter/shell/platform/windows/task_runner.cc
+++ b/engine/src/flutter/shell/platform/windows/task_runner.cc
@@ -64,9 +64,6 @@ std::chrono::nanoseconds TaskRunner::ProcessTasks() {
   {
     std::lock_guard<std::mutex> lock(task_queue_mutex_);
     if (task_queue_.empty()) {
-      // TaskRunnerWindow::SetTimer() has special handling for
-      // std::chrono::nanoseconds::max() to avoid overflow when calculating the
-      // absolute timer fire time.
       return std::chrono::nanoseconds::max();
     } else {
       return task_queue_.top().fire_time - now;

--- a/engine/src/flutter/shell/platform/windows/task_runner_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/task_runner_unittests.cc
@@ -121,7 +121,7 @@ class TestTaskRunnerWindow : public TaskRunnerWindow {
   TestTaskRunnerWindow() : TaskRunnerWindow() {}
 };
 
-TEST(TaskRunnerTest, EmptyTaskRunnerReturnsNanSecondsMax) {
+TEST(TaskRunnerTest, EmptyTaskRunnerReturnsNanoSecondsMax) {
   TaskRunner runner(MockGetCurrentTime, [](const FlutterTask*) {});
   auto res = runner.ProcessTasks();
   EXPECT_EQ(res, std::chrono::nanoseconds::max());

--- a/engine/src/flutter/shell/platform/windows/task_runner_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/task_runner_unittests.cc
@@ -121,6 +121,12 @@ class TestTaskRunnerWindow : public TaskRunnerWindow {
   TestTaskRunnerWindow() : TaskRunnerWindow() {}
 };
 
+TEST(TaskRunnerTest, EmptyTaskRunnerReturnsNanSecondsMax) {
+  TaskRunner runner(MockGetCurrentTime, [](const FlutterTask*) {});
+  auto res = runner.ProcessTasks();
+  EXPECT_EQ(res, std::chrono::nanoseconds::max());
+}
+
 TEST(TaskRunnerTest, TaskRunnerWindowCoalescesWakeUpMessages) {
   class Delegate : public TaskRunnerWindow::Delegate {
    public:

--- a/engine/src/flutter/shell/platform/windows/task_runner_window.cc
+++ b/engine/src/flutter/shell/platform/windows/task_runner_window.cc
@@ -185,12 +185,11 @@ void TaskRunnerWindow::ProcessTasks() {
 }
 
 void TaskRunnerWindow::SetTimer(std::chrono::nanoseconds when) {
-  if (when == std::chrono::nanoseconds::max()) {
-    timer_thread_.ScheduleAt(
-        std::chrono::time_point<std::chrono::high_resolution_clock>::max());
-  } else {
-    timer_thread_.ScheduleAt(std::chrono::high_resolution_clock::now() + when);
-  }
+  auto now = std::chrono::high_resolution_clock::now();
+  auto remaining_to_max =
+      std::chrono::nanoseconds::max() - now.time_since_epoch();
+  when = std::min(when, remaining_to_max);
+  timer_thread_.ScheduleAt(now + when);
 }
 
 WNDCLASS TaskRunnerWindow::RegisterWindowClass() {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/182501

Right now empty `TaskRunner::ProcessTasks()` returns `TaskTimePoint::max() - now` (relative time). This causes problems, because the value is later used  in `TaskRunnerWindow` to schedule timer at `std::chrono::high_resolution_clock::now() + relative_time`). This of course overflows, because the new `now()` in `TaskRunnerWindow` is higher than the value used to calculate original delta inside `TaskRunner`.

`TaskRunnerWindow` already had special case where it checks for `std::chrono::nanoseconds::max()`. In this PR the behavior of `TaskRunnerWindow::SetTimer` has been updated to check for overflow rather than excepcting a special value.

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
