### PR TITLE
Fix GitHub workflows to use the `flutteractionsbot` mirror for PR branches.

### DIFF
--- a/.github/workflows/merge-changelog.yml
+++ b/.github/workflows/merge-changelog.yml
@@ -19,22 +19,25 @@ jobs:
       - name: Setup Repository
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
+          repository: flutteractionsbot/flutter
+          token: ${{ secrets.FLUTTERACTIONSBOT_CP_TOKEN }}
           ref: master
-
-      # avoid downloading hundreds of other branches/history
-      # utilizing `fetch-depth:0` in actions/checkout would clone everything.
-      - name: Fetch Stable Branch Only
-        run: git fetch origin stable:stable --depth=1
 
       - name: Configure git
         run: |
           git config user.name "[bot] Merge Changelog"
           git config user.email "<>"
+          git remote add upstream https://github.com/flutter/flutter.git
+
+      # avoid downloading hundreds of other branches/history
+      # utilizing `fetch-depth:0` in actions/checkout would clone everything.
+      - name: Fetch Stable Branch Only
+        run: git fetch upstream stable:stable --depth=1
 
       - name: Read CHANGELOG.md from the stable branch
         id: read_stable_changelog
         run: |
-          # origin/stable is locally mapped to stable
+          # upstream/stable is locally mapped to stable
           # use the local stable ref from above
           CHANGELOG_CONTENT=$(git show stable:CHANGELOG.md)
           echo "CHANGELOG_CONTENT<<EOF" >> $GITHUB_ENV
@@ -43,6 +46,8 @@ jobs:
 
       - name: Prepare PR branch and commit changes
         id: prepare_pr_branch
+        env:
+          GH_TOKEN: ${{ secrets.FLUTTERACTIONSBOT_CP_TOKEN }}
         run: |
           PR_BRANCH="sync-changelog-stable-to-master-$(date +%s)"
           echo "pr_branch_name=$PR_BRANCH" >> "$GITHUB_OUTPUT"
@@ -54,13 +59,14 @@ jobs:
 
       - name: Create Pull Request
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.FLUTTERACTIONSBOT_CP_TOKEN }}
         run: |
           PR_HEAD_BRANCH=${{ steps.prepare_pr_branch.outputs.pr_branch_name }}
 
           gh pr create \
             --base master \
-            --head "$PR_HEAD_BRANCH" \
+            --head flutteractionsbot:$PR_HEAD_BRANCH \
+            --repo flutter/flutter \
             --title "Sync CHANGELOG.md from stable" \
             --body "This PR automates the synchronization of \`CHANGELOG.md\` from the \`stable\` branch to the \`master\` branch." \
             --label autosubmit

--- a/.github/workflows/merge-changelog.yml
+++ b/.github/workflows/merge-changelog.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Configure git
         run: |
-          git config user.name "[bot] Merge Changelog"
+          git config user.name "GitHub Actions Bot"
           git config user.email "<>"
           git remote add upstream https://github.com/flutter/flutter.git
 

--- a/.github/workflows/roll-dart-dependencies.yml
+++ b/.github/workflows/roll-dart-dependencies.yml
@@ -18,6 +18,24 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          repository: flutteractionsbot/flutter
+          token: ${{ secrets.FLUTTERACTIONSBOT_CP_TOKEN }}
+          ref: master
+
+      - name: Configure git
+        env:
+          GH_TOKEN: ${{ secrets.FLUTTERACTIONSBOT_CP_TOKEN }}
+        run: |
+          git config user.name "[bot] Update Dart Dependencies"
+          git config user.email "<>"
+          git remote add upstream https://github.com/flutter/flutter.git
+          git fetch upstream ${{ github.ref_name }}
+
+          BRANCH_NAME="sync-dart-${{ inputs.dart_hash }}"
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+
+          git checkout -b "$BRANCH_NAME" upstream/${{ github.ref_name }}
 
       - name: Download and Decode Dart DEPS
         id: download-deps
@@ -78,20 +96,15 @@ jobs:
       - name: Create PR if Changed
         if: steps.git-check.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.FLUTTERACTIONSBOT_CP_TOKEN }}
         run: |
-          git config user.name "[bot] Update Dart Dependencies"
-          git config user.email "<>"
-
-          BRANCH_NAME="sync-dart-${{ inputs.dart_hash }}"
-
-          git checkout -b "$BRANCH_NAME"
           git add DEPS
-          git commit -m "Update flutter DEPS to dart $DART_HASH"
+          git commit -m "Update flutter DEPS to dart ${{ inputs.dart_hash }}"
           git push origin "$BRANCH_NAME" --force
 
           gh pr create \
             --title "[${{ github.ref_name }}] Update Flutter DEPS to Dart ${{ inputs.dart_hash }}" \
             --body "This PR updates the transitive dependencies in the engine \`DEPS\` file based on Dart SDK hash \`${{ inputs.dart_hash }}\`." \
+            --repo flutter/flutter \
             --base ${{ github.ref_name }} \
-            --head "$BRANCH_NAME"
+            --head flutteractionsbot:$BRANCH_NAME

--- a/.github/workflows/roll-dart-dependencies.yml
+++ b/.github/workflows/roll-dart-dependencies.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.FLUTTERACTIONSBOT_CP_TOKEN }}
         run: |
-          git config user.name "[bot] Update Dart Dependencies"
+          git config user.name "GitHub Actions Bot"
           git config user.email "<>"
           git remote add upstream https://github.com/flutter/flutter.git
           git fetch upstream ${{ github.ref_name }}

--- a/.github/workflows/sync-engine-version.yml
+++ b/.github/workflows/sync-engine-version.yml
@@ -13,6 +13,24 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          repository: flutteractionsbot/flutter
+          token: ${{ secrets.FLUTTERACTIONSBOT_CP_TOKEN }}
+          ref: master
+
+      - name: Configure git
+        env:
+          GH_TOKEN: ${{ secrets.FLUTTERACTIONSBOT_CP_TOKEN }}
+        run: |
+          git config user.name "[bot] Sync Engine Version"
+          git config user.email "<>"
+          git remote add upstream https://github.com/flutter/flutter.git
+          git fetch upstream ${{ github.ref_name }}
+
+          BRANCH_NAME="update-engine-$(date +%s)"
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+
+          git checkout -b "$BRANCH_NAME" upstream/${{ github.ref_name }}
 
       - name: Generate and Capture Hash
         id: generate-hash
@@ -47,15 +65,9 @@ jobs:
       - name: Create PR if Changed
         if: steps.git-check.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.FLUTTERACTIONSBOT_CP_TOKEN }}
         run: |
-          # Configure Git
-          git config user.name "[bot] Sync Engine Version"
-          git config user.email "<>"
-
-          # Create and push a unique branch
-          BRANCH_NAME="update-engine-$(date +%s)"
-          git checkout -b "$BRANCH_NAME"
+          # Make a commit and push to the branch.
           git add bin/internal/engine.version
           git commit -m "Update engine.version to $(cat bin/internal/engine.version)"
           git push origin "$BRANCH_NAME"
@@ -64,5 +76,6 @@ jobs:
           gh pr create \
             --title "[${{ github.ref_name }}] Sync engine.version to ${{ env.ENGINE_HASH }}" \
             --body "Updates the engine.version file." \
+            --repo flutter/flutter \
             --base ${{ github.ref_name }} \
-            --head "$BRANCH_NAME"
+            --head flutteractionsbot:$BRANCH_NAME

--- a/.github/workflows/sync-engine-version.yml
+++ b/.github/workflows/sync-engine-version.yml
@@ -22,7 +22,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.FLUTTERACTIONSBOT_CP_TOKEN }}
         run: |
-          git config user.name "[bot] Sync Engine Version"
+          git config user.name "GitHub Actions Bot"
           git config user.email "<>"
           git remote add upstream https://github.com/flutter/flutter.git
           git fetch upstream ${{ github.ref_name }}


### PR DESCRIPTION
Branch creation is restricted in `flutter/flutter` and so GitHub workflows can't (by default) create any branches on the main repository. However, the `easy_cp` workflow already works around this by using the `flutteractionsbot` mirror to host the PR branches. This PR modifies our workflows to make them in line with the strategy that `easy_cp` uses.