### PR TITLE
Improve FFI code for windowing

### DIFF
--- a/packages/flutter/lib/src/widgets/_window_linux.dart
+++ b/packages/flutter/lib/src/widgets/_window_linux.dart
@@ -30,14 +30,14 @@ import 'binding.dart';
 // In C this would be INT_MAX, but since we can't determine that from Dart let's assume it's 32 bit signed. In any case this is far beyond any reasonable window size.
 const int _kMaxWindowDimensions = 0x7fffffff;
 
-/// The type of a GtkWindow.
+/// The type of a GtkWindow. Matches the GtkWindowType enum in gtk/gtktypes.h.
 enum _GtkWindowType {
   toplevel,
   // ignore: unused_field
   popup,
 }
 
-/// States a toplevel window can be in.
+/// States a toplevel window can be in. Matches the order of the GdkWindowState enum in gdk/gdkwindow.h, except these are bit positions when passed to GTK.
 enum _GdkWindowState {
   withdrawn,
   iconified,
@@ -58,7 +58,7 @@ enum _GdkWindowState {
   leftResizable,
 }
 
-/// Hints for the window manager on how to treat a window.
+/// Hints for the window manager on how to treat a window. Matches the GdkWindowTypeHint enum in gdk/gdkwindow.h.
 enum _GdkWindowTypeHint {
   // ignore: unused_field
   normal,

--- a/packages/flutter/lib/src/widgets/_window_linux.dart
+++ b/packages/flutter/lib/src/widgets/_window_linux.dart
@@ -30,6 +30,48 @@ import 'binding.dart';
 // In C this would be INT_MAX, but since we can't determine that from Dart let's assume it's 32 bit signed. In any case this is far beyond any reasonable window size.
 const int _kMaxWindowDimensions = 0x7fffffff;
 
+/// The type of a GtkWindow.
+enum _GtkWindowType { toplevel, popup }
+
+/// State of a tolevel window.
+enum _GdkWindowState {
+  withdrawn,
+  iconified,
+  maximized,
+  sticky,
+  fullscreen,
+  above,
+  below,
+  focused,
+  tiled,
+  topTiled,
+  topResizable,
+  rightTiled,
+  rightResizable,
+  bottomTiled,
+  bottomResizable,
+  leftTiled,
+  leftResizable,
+}
+
+/// Hints for the window manager on how to treat a window.
+enum _GdkWindowTypeHint {
+  normal,
+  dialog,
+  menu,
+  toolbar,
+  splashscreen,
+  utility,
+  dock,
+  desktop,
+  dropdown_menu,
+  popup_menu,
+  tooltip,
+  notification,
+  combo,
+  dnd,
+}
+
 const String _kWindowingDisabledErrorMessage = '''
 Windowing APIs are not enabled.
 
@@ -68,8 +110,10 @@ String _nativeToString(ffi.Pointer<ffi.Uint8> value) {
 
 /// Wraps GObject
 class _GObject {
+  /// Creates a wrapper to an existing [GObject] in [instance].
   const _GObject(this.instance);
 
+  /// The pointer to the underlying [GObject].
   final ffi.Pointer<ffi.NativeType> instance;
 
   /// Drop reference to this object.
@@ -83,6 +127,7 @@ class _GObject {
 
 /// Wraps GtkContainer
 class _GtkContainer extends _GtkWidget {
+  /// Creates a wrapper to an existing [GtkContainer] in [instance].
   const _GtkContainer(super.instance);
 
   /// Adds [child] widget to this container.
@@ -101,6 +146,7 @@ class _GtkContainer extends _GtkWidget {
 
 /// Wraps GtkWidget
 class _GtkWidget extends _GObject {
+  /// Creates a wrapper to an existing [GtkWidget] in [instance].
   const _GtkWidget(super.instance);
 
   /// Show the widget (defaults to hidden).
@@ -134,18 +180,27 @@ class _GtkWidget extends _GObject {
 
 /// Wraps GdkWindow
 class _GdkWindow extends _GObject {
+  /// Creates a wrapper to an existing [GdkWindow] in [instance].
   const _GdkWindow(super.instance);
 
-  /// Gets the window state bitfield (_GDK_WINDOW_STATE_*).
-  int getState() {
-    return _gdkWindowGetState(instance);
+  /// Gets the window state.
+  Set<_GdkWindowState> getState() {
+    final stateBits = _gdkWindowGetState(instance);
+    final states = <_GdkWindowState>{};
+    for (final state in _GdkWindowState.values) {
+      if ((stateBits & (1 << state.index)) != 0) {
+        states.add(state);
+      }
+    }
+
+    return states;
   }
 
   @ffi.Native<ffi.Int Function(ffi.Pointer<ffi.NativeType>)>(symbol: 'gdk_window_get_state')
   external static int _gdkWindowGetState(ffi.Pointer<ffi.NativeType> window);
 }
 
-/// Wrapds GdkGeometry
+/// Wraps GdkGeometry.
 final class _GdkGeometry extends ffi.Struct {
   factory _GdkGeometry() {
     return ffi.Struct.create();
@@ -185,16 +240,10 @@ final class _GdkGeometry extends ffi.Struct {
   external int winGravity;
 }
 
-const int _GDK_WINDOW_STATE_ICONIFIED = 1 << 1;
-const int _GDK_WINDOW_STATE_MAXIMIZED = 1 << 2;
-const int _GDK_WINDOW_STATE_FULLSCREEN = 1 << 4;
-
-const int _GDK_WINDOW_TYPE_HINT_DIALOG = 1;
-
 /// Wraps GtkWindow
 class _GtkWindow extends _GtkContainer {
   /// Create a new GtkWindow
-  _GtkWindow() : super(_gtkWindowNew(0));
+  _GtkWindow(_GtkWindowType type) : super(_gtkWindowNew(type.index));
 
   /// Make window visible and grab focus.
   void present() {
@@ -212,8 +261,8 @@ class _GtkWindow extends _GtkContainer {
   }
 
   /// Set the type of this window.
-  void setTypeHint(int hint) {
-    _gtkWindowSetTypeHint(instance, hint);
+  void setTypeHint(_GdkWindowTypeHint hint) {
+    _gtkWindowSetTypeHint(instance, hint.index);
   }
 
   /// Sets the title of the window.
@@ -402,17 +451,19 @@ class _GtkWindow extends _GtkContainer {
   external static bool _gtkWindowIsActive(ffi.Pointer<ffi.NativeType> widget);
 }
 
-/// Wraps FlView
+/// Wraps FlEngine.
+class _FlEngine extends _GObject {
+  /// Gets the FlEngine object for the engine with the given ID.
+  _FlEngine(int engineId) : super(ffi.Pointer<ffi.NativeType>.fromAddress(engineId));
+
+  /// Gets the engine object running in the current isolate.
+  factory _FlEngine.current() => _FlEngine(WidgetsBinding.instance.platformDispatcher.engineId!);
+}
+
+/// Wraps FlView.
 class _FlView extends _GtkWidget {
   /// Create a new FlView widget.
-  _FlView()
-    : super(
-        _flViewNewForEngine(
-          ffi.Pointer<ffi.NativeType>.fromAddress(
-            WidgetsBinding.instance.platformDispatcher.engineId!,
-          ),
-        ),
-      );
+  _FlView(_FlEngine engine) : super(_flViewNewForEngine(engine.instance));
 
   /// Get the ID for the Flutter view being shown in this widget.
   int getId() {
@@ -647,7 +698,7 @@ class RegularWindowControllerLinux extends RegularWindowController {
     String? title,
   }) : _owner = owner,
        _delegate = delegate,
-       _window = _GtkWindow(),
+       _window = _GtkWindow(_GtkWindowType.toplevel),
        super.empty() {
     if (!isWindowingEnabled) {
       throw UnsupportedError(_kWindowingDisabledErrorMessage);
@@ -673,7 +724,8 @@ class RegularWindowControllerLinux extends RegularWindowController {
     if (title != null) {
       setTitle(title);
     }
-    final view = _FlView();
+    final engine = _FlEngine.current();
+    final view = _FlView(engine);
     final int viewId = view.getId();
     rootView = WidgetsBinding.instance.platformDispatcher.views.firstWhere(
       (FlutterView view) => view.viewId == viewId,
@@ -715,16 +767,16 @@ class RegularWindowControllerLinux extends RegularWindowController {
 
   @override
   @internal
-  bool get isMaximized => (_window.getWindow().getState() & _GDK_WINDOW_STATE_MAXIMIZED) != 0;
+  bool get isMaximized => _window.getWindow().getState().contains(_GdkWindowState.maximized);
 
   @override
   @internal
   // NOTE: On Wayland this is never set, see https://gitlab.gnome.org/GNOME/gtk/-/issues/67
-  bool get isMinimized => (_window.getWindow().getState() & _GDK_WINDOW_STATE_ICONIFIED) != 0;
+  bool get isMinimized => _window.getWindow().getState().contains(_GdkWindowState.iconified);
 
   @override
   @internal
-  bool get isFullscreen => (_window.getWindow().getState() & _GDK_WINDOW_STATE_FULLSCREEN) != 0;
+  bool get isFullscreen => _window.getWindow().getState().contains(_GdkWindowState.fullscreen);
 
   @override
   @internal
@@ -816,13 +868,13 @@ class DialogWindowControllerLinux extends DialogWindowController {
   }) : _owner = owner,
        _delegate = delegate,
        _parent = parent,
-       _window = _GtkWindow(),
+       _window = _GtkWindow(_GtkWindowType.toplevel),
        super.empty() {
     if (!isWindowingEnabled) {
       throw UnsupportedError(_kWindowingDisabledErrorMessage);
     }
 
-    _window.setTypeHint(_GDK_WINDOW_TYPE_HINT_DIALOG);
+    _window.setTypeHint(_GdkWindowTypeHint.dialog);
     if (parent != null) {
       final _GtkWindow? parentWindow = owner._windows[parent.rootView.viewId];
       if (parentWindow != null) {
@@ -851,7 +903,8 @@ class DialogWindowControllerLinux extends DialogWindowController {
     if (title != null) {
       setTitle(title);
     }
-    final view = _FlView();
+    final engine = _FlEngine.current();
+    final view = _FlView(engine);
     final int viewId = view.getId();
     rootView = WidgetsBinding.instance.platformDispatcher.views.firstWhere(
       (FlutterView view) => view.viewId == viewId,
@@ -899,7 +952,7 @@ class DialogWindowControllerLinux extends DialogWindowController {
   @override
   @internal
   // NOTE: On Wayland this is never set, see https://gitlab.gnome.org/GNOME/gtk/-/issues/67
-  bool get isMinimized => (_window.getWindow().getState() & _GDK_WINDOW_STATE_ICONIFIED) != 0;
+  bool get isMinimized => _window.getWindow().getState().contains(_GdkWindowState.iconified);
 
   @override
   @internal

--- a/packages/flutter/lib/src/widgets/_window_linux.dart
+++ b/packages/flutter/lib/src/widgets/_window_linux.dart
@@ -33,7 +33,7 @@ const int _kMaxWindowDimensions = 0x7fffffff;
 /// The type of a GtkWindow.
 enum _GtkWindowType { toplevel, popup }
 
-/// State of a tolevel window.
+/// States a toplevel window can be in.
 enum _GdkWindowState {
   withdrawn,
   iconified,

--- a/packages/flutter/lib/src/widgets/_window_linux.dart
+++ b/packages/flutter/lib/src/widgets/_window_linux.dart
@@ -108,7 +108,7 @@ String _nativeToString(ffi.Pointer<ffi.Uint8> value) {
   return utf8.decode(value.asTypedList(length));
 }
 
-/// Wraps GObject
+/// Wraps GObject.
 class _GObject {
   /// Creates a wrapper to an existing [GObject] in [instance].
   const _GObject(this.instance);
@@ -125,7 +125,7 @@ class _GObject {
   external static void _unref(ffi.Pointer<ffi.NativeType> widget);
 }
 
-/// Wraps GtkContainer
+/// Wraps GtkContainer.
 class _GtkContainer extends _GtkWidget {
   /// Creates a wrapper to an existing [GtkContainer] in [instance].
   const _GtkContainer(super.instance);
@@ -144,7 +144,7 @@ class _GtkContainer extends _GtkWidget {
   );
 }
 
-/// Wraps GtkWidget
+/// Wraps GtkWidget.
 class _GtkWidget extends _GObject {
   /// Creates a wrapper to an existing [GtkWidget] in [instance].
   const _GtkWidget(super.instance);
@@ -178,7 +178,7 @@ class _GtkWidget extends _GObject {
   external static void _gtkWindowDestroy(ffi.Pointer<ffi.NativeType> widget);
 }
 
-/// Wraps GdkWindow
+/// Wraps GdkWindow.
 class _GdkWindow extends _GObject {
   /// Creates a wrapper to an existing [GdkWindow] in [instance].
   const _GdkWindow(super.instance);
@@ -240,7 +240,7 @@ final class _GdkGeometry extends ffi.Struct {
   external int winGravity;
 }
 
-/// Wraps GtkWindow
+/// Wraps GtkWindow.
 class _GtkWindow extends _GtkContainer {
   /// Create a new GtkWindow
   _GtkWindow(_GtkWindowType type) : super(_gtkWindowNew(type.index));

--- a/packages/flutter/lib/src/widgets/_window_linux.dart
+++ b/packages/flutter/lib/src/widgets/_window_linux.dart
@@ -30,6 +30,455 @@ import 'binding.dart';
 // In C this would be INT_MAX, but since we can't determine that from Dart let's assume it's 32 bit signed. In any case this is far beyond any reasonable window size.
 const int _kMaxWindowDimensions = 0x7fffffff;
 
+const String _kWindowingDisabledErrorMessage = '''
+Windowing APIs are not enabled.
+
+Windowing APIs are currently experimental. Do not use windowing APIs in
+production applications or plugins published to pub.dev.
+
+To try experimental windowing APIs:
+1. Switch to Flutter's main release channel.
+2. Turn on the windowing feature flag.
+
+See: https://github.com/flutter/flutter/issues/30701.
+''';
+
+/// [WindowingOwner] implementation for Linux.
+///
+/// If [Platform.isLinux] is false, then the constructor will throw an
+/// [UnsupportedError].
+///
+/// {@macro flutter.widgets.windowing.experimental}
+///
+/// See also:
+///
+///  * [WindowingOwner], the abstract class that manages native windows.
+@internal
+class WindowingOwnerLinux extends WindowingOwner {
+  /// Creates a new [WindowingOwnerLinux] instance.
+  ///
+  /// If [Platform.isLinux] is false, then this constructor will throw an
+  /// [UnsupportedError]
+  ///
+  /// {@macro flutter.widgets.windowing.experimental}
+  ///
+  /// See also:
+  ///
+  ///  * [WindowingOwner], the abstract class that manages native windows.
+  @internal
+  WindowingOwnerLinux() {
+    if (!isWindowingEnabled) {
+      throw UnsupportedError(_kWindowingDisabledErrorMessage);
+    }
+
+    if (!Platform.isLinux) {
+      throw UnsupportedError('Only available on the Linux platform');
+    }
+
+    assert(
+      WidgetsBinding.instance.platformDispatcher.engineId != null,
+      'WindowingOwnerLinux must be created after the engine has been initialized.',
+    );
+  }
+
+  /// GTK windows keyed by view ID.
+  final Map<int, _GtkWindow> _windows = <int, _GtkWindow>{};
+
+  @internal
+  @override
+  RegularWindowController createRegularWindowController({
+    Size? preferredSize,
+    BoxConstraints? preferredConstraints,
+    String? title,
+    required RegularWindowControllerDelegate delegate,
+  }) {
+    final controller = RegularWindowControllerLinux(
+      owner: this,
+      delegate: delegate,
+      preferredSize: preferredSize,
+      preferredConstraints: preferredConstraints,
+      title: title,
+    );
+    _windows[controller.rootView.viewId] = controller._window;
+    return controller;
+  }
+
+  @internal
+  @override
+  DialogWindowController createDialogWindowController({
+    required DialogWindowControllerDelegate delegate,
+    Size? preferredSize,
+    BoxConstraints? preferredConstraints,
+    BaseWindowController? parent,
+    String? title,
+  }) {
+    final controller = DialogWindowControllerLinux(
+      owner: this,
+      delegate: delegate,
+      preferredSize: preferredSize,
+      preferredConstraints: preferredConstraints,
+      parent: parent,
+      title: title,
+    );
+    _windows[controller.rootView.viewId] = controller._window;
+    return controller;
+  }
+
+  @internal
+  @override
+  TooltipWindowController createTooltipWindowController({
+    required TooltipWindowControllerDelegate delegate,
+    required BoxConstraints preferredConstraints,
+    required bool isSizedToContent,
+    required Rect anchorRect,
+    required WindowPositioner positioner,
+    required BaseWindowController parent,
+  }) {
+    throw UnimplementedError('Tooltip windows are not yet implemented on Linux.');
+  }
+
+  @internal
+  @override
+  PopupWindowController createPopupWindowController({
+    required PopupWindowControllerDelegate delegate,
+    required BoxConstraints preferredConstraints,
+    required Rect anchorRect,
+    required WindowPositioner positioner,
+    required BaseWindowController parent,
+  }) {
+    throw UnimplementedError('Popup windows are not yet implemented on Linux.');
+  }
+}
+
+/// Implementation of [RegularWindowController] for the Linux platform.
+///
+/// {@macro flutter.widgets.windowing.experimental}
+///
+/// See also:
+///
+///  * [RegularWindowController], the base class for regular windows.
+class RegularWindowControllerLinux extends RegularWindowController {
+  /// Creates a new regular window controller for Linux.
+  ///
+  /// When this constructor completes the native window has been created and
+  /// has a view associated with it.
+  ///
+  /// {@macro flutter.widgets.windowing.experimental}
+  ///
+  /// See also:
+  ///
+  ///  * [RegularWindowController], the base class for regular windows.
+  @internal
+  RegularWindowControllerLinux({
+    required WindowingOwnerLinux owner,
+    required RegularWindowControllerDelegate delegate,
+    Size? preferredSize,
+    BoxConstraints? preferredConstraints,
+    String? title,
+  }) : _owner = owner,
+       _delegate = delegate,
+       _window = _GtkWindow(_GtkWindowType.toplevel),
+       super.empty() {
+    if (!isWindowingEnabled) {
+      throw UnsupportedError(_kWindowingDisabledErrorMessage);
+    }
+
+    _windowMonitor = _FlWindowMonitor(
+      _window,
+      onConfigure: notifyListeners,
+      onStateChanged: notifyListeners,
+      onIsActiveNotify: notifyListeners,
+      onTitleNotify: notifyListeners,
+      onClose: () {
+        _delegate.onWindowCloseRequested(this);
+      },
+      onDestroy: _delegate.onWindowDestroyed,
+    );
+    if (preferredSize != null) {
+      _window.setDefaultSize(preferredSize.width.toInt(), preferredSize.height.toInt());
+    }
+    if (preferredConstraints != null) {
+      setConstraints(preferredConstraints);
+    }
+    if (title != null) {
+      setTitle(title);
+    }
+    final engine = _FlEngine.current();
+    final view = _FlView(engine);
+    final int viewId = view.getId();
+    rootView = WidgetsBinding.instance.platformDispatcher.views.firstWhere(
+      (FlutterView view) => view.viewId == viewId,
+    );
+    view.show();
+    _window.add(view);
+    _window.present();
+  }
+
+  final WindowingOwnerLinux _owner;
+  final RegularWindowControllerDelegate _delegate;
+  final _GtkWindow _window;
+  late final _FlWindowMonitor _windowMonitor;
+  bool _destroyed = false;
+
+  @override
+  @internal
+  Size get contentSize => _window.getSize();
+
+  @override
+  void destroy() {
+    if (_destroyed) {
+      return;
+    }
+    _window.destroy();
+    _windowMonitor.close();
+    _windowMonitor.unref();
+    _destroyed = true;
+    _owner._windows.remove(rootView.viewId);
+  }
+
+  @override
+  @internal
+  String get title => _window.getTitle();
+
+  @override
+  @internal
+  bool get isActivated => _window.isActive();
+
+  @override
+  @internal
+  bool get isMaximized => _window.getWindow().getState().contains(_GdkWindowState.maximized);
+
+  @override
+  @internal
+  // NOTE: On Wayland this is never set, see https://gitlab.gnome.org/GNOME/gtk/-/issues/67
+  bool get isMinimized => _window.getWindow().getState().contains(_GdkWindowState.iconified);
+
+  @override
+  @internal
+  bool get isFullscreen => _window.getWindow().getState().contains(_GdkWindowState.fullscreen);
+
+  @override
+  @internal
+  void setSize(Size size) {
+    _window.resize(size.width.toInt(), size.height.toInt());
+  }
+
+  @override
+  @internal
+  void setConstraints(BoxConstraints constraints) {
+    _window.setGeometryHints(
+      minWidth: constraints.minWidth.toInt(),
+      minHeight: constraints.minHeight.toInt(),
+      maxWidth: constraints.maxWidth.isInfinite ? 0x7fffffff : constraints.maxWidth.toInt(),
+      maxHeight: constraints.maxHeight.isInfinite ? 0x7fffffff : constraints.maxHeight.toInt(),
+    );
+  }
+
+  @override
+  @internal
+  void setTitle(String title) {
+    _window.setTitle(title);
+  }
+
+  @override
+  @internal
+  void activate() {
+    _window.present();
+  }
+
+  @override
+  @internal
+  void setMaximized(bool maximized) {
+    if (maximized) {
+      _window.maximize();
+    } else {
+      _window.unmaximize();
+    }
+  }
+
+  @override
+  @internal
+  void setMinimized(bool minimized) {
+    if (minimized) {
+      _window.iconify();
+    } else {
+      _window.deiconify();
+    }
+  }
+
+  @override
+  @internal
+  void setFullscreen(bool fullscreen, {Display? display}) {
+    // TODO(robert-ancell): display currently ignored
+    if (fullscreen) {
+      _window.fullscreen();
+    } else {
+      _window.unfullscreen();
+    }
+  }
+}
+
+/// Implementation of [DialogWindowController] for the Linux platform.
+///
+/// {@macro flutter.widgets.windowing.experimental}
+///
+/// See also:
+///
+///  * [DialogWindowController], the base class for dialog windows.
+class DialogWindowControllerLinux extends DialogWindowController {
+  /// Creates a new dialog window controller for Linux.
+  ///
+  /// When this constructor completes the native window has been created and
+  /// has a view associated with it.
+  ///
+  /// {@macro flutter.widgets.windowing.experimental}
+  ///
+  /// See also:
+  ///
+  ///  * [DialogWindowController], the base class for dialog windows.
+  @internal
+  DialogWindowControllerLinux({
+    required WindowingOwnerLinux owner,
+    required DialogWindowControllerDelegate delegate,
+    Size? preferredSize,
+    BoxConstraints? preferredConstraints,
+    BaseWindowController? parent,
+    String? title,
+  }) : _owner = owner,
+       _delegate = delegate,
+       _parent = parent,
+       _window = _GtkWindow(_GtkWindowType.toplevel),
+       super.empty() {
+    if (!isWindowingEnabled) {
+      throw UnsupportedError(_kWindowingDisabledErrorMessage);
+    }
+
+    _window.setTypeHint(_GdkWindowTypeHint.dialog);
+    if (parent != null) {
+      final _GtkWindow? parentWindow = owner._windows[parent.rootView.viewId];
+      if (parentWindow != null) {
+        _window.setTransientFor(parentWindow);
+        _window.setModal(true);
+      }
+    }
+
+    _windowMonitor = _FlWindowMonitor(
+      _window,
+      onConfigure: notifyListeners,
+      onStateChanged: notifyListeners,
+      onIsActiveNotify: notifyListeners,
+      onTitleNotify: notifyListeners,
+      onClose: () {
+        _delegate.onWindowCloseRequested(this);
+      },
+      onDestroy: _delegate.onWindowDestroyed,
+    );
+    if (preferredSize != null) {
+      _window.setDefaultSize(preferredSize.width.toInt(), preferredSize.height.toInt());
+    }
+    if (preferredConstraints != null) {
+      setConstraints(preferredConstraints);
+    }
+    if (title != null) {
+      setTitle(title);
+    }
+    final engine = _FlEngine.current();
+    final view = _FlView(engine);
+    final int viewId = view.getId();
+    rootView = WidgetsBinding.instance.platformDispatcher.views.firstWhere(
+      (FlutterView view) => view.viewId == viewId,
+    );
+    view.show();
+    _window.add(view);
+    _window.present();
+  }
+
+  final WindowingOwnerLinux _owner;
+  final DialogWindowControllerDelegate _delegate;
+  final _GtkWindow _window;
+  final BaseWindowController? _parent;
+  late final _FlWindowMonitor _windowMonitor;
+  bool _destroyed = false;
+
+  @override
+  @internal
+  Size get contentSize => _window.getSize();
+
+  @override
+  void destroy() {
+    if (_destroyed) {
+      return;
+    }
+    _window.destroy();
+    _windowMonitor.close();
+    _windowMonitor.unref();
+    _destroyed = true;
+    _owner._windows.remove(rootView.viewId);
+  }
+
+  @override
+  @internal
+  BaseWindowController? get parent => _parent;
+
+  @override
+  @internal
+  String get title => _window.getTitle();
+
+  @override
+  @internal
+  bool get isActivated => _window.isActive();
+
+  @override
+  @internal
+  // NOTE: On Wayland this is never set, see https://gitlab.gnome.org/GNOME/gtk/-/issues/67
+  bool get isMinimized => _window.getWindow().getState().contains(_GdkWindowState.iconified);
+
+  @override
+  @internal
+  void setSize(Size size) {
+    _window.resize(size.width.toInt(), size.height.toInt());
+  }
+
+  @override
+  @internal
+  void setConstraints(BoxConstraints constraints) {
+    _window.setGeometryHints(
+      minWidth: constraints.minWidth.toInt(),
+      minHeight: constraints.minHeight.toInt(),
+      maxWidth: constraints.maxWidth.isInfinite ? 0x7fffffff : constraints.maxWidth.toInt(),
+      maxHeight: constraints.maxHeight.isInfinite ? 0x7fffffff : constraints.maxHeight.toInt(),
+    );
+  }
+
+  @override
+  @internal
+  void setTitle(String title) {
+    _window.setTitle(title);
+  }
+
+  @override
+  @internal
+  void activate() {
+    _window.present();
+  }
+
+  @override
+  @internal
+  void setMinimized(bool minimized) {
+    if (minimized) {
+      _window.iconify();
+    } else {
+      _window.deiconify();
+    }
+  }
+}
+
+// The following classes are thin wrappers around the corresponding GTK/GDK
+// objects, with only the methods we need implemented. The method signatures
+// and enum values are designed to match the corresponding C APIs as closely
+// as possible, to minimize the amount of translation needed in the method
+// implementations.
+
 /// The type of a GtkWindow. Matches the GtkWindowType enum in gtk/gtktypes.h.
 enum _GtkWindowType {
   toplevel,
@@ -37,7 +486,8 @@ enum _GtkWindowType {
   popup,
 }
 
-/// States a toplevel window can be in. Matches the order of the GdkWindowState enum in gdk/gdkwindow.h, except these are bit positions when passed to GTK.
+/// States a toplevel window can be in. Matches the order of the GdkWindowState
+/// enum in gdk/gdkwindow.h, except these are bit positions when passed to GTK.
 enum _GdkWindowState {
   withdrawn,
   iconified,
@@ -58,7 +508,8 @@ enum _GdkWindowState {
   leftResizable,
 }
 
-/// Hints for the window manager on how to treat a window. Matches the GdkWindowTypeHint enum in gdk/gdkwindow.h.
+/// Hints for the window manager on how to treat a window. Matches the
+/// GdkWindowTypeHint enum in gdk/gdkwindow.h.
 enum _GdkWindowTypeHint {
   // ignore: unused_field
   normal,
@@ -88,19 +539,6 @@ enum _GdkWindowTypeHint {
   // ignore: unused_field
   dnd,
 }
-
-const String _kWindowingDisabledErrorMessage = '''
-Windowing APIs are not enabled.
-
-Windowing APIs are currently experimental. Do not use windowing APIs in
-production applications or plugins published to pub.dev.
-
-To try experimental windowing APIs:
-1. Switch to Flutter's main release channel.
-2. Turn on the windowing feature flag.
-
-See: https://github.com/flutter/flutter/issues/30701.
-''';
 
 @ffi.Native<ffi.Pointer<ffi.NativeType> Function(ffi.Int)>(symbol: 'g_malloc0')
 external ffi.Pointer<ffi.NativeType> _gMalloc0(int count);
@@ -579,434 +1017,4 @@ class _FlWindowMonitor extends _GObject {
     ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>> onClose,
     ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>> onDestroy,
   );
-}
-
-/// [WindowingOwner] implementation for Linux.
-///
-/// If [Platform.isLinux] is false, then the constructor will throw an
-/// [UnsupportedError].
-///
-/// {@macro flutter.widgets.windowing.experimental}
-///
-/// See also:
-///
-///  * [WindowingOwner], the abstract class that manages native windows.
-@internal
-class WindowingOwnerLinux extends WindowingOwner {
-  /// Creates a new [WindowingOwnerLinux] instance.
-  ///
-  /// If [Platform.isLinux] is false, then this constructor will throw an
-  /// [UnsupportedError]
-  ///
-  /// {@macro flutter.widgets.windowing.experimental}
-  ///
-  /// See also:
-  ///
-  ///  * [WindowingOwner], the abstract class that manages native windows.
-  @internal
-  WindowingOwnerLinux() {
-    if (!isWindowingEnabled) {
-      throw UnsupportedError(_kWindowingDisabledErrorMessage);
-    }
-
-    if (!Platform.isLinux) {
-      throw UnsupportedError('Only available on the Linux platform');
-    }
-
-    assert(
-      WidgetsBinding.instance.platformDispatcher.engineId != null,
-      'WindowingOwnerLinux must be created after the engine has been initialized.',
-    );
-  }
-
-  /// GTK windows keyed by view ID.
-  final Map<int, _GtkWindow> _windows = <int, _GtkWindow>{};
-
-  @internal
-  @override
-  RegularWindowController createRegularWindowController({
-    Size? preferredSize,
-    BoxConstraints? preferredConstraints,
-    String? title,
-    required RegularWindowControllerDelegate delegate,
-  }) {
-    final controller = RegularWindowControllerLinux(
-      owner: this,
-      delegate: delegate,
-      preferredSize: preferredSize,
-      preferredConstraints: preferredConstraints,
-      title: title,
-    );
-    _windows[controller.rootView.viewId] = controller._window;
-    return controller;
-  }
-
-  @internal
-  @override
-  DialogWindowController createDialogWindowController({
-    required DialogWindowControllerDelegate delegate,
-    Size? preferredSize,
-    BoxConstraints? preferredConstraints,
-    BaseWindowController? parent,
-    String? title,
-  }) {
-    final controller = DialogWindowControllerLinux(
-      owner: this,
-      delegate: delegate,
-      preferredSize: preferredSize,
-      preferredConstraints: preferredConstraints,
-      parent: parent,
-      title: title,
-    );
-    _windows[controller.rootView.viewId] = controller._window;
-    return controller;
-  }
-
-  @internal
-  @override
-  TooltipWindowController createTooltipWindowController({
-    required TooltipWindowControllerDelegate delegate,
-    required BoxConstraints preferredConstraints,
-    required bool isSizedToContent,
-    required Rect anchorRect,
-    required WindowPositioner positioner,
-    required BaseWindowController parent,
-  }) {
-    throw UnimplementedError('Tooltip windows are not yet implemented on Linux.');
-  }
-
-  @internal
-  @override
-  PopupWindowController createPopupWindowController({
-    required PopupWindowControllerDelegate delegate,
-    required BoxConstraints preferredConstraints,
-    required Rect anchorRect,
-    required WindowPositioner positioner,
-    required BaseWindowController parent,
-  }) {
-    throw UnimplementedError('Popup windows are not yet implemented on Linux.');
-  }
-}
-
-/// Implementation of [RegularWindowController] for the Linux platform.
-///
-/// {@macro flutter.widgets.windowing.experimental}
-///
-/// See also:
-///
-///  * [RegularWindowController], the base class for regular windows.
-class RegularWindowControllerLinux extends RegularWindowController {
-  /// Creates a new regular window controller for Linux.
-  ///
-  /// When this constructor completes the native window has been created and
-  /// has a view associated with it.
-  ///
-  /// {@macro flutter.widgets.windowing.experimental}
-  ///
-  /// See also:
-  ///
-  ///  * [RegularWindowController], the base class for regular windows.
-  @internal
-  RegularWindowControllerLinux({
-    required WindowingOwnerLinux owner,
-    required RegularWindowControllerDelegate delegate,
-    Size? preferredSize,
-    BoxConstraints? preferredConstraints,
-    String? title,
-  }) : _owner = owner,
-       _delegate = delegate,
-       _window = _GtkWindow(_GtkWindowType.toplevel),
-       super.empty() {
-    if (!isWindowingEnabled) {
-      throw UnsupportedError(_kWindowingDisabledErrorMessage);
-    }
-
-    _windowMonitor = _FlWindowMonitor(
-      _window,
-      onConfigure: notifyListeners,
-      onStateChanged: notifyListeners,
-      onIsActiveNotify: notifyListeners,
-      onTitleNotify: notifyListeners,
-      onClose: () {
-        _delegate.onWindowCloseRequested(this);
-      },
-      onDestroy: _delegate.onWindowDestroyed,
-    );
-    if (preferredSize != null) {
-      _window.setDefaultSize(preferredSize.width.toInt(), preferredSize.height.toInt());
-    }
-    if (preferredConstraints != null) {
-      setConstraints(preferredConstraints);
-    }
-    if (title != null) {
-      setTitle(title);
-    }
-    final engine = _FlEngine.current();
-    final view = _FlView(engine);
-    final int viewId = view.getId();
-    rootView = WidgetsBinding.instance.platformDispatcher.views.firstWhere(
-      (FlutterView view) => view.viewId == viewId,
-    );
-    view.show();
-    _window.add(view);
-    _window.present();
-  }
-
-  final WindowingOwnerLinux _owner;
-  final RegularWindowControllerDelegate _delegate;
-  final _GtkWindow _window;
-  late final _FlWindowMonitor _windowMonitor;
-  bool _destroyed = false;
-
-  @override
-  @internal
-  Size get contentSize => _window.getSize();
-
-  @override
-  void destroy() {
-    if (_destroyed) {
-      return;
-    }
-    _window.destroy();
-    _windowMonitor.close();
-    _windowMonitor.unref();
-    _destroyed = true;
-    _owner._windows.remove(rootView.viewId);
-  }
-
-  @override
-  @internal
-  String get title => _window.getTitle();
-
-  @override
-  @internal
-  bool get isActivated => _window.isActive();
-
-  @override
-  @internal
-  bool get isMaximized => _window.getWindow().getState().contains(_GdkWindowState.maximized);
-
-  @override
-  @internal
-  // NOTE: On Wayland this is never set, see https://gitlab.gnome.org/GNOME/gtk/-/issues/67
-  bool get isMinimized => _window.getWindow().getState().contains(_GdkWindowState.iconified);
-
-  @override
-  @internal
-  bool get isFullscreen => _window.getWindow().getState().contains(_GdkWindowState.fullscreen);
-
-  @override
-  @internal
-  void setSize(Size size) {
-    _window.resize(size.width.toInt(), size.height.toInt());
-  }
-
-  @override
-  @internal
-  void setConstraints(BoxConstraints constraints) {
-    _window.setGeometryHints(
-      minWidth: constraints.minWidth.toInt(),
-      minHeight: constraints.minHeight.toInt(),
-      maxWidth: constraints.maxWidth.isInfinite ? 0x7fffffff : constraints.maxWidth.toInt(),
-      maxHeight: constraints.maxHeight.isInfinite ? 0x7fffffff : constraints.maxHeight.toInt(),
-    );
-  }
-
-  @override
-  @internal
-  void setTitle(String title) {
-    _window.setTitle(title);
-  }
-
-  @override
-  @internal
-  void activate() {
-    _window.present();
-  }
-
-  @override
-  @internal
-  void setMaximized(bool maximized) {
-    if (maximized) {
-      _window.maximize();
-    } else {
-      _window.unmaximize();
-    }
-  }
-
-  @override
-  @internal
-  void setMinimized(bool minimized) {
-    if (minimized) {
-      _window.iconify();
-    } else {
-      _window.deiconify();
-    }
-  }
-
-  @override
-  @internal
-  void setFullscreen(bool fullscreen, {Display? display}) {
-    // TODO(robert-ancell): display currently ignored
-    if (fullscreen) {
-      _window.fullscreen();
-    } else {
-      _window.unfullscreen();
-    }
-  }
-}
-
-/// Implementation of [DialogWindowController] for the Linux platform.
-///
-/// {@macro flutter.widgets.windowing.experimental}
-///
-/// See also:
-///
-///  * [DialogWindowController], the base class for dialog windows.
-class DialogWindowControllerLinux extends DialogWindowController {
-  /// Creates a new dialog window controller for Linux.
-  ///
-  /// When this constructor completes the native window has been created and
-  /// has a view associated with it.
-  ///
-  /// {@macro flutter.widgets.windowing.experimental}
-  ///
-  /// See also:
-  ///
-  ///  * [DialogWindowController], the base class for dialog windows.
-  @internal
-  DialogWindowControllerLinux({
-    required WindowingOwnerLinux owner,
-    required DialogWindowControllerDelegate delegate,
-    Size? preferredSize,
-    BoxConstraints? preferredConstraints,
-    BaseWindowController? parent,
-    String? title,
-  }) : _owner = owner,
-       _delegate = delegate,
-       _parent = parent,
-       _window = _GtkWindow(_GtkWindowType.toplevel),
-       super.empty() {
-    if (!isWindowingEnabled) {
-      throw UnsupportedError(_kWindowingDisabledErrorMessage);
-    }
-
-    _window.setTypeHint(_GdkWindowTypeHint.dialog);
-    if (parent != null) {
-      final _GtkWindow? parentWindow = owner._windows[parent.rootView.viewId];
-      if (parentWindow != null) {
-        _window.setTransientFor(parentWindow);
-        _window.setModal(true);
-      }
-    }
-
-    _windowMonitor = _FlWindowMonitor(
-      _window,
-      onConfigure: notifyListeners,
-      onStateChanged: notifyListeners,
-      onIsActiveNotify: notifyListeners,
-      onTitleNotify: notifyListeners,
-      onClose: () {
-        _delegate.onWindowCloseRequested(this);
-      },
-      onDestroy: _delegate.onWindowDestroyed,
-    );
-    if (preferredSize != null) {
-      _window.setDefaultSize(preferredSize.width.toInt(), preferredSize.height.toInt());
-    }
-    if (preferredConstraints != null) {
-      setConstraints(preferredConstraints);
-    }
-    if (title != null) {
-      setTitle(title);
-    }
-    final engine = _FlEngine.current();
-    final view = _FlView(engine);
-    final int viewId = view.getId();
-    rootView = WidgetsBinding.instance.platformDispatcher.views.firstWhere(
-      (FlutterView view) => view.viewId == viewId,
-    );
-    view.show();
-    _window.add(view);
-    _window.present();
-  }
-
-  final WindowingOwnerLinux _owner;
-  final DialogWindowControllerDelegate _delegate;
-  final _GtkWindow _window;
-  final BaseWindowController? _parent;
-  late final _FlWindowMonitor _windowMonitor;
-  bool _destroyed = false;
-
-  @override
-  @internal
-  Size get contentSize => _window.getSize();
-
-  @override
-  void destroy() {
-    if (_destroyed) {
-      return;
-    }
-    _window.destroy();
-    _windowMonitor.close();
-    _windowMonitor.unref();
-    _destroyed = true;
-    _owner._windows.remove(rootView.viewId);
-  }
-
-  @override
-  @internal
-  BaseWindowController? get parent => _parent;
-
-  @override
-  @internal
-  String get title => _window.getTitle();
-
-  @override
-  @internal
-  bool get isActivated => _window.isActive();
-
-  @override
-  @internal
-  // NOTE: On Wayland this is never set, see https://gitlab.gnome.org/GNOME/gtk/-/issues/67
-  bool get isMinimized => _window.getWindow().getState().contains(_GdkWindowState.iconified);
-
-  @override
-  @internal
-  void setSize(Size size) {
-    _window.resize(size.width.toInt(), size.height.toInt());
-  }
-
-  @override
-  @internal
-  void setConstraints(BoxConstraints constraints) {
-    _window.setGeometryHints(
-      minWidth: constraints.minWidth.toInt(),
-      minHeight: constraints.minHeight.toInt(),
-      maxWidth: constraints.maxWidth.isInfinite ? 0x7fffffff : constraints.maxWidth.toInt(),
-      maxHeight: constraints.maxHeight.isInfinite ? 0x7fffffff : constraints.maxHeight.toInt(),
-    );
-  }
-
-  @override
-  @internal
-  void setTitle(String title) {
-    _window.setTitle(title);
-  }
-
-  @override
-  @internal
-  void activate() {
-    _window.present();
-  }
-
-  @override
-  @internal
-  void setMinimized(bool minimized) {
-    if (minimized) {
-      _window.iconify();
-    } else {
-      _window.deiconify();
-    }
-  }
 }

--- a/packages/flutter/lib/src/widgets/_window_linux.dart
+++ b/packages/flutter/lib/src/widgets/_window_linux.dart
@@ -31,7 +31,11 @@ import 'binding.dart';
 const int _kMaxWindowDimensions = 0x7fffffff;
 
 /// The type of a GtkWindow.
-enum _GtkWindowType { toplevel, popup }
+enum _GtkWindowType {
+  toplevel,
+  // ignore: unused_field
+  popup,
+}
 
 /// States a toplevel window can be in.
 enum _GdkWindowState {
@@ -56,19 +60,32 @@ enum _GdkWindowState {
 
 /// Hints for the window manager on how to treat a window.
 enum _GdkWindowTypeHint {
+  // ignore: unused_field
   normal,
   dialog,
+  // ignore: unused_field
   menu,
+  // ignore: unused_field
   toolbar,
+  // ignore: unused_field
   splashscreen,
+  // ignore: unused_field
   utility,
+  // ignore: unused_field
   dock,
+  // ignore: unused_field
   desktop,
+  // ignore: unused_field
   dropdown_menu,
+  // ignore: unused_field
   popup_menu,
+  // ignore: unused_field
   tooltip,
+  // ignore: unused_field
   notification,
+  // ignore: unused_field
   combo,
+  // ignore: unused_field
   dnd,
 }
 
@@ -185,9 +202,9 @@ class _GdkWindow extends _GObject {
 
   /// Gets the window state.
   Set<_GdkWindowState> getState() {
-    final stateBits = _gdkWindowGetState(instance);
+    final int stateBits = _gdkWindowGetState(instance);
     final states = <_GdkWindowState>{};
-    for (final state in _GdkWindowState.values) {
+    for (final _GdkWindowState state in _GdkWindowState.values) {
       if ((stateBits & (1 << state.index)) != 0) {
         states.add(state);
       }


### PR DESCRIPTION
- Add documentation
- Use enums
- Make _FlEngine object
- Moved FFI code to the bottom of the file - it can't be easily split into a separate file without being made public.
