### PR TITLE
[framework] Add fadeOutPlaceholder parameter to FadeInImage

### DIFF
--- a/packages/flutter/lib/src/widgets/fade_in_image.dart
+++ b/packages/flutter/lib/src/widgets/fade_in_image.dart
@@ -84,6 +84,7 @@ class FadeInImage extends StatefulWidget {
     this.fadeOutCurve = Curves.easeOut,
     this.fadeInDuration = const Duration(milliseconds: 700),
     this.fadeInCurve = Curves.easeIn,
+    this.fadeOutPlaceholder = true,
     this.color,
     this.colorBlendMode,
     this.placeholderColor,
@@ -141,6 +142,7 @@ class FadeInImage extends StatefulWidget {
     this.fadeOutCurve = Curves.easeOut,
     this.fadeInDuration = const Duration(milliseconds: 700),
     this.fadeInCurve = Curves.easeIn,
+    this.fadeOutPlaceholder = true,
     this.width,
     this.height,
     this.fit,
@@ -211,6 +213,7 @@ class FadeInImage extends StatefulWidget {
     this.fadeOutCurve = Curves.easeOut,
     this.fadeInDuration = const Duration(milliseconds: 700),
     this.fadeInCurve = Curves.easeIn,
+    this.fadeOutPlaceholder = true,
     this.width,
     this.height,
     this.fit,
@@ -277,6 +280,18 @@ class FadeInImage extends StatefulWidget {
 
   /// The curve of the fade-in animation for the [image].
   final Curve fadeInCurve;
+
+  /// Whether the [placeholder] is faded out when the [image] loads.
+  ///
+  /// When true (the default), the [placeholder] is faded out before the
+  /// target [image] is faded in, creating a sequential animation.
+  ///
+  /// When false, the [placeholder] is kept at full opacity while the target
+  /// [image] is faded in on top of it. This avoids a visual gap between the
+  /// [placeholder] disappearing and the target [image] appearing. The
+  /// [placeholder] is removed from the widget tree once the target [image]
+  /// is fully opaque.
+  final bool fadeOutPlaceholder;
 
   /// If non-null, require the image to have this width.
   ///
@@ -490,6 +505,7 @@ class _FadeInImageState extends State<FadeInImage> {
           fadeOutDuration: widget.fadeOutDuration,
           fadeInCurve: widget.fadeInCurve,
           fadeOutCurve: widget.fadeOutCurve,
+          fadeOutPlaceholder: widget.fadeOutPlaceholder,
         );
       },
     );
@@ -516,11 +532,12 @@ class _AnimatedFadeOutFadeIn extends ImplicitlyAnimatedWidget {
     required this.isTargetLoaded,
     required this.fadeOutDuration,
     required this.fadeOutCurve,
+    required this.fadeOutPlaceholder,
     required this.fadeInDuration,
     required this.fadeInCurve,
     required this.wasSynchronouslyLoaded,
   }) : assert(!wasSynchronouslyLoaded || isTargetLoaded),
-       super(duration: fadeInDuration + fadeOutDuration);
+       super(duration: fadeOutPlaceholder ? fadeInDuration + fadeOutDuration : fadeInDuration);
 
   final Widget target;
   final ProxyAnimation targetProxyAnimation;
@@ -531,6 +548,7 @@ class _AnimatedFadeOutFadeIn extends ImplicitlyAnimatedWidget {
   final Duration fadeOutDuration;
   final Curve fadeInCurve;
   final Curve fadeOutCurve;
+  final bool fadeOutPlaceholder;
   final bool wasSynchronouslyLoaded;
 
   @override
@@ -568,37 +586,52 @@ class _AnimatedFadeOutFadeInState extends ImplicitlyAnimatedWidgetState<_Animate
       return;
     }
 
-    _placeholderOpacityAnimation =
-        animation.drive(
-          TweenSequence<double>(<TweenSequenceItem<double>>[
-            TweenSequenceItem<double>(
-              tween: _placeholderOpacity!.chain(CurveTween(curve: widget.fadeOutCurve)),
-              weight: widget.fadeOutDuration.inMilliseconds.toDouble(),
-            ),
-            TweenSequenceItem<double>(
-              tween: ConstantTween<double>(0),
-              weight: widget.fadeInDuration.inMilliseconds.toDouble(),
-            ),
-          ]),
-        )..addStatusListener((AnimationStatus status) {
+    if (widget.fadeOutPlaceholder) {
+      _placeholderOpacityAnimation =
+          animation.drive(
+            TweenSequence<double>(<TweenSequenceItem<double>>[
+              TweenSequenceItem<double>(
+                tween: _placeholderOpacity!.chain(CurveTween(curve: widget.fadeOutCurve)),
+                weight: widget.fadeOutDuration.inMilliseconds.toDouble(),
+              ),
+              TweenSequenceItem<double>(
+                tween: ConstantTween<double>(0),
+                weight: widget.fadeInDuration.inMilliseconds.toDouble(),
+              ),
+            ]),
+          )..addStatusListener((AnimationStatus status) {
+            if (_placeholderOpacityAnimation!.isCompleted) {
+              // Need to rebuild to remove placeholder now that it is invisible.
+              setState(() {});
+            }
+          });
+
+      _targetOpacityAnimation = animation.drive(
+        TweenSequence<double>(<TweenSequenceItem<double>>[
+          TweenSequenceItem<double>(
+            tween: ConstantTween<double>(0),
+            weight: widget.fadeOutDuration.inMilliseconds.toDouble(),
+          ),
+          TweenSequenceItem<double>(
+            tween: _targetOpacity!.chain(CurveTween(curve: widget.fadeInCurve)),
+            weight: widget.fadeInDuration.inMilliseconds.toDouble(),
+          ),
+        ]),
+      );
+    } else {
+      _placeholderOpacityAnimation = animation.drive(ConstantTween<double>(1.0))
+        ..addStatusListener((AnimationStatus status) {
           if (_placeholderOpacityAnimation!.isCompleted) {
-            // Need to rebuild to remove placeholder now that it is invisible.
+            // Need to rebuild to remove placeholder now that it is fully
+            // behind the loaded target image.
             setState(() {});
           }
         });
 
-    _targetOpacityAnimation = animation.drive(
-      TweenSequence<double>(<TweenSequenceItem<double>>[
-        TweenSequenceItem<double>(
-          tween: ConstantTween<double>(0),
-          weight: widget.fadeOutDuration.inMilliseconds.toDouble(),
-        ),
-        TweenSequenceItem<double>(
-          tween: _targetOpacity!.chain(CurveTween(curve: widget.fadeInCurve)),
-          weight: widget.fadeInDuration.inMilliseconds.toDouble(),
-        ),
-      ]),
-    );
+      _targetOpacityAnimation = animation.drive(
+        _targetOpacity!.chain(CurveTween(curve: widget.fadeInCurve)),
+      );
+    }
 
     widget.targetProxyAnimation.parent = _targetOpacityAnimation;
     widget.placeholderProxyAnimation.parent = _placeholderOpacityAnimation;

--- a/packages/flutter/test/widgets/fade_in_image_test.dart
+++ b/packages/flutter/test/widgets/fade_in_image_test.dart
@@ -357,6 +357,45 @@ void main() {
       expect(find.byType(Image), findsOneWidget);
     });
 
+    testWidgets(
+      'keeps placeholder visible while target fades in when fadeOutPlaceholder is false',
+      (WidgetTester tester) async {
+        final placeholderProvider = TestImageProvider(placeholderImage);
+        final imageProvider = TestImageProvider(targetImage);
+
+        await tester.pumpWidget(
+          FadeInImage(
+            placeholder: placeholderProvider,
+            image: imageProvider,
+            fadeOutDuration: animationDuration,
+            fadeInDuration: animationDuration,
+            fadeOutPlaceholder: false,
+            fadeOutCurve: Curves.linear,
+            fadeInCurve: Curves.linear,
+            excludeFromSemantics: true,
+          ),
+        );
+
+        placeholderProvider.complete();
+        imageProvider.complete();
+        await tester.pump();
+
+        // During the fade-in animation, placeholder stays at full opacity
+        // while target fades in on top.
+        for (var i = 0; i < 5; i += 1) {
+          final FadeInImageParts parts = findFadeInImage(tester);
+          expect(parts.placeholder!.opacity, 1.0);
+          expect(parts.target.opacity, moreOrLessEquals(i / 5));
+          await tester.pump(const Duration(milliseconds: 10));
+        }
+
+        // After animation completes, placeholder is removed from tree.
+        await tester.pumpAndSettle();
+        expect(findFadeInImage(tester).placeholder, isNull);
+        expect(findFadeInImage(tester).target.opacity, 1.0);
+      },
+    );
+
     testWidgets("doesn't interrupt in-progress animation when animation values are updated", (
       WidgetTester tester,
     ) async {


### PR DESCRIPTION
Adds a `fadeOutPlaceholder` bool parameter to `FadeInImage` that controls whether the placeholder is faded out when the target image loads.

**Problem:** The current `FadeInImage` always fades out the placeholder before fading in the target image. This sequential animation creates a visual gap where the placeholder has faded out but the target image hasn't fully faded in yet, resulting in a flash of the background.

**Solution:** When `fadeOutPlaceholder` is set to `false`, the placeholder remains at full opacity while the target image fades in on top of it. Once the target image is fully opaque, the placeholder is removed from the widget tree. The default value is `true`, preserving the existing behavior.

The total animation duration when `fadeOutPlaceholder: false` is just `fadeInDuration` (no fadeOut phase), so the transition is also faster.

Fixes flutter/flutter#97068

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md