### PR TITLE
[cp-stable] GitHub workflows to assist with releases.

### DIFF
--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -1,0 +1,85 @@
+name: Cut Release Branch
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version string (format X.Y)'
+        required: true
+        type: string
+      commit_hash:
+        description: 'The hash of the commit to branch off of'
+        required: true
+        type: string
+
+jobs:
+  check-membership:
+    runs-on: ubuntu-latest
+    outputs:
+      is_member: ${{ steps.check.outputs.is_member }}
+    steps:
+      - name: Check if user is in the required team
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.FLUTTER_READ_ORG }}
+        run: |
+          # Use the GitHub CLI to check team membership
+          # Returns 204 if member, 404 if not
+          if gh api orgs/flutter/teams/flutter-release-eng/memberships/${{ github.actor }} --silent; then
+            echo "is_member=true" >> $GITHUB_OUTPUT
+          else
+            echo "::error::User ${{ github.actor }} is not a member of flutter-release-eng."
+            exit 1
+          fi
+
+  create-release-branch:
+    needs: check-membership
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to create branches and push commits
+
+    steps:
+      - name: Validate Version Format
+        run: |
+          if [[ ! "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Version must be in 'X.Y' format (e.g., 3.10)."
+            exit 1
+          fi
+
+      - name: Checkout target commit
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          ref: ${{ inputs.commit_hash }}
+
+      - name: Set Environment Variables
+        run: |
+          echo "BRANCH_NAME=flutter-${{ inputs.version }}-candidate.0" >> $GITHUB_ENV
+
+      - name: Check if branch already exists
+        run: |
+          if git ls-remote --exit-code --heads origin ${{ env.BRANCH_NAME }}; then
+            echo "Error: Branch ${{ env.BRANCH_NAME }} already exists on remote."
+            exit 1
+          fi
+
+      - name: Configure Git
+        run: |
+          git config user.name "[bot] Cut Release Branch"
+          git config user.email "<>"
+
+      - name: Create Branch and Version File
+        run: |
+          # Create and switch to the new branch locally
+          git checkout -b ${{ env.BRANCH_NAME }}
+
+          # Create the version file
+          mkdir -p bin/internal/
+          echo -n "${{ env.BRANCH_NAME }}" > bin/internal/release-candidate-branch.version
+
+          # Commit the change
+          git add bin/internal/release-candidate-branch.version
+          git commit -m "Initialize release branch ${{ env.BRANCH_NAME }}"
+
+      - name: Push new branch
+        run: |
+          git push origin ${{ env.BRANCH_NAME }}

--- a/.github/workflows/merge-changelog.yml
+++ b/.github/workflows/merge-changelog.yml
@@ -14,27 +14,40 @@ jobs:
       pull-requests: write
 
     steps:
+      # defaults to `fetch-depth:1` which only checks out the current branch
+      # since the action runs on master, it will only checkout master.
       - name: Setup Repository
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
-          repository: ${{ github.repository }}
+          repository: flutteractionsbot/flutter
+          token: ${{ secrets.FLUTTERACTIONSBOT_CP_TOKEN }}
           ref: master
 
       - name: Configure git
         run: |
-          git config user.name "[bot] Merge Changelog"
+          git config user.name "GitHub Actions Bot"
           git config user.email "<>"
+          git remote add upstream https://github.com/flutter/flutter.git
+
+      # avoid downloading hundreds of other branches/history
+      # utilizing `fetch-depth:0` in actions/checkout would clone everything.
+      - name: Fetch Stable Branch Only
+        run: git fetch upstream stable:stable --depth=1
 
       - name: Read CHANGELOG.md from the stable branch
         id: read_stable_changelog
         run: |
-          CHANGELOG_CONTENT=$(git show origin/stable:CHANGELOG.md)
+          # upstream/stable is locally mapped to stable
+          # use the local stable ref from above
+          CHANGELOG_CONTENT=$(git show stable:CHANGELOG.md)
           echo "CHANGELOG_CONTENT<<EOF" >> $GITHUB_ENV
           echo "$CHANGELOG_CONTENT" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
 
       - name: Prepare PR branch and commit changes
         id: prepare_pr_branch
+        env:
+          GH_TOKEN: ${{ secrets.FLUTTERACTIONSBOT_CP_TOKEN }}
         run: |
           PR_BRANCH="sync-changelog-stable-to-master-$(date +%s)"
           echo "pr_branch_name=$PR_BRANCH" >> "$GITHUB_OUTPUT"
@@ -46,13 +59,14 @@ jobs:
 
       - name: Create Pull Request
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.FLUTTERACTIONSBOT_CP_TOKEN }}
         run: |
           PR_HEAD_BRANCH=${{ steps.prepare_pr_branch.outputs.pr_branch_name }}
 
           gh pr create \
             --base master \
-            --head "$PR_HEAD_BRANCH" \
+            --head flutteractionsbot:$PR_HEAD_BRANCH \
+            --repo flutter/flutter \
             --title "Sync CHANGELOG.md from stable" \
             --body "This PR automates the synchronization of \`CHANGELOG.md\` from the \`stable\` branch to the \`master\` branch." \
             --label autosubmit

--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -1,0 +1,124 @@
+name: 🚀 Create Release Tracker
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version (format X.Y.Z for stable or X.Y.0-0.Z.pre for beta)'
+        required: true
+        type: string
+      release_channel:
+        description: 'Release Channel'
+        required: true
+        type: choice
+        options:
+          - stable
+          - beta
+      hotfix:
+        description: 'Hotfix Release'
+        required: true
+        type: boolean
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  create_issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Tracking Issue
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const version = "${{ inputs.version }}";
+            const channel = "${{ inputs.release_channel }}";
+            const hotfix = "${{ inputs.hotfix }}";
+            const releaseType = hotfix === "true" ? "hotfix" : "initial";
+
+            let versionValidator;
+            if (channel === 'stable') {
+              if (hotfix === 'true') {
+                versionValidator = /^\d+\.\d+\.[1-9]\d*$/;
+              } else {
+                versionValidator = /^\d+\.\d+\.0$/;
+              }
+            } else if (channel === 'beta') {
+              if (hotfix === 'true') {
+                versionValidator = /^\d+\.\d+\.0-0\.[1-9]\d*\.pre$/;
+              } else {
+                versionValidator = /^\d+\.\d+\.0-0\.1\.pre$/;
+              }
+            } else {
+              core.setFailed(`Validation Error: Invalid channel name: ${channel}`);
+            }
+
+            if (!versionValidator.test(version)) {
+              core.setFailed(`Validation Error: The version "${version}" is not a valid format for a ${channel} ${releaseType} release.`);
+              return;
+            }
+
+            const majorMinorVersion = version.match(/^(\d+\.\d+)/)[0];
+            const branchName = `flutter-${majorMinorVersion}-candidate.0`;
+
+            // Build the dynamic checklist
+            let body = `## Flutter Release\n`;
+            body += `Candidate Branch: [${branchName}](https://github.com/${context.repo.owner}/${context.repo.repo}/tree/${branchName})\n`;
+            body += `Tag: [${version}](https://github.com/{context.repo.owner}/${context.repo.repo}/releases/tag/${version})\n`;
+
+            body += `### 📋 Release Checklist\n\n`;
+
+            // Add link to branches etc
+
+            if (channel === 'beta' && hotfix !== 'true') {
+              body += '#### Branch Alignment\n';
+              body += '  - [ ] Stop the [Dart Auto Roller](https://autoroll.skia.org/r/dart-sdk-flutter)\n';
+              body += '  - [ ] Roll forward to aligned Dart hash\n';
+              body += '    - Dart Hash: [Paste the Dart hash here]\n';
+              body += '  - [ ] Wait for Google3 Roll to complete.\n';
+              body += '  - [ ] Restart the [Dart Auto Roller](https://autoroll.skia.org/r/dart-sdk-flutter)\n';
+
+              body += '#### Cut release branches\n';
+              body += '  - [ ] Cut new flutter branch: `' + branchName + '`\n';
+              body += '  - [ ] Cut new recipes branch: `' + branchName + '` [Gerrit UI](https://flutter-review.googlesource.com/admin/repos/recipes,branches)\n';
+            }
+
+            body += '#### Update release branch\n';
+
+            if (channel === 'beta' && hotfix !== 'true') {
+              body += '  - [ ] Create `release-candidate-branch.version` file on candidate branch\n';
+            } else {
+              body += `- [ ] Merge outstanding [cherry-picks](https://github.com/${context.repo.owner}/${context.repo.repo}/pulls?q=is%3Apr+is%3Aopen+label%3A"cp%3A+review")\n`;
+              body += '- [ ] Update Dart version if necessary\n';
+              body += '  - Dart Hash: [Paste the Dart hash here]\n';
+            }
+
+            body += '- [ ] Pin engine hash in `engine.version` if necessary\n'
+
+            if (channel === 'stable' && hotfix === 'true') {
+              body += '- [ ] Add changelog for stable release\n';
+            }
+
+            body += '#### Validate and publish release\n'
+            body += `- [ ] Run postsubmits and validate they are all passing on the [Flutter Dashboard](https://flutter-dashboard.appspot.com/#/build?repo=flutter&branch=${branchName})\n`;
+            body += '- [ ] Push release with MPA\n';
+            body += '- [ ] Check for the new versions on the [Flutter SDK Archive](https://docs.flutter.dev/install/archive)\n';
+
+            body += '- [ ] Announce the release on Discord\n';
+            body += '- [ ] Announce the release on Google internal channels\n';
+
+            if (channel === 'stable') {
+              body += '- [ ] Announce the release on flutter-announce mailing list\n';
+            }
+
+            if (channel === 'stable' && hotfix === 'true') {
+              body += '- [ ] Merge the changelog back to the `master` branch\n';
+            }
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `[${channel}] [${releaseType}] Flutter Release Version ${version}`,
+              body: body,
+              labels: ['release-tracker'],
+              assignees: [context.actor],
+            });

--- a/.github/workflows/roll-dart-dependencies.yml
+++ b/.github/workflows/roll-dart-dependencies.yml
@@ -1,0 +1,110 @@
+name: Roll Dart Dependencies
+
+on:
+  workflow_dispatch:
+    inputs:
+      dart_hash:
+        description: 'The Dart SDK commit hash to update to'
+        required: true
+        type: string
+
+jobs:
+  update-deps:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          repository: flutteractionsbot/flutter
+          token: ${{ secrets.FLUTTERACTIONSBOT_CP_TOKEN }}
+          ref: master
+
+      - name: Configure git
+        env:
+          GH_TOKEN: ${{ secrets.FLUTTERACTIONSBOT_CP_TOKEN }}
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
+          git remote add upstream https://github.com/flutter/flutter.git
+          git fetch upstream ${{ github.ref_name }}
+
+          BRANCH_NAME="sync-dart-${{ inputs.dart_hash }}"
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+
+          git checkout -b "$BRANCH_NAME" upstream/${{ github.ref_name }}
+
+      - name: Download and Decode Dart DEPS
+        id: download-deps
+        run: |
+          DART_HASH="${{ inputs.dart_hash }}"
+          URL="https://dart.googlesource.com/sdk/+/$DART_HASH/DEPS?format=TEXT"
+
+          echo "Fetching DEPS from $URL"
+
+          # Googlesource returns base64 encoded text when format=TEXT is used
+          RESPONSE=$(curl -s -f "$URL")
+
+          if [ $? -ne 0 ]; then
+            echo "::error::Failed to download DEPS file. Please verify the Dart hash: $DART_HASH"
+            exit 1
+          fi
+
+          echo "$RESPONSE" | base64 --decode > dart_deps_file
+
+          if [ ! -s dart_deps_file ]; then
+            echo "::error::Downloaded DEPS file is empty or decoding failed."
+            exit 1
+          fi
+
+      - name: Run Update Script
+        id: run-script
+        run: |
+          DART_HASH="${{ inputs.dart_hash }}"
+          DART_DEPS="dart_deps_file"
+          FLUTTER_DEPS="DEPS" # Root of the repository
+          SCRIPT="engine/src/tools/dart/create_updated_flutter_deps.py"
+
+          if [ ! -f "$SCRIPT" ]; then
+            echo "::error::Update script not found at $SCRIPT"
+            exit 1
+          fi
+
+          echo "Running $SCRIPT..."
+
+          # Execute the python script
+          if ! python3 "$SCRIPT" -d "$DART_DEPS" -f "$FLUTTER_DEPS" -r "$DART_HASH"; then
+            echo "::error::The python update script failed during execution."
+            exit 1
+          fi
+
+      - name: Check for Changes
+        id: git-check
+        run: |
+          # Check if the root DEPS file has changed
+          if git diff --exit-code DEPS; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "### No-op Success" >> $GITHUB_STEP_SUMMARY
+            echo "The DEPS file is already up to date with Dart hash \`${{ inputs.dart_hash }}\`." >> $GITHUB_STEP_SUMMARY
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create PR if Changed
+        if: steps.git-check.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.FLUTTERACTIONSBOT_CP_TOKEN }}
+        run: |
+          git add DEPS
+          git commit -m "Update flutter DEPS to dart ${{ inputs.dart_hash }}"
+          git push origin "$BRANCH_NAME" --force
+
+          gh pr create \
+            --title "[${{ github.ref_name }}] Update Flutter DEPS to Dart ${{ inputs.dart_hash }}" \
+            --body "This PR updates the transitive dependencies in the engine \`DEPS\` file based on Dart SDK hash \`${{ inputs.dart_hash }}\`." \
+            --repo flutter/flutter \
+            --base ${{ github.ref_name }} \
+            --head flutteractionsbot:$BRANCH_NAME

--- a/.github/workflows/sync-engine-version.yml
+++ b/.github/workflows/sync-engine-version.yml
@@ -1,0 +1,81 @@
+name: Sync Engine Version
+
+on:
+  workflow_dispatch:
+
+jobs:
+  sync-engine:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          repository: flutteractionsbot/flutter
+          token: ${{ secrets.FLUTTERACTIONSBOT_CP_TOKEN }}
+          ref: master
+
+      - name: Configure git
+        env:
+          GH_TOKEN: ${{ secrets.FLUTTERACTIONSBOT_CP_TOKEN }}
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
+          git remote add upstream https://github.com/flutter/flutter.git
+          git fetch upstream ${{ github.ref_name }}
+
+          BRANCH_NAME="update-engine-$(date +%s)"
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+
+          git checkout -b "$BRANCH_NAME" upstream/${{ github.ref_name }}
+
+      - name: Generate and Capture Hash
+        id: generate-hash
+        run: |
+          chmod +x bin/internal/last_engine_commit.sh
+
+          # Run the script and capture the output
+          ENGINE_HASH=$(./bin/internal/last_engine_commit.sh)
+
+          # Save to the version file
+          echo "$ENGINE_HASH" > bin/internal/engine.version
+
+          # Export to environment for later steps
+          echo "ENGINE_HASH=$ENGINE_HASH" >> $GITHUB_ENV
+
+          # Log it to the Action summary for easy viewing
+          echo "### Generated Engine Hash: \`$ENGINE_HASH\`" >> $GITHUB_STEP_SUMMARY
+
+      - name: Check for Changes
+        id: git-check
+        run: |
+          # -N (intent-to-add) treats untracked files as existing but empty
+          git add -N bin/internal/engine.version
+
+          if git diff --exit-code bin/internal/engine.version; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "No changes detected. Skipping PR." >> $GITHUB_STEP_SUMMARY
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create PR if Changed
+        if: steps.git-check.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.FLUTTERACTIONSBOT_CP_TOKEN }}
+        run: |
+          # Make a commit and push to the branch.
+          git add bin/internal/engine.version
+          git commit -m "Update engine.version to $(cat bin/internal/engine.version)"
+          git push origin "$BRANCH_NAME"
+
+          # Use the GitHub CLI (pre-installed on runners) to create the PR
+          gh pr create \
+            --title "[${{ github.ref_name }}] Sync engine.version to ${{ env.ENGINE_HASH }}" \
+            --body "Updates the engine.version file." \
+            --repo flutter/flutter \
+            --base ${{ github.ref_name }} \
+            --head flutteractionsbot:$BRANCH_NAME

--- a/engine/src/tools/dart/create_updated_flutter_deps.py
+++ b/engine/src/tools/dart/create_updated_flutter_deps.py
@@ -12,6 +12,7 @@
 
 import argparse
 import os
+import re
 import sys
 
 DART_SCRIPT_DIR = os.path.dirname(sys.argv[0])
@@ -53,6 +54,17 @@ def ParseDepsFile(deps_file):
 
   return (local_scope.get('vars', {}), local_scope.get('deps', {}))
 
+def GitHashArg(value):
+  """Validates that the string is a 40-character hex string."""
+  # If the argument is not passed, argparse usually handles the 'None'
+  # default, but this check ensures the string matches the pattern.
+  if not re.match(r"^[0-9a-f]{40}$", value):
+      raise argparse.ArgumentTypeError(
+          f"'{value}' is not a valid full git hash. "
+          "Expected a 40-character hexadecimal string."
+      )
+  return value
+
 def ParseArgs(args):
   args = args[1:]
   parser = argparse.ArgumentParser(
@@ -65,6 +77,9 @@ def ParseArgs(args):
       type=str,
       help='Flutter DEPS file.',
       default=FLUTTER_DEPS)
+  parser.add_argument('--dart_revision', '-r',
+      type=GitHashArg,
+      help='Dart revision to update to.')
   return parser.parse_args(args)
 
 def PrettifySourcePathForDEPS(flutter_vars, dep_path, source):
@@ -191,8 +206,13 @@ def Main(argv):
   lines = file.readlines()
   i = 0
   while i < len(lines):
-    updatedfile.write(lines[i])
     if lines[i].startswith("  'dart_revision':"):
+      if args.dart_revision is None:
+        # No dart revision supplied. Leave as-is.
+        updatedfile.write(lines[i])
+      else:
+        updatedfile.write("  'dart_revision': '%s',\n" % args.dart_revision)
+
       i = i + 2
       updatedfile.writelines([
         '\n',
@@ -205,6 +225,7 @@ def Main(argv):
       updatedfile.write('\n')
 
     elif lines[i].startswith("  # WARNING: Unused Dart dependencies"):
+      updatedfile.write(lines[i])
       updatedfile.write('\n')
       i = i + 1
       while i < len(lines) and not lines[i].startswith("  # WARNING: end of dart dependencies"):
@@ -213,6 +234,9 @@ def Main(argv):
       for dep_path, dep_source in new_dart_deps.items():
         updatedfile.write(f"  '{dep_path}':\n   {dep_source},\n\n")
 
+      updatedfile.write(lines[i])
+
+    else:
       updatedfile.write(lines[i])
     i = i + 1
 


### PR DESCRIPTION
This cherry-picks the new GitHub workflows for releases into the stable channel.

This change has very little risk and doesn't require a changelog entry since it doesn't affect code that ships to customers.

Note: this does not need to be merged until we actually plan to do a release. Currently, the CP queue is empty, so we don't really need to merge this until there is a reason to make a stable release.