### PR TITLE
chore: Don't unconditionally check tools/gn formatting

### DIFF
--- a/engine/src/flutter/ci/bin/format.dart
+++ b/engine/src/flutter/ci/bin/format.dart
@@ -983,11 +983,10 @@ class PythonFormatChecker extends FormatChecker {
   }
 
   Future<int> _runYapfCheck({required bool fixing}) async {
-    final filesToCheck = <String>[
-      ...await getFileList(<String>['*.py']),
-      // Always include flutter/tools/gn.
-      '${engineDir(repoDir).path}/tools/gn',
-    ];
+    final filesToCheck = await getFileList(<String>[
+      '*.py',
+      path.join(engineSubPath, 'tools', 'gn'),
+    ]);
 
     final cmd = <String>[
       yapfBin.path,

--- a/engine/src/flutter/ci/bin/format.dart
+++ b/engine/src/flutter/ci/bin/format.dart
@@ -983,10 +983,14 @@ class PythonFormatChecker extends FormatChecker {
   }
 
   Future<int> _runYapfCheck({required bool fixing}) async {
-    final filesToCheck = await getFileList(<String>[
+    final List<String> filesToCheck = await getFileList(<String>[
       '*.py',
       path.join(engineSubPath, 'tools', 'gn'),
     ]);
+    if (filesToCheck.isEmpty) {
+      message('No Python files with changes, skipping Python format check.');
+      return 0;
+    }
 
     final cmd = <String>[
       yapfBin.path,


### PR DESCRIPTION
Previously, the 'gn' script was hardcoded to be checked on every run. By moving it into the 'getFileList' call, it now correctly respects git diff and the '--all-files' flag, ensuring it is only formatted when actually modified.

This prevents me from hitting the "YAPF is not supported on Python 3.14" issue on every "git push".

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
