### PR TITLE
Fix whitespace in the windows Flutter tool console output

### DIFF
--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -135,7 +135,7 @@ GOTO :after_subroutine
     REM PowerShell command must have exit code set in order to prevent all non-zero exit codes from being translated
     REM into 1. The exit code 2 is used to detect the case where the major version is incorrect and there should be
     REM no subsequent retries.
-    ECHO Downloading Dart SDK from Flutter engine %dart_required_version%... 1>&2
+    ECHO Downloading Dart SDK from Flutter engine%dart_required_version%... 1>&2
     %powershell_executable% -ExecutionPolicy Bypass -NoProfile -Command "Unblock-File -Path '%update_dart_bin%'; & '%update_dart_bin%'; exit $LASTEXITCODE;"
     IF "%ERRORLEVEL%" EQU "2" (
       EXIT 1

--- a/packages/flutter_tools/test/integration.shard/batch_entrypoint_test.dart
+++ b/packages/flutter_tools/test/integration.shard/batch_entrypoint_test.dart
@@ -52,7 +52,7 @@ Future<void> main() async {
     // If 7-Zip is not installed, unexpected overwrites results in error messages.
     // See: https://github.com/flutter/flutter/issues/132592
     expect(dartSdkStamp.existsSync(), true);
-    expect(output, contains('Downloading Dart SDK from Flutter engine ...'));
+    expect(output, contains('Downloading Dart SDK from Flutter engine...'));
     // Do not assert on the exact unzipping method, as this could change on CI
     expect(output, contains(RegExp(r'Expanding downloaded archive with (.*)...')));
     expect(output, isNot(contains('Use the -Force parameter' /* Luke */)));


### PR DESCRIPTION
One single whitespace. That's it.

I've looked at this too many times: 
<img width="591" height="239" alt="grafik" src="https://github.com/user-attachments/assets/16590eef-b299-45d0-9861-9dd4e9fdec6f" />
