### PR TITLE
Enhance iOS logging: await log reader start in devices and simulators…

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -1834,7 +1834,7 @@ class IOSDeviceLogReader extends SharedIOSDeviceLogReader {
   // Connects the already-launched [idevicesyslogProcess] output to [linesController].
   //
   // Called synchronously when the first listener subscribes (via onListen).
-  // `start()` must have been awaited before any listener subscribes so that
+  // `startProcess()` must have been awaited before any listener subscribes so that
   // [idevicesyslogProcess] is available.
   void _connectSyslogOutput() {
     if (!useSyslogLogging) {

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -995,11 +995,11 @@ class IOSDevice extends Device {
         deviceLogReader.debuggerStream = iosDeployDebugger;
       }
     }
-    // Start the log reader process before subscribing to its stream so we
+    // Launch the log reader process before subscribing to its stream so we
     // don't miss the VM service URI the app emits on startup.
     // See https://github.com/flutter/flutter/issues/181771.
     if (deviceLogReader is SharedIOSDeviceLogReader) {
-      await deviceLogReader.start();
+      await deviceLogReader.startProcess();
     }
     // Don't port forward if debugging with a wireless device.
     return ProtocolDiscovery.vmService(
@@ -1456,12 +1456,12 @@ abstract class SharedIOSDeviceLogReader extends DeviceLogReader {
     }
   }
 
-  /// Start the underlying log reader process(es).
+  /// Launches the underlying log reader process(es).
   ///
   /// Must be awaited before subscribing to [logLines] to avoid a race
   /// condition where the app launches and emits the VM service URI before the
   /// log reader process has started. See https://github.com/flutter/flutter/issues/181771.
-  Future<void> start();
+  Future<void> startProcess();
 }
 
 /// Listens to multiple logging sources to get the logs from the physical iOS device.
@@ -1820,7 +1820,7 @@ class IOSDeviceLogReader extends SharedIOSDeviceLogReader {
   /// of the process output to the log stream is deferred to [_connectSyslogOutput],
   /// which is called synchronously when the first listener subscribes.
   @override
-  Future<void> start() async {
+  Future<void> startProcess() async {
     if (_sysLogStarted) {
       return;
     }

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -572,7 +572,7 @@ class IOSDevice extends Device {
 
       if (debuggingOptions.debuggingEnabled) {
         _logger.printTrace('Debugging is enabled, connecting to vmService');
-        vmServiceDiscovery = _setupDebuggerAndVmServiceDiscovery(
+        vmServiceDiscovery = await _setupDebuggerAndVmServiceDiscovery(
           package: package,
           bundle: bundle,
           debuggingOptions: debuggingOptions,
@@ -731,7 +731,7 @@ class IOSDevice extends Device {
             iosDeployDebugger!.lostConnection) {
           _logger.printStatus('Lost connection to device. Trying to connect again...');
           await dispose();
-          vmServiceDiscovery = _setupDebuggerAndVmServiceDiscovery(
+          vmServiceDiscovery = await _setupDebuggerAndVmServiceDiscovery(
             package: package,
             bundle: bundle,
             debuggingOptions: debuggingOptions,
@@ -967,14 +967,14 @@ class IOSDevice extends Device {
     );
   }
 
-  ProtocolDiscovery _setupDebuggerAndVmServiceDiscovery({
+  Future<ProtocolDiscovery> _setupDebuggerAndVmServiceDiscovery({
     required IOSApp package,
     required Directory bundle,
     required DebuggingOptions debuggingOptions,
     required List<String> launchArguments,
     required bool uninstallFirst,
     bool skipInstall = false,
-  }) {
+  }) async {
     final DeviceLogReader deviceLogReader = getLogReader(
       app: package,
       usingCISystem: debuggingOptions.usingCISystem,
@@ -994,6 +994,12 @@ class IOSDevice extends Device {
       if (deviceLogReader is IOSDeviceLogReader) {
         deviceLogReader.debuggerStream = iosDeployDebugger;
       }
+    }
+    // Start the log reader process before subscribing to its stream so we
+    // don't miss the VM service URI the app emits on startup.
+    // See https://github.com/flutter/flutter/issues/181771.
+    if (deviceLogReader is SharedIOSDeviceLogReader) {
+      await deviceLogReader.start();
     }
     // Don't port forward if debugging with a wireless device.
     return ProtocolDiscovery.vmService(
@@ -1449,6 +1455,13 @@ abstract class SharedIOSDeviceLogReader extends DeviceLogReader {
       linesController.add(message);
     }
   }
+
+  /// Start the underlying log reader process(es).
+  ///
+  /// Must be awaited before subscribing to [logLines] to avoid a race
+  /// condition where the app launches and emits the VM service URI before the
+  /// log reader process has started. See https://github.com/flutter/flutter/issues/181771.
+  Future<void> start() async {}
 }
 
 /// Listens to multiple logging sources to get the logs from the physical iOS device.
@@ -1555,9 +1568,11 @@ class IOSDeviceLogReader extends SharedIOSDeviceLogReader {
   @override
   @visibleForTesting
   late final linesController = StreamController<String>.broadcast(
-    onListen: _listenToSysLog,
+    onListen: _connectSyslogOutput,
     onCancel: dispose,
   );
+
+  bool _sysLogStarted = false;
 
   @visibleForTesting
   void addToLinesController(String message, IOSDeviceLogSource source) {
@@ -1800,13 +1815,38 @@ class IOSDeviceLogReader extends SharedIOSDeviceLogReader {
 
   /// Start and listen to `idevicesyslog` to get device logs for iOS versions
   /// prior to 13 or if [useSyslogLogging] and [useIOSDeployLogging] are `true`.
-  void _listenToSysLog() {
+  ///
+  /// Launches the `idevicesyslog` process and stores it. The actual connection
+  /// of the process output to the log stream is deferred to [_connectSyslogOutput],
+  /// which is called synchronously when the first listener subscribes.
+  @override
+  Future<void> start() async {
+    if (_sysLogStarted) {
+      return;
+    }
+    _sysLogStarted = true;
     if (!useSyslogLogging) {
       return;
     }
-    _iMobileDevice.startLogger(_deviceId, _isWirelesslyConnected).then<void>((Process process) {
-      process.stdout.transform(utf8LineDecoder).listen(_newSyslogLineHandler());
-      process.stderr.transform(utf8LineDecoder).listen(_newSyslogLineHandler());
+    idevicesyslogProcess = await _iMobileDevice.startLogger(_deviceId, _isWirelesslyConnected);
+  }
+
+  /// Connects the already-launched [idevicesyslogProcess] output to [linesController].
+  ///
+  /// Called synchronously when the first listener subscribes (via [onListen]).
+  /// [start] must have been awaited before any listener subscribes so that
+  /// [idevicesyslogProcess] is available.
+  void _connectSyslogOutput() {
+    if (!useSyslogLogging) {
+      return;
+    }
+    final Process? process = idevicesyslogProcess;
+    if (process == null) {
+      return;
+    }
+    process.stdout.transform(utf8LineDecoder).listen(_newSyslogLineHandler());
+    process.stderr.transform(utf8LineDecoder).listen(_newSyslogLineHandler());
+    unawaited(
       process.exitCode.whenComplete(() {
         if (!linesController.hasListener) {
           return;
@@ -1818,10 +1858,8 @@ class IOSDeviceLogReader extends SharedIOSDeviceLogReader {
           return;
         }
         linesController.close();
-      });
-      assert(idevicesyslogProcess == null);
-      idevicesyslogProcess = process;
-    });
+      }),
+    );
   }
 
   @visibleForTesting

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -1831,11 +1831,11 @@ class IOSDeviceLogReader extends SharedIOSDeviceLogReader {
     idevicesyslogProcess = await _iMobileDevice.startLogger(_deviceId, _isWirelesslyConnected);
   }
 
-  /// Connects the already-launched [idevicesyslogProcess] output to [linesController].
-  ///
-  /// Called synchronously when the first listener subscribes (via onListen).
-  /// `start()` must have been awaited before any listener subscribes so that
-  /// [idevicesyslogProcess] is available.
+  // Connects the already-launched [idevicesyslogProcess] output to [linesController].
+  //
+  // Called synchronously when the first listener subscribes (via onListen).
+  // `start()` must have been awaited before any listener subscribes so that
+  // [idevicesyslogProcess] is available.
   void _connectSyslogOutput() {
     if (!useSyslogLogging) {
       return;

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -1461,7 +1461,7 @@ abstract class SharedIOSDeviceLogReader extends DeviceLogReader {
   /// Must be awaited before subscribing to [logLines] to avoid a race
   /// condition where the app launches and emits the VM service URI before the
   /// log reader process has started. See https://github.com/flutter/flutter/issues/181771.
-  Future<void> start() async {}
+  Future<void> start();
 }
 
 /// Listens to multiple logging sources to get the logs from the physical iOS device.
@@ -1833,8 +1833,8 @@ class IOSDeviceLogReader extends SharedIOSDeviceLogReader {
 
   /// Connects the already-launched [idevicesyslogProcess] output to [linesController].
   ///
-  /// Called synchronously when the first listener subscribes (via [onListen]).
-  /// [start] must have been awaited before any listener subscribes so that
+  /// Called synchronously when the first listener subscribes (via onListen).
+  /// `start()` must have been awaited before any listener subscribes so that
   /// [idevicesyslogProcess] is available.
   void _connectSyslogOutput() {
     if (!useSyslogLogging) {

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -874,8 +874,8 @@ class _IOSSimulatorLogReader extends SharedIOSDeviceLogReader {
 
   /// Connects the already-launched log processes' output to [_linesController].
   ///
-  /// Called synchronously when the first listener subscribes (via [onListen]).
-  /// [start] must have been awaited before any listener subscribes so that
+  /// Called synchronously when the first listener subscribes (via onListen).
+  /// `start()` must have been awaited before any listener subscribes so that
   /// [_deviceProcess] and [_systemProcess] are available.
   void _connectProcessOutput() {
     if (_usesUnifiedLogging) {

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -477,8 +477,15 @@ class IOSSimulator extends Device {
 
     ProtocolDiscovery? vmServiceDiscovery;
     if (debuggingOptions.debuggingEnabled) {
+      final DeviceLogReader logReader = getLogReader(app: package);
+      // Start the log reader process before launching the app so we don't miss
+      // the VM service URI that the app emits on startup.
+      // See https://github.com/flutter/flutter/issues/181771.
+      if (logReader is SharedIOSDeviceLogReader) {
+        await logReader.start();
+      }
       vmServiceDiscovery = ProtocolDiscovery.vmService(
-        getLogReader(app: package),
+        logReader,
         ipv6: debuggingOptions.ipv6,
         hostPort: debuggingOptions.hostVmServicePort,
         devicePort: debuggingOptions.deviceVmServicePort,
@@ -820,9 +827,15 @@ class _IOSSimulatorLogReader extends SharedIOSDeviceLogReader {
   final String? _appName;
 
   late final _linesController = StreamController<String>.broadcast(
-    onListen: _start,
+    onListen: _connectProcessOutput,
     onCancel: _stop,
   );
+
+  bool _started = false;
+
+  // Whether unified logging (iOS 11+) or syslog is used.
+  // Determined during start() and used by the synchronous _connectProcessOutput().
+  bool _usesUnifiedLogging = false;
 
   @override
   @visibleForTesting
@@ -838,23 +851,41 @@ class _IOSSimulatorLogReader extends SharedIOSDeviceLogReader {
   @override
   String get name => device.name;
 
-  Future<void> _start() async {
+  @override
+  Future<void> start() async {
+    if (_started) {
+      return;
+    }
+    _started = true;
     // Unified logging iOS 11 and greater (introduced in iOS 10).
-    if (await device.sdkMajorVersion >= 11) {
+    _usesUnifiedLogging = await device.sdkMajorVersion >= 11;
+    if (_usesUnifiedLogging) {
       _deviceProcess = await launchDeviceUnifiedLogging(device, _appName);
-      _deviceProcess?.stdout.transform(utf8LineDecoder).listen(_onUnifiedLoggingLine);
-      _deviceProcess?.stderr.transform(utf8LineDecoder).listen(_onUnifiedLoggingLine);
     } else {
       // Fall back to syslog parsing.
       await device.ensureLogsExists();
       _deviceProcess = await launchDeviceSystemLogTool(device);
-      _deviceProcess?.stdout.transform(utf8LineDecoder).listen(_onSysLogDeviceLine);
-      _deviceProcess?.stderr.transform(utf8LineDecoder).listen(_onSysLogDeviceLine);
     }
 
     // Track system.log crashes.
     // ReportCrash[37965]: Saved crash report for FlutterRunner[37941]...
     _systemProcess = await launchSystemLogTool(device);
+  }
+
+  /// Connects the already-launched log processes' output to [_linesController].
+  ///
+  /// Called synchronously when the first listener subscribes (via [onListen]).
+  /// [start] must have been awaited before any listener subscribes so that
+  /// [_deviceProcess] and [_systemProcess] are available.
+  void _connectProcessOutput() {
+    if (_usesUnifiedLogging) {
+      _deviceProcess?.stdout.transform(utf8LineDecoder).listen(_onUnifiedLoggingLine);
+      _deviceProcess?.stderr.transform(utf8LineDecoder).listen(_onUnifiedLoggingLine);
+    } else {
+      _deviceProcess?.stdout.transform(utf8LineDecoder).listen(_onSysLogDeviceLine);
+      _deviceProcess?.stderr.transform(utf8LineDecoder).listen(_onSysLogDeviceLine);
+    }
+
     if (_systemProcess != null) {
       _systemProcess?.stdout.transform(utf8LineDecoder).listen(_onSystemLine);
       _systemProcess?.stderr.transform(utf8LineDecoder).listen(_onSystemLine);

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -482,7 +482,7 @@ class IOSSimulator extends Device {
       // the VM service URI that the app emits on startup.
       // See https://github.com/flutter/flutter/issues/181771.
       if (logReader is SharedIOSDeviceLogReader) {
-        await logReader.start();
+        await logReader.startProcess();
       }
       vmServiceDiscovery = ProtocolDiscovery.vmService(
         logReader,
@@ -852,7 +852,7 @@ class _IOSSimulatorLogReader extends SharedIOSDeviceLogReader {
   String get name => device.name;
 
   @override
-  Future<void> start() async {
+  Future<void> startProcess() async {
     if (_started) {
       return;
     }

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -875,7 +875,7 @@ class _IOSSimulatorLogReader extends SharedIOSDeviceLogReader {
   /// Connects the already-launched log processes' output to [_linesController].
   ///
   /// Called synchronously when the first listener subscribes (via onListen).
-  /// `start()` must have been awaited before any listener subscribes so that
+  /// `startProcess()` must have been awaited before any listener subscribes so that
   /// [_deviceProcess] and [_systemProcess] are available.
   void _connectProcessOutput() {
     if (_usesUnifiedLogging) {

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_logger_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_logger_test.dart
@@ -80,6 +80,7 @@ Runner(UIKit)[297] <Notice>: E is for enpitsu"
           ),
           xcode: FakeXcode(),
         );
+        await (logReader as IOSDeviceLogReader).start();
         final List<String> lines = await logReader.logLines.toList();
 
         expect(lines, <String>['A is for ari', 'I is for ichigo']);
@@ -110,6 +111,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
           ),
           xcode: FakeXcode(),
         );
+        await (logReader as IOSDeviceLogReader).start();
         final List<String> lines = await logReader.logLines.toList();
 
         expect(lines, <String>[
@@ -144,6 +146,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
         ),
         xcode: FakeXcode(),
       );
+      await (logReader as IOSDeviceLogReader).start();
       final List<String> lines = await logReader.logLines.toList();
 
       expect(lines, <String>[
@@ -642,6 +645,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
           usingCISystem: true,
           majorSdkVersion: 16,
         );
+        await (logReader as IOSDeviceLogReader).start();
         final List<String> lines = await logReader.logLines.toList();
 
         expect(logReader.useSyslogLogging, isTrue);
@@ -722,6 +726,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
         iosDeployDebugger.logLines = debuggingLogs;
         logReader.debuggerStream = iosDeployDebugger;
 
+        await (logReader as IOSDeviceLogReader).start();
         final List<String> lines = await logReader.logLines.toList();
 
         expect(logReader.useIOSDeployLogging, isFalse);
@@ -825,6 +830,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
         );
         await logReader.provideVmService(vmService);
 
+        await (logReader as IOSDeviceLogReader).start();
         final List<String> lines = await logReader.logLines.toList();
 
         // Wait for stream listeners to fire.
@@ -886,6 +892,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
         coreDeviceLauncher.coreDeviceLogForwarder.addLog(deviceCtlLog);
         coreDeviceLauncher.lldbLogForwarder.addLog(lldbLog);
 
+        await (logReader as IOSDeviceLogReader).start();
         expect(logReader.useCoreDeviceLogging, isFalse);
         await expectLater(logReader.logLines, neverEmits(deviceCtlLog));
 
@@ -915,6 +922,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
           expect(logReader.logSources.primarySource, IOSDeviceLogSource.iosDeploy);
           expect(logReader.logSources.fallbackSource, IOSDeviceLogSource.idevicesyslog);
 
+          await (logReader as IOSDeviceLogReader).start();
           final Future<List<String>> logLines = logReader.logLines.toList();
 
           logReader.addToLinesController(
@@ -963,6 +971,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
         expect(logReader.logSources.primarySource, IOSDeviceLogSource.idevicesyslog);
         expect(logReader.logSources.fallbackSource, isNull);
 
+        await (logReader as IOSDeviceLogReader).start();
         final Future<List<String>> logLines = logReader.logLines.toList();
 
         logReader.addToLinesController(
@@ -1013,6 +1022,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
           expect(logReader.logSources.primarySource, IOSDeviceLogSource.iosDeploy);
           expect(logReader.logSources.fallbackSource, IOSDeviceLogSource.idevicesyslog);
 
+          await (logReader as IOSDeviceLogReader).start();
           final Future<List<String>> logLines = logReader.logLines.toList();
 
           logReader.addToLinesController(
@@ -1077,6 +1087,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
           expect(logReader.logSources.primarySource, IOSDeviceLogSource.iosDeploy);
           expect(logReader.logSources.fallbackSource, IOSDeviceLogSource.idevicesyslog);
 
+          await (logReader as IOSDeviceLogReader).start();
           final Future<List<String>> logLines = logReader.logLines.toList();
 
           logReader.addToLinesController(
@@ -1136,6 +1147,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
         expect(logReader.logSources.primarySource, IOSDeviceLogSource.iosDeploy);
         expect(logReader.logSources.fallbackSource, IOSDeviceLogSource.idevicesyslog);
 
+        await (logReader as IOSDeviceLogReader).start();
         final Future<List<String>> logLines = logReader.logLines.toList();
 
         logReader.addToLinesController(

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_logger_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_logger_test.dart
@@ -645,7 +645,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
           usingCISystem: true,
           majorSdkVersion: 16,
         );
-        await (logReader as IOSDeviceLogReader).start();
+        await logReader.start();
         final List<String> lines = await logReader.logLines.toList();
 
         expect(logReader.useSyslogLogging, isTrue);
@@ -726,7 +726,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
         iosDeployDebugger.logLines = debuggingLogs;
         logReader.debuggerStream = iosDeployDebugger;
 
-        await (logReader as IOSDeviceLogReader).start();
+        await logReader.start();
         final List<String> lines = await logReader.logLines.toList();
 
         expect(logReader.useIOSDeployLogging, isFalse);
@@ -830,7 +830,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
         );
         await logReader.provideVmService(vmService);
 
-        await (logReader as IOSDeviceLogReader).start();
+        await logReader.start();
         final List<String> lines = await logReader.logLines.toList();
 
         // Wait for stream listeners to fire.
@@ -892,7 +892,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
         coreDeviceLauncher.coreDeviceLogForwarder.addLog(deviceCtlLog);
         coreDeviceLauncher.lldbLogForwarder.addLog(lldbLog);
 
-        await (logReader as IOSDeviceLogReader).start();
+        await logReader.start();
         expect(logReader.useCoreDeviceLogging, isFalse);
         await expectLater(logReader.logLines, neverEmits(deviceCtlLog));
 
@@ -922,7 +922,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
           expect(logReader.logSources.primarySource, IOSDeviceLogSource.iosDeploy);
           expect(logReader.logSources.fallbackSource, IOSDeviceLogSource.idevicesyslog);
 
-          await (logReader as IOSDeviceLogReader).start();
+          await logReader.start();
           final Future<List<String>> logLines = logReader.logLines.toList();
 
           logReader.addToLinesController(
@@ -971,7 +971,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
         expect(logReader.logSources.primarySource, IOSDeviceLogSource.idevicesyslog);
         expect(logReader.logSources.fallbackSource, isNull);
 
-        await (logReader as IOSDeviceLogReader).start();
+        await logReader.start();
         final Future<List<String>> logLines = logReader.logLines.toList();
 
         logReader.addToLinesController(
@@ -1022,7 +1022,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
           expect(logReader.logSources.primarySource, IOSDeviceLogSource.iosDeploy);
           expect(logReader.logSources.fallbackSource, IOSDeviceLogSource.idevicesyslog);
 
-          await (logReader as IOSDeviceLogReader).start();
+          await logReader.start();
           final Future<List<String>> logLines = logReader.logLines.toList();
 
           logReader.addToLinesController(
@@ -1087,7 +1087,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
           expect(logReader.logSources.primarySource, IOSDeviceLogSource.iosDeploy);
           expect(logReader.logSources.fallbackSource, IOSDeviceLogSource.idevicesyslog);
 
-          await (logReader as IOSDeviceLogReader).start();
+          await logReader.start();
           final Future<List<String>> logLines = logReader.logLines.toList();
 
           logReader.addToLinesController(
@@ -1147,7 +1147,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
         expect(logReader.logSources.primarySource, IOSDeviceLogSource.iosDeploy);
         expect(logReader.logSources.fallbackSource, IOSDeviceLogSource.idevicesyslog);
 
-        await (logReader as IOSDeviceLogReader).start();
+        await logReader.start();
         final Future<List<String>> logLines = logReader.logLines.toList();
 
         logReader.addToLinesController(

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_logger_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_logger_test.dart
@@ -80,7 +80,7 @@ Runner(UIKit)[297] <Notice>: E is for enpitsu"
           ),
           xcode: FakeXcode(),
         );
-        await (logReader as IOSDeviceLogReader).start();
+        await (logReader as IOSDeviceLogReader).startProcess();
         final List<String> lines = await logReader.logLines.toList();
 
         expect(lines, <String>['A is for ari', 'I is for ichigo']);
@@ -111,7 +111,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
           ),
           xcode: FakeXcode(),
         );
-        await (logReader as IOSDeviceLogReader).start();
+        await (logReader as IOSDeviceLogReader).startProcess();
         final List<String> lines = await logReader.logLines.toList();
 
         expect(lines, <String>[
@@ -146,7 +146,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
         ),
         xcode: FakeXcode(),
       );
-      await (logReader as IOSDeviceLogReader).start();
+      await (logReader as IOSDeviceLogReader).startProcess();
       final List<String> lines = await logReader.logLines.toList();
 
       expect(lines, <String>[
@@ -645,7 +645,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
           usingCISystem: true,
           majorSdkVersion: 16,
         );
-        await logReader.start();
+        await logReader.startProcess();
         final List<String> lines = await logReader.logLines.toList();
 
         expect(logReader.useSyslogLogging, isTrue);
@@ -726,7 +726,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
         iosDeployDebugger.logLines = debuggingLogs;
         logReader.debuggerStream = iosDeployDebugger;
 
-        await logReader.start();
+        await logReader.startProcess();
         final List<String> lines = await logReader.logLines.toList();
 
         expect(logReader.useIOSDeployLogging, isFalse);
@@ -830,7 +830,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
         );
         await logReader.provideVmService(vmService);
 
-        await logReader.start();
+        await logReader.startProcess();
         final List<String> lines = await logReader.logLines.toList();
 
         // Wait for stream listeners to fire.
@@ -892,7 +892,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
         coreDeviceLauncher.coreDeviceLogForwarder.addLog(deviceCtlLog);
         coreDeviceLauncher.lldbLogForwarder.addLog(lldbLog);
 
-        await logReader.start();
+        await logReader.startProcess();
         expect(logReader.useCoreDeviceLogging, isFalse);
         await expectLater(logReader.logLines, neverEmits(deviceCtlLog));
 
@@ -922,7 +922,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
           expect(logReader.logSources.primarySource, IOSDeviceLogSource.iosDeploy);
           expect(logReader.logSources.fallbackSource, IOSDeviceLogSource.idevicesyslog);
 
-          await logReader.start();
+          await logReader.startProcess();
           final Future<List<String>> logLines = logReader.logLines.toList();
 
           logReader.addToLinesController(
@@ -971,7 +971,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
         expect(logReader.logSources.primarySource, IOSDeviceLogSource.idevicesyslog);
         expect(logReader.logSources.fallbackSource, isNull);
 
-        await logReader.start();
+        await logReader.startProcess();
         final Future<List<String>> logLines = logReader.logLines.toList();
 
         logReader.addToLinesController(
@@ -1022,7 +1022,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
           expect(logReader.logSources.primarySource, IOSDeviceLogSource.iosDeploy);
           expect(logReader.logSources.fallbackSource, IOSDeviceLogSource.idevicesyslog);
 
-          await logReader.start();
+          await logReader.startProcess();
           final Future<List<String>> logLines = logReader.logLines.toList();
 
           logReader.addToLinesController(
@@ -1087,7 +1087,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
           expect(logReader.logSources.primarySource, IOSDeviceLogSource.iosDeploy);
           expect(logReader.logSources.fallbackSource, IOSDeviceLogSource.idevicesyslog);
 
-          await logReader.start();
+          await logReader.startProcess();
           final Future<List<String>> logLines = logReader.logLines.toList();
 
           logReader.addToLinesController(
@@ -1147,7 +1147,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
         expect(logReader.logSources.primarySource, IOSDeviceLogSource.iosDeploy);
         expect(logReader.logSources.fallbackSource, IOSDeviceLogSource.idevicesyslog);
 
-        await logReader.start();
+        await logReader.startProcess();
         final Future<List<String>> logLines = logReader.logLines.toList();
 
         logReader.addToLinesController(

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -1928,7 +1928,7 @@ class FakeSharedIOSDeviceLogReader extends SharedIOSDeviceLogReader {
   StreamController<String> get linesController => _linesController;
 
   @override
-  Future<void> start() async {}
+  Future<void> startProcess() async {}
 
   void _onListen() {
     _lineQueue.forEach(_linesController.add);

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -1927,6 +1927,9 @@ class FakeSharedIOSDeviceLogReader extends SharedIOSDeviceLogReader {
   @override
   StreamController<String> get linesController => _linesController;
 
+  @override
+  Future<void> start() async {}
+
   void _onListen() {
     _lineQueue.forEach(_linesController.add);
     _lineQueue.clear();

--- a/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
@@ -15,6 +15,7 @@ import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/device_port_forwarder.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/ios/application_package.dart';
+import 'package:flutter_tools/src/ios/devices.dart';
 import 'package:flutter_tools/src/ios/plist_parser.dart';
 import 'package:flutter_tools/src/ios/simulators.dart';
 import 'package:flutter_tools/src/macos/xcode.dart';
@@ -599,6 +600,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text''',
           final DeviceLogReader logReader = device.getLogReader(
             app: await BuildableIOSApp.fromProject(mockIosProject, null),
           );
+          await (logReader as SharedIOSDeviceLogReader).start();
 
           final List<String> lines = await logReader.logLines.toList();
           expect(lines, <String>[
@@ -643,6 +645,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text''',
           final DeviceLogReader logReader = device.getLogReader(
             app: await BuildableIOSApp.fromProject(mockIosProject, null),
           );
+          await (logReader as SharedIOSDeviceLogReader).start();
 
           final List<String> lines = await logReader.logLines.toList();
           expect(lines, <String>[
@@ -700,6 +703,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text''',
           final DeviceLogReader logReader = device.getLogReader(
             app: await BuildableIOSApp.fromProject(mockIosProject, null),
           );
+          await (logReader as SharedIOSDeviceLogReader).start();
 
           final List<String> lines = await logReader.logLines.toList();
           expect(lines, <String>[
@@ -782,6 +786,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text''',
           final DeviceLogReader logReader = device.getLogReader(
             app: await BuildableIOSApp.fromProject(mockIosProject, null),
           );
+          await (logReader as SharedIOSDeviceLogReader).start();
 
           final List<String> lines = await logReader.logLines.toList();
           expect(lines, <String>[
@@ -836,6 +841,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text''',
           final DeviceLogReader logReader = device.getLogReader(
             app: await BuildableIOSApp.fromProject(mockIosProject, null),
           );
+          await (logReader as SharedIOSDeviceLogReader).start();
 
           final List<String> lines = await logReader.logLines.toList();
           expect(lines, isEmpty);

--- a/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
@@ -600,7 +600,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text''',
           final DeviceLogReader logReader = device.getLogReader(
             app: await BuildableIOSApp.fromProject(mockIosProject, null),
           );
-          await (logReader as SharedIOSDeviceLogReader).start();
+          await (logReader as SharedIOSDeviceLogReader).startProcess();
 
           final List<String> lines = await logReader.logLines.toList();
           expect(lines, <String>[
@@ -645,7 +645,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text''',
           final DeviceLogReader logReader = device.getLogReader(
             app: await BuildableIOSApp.fromProject(mockIosProject, null),
           );
-          await (logReader as SharedIOSDeviceLogReader).start();
+          await (logReader as SharedIOSDeviceLogReader).startProcess();
 
           final List<String> lines = await logReader.logLines.toList();
           expect(lines, <String>[
@@ -703,7 +703,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text''',
           final DeviceLogReader logReader = device.getLogReader(
             app: await BuildableIOSApp.fromProject(mockIosProject, null),
           );
-          await (logReader as SharedIOSDeviceLogReader).start();
+          await (logReader as SharedIOSDeviceLogReader).startProcess();
 
           final List<String> lines = await logReader.logLines.toList();
           expect(lines, <String>[
@@ -786,7 +786,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text''',
           final DeviceLogReader logReader = device.getLogReader(
             app: await BuildableIOSApp.fromProject(mockIosProject, null),
           );
-          await (logReader as SharedIOSDeviceLogReader).start();
+          await (logReader as SharedIOSDeviceLogReader).startProcess();
 
           final List<String> lines = await logReader.logLines.toList();
           expect(lines, <String>[
@@ -841,7 +841,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text''',
           final DeviceLogReader logReader = device.getLogReader(
             app: await BuildableIOSApp.fromProject(mockIosProject, null),
           );
-          await (logReader as SharedIOSDeviceLogReader).start();
+          await (logReader as SharedIOSDeviceLogReader).startProcess();
 
           final List<String> lines = await logReader.logLines.toList();
           expect(lines, isEmpty);


### PR DESCRIPTION
Fix race condition in iOS log reader causing flutter test to hang on simulator

_IOSSimulatorLogReader and IOSDeviceLogReader both used StreamController.broadcast(onListen: _asyncFunction) to launch their log processes. The onListen callback is expected to be synchronous — the returned Future was silently dropped, meaning process startup was scheduled but never awaited. If the app launched quickly and emitted its VM service URI before the log reader process (xcrun simctl spawn ... log stream / idevicesyslog) had started, the URI was permanently missed and integration test execution never began.

Fix (two-phase initialization):

start() (async, awaited before subscribing) — launches the background log process(es) and stores the handles. Does not connect stdout/stderr yet.
_connectProcessOutput() / _connectSyslogOutput() (synchronous onListen callback) — called when the first listener subscribes; connects the already-running process output to the stream controller.
This guarantees the log process is running before the app launches, while keeping the onListen callback synchronous (so no events are dropped between connection and subscription).

Call sequence in production:

await logReader.start() — process launched and ready
ProtocolDiscovery.vmService(logReader, ...) — subscribes, triggers synchronous onListen connecting stdout
App launches, emits VM service URI — captured by the already-running process


Fixes - https://github.com/flutter/flutter/issues/181771
