### PR TITLE
[Impeller] For Android hardware buffers on Vulkan, use an alpha value of 1 if the buffer format always has opaque alpha

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.cc
@@ -9,6 +9,10 @@
 #include "impeller/renderer/backend/vulkan/texture_source_vk.h"
 #include "impeller/renderer/backend/vulkan/yuv_conversion_library_vk.h"
 
+// vulkan.hpp generates some clang-tidy warnings.
+// NOLINTBEGIN(clang-analyzer-security.PointerSub)
+// NOLINTBEGIN(clang-analyzer-core.StackAddressEscape)
+
 namespace impeller {
 
 namespace {
@@ -435,3 +439,6 @@ AHBTextureSourceVK::ImageViewInfo AHBTextureSourceVK::CreateImageViewInfo(
 }
 
 }  // namespace impeller
+
+// NOLINTEND(clang-analyzer-core.StackAddressEscape)
+// NOLINTEND(clang-analyzer-security.PointerSub)

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.cc
@@ -28,84 +28,11 @@ bool RequiresYCBCRConversion(vk::Format format) {
   return false;
 }
 
-using AHBProperties = vk::StructureChain<
-    // For VK_ANDROID_external_memory_android_hardware_buffer
-    vk::AndroidHardwareBufferPropertiesANDROID,
-    // For VK_ANDROID_external_memory_android_hardware_buffer
-    vk::AndroidHardwareBufferFormatPropertiesANDROID>;
-
-vk::UniqueImage CreateVKImageWrapperForAndroidHarwareBuffer(
-    const vk::Device& device,
-    const AHBProperties& ahb_props,
-    const AHardwareBuffer_Desc& ahb_desc) {
-  const auto& ahb_format =
-      ahb_props.get<vk::AndroidHardwareBufferFormatPropertiesANDROID>();
-
-  vk::StructureChain<vk::ImageCreateInfo,
-                     // For VK_KHR_external_memory
-                     vk::ExternalMemoryImageCreateInfo,
-                     // For VK_ANDROID_external_memory_android_hardware_buffer
-                     vk::ExternalFormatANDROID>
-      image_chain;
-
-  auto& image_info = image_chain.get<vk::ImageCreateInfo>();
-
-  vk::ImageUsageFlags image_usage_flags;
-  if (ahb_desc.usage & AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE) {
-    image_usage_flags |= vk::ImageUsageFlagBits::eSampled;
-  }
-  if (ahb_desc.usage & AHARDWAREBUFFER_USAGE_GPU_FRAMEBUFFER) {
-    image_usage_flags |= vk::ImageUsageFlagBits::eColorAttachment;
-    image_usage_flags |= vk::ImageUsageFlagBits::eInputAttachment;
-  }
-
-  vk::ImageCreateFlags image_create_flags;
-  if (ahb_desc.usage & AHARDWAREBUFFER_USAGE_PROTECTED_CONTENT) {
-    image_create_flags |= vk::ImageCreateFlagBits::eProtected;
-  }
-  if (ahb_desc.usage & AHARDWAREBUFFER_USAGE_GPU_CUBE_MAP) {
-    image_create_flags |= vk::ImageCreateFlagBits::eCubeCompatible;
-  }
-
-  image_info.imageType = vk::ImageType::e2D;
-  image_info.format = ahb_format.format;
-  image_info.extent.width = ahb_desc.width;
-  image_info.extent.height = ahb_desc.height;
-  image_info.extent.depth = 1;
-  image_info.mipLevels =
-      (ahb_desc.usage & AHARDWAREBUFFER_USAGE_GPU_MIPMAP_COMPLETE)
-          ? ISize{ahb_desc.width, ahb_desc.height}.MipCount()
-          : 1u;
-  image_info.arrayLayers = ahb_desc.layers;
-  image_info.samples = vk::SampleCountFlagBits::e1;
-  image_info.tiling = vk::ImageTiling::eOptimal;
-  image_info.usage = image_usage_flags;
-  image_info.flags = image_create_flags;
-  image_info.sharingMode = vk::SharingMode::eExclusive;
-  image_info.initialLayout = vk::ImageLayout::eUndefined;
-
-  image_chain.get<vk::ExternalMemoryImageCreateInfo>().handleTypes =
-      vk::ExternalMemoryHandleTypeFlagBits::eAndroidHardwareBufferANDROID;
-
-  // If the format isn't natively supported by Vulkan (i.e, be a part of the
-  // base vkFormat enum), an untyped "external format" must be specified when
-  // creating the image and the image views. Usually includes YUV formats.
-  if (ahb_format.format == vk::Format::eUndefined) {
-    image_chain.get<vk::ExternalFormatANDROID>().externalFormat =
-        ahb_format.externalFormat;
-  } else {
-    image_chain.unlink<vk::ExternalFormatANDROID>();
-  }
-
-  auto image = device.createImageUnique(image_chain.get());
-  if (image.result != vk::Result::eSuccess) {
-    VALIDATION_LOG << "Could not create image for external buffer: "
-                   << vk::to_string(image.result);
-    return {};
-  }
-
-  return std::move(image.value);
+bool HardwareBufferFormatHasOpaqueAlpha(AHardwareBuffer_Format format) {
+  return format == AHARDWAREBUFFER_FORMAT_R8G8B8X8_UNORM;
 }
+
+using AHBProperties = AHBTextureSourceVK::AHBProperties;
 
 vk::UniqueDeviceMemory ImportVKDeviceMemoryFromAndroidHarwareBuffer(
     const vk::Device& device,
@@ -187,53 +114,6 @@ std::shared_ptr<YUVConversionVK> CreateYUVConversion(
   }
 
   return context.GetYUVConversionLibrary()->GetConversion(conversion_chain);
-}
-
-vk::UniqueImageView CreateVKImageView(
-    const vk::Device& device,
-    const vk::Image& image,
-    const std::shared_ptr<YUVConversionVK>& yuv_conversion_wrapper,
-    const AHBProperties& ahb_props,
-    const AHardwareBuffer_Desc& ahb_desc) {
-  const auto& ahb_format =
-      ahb_props.get<vk::AndroidHardwareBufferFormatPropertiesANDROID>();
-
-  vk::StructureChain<vk::ImageViewCreateInfo,
-                     // Core in 1.1
-                     vk::SamplerYcbcrConversionInfo>
-      view_chain;
-
-  auto& view_info = view_chain.get();
-
-  view_info.image = image;
-  view_info.viewType = vk::ImageViewType::e2D;
-  view_info.format = ahb_format.format;
-  view_info.subresourceRange.aspectMask = vk::ImageAspectFlagBits::eColor;
-  view_info.subresourceRange.baseMipLevel = 0u;
-  view_info.subresourceRange.baseArrayLayer = 0u;
-  view_info.subresourceRange.levelCount =
-      (ahb_desc.usage & AHARDWAREBUFFER_USAGE_GPU_MIPMAP_COMPLETE)
-          ? ISize{ahb_desc.width, ahb_desc.height}.MipCount()
-          : 1u;
-  view_info.subresourceRange.layerCount = ahb_desc.layers;
-
-  // We need a custom YUV conversion only if we don't recognize the format.
-  if (view_info.format == vk::Format::eUndefined ||
-      RequiresYCBCRConversion(view_info.format)) {
-    view_chain.get<vk::SamplerYcbcrConversionInfo>().conversion =
-        yuv_conversion_wrapper->GetConversion();
-  } else {
-    view_chain.unlink<vk::SamplerYcbcrConversionInfo>();
-  }
-
-  auto image_view = device.createImageViewUnique(view_info);
-  if (image_view.result != vk::Result::eSuccess) {
-    VALIDATION_LOG << "Could not create external image view: "
-                   << vk::to_string(image_view.result);
-    return {};
-  }
-
-  return std::move(image_view.value);
 }
 
 PixelFormat ToPixelFormat(AHardwareBuffer_Format format) {
@@ -365,20 +245,22 @@ AHBTextureSourceVK::AHBTextureSourceVK(
   }
 
   // Create image view for the newly created image.
-  auto image_view = CreateVKImageView(device,          //
-                                      image.get(),     //
-                                      yuv_conversion,  //
-                                      ahb_props,       //
-                                      ahb_desc         //
+  auto image_info = CreateImageViewInfo(image.get(),     //
+                                        yuv_conversion,  //
+                                        ahb_props,       //
+                                        ahb_desc         //
   );
-  if (!image_view) {
+  auto image_view = device.createImageViewUnique(image_info.get());
+  if (image_view.result != vk::Result::eSuccess) {
+    VALIDATION_LOG << "Could not create external image view: "
+                   << vk::to_string(image_view.result);
     return;
   }
 
   device_memory_ = std::move(device_memory);
   image_ = std::move(image);
   yuv_conversion_ = std::move(yuv_conversion);
-  image_view_ = std::move(image_view);
+  image_view_ = std::move(image_view.value);
 
 #ifdef IMPELLER_DEBUG
   context.SetDebugName(device_memory_.get(), "AHB Device Memory");
@@ -438,6 +320,119 @@ std::shared_ptr<YUVConversionVK> AHBTextureSourceVK::GetYUVConversion() const {
 
 const android::HardwareBuffer* AHBTextureSourceVK::GetBackingStore() const {
   return backing_store_.get();
+}
+
+vk::UniqueImage AHBTextureSourceVK::CreateVKImageWrapperForAndroidHarwareBuffer(
+    const vk::Device& device,
+    const AHBProperties& ahb_props,
+    const AHardwareBuffer_Desc& ahb_desc) {
+  const auto& ahb_format =
+      ahb_props.get<vk::AndroidHardwareBufferFormatPropertiesANDROID>();
+
+  vk::StructureChain<vk::ImageCreateInfo,
+                     // For VK_KHR_external_memory
+                     vk::ExternalMemoryImageCreateInfo,
+                     // For VK_ANDROID_external_memory_android_hardware_buffer
+                     vk::ExternalFormatANDROID>
+      image_chain;
+
+  auto& image_info = image_chain.get<vk::ImageCreateInfo>();
+
+  vk::ImageUsageFlags image_usage_flags;
+  if (ahb_desc.usage & AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE) {
+    image_usage_flags |= vk::ImageUsageFlagBits::eSampled;
+  }
+  if (ahb_desc.usage & AHARDWAREBUFFER_USAGE_GPU_FRAMEBUFFER) {
+    image_usage_flags |= vk::ImageUsageFlagBits::eColorAttachment;
+    image_usage_flags |= vk::ImageUsageFlagBits::eInputAttachment;
+  }
+
+  vk::ImageCreateFlags image_create_flags;
+  if (ahb_desc.usage & AHARDWAREBUFFER_USAGE_PROTECTED_CONTENT) {
+    image_create_flags |= vk::ImageCreateFlagBits::eProtected;
+  }
+  if (ahb_desc.usage & AHARDWAREBUFFER_USAGE_GPU_CUBE_MAP) {
+    image_create_flags |= vk::ImageCreateFlagBits::eCubeCompatible;
+  }
+
+  image_info.imageType = vk::ImageType::e2D;
+  image_info.format = ahb_format.format;
+  image_info.extent.width = ahb_desc.width;
+  image_info.extent.height = ahb_desc.height;
+  image_info.extent.depth = 1;
+  image_info.mipLevels =
+      (ahb_desc.usage & AHARDWAREBUFFER_USAGE_GPU_MIPMAP_COMPLETE)
+          ? ISize{ahb_desc.width, ahb_desc.height}.MipCount()
+          : 1u;
+  image_info.arrayLayers = ahb_desc.layers;
+  image_info.samples = vk::SampleCountFlagBits::e1;
+  image_info.tiling = vk::ImageTiling::eOptimal;
+  image_info.usage = image_usage_flags;
+  image_info.flags = image_create_flags;
+  image_info.sharingMode = vk::SharingMode::eExclusive;
+  image_info.initialLayout = vk::ImageLayout::eUndefined;
+
+  image_chain.get<vk::ExternalMemoryImageCreateInfo>().handleTypes =
+      vk::ExternalMemoryHandleTypeFlagBits::eAndroidHardwareBufferANDROID;
+
+  // If the format isn't natively supported by Vulkan (i.e, be a part of the
+  // base vkFormat enum), an untyped "external format" must be specified when
+  // creating the image and the image views. Usually includes YUV formats.
+  if (ahb_format.format == vk::Format::eUndefined) {
+    image_chain.get<vk::ExternalFormatANDROID>().externalFormat =
+        ahb_format.externalFormat;
+  } else {
+    image_chain.unlink<vk::ExternalFormatANDROID>();
+  }
+
+  auto image = device.createImageUnique(image_chain.get());
+  if (image.result != vk::Result::eSuccess) {
+    VALIDATION_LOG << "Could not create image for external buffer: "
+                   << vk::to_string(image.result);
+    return {};
+  }
+
+  return std::move(image.value);
+}
+
+AHBTextureSourceVK::ImageViewInfo AHBTextureSourceVK::CreateImageViewInfo(
+    const vk::Image& image,
+    const std::shared_ptr<YUVConversionVK>& yuv_conversion_wrapper,
+    const AHBProperties& ahb_props,
+    const AHardwareBuffer_Desc& ahb_desc) {
+  const auto& ahb_format =
+      ahb_props.get<vk::AndroidHardwareBufferFormatPropertiesANDROID>();
+
+  ImageViewInfo view_chain;
+
+  auto& view_info = view_chain.get();
+
+  view_info.image = image;
+  view_info.viewType = vk::ImageViewType::e2D;
+  view_info.format = ahb_format.format;
+  if (HardwareBufferFormatHasOpaqueAlpha(
+          static_cast<AHardwareBuffer_Format>(ahb_desc.format))) {
+    view_info.components.a = vk::ComponentSwizzle::eOne;
+  }
+  view_info.subresourceRange.aspectMask = vk::ImageAspectFlagBits::eColor;
+  view_info.subresourceRange.baseMipLevel = 0u;
+  view_info.subresourceRange.baseArrayLayer = 0u;
+  view_info.subresourceRange.levelCount =
+      (ahb_desc.usage & AHARDWAREBUFFER_USAGE_GPU_MIPMAP_COMPLETE)
+          ? ISize{ahb_desc.width, ahb_desc.height}.MipCount()
+          : 1u;
+  view_info.subresourceRange.layerCount = ahb_desc.layers;
+
+  // We need a custom YUV conversion only if we don't recognize the format.
+  if (view_info.format == vk::Format::eUndefined ||
+      RequiresYCBCRConversion(view_info.format)) {
+    view_chain.get<vk::SamplerYcbcrConversionInfo>().conversion =
+        yuv_conversion_wrapper->GetConversion();
+  } else {
+    view_chain.unlink<vk::SamplerYcbcrConversionInfo>();
+  }
+
+  return view_chain;
 }
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.cc
@@ -13,6 +13,8 @@ namespace impeller {
 
 namespace {
 
+using AHBProperties = AHBTextureSourceVK::AHBProperties;
+
 bool RequiresYCBCRConversion(vk::Format format) {
   switch (format) {
     case vk::Format::eG8B8R83Plane420Unorm:
@@ -28,11 +30,9 @@ bool RequiresYCBCRConversion(vk::Format format) {
   return false;
 }
 
-bool HardwareBufferFormatHasOpaqueAlpha(AHardwareBuffer_Format format) {
+bool IsOpaque(AHardwareBuffer_Format format) {
   return format == AHARDWAREBUFFER_FORMAT_R8G8B8X8_UNORM;
 }
-
-using AHBProperties = AHBTextureSourceVK::AHBProperties;
 
 vk::UniqueDeviceMemory ImportVKDeviceMemoryFromAndroidHarwareBuffer(
     const vk::Device& device,
@@ -410,8 +410,7 @@ AHBTextureSourceVK::ImageViewInfo AHBTextureSourceVK::CreateImageViewInfo(
   view_info.image = image;
   view_info.viewType = vk::ImageViewType::e2D;
   view_info.format = ahb_format.format;
-  if (HardwareBufferFormatHasOpaqueAlpha(
-          static_cast<AHardwareBuffer_Format>(ahb_desc.format))) {
+  if (IsOpaque(static_cast<AHardwareBuffer_Format>(ahb_desc.format))) {
     view_info.components.a = vk::ComponentSwizzle::eOne;
   }
   view_info.subresourceRange.aspectMask = vk::ImageAspectFlagBits::eColor;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.h
@@ -71,11 +71,14 @@ class AHBTextureSourceVK final : public TextureSourceVK {
                                            // Core in 1.1
                                            vk::SamplerYcbcrConversionInfo>;
 
+  /// Create a VkImage that wraps an Android hardware buffer.
   static vk::UniqueImage CreateVKImageWrapperForAndroidHarwareBuffer(
       const vk::Device& device,
       const AHBProperties& ahb_props,
       const AHardwareBuffer_Desc& ahb_desc);
 
+  /// Create a VkImageViewCreateInfo that matches the properties of an Android
+  /// hardware buffer.
   static ImageViewInfo CreateImageViewInfo(
       const vk::Image& image,
       const std::shared_ptr<YUVConversionVK>& yuv_conversion_wrapper,

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.h
@@ -61,6 +61,27 @@ class AHBTextureSourceVK final : public TextureSourceVK {
 
   const android::HardwareBuffer* GetBackingStore() const;
 
+  using AHBProperties = vk::StructureChain<
+      // For VK_ANDROID_external_memory_android_hardware_buffer
+      vk::AndroidHardwareBufferPropertiesANDROID,
+      // For VK_ANDROID_external_memory_android_hardware_buffer
+      vk::AndroidHardwareBufferFormatPropertiesANDROID>;
+
+  using ImageViewInfo = vk::StructureChain<vk::ImageViewCreateInfo,
+                                           // Core in 1.1
+                                           vk::SamplerYcbcrConversionInfo>;
+
+  static vk::UniqueImage CreateVKImageWrapperForAndroidHarwareBuffer(
+      const vk::Device& device,
+      const AHBProperties& ahb_props,
+      const AHardwareBuffer_Desc& ahb_desc);
+
+  static ImageViewInfo CreateImageViewInfo(
+      const vk::Image& image,
+      const std::shared_ptr<YUVConversionVK>& yuv_conversion_wrapper,
+      const AHBProperties& ahb_props,
+      const AHardwareBuffer_Desc& ahb_desc);
+
  private:
   std::unique_ptr<android::HardwareBuffer> backing_store_;
   vk::UniqueDeviceMemory device_memory_ = {};

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk_unittests.cc
@@ -15,6 +15,22 @@
 
 namespace impeller::android::testing {
 
+struct UniqueAHardwareBufferTraits {
+  static AHardwareBuffer* InvalidValue() { return nullptr; }
+  static bool IsValid(AHardwareBuffer* value) { return value != nullptr; }
+  static void Free(AHardwareBuffer* value) { ::AHardwareBuffer_release(value); }
+};
+
+using UniqueAHardwareBuffer =
+    fml::UniqueObject<AHardwareBuffer*, UniqueAHardwareBufferTraits>;
+
+UniqueAHardwareBuffer AllocateAHardwareBuffer(
+    const AHardwareBuffer_Desc& desc) {
+  AHardwareBuffer* buffer = nullptr;
+  EXPECT_EQ(AHardwareBuffer_allocate(&desc, &buffer), 0);
+  return UniqueAHardwareBuffer(buffer);
+}
+
 // Set up context.
 std::shared_ptr<ContextVK> CreateContext() {
   auto vulkan_dylib = fml::NativeLibrary::Create("libvulkan.so");
@@ -80,13 +96,13 @@ TEST(AndroidVulkanTest, CanImportWithYUB) {
 
   EXPECT_EQ(AHardwareBuffer_isSupported(&desc), 1);
 
-  AHardwareBuffer* buffer = nullptr;
-  ASSERT_EQ(AHardwareBuffer_allocate(&desc, &buffer), 0);
+  UniqueAHardwareBuffer buffer = AllocateAHardwareBuffer(desc);
+  ASSERT_TRUE(buffer.is_valid());
 
   auto context_vk = CreateContext();
   ASSERT_TRUE(context_vk);
 
-  AHBTextureSourceVK source(context_vk, buffer, desc);
+  AHBTextureSourceVK source(context_vk, buffer.get(), desc);
 
   EXPECT_TRUE(source.IsValid());
   EXPECT_NE(source.GetYUVConversion(), nullptr);
@@ -113,15 +129,15 @@ TEST(AndroidVulkanTest, CreateImageViewForOpaqueAlpha) {
 
   EXPECT_EQ(AHardwareBuffer_isSupported(&desc), 1);
 
-  AHardwareBuffer* buffer = nullptr;
-  ASSERT_EQ(AHardwareBuffer_allocate(&desc, &buffer), 0);
+  UniqueAHardwareBuffer buffer = AllocateAHardwareBuffer(desc);
+  ASSERT_TRUE(buffer.is_valid());
 
   auto context_vk = CreateContext();
   ASSERT_TRUE(context_vk);
 
   AHBTextureSourceVK::AHBProperties ahb_props;
   ASSERT_EQ(context_vk->GetDevice().getAndroidHardwareBufferPropertiesANDROID(
-                buffer, &ahb_props.get()),
+                buffer.get(), &ahb_props.get()),
             vk::Result::eSuccess);
 
   auto image = AHBTextureSourceVK::CreateVKImageWrapperForAndroidHarwareBuffer(
@@ -131,7 +147,7 @@ TEST(AndroidVulkanTest, CreateImageViewForOpaqueAlpha) {
   auto image_info = AHBTextureSourceVK::CreateImageViewInfo(
       image.get(), nullptr, ahb_props, desc);
 
-  ASSERT_EQ(image_info.get().components.a, vk::ComponentSwizzle::eOne);
+  EXPECT_EQ(image_info.get().components.a, vk::ComponentSwizzle::eOne);
 
   context_vk->Shutdown();
 }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk_unittests.cc
@@ -16,7 +16,7 @@
 namespace impeller::android::testing {
 
 // Set up context.
-std::shared_ptr<Context> CreateContext() {
+std::shared_ptr<ContextVK> CreateContext() {
   auto vulkan_dylib = fml::NativeLibrary::Create("libvulkan.so");
   auto instance_proc_addr =
       vulkan_dylib->ResolveFunction<PFN_vkGetInstanceProcAddr>(
@@ -90,6 +90,48 @@ TEST(AndroidVulkanTest, CanImportWithYUB) {
 
   EXPECT_TRUE(source.IsValid());
   EXPECT_NE(source.GetYUVConversion(), nullptr);
+
+  context_vk->Shutdown();
+}
+
+TEST(AndroidVulkanTest, CreateImageViewForOpaqueAlpha) {
+  if (!HardwareBuffer::IsAvailableOnPlatform()) {
+    GTEST_SKIP() << "Hardware buffers are not supported on this platform.";
+  }
+
+  AHardwareBuffer_Desc desc;
+  desc.width = 16;
+  desc.height = 16;
+  desc.format = AHARDWAREBUFFER_FORMAT_R8G8B8X8_UNORM;
+  desc.stride = 0;
+  desc.layers = 1;
+  desc.rfu0 = 0;
+  desc.rfu1 = 0;
+  desc.usage = AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE |
+               AHARDWAREBUFFER_USAGE_CPU_WRITE_MASK |
+               AHARDWAREBUFFER_USAGE_CPU_READ_MASK;
+
+  EXPECT_EQ(AHardwareBuffer_isSupported(&desc), 1);
+
+  AHardwareBuffer* buffer = nullptr;
+  ASSERT_EQ(AHardwareBuffer_allocate(&desc, &buffer), 0);
+
+  auto context_vk = CreateContext();
+  ASSERT_TRUE(context_vk);
+
+  AHBTextureSourceVK::AHBProperties ahb_props;
+  ASSERT_EQ(context_vk->GetDevice().getAndroidHardwareBufferPropertiesANDROID(
+                buffer, &ahb_props.get()),
+            vk::Result::eSuccess);
+
+  auto image = AHBTextureSourceVK::CreateVKImageWrapperForAndroidHarwareBuffer(
+      context_vk->GetDevice(), ahb_props, desc);
+  ASSERT_TRUE(image);
+
+  auto image_info = AHBTextureSourceVK::CreateImageViewInfo(
+      image.get(), nullptr, ahb_props, desc);
+
+  ASSERT_EQ(image_info.get().components.a, vk::ComponentSwizzle::eOne);
 
   context_vk->Shutdown();
 }


### PR DESCRIPTION
The AHARDWAREBUFFER_FORMAT_R8G8B8X8_UNORM format specifies that the alpha value should be ignored and should always be treated as opaque.  For this format, configure the VkComponentMapping to set alpha to VK_COMPONENT_SWIZZLE_ONE.

Fixes https://github.com/flutter/flutter/issues/182825