### PR TITLE
Re-add extended attribute removed by SwiftPM

### DIFF
--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -663,13 +663,21 @@ Future<XcodeBuildResult> buildXcodeProject({
 /// Ensure the TARGET_BUILD_DIR has the `com.apple.xcode.CreatedByBuildSystem` extended attribute.
 /// When using SwiftPM, this attribute is missing. This is required for `xcodebuild clean`.
 void ensureTargetBuildDirAttribute(String targetBuildDirPath) {
-  globals.processUtils.runSync(<String>[
+  final RunResult result = globals.processUtils.runSync(<String>[
     'xattr',
     '-w',
     'com.apple.xcode.CreatedByBuildSystem',
     'true',
     targetBuildDirPath,
   ]);
+  if (result.exitCode != 0) {
+    globals.logger.printTrace(
+      'Failed to add xattr com.apple.xcode.CreatedByBuildSystem to $targetBuildDirPath.\n'
+      'Exit code: ${result.exitCode}\n'
+      'Stdout: ${result.stdout}\n'
+      'Stderr: ${result.stderr}',
+    );
+  }
 }
 
 /// Check if the Flutter framework's public headers have changed since last built.

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -613,6 +613,8 @@ Future<XcodeBuildResult> buildXcodeProject({
           XcodeSdk.IPhoneSimulator.platformName,
         );
       }
+
+      ensureTargetBuildDirAttribute(targetBuildDir);
       final String? appBundle = buildSettings['WRAPPER_NAME'];
       final String expectedOutputDirectory = globals.fs.path.join(targetBuildDir, appBundle);
       if (globals.fs.directory(expectedOutputDirectory).existsSync()) {
@@ -656,6 +658,18 @@ Future<XcodeBuildResult> buildXcodeProject({
       xcResult: xcResult,
     );
   }
+}
+
+/// Ensure the TARGET_BUILD_DIR has the `com.apple.xcode.CreatedByBuildSystem` extended attribute.
+/// When using SwiftPM, this attribute is missing. This is required for `xcodebuild clean`.
+void ensureTargetBuildDirAttribute(String targetBuildDirPath) {
+  globals.processUtils.runSync(<String>[
+    'xattr',
+    '-w',
+    'com.apple.xcode.CreatedByBuildSystem',
+    'true',
+    targetBuildDirPath,
+  ]);
 }
 
 /// Check if the Flutter framework's public headers have changed since last built.

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -614,7 +614,7 @@ Future<XcodeBuildResult> buildXcodeProject({
         );
       }
 
-      ensureTargetBuildDirAttribute(targetBuildDir);
+      await ensureTargetBuildDirAttribute(targetBuildDir);
       final String? appBundle = buildSettings['WRAPPER_NAME'];
       final String expectedOutputDirectory = globals.fs.path.join(targetBuildDir, appBundle);
       if (globals.fs.directory(expectedOutputDirectory).existsSync()) {
@@ -662,8 +662,8 @@ Future<XcodeBuildResult> buildXcodeProject({
 
 /// Ensure the TARGET_BUILD_DIR has the `com.apple.xcode.CreatedByBuildSystem` extended attribute.
 /// When using SwiftPM, this attribute is missing. This is required for `xcodebuild clean`.
-void ensureTargetBuildDirAttribute(String targetBuildDirPath) {
-  final RunResult result = globals.processUtils.runSync(<String>[
+Future<void> ensureTargetBuildDirAttribute(String targetBuildDirPath) async {
+  final RunResult result = await globals.processUtils.run(<String>[
     'xattr',
     '-w',
     'com.apple.xcode.CreatedByBuildSystem',

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ios_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ios_test.dart
@@ -114,18 +114,29 @@ void main() {
     command: <String>['xattr', '-r', '-d', 'com.apple.provenance', '/'],
   );
 
-  FakeCommand setUpRsyncCommand({void Function(List<String> command)? onRun}) {
-    return FakeCommand(
-      command: const <String>[
-        'rsync',
-        '-8',
-        '-av',
-        '--delete',
-        'build/ios/Release-iphoneos/Runner.app',
-        'build/ios/iphoneos',
-      ],
-      onRun: onRun,
-    );
+  List<FakeCommand> postBuildCommands({void Function(List<String> command)? onRun}) {
+    return [
+      const FakeCommand(
+        command: <String>[
+          'xattr',
+          '-w',
+          'com.apple.xcode.CreatedByBuildSystem',
+          'true',
+          'build/ios/Release-iphoneos',
+        ],
+      ),
+      FakeCommand(
+        command: const <String>[
+          'rsync',
+          '-8',
+          '-av',
+          '--delete',
+          'build/ios/Release-iphoneos/Runner.app',
+          'build/ios/iphoneos',
+        ],
+        onRun: onRun,
+      ),
+    ];
   }
 
   // Sets up xcresulttool command for Xcode versions below 16.
@@ -317,7 +328,7 @@ void main() {
                 .createSync(recursive: true);
           },
         ),
-        setUpRsyncCommand(),
+        ...postBuildCommands(),
       ]),
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
@@ -348,7 +359,7 @@ void main() {
                 .createSync(recursive: true);
           },
         ),
-        setUpRsyncCommand(),
+        ...postBuildCommands(),
       ]);
 
       await createTestCommandRunner(command).run(const <String>['build', 'ios', '--no-pub']);
@@ -395,7 +406,7 @@ void main() {
                 .createSync(recursive: true);
           },
         ),
-        setUpRsyncCommand(),
+        ...postBuildCommands(),
       ]),
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
@@ -434,7 +445,7 @@ void main() {
                 .createSync(recursive: true);
           },
         ),
-        setUpRsyncCommand(),
+        ...postBuildCommands(),
       ]),
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
@@ -466,7 +477,7 @@ void main() {
                 .createSync(recursive: true);
           },
         ),
-        setUpRsyncCommand(),
+        ...postBuildCommands(),
       ]);
 
       fileSystem
@@ -515,7 +526,7 @@ void main() {
                 .createSync(recursive: true);
           },
         ),
-        setUpRsyncCommand(),
+        ...postBuildCommands(),
       ]);
       createMinimalMockProjectFiles();
 
@@ -556,7 +567,7 @@ void main() {
                 .createSync(recursive: true);
           },
         ),
-        setUpRsyncCommand(),
+        ...postBuildCommands(),
       ]);
       createMinimalMockProjectFiles();
 
@@ -597,7 +608,7 @@ void main() {
                 .createSync(recursive: true);
           },
         ),
-        setUpRsyncCommand(),
+        ...postBuildCommands(),
       ]);
 
       await createTestCommandRunner(command).run(const <String>['build', 'ios', '--no-pub', '-v']);
@@ -647,7 +658,7 @@ void main() {
               ..writeAsStringSync('{}');
           },
         ),
-        setUpRsyncCommand(
+        ...postBuildCommands(
           onRun: (_) =>
               fileSystem.file('build/ios/iphoneos/Runner.app/Frameworks/App.framework/App')
                 ..createSync(recursive: true)
@@ -725,7 +736,7 @@ void main() {
                   .createSync(recursive: true);
             },
           ),
-          setUpRsyncCommand(
+          ...postBuildCommands(
             onRun: (_) =>
                 fileSystem.file('build/ios/iphoneos/Runner.app/Frameworks/App.framework/App')
                   ..createSync(recursive: true)
@@ -780,7 +791,7 @@ void main() {
                   .createSync(recursive: true);
             },
           ),
-          setUpRsyncCommand(
+          ...postBuildCommands(
             onRun: (_) =>
                 fileSystem.file('build/ios/iphoneos/Runner.app/Frameworks/App.framework/App')
                   ..createSync(recursive: true)
@@ -831,7 +842,7 @@ void main() {
             },
           ),
           setUpLegacyXCResultCommand(),
-          setUpRsyncCommand(),
+          ...postBuildCommands(),
         ]);
 
         createMinimalMockProjectFiles();
@@ -876,7 +887,7 @@ void main() {
             stdout: 'Lots of spew from Xcode',
           ),
           setUpLegacyXCResultCommand(stdout: kSampleResultJsonWithIssues),
-          setUpRsyncCommand(),
+          ...postBuildCommands(),
         ]);
 
         createMinimalMockProjectFiles();
@@ -926,7 +937,7 @@ void main() {
             },
           ),
           setUpLegacyXCResultCommand(stdout: kSampleResultJsonWithIssuesToBeDiscarded),
-          setUpRsyncCommand(),
+          ...postBuildCommands(),
         ]);
 
         createMinimalMockProjectFiles();
@@ -977,7 +988,7 @@ void main() {
           xattrCommand2,
           setUpFakeXcodeBuildHandler(exitCode: 1),
           setUpLegacyXCResultCommand(stdout: kSampleResultJsonWithIssues),
-          setUpRsyncCommand(),
+          ...postBuildCommands(),
         ]);
 
         createMinimalMockProjectFiles();
@@ -1023,7 +1034,7 @@ void main() {
             },
           ),
           setUpLegacyXCResultCommand(stdout: kSampleResultJsonWithProvisionIssue),
-          setUpRsyncCommand(),
+          ...postBuildCommands(),
         ]);
 
         createMinimalMockProjectFiles();
@@ -1082,7 +1093,7 @@ void main() {
             },
           ),
           setUpLegacyXCResultCommand(stdout: kSampleResultJsonWithNoProvisioningProfileIssue),
-          setUpRsyncCommand(),
+          ...postBuildCommands(),
         ]);
 
         createMinimalMockProjectFiles();
@@ -1132,7 +1143,7 @@ void main() {
             },
           ),
           setUpLegacyXCResultCommand(stdout: kSampleResultJsonWithActionIssues),
-          setUpRsyncCommand(),
+          ...postBuildCommands(),
         ]);
 
         createMinimalMockProjectFiles();
@@ -1196,7 +1207,7 @@ void main() {
             },
           ),
           setUpLegacyXCResultCommand(stdout: kSampleResultJsonNoIssues),
-          setUpRsyncCommand(),
+          ...postBuildCommands(),
         ]);
 
         createMinimalMockProjectFiles();
@@ -1240,7 +1251,7 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
             },
           ),
           setUpLegacyXCResultCommand(stdout: kSampleResultJsonInvalidIssuesMap),
-          setUpRsyncCommand(),
+          ...postBuildCommands(),
         ]);
 
         createMinimalMockProjectFiles();
@@ -1284,7 +1295,7 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
             },
           ),
           setUpLegacyXCResultCommand(stdout: kSampleResultJsonInvalidIssuesMap),
-          setUpRsyncCommand(),
+          ...postBuildCommands(),
         ]);
 
         createMinimalMockProjectFiles();
@@ -1344,7 +1355,7 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
             },
           ),
           setUpLegacyXCResultCommand(stdout: kSampleResultJsonNoIssues),
-          setUpRsyncCommand(),
+          ...postBuildCommands(),
         ]),
         Pub: ThrowingPub.new,
         EnvironmentType: () => EnvironmentType.physical,
@@ -1375,7 +1386,7 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
             },
           ),
           setUpLegacyXCResultCommand(stdout: kSampleResultJsonInvalidIssuesMap),
-          setUpRsyncCommand(),
+          ...postBuildCommands(),
         ]);
 
         createMinimalMockProjectFiles();
@@ -1419,7 +1430,7 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
             },
           ),
           setUpLegacyXCResultCommand(stdout: kSampleResultJsonWithNoProvisioningProfileIssue),
-          setUpRsyncCommand(),
+          ...postBuildCommands(),
         ]);
 
         createMinimalMockProjectFiles();
@@ -1465,7 +1476,7 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
             },
           ),
           setUpLegacyXCResultCommand(stdout: kSampleResultJsonWithProvisionIssue),
-          setUpRsyncCommand(),
+          ...postBuildCommands(),
         ]);
 
         createMinimalMockProjectFiles();
@@ -1521,7 +1532,7 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
             },
           ),
           setUpLegacyXCResultCommand(),
-          setUpRsyncCommand(),
+          ...postBuildCommands(),
         ]);
 
         createMinimalMockProjectFiles();
@@ -1568,7 +1579,7 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
             },
           ),
           setUpLegacyXCResultCommand(stdout: kSampleResultJsonWithIssues),
-          setUpRsyncCommand(),
+          ...postBuildCommands(),
         ]);
 
         createMinimalMockProjectFiles();
@@ -1620,7 +1631,7 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
             },
           ),
           setUpLegacyXCResultCommand(stdout: kSampleResultJsonWithIssuesToBeDiscarded),
-          setUpRsyncCommand(),
+          ...postBuildCommands(),
         ]);
 
         createMinimalMockProjectFiles();
@@ -1673,7 +1684,7 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
           xattrCommand2,
           setUpFakeXcodeBuildHandler(simulator: true, exitCode: 1),
           setUpLegacyXCResultCommand(stdout: kSampleResultJsonWithIssues),
-          setUpRsyncCommand(),
+          ...postBuildCommands(),
         ]);
 
         createMinimalMockProjectFiles();

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
@@ -52,6 +52,12 @@ List<FakeCommand> xattrCommands(FlutterProject flutterProject) {
   ];
 }
 
+FakeCommand xattrCreatedByBuildSystemCommand(String outputDirPath) {
+  return FakeCommand(
+    command: <String>['xattr', '-w', 'com.apple.xcode.CreatedByBuildSystem', 'true', outputDirPath],
+  );
+}
+
 const kRunReleaseArgs = <String>[
   'xcrun',
   'xcodebuild',
@@ -253,6 +259,7 @@ void main() {
 
         processManager.addCommands(xattrCommands(flutterProject));
         processManager.addCommand(const FakeCommand(command: kRunReleaseArgs));
+        processManager.addCommand(xattrCreatedByBuildSystemCommand('build/ios/Release-iphoneos'));
         processManager.addCommand(
           const FakeCommand(
             command: <String>[
@@ -369,6 +376,7 @@ void main() {
             ],
           ),
         );
+        processManager.addCommand(xattrCreatedByBuildSystemCommand('build/ios/Release-iphoneos'));
         processManager.addCommand(
           const FakeCommand(
             command: <String>[
@@ -514,6 +522,7 @@ void main() {
                 );
               },
             ),
+            xattrCreatedByBuildSystemCommand('build/ios/Release-iphoneos'),
             FakeCommand(
               command: <String>[
                 iosDeployPath,
@@ -609,6 +618,7 @@ void main() {
                 'COMPILER_INDEX_STORE_ENABLE=NO',
               ],
             ),
+            xattrCreatedByBuildSystemCommand('build/ios/Release-iphoneos'),
           ]);
 
           await iosDevice.startApp(
@@ -666,6 +676,7 @@ void main() {
           ),
         );
         processManager.addCommand(const FakeCommand(command: kRunReleaseArgs));
+        processManager.addCommand(xattrCreatedByBuildSystemCommand('build/ios/Release-iphoneos'));
         processManager.addCommand(
           FakeCommand(
             command: <String>[


### PR DESCRIPTION
After migrating to SwiftPM, the `com.apple.xcode.CreatedByBuildSystem` extended attribute is removed from the target build directory (e.g. `build/ios/Release-iphoneos`). This causes `xcodebuild clean` to fail. This appears to be an Xcode bug. To workaround it, we add it back.

Fixes https://github.com/flutter/flutter/issues/183006.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
