### PR TITLE
License page package exclusions

### DIFF
--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -71,6 +71,7 @@ class AboutListTile extends StatelessWidget {
     this.applicationVersion,
     this.applicationIcon,
     this.applicationLegalese,
+    this.packageFilter,
     this.aboutBoxChildren,
     this.dense,
   });
@@ -123,6 +124,12 @@ class AboutListTile extends StatelessWidget {
   /// Defaults to the empty string.
   final String? applicationLegalese;
 
+  /// A callback to filter the packages being shown.
+  ///
+  /// By default, all packages the application uses are included, even
+  /// transitive dependencies.
+  final bool Function(String packageName)? packageFilter;
+
   /// Widgets to add to the [AboutDialog] after the name, version, and legalese.
   ///
   /// This could include a link to a Web site, some descriptive text, credits,
@@ -159,6 +166,7 @@ class AboutListTile extends StatelessWidget {
           applicationVersion: applicationVersion,
           applicationIcon: applicationIcon,
           applicationLegalese: applicationLegalese,
+          packageFilter: packageFilter,
           children: aboutBoxChildren,
         );
       },
@@ -189,6 +197,7 @@ void showAboutDialog({
   String? applicationVersion,
   Widget? applicationIcon,
   String? applicationLegalese,
+  bool Function(String packageName)? packageFilter,
   List<Widget>? children,
   bool barrierDismissible = true,
   Color? barrierColor,
@@ -209,6 +218,7 @@ void showAboutDialog({
         applicationVersion: applicationVersion,
         applicationIcon: applicationIcon,
         applicationLegalese: applicationLegalese,
+        packageFilter: packageFilter,
         children: children,
       );
     },
@@ -298,6 +308,7 @@ void showLicensePage({
   String? applicationVersion,
   Widget? applicationIcon,
   String? applicationLegalese,
+  bool Function(String packageName)? packageFilter,
   bool useRootNavigator = false,
 }) {
   final CapturedThemes themes = InheritedTheme.capture(
@@ -312,6 +323,7 @@ void showLicensePage({
           applicationVersion: applicationVersion,
           applicationIcon: applicationIcon,
           applicationLegalese: applicationLegalese,
+          packageFilter: packageFilter,
         ),
       ),
     ),
@@ -349,6 +361,7 @@ class AboutDialog extends StatelessWidget {
     this.applicationVersion,
     this.applicationIcon,
     this.applicationLegalese,
+    this.packageFilter,
     this.children,
   });
 
@@ -371,6 +384,7 @@ class AboutDialog extends StatelessWidget {
     String? applicationVersion,
     Widget? applicationIcon,
     String? applicationLegalese,
+    bool Function(String packageName)? packageFilter,
     List<Widget>? children,
   }) = _AdaptiveAboutDialog;
 
@@ -401,6 +415,12 @@ class AboutDialog extends StatelessWidget {
   ///
   /// Defaults to the empty string.
   final String? applicationLegalese;
+
+  /// A callback to filter the packages being shown.
+  ///
+  /// By default, all packages the application uses are included, even
+  /// transitive dependencies.
+  final bool Function(String packageName)? packageFilter;
 
   /// Widgets to add to the dialog box after the name, version, and legalese.
   ///
@@ -457,6 +477,7 @@ class AboutDialog extends StatelessWidget {
               applicationVersion: applicationVersion,
               applicationIcon: applicationIcon,
               applicationLegalese: applicationLegalese,
+              packageFilter: packageFilter,
             );
           },
         ),
@@ -483,6 +504,7 @@ class _AdaptiveAboutDialog extends AboutDialog {
     super.applicationVersion,
     super.applicationIcon,
     super.applicationLegalese,
+    super.packageFilter,
     super.children,
   });
 
@@ -507,6 +529,7 @@ class _AdaptiveAboutDialog extends AboutDialog {
                 applicationVersion: applicationVersion,
                 applicationIcon: applicationIcon,
                 applicationLegalese: applicationLegalese,
+                packageFilter: packageFilter,
               );
             },
           ),
@@ -539,6 +562,7 @@ class _AdaptiveAboutDialog extends AboutDialog {
                 applicationVersion: applicationVersion,
                 applicationIcon: applicationIcon,
                 applicationLegalese: applicationLegalese,
+                packageFilter: packageFilter,
               );
             },
           ),
@@ -621,6 +645,7 @@ class LicensePage extends StatefulWidget {
     this.applicationVersion,
     this.applicationIcon,
     this.applicationLegalese,
+    this.packageFilter,
   });
 
   /// The name of the application.
@@ -650,6 +675,12 @@ class LicensePage extends StatefulWidget {
   ///
   /// Defaults to the empty string.
   final String? applicationLegalese;
+
+  /// A callback to filter the packages being shown.
+  ///
+  /// By default, all packages the application uses are included, even
+  /// transitive dependencies.
+  final bool Function(String packageName)? packageFilter;
 
   @override
   State<LicensePage> createState() => _LicensePageState();
@@ -691,7 +722,12 @@ class _LicensePageState extends State<LicensePage> {
       version: widget.applicationVersion ?? _defaultApplicationVersion(context),
       legalese: widget.applicationLegalese,
     );
-    return _PackagesView(about: about, isLateral: isLateral, selectedId: selectedId);
+    return _PackagesView(
+      about: about,
+      isLateral: isLateral,
+      selectedId: selectedId,
+      packageFilter: widget.packageFilter ?? (_) => true,
+    );
   }
 }
 
@@ -739,23 +775,36 @@ class _AboutProgram extends StatelessWidget {
 }
 
 class _PackagesView extends StatefulWidget {
-  const _PackagesView({required this.about, required this.isLateral, required this.selectedId});
+  const _PackagesView({
+    required this.about,
+    required this.isLateral,
+    required this.selectedId,
+    required this.packageFilter
+  });
 
   final Widget about;
   final bool isLateral;
   final ValueNotifier<int?> selectedId;
+  final bool Function(String packageName) packageFilter;
 
   @override
   _PackagesViewState createState() => _PackagesViewState();
 }
 
 class _PackagesViewState extends State<_PackagesView> {
-  final Future<_LicenseData> licenses = LicenseRegistry.licenses
-      .fold<_LicenseData>(
-        _LicenseData(),
-        (_LicenseData prev, LicenseEntry license) => prev..addLicense(license),
-      )
-      .then((_LicenseData licenseData) => licenseData..sortPackages());
+  late final Future<_LicenseData> licenses;
+
+  @override
+  void initState() {
+    super.initState();
+
+    licenses = LicenseRegistry.licenses
+        .fold<_LicenseData>(
+          _LicenseData(), (_LicenseData prev, LicenseEntry license) =>
+          prev..addLicense(license, widget.packageFilter)
+        )
+        .then((_LicenseData licenseData) => licenseData..sortPackages());
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -917,10 +966,14 @@ class _LicenseData {
   // for delivered application.
   String? firstPackage;
 
-  void addLicense(LicenseEntry entry) {
+  void addLicense(LicenseEntry entry, bool Function(String packageName) packageFilter) {
     // Before the license can be added, we must first record the packages to
     // which it belongs.
     for (final String package in entry.packages) {
+      if (!packageFilter(package)) {
+        continue;
+      }
+
       _addPackage(package);
       // Bind this license to the package using the next index value. This
       // creates a contract that this license must be inserted at this same

--- a/packages/flutter/test/material/about_test.dart
+++ b/packages/flutter/test/material/about_test.dart
@@ -2000,6 +2000,29 @@ void main() {
     final Finder xText = find.text('X');
     expect(tester.getSize(xText).isEmpty, isTrue);
   });
+
+  testWidgets('LicensePage filters packages', (WidgetTester tester) async {
+    LicenseRegistry.addLicense(() {
+      return Stream<LicenseEntry>.fromIterable([
+        const LicenseEntryWithLineBreaks(['foo', 'bar'], 'License Text'),
+      ]);
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        title: 'Pirate app',
+        home: Center(
+          child: LicensePage(
+            packageFilter: (name) => name != 'foo',
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('foo'), findsNothing);
+    expect(find.text('bar'), findsOneWidget);
+    expect(find.text('License Text'), findsOneWidget);
+  });
 }
 
 class FakeLicenseEntry extends LicenseEntry {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

This PR adds a parameter for the `showAboutDialog` (and related) methods to filter the shown packages.

Something like this solution was requested in #100746.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
