### PR TITLE
[build] Generate debug info for assembly.

### DIFF
--- a/engine/src/build/config/compiler/BUILD.gn
+++ b/engine/src/build/config/compiler/BUILD.gn
@@ -1103,6 +1103,7 @@ config("symbols") {
     }
   } else {
     cflags = [ "-g2" ]
+    asmflags = [ "-g" ]
     if (is_apple) {
       swiftflags = [ "-g" ]
     }
@@ -1115,12 +1116,14 @@ config("minimal_symbols") {
     ldflags = [ "/DEBUG" ]
   } else {
     cflags = [ "-g1" ]
+    asmflags = [ "-g" ]
   }
 }
 
 config("no_symbols") {
   if (!is_win) {
     cflags = [ "-g0" ]
+    asmflags = [ "-g0" ]
   }
 }
 


### PR DESCRIPTION
This allows bloaty to attribute functions (but not variables) written in assembly to their source file. Which in turn allows the binary_size visualization to group, e.g., all the boringssl crypto kernels under boringssl instead of them all appearing at the top level.