### PR TITLE
Update 'a: text input' globs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -44,8 +44,10 @@
   - changed-files:
     - all-globs-to-any-file:
       - '**/*text*'
+      - '**/*Text*'
       - '!**/*context*'
-      - '!**/*texture*'
+      - '!**/*Context*'
+      - '!**/*Texture*'
 
 'd: api docs':
   - changed-files:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -43,11 +43,9 @@
 'a: text input':
   - changed-files:
     - all-globs-to-any-file:
-      - '**/*text*'
-      - '**/*Text*'
-      - '!**/*context*'
-      - '!**/*Context*'
-      - '!**/*Texture*'
+      - '**/*[tT]ext*'
+      - '!**/*[cC]ontext*'
+      - '!**/*[tT]exture*'
 
 'd: api docs':
   - changed-files:


### PR DESCRIPTION
Ensure updates to iOS's text input plugin show up on the text input team's PR triage.

### Motivation

This PR updates the iOS text input plugin but does not have the expected `a: text input` label: https://github.com/flutter/flutter/pull/182661

<img width="512" height="109" alt="image" src="https://github.com/user-attachments/assets/a625f8f0-dad9-42f3-9542-820d64414b2e" />

### Explanation

GitHub's labeler uses `git ls-files` to find files that match the glob. It seems this is case sensitive and `**/*text*` does not match file `FlutterTextInputPlugin`:

```
$ git ls-files '**/*text*'
...
engine/src/flutter/shell/platform/embedder/tests/embedder_test_context_vulkan.h
engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/text-input/BUILD.gn
...
```

```
$ git ls-files '**/*[tT]ext*'
...
engine/src/flutter/shell/platform/embedder/tests/embedder_test_context_vulkan.h
...
engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.h
engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
...
engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/text-input/BUILD.gn
...
```

