### PR TITLE
fix: null safety for SelectableRegionState.startGlyphHeight and endGlyphHeight

### DIFF
--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -29,15 +29,15 @@ import 'framework.dart';
 import 'gesture_detector.dart';
 import 'magnifier.dart';
 import 'media_query.dart';
+import 'notification_listener.dart';
 import 'overlay.dart';
 import 'platform_selectable_region_context_menu.dart';
+import 'scroll_notification.dart';
 import 'selection_container.dart';
 import 'tap_region.dart';
 import 'text_editing_intents.dart';
 import 'text_selection.dart';
 import 'text_selection_toolbar_anchors.dart';
-import 'notification_listener.dart';
-import 'scroll_notification.dart';
 
 // Examples can assume:
 // late GlobalKey key;
@@ -1982,10 +1982,10 @@ class SelectableRegionState extends State<SelectableRegion>
       onNotification: (notification) {
         _selectionDelegate.layoutDidChange();
         _updateSelectedContentIfNeeded();
-        final lastSelection = _lastSelectedContent;
+        final SelectedContent? lastSelection = _lastSelectedContent;
         if (lastSelection != null && lastSelection.plainText.isNotEmpty) {
           _showHandles();
-          final selectionOverlay = _selectionOverlay;
+          final SelectionOverlay? selectionOverlay = _selectionOverlay;
           if (selectionOverlay == null ||
               !selectionOverlay.toolbarIsVisible) {
             _showToolbar();

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -36,6 +36,8 @@ import 'tap_region.dart';
 import 'text_editing_intents.dart';
 import 'text_selection.dart';
 import 'text_selection_toolbar_anchors.dart';
+import 'notification_listener.dart';
+import 'scroll_notification.dart';
 
 // Examples can assume:
 // late GlobalKey key;
@@ -1775,12 +1777,12 @@ class SelectableRegionState extends State<SelectableRegion>
 
   /// The line height at the start of the current selection.
   double get startGlyphHeight {
-    return _selectionDelegate.value.startSelectionPoint!.lineHeight;
+    return _selectionDelegate.value.startSelectionPoint?.lineHeight ?? 0;
   }
 
   /// The line height at the end of the current selection.
   double get endGlyphHeight {
-    return _selectionDelegate.value.endSelectionPoint!.lineHeight;
+    return _selectionDelegate.value.endSelectionPoint?.lineHeight ?? 0;
   }
 
   /// Returns the local coordinates of the endpoints of the current selection.
@@ -1946,7 +1948,7 @@ class SelectableRegionState extends State<SelectableRegion>
     if (_webContextMenuEnabled) {
       result = PlatformSelectableRegionContextMenu(child: result);
     }
-    return TapRegion(
+    final tapRegion = TapRegion(
       groupId: SelectableRegion,
       onTapOutside: (PointerDownEvent event) {
         // To match the native web behavior, this selectable region is
@@ -1975,6 +1977,23 @@ class SelectableRegionState extends State<SelectableRegion>
           ),
         ),
       ),
+    );
+    return NotificationListener<ScrollEndNotification>(
+      onNotification: (notification) {
+        _updateSelectedContentIfNeeded();
+        _updateSelectionStatus();
+        final lastSelection = _lastSelectedContent;
+        if (lastSelection != null && lastSelection.plainText.isNotEmpty) {
+          _showHandles();
+          final selectionOverlay = _selectionOverlay;
+          if (selectionOverlay == null ||
+              !selectionOverlay.toolbarIsVisible) {
+            _showToolbar();
+          }
+        }
+        return false;
+      },
+      child: tapRegion,
     );
   }
 }

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1980,8 +1980,8 @@ class SelectableRegionState extends State<SelectableRegion>
     );
     return NotificationListener<ScrollEndNotification>(
       onNotification: (notification) {
+        _selectionDelegate.layoutDidChange();
         _updateSelectedContentIfNeeded();
-        _updateSelectionStatus();
         final lastSelection = _lastSelectedContent;
         if (lastSelection != null && lastSelection.plainText.isNotEmpty) {
           _showHandles();

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1986,8 +1986,7 @@ class SelectableRegionState extends State<SelectableRegion>
         if (lastSelection != null && lastSelection.plainText.isNotEmpty) {
           _showHandles();
           final SelectionOverlay? selectionOverlay = _selectionOverlay;
-          if (selectionOverlay == null ||
-              !selectionOverlay.toolbarIsVisible) {
+          if (selectionOverlay == null || !selectionOverlay.toolbarIsVisible) {
             _showToolbar();
           }
         }

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -904,7 +904,7 @@ void main() {
         // Should not throw - startGlyphHeight/endGlyphHeight return 0 when points are null.
         expect(tester.takeException(), isNull);
       },
-      skip: kIsWeb, // Web uses native context menu
+      skip: kIsWeb, // [intended] Web uses its native context menu.
     );
 
     testWidgets(
@@ -922,11 +922,7 @@ void main() {
               child: NullSelectionPointDelegateWidget(
                 key: delegateKey,
                 child: const Column(
-                  children: <Widget>[
-                    Text('First'),
-                    Text('Second'),
-                    Text('Third'),
-                  ],
+                  children: <Widget>[Text('First'), Text('Second'), Text('Third')],
                 ),
               ),
             ),
@@ -6761,12 +6757,10 @@ class NullSelectionPointDelegateWidget extends StatefulWidget {
   final Widget child;
 
   @override
-  State<NullSelectionPointDelegateWidget> createState() =>
-      NullSelectionPointDelegateWidgetState();
+  State<NullSelectionPointDelegateWidget> createState() => NullSelectionPointDelegateWidgetState();
 }
 
-class NullSelectionPointDelegateWidgetState
-    extends State<NullSelectionPointDelegateWidget> {
+class NullSelectionPointDelegateWidgetState extends State<NullSelectionPointDelegateWidget> {
   late final NullSelectionPointDelegate delegate;
 
   @override
@@ -6783,10 +6777,7 @@ class NullSelectionPointDelegateWidgetState
 
   @override
   Widget build(BuildContext context) {
-    return SelectionContainer(
-      delegate: delegate,
-      child: widget.child,
-    );
+    return SelectionContainer(delegate: delegate, child: widget.child);
   }
 }
 

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -947,7 +947,7 @@ void main() {
         await tester.pumpAndSettle();
 
         // Switch delegate to return null selection points (simulates off-screen scenario).
-        final delegate = delegateKey.currentState!.delegate;
+        final NullSelectionPointDelegate delegate = delegateKey.currentState!.delegate;
         delegate.useNullSelectionPoints = true;
         delegate.notifyListeners();
         await tester.pump();
@@ -961,7 +961,7 @@ void main() {
         expect(state.startGlyphHeight, 0);
         expect(state.endGlyphHeight, 0);
       },
-      skip: kIsWeb,
+      skip: kIsWeb, // [intended] Web uses its native context menu.
     );
 
     testWidgets('mouse long press does not send select-word event', (WidgetTester tester) async {
@@ -6747,8 +6747,6 @@ class NullSelectionPointDelegate extends StaticSelectionContainerDelegate {
       return SelectionGeometry(
         status: geometry.status,
         hasContent: geometry.hasContent,
-        startSelectionPoint: null,
-        endSelectionPoint: null,
         selectionRects: geometry.selectionRects,
       );
     }

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -841,6 +841,129 @@ void main() {
       expect(renderSelectionSpy.events.length, 0);
     });
 
+    testWidgets(
+      'SelectionArea + ListView: select across multiple lines and scroll does not crash',
+      (WidgetTester tester) async {
+        // Regression test: when selection spans across ListView items and user scrolls,
+        // startSelectionPoint/endSelectionPoint may be null (off-screen). Verifies that
+        // startGlyphHeight/endGlyphHeight return 0 and do not crash.
+        await tester.pumpWidget(
+          MaterialApp(
+            home: SelectableRegion(
+              selectionControls: materialTextSelectionControls,
+              child: SizedBox(
+                height: 400,
+                child: ListView(
+                  children: List<Widget>.generate(
+                    15,
+                    (int i) => Text(
+                      'Line $i: Selectable text content for testing',
+                      style: const TextStyle(fontSize: 20),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final RenderParagraph firstParagraph = tester.renderObject<RenderParagraph>(
+          find.descendant(
+            of: find.text('Line 0: Selectable text content for testing'),
+            matching: find.byType(RichText),
+          ),
+        );
+        final RenderParagraph thirdParagraph = tester.renderObject<RenderParagraph>(
+          find.descendant(
+            of: find.text('Line 2: Selectable text content for testing'),
+            matching: find.byType(RichText),
+          ),
+        );
+
+        // Select from first line to third line (cross-line selection).
+        final TestGesture selectGesture = await tester.startGesture(
+          textOffsetToPosition(firstParagraph, 2),
+          kind: PointerDeviceKind.mouse,
+        );
+        addTearDown(selectGesture.removePointer);
+        await tester.pump();
+        await selectGesture.moveTo(textOffsetToPosition(thirdParagraph, 15));
+        await tester.pump();
+        await selectGesture.up();
+        await tester.pumpAndSettle();
+
+        // Verify selection exists.
+        expect(firstParagraph.selections.isNotEmpty, isTrue);
+        expect(thirdParagraph.selections.isNotEmpty, isTrue);
+
+        // Simulate scroll - this may cause selection points to become null when off-screen.
+        await tester.drag(find.byType(ListView), const Offset(0, -150));
+        await tester.pumpAndSettle();
+
+        // Should not throw - startGlyphHeight/endGlyphHeight return 0 when points are null.
+        expect(tester.takeException(), isNull);
+      },
+      skip: kIsWeb, // Web uses native context menu
+    );
+
+    testWidgets(
+      'startGlyphHeight and endGlyphHeight return 0 when startSelectionPoint/endSelectionPoint are null',
+      (WidgetTester tester) async {
+        // Directly tests the fix: when SelectionGeometry has null start/end points
+        // (e.g. selection off-screen in scrollable), startGlyphHeight and
+        // endGlyphHeight must not crash and must return 0.
+        final delegateKey = GlobalKey<NullSelectionPointDelegateWidgetState>();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: SelectableRegion(
+              selectionControls: materialTextSelectionControls,
+              child: NullSelectionPointDelegateWidget(
+                key: delegateKey,
+                child: const Column(
+                  children: <Widget>[
+                    Text('First'),
+                    Text('Second'),
+                    Text('Third'),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(
+          find.descendant(of: find.text('Second'), matching: find.byType(RichText)),
+        );
+        final TestGesture gesture = await tester.startGesture(
+          textOffsetToPosition(paragraph, 2),
+          kind: PointerDeviceKind.mouse,
+        );
+        addTearDown(gesture.removePointer);
+        await gesture.moveTo(textOffsetToPosition(paragraph, 5));
+        await gesture.up();
+        await tester.pumpAndSettle();
+
+        // Switch delegate to return null selection points (simulates off-screen scenario).
+        final delegate = delegateKey.currentState!.delegate;
+        delegate.useNullSelectionPoints = true;
+        delegate.notifyListeners();
+        await tester.pump();
+
+        final SelectableRegionState state = tester.state<SelectableRegionState>(
+          find.byType(SelectableRegion),
+        );
+        // Access the getters - should not throw, must return 0 when points are null.
+        expect(() => state.startGlyphHeight, returnsNormally);
+        expect(() => state.endGlyphHeight, returnsNormally);
+        expect(state.startGlyphHeight, 0);
+        expect(state.endGlyphHeight, 0);
+      },
+      skip: kIsWeb,
+    );
+
     testWidgets('mouse long press does not send select-word event', (WidgetTester tester) async {
       final spy = UniqueKey();
 
@@ -6610,6 +6733,63 @@ void main() {
       SystemMouseCursors.grab,
     );
   });
+}
+
+/// A [SelectionContainerDelegate] that can return [SelectionGeometry] with null
+/// [startSelectionPoint] and [endSelectionPoint] to test off-screen selection handling.
+class NullSelectionPointDelegate extends StaticSelectionContainerDelegate {
+  bool useNullSelectionPoints = false;
+
+  @override
+  SelectionGeometry get value {
+    final SelectionGeometry geometry = super.value;
+    if (useNullSelectionPoints && geometry.hasSelection) {
+      return SelectionGeometry(
+        status: geometry.status,
+        hasContent: geometry.hasContent,
+        startSelectionPoint: null,
+        endSelectionPoint: null,
+        selectionRects: geometry.selectionRects,
+      );
+    }
+    return geometry;
+  }
+}
+
+/// Widget that holds [NullSelectionPointDelegate] for testing.
+class NullSelectionPointDelegateWidget extends StatefulWidget {
+  const NullSelectionPointDelegateWidget({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  State<NullSelectionPointDelegateWidget> createState() =>
+      NullSelectionPointDelegateWidgetState();
+}
+
+class NullSelectionPointDelegateWidgetState
+    extends State<NullSelectionPointDelegateWidget> {
+  late final NullSelectionPointDelegate delegate;
+
+  @override
+  void initState() {
+    super.initState();
+    delegate = NullSelectionPointDelegate();
+  }
+
+  @override
+  void dispose() {
+    delegate.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SelectionContainer(
+      delegate: delegate,
+      child: widget.child,
+    );
+  }
 }
 
 class ColumnSelectionContainerDelegate extends StaticSelectionContainerDelegate {


### PR DESCRIPTION
## Description

Partial fix for #124078.

When selection endpoints move outside the viewport or cache extent in a scrollable `SelectionArea`, `startSelectionPoint` and `endSelectionPoint` may become null. This PR makes `SelectableRegionState.startGlyphHeight` and `SelectableRegionState.endGlyphHeight` null-safe so `contextMenuAnchors` does not crash when those values are queried.

This PR also refreshes selection state after scroll ends so the selection UI can recover when the selection remains valid.

## Changes

- Make `startGlyphHeight` return `0.0` when `startSelectionPoint` is null
- Make `endGlyphHeight` return `0.0` when `endSelectionPoint` is null
- Refresh selection state on `ScrollEndNotification`
- Add regression tests for null selection-point handling in scrollable selection scenarios

## Related Issues

- Partial fix for #124078
- Related to #122725

## Notes

This PR does not fix #175016, which appears to be a different null-crash path in `_updateLastSelectionEdgeLocationsFromGeometries()`.

## Testing

- Added widget tests covering null selection-point cases
- Manually validated selection in a scrollable `SelectionArea`
