### PR TITLE
flutter_gpu texture mipmapping.

### DIFF
--- a/engine/src/flutter/impeller/compiler/reflector.cc
+++ b/engine/src/flutter/impeller/compiler/reflector.cc
@@ -556,6 +556,31 @@ std::shared_ptr<ShaderBundleData> Reflector::GenerateShaderBundleData() const {
       uniform_struct_field.element_size_in_bytes = struct_member.size;
       uniform_struct_field.total_size_in_bytes = struct_member.byte_length;
       uniform_struct_field.array_elements = struct_member.array_elements;
+      if (struct_member.float_type.has_value()) {
+        auto float_type = struct_member.float_type.value();
+        if (float_type == "ShaderFloatType::kFloat") {
+          uniform_struct_field.float_type =
+              fb::shaderbundle::ShaderFloatType::kFloat;
+        } else if (float_type == "ShaderFloatType::kVec2") {
+          uniform_struct_field.float_type =
+              fb::shaderbundle::ShaderFloatType::kVec2;
+        } else if (float_type == "ShaderFloatType::kVec3") {
+          uniform_struct_field.float_type =
+              fb::shaderbundle::ShaderFloatType::kVec3;
+        } else if (float_type == "ShaderFloatType::kVec4") {
+          uniform_struct_field.float_type =
+              fb::shaderbundle::ShaderFloatType::kVec4;
+        } else if (float_type == "ShaderFloatType::kMat2") {
+          uniform_struct_field.float_type =
+              fb::shaderbundle::ShaderFloatType::kMat2;
+        } else if (float_type == "ShaderFloatType::kMat3") {
+          uniform_struct_field.float_type =
+              fb::shaderbundle::ShaderFloatType::kMat3;
+        } else if (float_type == "ShaderFloatType::kMat4") {
+          uniform_struct_field.float_type =
+              fb::shaderbundle::ShaderFloatType::kMat4;
+        }
+      }
       uniform_struct.fields.push_back(uniform_struct_field);
     }
     uniform_struct.size_in_bytes = size_in_bytes;

--- a/engine/src/flutter/impeller/compiler/shader_bundle_data.cc
+++ b/engine/src/flutter/impeller/compiler/shader_bundle_data.cc
@@ -189,6 +189,7 @@ ShaderBundleData::CreateFlatbuffer() const {
       field_desc->element_size_in_bytes = field.element_size_in_bytes;
       field_desc->total_size_in_bytes = field.total_size_in_bytes;
       field_desc->array_elements = field.array_elements.value_or(0);
+      field_desc->float_type = field.float_type;
       desc->fields.push_back(std::move(field_desc));
     }
 

--- a/engine/src/flutter/impeller/compiler/shader_bundle_data.h
+++ b/engine/src/flutter/impeller/compiler/shader_bundle_data.h
@@ -25,6 +25,8 @@ class ShaderBundleData {
     size_t element_size_in_bytes = 0u;
     size_t total_size_in_bytes = 0u;
     std::optional<size_t> array_elements = std::nullopt;
+    fb::shaderbundle::ShaderFloatType float_type =
+        fb::shaderbundle::ShaderFloatType::kUnknown;
   };
 
   struct ShaderUniformStruct {

--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -403,7 +403,8 @@ bool BufferBindingsGLES::BindUniformBufferV2(
     }
 
     if (!member.float_type.has_value()) {
-      VALIDATION_LOG << "Float uniform should have a float type.";
+      VALIDATION_LOG << "Float uniform should have a float type for key: "
+                     << member.name;
       return false;
     }
 

--- a/engine/src/flutter/impeller/shader_bundle/shader_bundle.fbs
+++ b/engine/src/flutter/impeller/shader_bundle/shader_bundle.fbs
@@ -49,6 +49,17 @@ enum UniformDataType:uint32 {
   kSampledImage,
 }
 
+enum ShaderFloatType:uint32 {
+  kUnknown,
+  kFloat,
+  kVec2,
+  kVec3,
+  kVec4,
+  kMat2,
+  kMat3,
+  kMat4,
+}
+
 // This contains the same attribute reflection data as
 // impeller::ShaderStageIOSlot.
 table ShaderInput {
@@ -71,6 +82,7 @@ table ShaderUniformStructField {
   total_size_in_bytes: uint64;
   // Zero indicates that this field is not an array element.
   array_elements: uint64;
+  float_type: ShaderFloatType = kUnknown;
 }
 
 table ShaderUniformStruct {

--- a/engine/src/flutter/lib/gpu/command_buffer.cc
+++ b/engine/src/flutter/lib/gpu/command_buffer.cc
@@ -5,7 +5,9 @@
 #include "flutter/lib/gpu/command_buffer.h"
 
 #include "dart_api.h"
+#include "flutter/lib/gpu/texture.h"
 #include "fml/make_copyable.h"
+#include "impeller/renderer/blit_pass.h"
 #include "impeller/renderer/command_buffer.h"
 #include "impeller/renderer/render_pass.h"
 #include "lib/ui/ui_dart_state.h"
@@ -30,7 +32,21 @@ std::shared_ptr<impeller::CommandBuffer> CommandBuffer::GetCommandBuffer() {
 
 void CommandBuffer::AddRenderPass(
     std::shared_ptr<impeller::RenderPass> render_pass) {
-  encodables_.push_back(std::move(render_pass));
+  encodables_.push_back(
+      [pass = std::move(render_pass)]() { return pass->EncodeCommands(); });
+}
+
+bool CommandBuffer::GenerateMipmap(
+    const std::shared_ptr<impeller::Texture>& texture) {
+  encodables_.push_back([command_buffer = command_buffer_, texture]() {
+    auto blit_pass = command_buffer->CreateBlitPass();
+    if (!blit_pass) {
+      return false;
+    }
+    blit_pass->GenerateMipmap(texture);
+    return blit_pass->EncodeCommands();
+  });
+  return true;
 }
 
 bool CommandBuffer::Submit() {
@@ -50,7 +66,7 @@ bool CommandBuffer::Submit(
                            completion_callback = completion_callback,
                            encodables = encodables_]() mutable {
           for (auto& encodable : encodables) {
-            encodable->EncodeCommands();
+            encodable();
           }
 
           context->GetCommandQueue()->Submit({command_buffer},
@@ -61,7 +77,7 @@ bool CommandBuffer::Submit(
   }
 
   for (auto& encodable : encodables_) {
-    encodable->EncodeCommands();
+    encodable();
   }
 
   auto status = context_->GetCommandQueue()->Submit({command_buffer_},
@@ -135,6 +151,16 @@ Dart_Handle InternalFlutterGpu_CommandBuffer_Submit(
   bool success = wrapper->Submit(ui_task_completion_callback);
   if (!success) {
     return tonic::ToDart("Failed to submit CommandBuffer");
+  }
+  return Dart_Null();
+}
+
+Dart_Handle InternalFlutterGpu_CommandBuffer_GenerateMipmap(
+    flutter::gpu::CommandBuffer* wrapper,
+    flutter::gpu::Texture* texture) {
+  bool success = wrapper->GenerateMipmap(texture->GetTexture());
+  if (!success) {
+    return tonic::ToDart("Failed to encode mipmap generation");
   }
   return Dart_Null();
 }

--- a/engine/src/flutter/lib/gpu/command_buffer.h
+++ b/engine/src/flutter/lib/gpu/command_buffer.h
@@ -8,11 +8,14 @@
 #include "flutter/lib/gpu/context.h"
 #include "flutter/lib/gpu/export.h"
 #include "flutter/lib/ui/dart_wrapper.h"
-#include "impeller/renderer/command_buffer.h"
 #include "impeller/renderer/context.h"
+
+#include <functional>
 
 namespace flutter {
 namespace gpu {
+
+class Texture;
 
 class CommandBuffer : public RefCountedDartWrappable<CommandBuffer> {
   DEFINE_WRAPPERTYPEINFO();
@@ -26,6 +29,8 @@ class CommandBuffer : public RefCountedDartWrappable<CommandBuffer> {
 
   void AddRenderPass(std::shared_ptr<impeller::RenderPass> render_pass);
 
+  bool GenerateMipmap(const std::shared_ptr<impeller::Texture>& texture);
+
   bool Submit();
   bool Submit(
       const impeller::CommandBuffer::CompletionCallback& completion_callback);
@@ -35,7 +40,7 @@ class CommandBuffer : public RefCountedDartWrappable<CommandBuffer> {
  private:
   std::shared_ptr<impeller::Context> context_;
   std::shared_ptr<impeller::CommandBuffer> command_buffer_;
-  std::vector<std::shared_ptr<impeller::RenderPass>> encodables_;
+  std::vector<std::function<bool()>> encodables_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(CommandBuffer);
 };
@@ -58,6 +63,11 @@ FLUTTER_GPU_EXPORT
 extern Dart_Handle InternalFlutterGpu_CommandBuffer_Submit(
     flutter::gpu::CommandBuffer* wrapper,
     Dart_Handle completion_callback);
+
+FLUTTER_GPU_EXPORT
+extern Dart_Handle InternalFlutterGpu_CommandBuffer_GenerateMipmap(
+    flutter::gpu::CommandBuffer* wrapper,
+    flutter::gpu::Texture* texture);
 
 }  // extern "C"
 

--- a/engine/src/flutter/lib/gpu/lib/src/command_buffer.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/command_buffer.dart
@@ -20,6 +20,13 @@ base class CommandBuffer extends NativeFieldWrapperClass1 {
     return RenderPass._(_gpuContext, this, renderTarget);
   }
 
+  void generateMipmap(Texture texture) {
+    String? error = _generateMipmap(texture);
+    if (error != null) {
+      throw Exception(error);
+    }
+  }
+
   void submit({CompletionCallback? completionCallback}) {
     String? error = _submit(completionCallback);
     if (error != null) {
@@ -37,4 +44,9 @@ base class CommandBuffer extends NativeFieldWrapperClass1 {
     symbol: 'InternalFlutterGpu_CommandBuffer_Submit',
   )
   external String? _submit(CompletionCallback? completionCallback);
+
+  @Native<Handle Function(Pointer<Void>, Pointer<Void>)>(
+    symbol: 'InternalFlutterGpu_CommandBuffer_GenerateMipmap',
+  )
+  external String? _generateMipmap(Texture texture);
 }

--- a/engine/src/flutter/lib/gpu/lib/src/context.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/context.dart
@@ -125,6 +125,7 @@ base class GpuContext extends NativeFieldWrapperClass1 {
     bool enableRenderTargetUsage = true,
     bool enableShaderReadUsage = true,
     bool enableShaderWriteUsage = false,
+    bool enableMipmap = false,
   }) {
     final resolvedTextureType =
         textureType ??
@@ -143,6 +144,7 @@ base class GpuContext extends NativeFieldWrapperClass1 {
       enableRenderTargetUsage,
       enableShaderReadUsage,
       enableShaderWriteUsage,
+      enableMipmap,
     );
     if (!result.isValid) {
       throw Exception('Texture creation failed');

--- a/engine/src/flutter/lib/gpu/lib/src/texture.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/texture.dart
@@ -25,6 +25,7 @@ base class Texture extends NativeFieldWrapperClass1 {
     this.enableRenderTargetUsage,
     this.enableShaderReadUsage,
     this.enableShaderWriteUsage,
+    this.enableMipmap,
   ) : _gpuContext = gpuContext,
       _coordinateSystem = coordinateSystem {
     if (sampleCount != 1 && sampleCount != 4) {
@@ -42,6 +43,7 @@ base class Texture extends NativeFieldWrapperClass1 {
       enableRenderTargetUsage,
       enableShaderReadUsage,
       enableShaderWriteUsage,
+      enableMipmap,
     );
   }
 
@@ -64,6 +66,9 @@ base class Texture extends NativeFieldWrapperClass1 {
   ///
   /// Note that this is distinct from [enableRenderTargetUsage].
   final bool enableShaderWriteUsage;
+
+  /// Whether the texture has mipmaps enabled.
+  final bool enableMipmap;
 
   TextureCoordinateSystem _coordinateSystem;
   TextureCoordinateSystem get coordinateSystem {
@@ -135,6 +140,7 @@ base class Texture extends NativeFieldWrapperClass1 {
       Bool,
       Bool,
       Bool,
+      Bool,
     )
   >(symbol: 'InternalFlutterGpu_Texture_Initialize')
   external bool _initialize(
@@ -149,6 +155,7 @@ base class Texture extends NativeFieldWrapperClass1 {
     bool enableRenderTargetUsage,
     bool enableShaderReadUsage,
     bool enableShaderWriteUsage,
+    bool enableMipmap,
   );
 
   @Native<Void Function(Handle, Int)>(

--- a/engine/src/flutter/lib/gpu/shader_library.cc
+++ b/engine/src/flutter/lib/gpu/shader_library.cc
@@ -124,6 +124,28 @@ static impeller::ShaderType FromUniformType(
   }
 }
 
+static std::optional<impeller::ShaderFloatType> FromFloatType(
+    impeller::fb::shaderbundle::ShaderFloatType float_type) {
+  switch (float_type) {
+    case impeller::fb::shaderbundle::ShaderFloatType::kFloat:
+      return impeller::ShaderFloatType::kFloat;
+    case impeller::fb::shaderbundle::ShaderFloatType::kVec2:
+      return impeller::ShaderFloatType::kVec2;
+    case impeller::fb::shaderbundle::ShaderFloatType::kVec3:
+      return impeller::ShaderFloatType::kVec3;
+    case impeller::fb::shaderbundle::ShaderFloatType::kVec4:
+      return impeller::ShaderFloatType::kVec4;
+    case impeller::fb::shaderbundle::ShaderFloatType::kMat2:
+      return impeller::ShaderFloatType::kMat2;
+    case impeller::fb::shaderbundle::ShaderFloatType::kMat3:
+      return impeller::ShaderFloatType::kMat3;
+    case impeller::fb::shaderbundle::ShaderFloatType::kMat4:
+      return impeller::ShaderFloatType::kMat4;
+    case impeller::fb::shaderbundle::ShaderFloatType::kUnknown:
+      return std::nullopt;
+  }
+}
+
 static size_t SizeOfInputType(
     impeller::fb::shaderbundle::InputDataType input_type) {
   switch (input_type) {
@@ -231,6 +253,7 @@ fml::RefPtr<ShaderLibrary> ShaderLibrary::MakeFromFlatbuffer(
                     struct_member->array_elements() == 0
                         ? std::optional<size_t>(std::nullopt)
                         : static_cast<size_t>(struct_member->array_elements()),
+                .float_type = FromFloatType(struct_member->float_type()),
             });
           }
         }

--- a/engine/src/flutter/lib/gpu/texture.cc
+++ b/engine/src/flutter/lib/gpu/texture.cc
@@ -105,7 +105,8 @@ bool InternalFlutterGpu_Texture_Initialize(Dart_Handle wrapper,
                                            int texture_type,
                                            bool enable_render_target_usage,
                                            bool enable_shader_read_usage,
-                                           bool enable_shader_write_usage) {
+                                           bool enable_shader_write_usage,
+                                           bool enable_mipmap) {
   impeller::TextureDescriptor desc;
   desc.storage_mode = flutter::gpu::ToImpellerStorageMode(storage_mode);
   desc.size = {width, height};
@@ -119,6 +120,9 @@ bool InternalFlutterGpu_Texture_Initialize(Dart_Handle wrapper,
   }
   if (enable_shader_write_usage) {
     desc.usage |= impeller::TextureUsage::kShaderWrite;
+  }
+  if (enable_mipmap) {
+    desc.mip_count = desc.size.MipCount();
   }
   switch (sample_count) {
     case 1:

--- a/engine/src/flutter/lib/gpu/texture.h
+++ b/engine/src/flutter/lib/gpu/texture.h
@@ -61,7 +61,8 @@ extern bool InternalFlutterGpu_Texture_Initialize(
     int texture_type,
     bool enable_render_target_usage,
     bool enable_shader_read_usage,
-    bool enable_shader_write_usage);
+    bool enable_shader_write_usage,
+    bool enae_mip_map);
 
 FLUTTER_GPU_EXPORT
 extern void InternalFlutterGpu_Texture_SetCoordinateSystem(


### PR DESCRIPTION
## Title:
[flutter_gpu] Add support for generating mipmaps and fix GLES uniform type unpacking

## Context
I try to use flutter to implement a mobile game with 3D elements and I immediately found lack of mipmaps troublesome. While this fix might not fit `flutter_gpu` roadmap, I think sharing it might be helpful to someone, or, by chance helpful to flutter team.

## Description
This PR introduces the ability to generate mipmaps for textures created via the `flutter_gpu` API and resolves an associated crash on the OpenGLES backend caused by incomplete shader uniform reflections. 

The changes can be broken down into two main areas:

### 1. Mipmap Generation in `flutter_gpu`
Previously, `flutter_gpu` hardcoded the `mip_count` of `TextureDescriptor`s to 1 and lacked a mechanism to trigger mipmap generation. This PR exposes Impeller's existing mipmap functionality and adjusts the [CommandBuffer](cci:1://file:///home/mati/flutter/engine/src/flutter/lib/gpu/command_buffer.cc:20:0-24:51) to support [BlitPass](cci:1://file:///home/mati/flutter/engine/src/flutter/impeller/renderer/backend/gles/blit_pass_gles.cc:16:0-18:51) operations.
* **Dart API:** 
  * Added an `enableMipmap` (default `false`) parameter to `GpuContext.createTexture()` and `Texture._initialize()`.
  * Added a [generateMipmap(Texture)](cci:1://file:///home/mati/flutter/engine/src/flutter/lib/gpu/lib/src/command_buffer.dart:22:2-27:3) method to the [CommandBuffer](cci:1://file:///home/mati/flutter/engine/src/flutter/lib/gpu/command_buffer.cc:20:0-24:51).
* **C++ API:** 
  * Updated [InternalFlutterGpu_Texture_Initialize](cci:1://file:///home/mati/flutter/engine/src/flutter/lib/gpu/texture.cc:96:0-157:1) to dynamically set `desc.mip_count = desc.size.MipCount()` when mipmapping is enabled.
  * Changed the internal `encodables_` list in `flutter::gpu::CommandBuffer` from storing shared [RenderPass](cci:1://file:///home/mati/flutter/engine/src/flutter/impeller/renderer/render_pass.h:278:2-278:41) pointers to storing type-erased closures (`std::vector<std::function<bool()>>`). This allows encoding both [RenderPass](cci:1://file:///home/mati/flutter/engine/src/flutter/impeller/renderer/render_pass.h:278:2-278:41) and [BlitPass](cci:1://file:///home/mati/flutter/engine/src/flutter/impeller/renderer/backend/gles/blit_pass_gles.cc:16:0-18:51) commands.
  * Implemented `CommandBuffer::GenerateMipmap`, which internally produces a [BlitPass](cci:1://file:///home/mati/flutter/engine/src/flutter/impeller/renderer/backend/gles/blit_pass_gles.cc:16:0-18:51) to generate mipmaps when the command buffer is submitted.

### 2. Shader Uniform `float_type` Reflection Fix
While testing mipmap support on the Android GLES backend, a crash occurred during float uniform binding (`BufferBindingsGLES::BindUniformBufferV2`) due to missing `float_type` information in the unpacked shader bundle.
* **impellerc & FlatBuffers:** 
  * Added a `ShaderFloatType` enum to the flatbuffers schema ([shader_bundle.fbs](cci:7://file:///home/mati/flutter/engine/src/flutter/impeller/shader_bundle/shader_bundle.fbs:0:0-0:0)).
  * Added the `float_type` property to [ShaderUniformStructField](cci:2://file:///home/mati/flutter/engine/src/flutter/impeller/compiler/shader_bundle_data.h:19:2-29:3) to persist scalar, vector, and matrix float dimensions.
  * Updated `shader_bundle_data.cc/h` and [reflector.cc](cci:7://file:///home/mati/flutter/engine/src/flutter/impeller/compiler/reflector.cc:0:0-0:0) to map the recognized `float_type` to the new flatbuffers enum when compiling the flatbuffer payload.
* **flutter_gpu Unpacking:**
  * Updated [shader_library.cc](cci:7://file:///home/mati/flutter/engine/src/flutter/lib/gpu/shader_library.cc:0:0-0:0) in the `flutter_gpu` runtime to extract the `float_type` from the flatbuffer and populate `impeller::ShaderStructMemberMetadata` properly, resolving the crash in the GLES backend.

## Related Issues:
* Only similar issue found is #145014, however even basic Impeller mipmap generation exposed to `flutter_gpu` would be a good starting point.

## API Changes:
**`GpuContext.createTexture` (Dart):**
```diff
  Texture createTexture(
    TextureType? textureType,
    TextureStorageMode? storageMode,
    int width,
    int height, {
    int sampleCount = 1,
    TextureFormat format = TextureFormat.r8g8b8a8UNormInt,
    TextureCoordinateSystem coordinateSystem = TextureCoordinateSystem.renderToTexture,
    bool enableRenderTargetUsage = true,
    bool enableShaderReadUsage = true,
    bool enableShaderWriteUsage = false,
+   bool enableMipmap = false,
  })
