### PR TITLE
Fix Wayland memory leak by image cleanup and render_sibling reuse

### DIFF
--- a/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.cc
@@ -53,6 +53,10 @@ struct _FlCompositorOpenGL {
   // Last rendered frame.
   FlFramebuffer* framebuffer;
 
+  // Reusable sibling framebuffer for gdk_cairo_draw_from_gl (Wayland).
+  // Avoids per-frame texture churn that GTK/Wayland retains.
+  FlFramebuffer* render_sibling;
+
   // Last rendered frame pixels (only set if shareable is TRUE).
   uint8_t* pixels;
 
@@ -251,9 +255,13 @@ static gboolean fl_compositor_opengl_present_layers(FlCompositor* compositor,
   if (self->framebuffer == nullptr ||
       fl_framebuffer_get_width(self->framebuffer) != width ||
       fl_framebuffer_get_height(self->framebuffer) != height) {
-    g_clear_object(&self->framebuffer);
-    self->framebuffer =
+    // Allocate new framebuffer before disposing old ones to avoid GL texture
+    // ID collision (engine may dispose backing stores later with recycled IDs).
+    FlFramebuffer* new_framebuffer =
         fl_framebuffer_new(general_format, width, height, self->shareable);
+    g_clear_object(&self->render_sibling);
+    g_clear_object(&self->framebuffer);
+    self->framebuffer = new_framebuffer;
 
     // If not shareable make buffer to copy frame pixels into.
     if (!self->shareable) {
@@ -423,9 +431,12 @@ static gboolean fl_compositor_opengl_render(FlCompositor* compositor,
   }
 
   if (fl_framebuffer_get_shareable(self->framebuffer)) {
-    g_autoptr(FlFramebuffer) sibling =
-        fl_framebuffer_create_sibling(self->framebuffer);
-    gdk_cairo_draw_from_gl(cr, window, fl_framebuffer_get_texture_id(sibling),
+    if (self->render_sibling == nullptr) {
+      self->render_sibling =
+          fl_framebuffer_create_sibling(self->framebuffer);
+    }
+    gdk_cairo_draw_from_gl(cr, window,
+                           fl_framebuffer_get_texture_id(self->render_sibling),
                            GL_TEXTURE, scale_factor, 0, 0, width, height);
   } else {
     GLint saved_texture_binding;
@@ -459,6 +470,7 @@ static void fl_compositor_opengl_dispose(GObject* object) {
 
   g_clear_object(&self->task_runner);
   g_clear_object(&self->opengl_manager);
+  g_clear_object(&self->render_sibling);
   g_clear_object(&self->framebuffer);
   g_clear_pointer(&self->pixels, g_free);
   g_mutex_clear(&self->frame_mutex);

--- a/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.cc
@@ -432,8 +432,7 @@ static gboolean fl_compositor_opengl_render(FlCompositor* compositor,
 
   if (fl_framebuffer_get_shareable(self->framebuffer)) {
     if (self->render_sibling == nullptr) {
-      self->render_sibling =
-          fl_framebuffer_create_sibling(self->framebuffer);
+      self->render_sibling = fl_framebuffer_create_sibling(self->framebuffer);
     }
     gdk_cairo_draw_from_gl(cr, window,
                            fl_framebuffer_get_texture_id(self->render_sibling),

--- a/engine/src/flutter/shell/platform/linux/fl_framebuffer.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_framebuffer.cc
@@ -62,7 +62,8 @@ static void fl_framebuffer_dispose(GObject* object) {
       eglDestroyImageKHR(egl_display, self->image);
       self->image = nullptr;
     } else {
-      g_warning("Failed to destroy EGL image: Failed to get current EGL display");
+      g_warning(
+          "Failed to destroy EGL image: Failed to get current EGL display");
     }
   }
 

--- a/engine/src/flutter/shell/platform/linux/fl_framebuffer.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_framebuffer.cc
@@ -27,6 +27,9 @@ struct _FlFramebuffer {
 
   // EGL image for this texture.
   EGLImage image;
+
+  // TRUE if this object owns [image] and must destroy it.
+  gboolean owns_image;
 };
 
 G_DEFINE_TYPE(FlFramebuffer, fl_framebuffer, G_TYPE_OBJECT)
@@ -52,6 +55,16 @@ static EGLImage create_egl_image(GLuint texture_id) {
 
 static void fl_framebuffer_dispose(GObject* object) {
   FlFramebuffer* self = FL_FRAMEBUFFER(object);
+
+  if (self->owns_image && self->image != nullptr) {
+    EGLDisplay egl_display = eglGetCurrentDisplay();
+    if (egl_display != EGL_NO_DISPLAY) {
+      eglDestroyImageKHR(egl_display, self->image);
+      self->image = nullptr;
+    } else {
+      g_warning("Failed to destroy EGL image: Failed to get current EGL display");
+    }
+  }
 
   glDeleteFramebuffers(1, &self->framebuffer_id);
   glDeleteTextures(1, &self->texture_id);
@@ -92,6 +105,7 @@ FlFramebuffer* fl_framebuffer_new(GLint format,
 
   if (shareable) {
     self->image = create_egl_image(self->texture_id);
+    self->owns_image = self->image != nullptr;
   }
 
   glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
@@ -127,6 +141,7 @@ FlFramebuffer* fl_framebuffer_create_sibling(FlFramebuffer* self) {
   sibling->width = self->width;
   sibling->height = self->height;
   sibling->image = self->image;
+  sibling->owns_image = FALSE;
 
   // Make texture from existing image.
   glGenTextures(1, &sibling->texture_id);

--- a/engine/src/flutter/shell/platform/linux/fl_framebuffer_test.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_framebuffer_test.cc
@@ -44,6 +44,7 @@ TEST(FlFramebufferTest, Sibling) {
   ::testing::NiceMock<flutter::testing::MockEpoxy> epoxy;
 
   EXPECT_CALL(epoxy, eglCreateImageKHR);
+  EXPECT_CALL(epoxy, eglDestroyImageKHR).WillOnce(::testing::Return(EGL_TRUE));
   g_autoptr(FlFramebuffer) framebuffer =
       fl_framebuffer_new(GL_RGB, 100, 100, TRUE);
   g_autoptr(FlFramebuffer) sibling = fl_framebuffer_create_sibling(framebuffer);

--- a/engine/src/flutter/shell/platform/linux/testing/mock_epoxy.cc
+++ b/engine/src/flutter/shell/platform/linux/testing/mock_epoxy.cc
@@ -386,7 +386,7 @@ EGLImageKHR _eglCreateImageKHR(EGLDisplay dpy,
 
 EGLBoolean _eglDestroyImageKHR(EGLDisplay dpy, EGLImageKHR image) {
   if (mock) {
-    mock->eglDestroyImageKHR(dpy, image);
+    return mock->eglDestroyImageKHR(dpy, image);
   }
   return EGL_TRUE;
 }

--- a/engine/src/flutter/shell/platform/linux/testing/mock_epoxy.cc
+++ b/engine/src/flutter/shell/platform/linux/testing/mock_epoxy.cc
@@ -384,6 +384,13 @@ EGLImageKHR _eglCreateImageKHR(EGLDisplay dpy,
   return &mock_image;
 }
 
+EGLBoolean _eglDestroyImageKHR(EGLDisplay dpy, EGLImageKHR image) {
+  if (mock) {
+    mock->eglDestroyImageKHR(dpy, image);
+  }
+  return EGL_TRUE;
+}
+
 static GLuint bound_texture_2d;
 
 static std::map<GLenum, GLuint> framebuffer_renderbuffers;
@@ -663,7 +670,7 @@ EGLImageKHR (*epoxy_eglCreateImageKHR)(EGLDisplay dpy,
                                        EGLenum target,
                                        EGLClientBuffer buffer,
                                        const EGLint* attrib_list);
-
+EGLBoolean (*epoxy_eglDestroyImageKHR)(EGLDisplay dpy, EGLImageKHR image);
 void (*epoxy_glAttachShader)(GLuint program, GLuint shader);
 void (*epoxy_glBindFramebuffer)(GLenum target, GLuint framebuffer);
 void (*epoxy_glBindRenderbuffer)(GLenum target, GLuint renderbuffer);
@@ -739,7 +746,7 @@ static void library_init() {
   epoxy_eglQueryContext = _eglQueryContext;
   epoxy_eglSwapBuffers = _eglSwapBuffers;
   epoxy_eglCreateImageKHR = _eglCreateImageKHR;
-
+  epoxy_eglDestroyImageKHR = _eglDestroyImageKHR;
   epoxy_glAttachShader = _glAttachShader;
   epoxy_glBindFramebuffer = _glBindFramebuffer;
   epoxy_glBindRenderbuffer = _glBindRenderbuffer;

--- a/engine/src/flutter/shell/platform/linux/testing/mock_epoxy.h
+++ b/engine/src/flutter/shell/platform/linux/testing/mock_epoxy.h
@@ -28,6 +28,7 @@ class MockEpoxy {
                EGLenum target,
                EGLClientBuffer buffer,
                const EGLint* attrib_list));
+  MOCK_METHOD(void, eglDestroyImageKHR, (EGLDisplay dpy, EGLImage image));
   MOCK_METHOD(void, glClearColor, (GLfloat r, GLfloat g, GLfloat b, GLfloat a));
   MOCK_METHOD(void,
               glBlitFramebuffer,

--- a/engine/src/flutter/shell/platform/linux/testing/mock_epoxy.h
+++ b/engine/src/flutter/shell/platform/linux/testing/mock_epoxy.h
@@ -28,7 +28,7 @@ class MockEpoxy {
                EGLenum target,
                EGLClientBuffer buffer,
                const EGLint* attrib_list));
-  MOCK_METHOD(void, eglDestroyImageKHR, (EGLDisplay dpy, EGLImage image));
+  MOCK_METHOD(EGLBoolean, eglDestroyImageKHR, (EGLDisplay dpy, EGLImage image));
   MOCK_METHOD(void, glClearColor, (GLfloat r, GLfloat g, GLfloat b, GLfloat a));
   MOCK_METHOD(void,
               glBlitFramebuffer,


### PR DESCRIPTION
Improve image cleanup and reuse render_sibling to avoid memory leak.

We observed a memory leak on Linux Desktop with Wayland on embedded ARM cpu and an OpenGL ES driver.
While the fix works in our environment, I'm not sure it's correct in all scenarios. Maybe someone with more experience in the Flutter Linux rendering can review and provide some feedback.
The memory leak seems related to issue mentioned below.  

https://github.com/flutter/flutter/issues/182192


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
