### PR TITLE
[beta] Pass the `-f` flag since engine.version is in .gitignore by default.

### DIFF
--- a/.github/workflows/sync-engine-version.yml
+++ b/.github/workflows/sync-engine-version.yml
@@ -53,7 +53,8 @@ jobs:
         id: git-check
         run: |
           # -N (intent-to-add) treats untracked files as existing but empty
-          git add -N bin/internal/engine.version
+          # -f adds even if it's in the .gitignore (which it usually is)
+          git add -N -f bin/internal/engine.version
 
           if git diff --exit-code bin/internal/engine.version; then
             echo "changed=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This fixes a github workflow for syncing the engine.