### PR TITLE
[stable] Use CLA-approved email and username for github workflow commits.

### DIFF
--- a/.github/workflows/easy-cp.yml
+++ b/.github/workflows/easy-cp.yml
@@ -59,8 +59,8 @@ jobs:
         id: attempt-cp
         working-directory: ./flutter
         run: |
-          git config user.name "GitHub Actions Bot"
-          git config user.email "<>"
+          git config user.name "flutteractionsbot"
+          git config user.email "<flutter-actions-bot@google.com>"
           git remote add upstream https://github.com/flutter/flutter.git
           git fetch upstream $RELEASE_BRANCH
           git fetch upstream master

--- a/.github/workflows/merge-changelog.yml
+++ b/.github/workflows/merge-changelog.yml
@@ -25,8 +25,8 @@ jobs:
 
       - name: Configure git
         run: |
-          git config user.name "GitHub Actions Bot"
-          git config user.email "<>"
+          git config user.name "flutteractionsbot"
+          git config user.email "<flutter-actions-bot@google.com>"
           git remote add upstream https://github.com/flutter/flutter.git
 
       # avoid downloading hundreds of other branches/history

--- a/.github/workflows/roll-dart-dependencies.yml
+++ b/.github/workflows/roll-dart-dependencies.yml
@@ -27,8 +27,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.FLUTTERACTIONSBOT_CP_TOKEN }}
         run: |
-          git config user.name "GitHub Actions Bot"
-          git config user.email "<>"
+          git config user.name "flutteractionsbot"
+          git config user.email "<flutter-actions-bot@google.com>"
           git remote add upstream https://github.com/flutter/flutter.git
           git fetch upstream ${{ github.ref_name }}
 

--- a/.github/workflows/sync-engine-version.yml
+++ b/.github/workflows/sync-engine-version.yml
@@ -22,8 +22,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.FLUTTERACTIONSBOT_CP_TOKEN }}
         run: |
-          git config user.name "GitHub Actions Bot"
-          git config user.email "<>"
+          git config user.name "flutteractionsbot"
+          git config user.email "<flutter-actions-bot@google.com>"
           git remote add upstream https://github.com/flutter/flutter.git
           git fetch upstream ${{ github.ref_name }}
 
@@ -53,7 +53,8 @@ jobs:
         id: git-check
         run: |
           # -N (intent-to-add) treats untracked files as existing but empty
-          git add -N bin/internal/engine.version
+          # -f adds even if it's in the .gitignore (which it usually is)
+          git add -N -f bin/internal/engine.version
 
           if git diff --exit-code bin/internal/engine.version; then
             echo "changed=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This uses an email and username which is recognized by the Google CLA when writing commits from our GitHub workflows.

This also fixes an issue with the engine version sync workflow when adding the `engine.version` file, since it is typically .gitignored
