### PR TITLE
[A11y] in calendar date picker, remove SemanticsService.sendAnnouncement usage for android. 

### DIFF
--- a/packages/flutter/lib/src/material/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/calendar_date_picker.dart
@@ -199,25 +199,9 @@ class CalendarDatePicker extends StatefulWidget {
   State<CalendarDatePicker> createState() => _CalendarDatePickerState();
 }
 
-mixin _LiveRegionAnnouncementMixin<T extends StatefulWidget> on State<T> {
-  String _announcementText = '';
-
-  // Auxiliary method for handling the difference between platforms
-  void _announce(String message) {
-    // SemanticsService.sendAnnouncement is deprecated on android.
-    // We use live region to achieve the announcement effect instead.
-    if (Theme.of(context).platform == TargetPlatform.android) {
-      _announcementText = message;
-    } else {
-      // Maintains the mandatory announcement for other platforms
-      SemanticsService.sendAnnouncement(View.of(context), message, Directionality.of(context));
-    }
-  }
-}
-
-class _CalendarDatePickerState extends State<CalendarDatePicker>
-    with _LiveRegionAnnouncementMixin<CalendarDatePicker> {
+class _CalendarDatePickerState extends State<CalendarDatePicker> {
   bool _announcedInitialDate = false;
+  String _announcementText = '';
   late DatePickerMode _mode;
   late DateTime _currentDisplayedMonthDate;
   DateTime? _selectedDate;
@@ -254,6 +238,18 @@ class _CalendarDatePickerState extends State<CalendarDatePicker>
       final bool isToday = widget.calendarDelegate.isSameDay(widget.currentDate, _selectedDate);
       final semanticLabelSuffix = isToday ? ', ${_localizations.currentDateLabel}' : '';
       _announce('${_localizations.formatFullDate(_selectedDate!)}$semanticLabelSuffix');
+    }
+  }
+
+  // Auxiliary method for handling the difference between platforms
+  void _announce(String message) {
+    // SemanticsService.sendAnnouncement is deprecated on android.
+    // We use live region to achieve the announcement effect instead.
+    if (Theme.of(context).platform == TargetPlatform.android) {
+      _announcementText = message;
+    } else {
+      // Maintains the mandatory announcement for other platforms
+      SemanticsService.sendAnnouncement(View.of(context), message, Directionality.of(context));
     }
   }
 
@@ -618,9 +614,9 @@ class _MonthPicker extends StatefulWidget {
   _MonthPickerState createState() => _MonthPickerState();
 }
 
-class _MonthPickerState extends State<_MonthPicker>
-    with _LiveRegionAnnouncementMixin<_MonthPicker> {
+class _MonthPickerState extends State<_MonthPicker> {
   final GlobalKey _pageViewKey = GlobalKey();
+  String _announcementText = '';
   late DateTime _currentMonth;
   late PageController _pageController;
   late MaterialLocalizations _localizations;
@@ -676,6 +672,18 @@ class _MonthPickerState extends State<_MonthPicker>
   void _handleDateSelected(DateTime selectedDate) {
     _focusedDay = selectedDate;
     widget.onChanged(selectedDate);
+  }
+
+  // Auxiliary method for handling the difference between platforms
+  void _announce(String message) {
+    // SemanticsService.sendAnnouncement is deprecated on android.
+    // We use live region to achieve the announcement effect instead.
+    if (Theme.of(context).platform == TargetPlatform.android) {
+      _announcementText = message;
+    } else {
+      // Maintains the mandatory announcement for other platforms
+      SemanticsService.sendAnnouncement(View.of(context), message, Directionality.of(context));
+    }
   }
 
   void _handleMonthPageChanged(int monthPage) {
@@ -877,15 +885,13 @@ class _MonthPickerState extends State<_MonthPicker>
     final Color? subHeaderForegroundColor =
         DatePickerTheme.of(context).subHeaderForegroundColor ??
         DatePickerTheme.defaults(context).subHeaderForegroundColor;
-    final bool isAndroid = Theme.of(context).platform == TargetPlatform.android;
+
     return Semantics(
       container: true,
       explicitChildNodes: true,
-      liveRegion: isAndroid,
-      accessibilityFocusBlockType: isAndroid
-          ? AccessibilityFocusBlockType.blockNode
-          : AccessibilityFocusBlockType.none,
-      label: isAndroid ? _announcementText : null,
+      liveRegion: Theme.of(context).platform == TargetPlatform.android,
+      accessibilityFocusBlockType: AccessibilityFocusBlockType.blockNode,
+      label: Theme.of(context).platform == TargetPlatform.android ? _announcementText : null,
       child: Column(
         children: <Widget>[
           SizedBox(

--- a/packages/flutter/lib/src/material/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/calendar_date_picker.dart
@@ -403,15 +403,16 @@ class _CalendarDatePickerState extends State<CalendarDatePicker> {
     );
     return Stack(
       children: <Widget>[
-        (MediaQuery.maybeSupportsAnnounceOf(context) ?? false)
-            ? picker
-            : Semantics(
-                container: true,
-                liveRegion: true,
-                accessibilityFocusBlockType: AccessibilityFocusBlockType.blockNode,
-                label: _announcementText,
-                child: picker,
-              ),
+        if (MediaQuery.maybeSupportsAnnounceOf(context) ?? false)
+          picker
+        else
+          Semantics(
+            container: true,
+            liveRegion: true,
+            accessibilityFocusBlockType: AccessibilityFocusBlockType.blockNode,
+            label: _announcementText,
+            child: picker,
+          ),
 
         // Put the mode toggle button on top so that it won't be covered up by the _MonthPicker
         MediaQuery.withClampedTextScaling(
@@ -619,7 +620,6 @@ class _MonthPickerState extends State<_MonthPicker> {
   late DateTime _currentMonth;
   late PageController _pageController;
   late MaterialLocalizations _localizations;
-  late TextDirection _textDirection;
   Map<ShortcutActivator, Intent>? _shortcutMap;
   Map<Type, Action<Intent>>? _actionMap;
   late FocusNode _dayGridFocus;
@@ -658,7 +658,6 @@ class _MonthPickerState extends State<_MonthPicker> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     _localizations = MaterialLocalizations.of(context);
-    _textDirection = Directionality.of(context);
   }
 
   @override
@@ -884,7 +883,7 @@ class _MonthPickerState extends State<_MonthPicker> {
         DatePickerTheme.of(context).subHeaderForegroundColor ??
         DatePickerTheme.defaults(context).subHeaderForegroundColor;
 
-    final supportsAnnounce = MediaQuery.maybeSupportsAnnounceOf(context) ?? false;
+    final bool supportsAnnounce = MediaQuery.maybeSupportsAnnounceOf(context) ?? false;
     return Semantics(
       container: true,
       explicitChildNodes: true,

--- a/packages/flutter/lib/src/material/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/calendar_date_picker.dart
@@ -199,9 +199,25 @@ class CalendarDatePicker extends StatefulWidget {
   State<CalendarDatePicker> createState() => _CalendarDatePickerState();
 }
 
-class _CalendarDatePickerState extends State<CalendarDatePicker> {
-  bool _announcedInitialDate = false;
+mixin _LiveRegionAnnouncementMixin<T extends StatefulWidget> on State<T> {
   String _announcementText = '';
+
+  // Auxiliary method for handling the difference between platforms
+  void _announce(String message) {
+    // SemanticsService.sendAnnouncement is deprecated on android.
+    // We use live region to achieve the announcement effect instead.
+    if (Theme.of(context).platform == TargetPlatform.android) {
+      _announcementText = message;
+    } else {
+      // Maintains the mandatory announcement for other platforms
+      SemanticsService.sendAnnouncement(View.of(context), message, Directionality.of(context));
+    }
+  }
+}
+
+class _CalendarDatePickerState extends State<CalendarDatePicker>
+    with _LiveRegionAnnouncementMixin<CalendarDatePicker> {
+  bool _announcedInitialDate = false;
   late DatePickerMode _mode;
   late DateTime _currentDisplayedMonthDate;
   DateTime? _selectedDate;
@@ -238,18 +254,6 @@ class _CalendarDatePickerState extends State<CalendarDatePicker> {
       final bool isToday = widget.calendarDelegate.isSameDay(widget.currentDate, _selectedDate);
       final semanticLabelSuffix = isToday ? ', ${_localizations.currentDateLabel}' : '';
       _announce('${_localizations.formatFullDate(_selectedDate!)}$semanticLabelSuffix');
-    }
-  }
-
-  // Auxiliary method for handling the difference between platforms
-  void _announce(String message) {
-    // SemanticsService.sendAnnouncement is deprecated on android.
-    // We use live region to achieve the announcement effect instead.
-    if (Theme.of(context).platform == TargetPlatform.android) {
-      _announcementText = message;
-    } else {
-      // Maintains the mandatory announcement for other platforms
-      SemanticsService.sendAnnouncement(View.of(context), message, Directionality.of(context));
     }
   }
 
@@ -614,9 +618,9 @@ class _MonthPicker extends StatefulWidget {
   _MonthPickerState createState() => _MonthPickerState();
 }
 
-class _MonthPickerState extends State<_MonthPicker> {
+class _MonthPickerState extends State<_MonthPicker>
+    with _LiveRegionAnnouncementMixin<_MonthPicker> {
   final GlobalKey _pageViewKey = GlobalKey();
-  String _announcementText = '';
   late DateTime _currentMonth;
   late PageController _pageController;
   late MaterialLocalizations _localizations;
@@ -672,18 +676,6 @@ class _MonthPickerState extends State<_MonthPicker> {
   void _handleDateSelected(DateTime selectedDate) {
     _focusedDay = selectedDate;
     widget.onChanged(selectedDate);
-  }
-
-  // Auxiliary method for handling the difference between platforms
-  void _announce(String message) {
-    // SemanticsService.sendAnnouncement is deprecated on android.
-    // We use live region to achieve the announcement effect instead.
-    if (Theme.of(context).platform == TargetPlatform.android) {
-      _announcementText = message;
-    } else {
-      // Maintains the mandatory announcement for other platforms
-      SemanticsService.sendAnnouncement(View.of(context), message, Directionality.of(context));
-    }
   }
 
   void _handleMonthPageChanged(int monthPage) {
@@ -885,13 +877,15 @@ class _MonthPickerState extends State<_MonthPicker> {
     final Color? subHeaderForegroundColor =
         DatePickerTheme.of(context).subHeaderForegroundColor ??
         DatePickerTheme.defaults(context).subHeaderForegroundColor;
-
+    final bool isAndroid = Theme.of(context).platform == TargetPlatform.android;
     return Semantics(
       container: true,
       explicitChildNodes: true,
-      liveRegion: Theme.of(context).platform == TargetPlatform.android,
-      accessibilityFocusBlockType: AccessibilityFocusBlockType.blockNode,
-      label: Theme.of(context).platform == TargetPlatform.android ? _announcementText : null,
+      liveRegion: isAndroid,
+      accessibilityFocusBlockType: isAndroid
+          ? AccessibilityFocusBlockType.blockNode
+          : AccessibilityFocusBlockType.none,
+      label: isAndroid ? _announcementText : null,
       child: Column(
         children: <Widget>[
           SizedBox(

--- a/packages/flutter/lib/src/material/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/calendar_date_picker.dart
@@ -243,13 +243,12 @@ class _CalendarDatePickerState extends State<CalendarDatePicker> {
 
   // Auxiliary method for handling the difference between platforms
   void _announce(String message) {
-    // SemanticsService.sendAnnouncement is deprecated on android.
-    // We use live region to achieve the announcement effect instead.
-    if (Theme.of(context).platform == TargetPlatform.android) {
-      _announcementText = message;
-    } else {
-      // Maintains the mandatory announcement for other platforms
+    if (MediaQuery.maybeSupportsAnnounceOf(context) ?? false) {
       SemanticsService.sendAnnouncement(View.of(context), message, Directionality.of(context));
+    } else {
+      // If SemanticsService.sendAnnouncement is not supported,
+      // we use live region to achieve the announcement effect instead.
+      _announcementText = message;
     }
   }
 
@@ -404,15 +403,15 @@ class _CalendarDatePickerState extends State<CalendarDatePicker> {
     );
     return Stack(
       children: <Widget>[
-        Theme.of(context).platform == TargetPlatform.android
-            ? Semantics(
+        (MediaQuery.maybeSupportsAnnounceOf(context) ?? false)
+            ? picker
+            : Semantics(
                 container: true,
                 liveRegion: true,
                 accessibilityFocusBlockType: AccessibilityFocusBlockType.blockNode,
                 label: _announcementText,
                 child: picker,
-              )
-            : picker,
+              ),
 
         // Put the mode toggle button on top so that it won't be covered up by the _MonthPicker
         MediaQuery.withClampedTextScaling(
@@ -676,13 +675,12 @@ class _MonthPickerState extends State<_MonthPicker> {
 
   // Auxiliary method for handling the difference between platforms
   void _announce(String message) {
-    // SemanticsService.sendAnnouncement is deprecated on android.
-    // We use live region to achieve the announcement effect instead.
-    if (Theme.of(context).platform == TargetPlatform.android) {
-      _announcementText = message;
-    } else {
-      // Maintains the mandatory announcement for other platforms
+    if (MediaQuery.maybeSupportsAnnounceOf(context) ?? false) {
       SemanticsService.sendAnnouncement(View.of(context), message, Directionality.of(context));
+    } else {
+      // If SemanticsService.sendAnnouncement is not supported,
+      // we use live region to achieve the announcement effect instead.
+      _announcementText = message;
     }
   }
 
@@ -886,12 +884,15 @@ class _MonthPickerState extends State<_MonthPicker> {
         DatePickerTheme.of(context).subHeaderForegroundColor ??
         DatePickerTheme.defaults(context).subHeaderForegroundColor;
 
+    final supportsAnnounce = MediaQuery.maybeSupportsAnnounceOf(context) ?? false;
     return Semantics(
       container: true,
       explicitChildNodes: true,
-      liveRegion: Theme.of(context).platform == TargetPlatform.android,
-      accessibilityFocusBlockType: AccessibilityFocusBlockType.blockNode,
-      label: Theme.of(context).platform == TargetPlatform.android ? _announcementText : null,
+      liveRegion: !supportsAnnounce,
+      accessibilityFocusBlockType: !supportsAnnounce
+          ? AccessibilityFocusBlockType.blockNode
+          : AccessibilityFocusBlockType.none,
+      label: !supportsAnnounce ? _announcementText : null,
       child: Column(
         children: <Widget>[
           SizedBox(

--- a/packages/flutter/lib/src/material/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/calendar_date_picker.dart
@@ -201,6 +201,7 @@ class CalendarDatePicker extends StatefulWidget {
 
 class _CalendarDatePickerState extends State<CalendarDatePicker> {
   bool _announcedInitialDate = false;
+  String _announcementText = '';
   late DatePickerMode _mode;
   late DateTime _currentDisplayedMonthDate;
   DateTime? _selectedDate;
@@ -236,11 +237,19 @@ class _CalendarDatePickerState extends State<CalendarDatePicker> {
       _announcedInitialDate = true;
       final bool isToday = widget.calendarDelegate.isSameDay(widget.currentDate, _selectedDate);
       final semanticLabelSuffix = isToday ? ', ${_localizations.currentDateLabel}' : '';
-      SemanticsService.sendAnnouncement(
-        View.of(context),
-        '${_localizations.formatFullDate(_selectedDate!)}$semanticLabelSuffix',
-        _textDirection,
-      );
+      _announce('${_localizations.formatFullDate(_selectedDate!)}$semanticLabelSuffix');
+    }
+  }
+
+  // Auxiliary method for handling the difference between platforms
+  void _announce(String message) {
+    // SemanticsService.sendAnnouncement is deprecated on android.
+    // We use live region to achieve the announcement effect instead.
+    if (Theme.of(context).platform == TargetPlatform.android) {
+      _announcementText = message;
+    } else {
+      // Maintains the mandatory announcement for other platforms
+      SemanticsService.sendAnnouncement(View.of(context), message, Directionality.of(context));
     }
   }
 
@@ -266,7 +275,7 @@ class _CalendarDatePickerState extends State<CalendarDatePicker> {
           DatePickerMode.day => widget.calendarDelegate.formatMonthYear(selected, _localizations),
           DatePickerMode.year => widget.calendarDelegate.formatYear(selected.year, _localizations),
         };
-        SemanticsService.sendAnnouncement(View.of(context), message, _textDirection);
+        _announce(message);
       }
     });
   }
@@ -389,9 +398,22 @@ class _CalendarDatePickerState extends State<CalendarDatePicker> {
     final double scaledMaxDayPickerHeight = textScaleFactor > 1.3
         ? maxDayPickerHeight + ((_maxDayPickerRowCount + 1) * ((textScaleFactor - 1) * 8))
         : maxDayPickerHeight;
+    final picker = SizedBox(
+      height: _subHeaderHeight + scaledMaxDayPickerHeight,
+      child: _buildPicker(),
+    );
     return Stack(
       children: <Widget>[
-        SizedBox(height: _subHeaderHeight + scaledMaxDayPickerHeight, child: _buildPicker()),
+        Theme.of(context).platform == TargetPlatform.android
+            ? Semantics(
+                container: true,
+                liveRegion: true,
+                accessibilityFocusBlockType: AccessibilityFocusBlockType.blockNode,
+                label: _announcementText,
+                child: picker,
+              )
+            : picker,
+
         // Put the mode toggle button on top so that it won't be covered up by the _MonthPicker
         MediaQuery.withClampedTextScaling(
           maxScaleFactor: _kModeToggleButtonMaxScaleFactor,
@@ -594,6 +616,7 @@ class _MonthPicker extends StatefulWidget {
 
 class _MonthPickerState extends State<_MonthPicker> {
   final GlobalKey _pageViewKey = GlobalKey();
+  String _announcementText = '';
   late DateTime _currentMonth;
   late PageController _pageController;
   late MaterialLocalizations _localizations;
@@ -651,6 +674,18 @@ class _MonthPickerState extends State<_MonthPicker> {
     widget.onChanged(selectedDate);
   }
 
+  // Auxiliary method for handling the difference between platforms
+  void _announce(String message) {
+    // SemanticsService.sendAnnouncement is deprecated on android.
+    // We use live region to achieve the announcement effect instead.
+    if (Theme.of(context).platform == TargetPlatform.android) {
+      _announcementText = message;
+    } else {
+      // Maintains the mandatory announcement for other platforms
+      SemanticsService.sendAnnouncement(View.of(context), message, Directionality.of(context));
+    }
+  }
+
   void _handleMonthPageChanged(int monthPage) {
     setState(() {
       final DateTime monthDate = widget.calendarDelegate.addMonthsToMonthDate(
@@ -667,11 +702,7 @@ class _MonthPickerState extends State<_MonthPicker> {
           // the same day of the month.
           _focusedDay = _focusableDayForMonth(_currentMonth, _focusedDay!.day);
         }
-        SemanticsService.sendAnnouncement(
-          View.of(context),
-          widget.calendarDelegate.formatMonthYear(_currentMonth, _localizations),
-          _textDirection,
-        );
+        _announce(widget.calendarDelegate.formatMonthYear(_currentMonth, _localizations));
       }
     });
   }
@@ -858,6 +889,9 @@ class _MonthPickerState extends State<_MonthPicker> {
     return Semantics(
       container: true,
       explicitChildNodes: true,
+      liveRegion: Theme.of(context).platform == TargetPlatform.android,
+      accessibilityFocusBlockType: AccessibilityFocusBlockType.blockNode,
+      label: Theme.of(context).platform == TargetPlatform.android ? _announcementText : null,
       child: Column(
         children: <Widget>[
           SizedBox(

--- a/packages/flutter/test/material/calendar_date_picker_test.dart
+++ b/packages/flutter/test/material/calendar_date_picker_test.dart
@@ -1710,8 +1710,98 @@ void main() {
     });
   });
 
-    group('when supportsAnnounce is true, check announcement ', () {
-    ... add test
+  group('when supportsAnnounce is true, check announcement', () {
+    testWidgets('Initial date announcement', (WidgetTester tester) async {
+      final SemanticsHandle semantics = tester.ensureSemantics();
+      const localizations = DefaultMaterialLocalizations();
+      final initialDate = DateTime(2016, DateTime.january, 15);
+      final String expectedLabel = localizations.formatFullDate(initialDate);
+
+      await tester.pumpWidget(
+        MediaQuery(
+          data: const MediaQueryData(supportsAnnounce: true),
+          child: calendarDatePicker(initialDate: initialDate),
+        ),
+      );
+
+      expect(tester.takeAnnouncements(), [
+        isAccessibilityAnnouncement(expectedLabel, textDirection: TextDirection.ltr),
+      ]);
+
+      semantics.dispose();
+    }, variant: TargetPlatformVariant.only(TargetPlatform.android));
+
+    testWidgets(
+      'Month navigation announcement on Android',
+      (WidgetTester tester) async {
+        final SemanticsHandle semantics = tester.ensureSemantics();
+        final initialDate = DateTime(2016, DateTime.january, 15);
+
+        await tester.pumpWidget(
+          MediaQuery(
+            data: const MediaQueryData(supportsAnnounce: true),
+            child: calendarDatePicker(initialDate: initialDate),
+          ),
+        );
+
+        // Clear any initial announcements.
+        tester.takeAnnouncements();
+
+        // Tap next month.
+        await tester.tap(nextMonthIcon);
+        await tester.pumpAndSettle();
+
+        const String expectedLabel = 'February 2016';
+        expect(tester.takeAnnouncements(), [
+          isAccessibilityAnnouncement(expectedLabel, textDirection: TextDirection.ltr),
+        ]);
+
+        semantics.dispose();
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
+
+    testWidgets(
+      'Mode toggle announcement on Android',
+      (WidgetTester tester) async {
+        final SemanticsHandle semantics = tester.ensureSemantics();
+        final initialDate = DateTime(2016, DateTime.january, 15);
+
+        await tester.pumpWidget(
+          MediaQuery(
+            data: const MediaQueryData(supportsAnnounce: true),
+            child: calendarDatePicker(initialDate: initialDate),
+          ),
+        );
+
+        // Clear any initial announcements.
+        tester.takeAnnouncements();
+
+        // Switch to year mode.
+        final Finder modeToggleButton = find.byWidgetPredicate(
+          (Widget widget) => widget.runtimeType.toString() == '_DatePickerModeToggleButton',
+        );
+        await tester.tap(modeToggleButton);
+        await tester.pumpAndSettle();
+
+        const String yearLabel = '2016';
+        expect(tester.takeAnnouncements(), [
+          isAccessibilityAnnouncement(yearLabel, textDirection: TextDirection.ltr),
+        ]);
+
+        // Switch back to day mode.
+        await tester.tap(modeToggleButton);
+        await tester.pumpAndSettle();
+
+        const String dayLabel = 'January 2016';
+        expect(tester.takeAnnouncements(), [
+          isAccessibilityAnnouncement(dayLabel, textDirection: TextDirection.ltr),
+        ]);
+
+        semantics.dispose();
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
   });
 
   group('when supportsAnnounce is false, use live region to announce', () {

--- a/packages/flutter/test/material/calendar_date_picker_test.dart
+++ b/packages/flutter/test/material/calendar_date_picker_test.dart
@@ -1709,7 +1709,12 @@ void main() {
       expect((innerMaterial as dynamic).debugInkFeatures, hasLength(31));
     });
   });
-  group('live region announcements', () {
+
+    group('when supportsAnnounce is true, check announcement ', () {
+    ... add test
+  });
+
+  group('when supportsAnnounce is false, use live region to announce', () {
     testWidgets('Initial date announcement', (WidgetTester tester) async {
       final SemanticsHandle semantics = tester.ensureSemantics();
       const localizations = DefaultMaterialLocalizations();

--- a/packages/flutter/test/material/calendar_date_picker_test.dart
+++ b/packages/flutter/test/material/calendar_date_picker_test.dart
@@ -1709,30 +1709,34 @@ void main() {
       expect((innerMaterial as dynamic).debugInkFeatures, hasLength(31));
     });
   });
-  group('Android announcements', () {
-    testWidgets(
-      'Initial date announcement on Android',
-      (WidgetTester tester) async {
-        final SemanticsHandle semantics = tester.ensureSemantics();
-        const localizations = DefaultMaterialLocalizations();
-        final initialDate = DateTime(2016, DateTime.january, 15);
-        final String expectedLabel = localizations.formatFullDate(initialDate);
+  group('live region announcements', () {
+    testWidgets('Initial date announcement', (WidgetTester tester) async {
+      final SemanticsHandle semantics = tester.ensureSemantics();
+      const localizations = DefaultMaterialLocalizations();
+      final initialDate = DateTime(2016, DateTime.january, 15);
+      final String expectedLabel = localizations.formatFullDate(initialDate);
 
-        await tester.pumpWidget(calendarDatePicker(initialDate: initialDate));
+      await tester.pumpWidget(
+        MediaQuery(
+          data: MediaQueryData(supportsAnnounce: false),
+          child: calendarDatePicker(initialDate: initialDate),
+        ),
+      );
 
-        // Verify that the live region exists and has the correct label.
-        final Finder liveRegionFinder = find.byWidgetPredicate(
-          (Widget widget) => widget is Semantics && widget.properties.label == expectedLabel && widget.properties.liveRegion == true,
-        );
-        expect(
-          tester.getSemantics(liveRegionFinder),
-          matchesSemantics(label: expectedLabel, isLiveRegion: true),
-        );
+      // Verify that the live region exists and has the correct label.
+      final Finder liveRegionFinder = find.byWidgetPredicate(
+        (Widget widget) =>
+            widget is Semantics &&
+            widget.properties.label == expectedLabel &&
+            widget.properties.liveRegion == true,
+      );
+      expect(
+        tester.getSemantics(liveRegionFinder),
+        matchesSemantics(label: expectedLabel, isLiveRegion: true),
+      );
 
-        semantics.dispose();
-      },
-      variant: TargetPlatformVariant.only(TargetPlatform.android),
-    );
+      semantics.dispose();
+    }, variant: TargetPlatformVariant.only(TargetPlatform.android));
 
     testWidgets(
       'Month navigation announcement on Android',
@@ -1740,7 +1744,12 @@ void main() {
         final SemanticsHandle semantics = tester.ensureSemantics();
         final initialDate = DateTime(2016, DateTime.january, 15);
 
-        await tester.pumpWidget(calendarDatePicker(initialDate: initialDate));
+        await tester.pumpWidget(
+          MediaQuery(
+            data: MediaQueryData(supportsAnnounce: false),
+            child: calendarDatePicker(initialDate: initialDate),
+          ),
+        );
 
         // Tap next month.
         await tester.tap(nextMonthIcon);
@@ -1750,7 +1759,10 @@ void main() {
         // Verify that the live region exists and has the correct label.
         const String expectedLabel = 'February 2016';
         final Finder liveRegionFinder = find.byWidgetPredicate(
-          (Widget widget) => widget is Semantics && widget.properties.label == expectedLabel && widget.properties.liveRegion == true,
+          (Widget widget) =>
+              widget is Semantics &&
+              widget.properties.label == expectedLabel &&
+              widget.properties.liveRegion == true,
         );
         expect(
           tester.getSemantics(liveRegionFinder),
@@ -1768,17 +1780,27 @@ void main() {
         final SemanticsHandle semantics = tester.ensureSemantics();
         final initialDate = DateTime(2016, DateTime.january, 15);
 
-        await tester.pumpWidget(calendarDatePicker(initialDate: initialDate));
+        await tester.pumpWidget(
+          MediaQuery(
+            data: MediaQueryData(supportsAnnounce: false),
+            child: calendarDatePicker(initialDate: initialDate),
+          ),
+        );
 
         // Switch to year mode.
-        final Finder modeToggleButton = find.byWidgetPredicate((Widget widget) => widget.runtimeType.toString() == '_DatePickerModeToggleButton');
+        final Finder modeToggleButton = find.byWidgetPredicate(
+          (Widget widget) => widget.runtimeType.toString() == '_DatePickerModeToggleButton',
+        );
         await tester.tap(modeToggleButton);
         await tester.pumpAndSettle();
 
         // Verify that the live region exists and has the correct label.
         const String yearLabel = '2016';
         final Finder yearLiveRegionFinder = find.byWidgetPredicate(
-          (Widget widget) => widget is Semantics && widget.properties.label == yearLabel && widget.properties.liveRegion == true,
+          (Widget widget) =>
+              widget is Semantics &&
+              widget.properties.label == yearLabel &&
+              widget.properties.liveRegion == true,
         );
         expect(
           tester.getSemantics(yearLiveRegionFinder),
@@ -1792,7 +1814,10 @@ void main() {
         // Verify that the live region exists and has the correct label.
         const String dayLabel = 'January 2016';
         final Finder dayLiveRegionFinder = find.byWidgetPredicate(
-          (Widget widget) => widget is Semantics && widget.properties.label == dayLabel && widget.properties.liveRegion == true,
+          (Widget widget) =>
+              widget is Semantics &&
+              widget.properties.label == dayLabel &&
+              widget.properties.liveRegion == true,
         );
         expect(
           tester.getSemantics(dayLiveRegionFinder),

--- a/packages/flutter/test/material/calendar_date_picker_test.dart
+++ b/packages/flutter/test/material/calendar_date_picker_test.dart
@@ -1751,7 +1751,7 @@ void main() {
         await tester.tap(nextMonthIcon);
         await tester.pumpAndSettle();
 
-        const String expectedLabel = 'February 2016';
+        const expectedLabel = 'February 2016';
         expect(tester.takeAnnouncements(), [
           isAccessibilityAnnouncement(expectedLabel, textDirection: TextDirection.ltr),
         ]);
@@ -1784,7 +1784,7 @@ void main() {
         await tester.tap(modeToggleButton);
         await tester.pumpAndSettle();
 
-        const String yearLabel = '2016';
+        const yearLabel = '2016';
         expect(tester.takeAnnouncements(), [
           isAccessibilityAnnouncement(yearLabel, textDirection: TextDirection.ltr),
         ]);
@@ -1793,7 +1793,7 @@ void main() {
         await tester.tap(modeToggleButton);
         await tester.pumpAndSettle();
 
-        const String dayLabel = 'January 2016';
+        const dayLabel = 'January 2016';
         expect(tester.takeAnnouncements(), [
           isAccessibilityAnnouncement(dayLabel, textDirection: TextDirection.ltr),
         ]);
@@ -1813,7 +1813,7 @@ void main() {
 
       await tester.pumpWidget(
         MediaQuery(
-          data: MediaQueryData(supportsAnnounce: false),
+          data: const MediaQueryData(),
           child: calendarDatePicker(initialDate: initialDate),
         ),
       );
@@ -1823,7 +1823,7 @@ void main() {
         (Widget widget) =>
             widget is Semantics &&
             widget.properties.label == expectedLabel &&
-            widget.properties.liveRegion == true,
+            (widget.properties.liveRegion ?? false),
       );
       expect(
         tester.getSemantics(liveRegionFinder),
@@ -1841,7 +1841,7 @@ void main() {
 
         await tester.pumpWidget(
           MediaQuery(
-            data: MediaQueryData(supportsAnnounce: false),
+            data: const MediaQueryData(),
             child: calendarDatePicker(initialDate: initialDate),
           ),
         );
@@ -1852,12 +1852,12 @@ void main() {
 
         // The _MonthPicker live region should be updated.
         // Verify that the live region exists and has the correct label.
-        const String expectedLabel = 'February 2016';
+        const expectedLabel = 'February 2016';
         final Finder liveRegionFinder = find.byWidgetPredicate(
           (Widget widget) =>
               widget is Semantics &&
               widget.properties.label == expectedLabel &&
-              widget.properties.liveRegion == true,
+              (widget.properties.liveRegion ?? false),
         );
         expect(
           tester.getSemantics(liveRegionFinder),
@@ -1877,7 +1877,7 @@ void main() {
 
         await tester.pumpWidget(
           MediaQuery(
-            data: MediaQueryData(supportsAnnounce: false),
+            data: const MediaQueryData(),
             child: calendarDatePicker(initialDate: initialDate),
           ),
         );
@@ -1890,12 +1890,12 @@ void main() {
         await tester.pumpAndSettle();
 
         // Verify that the live region exists and has the correct label.
-        const String yearLabel = '2016';
+        const yearLabel = '2016';
         final Finder yearLiveRegionFinder = find.byWidgetPredicate(
           (Widget widget) =>
               widget is Semantics &&
               widget.properties.label == yearLabel &&
-              widget.properties.liveRegion == true,
+              (widget.properties.liveRegion ?? false),
         );
         expect(
           tester.getSemantics(yearLiveRegionFinder),
@@ -1907,12 +1907,12 @@ void main() {
         await tester.pumpAndSettle();
 
         // Verify that the live region exists and has the correct label.
-        const String dayLabel = 'January 2016';
+        const dayLabel = 'January 2016';
         final Finder dayLiveRegionFinder = find.byWidgetPredicate(
           (Widget widget) =>
               widget is Semantics &&
               widget.properties.label == dayLabel &&
-              widget.properties.liveRegion == true,
+              (widget.properties.liveRegion ?? false),
         );
         expect(
           tester.getSemantics(dayLiveRegionFinder),

--- a/packages/flutter/test/material/calendar_date_picker_test.dart
+++ b/packages/flutter/test/material/calendar_date_picker_test.dart
@@ -1709,6 +1709,101 @@ void main() {
       expect((innerMaterial as dynamic).debugInkFeatures, hasLength(31));
     });
   });
+  group('Android announcements', () {
+    testWidgets(
+      'Initial date announcement on Android',
+      (WidgetTester tester) async {
+        final SemanticsHandle semantics = tester.ensureSemantics();
+        const localizations = DefaultMaterialLocalizations();
+        final initialDate = DateTime(2016, DateTime.january, 15);
+        final String expectedLabel = localizations.formatFullDate(initialDate);
+
+        await tester.pumpWidget(calendarDatePicker(initialDate: initialDate));
+
+        // Verify that the live region exists and has the correct label.
+        final Finder liveRegionFinder = find.byWidgetPredicate(
+          (Widget widget) => widget is Semantics && widget.properties.label == expectedLabel && widget.properties.liveRegion == true,
+        );
+        expect(
+          tester.getSemantics(liveRegionFinder),
+          matchesSemantics(label: expectedLabel, isLiveRegion: true),
+        );
+
+        semantics.dispose();
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
+
+    testWidgets(
+      'Month navigation announcement on Android',
+      (WidgetTester tester) async {
+        final SemanticsHandle semantics = tester.ensureSemantics();
+        final initialDate = DateTime(2016, DateTime.january, 15);
+
+        await tester.pumpWidget(calendarDatePicker(initialDate: initialDate));
+
+        // Tap next month.
+        await tester.tap(nextMonthIcon);
+        await tester.pumpAndSettle();
+
+        // The _MonthPicker live region should be updated.
+        // Verify that the live region exists and has the correct label.
+        const String expectedLabel = 'February 2016';
+        final Finder liveRegionFinder = find.byWidgetPredicate(
+          (Widget widget) => widget is Semantics && widget.properties.label == expectedLabel && widget.properties.liveRegion == true,
+        );
+        expect(
+          tester.getSemantics(liveRegionFinder),
+          matchesSemantics(label: expectedLabel, isLiveRegion: true),
+        );
+
+        semantics.dispose();
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
+
+    testWidgets(
+      'Mode toggle announcement on Android',
+      (WidgetTester tester) async {
+        final SemanticsHandle semantics = tester.ensureSemantics();
+        final initialDate = DateTime(2016, DateTime.january, 15);
+
+        await tester.pumpWidget(calendarDatePicker(initialDate: initialDate));
+
+        // Switch to year mode.
+        final Finder modeToggleButton = find.byWidgetPredicate((Widget widget) => widget.runtimeType.toString() == '_DatePickerModeToggleButton');
+        await tester.tap(modeToggleButton);
+        await tester.pumpAndSettle();
+
+        // Verify that the live region exists and has the correct label.
+        const String yearLabel = '2016';
+        final Finder yearLiveRegionFinder = find.byWidgetPredicate(
+          (Widget widget) => widget is Semantics && widget.properties.label == yearLabel && widget.properties.liveRegion == true,
+        );
+        expect(
+          tester.getSemantics(yearLiveRegionFinder),
+          matchesSemantics(label: yearLabel, isLiveRegion: true),
+        );
+
+        // Switch back to day mode.
+        await tester.tap(modeToggleButton);
+        await tester.pumpAndSettle();
+
+        // Verify that the live region exists and has the correct label.
+        const String dayLabel = 'January 2016';
+        final Finder dayLiveRegionFinder = find.byWidgetPredicate(
+          (Widget widget) => widget is Semantics && widget.properties.label == dayLabel && widget.properties.liveRegion == true,
+        );
+        expect(
+          tester.getSemantics(dayLiveRegionFinder),
+          matchesSemantics(label: dayLabel, isLiveRegion: true),
+        );
+
+        semantics.dispose();
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
+  });
 
   group('YearPicker', () {
     testWidgets('Current year is visible in year picker', (WidgetTester tester) async {


### PR DESCRIPTION
fix: https://github.com/flutter/flutter/issues/180096 

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
