### PR TITLE
Support mixed color spaces in `Color.lerp`

### DIFF
--- a/engine/src/flutter/lib/ui/painting.dart
+++ b/engine/src/flutter/lib/ui/painting.dart
@@ -436,22 +436,19 @@ class Color {
     } else {
       if (x == null) {
         return _scaleAlpha(y, t);
-      } else if (x.colorSpace == y.colorSpace) {
-        return Color.from(
-          alpha: clampDouble(_lerpDouble(x.a, y.a, t), 0, 1),
-          red: clampDouble(_lerpDouble(x.r, y.r, t), 0, 1),
-          green: clampDouble(_lerpDouble(x.g, y.g, t), 0, 1),
-          blue: clampDouble(_lerpDouble(x.b, y.b, t), 0, 1),
-          colorSpace: x.colorSpace,
-        );
       } else {
-        final ColorSpace resultColorSpace = _widerColorSpace(x.colorSpace, y.colorSpace);
-        final Color a = x.colorSpace == resultColorSpace
-            ? x
-            : x.withValues(colorSpace: resultColorSpace);
-        final Color b = y.colorSpace == resultColorSpace
-            ? y
-            : y.withValues(colorSpace: resultColorSpace);
+        final Color a;
+        final Color b;
+        final ColorSpace resultColorSpace;
+        if (x.colorSpace == y.colorSpace) {
+          a = x;
+          b = y;
+          resultColorSpace = x.colorSpace;
+        } else {
+          resultColorSpace = _widerColorSpace(x.colorSpace, y.colorSpace);
+          a = x.withValues(colorSpace: resultColorSpace);
+          b = y.withValues(colorSpace: resultColorSpace);
+        }
         return Color.from(
           alpha: clampDouble(_lerpDouble(a.a, b.a, t), 0, 1),
           red: clampDouble(_lerpDouble(a.r, b.r, t), 0, 1),

--- a/engine/src/flutter/lib/ui/painting.dart
+++ b/engine/src/flutter/lib/ui/painting.dart
@@ -57,9 +57,6 @@ Color _scaleAlpha(Color x, double factor) {
   return x.withValues(alpha: clampDouble(x.a * factor, 0, 1));
 }
 
-/// Returns the wider of two color spaces.
-///
-/// Display P3 is considered wider than sRGB.
 ColorSpace _widerColorSpace(ColorSpace a, ColorSpace b) {
   return a == ColorSpace.displayP3 || b == ColorSpace.displayP3 ? ColorSpace.displayP3 : a;
 }

--- a/engine/src/flutter/lib/ui/painting.dart
+++ b/engine/src/flutter/lib/ui/painting.dart
@@ -57,6 +57,13 @@ Color _scaleAlpha(Color x, double factor) {
   return x.withValues(alpha: clampDouble(x.a * factor, 0, 1));
 }
 
+/// Returns the wider of two color spaces.
+///
+/// Display P3 is considered wider than sRGB.
+ColorSpace _widerColorSpace(ColorSpace a, ColorSpace b) {
+  return a == ColorSpace.displayP3 || b == ColorSpace.displayP3 ? ColorSpace.displayP3 : a;
+}
+
 /// An immutable color value in ARGB format.
 ///
 /// Consider the light teal of the [Flutter logo](https://flutter.dev/brand). It
@@ -412,6 +419,11 @@ class Color {
   ///
   /// Values for `t` are usually obtained from an [Animation<double>], such as
   /// an [AnimationController].
+  ///
+  /// If the two colors are in different color spaces, both are converted to
+  /// the wider gamut color space before interpolating. The result will be in
+  /// the wider gamut color space. For example, interpolating between an sRGB
+  /// color and a Display P3 color will produce a Display P3 result.
   static Color? lerp(Color? x, Color? y, double t) {
     assert(x?.colorSpace != ColorSpace.extendedSRGB);
     assert(y?.colorSpace != ColorSpace.extendedSRGB);
@@ -424,14 +436,28 @@ class Color {
     } else {
       if (x == null) {
         return _scaleAlpha(y, t);
-      } else {
-        assert(x.colorSpace == y.colorSpace);
+      } else if (x.colorSpace == y.colorSpace) {
         return Color.from(
           alpha: clampDouble(_lerpDouble(x.a, y.a, t), 0, 1),
           red: clampDouble(_lerpDouble(x.r, y.r, t), 0, 1),
           green: clampDouble(_lerpDouble(x.g, y.g, t), 0, 1),
           blue: clampDouble(_lerpDouble(x.b, y.b, t), 0, 1),
           colorSpace: x.colorSpace,
+        );
+      } else {
+        final ColorSpace resultColorSpace = _widerColorSpace(x.colorSpace, y.colorSpace);
+        final Color a = x.colorSpace == resultColorSpace
+            ? x
+            : x.withValues(colorSpace: resultColorSpace);
+        final Color b = y.colorSpace == resultColorSpace
+            ? y
+            : y.withValues(colorSpace: resultColorSpace);
+        return Color.from(
+          alpha: clampDouble(_lerpDouble(a.a, b.a, t), 0, 1),
+          red: clampDouble(_lerpDouble(a.r, b.r, t), 0, 1),
+          green: clampDouble(_lerpDouble(a.g, b.g, t), 0, 1),
+          blue: clampDouble(_lerpDouble(a.b, b.b, t), 0, 1),
+          colorSpace: resultColorSpace,
         );
       }
     }

--- a/engine/src/flutter/lib/web_ui/lib/painting.dart
+++ b/engine/src/flutter/lib/web_ui/lib/painting.dart
@@ -21,6 +21,10 @@ Color _scaleAlpha(Color x, double factor) {
   return x.withValues(alpha: (x.a * factor).clamp(0, 1));
 }
 
+ColorSpace _widerColorSpace(ColorSpace a, ColorSpace b) {
+  return a == ColorSpace.displayP3 || b == ColorSpace.displayP3 ? ColorSpace.displayP3 : a;
+}
+
 class Color {
   const Color(int value)
     : this._fromARGBC(value >> 24, value >> 16, value >> 8, value, ColorSpace.sRGB);
@@ -157,14 +161,28 @@ class Color {
     } else {
       if (x == null) {
         return _scaleAlpha(y, t);
-      } else {
-        assert(x.colorSpace == y.colorSpace);
+      } else if (x.colorSpace == y.colorSpace) {
         return Color.from(
           alpha: _lerpDouble(x.a, y.a, t).clamp(0, 1),
           red: _lerpDouble(x.r, y.r, t).clamp(0, 1),
           green: _lerpDouble(x.g, y.g, t).clamp(0, 1),
           blue: _lerpDouble(x.b, y.b, t).clamp(0, 1),
           colorSpace: x.colorSpace,
+        );
+      } else {
+        final ColorSpace resultColorSpace = _widerColorSpace(x.colorSpace, y.colorSpace);
+        final Color a = x.colorSpace == resultColorSpace
+            ? x
+            : x.withValues(colorSpace: resultColorSpace);
+        final Color b = y.colorSpace == resultColorSpace
+            ? y
+            : y.withValues(colorSpace: resultColorSpace);
+        return Color.from(
+          alpha: _lerpDouble(a.a, b.a, t).clamp(0, 1),
+          red: _lerpDouble(a.r, b.r, t).clamp(0, 1),
+          green: _lerpDouble(a.g, b.g, t).clamp(0, 1),
+          blue: _lerpDouble(a.b, b.b, t).clamp(0, 1),
+          colorSpace: resultColorSpace,
         );
       }
     }

--- a/engine/src/flutter/lib/web_ui/lib/painting.dart
+++ b/engine/src/flutter/lib/web_ui/lib/painting.dart
@@ -161,22 +161,19 @@ class Color {
     } else {
       if (x == null) {
         return _scaleAlpha(y, t);
-      } else if (x.colorSpace == y.colorSpace) {
-        return Color.from(
-          alpha: _lerpDouble(x.a, y.a, t).clamp(0, 1),
-          red: _lerpDouble(x.r, y.r, t).clamp(0, 1),
-          green: _lerpDouble(x.g, y.g, t).clamp(0, 1),
-          blue: _lerpDouble(x.b, y.b, t).clamp(0, 1),
-          colorSpace: x.colorSpace,
-        );
       } else {
-        final ColorSpace resultColorSpace = _widerColorSpace(x.colorSpace, y.colorSpace);
-        final Color a = x.colorSpace == resultColorSpace
-            ? x
-            : x.withValues(colorSpace: resultColorSpace);
-        final Color b = y.colorSpace == resultColorSpace
-            ? y
-            : y.withValues(colorSpace: resultColorSpace);
+        final Color a;
+        final Color b;
+        final ColorSpace resultColorSpace;
+        if (x.colorSpace == y.colorSpace) {
+          a = x;
+          b = y;
+          resultColorSpace = x.colorSpace;
+        } else {
+          resultColorSpace = _widerColorSpace(x.colorSpace, y.colorSpace);
+          a = x.withValues(colorSpace: resultColorSpace);
+          b = y.withValues(colorSpace: resultColorSpace);
+        }
         return Color.from(
           alpha: _lerpDouble(a.a, b.a, t).clamp(0, 1),
           red: _lerpDouble(a.r, b.r, t).clamp(0, 1),

--- a/engine/src/flutter/testing/dart/color_test.dart
+++ b/engine/src/flutter/testing/dart/color_test.dart
@@ -102,20 +102,6 @@ void main() {
     );
   });
 
-  test('Color.lerp different colorspaces', () {
-    var didThrow = false;
-    try {
-      Color.lerp(
-        const Color.from(alpha: 1, red: 1, green: 0, blue: 0, colorSpace: ColorSpace.displayP3),
-        const Color.from(alpha: 1, red: 1, green: 0, blue: 0),
-        0.0,
-      );
-    } catch (ex) {
-      didThrow = true;
-    }
-    expect(didThrow, isTrue);
-  });
-
   test('Color.lerp same colorspaces', () {
     expect(
       Color.lerp(
@@ -127,6 +113,79 @@ void main() {
         const Color.from(alpha: 1, red: 0.2, green: 0, blue: 0, colorSpace: ColorSpace.displayP3),
       ),
     );
+  });
+
+  test('Color.lerp mixed colorspaces produces displayP3 result', () {
+    final Color? result = Color.lerp(
+      const Color.from(alpha: 1, red: 1, green: 0, blue: 0, colorSpace: ColorSpace.displayP3),
+      const Color.from(alpha: 1, red: 0, green: 0, blue: 1),
+      0.0,
+    );
+    expect(result!.colorSpace, equals(ColorSpace.displayP3));
+  });
+
+  test('Color.lerp mixed colorspaces sRGB x and displayP3 y at t=0', () {
+    final Color? result = Color.lerp(
+      const Color.from(alpha: 1, red: 1, green: 0, blue: 0),
+      const Color.from(alpha: 1, red: 0, green: 1, blue: 0, colorSpace: ColorSpace.displayP3),
+      0.0,
+    );
+    expect(result!.colorSpace, equals(ColorSpace.displayP3));
+    final Color expectedP3 = const Color.from(
+      alpha: 1,
+      red: 1,
+      green: 0,
+      blue: 0,
+    ).withValues(colorSpace: ColorSpace.displayP3);
+    expect(result, colorMatches(expectedP3));
+  });
+
+  test('Color.lerp mixed colorspaces displayP3 x and sRGB y at t=1', () {
+    final Color? result = Color.lerp(
+      const Color.from(alpha: 1, red: 0, green: 1, blue: 0, colorSpace: ColorSpace.displayP3),
+      const Color.from(alpha: 1, red: 1, green: 0, blue: 0),
+      1.0,
+    );
+    expect(result!.colorSpace, equals(ColorSpace.displayP3));
+    final Color expectedP3 = const Color.from(
+      alpha: 1,
+      red: 1,
+      green: 0,
+      blue: 0,
+    ).withValues(colorSpace: ColorSpace.displayP3);
+    expect(result, colorMatches(expectedP3));
+  });
+
+  test('Color.lerp mixed colorspaces at midpoint', () {
+    const Color srgbRed = Color.from(alpha: 1, red: 1, green: 0, blue: 0);
+    const Color p3Green = Color.from(
+      alpha: 1,
+      red: 0,
+      green: 1,
+      blue: 0,
+      colorSpace: ColorSpace.displayP3,
+    );
+    final Color? result = Color.lerp(srgbRed, p3Green, 0.5);
+    expect(result!.colorSpace, equals(ColorSpace.displayP3));
+    final Color srgbRedAsP3 = srgbRed.withValues(colorSpace: ColorSpace.displayP3);
+    expect(result.a, closeTo((srgbRedAsP3.a + p3Green.a) / 2, 1e-4));
+    expect(result.r, closeTo((srgbRedAsP3.r + p3Green.r) / 2, 1e-4));
+    expect(result.g, closeTo((srgbRedAsP3.g + p3Green.g) / 2, 1e-4));
+    expect(result.b, closeTo((srgbRedAsP3.b + p3Green.b) / 2, 1e-4));
+  });
+
+  test('Color.lerp mixed colorspaces with different alpha values', () {
+    const Color srgbColor = Color.from(alpha: 0.5, red: 1, green: 0, blue: 0);
+    const Color p3Color = Color.from(
+      alpha: 1,
+      red: 0,
+      green: 0,
+      blue: 1,
+      colorSpace: ColorSpace.displayP3,
+    );
+    final Color? result = Color.lerp(srgbColor, p3Color, 0.5);
+    expect(result!.colorSpace, equals(ColorSpace.displayP3));
+    expect(result.a, closeTo(0.75, 1e-4));
   });
 
   test('Color.alphaBlend', () {

--- a/engine/src/flutter/testing/dart/color_test.dart
+++ b/engine/src/flutter/testing/dart/color_test.dart
@@ -157,8 +157,8 @@ void main() {
   });
 
   test('Color.lerp mixed colorspaces at midpoint', () {
-    const Color srgbRed = Color.from(alpha: 1, red: 1, green: 0, blue: 0);
-    const Color p3Green = Color.from(
+    const srgbRed = Color.from(alpha: 1, red: 1, green: 0, blue: 0);
+    const p3Green = Color.from(
       alpha: 1,
       red: 0,
       green: 1,
@@ -168,7 +168,7 @@ void main() {
     final Color? result = Color.lerp(srgbRed, p3Green, 0.5);
     expect(result!.colorSpace, equals(ColorSpace.displayP3));
     final Color srgbRedAsP3 = srgbRed.withValues(colorSpace: ColorSpace.displayP3);
-    final Color expected = Color.from(
+    final expected = Color.from(
       alpha: (srgbRedAsP3.a + p3Green.a) / 2,
       red: (srgbRedAsP3.r + p3Green.r) / 2,
       green: (srgbRedAsP3.g + p3Green.g) / 2,
@@ -179,8 +179,8 @@ void main() {
   });
 
   test('Color.lerp mixed colorspaces with different alpha values', () {
-    const Color srgbColor = Color.from(alpha: 0.5, red: 1, green: 0, blue: 0);
-    const Color p3Color = Color.from(
+    const srgbColor = Color.from(alpha: 0.5, red: 1, green: 0, blue: 0);
+    const p3Color = Color.from(
       alpha: 1,
       red: 0,
       green: 0,

--- a/engine/src/flutter/testing/dart/color_test.dart
+++ b/engine/src/flutter/testing/dart/color_test.dart
@@ -168,10 +168,14 @@ void main() {
     final Color? result = Color.lerp(srgbRed, p3Green, 0.5);
     expect(result!.colorSpace, equals(ColorSpace.displayP3));
     final Color srgbRedAsP3 = srgbRed.withValues(colorSpace: ColorSpace.displayP3);
-    expect(result.a, closeTo((srgbRedAsP3.a + p3Green.a) / 2, 1e-4));
-    expect(result.r, closeTo((srgbRedAsP3.r + p3Green.r) / 2, 1e-4));
-    expect(result.g, closeTo((srgbRedAsP3.g + p3Green.g) / 2, 1e-4));
-    expect(result.b, closeTo((srgbRedAsP3.b + p3Green.b) / 2, 1e-4));
+    final Color expected = Color.from(
+      alpha: (srgbRedAsP3.a + p3Green.a) / 2,
+      red: (srgbRedAsP3.r + p3Green.r) / 2,
+      green: (srgbRedAsP3.g + p3Green.g) / 2,
+      blue: (srgbRedAsP3.b + p3Green.b) / 2,
+      colorSpace: ColorSpace.displayP3,
+    );
+    expect(result, colorMatches(expected, threshold: 1e-4));
   });
 
   test('Color.lerp mixed colorspaces with different alpha values', () {


### PR DESCRIPTION
Instead of asserting that both colors must share the same color space, Color.lerp now converts both colors to the wider gamut color space before interpolating. For example, lerping between an sRGB color and a Display P3 color produces a Display P3 result.

Instead of asserting that both colors must share the same color space, Color.lerp now converts both colors to the wider gamut color space before interpolating. For example, lerping between an sRGB color and a Display P3 color produces a Display P3 result.

Fixes: #182777

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.