### PR TITLE
Use base-config from network-security-config

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/loader/ApplicationInfoLoader.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/loader/ApplicationInfoLoader.java
@@ -11,7 +11,6 @@ import android.content.res.XmlResourceParser;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 import java.io.IOException;
-import org.json.JSONArray;
 import org.xmlpull.v1.XmlPullParserException;
 
 /** Loads application information given a Context. */
@@ -54,89 +53,40 @@ public final class ApplicationInfoLoader {
     return metadata.getBoolean(key, defaultValue);
   }
 
-  private static String getNetworkPolicy(ApplicationInfo appInfo, Context context) {
+  private static boolean getNetworkPolicy(ApplicationInfo appInfo, Context context) {
     // We cannot use reflection to look at networkSecurityConfigRes because
     // Android throws an error when we try to access fields marked as This member is not intended
     // for public use, and is only visible for testing..
     // Instead we rely on metadata.
     Bundle metadata = appInfo.metaData;
     if (metadata == null) {
-      return null;
+      return false;
     }
 
     int networkSecurityConfigRes = metadata.getInt(NETWORK_POLICY_METADATA_KEY, 0);
     if (networkSecurityConfigRes <= 0) {
-      return null;
+      return false;
     }
 
-    JSONArray output = new JSONArray();
+    boolean disallowInsecureConnections = false;
+
     try {
       XmlResourceParser xrp = context.getResources().getXml(networkSecurityConfigRes);
       xrp.next();
       int eventType = xrp.getEventType();
       while (eventType != XmlResourceParser.END_DOCUMENT) {
         if (eventType == XmlResourceParser.START_TAG) {
-          if (xrp.getName().equals("domain-config")) {
-            parseDomainConfig(xrp, output, false);
+          if (xrp.getName().equals("base-config")) {
+            disallowInsecureConnections =
+                !xrp.getAttributeBooleanValue(null, "cleartextTrafficPermitted", true);
           }
         }
         eventType = xrp.next();
       }
     } catch (IOException | XmlPullParserException e) {
-      return null;
+      return false;
     }
-    return output.toString();
-  }
-
-  private static void parseDomainConfig(
-      XmlResourceParser xrp, JSONArray output, boolean inheritedCleartextPermitted)
-      throws IOException, XmlPullParserException {
-    boolean cleartextTrafficPermitted =
-        xrp.getAttributeBooleanValue(
-            null, "cleartextTrafficPermitted", inheritedCleartextPermitted);
-    while (true) {
-      int eventType = xrp.next();
-      if (eventType == XmlResourceParser.START_TAG) {
-        if (xrp.getName().equals("domain")) {
-          // There can be multiple domains.
-          parseDomain(xrp, output, cleartextTrafficPermitted);
-        } else if (xrp.getName().equals("domain-config")) {
-          parseDomainConfig(xrp, output, cleartextTrafficPermitted);
-        } else {
-          skipTag(xrp);
-        }
-      } else if (eventType == XmlResourceParser.END_TAG) {
-        break;
-      }
-    }
-  }
-
-  private static void skipTag(XmlResourceParser xrp) throws IOException, XmlPullParserException {
-    String name = xrp.getName();
-    int eventType = xrp.getEventType();
-    while (eventType != XmlResourceParser.END_TAG || xrp.getName() != name) {
-      eventType = xrp.next();
-    }
-  }
-
-  private static void parseDomain(
-      XmlResourceParser xrp, JSONArray output, boolean cleartextPermitted)
-      throws IOException, XmlPullParserException {
-    boolean includeSubDomains = xrp.getAttributeBooleanValue(null, "includeSubdomains", false);
-    xrp.next();
-    if (xrp.getEventType() != XmlResourceParser.TEXT) {
-      throw new IllegalStateException("Expected text");
-    }
-    String domain = xrp.getText().trim();
-    JSONArray outputArray = new JSONArray();
-    outputArray.put(domain);
-    outputArray.put(includeSubDomains);
-    outputArray.put(cleartextPermitted);
-    output.put(outputArray);
-    xrp.next();
-    if (xrp.getEventType() != XmlResourceParser.END_TAG) {
-      throw new IllegalStateException("Expected end of domain tag");
-    }
+    return disallowInsecureConnections;
   }
 
   /**
@@ -151,8 +101,8 @@ public final class ApplicationInfoLoader {
         getString(appInfo.metaData, PUBLIC_VM_SNAPSHOT_DATA_KEY),
         getString(appInfo.metaData, PUBLIC_ISOLATE_SNAPSHOT_DATA_KEY),
         getString(appInfo.metaData, PUBLIC_FLUTTER_ASSETS_DIR_KEY),
-        getNetworkPolicy(appInfo, applicationContext),
         appInfo.nativeLibraryDir,
-        getBoolean(appInfo.metaData, PUBLIC_AUTOMATICALLY_REGISTER_PLUGINS_METADATA_KEY, true));
+        getBoolean(appInfo.metaData, PUBLIC_AUTOMATICALLY_REGISTER_PLUGINS_METADATA_KEY, true),
+        getNetworkPolicy(appInfo, applicationContext));
   }
 }

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/loader/FlutterApplicationInfo.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/loader/FlutterApplicationInfo.java
@@ -15,18 +15,18 @@ public final class FlutterApplicationInfo {
   public final String vmSnapshotData;
   public final String isolateSnapshotData;
   public final String flutterAssetsDir;
-  public final String domainNetworkPolicy;
   public final String nativeLibraryDir;
   final boolean automaticallyRegisterPlugins;
+  final boolean disallowInsecureConnections;
 
   public FlutterApplicationInfo(
       String aotSharedLibraryName,
       String vmSnapshotData,
       String isolateSnapshotData,
       String flutterAssetsDir,
-      String domainNetworkPolicy,
       String nativeLibraryDir,
-      boolean automaticallyRegisterPlugins) {
+      boolean automaticallyRegisterPlugins,
+      boolean disallowInsecureConnections) {
     this.aotSharedLibraryName =
         aotSharedLibraryName == null ? DEFAULT_AOT_SHARED_LIBRARY_NAME : aotSharedLibraryName;
     this.vmSnapshotData = vmSnapshotData == null ? DEFAULT_VM_SNAPSHOT_DATA : vmSnapshotData;
@@ -35,7 +35,7 @@ public final class FlutterApplicationInfo {
     this.flutterAssetsDir =
         flutterAssetsDir == null ? DEFAULT_FLUTTER_ASSETS_DIR : flutterAssetsDir;
     this.nativeLibraryDir = nativeLibraryDir;
-    this.domainNetworkPolicy = domainNetworkPolicy == null ? "" : domainNetworkPolicy;
     this.automaticallyRegisterPlugins = automaticallyRegisterPlugins;
+    this.disallowInsecureConnections = disallowInsecureConnections;
   }
 }

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -377,9 +377,11 @@ public class FlutterLoader {
       }
 
       shellArgs.add("--cache-dir-path=" + result.engineCachesPath);
-      if (flutterApplicationInfo.domainNetworkPolicy != null) {
-        shellArgs.add("--domain-network-policy=" + flutterApplicationInfo.domainNetworkPolicy);
+
+      if (flutterApplicationInfo.disallowInsecureConnections) {
+        shellArgs.add("--disallow-insecure-connections");
       }
+
       if (settings.getLogTag() != null) {
         shellArgs.add("--log-tag=" + settings.getLogTag());
       }


### PR DESCRIPTION
Currently, there is no way for the Android embedder to turn off insecure dart sockets.  This connects the base-config from the network-security-config.xml to at least control this.

Addresses: https://github.com/flutter/flutter/issues/183153

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.
