### PR TITLE
Rename ExecutionModelToString to ExecutionModelToStringName.

### DIFF
--- a/engine/src/flutter/impeller/compiler/reflector.cc
+++ b/engine/src/flutter/impeller/compiler/reflector.cc
@@ -32,7 +32,7 @@
 namespace impeller {
 namespace compiler {
 
-static std::string ExecutionModelToString(spv::ExecutionModel model) {
+static std::string ExecutionModelToStringName(spv::ExecutionModel model) {
   switch (model) {
     case spv::ExecutionModel::ExecutionModelVertex:
       return "vertex";
@@ -151,7 +151,7 @@ std::optional<nlohmann::json> Reflector::GenerateTemplateArguments() const {
   {
     root["entrypoint"] = options_.entry_point_name;
     root["shader_name"] = options_.shader_name;
-    root["shader_stage"] = ExecutionModelToString(execution_model);
+    root["shader_stage"] = ExecutionModelToStringName(execution_model);
     root["header_file_name"] = options_.header_file_name;
   }
 


### PR DESCRIPTION
The function of the same name `ExecutionModelToString` was added in spirv.hpp[1] in a commit later than the one we pinned to, and it is a build failure when we compile against the later version.

Renaming it to prevent that.

[1]: https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Cross/+/a4598963b576cb4824b162ccac2c060db395cac4/spirv.hpp#3045
