### PR TITLE
Make compileShader() retry without sksl if it fails with sksl.

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/tools/shader_compiler.dart
+++ b/packages/flutter_tools/lib/src/build_system/tools/shader_compiler.dart
@@ -208,7 +208,7 @@ class ShaderCompiler {
     if (retryWithoutSksl) {
       shaderTargets.remove('--sksl');
       final List<String> retryCmd = makeImpellercCommand(shaderTargets);
-      _logger.printTrace('Retrying impellerc command without sksl: $cmd');
+      _logger.printTrace('Retrying impellerc command without sksl: $retryCmd');
       final ProcessResult retryResult = await _processManager.run(retryCmd, stderrEncoding: utf8);
       if (retryResult.exitCode != 0) {
         // Retry failed.

--- a/packages/flutter_tools/lib/src/build_system/tools/shader_compiler.dart
+++ b/packages/flutter_tools/lib/src/build_system/tools/shader_compiler.dart
@@ -173,9 +173,9 @@ class ShaderCompiler {
     }
 
     final String shaderLibPath = _fs.path.join(impellerc.parent.absolute.path, 'shader_lib');
-    final cmd = <String>[
+    List<String> makeImpellercCommand(List<String> targets) => <String>[
       impellerc.path,
-      ..._shaderTargetsFromTargetPlatform(targetPlatform),
+      ...targets,
       '--iplr',
       if (targetPlatform == TargetPlatform.web_javascript) '--json',
       '--sl=$outputPath',
@@ -185,18 +185,53 @@ class ShaderCompiler {
       '--include=${input.parent.path}',
       '--include=$shaderLibPath',
     ];
-    _logger.printTrace('shaderc command: $cmd');
-    final Process impellercProcess = await _processManager.start(cmd);
-    final int code = await impellercProcess.exitCode;
-    if (code != 0) {
-      final String stdout = await utf8.decodeStream(impellercProcess.stdout);
-      final String stderr = await utf8.decodeStream(impellercProcess.stderr);
-      _logger.printTrace(stdout);
-      _logger.printError(stderr);
+
+    var failure = false;
+    var retryWithoutSksl = false;
+
+    final List<String> shaderTargets = _shaderTargetsFromTargetPlatform(targetPlatform);
+    final List<String> cmd = makeImpellercCommand(shaderTargets);
+    _logger.printTrace('impellerc command: $cmd');
+    final ProcessResult result = await _processManager.run(cmd, stderrEncoding: utf8);
+    if (result.exitCode != 0) {
+      // Maybe retry impellerc command without --sksl.
+      if (!(shaderTargets.length > 1 && shaderTargets.contains('--sksl'))) {
+        // The original command did not target sksl or targeted only sksl, so
+        // we can't retry without --sksl.
+        _logger.printError('impellerc failure: ${result.stderr}');
+        failure = true;
+      } else {
+        retryWithoutSksl = true;
+      }
+    }
+
+    if (retryWithoutSksl) {
+      shaderTargets.remove('--sksl');
+      final List<String> retryCmd = makeImpellercCommand(shaderTargets);
+      _logger.printTrace('Retrying impellerc command without sksl: $cmd');
+      final ProcessResult retryResult = await _processManager.run(retryCmd, stderrEncoding: utf8);
+      if (retryResult.exitCode != 0) {
+        // Retry failed.
+        _logger.printError('impellerc failure: ${retryResult.stderr}');
+        failure = true;
+      } else {
+        // Retry succeeded. Don't fail, but log a warning message and the sksl
+        // compiler error.
+        // The "warning: " prefix must be used to make these non-fatal log
+        // messages appear in the console when building with the Xcode backend.
+        _logger.printError(
+          'warning: Shader `${input.path}` is incompatible with SkSL. This '
+          'shader will not load when running with the Skia backend.',
+        );
+        _logger.printError('impellerc failure: ${result.stderr}');
+      }
+    }
+
+    if (failure) {
       if (fatal) {
         throw ShaderCompilerException._(
           'Shader compilation of "${input.path}" to "$outputPath" '
-          'failed with exit code $code.',
+          'failed with exit code ${result.exitCode}.',
         );
       }
       return false;

--- a/packages/flutter_tools/test/integration.shard/shader_compiler_test.dart
+++ b/packages/flutter_tools/test/integration.shard/shader_compiler_test.dart
@@ -18,7 +18,7 @@ void main() {
     logger = BufferLogger.test();
   });
 
-  Future<void> testCompileShader(String source) async {
+  Future<bool> testCompileShader(String source, {required bool targetSkslOnly}) async {
     final Directory tmpDir = globals.fs.systemTempDirectory.createTempSync('shader_compiler_test.');
     final File file = tmpDir.childFile('test_shader.frag')..writeAsStringSync(source);
     final shaderCompiler = ShaderCompiler(
@@ -27,10 +27,14 @@ void main() {
       fileSystem: globals.fs,
       artifacts: globals.artifacts!,
     );
-    await shaderCompiler.compileShader(
+    return shaderCompiler.compileShader(
       input: file,
       outputPath: tmpDir.childFile('test_shader.frag.out').path,
-      targetPlatform: TargetPlatform.tester,
+      targetPlatform: targetSkslOnly
+          // web_javascript compiles to sksl only.
+          ? TargetPlatform.web_javascript
+          // tester compiles to sksl and runtime-stage-vulkan
+          : TargetPlatform.tester,
     );
   }
 
@@ -73,26 +77,42 @@ void main() {
     expect(resultFile.statSync().mode & expectedMode, equals(expectedMode));
   });
 
-  testUsingContext('Compilation error with in storage', () async {
+  group('shader with inputs', () {
     const kShaderWithInput = '''
-in float foo;
+    in float foo;
 
-out vec4 fragColor;
+    out vec4 fragColor;
 
-void main() {
-  fragColor = vec4(1.0, 0.0, 0.0, 1.0);
-}
-''';
+    void main() {
+      fragColor = vec4(1.0, 0.0, 0.0, 1.0);
+    }
+    ''';
 
-    await expectLater(
-      () => testCompileShader(kShaderWithInput),
-      throwsA(isA<ShaderCompilerException>()),
-    );
-    expect(logger.errorText, contains('SkSL does not support inputs'));
+    testUsingContext('fails SkSL compilation', () async {
+      await expectLater(
+        () => testCompileShader(kShaderWithInput, targetSkslOnly: true),
+        throwsA(isA<ShaderCompilerException>()),
+      );
+      expect(logger.errorText, contains('SkSL does not support inputs'));
+    });
+
+    testUsingContext('succeeds with non-SkSL compilation', () async {
+      final bool compileResult = await testCompileShader(kShaderWithInput, targetSkslOnly: false);
+      expect(compileResult, true);
+      expect(
+        logger.errorText,
+        matches(
+          r'warning: Shader `.+` is incompatible with SkSL. '
+          r'This shader will not load when running with the Skia backend.\n'
+          r'impellerc failure: There was a compiler error: '
+          r"SkSL does not support inputs: 'foo'",
+        ),
+      );
+    });
   });
 
-  testUsingContext('Compilation error with UBO', () async {
-    const kShaderWithInput = '''
+  group('shader with UBO', () {
+    const kShaderWithUbo = '''
 uniform Data {
   vec4 foo;
 } data;
@@ -104,17 +124,31 @@ void main() {
 }
 ''';
 
-    await expectLater(
-      () => testCompileShader(kShaderWithInput),
-      throwsA(isA<ShaderCompilerException>()),
-    );
-    expect(logger.errorText, contains('SkSL does not support UBOs or SSBOs'));
+    testUsingContext('fails SkSL compilation', () async {
+      await expectLater(
+        () => testCompileShader(kShaderWithUbo, targetSkslOnly: true),
+        throwsA(isA<ShaderCompilerException>()),
+      );
+      expect(logger.errorText, contains('SkSL does not support UBOs or SSBOs'));
+    });
+
+    testUsingContext('succeeds with non-SkSL compilation', () async {
+      final bool compileResult = await testCompileShader(kShaderWithUbo, targetSkslOnly: false);
+      expect(compileResult, true);
+      expect(
+        logger.errorText,
+        matches(
+          r'warning: Shader `.+` is incompatible with SkSL. '
+          r'This shader will not load when running with the Skia backend.\n'
+          r'impellerc failure: There was a compiler error: '
+          r"SkSL does not support UBOs or SSBOs: 'data'",
+        ),
+      );
+    });
   });
 
-  testUsingContext(
-    'Compilation error with texture arguments besides position or sampler',
-    () async {
-      const kShaderWithInput = '''
+  group('shader with texture arguments besides position or sampler', () {
+    const kShaderWithTextureArguments = '''
 uniform sampler2D tex;
 
 out vec4 fragColor;
@@ -124,31 +158,95 @@ void main() {
 }
 ''';
 
+    testUsingContext('fails SkSL compilation', () async {
       await expectLater(
-        () => testCompileShader(kShaderWithInput),
+        () => testCompileShader(kShaderWithTextureArguments, targetSkslOnly: true),
         throwsA(isA<ShaderCompilerException>()),
       );
       expect(
         logger.errorText,
         contains('Only sampler and position arguments are supported in texture() calls'),
       );
-    },
-  );
+    });
 
-  testUsingContext('Compilation error with uint8 uniforms', () async {
-    const kShaderWithInput = '''
-#version 310 es
+    testUsingContext('succeeds with non-SkSL compilation', () async {
+      final bool compileResult = await testCompileShader(
+        kShaderWithTextureArguments,
+        targetSkslOnly: false,
+      );
+      expect(compileResult, true);
+      expect(
+        logger.errorText,
+        matches(
+          r'warning: Shader `.+` is incompatible with SkSL. '
+          r'This shader will not load when running with the Skia backend.\n'
+          r'impellerc failure: There was a compiler error: '
+          r'Only sampler and position arguments are supported in texture\(\) calls.',
+        ),
+      );
+    });
+  });
 
-layout(location = 0) uniform uint foo;
-layout(location = 0) out vec4 fragColor;
+  group('shader with uint8 uniforms', () {
+    const kShaderWithUint8Uniforms = '''
+  #version 310 es
 
-void main() {}
+  layout(location = 0) uniform uint foo;
+  layout(location = 0) out vec4 fragColor;
+
+  void main() {}
+  ''';
+
+    testUsingContext('fails SkSL compilation', () async {
+      await expectLater(
+        () => testCompileShader(kShaderWithUint8Uniforms, targetSkslOnly: true),
+        throwsA(isA<ShaderCompilerException>()),
+      );
+      expect(logger.errorText, contains('SkSL does not support unsigned integers'));
+    });
+
+    testUsingContext('fails with non-SkSL compilation', () async {
+      await expectLater(
+        () => testCompileShader(kShaderWithUint8Uniforms, targetSkslOnly: false),
+        throwsA(isA<ShaderCompilerException>()),
+      );
+      expect(logger.errorText, contains('Non-floating-type struct member foo is not supported.'));
+    });
+  });
+
+  group('shader with array initializer list', () {
+    const kShaderWithArrayInitializer = '''
+out vec4 fragColor;
+
+void main() {
+  float array_with_initializer_list[2] = {1.0, 0.0};
+  fragColor = vec4(1.0, 0.0, 0.0, 1.0);
+}
 ''';
 
-    await expectLater(
-      () => testCompileShader(kShaderWithInput),
-      throwsA(isA<ShaderCompilerException>()),
-    );
-    expect(logger.errorText, contains('SkSL does not support unsigned integers'));
+    testUsingContext('fails SkSL compilation', () async {
+      await expectLater(
+        () => testCompileShader(kShaderWithArrayInitializer, targetSkslOnly: true),
+        throwsA(isA<ShaderCompilerException>()),
+      );
+      expect(logger.errorText, contains('SkSL does not support array initializers'));
+    });
+
+    testUsingContext('succeeds with non-SkSL compilation', () async {
+      final bool compilationResult = await testCompileShader(
+        kShaderWithArrayInitializer,
+        targetSkslOnly: false,
+      );
+      expect(compilationResult, isTrue);
+      expect(
+        logger.errorText,
+        matches(
+          r'warning: Shader `.+` is incompatible with SkSL. '
+          r'This shader will not load when running with the Skia backend.\n'
+          r'impellerc failure: There was a compiler error: '
+          r'SkSL does not support array initializers: .+',
+        ),
+      );
+    });
   });
 }


### PR DESCRIPTION
Updates `compileShader()` in `shader_compiler.dart` to retry `impellerc` without sksl if calling it with sksl fails.

Fixes #182400

<details><summary>Running an app with a non-sksl-compatible shader:</summary>

```
❯ flutter run -d mac
Launching lib/main.dart on macOS in debug mode...
warning: Shader `/Users/bensonluk/projects/hello_flutter/shaders/simple.frag` is incompatible with SkSL. This shader will not load when running with the Skia backend.
impellerc failure: There was a compiler error: SkSL does not support array initializers: /Users/bensonluk/projects/hello_flutter/shaders/simple.frag:12
Project /Users/bensonluk/projects/hello_flutter built and packaged successfully.
Building macOS application...
✓ Built build/macos/Build/Products/Debug/hello_flutter.app
2026-03-03 11:38:35.093 hello_flutter[76976:83279294] Running with merged UI and platform thread. Experimental.
Failed to foreground app; open returned 1
Syncing files to device macOS...                                    39ms

Flutter run key commands.
r Hot reload. 🔥🔥🔥
R Hot restart.
h List all available interactive commands.
d Detach (terminate "flutter run" but leave application running).
c Clear the screen
q Quit (terminate the application on the device).

A Dart VM Service on macOS is available at: http://127.0.0.1:57483/Nr_RN4azQw8=/
The Flutter DevTools debugger and profiler on macOS is available at: http://127.0.0.1:57483/Nr_RN4azQw8=/devtools/?uri=ws://127.0.0.1:57483/Nr_RN4azQw8=/ws
```
</details>

<details><summary>Running an app with multiple non-sksl-compatible shaders with longer error messages:</summary>

```
❯ flutter run -d mac
Launching lib/main.dart on macOS in debug mode...
warning: Shader `/Users/bensonluk/projects/flutter_liquid_glass/packages/liquid_glass_renderer/lib/assets/shaders/liquid_glass_arbitrary.frag` is incompatible with SkSL. This shader will not load when running with the Skia backend.
impellerc failure: Compilation failed for target: SkSL
"/Users/bensonluk/projects/flutter_liquid_glass/packages/liquid_glass_renderer/lib/assets/shaders/liquid_glass_arbitrary.frag":
Compiled to invalid SkSL:
        // This SkSL shader is autogenerated by spirv-cross.

        float4 flutter_FragCoord;

        uniform vec2 uSize;
        uniform vec2 uForegroundSize;
... (truncated 426 lines)
SkSL Error:
        error: 58: loop index initializer must be a constant expression
                for (int x = _703; x <= sampleRadius; x++)
                     ^^^^^^^^^^^^
        error: 55: loop index initializer must be a constant expression
            for (int y = _692; y <= sampleRadius; y++)
                 ^^^^^^^^^^^^
... (truncated 350 lines)
Full "liquid_glass_arbitrary" error output written to "/tmp/flutter_4Te755VI/impellerc_verbose_error.txt"

warning: Shader `/Users/bensonluk/projects/flutter_liquid_glass/packages/liquid_glass_renderer/lib/assets/shaders/liquid_glass_geometry_blended.frag` is incompatible with SkSL. This shader will not load when running with the Skia backend.
impellerc failure: Compilation failed for target: SkSL
"/Users/bensonluk/projects/flutter_liquid_glass/packages/liquid_glass_renderer/lib/assets/shaders/liquid_glass_geometry_blended.frag":
Compiled to invalid SkSL:
        // This SkSL shader is autogenerated by spirv-cross.

        float4 flutter_FragCoord;

        uniform vec2 uSize;
        uniform vec4 uOpticalProps;
... (truncated 229 lines)
SkSL Error:
        error: 111: initializers are not permitted on arrays (or structs containing arrays)
            float param_2[96] = shapeData;
                                ^^^^^^^^^
        error: 112: unknown identifier 'param_2'
            float result = FLT_flutter_local_getShapeSDFFromArray(param, param_1, param_2);
                                                                                  ^^^^^^^
... (truncated 185 lines)
Full "liquid_glass_geometry_blended" error output written to "/tmp/flutter_3qE1Q4aI/impellerc_verbose_error.txt"

warning: Shader `/Users/bensonluk/projects/flutter_liquid_glass/packages/liquid_glass_renderer/lib/assets/shaders/liquid_glass_filter.frag` is incompatible with SkSL. This shader will not load when running with the Skia backend.
impellerc failure: Compilation failed for target: SkSL
"/Users/bensonluk/projects/flutter_liquid_glass/packages/liquid_glass_renderer/lib/assets/shaders/liquid_glass_filter.frag":
Compiled to invalid SkSL:
        // This SkSL shader is autogenerated by spirv-cross.

        float4 flutter_FragCoord;

        uniform vec2 uSize;
        uniform vec4 uGlassColor;
... (truncated 426 lines)
SkSL Error:
        error: 121: initializers are not permitted on arrays (or structs containing arrays)
            float param_2[96] = shapeData;
                                ^^^^^^^^^
        error: 122: unknown identifier 'param_2'
            float result = FLT_flutter_local_getShapeSDFFromArray(param, param_1, param_2);
                                                                                  ^^^^^^^
... (truncated 488 lines)
Full "liquid_glass_filter" error output written to "/tmp/flutter_OQtgOkth/impellerc_verbose_error.txt"
Project /Users/bensonluk/projects/flutter_liquid_glass/packages/liquid_glass_renderer/example built and packaged successfully.Command PhaseScriptExecution emitted errors but did not return a nonzero exit code to indicate failure
Building macOS application...
✓ Built build/macos/Build/Products/Debug/liquid_glass_renderer_example.app
2026-03-03 11:39:31.435 liquid_glass_renderer_example[77352:83282562] Running with merged UI and platform thread. Experimental.
Failed to foreground app; open returned 1
flutter: Initializing logger: lgr
flutter: lgr.render.layer > WARNING: LiquidGlassLayer is only supported when using Impeller at the moment. Falling back to FakeGlass for LiquidGlassLayer. To prevent this warning, enable Impeller, or set LiquidGlassLayer.fake to true before you use liquid glass widgets on Skia.
flutter: lgr.render.layer > WARNING: LiquidGlassLayer is only supported when using Impeller at the moment. Falling back to FakeGlass for LiquidGlassLayer. To prevent this warning, enable Impeller, or set LiquidGlassLayer.fake to true before you use liquid glass widgets on Skia.
Syncing files to device macOS...                                    47ms

Flutter run key commands.
r Hot reload. 🔥🔥🔥
R Hot restart.
h List all available interactive commands.
d Detach (terminate "flutter run" but leave application running).
c Clear the screen
q Quit (terminate the application on the device).

A Dart VM Service on macOS is available at: http://127.0.0.1:57532/tQZkdNat5B0=/
The Flutter DevTools debugger and profiler on macOS is available at: http://127.0.0.1:57532/tQZkdNat5B0=/devtools/?uri=ws://127.0.0.1:57532/tQZkdNat5B0=/ws
```
</details>

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
