### PR TITLE
[flutter_tools] clarify Windows symlink failure on ReFS

### DIFF
--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -1145,12 +1145,16 @@ void handleSymlinkException(
           : 'You must build from a terminal run as administrator.';
       throwToolExit('Building with plugins requires symlink support.\n\n$instructions');
     }
-    // ERROR_INVALID_FUNCTION, trying to link across drives, which is not supported
+    // ERROR_INVALID_FUNCTION can happen when symlinks are unsupported on the
+    // underlying filesystem, such as ReFS, or when Windows cannot create the
+    // requested link.
     if (e.osError?.errorCode == 1) {
       throwToolExit(
         'Creating symlink from $source to $destination failed with '
-        'ERROR_INVALID_FUNCTION. Try moving your Flutter project to the same '
-        'drive as your Flutter SDK.',
+        'ERROR_INVALID_FUNCTION. This can happen when symlinks are unsupported '
+        'by the filesystem, such as on Windows ReFS Dev Drives. Try moving '
+        'your Flutter project to a filesystem with symlink support, such as '
+        'NTFS.',
       );
     }
   }

--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -1145,16 +1145,19 @@ void handleSymlinkException(
           : 'You must build from a terminal run as administrator.';
       throwToolExit('Building with plugins requires symlink support.\n\n$instructions');
     }
-    // ERROR_INVALID_FUNCTION can happen when symlinks are unsupported on the
-    // underlying filesystem, such as ReFS, or when Windows cannot create the
-    // requested link.
+    // ERROR_INVALID_FUNCTION can happen when source and destination are on
+    // different drives, when symlinks are unsupported on the underlying
+    // filesystem (such as ReFS), or when Windows cannot create the requested
+    // link.
     if (e.osError?.errorCode == 1) {
       throwToolExit(
         'Creating symlink from $source to $destination failed with '
-        'ERROR_INVALID_FUNCTION. This can happen when symlinks are unsupported '
-        'by the filesystem, such as on Windows ReFS Dev Drives. Try moving '
-        'your Flutter project to a filesystem with symlink support, such as '
-        'NTFS.',
+        'ERROR_INVALID_FUNCTION. This can happen when source and destination '
+        'are on different drives. Make sure your Flutter project and pub cache '
+        'are on the same drive. This can also happen when symlinks are '
+        'unsupported by the filesystem, such as on Windows ReFS Dev Drives. '
+        'Try moving your Flutter project to a filesystem with symlink support, '
+        'such as NTFS.',
       );
     }
   }

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -2323,7 +2323,7 @@ flutter:
     );
 
     testWithoutContext(
-      'Symlink failures explain when the filesystem does not support symlinks',
+      'Symlink failures explain same-drive and filesystem-support requirements',
       () async {
         final Platform platform = FakePlatform(operatingSystem: 'windows');
         final os = FakeOperatingSystemUtils('Microsoft Windows [Version 10.0.14972]');
@@ -2338,9 +2338,19 @@ flutter:
             source: pubCachePath,
             destination: ephemeralPackagePath,
           ),
+          throwsToolExit(message: 'Make sure your Flutter project and pub cache are on the same drive.'),
+        );
+        expect(
+          () => handleSymlinkException(
+            e,
+            platform: platform,
+            os: os,
+            source: pubCachePath,
+            destination: ephemeralPackagePath,
+          ),
           throwsToolExit(
             message:
-                'This can happen when symlinks are unsupported by the filesystem, such as on Windows ReFS Dev Drives.',
+                'This can also happen when symlinks are unsupported by the filesystem, such as on Windows ReFS Dev Drives.',
           ),
         );
       },

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -2323,7 +2323,7 @@ flutter:
     );
 
     testWithoutContext(
-      'Symlink failures instruct developers to have their project on the same drive as their SDK',
+      'Symlink failures explain when the filesystem does not support symlinks',
       () async {
         final Platform platform = FakePlatform(operatingSystem: 'windows');
         final os = FakeOperatingSystemUtils('Microsoft Windows [Version 10.0.14972]');
@@ -2339,7 +2339,8 @@ flutter:
             destination: ephemeralPackagePath,
           ),
           throwsToolExit(
-            message: 'Try moving your Flutter project to the same drive as your Flutter SDK',
+            message:
+                'This can happen when symlinks are unsupported by the filesystem, such as on Windows ReFS Dev Drives.',
           ),
         );
       },


### PR DESCRIPTION
Fixes #182742

## Summary
This updates the Windows plugin symlink failure message for `ERROR_INVALID_FUNCTION` so it no longer assumes the only cause is being on different drives.

On Windows ReFS Dev Drives, symlink creation can fail with `ERROR_INVALID_FUNCTION` because the filesystem does not support symlinks at all. In that case, the previous message was misleading. This change clarifies that the failure can be caused by filesystem limitations such as ReFS and suggests moving the project to a filesystem with symlink support, such as NTFS.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

## Tests
- `../../bin/dart test test/general.shard/plugins_test.dart --plain-name "Symlink failures explain when the filesystem does not support symlinks"`
- `../../bin/dart analyze lib/src/flutter_plugins.dart test/general.shard/plugins_test.dart`

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
