### PR TITLE
Exclude arm64 if any dependencies do and print warning when using Xcode 26

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -531,6 +531,7 @@ class IOSDevice extends Device {
           logger: globals.logger,
           platform: FlutterDarwinPlatform.ios,
           project: package.project.parent,
+          device: this,
         );
         _logger.printError('');
         return LaunchResult.failed();

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -336,6 +336,7 @@ Future<XcodeBuildResult> buildXcodeProject({
     project: project,
     targetOverride: targetOverride,
     buildInfo: buildInfo,
+    printWarnings: true,
   );
   if (app.project.usesSwiftPackageManager) {
     final String? iosDeploymentTarget = buildSettings['IPHONEOS_DEPLOYMENT_TARGET'];
@@ -1019,6 +1020,7 @@ _XCResultIssueHandlingResult _handleXCResultIssue({
         'Unable to find a destination matching the provided destination specifier',
       ) &&
       message.contains('platform:iOS Simulator, arch:x86_64,') &&
+      !message.contains('platform:iOS Simulator, arch:arm64,') &&
       !message.contains(
         'The requested device could not be found because no available devices matched the request.',
       )) {
@@ -1175,7 +1177,7 @@ Future<bool> _simulatorSupportsIntel(Device device) async {
     return true;
   }
   final String runtime = await device.sdkNameAndVersion;
-  final RunResult result = globals.processUtils.runSync([
+  final RunResult result = await globals.processUtils.run([
     ...globals.xcode!.xcrunCommand(),
     'simctl',
     'list',

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -796,6 +796,7 @@ Future<void> diagnoseXcodeBuildFailure(
   required FileSystem fileSystem,
   required FlutterDarwinPlatform platform,
   required FlutterProject project,
+  Device? device,
 }) async {
   final XcodeBuildExecution? xcodeBuildExecution = result.xcodeBuildExecution;
   if (xcodeBuildExecution != null &&
@@ -824,6 +825,7 @@ Future<void> diagnoseXcodeBuildFailure(
     platform: platform,
     logger: logger,
     fileSystem: fileSystem,
+    device: device,
   );
 
   if (!issueDetected && xcodeBuildExecution != null) {
@@ -1013,6 +1015,18 @@ _XCResultIssueHandlingResult _handleXCResultIssue({
       hasProvisioningProfileIssue: false,
       modifiedPrecompiledSource: true,
     );
+  } else if (message.contains(
+        'Unable to find a destination matching the provided destination specifier',
+      ) &&
+      message.contains('platform:iOS Simulator, arch:x86_64,') &&
+      !message.contains(
+        'The requested device could not be found because no available devices matched the request.',
+      )) {
+    return _XCResultIssueHandlingResult(
+      requiresProvisioningProfile: false,
+      hasProvisioningProfileIssue: false,
+      unableToFindArmDestination: true,
+    );
   }
   return _XCResultIssueHandlingResult(
     requiresProvisioningProfile: false,
@@ -1028,11 +1042,13 @@ Future<bool> _handleIssues(
   required FlutterDarwinPlatform platform,
   required Logger logger,
   required FileSystem fileSystem,
+  Device? device,
 }) async {
   var requiresProvisioningProfile = false;
   var hasProvisioningProfileIssue = false;
   var issueDetected = false;
   var modifiedPrecompiledSource = false;
+  var unableToFindArmDestination = false;
   String? missingPlatform;
   final duplicateModules = <String>[];
   final missingModules = <String>[];
@@ -1059,6 +1075,7 @@ Future<bool> _handleIssues(
         missingModules.add(handlingResult.missingModule!);
       }
       modifiedPrecompiledSource = handlingResult.modifiedPrecompiledSource;
+      unableToFindArmDestination = handlingResult.unableToFindArmDestination;
       issueDetected = true;
     }
   } else if (xcResult != null) {
@@ -1133,8 +1150,40 @@ Future<bool> _handleIssues(
       'the cache.\n'
       '════════════════════════════════════════════════════════════════════════════════',
     );
+  } else if (unableToFindArmDestination &&
+      xcodeBuildExecution != null &&
+      xcodeBuildExecution.environmentType == EnvironmentType.simulator &&
+      device != null) {
+    final bool simulatorSupportsIntel = await _simulatorSupportsIntel(device);
+    if (!simulatorSupportsIntel) {
+      logger.printError(
+        '════════════════════════════════════════════════════════════════════════════════\n'
+        'The selected simulator is incompatible with the current build settings.\n'
+        'Please use a simulator that supports x86_64, such as a simulator prior to iOS 26 or '
+        'download the universal variant of the iOS 26 simulator using '
+        '"xcodebuild -downloadPlatform iOS -architectureVariant universal".\n'
+        '════════════════════════════════════════════════════════════════════════════════',
+      );
+    }
   }
   return issueDetected;
+}
+
+Future<bool> _simulatorSupportsIntel(Device device) async {
+  final Version? xcodeVersion = globals.xcode?.currentVersion;
+  if (xcodeVersion != null && xcodeVersion.major < 26) {
+    return true;
+  }
+  final String runtime = await device.sdkNameAndVersion;
+  final RunResult result = globals.processUtils.runSync([
+    ...globals.xcode!.xcrunCommand(),
+    'simctl',
+    'list',
+    'runtimes',
+    runtime,
+    '--json',
+  ]);
+  return result.stdout.contains('x86_64');
 }
 
 /// Returns true if a Package.swift is found for the plugin and a podspec is not.
@@ -1271,6 +1320,7 @@ class _XCResultIssueHandlingResult {
     this.duplicateModule,
     this.missingModule,
     this.modifiedPrecompiledSource = false,
+    this.unableToFindArmDestination = false,
   });
 
   /// An issue indicates that user didn't provide the provisioning profile.
@@ -1292,6 +1342,8 @@ class _XCResultIssueHandlingResult {
   /// An issue indicates that a source file, such as a header in the Flutter framework, has
   /// changed since last built. This requires "flutter clean" to resolve.
   final bool modifiedPrecompiledSource;
+
+  final bool unableToFindArmDestination;
 }
 
 const _kResultBundlePath = 'temporary_xcresult_bundle';

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -559,6 +559,7 @@ class IOSSimulator extends Device {
         logger: globals.logger,
         platform: FlutterDarwinPlatform.ios,
         project: app.project.parent,
+        device: this,
       );
       throwToolExit('Could not build the application for the simulator.');
     }

--- a/packages/flutter_tools/lib/src/ios/xcode_build_settings.dart
+++ b/packages/flutter_tools/lib/src/ios/xcode_build_settings.dart
@@ -5,7 +5,6 @@
 import '../artifacts.dart';
 import '../base/common.dart';
 import '../base/file_system.dart';
-import '../base/version.dart';
 import '../build_info.dart';
 import '../cache.dart';
 import '../flutter_manifest.dart';
@@ -240,11 +239,10 @@ Future<List<String>> _xcodeBuildSettingsLines({
     // If any plugins or their dependencies do not support arm64 simulators
     // (to run natively without Rosetta translation on an ARM Mac),
     // the app will fail to build unless it also excludes arm64 simulators.
-    final Version? xcodeVersion = globals.xcode?.currentVersion;
-    if (xcodeVersion != null && xcodeVersion.major >= 26) {
-      await project.ios.checkForPluginsExcludingArmSimulator();
+    var excludedSimulatorArchs = 'i386';
+    if (!(await project.ios.pluginsSupportArmSimulator())) {
+      excludedSimulatorArchs += ' arm64';
     }
-    const excludedSimulatorArchs = 'i386';
     xcodeBuildSettings.add(
       'EXCLUDED_ARCHS[sdk=${XcodeSdk.IPhoneSimulator.platformName}*]=$excludedSimulatorArchs',
     );

--- a/packages/flutter_tools/lib/src/ios/xcode_build_settings.dart
+++ b/packages/flutter_tools/lib/src/ios/xcode_build_settings.dart
@@ -35,6 +35,7 @@ Future<void> updateGeneratedXcodeProperties({
   bool useMacOSConfig = false,
   String? buildDirOverride,
   String? configurationBuildDir,
+  bool printWarnings = false,
 }) async {
   final List<String> xcodeBuildSettings = await _xcodeBuildSettingsLines(
     project: project,
@@ -43,6 +44,7 @@ Future<void> updateGeneratedXcodeProperties({
     useMacOSConfig: useMacOSConfig,
     buildDirOverride: buildDirOverride,
     configurationBuildDir: configurationBuildDir,
+    printWarnings: printWarnings,
   );
 
   _updateGeneratedXcodePropertiesFile(
@@ -149,6 +151,7 @@ Future<List<String>> _xcodeBuildSettingsLines({
   bool useMacOSConfig = false,
   String? buildDirOverride,
   String? configurationBuildDir,
+  required bool printWarnings,
 }) async {
   final xcodeBuildSettings = <String>[];
 
@@ -240,7 +243,7 @@ Future<List<String>> _xcodeBuildSettingsLines({
     // (to run natively without Rosetta translation on an ARM Mac),
     // the app will fail to build unless it also excludes arm64 simulators.
     var excludedSimulatorArchs = 'i386';
-    if (!(await project.ios.pluginsSupportArmSimulator())) {
+    if (!(await project.ios.pluginsSupportArmSimulator(printWarnings: printWarnings))) {
       excludedSimulatorArchs += ' arm64';
     }
     xcodeBuildSettings.add(

--- a/packages/flutter_tools/lib/src/xcode_project.dart
+++ b/packages/flutter_tools/lib/src/xcode_project.dart
@@ -5,6 +5,8 @@
 /// @docImport 'ios/mac.dart';
 library;
 
+import 'package:yaml/yaml.dart' as yaml;
+
 import 'base/error_handling_io.dart';
 import 'base/file_system.dart';
 import 'base/logger.dart';
@@ -489,77 +491,191 @@ def __lldb_init_module(debugger: lldb.SBDebugger, _):
   /// True if the app project uses Swift.
   bool get isSwift => appDelegateSwift.existsSync();
 
-  /// Prints a warning if any plugin(s) are excluding `arm64` architecture.
+  bool _warnedAboutExcludingArm = false;
+
+  /// Returns true if all plugins and their dependencies support arm64.
   ///
-  /// Xcode 26 no longer allows you to build x86-only architecture for the simulator
-  Future<void> checkForPluginsExcludingArmSimulator() async {
+  /// When using Xcode 26+, print a warning if a plugin or its dependencies does not support
+  /// arm64.
+  Future<bool> pluginsSupportArmSimulator() async {
+    final Version? xcodeVersion = globals.xcode?.currentVersion;
     final Directory podXcodeProject = hostAppRoot
         .childDirectory('Pods')
         .childDirectory('Pods.xcodeproj');
     if (!podXcodeProject.existsSync()) {
-      return;
+      return true;
     }
 
     final XcodeProjectInterpreter? xcodeProjectInterpreter = globals.xcodeProjectInterpreter;
     if (xcodeProjectInterpreter == null) {
-      return;
+      // Xcode isn't installed, don't try to check.
+      return true;
     }
     final String? buildSettings = await xcodeProjectInterpreter.pluginsBuildSettingsOutput(
       podXcodeProject,
     );
-
     if (buildSettings == null || buildSettings.isEmpty) {
-      return;
+      return false;
     }
 
+    // When using Xcode 26, print a warning if a target does not support arm.
+    if (xcodeVersion != null && xcodeVersion.major >= 26 && !_warnedAboutExcludingArm) {
+      final List<({String target, String? plugin})> targetsExcludingArm =
+          await _targetsExcludingArm(buildSettings);
+      if (targetsExcludingArm.isNotEmpty) {
+        final String list = targetsExcludingArm
+            .map((target) {
+              var targetItem = '  - ${target.target}';
+              if (target.target == target.plugin) {
+                targetItem = '$targetItem (Flutter plugin)';
+              } else if (target.plugin != null) {
+                targetItem =
+                    '$targetItem (transitive dependency of Flutter plugin ${target.plugin})';
+              }
+              return targetItem;
+            })
+            .join('\n');
+        globals.logger.printWarning(
+          'The following target(s) do not support arm64 architecture, which is a requirement for '
+          'Apple Silicon iOS 26+ simulators:\n'
+          '$list\n\n'
+          'Please contact plugin maintainers to request arm64 support to continue to be able to '
+          'use the plugin on a simulator.',
+        );
+        _warnedAboutExcludingArm = true;
+      }
+    }
+
+    return !buildSettings.contains(RegExp('EXCLUDED_ARCHS.*arm64'));
+  }
+
+  /// Returns a list of targets and their associated plugin (if found) that exclude arm64 architecture.
+  Future<List<({String target, String? plugin})>> _targetsExcludingArm(String buildSettings) async {
+    final Map<String, List<String>> cocoapodsTree = _cocoapodTree();
     final List<Plugin> allPlugins = await findPlugins(parent);
-    final iosPluginTargetNames = <String>{
+    final pluginNames = <String>{
       for (final Plugin plugin in allPlugins)
         if (plugin.platforms.containsKey(IOSPlugin.kConfigKey)) plugin.name,
     };
-    if (iosPluginTargetNames.isEmpty) {
-      return;
-    }
-
-    final targetHeader = RegExp(
+    final targetHeaderPattern = RegExp(
       r'^Build settings for action build and target "?([^":\r\n]+)"?:\s*$',
     );
 
-    final pluginsExcludingArmArch = <String>{};
+    final List<({String target, String? plugin})> foundTargets = [];
     String? currentTarget;
-
     for (final String eachLine in buildSettings.split('\n')) {
       final String settingsLine = eachLine.trim();
-
-      final RegExpMatch? headerMatch = targetHeader.firstMatch(settingsLine);
+      final RegExpMatch? headerMatch = targetHeaderPattern.firstMatch(settingsLine);
       if (headerMatch != null) {
         currentTarget = headerMatch.group(1)!.trim();
         continue;
       }
-
-      if (currentTarget == null || !iosPluginTargetNames.contains(currentTarget)) {
+      if (currentTarget == null ||
+          !settingsLine.startsWith('EXCLUDED_ARCHS') ||
+          !settingsLine.contains('=')) {
         continue;
       }
-
-      if (!settingsLine.startsWith('EXCLUDED_ARCHS') || !settingsLine.contains('=')) {
-        continue;
-      }
-
       final Iterable<String> tokens = settingsLine.split(' ');
-      if (tokens.contains('arm64')) {
-        pluginsExcludingArmArch.add(currentTarget);
+      if (!tokens.contains('arm64')) {
+        continue;
+      }
+
+      if (pluginNames.contains(currentTarget)) {
+        foundTargets.add((target: currentTarget, plugin: currentTarget));
+      } else {
+        // If it's not a plugin, it may de a transitive dependency of a plugin
+        final String? parentPlugin = _pluginUsingDependency(
+          targetName: currentTarget,
+          pluginNames: pluginNames.toList(),
+          cocoapodsTree: cocoapodsTree,
+        );
+        if (parentPlugin != null) {
+          foundTargets.add((target: currentTarget, plugin: parentPlugin));
+        } else if (currentTarget.startsWith('Pods-')) {
+          continue;
+        } else {
+          foundTargets.add((target: currentTarget, plugin: null));
+        }
       }
     }
+    return foundTargets;
+  }
 
-    if (pluginsExcludingArmArch.isNotEmpty) {
-      final String list = pluginsExcludingArmArch.map((String n) => '  - $n').join('\n');
-
-      globals.logger.printWarning(
-        'The following plugin(s) are excluding the arm64 architecture, which is a requirement for Xcode 26+:\n'
-        '$list\n'
-        'Consider installing the "Universal" Xcode or file an issue with the plugin(s) to support arm64.',
-      );
+  /// Returns the plugin that uses the given target.
+  String? _pluginUsingDependency({
+    required String targetName,
+    required List<String> pluginNames,
+    required Map<String, List<String>> cocoapodsTree,
+  }) {
+    final String? pluginName = _findPluginForDependency(targetName, cocoapodsTree, pluginNames);
+    if (pluginName != null) {
+      return pluginName;
     }
+    if (targetName.contains('-')) {
+      // If the target has a - in the name, the first part is often the pod name
+      return _findPluginForDependency(targetName.split('-').first, cocoapodsTree, pluginNames);
+    } else {
+      return _findPluginForDependency(targetName, cocoapodsTree, pluginNames, searchByPrefix: true);
+    }
+  }
+
+  /// Returns a map of pods and their dependencies.
+  Map<String, List<String>> _cocoapodTree() {
+    final Map<String, List<String>> podDependencies = {};
+    try {
+      if (podfileLock.existsSync()) {
+        final String podfileLockString = podfileLock.readAsStringSync().split('\n\n').first;
+        final dynamic podsYaml = yaml.loadYaml(podfileLockString);
+        if (podsYaml is yaml.YamlMap) {
+          final dynamic podsList = podsYaml['PODS'];
+          if (podsList is List<dynamic>) {
+            // ignore: specify_nonobvious_local_variable_types
+            for (final dynamic pod in podsList) {
+              if (pod is yaml.YamlMap) {
+                final name = pod.keys.first as String;
+                final dynamic value = pod.value[name];
+                if (value is yaml.YamlList) {
+                  podDependencies[name.split(' ').first] = value
+                      .map((dep) => (dep as String).split(' ').first)
+                      .toList();
+                }
+              }
+            }
+          }
+        }
+      }
+    } on Exception {
+      globals.logger.printTrace('Failed to parse podfile.lock');
+    }
+
+    return podDependencies;
+  }
+
+  String? _findPluginForDependency(
+    String transitiveDependency,
+    Map<String, List<String>> cocoapodTree,
+    List<String> pluginNames, {
+    bool searchByPrefix = false,
+  }) {
+    for (final MapEntry<String, List<String>> pod in cocoapodTree.entries) {
+      final String podName = pod.key;
+      final List<String> podDependencies = pod.value;
+      bool podHasTransitiveDependency;
+      if (searchByPrefix) {
+        podHasTransitiveDependency = podDependencies.any(
+          (dep) => dep.startsWith('$transitiveDependency/'),
+        );
+      } else {
+        podHasTransitiveDependency = podDependencies.contains(transitiveDependency);
+      }
+      if (podHasTransitiveDependency) {
+        if (pluginNames.contains(podName)) {
+          return podName;
+        }
+        return _findPluginForDependency(podName, cocoapodTree, pluginNames);
+      }
+    }
+    return null;
   }
 
   @override

--- a/packages/flutter_tools/lib/src/xcode_project.dart
+++ b/packages/flutter_tools/lib/src/xcode_project.dart
@@ -491,13 +491,11 @@ def __lldb_init_module(debugger: lldb.SBDebugger, _):
   /// True if the app project uses Swift.
   bool get isSwift => appDelegateSwift.existsSync();
 
-  bool _warnedAboutExcludingArm = false;
-
   /// Returns true if all plugins and their dependencies support arm64.
   ///
   /// When using Xcode 26+, print a warning if a plugin or its dependencies does not support
   /// arm64.
-  Future<bool> pluginsSupportArmSimulator() async {
+  Future<bool> pluginsSupportArmSimulator({required bool printWarnings}) async {
     final Version? xcodeVersion = globals.xcode?.currentVersion;
     final Directory podXcodeProject = hostAppRoot
         .childDirectory('Pods')
@@ -515,11 +513,12 @@ def __lldb_init_module(debugger: lldb.SBDebugger, _):
       podXcodeProject,
     );
     if (buildSettings == null || buildSettings.isEmpty) {
-      return false;
+      globals.logger.printTrace('Unable to get build settings for Pods.');
+      return true;
     }
 
     // When using Xcode 26, print a warning if a target does not support arm.
-    if (xcodeVersion != null && xcodeVersion.major >= 26 && !_warnedAboutExcludingArm) {
+    if (xcodeVersion != null && xcodeVersion.major >= 26 && printWarnings) {
       final List<({String target, String? plugin})> targetsExcludingArm =
           await _targetsExcludingArm(buildSettings);
       if (targetsExcludingArm.isNotEmpty) {
@@ -542,7 +541,6 @@ def __lldb_init_module(debugger: lldb.SBDebugger, _):
           'Please contact plugin maintainers to request arm64 support to continue to be able to '
           'use the plugin on a simulator.',
         );
-        _warnedAboutExcludingArm = true;
       }
     }
 
@@ -551,7 +549,7 @@ def __lldb_init_module(debugger: lldb.SBDebugger, _):
 
   /// Returns a list of targets and their associated plugin (if found) that exclude arm64 architecture.
   Future<List<({String target, String? plugin})>> _targetsExcludingArm(String buildSettings) async {
-    final Map<String, List<String>> cocoapodsTree = _cocoapodTree();
+    final Map<String, List<String>> cocoapodsDependencyGraph = _cocoapodsDependencyGraph();
     final List<Plugin> allPlugins = await findPlugins(parent);
     final pluginNames = <String>{
       for (final Plugin plugin in allPlugins)
@@ -583,15 +581,16 @@ def __lldb_init_module(debugger: lldb.SBDebugger, _):
       if (pluginNames.contains(currentTarget)) {
         foundTargets.add((target: currentTarget, plugin: currentTarget));
       } else {
-        // If it's not a plugin, it may de a transitive dependency of a plugin
+        // If it's not a plugin, it may be a transitive dependency of a plugin
         final String? parentPlugin = _pluginUsingDependency(
           targetName: currentTarget,
           pluginNames: pluginNames.toList(),
-          cocoapodsTree: cocoapodsTree,
+          cocoapodsDependencyGraph: cocoapodsDependencyGraph,
         );
         if (parentPlugin != null) {
           foundTargets.add((target: currentTarget, plugin: parentPlugin));
         } else if (currentTarget.startsWith('Pods-')) {
+          // Skip Pods- targets since they are not actual dependencies.
           continue;
         } else {
           foundTargets.add((target: currentTarget, plugin: null));
@@ -605,22 +604,38 @@ def __lldb_init_module(debugger: lldb.SBDebugger, _):
   String? _pluginUsingDependency({
     required String targetName,
     required List<String> pluginNames,
-    required Map<String, List<String>> cocoapodsTree,
+    required Map<String, List<String>> cocoapodsDependencyGraph,
   }) {
-    final String? pluginName = _findPluginForDependency(targetName, cocoapodsTree, pluginNames);
+    final String? pluginName = _findPluginForDependency(
+      targetName,
+      cocoapodsDependencyGraph,
+      pluginNames,
+    );
     if (pluginName != null) {
       return pluginName;
     }
     if (targetName.contains('-')) {
-      // If the target has a - in the name, the first part is often the pod name
-      return _findPluginForDependency(targetName.split('-').first, cocoapodsTree, pluginNames);
+      // Resource bundle targets are prefixed with the name of the pod and then the name of the
+      // resource. Strip the resource name to get the pod name.
+      return _findPluginForDependency(
+        targetName.split('-').first,
+        cocoapodsDependencyGraph,
+        pluginNames,
+      );
     } else {
-      return _findPluginForDependency(targetName, cocoapodsTree, pluginNames, searchByPrefix: true);
+      // Sometimes the target name is a prefix of pod name.
+      // Example: target name "GoogleMLKit" and pod name "GoogleMLKit/Translate".
+      return _findPluginForDependency(
+        targetName,
+        cocoapodsDependencyGraph,
+        pluginNames,
+        searchByPrefix: true,
+      );
     }
   }
 
   /// Returns a map of pods and their dependencies.
-  Map<String, List<String>> _cocoapodTree() {
+  Map<String, List<String>> _cocoapodsDependencyGraph() {
     final Map<String, List<String>> podDependencies = {};
     try {
       if (podfileLock.existsSync()) {
@@ -644,15 +659,16 @@ def __lldb_init_module(debugger: lldb.SBDebugger, _):
           }
         }
       }
-    } on Exception {
-      globals.logger.printTrace('Failed to parse podfile.lock');
+    } on Exception catch (e) {
+      globals.logger.printTrace('Failed to parse podfile.lock: $e');
     }
 
     return podDependencies;
   }
 
+  /// Recursively searches the pod dependency graph for a Flutter plugin that uses the given target.
   String? _findPluginForDependency(
-    String transitiveDependency,
+    String targetName,
     Map<String, List<String>> cocoapodTree,
     List<String> pluginNames, {
     bool searchByPrefix = false,
@@ -660,15 +676,13 @@ def __lldb_init_module(debugger: lldb.SBDebugger, _):
     for (final MapEntry<String, List<String>> pod in cocoapodTree.entries) {
       final String podName = pod.key;
       final List<String> podDependencies = pod.value;
-      bool podHasTransitiveDependency;
+      bool podHasTargetAsDependency;
       if (searchByPrefix) {
-        podHasTransitiveDependency = podDependencies.any(
-          (dep) => dep.startsWith('$transitiveDependency/'),
-        );
+        podHasTargetAsDependency = podDependencies.any((dep) => dep.startsWith('$targetName/'));
       } else {
-        podHasTransitiveDependency = podDependencies.contains(transitiveDependency);
+        podHasTargetAsDependency = podDependencies.contains(targetName);
       }
-      if (podHasTransitiveDependency) {
+      if (podHasTargetAsDependency) {
         if (pluginNames.contains(podName)) {
           return podName;
         }

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -1188,69 +1188,6 @@ Information about project "Runner":
       }
 
       testUsingContext(
-        'excludes arm64 simulator when build setting fetch fails',
-        () async {
-          const BuildInfo buildInfo = BuildInfo.debug;
-
-          final Directory projectDir = fs.directory('path/to/project')..createSync(recursive: true);
-          projectDir.childFile('pubspec.yaml')
-            ..createSync(recursive: true)
-            ..writeAsStringSync('name: my_app\n');
-
-          final FlutterProject project = FlutterProject.fromDirectoryTest(projectDir);
-
-          final Directory podXcodeProject =
-              project.ios.hostAppRoot.childDirectory('Pods').childDirectory('Pods.xcodeproj')
-                ..createSync(recursive: true);
-          project.ios.podManifestLock.createSync(recursive: true);
-
-          final String buildDirectory = fs.path.absolute('build', 'ios');
-
-          fakeProcessManager.addCommands(<FakeCommand>[
-            kWhichSysctlCommand,
-            kARMCheckCommand,
-            FakeCommand(
-              command: <String>[
-                '/usr/bin/arch',
-                '-arm64e',
-                'xcrun',
-                'xcodebuild',
-                '-alltargets',
-                '-sdk',
-                'iphonesimulator',
-                '-project',
-                podXcodeProject.path,
-                '-showBuildSettings',
-                'BUILD_DIR=$buildDirectory',
-                'OBJROOT=$buildDirectory',
-              ],
-              exitCode: 1,
-            ),
-          ]);
-
-          await updateGeneratedXcodeProperties(project: project, buildInfo: buildInfo);
-
-          expect(fakeProcessManager, hasNoRemainingExpectations);
-
-          final File config = fs.file('path/to/project/ios/Flutter/Generated.xcconfig');
-          expect(
-            config.readAsStringSync(),
-            contains('EXCLUDED_ARCHS[sdk=iphonesimulator*]=i386 arm64'),
-          );
-          expect(config.readAsStringSync(), contains('EXCLUDED_ARCHS[sdk=iphoneos*]=armv7'));
-        },
-        overrides: <Type, Generator>{
-          Artifacts: () => localIosArtifacts,
-          Platform: () => macOS,
-          FileSystem: () => fs,
-          ProcessManager: () => fakeProcessManager,
-          XcodeProjectInterpreter: () => xcodeProjectInterpreter,
-          Xcode: () => xcode,
-          Logger: () => logger,
-        },
-      );
-
-      testUsingContext(
         'prints Warning when a plugin or transitive dependency excludes arm64 on Xcode 26+',
         () async {
           const BuildInfo buildInfo = BuildInfo.debug;
@@ -1325,7 +1262,11 @@ PODS:
   - ThirdPodDependency (1.0.0):
   - FourthPodDependency (1.0.0):
 ''');
-          await updateGeneratedXcodeProperties(project: project, buildInfo: buildInfo);
+          await updateGeneratedXcodeProperties(
+            project: project,
+            buildInfo: buildInfo,
+            printWarnings: true,
+          );
 
           expect(
             logger.warningText,
@@ -1403,7 +1344,11 @@ Build settings for action build and target good_plugin:
             ),
           ]);
 
-          await updateGeneratedXcodeProperties(project: project, buildInfo: buildInfo);
+          await updateGeneratedXcodeProperties(
+            project: project,
+            buildInfo: buildInfo,
+            printWarnings: true,
+          );
 
           final File config = fs.file('path/to/project/ios/Flutter/Generated.xcconfig');
           expect(logger.warningText, isEmpty);
@@ -1467,7 +1412,11 @@ Build settings for action build and target good_plugin:
             ),
           ]);
 
-          await updateGeneratedXcodeProperties(project: project, buildInfo: buildInfo);
+          await updateGeneratedXcodeProperties(
+            project: project,
+            buildInfo: buildInfo,
+            printWarnings: true,
+          );
 
           final File config = fs.file('path/to/project/ios/Flutter/Generated.xcconfig');
           expect(logger.warningText, isEmpty);
@@ -1532,7 +1481,11 @@ Build settings for action build and target bad_plugin:
             ),
           ]);
 
-          await updateGeneratedXcodeProperties(project: project, buildInfo: buildInfo);
+          await updateGeneratedXcodeProperties(
+            project: project,
+            buildInfo: buildInfo,
+            printWarnings: true,
+          );
 
           expect(
             logger.warningText,
@@ -1641,7 +1594,11 @@ PODS:
   - ThirdPodDependency (1.0.0):
   - FourthPodDependency (1.0.0):
 ''');
-          await updateGeneratedXcodeProperties(project: project, buildInfo: buildInfo);
+          await updateGeneratedXcodeProperties(
+            project: project,
+            buildInfo: buildInfo,
+            printWarnings: true,
+          );
 
           expect(logger.warningText, isEmpty);
           expect(fakeProcessManager, hasNoRemainingExpectations);

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -1188,7 +1188,70 @@ Information about project "Runner":
       }
 
       testUsingContext(
-        'prints Warning when a plugin excludes arm64 on Xcode 26+',
+        'excludes arm64 simulator when build setting fetch fails',
+        () async {
+          const BuildInfo buildInfo = BuildInfo.debug;
+
+          final Directory projectDir = fs.directory('path/to/project')..createSync(recursive: true);
+          projectDir.childFile('pubspec.yaml')
+            ..createSync(recursive: true)
+            ..writeAsStringSync('name: my_app\n');
+
+          final FlutterProject project = FlutterProject.fromDirectoryTest(projectDir);
+
+          final Directory podXcodeProject =
+              project.ios.hostAppRoot.childDirectory('Pods').childDirectory('Pods.xcodeproj')
+                ..createSync(recursive: true);
+          project.ios.podManifestLock.createSync(recursive: true);
+
+          final String buildDirectory = fs.path.absolute('build', 'ios');
+
+          fakeProcessManager.addCommands(<FakeCommand>[
+            kWhichSysctlCommand,
+            kARMCheckCommand,
+            FakeCommand(
+              command: <String>[
+                '/usr/bin/arch',
+                '-arm64e',
+                'xcrun',
+                'xcodebuild',
+                '-alltargets',
+                '-sdk',
+                'iphonesimulator',
+                '-project',
+                podXcodeProject.path,
+                '-showBuildSettings',
+                'BUILD_DIR=$buildDirectory',
+                'OBJROOT=$buildDirectory',
+              ],
+              exitCode: 1,
+            ),
+          ]);
+
+          await updateGeneratedXcodeProperties(project: project, buildInfo: buildInfo);
+
+          expect(fakeProcessManager, hasNoRemainingExpectations);
+
+          final File config = fs.file('path/to/project/ios/Flutter/Generated.xcconfig');
+          expect(
+            config.readAsStringSync(),
+            contains('EXCLUDED_ARCHS[sdk=iphonesimulator*]=i386 arm64'),
+          );
+          expect(config.readAsStringSync(), contains('EXCLUDED_ARCHS[sdk=iphoneos*]=armv7'));
+        },
+        overrides: <Type, Generator>{
+          Artifacts: () => localIosArtifacts,
+          Platform: () => macOS,
+          FileSystem: () => fs,
+          ProcessManager: () => fakeProcessManager,
+          XcodeProjectInterpreter: () => xcodeProjectInterpreter,
+          Xcode: () => xcode,
+          Logger: () => logger,
+        },
+      );
+
+      testUsingContext(
+        'prints Warning when a plugin or transitive dependency excludes arm64 on Xcode 26+',
         () async {
           const BuildInfo buildInfo = BuildInfo.debug;
 
@@ -1230,22 +1293,60 @@ Information about project "Runner":
 Build settings for action build and target bad_plugin:
     EXCLUDED_ARCHS = i386 arm64
 
+Build settings for action build and target BadPluginPodDependency:
+    EXCLUDED_ARCHS = i386 arm64
+
+Build settings for action build and target SecondPodDependency:
+    EXCLUDED_ARCHS = i386 arm64
+
+Build settings for action build and target ThirdPodDependency-Sub:
+    EXCLUDED_ARCHS = i386 arm64
+
+Build settings for action build and target FourthPodDependency:
+    EXCLUDED_ARCHS = i386 arm64
+
 Build settings for action build and target good_plugin:
     EXCLUDED_ARCHS = i386
 ''',
             ),
           ]);
 
+          fs.file('path/to/project/ios/Podfile.lock').writeAsStringSync('''
+PODS:
+  - good_plugin (1.0.0):
+    - Flutter
+  - bad_plugin (1.0.0):
+    - Flutter
+    - BadPluginPodDependency
+  - BadPluginPodDependency (1.0.0):
+    - SecondPodDependency/Sub
+  - SecondPodDependency/Sub (1.0.0):
+    - ThirdPodDependency
+  - ThirdPodDependency (1.0.0):
+  - FourthPodDependency (1.0.0):
+''');
           await updateGeneratedXcodeProperties(project: project, buildInfo: buildInfo);
 
           expect(
             logger.warningText,
             contains(
-              'The following plugin(s) are excluding the arm64 architecture, which is a requirement for Xcode 26+',
+              'The following target(s) do not support arm64 architecture, which is a requirement for '
+              'Apple Silicon iOS 26+ simulators:\n'
+              '  - bad_plugin (Flutter plugin)\n'
+              '  - BadPluginPodDependency (transitive dependency of Flutter plugin bad_plugin)\n'
+              '  - SecondPodDependency (transitive dependency of Flutter plugin bad_plugin)\n'
+              '  - ThirdPodDependency-Sub (transitive dependency of Flutter plugin bad_plugin)\n'
+              '  - FourthPodDependency\n',
             ),
           );
-          expect(logger.warningText, contains('bad_plugin'));
           expect(fakeProcessManager, hasNoRemainingExpectations);
+
+          final File config = fs.file('path/to/project/ios/Flutter/Generated.xcconfig');
+          expect(
+            config.readAsStringSync(),
+            contains('EXCLUDED_ARCHS[sdk=iphonesimulator*]=i386 arm64'),
+          );
+          expect(config.readAsStringSync(), contains('EXCLUDED_ARCHS[sdk=iphoneos*]=armv7'));
         },
         overrides: <Type, Generator>{
           Artifacts: () => localIosArtifacts,
@@ -1257,8 +1358,9 @@ Build settings for action build and target good_plugin:
           Logger: () => logger,
         },
       );
+
       testUsingContext(
-        'succeeds when no plugins exclude arm64 on Xcode 26+',
+        'does not exclude arm64 simulator when supported by all plugins',
         () async {
           const BuildInfo buildInfo = BuildInfo.debug;
 
@@ -1304,6 +1406,7 @@ Build settings for action build and target good_plugin:
           await updateGeneratedXcodeProperties(project: project, buildInfo: buildInfo);
 
           final File config = fs.file('path/to/project/ios/Flutter/Generated.xcconfig');
+          expect(logger.warningText, isEmpty);
           expect(config.readAsStringSync(), contains('EXCLUDED_ARCHS[sdk=iphonesimulator*]=i386'));
           expect(config.readAsStringSync(), contains('EXCLUDED_ARCHS[sdk=iphoneos*]=armv7'));
           expect(fakeProcessManager, hasNoRemainingExpectations);
@@ -1338,7 +1441,6 @@ Build settings for action build and target good_plugin:
           createFakePlugins(project, fs, <String>['good_plugin']);
 
           final String buildDirectory = fs.path.absolute('build', 'ios');
-          final testLogger = BufferLogger.test();
 
           fakeProcessManager.addCommands(<FakeCommand>[
             kWhichSysctlCommand,
@@ -1367,7 +1469,10 @@ Build settings for action build and target good_plugin:
 
           await updateGeneratedXcodeProperties(project: project, buildInfo: buildInfo);
 
-          expect(testLogger.warningText, isEmpty);
+          final File config = fs.file('path/to/project/ios/Flutter/Generated.xcconfig');
+          expect(logger.warningText, isEmpty);
+          expect(config.readAsStringSync(), contains('EXCLUDED_ARCHS[sdk=iphonesimulator*]=i386'));
+          expect(config.readAsStringSync(), contains('EXCLUDED_ARCHS[sdk=iphoneos*]=armv7'));
           expect(fakeProcessManager, hasNoRemainingExpectations);
         },
         overrides: <Type, Generator>{
@@ -1432,11 +1537,15 @@ Build settings for action build and target bad_plugin:
           expect(
             logger.warningText,
             contains(
-              'The following plugin(s) are excluding the arm64 architecture, which is a requirement for Xcode 26+',
+              'The following target(s) do not support arm64 architecture, which is a requirement for '
+              'Apple Silicon iOS 26+ simulators:',
             ),
           );
           expect(logger.warningText, contains('bad_plugin'));
           expect(fakeProcessManager, hasNoRemainingExpectations);
+          final File config = fs.file('path/to/project/ios/Flutter/Generated.xcconfig');
+          expect(config.readAsStringSync(), contains('EXCLUDED_ARCHS[sdk=iphonesimulator*]=i386'));
+          expect(config.readAsStringSync(), contains('EXCLUDED_ARCHS[sdk=iphoneos*]=armv7'));
         },
         overrides: <Type, Generator>{
           Artifacts: () => localIosArtifacts,
@@ -1450,8 +1559,16 @@ Build settings for action build and target bad_plugin:
       );
 
       testUsingContext(
-        'ignores non-plugin targets that exclude arm64',
+        'does not print warning on Xcode < 26',
         () async {
+          xcodeProjectInterpreter = XcodeProjectInterpreter.test(
+            processManager: fakeProcessManager,
+            version: Version(16, 0, 0),
+          );
+          xcode = Xcode.test(
+            processManager: fakeProcessManager,
+            xcodeProjectInterpreter: xcodeProjectInterpreter,
+          );
           const BuildInfo buildInfo = BuildInfo.debug;
 
           final Directory projectDir = fs.directory('path/to/project')..createSync(recursive: true);
@@ -1466,10 +1583,9 @@ Build settings for action build and target bad_plugin:
                 ..createSync(recursive: true);
           project.ios.podManifestLock.createSync(recursive: true);
 
-          createFakePlugins(project, fs, <String>['good_plugin']);
+          createFakePlugins(project, fs, <String>['bad_plugin', 'good_plugin']);
 
           final String buildDirectory = fs.path.absolute('build', 'ios');
-          final testLogger = BufferLogger.test();
 
           fakeProcessManager.addCommands(<FakeCommand>[
             kWhichSysctlCommand,
@@ -1490,8 +1606,20 @@ Build settings for action build and target bad_plugin:
                 'OBJROOT=$buildDirectory',
               ],
               stdout: '''
-Build settings for action build and target SomeNonPluginTarget:
-    EXCLUDED_ARCHS = arm64
+Build settings for action build and target bad_plugin:
+    EXCLUDED_ARCHS = i386 arm64
+
+Build settings for action build and target BadPluginPodDependency:
+    EXCLUDED_ARCHS = i386 arm64
+
+Build settings for action build and target SecondPodDependency:
+    EXCLUDED_ARCHS = i386 arm64
+
+Build settings for action build and target ThirdPodDependency-Sub:
+    EXCLUDED_ARCHS = i386 arm64
+
+Build settings for action build and target FourthPodDependency:
+    EXCLUDED_ARCHS = i386 arm64
 
 Build settings for action build and target good_plugin:
     EXCLUDED_ARCHS = i386
@@ -1499,49 +1627,31 @@ Build settings for action build and target good_plugin:
             ),
           ]);
 
+          fs.file('path/to/project/ios/Podfile.lock').writeAsStringSync('''
+PODS:
+  - good_plugin (1.0.0):
+    - Flutter
+  - bad_plugin (1.0.0):
+    - Flutter
+    - BadPluginPodDependency
+  - BadPluginPodDependency (1.0.0):
+    - SecondPodDependency/Sub
+  - SecondPodDependency/Sub (1.0.0):
+    - ThirdPodDependency
+  - ThirdPodDependency (1.0.0):
+  - FourthPodDependency (1.0.0):
+''');
           await updateGeneratedXcodeProperties(project: project, buildInfo: buildInfo);
 
-          expect(testLogger.warningText, isEmpty);
+          expect(logger.warningText, isEmpty);
           expect(fakeProcessManager, hasNoRemainingExpectations);
-        },
-        overrides: <Type, Generator>{
-          Artifacts: () => localIosArtifacts,
-          Platform: () => macOS,
-          FileSystem: () => fs,
-          ProcessManager: () => fakeProcessManager,
-          XcodeProjectInterpreter: () => xcodeProjectInterpreter,
-          Xcode: () => xcode,
-          Logger: () => BufferLogger.test(),
-        },
-      );
-
-      testUsingContext(
-        'succeeds and skips check on Xcode 16 even if a plugin excludes arm64',
-        () async {
-          xcodeProjectInterpreter = XcodeProjectInterpreter.test(
-            processManager: fakeProcessManager,
-            version: Version(16, 0, 0),
-          );
-          xcode = Xcode.test(
-            processManager: fakeProcessManager,
-            xcodeProjectInterpreter: xcodeProjectInterpreter,
-          );
-
-          const BuildInfo buildInfo = BuildInfo.debug;
-          final FlutterProject project = FlutterProject.fromDirectoryTest(
-            fs.directory('path/to/project'),
-          );
-          project.ios.hostAppRoot
-              .childDirectory('Pods')
-              .childDirectory('Pods.xcodeproj')
-              .createSync(recursive: true);
-
-          await updateGeneratedXcodeProperties(project: project, buildInfo: buildInfo);
 
           final File config = fs.file('path/to/project/ios/Flutter/Generated.xcconfig');
-          expect(config.readAsStringSync(), contains('EXCLUDED_ARCHS[sdk=iphonesimulator*]=i386'));
+          expect(
+            config.readAsStringSync(),
+            contains('EXCLUDED_ARCHS[sdk=iphonesimulator*]=i386 arm64'),
+          );
           expect(config.readAsStringSync(), contains('EXCLUDED_ARCHS[sdk=iphoneos*]=armv7'));
-          expect(fakeProcessManager, hasNoRemainingExpectations);
         },
         overrides: <Type, Generator>{
           Artifacts: () => localIosArtifacts,


### PR DESCRIPTION
If any Pod dependencies exclude the arm64 architecture for simulators, Flutter excludes it too. This will force Xcode to build it in an x86 architecture. However, iOS 26 introduced arm-only simulators. So when using Xcode 26, print a warning with the list of plugins/targets that are excluding arm and direct them to request arm support. Then if the build fails due to targeting an arm-only simulator, give a guided message to switch to an x86 simulator.

Fixes https://github.com/flutter/flutter/issues/182748.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
