### PR TITLE
Filter 'waiting for customer response' issues from macOS triage

### DIFF
--- a/docs/triage/README.md
+++ b/docs/triage/README.md
@@ -283,7 +283,7 @@ See the [Flutter Infra Team Triage](./Infra-Triage.md) page.
 
 - [P0 list](https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3Ateam-ios%2Cteam-macos+label%3AP0+sort%3Aupdated-asc+)
 - [iOS incoming issue list](https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3Ateam-ios%2Cfyi-ios+-label%3Atriaged-ios+-label%3A%22will+need+additional+triage%22+-label%3A%22waiting+for+customer+response%22+sort%3Aupdated-asc+)
-- [macOS incoming issue list](https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3Ateam-macos%2Cfyi-macos+-label%3Atriaged-macos+-label%3A%22will+need+additional+triage%22+sort%3Aupdated-asc+)
+- [macOS incoming issue list](https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3Ateam-macos%2Cfyi-macos+-label%3Atriaged-macos+-label%3A%22will+need+additional+triage%22+-label%3A%22waiting+for+customer+response%22+sort%3Aupdated-asc)
 - [Apple news](https://developer.apple.com/news) - check for updates that might affect us.
 - [hackers-ios channel on Discord](https://discord.com/channels/608014603317936148/846507953959862273)
 - [hackers-desktop channel on Discord](https://discord.com/channels/608014603317936148/608020180177780791)


### PR DESCRIPTION
Updates the "macOS incoming issue list" query to filter issues labeled `waiting for customer response`, similar to the "iOS incoming issue list" query.