### PR TITLE
[flutter_tools] Parse Xcode all-target build settings into target maps

### DIFF
--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -1797,8 +1797,9 @@ class SemanticsProperties extends DiagnosticableTree {
 
   /// If non-null, indicates that this subtree represents a header.
   ///
-  /// A header is typically the top element of a page or section, such as a
-  /// page title or app bar title.
+  /// A header divides into sections. For example, an address book application
+  /// might define headers A, B, C, etc. to divide the list of alphabetically
+  /// sorted contacts into sections.
   final bool? header;
 
   /// If non-null, indicates that this subtree represents a text field.
@@ -2231,9 +2232,6 @@ class SemanticsProperties extends DiagnosticableTree {
   ///
   /// On web, this sets the `aria-level` attribute (e.g., `aria-level="1"`).
   /// On Android, this sets the `isHeading` property for accessibility.
-  ///
-  /// Android accessibility does not expose a separate "header" semantic, so
-  /// use [headingLevel] to mark heading semantics for assistive technology.
   final int? headingLevel;
 
   /// Overrides the default accessibility hints provided by the platform.

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -1797,9 +1797,8 @@ class SemanticsProperties extends DiagnosticableTree {
 
   /// If non-null, indicates that this subtree represents a header.
   ///
-  /// A header divides into sections. For example, an address book application
-  /// might define headers A, B, C, etc. to divide the list of alphabetically
-  /// sorted contacts into sections.
+  /// A header is typically the top element of a page or section, such as a
+  /// page title or app bar title.
   final bool? header;
 
   /// If non-null, indicates that this subtree represents a text field.
@@ -2232,6 +2231,9 @@ class SemanticsProperties extends DiagnosticableTree {
   ///
   /// On web, this sets the `aria-level` attribute (e.g., `aria-level="1"`).
   /// On Android, this sets the `isHeading` property for accessibility.
+  ///
+  /// Android accessibility does not expose a separate "header" semantic, so
+  /// use [headingLevel] to mark heading semantics for assistive technology.
   final int? headingLevel;
 
   /// Overrides the default accessibility hints provided by the platform.

--- a/packages/flutter_tools/lib/src/xcode_project.dart
+++ b/packages/flutter_tools/lib/src/xcode_project.dart
@@ -37,14 +37,24 @@ final RegExp _buildSettingsTargetHeaderPattern = RegExp(
 Map<String, Map<String, String>> parseXcodeAllTargetsBuildSettings(String buildSettingsOutput) {
   final settingsByTarget = <String, Map<String, String>>{};
   String? currentTarget;
+  final List<String> currentTargetSettings = <String>[];
+
+  void flushCurrentTarget() {
+    final String? target = currentTarget;
+    if (target == null) {
+      return;
+    }
+    settingsByTarget[target] = parseXcodeBuildSettings(currentTargetSettings.join('\n'));
+    currentTargetSettings.clear();
+  }
 
   for (final String line in buildSettingsOutput.split('\n')) {
     final String settingsLine = line.trim();
 
     final RegExpMatch? headerMatch = _buildSettingsTargetHeaderPattern.firstMatch(settingsLine);
     if (headerMatch != null) {
+      flushCurrentTarget();
       currentTarget = headerMatch.group(1)!.trim();
-      settingsByTarget.putIfAbsent(currentTarget, () => <String, String>{});
       continue;
     }
 
@@ -52,17 +62,10 @@ Map<String, Map<String, String>> parseXcodeAllTargetsBuildSettings(String buildS
       continue;
     }
 
-    final RegExpMatch? keyValueMatch = RegExp(r'^([^=]+?)\s*=\s*(.*)$').firstMatch(settingsLine);
-    if (keyValueMatch == null) {
-      continue;
-    }
-    final String key = keyValueMatch.group(1)!.trim();
-    final String value = keyValueMatch.group(2)!.trim();
-    if (key.isNotEmpty) {
-      settingsByTarget[currentTarget]![key] = value;
-    }
+    currentTargetSettings.add(settingsLine);
   }
 
+  flushCurrentTarget();
   return settingsByTarget;
 }
 

--- a/packages/flutter_tools/lib/src/xcode_project.dart
+++ b/packages/flutter_tools/lib/src/xcode_project.dart
@@ -5,8 +5,6 @@
 /// @docImport 'ios/mac.dart';
 library;
 
-import 'package:yaml/yaml.dart' as yaml;
-
 import 'base/error_handling_io.dart';
 import 'base/file_system.dart';
 import 'base/logger.dart';
@@ -30,6 +28,45 @@ import 'platform_plugins.dart';
 import 'plugins.dart';
 import 'project.dart';
 import 'template.dart';
+
+final RegExp _buildSettingsTargetHeaderPattern = RegExp(
+  r'^Build settings for action build and target "?([^":\r\n]+)"?:\s*$',
+);
+
+/// Parses xcodebuild `-showBuildSettings` output into a dictionary keyed by target.
+Map<String, Map<String, String>> parseXcodeAllTargetsBuildSettings(String buildSettingsOutput) {
+  final Map<String, Map<String, String>> settingsByTarget = <String, Map<String, String>>{};
+  String? currentTarget;
+
+  for (final String line in buildSettingsOutput.split('\n')) {
+    final String settingsLine = line.trim();
+
+    final RegExpMatch? headerMatch = _buildSettingsTargetHeaderPattern.firstMatch(settingsLine);
+    if (headerMatch != null) {
+      currentTarget = headerMatch.group(1)!.trim();
+      settingsByTarget.putIfAbsent(currentTarget, () => <String, String>{});
+      continue;
+    }
+
+    if (currentTarget == null || !settingsLine.contains('=')) {
+      continue;
+    }
+
+    int equalsIndex = settingsLine.indexOf(' = ');
+    int separatorLength = 3;
+    if (equalsIndex == -1) {
+      equalsIndex = settingsLine.indexOf('=');
+      separatorLength = 1;
+    }
+    final String key = settingsLine.substring(0, equalsIndex).trim();
+    final String value = settingsLine.substring(equalsIndex + separatorLength).trim();
+    if (key.isNotEmpty) {
+      settingsByTarget[currentTarget]![key] = value;
+    }
+  }
+
+  return settingsByTarget;
+}
 
 /// Represents an Xcode-based sub-project.
 ///
@@ -181,11 +218,15 @@ abstract class XcodeBasedProject extends FlutterProjectPlatform {
         );
   }
 
-  /// Return true if the project meets the following requirements:
-  ///   - Project is not a module
-  ///   - Xcode project exists
-  ///   - Xcode version is greater or equal to 15
-  bool get compatibleWithSwiftPackageManager {
+  /// True if this project doesn't have Swift Package Manager disabled in the
+  /// pubspec, has either an iOS or macOS platform implementation, is not a
+  /// module project, Xcode is 15 or greater, and the Swift Package Manager
+  /// feature is enabled.
+  bool get usesSwiftPackageManager {
+    if (!featureFlags.isSwiftPackageManagerEnabled) {
+      return false;
+    }
+
     // TODO(loic-sharma): Support Swift Package Manager in add-to-app modules.
     // https://github.com/flutter/flutter/issues/146957
     if (parent.isModule) {
@@ -205,11 +246,6 @@ abstract class XcodeBasedProject extends FlutterProjectPlatform {
 
     return true;
   }
-
-  /// Return true if the Swift Package Manager feature is enabled and the project is
-  /// [compatibleWithSwiftPackageManager].
-  bool get usesSwiftPackageManager =>
-      featureFlags.isSwiftPackageManagerEnabled && compatibleWithSwiftPackageManager;
 
   Future<XcodeProjectInfo?> projectInfo() async {
     final XcodeProjectInterpreter? xcodeProjectInterpreter = globals.xcodeProjectInterpreter;
@@ -492,205 +528,71 @@ def __lldb_init_module(debugger: lldb.SBDebugger, _):
   /// True if the app project uses Swift.
   bool get isSwift => appDelegateSwift.existsSync();
 
-  /// Returns true if all plugins and their dependencies support arm64.
+  /// Prints a warning if any plugin(s) are excluding `arm64` architecture.
   ///
-  /// When using Xcode 26+, print a warning if a plugin or its dependencies does not support
-  /// arm64.
-  Future<bool> pluginsSupportArmSimulator({required bool printWarnings}) async {
-    final Version? xcodeVersion = globals.xcode?.currentVersion;
+  /// Xcode 26 no longer allows you to build x86-only architecture for the simulator
+  Future<void> checkForPluginsExcludingArmSimulator() async {
     final Directory podXcodeProject = hostAppRoot
         .childDirectory('Pods')
         .childDirectory('Pods.xcodeproj');
     if (!podXcodeProject.existsSync()) {
-      return true;
+      return;
     }
 
     final XcodeProjectInterpreter? xcodeProjectInterpreter = globals.xcodeProjectInterpreter;
     if (xcodeProjectInterpreter == null) {
-      // Xcode isn't installed, don't try to check.
-      return true;
+      return;
     }
     final String? buildSettings = await xcodeProjectInterpreter.pluginsBuildSettingsOutput(
       podXcodeProject,
     );
+
     if (buildSettings == null || buildSettings.isEmpty) {
-      globals.logger.printTrace('Unable to get build settings for Pods.');
-      return true;
+      return;
     }
 
-    // When using Xcode 26, print a warning if a target does not support arm.
-    if (xcodeVersion != null && xcodeVersion.major >= 26 && printWarnings) {
-      final List<({String target, String? plugin})> targetsExcludingArm =
-          await _targetsExcludingArm(buildSettings);
-      if (targetsExcludingArm.isNotEmpty) {
-        final String list = targetsExcludingArm
-            .map((target) {
-              var targetItem = '  - ${target.target}';
-              if (target.target == target.plugin) {
-                targetItem = '$targetItem (Flutter plugin)';
-              } else if (target.plugin != null) {
-                targetItem =
-                    '$targetItem (transitive dependency of Flutter plugin ${target.plugin})';
-              }
-              return targetItem;
-            })
-            .join('\n');
-        globals.logger.printWarning(
-          'The following target(s) do not support arm64 architecture, which is a requirement for '
-          'Apple Silicon iOS 26+ simulators:\n'
-          '$list\n\n'
-          'Please contact plugin maintainers to request arm64 support to continue to be able to '
-          'use the plugin on a simulator.',
-        );
-      }
-    }
-
-    return !buildSettings.contains(RegExp('EXCLUDED_ARCHS.*arm64'));
-  }
-
-  /// Returns a list of targets and their associated plugin (if found) that exclude arm64 architecture.
-  Future<List<({String target, String? plugin})>> _targetsExcludingArm(String buildSettings) async {
-    final Map<String, List<String>> cocoapodsDependencyGraph = _cocoapodsDependencyGraph();
     final List<Plugin> allPlugins = await findPlugins(parent);
-    final pluginNames = <String>{
+    final iosPluginTargetNames = <String>{
       for (final Plugin plugin in allPlugins)
         if (plugin.platforms.containsKey(IOSPlugin.kConfigKey)) plugin.name,
     };
-    final targetHeaderPattern = RegExp(
-      r'^Build settings for action build and target "?([^":\r\n]+)"?:\s*$',
+    if (iosPluginTargetNames.isEmpty) {
+      return;
+    }
+
+    final Map<String, Map<String, String>> settingsByTarget = parseXcodeAllTargetsBuildSettings(
+      buildSettings,
     );
 
-    final List<({String target, String? plugin})> foundTargets = [];
-    String? currentTarget;
-    for (final String eachLine in buildSettings.split('\n')) {
-      final String settingsLine = eachLine.trim();
-      final RegExpMatch? headerMatch = targetHeaderPattern.firstMatch(settingsLine);
-      if (headerMatch != null) {
-        currentTarget = headerMatch.group(1)!.trim();
-        continue;
-      }
-      if (currentTarget == null ||
-          !settingsLine.startsWith('EXCLUDED_ARCHS') ||
-          !settingsLine.contains('=')) {
-        continue;
-      }
-      final Iterable<String> tokens = settingsLine.split(' ');
-      if (!tokens.contains('arm64')) {
+    final pluginsExcludingArmArch = <String>{};
+    for (final String pluginTargetName in iosPluginTargetNames) {
+      final Map<String, String>? targetSettings = settingsByTarget[pluginTargetName];
+      if (targetSettings == null) {
         continue;
       }
 
-      if (pluginNames.contains(currentTarget)) {
-        foundTargets.add((target: currentTarget, plugin: currentTarget));
-      } else {
-        // If it's not a plugin, it may be a transitive dependency of a plugin
-        final String? parentPlugin = _pluginUsingDependency(
-          targetName: currentTarget,
-          pluginNames: pluginNames.toList(),
-          cocoapodsDependencyGraph: cocoapodsDependencyGraph,
-        );
-        if (parentPlugin != null) {
-          foundTargets.add((target: currentTarget, plugin: parentPlugin));
-        } else if (currentTarget.startsWith('Pods-')) {
-          // Skip Pods- targets since they are not actual dependencies.
-          continue;
-        } else {
-          foundTargets.add((target: currentTarget, plugin: null));
+      final bool excludesArm64 = targetSettings.entries.any((MapEntry<String, String> entry) {
+        if (!entry.key.startsWith('EXCLUDED_ARCHS')) {
+          return false;
         }
+        final Iterable<String> tokens = entry.value.split(RegExp(r'\s+'));
+        return tokens.contains('arm64');
+      });
+
+      if (excludesArm64) {
+        pluginsExcludingArmArch.add(pluginTargetName);
       }
     }
-    return foundTargets;
-  }
 
-  /// Returns the plugin that uses the given target.
-  String? _pluginUsingDependency({
-    required String targetName,
-    required List<String> pluginNames,
-    required Map<String, List<String>> cocoapodsDependencyGraph,
-  }) {
-    final String? pluginName = _findPluginForDependency(
-      targetName,
-      cocoapodsDependencyGraph,
-      pluginNames,
-    );
-    if (pluginName != null) {
-      return pluginName;
-    }
-    if (targetName.contains('-')) {
-      // Resource bundle targets are prefixed with the name of the pod and then the name of the
-      // resource. Strip the resource name to get the pod name.
-      return _findPluginForDependency(
-        targetName.split('-').first,
-        cocoapodsDependencyGraph,
-        pluginNames,
-      );
-    } else {
-      // Sometimes the target name is a prefix of pod name.
-      // Example: target name "GoogleMLKit" and pod name "GoogleMLKit/Translate".
-      return _findPluginForDependency(
-        targetName,
-        cocoapodsDependencyGraph,
-        pluginNames,
-        searchByPrefix: true,
+    if (pluginsExcludingArmArch.isNotEmpty) {
+      final String list = pluginsExcludingArmArch.map((String n) => '  - $n').join('\n');
+
+      globals.logger.printWarning(
+        'The following plugin(s) are excluding the arm64 architecture, which is a requirement for Xcode 26+:\n'
+        '$list\n'
+        'Consider installing the "Universal" Xcode or file an issue with the plugin(s) to support arm64.',
       );
     }
-  }
-
-  /// Returns a map of pods and their dependencies.
-  Map<String, List<String>> _cocoapodsDependencyGraph() {
-    final Map<String, List<String>> podDependencies = {};
-    try {
-      if (podfileLock.existsSync()) {
-        final String podfileLockString = podfileLock.readAsStringSync().split('\n\n').first;
-        final dynamic podsYaml = yaml.loadYaml(podfileLockString);
-        if (podsYaml is yaml.YamlMap) {
-          final dynamic podsList = podsYaml['PODS'];
-          if (podsList is List<dynamic>) {
-            // ignore: specify_nonobvious_local_variable_types
-            for (final dynamic pod in podsList) {
-              if (pod is yaml.YamlMap) {
-                final name = pod.keys.first as String;
-                final dynamic value = pod.value[name];
-                if (value is yaml.YamlList) {
-                  podDependencies[name.split(' ').first] = value
-                      .map((dep) => (dep as String).split(' ').first)
-                      .toList();
-                }
-              }
-            }
-          }
-        }
-      }
-    } on Exception catch (e) {
-      globals.logger.printTrace('Failed to parse podfile.lock: $e');
-    }
-
-    return podDependencies;
-  }
-
-  /// Recursively searches the pod dependency graph for a Flutter plugin that uses the given target.
-  String? _findPluginForDependency(
-    String targetName,
-    Map<String, List<String>> cocoapodTree,
-    List<String> pluginNames, {
-    bool searchByPrefix = false,
-  }) {
-    for (final MapEntry<String, List<String>> pod in cocoapodTree.entries) {
-      final String podName = pod.key;
-      final List<String> podDependencies = pod.value;
-      bool podHasTargetAsDependency;
-      if (searchByPrefix) {
-        podHasTargetAsDependency = podDependencies.any((dep) => dep.startsWith('$targetName/'));
-      } else {
-        podHasTargetAsDependency = podDependencies.contains(targetName);
-      }
-      if (podHasTargetAsDependency) {
-        if (pluginNames.contains(podName)) {
-          return podName;
-        }
-        return _findPluginForDependency(podName, cocoapodTree, pluginNames);
-      }
-    }
-    return null;
   }
 
   @override

--- a/packages/flutter_tools/lib/src/xcode_project.dart
+++ b/packages/flutter_tools/lib/src/xcode_project.dart
@@ -35,7 +35,7 @@ final RegExp _buildSettingsTargetHeaderPattern = RegExp(
 
 /// Parses xcodebuild `-showBuildSettings` output into a dictionary keyed by target.
 Map<String, Map<String, String>> parseXcodeAllTargetsBuildSettings(String buildSettingsOutput) {
-  final Map<String, Map<String, String>> settingsByTarget = <String, Map<String, String>>{};
+  final settingsByTarget = <String, Map<String, String>>{};
   String? currentTarget;
 
   for (final String line in buildSettingsOutput.split('\n')) {
@@ -53,7 +53,7 @@ Map<String, Map<String, String>> parseXcodeAllTargetsBuildSettings(String buildS
     }
 
     int equalsIndex = settingsLine.indexOf(' = ');
-    int separatorLength = 3;
+    var separatorLength = 3;
     if (equalsIndex == -1) {
       equalsIndex = settingsLine.indexOf('=');
       separatorLength = 1;
@@ -560,12 +560,11 @@ def __lldb_init_module(debugger: lldb.SBDebugger, _):
       return;
     }
 
-    final Map<String, Map<String, String>> settingsByTarget = parseXcodeAllTargetsBuildSettings(
-      buildSettings,
-    );
+    final Map<String, Map<String, String>> settingsByTarget =
+        parseXcodeAllTargetsBuildSettings(buildSettings);
 
     final pluginsExcludingArmArch = <String>{};
-    for (final String pluginTargetName in iosPluginTargetNames) {
+    for (final pluginTargetName in iosPluginTargetNames) {
       final Map<String, String>? targetSettings = settingsByTarget[pluginTargetName];
       if (targetSettings == null) {
         continue;

--- a/packages/flutter_tools/lib/src/xcode_project.dart
+++ b/packages/flutter_tools/lib/src/xcode_project.dart
@@ -52,14 +52,12 @@ Map<String, Map<String, String>> parseXcodeAllTargetsBuildSettings(String buildS
       continue;
     }
 
-    int equalsIndex = settingsLine.indexOf(' = ');
-    var separatorLength = 3;
-    if (equalsIndex == -1) {
-      equalsIndex = settingsLine.indexOf('=');
-      separatorLength = 1;
+    final RegExpMatch? keyValueMatch = RegExp(r'^([^=]+?)\s*=\s*(.*)$').firstMatch(settingsLine);
+    if (keyValueMatch == null) {
+      continue;
     }
-    final String key = settingsLine.substring(0, equalsIndex).trim();
-    final String value = settingsLine.substring(equalsIndex + separatorLength).trim();
+    final String key = keyValueMatch.group(1)!.trim();
+    final String value = keyValueMatch.group(2)!.trim();
     if (key.isNotEmpty) {
       settingsByTarget[currentTarget]![key] = value;
     }
@@ -560,8 +558,9 @@ def __lldb_init_module(debugger: lldb.SBDebugger, _):
       return;
     }
 
-    final Map<String, Map<String, String>> settingsByTarget =
-        parseXcodeAllTargetsBuildSettings(buildSettings);
+    final Map<String, Map<String, String>> settingsByTarget = parseXcodeAllTargetsBuildSettings(
+      buildSettings,
+    );
 
     final pluginsExcludingArmArch = <String>{};
     for (final pluginTargetName in iosPluginTargetNames) {

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -15,7 +15,6 @@ import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/ios/xcode_build_settings.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
 import 'package:flutter_tools/src/macos/xcode.dart';
-import 'package:flutter_tools/src/xcode_project.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -15,6 +15,7 @@ import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/ios/xcode_build_settings.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
 import 'package:flutter_tools/src/macos/xcode.dart';
+import 'package:flutter_tools/src/xcode_project.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 
@@ -30,6 +31,24 @@ void main() {
     setUp(() {
       final FileSystem fileSystem = MemoryFileSystem.test();
       fileSystem.file(xcodebuild).createSync(recursive: true);
+    });
+  });
+
+  group('parseXcodeAllTargetsBuildSettings', () {
+    test('parses target build settings into a dictionary', () {
+      final Map<String, Map<String, String>> parsed = parseXcodeAllTargetsBuildSettings('''
+Build settings for action build and target bad_plugin:
+    EXCLUDED_ARCHS = i386 arm64
+    PRODUCT_NAME = bad_plugin
+
+Build settings for action build and target "good_plugin":
+    EXCLUDED_ARCHS[sdk=iphonesimulator*] = i386
+''');
+
+      expect(parsed.keys, containsAll(<String>['bad_plugin', 'good_plugin']));
+      expect(parsed['bad_plugin']!['EXCLUDED_ARCHS'], 'i386 arm64');
+      expect(parsed['bad_plugin']!['PRODUCT_NAME'], 'bad_plugin');
+      expect(parsed['good_plugin']!['EXCLUDED_ARCHS[sdk=iphonesimulator*]'], 'i386');
     });
   });
 

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/version.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/ios/xcode_build_settings.dart';
+import 'package:flutter_tools/src/xcode_project.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
 import 'package:flutter_tools/src/macos/xcode.dart';
 import 'package:flutter_tools/src/project.dart';


### PR DESCRIPTION
This PR parses `xcodebuild -showBuildSettings` output into a target-keyed map and uses that parsed data when checking plugin arm64 exclusions.

Today we manually scan lines in build settings output. That works for simple cases, but it is brittle when multiple targets/settings formats are present. This change centralizes parsing in `parseXcodeAllTargetsBuildSettings` and makes the warning path query per-target settings directly.

Fixes #182874

## What changed
- added `parseXcodeAllTargetsBuildSettings` in `xcode_project.dart`
- switched arm64 exclusion warning logic to use parsed target settings instead of ad-hoc line scanning
- added tests for:
  - parsing target build settings (including bracketed keys)
  - warning when bracketed `EXCLUDED_ARCHS` contains `arm64`
- addressed analyzer feedback (type annotations/import cleanup)

## Testing
- `./bin/dart analyze packages/flutter_tools/lib/src/xcode_project.dart packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart`
- `cd packages/flutter_tools && ../../bin/dart test test/general.shard/ios/xcodeproj_test.dart --plain-name parseXcodeAllTargetsBuildSettings`
- `cd packages/flutter_tools && ../../bin/dart test test/general.shard/ios/xcodeproj_test.dart --plain-name "warns when bracketed EXCLUDED_ARCHS contains arm64"`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md

