### PR TITLE
Add back in accidentally removed line from `create_updated_flutter_deps.py`

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -363,6 +363,7 @@ deps = {
   'engine/src/flutter/third_party/dart/tools/sdks/dart-sdk':
    {'dep_type': 'cipd', 'packages': [{'package': 'dart/dart-sdk/${{platform}}', 'version': 'git_revision:bc20d999d68a261ae12c56bab7ba304bd0de5346'}]},
 
+  # WARNING: end of dart dependencies list that is cleaned up automatically - see create_updated_flutter_deps.py.
 
   # Prebuilt Dart SDK of the same revision as the Dart SDK source checkout
   'engine/src/flutter/prebuilts/linux-x64/dart-sdk': {

--- a/engine/src/tools/dart/create_updated_flutter_deps.py
+++ b/engine/src/tools/dart/create_updated_flutter_deps.py
@@ -234,6 +234,8 @@ def Main(argv):
       for dep_path, dep_source in new_dart_deps.items():
         updatedfile.write(f"  '{dep_path}':\n   {dep_source},\n\n")
 
+      updatedfile.write(lines[i])
+
     else:
       updatedfile.write(lines[i])
     i = i + 1


### PR DESCRIPTION
This line was accidentally deleted in https://github.com/flutter/flutter/pull/181978, which has caused some of our autorollers to fail.