### PR TITLE
Add GLES support for the same pixel formats for copying texture -> buffer as when copying buffer -> texture

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/gles/blit_command_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/blit_command_gles.cc
@@ -146,93 +146,6 @@ bool BlitCopyTextureToTextureCommandGLES::Encode(
   return true;
 };
 
-namespace {
-struct TexImage2DData {
-  GLint internal_format = 0;
-  GLenum external_format = GL_NONE;
-  GLenum type = GL_NONE;
-  BufferView buffer_view;
-
-  explicit TexImage2DData(PixelFormat pixel_format, bool supports_bgra) {
-    switch (pixel_format) {
-      case PixelFormat::kA8UNormInt:
-        internal_format = GL_ALPHA;
-        external_format = GL_ALPHA;
-        type = GL_UNSIGNED_BYTE;
-        break;
-      case PixelFormat::kR8UNormInt:
-        internal_format = GL_RED;
-        external_format = GL_RED;
-        type = GL_UNSIGNED_BYTE;
-        break;
-      case PixelFormat::kR8G8B8A8UNormInt:
-      case PixelFormat::kR8G8B8A8UNormIntSRGB:
-        internal_format = GL_RGBA;
-        external_format = GL_RGBA;
-        type = GL_UNSIGNED_BYTE;
-        break;
-      case PixelFormat::kB8G8R8A8UNormInt:
-      case PixelFormat::kB8G8R8A8UNormIntSRGB:
-        if (supports_bgra) {
-          internal_format = GL_BGRA_EXT;
-          external_format = GL_BGRA_EXT;
-        } else {
-          internal_format = GL_RGBA;
-          external_format = GL_RGBA;
-        }
-        type = GL_UNSIGNED_BYTE;
-        break;
-      case PixelFormat::kR32G32B32A32Float:
-        internal_format = GL_RGBA;
-        external_format = GL_RGBA;
-        type = GL_FLOAT;
-        break;
-      case PixelFormat::kR32Float:
-        internal_format = GL_RED;
-        external_format = GL_RED;
-        type = GL_FLOAT;
-        break;
-      case PixelFormat::kR16G16B16A16Float:
-        internal_format = GL_RGBA;
-        external_format = GL_RGBA;
-        type = GL_HALF_FLOAT;
-        break;
-      case PixelFormat::kS8UInt:
-        // Pure stencil textures are only available in OpenGL 4.4+, which is
-        // ~0% of mobile devices. Instead, we use a depth-stencil texture and
-        // only use the stencil component.
-        //
-        // https://registry.khronos.org/OpenGL-Refpages/gl4/html/glTexImage2D.xhtml
-      case PixelFormat::kD24UnormS8Uint:
-        internal_format = GL_DEPTH_STENCIL;
-        external_format = GL_DEPTH_STENCIL;
-        type = GL_UNSIGNED_INT_24_8;
-        break;
-      case PixelFormat::kUnknown:
-      case PixelFormat::kD32FloatS8UInt:
-      case PixelFormat::kR8G8UNormInt:
-      case PixelFormat::kB10G10R10XRSRGB:
-      case PixelFormat::kB10G10R10XR:
-      case PixelFormat::kB10G10R10A10XR:
-        return;
-    }
-    is_valid_ = true;
-  }
-
-  TexImage2DData(PixelFormat pixel_format,
-                 BufferView p_buffer_view,
-                 bool supports_bgra)
-      : TexImage2DData(pixel_format, supports_bgra) {
-    buffer_view = std::move(p_buffer_view);
-  }
-
-  bool IsValid() const { return is_valid_; }
-
- private:
-  bool is_valid_ = false;
-};
-}  // namespace
-
 BlitCopyBufferToTextureCommandGLES::~BlitCopyBufferToTextureCommandGLES() =
     default;
 
@@ -291,11 +204,12 @@ bool BlitCopyBufferToTextureCommandGLES::Encode(
       break;
   }
 
-  TexImage2DData data(tex_descriptor.format, source,
-                      /*supports_bgra=*/
-                      reactor.GetProcTable().GetDescription()->HasExtension(
-                          "GL_EXT_texture_format_BGRA8888"));
-  if (!data.IsValid()) {
+  std::optional<PixelFormatGLES> gles_format =
+      ToPixelFormatGLES(tex_descriptor.format,
+                        /*supports_bgra=*/
+                        reactor.GetProcTable().GetDescription()->HasExtension(
+                            "GL_EXT_texture_format_BGRA8888"));
+  if (!gles_format.has_value()) {
     VALIDATION_LOG << "Invalid texture format.";
     return false;
   }
@@ -308,22 +222,21 @@ bool BlitCopyBufferToTextureCommandGLES::Encode(
   }
   const auto& gl = reactor.GetProcTable();
   gl.BindTexture(texture_type, gl_handle.value());
-  const GLvoid* tex_data = data.buffer_view.GetBuffer()->OnGetContents() +
-                           data.buffer_view.GetRange().offset;
+  const GLvoid* tex_data =
+      source.GetBuffer()->OnGetContents() + source.GetRange().offset;
 
   // GL_INVALID_OPERATION if the texture array has not been
   // defined by a previous glTexImage2D operation.
   if (!texture_gles.IsSliceInitialized(slice)) {
-    gl.TexImage2D(texture_target,              // target
-                  mip_level,                   // LOD level
-                  data.internal_format,        // internal format
-                  tex_descriptor.size.width,   // width
-                  tex_descriptor.size.height,  // height
-                  0u,                          // border
-                  data.external_format,        // external format
-                  data.type,                   // type
-                  nullptr                      // data
-    );
+    gl.TexImage2D(texture_target,                // target
+                  mip_level,                     // LOD level
+                  gles_format->internal_format,  // internal format
+                  tex_descriptor.size.width,     // width
+                  tex_descriptor.size.height,    // height
+                  0u,                            // border
+                  gles_format->external_format,  // format
+                  gles_format->type,             // type
+                  nullptr);                      // data
     texture_gles.MarkSliceInitialized(slice);
   }
 
@@ -335,11 +248,9 @@ bool BlitCopyBufferToTextureCommandGLES::Encode(
                      destination_region.GetY(),       // yoffset
                      destination_region.GetWidth(),   // width
                      destination_region.GetHeight(),  // height
-                     data.external_format,            // external format
-                     data.type,                       // type
-                     tex_data                         // data
-
-    );
+                     gles_format->external_format,    // format
+                     gles_format->type,               // type
+                     tex_data);                       // data
   }
   return true;
 }
@@ -356,20 +267,14 @@ bool BlitCopyTextureToBufferCommandGLES::Encode(
   const auto& gl = reactor.GetProcTable();
 
   PixelFormat source_format = source->GetTextureDescriptor().format;
-  GLenum format;
-  if (source_format == PixelFormat::kR8G8B8A8UNormInt) {
-    format = GL_RGBA;
-  } else if (gl.GetDescription()->HasExtension(
-                 "GL_EXT_texture_format_BGRA8888")) {
-    if (source_format == PixelFormat::kB8G8R8A8UNormInt) {
-      format = GL_BGRA_EXT;
-    } else {
-      VALIDATION_LOG << "Only textures with pixel format RGBA or BGRA are "
-                        "supported.";
-      return false;
-    }
-  } else {
-    VALIDATION_LOG << "Only textures with pixel format RGBA are supported.";
+  std::optional<PixelFormatGLES> gles_format =
+      ToPixelFormatGLES(source_format,
+                        /*supports_bgra=*/
+                        reactor.GetProcTable().GetDescription()->HasExtension(
+                            "GL_EXT_texture_format_BGRA8888"));
+
+  if (!gles_format.has_value()) {
+    VALIDATION_LOG << "Texture has unsupported pixel format.";
     return false;
   }
 
@@ -388,23 +293,27 @@ bool BlitCopyTextureToBufferCommandGLES::Encode(
   }
 
   DeviceBufferGLES::Cast(*destination)
-      .UpdateBufferData([&gl, this, format, coord_system,
-                         rows = source->GetSize().height](uint8_t* data,
-
-                                                          size_t length) {
-        gl.ReadPixels(source_region.GetX(), source_region.GetY(),
-                      source_region.GetWidth(), source_region.GetHeight(),
-                      format, GL_UNSIGNED_BYTE, data + destination_offset);
-        switch (coord_system) {
-          case TextureCoordinateSystem::kUploadFromHost:
-            break;
-          case TextureCoordinateSystem::kRenderToTexture:
-            // The texture is upside down, and must be inverted when copying
-            // byte data out.
-            FlipImage(data + destination_offset, source_region.GetWidth(),
-                      source_region.GetHeight(), 4);
-        }
-      });
+      .UpdateBufferData(
+          [&gl,                                                          //
+           this,                                                         //
+           format = gles_format->external_format,                        //
+           type = gles_format->type,                                     //
+           coord_system,                                                 //
+           bytes_per_pixel = BytesPerPixelForPixelFormat(source_format)  //
+  ](uint8_t* data, size_t length) {
+            gl.ReadPixels(source_region.GetX(), source_region.GetY(),
+                          source_region.GetWidth(), source_region.GetHeight(),
+                          format, type, data + destination_offset);
+            switch (coord_system) {
+              case TextureCoordinateSystem::kUploadFromHost:
+                break;
+              case TextureCoordinateSystem::kRenderToTexture:
+                // The texture is upside down, and must be inverted when copying
+                // byte data out.
+                FlipImage(data + destination_offset, source_region.GetWidth(),
+                          source_region.GetHeight(), bytes_per_pixel);
+            }
+          });
 
   return true;
 };

--- a/engine/src/flutter/impeller/renderer/backend/gles/blit_command_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/blit_command_gles_unittests.cc
@@ -234,6 +234,7 @@ TEST(BlitCommandGLESTest, BlitCopyTextureToBufferCommandGLESBGRA) {
 TEST(BlitCommandGLESTest,
      BlitCopyTextureToBufferCommandGLESUnsupportedPixelFormats) {
   auto mock_gles_impl = std::make_unique<MockGLESImpl>();
+  auto& mock_gles_impl_ref = *mock_gles_impl;
 
   std::shared_ptr<MockGLES> mock_gl = MockGLES::Init(std::move(mock_gles_impl));
   auto reactor = std::make_shared<TestReactorGLES>();
@@ -242,21 +243,25 @@ TEST(BlitCommandGLESTest,
 
   std::shared_ptr<DeviceBufferGLES> dest_buffer = CreateBuffer(reactor);
 
-  std::shared_ptr<TextureGLES> source_texture_bgra =
-      CreateTexture(reactor, PixelFormat::kB8G8R8A8UNormInt);
-  BlitCopyTextureToBufferCommandGLES command_for_bgra =
-      CreateCopyTextureToBufferCommand(source_texture_bgra, dest_buffer);
+  std::shared_ptr<TextureGLES> source_texture_D32FloatS8Uint =
+      CreateTexture(reactor, PixelFormat::kD32FloatS8UInt);
+  BlitCopyTextureToBufferCommandGLES command_for_D32FloatS8Uint =
+      CreateCopyTextureToBufferCommand(source_texture_D32FloatS8Uint,
+                                       dest_buffer);
 
-  std::shared_ptr<TextureGLES> source_texture_rgba16 =
-      CreateTexture(reactor, PixelFormat::kR16G16B16A16Float);
-  BlitCopyTextureToBufferCommandGLES command_for_rgba16 =
-      CreateCopyTextureToBufferCommand(source_texture_rgba16, dest_buffer);
+  std::shared_ptr<TextureGLES> source_texture_R8G8UNormInt =
+      CreateTexture(reactor, PixelFormat::kR8G8UNormInt);
+  BlitCopyTextureToBufferCommandGLES command_for_R8G8UNormInt =
+      CreateCopyTextureToBufferCommand(source_texture_R8G8UNormInt,
+                                       dest_buffer);
 
-  // GL does not support texture with bgra pixel format.
-  EXPECT_FALSE(command_for_bgra.Encode(*reactor));
+  EXPECT_CALL(mock_gles_impl_ref, CheckFramebufferStatus(_)).Times(0);
+
+  // GL does not support texture with an unsupported pixel format.
+  EXPECT_FALSE(command_for_D32FloatS8Uint.Encode(*reactor));
 
   // GL does not support texture with another unsupported pixel format.
-  EXPECT_FALSE(command_for_rgba16.Encode(*reactor));
+  EXPECT_FALSE(command_for_R8G8UNormInt.Encode(*reactor));
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/renderer/backend/gles/formats_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/formats_gles.cc
@@ -39,10 +39,6 @@ std::optional<PixelFormatGLES> ToPixelFormatGLES(PixelFormat pixel_format,
       format.type = GL_UNSIGNED_BYTE;
       break;
     case PixelFormat::kR8G8B8A8UNormInt:
-      format.internal_format = GL_RGBA;
-      format.external_format = GL_RGBA;
-      format.type = GL_UNSIGNED_BYTE;
-      break;
     case PixelFormat::kR8G8B8A8UNormIntSRGB:
       format.internal_format = GL_RGBA;
       format.external_format = GL_RGBA;

--- a/engine/src/flutter/impeller/renderer/backend/gles/formats_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/formats_gles.cc
@@ -23,4 +23,77 @@ std::string DebugToFramebufferError(int status) {
   }
 }
 
+std::optional<PixelFormatGLES> ToPixelFormatGLES(PixelFormat pixel_format,
+                                                 bool supports_bgra) {
+  PixelFormatGLES format;
+
+  switch (pixel_format) {
+    case PixelFormat::kA8UNormInt:
+      format.internal_format = GL_ALPHA;
+      format.external_format = GL_ALPHA;
+      format.type = GL_UNSIGNED_BYTE;
+      break;
+    case PixelFormat::kR8UNormInt:
+      format.internal_format = GL_RED;
+      format.external_format = GL_RED;
+      format.type = GL_UNSIGNED_BYTE;
+      break;
+    case PixelFormat::kR8G8B8A8UNormInt:
+      format.internal_format = GL_RGBA;
+      format.external_format = GL_RGBA;
+      format.type = GL_UNSIGNED_BYTE;
+      break;
+    case PixelFormat::kR8G8B8A8UNormIntSRGB:
+      format.internal_format = GL_RGBA;
+      format.external_format = GL_RGBA;
+      format.type = GL_UNSIGNED_BYTE;
+      break;
+    case PixelFormat::kB8G8R8A8UNormInt:
+    case PixelFormat::kB8G8R8A8UNormIntSRGB:
+      if (supports_bgra) {
+        format.internal_format = GL_BGRA_EXT;
+        format.external_format = GL_BGRA_EXT;
+      } else {
+        format.internal_format = GL_RGBA;
+        format.external_format = GL_RGBA;
+      }
+      format.type = GL_UNSIGNED_BYTE;
+      break;
+    case PixelFormat::kR32G32B32A32Float:
+      format.internal_format = GL_RGBA32F;
+      format.external_format = GL_RGBA;
+      format.type = GL_FLOAT;
+      break;
+    case PixelFormat::kR32Float:
+      format.internal_format = GL_R32F;
+      format.external_format = GL_RED;
+      format.type = GL_FLOAT;
+      break;
+    case PixelFormat::kR16G16B16A16Float:
+      format.internal_format = GL_RGBA16F;
+      format.external_format = GL_RGBA;
+      format.type = GL_HALF_FLOAT;
+      break;
+    case PixelFormat::kS8UInt:
+      // Pure stencil textures are only available in OpenGL 4.4+, which is
+      // ~0% of mobile devices. Instead, we use a depth-stencil texture and
+      // only use the stencil component.
+      //
+      // https://registry.khronos.org/OpenGL-Refpages/gl4/html/glTexImage2D.xhtml
+    case PixelFormat::kD24UnormS8Uint:
+      format.internal_format = GL_DEPTH_STENCIL;
+      format.external_format = GL_DEPTH_STENCIL;
+      format.type = GL_UNSIGNED_INT_24_8;
+      break;
+    case PixelFormat::kUnknown:
+    case PixelFormat::kD32FloatS8UInt:
+    case PixelFormat::kR8G8UNormInt:
+    case PixelFormat::kB10G10R10XRSRGB:
+    case PixelFormat::kB10G10R10XR:
+    case PixelFormat::kB10G10R10A10XR:
+      return std::nullopt;
+  }
+  return format;
+}
+
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/gles/formats_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/formats_gles.h
@@ -196,6 +196,15 @@ constexpr std::optional<GLenum> ToTextureTarget(TextureType type) {
   FML_UNREACHABLE();
 }
 
+struct PixelFormatGLES {
+  GLint internal_format = 0;
+  GLenum external_format = GL_NONE;
+  GLenum type = GL_NONE;
+};
+
+std::optional<PixelFormatGLES> ToPixelFormatGLES(PixelFormat format,
+                                                 bool supports_bgra);
+
 std::string DebugToFramebufferError(int status);
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.cc
@@ -287,6 +287,8 @@ bool TextureGLES::OnSetContents(std::shared_ptr<const fml::Mapping> mapping,
     }
 
     {
+      TRACE_EVENT1("impeller", "TexImage2DUpload", "Bytes",
+                   std::to_string(mapping->GetSize()).c_str());
       gl.PixelStorei(GL_UNPACK_ALIGNMENT, 1);
       gl.TexImage2D(texture_target,          // target
                     0u,                      // LOD level

--- a/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.cc
@@ -16,7 +16,6 @@
 #include "impeller/core/formats.h"
 #include "impeller/core/texture_descriptor.h"
 #include "impeller/renderer/backend/gles/formats_gles.h"
-#include "impeller/renderer/backend/gles/handle_gles.h"
 
 namespace impeller {
 
@@ -62,90 +61,6 @@ static TextureGLES::Type GetTextureTypeFromDescriptor(
                  : TextureGLES::Type::kTexture;
 }
 
-struct TexImage2DData {
-  GLint internal_format = 0;
-  GLenum external_format = GL_NONE;
-  GLenum type = GL_NONE;
-  std::shared_ptr<const fml::Mapping> data;
-
-  explicit TexImage2DData(PixelFormat pixel_format, bool supports_bgra) {
-    switch (pixel_format) {
-      case PixelFormat::kA8UNormInt:
-        internal_format = GL_ALPHA;
-        external_format = GL_ALPHA;
-        type = GL_UNSIGNED_BYTE;
-        break;
-      case PixelFormat::kR8UNormInt:
-        internal_format = GL_RED;
-        external_format = GL_RED;
-        type = GL_UNSIGNED_BYTE;
-        break;
-      case PixelFormat::kB8G8R8A8UNormInt:
-      case PixelFormat::kB8G8R8A8UNormIntSRGB:
-        if (supports_bgra) {
-          internal_format = GL_BGRA_EXT;
-          external_format = GL_BGRA_EXT;
-        } else {
-          internal_format = GL_RGBA;
-          external_format = GL_RGBA;
-        }
-        type = GL_UNSIGNED_BYTE;
-        break;
-      case PixelFormat::kR8G8B8A8UNormInt:
-      case PixelFormat::kR8G8B8A8UNormIntSRGB:
-        internal_format = GL_RGBA;
-        external_format = GL_RGBA;
-        type = GL_UNSIGNED_BYTE;
-        break;
-      case PixelFormat::kR32Float:
-        internal_format = GL_R32F;
-        external_format = GL_RGBA;
-        type = GL_FLOAT;
-        break;
-      case PixelFormat::kR32G32B32A32Float:
-        internal_format = GL_RGBA32F;
-        external_format = GL_RGBA;
-        type = GL_FLOAT;
-        break;
-      case PixelFormat::kR16G16B16A16Float:
-        internal_format = GL_RGBA16F;
-        external_format = GL_RGBA;
-        type = GL_HALF_FLOAT;
-        break;
-      case PixelFormat::kS8UInt:
-        // Pure stencil textures are only available in OpenGL 4.4+, which is
-        // ~0% of mobile devices. Instead, we use a depth-stencil texture and
-        // only use the stencil component.
-        //
-        // https://registry.khronos.org/OpenGL-Refpages/gl4/html/glTexImage2D.xhtml
-      case PixelFormat::kD24UnormS8Uint:
-        internal_format = GL_DEPTH_STENCIL;
-        external_format = GL_DEPTH_STENCIL;
-        type = GL_UNSIGNED_INT_24_8;
-        break;
-      case PixelFormat::kUnknown:
-      case PixelFormat::kD32FloatS8UInt:
-      case PixelFormat::kR8G8UNormInt:
-      case PixelFormat::kB10G10R10XRSRGB:
-      case PixelFormat::kB10G10R10XR:
-      case PixelFormat::kB10G10R10A10XR:
-        return;
-    }
-    is_valid_ = true;
-  }
-
-  TexImage2DData(PixelFormat pixel_format,
-                 std::shared_ptr<const fml::Mapping> mapping,
-                 bool supports_bgra)
-      : TexImage2DData(pixel_format, supports_bgra) {
-    data = std::move(mapping);
-  }
-
-  bool IsValid() const { return is_valid_; }
-
- private:
-  bool is_valid_ = false;
-};
 }  // namespace
 
 HandleType ToHandleType(TextureGLES::Type type) {
@@ -341,21 +256,22 @@ bool TextureGLES::OnSetContents(std::shared_ptr<const fml::Mapping> mapping,
       break;
   }
 
-  auto data = std::make_shared<TexImage2DData>(
-      tex_descriptor.format, std::move(mapping),
-      /*supports_bgra=*/
-      reactor_->GetProcTable().GetDescription()->HasExtension(
-          "GL_EXT_texture_format_BGRA8888"));
-  if (!data || !data->IsValid()) {
+  std::optional<PixelFormatGLES> gles_format =
+      ToPixelFormatGLES(tex_descriptor.format,
+                        /*supports_bgra=*/
+                        reactor_->GetProcTable().GetDescription()->HasExtension(
+                            "GL_EXT_texture_format_BGRA8888"));
+  if (!gles_format.has_value()) {
     VALIDATION_LOG << "Invalid texture format.";
     return false;
   }
 
-  ReactorGLES::Operation texture_upload = [handle = handle_,            //
-                                           data,                        //
-                                           size = tex_descriptor.size,  //
-                                           texture_type,                //
-                                           texture_target               //
+  ReactorGLES::Operation texture_upload = [handle = handle_,              //
+                                           mapping,                       //
+                                           format = gles_format.value(),  //
+                                           size = tex_descriptor.size,    //
+                                           texture_type,                  //
+                                           texture_target                 //
   ](const auto& reactor) {
     auto gl_handle = reactor.GetGLHandle(handle);
     if (!gl_handle.has_value()) {
@@ -366,24 +282,21 @@ bool TextureGLES::OnSetContents(std::shared_ptr<const fml::Mapping> mapping,
     const auto& gl = reactor.GetProcTable();
     gl.BindTexture(texture_type, gl_handle.value());
     const GLvoid* tex_data = nullptr;
-    if (data->data) {
-      tex_data = data->data->GetMapping();
+    if (mapping) {
+      tex_data = mapping->GetMapping();
     }
 
     {
-      TRACE_EVENT1("impeller", "TexImage2DUpload", "Bytes",
-                   std::to_string(data->data->GetSize()).c_str());
       gl.PixelStorei(GL_UNPACK_ALIGNMENT, 1);
-      gl.TexImage2D(texture_target,         // target
-                    0u,                     // LOD level
-                    data->internal_format,  // internal format
-                    size.width,             // width
-                    size.height,            // height
-                    0u,                     // border
-                    data->external_format,  // external format
-                    data->type,             // type
-                    tex_data                // data
-      );
+      gl.TexImage2D(texture_target,          // target
+                    0u,                      // LOD level
+                    format.internal_format,  // internal format
+                    size.width,              // width
+                    size.height,             // height
+                    0u,                      // border
+                    format.external_format,  // format
+                    format.type,             // type
+                    tex_data);               // data
     }
   };
 
@@ -461,12 +374,12 @@ void TextureGLES::InitializeContentsIfNecessary() const {
   switch (type_) {
     case Type::kTexture:
     case Type::kTextureMultisampled: {
-      TexImage2DData tex_data(
+      std::optional<PixelFormatGLES> gles_format = ToPixelFormatGLES(
           GetTextureDescriptor().format,
           /*supports_bgra=*/
           reactor_->GetProcTable().GetDescription()->HasExtension(
               "GL_EXT_texture_format_BGRA8888"));
-      if (!tex_data.IsValid()) {
+      if (!gles_format.has_value()) {
         VALIDATION_LOG << "Invalid format for texture image.";
         return;
       }
@@ -475,13 +388,13 @@ void TextureGLES::InitializeContentsIfNecessary() const {
         TRACE_EVENT0("impeller", "TexImage2DInitialization");
         gl.TexImage2D(GL_TEXTURE_2D,  // target
                       0u,             // LOD level (base mip level size checked)
-                      tex_data.internal_format,  // internal format
-                      size.width,                // width
-                      size.height,               // height
-                      0u,                        // border
-                      tex_data.external_format,  // format
-                      tex_data.type,             // type
-                      nullptr                    // data
+                      gles_format->internal_format,  // internal format
+                      size.width,                    // width
+                      size.height,                   // height
+                      0u,                            // border
+                      gles_format->external_format,  // format
+                      gles_format->type,             // type
+                      nullptr                        // data
         );
       }
     } break;

--- a/engine/src/flutter/testing/run_tests.py
+++ b/engine/src/flutter/testing/run_tests.py
@@ -938,7 +938,6 @@ def gather_dart_tests(
 
   opengles_skipped_tests = [
       'gpu_test.dart',
-      'high_bitrate_texture_test.dart',
   ]
 
   impeller_backends = ['', 'vulkan', 'opengles']


### PR DESCRIPTION
`BlitCopyBufferToTextureCommandGLES` (and initializing/setting texture contents in `TextureGLES`) supports a bunch of different pixel formats, as defined in the `TexImage2DData` constructors in `blit_command_gles.cc` and `texture_gles.cc`.

But `BlitCopyTextureToBufferCommandGLES` only has support specifically for `kR8G8B8A8UNormInt` and `kB8G8R8A8UNormInt`.

This makes `BlitCopyTextureToBufferCommandGLES` support the same pixel formats as `BlitCopyBufferToTextureCommandGLES` and `TextureGLES`.

Fixes https://github.com/flutter/flutter/issues/183462

## Changes:

### Share `ToPixelFormatGLES`

`blit_command_gles.cc` and `texture_gles.cc` have almost-duplicate logic to convert `impeller::PixelFormat` to a `GLint internal_format`, a `GLenum external_format`, and a `GLenum type`. Factor this out into a shared `ToPixelFormatGLES` function in `formats_gles.h/cc`.

Where there were differences between the `blit_command_gles.cc` and `texture_gles.cc`:
- `kR32G32B32A32Float`:
  - `blit_command_gles.cc` has `internal_format = GL_RGBA`, `external_format = GL_RGBA`
  - `texture_gles.cc` has `internal_format = GL_RGBA32F`, `external_format = GL_RGBA`
  - I used `internal_format = GL_RGBA32F`, `external_format = GL_RGBA`
- `kR16G16B16A16Float`:
  - `blit_command_gles.cc` has `internal_format = GL_RGBA`, `external_format = GL_RGBA`
  - `texture_gles.cc` has `internal_format = GL_RGBA16F`, `external_format = GL_RGBA`
  - I used `internal_format = GL_RGBA16F`, `external_format = GL_RGBA`
- `kR32Float`:
  - `blit_command_gles.cc` has `internal_format = GL_RED`, `external_format = GL_RED`
  - `texture_gles.cc` has `internal_format = GL_R32F`, `external_format = GL_RGBA`
  - I used `internal_format = GL_R32F`, `external_format = GL_RED`

All the other PixelFormat cases were the same between the two files and copied over directly.

### Remove `TexImage2DData`

`blit_command_gles.cc` and `texture_gles.cc` each define a `TexImage2DData` struct which just contains the pixel format data and sometimes an optional data buffer. I removed both of these. Instead, we just use the `ToPixelFormatGLES` return value directly, and use the source data buffer directly.

### Improve pixel format support in `BlitCopyTextureToBufferCommandGLES::Encode()`

In `BlitCopyTextureToBufferCommandGLES::Encode()`, use `ToPixelFormatGLES()` to determine the format and type used for `gl.ReadPixels()`. This expands the existing functionality that only supported two specific pixel formats.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
