### PR TITLE
[flutter_tools] Fix macOS flutter attach VM service discovery

### DIFF
--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -59,6 +59,7 @@ class MacOSDevice extends DesktopDevice {
     return flutterProject.macos.existsSync();
   }
 
+  /// Returns a [VMServiceDiscoveryForAttach] that uses both mDNS and log scanning.
   @override
   VMServiceDiscoveryForAttach getVMServiceDiscoveryForAttach({
     String? appId,

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -12,6 +12,7 @@ import '../base/platform.dart';
 import '../build_info.dart';
 import '../desktop_device.dart';
 import '../device.dart';
+import '../device_vm_service_discovery_for_attach.dart';
 import '../macos/application_package.dart';
 import '../project.dart';
 import 'build_macos.dart';
@@ -56,6 +57,37 @@ class MacOSDevice extends DesktopDevice {
   @override
   bool isSupportedForProject(FlutterProject flutterProject) {
     return flutterProject.macos.existsSync();
+  }
+
+  @override
+  VMServiceDiscoveryForAttach getVMServiceDiscoveryForAttach({
+    String? appId,
+    String? fuchsiaModule,
+    int? filterDevicePort,
+    int? expectedHostPort,
+    required bool ipv6,
+    required Logger logger,
+  }) {
+    final mdnsVMServiceDiscoveryForAttach = MdnsVMServiceDiscoveryForAttach(
+      device: this,
+      appId: appId,
+      deviceVmservicePort: filterDevicePort,
+      hostVmservicePort: expectedHostPort,
+      usesIpv6: ipv6,
+      useDeviceIPAsHost: false,
+    );
+
+    return DelegateVMServiceDiscoveryForAttach(<VMServiceDiscoveryForAttach>[
+      mdnsVMServiceDiscoveryForAttach,
+      super.getVMServiceDiscoveryForAttach(
+        appId: appId,
+        fuchsiaModule: fuchsiaModule,
+        filterDevicePort: filterDevicePort,
+        expectedHostPort: expectedHostPort,
+        ipv6: ipv6,
+        logger: logger,
+      ),
+    ]);
   }
 
   @override

--- a/packages/flutter_tools/test/general.shard/macos/macos_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/macos_device_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/device.dart';
+import 'package:flutter_tools/src/device_vm_service_discovery_for_attach.dart';
 import 'package:flutter_tools/src/macos/application_package.dart';
 import 'package:flutter_tools/src/macos/macos_device.dart';
 import 'package:flutter_tools/src/macos/macos_workflow.dart';
@@ -47,6 +48,27 @@ void main() {
     expect(device.supportsRuntimeMode(BuildMode.profile), true);
     expect(device.supportsRuntimeMode(BuildMode.release), true);
     expect(device.supportsRuntimeMode(BuildMode.jitRelease), false);
+  });
+
+  testWithoutContext('uses mDNS and log scanning discovery when attaching', () async {
+    final device = MacOSDevice(
+      processManager: FakeProcessManager.any(),
+      logger: BufferLogger.test(),
+      fileSystem: MemoryFileSystem.test(),
+      operatingSystemUtils: FakeOperatingSystemUtils(),
+    );
+
+    final VMServiceDiscoveryForAttach discovery = device.getVMServiceDiscoveryForAttach(
+      ipv6: false,
+      logger: BufferLogger.test(),
+    );
+
+    expect(discovery, isA<DelegateVMServiceDiscoveryForAttach>());
+    final List<VMServiceDiscoveryForAttach> delegates =
+        (discovery as DelegateVMServiceDiscoveryForAttach).delegates;
+    expect(delegates, hasLength(2));
+    expect(delegates.first, isA<MdnsVMServiceDiscoveryForAttach>());
+    expect(delegates.last, isA<LogScanningVMServiceDiscoveryForAttach>());
   });
 
   testWithoutContext('Attaches to log reader when running in release mode', () async {


### PR DESCRIPTION
This updates macOS `flutter attach` VM service discovery to use both mDNS and log scanning.

Before this change, macOS attach relied on log-based VM service discovery on the macOS path. In cases where that path did not surface the VM service URI reliably, attach could miss it and time out.

This change matches the iOS simulator/device attach strategy by delegating to:
- mDNS discovery
- existing log-scanning discovery as fallback

Fixes flutter/flutter#183248

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

## Tests

- `../../bin/cache/dart-sdk/bin/dart analyze lib/src/macos/macos_device.dart test/general.shard/macos/macos_device_test.dart`
- `../../bin/cache/dart-sdk/bin/dart test test/general.shard/macos/macos_device_test.dart`


