### PR TITLE
Re-specify the ndk version in various test apps, to prevent ndk download

### DIFF
--- a/dev/a11y_assessments/android/app/build.gradle
+++ b/dev/a11y_assessments/android/app/build.gradle
@@ -35,7 +35,7 @@ if (keystorePropertiesFile.exists()) {
 android {
     namespace = "com.example.a11y_assessments"
     compileSdk = flutter.compileSdkVersion
-
+    ndkVersion = flutter.ndkVersion
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17

--- a/dev/benchmarks/complex_layout/android/app/build.gradle
+++ b/dev/benchmarks/complex_layout/android/app/build.gradle
@@ -28,6 +28,7 @@ if (flutterVersionName == null) {
 android {
     namespace = "com.yourcompany.complexLayout"
     compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
 
 
     compileOptions {

--- a/dev/benchmarks/macrobenchmarks/android/app/build.gradle
+++ b/dev/benchmarks/macrobenchmarks/android/app/build.gradle
@@ -28,6 +28,7 @@ if (flutterVersionName == null) {
 android {
     namespace = "com.example.macrobenchmarks"
     compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
 
 
     compileOptions {

--- a/dev/benchmarks/microbenchmarks/android/app/build.gradle
+++ b/dev/benchmarks/microbenchmarks/android/app/build.gradle
@@ -28,6 +28,7 @@ if (flutterVersionName == null) {
 android {
     namespace = "com.yourcompany.microbenchmarks"
     compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
 
 
     compileOptions {

--- a/dev/benchmarks/multiple_flutters/android/app/build.gradle
+++ b/dev/benchmarks/multiple_flutters/android/app/build.gradle
@@ -15,6 +15,7 @@ android {
 
     namespace = "dev.flutter.multipleflutters"
     compileSdk = 36
+    ndkVersion = "28.2.13676358" // This version must exactly match the version of the NDK that the recipe pulls from CIPD.
 
 
     compileOptions {

--- a/dev/benchmarks/platform_views_layout/android/app/build.gradle
+++ b/dev/benchmarks/platform_views_layout/android/app/build.gradle
@@ -28,6 +28,7 @@ if (flutterVersionName == null) {
 android {
     namespace = "dev.benchmarks.platform_views_layout"
     compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
 
 
     compileOptions {

--- a/dev/benchmarks/platform_views_layout_hybrid_composition/android/app/build.gradle
+++ b/dev/benchmarks/platform_views_layout_hybrid_composition/android/app/build.gradle
@@ -28,6 +28,7 @@ if (flutterVersionName == null) {
 android {
     namespace = "dev.benchmarks.platform_views_layout_hybrid_composition"
     compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
 
 
     compileOptions {

--- a/dev/benchmarks/test_apps/stocks/android/app/build.gradle
+++ b/dev/benchmarks/test_apps/stocks/android/app/build.gradle
@@ -28,6 +28,7 @@ if (flutterVersionName == null) {
 android {
     namespace = "io.flutter.examples.stocks"
     compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
 
 
     compileOptions {

--- a/dev/integration_tests/android_engine_test/android/app/build.gradle
+++ b/dev/integration_tests/android_engine_test/android/app/build.gradle
@@ -12,6 +12,7 @@ plugins {
 android {
     namespace = "com.example.android_engine_test"
     compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
 
 
     compileOptions {

--- a/dev/integration_tests/android_semantics_testing/android/app/build.gradle
+++ b/dev/integration_tests/android_semantics_testing/android/app/build.gradle
@@ -19,6 +19,7 @@ if (localPropertiesFile.exists()) {
 android {
     namespace = "com.yourcompany.platforminteraction"
     compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
 
 
     compileOptions {

--- a/dev/integration_tests/android_verified_input/android/app/build.gradle
+++ b/dev/integration_tests/android_verified_input/android/app/build.gradle
@@ -29,6 +29,8 @@ if (flutterVersionName == null) {
 android {
     namespace "io.flutter.integration.android_verified_input"
     compileSdk flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
+
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/dev/integration_tests/android_views/android/app/build.gradle
+++ b/dev/integration_tests/android_views/android/app/build.gradle
@@ -28,6 +28,7 @@ if (flutterVersionName == null) {
 android {
     namespace = 'io.flutter.integration.platformviews'
     compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
 
 
     compileOptions {

--- a/dev/integration_tests/channels/android/app/build.gradle
+++ b/dev/integration_tests/channels/android/app/build.gradle
@@ -29,6 +29,8 @@ if (flutterVersionName == null) {
 android {
     namespace = "com.example.channels"
     compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
+
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/dev/integration_tests/deferred_components_test/android/app/build.gradle
+++ b/dev/integration_tests/deferred_components_test/android/app/build.gradle
@@ -35,6 +35,7 @@ if (keystorePropertiesFile.exists()) {
 android {
     namespace = "io.flutter.integration.deferred_components_test"
     compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/dev/integration_tests/deferred_components_test/android/component1/build.gradle
+++ b/dev/integration_tests/deferred_components_test/android/component1/build.gradle
@@ -25,7 +25,7 @@ apply plugin: "com.android.dynamic-feature"
 android {
     namespace = "io.flutter.integration.deferred_components_test.component1"
     compileSdk = 36
-
+    ndkVersion = "28.2.13676358" // This version must exactly match the version of the NDK that the recipe pulls from CIPD.
 
     sourceSets {
         applicationVariants.all { variant ->

--- a/dev/integration_tests/external_textures/android/app/build.gradle
+++ b/dev/integration_tests/external_textures/android/app/build.gradle
@@ -18,6 +18,7 @@ if (localPropertiesFile.exists()) {
 android {
     namespace = "io.flutter.externalui"
     compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
 
 
     compileOptions {

--- a/dev/integration_tests/flavors/android/app/build.gradle
+++ b/dev/integration_tests/flavors/android/app/build.gradle
@@ -18,6 +18,7 @@ if (localPropertiesFile.exists()) {
 android {
     namespace = "com.yourcompany.flavors"
     compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
 
 
     compileOptions {

--- a/dev/integration_tests/flutter_gallery/android/app/build.gradle
+++ b/dev/integration_tests/flutter_gallery/android/app/build.gradle
@@ -47,6 +47,7 @@ if (flutterVersionName == null) {
 android {
     namespace = "io.flutter.demo.gallery"
     compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
 
 
     compileOptions {

--- a/dev/integration_tests/hybrid_android_views/android/app/build.gradle
+++ b/dev/integration_tests/hybrid_android_views/android/app/build.gradle
@@ -28,6 +28,7 @@ if (flutterVersionName == null) {
 android {
     namespace = "io.flutter.integration.platformviews"
     compileSdk flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/dev/integration_tests/module_host_with_custom_build_v2_embedding/app/build.gradle
+++ b/dev/integration_tests/module_host_with_custom_build_v2_embedding/app/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'com.android.application'
 android {
     namespace = "io.flutter.addtoapp"
     compileSdk = 36
-
+    ndkVersion = "28.2.13676358" // This version must exactly match the version of the NDK that the recipe pulls from CIPD.
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/dev/integration_tests/platform_interaction/android/app/build.gradle
+++ b/dev/integration_tests/platform_interaction/android/app/build.gradle
@@ -18,6 +18,7 @@ if (localPropertiesFile.exists()) {
 android {
     namespace = "com.yourcompany.platforminteraction"
     compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
 
 
     compileOptions {

--- a/dev/integration_tests/pure_android_host_apps/android_custom_host_app/SampleApp/build.gradle
+++ b/dev/integration_tests/pure_android_host_apps/android_custom_host_app/SampleApp/build.gradle
@@ -7,6 +7,7 @@ apply plugin: 'com.android.application'
 android {
     namespace = "io.flutter.add2app"
     compileSdk = 36
+    ndkVersion = "28.2.13676358" // This version must exactly match the version of the NDK that the recipe pulls from CIPD.
 
 
     compileOptions {

--- a/dev/integration_tests/pure_android_host_apps/android_host_app_v2_embedding/app/build.gradle
+++ b/dev/integration_tests/pure_android_host_apps/android_host_app_v2_embedding/app/build.gradle
@@ -7,6 +7,7 @@ apply plugin: 'com.android.application'
 android {
     namespace = "io.flutter.add2app"
     compileSdk = 36
+    ndkVersion = "28.2.13676358" // This version must exactly match the version of the NDK that the recipe pulls from CIPD.
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/dev/integration_tests/pure_android_host_apps/host_app_kotlin_gradle_dsl/app/build.gradle.kts
+++ b/dev/integration_tests/pure_android_host_apps/host_app_kotlin_gradle_dsl/app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 android {
     namespace = "com.example.myapplication"
     compileSdk = 36
-
+    ndkVersion = "28.2.13676358" // This version must exactly match the version of the NDK that the recipe pulls from CIPD.
 
     defaultConfig {
         applicationId = "com.example.myapplication"

--- a/dev/integration_tests/release_smoke_test/android/app/build.gradle
+++ b/dev/integration_tests/release_smoke_test/android/app/build.gradle
@@ -29,6 +29,7 @@ if (flutterVersionName == null) {
 android {
     namespace = "com.example.release_smoke_test"
     compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
 
 
     compileOptions {

--- a/dev/integration_tests/spell_check/android/app/build.gradle
+++ b/dev/integration_tests/spell_check/android/app/build.gradle
@@ -29,6 +29,7 @@ if (flutterVersionName == null) {
 android {
     namespace = "com.example.spell_check"
     compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
 
 
     compileOptions {

--- a/dev/manual_tests/android/app/build.gradle
+++ b/dev/manual_tests/android/app/build.gradle
@@ -29,6 +29,7 @@ if (flutterVersionName == null) {
 android {
     namespace = "dev.flutter.manual_tests"
     compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
 
 
     compileOptions {

--- a/dev/tracing_tests/android/app/build.gradle
+++ b/dev/tracing_tests/android/app/build.gradle
@@ -29,6 +29,7 @@ if (flutterVersionName == null) {
 android {
     namespace = "com.example.tracing_tests"
     compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
 
 
     compileOptions {

--- a/examples/flutter_view/android/app/build.gradle
+++ b/examples/flutter_view/android/app/build.gradle
@@ -10,6 +10,7 @@ plugins {
 android {
     namespace = "com.example.view"
     compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
 
 
     compileOptions {

--- a/examples/hello_world/android/app/build.gradle.kts
+++ b/examples/hello_world/android/app/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
 android {
     namespace = "io.flutter.examples.hello_world"
     compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8

--- a/examples/image_list/android/app/build.gradle
+++ b/examples/image_list/android/app/build.gradle
@@ -28,6 +28,7 @@ if (flutterVersionName == null) {
 android {
     namespace = "com.example.image_list"
     compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
 
 
     compileOptions {

--- a/examples/layers/android/app/build.gradle
+++ b/examples/layers/android/app/build.gradle
@@ -10,6 +10,7 @@ plugins {
 android {
     namespace = "io.flutter.examples.Layers"
     compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
 
 
     compileOptions {

--- a/examples/platform_channel/android/app/build.gradle
+++ b/examples/platform_channel/android/app/build.gradle
@@ -28,6 +28,7 @@ if (flutterVersionName == null) {
 android {
     namespace = "com.example.platformchannel"
     compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
 
 
     compileOptions {

--- a/examples/platform_view/android/app/build.gradle
+++ b/examples/platform_view/android/app/build.gradle
@@ -28,6 +28,7 @@ if (flutterVersionName == null) {
 android {
     namespace = "io.flutter.examples.platform_view"
     compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
 
 
     compileOptions {

--- a/packages/integration_test/example/android/app/build.gradle.kts
+++ b/packages/integration_test/example/android/app/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
 android {
     namespace = "com.example.integration_test_example"
     compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
When I landed https://github.com/flutter/flutter/pull/179920/ I was operating under the assumption that if there was no `ndkVersion` specified in the `android {}` block, AGP would use whatever NDK was present. This is not true - AGP has a default NDK version (dependent on your AGP version), and it checks only for that version (which is not the same as our pre-installed version in almost all (all?) cases). 

So we should re-add the `ndkVersion = flutter.ndkVersion`. This is also present in our templates, so it isn't a ci specific hack. It will align the version that AGP looks for with the version we are hosting on CI, so we will stop downloading.