### PR TITLE
Refactor RefreshIndicator scroll handling and arm/disarm logic

### DIFF
--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -413,9 +413,7 @@ class RefreshIndicatorState extends State<RefreshIndicator>
     if (notification is ScrollStartNotification && notification.dragDetails != null) {
       return true;
     }
-    if (notification is ScrollUpdateNotification &&
-        notification.dragDetails != null &&
-        widget.triggerMode == RefreshIndicatorTriggerMode.anywhere) {
+    if (notification is ScrollUpdateNotification && notification.dragDetails != null) {
       return true;
     }
     return false;
@@ -438,7 +436,16 @@ class RefreshIndicatorState extends State<RefreshIndicator>
     final bool isUserDrag = _isScrollTriggeredByUser(notification);
     final bool isAtEdge = _isAtScrollEdge(notification.metrics);
 
-    return isUserDrag && isAtEdge && _status == null && _start(notification.metrics.axisDirection);
+    if (!isUserDrag || !isAtEdge || _status != null) {
+      return false;
+    }
+
+    if (widget.triggerMode == RefreshIndicatorTriggerMode.onEdge &&
+        notification is! ScrollStartNotification) {
+      return false;
+    }
+
+    return _start(notification.metrics.axisDirection);
   }
 
   /// Evaluates whether the indicator should currently be displayed at the top or bottom based on axis direction.
@@ -578,13 +585,12 @@ class RefreshIndicatorState extends State<RefreshIndicator>
     assert(_isIndicatorAtTop == null);
     assert(_dragOffset == null);
 
-    final bool? atTop = _getIndicatorAtTop(direction);
-    if (atTop == null) {
-      // we dont support horizontal refresh indicator
+    _isIndicatorAtTop = _getIndicatorAtTop(direction);
+    if (_isIndicatorAtTop == null) {
+      // Does not support a horizontal refresh indicator.
       return false;
     }
 
-    _isIndicatorAtTop = atTop;
     _dragOffset = 0.0;
     _scaleController.value = 0.0;
     _positionController.value = 0.0;

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -550,8 +550,8 @@ class RefreshIndicatorState extends State<RefreshIndicator>
     if (_shouldStart(notification)) {
       setState(() {
         _status = RefreshIndicatorStatus.drag;
-        widget.onStatusChange?.call(_status);
       });
+      widget.onStatusChange?.call(_status);
       return false;
     }
 
@@ -591,17 +591,13 @@ class RefreshIndicatorState extends State<RefreshIndicator>
     assert(_isIndicatorAtTop == null);
     assert(_dragOffset == null);
 
-    switch (direction) {
-      case AxisDirection.down:
-      case AxisDirection.up:
-        _isIndicatorAtTop = true;
-      case AxisDirection.left:
-      case AxisDirection.right:
-        _isIndicatorAtTop = null;
-        // we do not support horizontal scroll views.
-        return false;
+    final bool? atTop = _getIndicatorAtTop(direction);
+    if (atTop == null) {
+      // we dont support horizontal refresh indicator
+      return false;
     }
 
+    _isIndicatorAtTop = atTop;
     _dragOffset = 0.0;
     _scaleController.value = 0.0;
     _positionController.value = 0.0;
@@ -622,7 +618,6 @@ class RefreshIndicatorState extends State<RefreshIndicator>
     _positionController.value = clampDouble(newValue, 0.0, 1.0); // This triggers various rebuilds.
 
     // Transition from `drag` to `armed` if the drag offset exceeds the armed threshold, and back to `drag` if it goes below.
-    debugPrint('positionController.value: ${_positionController.value}, status: $_status');
     if (_status == RefreshIndicatorStatus.drag && _positionController.value >= _kArmedThreshold) {
       _status = RefreshIndicatorStatus.armed;
       widget.onStatusChange?.call(_status);

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -384,6 +384,7 @@ class RefreshIndicatorState extends State<RefreshIndicator>
     super.dispose();
   }
 
+  /// Configures the animation that interpolates the indicator's color.
   void _setupColorTween() {
     // Reset the current value color.
     _effectiveValueColor = widget.color ?? Theme.of(context).colorScheme.primary;
@@ -402,26 +403,105 @@ class RefreshIndicatorState extends State<RefreshIndicator>
     }
   }
 
+  /// Determines if the scroll notification was triggered by a user drag.
+  bool _isScrollTriggeredByUser(ScrollNotification notification) {
+    if (notification is ScrollStartNotification && notification.dragDetails != null) {
+      return true;
+    }
+    if (notification is ScrollUpdateNotification &&
+        notification.dragDetails != null &&
+        widget.triggerMode == RefreshIndicatorTriggerMode.anywhere) {
+      return true;
+    }
+    return false;
+  }
+
+  /// Determines if the scrollable is exactly at the top or bottom edge.
+  bool _isAtScrollEdge(ScrollMetrics metrics) {
+    final bool isAtTopEdge =
+        metrics.axisDirection == AxisDirection.up && metrics.extentAfter == 0.0;
+    final bool isAtBottomEdge =
+        metrics.axisDirection == AxisDirection.down && metrics.extentBefore == 0.0;
+    return isAtTopEdge || isAtBottomEdge;
+  }
+
+  /// Checks if conditions are met to start the refresh indicator animation.
   bool _shouldStart(ScrollNotification notification) {
     // If the notification.dragDetails is null, this scroll is not triggered by
     // user dragging. It may be a result of ScrollController.jumpTo or ballistic scroll.
     // In this case, we don't want to trigger the refresh indicator.
-    return ((notification is ScrollStartNotification && notification.dragDetails != null) ||
-            (notification is ScrollUpdateNotification &&
-                notification.dragDetails != null &&
-                widget.triggerMode == RefreshIndicatorTriggerMode.anywhere)) &&
-        ((notification.metrics.axisDirection == AxisDirection.up &&
-                notification.metrics.extentAfter == 0.0) ||
-            (notification.metrics.axisDirection == AxisDirection.down &&
-                notification.metrics.extentBefore == 0.0)) &&
-        _status == null &&
-        _start(notification.metrics.axisDirection);
+    final bool isUserDrag = _isScrollTriggeredByUser(notification);
+    final bool isAtEdge = _isAtScrollEdge(notification.metrics);
+
+    return isUserDrag && isAtEdge && _status == null && _start(notification.metrics.axisDirection);
   }
 
+  /// Evaluates whether the indicator should currently be displayed at the top or bottom based on axis direction.
+  bool? _getIndicatorAtTop(AxisDirection direction) {
+    return switch (direction) {
+      AxisDirection.down || AxisDirection.up => true,
+      AxisDirection.left || AxisDirection.right => null,
+    };
+  }
+
+  /// Handles drag offset changes for scroll update notifications.
+  void _handleScrollUpdateNotification(ScrollUpdateNotification notification) {
+    if (_status == RefreshIndicatorStatus.drag || _status == RefreshIndicatorStatus.armed) {
+      _updateDragOffset(notification.metrics.axisDirection, notification.scrollDelta!);
+      _checkDragOffset(notification.metrics.viewportDimension);
+    }
+    if (_status == RefreshIndicatorStatus.armed && notification.dragDetails == null) {
+      // On iOS start the refresh when the Scrollable bounces back from the
+      // overscroll (ScrollNotification indicating this don't have dragDetails
+      // because the scroll activity is not directly triggered by a drag).
+      _show();
+    }
+  }
+
+  /// Handles drag offset changes for overscroll notifications.
+  void _handleOverscrollNotification(OverscrollNotification notification) {
+    if (_status == RefreshIndicatorStatus.drag || _status == RefreshIndicatorStatus.armed) {
+      _updateDragOffset(notification.metrics.axisDirection, notification.overscroll);
+      _checkDragOffset(notification.metrics.viewportDimension);
+    }
+  }
+
+  /// Handles completion or cancellation of the drag gesture when scrolling ends.
+  void _handleScrollEndNotification(ScrollEndNotification notification) {
+    switch (_status) {
+      case RefreshIndicatorStatus.armed:
+        if (_positionController.value < 1.0) {
+          _dismiss(RefreshIndicatorStatus.canceled);
+        } else {
+          _show();
+        }
+      case RefreshIndicatorStatus.drag:
+        _dismiss(RefreshIndicatorStatus.canceled);
+      case RefreshIndicatorStatus.canceled:
+      case RefreshIndicatorStatus.done:
+      case RefreshIndicatorStatus.refresh:
+      case RefreshIndicatorStatus.snap:
+      case null:
+        // do nothing
+        break;
+    }
+  }
+
+  /// Accumulates the drag distance based on the scroll direction.
+  void _updateDragOffset(AxisDirection direction, double delta) {
+    if (direction == AxisDirection.down) {
+      _dragOffset = _dragOffset! - delta;
+    } else if (direction == AxisDirection.up) {
+      _dragOffset = _dragOffset! + delta;
+    }
+  }
+
+  /// Main handler for all scroll notifications. Routes to specific handlers based on notification type.
   bool _handleScrollNotification(ScrollNotification notification) {
     if (!widget.notificationPredicate(notification)) {
       return false;
     }
+
     if (_shouldStart(notification)) {
       setState(() {
         _status = RefreshIndicatorStatus.drag;
@@ -429,60 +509,26 @@ class RefreshIndicatorState extends State<RefreshIndicator>
       });
       return false;
     }
-    final bool? indicatorAtTopNow = switch (notification.metrics.axisDirection) {
-      AxisDirection.down || AxisDirection.up => true,
-      AxisDirection.left || AxisDirection.right => null,
-    };
+
+    final bool? indicatorAtTopNow = _getIndicatorAtTop(notification.metrics.axisDirection);
+
+    // If the scroll direction changes mid-drag, cancel the current drag operation.
     if (indicatorAtTopNow != _isIndicatorAtTop) {
       if (_status == RefreshIndicatorStatus.drag || _status == RefreshIndicatorStatus.armed) {
         _dismiss(RefreshIndicatorStatus.canceled);
       }
     } else if (notification is ScrollUpdateNotification) {
-      if (_status == RefreshIndicatorStatus.drag || _status == RefreshIndicatorStatus.armed) {
-        if (notification.metrics.axisDirection == AxisDirection.down) {
-          _dragOffset = _dragOffset! - notification.scrollDelta!;
-        } else if (notification.metrics.axisDirection == AxisDirection.up) {
-          _dragOffset = _dragOffset! + notification.scrollDelta!;
-        }
-        _checkDragOffset(notification.metrics.viewportDimension);
-      }
-      if (_status == RefreshIndicatorStatus.armed && notification.dragDetails == null) {
-        // On iOS start the refresh when the Scrollable bounces back from the
-        // overscroll (ScrollNotification indicating this don't have dragDetails
-        // because the scroll activity is not directly triggered by a drag).
-        _show();
-      }
+      _handleScrollUpdateNotification(notification);
     } else if (notification is OverscrollNotification) {
-      if (_status == RefreshIndicatorStatus.drag || _status == RefreshIndicatorStatus.armed) {
-        if (notification.metrics.axisDirection == AxisDirection.down) {
-          _dragOffset = _dragOffset! - notification.overscroll;
-        } else if (notification.metrics.axisDirection == AxisDirection.up) {
-          _dragOffset = _dragOffset! + notification.overscroll;
-        }
-        _checkDragOffset(notification.metrics.viewportDimension);
-      }
+      _handleOverscrollNotification(notification);
     } else if (notification is ScrollEndNotification) {
-      switch (_status) {
-        case RefreshIndicatorStatus.armed:
-          if (_positionController.value < 1.0) {
-            _dismiss(RefreshIndicatorStatus.canceled);
-          } else {
-            _show();
-          }
-        case RefreshIndicatorStatus.drag:
-          _dismiss(RefreshIndicatorStatus.canceled);
-        case RefreshIndicatorStatus.canceled:
-        case RefreshIndicatorStatus.done:
-        case RefreshIndicatorStatus.refresh:
-        case RefreshIndicatorStatus.snap:
-        case null:
-          // do nothing
-          break;
-      }
+      _handleScrollEndNotification(notification);
     }
+
     return false;
   }
 
+  /// Handles overscroll indicator notification to selectively allow or disallow the standard glow/stretch effects.
   bool _handleIndicatorNotification(OverscrollIndicatorNotification notification) {
     if (notification.depth != 0 || !notification.leading) {
       return false;
@@ -494,10 +540,12 @@ class RefreshIndicatorState extends State<RefreshIndicator>
     return false;
   }
 
+  /// Initializes state when a drag interaction starts.
   bool _start(AxisDirection direction) {
     assert(_status == null);
     assert(_isIndicatorAtTop == null);
     assert(_dragOffset == null);
+
     switch (direction) {
       case AxisDirection.down:
       case AxisDirection.up:
@@ -508,19 +556,26 @@ class RefreshIndicatorState extends State<RefreshIndicator>
         // we do not support horizontal scroll views.
         return false;
     }
+
     _dragOffset = 0.0;
     _scaleController.value = 0.0;
     _positionController.value = 0.0;
     return true;
   }
 
+  /// Calculates the visual position of the indicator based on the drag offset.
+  /// Also transitions status from `drag` to `armed` if pulled far enough.
   void _checkDragOffset(double containerExtent) {
     assert(_status == RefreshIndicatorStatus.drag || _status == RefreshIndicatorStatus.armed);
+
     double newValue = _dragOffset! / (containerExtent * _kDragContainerExtentPercentage);
     if (_status == RefreshIndicatorStatus.armed) {
       newValue = math.max(newValue, 1.0 / _kDragSizeFactorLimit);
     }
+
     _positionController.value = clampDouble(newValue, 0.0, 1.0); // This triggers various rebuilds.
+
+    // Once the visual indicator color becomes fully opaque, the indicator is considered "armed".
     if (_status == RefreshIndicatorStatus.drag &&
         _valueColor.value!.alpha == _effectiveValueColor.alpha) {
       _status = RefreshIndicatorStatus.armed;
@@ -528,17 +583,19 @@ class RefreshIndicatorState extends State<RefreshIndicator>
     }
   }
 
-  // Stop showing the refresh indicator.
+  /// Stops showing the refresh indicator and resets the state.
   Future<void> _dismiss(RefreshIndicatorStatus newMode) async {
     await Future<void>.value();
     // This can only be called from _show() when refreshing and
     // _handleScrollNotification in response to a ScrollEndNotification or
     // direction change.
     assert(newMode == RefreshIndicatorStatus.canceled || newMode == RefreshIndicatorStatus.done);
+
     setState(() {
       _status = newMode;
       widget.onStatusChange?.call(_status);
     });
+
     switch (_status!) {
       case RefreshIndicatorStatus.done:
         await _scaleController.animateTo(1.0, duration: _kIndicatorScaleDuration);
@@ -550,6 +607,7 @@ class RefreshIndicatorState extends State<RefreshIndicator>
       case RefreshIndicatorStatus.snap:
         assert(false);
     }
+
     if (mounted && _status == newMode) {
       _dragOffset = null;
       _isIndicatorAtTop = null;
@@ -559,13 +617,17 @@ class RefreshIndicatorState extends State<RefreshIndicator>
     }
   }
 
+  /// Triggers the visual transition to the snap position and calls the onRefresh callback.
   void _show() {
     assert(_status != RefreshIndicatorStatus.refresh);
     assert(_status != RefreshIndicatorStatus.snap);
+
     final completer = Completer<void>();
     _pendingRefreshFuture = completer.future;
+
     _status = RefreshIndicatorStatus.snap;
     widget.onStatusChange?.call(_status);
+
     _positionController
         .animateTo(1.0 / _kDragSizeFactorLimit, duration: _kIndicatorSnapDuration)
         .then<void>((void value) {
@@ -616,6 +678,7 @@ class RefreshIndicatorState extends State<RefreshIndicator>
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterialLocalizations(context));
+
     final Widget child = NotificationListener<ScrollNotification>(
       onNotification: _handleScrollNotification,
       child: NotificationListener<OverscrollIndicatorNotification>(
@@ -623,6 +686,7 @@ class RefreshIndicatorState extends State<RefreshIndicator>
         child: widget.child,
       ),
     );
+
     assert(() {
       if (_status == null) {
         assert(_dragOffset == null);

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -162,9 +162,9 @@ class RefreshIndicator extends StatefulWidget {
     this.strokeWidth = RefreshProgressIndicator.defaultStrokeWidth,
     this.triggerMode = RefreshIndicatorTriggerMode.onEdge,
     this.elevation = 2.0,
+    this.onStatusChange,
     required this.child,
   }) : _indicatorType = _IndicatorType.material,
-       onStatusChange = null,
        assert(elevation >= 0.0);
 
   /// Creates an adaptive [RefreshIndicator] based on whether the target
@@ -196,9 +196,9 @@ class RefreshIndicator extends StatefulWidget {
     this.strokeWidth = RefreshProgressIndicator.defaultStrokeWidth,
     this.triggerMode = RefreshIndicatorTriggerMode.onEdge,
     this.elevation = 2.0,
+    this.onStatusChange,
     required this.child,
   }) : _indicatorType = _IndicatorType.adaptive,
-       onStatusChange = null,
        assert(elevation >= 0.0);
 
   /// Creates a [RefreshIndicator] with no spinner and calls `onRefresh` when
@@ -349,6 +349,8 @@ class RefreshIndicatorState extends State<RefreshIndicator>
 
   static final Animatable<double> _oneToZeroTween = Tween<double>(begin: 1.0, end: 0.0);
 
+  double _lastOverscroll = 0.0;
+
   @protected
   @override
   void initState() {
@@ -447,34 +449,21 @@ class RefreshIndicatorState extends State<RefreshIndicator>
     };
   }
 
-  double? _scrollDelta = 0.0;
-  double? _overscroll = 0.0;
-
   /// Handles drag offset changes for scroll update notifications.
   void _handleScrollUpdateNotification(ScrollUpdateNotification notification) {
     final double delta = notification.scrollDelta ?? 0.0;
-    _scrollDelta = delta;
 
-    debugPrint(
-      'dragOffset: $_dragOffset, ScrollUpdateNotification: overscroll=$_overscroll, scrollDelta=$delta',
-    );
     if (_status == RefreshIndicatorStatus.drag || _status == RefreshIndicatorStatus.armed) {
       final ScrollPosition position = Scrollable.of(notification.context!).position;
 
-      if (delta != 0.0 && _overscroll != null && _overscroll!.abs() > 0.0) {
+      if (delta != 0.0 && _lastOverscroll.abs() > 0.0) {
         final bool isCanceling =
             (notification.metrics.axisDirection == AxisDirection.down && delta > 0.0) ||
             (notification.metrics.axisDirection == AxisDirection.up && delta < 0.0);
 
-        debugPrint('isCanceling: $isCanceling');
-
         if (isCanceling && _dragOffset! > 0.0) {
           final double consumedDelta = math.min(delta.abs(), _dragOffset!);
           final double correction = delta > 0.0 ? consumedDelta : -consumedDelta;
-
-          debugPrint(
-            'dragOffset: $_dragOffset, delta: $delta, correction: $correction, consumedDelta: $consumedDelta',
-          );
 
           position.correctBy(-correction);
 
@@ -483,7 +472,7 @@ class RefreshIndicatorState extends State<RefreshIndicator>
           _updateDragOffset(notification.metrics.axisDirection, delta);
         }
 
-        _checkDragOffset(notification.metrics.viewportDimension, canBeDisarmed: true);
+        _checkDragOffset(notification.metrics.viewportDimension);
       } else {
         _updateDragOffset(notification.metrics.axisDirection, notification.scrollDelta!);
         _checkDragOffset(notification.metrics.viewportDimension, canBeDisarmed: false);
@@ -503,8 +492,7 @@ class RefreshIndicatorState extends State<RefreshIndicator>
   /// when the scroll activity changes from a drag to a ballistic scroll.
   void _handleOverscrollNotification(OverscrollNotification notification) {
     final double overscroll = notification.overscroll;
-    _overscroll = overscroll;
-    debugPrint('OverscrollNotification: overscroll=$overscroll, scrollDelta=$_scrollDelta');
+    _lastOverscroll = overscroll;
 
     if (_status == RefreshIndicatorStatus.drag || _status == RefreshIndicatorStatus.armed) {
       _updateDragOffset(notification.metrics.axisDirection, notification.overscroll);
@@ -514,8 +502,7 @@ class RefreshIndicatorState extends State<RefreshIndicator>
 
   /// Handles completion or cancellation of the drag gesture when scrolling ends.
   void _handleScrollEndNotification(ScrollEndNotification notification) {
-    _overscroll = null;
-    _scrollDelta = null;
+    _lastOverscroll = 0.0;
     switch (_status) {
       case RefreshIndicatorStatus.armed:
         _show();
@@ -638,8 +625,8 @@ class RefreshIndicatorState extends State<RefreshIndicator>
 
     setState(() {
       _status = newMode;
-      widget.onStatusChange?.call(_status);
     });
+    widget.onStatusChange?.call(_status);
 
     switch (_status!) {
       case RefreshIndicatorStatus.done:
@@ -658,8 +645,8 @@ class RefreshIndicatorState extends State<RefreshIndicator>
       _isIndicatorAtTop = null;
       setState(() {
         _status = null;
-        widget.onStatusChange?.call(_status);
       });
+      widget.onStatusChange?.call(_status);
     }
   }
 
@@ -681,8 +668,8 @@ class RefreshIndicatorState extends State<RefreshIndicator>
         setState(() {
           // Show the indeterminate progress indicator.
           _status = RefreshIndicatorStatus.refresh;
-          widget.onStatusChange?.call(_status);
         });
+        widget.onStatusChange?.call(_status);
 
         final Future<void> refreshResult = widget.onRefresh();
         refreshResult.whenComplete(() {

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -24,6 +24,9 @@ const double _kDragContainerExtentPercentage = 0.25;
 // displacement; max displacement = _kDragSizeFactorLimit * displacement.
 const double _kDragSizeFactorLimit = 1.5;
 
+// The threshold at which the indicator is "armed" and ready to trigger a refresh when released.
+const double _kArmedThreshold = 1.0 / _kDragSizeFactorLimit; // ~0.66
+
 // When the scroll ends, the duration of the refresh indicator's animation
 // to the RefreshIndicator's displacement.
 const Duration _kIndicatorSnapDuration = Duration(milliseconds: 150);
@@ -398,7 +401,7 @@ class RefreshIndicatorState extends State<RefreshIndicator>
         ColorTween(
           begin: color.withAlpha(0),
           end: color.withAlpha(color.alpha),
-        ).chain(CurveTween(curve: const Interval(0.0, 1.0 / _kDragSizeFactorLimit))),
+        ).chain(CurveTween(curve: const Interval(0.0, _kArmedThreshold))),
       );
     }
   }
@@ -448,8 +451,9 @@ class RefreshIndicatorState extends State<RefreshIndicator>
   void _handleScrollUpdateNotification(ScrollUpdateNotification notification) {
     if (_status == RefreshIndicatorStatus.drag || _status == RefreshIndicatorStatus.armed) {
       _updateDragOffset(notification.metrics.axisDirection, notification.scrollDelta!);
-      _checkDragOffset(notification.metrics.viewportDimension);
+      _checkDragOffset(notification.metrics.viewportDimension, canBeDisarmed: false);
     }
+
     if (_status == RefreshIndicatorStatus.armed && notification.dragDetails == null) {
       // On iOS start the refresh when the Scrollable bounces back from the
       // overscroll (ScrollNotification indicating this don't have dragDetails
@@ -458,7 +462,9 @@ class RefreshIndicatorState extends State<RefreshIndicator>
     }
   }
 
-  /// Handles drag offset changes for overscroll notifications.
+  /// Handles drag offset changes for overscroll notifications. Only Android sends these notifications,
+  /// so this is only called on Android. On iOS, the refresh is triggered in response to a ScrollUpdateNotification
+  /// when the scroll activity changes from a drag to a ballistic scroll.
   void _handleOverscrollNotification(OverscrollNotification notification) {
     if (_status == RefreshIndicatorStatus.drag || _status == RefreshIndicatorStatus.armed) {
       _updateDragOffset(notification.metrics.axisDirection, notification.overscroll);
@@ -565,20 +571,24 @@ class RefreshIndicatorState extends State<RefreshIndicator>
 
   /// Calculates the visual position of the indicator based on the drag offset.
   /// Also transitions status from `drag` to `armed` if pulled far enough.
-  void _checkDragOffset(double containerExtent) {
+  void _checkDragOffset(double containerExtent, {bool canBeDisarmed = true}) {
     assert(_status == RefreshIndicatorStatus.drag || _status == RefreshIndicatorStatus.armed);
 
     double newValue = _dragOffset! / (containerExtent * _kDragContainerExtentPercentage);
-    if (_status == RefreshIndicatorStatus.armed) {
-      newValue = math.max(newValue, 1.0 / _kDragSizeFactorLimit);
+
+    if (_status == RefreshIndicatorStatus.armed && !canBeDisarmed) {
+      newValue = math.max(newValue, _kArmedThreshold);
     }
 
     _positionController.value = clampDouble(newValue, 0.0, 1.0); // This triggers various rebuilds.
 
-    // Once the visual indicator color becomes fully opaque, the indicator is considered "armed".
-    if (_status == RefreshIndicatorStatus.drag &&
-        _valueColor.value!.alpha == _effectiveValueColor.alpha) {
+    // Transition from `drag` to `armed` if the drag offset exceeds the armed threshold, and back to `drag` if it goes below.
+    if (_status == RefreshIndicatorStatus.drag && _positionController.value >= _kArmedThreshold) {
       _status = RefreshIndicatorStatus.armed;
+      widget.onStatusChange?.call(_status);
+    } else if (_status == RefreshIndicatorStatus.armed &&
+        _positionController.value < _kArmedThreshold) {
+      _status = RefreshIndicatorStatus.drag;
       widget.onStatusChange?.call(_status);
     }
   }
@@ -628,24 +638,24 @@ class RefreshIndicatorState extends State<RefreshIndicator>
     _status = RefreshIndicatorStatus.snap;
     widget.onStatusChange?.call(_status);
 
-    _positionController
-        .animateTo(1.0 / _kDragSizeFactorLimit, duration: _kIndicatorSnapDuration)
-        .then<void>((void value) {
-          if (mounted && _status == RefreshIndicatorStatus.snap) {
-            setState(() {
-              // Show the indeterminate progress indicator.
-              _status = RefreshIndicatorStatus.refresh;
-            });
+    _positionController.animateTo(_kArmedThreshold, duration: _kIndicatorSnapDuration).then<void>((
+      void value,
+    ) {
+      if (mounted && _status == RefreshIndicatorStatus.snap) {
+        setState(() {
+          // Show the indeterminate progress indicator.
+          _status = RefreshIndicatorStatus.refresh;
+        });
 
-            final Future<void> refreshResult = widget.onRefresh();
-            refreshResult.whenComplete(() {
-              if (mounted && _status == RefreshIndicatorStatus.refresh) {
-                completer.complete();
-                _dismiss(RefreshIndicatorStatus.done);
-              }
-            });
+        final Future<void> refreshResult = widget.onRefresh();
+        refreshResult.whenComplete(() {
+          if (mounted && _status == RefreshIndicatorStatus.refresh) {
+            completer.complete();
+            _dismiss(RefreshIndicatorStatus.done);
           }
         });
+      }
+    });
   }
 
   /// Show the refresh indicator and run the refresh callback as if it had

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -447,11 +447,47 @@ class RefreshIndicatorState extends State<RefreshIndicator>
     };
   }
 
+  double? _scrollDelta = 0.0;
+  double? _overscroll = 0.0;
+
   /// Handles drag offset changes for scroll update notifications.
   void _handleScrollUpdateNotification(ScrollUpdateNotification notification) {
+    final double delta = notification.scrollDelta ?? 0.0;
+    _scrollDelta = delta;
+
+    debugPrint(
+      'dragOffset: $_dragOffset, ScrollUpdateNotification: overscroll=$_overscroll, scrollDelta=$delta',
+    );
     if (_status == RefreshIndicatorStatus.drag || _status == RefreshIndicatorStatus.armed) {
-      _updateDragOffset(notification.metrics.axisDirection, notification.scrollDelta!);
-      _checkDragOffset(notification.metrics.viewportDimension, canBeDisarmed: false);
+      final ScrollPosition position = Scrollable.of(notification.context!).position;
+
+      if (delta != 0.0 && _overscroll != null && _overscroll!.abs() > 0.0) {
+        final bool isCanceling =
+            (notification.metrics.axisDirection == AxisDirection.down && delta > 0.0) ||
+            (notification.metrics.axisDirection == AxisDirection.up && delta < 0.0);
+
+        debugPrint('isCanceling: $isCanceling');
+
+        if (isCanceling && _dragOffset! > 0.0) {
+          final double consumedDelta = math.min(delta.abs(), _dragOffset!);
+          final double correction = delta > 0.0 ? consumedDelta : -consumedDelta;
+
+          debugPrint(
+            'dragOffset: $_dragOffset, delta: $delta, correction: $correction, consumedDelta: $consumedDelta',
+          );
+
+          position.correctBy(-correction);
+
+          _updateDragOffset(notification.metrics.axisDirection, correction);
+        } else {
+          _updateDragOffset(notification.metrics.axisDirection, delta);
+        }
+
+        _checkDragOffset(notification.metrics.viewportDimension, canBeDisarmed: true);
+      } else {
+        _updateDragOffset(notification.metrics.axisDirection, notification.scrollDelta!);
+        _checkDragOffset(notification.metrics.viewportDimension, canBeDisarmed: false);
+      }
     }
 
     if (_status == RefreshIndicatorStatus.armed && notification.dragDetails == null) {
@@ -466,6 +502,10 @@ class RefreshIndicatorState extends State<RefreshIndicator>
   /// so this is only called on Android. On iOS, the refresh is triggered in response to a ScrollUpdateNotification
   /// when the scroll activity changes from a drag to a ballistic scroll.
   void _handleOverscrollNotification(OverscrollNotification notification) {
+    final double overscroll = notification.overscroll;
+    _overscroll = overscroll;
+    debugPrint('OverscrollNotification: overscroll=$overscroll, scrollDelta=$_scrollDelta');
+
     if (_status == RefreshIndicatorStatus.drag || _status == RefreshIndicatorStatus.armed) {
       _updateDragOffset(notification.metrics.axisDirection, notification.overscroll);
       _checkDragOffset(notification.metrics.viewportDimension);
@@ -474,13 +514,12 @@ class RefreshIndicatorState extends State<RefreshIndicator>
 
   /// Handles completion or cancellation of the drag gesture when scrolling ends.
   void _handleScrollEndNotification(ScrollEndNotification notification) {
+    _overscroll = null;
+    _scrollDelta = null;
     switch (_status) {
       case RefreshIndicatorStatus.armed:
-        if (_positionController.value < 1.0) {
-          _dismiss(RefreshIndicatorStatus.canceled);
-        } else {
-          _show();
-        }
+        _show();
+
       case RefreshIndicatorStatus.drag:
         _dismiss(RefreshIndicatorStatus.canceled);
       case RefreshIndicatorStatus.canceled:
@@ -539,7 +578,7 @@ class RefreshIndicatorState extends State<RefreshIndicator>
     if (notification.depth != 0 || !notification.leading) {
       return false;
     }
-    if (_status == RefreshIndicatorStatus.drag) {
+    if (_status == RefreshIndicatorStatus.drag || _status == RefreshIndicatorStatus.armed) {
       notification.disallowIndicator();
       return true;
     }
@@ -583,6 +622,7 @@ class RefreshIndicatorState extends State<RefreshIndicator>
     _positionController.value = clampDouble(newValue, 0.0, 1.0); // This triggers various rebuilds.
 
     // Transition from `drag` to `armed` if the drag offset exceeds the armed threshold, and back to `drag` if it goes below.
+    debugPrint('positionController.value: ${_positionController.value}, status: $_status');
     if (_status == RefreshIndicatorStatus.drag && _positionController.value >= _kArmedThreshold) {
       _status = RefreshIndicatorStatus.armed;
       widget.onStatusChange?.call(_status);
@@ -623,6 +663,7 @@ class RefreshIndicatorState extends State<RefreshIndicator>
       _isIndicatorAtTop = null;
       setState(() {
         _status = null;
+        widget.onStatusChange?.call(_status);
       });
     }
   }
@@ -645,6 +686,7 @@ class RefreshIndicatorState extends State<RefreshIndicator>
         setState(() {
           // Show the indeterminate progress indicator.
           _status = RefreshIndicatorStatus.refresh;
+          widget.onStatusChange?.call(_status);
         });
 
         final Future<void> refreshResult = widget.onRefresh();

--- a/packages/flutter/test/material/refresh_indicator_test.dart
+++ b/packages/flutter/test/material/refresh_indicator_test.dart
@@ -287,7 +287,7 @@ void main() {
     await tester.sendEventToBinding(testPointer.down(startLocation));
     await tester.sendEventToBinding(testPointer.move(startLocation + const Offset(0.0, 175)));
     await tester.pump();
-    await tester.sendEventToBinding(testPointer.move(startLocation + const Offset(0.0, 149)));
+    await tester.sendEventToBinding(testPointer.move(startLocation + const Offset(0.0, 99)));
     await tester.pump();
     await tester.sendEventToBinding(testPointer.up());
     await tester.pump();

--- a/packages/flutter/test/material/refresh_indicator_test.dart
+++ b/packages/flutter/test/material/refresh_indicator_test.dart
@@ -1317,9 +1317,7 @@ void main() {
     );
 
     await tester.fling(find.text('X'), const Offset(0.0, 300.0), 1000.0);
-    await tester.pump();
-    await tester.pump(const Duration(seconds: 1));
-    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpAndSettle();
 
     expect(refreshCalled, false);
     expect(find.byType(RefreshProgressIndicator), findsNothing);
@@ -1343,9 +1341,7 @@ void main() {
     );
 
     refreshKey.currentState!.show();
-    await tester.pump();
-    await tester.pump(const Duration(seconds: 1));
-    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpAndSettle();
 
     expect(refreshCalled, true);
   });
@@ -1354,7 +1350,7 @@ void main() {
     WidgetTester tester,
   ) async {
     refreshCalled = false;
-    final Completer<void> refreshCompleter = Completer<void>();
+    final refreshCompleter = Completer<void>();
 
     await tester.pumpWidget(
       MaterialApp(
@@ -1387,7 +1383,7 @@ void main() {
   });
 
   testWidgets('RefreshIndicator respects exact displacement property', (WidgetTester tester) async {
-    const double customDisplacement = 120.0;
+    const customDisplacement = 120.0;
 
     await tester.pumpWidget(
       MaterialApp(
@@ -1459,7 +1455,7 @@ void main() {
     WidgetTester tester,
   ) async {
     refreshCalled = false;
-    final ScrollController scrollController = ScrollController();
+    final scrollController = ScrollController();
 
     await tester.pumpWidget(
       MaterialApp(
@@ -1490,7 +1486,7 @@ void main() {
   testWidgets('ListView can still be scrolled while RefreshIndicator is spinning', (
     WidgetTester tester,
   ) async {
-    final ScrollController scrollController = ScrollController();
+    final scrollController = ScrollController();
 
     await tester.pumpWidget(
       MaterialApp(
@@ -1527,7 +1523,7 @@ void main() {
   testWidgets(
     'Correct status sequence for complete refresh (drag -> armed -> snap -> refresh -> done)',
     (WidgetTester tester) async {
-      final List<String> statusLog = <String>[];
+      final statusLog = <String>[];
 
       await tester.pumpWidget(
         MaterialApp(

--- a/packages/flutter/test/material/refresh_indicator_test.dart
+++ b/packages/flutter/test/material/refresh_indicator_test.dart
@@ -1270,4 +1270,285 @@ void main() {
     await gesture.up();
     await tester.pumpAndSettle();
   });
+
+  testWidgets('RefreshIndicator responds to backgroundColor', (WidgetTester tester) async {
+    const Color customBgColor = Colors.orange;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RefreshIndicator(
+          onRefresh: holdRefresh,
+          backgroundColor: customBgColor,
+          child: ListView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            children: const <Widget>[SizedBox(height: 200.0, child: Text('X'))],
+          ),
+        ),
+      ),
+    );
+    await tester.fling(find.text('X'), const Offset(0.0, 300.0), 100.0);
+    await tester.pump();
+
+    tester.state<RefreshIndicatorState>(find.byType(RefreshIndicator)).show();
+    await tester.pump();
+
+    final RefreshProgressIndicator indicator = tester.widget<RefreshProgressIndicator>(
+      find.byType(RefreshProgressIndicator),
+    );
+
+    expect(indicator.backgroundColor, customBgColor);
+  });
+
+  testWidgets('RefreshIndicator ignores scroll if notificationPredicate returns false', (
+    WidgetTester tester,
+  ) async {
+    refreshCalled = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RefreshIndicator(
+          onRefresh: refresh,
+          notificationPredicate: (ScrollNotification notification) => false,
+          child: ListView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            children: const <Widget>[SizedBox(height: 200.0, child: Text('X'))],
+          ),
+        ),
+      ),
+    );
+
+    await tester.fling(find.text('X'), const Offset(0.0, 300.0), 1000.0);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(refreshCalled, false);
+    expect(find.byType(RefreshProgressIndicator), findsNothing);
+  });
+
+  testWidgets('RefreshIndicator can be triggered via GlobalKey', (WidgetTester tester) async {
+    refreshCalled = false;
+    final refreshKey = GlobalKey<RefreshIndicatorState>();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RefreshIndicator(
+          key: refreshKey,
+          onRefresh: refresh,
+          child: ListView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            children: const <Widget>[SizedBox(height: 200.0, child: Text('X'))],
+          ),
+        ),
+      ),
+    );
+
+    refreshKey.currentState!.show();
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(refreshCalled, true);
+  });
+
+  testWidgets('RefreshIndicator does not crash if disposed during refresh', (
+    WidgetTester tester,
+  ) async {
+    refreshCalled = false;
+    final Completer<void> refreshCompleter = Completer<void>();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RefreshIndicator(
+          onRefresh: () {
+            refreshCalled = true;
+            return refreshCompleter.future;
+          },
+          child: ListView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            children: const <Widget>[SizedBox(height: 200.0, child: Text('X'))],
+          ),
+        ),
+      ),
+    );
+
+    await tester.fling(find.text('X'), const Offset(0.0, 300.0), 1000.0);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(refreshCalled, true);
+    expect(find.byType(RefreshProgressIndicator), findsOneWidget);
+
+    await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+
+    refreshCompleter.complete();
+    await tester.pumpAndSettle();
+
+    expect(find.byType(RefreshIndicator), findsNothing);
+  });
+
+  testWidgets('RefreshIndicator respects exact displacement property', (WidgetTester tester) async {
+    const double customDisplacement = 120.0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RefreshIndicator(
+          onRefresh: holdRefresh,
+          displacement: customDisplacement,
+          child: ListView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            children: const <Widget>[SizedBox(height: 200.0, child: Text('X'))],
+          ),
+        ),
+      ),
+    );
+
+    await tester.fling(find.text('X'), const Offset(0.0, 500.0), 1000.0);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    final Offset indicatorTopLeft = tester.getTopLeft(find.byType(RefreshProgressIndicator));
+    expect(indicatorTopLeft.dy, lessThanOrEqualTo(customDisplacement));
+  });
+
+  testWidgets('NeverScrollableScrollPhysics prevents pull to refresh', (WidgetTester tester) async {
+    refreshCalled = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RefreshIndicator(
+          onRefresh: refresh,
+          child: ListView(
+            physics: const NeverScrollableScrollPhysics(),
+            children: const <Widget>[SizedBox(height: 200.0, child: Text('X'))],
+          ),
+        ),
+      ),
+    );
+
+    await tester.fling(find.text('X'), const Offset(0.0, 300.0), 1000.0);
+    await tester.pumpAndSettle();
+
+    expect(refreshCalled, false);
+    expect(find.byType(RefreshProgressIndicator), findsNothing);
+  });
+
+  testWidgets('Works correctly with PageScrollPhysics (PageView)', (WidgetTester tester) async {
+    refreshCalled = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RefreshIndicator(
+          onRefresh: refresh,
+          child: PageView(
+            scrollDirection: Axis.vertical,
+            physics: const AlwaysScrollableScrollPhysics(),
+            children: const <Widget>[
+              Center(child: Text('Page 1')),
+              Center(child: Text('Page 2')),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    await tester.fling(find.text('Page 1'), const Offset(0.0, 400.0), 1000.0);
+    await tester.pumpAndSettle();
+
+    expect(refreshCalled, true);
+  });
+
+  testWidgets('Overscrolling at the bottom of the list does not trigger refresh', (
+    WidgetTester tester,
+  ) async {
+    refreshCalled = false;
+    final ScrollController scrollController = ScrollController();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RefreshIndicator(
+          onRefresh: refresh,
+          child: ListView(
+            controller: scrollController,
+            physics: const AlwaysScrollableScrollPhysics(),
+            children: List<Widget>.generate(
+              20,
+              (int i) => SizedBox(height: 100.0, child: Text('Item $i')),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    scrollController.jumpTo(scrollController.position.maxScrollExtent);
+    await tester.pump();
+
+    await tester.fling(find.text('Item 19'), const Offset(0.0, -300.0), 1000.0);
+    await tester.pumpAndSettle();
+
+    expect(refreshCalled, false);
+    scrollController.dispose();
+  });
+
+  testWidgets('ListView can still be scrolled while RefreshIndicator is spinning', (
+    WidgetTester tester,
+  ) async {
+    final ScrollController scrollController = ScrollController();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RefreshIndicator(
+          onRefresh: holdRefresh,
+          child: ListView(
+            controller: scrollController,
+            physics: const AlwaysScrollableScrollPhysics(),
+            children: List<Widget>.generate(
+              20,
+              (int i) => SizedBox(height: 100.0, child: Text('Item $i')),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    tester.state<RefreshIndicatorState>(find.byType(RefreshIndicator)).show();
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(find.byType(RefreshProgressIndicator), findsOneWidget);
+    expect(scrollController.offset, 0.0);
+
+    await tester.drag(find.byType(ListView), const Offset(0.0, -300.0));
+    await tester.pump();
+
+    expect(scrollController.offset, 300.0);
+    expect(find.byType(RefreshProgressIndicator), findsOneWidget);
+
+    scrollController.dispose();
+  });
+
+  testWidgets(
+    'Correct status sequence for complete refresh (drag -> armed -> snap -> refresh -> done)',
+    (WidgetTester tester) async {
+      final List<String> statusLog = <String>[];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: RefreshIndicator.noSpinner(
+            onStatusChange: (RefreshIndicatorStatus? status) {
+              if (status != null) {
+                statusLog.add(status.name);
+              }
+            },
+            onRefresh: refresh,
+            child: ListView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              children: const <Widget>[SizedBox(height: 200.0, child: Text('X'))],
+            ),
+          ),
+        ),
+      );
+
+      await tester.fling(find.text('X'), const Offset(0.0, 600.0), 1000.0);
+      await tester.pumpAndSettle();
+      expect(statusLog, containsAllInOrder(<String>['drag', 'armed', 'snap', 'refresh', 'done']));
+    },
+  );
 }


### PR DESCRIPTION
Fixes #36158
Fixes #165950 
Fixes #94933 

RefresIndicator can now be correctly cancelled and ListView does not scroll during cancellation. The `refresh` state is now used and it no longer gets stuck on `done` after `refresh`. And the glow no longer appears on Material 2

<details><summary>Code Sample</summary>
<p>


```dart
import 'package:flutter/material.dart';

void main() {
  runApp(const MainApp());
}

class MainApp extends StatefulWidget {
  const MainApp({super.key});

  @override
  State<MainApp> createState() => _MainAppState();
}

class _MainAppState extends State<MainApp> {
  bool _refreshing = false;
  RefreshIndicatorStatus? _status;

  void _onStatusChange(RefreshIndicatorStatus? status) {
    setState(() {
      _status = status;
    });
  }

  Future<void> _onRefresh() async {
    setState(() {
      _refreshing = true;
    });
    await Future.delayed(Duration(seconds: 1));
    setState(() {
      _refreshing = false;
    });
  }

  /// Just for visual feedback
  Color get _color => switch (_status) {
    RefreshIndicatorStatus.drag => Colors.blue,
    RefreshIndicatorStatus.armed => Colors.red,
    RefreshIndicatorStatus.snap => Colors.yellow,
    RefreshIndicatorStatus.refresh => Colors.purple,
    RefreshIndicatorStatus.done => Colors.green,
    RefreshIndicatorStatus.canceled => Colors.orange,
    _ => Colors.white,
  };

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      home: Scaffold(
        body: RefreshIndicator.noSpinner(
          onStatusChange: _onStatusChange,
          onRefresh: _onRefresh,
          child: CustomScrollView(
            physics: const AlwaysScrollableScrollPhysics(),
            slivers: [
              SliverFillRemaining(
                child: Container(
                  color: _color,
                  child: Center(
                    child: Column(
                      mainAxisAlignment: MainAxisAlignment.center,
                      children: [
                        Text(_status?.toString() ?? 'Pull to refresh'),
                        if (_refreshing) const CircularProgressIndicator(),
                      ],
                    ),
                  ),
                ),
              ),
            ],
          ),
        ),
      ),
    );
  }
}

``` 

</p>
</details> 

<details><summary>Details</summary>
<p>

### After



<details><summary>Android</summary>
<p>


https://github.com/user-attachments/assets/6e6493dd-ce2a-42b1-be7b-a0c06c15b8a6

https://github.com/user-attachments/assets/ebe05c8d-fb62-4fb5-851c-081ab9a15a0a


</p>
</details> 


<details><summary>IOS</summary>
<p>

https://github.com/user-attachments/assets/3f010880-a856-4893-9ad7-f88c3bc99abd

https://github.com/user-attachments/assets/5d276fde-19e2-401a-b5a2-f5b486434caf

</p>
</details> 



### Before


<details><summary>Details</summary>
<p>


https://github.com/user-attachments/assets/80d4718a-994e-4b5e-87b1-feaf1ed77243

https://github.com/user-attachments/assets/e14ebd4d-3655-4161-b966-46171233f8e5



</p>
</details> 



<details><summary>IOS</summary>
<p>


https://github.com/user-attachments/assets/b25cb931-7214-4689-bf54-fb55c47fc68a

https://github.com/user-attachments/assets/f025e286-0a93-4c6f-8f0f-34207ab02419


</p>
</details> 


</p>
</details> 



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.