### PR TITLE
Update gradle utils to know about kgp 2.3.10 constraints

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle_utils.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_utils.dart
@@ -579,8 +579,8 @@ bool validateGradleAndKGP(Logger logger, {required String? kgpV, required String
     // Documented max is 9.0.0, using 9.0.99 non inclusive covers patch versions.
     return isWithinVersionRange(gradleV, min: '7.6.3', max: '9.0.99', inclusiveMax: false);
   }
-  // Documented max is 2.3.0, using 2.2.29 covers patch versions.
-  if (isWithinVersionRange(kgpV, min: '2.2.20', max: '2.2.29')) {
+  // Documented max is 2.2.21, using 2.3.0 covers patch versions.
+  if (isWithinVersionRange(kgpV, min: '2.2.20', max: '2.3.0')) {
     // Documented max is 8.14, using 8.14.99 non inclusive covers patch versions.
     return isWithinVersionRange(gradleV, min: '7.6.3', max: '8.14.99', inclusiveMax: false);
   }
@@ -694,12 +694,12 @@ bool validateAgpAndKgp(Logger logger, {required String? kgpV, required String? a
     return isWithinVersionRange(agpV, min: '8.2.2', max: '9.0.99', inclusiveMax: false);
   }
   // Documented max is 2.3.0
-  if (isWithinVersionRange(kgpV, min: '2.3.0', max: '2.3.0')) {
+  if (isWithinVersionRange(kgpV, min: '2.3.0', max: '2.3.10', inclusiveMax: false)) {
     // Documented max is 8.13.0
     return isWithinVersionRange(agpV, min: '8.2.2', max: '8.14', inclusiveMax: false);
   }
   // Documented max is 2.2.20
-  if (isWithinVersionRange(kgpV, min: '2.2.20', max: '2.2.29')) {
+  if (isWithinVersionRange(kgpV, min: '2.2.20', max: '2.3.0', inclusiveMax: false)) {
     // Documented max is 8.11.1
     return isWithinVersionRange(agpV, min: '7.3.1', max: '8.12', inclusiveMax: false);
   }

--- a/packages/flutter_tools/lib/src/android/gradle_utils.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_utils.dart
@@ -79,7 +79,7 @@ const maxKnownAndSupportedGradleVersion = '9.1.0';
 //
 // Supported here means supported by the tooling for
 // flutter analyze --suggestions and does not imply broader flutter support.
-const maxKnownAndSupportedKgpVersion = '2.3.0';
+const maxKnownAndSupportedKgpVersion = '2.3.10';
 
 // Update this when new versions of AGP come out.
 //
@@ -574,7 +574,12 @@ bool validateGradleAndKGP(Logger logger, {required String? kgpV, required String
   // Continuous KGP version handling is prefered in case an emergency patch to a
   // past release is shipped this code will assume the version range that is closest.
 
-  // Documented max is 2.20, using 2.2.29 covers patch versions.
+  // Documented max is 2.3.10, using 2.3.29 covers patch versions.
+  if (isWithinVersionRange(kgpV, min: '2.3.0', max: '2.3.29')) {
+    // Documented max is 9.0.0, using 9.0.99 non inclusive covers patch versions.
+    return isWithinVersionRange(gradleV, min: '7.6.3', max: '9.0.99', inclusiveMax: false);
+  }
+  // Documented max is 2.3.0, using 2.2.29 covers patch versions.
   if (isWithinVersionRange(kgpV, min: '2.2.20', max: '2.2.29')) {
     // Documented max is 8.14, using 8.14.99 non inclusive covers patch versions.
     return isWithinVersionRange(gradleV, min: '7.6.3', max: '8.14.99', inclusiveMax: false);
@@ -683,12 +688,16 @@ bool validateAgpAndKgp(Logger logger, {required String? kgpV, required String? a
   // Continuous KGP version handling is prefered in case an emergency patch to a
   // past release is shipped this code will assume the version range that is closest.
 
+  // Documented max is 2.3.10
+  if (isWithinVersionRange(kgpV, min: '2.3.10', max: '2.3.29')) {
+    // Documented max is 9.0.0
+    return isWithinVersionRange(agpV, min: '8.2.2', max: '9.0.99', inclusiveMax: false);
+  }
   // Documented max is 2.3.0
   if (isWithinVersionRange(kgpV, min: '2.3.0', max: '2.3.0')) {
     // Documented max is 8.13.0
     return isWithinVersionRange(agpV, min: '8.2.2', max: '8.14', inclusiveMax: false);
   }
-
   // Documented max is 2.2.20
   if (isWithinVersionRange(kgpV, min: '2.2.20', max: '2.2.29')) {
     // Documented max is 8.11.1

--- a/packages/flutter_tools/test/general.shard/android/gradle_utils_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_utils_test.dart
@@ -893,6 +893,8 @@ pluginManagement {
         ),
 
         // Kotlin version at the edge of support window.
+        GradleKgpTestData(true, kgpVersion: '2.3.10', gradleVersion: '8.14'),
+        GradleKgpTestData(true, kgpVersion: '2.3.0', gradleVersion: '8.14'),
         GradleKgpTestData(true, kgpVersion: '2.2.20', gradleVersion: '8.14'),
         GradleKgpTestData(true, kgpVersion: '2.2.10', gradleVersion: '8.14'),
         GradleKgpTestData(true, kgpVersion: '2.2.20', gradleVersion: '7.6.3'),
@@ -918,6 +920,8 @@ pluginManagement {
         GradleKgpTestData(true, kgpVersion: '1.6.21', gradleVersion: '6.1.1'),
         GradleKgpTestData(true, kgpVersion: '1.6.20', gradleVersion: '7.0.2'),
         // Gradle at the edge of the suppport window.
+        GradleKgpTestData(true, kgpVersion: '2.3.10', gradleVersion: '9.0.1'),
+        GradleKgpTestData(true, kgpVersion: '2.3.0', gradleVersion: '9.0.0'),
         GradleKgpTestData(true, kgpVersion: '2.2.20', gradleVersion: '8.14'),
         GradleKgpTestData(true, kgpVersion: '2.2.10', gradleVersion: '8.14'),
         GradleKgpTestData(true, kgpVersion: '2.2.0', gradleVersion: '8.14'),
@@ -942,8 +946,10 @@ pluginManagement {
         GradleKgpTestData(true, kgpVersion: '1.6.21', gradleVersion: '6.7.1'),
         GradleKgpTestData(true, kgpVersion: '1.6.21', gradleVersion: '6.5'),
         // Kotlin newer than max known.
-        GradleKgpTestData(true, kgpVersion: '2.2.29', gradleVersion: '8.12.1'),
+        GradleKgpTestData(true, kgpVersion: '2.3.29', gradleVersion: '8.12.1'),
         // Kotlin too new for gradle version.
+        GradleKgpTestData(false, kgpVersion: '2.3.10', gradleVersion: '7.6.2'),
+        GradleKgpTestData(false, kgpVersion: '2.3.0', gradleVersion: '7.6.2'),
         GradleKgpTestData(false, kgpVersion: '2.2.20', gradleVersion: '7.6.2'),
         GradleKgpTestData(false, kgpVersion: '2.2.10', gradleVersion: '7.6.2'),
         GradleKgpTestData(false, kgpVersion: '2.2.0', gradleVersion: '7.6.2'),
@@ -1007,6 +1013,7 @@ pluginManagement {
         ),
 
         // Kotlin version at the edge of support window.
+        KgpAgpTestData(true, kgpVersion: '2.3.10', agpVersion: '9.0.0'),
         KgpAgpTestData(true, kgpVersion: '2.3.0', agpVersion: '8.13.0'),
         KgpAgpTestData(true, kgpVersion: '2.3.0', agpVersion: '8.2.2'),
         KgpAgpTestData(true, kgpVersion: '2.2.20', agpVersion: '8.11.1'),
@@ -1016,7 +1023,7 @@ pluginManagement {
         KgpAgpTestData(true, kgpVersion: '2.1.20', agpVersion: '8.7.2'),
         KgpAgpTestData(true, kgpVersion: '2.1.20', agpVersion: '7.3.1'),
         // AGP Versions not "fully supported" by kotlin
-        KgpAgpTestData(true, kgpVersion: '2.3.0', agpVersion: '9.0'),
+        KgpAgpTestData(true, kgpVersion: '2.3.10', agpVersion: '9.1'),
         // Gradle versions inspired by
         // https://developer.android.com/build/releases/gradle-plugin#expandable-1
         KgpAgpTestData(true, kgpVersion: '2.1.5', agpVersion: '8.7'),


### PR DESCRIPTION
I noticed that kgp 2.3.10 was released so I went to update the code that `--suggestions` relies on. 
<img width="865" height="376" alt="Screenshot 2026-03-09 at 4 32 38 PM" src="https://github.com/user-attachments/assets/eaae19ef-1af3-4606-9e6e-649e77151224" />


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

