### PR TITLE
TextField: add code-point mode for maxLength counting

### DIFF
--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -282,6 +282,7 @@ class TextField extends StatefulWidget {
     this.expands = false,
     this.maxLength,
     this.maxLengthEnforcement,
+    this.maxLengthCountType = MaxLengthCountType.characters,
     this.onChanged,
     this.onEditingComplete,
     this.onSubmitted,
@@ -580,6 +581,9 @@ class TextField extends StatefulWidget {
   ///
   /// {@macro flutter.services.textFormatter.maxLengthEnforcement}
   final MaxLengthEnforcement? maxLengthEnforcement;
+
+  /// Determines how text length is counted for [maxLength].
+  final MaxLengthCountType maxLengthCountType;
 
   /// {@macro flutter.widgets.editableText.onChanged}
   ///
@@ -1031,6 +1035,13 @@ class TextField extends StatefulWidget {
       ),
     );
     properties.add(
+      EnumProperty<MaxLengthCountType>(
+        'maxLengthCountType',
+        maxLengthCountType,
+        defaultValue: MaxLengthCountType.characters,
+      ),
+    );
+    properties.add(
       EnumProperty<TextInputAction>('textInputAction', textInputAction, defaultValue: null),
     );
     properties.add(
@@ -1171,14 +1182,17 @@ class _TextFieldState extends State<TextField>
 
   bool get _isEnabled => widget.enabled ?? widget.decoration?.enabled ?? true;
 
-  int get _currentLength => _effectiveController.value.text.characters.length;
+  int get _currentLength => LengthLimitingTextInputFormatter.getTextLength(
+    _effectiveController.value.text,
+    maxLengthCountType: widget.maxLengthCountType,
+  );
 
   bool get _hasIntrinsicError =>
       widget.maxLength != null &&
       widget.maxLength! > 0 &&
       (widget.controller == null
-          ? !restorePending && _effectiveController.value.text.characters.length > widget.maxLength!
-          : _effectiveController.value.text.characters.length > widget.maxLength!);
+          ? !restorePending && _currentLength > widget.maxLength!
+          : _currentLength > widget.maxLength!);
 
   bool get _hasError =>
       widget.decoration?.errorText != null ||
@@ -1545,6 +1559,7 @@ class _TextFieldState extends State<TextField>
         LengthLimitingTextInputFormatter(
           widget.maxLength,
           maxLengthEnforcement: _effectiveMaxLengthEnforcement,
+          maxLengthCountType: widget.maxLengthCountType,
         ),
     ];
 

--- a/packages/flutter/lib/src/services/text_formatter.dart
+++ b/packages/flutter/lib/src/services/text_formatter.dart
@@ -67,6 +67,15 @@ enum MaxLengthEnforcement {
   truncateAfterCompositionEnds,
 }
 
+/// Mechanisms for counting text length when max length is configured.
+enum MaxLengthCountType {
+  /// Count text as user-perceived grapheme clusters.
+  characters,
+
+  /// Count text as Unicode code points.
+  codePoints,
+}
+
 /// A [TextInputFormatter] can be optionally injected into an [EditableText]
 /// to provide as-you-type validation and formatting of the text being edited.
 ///
@@ -448,8 +457,11 @@ class LengthLimitingTextInputFormatter extends TextInputFormatter {
   ///
   /// The [maxLength] must be null, -1 or greater than zero. If it is null or -1
   /// then no limit is enforced.
-  LengthLimitingTextInputFormatter(this.maxLength, {this.maxLengthEnforcement})
-    : assert(maxLength == null || maxLength == -1 || maxLength > 0);
+  LengthLimitingTextInputFormatter(
+    this.maxLength, {
+    this.maxLengthEnforcement,
+    this.maxLengthCountType = MaxLengthCountType.characters,
+  }) : assert(maxLength == null || maxLength == -1 || maxLength > 0);
 
   /// The limit on the number of user-perceived characters that this formatter
   /// will allow.
@@ -496,6 +508,9 @@ class LengthLimitingTextInputFormatter extends TextInputFormatter {
   /// {@macro flutter.services.textFormatter.maxLengthEnforcement}
   final MaxLengthEnforcement? maxLengthEnforcement;
 
+  /// Determines how text length is counted for [maxLength].
+  final MaxLengthCountType maxLengthCountType;
+
   /// Returns a [MaxLengthEnforcement] that follows the specified [platform]'s
   /// convention.
   ///
@@ -531,19 +546,24 @@ class LengthLimitingTextInputFormatter extends TextInputFormatter {
     }
   }
 
-  /// Truncate the given TextEditingValue to maxLength user-perceived
-  /// characters.
-  ///
-  /// See also:
-  ///  * [Dart's characters package](https://pub.dev/packages/characters).
-  ///  * [Dart's documentation on runes and grapheme clusters](https://dart.dev/guides/language/language-tour#runes-and-grapheme-clusters).
+  /// Truncate the given TextEditingValue to maxLength by [maxLengthCountType].
   @visibleForTesting
-  static TextEditingValue truncate(TextEditingValue value, int maxLength) {
-    final iterator = CharacterRange(value.text);
-    if (value.text.characters.length > maxLength) {
-      iterator.expandNext(maxLength);
+  static TextEditingValue truncate(
+    TextEditingValue value,
+    int maxLength, {
+    MaxLengthCountType maxLengthCountType = MaxLengthCountType.characters,
+  }) {
+    final String truncated;
+    switch (maxLengthCountType) {
+      case MaxLengthCountType.characters:
+        final iterator = CharacterRange(value.text);
+        if (value.text.characters.length > maxLength) {
+          iterator.expandNext(maxLength);
+        }
+        truncated = iterator.current;
+      case MaxLengthCountType.codePoints:
+        truncated = String.fromCharCodes(value.text.runes.take(maxLength));
     }
-    final String truncated = iterator.current;
 
     return TextEditingValue(
       text: truncated,
@@ -560,11 +580,25 @@ class LengthLimitingTextInputFormatter extends TextInputFormatter {
     );
   }
 
+  static int getTextLength(
+    String text, {
+    MaxLengthCountType maxLengthCountType = MaxLengthCountType.characters,
+  }) {
+    switch (maxLengthCountType) {
+      case MaxLengthCountType.characters:
+        return text.characters.length;
+      case MaxLengthCountType.codePoints:
+        return text.runes.length;
+    }
+  }
+
   @override
   TextEditingValue formatEditUpdate(TextEditingValue oldValue, TextEditingValue newValue) {
     final int? maxLength = this.maxLength;
 
-    if (maxLength == null || maxLength == -1 || newValue.text.characters.length <= maxLength) {
+    if (maxLength == null ||
+        maxLength == -1 ||
+        getTextLength(newValue.text, maxLengthCountType: maxLengthCountType) <= maxLength) {
       return newValue;
     }
 
@@ -576,16 +610,18 @@ class LengthLimitingTextInputFormatter extends TextInputFormatter {
       case MaxLengthEnforcement.enforced:
         // If already at the maximum and tried to enter even more, and has no
         // selection, keep the old value.
-        if (oldValue.text.characters.length == maxLength && oldValue.selection.isCollapsed) {
+        if (getTextLength(oldValue.text, maxLengthCountType: maxLengthCountType) == maxLength &&
+            oldValue.selection.isCollapsed) {
           return oldValue;
         }
 
         // Enforced to return a truncated value.
-        return truncate(newValue, maxLength);
+        return truncate(newValue, maxLength, maxLengthCountType: maxLengthCountType);
       case MaxLengthEnforcement.truncateAfterCompositionEnds:
         // If already at the maximum and tried to enter even more, and the old
         // value is not composing, keep the old value.
-        if (oldValue.text.characters.length == maxLength && !oldValue.composing.isValid) {
+        if (getTextLength(oldValue.text, maxLengthCountType: maxLengthCountType) == maxLength &&
+            !oldValue.composing.isValid) {
           return oldValue;
         }
 
@@ -596,7 +632,7 @@ class LengthLimitingTextInputFormatter extends TextInputFormatter {
           return newValue;
         }
 
-        return truncate(newValue, maxLength);
+        return truncate(newValue, maxLength, maxLengthCountType: maxLengthCountType);
     }
   }
 }

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -6936,6 +6936,26 @@ void main() {
     expect(find.text('1/10'), findsOneWidget);
   });
 
+  testWidgets('maxLength counter can measure Unicode code points', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Material(
+          child: Center(
+            child: TextField(maxLength: 10, maxLengthCountType: MaxLengthCountType.codePoints),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('0/10'), findsOneWidget);
+
+    const familyEmoji = '👨👩👦';
+    await tester.enterText(find.byType(TextField), familyEmoji);
+    await tester.pump();
+
+    expect(find.text('3/10'), findsOneWidget);
+  });
+
   testWidgets('setting maxLength to TextField.noMaxLength shows only entered length', (
     WidgetTester tester,
   ) async {

--- a/packages/flutter/test/services/text_formatter_test.dart
+++ b/packages/flutter/test/services/text_formatter_test.dart
@@ -439,6 +439,17 @@ void main() {
         expect(truncated.selection.baseOffset, stringTruncated.length);
         expect(truncated.selection.extentOffset, stringTruncated.length);
       });
+
+      test('Can count as Unicode code points', () async {
+        const stringOverflowing = 'o\u03081234567890';
+        const value = TextEditingValue(text: stringOverflowing);
+        final TextEditingValue truncated = LengthLimitingTextInputFormatter.truncate(
+          value,
+          10,
+          maxLengthCountType: MaxLengthCountType.codePoints,
+        );
+        expect(truncated.text, 'o\u030812345678');
+      });
     });
 
     group('formatEditUpdate', () {
@@ -466,6 +477,17 @@ void main() {
         final formatter = LengthLimitingTextInputFormatter(maxLength);
         final TextEditingValue formatted = formatter.formatEditUpdate(oldValue, newValue);
         expect(formatted.text, 'bbbbbbbbbb');
+      });
+
+      test('Can enforce maxLength using code points', () async {
+        const oldValue = TextEditingValue(text: '');
+        const newValue = TextEditingValue(text: 'o\u03081234567890');
+        final formatter = LengthLimitingTextInputFormatter(
+          maxLength,
+          maxLengthCountType: MaxLengthCountType.codePoints,
+        );
+        final TextEditingValue formatted = formatter.formatEditUpdate(oldValue, newValue);
+        expect(formatted.text, 'o\u030812345678');
       });
     });
 


### PR DESCRIPTION
Part of #182907

## Problem
`TextField.maxLength` currently counts user-perceived grapheme clusters only. Some apps need client-side validation based on Unicode code points to match server-side constraints.

## Fix
- Add `MaxLengthCountType` with:
  - `characters` (default, existing behavior)
  - `codePoints`
- Extend `LengthLimitingTextInputFormatter` with `maxLengthCountType` and use it for:
  - counting current length
  - truncation behavior
  - max-length enforcement checks
- Add `TextField.maxLengthCountType` and wire it into:
  - intrinsic error state
  - counter display
  - internal `LengthLimitingTextInputFormatter`

## Impact
- Existing apps keep current behavior by default.
- Apps can opt into code-point counting to align with backend validation rules.
- Counter and enforcement remain consistent under the selected counting mode.

## Validation
- `./bin/flutter --suppress-analytics test packages/flutter/test/services/text_formatter_test.dart --plain-name "Can count as Unicode code points"`
- `./bin/flutter --suppress-analytics test packages/flutter/test/services/text_formatter_test.dart --plain-name "Can enforce maxLength using code points"`
- `./bin/flutter --suppress-analytics test packages/flutter/test/material/text_field_test.dart --plain-name "maxLength counter can measure Unicode code points"`
- All passed.
