### PR TITLE
Add calls to await `flutterDriver.waitUntilFirstFrameRasterized()` for all `android_engine_test` screenshot tests

### DIFF
--- a/dev/integration_tests/android_engine_test/test_driver/external_texture/surface_producer_smiley_face_main_test.dart
+++ b/dev/integration_tests/android_engine_test/test_driver/external_texture/surface_producer_smiley_face_main_test.dart
@@ -34,6 +34,7 @@ void main() async {
     flutterDriver = await FlutterDriver.connect();
     nativeDriver = await AndroidNativeDriver.connect(flutterDriver);
     await nativeDriver.configureForScreenshotTesting();
+    await flutterDriver.waitUntilFirstFrameRasterized();
   });
 
   tearDownAll(() async {

--- a/dev/integration_tests/android_engine_test/test_driver/external_texture/surface_texture_smiley_face_main_test.dart
+++ b/dev/integration_tests/android_engine_test/test_driver/external_texture/surface_texture_smiley_face_main_test.dart
@@ -33,6 +33,7 @@ void main() async {
     flutterDriver = await FlutterDriver.connect();
     nativeDriver = await AndroidNativeDriver.connect(flutterDriver);
     await nativeDriver.configureForScreenshotTesting();
+    await flutterDriver.waitUntilFirstFrameRasterized();
   });
 
   tearDownAll(() async {

--- a/dev/integration_tests/android_engine_test/test_driver/flutter_rendered_blue_rectangle_main_test.dart
+++ b/dev/integration_tests/android_engine_test/test_driver/flutter_rendered_blue_rectangle_main_test.dart
@@ -33,6 +33,7 @@ void main() async {
     flutterDriver = await FlutterDriver.connect();
     nativeDriver = await AndroidNativeDriver.connect(flutterDriver);
     await nativeDriver.configureForScreenshotTesting();
+    await flutterDriver.waitUntilFirstFrameRasterized();
   });
 
   tearDownAll(() async {

--- a/dev/integration_tests/android_engine_test/test_driver/hcpp/tap_color_change_main_test.dart
+++ b/dev/integration_tests/android_engine_test/test_driver/hcpp/tap_color_change_main_test.dart
@@ -37,6 +37,7 @@ void main() async {
     flutterDriver = await FlutterDriver.connect();
     nativeDriver = await AndroidNativeDriver.connect(flutterDriver);
     await nativeDriver.configureForScreenshotTesting();
+    await flutterDriver.waitUntilFirstFrameRasterized();
   });
 
   tearDownAll(() async {

--- a/dev/integration_tests/android_engine_test/test_driver/platform_view/hide_show_hide_main_test.dart
+++ b/dev/integration_tests/android_engine_test/test_driver/platform_view/hide_show_hide_main_test.dart
@@ -20,6 +20,7 @@ void main() async {
     flutterDriver = await FlutterDriver.connect();
     nativeDriver = await AndroidNativeDriver.connect(flutterDriver);
     await nativeDriver.configureForScreenshotTesting();
+    await flutterDriver.waitUntilFirstFrameRasterized();
   });
 
   tearDownAll(() async {

--- a/dev/integration_tests/android_engine_test/test_driver/platform_view_tap_color_change_main_test.dart
+++ b/dev/integration_tests/android_engine_test/test_driver/platform_view_tap_color_change_main_test.dart
@@ -33,6 +33,7 @@ void main() async {
     flutterDriver = await FlutterDriver.connect();
     nativeDriver = await AndroidNativeDriver.connect(flutterDriver);
     await nativeDriver.configureForScreenshotTesting();
+    await flutterDriver.waitUntilFirstFrameRasterized();
   });
 
   tearDownAll(() async {


### PR DESCRIPTION
Speculative fix for flakes where we see a full black screen image in the golden tests from time to time ([for example](https://flutter-gold.skia.org/detail?grouping=name%3Dandroid_engine_test.vulkan.platform_view_tap_color_change_initial%26source_type%3Dflutter&digest=5ba6df7acef516f7dab78587cf30ce20)). I don't have solid proof, but I've only ever seen those cases happen in this set of tests, which all are missing a call to `flutterDriver.waitUntilFirstFrameRasterized()`.

Even if the change doesn't fix the problem, it abstractly makes more sense to me to wait for the first frame to be rasterized before we go off trying to screenshot anything anyways, so I would not regret this change even if it does nothing.
