### PR TITLE
refactor: remove material import from animated_cross_fade, physical_model_test, pinned_header_sliver_test, spell_check_test

### DIFF
--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -141,7 +141,6 @@ class TestsCrossImportChecker {
     'packages/flutter/test/widgets/autocomplete_test.dart',
     'packages/flutter/test/widgets/shadow_test.dart',
     'packages/flutter/test/widgets/routes_transition_test.dart',
-    'packages/flutter/test/widgets/animated_cross_fade_test.dart',
     'packages/flutter/test/widgets/editable_text_shortcuts_test.dart',
     'packages/flutter/test/widgets/router_test.dart',
     'packages/flutter/test/widgets/editable_text_test.dart',
@@ -163,8 +162,6 @@ class TestsCrossImportChecker {
     'packages/flutter/test/widgets/scrollable_in_overlay_test.dart',
     'packages/flutter/test/widgets/nested_scroll_view_test.dart',
     'packages/flutter/test/widgets/scrollable_selection_test.dart',
-    'packages/flutter/test/widgets/physical_model_test.dart',
-    'packages/flutter/test/widgets/spell_check_test.dart',
     'packages/flutter/test/widgets/toggleable_test.dart',
     'packages/flutter/test/widgets/draggable_test.dart',
     'packages/flutter/test/widgets/page_transitions_builder_test.dart',
@@ -183,7 +180,6 @@ class TestsCrossImportChecker {
     'packages/flutter/test/widgets/baseline_test.dart',
     'packages/flutter/test/widgets/selection_container_test.dart',
     'packages/flutter/test/widgets/scrollable_semantics_test.dart',
-    'packages/flutter/test/widgets/pinned_header_sliver_test.dart',
     'packages/flutter/test/widgets/form_test.dart',
   };
 

--- a/packages/flutter/test/widgets/animated_cross_fade_test.dart
+++ b/packages/flutter/test/widgets/animated_cross_fade_test.dart
@@ -2,9 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'button_tester.dart';
 
 void main() {
   testWidgets('AnimatedCrossFade test', (WidgetTester tester) async {
@@ -304,8 +306,8 @@ void main() {
       Directionality(
         textDirection: TextDirection.ltr,
         child: AnimatedCrossFade(
-          firstChild: TextButton(onPressed: () {}, child: const Text('AAA')),
-          secondChild: TextButton(onPressed: () {}, child: const Text('BBB')),
+          firstChild: TestButton(onPressed: () {}, child: const Text('AAA')),
+          secondChild: TestButton(onPressed: () {}, child: const Text('BBB')),
           crossFadeState: CrossFadeState.showFirst,
           duration: const Duration(milliseconds: 50),
         ),
@@ -328,8 +330,8 @@ void main() {
       Directionality(
         textDirection: TextDirection.ltr,
         child: AnimatedCrossFade(
-          firstChild: TextButton(onPressed: () {}, child: const Text('AAA')),
-          secondChild: TextButton(onPressed: () {}, child: const Text('BBB')),
+          firstChild: TestButton(onPressed: () {}, child: const Text('AAA')),
+          secondChild: TestButton(onPressed: () {}, child: const Text('BBB')),
           crossFadeState: CrossFadeState.showFirst,
           duration: const Duration(milliseconds: 50),
           excludeBottomFocus: false,
@@ -362,12 +364,15 @@ void main() {
             textDirection: TextDirection.ltr,
             child: AnimatedCrossFade(
               firstChild: const Text('AAA'),
-              secondChild: TextButton(
-                style: TextButton.styleFrom(minimumSize: const Size(double.infinity, 600)),
-                onPressed: () {
-                  numberOfTouchEventNoticed++;
-                },
-                child: const Text('BBB'),
+              secondChild: SizedBox(
+                width: double.infinity,
+                height: 600,
+                child: TestButton(
+                  onPressed: () {
+                    numberOfTouchEventNoticed++;
+                  },
+                  child: const Text('BBB'),
+                ),
               ),
               crossFadeState: crossFadeState,
               duration: const Duration(milliseconds: 50),

--- a/packages/flutter/test/widgets/physical_model_test.dart
+++ b/packages/flutter/test/widgets/physical_model_test.dart
@@ -14,6 +14,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'widgets_app_tester.dart';
 
 const Color _debugBlack = Color(0xFF000000);
+const Color _debugCanvas = Color(0xFFFAFAFA);
+const Color _debugText = Color(0xDD000000);
 
 void main() {
   testWidgets('PhysicalModel updates clipBehavior in updateRenderObject', (
@@ -77,27 +79,30 @@ void main() {
         data: MediaQueryData(),
         child: Directionality(
           textDirection: TextDirection.ltr,
-          child: Padding(
-            padding: EdgeInsets.all(50),
-            child: Row(
-              children: <Widget>[
-                PhysicalModel(
-                  color: _debugBlack,
-                  child: Text('A long long long long long long long string'),
-                ),
-                PhysicalModel(
-                  color: _debugBlack,
-                  child: Text('A long long long long long long long string'),
-                ),
-                PhysicalModel(
-                  color: _debugBlack,
-                  child: Text('A long long long long long long long string'),
-                ),
-                PhysicalModel(
-                  color: _debugBlack,
-                  child: Text('A long long long long long long long string'),
-                ),
-              ],
+          child: DefaultTextStyle(
+            style: TextStyle(color: _debugText, fontFamily: 'Roboto'),
+            child: Padding(
+              padding: EdgeInsets.all(50),
+              child: Row(
+                children: <Widget>[
+                  PhysicalModel(
+                    color: _debugCanvas,
+                    child: Text('A long long long long long long long string'),
+                  ),
+                  PhysicalModel(
+                    color: _debugCanvas,
+                    child: Text('A long long long long long long long string'),
+                  ),
+                  PhysicalModel(
+                    color: _debugCanvas,
+                    child: Text('A long long long long long long long string'),
+                  ),
+                  PhysicalModel(
+                    color: _debugCanvas,
+                    child: Text('A long long long long long long long string'),
+                  ),
+                ],
+              ),
             ),
           ),
         ),

--- a/packages/flutter/test/widgets/physical_model_test.dart
+++ b/packages/flutter/test/widgets/physical_model_test.dart
@@ -13,13 +13,13 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'widgets_app_tester.dart';
 
-const Color _debugRed = Color(0xFFFF0000);
+const Color _debugBlack = Color(0xFF000000);
 
 void main() {
   testWidgets('PhysicalModel updates clipBehavior in updateRenderObject', (
     WidgetTester tester,
   ) async {
-    await tester.pumpWidget(const TestWidgetsApp(home: PhysicalModel(color: _debugRed)));
+    await tester.pumpWidget(const TestWidgetsApp(home: PhysicalModel(color: _debugBlack)));
 
     final RenderPhysicalModel renderPhysicalModel = tester.allRenderObjects
         .whereType<RenderPhysicalModel>()
@@ -29,7 +29,7 @@ void main() {
 
     await tester.pumpWidget(
       const TestWidgetsApp(
-        home: PhysicalModel(clipBehavior: Clip.antiAlias, color: _debugRed),
+        home: PhysicalModel(clipBehavior: Clip.antiAlias, color: _debugBlack),
       ),
     );
 
@@ -42,7 +42,7 @@ void main() {
     await tester.pumpWidget(
       const TestWidgetsApp(
         home: PhysicalShape(
-          color: _debugRed,
+          color: _debugBlack,
           clipper: ShapeBorderClipper(shape: CircleBorder()),
         ),
       ),
@@ -58,7 +58,7 @@ void main() {
       const TestWidgetsApp(
         home: PhysicalShape(
           clipBehavior: Clip.antiAlias,
-          color: _debugRed,
+          color: _debugBlack,
           clipper: ShapeBorderClipper(shape: CircleBorder()),
         ),
       ),
@@ -82,19 +82,19 @@ void main() {
             child: Row(
               children: <Widget>[
                 PhysicalModel(
-                  color: _debugRed,
+                  color: _debugBlack,
                   child: Text('A long long long long long long long string'),
                 ),
                 PhysicalModel(
-                  color: _debugRed,
+                  color: _debugBlack,
                   child: Text('A long long long long long long long string'),
                 ),
                 PhysicalModel(
-                  color: _debugRed,
+                  color: _debugBlack,
                   child: Text('A long long long long long long long string'),
                 ),
                 PhysicalModel(
-                  color: _debugRed,
+                  color: _debugBlack,
                   child: Text('A long long long long long long long string'),
                 ),
               ],

--- a/packages/flutter/test/widgets/physical_model_test.dart
+++ b/packages/flutter/test/widgets/physical_model_test.dart
@@ -7,15 +7,19 @@
 @Tags(<String>['reduced-test-set'])
 library;
 
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'widgets_app_tester.dart';
+
+const Color _debugRed = Color(0xFFFF0000);
 
 void main() {
   testWidgets('PhysicalModel updates clipBehavior in updateRenderObject', (
     WidgetTester tester,
   ) async {
-    await tester.pumpWidget(const MaterialApp(home: PhysicalModel(color: Colors.red)));
+    await tester.pumpWidget(const TestWidgetsApp(home: PhysicalModel(color: _debugRed)));
 
     final RenderPhysicalModel renderPhysicalModel = tester.allRenderObjects
         .whereType<RenderPhysicalModel>()
@@ -24,8 +28,8 @@ void main() {
     expect(renderPhysicalModel.clipBehavior, equals(Clip.none));
 
     await tester.pumpWidget(
-      const MaterialApp(
-        home: PhysicalModel(clipBehavior: Clip.antiAlias, color: Colors.red),
+      const TestWidgetsApp(
+        home: PhysicalModel(clipBehavior: Clip.antiAlias, color: _debugRed),
       ),
     );
 
@@ -36,9 +40,9 @@ void main() {
     WidgetTester tester,
   ) async {
     await tester.pumpWidget(
-      const MaterialApp(
+      const TestWidgetsApp(
         home: PhysicalShape(
-          color: Colors.red,
+          color: _debugRed,
           clipper: ShapeBorderClipper(shape: CircleBorder()),
         ),
       ),
@@ -51,10 +55,10 @@ void main() {
     expect(renderPhysicalShape.clipBehavior, equals(Clip.none));
 
     await tester.pumpWidget(
-      const MaterialApp(
+      const TestWidgetsApp(
         home: PhysicalShape(
           clipBehavior: Clip.antiAlias,
-          color: Colors.red,
+          color: _debugRed,
           clipper: ShapeBorderClipper(shape: CircleBorder()),
         ),
       ),
@@ -68,23 +72,32 @@ void main() {
   ) async {
     const key = Key('test');
     await tester.pumpWidget(
-      Theme(
-        data: ThemeData(useMaterial3: false),
-        child: const MediaQuery(
-          key: key,
-          data: MediaQueryData(),
-          child: Directionality(
-            textDirection: TextDirection.ltr,
-            child: Padding(
-              padding: EdgeInsets.all(50),
-              child: Row(
-                children: <Widget>[
-                  Material(child: Text('A long long long long long long long string')),
-                  Material(child: Text('A long long long long long long long string')),
-                  Material(child: Text('A long long long long long long long string')),
-                  Material(child: Text('A long long long long long long long string')),
-                ],
-              ),
+      const MediaQuery(
+        key: key,
+        data: MediaQueryData(),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Padding(
+            padding: EdgeInsets.all(50),
+            child: Row(
+              children: <Widget>[
+                PhysicalModel(
+                  color: _debugRed,
+                  child: Text('A long long long long long long long string'),
+                ),
+                PhysicalModel(
+                  color: _debugRed,
+                  child: Text('A long long long long long long long string'),
+                ),
+                PhysicalModel(
+                  color: _debugRed,
+                  child: Text('A long long long long long long long string'),
+                ),
+                PhysicalModel(
+                  color: _debugRed,
+                  child: Text('A long long long long long long long string'),
+                ),
+              ],
             ),
           ),
         ),

--- a/packages/flutter/test/widgets/pinned_header_sliver_test.dart
+++ b/packages/flutter/test/widgets/pinned_header_sliver_test.dart
@@ -2,25 +2,25 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'widgets_app_tester.dart';
 
 void main() {
   testWidgets('PinnedHeaderSliver basics', (WidgetTester tester) async {
     Widget buildFrame({required Axis axis, required bool reverse}) {
-      return MaterialApp(
-        home: Scaffold(
-          body: CustomScrollView(
-            scrollDirection: axis,
-            reverse: reverse,
-            slivers: <Widget>[
-              const PinnedHeaderSliver(child: Text('PinnedHeaderSliver')),
-              SliverList.builder(
-                itemCount: 100,
-                itemBuilder: (BuildContext context, int index) => Text('Item $index'),
-              ),
-            ],
-          ),
+      return TestWidgetsApp(
+        home: CustomScrollView(
+          scrollDirection: axis,
+          reverse: reverse,
+          slivers: <Widget>[
+            const PinnedHeaderSliver(child: Text('PinnedHeaderSliver')),
+            SliverList.builder(
+              itemCount: 100,
+              itemBuilder: (BuildContext context, int index) => Text('Item $index'),
+            ),
+          ],
         ),
       );
     }
@@ -147,19 +147,17 @@ void main() {
     WidgetTester tester,
   ) async {
     await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: CustomScrollView(
-            slivers: <Widget>[
-              const PinnedHeaderSliver(child: Text('PinnedHeaderSliver 0')),
-              const PinnedHeaderSliver(child: Text('PinnedHeaderSliver 1')),
-              const PinnedHeaderSliver(child: Text('PinnedHeaderSliver 2')),
-              SliverList.builder(
-                itemCount: 100,
-                itemBuilder: (BuildContext context, int index) => Text('Item $index'),
-              ),
-            ],
-          ),
+      TestWidgetsApp(
+        home: CustomScrollView(
+          slivers: <Widget>[
+            const PinnedHeaderSliver(child: Text('PinnedHeaderSliver 0')),
+            const PinnedHeaderSliver(child: Text('PinnedHeaderSliver 1')),
+            const PinnedHeaderSliver(child: Text('PinnedHeaderSliver 2')),
+            SliverList.builder(
+              itemCount: 100,
+              itemBuilder: (BuildContext context, int index) => Text('Item $index'),
+            ),
+          ],
         ),
       ),
     );
@@ -181,31 +179,29 @@ void main() {
     WidgetTester tester,
   ) async {
     await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: CustomScrollView(
-            slivers: <Widget>[
-              SliverList.builder(
-                itemCount: 2,
-                itemBuilder: (BuildContext context, int index) => Text('Item 0.$index'),
-              ),
-              const PinnedHeaderSliver(child: Text('PinnedHeaderSliver 0')),
-              SliverList.builder(
-                itemCount: 2,
-                itemBuilder: (BuildContext context, int index) => Text('Item 1.$index'),
-              ),
-              const PinnedHeaderSliver(child: Text('PinnedHeaderSliver 1')),
-              SliverList.builder(
-                itemCount: 2,
-                itemBuilder: (BuildContext context, int index) => Text('Item 2.$index'),
-              ),
-              const PinnedHeaderSliver(child: Text('PinnedHeaderSliver 2')),
-              SliverList.builder(
-                itemCount: 100,
-                itemBuilder: (BuildContext context, int index) => Text('Item $index'),
-              ),
-            ],
-          ),
+      TestWidgetsApp(
+        home: CustomScrollView(
+          slivers: <Widget>[
+            SliverList.builder(
+              itemCount: 2,
+              itemBuilder: (BuildContext context, int index) => Text('Item 0.$index'),
+            ),
+            const PinnedHeaderSliver(child: Text('PinnedHeaderSliver 0')),
+            SliverList.builder(
+              itemCount: 2,
+              itemBuilder: (BuildContext context, int index) => Text('Item 1.$index'),
+            ),
+            const PinnedHeaderSliver(child: Text('PinnedHeaderSliver 1')),
+            SliverList.builder(
+              itemCount: 2,
+              itemBuilder: (BuildContext context, int index) => Text('Item 2.$index'),
+            ),
+            const PinnedHeaderSliver(child: Text('PinnedHeaderSliver 2')),
+            SliverList.builder(
+              itemCount: 100,
+              itemBuilder: (BuildContext context, int index) => Text('Item $index'),
+            ),
+          ],
         ),
       ),
     );

--- a/packages/flutter/test/widgets/spell_check_test.dart
+++ b/packages/flutter/test/widgets/spell_check_test.dart
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 late TextStyle composingStyle;
@@ -14,7 +14,11 @@ void main() {
     composingStyle = const TextStyle(decoration: TextDecoration.underline);
 
     // Using Android handling for testing.
-    misspelledTextStyle = TextField.materialMisspelledTextStyle;
+    misspelledTextStyle = const TextStyle(
+      decoration: TextDecoration.underline,
+      decorationColor: Color(0xFFFF0000),
+      decorationStyle: TextDecorationStyle.wavy,
+    );
   });
 
   testWidgets(


### PR DESCRIPTION
This PR removes Material imports from animated_cross_fade, physical_model_test, pinned_header_sliver_test, spell_check_test.

part of: https://github.com/flutter/flutter/issues/177415

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.