### PR TITLE
[Impeller] Do not delete the GL object in a HandleGLES if the handle has a cleanup callback

### DIFF
--- a/engine/src/flutter/fml/closure.h
+++ b/engine/src/flutter/fml/closure.h
@@ -47,6 +47,8 @@ class ScopedCleanupClosure final {
 
   ~ScopedCleanupClosure() { Reset(); }
 
+  explicit operator bool() const { return static_cast<bool>(closure_); }
+
   fml::closure SetClosure(const fml::closure& closure) {
     auto old_closure = closure_;
     closure_ = closure;

--- a/engine/src/flutter/impeller/renderer/backend/gles/reactor_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/reactor_gles.cc
@@ -315,8 +315,12 @@ bool ReactorGLES::ConsolidateHandles() {
         if (owner_thread.has_value() && *owner_thread != current_thread) {
           continue;
         }
-        handles_to_delete.emplace_back(
-            std::make_tuple(handle.first, handle.second.name));
+        std::optional<GLStorage> storage;
+        // Do not delete the GL object if the handle has a cleanup callback.
+        if (!handle.second.callback) {
+          storage = handle.second.name;
+        }
+        handles_to_delete.emplace_back(std::make_tuple(handle.first, storage));
         continue;
       }
       // Create live handles.

--- a/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
@@ -165,12 +165,14 @@ sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTextureImpeller(
     FML_LOG(ERROR) << "Could not create external texture";
     return nullptr;
   }
-  // Set a no-op cleanup callback if the texture does not provide a callback.
-  // The presence of a cleanup callback indicates that the embedder controls
-  // the GL texture's lifetime and Impeller should not delete it.
-  VoidCallback destruction_callback = texture->destruction_callback
-                                          ? texture->destruction_callback
-                                          : [](void*) {};
+
+  VoidCallback destruction_callback = texture->destruction_callback;
+  if (!destruction_callback) {
+    // Set a no-op cleanup callback if the texture does not provide a callback.
+    // The presence of a cleanup callback indicates that the embedder controls
+    // the GL texture's lifetime and Impeller should not delete it.
+    destruction_callback = [](void*) {};
+  }
   auto cleanup_callback = [callback = destruction_callback,
                            user_data = texture->user_data]() {
     callback(user_data);
@@ -180,6 +182,7 @@ sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTextureImpeller(
     FML_LOG(ERROR) << "Could not register destruction callback";
     return nullptr;
   }
+
   image->SetCoordinateSystem(
       impeller::TextureCoordinateSystem::kUploadFromHost);
 

--- a/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
@@ -138,6 +138,13 @@ sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTextureImpeller(
     return nullptr;
   }
 
+  // Call the destruction callback if an error occurs.
+  fml::ScopedCleanupClosure scoped_cleanup([&texture]() {
+    if (texture->destruction_callback) {
+      texture->destruction_callback(texture->user_data);
+    }
+  });
+
   if (texture->format != GL_RGBA8) {
     FML_LOG(ERROR) << "Only support GL_RGBA8 format now";
     return nullptr;
@@ -155,24 +162,28 @@ sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTextureImpeller(
       impeller::TextureGLES::WrapTexture(context.GetReactor(), desc, handle);
 
   if (!image) {
-    // In case Skia rejects the image, call the release proc so that
-    // embedders can perform collection of intermediates.
-    if (texture->destruction_callback) {
-      texture->destruction_callback(texture->user_data);
-    }
     FML_LOG(ERROR) << "Could not create external texture";
     return nullptr;
   }
-  if (texture->destruction_callback &&
-      !context.GetReactor()->RegisterCleanupCallback(
-          handle,
-          [callback = texture->destruction_callback,
-           user_data = texture->user_data]() { callback(user_data); })) {
+  // Set a no-op cleanup callback if the texture does not provide a callback.
+  // The presence of a cleanup callback indicates that the embedder controls
+  // the GL texture's lifetime and Impeller should not delete it.
+  VoidCallback destruction_callback = texture->destruction_callback
+                                          ? texture->destruction_callback
+                                          : [](void*) {};
+  auto cleanup_callback = [callback = destruction_callback,
+                           user_data = texture->user_data]() {
+    callback(user_data);
+  };
+  if (!context.GetReactor()->RegisterCleanupCallback(handle,
+                                                     cleanup_callback)) {
     FML_LOG(ERROR) << "Could not register destruction callback";
     return nullptr;
   }
   image->SetCoordinateSystem(
       impeller::TextureCoordinateSystem::kUploadFromHost);
+
+  scoped_cleanup.Release();
 
   return impeller::DlImageImpeller::Make(image);
 }

--- a/engine/src/flutter/shell/platform/embedder/tests/embedder_gl_unittests.cc
+++ b/engine/src/flutter/shell/platform/embedder/tests/embedder_gl_unittests.cc
@@ -4909,7 +4909,8 @@ TEST_F(EmbedderTest, RenderTextureWithImpellerOpenGL) {
   latch.Wait();
   ASSERT_TRUE(
       ImageMatchesFixture("external_texture_impeller.png", rendered_scene));
-  for (int i = 0; i < 5; i++) {
+  constexpr int kFrameCount = 5;
+  for (int i = 0; i < kFrameCount; i++) {
     rendered_scene = context.GetNextSceneImage();
     ASSERT_TRUE(embedder_engine->MarkTextureFrameAvailable(1));
     latch.Wait();

--- a/engine/src/flutter/shell/platform/embedder/tests/embedder_gl_unittests.cc
+++ b/engine/src/flutter/shell/platform/embedder/tests/embedder_gl_unittests.cc
@@ -4830,17 +4830,16 @@ TEST_F(EmbedderTest, CanRenderWithImpellerOpenGL) {
 }
 
 TEST_F(EmbedderTest, RenderTextureWithImpellerOpenGL) {
+  constexpr int kWidth = 800;
+  constexpr int kHeight = 600;
   auto& context = GetEmbedderContext<EmbedderTestContextGL>();
   EmbedderConfigBuilder builder(context);
   fml::AutoResetWaitableEvent latch;
-  bool present_called = false;
-  context.SetGLPresentCallback([&](FlutterPresentInfo present_info) {
-    present_called = true;
-    latch.Signal();
-  });
+  context.SetGLPresentCallback(
+      [&](FlutterPresentInfo present_info) { latch.Signal(); });
   builder.AddCommandLineArgument("--enable-impeller");
   builder.SetDartEntrypoint("render_texture_impeller_test");
-  builder.SetSurface(DlISize(800, 600));
+  builder.SetSurface(DlISize(kWidth, kHeight));
   typedef void (*glGenTexturesProc)(GLsizei n, GLuint* textures);
   typedef void (*glBindTextureProc)(GLenum n, GLuint texture);
   typedef void (*glTexImage2DProc)(GLenum target, GLint level,
@@ -4859,15 +4858,15 @@ TEST_F(EmbedderTest, RenderTextureWithImpellerOpenGL) {
   context.GetRendererConfig().open_gl.gl_external_texture_frame_callback =
       [](void* user_data, int64_t texture_id, size_t width, size_t height,
          FlutterOpenGLTexture* texture) -> bool {
-    std::vector<uint8_t> buffer(800 * 600 * 4);
-    for (int i = 0; i < 800 * 300; ++i) {
+    std::vector<uint8_t> buffer(kWidth * kHeight * 4);
+    for (int i = 0; i < kWidth * kHeight / 2; ++i) {
       buffer[i * 4 + 0] = 255;  // Red channel
       buffer[i * 4 + 1] = 0;    // Green channel
       buffer[i * 4 + 2] = 0;    // Blue channel
       buffer[i * 4 + 3] = 255;  // Alpha channel (fully opaque)
     }
 
-    for (int i = 800 * 300; i < 800 * 600; ++i) {
+    for (int i = kWidth * kHeight / 2; i < kWidth * kHeight; ++i) {
       buffer[i * 4 + 0] = 0;    // Red channel
       buffer[i * 4 + 1] = 0;    // Green channel
       buffer[i * 4 + 2] = 255;  // Blue channel
@@ -4878,7 +4877,7 @@ TEST_F(EmbedderTest, RenderTextureWithImpellerOpenGL) {
       glGenTextures(1, &gl_texture);
     }
     glBindTexture(GL_TEXTURE_2D, gl_texture);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, 800, 600, 0, GL_RGBA,
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, kWidth, kHeight, 0, GL_RGBA,
                  GL_UNSIGNED_BYTE, buffer.data());
     texture->target = GL_TEXTURE_2D;
     texture->name = gl_texture;
@@ -4896,13 +4895,14 @@ TEST_F(EmbedderTest, RenderTextureWithImpellerOpenGL) {
 
   flutter::EmbedderEngine* embedder_engine = ToEmbedderEngine(engine.get());
 
-  ASSERT_TRUE(embedder_engine->RegisterTexture(1));
+  constexpr int texture_id = 1;
+  ASSERT_TRUE(embedder_engine->RegisterTexture(texture_id));
 
   // Send a window metrics events so frames may be scheduled.
   FlutterWindowMetricsEvent event = {};
   event.struct_size = sizeof(event);
-  event.width = 800;
-  event.height = 600;
+  event.width = kWidth;
+  event.height = kHeight;
   event.pixel_ratio = 1.0;
   ASSERT_EQ(FlutterEngineSendWindowMetricsEvent(engine.get(), &event),
             kSuccess);
@@ -4912,11 +4912,107 @@ TEST_F(EmbedderTest, RenderTextureWithImpellerOpenGL) {
   constexpr int kFrameCount = 5;
   for (int i = 0; i < kFrameCount; i++) {
     rendered_scene = context.GetNextSceneImage();
-    ASSERT_TRUE(embedder_engine->MarkTextureFrameAvailable(1));
+    ASSERT_TRUE(embedder_engine->MarkTextureFrameAvailable(texture_id));
     latch.Wait();
     ASSERT_TRUE(
         ImageMatchesFixture("external_texture_impeller.png", rendered_scene));
   }
+}
+
+TEST_F(EmbedderTest, RenderTextureWithImpellerOpenGLDestructCallback) {
+  constexpr int kWidth = 800;
+  constexpr int kHeight = 600;
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
+  EmbedderConfigBuilder builder(context);
+  fml::AutoResetWaitableEvent latch;
+  context.SetGLPresentCallback(
+      [&](FlutterPresentInfo present_info) { latch.Signal(); });
+  builder.AddCommandLineArgument("--enable-impeller");
+  builder.SetDartEntrypoint("render_texture_impeller_test");
+  builder.SetSurface(DlISize(kWidth, kHeight));
+  typedef void (*glGenTexturesProc)(GLsizei n, GLuint* textures);
+  typedef void (*glBindTextureProc)(GLenum n, GLuint texture);
+  typedef void (*glTexImage2DProc)(GLenum target, GLint level,
+                                   GLint internalformat, GLsizei width,
+                                   GLsizei height, GLint border, GLenum format,
+                                   GLenum type, const void* pixels);
+  static glGenTexturesProc glGenTextures = reinterpret_cast<glGenTexturesProc>(
+      context.GLGetProcAddress("glGenTextures"));
+  static glBindTextureProc glBindTexture = reinterpret_cast<glBindTextureProc>(
+      context.GLGetProcAddress("glBindTexture"));
+  static glTexImage2DProc glTexImage2D = reinterpret_cast<glTexImage2DProc>(
+      context.GLGetProcAddress("glTexImage2D"));
+
+  auto rendered_scene = context.GetNextSceneImage();
+
+  static bool destruction_callback_called = false;
+  static auto destruction_callback = [](void* user_data) {
+    GLuint gl_texture =
+        static_cast<GLuint>(reinterpret_cast<uintptr_t>(user_data));
+    glDeleteTextures(1, &gl_texture);
+    destruction_callback_called = true;
+  };
+  context.GetRendererConfig().open_gl.gl_external_texture_frame_callback =
+      [](void* user_data, int64_t texture_id, size_t width, size_t height,
+         FlutterOpenGLTexture* texture) -> bool {
+    std::vector<uint8_t> buffer(kWidth * kHeight * 4);
+    for (int i = 0; i < kWidth * kHeight / 2; ++i) {
+      buffer[i * 4 + 0] = 255;  // Red channel
+      buffer[i * 4 + 1] = 0;    // Green channel
+      buffer[i * 4 + 2] = 0;    // Blue channel
+      buffer[i * 4 + 3] = 255;  // Alpha channel (fully opaque)
+    }
+
+    for (int i = kWidth * kHeight / 2; i < kWidth * kHeight; ++i) {
+      buffer[i * 4 + 0] = 0;    // Red channel
+      buffer[i * 4 + 1] = 0;    // Green channel
+      buffer[i * 4 + 2] = 255;  // Blue channel
+      buffer[i * 4 + 3] = 255;  // Alpha channel (fully opaque)
+    }
+
+    GLuint gl_texture;
+    glGenTextures(1, &gl_texture);
+    glBindTexture(GL_TEXTURE_2D, gl_texture);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, kWidth, kHeight, 0, GL_RGBA,
+                 GL_UNSIGNED_BYTE, buffer.data());
+    texture->target = GL_TEXTURE_2D;
+    texture->name = gl_texture;
+    texture->format = GL_RGBA8;
+    texture->destruction_callback = destruction_callback;
+    texture->user_data = reinterpret_cast<void*>(gl_texture);
+    texture->width = width;
+    texture->height = height;
+    return true;
+  };
+
+  auto engine = builder.LaunchEngine();
+
+  ASSERT_TRUE(engine.is_valid());
+
+  flutter::EmbedderEngine* embedder_engine = ToEmbedderEngine(engine.get());
+
+  constexpr int texture_id = 1;
+  ASSERT_TRUE(embedder_engine->RegisterTexture(texture_id));
+
+  // Send a window metrics events so frames may be scheduled.
+  FlutterWindowMetricsEvent event = {};
+  event.struct_size = sizeof(event);
+  event.width = kWidth;
+  event.height = kHeight;
+  event.pixel_ratio = 1.0;
+  ASSERT_EQ(FlutterEngineSendWindowMetricsEvent(engine.get(), &event),
+            kSuccess);
+  latch.Wait();
+  ASSERT_TRUE(
+      ImageMatchesFixture("external_texture_impeller.png", rendered_scene));
+
+  // Render a second frame.
+  ASSERT_TRUE(embedder_engine->MarkTextureFrameAvailable(texture_id));
+  latch.Wait();
+
+  // After the second frame completes, Impeller will have collected the handle
+  // of the first frame's texture and called its destruction callback.
+  ASSERT_TRUE(destruction_callback_called);
 }
 
 TEST_F(EmbedderTest, ImpellerOpenGLImageSnapshot) {

--- a/engine/src/flutter/shell/platform/embedder/tests/embedder_gl_unittests.cc
+++ b/engine/src/flutter/shell/platform/embedder/tests/embedder_gl_unittests.cc
@@ -4854,6 +4854,7 @@ TEST_F(EmbedderTest, RenderTextureWithImpellerOpenGL) {
   static glTexImage2DProc glTexImage2D = reinterpret_cast<glTexImage2DProc>(
       context.GLGetProcAddress("glTexImage2D"));
 
+  static GLuint gl_texture = 0;
   auto rendered_scene = context.GetNextSceneImage();
   context.GetRendererConfig().open_gl.gl_external_texture_frame_callback =
       [](void* user_data, int64_t texture_id, size_t width, size_t height,
@@ -4873,8 +4874,9 @@ TEST_F(EmbedderTest, RenderTextureWithImpellerOpenGL) {
       buffer[i * 4 + 3] = 255;  // Alpha channel (fully opaque)
     }
 
-    GLuint gl_texture;
-    glGenTextures(1, &gl_texture);
+    if (gl_texture == 0) {
+      glGenTextures(1, &gl_texture);
+    }
     glBindTexture(GL_TEXTURE_2D, gl_texture);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, 800, 600, 0, GL_RGBA,
                  GL_UNSIGNED_BYTE, buffer.data());
@@ -4895,7 +4897,6 @@ TEST_F(EmbedderTest, RenderTextureWithImpellerOpenGL) {
   flutter::EmbedderEngine* embedder_engine = ToEmbedderEngine(engine.get());
 
   ASSERT_TRUE(embedder_engine->RegisterTexture(1));
-  ASSERT_TRUE(embedder_engine->MarkTextureFrameAvailable(1));
 
   // Send a window metrics events so frames may be scheduled.
   FlutterWindowMetricsEvent event = {};
@@ -4908,6 +4909,13 @@ TEST_F(EmbedderTest, RenderTextureWithImpellerOpenGL) {
   latch.Wait();
   ASSERT_TRUE(
       ImageMatchesFixture("external_texture_impeller.png", rendered_scene));
+  for (int i = 0; i < 5; i++) {
+    rendered_scene = context.GetNextSceneImage();
+    ASSERT_TRUE(embedder_engine->MarkTextureFrameAvailable(1));
+    latch.Wait();
+    ASSERT_TRUE(
+        ImageMatchesFixture("external_texture_impeller.png", rendered_scene));
+  }
 }
 
 TEST_F(EmbedderTest, ImpellerOpenGLImageSnapshot) {

--- a/engine/src/flutter/shell/platform/linux/fl_pixel_buffer_texture.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_pixel_buffer_texture.cc
@@ -108,12 +108,10 @@ gboolean fl_pixel_buffer_texture_populate(FlPixelBufferTexture* texture,
   opengl_texture->target = GL_TEXTURE_2D;
   opengl_texture->name = priv->texture_id;
   opengl_texture->format = GL_RGBA8;
+  opengl_texture->destruction_callback = nullptr;
   opengl_texture->user_data = nullptr;
   opengl_texture->width = width;
   opengl_texture->height = height;
-  // Set a no-op destruction callback to indicate that the embedder controls
-  // this texture's lifetime and Impeller should not delete it.
-  opengl_texture->destruction_callback = [](void*) {};
 
   return TRUE;
 }

--- a/engine/src/flutter/shell/platform/linux/fl_pixel_buffer_texture.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_pixel_buffer_texture.cc
@@ -108,10 +108,12 @@ gboolean fl_pixel_buffer_texture_populate(FlPixelBufferTexture* texture,
   opengl_texture->target = GL_TEXTURE_2D;
   opengl_texture->name = priv->texture_id;
   opengl_texture->format = GL_RGBA8;
-  opengl_texture->destruction_callback = nullptr;
   opengl_texture->user_data = nullptr;
   opengl_texture->width = width;
   opengl_texture->height = height;
+  // Set a no-op destruction callback to indicate that the embedder controls
+  // this texture's lifetime and Impeller should not delete it.
+  opengl_texture->destruction_callback = [](void*) {};
 
   return TRUE;
 }


### PR DESCRIPTION
This allows embedders to control the lifetime of textures wrapped by HandleGLES.  If the embedder calls RegisterCleanupCallback on the handle, then ReactorGLES will not delete the texture when the handle is collected.

Fixes https://github.com/flutter/flutter/issues/183058