### PR TITLE
Add `UnlabaledLeafNodeEvaluation`

### DIFF
--- a/packages/flutter/lib/src/widgets/_accessibility_evaluations.dart
+++ b/packages/flutter/lib/src/widgets/_accessibility_evaluations.dart
@@ -584,3 +584,58 @@ Iterable<Element> _collectElementsByText(Element root, String text) {
   });
   return result;
 }
+
+/// {@macro flutter.widgets.accessibility_evaluations.internal}
+///
+/// An evaluation which enforces that all leaf semantics nodes have a label,
+/// value, hint, or tooltip.
+@internal
+class UnlabeledLeafNodeEvaluation extends AccessibilityEvaluation {
+  const UnlabeledLeafNodeEvaluation();
+
+  @override
+  FutureOr<EvaluationResult> _evaluate(WidgetsBinding binding) {
+    final violations = <Violation>[];
+    for (final RenderView view in binding.renderViews) {
+      violations.addAll(_traverse(view.owner!.semanticsOwner!.rootSemanticsNode!));
+    }
+    return EvaluationResult(violations);
+  }
+
+  List<Violation> _traverse(SemanticsNode node) {
+    final violations = <Violation>[];
+    bool hasChildren = false;
+    node.visitChildren((SemanticsNode child) {
+      hasChildren = true;
+      violations.addAll(_traverse(child));
+      return true;
+    });
+
+    if (node.isMergedIntoParent ||
+        node.isInvisible ||
+        node.flagsCollection.isHidden) {
+      return violations;
+    }
+
+    // If not merging descendants and has children, it's not a leaf.
+    if (hasChildren && !node.mergeAllDescendantsIntoThisNode) {
+      return violations;
+    }
+
+    final SemanticsData data = node.getSemanticsData();
+    if (data.label.trim().isEmpty &&
+        data.value.trim().isEmpty &&
+        data.hint.trim().isEmpty &&
+        data.tooltip.trim().isEmpty) {
+      violations.add(
+        Violation(
+          node,
+          '$node: expected leaf semantics node to have a label, value, hint, or tooltip, '
+          'but none was found.',
+        ),
+      );
+    }
+
+    return violations;
+  }
+}

--- a/packages/flutter/lib/src/widgets/_accessibility_evaluations.dart
+++ b/packages/flutter/lib/src/widgets/_accessibility_evaluations.dart
@@ -612,7 +612,7 @@ bool _isImportantForAccessibility(SemanticsNode node) {
     return false;
   }
 
-  final bool hasNonScrollingAction = data.actions & ~_scrollingActions != 0;
+  final hasNonScrollingAction = data.actions & ~_scrollingActions != 0;
   if (hasNonScrollingAction) {
     return true;
   }

--- a/packages/flutter/lib/src/widgets/_accessibility_evaluations.dart
+++ b/packages/flutter/lib/src/widgets/_accessibility_evaluations.dart
@@ -611,9 +611,7 @@ class UnlabeledLeafNodeEvaluation extends AccessibilityEvaluation {
       return true;
     });
 
-    if (node.isMergedIntoParent ||
-        node.isInvisible ||
-        node.flagsCollection.isHidden) {
+    if (node.isMergedIntoParent || node.isInvisible || node.flagsCollection.isHidden) {
       return violations;
     }
 

--- a/packages/flutter/lib/src/widgets/_accessibility_evaluations.dart
+++ b/packages/flutter/lib/src/widgets/_accessibility_evaluations.dart
@@ -604,7 +604,7 @@ class UnlabeledLeafNodeEvaluation extends AccessibilityEvaluation {
 
   List<Violation> _traverse(SemanticsNode node) {
     final violations = <Violation>[];
-    bool hasChildren = false;
+    var hasChildren = false;
     node.visitChildren((SemanticsNode child) {
       hasChildren = true;
       violations.addAll(_traverse(child));

--- a/packages/flutter/lib/src/widgets/_accessibility_evaluations.dart
+++ b/packages/flutter/lib/src/widgets/_accessibility_evaluations.dart
@@ -585,6 +585,65 @@ Iterable<Element> _collectElementsByText(Element root, String text) {
   return result;
 }
 
+final int _scrollingActions =
+    SemanticsAction.scrollUp.index |
+    SemanticsAction.scrollDown.index |
+    SemanticsAction.scrollLeft.index |
+    SemanticsAction.scrollRight.index |
+    SemanticsAction.scrollToOffset.index;
+
+/// Whether or not the node is important for accessibility. Should match most cases
+/// on the platforms, but certain edge cases will be inconsistent.
+///
+/// Based on:
+///
+/// * [flutter/engine/AccessibilityBridge.java#SemanticsNode.isFocusable()](https://github.com/flutter/flutter/blob/main/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java#L2641)
+/// * [flutter/engine/SemanticsObject.mm#SemanticsObject.isAccessibilityElement](https://github.com/flutter/flutter/blob/main/engine/src/flutter/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm#L449)
+bool _isImportantForAccessibility(SemanticsNode node) {
+  if (node.isMergedIntoParent) {
+    // If this node is merged, all its information are present on an ancestor
+    // node.
+    return false;
+  }
+  final SemanticsData data = node.getSemanticsData();
+  // If the node scopes a route, it doesn't matter what other flags/actions it
+  // has, it is _not_ important for accessibility, so we short circuit.
+  if (data.flagsCollection.scopesRoute) {
+    return false;
+  }
+
+  final bool hasNonScrollingAction = data.actions & ~_scrollingActions != 0;
+  if (hasNonScrollingAction) {
+    return true;
+  }
+
+  /// Based on Android's FOCUSABLE_FLAGS. See [flutter/engine/AccessibilityBridge.java](https://github.com/flutter/flutter/blob/main/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java).
+  final bool hasImportantFlag =
+      data.flagsCollection.isChecked != ui.CheckedState.none ||
+      data.flagsCollection.isToggled != ui.Tristate.none ||
+      data.flagsCollection.isEnabled != ui.Tristate.none ||
+      data.flagsCollection.isButton ||
+      data.flagsCollection.isTextField ||
+      data.flagsCollection.isFocused != ui.Tristate.none ||
+      data.flagsCollection.isSlider ||
+      data.flagsCollection.isInMutuallyExclusiveGroup;
+
+  if (hasImportantFlag) {
+    return true;
+  }
+
+  final bool hasContent =
+      data.label.isNotEmpty ||
+      data.value.isNotEmpty ||
+      data.hint.isNotEmpty ||
+      data.tooltip.isNotEmpty;
+  if (hasContent) {
+    return true;
+  }
+
+  return false;
+}
+
 /// {@macro flutter.widgets.accessibility_evaluations.internal}
 ///
 /// An evaluation which enforces that all leaf semantics nodes have a label,
@@ -611,12 +670,16 @@ class UnlabeledLeafNodeEvaluation extends AccessibilityEvaluation {
       return true;
     });
 
-    if (node.isMergedIntoParent || node.isInvisible || node.flagsCollection.isHidden) {
+    if (node.isInvisible || node.flagsCollection.isHidden) {
       return violations;
     }
 
     // If not merging descendants and has children, it's not a leaf.
     if (hasChildren && !node.mergeAllDescendantsIntoThisNode) {
+      return violations;
+    }
+
+    if (!_isImportantForAccessibility(node)) {
       return violations;
     }
 

--- a/packages/flutter/test/widgets/accessibility_evaluations_test.dart
+++ b/packages/flutter/test/widgets/accessibility_evaluations_test.dart
@@ -231,6 +231,7 @@ void main() {
         TestWidgetsApp(
           home: Semantics(
             container: true,
+            onTap: () {},
             value: 'test',
             child: const SizedBox(width: 10.0, height: 10.0),
           ),
@@ -247,6 +248,7 @@ void main() {
         TestWidgetsApp(
           home: Semantics(
             container: true,
+            onTap: () {},
             hint: 'test',
             child: const SizedBox(width: 10.0, height: 10.0),
           ),
@@ -261,7 +263,11 @@ void main() {
       final SemanticsHandle handle = tester.ensureSemantics();
       await tester.pumpWidget(
         TestWidgetsApp(
-          home: Semantics(container: true, child: const SizedBox(width: 10.0, height: 10.0)),
+          home: Semantics(
+            container: true,
+            onTap: () {},
+            child: const SizedBox(width: 10.0, height: 10.0),
+          ),
         ),
       );
       final EvaluationResult result = await evaluation.evaluate(tester.binding);
@@ -273,15 +279,94 @@ void main() {
       handle.dispose();
     });
 
+    testWidgets('Fails if button node has no label', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: Semantics(
+            container: true,
+            button: true,
+            child: const SizedBox(width: 10.0, height: 10.0),
+          ),
+        ),
+      );
+      final EvaluationResult result = await evaluation.evaluate(tester.binding);
+      expect(result.violations, hasLength(1));
+      expect(
+        result.violations.first.reason,
+        contains('expected leaf semantics node to have a label'),
+      );
+      handle.dispose();
+    });
+
+    testWidgets('Fails if focusable node has no label', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: Semantics(
+            container: true,
+            focusable: true,
+            child: const SizedBox(width: 10.0, height: 10.0),
+          ),
+        ),
+      );
+      final EvaluationResult result = await evaluation.evaluate(tester.binding);
+      expect(result.violations, hasLength(1));
+      expect(
+        result.violations.first.reason,
+        contains('expected leaf semantics node to have a label'),
+      );
+      handle.dispose();
+    });
+
+    testWidgets('Passes if actionable node is hidden', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: Semantics(
+            container: true,
+            hidden: true,
+            button: true,
+            child: const SizedBox(width: 10.0, height: 10.0),
+          ),
+        ),
+      );
+      final EvaluationResult result = await evaluation.evaluate(tester.binding);
+      expect(result.violations, isEmpty);
+      handle.dispose();
+    });
+
+    testWidgets('Passes if node is not focusable or actionable', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      // For a container without any actions or focusable flags, even though it has no label,
+      // it should not produce a violation because it is not "important".
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: Semantics(
+            container: true,
+            child: const SizedBox(width: 10.0, height: 10.0),
+          ),
+        ),
+      );
+      final EvaluationResult result = await evaluation.evaluate(tester.binding);
+      expect(result.violations, isEmpty);
+      handle.dispose();
+    });
+
     testWidgets('Passes if node is not a leaf', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
       await tester.pumpWidget(
         TestWidgetsApp(
           home: Semantics(
             container: true,
+            onTap: () {},
             child: Column(
               children: <Widget>[
-                Semantics(label: 'Child 1', child: const SizedBox(width: 10, height: 10)),
+                Semantics(
+                  label: 'Child 1',
+                  onTap: () {},
+                  child: const SizedBox(width: 10, height: 10),
+                ),
               ],
             ),
           ),
@@ -299,14 +384,18 @@ void main() {
           home: MergeSemantics(
             child: Column(
               children: <Widget>[
-                Semantics(label: 'Child 1', child: const SizedBox(width: 10, height: 10)),
+                Semantics(
+                  label: 'Child 1',
+                  onTap: () {},
+                  child: const SizedBox(width: 10, height: 10),
+                ),
               ],
             ),
           ),
         ),
       );
       final EvaluationResult result = await evaluation.evaluate(tester.binding);
-      expect(result.violations, isEmpty); // Should pass (merged node has label from child)
+      expect(result.violations, isEmpty); // merged node has label from child.
       handle.dispose();
     });
 
@@ -315,7 +404,11 @@ void main() {
       await tester.pumpWidget(
         TestWidgetsApp(
           home: MergeSemantics(
-            child: Semantics(container: true, child: const SizedBox(width: 10, height: 10)),
+            child: Semantics(
+              container: true,
+              onTap: () {},
+              child: const SizedBox(width: 10, height: 10),
+            ),
           ),
         ),
       );

--- a/packages/flutter/test/widgets/accessibility_evaluations_test.dart
+++ b/packages/flutter/test/widgets/accessibility_evaluations_test.dart
@@ -180,4 +180,121 @@ void main() {
       handle.dispose();
     });
   });
+
+  group('UnlabeledLeafNodeEvaluation', () {
+    late final Set<String> originalFeatureFlags;
+    setUpAll(() {
+      originalFeatureFlags = {...debugEnabledFeatureFlags};
+      debugEnabledFeatureFlags.add('accessibility_evaluations');
+    });
+    tearDownAll(() {
+      debugEnabledFeatureFlags.clear();
+      debugEnabledFeatureFlags.addAll(originalFeatureFlags);
+    });
+
+    const evaluation = UnlabeledLeafNodeEvaluation();
+
+    testWidgets('Passes if node has label', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: Semantics(
+            container: true,
+            label: 'test',
+            child: const SizedBox(width: 10.0, height: 10.0),
+          ),
+        ),
+      );
+      final EvaluationResult result = await evaluation.evaluate(tester.binding);
+      expect(result.violations, isEmpty); // Should pass
+      handle.dispose();
+    });
+
+    testWidgets('Passes if node has tooltip', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: Semantics(
+            container: true,
+            tooltip: 'test',
+            child: const SizedBox(width: 10.0, height: 10.0),
+          ),
+        ),
+      );
+      final EvaluationResult result = await evaluation.evaluate(tester.binding);
+      expect(result.violations, isEmpty); // Should pass
+      handle.dispose();
+    });
+
+    testWidgets('Fails if node has no label', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: Semantics(container: true, child: const SizedBox(width: 10.0, height: 10.0)),
+        ),
+      );
+      final EvaluationResult result = await evaluation.evaluate(tester.binding);
+      expect(result.violations, hasLength(1));
+      expect(
+        result.violations.first.reason,
+        contains('expected leaf semantics node to have a label'),
+      );
+      handle.dispose();
+    });
+
+    testWidgets('Passes if node is not a leaf', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: Semantics(
+            container: true,
+            child: Column(
+              children: <Widget>[
+                Semantics(label: 'Child 1', child: const SizedBox(width: 10, height: 10)),
+              ],
+            ),
+          ),
+        ),
+      );
+      final EvaluationResult result = await evaluation.evaluate(tester.binding);
+      expect(result.violations, isEmpty); // Should pass
+      handle.dispose();
+    });
+
+    testWidgets('Passes if node merges descendants', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: MergeSemantics(
+            child: Column(
+              children: <Widget>[
+                Semantics(label: 'Child 1', child: const SizedBox(width: 10, height: 10)),
+              ],
+            ),
+          ),
+        ),
+      );
+      final EvaluationResult result = await evaluation.evaluate(tester.binding);
+      expect(result.violations, isEmpty); // Should pass (merged node has label from child)
+      handle.dispose();
+    });
+
+    testWidgets('Fails if node merges descendants but has no label', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: MergeSemantics(
+            child: Semantics(container: true, child: const SizedBox(width: 10, height: 10)),
+          ),
+        ),
+      );
+      final EvaluationResult result = await evaluation.evaluate(tester.binding);
+      expect(result.violations, hasLength(1));
+      expect(
+        result.violations.first.reason,
+        contains('expected leaf semantics node to have a label'),
+      );
+      handle.dispose();
+    });
+  });
 }

--- a/packages/flutter/test/widgets/accessibility_evaluations_test.dart
+++ b/packages/flutter/test/widgets/accessibility_evaluations_test.dart
@@ -206,7 +206,7 @@ void main() {
         ),
       );
       final EvaluationResult result = await evaluation.evaluate(tester.binding);
-      expect(result.violations, isEmpty); // Should pass
+      expect(result.violations, isEmpty);
       handle.dispose();
     });
 
@@ -222,7 +222,38 @@ void main() {
         ),
       );
       final EvaluationResult result = await evaluation.evaluate(tester.binding);
-      expect(result.violations, isEmpty); // Should pass
+      expect(result.violations, isEmpty);
+      handle.dispose();
+    });
+    testWidgets('Passes if node has value', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: Semantics(
+            container: true,
+            value: 'test',
+            child: const SizedBox(width: 10.0, height: 10.0),
+          ),
+        ),
+      );
+      final EvaluationResult result = await evaluation.evaluate(tester.binding);
+      expect(result.violations, isEmpty);
+      handle.dispose();
+    });
+
+    testWidgets('Passes if node has hint', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: Semantics(
+            container: true,
+            hint: 'test',
+            child: const SizedBox(width: 10.0, height: 10.0),
+          ),
+        ),
+      );
+      final EvaluationResult result = await evaluation.evaluate(tester.binding);
+      expect(result.violations, isEmpty);
       handle.dispose();
     });
 
@@ -257,7 +288,7 @@ void main() {
         ),
       );
       final EvaluationResult result = await evaluation.evaluate(tester.binding);
-      expect(result.violations, isEmpty); // Should pass
+      expect(result.violations, isEmpty);
       handle.dispose();
     });
 

--- a/packages/flutter/test/widgets/accessibility_evaluations_test.dart
+++ b/packages/flutter/test/widgets/accessibility_evaluations_test.dart
@@ -342,10 +342,7 @@ void main() {
       // it should not produce a violation because it is not "important".
       await tester.pumpWidget(
         TestWidgetsApp(
-          home: Semantics(
-            container: true,
-            child: const SizedBox(width: 10.0, height: 10.0),
-          ),
+          home: Semantics(container: true, child: const SizedBox(width: 10.0, height: 10.0)),
         ),
       );
       final EvaluationResult result = await evaluation.evaluate(tester.binding);

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -334,6 +334,11 @@ class SemanticsController {
   ///
   /// * [flutter/engine/AccessibilityBridge.java#SemanticsNode.isFocusable()](https://github.com/flutter/flutter/blob/main/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java#L2641)
   /// * [flutter/engine/SemanticsObject.mm#SemanticsObject.isAccessibilityElement](https://github.com/flutter/flutter/blob/main/engine/src/flutter/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm#L449)
+  //
+  // TODO(quncheng): If this method is modified, please also update the copy of
+  // this method located in `packages/flutter/lib/src/widgets/_accessibility_evaluations.dart`.
+  // This private method will be removed once the feature flag
+  // `isAccessibilityEvaluationsEnabled` is turned on.
   bool _isImportantForAccessibility(SemanticsNode node) {
     if (node.isMergedIntoParent) {
       // If this node is merged, all its information are present on an ancestor


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/94485

This PR is to add an `UnlabeledLeafNodeEvaluation` to check whether there is a leaf node that has no label/tooltip/hint/value.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
