### PR TITLE
Fix reselection issue after the text is cleared

### DIFF
--- a/packages/flutter/lib/src/widgets/autocomplete.dart
+++ b/packages/flutter/lib/src/widgets/autocomplete.dart
@@ -516,6 +516,7 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
       selection: TextSelection.collapsed(offset: selectionString.length),
       text: selectionString,
     );
+    _lastFieldText = selectionString;
     widget.onSelected?.call(nextSelection);
     if (_optionsViewController.isShowing) {
       _optionsViewController.hide(); // Close the options view after a selection is made.

--- a/packages/flutter/test/material/autocomplete_test.dart
+++ b/packages/flutter/test/material/autocomplete_test.dart
@@ -906,4 +906,69 @@ void main() {
       ),
     );
   });
+
+  testWidgets('Same option in Autocomplete should be selectable again after text is cleared', (
+    WidgetTester tester,
+  ) async {
+    final textCtrl = TextEditingController();
+    addTearDown(textCtrl.dispose);
+    final textFocus = FocusNode();
+    addTearDown(textFocus.dispose);
+    final listItem = <String>['test', 'abc', 'dexter'];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Row(
+            children: <Widget>[
+              Expanded(
+                child: Autocomplete<String>(
+                  textEditingController: textCtrl,
+                  focusNode: textFocus,
+                  optionsBuilder: (TextEditingValue textEditingValue) {
+                    return listItem.where(
+                      (String e) => e.toLowerCase().contains(textEditingValue.text.toLowerCase()),
+                    );
+                  },
+                ),
+              ),
+              IconButton(
+                key: const ValueKey<String>('clear'),
+                onPressed: () {
+                  textCtrl.clear();
+                },
+                icon: const Icon(Icons.add),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    // Open the popup menu.
+    await tester.enterText(find.byType(TextField), '');
+    await tester.pumpAndSettle();
+    expect(find.text('test'), findsOneWidget);
+
+    // Select option 'test'
+    await tester.tap(find.text('test'));
+    await tester.pumpAndSettle();
+    expect(textCtrl.text, 'test');
+
+    // Clear text using the icon button
+    await tester.tap(find.byKey(const ValueKey<String>('clear')));
+    textFocus.unfocus();
+    await tester.pumpAndSettle();
+    expect(textCtrl.text, '');
+
+    // Select 'test' again
+    await tester.tap(find.byType(TextField));
+    await tester.pumpAndSettle();
+    expect(find.text('test'), findsWidgets);
+    await tester.tap(find.text('test').last);
+    await tester.pumpAndSettle();
+
+    // The text field should be updated to 'test'.
+    expect(textCtrl.text, 'test');
+  });
 }

--- a/packages/flutter/test/widgets/autocomplete_test.dart
+++ b/packages/flutter/test/widgets/autocomplete_test.dart
@@ -3830,7 +3830,7 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('Same option should be selectable after text is cleared', (
+  testWidgets('Same option in RawAutocomplete should be selectable again after text is cleared', (
     WidgetTester tester,
   ) async {
     final textCtrl = TextEditingController();
@@ -3840,36 +3840,57 @@ void main() {
     final listItem = <String>['test', 'abc', 'dexter'];
 
     await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: Row(
-            children: <Widget>[
-              Expanded(
-                child: Autocomplete<String>(
-                  textEditingController: textCtrl,
-                  focusNode: textFocus,
-                  optionsBuilder: (TextEditingValue textEditingValue) {
-                    return listItem.where(
-                      (String e) => e.toLowerCase().contains(textEditingValue.text.toLowerCase()),
-                    );
-                  },
-                ),
-              ),
-              IconButton(
-                key: const ValueKey<String>('clear'),
-                onPressed: () {
-                  textCtrl.clear();
+      TestWidgetsApp(
+        home: Row(
+          children: <Widget>[
+            Expanded(
+              child: RawAutocomplete<String>(
+                textEditingController: textCtrl,
+                focusNode: textFocus,
+                optionsBuilder: (TextEditingValue textEditingValue) {
+                  return listItem.where((String e) => e.contains(textEditingValue.text));
                 },
-                icon: const Icon(Icons.add),
+                fieldViewBuilder:
+                    (
+                      BuildContext context,
+                      TextEditingController textEditingController,
+                      FocusNode focusNode,
+                      VoidCallback onFieldSubmitted,
+                    ) {
+                      return TestTextField(controller: textEditingController, focusNode: focusNode);
+                    },
+                optionsViewBuilder:
+                    (
+                      BuildContext context,
+                      AutocompleteOnSelected<String> onSelected,
+                      Iterable<String> options,
+                    ) {
+                      return ListView.builder(
+                        itemCount: options.length,
+                        itemBuilder: (BuildContext context, int index) {
+                          final String option = options.elementAt(index);
+                          return GestureDetector(
+                            onTap: () => onSelected(option),
+                            child: Text(option),
+                          );
+                        },
+                      );
+                    },
               ),
-            ],
-          ),
+            ),
+            GestureDetector(
+              onTap: () {
+                textCtrl.clear();
+              },
+              child: const Text('Clear'),
+            ),
+          ],
         ),
       ),
     );
 
     // Open the popup menu.
-    await tester.enterText(find.byType(TextField), '');
+    await tester.enterText(find.byType(TestTextField), '');
     await tester.pumpAndSettle();
     expect(find.text('test'), findsOneWidget);
 
@@ -3878,14 +3899,14 @@ void main() {
     await tester.pumpAndSettle();
     expect(textCtrl.text, 'test');
 
-    // Clear text using the icon button
-    await tester.tap(find.byKey(const ValueKey<String>('clear')));
+    // Clear text
+    await tester.tap(find.text('Clear'));
     textFocus.unfocus();
     await tester.pumpAndSettle();
     expect(textCtrl.text, '');
 
     // Select 'test' again
-    await tester.tap(find.byType(TextField));
+    await tester.tap(find.byType(TestTextField));
     await tester.pumpAndSettle();
     expect(find.text('test'), findsWidgets);
     await tester.tap(find.text('test').last);

--- a/packages/flutter/test/widgets/autocomplete_test.dart
+++ b/packages/flutter/test/widgets/autocomplete_test.dart
@@ -3829,4 +3829,70 @@ void main() {
 
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets(
+    'Same option should be selectable after text is cleared',
+    (WidgetTester tester) async {
+      final textCtrl = TextEditingController();
+      addTearDown(textCtrl.dispose);
+      final textFocus = FocusNode();
+      addTearDown(textFocus.dispose);
+      final listItem = <String>['test', 'abc', 'dexter'];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Row(
+              children: <Widget>[
+                Expanded(
+                  child: Autocomplete<String>(
+                    textEditingController: textCtrl,
+                    focusNode: textFocus,
+                    optionsBuilder: (TextEditingValue textEditingValue) {
+                      return listItem.where(
+                        (String e) => e.toLowerCase().contains(textEditingValue.text.toLowerCase()),
+                      );
+                    },
+                  ),
+                ),
+                IconButton(
+                  key: const ValueKey<String>('clear'),
+                  onPressed: () {
+                    textCtrl.clear();
+                  },
+                  icon: const Icon(Icons.add),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      // Open the popup menu.
+      await tester.enterText(find.byType(TextField), '');
+      await tester.pumpAndSettle();
+      expect(find.text('test'), findsOneWidget);
+
+      // Select option 'test'
+      await tester.tap(find.text('test'));
+      await tester.pumpAndSettle();
+      expect(textCtrl.text, 'test');
+
+      // Clear text using the icon button
+      await tester.tap(find.byKey(const ValueKey<String>('clear')));
+      textFocus.unfocus();
+      await tester.pumpAndSettle();
+      expect(textCtrl.text, '');
+
+      // Select 'test' again
+      await tester.tap(find.byType(TextField));
+      await tester.pumpAndSettle();
+      expect(find.text('test'), findsWidgets);
+      await tester.tap(find.text('test').last);
+      await tester.pumpAndSettle();
+
+      // The text field should be updated to 'test'.
+      expect(textCtrl.text, 'test');
+    },
+  );
 }

--- a/packages/flutter/test/widgets/autocomplete_test.dart
+++ b/packages/flutter/test/widgets/autocomplete_test.dart
@@ -3830,69 +3830,68 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets(
-    'Same option should be selectable after text is cleared',
-    (WidgetTester tester) async {
-      final textCtrl = TextEditingController();
-      addTearDown(textCtrl.dispose);
-      final textFocus = FocusNode();
-      addTearDown(textFocus.dispose);
-      final listItem = <String>['test', 'abc', 'dexter'];
+  testWidgets('Same option should be selectable after text is cleared', (
+    WidgetTester tester,
+  ) async {
+    final textCtrl = TextEditingController();
+    addTearDown(textCtrl.dispose);
+    final textFocus = FocusNode();
+    addTearDown(textFocus.dispose);
+    final listItem = <String>['test', 'abc', 'dexter'];
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: Row(
-              children: <Widget>[
-                Expanded(
-                  child: Autocomplete<String>(
-                    textEditingController: textCtrl,
-                    focusNode: textFocus,
-                    optionsBuilder: (TextEditingValue textEditingValue) {
-                      return listItem.where(
-                        (String e) => e.toLowerCase().contains(textEditingValue.text.toLowerCase()),
-                      );
-                    },
-                  ),
-                ),
-                IconButton(
-                  key: const ValueKey<String>('clear'),
-                  onPressed: () {
-                    textCtrl.clear();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Row(
+            children: <Widget>[
+              Expanded(
+                child: Autocomplete<String>(
+                  textEditingController: textCtrl,
+                  focusNode: textFocus,
+                  optionsBuilder: (TextEditingValue textEditingValue) {
+                    return listItem.where(
+                      (String e) => e.toLowerCase().contains(textEditingValue.text.toLowerCase()),
+                    );
                   },
-                  icon: const Icon(Icons.add),
                 ),
-              ],
-            ),
+              ),
+              IconButton(
+                key: const ValueKey<String>('clear'),
+                onPressed: () {
+                  textCtrl.clear();
+                },
+                icon: const Icon(Icons.add),
+              ),
+            ],
           ),
         ),
-      );
+      ),
+    );
 
-      // Open the popup menu.
-      await tester.enterText(find.byType(TextField), '');
-      await tester.pumpAndSettle();
-      expect(find.text('test'), findsOneWidget);
+    // Open the popup menu.
+    await tester.enterText(find.byType(TextField), '');
+    await tester.pumpAndSettle();
+    expect(find.text('test'), findsOneWidget);
 
-      // Select option 'test'
-      await tester.tap(find.text('test'));
-      await tester.pumpAndSettle();
-      expect(textCtrl.text, 'test');
+    // Select option 'test'
+    await tester.tap(find.text('test'));
+    await tester.pumpAndSettle();
+    expect(textCtrl.text, 'test');
 
-      // Clear text using the icon button
-      await tester.tap(find.byKey(const ValueKey<String>('clear')));
-      textFocus.unfocus();
-      await tester.pumpAndSettle();
-      expect(textCtrl.text, '');
+    // Clear text using the icon button
+    await tester.tap(find.byKey(const ValueKey<String>('clear')));
+    textFocus.unfocus();
+    await tester.pumpAndSettle();
+    expect(textCtrl.text, '');
 
-      // Select 'test' again
-      await tester.tap(find.byType(TextField));
-      await tester.pumpAndSettle();
-      expect(find.text('test'), findsWidgets);
-      await tester.tap(find.text('test').last);
-      await tester.pumpAndSettle();
+    // Select 'test' again
+    await tester.tap(find.byType(TextField));
+    await tester.pumpAndSettle();
+    expect(find.text('test'), findsWidgets);
+    await tester.tap(find.text('test').last);
+    await tester.pumpAndSettle();
 
-      // The text field should be updated to 'test'.
-      expect(textCtrl.text, 'test');
-    },
-  );
+    // The text field should be updated to 'test'.
+    expect(textCtrl.text, 'test');
+  });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/182927

This PR is to fix a Autocomplete re-selection issue when an option is cleared up and re-selected again. When `_select()` is called, `_selecting` is set to `true` and the `_textEditingController` is updated which caused `_onChangedField()` be called but returned early. In this case, we should update `_lastFieldText` to the `newSelection`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
