### PR TITLE
[web] Fix failure on Firefox 148

### DIFF
--- a/engine/src/flutter/lib/web_ui/test/canvaskit/canvaskit_api_tt_on_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/canvaskit/canvaskit_api_tt_on_test.dart
@@ -42,13 +42,13 @@ void testMainWithTTOn() {
         createTrustedScriptUrl(badUrl);
       }, throwsAssertionError);
     });
-  }, skip: !isBlink);
+  }, skip: domWindow.trustedTypes == null);
 
   group('Trusted Types API NOT supported', () {
     test('createTrustedScriptUrl - returns unmodified url', () async {
       expect(createTrustedScriptUrl(badUrl), badUrl);
     });
-  }, skip: isBlink);
+  }, skip: domWindow.trustedTypes != null);
 }
 
 /// Enables Trusted Types by setting the appropriate meta tag in the DOM:

--- a/engine/src/flutter/lib/web_ui/test/canvaskit/canvaskit_api_tt_on_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/canvaskit/canvaskit_api_tt_on_test.dart
@@ -5,12 +5,9 @@
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
-import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 import '../common/matchers.dart';
 import 'canvaskit_api_test.dart';
-
-final bool isBlink = ui_web.browser.browserEngine == ui_web.BrowserEngine.blink;
 
 const String goodUrl = 'https://www.unpkg.com/blah-blah/33.x/canvaskit.js';
 const String badUrl = 'https://www.unpkg.com/soemthing/not-canvaskit.js';


### PR DESCRIPTION
Prior to 148, Firefox didn't have support for `TrustedTypes`, so it made sense to always run the non-TrustedTypes test on Firefox.

With 148, Firefox [added support](https://www.firefox.com/en-US/firefox/148.0/releasenotes/) for TrustedTypes, but we are still running the non-TrustedTypes tests on Firefox.

Solution: instead of skipping tests based on browser name, let's detect at runtime if the browser supports TrustedTypes or not.

Example failure: https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8688958443747938497/+/u/test:_run_suite_firefox-dart2js-canvaskit-canvaskit/stdout