### PR TITLE
[Impeller] Update comments to reflect new info about 2-pass rendering

### DIFF
--- a/engine/src/flutter/impeller/display_list/dl_dispatcher.h
+++ b/engine/src/flutter/impeller/display_list/dl_dispatcher.h
@@ -339,7 +339,7 @@ class CanvasDlDispatcher : public DlDispatcherBase {
   Canvas& GetCanvas() override;
 };
 
-/// Performs a first pass over the display list to collect infomation
+/// Performs a first pass over the display list to collect information
 /// that will be useful in a second pass by the CanvasDlDispatcher.
 /// This class collects things like text frames and backdrop filters.
 class FirstPassDispatcher : public flutter::IgnoreAttributeDispatchHelper,

--- a/engine/src/flutter/impeller/display_list/dl_dispatcher.h
+++ b/engine/src/flutter/impeller/display_list/dl_dispatcher.h
@@ -41,7 +41,7 @@ using DlPath = flutter::DlPath;
 /// The second pass is conducted using CanvasDlDispatcher to perform the
 /// actual rendering using a Canvas and data provided by the first pass.
 ///
-/// \\important It is important to note that the 2 passes perform slightly
+/// @important It is important to note that the 2 passes perform slightly
 /// different DisplayList culling and may process different subsets of the
 /// frame's operations.
 /// See https://github.com/flutter/flutter/issues/182639

--- a/engine/src/flutter/impeller/display_list/dl_dispatcher.h
+++ b/engine/src/flutter/impeller/display_list/dl_dispatcher.h
@@ -28,6 +28,35 @@ using DlRoundRect = flutter::DlRoundRect;
 using DlRoundSuperellipse = flutter::DlRoundSuperellipse;
 using DlPath = flutter::DlPath;
 
+//////////////////////////////////////////////////////////////////////////
+/// Important implementation note.
+///
+/// The Impeller DisplayList Dispatcher implementation is divided into
+/// two parts and conducted in two passes.
+///
+/// The first pass is conducted using the FirstPassDispatcher which
+/// examines the rendering ops for important conditions needed by the
+/// rendering pass and computes some needed information for them.
+///
+/// The second pass is conducted using CanvasDlDispatcher to perform the
+/// actual rendering using a Canvas and data provided by the first pass.
+///
+/// \\important It is important to note that the 2 passes perform slightly
+/// different DisplayList culling and may process different subsets of the
+/// frame's operations.
+/// See https://github.com/flutter/flutter/issues/182639
+///
+/// Given the above issue any data precomputed by the first pass should
+/// be presented in a way that doesn't assume a 1:1 correlation of the
+/// rendering operations in both passes (perhaps provide it in a map
+/// instead of a vector). While we have not yet observed and cases where
+/// an operation is missed during the first pass but still processed in
+/// the rendering pass, it would be wise to include a backup plan in
+/// the canvas dispatcher for when the data was not forwarded.
+//////////////////////////////////////////////////////////////////////////
+
+/// Base (virtual) dispatcher utility class to implement most DlOpReceiver
+/// operations for other specific classes.
 class DlDispatcherBase : public flutter::DlOpReceiver {
  public:
   // |flutter::DlOpReceiver|
@@ -260,6 +289,10 @@ class DlDispatcherBase : public flutter::DlOpReceiver {
                                  const Paint& paint);
 };
 
+/// Specific non-virtual dispatcher utility class that uses DlDispatcherBase
+/// to implement most operations but provides additional implementation of
+/// operations that are specific to the rendering pass of the Impeller
+/// 2-pass rendering procedure.
 class CanvasDlDispatcher : public DlDispatcherBase {
  public:
   CanvasDlDispatcher(ContentContext& renderer,
@@ -306,8 +339,9 @@ class CanvasDlDispatcher : public DlDispatcherBase {
   Canvas& GetCanvas() override;
 };
 
-/// Performs a first pass over the display list to collect infomation.
-/// Collects things like text frames and backdrop filters.
+/// Performs a first pass over the display list to collect infomation
+/// that will be useful in a second pass by the CanvasDlDispatcher.
+/// This class collects things like text frames and backdrop filters.
 class FirstPassDispatcher : public flutter::IgnoreAttributeDispatchHelper,
                             public flutter::IgnoreClipDispatchHelper,
                             public flutter::IgnoreDrawDispatchHelper {

--- a/engine/src/flutter/impeller/typographer/glyph_atlas.h
+++ b/engine/src/flutter/impeller/typographer/glyph_atlas.h
@@ -20,9 +20,9 @@ namespace impeller {
 class FontGlyphAtlas;
 
 struct FrameBounds {
-  /// The bounds of the glyph within the glyph atlas.
+  /// The bounds of the glyph within the glyph atlas texture.
   Rect atlas_bounds;
-  /// The local glyph bounds.
+  /// The glyph bounds within the local coordinate system.
   Rect glyph_bounds;
   /// Whether [atlas_bounds] are still a placeholder and have
   /// not yet been computed.

--- a/engine/src/flutter/impeller/typographer/text_frame.h
+++ b/engine/src/flutter/impeller/typographer/text_frame.h
@@ -23,9 +23,6 @@ using PathCreator = std::function<fml::StatusOr<flutter::DlPath>()>;
 ///
 ///             This object is typically the entrypoint in the Impeller type
 ///             rendering subsystem.
-///
-/// A text frame should not be reused in multiple places within a single frame,
-/// as internally it is used as a cache for various glyph properties.
 class TextFrame {
  public:
   TextFrame();
@@ -49,7 +46,7 @@ class TextFrame {
   /// @brief      The conservative bounding box for this text frame.
   ///
   /// @return     The bounds rectangle. If there are no glyphs in this text
-  ///             frame and empty Rectangle is returned instead.
+  ///             frame an empty Rectangle is returned instead.
   ///
   Rect GetBounds() const;
 
@@ -68,16 +65,21 @@ class TextFrame {
   const std::vector<TextRun>& GetRuns() const;
 
   //----------------------------------------------------------------------------
-  /// @brief      Returns the paint color this text frame was recorded with.
+  /// @brief      Returns whether any glyph in any run in this TextFrame
+  ///             is colored and so would be cached with color already
+  ///             baked in to the colored glyph.
   ///
-  ///             Non-bitmap/COLR fonts always use a black text color here, but
+  ///             Non-bitmap/COLR fonts only store an alpha bitmap, but
   ///             COLR fonts can potentially use the paint color in the glyph
-  ///             atlas, so this color must be considered as part of the cache
-  ///             key.
+  ///             atlas, so the color the text is being rendered with must
+  ///             be considered as part of the cache key.
   bool HasColor() const;
 
   //----------------------------------------------------------------------------
   /// @brief      The type of atlas this run should be place in.
+  ///
+  ///             This return value depends primarily on the HasColor
+  ///             property.
   GlyphAtlas::Type GetAtlasType() const;
 
   /// @brief If this text frame contains a single glyph (such as for an Icon),
@@ -89,19 +91,11 @@ class TextFrame {
 
   fml::StatusOr<flutter::DlPath> GetPath() const;
 
-  Point GetOffset() const;
-
  private:
   std::vector<TextRun> runs_;
   Rect bounds_;
   bool has_color_;
   const PathCreator path_creator_;
-};
-
-struct RenderableText {
-  const std::shared_ptr<TextFrame> text_frame;
-  const Matrix origin_transform;
-  const std::optional<GlyphProperties> properties;
 };
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/typographer/typographer_context.h
+++ b/engine/src/flutter/impeller/typographer/typographer_context.h
@@ -16,7 +16,7 @@ namespace impeller {
 /// The data associated with a single rendering instance of a TextFrame,
 /// used to pre-load the glyph atlas with glyph and bounds information.
 struct RenderableText {
-  /// The TextFrame being rendered
+  /// The TextFrame being rendered.
   const std::shared_ptr<TextFrame> text_frame;
 
   /// The transform that places the origin of the TextFrame within screen

--- a/engine/src/flutter/impeller/typographer/typographer_context.h
+++ b/engine/src/flutter/impeller/typographer/typographer_context.h
@@ -13,12 +13,27 @@
 
 namespace impeller {
 
+/// The data associated with a single rendering instance of a TextFrame,
+/// used to pre-load the glyph atlas with glyph and bounds information.
+struct RenderableText {
+  /// The TextFrame being rendered
+  const std::shared_ptr<TextFrame> text_frame;
+
+  /// The transform that places the origin of the TextFrame within screen
+  /// space. This is the current transform (ctm) of the graphics context
+  /// translated by the local space position of the TextFrame.
+  const Matrix origin_transform;
+
+  /// The properties needed for rendering stroked text and/or the color
+  /// needed to cache a TextFrame where HasColor() == true.
+  const std::optional<GlyphProperties> properties;
+};
+
 //------------------------------------------------------------------------------
 /// @brief      The graphics context necessary to render text.
 ///
 ///             This is necessary to create and reference resources related to
 ///             rendering text on the GPU.
-///
 ///
 class TypographerContext {
  public:


### PR DESCRIPTION
This is a follow-on to https://github.com/flutter/flutter/pull/182886 where new information about the Impeller 2-pass rendering system and, in particular, how it applies to glyph caching was uncovered. Some of the comments were stale after those discoveries so this PR addresses those changes.

Most of the changes are added or modified comments.
One obsolete method had a declaration and no definition, the declaration is removed.
One new structure is moved to a different header file with which it is more closely associated.

There are no test updates since no implementations were changed.