### PR TITLE
[Impeller] Do not wait for a frame's acquire fence if the frame was never presented

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/khr/khr_swapchain_impl_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/khr/khr_swapchain_impl_vk.cc
@@ -22,6 +22,7 @@ static constexpr size_t kMaxFramesInFlight = 2u;
 
 struct KHRFrameSynchronizerVK {
   vk::UniqueFence acquire;
+  bool acquire_fence_pending = false;
   vk::UniqueSemaphore render_ready;
   std::shared_ptr<CommandBuffer> final_cmd_buffer;
   bool is_valid = false;
@@ -29,8 +30,7 @@ struct KHRFrameSynchronizerVK {
   bool has_onscreen = false;
 
   explicit KHRFrameSynchronizerVK(const vk::Device& device) {
-    auto acquire_res = device.createFenceUnique(
-        vk::FenceCreateInfo{vk::FenceCreateFlagBits::eSignaled});
+    auto acquire_res = device.createFenceUnique({});
     auto render_res = device.createSemaphoreUnique({});
     if (acquire_res.result != vk::Result::eSuccess ||
         render_res.result != vk::Result::eSuccess) {
@@ -45,6 +45,9 @@ struct KHRFrameSynchronizerVK {
   ~KHRFrameSynchronizerVK() = default;
 
   bool WaitForFence(const vk::Device& device) {
+    if (!acquire_fence_pending) {
+      return true;
+    }
     if (auto result = device.waitForFences(
             *acquire,                             // fence
             true,                                 // wait all
@@ -54,6 +57,7 @@ struct KHRFrameSynchronizerVK {
       VALIDATION_LOG << "Fence wait failed: " << vk::to_string(result);
       return false;
     }
+    acquire_fence_pending = false;
     if (auto result = device.resetFences(*acquire);
         result != vk::Result::eSuccess) {
       VALIDATION_LOG << "Could not reset fence: " << vk::to_string(result);
@@ -485,6 +489,7 @@ bool KHRSwapchainImplVK::Present(
                      << vk::to_string(result);
       return false;
     }
+    sync->acquire_fence_pending = true;
   }
 
   //----------------------------------------------------------------------------

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
@@ -541,11 +541,18 @@ VkResult vkQueueSubmit(VkQueue queue,
   return VK_SUCCESS;
 }
 
+static thread_local std::function<std::remove_pointer_t<PFN_vkWaitForFences>>
+    g_wait_for_fences_callback;
+
 VkResult vkWaitForFences(VkDevice device,
                          uint32_t fenceCount,
                          const VkFence* pFences,
                          VkBool32 waitAll,
                          uint64_t timeout) {
+  if (g_wait_for_fences_callback) {
+    return g_wait_for_fences_callback(device, fenceCount, pFences, waitAll,
+                                      timeout);
+  }
   return VK_SUCCESS;
 }
 
@@ -753,12 +760,20 @@ void vkDestroySemaphore(VkDevice device,
   delete reinterpret_cast<MockSemaphore*>(semaphore);
 }
 
+static thread_local std::function<
+    std::remove_pointer_t<PFN_vkAcquireNextImageKHR>>
+    g_acquire_next_image_callback;
+
 VkResult vkAcquireNextImageKHR(VkDevice device,
                                VkSwapchainKHR swapchain,
                                uint64_t timeout,
                                VkSemaphore semaphore,
                                VkFence fence,
                                uint32_t* pImageIndex) {
+  if (g_acquire_next_image_callback) {
+    return g_acquire_next_image_callback(device, swapchain, timeout, semaphore,
+                                         fence, pImageIndex);
+  }
   auto current_index =
       reinterpret_cast<MockSwapchainKHR*>(swapchain)->current_image++;
   *pImageIndex = (current_index + 1) % 3u;
@@ -997,6 +1012,8 @@ std::shared_ptr<ContextVK> MockVulkanContextBuilder::Build() {
   g_instance_layers = instance_layers_;
   g_format_properties_callback = format_properties_callback_;
   g_physical_device_properties_callback = physical_properties_callback_;
+  g_acquire_next_image_callback = acquire_next_image_callback_;
+  g_wait_for_fences_callback = wait_for_fences_callback_;
   settings.embedder_data = embedder_data_;
   std::shared_ptr<ContextVK> result = ContextVK::Create(std::move(settings));
   return result;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.h
@@ -117,14 +117,14 @@ class MockVulkanContextBuilder {
   MockVulkanContextBuilder SetAcquireNextImageCallback(
       std::function<std::remove_pointer_t<PFN_vkAcquireNextImageKHR>>
           acquire_next_image_callback) {
-    acquire_next_image_callback_ = acquire_next_image_callback;
+    acquire_next_image_callback_ = std::move(acquire_next_image_callback);
     return *this;
   }
 
   MockVulkanContextBuilder SetWaitForFencesCallback(
       std::function<std::remove_pointer_t<PFN_vkWaitForFences>>
           wait_for_fences_callback) {
-    wait_for_fences_callback_ = wait_for_fences_callback;
+    wait_for_fences_callback_ = std::move(wait_for_fences_callback);
     return *this;
   }
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.h
@@ -114,6 +114,20 @@ class MockVulkanContextBuilder {
     return *this;
   }
 
+  MockVulkanContextBuilder SetAcquireNextImageCallback(
+      std::function<std::remove_pointer_t<PFN_vkAcquireNextImageKHR>>
+          acquire_next_image_callback) {
+    acquire_next_image_callback_ = acquire_next_image_callback;
+    return *this;
+  }
+
+  MockVulkanContextBuilder SetWaitForFencesCallback(
+      std::function<std::remove_pointer_t<PFN_vkWaitForFences>>
+          wait_for_fences_callback) {
+    wait_for_fences_callback_ = wait_for_fences_callback;
+    return *this;
+  }
+
  private:
   std::function<void(ContextVK::Settings&)> settings_callback_;
   std::vector<std::string> instance_extensions_;
@@ -126,6 +140,10 @@ class MockVulkanContextBuilder {
   std::function<void(VkPhysicalDevice device,
                      VkPhysicalDeviceProperties* physicalProperties)>
       physical_properties_callback_;
+  std::function<std::remove_pointer_t<PFN_vkAcquireNextImageKHR>>
+      acquire_next_image_callback_;
+  std::function<std::remove_pointer_t<PFN_vkWaitForFences>>
+      wait_for_fences_callback_;
 };
 
 /// @brief Override the image size returned by all swapchain images.

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/swapchain_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/swapchain_unittests.cc
@@ -138,7 +138,7 @@ TEST(SwapchainTest, CachesRenderPassOnSwapchainImage) {
 }
 
 TEST(SwapchainTest, NoFenceWaitAfterAcquireNextImageFailure) {
-  bool wait_for_fences_called;
+  bool wait_for_fences_called = false;
   auto const context =
       MockVulkanContextBuilder()
           .SetAcquireNextImageCallback(

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/swapchain_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/swapchain_unittests.cc
@@ -137,5 +137,31 @@ TEST(SwapchainTest, CachesRenderPassOnSwapchainImage) {
   }
 }
 
+TEST(SwapchainTest, NoFenceWaitAfterAcquireNextImageFailure) {
+  bool wait_for_fences_called;
+  auto const context =
+      MockVulkanContextBuilder()
+          .SetAcquireNextImageCallback(
+              [](VkDevice, VkSwapchainKHR, uint64_t, VkSemaphore, VkFence,
+                 uint32_t*) -> VkResult { return VK_ERROR_SURFACE_LOST_KHR; })
+          .SetWaitForFencesCallback([&](VkDevice, uint32_t, const VkFence*,
+                                        VkBool32, uint64_t) -> VkResult {
+            wait_for_fences_called = true;
+            return VK_SUCCESS;
+          })
+          .Build();
+
+  auto surface = CreateSurface(*context);
+  SetSwapchainImageSize(ISize{1, 1});
+  auto swapchain =
+      KHRSwapchainVK::Create(context, std::move(surface), ISize{1, 1},
+                             /*enable_msaa=*/false);
+  auto image = swapchain->AcquireNextDrawable();
+  EXPECT_FALSE(image);
+
+  swapchain->AcquireNextDrawable();
+  EXPECT_FALSE(wait_for_fences_called);
+}
+
 }  // namespace testing
 }  // namespace impeller


### PR DESCRIPTION
This could happen if a previous call to vkAcquireNextImageKHR failed.  If that occurs, then AcquireNextDrawable will not return a surface. The caller will not render a frame or call Present, and the fence will never be signaled.

See internal issue b/488786379