### PR TITLE
Add macOS Xcode build failure diagnostics

### DIFF
--- a/packages/flutter_tools/lib/src/darwin/xcode_build_failure_diagnostics.dart
+++ b/packages/flutter_tools/lib/src/darwin/xcode_build_failure_diagnostics.dart
@@ -1,0 +1,194 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import '../base/file_system.dart';
+import '../base/version.dart';
+import '../convert.dart';
+import '../flutter_plugins.dart';
+import '../macos/swift_package_manager.dart';
+import '../plugins.dart';
+import '../project.dart';
+import 'darwin.dart';
+
+final class XcodeBuildFailureDiagnostics {
+  static XcodeBuildFailureOutputAnalysis analyzeOutput(String? output) {
+    if (output == null || output.isEmpty) {
+      return const XcodeBuildFailureOutputAnalysis();
+    }
+
+    final duplicateModules = <String>{};
+    final missingModules = <String>{};
+    XcodeBuildFailurePlatformMismatch? highestPlatformMismatch;
+
+    for (final RegExpMatch match in _swiftPackageManagerMinPlatformMismatchPattern.allMatches(
+      output,
+    )) {
+      final String? requiredByProduct = match.group(1);
+      final Version? requiredMinVersion = Version.parse(match.group(2));
+      final Version? targetSupportedVersion = Version.parse(match.group(4));
+      final String? targetName = match.group(5);
+      if (targetName != kFlutterGeneratedPluginSwiftPackageName ||
+          requiredByProduct == null ||
+          requiredMinVersion == null ||
+          targetSupportedVersion == null) {
+        continue;
+      }
+      if (highestPlatformMismatch == null ||
+          requiredMinVersion > highestPlatformMismatch.requiredVersion) {
+        highestPlatformMismatch = XcodeBuildFailurePlatformMismatch(
+          requiredByProduct: requiredByProduct,
+          requiredVersion: requiredMinVersion,
+          supportedVersion: targetSupportedVersion,
+        );
+      }
+    }
+
+    for (final String line in LineSplitter.split(output)) {
+      final String? duplicateModule = parseModuleRedefinition(line);
+      if (duplicateModule != null) {
+        duplicateModules.add(duplicateModule);
+      }
+
+      final String? missingModule = parseMissingModule(line);
+      if (missingModule != null) {
+        missingModules.add(missingModule);
+      }
+    }
+
+    final String? duplicateSymbolModule = parseDuplicateSymbols(output);
+    if (duplicateSymbolModule != null) {
+      duplicateModules.add(duplicateSymbolModule);
+    }
+
+    return XcodeBuildFailureOutputAnalysis(
+      platformMismatch: highestPlatformMismatch,
+      duplicateModules: duplicateModules,
+      missingModules: missingModules,
+    );
+  }
+
+  static String? parseModuleRedefinition(String message) {
+    final RegExpMatch? match = _moduleRedefinitionPattern.firstMatch(message);
+    return match?.group(1);
+  }
+
+  static String? parseDuplicateSymbols(String message) {
+    final RegExpMatch? match = _duplicateSymbolsPattern.firstMatch(message);
+    final String? module = match?.group(1);
+    if (module == null) {
+      return null;
+    }
+    return module.split('/').last.split('[').first.split('(').first;
+  }
+
+  static String? parseMissingModule(String message) {
+    final RegExpMatch? match = _missingModulePattern.firstMatch(message);
+    return match?.group(1);
+  }
+
+  static Future<List<String>> findSwiftPackageOnlyPlugins({
+    required FlutterDarwinPlatform platform,
+    required FlutterProject project,
+    required List<String> pluginNames,
+    required FileSystem fileSystem,
+  }) async {
+    final pluginsByName = <String, Plugin>{
+      for (final Plugin plugin in await findPlugins(project)) plugin.name.toLowerCase(): plugin,
+    };
+    final swiftPackageOnlyPlugins = <String>[];
+    for (final pluginName in pluginNames) {
+      final Plugin? matched = pluginsByName[pluginName.toLowerCase()];
+      if (matched == null || matched.platforms[platform.name] == null) {
+        continue;
+      }
+
+      final String? swiftPackagePath = matched.pluginSwiftPackageManifestPath(
+        fileSystem,
+        platform.name,
+      );
+      final bool swiftPackageExists =
+          swiftPackagePath != null && fileSystem.file(swiftPackagePath).existsSync();
+
+      final String? podspecPath = matched.pluginPodspecPath(fileSystem, platform.name);
+      final bool podspecExists = podspecPath != null && fileSystem.file(podspecPath).existsSync();
+
+      if (swiftPackageExists && !podspecExists) {
+        swiftPackageOnlyPlugins.add(pluginName);
+      }
+    }
+    return swiftPackageOnlyPlugins;
+  }
+
+  static String swiftPackageManagerMinPlatformMismatchMessage(
+    XcodeBuildFailurePlatformMismatch platformMismatch,
+  ) {
+    return '''
+To fix this error, increase your app's minimum platform version from ${platformMismatch.supportedVersion} to at least ${platformMismatch.requiredVersion} or remove the ${platformMismatch.requiredByProduct} dependency.
+
+To increase your app's minimum platform version, follow these instructions:
+  https://docs.flutter.dev/packages-and-plugins/swift-package-manager/for-app-developers#how-to-use-a-swift-package-manager-flutter-plugin-that-requires-a-higher-os-version
+''';
+  }
+
+  static String mixedDependencyManagerDuplicateModulesMessage({
+    required FlutterDarwinPlatform platform,
+    required List<String> duplicateModules,
+  }) {
+    final podfileLockPath = platform == FlutterDarwinPlatform.ios
+        ? 'ios/Podfile.lock'
+        : 'macos/Podfile.lock';
+    return 'Your project uses both CocoaPods and Swift Package Manager, which can '
+        'cause the above error. It may be caused by there being both a CocoaPod '
+        'and Swift Package Manager dependency for the following module(s): '
+        '${duplicateModules.join(', ')}.\n\n'
+        'You can try to identify which Pod the conflicting module is from by '
+        'looking at your "$podfileLockPath" dependency tree and requesting the '
+        'author add Swift Package Manager compatibility. See https://stackoverflow.com/a/27955017 '
+        'to learn more about understanding Podlock dependency tree. \n\n'
+        '$kDisableSwiftPMInstructions';
+  }
+
+  static String swiftPackageOnlyPluginsInCocoapodsMessage(List<String> swiftPackageOnlyPlugins) {
+    return 'Your project uses CocoaPods as a dependency manager, but the following '
+        'plugin(s) only support Swift Package Manager: ${swiftPackageOnlyPlugins.join(', ')}.\n'
+        'Try enabling Swift Package Manager with "flutter config --enable-swift-package-manager".';
+  }
+}
+
+final class XcodeBuildFailureOutputAnalysis {
+  const XcodeBuildFailureOutputAnalysis({
+    this.platformMismatch,
+    this.duplicateModules = const <String>{},
+    this.missingModules = const <String>{},
+  });
+
+  final XcodeBuildFailurePlatformMismatch? platformMismatch;
+  final Set<String> duplicateModules;
+  final Set<String> missingModules;
+}
+
+final class XcodeBuildFailurePlatformMismatch {
+  const XcodeBuildFailurePlatformMismatch({
+    required this.requiredByProduct,
+    required this.requiredVersion,
+    required this.supportedVersion,
+  });
+
+  final String requiredByProduct;
+  final Version requiredVersion;
+  final Version supportedVersion;
+}
+
+final RegExp _swiftPackageManagerMinPlatformMismatchPattern = RegExp(
+  r"The package product '([^']+)' requires minimum platform version "
+  r'([0-9\.]+) for the (iOS|macOS) platform, but this target supports '
+  r"([0-9\.]+)(?: \(in target '([^']+)' from project '[^']+'\))?",
+  caseSensitive: false,
+);
+
+final RegExp _moduleRedefinitionPattern = RegExp(r"Redefinition of module '(.*?)'");
+
+final RegExp _duplicateSymbolsPattern = RegExp(r'duplicate symbol [\s|\S]*?\/(.*)\.o');
+
+final RegExp _missingModulePattern = RegExp(r"Module '(.*?)' not found");

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -20,10 +20,10 @@ import '../base/version.dart';
 import '../build_info.dart';
 import '../cache.dart';
 import '../darwin/darwin.dart';
+import '../darwin/xcode_build_failure_diagnostics.dart';
 import '../device.dart';
 import '../features.dart';
 import '../flutter_manifest.dart';
-import '../flutter_plugins.dart';
 import '../globals.dart' as globals;
 import '../macos/cocoapod_utils.dart';
 import '../macos/swift_package_manager.dart';
@@ -35,7 +35,6 @@ import '../migrations/uiscene_migration.dart';
 import '../migrations/xcode_project_object_version_migration.dart';
 import '../migrations/xcode_script_build_phase_migration.dart';
 import '../migrations/xcode_thin_binary_build_phase_input_paths_migration.dart';
-import '../plugins.dart';
 import '../project.dart';
 import 'application_package.dart';
 import 'code_signing.dart';
@@ -1006,7 +1005,7 @@ _XCResultIssueHandlingResult _handleXCResultIssue({
       );
     }
   } else if (message.toLowerCase().contains('redefinition of module')) {
-    final String? duplicateModule = _parseModuleRedefinition(message);
+    final String? duplicateModule = XcodeBuildFailureDiagnostics.parseModuleRedefinition(message);
     return _XCResultIssueHandlingResult(
       requiresProvisioningProfile: false,
       hasProvisioningProfileIssue: false,
@@ -1016,7 +1015,9 @@ _XCResultIssueHandlingResult _handleXCResultIssue({
     // The message does not contain the plugin name, must parse the stdout.
     String? duplicateModule;
     if (result.stdout != null) {
-      duplicateModule = _parseDuplicateSymbols(result.stdout!);
+      duplicateModule = XcodeBuildFailureDiagnostics.analyzeOutput(
+        result.stdout,
+      ).duplicateModules.firstOrNull;
     }
     return _XCResultIssueHandlingResult(
       requiresProvisioningProfile: false,
@@ -1024,7 +1025,7 @@ _XCResultIssueHandlingResult _handleXCResultIssue({
       duplicateModule: duplicateModule,
     );
   } else if (message.toLowerCase().contains('not found')) {
-    final String? missingModule = _parseMissingModule(message);
+    final String? missingModule = XcodeBuildFailureDiagnostics.parseMissingModule(message);
     if (missingModule != null) {
       return _XCResultIssueHandlingResult(
         requiresProvisioningProfile: false,
@@ -1109,8 +1110,8 @@ Future<bool> _handleIssues(
   }
 
   final XcodeBasedProject xcodeProject = platform.xcodeProject(project);
-  final String? swiftPackageManagerMinPlatformMismatchMessage =
-      _swiftPackageManagerMinPlatformMismatchMessageFromStdout(result.stdout);
+  final XcodeBuildFailureOutputAnalysis stdoutDiagnostics =
+      XcodeBuildFailureDiagnostics.analyzeOutput(result.stdout);
 
   if (requiresProvisioningProfile) {
     logger.printError(noProvisioningProfileInstruction, emphasis: true);
@@ -1132,45 +1133,41 @@ Future<bool> _handleIssues(
     logger.printError("Also try selecting 'Product > Build' to fix the problem.");
   } else if (missingPlatform != null) {
     logger.printError(missingPlatformInstructions(missingPlatform), emphasis: true);
-  } else if (swiftPackageManagerMinPlatformMismatchMessage != null) {
-    logger.printError(swiftPackageManagerMinPlatformMismatchMessage, emphasis: true);
+  } else if (stdoutDiagnostics.platformMismatch != null) {
+    logger.printError(
+      XcodeBuildFailureDiagnostics.swiftPackageManagerMinPlatformMismatchMessage(
+        stdoutDiagnostics.platformMismatch!,
+      ),
+      emphasis: true,
+    );
     issueDetected = true;
   } else if (duplicateModules.isNotEmpty) {
     final bool usesCocoapods = xcodeProject.podfile.existsSync();
     final bool usesSwiftPackageManager = xcodeProject.usesSwiftPackageManager;
     if (usesCocoapods && usesSwiftPackageManager) {
       logger.printError(
-        'Your project uses both CocoaPods and Swift Package Manager, which can '
-        'cause the above error. It may be caused by there being both a CocoaPod '
-        'and Swift Package Manager dependency for the following module(s): '
-        '${duplicateModules.join(', ')}.\n\n'
-        'You can try to identify which Pod the conflicting module is from by '
-        'looking at your "ios/Podfile.lock" dependency tree and requesting the '
-        'author add Swift Package Manager compatibility. See https://stackoverflow.com/a/27955017 '
-        'to learn more about understanding Podlock dependency tree. \n\n'
-        '$kDisableSwiftPMInstructions',
+        XcodeBuildFailureDiagnostics.mixedDependencyManagerDuplicateModulesMessage(
+          platform: platform,
+          duplicateModules: duplicateModules,
+        ),
       );
     }
   } else if (missingModules.isNotEmpty) {
     final bool usesCocoapods = xcodeProject.podfile.existsSync();
     final bool usesSwiftPackageManager = xcodeProject.usesSwiftPackageManager;
     if (usesCocoapods && !usesSwiftPackageManager) {
-      final swiftPackageOnlyPlugins = <String>[];
-      for (final module in missingModules) {
-        if (await _isPluginSwiftPackageOnly(
-          platform: platform,
-          project: project,
-          pluginName: module,
-          fileSystem: fileSystem,
-        )) {
-          swiftPackageOnlyPlugins.add(module);
-        }
-      }
+      final List<String> swiftPackageOnlyPlugins =
+          await XcodeBuildFailureDiagnostics.findSwiftPackageOnlyPlugins(
+            platform: platform,
+            project: project,
+            pluginNames: missingModules,
+            fileSystem: fileSystem,
+          );
       if (swiftPackageOnlyPlugins.isNotEmpty) {
         logger.printError(
-          'Your project uses CocoaPods as a dependency manager, but the following '
-          'plugin(s) only support Swift Package Manager: ${swiftPackageOnlyPlugins.join(', ')}.\n'
-          'Try enabling Swift Package Manager with "flutter config --enable-swift-package-manager".',
+          XcodeBuildFailureDiagnostics.swiftPackageOnlyPluginsInCocoapodsMessage(
+            swiftPackageOnlyPlugins,
+          ),
         );
       }
     }
@@ -1218,36 +1215,6 @@ Future<bool> _simulatorSupportsIntel(Device device) async {
 }
 
 /// Returns true if a Package.swift is found for the plugin and a podspec is not.
-Future<bool> _isPluginSwiftPackageOnly({
-  required FlutterDarwinPlatform platform,
-  required FlutterProject project,
-  required String pluginName,
-  required FileSystem fileSystem,
-}) async {
-  final List<Plugin> plugins = await findPlugins(project);
-  final Plugin? matched = plugins
-      .where(
-        (Plugin plugin) =>
-            plugin.name.toLowerCase() == pluginName.toLowerCase() &&
-            plugin.platforms[platform.name] != null,
-      )
-      .firstOrNull;
-  if (matched == null) {
-    return false;
-  }
-  final String? swiftPackagePath = matched.pluginSwiftPackageManifestPath(
-    fileSystem,
-    platform.name,
-  );
-  final bool swiftPackageExists =
-      swiftPackagePath != null && fileSystem.file(swiftPackagePath).existsSync();
-
-  final String? podspecPath = matched.pluginPodspecPath(fileSystem, platform.name);
-  final bool podspecExists = podspecPath != null && fileSystem.file(podspecPath).existsSync();
-
-  return swiftPackageExists && !podspecExists;
-}
-
 // Return 'true' a missing development team issue is detected.
 bool _missingDevelopmentTeam(XcodeBuildExecution? xcodeBuildExecution) {
   // Make sure the user has specified one of:
@@ -1303,93 +1270,6 @@ String? _parseMissingPlatform(String message) {
     r'error:(.*?) is not installed\. To use with Xcode, first download and install the platform',
   );
   return pattern.firstMatch(message)?.group(1);
-}
-
-String? _swiftPackageManagerMinPlatformMismatchMessageFromStdout(String? stdout) {
-  if (stdout == null || stdout.isEmpty) {
-    return null;
-  }
-
-  final pattern = RegExp(
-    r"The package product '([^']+)' requires minimum platform version "
-    r'([0-9\.]+) for the (iOS|macOS) platform, but this target supports '
-    r"([0-9\.]+)(?: \(in target '([^']+)' from project '[^']+'\))?",
-    caseSensitive: false,
-  );
-
-  // We keep only the highest required version because bumping app minimum
-  // version to that value also satisfies lower plugin requirements.
-  // `highestSupportedVersion` is from the same mismatch to report "from X to Y".
-  String? highestRequiredByProduct;
-  Version? highestRequiredVersion;
-  Version? highestSupportedVersion;
-  for (final RegExpMatch match in pattern.allMatches(stdout)) {
-    final String? requiredByProduct = match.group(1);
-    final Version? requiredMinVersion = Version.parse(match.group(2));
-    final Version? targetSupportedVersion = Version.parse(match.group(4));
-    final String? targetName = match.group(5);
-    if (targetName != kFlutterGeneratedPluginSwiftPackageName) {
-      continue;
-    }
-    if (requiredByProduct == null || requiredMinVersion == null || targetSupportedVersion == null) {
-      continue;
-    }
-    if (highestRequiredVersion == null || requiredMinVersion > highestRequiredVersion) {
-      highestRequiredByProduct = requiredByProduct;
-      highestRequiredVersion = requiredMinVersion;
-      highestSupportedVersion = targetSupportedVersion;
-    }
-  }
-
-  if (highestRequiredByProduct == null ||
-      highestRequiredVersion == null ||
-      highestSupportedVersion == null) {
-    return null;
-  }
-
-  return '''
-To fix this error, increase your app's minimum platform version from $highestSupportedVersion to at least $highestRequiredVersion or remove the $highestRequiredByProduct dependency.
-
-To increase your app's minimum platform version, follow these instructions:
-  https://docs.flutter.dev/packages-and-plugins/swift-package-manager/for-app-developers#how-to-use-a-swift-package-manager-flutter-plugin-that-requires-a-higher-os-version
-''';
-}
-
-String? _parseModuleRedefinition(String message) {
-  // Example: "Redefinition of module 'plugin_1_name'"
-  final pattern = RegExp(r"Redefinition of module '(.*?)'");
-  final RegExpMatch? match = pattern.firstMatch(message);
-  if (match != null && match.groupCount > 0) {
-    final String? version = match.group(1);
-    return version;
-  }
-  return null;
-}
-
-String? _parseDuplicateSymbols(String message) {
-  // Example: "duplicate symbol '_$s29plugin_1_name23PluginNamePluginC9setDouble3key5valueySS_SdtF' in:
-  //             /Users/username/path/to/app/build/ios/Debug-iphonesimulator/plugin_1_name/plugin_1_name.framework/plugin_1_name[arm64][5](PluginNamePlugin.o)
-  final pattern = RegExp(r'duplicate symbol [\s|\S]*?\/(.*)\.o');
-  final RegExpMatch? match = pattern.firstMatch(message);
-  if (match != null && match.groupCount > 0) {
-    final String? version = match.group(1);
-    if (version != null) {
-      return version.split('/').last.split('[').first.split('(').first;
-    }
-    return version;
-  }
-  return null;
-}
-
-String? _parseMissingModule(String message) {
-  // Example: "Module 'plugin_1_name' not found"
-  final pattern = RegExp(r"Module '(.*?)' not found");
-  final RegExpMatch? match = pattern.firstMatch(message);
-  if (match != null && match.groupCount > 0) {
-    final String? version = match.group(1);
-    return version;
-  }
-  return null;
 }
 
 // The result of [_handleXCResultIssue].

--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -15,6 +15,7 @@ import '../base/utils.dart';
 import '../build_info.dart';
 import '../convert.dart';
 import '../darwin/darwin.dart';
+import '../darwin/xcode_build_failure_diagnostics.dart';
 import '../globals.dart' as globals;
 import '../ios/migrations/metal_api_validation_migration.dart';
 import '../ios/xcode_build_settings.dart';
@@ -180,6 +181,7 @@ Future<void> buildMacOS({
   final sw = Stopwatch()..start();
   final Status status = globals.logger.startProgress('Building macOS application...');
   int result;
+  final xcodeBuildOutput = StringBuffer();
 
   File? disabledSandboxEntitlementFile;
   if (usingCISystem) {
@@ -213,6 +215,14 @@ Future<void> buildMacOS({
   // when dependencies don't support them
   final String? excludedArches = buildSettings['EXCLUDED_ARCHS'];
 
+  String? captureAndFilterBuildOutput(String line) {
+    xcodeBuildOutput.writeln(line);
+    if (verboseLogging) {
+      return line;
+    }
+    return _filteredOutput.hasMatch(line) ? line : null;
+  }
+
   try {
     result = await globals.processUtils.stream(
       <String>[
@@ -243,15 +253,54 @@ Future<void> buildMacOS({
       ],
       trace: true,
       stdoutErrorMatcher: verboseLogging ? null : _filteredOutput,
-      mapFunction: verboseLogging
-          ? null
-          : (String line) => _filteredOutput.hasMatch(line) ? line : null,
+      mapFunction: captureAndFilterBuildOutput,
     );
   } finally {
     status.cancel();
   }
 
   if (result != 0) {
+    final XcodeBuildFailureOutputAnalysis stdoutDiagnostics =
+        XcodeBuildFailureDiagnostics.analyzeOutput(xcodeBuildOutput.toString());
+
+    if (stdoutDiagnostics.platformMismatch != null) {
+      globals.logger.printError(
+        XcodeBuildFailureDiagnostics.swiftPackageManagerMinPlatformMismatchMessage(
+          stdoutDiagnostics.platformMismatch!,
+        ),
+        emphasis: true,
+      );
+    } else {
+      final bool usesCocoapods = flutterProject.macos.podfile.existsSync();
+      final bool usesSwiftPackageManager = flutterProject.macos.usesSwiftPackageManager;
+      if (stdoutDiagnostics.duplicateModules.isNotEmpty &&
+          usesCocoapods &&
+          usesSwiftPackageManager) {
+        globals.logger.printError(
+          XcodeBuildFailureDiagnostics.mixedDependencyManagerDuplicateModulesMessage(
+            platform: FlutterDarwinPlatform.macos,
+            duplicateModules: stdoutDiagnostics.duplicateModules.toList(),
+          ),
+        );
+      } else if (stdoutDiagnostics.missingModules.isNotEmpty &&
+          usesCocoapods &&
+          !usesSwiftPackageManager) {
+        final List<String> swiftPackageOnlyPlugins =
+            await XcodeBuildFailureDiagnostics.findSwiftPackageOnlyPlugins(
+              platform: FlutterDarwinPlatform.macos,
+              project: flutterProject,
+              pluginNames: stdoutDiagnostics.missingModules.toList(),
+              fileSystem: globals.fs,
+            );
+        if (swiftPackageOnlyPlugins.isNotEmpty) {
+          globals.logger.printError(
+            XcodeBuildFailureDiagnostics.swiftPackageOnlyPluginsInCocoapodsMessage(
+              swiftPackageOnlyPlugins,
+            ),
+          );
+        }
+      }
+    }
     throwToolExit('Build process failed');
   }
   final String? applicationBundle = MacOSApp.fromMacOSProject(

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
@@ -20,7 +20,9 @@ import 'package:flutter_tools/src/commands/build_macos.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
+import 'package:flutter_tools/src/macos/cocoapods.dart';
 import 'package:flutter_tools/src/project.dart';
+import 'package:test/fake.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 
 import '../../src/common.dart';
@@ -60,6 +62,20 @@ class FakeXcodeProjectInterpreterWithBuildSettings extends FakeXcodeProjectInter
     Duration timeout = const Duration(minutes: 1),
   }) async {
     return <String, String>{...overrides, 'PRODUCT_BUNDLE_IDENTIFIER': 'com.example.test'};
+  }
+}
+
+class FakeCocoaPods extends Fake implements CocoaPods {
+  @override
+  void invalidatePodInstallOutput(XcodeBasedProject xcodeProject) {}
+
+  @override
+  Future<bool> processPods({
+    required XcodeBasedProject xcodeProject,
+    required BuildMode buildMode,
+    bool dependenciesChanged = true,
+  }) async {
+    return false;
   }
 }
 
@@ -124,6 +140,9 @@ void main() {
     void Function(List<String> command)? onRun,
     List<String>? additionalCommandArguments,
     String hostPlatformArch = 'x86_64',
+    int exitCode = 0,
+    String? stdout,
+    String? stderr,
   }) {
     final FlutterProject flutterProject = FlutterProject.fromDirectory(fileSystem.currentDirectory);
     final Directory flutterBuildDir = fileSystem.directory(getMacOSBuildDirectory());
@@ -151,14 +170,18 @@ void main() {
         'COMPILER_INDEX_STORE_ENABLE=NO',
         ...?additionalCommandArguments,
       ],
-      stdout: '''
+      stdout:
+          stdout ??
+          '''
 STDOUT STUFF
 note: Using new build system
 note: Planning
 note: Build preparation complete
 note: Building targets in dependency order
 ''',
-      stderr: '''
+      stderr:
+          stderr ??
+          '''
 2022-03-24 10:07:21.954 xcodebuild[2096:1927385] Requested but did not find extension point with identifier Xcode.IDEKit.ExtensionSentinelHostApplications for extension Xcode.DebuggerFoundation.AppExtensionHosts.watchOS of plug-in com.apple.dt.IDEWatchSupportCore
 2022-03-24 10:07:21.954 xcodebuild[2096:1927385] Requested but did not find extension point with identifier Xcode.IDEKit.ExtensionPointIdentifierToBundleIdentifier for extension Xcode.DebuggerFoundation.AppExtensionToBundleIdentifierMap.watchOS of plug-in com.apple.dt.IDEWatchSupportCore
 2023-11-10 10:44:58.030 xcodebuild[61115:1017566] [MT] DVTAssertions: Warning in /System/Volumes/Data/SWE/Apps/DT/BuildRoots/BuildRoot11/ActiveBuildRoot/Library/Caches/com.apple.xbs/Sources/IDEFrameworks/IDEFrameworks-22267/IDEFoundation/Provisioning/Capabilities Infrastructure/IDECapabilityQuerySelection.swift:103
@@ -168,6 +191,7 @@ Thread:   <_NSMainThread: 0x6000027c0280>{number = 1, name = main}
 Please file a bug at https://feedbackassistant.apple.com with this warning message and any useful information you can provide.
 STDERR STUFF
 ''',
+      exitCode: exitCode,
       onRun: (List<String> command) {
         fileSystem.file(fileSystem.path.join('macos', 'Flutter', 'ephemeral', '.app_filename'))
           ..createSync(recursive: true)
@@ -176,6 +200,35 @@ STDERR STUFF
           onRun(command);
         }
       },
+    );
+  }
+
+  void setUpSwiftPackageOnlyMacOSPlugin(String pluginName) {
+    final Directory pluginDirectory = fileSystem.directory(
+      fileSystem.path.join('plugins', pluginName),
+    )..createSync(recursive: true);
+    pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
+name: $pluginName
+flutter:
+  plugin:
+    platforms:
+      macos:
+        pluginClass: ${pluginName}Plugin
+''');
+    pluginDirectory
+        .childFile(fileSystem.path.join('macos', pluginName, 'Package.swift'))
+        .createSync(recursive: true);
+
+    fileSystem.file('pubspec.yaml').writeAsStringSync('''
+name: my_app
+dependencies:
+  $pluginName:
+    path: plugins/$pluginName
+''');
+    writePackageConfigFiles(
+      directory: fileSystem.currentDirectory,
+      mainLibName: 'my_app',
+      packages: <String, String>{pluginName: fileSystem.path.join('plugins', pluginName)},
     );
   }
 
@@ -345,6 +398,191 @@ STDERR STUFF
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
       FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
+      OperatingSystemUtils: () => FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_x64),
+    },
+  );
+
+  testUsingContext(
+    'macOS build prints SwiftPM minimum deployment guidance on mismatch',
+    () async {
+      final command = BuildCommand(
+        androidSdk: FakeAndroidSdk(),
+        buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+        fileSystem: fileSystem,
+        logger: logger,
+        osUtils: FakeOperatingSystemUtils(),
+      );
+      createMinimalMockProjectFiles();
+
+      await expectLater(
+        createTestCommandRunner(
+          command,
+        ).run(const <String>['build', 'macos', '--debug', '--no-pub']),
+        throwsToolExit(message: 'Build process failed'),
+      );
+
+      expect(
+        testLogger.errorText,
+        contains(
+          "To fix this error, increase your app's minimum platform version from 11.0 to at least 12.0",
+        ),
+      );
+      expect(testLogger.errorText, contains('or remove the cloud-firestore dependency.'));
+    },
+    overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
+        setUpFakeXcodeBuildHandler(
+          'Debug',
+          exitCode: 1,
+          stderr: '''
+error: The package product 'cloud-firestore' requires minimum platform version 12.0 for the macOS platform, but this target supports 11.0 (in target 'FlutterGeneratedPluginSwiftPackage' from project 'FlutterGeneratedPluginSwiftPackage')
+''',
+        ),
+      ]),
+      Pub: ThrowingPub.new,
+      Platform: () => macosPlatform,
+      FeatureFlags: () =>
+          TestFeatureFlags(isMacOSEnabled: true, isSwiftPackageManagerEnabled: true),
+      CocoaPods: () => FakeCocoaPods(),
+      OperatingSystemUtils: () => FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_x64),
+    },
+  );
+
+  testUsingContext(
+    'macOS build does not print app minimum deployment guidance for non-target mismatch',
+    () async {
+      final command = BuildCommand(
+        androidSdk: FakeAndroidSdk(),
+        buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+        fileSystem: fileSystem,
+        logger: logger,
+        osUtils: FakeOperatingSystemUtils(),
+      );
+      createMinimalMockProjectFiles();
+
+      await expectLater(
+        createTestCommandRunner(
+          command,
+        ).run(const <String>['build', 'macos', '--debug', '--no-pub']),
+        throwsToolExit(message: 'Build process failed'),
+      );
+
+      expect(
+        testLogger.errorText,
+        isNot(contains("To fix this error, increase your app's minimum platform version")),
+      );
+    },
+    overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
+        setUpFakeXcodeBuildHandler(
+          'Debug',
+          exitCode: 1,
+          stderr: '''
+error: The package product 'cloud-firestore' requires minimum platform version 12.0 for the macOS platform, but this target supports 11.0 (in target 'cloud_firestore' from project 'cloud_firestore')
+''',
+        ),
+      ]),
+      Pub: ThrowingPub.new,
+      Platform: () => macosPlatform,
+      FeatureFlags: () =>
+          TestFeatureFlags(isMacOSEnabled: true, isSwiftPackageManagerEnabled: true),
+      OperatingSystemUtils: () => FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_x64),
+    },
+  );
+
+  testUsingContext(
+    'macOS build prints mixed dependency-manager guidance for duplicate modules',
+    () async {
+      final command = BuildCommand(
+        androidSdk: FakeAndroidSdk(),
+        buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+        fileSystem: fileSystem,
+        logger: logger,
+        osUtils: FakeOperatingSystemUtils(),
+      );
+      createMinimalMockProjectFiles();
+      fileSystem.file(fileSystem.path.join('macos', 'Podfile')).createSync(recursive: true);
+
+      await expectLater(
+        createTestCommandRunner(
+          command,
+        ).run(const <String>['build', 'macos', '--debug', '--no-pub']),
+        throwsToolExit(message: 'Build process failed'),
+      );
+
+      expect(
+        testLogger.errorText,
+        contains(
+          'Your project uses both CocoaPods and Swift Package Manager, which can cause the above error.',
+        ),
+      );
+      expect(testLogger.errorText, contains('for the following module(s): cloud_firestore.'));
+      expect(testLogger.errorText, contains('"macos/Podfile.lock" dependency tree'));
+    },
+    overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
+        setUpFakeXcodeBuildHandler(
+          'Debug',
+          exitCode: 1,
+          stderr: "error: Redefinition of module 'cloud_firestore'\n",
+        ),
+      ]),
+      Pub: ThrowingPub.new,
+      Platform: () => macosPlatform,
+      FeatureFlags: () =>
+          TestFeatureFlags(isMacOSEnabled: true, isSwiftPackageManagerEnabled: true),
+      OperatingSystemUtils: () => FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_x64),
+    },
+  );
+
+  testUsingContext(
+    'macOS build prints SwiftPM-only plugin guidance for missing modules with CocoaPods',
+    () async {
+      final command = BuildCommand(
+        androidSdk: FakeAndroidSdk(),
+        buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+        fileSystem: fileSystem,
+        logger: logger,
+        osUtils: FakeOperatingSystemUtils(),
+      );
+      createMinimalMockProjectFiles();
+      fileSystem.file(fileSystem.path.join('macos', 'Podfile')).createSync(recursive: true);
+      setUpSwiftPackageOnlyMacOSPlugin('swift_only_plugin');
+
+      await expectLater(
+        createTestCommandRunner(
+          command,
+        ).run(const <String>['build', 'macos', '--debug', '--no-pub']),
+        throwsToolExit(message: 'Build process failed'),
+      );
+
+      expect(
+        testLogger.errorText,
+        contains('plugin(s) only support Swift Package Manager: swift_only_plugin.'),
+      );
+      expect(
+        testLogger.errorText,
+        contains(
+          'Try enabling Swift Package Manager with "flutter config --enable-swift-package-manager".',
+        ),
+      );
+    },
+    overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
+        setUpFakeXcodeBuildHandler(
+          'Debug',
+          exitCode: 1,
+          stderr: "error: Module 'swift_only_plugin' not found\n",
+        ),
+      ]),
+      Pub: ThrowingPub.new,
+      Platform: () => macosPlatform,
+      FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
+      CocoaPods: () => FakeCocoaPods(),
       OperatingSystemUtils: () => FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_x64),
     },
   );

--- a/packages/flutter_tools/test/general.shard/darwin/xcode_build_failure_diagnostics_test.dart
+++ b/packages/flutter_tools/test/general.shard/darwin/xcode_build_failure_diagnostics_test.dart
@@ -1,0 +1,103 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_tools/src/darwin/xcode_build_failure_diagnostics.dart';
+
+import '../../src/common.dart';
+
+void main() {
+  group('XcodeBuildFailureDiagnostics.analyzeOutput', () {
+    testWithoutContext('picks highest required version for FlutterGeneratedPluginSwiftPackage', () {
+      const stdout =
+          "error: The package product 'some-low-requirement-plugin' requires "
+          'minimum platform version 14.0 for the iOS platform, but this target supports 13.0 '
+          "(in target 'FlutterGeneratedPluginSwiftPackage' from project 'FlutterGeneratedPluginSwiftPackage')\n"
+          "error: The package product 'cloud-firestore' requires minimum platform version 15.0 "
+          'for the iOS platform, but this target supports 13.0 '
+          "(in target 'FlutterGeneratedPluginSwiftPackage' from project 'FlutterGeneratedPluginSwiftPackage')";
+
+      final XcodeBuildFailureOutputAnalysis analysis = XcodeBuildFailureDiagnostics.analyzeOutput(
+        stdout,
+      );
+
+      expect(analysis.platformMismatch?.requiredByProduct, 'cloud-firestore');
+      expect(analysis.platformMismatch?.supportedVersion.toString(), '13.0');
+      expect(analysis.platformMismatch?.requiredVersion.toString(), '15.0');
+    });
+
+    testWithoutContext('returns null for non-FlutterGeneratedPluginSwiftPackage targets', () {
+      const stdout =
+          "error: The package product 'cloud-firestore' requires "
+          'minimum platform version 15.0 for the iOS platform, but this target supports 13.0 '
+          "(in target 'cloud_firestore' from project 'cloud_firestore')";
+
+      expect(XcodeBuildFailureDiagnostics.analyzeOutput(stdout).platformMismatch, isNull);
+    });
+
+    testWithoutContext('collects duplicate and missing modules from stdout', () {
+      const stdout =
+          "Redefinition of module 'cloud_firestore'\n"
+          "Module 'swift_only_plugin' not found\n"
+          "duplicate symbol '_\$s29plugin_1_name23PluginNamePluginC9setDouble3key5valueySS_SdtF' in:\n"
+          '/Users/username/path/to/app/build/ios/Debug-iphonesimulator/plugin_1_name/'
+          'plugin_1_name.framework/plugin_1_name[arm64][5](PluginNamePlugin.o)';
+
+      final XcodeBuildFailureOutputAnalysis analysis = XcodeBuildFailureDiagnostics.analyzeOutput(
+        stdout,
+      );
+
+      expect(analysis.duplicateModules, containsAll(<String>{'cloud_firestore', 'plugin_1_name'}));
+      expect(analysis.missingModules, contains('swift_only_plugin'));
+    });
+  });
+
+  group('XcodeBuildFailureDiagnostics.parseModuleRedefinition', () {
+    testWithoutContext('parses module name', () {
+      expect(
+        XcodeBuildFailureDiagnostics.parseModuleRedefinition("Redefinition of module 'my_plugin'"),
+        'my_plugin',
+      );
+    });
+
+    testWithoutContext('returns null for non-target message', () {
+      expect(
+        XcodeBuildFailureDiagnostics.parseModuleRedefinition('No module conflict here'),
+        isNull,
+      );
+    });
+  });
+
+  group('XcodeBuildFailureDiagnostics.parseDuplicateSymbols', () {
+    testWithoutContext('parses module name from duplicate symbol output', () {
+      expect(
+        XcodeBuildFailureDiagnostics.parseDuplicateSymbols(
+          "duplicate symbol '_\$s29plugin_1_name23PluginNamePluginC9setDouble3key5valueySS_SdtF' in:\n"
+          '/Users/username/path/to/app/build/ios/Debug-iphonesimulator/plugin_1_name/'
+          'plugin_1_name.framework/plugin_1_name[arm64][5](PluginNamePlugin.o)',
+        ),
+        'plugin_1_name',
+      );
+    });
+
+    testWithoutContext('returns null for non-target message', () {
+      expect(
+        XcodeBuildFailureDiagnostics.parseDuplicateSymbols('No duplicate symbol here'),
+        isNull,
+      );
+    });
+  });
+
+  group('XcodeBuildFailureDiagnostics.parseMissingModule', () {
+    testWithoutContext('parses missing module name', () {
+      expect(
+        XcodeBuildFailureDiagnostics.parseMissingModule("Module 'plugin_1_name' not found"),
+        'plugin_1_name',
+      );
+    });
+
+    testWithoutContext('returns null for non-target message', () {
+      expect(XcodeBuildFailureDiagnostics.parseMissingModule('No missing module here'), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

This PR does three things:

1. Extracts shared Darwin Xcode failure parsing helpers.
2. Reuses those helpers from the existing iOS path without changing behavior.
3. Adds the same targeted diagnostics to macOS build failures.

See #144397

## Scope

- In scope: add parity for common macOS Xcode dependency-manager failure diagnostics.
- Out of scope: unifying the iOS and macOS build methods.
- Platform scope: iOS and macOS internals, with new user-facing diagnostics on macOS.

## Why This Approach

- Uses raw build output as the source of truth for cases where structured output is incomplete.
- Keeps the change narrowly scoped to the issue while reusing shared helpers.
- Preserves existing iOS behavior during the extraction.

## Validation

- `dart format` on touched files
- `./bin/dart --enable-asserts dev/tools/bin/format.dart`
- `dart analyze packages/flutter_tools` (targeted files)
- `dart test packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart`
- `dart test packages/flutter_tools/test/general.shard/ios/mac_test.dart`
- `dart test packages/flutter_tools/test/general.shard/darwin/xcode_build_failure_diagnostics_test.dart`

## Notes

- I asked on #144397 whether you would prefer this smaller step or full build-method unification first.
- Happy to rework this if you would rather only take the unified approach.

## Pre-launch Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I read the Tree Hygiene wiki page, which explains my responsibilities.
- [x] I read and followed the Flutter Style Guide, including Features we expect every widget to implement.
- [x] I signed the CLA.
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is test-exempt.
- [x] I followed the breaking change policy and added Data Driven Fixes where supported.
- [x] All existing and new tests are passing.