### PR TITLE
[CP-stable] Update lifecycle event loops to be mutation-safe

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
@@ -82,7 +82,7 @@ static BOOL IsPowerOfTwo(NSUInteger x) {
 }
 
 - (BOOL)hasPluginThatRespondsToSelector:(SEL)selector {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates.allObjects) {
     if (!delegate) {
       continue;
     }
@@ -177,7 +177,7 @@ static BOOL IsPowerOfTwo(NSUInteger x) {
                isFallbackForScene:(BOOL)isFallback {
   // Use a snapshot of the delegates to allow plugins to add or remove themselves
   // during the notification loop without causing a mutation crash.
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates.allObjects) {
     if (!delegate || (isFallback && [self pluginSupportsSceneLifecycle:delegate])) {
       continue;
     }
@@ -225,7 +225,7 @@ static NSDictionary<UIApplicationLaunchOptionsKey, id>* ConvertConnectionOptions
     self.didForwardApplicationWillLaunch = YES;
   }
   flutter::DartCallbackCache::LoadCacheFromDisk();
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates.allObjects) {
     if (!delegate) {
       continue;
     }
@@ -277,7 +277,7 @@ static NSDictionary<UIApplicationLaunchOptionsKey, id>* ConvertConnectionOptions
 
 - (void)applicationDidEnterBackground:(UIApplication*)application
                    isFallbackForScene:(BOOL)isFallback {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates.allObjects) {
     if (!delegate || (isFallback && [self pluginSupportsSceneLifecycle:delegate])) {
       continue;
     }
@@ -312,7 +312,7 @@ static NSDictionary<UIApplicationLaunchOptionsKey, id>* ConvertConnectionOptions
 
 - (void)applicationWillEnterForeground:(UIApplication*)application
                     isFallbackForScene:(BOOL)isFallback {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates.allObjects) {
     if (!delegate || (isFallback && [self pluginSupportsSceneLifecycle:delegate])) {
       continue;
     }
@@ -341,7 +341,7 @@ static NSDictionary<UIApplicationLaunchOptionsKey, id>* ConvertConnectionOptions
 
 - (void)applicationWillResignActive:(UIApplication*)application
                  isFallbackForScene:(BOOL)isFallback {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates.allObjects) {
     if (!delegate || (isFallback && [self pluginSupportsSceneLifecycle:delegate])) {
       continue;
     }
@@ -369,7 +369,7 @@ static NSDictionary<UIApplicationLaunchOptionsKey, id>* ConvertConnectionOptions
 }
 
 - (void)applicationDidBecomeActive:(UIApplication*)application isFallbackForScene:(BOOL)isFallback {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates.allObjects) {
     if (!delegate || (isFallback && [self pluginSupportsSceneLifecycle:delegate])) {
       continue;
     }
@@ -382,7 +382,7 @@ static NSDictionary<UIApplicationLaunchOptionsKey, id>* ConvertConnectionOptions
 - (void)handleWillTerminate:(NSNotification*)notification
     NS_EXTENSION_UNAVAILABLE_IOS("Disallowed in app extensions") {
   UIApplication* application = [UIApplication sharedApplication];
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates.allObjects) {
     if (!delegate) {
       continue;
     }
@@ -396,7 +396,7 @@ static NSDictionary<UIApplicationLaunchOptionsKey, id>* ConvertConnectionOptions
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 - (void)application:(UIApplication*)application
     didRegisterUserNotificationSettings:(UIUserNotificationSettings*)notificationSettings {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates.allObjects) {
     if (!delegate) {
       continue;
     }
@@ -409,7 +409,7 @@ static NSDictionary<UIApplicationLaunchOptionsKey, id>* ConvertConnectionOptions
 
 - (void)application:(UIApplication*)application
     didRegisterForRemoteNotificationsWithDeviceToken:(NSData*)deviceToken {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates.allObjects) {
     if (!delegate) {
       continue;
     }
@@ -422,7 +422,7 @@ static NSDictionary<UIApplicationLaunchOptionsKey, id>* ConvertConnectionOptions
 
 - (void)application:(UIApplication*)application
     didFailToRegisterForRemoteNotificationsWithError:(NSError*)error {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates.allObjects) {
     if (!delegate) {
       continue;
     }
@@ -435,7 +435,7 @@ static NSDictionary<UIApplicationLaunchOptionsKey, id>* ConvertConnectionOptions
 - (void)application:(UIApplication*)application
     didReceiveRemoteNotification:(NSDictionary*)userInfo
           fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates.allObjects) {
     if (!delegate) {
       continue;
     }
@@ -453,7 +453,7 @@ static NSDictionary<UIApplicationLaunchOptionsKey, id>* ConvertConnectionOptions
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 - (void)application:(UIApplication*)application
     didReceiveLocalNotification:(UILocalNotification*)notification {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates.allObjects) {
     if (!delegate) {
       continue;
     }
@@ -468,7 +468,7 @@ static NSDictionary<UIApplicationLaunchOptionsKey, id>* ConvertConnectionOptions
        willPresentNotification:(UNNotification*)notification
          withCompletionHandler:
              (void (^)(UNNotificationPresentationOptions options))completionHandler {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates.allObjects) {
     if ([delegate respondsToSelector:_cmd]) {
       [delegate userNotificationCenter:center
                willPresentNotification:notification
@@ -480,7 +480,7 @@ static NSDictionary<UIApplicationLaunchOptionsKey, id>* ConvertConnectionOptions
 - (void)userNotificationCenter:(UNUserNotificationCenter*)center
     didReceiveNotificationResponse:(UNNotificationResponse*)response
              withCompletionHandler:(void (^)(void))completionHandler {
-  for (id<FlutterApplicationLifeCycleDelegate> delegate in _delegates) {
+  for (id<FlutterApplicationLifeCycleDelegate> delegate in _delegates.allObjects) {
     if ([delegate respondsToSelector:_cmd]) {
       [delegate userNotificationCenter:center
           didReceiveNotificationResponse:response
@@ -511,7 +511,7 @@ static NSDictionary<UIApplicationLaunchOptionsKey, id>* ConvertConnectionOptions
                openURL:(NSURL*)url
                options:(NSDictionary<UIApplicationOpenURLOptionsKey, id>*)options
     isFallbackForScene:(BOOL)isFallback {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates.allObjects) {
     if (!delegate || (isFallback && [self pluginSupportsSceneLifecycle:delegate])) {
       continue;
     }
@@ -553,7 +553,7 @@ static NSDictionary<UIApplicationOpenURLOptionsKey, id>* ConvertOptions(
 }
 
 - (BOOL)application:(UIApplication*)application handleOpenURL:(NSURL*)url {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates.allObjects) {
     if (!delegate) {
       continue;
     }
@@ -570,7 +570,7 @@ static NSDictionary<UIApplicationOpenURLOptionsKey, id>* ConvertOptions(
               openURL:(NSURL*)url
     sourceApplication:(NSString*)sourceApplication
            annotation:(id)annotation {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates.allObjects) {
     if (!delegate) {
       continue;
     }
@@ -611,7 +611,7 @@ static NSDictionary<UIApplicationOpenURLOptionsKey, id>* ConvertOptions(
     performActionForShortcutItem:(UIApplicationShortcutItem*)shortcutItem
                completionHandler:(void (^)(BOOL succeeded))completionHandler
               isFallbackForScene:(BOOL)isFallback {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates.allObjects) {
     if (!delegate || (isFallback && [self pluginSupportsSceneLifecycle:delegate])) {
       continue;
     }
@@ -630,7 +630,7 @@ static NSDictionary<UIApplicationOpenURLOptionsKey, id>* ConvertOptions(
 - (BOOL)application:(UIApplication*)application
     handleEventsForBackgroundURLSession:(nonnull NSString*)identifier
                       completionHandler:(nonnull void (^)())completionHandler {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates.allObjects) {
     if (!delegate) {
       continue;
     }
@@ -647,7 +647,7 @@ static NSDictionary<UIApplicationOpenURLOptionsKey, id>* ConvertOptions(
 
 - (BOOL)application:(UIApplication*)application
     performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates.allObjects) {
     if (!delegate) {
       continue;
     }
@@ -684,7 +684,7 @@ static NSDictionary<UIApplicationOpenURLOptionsKey, id>* ConvertOptions(
     continueUserActivity:(NSUserActivity*)userActivity
       restorationHandler:(void (^)(NSArray*))restorationHandler
       isFallbackForScene:(BOOL)isFallback {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates.allObjects) {
     if (!delegate || (isFallback && [self pluginSupportsSceneLifecycle:delegate])) {
       continue;
     }

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
@@ -175,7 +175,9 @@ static BOOL IsPowerOfTwo(NSUInteger x) {
 - (BOOL)application:(UIApplication*)application
     didFinishLaunchingWithOptions:(NSDictionary*)launchOptions
                isFallbackForScene:(BOOL)isFallback {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+  // Use a snapshot of the delegates to allow plugins to add or remove themselves
+  // during the notification loop without causing a mutation crash.
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
     if (!delegate || (isFallback && [self pluginSupportsSceneLifecycle:delegate])) {
       continue;
     }
@@ -275,7 +277,7 @@ static NSDictionary<UIApplicationLaunchOptionsKey, id>* ConvertConnectionOptions
 
 - (void)applicationDidEnterBackground:(UIApplication*)application
                    isFallbackForScene:(BOOL)isFallback {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
     if (!delegate || (isFallback && [self pluginSupportsSceneLifecycle:delegate])) {
       continue;
     }
@@ -310,7 +312,7 @@ static NSDictionary<UIApplicationLaunchOptionsKey, id>* ConvertConnectionOptions
 
 - (void)applicationWillEnterForeground:(UIApplication*)application
                     isFallbackForScene:(BOOL)isFallback {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
     if (!delegate || (isFallback && [self pluginSupportsSceneLifecycle:delegate])) {
       continue;
     }
@@ -339,7 +341,7 @@ static NSDictionary<UIApplicationLaunchOptionsKey, id>* ConvertConnectionOptions
 
 - (void)applicationWillResignActive:(UIApplication*)application
                  isFallbackForScene:(BOOL)isFallback {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
     if (!delegate || (isFallback && [self pluginSupportsSceneLifecycle:delegate])) {
       continue;
     }
@@ -367,7 +369,7 @@ static NSDictionary<UIApplicationLaunchOptionsKey, id>* ConvertConnectionOptions
 }
 
 - (void)applicationDidBecomeActive:(UIApplication*)application isFallbackForScene:(BOOL)isFallback {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
     if (!delegate || (isFallback && [self pluginSupportsSceneLifecycle:delegate])) {
       continue;
     }
@@ -380,7 +382,7 @@ static NSDictionary<UIApplicationLaunchOptionsKey, id>* ConvertConnectionOptions
 - (void)handleWillTerminate:(NSNotification*)notification
     NS_EXTENSION_UNAVAILABLE_IOS("Disallowed in app extensions") {
   UIApplication* application = [UIApplication sharedApplication];
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
     if (!delegate) {
       continue;
     }
@@ -394,7 +396,7 @@ static NSDictionary<UIApplicationLaunchOptionsKey, id>* ConvertConnectionOptions
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 - (void)application:(UIApplication*)application
     didRegisterUserNotificationSettings:(UIUserNotificationSettings*)notificationSettings {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
     if (!delegate) {
       continue;
     }
@@ -407,7 +409,7 @@ static NSDictionary<UIApplicationLaunchOptionsKey, id>* ConvertConnectionOptions
 
 - (void)application:(UIApplication*)application
     didRegisterForRemoteNotificationsWithDeviceToken:(NSData*)deviceToken {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
     if (!delegate) {
       continue;
     }
@@ -420,7 +422,7 @@ static NSDictionary<UIApplicationLaunchOptionsKey, id>* ConvertConnectionOptions
 
 - (void)application:(UIApplication*)application
     didFailToRegisterForRemoteNotificationsWithError:(NSError*)error {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
     if (!delegate) {
       continue;
     }
@@ -433,7 +435,7 @@ static NSDictionary<UIApplicationLaunchOptionsKey, id>* ConvertConnectionOptions
 - (void)application:(UIApplication*)application
     didReceiveRemoteNotification:(NSDictionary*)userInfo
           fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
     if (!delegate) {
       continue;
     }
@@ -451,7 +453,7 @@ static NSDictionary<UIApplicationLaunchOptionsKey, id>* ConvertConnectionOptions
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 - (void)application:(UIApplication*)application
     didReceiveLocalNotification:(UILocalNotification*)notification {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
     if (!delegate) {
       continue;
     }
@@ -466,7 +468,7 @@ static NSDictionary<UIApplicationLaunchOptionsKey, id>* ConvertConnectionOptions
        willPresentNotification:(UNNotification*)notification
          withCompletionHandler:
              (void (^)(UNNotificationPresentationOptions options))completionHandler {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
     if ([delegate respondsToSelector:_cmd]) {
       [delegate userNotificationCenter:center
                willPresentNotification:notification
@@ -509,7 +511,7 @@ static NSDictionary<UIApplicationLaunchOptionsKey, id>* ConvertConnectionOptions
                openURL:(NSURL*)url
                options:(NSDictionary<UIApplicationOpenURLOptionsKey, id>*)options
     isFallbackForScene:(BOOL)isFallback {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
     if (!delegate || (isFallback && [self pluginSupportsSceneLifecycle:delegate])) {
       continue;
     }
@@ -551,7 +553,7 @@ static NSDictionary<UIApplicationOpenURLOptionsKey, id>* ConvertOptions(
 }
 
 - (BOOL)application:(UIApplication*)application handleOpenURL:(NSURL*)url {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
     if (!delegate) {
       continue;
     }
@@ -568,7 +570,7 @@ static NSDictionary<UIApplicationOpenURLOptionsKey, id>* ConvertOptions(
               openURL:(NSURL*)url
     sourceApplication:(NSString*)sourceApplication
            annotation:(id)annotation {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
     if (!delegate) {
       continue;
     }
@@ -609,7 +611,7 @@ static NSDictionary<UIApplicationOpenURLOptionsKey, id>* ConvertOptions(
     performActionForShortcutItem:(UIApplicationShortcutItem*)shortcutItem
                completionHandler:(void (^)(BOOL succeeded))completionHandler
               isFallbackForScene:(BOOL)isFallback {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
     if (!delegate || (isFallback && [self pluginSupportsSceneLifecycle:delegate])) {
       continue;
     }
@@ -628,7 +630,7 @@ static NSDictionary<UIApplicationOpenURLOptionsKey, id>* ConvertOptions(
 - (BOOL)application:(UIApplication*)application
     handleEventsForBackgroundURLSession:(nonnull NSString*)identifier
                       completionHandler:(nonnull void (^)())completionHandler {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
     if (!delegate) {
       continue;
     }
@@ -645,7 +647,7 @@ static NSDictionary<UIApplicationOpenURLOptionsKey, id>* ConvertOptions(
 
 - (BOOL)application:(UIApplication*)application
     performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
     if (!delegate) {
       continue;
     }
@@ -682,7 +684,7 @@ static NSDictionary<UIApplicationOpenURLOptionsKey, id>* ConvertOptions(
     continueUserActivity:(NSUserActivity*)userActivity
       restorationHandler:(void (^)(NSArray*))restorationHandler
       isFallbackForScene:(BOOL)isFallback {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
     if (!delegate || (isFallback && [self pluginSupportsSceneLifecycle:delegate])) {
       continue;
     }


### PR DESCRIPTION
### Issue Link:
What is the link to the issue this cherry-pick is addressing?

https://github.com/flutter/flutter/issues/182361

### Impact Description:
What is the impact (ex. visual jank on Samsung phones, app crash, cannot ship an iOS app)?
Does it impact development (ex. flutter doctor crashes when Android Studio is installed),
or the shipping of production apps (the app crashes on launch).
This information is for domain experts and release engineers to understand the consequences of saying yes or no to the cherry pick.

iOS app may crash when plugin registers for lifecycle events.

### Changelog Description:
Explain this cherry pick:
* In one line that is accessible to most Flutter developers.
* That describes the state prior to the fix.
* That includes which platforms are impacted.
See [best practices](https://github.com/flutter/flutter/blob/main/docs/releases/Hotfix-Documentation-Best-Practices.md) for examples.

[flutter/182361] When iOS plugins register to receive lifecycle events during an event, a crash may occur. 

### Workaround:
Is there a workaround for this issue?

No

### Risk:
What is the risk level of this cherry-pick?

  - [x] Low
  - [ ] Medium
  - [ ] High

### Test Coverage:
Are you confident that your fix is well-tested by automated tests?

  - [x] Yes
  - [ ] No

### Validation Steps:
What are the steps to validate that this fix works?

N/A. This isn't easily reproducible (likely a race condition)
