### PR TITLE
[packages_autoroller] Handle ProcessException in Git.run

### DIFF
--- a/dev/packages_autoroller/lib/src/git.dart
+++ b/dev/packages_autoroller/lib/src/git.dart
@@ -40,8 +40,8 @@ final class Git {
     late final ProcessResult result;
     try {
       result = await _run(args, workingDirectory);
-    } on ProcessException {
-      _reportFailureAndExit(args, workingDirectory, result, explanation);
+    } on ProcessException catch (exception) {
+      _reportProcessExceptionAndExit(args, workingDirectory, exception, explanation);
     }
     if (result.exitCode != 0 && !allowNonZeroExitCode) {
       _reportFailureAndExit(args, workingDirectory, result, explanation);
@@ -78,6 +78,21 @@ final class Git {
     if ((result.stderr as String).isNotEmpty) {
       message.writeln('stderr from git:\n${result.stderr}\n');
     }
+    throw GitException(message.toString(), args);
+  }
+
+  Never _reportProcessExceptionAndExit(
+    List<String> args,
+    String workingDirectory,
+    ProcessException exception,
+    String explanation,
+  ) {
+    final message = StringBuffer()
+      ..writeln(
+        'Command "git ${args.join(' ')}" failed in directory "$workingDirectory" to '
+        '$explanation.',
+      )
+      ..writeln('ProcessException from git: $exception');
     throw GitException(message.toString(), args);
   }
 }

--- a/dev/packages_autoroller/lib/src/git.dart
+++ b/dev/packages_autoroller/lib/src/git.dart
@@ -16,6 +16,12 @@ import 'package:process/process.dart';
 final class Git {
   const Git(this.processManager);
 
+  static final RegExp _urlCredentialPattern = RegExp(r'([a-zA-Z][a-zA-Z0-9+.-]*:\/\/)([^\/@\s]+)@');
+
+  static final RegExp _githubTokenPattern = RegExp(
+    r'\b(?:ghp|gho|ghu|ghs|ghr|github_pat)_[A-Za-z0-9_]+\b',
+  );
+
   final ProcessManager processManager;
 
   Future<String> getOutput(
@@ -63,37 +69,49 @@ final class Git {
     ProcessResult result,
     String explanation,
   ) {
+    final String redactedCommand = _redactPotentialSecrets(args.join(' '));
     final message = StringBuffer();
     if (result.exitCode != 0) {
       message.writeln(
-        'Command "git ${args.join(' ')}" failed in directory "$workingDirectory" to '
+        'Command "git $redactedCommand" failed in directory "$workingDirectory" to '
         '$explanation. Git exited with error code ${result.exitCode}.',
       );
     } else {
-      message.writeln('Command "git ${args.join(' ')}" failed to $explanation.');
+      message.writeln('Command "git $redactedCommand" failed to $explanation.');
     }
     if ((result.stdout as String).isNotEmpty) {
-      message.writeln('stdout from git:\n${result.stdout}\n');
+      message.writeln('stdout from git:\n${_redactPotentialSecrets(result.stdout as String)}\n');
     }
     if ((result.stderr as String).isNotEmpty) {
-      message.writeln('stderr from git:\n${result.stderr}\n');
+      message.writeln('stderr from git:\n${_redactPotentialSecrets(result.stderr as String)}\n');
     }
     throw GitException(message.toString(), args);
   }
 
+  /// Throw a [GitException] when spawning `git` fails before command execution.
   Never _reportProcessExceptionAndExit(
     List<String> args,
     String workingDirectory,
     ProcessException exception,
     String explanation,
   ) {
+    final String redactedCommand = _redactPotentialSecrets(args.join(' '));
     final message = StringBuffer()
       ..writeln(
-        'Command "git ${args.join(' ')}" failed in directory "$workingDirectory" to '
+        'Command "git $redactedCommand" failed in directory "$workingDirectory" to '
         '$explanation.',
       )
-      ..writeln('ProcessException from git: $exception');
+      ..writeln('ProcessException from git: ${_redactPotentialSecrets(exception.toString())}');
     throw GitException(message.toString(), args);
+  }
+
+  static String _redactPotentialSecrets(String text) {
+    final String redactedUrlCredentials = text.replaceAllMapped(_urlCredentialPattern, (
+      Match match,
+    ) {
+      return '${match.group(1)}[REDACTED]@';
+    });
+    return redactedUrlCredentials.replaceAll(_githubTokenPattern, '[REDACTED]');
   }
 }
 

--- a/dev/packages_autoroller/test/git_test.dart
+++ b/dev/packages_autoroller/test/git_test.dart
@@ -33,5 +33,78 @@ void main() {
       );
       expect(processManager, hasNoRemainingExpectations);
     });
+
+    test('redacts URL credentials when starting git fails', () async {
+      const remoteWithToken = 'https://super-secret-token@github.com/flutter/flutter.git';
+      final processManager = FakeProcessManager.list(<FakeCommand>[
+        const FakeCommand(
+          command: <String>['git', 'push', remoteWithToken, 'HEAD:master'],
+          exception: ProcessException(
+            'git',
+            <String>['push', remoteWithToken, 'HEAD:master'],
+            'authentication failed for https://super-secret-token@github.com/flutter/flutter.git',
+            128,
+          ),
+        ),
+      ]);
+      final git = Git(processManager);
+
+      await expectLater(
+        () => git.run(
+          <String>['push', remoteWithToken, 'HEAD:master'],
+          'push to upstream',
+          workingDirectory: '/tmp',
+        ),
+        throwsA(
+          isA<GitException>()
+              .having(
+                (GitException e) => e.message,
+                'message contains redacted URL',
+                contains('https://[REDACTED]@github.com/flutter/flutter.git'),
+              )
+              .having(
+                (GitException e) => e.message,
+                'message does not contain raw token',
+                isNot(contains('super-secret-token@github.com')),
+              ),
+        ),
+      );
+      expect(processManager, hasNoRemainingExpectations);
+    });
+
+    test('redacts URL credentials on non-zero git exit', () async {
+      const remoteWithToken = 'https://super-secret-token@github.com/flutter/flutter.git';
+      final processManager = FakeProcessManager.list(<FakeCommand>[
+        const FakeCommand(
+          command: <String>['git', 'push', remoteWithToken, 'HEAD:master'],
+          exitCode: 1,
+          stderr:
+              'fatal: could not read Password for "https://super-secret-token@github.com": No such device or address',
+        ),
+      ]);
+      final git = Git(processManager);
+
+      await expectLater(
+        () => git.run(
+          <String>['push', remoteWithToken, 'HEAD:master'],
+          'push to upstream',
+          workingDirectory: '/tmp',
+        ),
+        throwsA(
+          isA<GitException>()
+              .having(
+                (GitException e) => e.message,
+                'message contains redacted URL',
+                contains('https://[REDACTED]@github.com/flutter/flutter.git'),
+              )
+              .having(
+                (GitException e) => e.message,
+                'message does not contain raw token',
+                isNot(contains('super-secret-token@github.com')),
+              ),
+        ),
+      );
+      expect(processManager, hasNoRemainingExpectations);
+    });
   });
 }

--- a/dev/packages_autoroller/test/git_test.dart
+++ b/dev/packages_autoroller/test/git_test.dart
@@ -1,0 +1,37 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:packages_autoroller/src/git.dart';
+
+import 'common.dart';
+
+void main() {
+  group('Git.run', () {
+    test('throws GitException if starting git fails', () async {
+      final processManager = FakeProcessManager.list(<FakeCommand>[
+        const FakeCommand(
+          command: <String>['git', 'status'],
+          exception: ProcessException('git', <String>['status'], 'No such file or directory', 2),
+        ),
+      ]);
+      final git = Git(processManager);
+
+      await expectLater(
+        () => git.run(<String>['status'], 'check git status', workingDirectory: '/tmp'),
+        throwsA(
+          isA<GitException>()
+              .having((GitException e) => e.message, 'message', contains('check git status'))
+              .having(
+                (GitException e) => e.message,
+                'message',
+                contains('No such file or directory'),
+              ),
+        ),
+      );
+      expect(processManager, hasNoRemainingExpectations);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
`Git.run` could throw a `LateInitializationError` when `processManager.run(...)` fails to start git and throws `ProcessException`. In that path, `result` was uninitialized but still passed to `_reportFailureAndExit(...)`.

This change handles `ProcessException` explicitly and throws a `GitException` with context.

Follow-up hardening also redacts potential secrets from all `GitException` message paths so command arguments, `ProcessException` text, and git stdout/stderr do not leak URL-embedded credentials or common GitHub token formats.

## Changes
- Add `_reportProcessExceptionAndExit(...)` in `dev/packages_autoroller/lib/src/git.dart`.
- Catch `ProcessException` in `Git.run` and route to the new reporter.
- Add internal secret redaction utility and apply it to:
  - rendered git command args
  - `ProcessException` string output
  - git stdout/stderr in failure messages
- Add doc comment for `_reportProcessExceptionAndExit(...)`.
- Add `dev/packages_autoroller/test/git_test.dart` with tests for:
  - startup failure throwing `GitException`
  - credential redaction in `ProcessException` path
  - credential redaction in non-zero-exit path

## Validation
In `dev/packages_autoroller`:
- `dart format --output=none --set-exit-if-changed lib/src/git.dart test/git_test.dart`
- `dart analyze`
- `dart test`

All checks passed locally.