### PR TITLE
Fix black screen issue when rendering pixel buffer on Linux

### DIFF
--- a/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
@@ -177,7 +177,6 @@ EmbedderExternalTextureGL::CreateTextureGLES(
     FlutterOpenGLTexture* texture) {
   impeller::TextureDescriptor desc;
   desc.size = impeller::ISize(texture->width, texture->height);
-  desc.storage_mode = impeller::StorageMode::kDevicePrivate;
   desc.format = impeller::PixelFormat::kR8G8B8A8UNormInt;
 
   auto type = ToImpellerTextureType(texture->target);

--- a/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
@@ -157,9 +157,9 @@ sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTextureImpeller(
     return nullptr;
   }
 
-  if (texture_gles_) {
-    texture_gles_->Leak();
-    texture_gles_ = nullptr;
+  if (texture_gles_ && texture_gles_->GetGLHandle().has_value() &&
+      texture_gles_->GetGLHandle().value() == texture->name) {
+    return impeller::DlImageImpeller::Make(texture_gles_);
   }
 
   texture_gles_ = CreateTextureGLES(aiks_context, texture.get());

--- a/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
@@ -27,6 +27,19 @@
 
 namespace flutter {
 
+constexpr std::optional<impeller::TextureType> ToImpellerTextureType(
+    GLenum type) {
+  switch (type) {
+    case GL_TEXTURE_2D:
+      return impeller::TextureType::kTexture2D;
+    case GL_TEXTURE_CUBE_MAP:
+      return impeller::TextureType::kTextureCube;
+    case GL_TEXTURE_EXTERNAL_OES:
+      return impeller::TextureType::kTextureExternalOES;
+  }
+  FML_UNREACHABLE();
+}
+
 EmbedderExternalTextureGL::EmbedderExternalTextureGL(
     int64_t texture_identifier,
     const ExternalTextureCallback& callback)
@@ -143,9 +156,29 @@ sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTextureImpeller(
     return nullptr;
   }
 
+  if (texture_gles_) {
+    texture_gles_->Leak();
+    texture_gles_ = nullptr;
+  }
+
+  texture_gles_ = CreateTextureGLES(aiks_context, texture.get());
+
+  if (!texture_gles_) {
+    return nullptr;
+  }
+
+  return impeller::DlImageImpeller::Make(texture_gles_);
+}
+
+std::shared_ptr<impeller::TextureGLES>
+EmbedderExternalTextureGL::CreateTextureGLES(
+    impeller::AiksContext* aiks_context,
+    FlutterOpenGLTexture* texture) {
   impeller::TextureDescriptor desc;
   desc.size = impeller::ISize(texture->width, texture->height);
+  desc.storage_mode = impeller::StorageMode::kDevicePrivate;
   desc.format = impeller::PixelFormat::kR8G8B8A8UNormInt;
+  desc.type = ToImpellerTextureType(texture->target).value();
 
   impeller::ContextGLES& context =
       impeller::ContextGLES::Cast(*aiks_context->GetContext());
@@ -174,7 +207,7 @@ sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTextureImpeller(
   image->SetCoordinateSystem(
       impeller::TextureCoordinateSystem::kUploadFromHost);
 
-  return impeller::DlImageImpeller::Make(image);
+  return image;
 }
 
 // |flutter::Texture|

--- a/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
@@ -165,6 +165,9 @@ sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTextureImpeller(
   texture_gles_ = CreateTextureGLES(aiks_context, texture.get());
 
   if (!texture_gles_) {
+    if (texture->destruction_callback) {
+      texture->destruction_callback(texture->user_data);
+    }
     return nullptr;
   }
 
@@ -181,9 +184,7 @@ EmbedderExternalTextureGL::CreateTextureGLES(
 
   auto type = ToImpellerTextureType(texture->target);
   if (!type.has_value()) {
-    if (texture->destruction_callback) {
-      texture->destruction_callback(texture->user_data);
-    }
+    FML_LOG(ERROR) << "Could not convert to impeller texture type";
     return nullptr;
   }
   desc.type = type.value();
@@ -197,9 +198,6 @@ EmbedderExternalTextureGL::CreateTextureGLES(
   if (!image) {
     // In case Skia rejects the image, call the release proc so that
     // embedders can perform collection of intermediates.
-    if (texture->destruction_callback) {
-      texture->destruction_callback(texture->user_data);
-    }
     FML_LOG(ERROR) << "Could not create external texture";
     return nullptr;
   }

--- a/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
@@ -36,8 +36,9 @@ constexpr std::optional<impeller::TextureType> ToImpellerTextureType(
       return impeller::TextureType::kTextureCube;
     case GL_TEXTURE_EXTERNAL_OES:
       return impeller::TextureType::kTextureExternalOES;
+    default:
+      return std::nullopt;
   }
-  FML_UNREACHABLE();
 }
 
 EmbedderExternalTextureGL::EmbedderExternalTextureGL(
@@ -178,8 +179,15 @@ EmbedderExternalTextureGL::CreateTextureGLES(
   desc.size = impeller::ISize(texture->width, texture->height);
   desc.storage_mode = impeller::StorageMode::kDevicePrivate;
   desc.format = impeller::PixelFormat::kR8G8B8A8UNormInt;
-  desc.type = ToImpellerTextureType(texture->target).value();
 
+  auto type = ToImpellerTextureType(texture->target);
+  if (!type.has_value()) {
+    if (texture->destruction_callback) {
+      texture->destruction_callback(texture->user_data);
+    }
+    return nullptr;
+  }
+  desc.type = type.value();
   impeller::ContextGLES& context =
       impeller::ContextGLES::Cast(*aiks_context->GetContext());
   impeller::HandleGLES handle = context.GetReactor()->CreateHandle(

--- a/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.h
+++ b/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.h
@@ -8,6 +8,7 @@
 #include "flutter/common/graphics/texture.h"
 #include "flutter/fml/macros.h"
 #include "flutter/shell/platform/embedder/embedder.h"
+#include "impeller/renderer/backend/gles/texture_gles.h"
 #include "third_party/skia/include/core/SkSize.h"
 
 namespace flutter {
@@ -25,6 +26,7 @@ class EmbedderExternalTextureGL : public flutter::Texture {
  private:
   const ExternalTextureCallback& external_texture_callback_;
   sk_sp<DlImage> last_image_;
+  std::shared_ptr<impeller::TextureGLES> texture_gles_;
 
   sk_sp<DlImage> ResolveTexture(int64_t texture_id,
                                 GrDirectContext* context,
@@ -38,6 +40,10 @@ class EmbedderExternalTextureGL : public flutter::Texture {
   sk_sp<DlImage> ResolveTextureImpeller(int64_t texture_id,
                                         impeller::AiksContext* aiks_context,
                                         const SkISize& size);
+
+  std::shared_ptr<impeller::TextureGLES> CreateTextureGLES(
+      impeller::AiksContext* aiks_context,
+      FlutterOpenGLTexture* texture);
 
   // |flutter::Texture|
   void Paint(PaintContext& context,

--- a/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.h
+++ b/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.h
@@ -26,6 +26,11 @@ class EmbedderExternalTextureGL : public flutter::Texture {
  private:
   const ExternalTextureCallback& external_texture_callback_;
   sk_sp<DlImage> last_image_;
+  // If a impeller::TextureGLES and impeller::HandleGLES are created every time
+  // when a texture is rendered. the impeller::TextureGLES destructor is called
+  // after rendering, and impeller::RefactorGLES will destroy
+  // impeller::HandleGLES.Now add texture_gles_ new variable to ensure that the
+  // gl handle is not destroyed if the same gl handle is used every time.
   std::shared_ptr<impeller::TextureGLES> texture_gles_;
 
   sk_sp<DlImage> ResolveTexture(int64_t texture_id,

--- a/engine/src/flutter/shell/platform/embedder/tests/embedder_gl_unittests.cc
+++ b/engine/src/flutter/shell/platform/embedder/tests/embedder_gl_unittests.cc
@@ -4910,6 +4910,88 @@ TEST_F(EmbedderTest, RenderTextureWithImpellerOpenGL) {
       ImageMatchesFixture("external_texture_impeller.png", rendered_scene));
 }
 
+TEST_F(EmbedderTest, RenderMultiFramesTextureWithImpellerOpenGL) {
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
+  EmbedderConfigBuilder builder(context);
+  builder.AddCommandLineArgument("--enable-impeller");
+  builder.SetDartEntrypoint("render_texture_impeller_test");
+  builder.SetSurface(DlISize(800, 600));
+  typedef void (*glGenTexturesProc)(GLsizei n, GLuint* textures);
+  typedef void (*glBindTextureProc)(GLenum n, GLuint texture);
+  typedef void (*glTexImage2DProc)(GLenum target, GLint level,
+                                   GLint internalformat, GLsizei width,
+                                   GLsizei height, GLint border, GLenum format,
+                                   GLenum type, const void* pixels);
+  static glGenTexturesProc glGenTextures = reinterpret_cast<glGenTexturesProc>(
+      context.GLGetProcAddress("glGenTextures"));
+  static glBindTextureProc glBindTexture = reinterpret_cast<glBindTextureProc>(
+      context.GLGetProcAddress("glBindTexture"));
+  static glTexImage2DProc glTexImage2D = reinterpret_cast<glTexImage2DProc>(
+      context.GLGetProcAddress("glTexImage2D"));
+  static GLuint gl_texture = 0;
+  std::future<sk_sp<SkImage>> rendered_scene;
+  context.GetRendererConfig().open_gl.gl_external_texture_frame_callback =
+      [](void* user_data, int64_t texture_id, size_t width, size_t height,
+         FlutterOpenGLTexture* texture) -> bool {
+    std::vector<uint8_t> buffer(800 * 600 * 4);
+    for (int i = 0; i < 800 * 300; ++i) {
+      buffer[i * 4 + 0] = 255;  // Red channel
+      buffer[i * 4 + 1] = 0;    // Green channel
+      buffer[i * 4 + 2] = 0;    // Blue channel
+      buffer[i * 4 + 3] = 255;  // Alpha channel (fully opaque)
+    }
+
+    for (int i = 800 * 300; i < 800 * 600; ++i) {
+      buffer[i * 4 + 0] = 0;    // Red channel
+      buffer[i * 4 + 1] = 0;    // Green channel
+      buffer[i * 4 + 2] = 255;  // Blue channel
+      buffer[i * 4 + 3] = 255;  // Alpha channel (fully opaque)
+    }
+    if (gl_texture == 0) {
+      glGenTextures(1, &gl_texture);
+    }
+    glBindTexture(GL_TEXTURE_2D, gl_texture);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, 800, 600, 0, GL_RGBA,
+                 GL_UNSIGNED_BYTE, buffer.data());
+    texture->target = GL_TEXTURE_2D;
+    texture->name = gl_texture;
+    texture->format = GL_RGBA8;
+    texture->destruction_callback = nullptr;
+    texture->user_data = nullptr;
+    texture->width = width;
+    texture->height = height;
+    return true;
+  };
+
+  auto engine = builder.LaunchEngine();
+
+  ASSERT_TRUE(engine.is_valid());
+
+  flutter::EmbedderEngine* embedder_engine = ToEmbedderEngine(engine.get());
+
+  ASSERT_TRUE(embedder_engine->RegisterTexture(1));
+  static int frame_count = 0;
+  fml::CountDownLatch latch(4);
+  context.SetGLPresentCallback([&](FlutterPresentInfo present_info) {
+    ASSERT_TRUE(embedder_engine->MarkTextureFrameAvailable(1));
+    if (frame_count++ == 2) {
+      rendered_scene = context.GetNextSceneImage();
+    }
+    latch.CountDown();
+  });
+  // Send a window metrics events so frames may be scheduled.
+  FlutterWindowMetricsEvent event = {};
+  event.struct_size = sizeof(event);
+  event.width = 800;
+  event.height = 600;
+  event.pixel_ratio = 1.0;
+  ASSERT_EQ(FlutterEngineSendWindowMetricsEvent(engine.get(), &event),
+            kSuccess);
+  latch.Wait();
+  ASSERT_TRUE(
+      ImageMatchesFixture("external_texture_impeller.png", rendered_scene));
+}
+
 TEST_F(EmbedderTest, ImpellerOpenGLImageSnapshot) {
   auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 

--- a/engine/src/flutter/shell/platform/embedder/tests/embedder_gl_unittests.cc
+++ b/engine/src/flutter/shell/platform/embedder/tests/embedder_gl_unittests.cc
@@ -4929,7 +4929,6 @@ TEST_F(EmbedderTest, RenderMultiFramesTextureWithImpellerOpenGL) {
   static glTexImage2DProc glTexImage2D = reinterpret_cast<glTexImage2DProc>(
       context.GLGetProcAddress("glTexImage2D"));
   static GLuint gl_texture = 0;
-  std::future<sk_sp<SkImage>> rendered_scene;
   context.GetRendererConfig().open_gl.gl_external_texture_frame_callback =
       [](void* user_data, int64_t texture_id, size_t width, size_t height,
          FlutterOpenGLTexture* texture) -> bool {
@@ -4971,12 +4970,17 @@ TEST_F(EmbedderTest, RenderMultiFramesTextureWithImpellerOpenGL) {
 
   ASSERT_TRUE(embedder_engine->RegisterTexture(1));
   static int frame_count = 0;
-  fml::CountDownLatch latch(4);
+  static int max_frame_count = 4;
+  fml::CountDownLatch latch(max_frame_count);
+  std::future<sk_sp<SkImage>> rendered_scene = context.GetNextSceneImage();
   context.SetGLPresentCallback([&](FlutterPresentInfo present_info) {
-    ASSERT_TRUE(embedder_engine->MarkTextureFrameAvailable(1));
-    if (frame_count++ == 2) {
+    if (frame_count > 0 && frame_count < max_frame_count) {
+      ASSERT_TRUE(
+          ImageMatchesFixture("external_texture_impeller.png", rendered_scene));
       rendered_scene = context.GetNextSceneImage();
     }
+    frame_count++;
+    ASSERT_TRUE(embedder_engine->MarkTextureFrameAvailable(1));
     latch.CountDown();
   });
   // Send a window metrics events so frames may be scheduled.

--- a/engine/src/flutter/shell/platform/embedder/tests/embedder_gl_unittests.cc
+++ b/engine/src/flutter/shell/platform/embedder/tests/embedder_gl_unittests.cc
@@ -4854,6 +4854,7 @@ TEST_F(EmbedderTest, RenderTextureWithImpellerOpenGL) {
   static glTexImage2DProc glTexImage2D = reinterpret_cast<glTexImage2DProc>(
       context.GLGetProcAddress("glTexImage2D"));
 
+  static GLuint gl_texture = 0;
   auto rendered_scene = context.GetNextSceneImage();
   context.GetRendererConfig().open_gl.gl_external_texture_frame_callback =
       [](void* user_data, int64_t texture_id, size_t width, size_t height,
@@ -4873,79 +4874,6 @@ TEST_F(EmbedderTest, RenderTextureWithImpellerOpenGL) {
       buffer[i * 4 + 3] = 255;  // Alpha channel (fully opaque)
     }
 
-    GLuint gl_texture;
-    glGenTextures(1, &gl_texture);
-    glBindTexture(GL_TEXTURE_2D, gl_texture);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, 800, 600, 0, GL_RGBA,
-                 GL_UNSIGNED_BYTE, buffer.data());
-    texture->target = GL_TEXTURE_2D;
-    texture->name = gl_texture;
-    texture->format = GL_RGBA8;
-    texture->destruction_callback = nullptr;
-    texture->user_data = nullptr;
-    texture->width = width;
-    texture->height = height;
-    return true;
-  };
-
-  auto engine = builder.LaunchEngine();
-
-  ASSERT_TRUE(engine.is_valid());
-
-  flutter::EmbedderEngine* embedder_engine = ToEmbedderEngine(engine.get());
-
-  ASSERT_TRUE(embedder_engine->RegisterTexture(1));
-  ASSERT_TRUE(embedder_engine->MarkTextureFrameAvailable(1));
-
-  // Send a window metrics events so frames may be scheduled.
-  FlutterWindowMetricsEvent event = {};
-  event.struct_size = sizeof(event);
-  event.width = 800;
-  event.height = 600;
-  event.pixel_ratio = 1.0;
-  ASSERT_EQ(FlutterEngineSendWindowMetricsEvent(engine.get(), &event),
-            kSuccess);
-  latch.Wait();
-  ASSERT_TRUE(
-      ImageMatchesFixture("external_texture_impeller.png", rendered_scene));
-}
-
-TEST_F(EmbedderTest, RenderMultiFramesTextureWithImpellerOpenGL) {
-  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
-  EmbedderConfigBuilder builder(context);
-  builder.AddCommandLineArgument("--enable-impeller");
-  builder.SetDartEntrypoint("render_texture_impeller_test");
-  builder.SetSurface(DlISize(800, 600));
-  typedef void (*glGenTexturesProc)(GLsizei n, GLuint* textures);
-  typedef void (*glBindTextureProc)(GLenum n, GLuint texture);
-  typedef void (*glTexImage2DProc)(GLenum target, GLint level,
-                                   GLint internalformat, GLsizei width,
-                                   GLsizei height, GLint border, GLenum format,
-                                   GLenum type, const void* pixels);
-  static glGenTexturesProc glGenTextures = reinterpret_cast<glGenTexturesProc>(
-      context.GLGetProcAddress("glGenTextures"));
-  static glBindTextureProc glBindTexture = reinterpret_cast<glBindTextureProc>(
-      context.GLGetProcAddress("glBindTexture"));
-  static glTexImage2DProc glTexImage2D = reinterpret_cast<glTexImage2DProc>(
-      context.GLGetProcAddress("glTexImage2D"));
-  static GLuint gl_texture = 0;
-  context.GetRendererConfig().open_gl.gl_external_texture_frame_callback =
-      [](void* user_data, int64_t texture_id, size_t width, size_t height,
-         FlutterOpenGLTexture* texture) -> bool {
-    std::vector<uint8_t> buffer(800 * 600 * 4);
-    for (int i = 0; i < 800 * 300; ++i) {
-      buffer[i * 4 + 0] = 255;  // Red channel
-      buffer[i * 4 + 1] = 0;    // Green channel
-      buffer[i * 4 + 2] = 0;    // Blue channel
-      buffer[i * 4 + 3] = 255;  // Alpha channel (fully opaque)
-    }
-
-    for (int i = 800 * 300; i < 800 * 600; ++i) {
-      buffer[i * 4 + 0] = 0;    // Red channel
-      buffer[i * 4 + 1] = 0;    // Green channel
-      buffer[i * 4 + 2] = 255;  // Blue channel
-      buffer[i * 4 + 3] = 255;  // Alpha channel (fully opaque)
-    }
     if (gl_texture == 0) {
       glGenTextures(1, &gl_texture);
     }
@@ -4969,20 +4897,7 @@ TEST_F(EmbedderTest, RenderMultiFramesTextureWithImpellerOpenGL) {
   flutter::EmbedderEngine* embedder_engine = ToEmbedderEngine(engine.get());
 
   ASSERT_TRUE(embedder_engine->RegisterTexture(1));
-  static int frame_count = 0;
-  static int max_frame_count = 4;
-  fml::CountDownLatch latch(max_frame_count);
-  std::future<sk_sp<SkImage>> rendered_scene = context.GetNextSceneImage();
-  context.SetGLPresentCallback([&](FlutterPresentInfo present_info) {
-    if (frame_count > 0 && frame_count < max_frame_count) {
-      ASSERT_TRUE(
-          ImageMatchesFixture("external_texture_impeller.png", rendered_scene));
-      rendered_scene = context.GetNextSceneImage();
-    }
-    frame_count++;
-    ASSERT_TRUE(embedder_engine->MarkTextureFrameAvailable(1));
-    latch.CountDown();
-  });
+
   // Send a window metrics events so frames may be scheduled.
   FlutterWindowMetricsEvent event = {};
   event.struct_size = sizeof(event);
@@ -4994,6 +4909,13 @@ TEST_F(EmbedderTest, RenderMultiFramesTextureWithImpellerOpenGL) {
   latch.Wait();
   ASSERT_TRUE(
       ImageMatchesFixture("external_texture_impeller.png", rendered_scene));
+  for (int i = 0; i < 5; i++) {
+    rendered_scene = context.GetNextSceneImage();
+    ASSERT_TRUE(embedder_engine->MarkTextureFrameAvailable(1));
+    latch.Wait();
+    ASSERT_TRUE(
+        ImageMatchesFixture("external_texture_impeller.png", rendered_scene));
+  }
 }
 
 TEST_F(EmbedderTest, ImpellerOpenGLImageSnapshot) {


### PR DESCRIPTION
If a TextureGLES and HandleGLES are created every time a texture is rendered, the TextureGLES destructor is called after rendering, and RefactorGLES destroys HandleGLES.
However, in [Linux ](https://github.com/flutter/flutter/blob/master/engine/src/flutter/shell/platform/linux/fl_pixel_buffer_texture.cc#L109)and [Windows ](https://github.com/flutter/flutter/blob/master/engine/src/flutter/shell/platform/windows/external_texture_pixelbuffer.cc#L33)texture rendering code, only one gl handle is created. This means that when rendering the second frame, RefactorGLES destroys the gl handle from the first frame. Because it's the same gl handle, the result is a black screen starting from the second frame.
The reason we didn't notice the problem before was because only one frame was rendered.
My solution is that if the same gl handle is used, it doesn't need to be recreated and won't be destroyed.

Fix https://github.com/flutter/flutter/issues/183058
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
