### PR TITLE
Make the circle.frag Anti Aliasing continuous around 2px

### DIFF
--- a/engine/src/flutter/impeller/entity/shaders/circle.frag
+++ b/engine/src/flutter/impeller/entity/shaders/circle.frag
@@ -52,14 +52,14 @@ void main() {
   float pixel_derivative_sdf =
       length(vec2(dFdx(sdf_distance), dFdy(sdf_distance)));
 
-  // If the screen space derivative is less than the stroke width,
-  // only one pixel can be covered and shouldn't be faded.
-  if (frag_info.stroked > 0.0 &&
-      pixel_derivative_sdf * 2.0 >= frag_info.stroke_width) {
-    sdf_distance = -frag_info.radius;
-  }
-
+  // Clamp the AA fade width so it never exceeds half the stroke's
+  // screen-pixel width. This makes the fade width scale with stroke width.
+  // Making the transition continuous
   float fade_width = pixel_derivative_sdf * frag_info.aa_pixels;
+  if (frag_info.stroked > 0.0) {
+    float stroke_pixels = frag_info.stroke_width / pixel_derivative_sdf;
+    fade_width = min(fade_width, stroke_pixels * 0.5);
+  }
   // The sdf_distance will be -pixel_derivative_sdf*N exactly at N pixels away
   // from the edge of the circle
   float alpha = 1.0 - smoothstep(-fade_width, 0.0, sdf_distance);

--- a/engine/src/flutter/impeller/entity/shaders/circle.frag
+++ b/engine/src/flutter/impeller/entity/shaders/circle.frag
@@ -52,13 +52,11 @@ void main() {
   float pixel_derivative_sdf =
       length(vec2(dFdx(sdf_distance), dFdy(sdf_distance)));
 
-  // Clamp the AA fade width so it never exceeds half the stroke's
-  // screen-pixel width. This makes the fade width scale with stroke width.
-  // Making the transition continuous
+  // Clamp the AA fade width so it never exceeds half the stroke width.
+  // Both values are in device-space units, making the transition continuous.
   float fade_width = pixel_derivative_sdf * frag_info.aa_pixels;
   if (frag_info.stroked > 0.0) {
-    float stroke_pixels = frag_info.stroke_width / pixel_derivative_sdf;
-    fade_width = min(fade_width, stroke_pixels * 0.5);
+    fade_width = min(fade_width, frag_info.stroke_width * 0.5);
   }
   // The sdf_distance will be -pixel_derivative_sdf*N exactly at N pixels away
   // from the edge of the circle


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

Currently Circle.frag has a hard limit of 2 pixels below which it gives full opacity to the ring

```GLSL
if (frag_info.stroked > 0.0 &&
      pixel_derivative_sdf * 2.0 >= frag_info.stroke_width) {
    sdf_distance = -frag_info.radius;
  }
```
So `float alpha = 1.0 - smoothstep(-fade_width, 0.0, sdf_distance);` was discontinuous at that border since `sdf_distance` jumped abruptly.

Fixes https://github.com/flutter/flutter/issues/183339

With this update fade width varies smoothly with stroke width, until 2px at which point both are equal, eliminating a discontinuity



https://github.com/user-attachments/assets/573d7969-3389-446b-89db-59ad1bc3a2b9




## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
