### PR TITLE
Cleanup MockVulkan when the vulkan instance is destroyed

### DIFF
--- a/dev/integration_tests/android_engine_test/README.md
+++ b/dev/integration_tests/android_engine_test/README.md
@@ -65,6 +65,19 @@ $ flutter run lib/external_texture/surface_producer_smiley_face_main.dart
 $ flutter drive lib/external_texture/surface_producer_smiley_face_main.dart
 ```
 
+### `external_texture/surface_texture_image_smiley_face`
+
+This app displays a full screen rectangular deformed smiley face with a yellow
+background. It tests `getImageFromTexture` API in dart:ui.
+
+```sh
+# Run the app
+$ flutter run lib/external_texture/surface_texture_image_smiley_face_main.dart
+
+# Run the test
+$ flutter drive lib/external_texture/surface_texture_image_smiley_face_main.dart
+```
+
 ### `external_texture/surface_texture_smiley_face`
 
 This app displays a full screen rectangular deformed smiley face with a yellow

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/BUILD.gn
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/BUILD.gn
@@ -35,7 +35,6 @@ impeller_component("vulkan_unittests") {
     ":vulkan",
     "../../../playground:playground_test",
     "//flutter/testing:testing_lib",
-    "//third_party/abseil-cpp/absl/base:no_destructor",
   ]
 }
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/BUILD.gn
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/BUILD.gn
@@ -35,6 +35,7 @@ impeller_component("vulkan_unittests") {
     ":vulkan",
     "../../../playground:playground_test",
     "//flutter/testing:testing_lib",
+    "//third_party/abseil-cpp/absl/base:no_destructor",
   ]
 }
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
@@ -125,6 +125,8 @@ struct MockVulkanState {
 
 class MockVulkanStatePtr {
  public:
+  MockVulkanStatePtr() = default;
+
   ~MockVulkanStatePtr() {
     FML_CHECK(ptr_ == nullptr)
         << "MockVulkanState was not null upon thread exit. Leak detected!";
@@ -137,6 +139,8 @@ class MockVulkanStatePtr {
     ptr_ = ptr;
   }
 
+  MockVulkanStatePtr(const MockVulkanStatePtr&) = delete;
+  MockVulkanStatePtr& operator=(const MockVulkanStatePtr&) = delete;
   MockVulkanState* get() const { return ptr_; }
   MockVulkanState& operator*() const { return *ptr_; }
   MockVulkanState* operator->() const { return ptr_; }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
@@ -12,7 +12,6 @@
 #include "flutter/fml/logging.h"
 #include "impeller/base/thread_safety.h"
 #include "impeller/renderer/backend/vulkan/vk.h"  // IWYU pragma: keep.
-#include "third_party/abseil-cpp/absl/base/no_destructor.h"
 #include "third_party/swiftshader/include/vulkan/vulkan_core.h"
 #include "vulkan/vulkan.hpp"
 
@@ -124,12 +123,34 @@ struct MockVulkanState {
       acquire_next_image_callback;
 };
 
-static thread_local absl::NoDestructor<std::unique_ptr<MockVulkanState>>
-    g_mock_vulkan_state;
+class MockVulkanStatePtr {
+ public:
+  ~MockVulkanStatePtr() {
+    FML_CHECK(ptr_ == nullptr)
+        << "MockVulkanState was not null upon thread exit. Leak detected!";
+  }
+
+  void reset(MockVulkanState* ptr = nullptr) {
+    if (ptr_) {
+      delete ptr_;
+    }
+    ptr_ = ptr;
+  }
+
+  MockVulkanState* get() const { return ptr_; }
+  MockVulkanState& operator*() const { return *ptr_; }
+  MockVulkanState* operator->() const { return ptr_; }
+  explicit operator bool() const { return ptr_ != nullptr; }
+
+ private:
+  MockVulkanState* ptr_ = nullptr;
+};
+
+static thread_local MockVulkanStatePtr g_mock_vulkan_state;
 
 static MockVulkanState& GetMockVulkanState() {
-  FML_CHECK(*g_mock_vulkan_state) << "MockVulkanState must be initialized.";
-  return **g_mock_vulkan_state;
+  FML_CHECK(g_mock_vulkan_state) << "MockVulkanState must be initialized.";
+  return *g_mock_vulkan_state;
 }
 
 void noop() {}
@@ -422,8 +443,8 @@ void vkDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator) {
 
 void vkDestroyInstance(VkInstance instance,
                        const VkAllocationCallbacks* pAllocator) {
-  if (*g_mock_vulkan_state) {
-    (*g_mock_vulkan_state).reset();
+  if (g_mock_vulkan_state) {
+    g_mock_vulkan_state.reset();
   }
 }
 
@@ -569,7 +590,7 @@ VkResult vkWaitForFences(VkDevice device,
                          const VkFence* pFences,
                          VkBool32 waitAll,
                          uint64_t timeout) {
-  if (*g_mock_vulkan_state && GetMockVulkanState().wait_for_fences_callback) {
+  if (g_mock_vulkan_state && GetMockVulkanState().wait_for_fences_callback) {
     return GetMockVulkanState().wait_for_fences_callback(
         device, fenceCount, pFences, waitAll, timeout);
   }
@@ -786,8 +807,7 @@ VkResult vkAcquireNextImageKHR(VkDevice device,
                                VkSemaphore semaphore,
                                VkFence fence,
                                uint32_t* pImageIndex) {
-  if (*g_mock_vulkan_state &&
-      GetMockVulkanState().acquire_next_image_callback) {
+  if (g_mock_vulkan_state && GetMockVulkanState().acquire_next_image_callback) {
     return GetMockVulkanState().acquire_next_image_callback(
         device, swapchain, timeout, semaphore, fence, pImageIndex);
   }
@@ -1027,16 +1047,15 @@ std::shared_ptr<ContextVK> MockVulkanContextBuilder::Build() {
   if (settings_callback_) {
     settings_callback_(settings);
   }
-  *g_mock_vulkan_state = std::make_unique<MockVulkanState>();
-  (*g_mock_vulkan_state)->instance_extensions = instance_extensions_;
-  (*g_mock_vulkan_state)->instance_layers = instance_layers_;
-  (*g_mock_vulkan_state)->format_properties_callback =
-      format_properties_callback_;
-  (*g_mock_vulkan_state)->physical_device_properties_callback =
+  g_mock_vulkan_state.reset(new MockVulkanState());
+  g_mock_vulkan_state->instance_extensions = instance_extensions_;
+  g_mock_vulkan_state->instance_layers = instance_layers_;
+  g_mock_vulkan_state->format_properties_callback = format_properties_callback_;
+  g_mock_vulkan_state->physical_device_properties_callback =
       physical_properties_callback_;
-  (*g_mock_vulkan_state)->acquire_next_image_callback =
+  g_mock_vulkan_state->acquire_next_image_callback =
       acquire_next_image_callback_;
-  (*g_mock_vulkan_state)->wait_for_fences_callback = wait_for_fences_callback_;
+  g_mock_vulkan_state->wait_for_fences_callback = wait_for_fences_callback_;
   settings.embedder_data = embedder_data_;
   std::shared_ptr<ContextVK> result = ContextVK::Create(std::move(settings));
   return result;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
@@ -9,11 +9,12 @@
 #include <utility>
 #include <vector>
 
+#include "flutter/fml/logging.h"
 #include "impeller/base/thread_safety.h"
 #include "impeller/renderer/backend/vulkan/vk.h"  // IWYU pragma: keep.
+#include "third_party/abseil-cpp/absl/base/no_destructor.h"
 #include "third_party/swiftshader/include/vulkan/vulkan_core.h"
 #include "vulkan/vulkan.hpp"
-#include "vulkan/vulkan_core.h"
 
 namespace impeller {
 namespace testing {
@@ -121,18 +122,15 @@ struct MockVulkanState {
       wait_for_fences_callback;
   std::function<std::remove_pointer_t<PFN_vkAcquireNextImageKHR>>
       acquire_next_image_callback;
-
-  void Clear() {
-    instance_extensions.clear();
-    instance_layers.clear();
-    format_properties_callback = nullptr;
-    physical_device_properties_callback = nullptr;
-    wait_for_fences_callback = nullptr;
-    acquire_next_image_callback = nullptr;
-  }
 };
 
-static thread_local MockVulkanState g_mock_vulkan_state;
+static thread_local absl::NoDestructor<std::unique_ptr<MockVulkanState>>
+    g_mock_vulkan_state;
+
+static MockVulkanState& GetMockVulkanState() {
+  FML_CHECK(*g_mock_vulkan_state) << "MockVulkanState must be initialized.";
+  return **g_mock_vulkan_state;
+}
 
 void noop() {}
 
@@ -141,10 +139,10 @@ VkResult vkEnumerateInstanceExtensionProperties(
     uint32_t* pPropertyCount,
     VkExtensionProperties* pProperties) {
   if (!pProperties) {
-    *pPropertyCount = g_mock_vulkan_state.instance_extensions.size();
+    *pPropertyCount = GetMockVulkanState().instance_extensions.size();
   } else {
     uint32_t count = 0;
-    for (const std::string& ext : g_mock_vulkan_state.instance_extensions) {
+    for (const std::string& ext : GetMockVulkanState().instance_extensions) {
       strncpy(pProperties[count].extensionName, ext.c_str(),
               sizeof(VkExtensionProperties::extensionName));
       pProperties[count].specVersion = 0;
@@ -157,10 +155,10 @@ VkResult vkEnumerateInstanceExtensionProperties(
 VkResult vkEnumerateInstanceLayerProperties(uint32_t* pPropertyCount,
                                             VkLayerProperties* pProperties) {
   if (!pProperties) {
-    *pPropertyCount = g_mock_vulkan_state.instance_layers.size();
+    *pPropertyCount = GetMockVulkanState().instance_layers.size();
   } else {
     uint32_t count = 0;
-    for (const std::string& layer : g_mock_vulkan_state.instance_layers) {
+    for (const std::string& layer : GetMockVulkanState().instance_layers) {
       strncpy(pProperties[count].layerName, layer.c_str(),
               sizeof(VkLayerProperties::layerName));
       pProperties[count].specVersion = 0;
@@ -185,9 +183,9 @@ void vkGetPhysicalDeviceFormatProperties(
     VkPhysicalDevice physicalDevice,
     VkFormat format,
     VkFormatProperties* pFormatProperties) {
-  if (g_mock_vulkan_state.format_properties_callback) {
-    g_mock_vulkan_state.format_properties_callback(physicalDevice, format,
-                                                   pFormatProperties);
+  if (GetMockVulkanState().format_properties_callback) {
+    GetMockVulkanState().format_properties_callback(physicalDevice, format,
+                                                    pFormatProperties);
   }
 }
 
@@ -198,9 +196,9 @@ void vkGetPhysicalDeviceProperties(VkPhysicalDevice physicalDevice,
                                       VK_SAMPLE_COUNT_4_BIT);
   pProperties->limits.maxImageDimension2D = 4096;
   pProperties->limits.timestampPeriod = 1;
-  if (g_mock_vulkan_state.physical_device_properties_callback) {
-    g_mock_vulkan_state.physical_device_properties_callback(physicalDevice,
-                                                            pProperties);
+  if (GetMockVulkanState().physical_device_properties_callback) {
+    GetMockVulkanState().physical_device_properties_callback(physicalDevice,
+                                                             pProperties);
   }
 }
 
@@ -420,7 +418,9 @@ void vkDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator) {
   MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
   mock_device->AddCalledFunction("vkDestroyDevice");
   delete reinterpret_cast<MockDevice*>(device);
-  g_mock_vulkan_state.Clear();
+  if (*g_mock_vulkan_state) {
+    (*g_mock_vulkan_state).reset();
+  }
 }
 
 void vkDestroyPipeline(VkDevice device,
@@ -565,8 +565,11 @@ VkResult vkWaitForFences(VkDevice device,
                          const VkFence* pFences,
                          VkBool32 waitAll,
                          uint64_t timeout) {
-  if (g_mock_vulkan_state.wait_for_fences_callback) {
-    return g_mock_vulkan_state.wait_for_fences_callback(
+  if (!*g_mock_vulkan_state) {
+    return VK_SUCCESS;
+  }
+  if (GetMockVulkanState().wait_for_fences_callback) {
+    return GetMockVulkanState().wait_for_fences_callback(
         device, fenceCount, pFences, waitAll, timeout);
   }
   return VK_SUCCESS;
@@ -782,8 +785,9 @@ VkResult vkAcquireNextImageKHR(VkDevice device,
                                VkSemaphore semaphore,
                                VkFence fence,
                                uint32_t* pImageIndex) {
-  if (g_mock_vulkan_state.acquire_next_image_callback) {
-    return g_mock_vulkan_state.acquire_next_image_callback(
+  if (*g_mock_vulkan_state &&
+      GetMockVulkanState().acquire_next_image_callback) {
+    return GetMockVulkanState().acquire_next_image_callback(
         device, swapchain, timeout, semaphore, fence, pImageIndex);
   }
   auto current_index =
@@ -1020,14 +1024,16 @@ std::shared_ptr<ContextVK> MockVulkanContextBuilder::Build() {
   if (settings_callback_) {
     settings_callback_(settings);
   }
-  g_mock_vulkan_state.instance_extensions = instance_extensions_;
-  g_mock_vulkan_state.instance_layers = instance_layers_;
-  g_mock_vulkan_state.format_properties_callback = format_properties_callback_;
-  g_mock_vulkan_state.physical_device_properties_callback =
+  *g_mock_vulkan_state = std::make_unique<MockVulkanState>();
+  (*g_mock_vulkan_state)->instance_extensions = instance_extensions_;
+  (*g_mock_vulkan_state)->instance_layers = instance_layers_;
+  (*g_mock_vulkan_state)->format_properties_callback =
+      format_properties_callback_;
+  (*g_mock_vulkan_state)->physical_device_properties_callback =
       physical_properties_callback_;
-  g_mock_vulkan_state.acquire_next_image_callback =
+  (*g_mock_vulkan_state)->acquire_next_image_callback =
       acquire_next_image_callback_;
-  g_mock_vulkan_state.wait_for_fences_callback = wait_for_fences_callback_;
+  (*g_mock_vulkan_state)->wait_for_fences_callback = wait_for_fences_callback_;
   settings.embedder_data = embedder_data_;
   std::shared_ptr<ContextVK> result = ContextVK::Create(std::move(settings));
   return result;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
@@ -107,19 +107,44 @@ class MockDevice final {
       IPLR_GUARDED_BY(commmand_pools_mutex_);
 };
 
-void noop() {}
+struct MockVulkanState {
+  std::vector<std::string> instance_extensions;
+  std::vector<std::string> instance_layers;
+  std::function<void(VkPhysicalDevice physicalDevice,
+                     VkFormat format,
+                     VkFormatProperties* pFormatProperties)>
+      format_properties_callback;
+  std::function<void(VkPhysicalDevice physicalDevice,
+                     VkPhysicalDeviceProperties* pProperties)>
+      physical_device_properties_callback;
+  std::function<std::remove_pointer_t<PFN_vkWaitForFences>>
+      wait_for_fences_callback;
+  std::function<std::remove_pointer_t<PFN_vkAcquireNextImageKHR>>
+      acquire_next_image_callback;
 
-static thread_local std::vector<std::string> g_instance_extensions;
+  void Clear() {
+    instance_extensions.clear();
+    instance_layers.clear();
+    format_properties_callback = nullptr;
+    physical_device_properties_callback = nullptr;
+    wait_for_fences_callback = nullptr;
+    acquire_next_image_callback = nullptr;
+  }
+};
+
+static thread_local MockVulkanState g_mock_vulkan_state;
+
+void noop() {}
 
 VkResult vkEnumerateInstanceExtensionProperties(
     const char* pLayerName,
     uint32_t* pPropertyCount,
     VkExtensionProperties* pProperties) {
   if (!pProperties) {
-    *pPropertyCount = g_instance_extensions.size();
+    *pPropertyCount = g_mock_vulkan_state.instance_extensions.size();
   } else {
     uint32_t count = 0;
-    for (const std::string& ext : g_instance_extensions) {
+    for (const std::string& ext : g_mock_vulkan_state.instance_extensions) {
       strncpy(pProperties[count].extensionName, ext.c_str(),
               sizeof(VkExtensionProperties::extensionName));
       pProperties[count].specVersion = 0;
@@ -129,15 +154,13 @@ VkResult vkEnumerateInstanceExtensionProperties(
   return VK_SUCCESS;
 }
 
-static thread_local std::vector<std::string> g_instance_layers;
-
 VkResult vkEnumerateInstanceLayerProperties(uint32_t* pPropertyCount,
                                             VkLayerProperties* pProperties) {
   if (!pProperties) {
-    *pPropertyCount = g_instance_layers.size();
+    *pPropertyCount = g_mock_vulkan_state.instance_layers.size();
   } else {
     uint32_t count = 0;
-    for (const std::string& layer : g_instance_layers) {
+    for (const std::string& layer : g_mock_vulkan_state.instance_layers) {
       strncpy(pProperties[count].layerName, layer.c_str(),
               sizeof(VkLayerProperties::layerName));
       pProperties[count].specVersion = 0;
@@ -158,21 +181,15 @@ VkResult vkEnumeratePhysicalDevices(VkInstance instance,
   return VK_SUCCESS;
 }
 
-static thread_local std::function<void(VkPhysicalDevice physicalDevice,
-                                       VkFormat format,
-                                       VkFormatProperties* pFormatProperties)>
-    g_format_properties_callback;
-
 void vkGetPhysicalDeviceFormatProperties(
     VkPhysicalDevice physicalDevice,
     VkFormat format,
     VkFormatProperties* pFormatProperties) {
-  g_format_properties_callback(physicalDevice, format, pFormatProperties);
+  if (g_mock_vulkan_state.format_properties_callback) {
+    g_mock_vulkan_state.format_properties_callback(physicalDevice, format,
+                                                   pFormatProperties);
+  }
 }
-
-static thread_local std::function<void(VkPhysicalDevice physicalDevice,
-                                       VkPhysicalDeviceProperties* pProperties)>
-    g_physical_device_properties_callback;
 
 void vkGetPhysicalDeviceProperties(VkPhysicalDevice physicalDevice,
                                    VkPhysicalDeviceProperties* pProperties) {
@@ -181,8 +198,9 @@ void vkGetPhysicalDeviceProperties(VkPhysicalDevice physicalDevice,
                                       VK_SAMPLE_COUNT_4_BIT);
   pProperties->limits.maxImageDimension2D = 4096;
   pProperties->limits.timestampPeriod = 1;
-  if (g_physical_device_properties_callback) {
-    g_physical_device_properties_callback(physicalDevice, pProperties);
+  if (g_mock_vulkan_state.physical_device_properties_callback) {
+    g_mock_vulkan_state.physical_device_properties_callback(physicalDevice,
+                                                            pProperties);
   }
 }
 
@@ -402,6 +420,7 @@ void vkDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator) {
   MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
   mock_device->AddCalledFunction("vkDestroyDevice");
   delete reinterpret_cast<MockDevice*>(device);
+  g_mock_vulkan_state.Clear();
 }
 
 void vkDestroyPipeline(VkDevice device,
@@ -541,17 +560,14 @@ VkResult vkQueueSubmit(VkQueue queue,
   return VK_SUCCESS;
 }
 
-static thread_local std::function<std::remove_pointer_t<PFN_vkWaitForFences>>
-    g_wait_for_fences_callback;
-
 VkResult vkWaitForFences(VkDevice device,
                          uint32_t fenceCount,
                          const VkFence* pFences,
                          VkBool32 waitAll,
                          uint64_t timeout) {
-  if (g_wait_for_fences_callback) {
-    return g_wait_for_fences_callback(device, fenceCount, pFences, waitAll,
-                                      timeout);
+  if (g_mock_vulkan_state.wait_for_fences_callback) {
+    return g_mock_vulkan_state.wait_for_fences_callback(
+        device, fenceCount, pFences, waitAll, timeout);
   }
   return VK_SUCCESS;
 }
@@ -760,19 +776,15 @@ void vkDestroySemaphore(VkDevice device,
   delete reinterpret_cast<MockSemaphore*>(semaphore);
 }
 
-static thread_local std::function<
-    std::remove_pointer_t<PFN_vkAcquireNextImageKHR>>
-    g_acquire_next_image_callback;
-
 VkResult vkAcquireNextImageKHR(VkDevice device,
                                VkSwapchainKHR swapchain,
                                uint64_t timeout,
                                VkSemaphore semaphore,
                                VkFence fence,
                                uint32_t* pImageIndex) {
-  if (g_acquire_next_image_callback) {
-    return g_acquire_next_image_callback(device, swapchain, timeout, semaphore,
-                                         fence, pImageIndex);
+  if (g_mock_vulkan_state.acquire_next_image_callback) {
+    return g_mock_vulkan_state.acquire_next_image_callback(
+        device, swapchain, timeout, semaphore, fence, pImageIndex);
   }
   auto current_index =
       reinterpret_cast<MockSwapchainKHR*>(swapchain)->current_image++;
@@ -1008,12 +1020,14 @@ std::shared_ptr<ContextVK> MockVulkanContextBuilder::Build() {
   if (settings_callback_) {
     settings_callback_(settings);
   }
-  g_instance_extensions = instance_extensions_;
-  g_instance_layers = instance_layers_;
-  g_format_properties_callback = format_properties_callback_;
-  g_physical_device_properties_callback = physical_properties_callback_;
-  g_acquire_next_image_callback = acquire_next_image_callback_;
-  g_wait_for_fences_callback = wait_for_fences_callback_;
+  g_mock_vulkan_state.instance_extensions = instance_extensions_;
+  g_mock_vulkan_state.instance_layers = instance_layers_;
+  g_mock_vulkan_state.format_properties_callback = format_properties_callback_;
+  g_mock_vulkan_state.physical_device_properties_callback =
+      physical_properties_callback_;
+  g_mock_vulkan_state.acquire_next_image_callback =
+      acquire_next_image_callback_;
+  g_mock_vulkan_state.wait_for_fences_callback = wait_for_fences_callback_;
   settings.embedder_data = embedder_data_;
   std::shared_ptr<ContextVK> result = ContextVK::Create(std::move(settings));
   return result;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
@@ -418,6 +418,10 @@ void vkDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator) {
   MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
   mock_device->AddCalledFunction("vkDestroyDevice");
   delete reinterpret_cast<MockDevice*>(device);
+}
+
+void vkDestroyInstance(VkInstance instance,
+                       const VkAllocationCallbacks* pAllocator) {
   if (*g_mock_vulkan_state) {
     (*g_mock_vulkan_state).reset();
   }
@@ -565,10 +569,7 @@ VkResult vkWaitForFences(VkDevice device,
                          const VkFence* pFences,
                          VkBool32 waitAll,
                          uint64_t timeout) {
-  if (!*g_mock_vulkan_state) {
-    return VK_SUCCESS;
-  }
-  if (GetMockVulkanState().wait_for_fences_callback) {
+  if (*g_mock_vulkan_state && GetMockVulkanState().wait_for_fences_callback) {
     return GetMockVulkanState().wait_for_fences_callback(
         device, fenceCount, pFences, waitAll, timeout);
   }
@@ -906,6 +907,8 @@ PFN_vkVoidFunction GetMockVulkanProcAddress(VkInstance instance,
     return reinterpret_cast<PFN_vkVoidFunction>(vkCreateGraphicsPipelines);
   } else if (strcmp("vkDestroyDevice", pName) == 0) {
     return reinterpret_cast<PFN_vkVoidFunction>(vkDestroyDevice);
+  } else if (strcmp("vkDestroyInstance", pName) == 0) {
+    return reinterpret_cast<PFN_vkVoidFunction>(vkDestroyInstance);
   } else if (strcmp("vkDestroyPipeline", pName) == 0) {
     return reinterpret_cast<PFN_vkVoidFunction>(vkDestroyPipeline);
   } else if (strcmp("vkCreateShaderModule", pName) == 0) {


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/183323

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
