### PR TITLE
docs: document Play Console symbol upload for Android desymbolication

### DIFF
--- a/docs/engine/Crashes.md
+++ b/docs/engine/Crashes.md
@@ -122,7 +122,19 @@ app.android-arm64.symbols  →  app-android-arm64.so
 app.android-x64.symbols    →  app-android-x64.so
 ```
 
-Then upload the renamed `.so` files to Play Console under **All app bundles > All app bundles > Native debug symbols**.
+Then zip the renamed files together with the corresponding `libflutter.so` per ABI and upload to Play Console under **All app bundles > All app bundles > Native debug symbols**:
+
+```
+├── arm64-v8a
+│   ├── app-android-arm64.so
+│   └── libflutter.so
+├── armeabi-v7a
+│   ├── app-android-arm.so
+│   └── libflutter.so
+└── x86_64
+    ├── app-android-x64.so
+    └── libflutter.so
+```
 
 ### iOS
 

--- a/docs/engine/Crashes.md
+++ b/docs/engine/Crashes.md
@@ -97,6 +97,32 @@ If you have made your own builds, you can use ndk-stack directly:
 adb logcat | ~/dev/engine/src/third_party/android_tools/ndk/prebuilt/linux-x86_64/bin/ndk-stack -sym ~/dev/engine/src/out/android_debug_unopt
 ```
 
+### Desymbolication in Google Play Console
+
+Google Play Console can automatically desymbolicate crash reports when you upload the correct native symbol files. Two libraries are involved: `libflutter.so` (the engine) and `libapp.so` (your Dart AOT code).
+
+#### `libflutter.so` symbols
+
+- **Flutter >= 3.32**: The unstripped `libflutter.so` is bundled inside the release AAB since [#161546](https://github.com/flutter/flutter/pull/161546). Play Console picks it up automatically — no manual upload required.
+- **Flutter < 3.32**: Download the symbols zip and upload it manually to Play Console:
+  ```
+  https://storage.googleapis.com/flutter_infra_release/flutter/<ENGINE_VERSION>/android-<arm|arm64|x64>-release/symbols.zip
+  ```
+  Replace `<ENGINE_VERSION>` with your engine revision (see [Get the symbols](#get-the-symbols) above) and `<arm|arm64|x64>` with your target architecture.
+
+#### `libapp.so` symbols (Dart obfuscation)
+
+When building with `--obfuscate --split-debug-info=<dir>`, Flutter generates symbol files named like `app.android-arm64.symbols`. Play Console requires a `.so` extension to accept these uploads.
+
+A [fix](https://github.com/flutter/flutter/pull/181275) for proper symbol packaging has been merged to `master` but is not yet in a stable release. In the meantime, rename each generated symbol file by replacing the `.symbols` extension with `.so` and changing the first `.` separator to `-`:
+
+```
+app.android-arm64.symbols  →  app-android-arm64.so
+app.android-x64.symbols    →  app-android-x64.so
+```
+
+Then upload the renamed `.so` files to Play Console under **Android vitals > Deobfuscation files**.
+
 ### iOS
 
 Since Flutter 3.24, symbols can be found in the Flutter framework's artifact

--- a/docs/engine/Crashes.md
+++ b/docs/engine/Crashes.md
@@ -114,9 +114,10 @@ Google Play Console can automatically desymbolicate crash reports when you uploa
 
 When building with `--obfuscate --split-debug-info=<dir>`, Flutter generates symbol files named like `app.android-arm64.symbols`. Play Console requires a `.so` extension to accept these uploads.
 
-A [fix](https://github.com/flutter/flutter/pull/181275) for proper symbol packaging has been merged to `master` but is not yet in a stable release. In the meantime, rename each generated symbol file by replacing the `.symbols` extension with `.so` and changing the first `.` separator to `-`:
+A [fix](https://github.com/flutter/flutter/pull/181275) for proper symbol packaging has been merged to `master` but is not yet in a stable release. In the meantime, rename each generated symbol file from `app.<arch>.symbols` to `app-<arch>.so`:
 
 ```
+app.android-arm.symbols    →  app-android-arm.so
 app.android-arm64.symbols  →  app-android-arm64.so
 app.android-x64.symbols    →  app-android-x64.so
 ```

--- a/docs/engine/Crashes.md
+++ b/docs/engine/Crashes.md
@@ -121,7 +121,7 @@ app.android-arm64.symbols  →  app-android-arm64.so
 app.android-x64.symbols    →  app-android-x64.so
 ```
 
-Then upload the renamed `.so` files to Play Console under **Android vitals > Deobfuscation files**.
+Then upload the renamed `.so` files to Play Console under **All app bundles > All app bundles > Native debug symbols**.
 
 ### iOS
 


### PR DESCRIPTION
This PR adds a new section to `docs/engine/Crashes.md` documenting how to upload native debug symbols to Google Play Console for automatic desymbolication of Android crash reports.

The existing doc covers manual symbolication (ndk-stack, addr2line) but does not explain the Play Console upload workflow. Developers hitting obfuscated ANR/crash stacktraces in Play Console have no guidance on which files to upload or how to obtain them.

**What is added:**
- How to obtain and upload `libflutter.so` symbols (automatic for Flutter ≥ 3.32  via #161546; manual download URL for older versions).
- A workaround for `libapp.so` symbols when building with `--obfuscate  --split-debug-info`: rename the generated `.symbols` files to `.so` so Play  Console accepts them.

**Note:** A proper fix for the `libapp.so` packaging issue has been merged to `master` (#181275) but is not yet in a stable release. Once a stable release ships with that fix, the workaround paragraph in this doc should be updated or
removed accordingly.

Fixes #182653

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
