### PR TITLE
[Android] Avoid plugin auto-registration during FlutterFragmentActivity recreate timing window

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
@@ -744,7 +744,17 @@ public class FlutterFragmentActivity extends FragmentActivity
    */
   @Override
   public void configureFlutterEngine(@NonNull FlutterEngine flutterEngine) {
-    if (flutterFragment != null && flutterFragment.isFlutterEngineInjected()) {
+    FlutterFragment attachedFlutterFragment = flutterFragment;
+    if (attachedFlutterFragment == null) {
+      // During activity recreation, `FragmentManager` may restore and attach an existing
+      // `FlutterFragment` before `ensureFlutterFragmentCreated()` refreshes the
+      // `flutterFragment` field.
+      // Query by tag here so plugin auto-registration can still honor the injected-engine guard.
+      // Keep `flutterFragment` field ownership in `ensureFlutterFragmentCreated()`; this lookup
+      // only informs the guard.
+      attachedFlutterFragment = retrieveExistingFlutterFragmentIfPossible();
+    }
+    if (attachedFlutterFragment != null && attachedFlutterFragment.isFlutterEngineInjected()) {
       // If the FlutterEngine was explicitly built and injected into this FlutterActivity, the
       // builder should explicitly decide whether to automatically register plugins via the
       // FlutterEngine's construction parameter or via the AndroidManifest metadata.

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
@@ -260,6 +260,48 @@ public class FlutterFragmentActivityTest {
   }
 
   @Test
+  public void configureFlutterEngine_doesNotRegisterPluginsWhenRecoveredInjectedFragmentIsFound() {
+    FlutterFragmentActivityWithProvidedEngine activity =
+        spy(Robolectric.buildActivity(FlutterFragmentActivityWithProvidedEngine.class).get());
+
+    FlutterFragment fragment = mock(FlutterFragment.class);
+    when(fragment.isFlutterEngineInjected()).thenReturn(true);
+    when(activity.retrieveExistingFlutterFragmentIfPossible()).thenReturn(fragment);
+
+    FlutterEngine engine = mock(FlutterEngine.class);
+    activity.configureFlutterEngine(engine);
+
+    assertTrue(GeneratedPluginRegistrant.getRegisteredEngines().isEmpty());
+  }
+
+  @Test
+  public void recreate_withCachedEngine_doesNotRegisterPlugins() {
+    FlutterLoader mockFlutterLoader = mock(FlutterLoader.class);
+    FlutterJNI mockFlutterJni = mock(FlutterJNI.class);
+    when(mockFlutterJni.isAttached()).thenReturn(true);
+    when(mockFlutterLoader.automaticallyRegisterPlugins()).thenReturn(false);
+
+    FlutterEngine cachedEngine =
+        new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni, new String[] {}, false);
+    final String cachedEngineId = "recreate_cached_engine";
+    FlutterEngineCache.getInstance().put(cachedEngineId, cachedEngine);
+    Intent intent = FlutterFragmentActivity.withCachedEngine(cachedEngineId).build(ctx);
+
+    try (ActivityScenario<FlutterFragmentActivity> scenario = ActivityScenario.launch(intent)) {
+      scenario.onActivity(
+          activity -> assertTrue(GeneratedPluginRegistrant.getRegisteredEngines().isEmpty()));
+
+      scenario.recreate();
+
+      scenario.onActivity(
+          activity -> assertTrue(GeneratedPluginRegistrant.getRegisteredEngines().isEmpty()));
+    } finally {
+      FlutterEngineCache.getInstance().remove(cachedEngineId);
+      cachedEngine.destroy();
+    }
+  }
+
+  @Test
   @Config(minSdk = Build.API_LEVELS.API_34)
   @TargetApi(Build.API_LEVELS.API_34)
   public void whenUsingCachedEngine_predictiveBackStateIsSaved() {


### PR DESCRIPTION


<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

This PR fixes an Android embedding timing issue in `FlutterFragmentActivity` during Activity recreation.

When an Activity is being recreated, `FragmentManager` can restore/attach an existing `FlutterFragment` before `ensureFlutterFragmentCreated()` refreshes the `flutterFragment` field.  
In that window, `configureFlutterEngine()` may run with `flutterFragment == null`, miss the injected-engine guard, and incorrectly call `GeneratedPluginRegister.registerGeneratedPlugins(...)`.

That can lead to unintended plugin lifecycle behavior in real apps.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
