### PR TITLE
a11y: expose selectable paragraph semantics as read-only text field

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1225,6 +1225,12 @@ class RenderParagraph extends RenderBox
       config.attributedLabel = _cachedAttributedLabels![0];
       config.textDirection = textDirection;
     }
+
+    if (_registrar != null) {
+      config
+        ..isTextField = true
+        ..isReadOnly = true;
+    }
   }
 
   ChildSemanticsConfigurationsResult _childSemanticsConfigurationsDelegate(

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1226,7 +1226,7 @@ class RenderParagraph extends RenderBox
       config.textDirection = textDirection;
     }
 
-    if (_registrar != null) {
+    if (_registrar != null && !needsAssembleSemanticsNode && !needsChildConfigurationsDelegate) {
       config
         ..isTextField = true
         ..isReadOnly = true;

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -1015,6 +1015,23 @@ void main() {
       expect(config.isReadOnly, isTrue);
     });
 
+    test('does not expose text-field semantics when rich text needs child semantics', () {
+      final registrar = TestSelectionRegistrar();
+      final gestureRecognizer = TapGestureRecognizer()..onTap = () {};
+      addTearDown(gestureRecognizer.dispose);
+      final paragraph = RenderParagraph(
+        TextSpan(text: 'hello world', recognizer: gestureRecognizer),
+        textDirection: TextDirection.ltr,
+        registrar: registrar,
+      );
+
+      final SemanticsConfiguration config = SemanticsConfiguration();
+      paragraph.describeSemanticsConfiguration(config);
+
+      expect(config.isTextField, isFalse);
+      expect(config.isReadOnly, isFalse);
+    });
+
     test('paints selection highlight', () async {
       final registrar = TestSelectionRegistrar();
       const selectionColor = Color(0xAF6694e8);

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -1008,7 +1008,7 @@ void main() {
         registrar: registrar,
       );
 
-      final SemanticsConfiguration config = SemanticsConfiguration();
+      final config = SemanticsConfiguration();
       paragraph.describeSemanticsConfiguration(config);
 
       expect(config.isTextField, isTrue);
@@ -1025,7 +1025,7 @@ void main() {
         registrar: registrar,
       );
 
-      final SemanticsConfiguration config = SemanticsConfiguration();
+      final config = SemanticsConfiguration();
       paragraph.describeSemanticsConfiguration(config);
 
       expect(config.isTextField, isFalse);

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -1000,6 +1000,21 @@ void main() {
       expect(registrar.selectables.length, 0);
     });
 
+    test('exposes selectable paragraph semantics as read-only text field', () {
+      final registrar = TestSelectionRegistrar();
+      final paragraph = RenderParagraph(
+        const TextSpan(text: 'hello world'),
+        textDirection: TextDirection.ltr,
+        registrar: registrar,
+      );
+
+      final SemanticsConfiguration config = SemanticsConfiguration();
+      paragraph.describeSemanticsConfiguration(config);
+
+      expect(config.isTextField, isTrue);
+      expect(config.isReadOnly, isTrue);
+    });
+
     test('paints selection highlight', () async {
       final registrar = TestSelectionRegistrar();
       const selectionColor = Color(0xAF6694e8);


### PR DESCRIPTION
Part of #182909

## Problem
`SelectableRegion` text could be exposed to assistive technologies as plain static text semantics, which can cause screen readers to treat it as not selectable.

## Fix
- In `RenderParagraph.describeSemanticsConfiguration`, when the paragraph participates in selection (`registrar != null`), expose semantics as:
  - `isTextField = true`
  - `isReadOnly = true`
- Added rendering test coverage to verify selectable paragraph semantics are exposed as a read-only text field.

## Impact
- Improves accessibility semantics for selectable text regions.
- Helps screen readers identify selectable text context more accurately without making it editable.
- Existing non-selectable paragraphs are unchanged.

## Validation
- `./bin/flutter --suppress-analytics test packages/flutter/test/rendering/paragraph_test.dart --plain-name "exposes selectable paragraph semantics as read-only text field"`
- `./bin/flutter --suppress-analytics test packages/flutter/test/rendering/paragraph_test.dart --plain-name "subscribe to SelectionRegistrar"`
- All passed.

