### PR TITLE
chore: Migrate gsutil usage to gcloud storage

### DIFF
--- a/dev/bots/README.md
+++ b/dev/bots/README.md
@@ -48,7 +48,7 @@ To run `prepare_package.dart` locally:
 - Run `dart [path to your normal Flutter repo]/dev/bots/prepare_package.dart
   --temp_dir=. --revision=[revision to package] --branch=[branch to deploy to]
   --publish`.
-- If you're running into `gsutil` permission issues, check with @Hixie to make sure
+- If you're running into `gcloud storage` permission issues, check with @Hixie to make sure
   you have the right push permissions.
 
 ### Editing a recipe
@@ -173,7 +173,7 @@ dart ./unpublish_package.dart --confirm --temp_dir=/tmp/foo --revision d444a455d
 ```
 
 and it will perform the actions. You will of course need to have access
-to the cloud storage server and have `gsutil` installed to perform this
+to the cloud storage server and have `gcloud storage` installed to perform this
 operation. Only runs on Linux or macOS systems.
 
 See `dart ./unpublish_package.dart --help` for more details.

--- a/dev/bots/prepare_package.dart
+++ b/dev/bots/prepare_package.dart
@@ -63,7 +63,7 @@ Future<void> main(List<String> rawArguments) async {
   argParser.addFlag(
     'dry_run',
     negatable: false,
-    help: 'Prints gsutil commands instead of executing them.',
+    help: 'Prints gcloud storage commands instead of executing them.',
   );
   argParser.addFlag('help', negatable: false, help: 'Print help for this command.');
 

--- a/dev/bots/unpublish_package.dart
+++ b/dev/bots/unpublish_package.dart
@@ -281,7 +281,7 @@ class ArchiveUnpublisher {
   Future<Map<String, dynamic>> _loadMetadata() async {
     final metadataFile = File(path.join(tempDir.absolute.path, getMetadataFilename(platform)));
     // Always run this, even in dry runs.
-    await _runGsUtil(<String>['cp', metadataGsPath, metadataFile.absolute.path], confirm: true);
+    await _runGcloudStorage(<String>['cp', metadataGsPath, metadataFile.absolute.path], confirm: true);
     final String currentMetadata = metadataFile.readAsStringSync();
     if (currentMetadata.isEmpty) {
       throw UnpublishException('Empty metadata received from server');
@@ -298,8 +298,8 @@ class ArchiveUnpublisher {
   }
 
   Future<void> _updateMetadata(Map<String, dynamic> jsonData) async {
-    // We can't just cat the metadata from the server with 'gsutil cat', because
-    // Windows wants to echo the commands that execute in gsutil.bat to the
+    // We can't just cat the metadata from the server with 'gcloud storage cat', because
+    // Windows wants to echo the commands that execute in gcloud.cmd to the
     // stdout when we do that. So, we copy the file locally and then read it
     // back in.
     final metadataFile = File(path.join(tempDir.absolute.path, getMetadataFilename(platform)));
@@ -311,13 +311,13 @@ class ArchiveUnpublisher {
     await _cloudReplaceDest(metadataFile.absolute.path, metadataGsPath);
   }
 
-  Future<String> _runGsUtil(
+  Future<String> _runGcloudStorage(
     List<String> args, {
     Directory? workingDirectory,
     bool failOk = false,
     bool confirm = false,
   }) async {
-    final command = <String>['gsutil', '--', ...args];
+    final command = <String>['gcloud', 'storage', ...args];
     if (confirm) {
       return _processRunner.runProcess(command, workingDirectory: workingDirectory, failOk: failOk);
     } else {
@@ -337,7 +337,7 @@ class ArchiveUnpublisher {
         print('  $file');
       }
     }
-    await _runGsUtil(<String>['rm', ...files], failOk: true, confirm: confirmed);
+    await _runGcloudStorage(<String>['rm', ...files], failOk: true, confirm: confirmed);
   }
 
   Future<String> _cloudReplaceDest(String src, String dest) async {
@@ -345,7 +345,7 @@ class ArchiveUnpublisher {
     assert(!src.startsWith('gs:'), '_cloudReplaceDest must have a local source file.');
     // We often don't have permission to overwrite, but
     // we have permission to remove, so that's what we do first.
-    await _runGsUtil(<String>['rm', dest], failOk: true, confirm: confirmed);
+    await _runGcloudStorage(<String>['rm', dest], failOk: true, confirm: confirmed);
     String? mimeType;
     if (dest.endsWith('.tar.xz')) {
       mimeType = 'application/x-gtar';
@@ -356,13 +356,13 @@ class ArchiveUnpublisher {
     if (dest.endsWith('.json')) {
       mimeType = 'application/json';
     }
-    final args = <String>[
-      // Use our preferred MIME type for the files we care about
-      // and let gsutil figure it out for anything else.
-      if (mimeType != null) ...<String>['-h', 'Content-Type:$mimeType'],
-      ...<String>['cp', src, dest],
-    ];
-    return _runGsUtil(args, confirm: confirmed);
+    final args = <String>['cp', src, dest];
+    // Use our preferred MIME type for the files we care about
+    // and let gcloud storage figure it out for anything else.
+    if (mimeType != null) {
+      args.add('--content-type=$mimeType');
+    }
+    return _runGcloudStorage(args, confirm: confirmed);
   }
 }
 

--- a/dev/tools/repackage_gradle_wrapper.sh
+++ b/dev/tools/repackage_gradle_wrapper.sh
@@ -68,7 +68,7 @@ popd > /dev/null
 echo
 echo "Uploading repackaged gradle wrapper..."
 echo "Content hash: $STAMP"
-gsutil.py cp -n "$WRAPPER_TEMP_DIR/gradle-wrapper.tgz" "gs://flutter_infra_release/gradle-wrapper/$STAMP/gradle-wrapper.tgz"
+gcloud storage cp --no-clobber "$WRAPPER_TEMP_DIR/gradle-wrapper.tgz" "gs://flutter_infra_release/gradle-wrapper/$STAMP/gradle-wrapper.tgz"
 
 echo "flutter_infra_release/gradle-wrapper/$STAMP/gradle-wrapper.tgz" > "$WRAPPER_VERSION_PATH"
 

--- a/engine/src/flutter/tools/fuchsia/upload_to_symbol_server.py
+++ b/engine/src/flutter/tools/fuchsia/upload_to_symbol_server.py
@@ -31,8 +31,7 @@ def remote_filename(exec_path):
 
 
 def exists_remotely(remote_path):
-  gsutil = os.path.join(os.environ['DEPOT_TOOLS'], 'gsutil.py')
-  command = ['python3', gsutil, '--', 'stat', remote_path]
+  command = ['gcloud', 'storage', 'objects', 'list', '--stat', '--fetch-encrypted-object-hashes', remote_path]
   process = subprocess.Popen(command, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
   stdout, stderr = process.communicate()
   return_code = process.wait()
@@ -59,8 +58,7 @@ def process_symbols(should_upload, symbol_dir):
         FUCHSIA_ARTIFACTS_BUCKET_NAME, FUCHSIA_ARTIFACTS_DEBUG_NAMESPACE, remote_filename(file)
     )
     if should_upload and not exists_remotely(remote_path):
-      gsutil = os.path.join(os.environ['DEPOT_TOOLS'], 'gsutil.py')
-      command = ['python3', gsutil, '--', 'cp', file, remote_path]
+      command = ['gcloud', 'storage', 'cp', file, remote_path]
       subprocess.check_call(command)
     else:
       print(remote_path)


### PR DESCRIPTION
Automated: Migrate {target_path} from gsutil to gcloud storage

This CL is part of the on going effort to migrate from the legacy `gsutil` tool to the new and improved `gcloud storage` command-line interface.
`gcloud storage` is the recommended and modern tool for interacting with Google Cloud Storage, offering better performance, unified authentication, and a more consistent command structure with other `gcloud` components. 🚀

### Automation Details

This change was **generated automatically** by an agent that targets users of `gsutil`.
The transformations applied are based on the  [gsutil to gcloud storage migration guide](http://go/gsutil-gcloud-storage-migration-guide).

### ⚠️ Action Required: Please Review and Test Carefully

While we have based the automation on the migration guide, every use case is unique.
**It is crucial that you thoroughly test these changes in environments appropriate to your use-case before merging.**  
Be aware of potential differences between `gsutil` and `gcloud storage` that could impact your workflows.  
For instance, the structure of command output may have changed, requiring updates to any scripts that parse it. Similarly, command behavior can differ subtly; the `gcloud storage rsync` command has a different file deletion logic than `gsutil rsync`, which could lead to unintended file deletions.  

Our migration guides can help guide you through a list of mappings and some notable differences between the two tools.

Standard presubmit tests are run as part of this CL's workflow. **If you need to target an additional test workflow or require assistance with testing, please let us know.**

Please verify that all your Cloud Storage operations continue to work as expected to avoid any potential disruptions in production.

### Support and Collaboration

The `GCS CLI` team is here to help! If you encounter any issues, have a complex use case that this automated change doesn't cover, or face any other blockers, please don't hesitate to reach out.
We are happy to work with you to test and adjust these changes as needed.

**Contact:** `gcs-cli-hyd@google.com`

We appreciate your partnership in this important migration effort!

#gsutil-migration
