### PR TITLE
[flutter_tools] Avoid File.exists and File.stat, as per enforced lint rule

### DIFF
--- a/packages/flutter_goldens/lib/skia_client.dart
+++ b/packages/flutter_goldens/lib/skia_client.dart
@@ -233,7 +233,7 @@ class SkiaGoldClient {
       // tree.
       String? resultContents;
       final File resultFile = workDirectory.childFile(fs.path.join('result-state.json'));
-      if (await resultFile.exists()) {
+      if (resultFile.existsSync()) {
         resultContents = await resultFile.readAsString();
       }
 
@@ -367,7 +367,7 @@ class SkiaGoldClient {
         !(resultStdout.contains('Untriaged') || resultStdout.contains('negative image'))) {
       String? resultContents;
       final File resultFile = workDirectory.childFile(fs.path.join('result-state.json'));
-      if (await resultFile.exists()) {
+      if (resultFile.existsSync()) {
         resultContents = await resultFile.readAsString();
       }
       final buf = StringBuffer()
@@ -482,7 +482,7 @@ class SkiaGoldClient {
   Future<bool> clientIsAuthorized() async {
     final File authFile = workDirectory.childFile(fs.path.join('temp', 'auth_opt.json'));
 
-    if (await authFile.exists()) {
+    if (authFile.existsSync()) {
       final String contents = await authFile.readAsString();
       final decoded = json.decode(contents) as Map<String, dynamic>;
       return !(decoded['GSUtil'] as bool);

--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -294,7 +294,7 @@ abstract class UnpackIOS extends UnpackDarwin {
         .childDirectory(FlutterDarwinPlatform.ios.frameworkName)
         .childFile(FlutterDarwinPlatform.ios.binaryName);
     final String frameworkBinaryPath = frameworkBinary.path;
-    if (!await frameworkBinary.exists()) {
+    if (!frameworkBinary.existsSync()) {
       throw Exception('Binary $frameworkBinaryPath does not exist, cannot thin');
     }
     await thinFramework(environment, frameworkBinaryPath, archs);

--- a/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
@@ -80,7 +80,7 @@ class DartBuild extends Target {
       outputDepfile.parent.createSync(recursive: true);
     }
     environment.depFileService.writeToFile(depfile, outputDepfile);
-    if (!await outputDepfile.exists()) {
+    if (!outputDepfile.existsSync()) {
       throw StateError("${outputDepfile.path} doesn't exist.");
     }
   }
@@ -167,14 +167,14 @@ class InstallCodeAssets extends Target {
       nativeAssetsFileUri: nativeAssetsFileUri,
       targetUri: targetUri,
     );
-    assert(await fileSystem.file(nativeAssetsFileUri).exists());
+    assert(fileSystem.file(nativeAssetsFileUri).existsSync());
 
     final depfile = Depfile(<File>[
       for (final Uri file in dartHookResult.filesToBeBundled) fileSystem.file(file),
     ], installedFiles);
     final File outputDepfile = environment.buildDir.childFile(depFilename);
     environment.depFileService.writeToFile(depfile, outputDepfile);
-    if (!await outputDepfile.exists()) {
+    if (!outputDepfile.existsSync()) {
       throwToolExit("${outputDepfile.path} doesn't exist.");
     }
   }

--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -705,7 +705,7 @@ _flutter.buildConfig = ${jsonEncode(buildConfig)};
         environment.serviceWorkerStrategy == ServiceWorkerStrategy.offlineFirst;
     final File inputFlutterBootstrapJs = webResources.childFile('flutter_bootstrap.js');
     final String inputBootstrapContent;
-    if (await inputFlutterBootstrapJs.exists()) {
+    if (inputFlutterBootstrapJs.existsSync()) {
       inputBootstrapContent = await inputFlutterBootstrapJs.readAsString();
     } else {
       inputBootstrapContent = generateDefaultFlutterBootstrapScript(

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -1252,7 +1252,7 @@ class DeviceDomain extends Domain {
     final tempFileName = 'screenshot_${_id++}';
     final File tempFile = daemon.proxyDomain.tempDirectory.childFile(tempFileName);
     await device.takeScreenshot(tempFile);
-    if (await tempFile.exists()) {
+    if (tempFile.existsSync()) {
       final String imageBase64 = base64.encode(await tempFile.readAsBytes());
       return imageBase64;
     } else {
@@ -1665,7 +1665,7 @@ class ProxyDomain extends Domain {
     final String path = _getStringArg(args, 'path', required: true)!;
     final bool cacheResult = _getBoolArg(args, 'cacheResult') ?? false;
     final File file = tempDirectory.childFile(path);
-    if (!await file.exists()) {
+    if (!file.existsSync()) {
       return null;
     }
     final File hashFile = file.parent.childFile('${file.basename}.hashes');
@@ -1688,7 +1688,7 @@ class ProxyDomain extends Domain {
   Future<bool?> updateFile(Map<String, Object?> args, Stream<List<int>>? binary) async {
     final String path = _getStringArg(args, 'path', required: true)!;
     final File file = tempDirectory.childFile(path);
-    if (!await file.exists()) {
+    if (!file.existsSync()) {
       return null;
     }
     final List<Map<String, Object?>> deltaJson = (args['delta']! as List<Object?>)

--- a/packages/flutter_tools/lib/src/flutter_cache.dart
+++ b/packages/flutter_tools/lib/src/flutter_cache.dart
@@ -236,7 +236,7 @@ class LegacyCanvasKitRemover extends ArtifactSet {
 
   @override
   Future<bool> isUpToDate(FileSystem fileSystem) async =>
-      !(await _getLegacyCanvasKitDirectory(fileSystem).exists());
+      !_getLegacyCanvasKitDirectory(fileSystem).existsSync();
 
   @override
   Future<void> update(

--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -32,7 +32,7 @@ import 'plugins.dart';
 import 'project.dart';
 
 Future<bool> _fileContentsUnchanged(File file, String renderedTemplate) async {
-  if (!await file.exists()) {
+  if (!file.existsSync()) {
     return false;
   }
   final List<int> fileBytes = await file.readAsBytes();
@@ -1808,7 +1808,7 @@ Future<void> generateMainDartWithPluginRegistrant(
   final File newMainDart = rootProject.dartPluginRegistrant;
   if (resolutions.isEmpty) {
     try {
-      if (await newMainDart.exists()) {
+      if (newMainDart.existsSync()) {
         await newMainDart.delete();
       }
     } on FileSystemException catch (error) {

--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -250,7 +250,7 @@ class WebDevFS implements DevFS {
 
   Future<void> _validateTemplateFile(String filename) async {
     final File file = fileSystem.currentDirectory.childDirectory('web').childFile(filename);
-    if (!await file.exists()) {
+    if (!file.existsSync()) {
       return;
     }
 

--- a/packages/flutter_tools/lib/src/isolated/native_assets/ios/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/ios/native_assets.dart
@@ -108,7 +108,7 @@ Future<List<File>> copyNativeCodeAssetsIOS(
     final Uri assetTargetUri = targetUri.resolveUri(target);
     final File dylibFile = fileSystem.file(assetTargetUri);
     final Directory frameworkDir = dylibFile.parent;
-    if (!await frameworkDir.exists()) {
+    if (!frameworkDir.existsSync()) {
       await frameworkDir.create(recursive: true);
     }
     await lipoDylibs(dylibFile, sources);

--- a/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets.dart
@@ -122,7 +122,7 @@ Future<List<File>> copyNativeCodeAssetsMacOS(
     final Uri assetTargetUri = targetUri.resolveUri(target);
     final String name = assetTargetUri.pathSegments.last;
     final Directory frameworkDir = fileSystem.file(assetTargetUri).parent;
-    if (await frameworkDir.exists()) {
+    if (frameworkDir.existsSync()) {
       await frameworkDir.delete(recursive: true);
     }
     // MyFramework.framework/                           frameworkDir
@@ -226,7 +226,7 @@ Future<List<File>> copyNativeCodeAssetsMacOSFlutterTester(
     final Uri assetTargetUri = targetUri.resolveUri(target);
     final File dylibFile = fileSystem.file(assetTargetUri);
     final Directory targetParent = dylibFile.parent;
-    if (!await targetParent.exists()) {
+    if (!targetParent.existsSync()) {
       await targetParent.create(recursive: true);
     }
     await lipoDylibs(dylibFile, sources);

--- a/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
@@ -288,7 +288,7 @@ Future<Uri> _writeNativeAssetsJson(
   final String nativeAssetsDartContents = _toNativeAssetsJsonFile(assets);
   final File nativeAssetsFile = fileSystem.file(nativeAssetsJsonUri);
   final Directory parentDirectory = nativeAssetsFile.parent;
-  if (!await parentDirectory.exists()) {
+  if (!parentDirectory.existsSync()) {
     await parentDirectory.create(recursive: true);
   }
   await nativeAssetsFile.writeAsString(nativeAssetsDartContents);

--- a/packages/flutter_tools/lib/src/isolated/native_assets/test/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/test/native_assets.dart
@@ -94,7 +94,7 @@ Future<Uri?> testCompilerBuildNativeAssets(BuildInfo buildInfo) async {
     nativeAssetsFileUri: nativeAssetsFileUri,
     targetUri: projectUri.resolve('${getBuildDirectory()}/native_assets/$osName/'),
   );
-  assert(await globals.fs.file(nativeAssetsFileUri).exists());
+  assert(globals.fs.file(nativeAssetsFileUri).existsSync());
 
   return nativeAssetsFileUri;
 }

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -1603,6 +1603,8 @@ class ProjectFileInvalidator {
             // uri.toFilePath() does not work with MultiRootFileSystem.
             () =>
                 (uri.hasScheme && uri.scheme != 'file'
+			// TODO(srawlins): Switch from using `stat` to using `statSync`.
+			// ignore: avoid_slow_async_io
                         ? _fileSystem.file(uri).stat()
                         : _fileSystem.stat(uri.toFilePath(windows: _platform.isWindows)))
                     .then((FileStat stat) {

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -1603,8 +1603,8 @@ class ProjectFileInvalidator {
             // uri.toFilePath() does not work with MultiRootFileSystem.
             () =>
                 (uri.hasScheme && uri.scheme != 'file'
-			// TODO(srawlins): Switch from using `stat` to using `statSync`.
-			// ignore: avoid_slow_async_io
+                        // TODO(srawlins): Switch from using `stat` to using `statSync`.
+                        // ignore: avoid_slow_async_io
                         ? _fileSystem.file(uri).stat()
                         : _fileSystem.stat(uri.toFilePath(windows: _platform.isWindows)))
                     .then((FileStat stat) {

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -210,7 +210,7 @@ interface class FlutterTestRunner {
         .childDirectory('.dart_tool')
         .childFile('package_config.json');
     PackageConfig? projectPackageConfig;
-    if (await packageConfigFile.exists()) {
+    if (packageConfigFile.existsSync()) {
       projectPackageConfig = PackageConfig.parseBytes(
         packageConfigFile.readAsBytesSync(),
         Uri.file(flutterProject.directory.path),


### PR DESCRIPTION
`avoid_slow_async_io` is already enforced, but there was a bug where it wasn't catching `File.exists` and `File.stat`. This PR prepares flutter/flutter for a fix.

The fix is landing to support extension types: https://github.com/dart-lang/sdk/issues/58838.
The fix will be a re-landing of https://dart-review.googlesource.com/c/sdk/+/486420.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

