### PR TITLE
refactor: remove material from baseline_test, slivers_test

### DIFF
--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -168,12 +168,10 @@ class TestsCrossImportChecker {
     'packages/flutter/test/widgets/navigator_test.dart',
     'packages/flutter/test/widgets/page_view_test.dart',
     'packages/flutter/test/widgets/page_forward_transitions_test.dart',
-    'packages/flutter/test/widgets/slivers_test.dart',
     'packages/flutter/test/widgets/navigator_restoration_test.dart',
     'packages/flutter/test/widgets/sliver_prototype_item_extent_test.dart',
     'packages/flutter/test/widgets/image_filter_test.dart',
     'packages/flutter/test/widgets/navigator_on_did_remove_page_test.dart',
-    'packages/flutter/test/widgets/baseline_test.dart',
     'packages/flutter/test/widgets/scrollable_semantics_test.dart',
     'packages/flutter/test/widgets/form_test.dart',
   };

--- a/packages/flutter/test/widgets/baseline_test.dart
+++ b/packages/flutter/test/widgets/baseline_test.dart
@@ -2,10 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'list_tile_tester.dart';
+import 'widgets_app_tester.dart';
+
+const Color _debugChipColor = Color(0xFFCCCCCC);
 
 void main() {
   testWidgets('Baseline - control test', (WidgetTester tester) async {
@@ -42,17 +45,15 @@ void main() {
     debugCheckIntrinsicSizes = false;
     var calls = 0;
     await tester.pumpWidget(
-      MaterialApp(
-        home: Material(
-          child: Baseline(
-            baseline: 100.0,
-            baselineType: TextBaseline.alphabetic,
-            child: Chip(
-              label: BaselineDetector(() {
-                assert(!debugCheckIntrinsicSizes);
-                calls += 1;
-              }),
-            ),
+      TestWidgetsApp(
+        home: Baseline(
+          baseline: 100.0,
+          baselineType: TextBaseline.alphabetic,
+          child: TestChip(
+            label: BaselineDetector(() {
+              assert(!debugCheckIntrinsicSizes);
+              calls += 1;
+            }),
           ),
         ),
       ),
@@ -71,17 +72,15 @@ void main() {
     debugCheckIntrinsicSizes = false;
     var calls = 0;
     await tester.pumpWidget(
-      MaterialApp(
-        home: Material(
-          child: Baseline(
-            baseline: 100.0,
-            baselineType: TextBaseline.alphabetic,
-            child: TestListTile(
-              title: BaselineDetector(() {
-                assert(!debugCheckIntrinsicSizes);
-                calls += 1;
-              }),
-            ),
+      TestWidgetsApp(
+        home: Baseline(
+          baseline: 100.0,
+          baselineType: TextBaseline.alphabetic,
+          child: TestListTile(
+            title: BaselineDetector(() {
+              assert(!debugCheckIntrinsicSizes);
+              calls += 1;
+            }),
           ),
         ),
       ),
@@ -97,16 +96,14 @@ void main() {
 
   testWidgets("LayoutBuilder returns child's baseline", (WidgetTester tester) async {
     await tester.pumpWidget(
-      MaterialApp(
-        home: Material(
-          child: Baseline(
-            baseline: 180.0,
-            baselineType: TextBaseline.alphabetic,
-            child: LayoutBuilder(
-              builder: (BuildContext context, BoxConstraints constraints) {
-                return BaselineDetector(() {});
-              },
-            ),
+      TestWidgetsApp(
+        home: Baseline(
+          baseline: 180.0,
+          baselineType: TextBaseline.alphabetic,
+          child: LayoutBuilder(
+            builder: (BuildContext context, BoxConstraints constraints) {
+              return BaselineDetector(() {});
+            },
           ),
         ),
       ),
@@ -114,6 +111,29 @@ void main() {
 
     expect(tester.getRect(find.byType(BaselineDetector)).top, 160.0);
   });
+}
+
+class TestChip extends StatelessWidget {
+  const TestChip({required this.label, super.key});
+
+  final Widget label;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: const BoxDecoration(
+        color: _debugChipColor,
+        borderRadius: BorderRadius.all(Radius.circular(16.0)),
+      ),
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(minHeight: 32.0),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 4.0),
+          child: label,
+        ),
+      ),
+    );
+  }
 }
 
 class BaselineDetector extends LeafRenderObjectWidget {

--- a/packages/flutter/test/widgets/slivers_test.dart
+++ b/packages/flutter/test/widgets/slivers_test.dart
@@ -3,12 +3,15 @@
 // found in the LICENSE file.
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'list_tile_tester.dart';
 import 'semantics_tester.dart';
+import 'widgets_app_tester.dart';
+
+const Color _debugEvenColor = Color(0xFF00FF00);
+const Color _debugOddColor = Color(0xFFFF0000);
 
 Future<void> test(WidgetTester tester, double offset, {double anchor = 0.0}) {
   final viewportOffset = ViewportOffset.fixed(offset);
@@ -67,6 +70,31 @@ void verify(WidgetTester tester, List<Offset> idealPositions, List<bool> idealVi
       .toList();
   expect(actualPositions, equals(idealPositions));
   expect(actualVisibles, equals(idealVisibles));
+}
+
+Widget _buildSliverTestApp({required Widget child, Key? key}) {
+  return TestWidgetsApp(
+    home: SizedBox.expand(key: key, child: child),
+  );
+}
+
+Widget _buildIndexedTapTarget({required int index, required VoidCallback onTap}) {
+  return GestureDetector(
+    behavior: HitTestBehavior.opaque,
+    onTap: onTap,
+    child: ColoredBox(
+      color: index.isEven ? _debugEvenColor : _debugOddColor,
+      child: Text('Index $index'),
+    ),
+  );
+}
+
+Widget _buildTapTarget({required String label, required Color color, required VoidCallback onTap}) {
+  return GestureDetector(
+    behavior: HitTestBehavior.opaque,
+    onTap: onTap,
+    child: ColoredBox(color: color, child: Text(label)),
+  );
 }
 
 void main() {
@@ -479,19 +507,20 @@ void main() {
     var skip = true;
     Widget buildItem(BuildContext context, int index) {
       return !skip || index.isEven
-          ? Card(
-              child: TestListTile(title: Text('item$index', style: const TextStyle(fontSize: 80))),
+          ? SizedBox(
+              height: 96.0,
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: Text('item$index', style: const TextStyle(fontSize: 72)),
+              ),
             )
-          : Container();
+          : const SizedBox.shrink();
     }
 
     await tester.pumpWidget(
-      MaterialApp(
-        theme: ThemeData(useMaterial3: false),
-        home: Scaffold(
-          body: CustomScrollView(
-            slivers: <Widget>[SliverList.builder(itemCount: 30, itemBuilder: buildItem)],
-          ),
+      TestWidgetsApp(
+        home: CustomScrollView(
+          slivers: <Widget>[SliverList.builder(itemCount: 30, itemBuilder: buildItem)],
         ),
       ),
     );
@@ -509,11 +538,9 @@ void main() {
 
     skip = false;
     await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: CustomScrollView(
-            slivers: <Widget>[SliverList.builder(itemCount: 30, itemBuilder: buildItem)],
-          ),
+      TestWidgetsApp(
+        home: CustomScrollView(
+          slivers: <Widget>[SliverList.builder(itemCount: 30, itemBuilder: buildItem)],
         ),
       ),
     );
@@ -708,20 +735,7 @@ void main() {
   );
 
   Widget boilerPlate(List<Widget> slivers) {
-    return Localizations(
-      locale: const Locale('en', 'us'),
-      delegates: const <LocalizationsDelegate<dynamic>>[
-        DefaultWidgetsLocalizations.delegate,
-        DefaultMaterialLocalizations.delegate,
-      ],
-      child: Directionality(
-        textDirection: TextDirection.ltr,
-        child: MediaQuery(
-          data: const MediaQueryData(),
-          child: CustomScrollView(slivers: slivers),
-        ),
-      ),
-    );
+    return TestWidgetsApp(home: CustomScrollView(slivers: slivers));
   }
 
   group('SliverOffstage - ', () {
@@ -983,11 +997,9 @@ void main() {
           SliverList(
             delegate: SliverChildBuilderDelegate(
               (BuildContext context, int index) {
-                return Card(
-                  child: Padding(
-                    padding: const EdgeInsets.all(8.0),
-                    child: Text('Lorem Ipsum $index'),
-                  ),
+                return Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Text('Lorem Ipsum $index'),
                 );
               },
               childCount: 50,
@@ -1011,16 +1023,14 @@ void main() {
   testWidgets('SliverList handles 0 scrollOffsetCorrection', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/62198
     await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: CustomScrollView(
-            physics: const BouncingScrollPhysics(parent: AlwaysScrollableScrollPhysics()),
-            slivers: <Widget>[
-              SliverList.list(
-                children: const <Widget>[SizedBox.shrink(), Text('index 1'), Text('index 2')],
-              ),
-            ],
-          ),
+      _buildSliverTestApp(
+        child: CustomScrollView(
+          physics: const BouncingScrollPhysics(parent: AlwaysScrollableScrollPhysics()),
+          slivers: <Widget>[
+            SliverList.list(
+              children: const <Widget>[SizedBox.shrink(), Text('index 1'), Text('index 2')],
+            ),
+          ],
         ),
       ),
     );
@@ -1035,27 +1045,22 @@ void main() {
     var secondTapped = 0;
     final Key key = UniqueKey();
     await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          key: key,
-          body: CustomScrollView(
-            slivers: <Widget>[
-              SliverGrid(
-                delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
-                  return Material(
-                    color: index.isEven ? Colors.yellow : Colors.red,
-                    child: InkWell(
-                      onTap: () {
-                        index.isEven ? firstTapped++ : secondTapped++;
-                      },
-                      child: Text('Index $index'),
-                    ),
-                  );
-                }, childCount: 2),
-                gridDelegate: _TestArbitrarySliverGridDelegate(),
-              ),
-            ],
-          ),
+      _buildSliverTestApp(
+        key: key,
+        child: CustomScrollView(
+          slivers: <Widget>[
+            SliverGrid(
+              delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+                return _buildIndexedTapTarget(
+                  index: index,
+                  onTap: () {
+                    index.isEven ? firstTapped++ : secondTapped++;
+                  },
+                );
+              }, childCount: 2),
+              gridDelegate: _TestArbitrarySliverGridDelegate(),
+            ),
+          ],
         ),
       ),
     );
@@ -1090,23 +1095,20 @@ void main() {
     WidgetTester tester,
   ) async {
     await tester.pumpWidget(
-      MaterialApp(
-        home: Directionality(
-          textDirection: TextDirection.ltr,
-          child: SizedBox(
-            height: 200,
-            child: CustomScrollView(
-              slivers: <Widget>[
-                SliverFixedExtentList.builder(
-                  itemExtent: 50,
-                  itemCount: 3,
-                  semanticIndexOffset: 10,
-                  itemBuilder: (BuildContext context, int index) {
-                    return SizedBox(height: 50, child: Text('Item $index'));
-                  },
-                ),
-              ],
-            ),
+      TestWidgetsApp(
+        home: SizedBox(
+          height: 200,
+          child: CustomScrollView(
+            slivers: <Widget>[
+              SliverFixedExtentList.builder(
+                itemExtent: 50,
+                itemCount: 3,
+                semanticIndexOffset: 10,
+                itemBuilder: (BuildContext context, int index) {
+                  return SizedBox(height: 50, child: Text('Item $index'));
+                },
+              ),
+            ],
           ),
         ),
       ),
@@ -1132,29 +1134,22 @@ void main() {
   testWidgets('SliverList.builder can build children', (WidgetTester tester) async {
     var firstTapped = 0;
     var secondTapped = 0;
-    final Key key = UniqueKey();
     await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          key: key,
-          body: CustomScrollView(
-            slivers: <Widget>[
-              SliverList.builder(
-                itemCount: 2,
-                itemBuilder: (BuildContext context, int index) {
-                  return Material(
-                    color: index.isEven ? Colors.yellow : Colors.red,
-                    child: InkWell(
-                      onTap: () {
-                        index.isEven ? firstTapped++ : secondTapped++;
-                      },
-                      child: Text('Index $index'),
-                    ),
-                  );
-                },
-              ),
-            ],
-          ),
+      _buildSliverTestApp(
+        child: CustomScrollView(
+          slivers: <Widget>[
+            SliverList.builder(
+              itemCount: 2,
+              itemBuilder: (BuildContext context, int index) {
+                return _buildIndexedTapTarget(
+                  index: index,
+                  onTap: () {
+                    index.isEven ? firstTapped++ : secondTapped++;
+                  },
+                );
+              },
+            ),
+          ],
         ),
       ),
     );
@@ -1172,29 +1167,22 @@ void main() {
   testWidgets('SliverList.builder can build children', (WidgetTester tester) async {
     var firstTapped = 0;
     var secondTapped = 0;
-    final Key key = UniqueKey();
     await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          key: key,
-          body: CustomScrollView(
-            slivers: <Widget>[
-              SliverList.builder(
-                itemCount: 2,
-                itemBuilder: (BuildContext context, int index) {
-                  return Material(
-                    color: index.isEven ? Colors.yellow : Colors.red,
-                    child: InkWell(
-                      onTap: () {
-                        index.isEven ? firstTapped++ : secondTapped++;
-                      },
-                      child: Text('Index $index'),
-                    ),
-                  );
-                },
-              ),
-            ],
-          ),
+      _buildSliverTestApp(
+        child: CustomScrollView(
+          slivers: <Widget>[
+            SliverList.builder(
+              itemCount: 2,
+              itemBuilder: (BuildContext context, int index) {
+                return _buildIndexedTapTarget(
+                  index: index,
+                  onTap: () {
+                    index.isEven ? firstTapped++ : secondTapped++;
+                  },
+                );
+              },
+            ),
+          ],
         ),
       ),
     );
@@ -1212,30 +1200,23 @@ void main() {
   testWidgets('SliverList.separated can build children', (WidgetTester tester) async {
     var firstTapped = 0;
     var secondTapped = 0;
-    final Key key = UniqueKey();
     await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          key: key,
-          body: CustomScrollView(
-            slivers: <Widget>[
-              SliverList.separated(
-                itemCount: 2,
-                itemBuilder: (BuildContext context, int index) {
-                  return Material(
-                    color: index.isEven ? Colors.yellow : Colors.red,
-                    child: InkWell(
-                      onTap: () {
-                        index.isEven ? firstTapped++ : secondTapped++;
-                      },
-                      child: Text('Index $index'),
-                    ),
-                  );
-                },
-                separatorBuilder: (BuildContext context, int index) => Text('Separator $index'),
-              ),
-            ],
-          ),
+      _buildSliverTestApp(
+        child: CustomScrollView(
+          slivers: <Widget>[
+            SliverList.separated(
+              itemCount: 2,
+              itemBuilder: (BuildContext context, int index) {
+                return _buildIndexedTapTarget(
+                  index: index,
+                  onTap: () {
+                    index.isEven ? firstTapped++ : secondTapped++;
+                  },
+                );
+              },
+              separatorBuilder: (BuildContext context, int index) => Text('Separator $index'),
+            ),
+          ],
         ),
       ),
     );
@@ -1251,20 +1232,16 @@ void main() {
   });
 
   testWidgets('SliverList.separated has correct number of children', (WidgetTester tester) async {
-    final Key key = UniqueKey();
     await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          key: key,
-          body: CustomScrollView(
-            slivers: <Widget>[
-              SliverList.separated(
-                itemCount: 2,
-                itemBuilder: (BuildContext context, int index) => const Text('item'),
-                separatorBuilder: (BuildContext context, int index) => const Text('separator'),
-              ),
-            ],
-          ),
+      _buildSliverTestApp(
+        child: CustomScrollView(
+          slivers: <Widget>[
+            SliverList.separated(
+              itemCount: 2,
+              itemBuilder: (BuildContext context, int index) => const Text('item'),
+              separatorBuilder: (BuildContext context, int index) => const Text('separator'),
+            ),
+          ],
         ),
       ),
     );
@@ -1275,27 +1252,25 @@ void main() {
   testWidgets('SliverList.list can build children', (WidgetTester tester) async {
     var firstTapped = 0;
     var secondTapped = 0;
-    final Key key = UniqueKey();
     await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          key: key,
-          body: CustomScrollView(
-            slivers: <Widget>[
-              SliverList.list(
-                children: <Widget>[
-                  Material(
-                    color: Colors.yellow,
-                    child: InkWell(onTap: () => firstTapped++, child: const Text('Index 0')),
-                  ),
-                  Material(
-                    color: Colors.red,
-                    child: InkWell(onTap: () => secondTapped++, child: const Text('Index 1')),
-                  ),
-                ],
-              ),
-            ],
-          ),
+      _buildSliverTestApp(
+        child: CustomScrollView(
+          slivers: <Widget>[
+            SliverList.list(
+              children: <Widget>[
+                _buildTapTarget(
+                  label: 'Index 0',
+                  color: _debugEvenColor,
+                  onTap: () => firstTapped++,
+                ),
+                _buildTapTarget(
+                  label: 'Index 1',
+                  color: _debugOddColor,
+                  onTap: () => secondTapped++,
+                ),
+              ],
+            ),
+          ],
         ),
       ),
     );
@@ -1313,30 +1288,23 @@ void main() {
   testWidgets('SliverFixedExtentList.builder can build children', (WidgetTester tester) async {
     var firstTapped = 0;
     var secondTapped = 0;
-    final Key key = UniqueKey();
     await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          key: key,
-          body: CustomScrollView(
-            slivers: <Widget>[
-              SliverFixedExtentList.builder(
-                itemCount: 2,
-                itemExtent: 100,
-                itemBuilder: (BuildContext context, int index) {
-                  return Material(
-                    color: index.isEven ? Colors.yellow : Colors.red,
-                    child: InkWell(
-                      onTap: () {
-                        index.isEven ? firstTapped++ : secondTapped++;
-                      },
-                      child: Text('Index $index'),
-                    ),
-                  );
-                },
-              ),
-            ],
-          ),
+      _buildSliverTestApp(
+        child: CustomScrollView(
+          slivers: <Widget>[
+            SliverFixedExtentList.builder(
+              itemCount: 2,
+              itemExtent: 100,
+              itemBuilder: (BuildContext context, int index) {
+                return _buildIndexedTapTarget(
+                  index: index,
+                  onTap: () {
+                    index.isEven ? firstTapped++ : secondTapped++;
+                  },
+                );
+              },
+            ),
+          ],
         ),
       ),
     );
@@ -1353,28 +1321,26 @@ void main() {
   testWidgets('SliverList.list can build children', (WidgetTester tester) async {
     var firstTapped = 0;
     var secondTapped = 0;
-    final Key key = UniqueKey();
     await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          key: key,
-          body: CustomScrollView(
-            slivers: <Widget>[
-              SliverFixedExtentList.list(
-                itemExtent: 100,
-                children: <Widget>[
-                  Material(
-                    color: Colors.yellow,
-                    child: InkWell(onTap: () => firstTapped++, child: const Text('Index 0')),
-                  ),
-                  Material(
-                    color: Colors.red,
-                    child: InkWell(onTap: () => secondTapped++, child: const Text('Index 1')),
-                  ),
-                ],
-              ),
-            ],
-          ),
+      _buildSliverTestApp(
+        child: CustomScrollView(
+          slivers: <Widget>[
+            SliverFixedExtentList.list(
+              itemExtent: 100,
+              children: <Widget>[
+                _buildTapTarget(
+                  label: 'Index 0',
+                  color: _debugEvenColor,
+                  onTap: () => firstTapped++,
+                ),
+                _buildTapTarget(
+                  label: 'Index 1',
+                  color: _debugOddColor,
+                  onTap: () => secondTapped++,
+                ),
+              ],
+            ),
+          ],
         ),
       ),
     );
@@ -1392,30 +1358,23 @@ void main() {
   testWidgets('SliverGrid.builder can build children', (WidgetTester tester) async {
     var firstTapped = 0;
     var secondTapped = 0;
-    final Key key = UniqueKey();
     await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          key: key,
-          body: CustomScrollView(
-            slivers: <Widget>[
-              SliverGrid.builder(
-                itemCount: 2,
-                itemBuilder: (BuildContext context, int index) {
-                  return Material(
-                    color: index.isEven ? Colors.yellow : Colors.red,
-                    child: InkWell(
-                      onTap: () {
-                        index.isEven ? firstTapped++ : secondTapped++;
-                      },
-                      child: Text('Index $index'),
-                    ),
-                  );
-                },
-                gridDelegate: _TestArbitrarySliverGridDelegate(),
-              ),
-            ],
-          ),
+      _buildSliverTestApp(
+        child: CustomScrollView(
+          slivers: <Widget>[
+            SliverGrid.builder(
+              itemCount: 2,
+              itemBuilder: (BuildContext context, int index) {
+                return _buildIndexedTapTarget(
+                  index: index,
+                  onTap: () {
+                    index.isEven ? firstTapped++ : secondTapped++;
+                  },
+                );
+              },
+              gridDelegate: _TestArbitrarySliverGridDelegate(),
+            ),
+          ],
         ),
       ),
     );
@@ -1433,28 +1392,22 @@ void main() {
   testWidgets('SliverGrid.list can display children', (WidgetTester tester) async {
     var firstTapped = 0;
     var secondTapped = 0;
-    final Key key = UniqueKey();
     await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          key: key,
-          body: CustomScrollView(
-            slivers: <Widget>[
-              SliverGrid.list(
-                gridDelegate: _TestArbitrarySliverGridDelegate(),
-                children: <Widget>[
-                  Material(
-                    color: Colors.yellow,
-                    child: InkWell(onTap: () => firstTapped++, child: const Text('First')),
-                  ),
-                  Material(
-                    color: Colors.red,
-                    child: InkWell(onTap: () => secondTapped++, child: const Text('Second')),
-                  ),
-                ],
-              ),
-            ],
-          ),
+      _buildSliverTestApp(
+        child: CustomScrollView(
+          slivers: <Widget>[
+            SliverGrid.list(
+              gridDelegate: _TestArbitrarySliverGridDelegate(),
+              children: <Widget>[
+                _buildTapTarget(label: 'First', color: _debugEvenColor, onTap: () => firstTapped++),
+                _buildTapTarget(
+                  label: 'Second',
+                  color: _debugOddColor,
+                  onTap: () => secondTapped++,
+                ),
+              ],
+            ),
+          ],
         ),
       ),
     );
@@ -1471,16 +1424,14 @@ void main() {
 
   testWidgets('SliverGrid.list with empty children list', (WidgetTester tester) async {
     await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: CustomScrollView(
-            slivers: <Widget>[
-              SliverGrid.list(
-                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 2),
-                children: const <Widget>[],
-              ),
-            ],
-          ),
+      _buildSliverTestApp(
+        child: CustomScrollView(
+          slivers: <Widget>[
+            SliverGrid.list(
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 2),
+              children: const <Widget>[],
+            ),
+          ],
         ),
       ),
     );
@@ -1491,20 +1442,18 @@ void main() {
 
   testWidgets('SliverGrid.builder respects semanticIndexOffset', (WidgetTester tester) async {
     await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: CustomScrollView(
-            slivers: <Widget>[
-              SliverGrid.builder(
-                itemCount: 3,
-                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 2),
-                semanticIndexOffset: 7,
-                itemBuilder: (BuildContext context, int index) {
-                  return Center(child: Text('G $index'));
-                },
-              ),
-            ],
-          ),
+      _buildSliverTestApp(
+        child: CustomScrollView(
+          slivers: <Widget>[
+            SliverGrid.builder(
+              itemCount: 3,
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 2),
+              semanticIndexOffset: 7,
+              itemBuilder: (BuildContext context, int index) {
+                return Center(child: Text('G $index'));
+              },
+            ),
+          ],
         ),
       ),
     );
@@ -1535,22 +1484,20 @@ void main() {
 
     // SliverGridDelegateWithFixedCrossAxisCount
     await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: CustomScrollView(
-            controller: controller,
-            slivers: <Widget>[
-              SliverGrid.builder(
-                itemCount: 0,
-                itemBuilder: (_, _) => Container(),
-                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                  crossAxisCount: 1,
-                  mainAxisSpacing: 10,
-                  childAspectRatio: 2.1,
-                ),
+      _buildSliverTestApp(
+        child: CustomScrollView(
+          controller: controller,
+          slivers: <Widget>[
+            SliverGrid.builder(
+              itemCount: 0,
+              itemBuilder: (_, _) => Container(),
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: 1,
+                mainAxisSpacing: 10,
+                childAspectRatio: 2.1,
               ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );
@@ -1560,20 +1507,16 @@ void main() {
 
     // SliverGridDelegateWithMaxCrossAxisExtent
     await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: CustomScrollView(
-            controller: controller,
-            slivers: <Widget>[
-              SliverGrid.builder(
-                itemCount: 0,
-                itemBuilder: (_, _) => Container(),
-                gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
-                  maxCrossAxisExtent: 30,
-                ),
-              ),
-            ],
-          ),
+      _buildSliverTestApp(
+        child: CustomScrollView(
+          controller: controller,
+          slivers: <Widget>[
+            SliverGrid.builder(
+              itemCount: 0,
+              itemBuilder: (_, _) => Container(),
+              gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(maxCrossAxisExtent: 30),
+            ),
+          ],
         ),
       ),
     );

--- a/packages/flutter/test/widgets/slivers_test.dart
+++ b/packages/flutter/test/widgets/slivers_test.dart
@@ -72,12 +72,6 @@ void verify(WidgetTester tester, List<Offset> idealPositions, List<bool> idealVi
   expect(actualVisibles, equals(idealVisibles));
 }
 
-Widget _buildSliverTestApp({required Widget child, Key? key}) {
-  return TestWidgetsApp(
-    home: SizedBox.expand(key: key, child: child),
-  );
-}
-
 Widget _buildIndexedTapTarget({required int index, required VoidCallback onTap}) {
   return GestureDetector(
     behavior: HitTestBehavior.opaque,
@@ -734,15 +728,15 @@ void main() {
     },
   );
 
-  Widget boilerPlate(List<Widget> slivers) {
-    return TestWidgetsApp(home: CustomScrollView(slivers: slivers));
-  }
-
   group('SliverOffstage - ', () {
     testWidgets('offstage true', (WidgetTester tester) async {
       final semantics = SemanticsTester(tester);
       await tester.pumpWidget(
-        boilerPlate(<Widget>[const SliverOffstage(sliver: SliverToBoxAdapter(child: Text('a')))]),
+        const TestWidgetsApp(
+          home: CustomScrollView(
+            slivers: <Widget>[SliverOffstage(sliver: SliverToBoxAdapter(child: Text('a')))],
+          ),
+        ),
       );
 
       expect(semantics.nodesWith(label: 'a'), hasLength(0));
@@ -757,9 +751,13 @@ void main() {
     testWidgets('offstage false', (WidgetTester tester) async {
       final semantics = SemanticsTester(tester);
       await tester.pumpWidget(
-        boilerPlate(<Widget>[
-          const SliverOffstage(offstage: false, sliver: SliverToBoxAdapter(child: Text('a'))),
-        ]),
+        const TestWidgetsApp(
+          home: CustomScrollView(
+            slivers: <Widget>[
+              SliverOffstage(offstage: false, sliver: SliverToBoxAdapter(child: Text('a'))),
+            ],
+          ),
+        ),
       );
 
       expect(semantics.nodesWith(label: 'a'), hasLength(1));
@@ -778,12 +776,16 @@ void main() {
 
       // Opacity 1.0: Semantics and painting
       await tester.pumpWidget(
-        boilerPlate(<Widget>[
-          const SliverOpacity(
-            sliver: SliverToBoxAdapter(child: Text('a', textDirection: TextDirection.rtl)),
-            opacity: 1.0,
+        const TestWidgetsApp(
+          home: CustomScrollView(
+            slivers: <Widget>[
+              SliverOpacity(
+                sliver: SliverToBoxAdapter(child: Text('a', textDirection: TextDirection.rtl)),
+                opacity: 1.0,
+              ),
+            ],
           ),
-        ]),
+        ),
       );
 
       expect(semantics.nodesWith(label: 'a'), hasLength(1));
@@ -791,12 +793,16 @@ void main() {
 
       // Opacity 0.0: Nothing
       await tester.pumpWidget(
-        boilerPlate(<Widget>[
-          const SliverOpacity(
-            sliver: SliverToBoxAdapter(child: Text('a', textDirection: TextDirection.rtl)),
-            opacity: 0.0,
+        const TestWidgetsApp(
+          home: CustomScrollView(
+            slivers: <Widget>[
+              SliverOpacity(
+                sliver: SliverToBoxAdapter(child: Text('a', textDirection: TextDirection.rtl)),
+                opacity: 0.0,
+              ),
+            ],
           ),
-        ]),
+        ),
       );
 
       expect(semantics.nodesWith(label: 'a'), hasLength(0));
@@ -804,13 +810,17 @@ void main() {
 
       // Opacity 0.0 with semantics: Just semantics
       await tester.pumpWidget(
-        boilerPlate(<Widget>[
-          const SliverOpacity(
-            sliver: SliverToBoxAdapter(child: Text('a', textDirection: TextDirection.rtl)),
-            opacity: 0.0,
-            alwaysIncludeSemantics: true,
+        const TestWidgetsApp(
+          home: CustomScrollView(
+            slivers: <Widget>[
+              SliverOpacity(
+                sliver: SliverToBoxAdapter(child: Text('a', textDirection: TextDirection.rtl)),
+                opacity: 0.0,
+                alwaysIncludeSemantics: true,
+              ),
+            ],
           ),
-        ]),
+        ),
       );
 
       expect(semantics.nodesWith(label: 'a'), hasLength(1));
@@ -818,12 +828,16 @@ void main() {
 
       // Opacity 0.0 without semantics: Nothing
       await tester.pumpWidget(
-        boilerPlate(<Widget>[
-          const SliverOpacity(
-            sliver: SliverToBoxAdapter(child: Text('a', textDirection: TextDirection.rtl)),
-            opacity: 0.0,
+        const TestWidgetsApp(
+          home: CustomScrollView(
+            slivers: <Widget>[
+              SliverOpacity(
+                sliver: SliverToBoxAdapter(child: Text('a', textDirection: TextDirection.rtl)),
+                opacity: 0.0,
+              ),
+            ],
           ),
-        ]),
+        ),
       );
 
       expect(semantics.nodesWith(label: 'a'), hasLength(0));
@@ -831,12 +845,16 @@ void main() {
 
       // Opacity 0.1: Semantics and painting
       await tester.pumpWidget(
-        boilerPlate(<Widget>[
-          const SliverOpacity(
-            sliver: SliverToBoxAdapter(child: Text('a', textDirection: TextDirection.rtl)),
-            opacity: 0.1,
+        const TestWidgetsApp(
+          home: CustomScrollView(
+            slivers: <Widget>[
+              SliverOpacity(
+                sliver: SliverToBoxAdapter(child: Text('a', textDirection: TextDirection.rtl)),
+                opacity: 0.1,
+              ),
+            ],
           ),
-        ]),
+        ),
       );
 
       expect(semantics.nodesWith(label: 'a'), hasLength(1));
@@ -844,12 +862,16 @@ void main() {
 
       // Opacity 0.1 without semantics: Still has semantics and painting
       await tester.pumpWidget(
-        boilerPlate(<Widget>[
-          const SliverOpacity(
-            sliver: SliverToBoxAdapter(child: Text('a', textDirection: TextDirection.rtl)),
-            opacity: 0.1,
+        const TestWidgetsApp(
+          home: CustomScrollView(
+            slivers: <Widget>[
+              SliverOpacity(
+                sliver: SliverToBoxAdapter(child: Text('a', textDirection: TextDirection.rtl)),
+                opacity: 0.1,
+              ),
+            ],
           ),
-        ]),
+        ),
       );
 
       expect(semantics.nodesWith(label: 'a'), hasLength(1));
@@ -857,13 +879,17 @@ void main() {
 
       // Opacity 0.1 with semantics: Semantics and painting
       await tester.pumpWidget(
-        boilerPlate(<Widget>[
-          const SliverOpacity(
-            sliver: SliverToBoxAdapter(child: Text('a', textDirection: TextDirection.rtl)),
-            opacity: 0.1,
-            alwaysIncludeSemantics: true,
+        const TestWidgetsApp(
+          home: CustomScrollView(
+            slivers: <Widget>[
+              SliverOpacity(
+                sliver: SliverToBoxAdapter(child: Text('a', textDirection: TextDirection.rtl)),
+                opacity: 0.1,
+                alwaysIncludeSemantics: true,
+              ),
+            ],
           ),
-        ]),
+        ),
       );
 
       expect(semantics.nodesWith(label: 'a'), hasLength(1));
@@ -878,19 +904,23 @@ void main() {
       final semantics = SemanticsTester(tester);
       final events = <String>[];
       await tester.pumpWidget(
-        boilerPlate(<Widget>[
-          SliverIgnorePointer(
-            ignoringSemantics: false,
-            sliver: SliverToBoxAdapter(
-              child: GestureDetector(
-                child: const Text('a'),
-                onTap: () {
-                  events.add('tap');
-                },
+        TestWidgetsApp(
+          home: CustomScrollView(
+            slivers: <Widget>[
+              SliverIgnorePointer(
+                ignoringSemantics: false,
+                sliver: SliverToBoxAdapter(
+                  child: GestureDetector(
+                    child: const Text('a'),
+                    onTap: () {
+                      events.add('tap');
+                    },
+                  ),
+                ),
               ),
-            ),
+            ],
           ),
-        ]),
+        ),
       );
       expect(semantics.nodesWith(label: 'a'), hasLength(1));
       await tester.tap(find.byType(GestureDetector), warnIfMissed: false);
@@ -902,20 +932,24 @@ void main() {
       final semantics = SemanticsTester(tester);
       final events = <String>[];
       await tester.pumpWidget(
-        boilerPlate(<Widget>[
-          SliverIgnorePointer(
-            ignoring: false,
-            ignoringSemantics: true,
-            sliver: SliverToBoxAdapter(
-              child: GestureDetector(
-                child: const Text('a'),
-                onTap: () {
-                  events.add('tap');
-                },
+        TestWidgetsApp(
+          home: CustomScrollView(
+            slivers: <Widget>[
+              SliverIgnorePointer(
+                ignoring: false,
+                ignoringSemantics: true,
+                sliver: SliverToBoxAdapter(
+                  child: GestureDetector(
+                    child: const Text('a'),
+                    onTap: () {
+                      events.add('tap');
+                    },
+                  ),
+                ),
               ),
-            ),
+            ],
           ),
-        ]),
+        ),
       );
       expect(semantics.nodesWith(label: 'a'), hasLength(0));
       await tester.tap(find.byType(GestureDetector));
@@ -926,13 +960,17 @@ void main() {
     testWidgets('ignoring only block semantics actions', (WidgetTester tester) async {
       final semantics = SemanticsTester(tester);
       await tester.pumpWidget(
-        boilerPlate(<Widget>[
-          SliverIgnorePointer(
-            sliver: SliverToBoxAdapter(
-              child: GestureDetector(child: const Text('a'), onTap: () {}),
-            ),
+        TestWidgetsApp(
+          home: CustomScrollView(
+            slivers: <Widget>[
+              SliverIgnorePointer(
+                sliver: SliverToBoxAdapter(
+                  child: GestureDetector(child: const Text('a'), onTap: () {}),
+                ),
+              ),
+            ],
           ),
-        ]),
+        ),
       );
       expect(semantics, includesNodeWith(label: 'a', actions: <SemanticsAction>[]));
       semantics.dispose();
@@ -942,19 +980,23 @@ void main() {
       final semantics = SemanticsTester(tester);
       final events = <String>[];
       await tester.pumpWidget(
-        boilerPlate(<Widget>[
-          SliverIgnorePointer(
-            ignoringSemantics: true,
-            sliver: SliverToBoxAdapter(
-              child: GestureDetector(
-                child: const Text('a'),
-                onTap: () {
-                  events.add('tap');
-                },
+        TestWidgetsApp(
+          home: CustomScrollView(
+            slivers: <Widget>[
+              SliverIgnorePointer(
+                ignoringSemantics: true,
+                sliver: SliverToBoxAdapter(
+                  child: GestureDetector(
+                    child: const Text('a'),
+                    onTap: () {
+                      events.add('tap');
+                    },
+                  ),
+                ),
               ),
-            ),
+            ],
           ),
-        ]),
+        ),
       );
       expect(semantics.nodesWith(label: 'a'), hasLength(0));
       await tester.tap(find.byType(GestureDetector), warnIfMissed: false);
@@ -966,20 +1008,24 @@ void main() {
       final semantics = SemanticsTester(tester);
       final events = <String>[];
       await tester.pumpWidget(
-        boilerPlate(<Widget>[
-          SliverIgnorePointer(
-            ignoring: false,
-            ignoringSemantics: false,
-            sliver: SliverToBoxAdapter(
-              child: GestureDetector(
-                child: const Text('a'),
-                onTap: () {
-                  events.add('tap');
-                },
+        TestWidgetsApp(
+          home: CustomScrollView(
+            slivers: <Widget>[
+              SliverIgnorePointer(
+                ignoring: false,
+                ignoringSemantics: false,
+                sliver: SliverToBoxAdapter(
+                  child: GestureDetector(
+                    child: const Text('a'),
+                    onTap: () {
+                      events.add('tap');
+                    },
+                  ),
+                ),
               ),
-            ),
+            ],
           ),
-        ]),
+        ),
       );
       expect(semantics.nodesWith(label: 'a'), hasLength(1));
       await tester.tap(find.byType(GestureDetector));
@@ -992,22 +1038,26 @@ void main() {
     testWidgets('ensure semantics', (WidgetTester tester) async {
       final semantics = SemanticsTester(tester);
       await tester.pumpWidget(
-        boilerPlate(<Widget>[
-          const SliverEnsureSemantics(sliver: SliverToBoxAdapter(child: Text('a'))),
-          SliverList(
-            delegate: SliverChildBuilderDelegate(
-              (BuildContext context, int index) {
-                return Padding(
-                  padding: const EdgeInsets.all(8.0),
-                  child: Text('Lorem Ipsum $index'),
-                );
-              },
-              childCount: 50,
-              semanticIndexOffset: 1,
-            ),
+        TestWidgetsApp(
+          home: CustomScrollView(
+            slivers: <Widget>[
+              const SliverEnsureSemantics(sliver: SliverToBoxAdapter(child: Text('a'))),
+              SliverList(
+                delegate: SliverChildBuilderDelegate(
+                  (BuildContext context, int index) {
+                    return Padding(
+                      padding: const EdgeInsets.all(8.0),
+                      child: Text('Lorem Ipsum $index'),
+                    );
+                  },
+                  childCount: 50,
+                  semanticIndexOffset: 1,
+                ),
+              ),
+              const SliverEnsureSemantics(sliver: SliverToBoxAdapter(child: Text('b'))),
+            ],
           ),
-          const SliverEnsureSemantics(sliver: SliverToBoxAdapter(child: Text('b'))),
-        ]),
+        ),
       );
 
       // Even though 'b' is outside of the Viewport and cacheExtent, since it is
@@ -1023,14 +1073,16 @@ void main() {
   testWidgets('SliverList handles 0 scrollOffsetCorrection', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/62198
     await tester.pumpWidget(
-      _buildSliverTestApp(
-        child: CustomScrollView(
-          physics: const BouncingScrollPhysics(parent: AlwaysScrollableScrollPhysics()),
-          slivers: <Widget>[
-            SliverList.list(
-              children: const <Widget>[SizedBox.shrink(), Text('index 1'), Text('index 2')],
-            ),
-          ],
+      TestWidgetsApp(
+        home: SizedBox.expand(
+          child: CustomScrollView(
+            physics: const BouncingScrollPhysics(parent: AlwaysScrollableScrollPhysics()),
+            slivers: <Widget>[
+              SliverList.list(
+                children: const <Widget>[SizedBox.shrink(), Text('index 1'), Text('index 2')],
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -1045,22 +1097,24 @@ void main() {
     var secondTapped = 0;
     final Key key = UniqueKey();
     await tester.pumpWidget(
-      _buildSliverTestApp(
-        key: key,
-        child: CustomScrollView(
-          slivers: <Widget>[
-            SliverGrid(
-              delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
-                return _buildIndexedTapTarget(
-                  index: index,
-                  onTap: () {
-                    index.isEven ? firstTapped++ : secondTapped++;
-                  },
-                );
-              }, childCount: 2),
-              gridDelegate: _TestArbitrarySliverGridDelegate(),
-            ),
-          ],
+      TestWidgetsApp(
+        home: SizedBox.expand(
+          key: key,
+          child: CustomScrollView(
+            slivers: <Widget>[
+              SliverGrid(
+                delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+                  return _buildIndexedTapTarget(
+                    index: index,
+                    onTap: () {
+                      index.isEven ? firstTapped++ : secondTapped++;
+                    },
+                  );
+                }, childCount: 2),
+                gridDelegate: _TestArbitrarySliverGridDelegate(),
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -1135,21 +1189,23 @@ void main() {
     var firstTapped = 0;
     var secondTapped = 0;
     await tester.pumpWidget(
-      _buildSliverTestApp(
-        child: CustomScrollView(
-          slivers: <Widget>[
-            SliverList.builder(
-              itemCount: 2,
-              itemBuilder: (BuildContext context, int index) {
-                return _buildIndexedTapTarget(
-                  index: index,
-                  onTap: () {
-                    index.isEven ? firstTapped++ : secondTapped++;
-                  },
-                );
-              },
-            ),
-          ],
+      TestWidgetsApp(
+        home: SizedBox.expand(
+          child: CustomScrollView(
+            slivers: <Widget>[
+              SliverList.builder(
+                itemCount: 2,
+                itemBuilder: (BuildContext context, int index) {
+                  return _buildIndexedTapTarget(
+                    index: index,
+                    onTap: () {
+                      index.isEven ? firstTapped++ : secondTapped++;
+                    },
+                  );
+                },
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -1168,21 +1224,23 @@ void main() {
     var firstTapped = 0;
     var secondTapped = 0;
     await tester.pumpWidget(
-      _buildSliverTestApp(
-        child: CustomScrollView(
-          slivers: <Widget>[
-            SliverList.builder(
-              itemCount: 2,
-              itemBuilder: (BuildContext context, int index) {
-                return _buildIndexedTapTarget(
-                  index: index,
-                  onTap: () {
-                    index.isEven ? firstTapped++ : secondTapped++;
-                  },
-                );
-              },
-            ),
-          ],
+      TestWidgetsApp(
+        home: SizedBox.expand(
+          child: CustomScrollView(
+            slivers: <Widget>[
+              SliverList.builder(
+                itemCount: 2,
+                itemBuilder: (BuildContext context, int index) {
+                  return _buildIndexedTapTarget(
+                    index: index,
+                    onTap: () {
+                      index.isEven ? firstTapped++ : secondTapped++;
+                    },
+                  );
+                },
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -1201,22 +1259,24 @@ void main() {
     var firstTapped = 0;
     var secondTapped = 0;
     await tester.pumpWidget(
-      _buildSliverTestApp(
-        child: CustomScrollView(
-          slivers: <Widget>[
-            SliverList.separated(
-              itemCount: 2,
-              itemBuilder: (BuildContext context, int index) {
-                return _buildIndexedTapTarget(
-                  index: index,
-                  onTap: () {
-                    index.isEven ? firstTapped++ : secondTapped++;
-                  },
-                );
-              },
-              separatorBuilder: (BuildContext context, int index) => Text('Separator $index'),
-            ),
-          ],
+      TestWidgetsApp(
+        home: SizedBox.expand(
+          child: CustomScrollView(
+            slivers: <Widget>[
+              SliverList.separated(
+                itemCount: 2,
+                itemBuilder: (BuildContext context, int index) {
+                  return _buildIndexedTapTarget(
+                    index: index,
+                    onTap: () {
+                      index.isEven ? firstTapped++ : secondTapped++;
+                    },
+                  );
+                },
+                separatorBuilder: (BuildContext context, int index) => Text('Separator $index'),
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -1233,15 +1293,17 @@ void main() {
 
   testWidgets('SliverList.separated has correct number of children', (WidgetTester tester) async {
     await tester.pumpWidget(
-      _buildSliverTestApp(
-        child: CustomScrollView(
-          slivers: <Widget>[
-            SliverList.separated(
-              itemCount: 2,
-              itemBuilder: (BuildContext context, int index) => const Text('item'),
-              separatorBuilder: (BuildContext context, int index) => const Text('separator'),
-            ),
-          ],
+      TestWidgetsApp(
+        home: SizedBox.expand(
+          child: CustomScrollView(
+            slivers: <Widget>[
+              SliverList.separated(
+                itemCount: 2,
+                itemBuilder: (BuildContext context, int index) => const Text('item'),
+                separatorBuilder: (BuildContext context, int index) => const Text('separator'),
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -1253,24 +1315,26 @@ void main() {
     var firstTapped = 0;
     var secondTapped = 0;
     await tester.pumpWidget(
-      _buildSliverTestApp(
-        child: CustomScrollView(
-          slivers: <Widget>[
-            SliverList.list(
-              children: <Widget>[
-                _buildTapTarget(
-                  label: 'Index 0',
-                  color: _debugEvenColor,
-                  onTap: () => firstTapped++,
-                ),
-                _buildTapTarget(
-                  label: 'Index 1',
-                  color: _debugOddColor,
-                  onTap: () => secondTapped++,
-                ),
-              ],
-            ),
-          ],
+      TestWidgetsApp(
+        home: SizedBox.expand(
+          child: CustomScrollView(
+            slivers: <Widget>[
+              SliverList.list(
+                children: <Widget>[
+                  _buildTapTarget(
+                    label: 'Index 0',
+                    color: _debugEvenColor,
+                    onTap: () => firstTapped++,
+                  ),
+                  _buildTapTarget(
+                    label: 'Index 1',
+                    color: _debugOddColor,
+                    onTap: () => secondTapped++,
+                  ),
+                ],
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -1289,22 +1353,24 @@ void main() {
     var firstTapped = 0;
     var secondTapped = 0;
     await tester.pumpWidget(
-      _buildSliverTestApp(
-        child: CustomScrollView(
-          slivers: <Widget>[
-            SliverFixedExtentList.builder(
-              itemCount: 2,
-              itemExtent: 100,
-              itemBuilder: (BuildContext context, int index) {
-                return _buildIndexedTapTarget(
-                  index: index,
-                  onTap: () {
-                    index.isEven ? firstTapped++ : secondTapped++;
-                  },
-                );
-              },
-            ),
-          ],
+      TestWidgetsApp(
+        home: SizedBox.expand(
+          child: CustomScrollView(
+            slivers: <Widget>[
+              SliverFixedExtentList.builder(
+                itemCount: 2,
+                itemExtent: 100,
+                itemBuilder: (BuildContext context, int index) {
+                  return _buildIndexedTapTarget(
+                    index: index,
+                    onTap: () {
+                      index.isEven ? firstTapped++ : secondTapped++;
+                    },
+                  );
+                },
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -1322,25 +1388,27 @@ void main() {
     var firstTapped = 0;
     var secondTapped = 0;
     await tester.pumpWidget(
-      _buildSliverTestApp(
-        child: CustomScrollView(
-          slivers: <Widget>[
-            SliverFixedExtentList.list(
-              itemExtent: 100,
-              children: <Widget>[
-                _buildTapTarget(
-                  label: 'Index 0',
-                  color: _debugEvenColor,
-                  onTap: () => firstTapped++,
-                ),
-                _buildTapTarget(
-                  label: 'Index 1',
-                  color: _debugOddColor,
-                  onTap: () => secondTapped++,
-                ),
-              ],
-            ),
-          ],
+      TestWidgetsApp(
+        home: SizedBox.expand(
+          child: CustomScrollView(
+            slivers: <Widget>[
+              SliverFixedExtentList.list(
+                itemExtent: 100,
+                children: <Widget>[
+                  _buildTapTarget(
+                    label: 'Index 0',
+                    color: _debugEvenColor,
+                    onTap: () => firstTapped++,
+                  ),
+                  _buildTapTarget(
+                    label: 'Index 1',
+                    color: _debugOddColor,
+                    onTap: () => secondTapped++,
+                  ),
+                ],
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -1359,22 +1427,24 @@ void main() {
     var firstTapped = 0;
     var secondTapped = 0;
     await tester.pumpWidget(
-      _buildSliverTestApp(
-        child: CustomScrollView(
-          slivers: <Widget>[
-            SliverGrid.builder(
-              itemCount: 2,
-              itemBuilder: (BuildContext context, int index) {
-                return _buildIndexedTapTarget(
-                  index: index,
-                  onTap: () {
-                    index.isEven ? firstTapped++ : secondTapped++;
-                  },
-                );
-              },
-              gridDelegate: _TestArbitrarySliverGridDelegate(),
-            ),
-          ],
+      TestWidgetsApp(
+        home: SizedBox.expand(
+          child: CustomScrollView(
+            slivers: <Widget>[
+              SliverGrid.builder(
+                itemCount: 2,
+                itemBuilder: (BuildContext context, int index) {
+                  return _buildIndexedTapTarget(
+                    index: index,
+                    onTap: () {
+                      index.isEven ? firstTapped++ : secondTapped++;
+                    },
+                  );
+                },
+                gridDelegate: _TestArbitrarySliverGridDelegate(),
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -1393,21 +1463,27 @@ void main() {
     var firstTapped = 0;
     var secondTapped = 0;
     await tester.pumpWidget(
-      _buildSliverTestApp(
-        child: CustomScrollView(
-          slivers: <Widget>[
-            SliverGrid.list(
-              gridDelegate: _TestArbitrarySliverGridDelegate(),
-              children: <Widget>[
-                _buildTapTarget(label: 'First', color: _debugEvenColor, onTap: () => firstTapped++),
-                _buildTapTarget(
-                  label: 'Second',
-                  color: _debugOddColor,
-                  onTap: () => secondTapped++,
-                ),
-              ],
-            ),
-          ],
+      TestWidgetsApp(
+        home: SizedBox.expand(
+          child: CustomScrollView(
+            slivers: <Widget>[
+              SliverGrid.list(
+                gridDelegate: _TestArbitrarySliverGridDelegate(),
+                children: <Widget>[
+                  _buildTapTarget(
+                    label: 'First',
+                    color: _debugEvenColor,
+                    onTap: () => firstTapped++,
+                  ),
+                  _buildTapTarget(
+                    label: 'Second',
+                    color: _debugOddColor,
+                    onTap: () => secondTapped++,
+                  ),
+                ],
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -1424,14 +1500,16 @@ void main() {
 
   testWidgets('SliverGrid.list with empty children list', (WidgetTester tester) async {
     await tester.pumpWidget(
-      _buildSliverTestApp(
-        child: CustomScrollView(
-          slivers: <Widget>[
-            SliverGrid.list(
-              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 2),
-              children: const <Widget>[],
-            ),
-          ],
+      TestWidgetsApp(
+        home: SizedBox.expand(
+          child: CustomScrollView(
+            slivers: <Widget>[
+              SliverGrid.list(
+                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 2),
+                children: const <Widget>[],
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -1442,18 +1520,20 @@ void main() {
 
   testWidgets('SliverGrid.builder respects semanticIndexOffset', (WidgetTester tester) async {
     await tester.pumpWidget(
-      _buildSliverTestApp(
-        child: CustomScrollView(
-          slivers: <Widget>[
-            SliverGrid.builder(
-              itemCount: 3,
-              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 2),
-              semanticIndexOffset: 7,
-              itemBuilder: (BuildContext context, int index) {
-                return Center(child: Text('G $index'));
-              },
-            ),
-          ],
+      TestWidgetsApp(
+        home: SizedBox.expand(
+          child: CustomScrollView(
+            slivers: <Widget>[
+              SliverGrid.builder(
+                itemCount: 3,
+                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 2),
+                semanticIndexOffset: 7,
+                itemBuilder: (BuildContext context, int index) {
+                  return Center(child: Text('G $index'));
+                },
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -1484,20 +1564,22 @@ void main() {
 
     // SliverGridDelegateWithFixedCrossAxisCount
     await tester.pumpWidget(
-      _buildSliverTestApp(
-        child: CustomScrollView(
-          controller: controller,
-          slivers: <Widget>[
-            SliverGrid.builder(
-              itemCount: 0,
-              itemBuilder: (_, _) => Container(),
-              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                crossAxisCount: 1,
-                mainAxisSpacing: 10,
-                childAspectRatio: 2.1,
+      TestWidgetsApp(
+        home: SizedBox.expand(
+          child: CustomScrollView(
+            controller: controller,
+            slivers: <Widget>[
+              SliverGrid.builder(
+                itemCount: 0,
+                itemBuilder: (_, _) => Container(),
+                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: 1,
+                  mainAxisSpacing: 10,
+                  childAspectRatio: 2.1,
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );
@@ -1507,16 +1589,20 @@ void main() {
 
     // SliverGridDelegateWithMaxCrossAxisExtent
     await tester.pumpWidget(
-      _buildSliverTestApp(
-        child: CustomScrollView(
-          controller: controller,
-          slivers: <Widget>[
-            SliverGrid.builder(
-              itemCount: 0,
-              itemBuilder: (_, _) => Container(),
-              gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(maxCrossAxisExtent: 30),
-            ),
-          ],
+      TestWidgetsApp(
+        home: SizedBox.expand(
+          child: CustomScrollView(
+            controller: controller,
+            slivers: <Widget>[
+              SliverGrid.builder(
+                itemCount: 0,
+                itemBuilder: (_, _) => Container(),
+                gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+                  maxCrossAxisExtent: 30,
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
This PR removes Material imports from baseline_test, slivers_test.

part of: https://github.com/flutter/flutter/issues/177415

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.