### PR TITLE
DlDeferredImageGPUImpeller::ImageWrapper texture thread safety improvements

### DIFF
--- a/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller.cc
+++ b/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller.cc
@@ -9,6 +9,11 @@
 
 #include "flutter/fml/make_copyable.h"
 
+// Disable a warning on Windows about use of deprecated atomic operations
+// on std::shared_ptr.  These functions are used because libcxx does not
+// yet support std::atomic<std::shared_ptr>.
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
 namespace flutter {
 
 sk_sp<DlDeferredImageGPUImpeller> DlDeferredImageGPUImpeller::Make(
@@ -132,8 +137,14 @@ void DlDeferredImageGPUImpeller::ImageWrapper::OnGrContextCreated() {}
 
 void DlDeferredImageGPUImpeller::ImageWrapper::OnGrContextDestroyed() {}
 
+const std::shared_ptr<impeller::Texture>
+DlDeferredImageGPUImpeller::ImageWrapper::texture() const {
+  return std::atomic_load(&texture_);
+}
+
 bool DlDeferredImageGPUImpeller::ImageWrapper::isTextureBacked() const {
-  return texture_ && texture_->IsValid();
+  std::shared_ptr<impeller::Texture> tex = std::atomic_load(&texture_);
+  return tex && tex->IsValid();
 }
 
 void DlDeferredImageGPUImpeller::ImageWrapper::SnapshotDisplayList(
@@ -172,7 +183,7 @@ void DlDeferredImageGPUImpeller::ImageWrapper::SnapshotDisplayList(
           wrapper->error_ = "Failed to create snapshot.";
           return;
         }
-        wrapper->texture_ = snapshot->impeller_texture();
+        std::atomic_store(&wrapper->texture_, snapshot->impeller_texture());
       }));
 }
 

--- a/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller.cc
+++ b/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller.cc
@@ -137,13 +137,13 @@ void DlDeferredImageGPUImpeller::ImageWrapper::OnGrContextCreated() {}
 
 void DlDeferredImageGPUImpeller::ImageWrapper::OnGrContextDestroyed() {}
 
-const std::shared_ptr<impeller::Texture>
+std::shared_ptr<impeller::Texture>
 DlDeferredImageGPUImpeller::ImageWrapper::texture() const {
   return std::atomic_load(&texture_);
 }
 
 bool DlDeferredImageGPUImpeller::ImageWrapper::isTextureBacked() const {
-  std::shared_ptr<impeller::Texture> tex = std::atomic_load(&texture_);
+  std::shared_ptr<impeller::Texture> tex = texture();
   return tex && tex->IsValid();
 }
 

--- a/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller.h
+++ b/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller.h
@@ -87,7 +87,7 @@ class DlDeferredImageGPUImpeller final : public DlImage {
 
     bool isTextureBacked() const;
 
-    const std::shared_ptr<impeller::Texture> texture() const;
+    std::shared_ptr<impeller::Texture> texture() const;
 
     const DlISize size() const { return size_; }
 

--- a/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller.h
+++ b/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller.h
@@ -87,10 +87,7 @@ class DlDeferredImageGPUImpeller final : public DlImage {
 
     bool isTextureBacked() const;
 
-    const std::shared_ptr<impeller::Texture> texture() const {
-      FML_DCHECK(raster_task_runner_->RunsTasksOnCurrentThread());
-      return texture_;
-    }
+    const std::shared_ptr<impeller::Texture> texture() const;
 
     const DlISize size() const { return size_; }
 

--- a/engine/src/flutter/lib/ui/painting/image.cc
+++ b/engine/src/flutter/lib/ui/painting/image.cc
@@ -43,9 +43,7 @@ void CanvasImage::dispose() {
 }
 
 int CanvasImage::colorSpace() {
-  if (image_->skia_image()) {
-    return ColorSpace::kSRGB;
-  } else if (image_->impeller_texture()) {
+  if (image_->impeller_texture()) {
 #if IMPELLER_SUPPORTS_RENDERING
     return ImageEncodingImpeller::GetColorSpace(image_->impeller_texture());
 #endif  // IMPELLER_SUPPORTS_RENDERING


### PR DESCRIPTION
* Use atomic read/write operations on ImageWrapper::texture_ (which is accessed from both the raster and UI threads)
* Remove an assert that restricted ImageWrapper::texture() to the raster thread
* Avoid calling DlImage::skia_image() on the UI thread in CanvasImage::colorSpace().  The DlDeferredImageGPUSkia::skia_image() implementation is only usable on the raster thread.

See discussion at https://github.com/flutter/flutter/pull/183046