### PR TITLE
Pass --web-define through to web runner when using --machine mode

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -665,6 +665,7 @@ class AppDomain extends Domain {
     String? route,
     DebuggingOptions options,
     bool enableHotReload, {
+    Map<String, String> webDefines = const <String, String>{},
     File? applicationBinary,
     required bool trackWidgetCreation,
     String? projectRootPath,
@@ -712,6 +713,7 @@ class AppDomain extends Domain {
         platform: globals.platform,
         outputPreferences: globals.outputPreferences,
         fileSystem: globals.fs,
+        webDefines: webDefines,
       );
     } else if (enableHotReload) {
       runner = HotRunner(

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -841,6 +841,7 @@ class RunCommand extends RunCommandBase {
           route,
           debuggingOptions,
           hotMode,
+          webDefines: extractWebDefines(),
           applicationBinary: applicationBinaryPath == null
               ? null
               : globals.fs.file(applicationBinaryPath),

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -530,6 +530,50 @@ void main() {
           },
         );
 
+        group('web', () {
+          late FakeWebRunnerFactory fakeWebRunnerFactory;
+
+          setUp(() {
+            fakeWebRunnerFactory = FakeWebRunnerFactory();
+          });
+
+          testUsingContext(
+            'can pass --web-define',
+            () async {
+              final command = RunCommand();
+              final device = FakeDevice(
+                platformType: PlatformType.web,
+                targetPlatform: TargetPlatform.web_javascript,
+              );
+              testDeviceManager.devices = <Device>[device];
+
+              await expectLater(
+                () => createTestCommandRunner(command).run(<String>[
+                  'run',
+                  '--no-pub',
+                  '--machine',
+                  '-d',
+                  device.id,
+                  '--web-define=NAME=VAL',
+                ]),
+                throwsToolExit(),
+              );
+              expect(fakeWebRunnerFactory.lastWebDefines, <String, String>{'NAME': 'VAL'});
+            },
+            overrides: <Type, Generator>{
+              Artifacts: () => artifacts,
+              Cache: () => Cache.test(processManager: FakeProcessManager.any()),
+              DeviceManager: () => testDeviceManager,
+              FeatureFlags: () => FakeFeatureFlags(),
+              FileSystem: () => fs,
+              ProcessManager: () => FakeProcessManager.any(),
+              Stdio: () => FakeStdio(),
+              Logger: () => MachineOutputLogger(parent: logger),
+              WebRunnerFactory: () => fakeWebRunnerFactory,
+            },
+          );
+        });
+
         testUsingContext(
           'can disable devtools with --no-devtools',
           () async {
@@ -1990,6 +2034,11 @@ class FakeResidentRunner extends Fake implements ResidentRunner {
     }
     return 0;
   }
+
+  @override
+  DebuggingOptions get debuggingOptions {
+    throwToolExit('');
+  }
 }
 
 class DaemonCapturingRunCommand extends RunCommand {
@@ -2019,6 +2068,7 @@ class CapturingAppDomain extends AppDomain {
     String? route,
     DebuggingOptions options,
     bool enableHotReload, {
+    Map<String, String>? webDefines,
     File? applicationBinary,
     required bool trackWidgetCreation,
     String? projectRootPath,
@@ -2074,6 +2124,7 @@ class FakeFeatureFlags extends Fake implements FeatureFlags {
 /// A Fake WebRunnerFactory that CAPTURES the debugging options passed to it.
 class FakeWebRunnerFactory extends Fake implements WebRunnerFactory {
   DebuggingOptions? lastOptions;
+  Map<String, String>? lastWebDefines;
 
   @override
   ResidentRunner createWebRunner(
@@ -2094,6 +2145,7 @@ class FakeWebRunnerFactory extends Fake implements WebRunnerFactory {
     Map<String, String> webDefines = const <String, String>{},
   }) {
     lastOptions = debuggingOptions;
+    lastWebDefines = webDefines;
     return FakeResidentRunner();
   }
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -2068,7 +2068,7 @@ class CapturingAppDomain extends AppDomain {
     String? route,
     DebuggingOptions options,
     bool enableHotReload, {
-    Map<String, String>? webDefines,
+    Map<String, String> webDefines = const <String, String>{},
     File? applicationBinary,
     required bool trackWidgetCreation,
     String? projectRootPath,


### PR DESCRIPTION
This passes `--web-define`s through to the machine daemon used when `flutter run` is invoked with `--machine` (which is the case for IDEs).

Fixes https://github.com/flutter/flutter/issues/183170
Fixes https://github.com/Dart-Code/Dart-Code/issues/5942

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
