### PR TITLE
(Test cross-imports) Remove legacy Material import from sliver_constraints_test

### DIFF
--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -133,7 +133,6 @@ class TestsCrossImportChecker {
     'packages/flutter/test/widgets/color_filter_test.dart',
     'packages/flutter/test/widgets/semantics_merge_test.dart',
     'packages/flutter/test/widgets/sliver_semantics_test.dart',
-    'packages/flutter/test/widgets/sliver_constraints_test.dart',
     'packages/flutter/test/widgets/autocomplete_test.dart',
     'packages/flutter/test/widgets/shadow_test.dart',
     'packages/flutter/test/widgets/routes_transition_test.dart',

--- a/packages/flutter/test/widgets/sliver_constraints_test.dart
+++ b/packages/flutter/test/widgets/sliver_constraints_test.dart
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -11,8 +11,9 @@ void main() {
     WidgetTester tester,
   ) async {
     await tester.pumpWidget(
-      MaterialApp(
-        home: CustomScrollView(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: CustomScrollView(
           slivers: <Widget>[
             const SliverToBoxAdapter(child: SizedBox(width: double.infinity, height: 150.0)),
             const SliverToBoxAdapter(child: SizedBox(width: double.infinity, height: 150.0)),


### PR DESCRIPTION
Part of #177412

## Summary
Removes a legacy Material dependency from a widgets test by replacing `MaterialApp` with the minimal required wrapper (`Directionality`) in:
- `packages/flutter/test/widgets/sliver_constraints_test.dart`

This keeps the test behavior unchanged while reducing cross-library coupling in the test suite.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

## Tests
- `./bin/dart analyze packages/flutter/test/widgets/sliver_constraints_test.dart`
- `./bin/flutter test packages/flutter/test/widgets/sliver_constraints_test.dart`

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md

