### PR TITLE
Fix Semantics expanded state not updating in PopupMenuButton and DropdownButton

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1401,7 +1401,6 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
 
   void _removeDropdownRoute() {
     _dropdownRoute?._dismiss();
-    _isMenuExpanded = false;
     _dropdownRoute = null;
     _lastOrientation = null;
   }
@@ -1505,6 +1504,11 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     focusNode.requestFocus();
     navigator.push(_dropdownRoute!).then<void>((_DropdownRouteResult<T>? newValue) {
       _removeDropdownRoute();
+      if (mounted) {
+        setState(() {
+          _isMenuExpanded = false;
+        });
+      }
       if (!mounted || newValue == null) {
         return;
       }
@@ -1512,7 +1516,9 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     });
 
     widget.onTap?.call();
-    _isMenuExpanded = true;
+    setState(() {
+      _isMenuExpanded = true;
+    });
   }
 
   // When isDense is true, reduce the height of this button from _kMenuItemHeight to

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -1692,7 +1692,9 @@ class PopupMenuButtonState<T> extends State<PopupMenuButton<T>> {
     // Only show the menu if there is something to show
     if (items.isNotEmpty) {
       widget.onOpened?.call();
-      _isMenuExpanded = true;
+      setState(() {
+        _isMenuExpanded = true;
+      });
       showMenu<T?>(
         context: context,
         elevation: widget.elevation,
@@ -1714,12 +1716,14 @@ class PopupMenuButtonState<T> extends State<PopupMenuButton<T>> {
         if (!mounted) {
           return null;
         }
+        setState(() {
+          _isMenuExpanded = false;
+        });
         if (newValue == null) {
           widget.onCanceled?.call();
           return null;
         }
         widget.onSelected?.call(newValue);
-        _isMenuExpanded = false;
       });
     }
   }

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -1440,6 +1440,62 @@ void main() {
     handle.dispose();
   });
 
+  testWidgets('Dropdown button Semantics expanded state should update when menu opens and closes', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/183432
+    const key = Key('test');
+    await tester.pumpWidget(buildFrame(buttonKey: key, onChanged: onChanged));
+
+    // Before opening: should have expanded state but not be expanded.
+    expect(
+      tester.getSemantics(find.byType(DropdownButton<String>)),
+      matchesSemantics(
+        isButton: true,
+        hasExpandedState: true,
+        label: 'two',
+        hasTapAction: true,
+        hasFocusAction: true,
+        isFocusable: true,
+      ),
+    );
+
+    // Open the menu.
+    await tester.tap(find.text('two'));
+    await tester.pumpAndSettle();
+
+    // While the menu is open, BlockSemantics in ModalBarrier blocks the
+    // button's semantics node (making tester.getSemantics return a stale node).
+    // Verify the Semantics widget's expanded property directly instead.
+    final Semantics expandedSemantics = tester.widget<Semantics>(
+      find.descendant(
+        of: find.byKey(key),
+        matching: find.byWidgetPredicate(
+          (Widget widget) => widget is Semantics && widget.properties.expanded != null,
+        ),
+      ),
+    );
+    expect(expandedSemantics.properties.expanded, isTrue);
+
+    // Close the menu by selecting an item.
+    await tester.tap(find.text('one').last);
+    await tester.pumpAndSettle();
+
+    // After closing: should have expanded state but not be expanded.
+    expect(
+      tester.getSemantics(find.byType(DropdownButton<String>)),
+      matchesSemantics(
+        isButton: true,
+        hasExpandedState: true,
+        label: 'two',
+        hasTapAction: true,
+        hasFocusAction: true,
+        isFocusable: true,
+        isFocused: true,
+      ),
+    );
+  });
+
   testWidgets('Dropdown menu includes semantics', (WidgetTester tester) async {
     final semantics = SemanticsTester(tester);
     const key = Key('test');

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -1382,6 +1382,74 @@ void main() {
     semantics.dispose();
   });
 
+  testWidgets('PopupMenuButton Semantics expanded state updates when menu opens and closes', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/183432
+    const key = Key('test');
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: PopupMenuButton<int>(
+            key: key,
+            itemBuilder: (BuildContext context) {
+              return <PopupMenuItem<int>>[
+                const PopupMenuItem<int>(value: 1, child: Text('Item 1')),
+                const PopupMenuItem<int>(value: 2, child: Text('Item 2')),
+              ];
+            },
+            child: const SizedBox(height: 100.0, width: 100.0, child: Text('XXX')),
+          ),
+        ),
+      ),
+    );
+
+    // Before opening: should have expanded state but not be expanded.
+    expect(
+      tester.getSemantics(find.byType(PopupMenuButton<int>)),
+      matchesSemantics(
+        hasExpandedState: true,
+        label: 'XXX',
+        hasTapAction: true,
+        hasFocusAction: true,
+        isFocusable: true,
+      ),
+    );
+
+    // Open the menu.
+    await tester.tap(find.text('XXX'));
+    await tester.pumpAndSettle();
+
+    // While the menu is open, BlockSemantics in ModalBarrier blocks the
+    // button's semantics node (making tester.getSemantics return a stale node).
+    // Verify the Semantics widget's expanded property directly instead.
+    final Semantics expandedSemantics = tester.widget<Semantics>(
+      find.descendant(
+        of: find.byKey(key),
+        matching: find.byWidgetPredicate(
+          (Widget widget) => widget is Semantics && widget.properties.expanded != null,
+        ),
+      ),
+    );
+    expect(expandedSemantics.properties.expanded, isTrue);
+
+    // Close the menu by selecting an item.
+    await tester.tap(find.text('Item 1').last);
+    await tester.pumpAndSettle();
+
+    // After closing: should have expanded state but not be expanded.
+    expect(
+      tester.getSemantics(find.byType(PopupMenuButton<int>)),
+      matchesSemantics(
+        hasExpandedState: true,
+        label: 'XXX',
+        hasTapAction: true,
+        hasFocusAction: true,
+        isFocusable: true,
+      ),
+    );
+  });
+
   testWidgets('PopupMenuItem merges the semantics of its descendants', (WidgetTester tester) async {
     final semantics = SemanticsTester(tester);
     await tester.pumpWidget(


### PR DESCRIPTION
Fixes #183432

## Description

`_isMenuExpanded` is updated without calling `setState()` in both `PopupMenuButton` and `DropdownButton`, so the `Semantics(expanded: _isMenuExpanded)` widget doesn't rebuild.

**`PopupMenuButton`**: The `expanded` state never updates at all since there is no `setState()` call anywhere in `PopupMenuButtonState`.

**`DropdownButton`**: Currently masked by `_handleFocusChanged`, which happens to call `setState()` whenever focus changes on open/close, but should not rely on this side effect.

### Changes

- Wrapped `_isMenuExpanded` assignments with `setState()` in both widgets.
- For `DropdownButton`, moved `_isMenuExpanded = false` from `_removeDropdownRoute()` to the `.then()` callback with a `mounted` guard. This avoids unnecessary `setState()` calls when `_removeDropdownRoute()` is invoked during `dispose()` or orientation changes in `build()`, where the menu state isn't actually changing from user interaction.

## Tests

Added regression tests for both `PopupMenuButton` and `DropdownButton` to verify the `expanded` semantics state updates correctly when the menu opens and closes.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.