### PR TITLE
fix: show window after first frame callback

### DIFF
--- a/engine/src/flutter/shell/platform/windows/flutter_windows_view.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_view.cc
@@ -726,8 +726,24 @@ void FlutterWindowsView::SendPointerEventWithData(
   }
 }
 
+void FlutterWindowsView::SetFirstFrameCallback(fml::closure callback) {
+  std::scoped_lock lock(first_frame_callback_mutex_);
+  first_frame_callback_ = std::move(callback);
+}
+
+void FlutterWindowsView::FireFirstFrameCallbackIfSet() {
+  std::scoped_lock lock(first_frame_callback_mutex_);
+  if (first_frame_callback_) {
+    fml::closure callback = std::move(first_frame_callback_);
+    first_frame_callback_ = nullptr;
+    engine_->task_runner()->PostTask(std::move(callback));
+  }
+}
+
 void FlutterWindowsView::OnFramePresented() {
   // Called on the engine's raster thread.
+  FireFirstFrameCallbackIfSet();
+
   std::unique_lock<std::mutex> lock(resize_mutex_);
 
   switch (resize_status_) {
@@ -766,8 +782,14 @@ bool FlutterWindowsView::ClearSoftwareBitmap() {
 bool FlutterWindowsView::PresentSoftwareBitmap(const void* allocation,
                                                size_t row_bytes,
                                                size_t height) {
-  return binding_handler_->OnBitmapSurfaceUpdated(allocation, row_bytes,
-                                                  height);
+  bool result =
+      binding_handler_->OnBitmapSurfaceUpdated(allocation, row_bytes, height);
+  if (result) {
+    // The software compositor does not call OnFramePresented, so fire the
+    // first frame callback here.
+    FireFirstFrameCallbackIfSet();
+  }
+  return result;
 }
 
 FlutterViewId FlutterWindowsView::view_id() const {

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_view.h
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_view.h
@@ -12,6 +12,7 @@
 #include <utility>
 #include <vector>
 
+#include "flutter/fml/closure.h"
 #include "flutter/fml/macros.h"
 #include "flutter/shell/geometry/geometry.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/plugin_registrar.h"
@@ -139,6 +140,12 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate {
   //
   // This completes a view resize if one is pending.
   virtual void OnFramePresented();
+
+  // Set a callback that is invoked on the platform thread after the first
+  // frame is presented for this view. The callback is called exactly once
+  // and then cleared. This can be used to defer showing the host window
+  // until the first frame is rendered, avoiding a blank window flash.
+  void SetFirstFrameCallback(fml::closure callback);
 
   // |WindowBindingHandlerDelegate|
   bool OnWindowSizeChanged(size_t width, size_t height) override;
@@ -434,6 +441,10 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate {
   void SendPointerEventWithData(const FlutterPointerEvent& event_data,
                                 PointerState* state);
 
+  // Fires |first_frame_callback_| on the platform thread if set, then clears
+  // it. Called from the raster thread after a frame is presented.
+  void FireFirstFrameCallbackIfSet();
+
   // If true, rendering to the window should synchronize with the vsync
   // to prevent screen tearing.
   bool NeedsVsync() const;
@@ -498,6 +509,13 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate {
 
   // Optional sizing delegate for views that are sized to content.
   FlutterWindowsViewSizingDelegate* sizing_delegate_ = nullptr;
+
+  // Mutex protecting |first_frame_callback_|.
+  std::mutex first_frame_callback_mutex_;
+
+  // Callback invoked on the platform thread after the first frame is
+  // presented. Set via |SetFirstFrameCallback| and cleared after invocation.
+  fml::closure first_frame_callback_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(FlutterWindowsView);
 };

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -1800,5 +1800,101 @@ TEST(FlutterWindowsViewTest, SizeChangeTriggersMetricsEventWhichHasDisplayId) {
   view.OnWindowSizeChanged(100, 100);
   EXPECT_TRUE(received_metrics);
 }
+// Verify that the first frame callback fires after OnFramePresented (OpenGL
+// rendering path).
+TEST(FlutterWindowsViewTest, FirstFrameCallbackFiresOnFramePresented) {
+  std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
+
+  std::unique_ptr<FlutterWindowsView> view =
+      engine->CreateView(std::make_unique<NiceMock<MockWindowBindingHandler>>(),
+                         /*is_sized_to_content=*/false, BoxConstraints());
+
+  bool callback_fired = false;
+  view->SetFirstFrameCallback([&callback_fired]() { callback_fired = true; });
+
+  // Simulate the raster thread presenting a frame.
+  view->OnFramePresented();
+
+  // The callback is posted to the platform thread's task runner.
+  // Process pending tasks to execute it.
+  engine->task_runner()->ProcessTasks();
+
+  EXPECT_TRUE(callback_fired);
+}
+
+// Verify that the first frame callback fires after PresentSoftwareBitmap
+// (software rendering path).
+TEST(FlutterWindowsViewTest, FirstFrameCallbackFiresOnSoftwareBitmapPresent) {
+  std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
+
+  auto window_binding_handler =
+      std::make_unique<NiceMock<MockWindowBindingHandler>>();
+  EXPECT_CALL(*window_binding_handler, OnBitmapSurfaceUpdated)
+      .WillOnce(Return(true));
+
+  std::unique_ptr<FlutterWindowsView> view =
+      engine->CreateView(std::move(window_binding_handler),
+                         /*is_sized_to_content=*/false, BoxConstraints());
+
+  bool callback_fired = false;
+  view->SetFirstFrameCallback([&callback_fired]() { callback_fired = true; });
+
+  // Simulate software rendering presenting a bitmap.
+  const uint32_t pixel = 0;
+  view->PresentSoftwareBitmap(&pixel, sizeof(pixel), 1);
+
+  // Process pending tasks.
+  engine->task_runner()->ProcessTasks();
+
+  EXPECT_TRUE(callback_fired);
+}
+
+// Verify that the first frame callback fires only once, even if multiple
+// frames are presented.
+TEST(FlutterWindowsViewTest, FirstFrameCallbackFiresOnlyOnce) {
+  std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
+
+  std::unique_ptr<FlutterWindowsView> view =
+      engine->CreateView(std::make_unique<NiceMock<MockWindowBindingHandler>>(),
+                         /*is_sized_to_content=*/false, BoxConstraints());
+
+  int callback_count = 0;
+  view->SetFirstFrameCallback([&callback_count]() { callback_count++; });
+
+  // Present two frames.
+  view->OnFramePresented();
+  view->OnFramePresented();
+
+  // Process all pending tasks.
+  engine->task_runner()->ProcessTasks();
+
+  EXPECT_EQ(callback_count, 1);
+}
+
+// Verify that the first frame callback does not fire if PresentSoftwareBitmap
+// fails.
+TEST(FlutterWindowsViewTest, FirstFrameCallbackSkippedOnFailedSoftwarePresent) {
+  std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
+
+  auto window_binding_handler =
+      std::make_unique<NiceMock<MockWindowBindingHandler>>();
+  EXPECT_CALL(*window_binding_handler, OnBitmapSurfaceUpdated)
+      .WillOnce(Return(false));
+
+  std::unique_ptr<FlutterWindowsView> view =
+      engine->CreateView(std::move(window_binding_handler),
+                         /*is_sized_to_content=*/false, BoxConstraints());
+
+  bool callback_fired = false;
+  view->SetFirstFrameCallback([&callback_fired]() { callback_fired = true; });
+
+  const uint32_t pixel = 0;
+  view->PresentSoftwareBitmap(&pixel, sizeof(pixel), 1);
+
+  engine->task_runner()->ProcessTasks();
+
+  EXPECT_FALSE(callback_fired);
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -1800,6 +1800,7 @@ TEST(FlutterWindowsViewTest, SizeChangeTriggersMetricsEventWhichHasDisplayId) {
   view.OnWindowSizeChanged(100, 100);
   EXPECT_TRUE(received_metrics);
 }
+
 // Verify that the first frame callback fires after OnFramePresented (OpenGL
 // rendering path).
 TEST(FlutterWindowsViewTest, FirstFrameCallbackFiresOnFramePresented) {

--- a/engine/src/flutter/shell/platform/windows/host_window.cc
+++ b/engine/src/flutter/shell/platform/windows/host_window.cc
@@ -311,12 +311,15 @@ void HostWindow::InitializeFlutterView(
 
   SetChildContent(view_controller_->view()->GetWindowHandle(), window_handle_);
 
-  // TODO(loicsharma): Hide the window until the first frame is rendered.
-  // Single window apps use the engine's next frame callback to show the
-  // window. This doesn't work for multi window apps as the engine cannot have
-  // multiple next frame callbacks. If multiple windows are created, only the
-  // last one will be shown.
-  ShowWindow(window_handle_, params.nCmdShow);
+  // Defer showing the window until the first frame is rendered so the user
+  // doesn't see a blank window. Each view has its own first-frame callback,
+  // so this works correctly for multi-window apps.
+  view_controller_->view()->SetFirstFrameCallback(
+      [hwnd = window_handle_, cmd_show = params.nCmdShow]() {
+        if (::IsWindow(hwnd)) {
+          ShowWindow(hwnd, cmd_show);
+        }
+      });
   SetWindowLongPtr(window_handle_, GWLP_USERDATA,
                    reinterpret_cast<LONG_PTR>(this));
 }


### PR DESCRIPTION
This PR adds first frame callback to FlutterWindowView such that we only show window after first frame.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
