### PR TITLE
Use isA to test for exceptions

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/style_manager.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/style_manager.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:js_interop';
+
 import 'package:meta/meta.dart';
 
 import '../browser_detection.dart';
@@ -165,19 +167,23 @@ void applyGlobalCssRulesToSheet(
         '  display: none;'
         '}',
       );
-    } on DomException catch (e) {
-      // Browsers that don't understand ::-ms-reveal throw a DOMException
-      // of type SyntaxError.
-      domWindow.console.warn(e);
-      // Add a fake rule if our code failed because we're under testing
-      assert(() {
-        styleElement.appendText(
-          '$cssSelectorPrefix input.fallback-for-fakey-browser-in-ci {'
-          '  display: none;'
-          '}',
-        );
-        return true;
-      }());
+    } catch (e) {
+      if (e.isA<DomException>()) {
+        // Browsers that don't understand ::-ms-reveal throw a DOMException
+        // of type SyntaxError.
+        domWindow.console.warn(e);
+        // Add a fake rule if our code failed because we're under testing
+        assert(() {
+          styleElement.appendText(
+            '$cssSelectorPrefix input.fallback-for-fakey-browser-in-ci {'
+            '  display: none;'
+            '}',
+          );
+          return true;
+        }());
+      } else {
+        rethrow;
+      }
     }
   }
 }


### PR DESCRIPTION
This code was never testing that the exception was a DOMException. When compiling to JS, this is just checking if it is a JS object and when compiling to Wasm, this is just checking if the value is a JS value. With recent [lint changes](https://dart-review.googlesource.com/c/sdk/+/483960), this will now be linted and will therefore block the SDK roll.

Instead, we should catch the exception without a type, do an isA check (now that it supports arbitrary values), and then rethrow if it isn't the exception we were looking for.

Note that this does mean if this code was accidentally catching a different JS value before, it now rethrows it.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].
