### PR TITLE
Add non-text color contrast evaluation for a11y

### DIFF
--- a/packages/flutter/lib/src/widgets/_accessibility_evaluations.dart
+++ b/packages/flutter/lib/src/widgets/_accessibility_evaluations.dart
@@ -289,7 +289,7 @@ abstract class _ContrastEvaluation extends AccessibilityEvaluation {
   }
 
   bool _shouldSkipNodeTraversal(SemanticsNode node) {
-    final bool isDisabled = node.flagsCollection.isEnabled == ui.Tristate.isFalse;
+    final isDisabled = node.flagsCollection.isEnabled == ui.Tristate.isFalse;
     return node.isInvisible ||
         node.isMergedIntoParent ||
         node.flagsCollection.isHidden ||
@@ -563,7 +563,7 @@ class MinimumNonTextContrastEvaluation extends _ContrastEvaluation {
     }
 
     final double devicePixelRatio = renderView.flutterView.devicePixelRatio;
-    final Rect logicalBounds = Rect.fromLTRB(
+    final logicalBounds = Rect.fromLTRB(
       nodeBounds.left / devicePixelRatio,
       nodeBounds.top / devicePixelRatio,
       nodeBounds.right / devicePixelRatio,

--- a/packages/flutter/lib/src/widgets/_accessibility_evaluations.dart
+++ b/packages/flutter/lib/src/widgets/_accessibility_evaluations.dart
@@ -299,8 +299,9 @@ class MinimumTextContrastEvaluation extends AccessibilityEvaluation {
       final double ratio = 1 / renderView.flutterView.devicePixelRatio;
       image = await layer.toImage(renderView.paintBounds, pixelRatio: ratio);
       final ByteData? byteData = await image.toByteData();
-
-      violations.addAll(await _evaluateNode(root, image, byteData!, renderView));
+      if (byteData != null) {
+        violations.addAll(await _evaluateNode(root, image, byteData, renderView));
+      }
       image.dispose();
     }
 
@@ -486,7 +487,7 @@ class MinimumTextContrastEvaluation extends AccessibilityEvaluation {
 /// An evaluation which verifies that all nodes that represent non-text controls
 /// meet minimum contrast levels of 3.0.
 ///
-/// The evaluatiosn are defined by the Web Content Accessibility Guidelines,
+/// The evaluations are defined by the Web Content Accessibility Guidelines,
 /// https://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast.html
 @internal
 class MinimumNonTextContrastEvaluation extends AccessibilityEvaluation {
@@ -511,8 +512,9 @@ class MinimumNonTextContrastEvaluation extends AccessibilityEvaluation {
       final double ratio = 1 / renderView.flutterView.devicePixelRatio;
       final ui.Image image = await layer.toImage(renderView.paintBounds, pixelRatio: ratio);
       final ByteData? byteData = await image.toByteData();
-
-      violations.addAll(await _evaluateNode(root, image, byteData!, renderView));
+      if (byteData != null) {
+        violations.addAll(await _evaluateNode(root, image, byteData, renderView));
+      }
       image.dispose();
     }
 
@@ -549,7 +551,6 @@ class MinimumNonTextContrastEvaluation extends AccessibilityEvaluation {
     if (_shouldSkipNode(data)) {
       return violations;
     }
-
     Rect nodeBounds = node.rect;
     SemanticsNode? current = node;
     while (current != null) {

--- a/packages/flutter/lib/src/widgets/_accessibility_evaluations.dart
+++ b/packages/flutter/lib/src/widgets/_accessibility_evaluations.dart
@@ -495,7 +495,6 @@ class MinimumTextContrastEvaluation extends _ContrastEvaluation {
     ];
   }
 
-
   /// Returns the required contrast ratio for the [fontSize] and [bold] setting.
   ///
   /// Defined by http://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html
@@ -609,8 +608,6 @@ class MinimumNonTextContrastEvaluation extends _ContrastEvaluation {
     );
     return violations;
   }
-
-
 }
 
 class _ContrastReport {

--- a/packages/flutter/lib/src/widgets/_accessibility_evaluations.dart
+++ b/packages/flutter/lib/src/widgets/_accessibility_evaluations.dart
@@ -596,7 +596,7 @@ class MinimumNonTextContrastEvaluation extends _ContrastEvaluation {
       Violation(
         node,
         '$node:\n'
-        'Expected non-text control contrast ratio of at least $_kMinimumRatioNonText '
+        'Expected non-text control contrast ratio of at least ${_kMinimumRatioNonText.toStringAsFixed(1)} '
         'but found ${contrastRatio.toStringAsFixed(2)}.\n'
         'The computed colors were:\n'
         'light - ${report.lightColor}, dark - ${report.darkColor}\n'

--- a/packages/flutter/lib/src/widgets/_accessibility_evaluations.dart
+++ b/packages/flutter/lib/src/widgets/_accessibility_evaluations.dart
@@ -249,10 +249,8 @@ abstract class _ContrastEvaluation extends AccessibilityEvaluation {
 
       final double ratio = 1 / renderView.flutterView.devicePixelRatio;
       final ui.Image image = await layer.toImage(renderView.paintBounds, pixelRatio: ratio);
-      final ByteData? byteData = await image.toByteData();
-      if (byteData != null) {
-        violations.addAll(await _evaluateNode(root, image, byteData, renderView));
-      }
+      final ByteData byteData = (await image.toByteData())!;
+      violations.addAll(await _evaluateNode(root, image, byteData, renderView));
       image.dispose();
     }
 
@@ -523,7 +521,7 @@ class MinimumNonTextContrastEvaluation extends _ContrastEvaluation {
   /// The minimum contrast ratio for non-text controls.
   ///
   /// Defined by http://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast.html
-  static const double kMinimumRatioNonText = 3.0;
+  static const double _kMinimumRatioNonText = 3.0;
 
   @override
   bool _shouldSkipNodeEvaluation(SemanticsData data) {
@@ -590,7 +588,7 @@ class MinimumNonTextContrastEvaluation extends _ContrastEvaluation {
     final report = _ContrastReport(colorHistogram);
     final double contrastRatio = report.contrastRatio();
 
-    if (contrastRatio - kMinimumRatioNonText >= _ContrastEvaluation._kContrastTolerance) {
+    if (contrastRatio - _kMinimumRatioNonText >= _ContrastEvaluation._kContrastTolerance) {
       return violations;
     }
 
@@ -598,7 +596,7 @@ class MinimumNonTextContrastEvaluation extends _ContrastEvaluation {
       Violation(
         node,
         '$node:\n'
-        'Expected non-text control contrast ratio of at least $kMinimumRatioNonText '
+        'Expected non-text control contrast ratio of at least $_kMinimumRatioNonText '
         'but found ${contrastRatio.toStringAsFixed(2)}.\n'
         'The computed colors were:\n'
         'light - ${report.lightColor}, dark - ${report.darkColor}\n'

--- a/packages/flutter/lib/src/widgets/_accessibility_evaluations.dart
+++ b/packages/flutter/lib/src/widgets/_accessibility_evaluations.dart
@@ -234,6 +234,79 @@ class LabeledTapTargetEvaluation extends AccessibilityEvaluation {
   }
 }
 
+/// Base class for evaluations that verify nodes meet minimum contrast levels.
+abstract class _ContrastEvaluation extends AccessibilityEvaluation {
+  const _ContrastEvaluation();
+
+  static const double _kContrastTolerance = -0.01;
+
+  @override
+  Future<EvaluationResult> _evaluate(WidgetsBinding binding) async {
+    final violations = <Violation>[];
+    for (final RenderView renderView in binding.renderViews) {
+      final layer = renderView.debugLayer! as OffsetLayer;
+      final SemanticsNode root = renderView.owner!.semanticsOwner!.rootSemanticsNode!;
+
+      final double ratio = 1 / renderView.flutterView.devicePixelRatio;
+      final ui.Image image = await layer.toImage(renderView.paintBounds, pixelRatio: ratio);
+      final ByteData? byteData = await image.toByteData();
+      if (byteData != null) {
+        violations.addAll(await _evaluateNode(root, image, byteData, renderView));
+      }
+      image.dispose();
+    }
+
+    return EvaluationResult(violations);
+  }
+
+  Future<List<Violation>> _evaluateNode(
+    SemanticsNode node,
+    ui.Image image,
+    ByteData byteData,
+    RenderView renderView,
+  ) async {
+    final violations = <Violation>[];
+
+    if (_shouldSkipNodeTraversal(node)) {
+      return violations;
+    }
+
+    final SemanticsData data = node.getSemanticsData();
+    final children = <SemanticsNode>[];
+    node.visitChildren((SemanticsNode child) {
+      children.add(child);
+      return true;
+    });
+    for (final child in children) {
+      violations.addAll(await _evaluateNode(child, image, byteData, renderView));
+    }
+
+    if (_shouldSkipNodeEvaluation(data)) {
+      return violations;
+    }
+
+    return evaluateNodeContent(node, data, image, byteData, renderView);
+  }
+
+  bool _shouldSkipNodeTraversal(SemanticsNode node) {
+    final bool isDisabled = node.flagsCollection.isEnabled == ui.Tristate.isFalse;
+    return node.isInvisible ||
+        node.isMergedIntoParent ||
+        node.flagsCollection.isHidden ||
+        isDisabled;
+  }
+
+  bool _shouldSkipNodeEvaluation(SemanticsData data);
+
+  Future<List<Violation>> evaluateNodeContent(
+    SemanticsNode node,
+    SemanticsData data,
+    ui.Image image,
+    ByteData byteData,
+    RenderView renderView,
+  );
+}
+
 /// {@macro flutter.widgets.accessibility_evaluations.internal}
 ///
 /// An evaluation which verifies that all nodes that contribute semantics via text
@@ -242,7 +315,7 @@ class LabeledTapTargetEvaluation extends AccessibilityEvaluation {
 /// The evaluations are defined by the Web Content Accessibility Guidelines,
 /// http://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html.
 @internal
-class MinimumTextContrastEvaluation extends AccessibilityEvaluation {
+class MinimumTextContrastEvaluation extends _ContrastEvaluation {
   /// Create a new [MinimumTextContrastEvaluation].
   const MinimumTextContrastEvaluation({
     required this.minNormalTextContrastRatio,
@@ -284,60 +357,19 @@ class MinimumTextContrastEvaluation extends AccessibilityEvaluation {
 
   static const double _kDefaultFontSize = 12.0;
 
-  static const double _tolerance = -0.01;
+  @override
+  bool _shouldSkipNodeEvaluation(SemanticsData data) =>
+      data.flagsCollection.scopesRoute || (data.label.trim().isEmpty && data.value.trim().isEmpty);
 
   @override
-  Future<EvaluationResult> _evaluate(WidgetsBinding binding) async {
-    final violations = <Violation>[];
-    for (final RenderView renderView in binding.renderViews) {
-      final layer = renderView.debugLayer! as OffsetLayer;
-      final SemanticsNode root = renderView.owner!.semanticsOwner!.rootSemanticsNode!;
-
-      late ui.Image image;
-      // Needs to be the same pixel ratio otherwise our dimensions won't match
-      // the last transform layer.
-      final double ratio = 1 / renderView.flutterView.devicePixelRatio;
-      image = await layer.toImage(renderView.paintBounds, pixelRatio: ratio);
-      final ByteData? byteData = await image.toByteData();
-      if (byteData != null) {
-        violations.addAll(await _evaluateNode(root, image, byteData, renderView));
-      }
-      image.dispose();
-    }
-
-    return EvaluationResult(violations);
-  }
-
-  Future<List<Violation>> _evaluateNode(
+  Future<List<Violation>> evaluateNodeContent(
     SemanticsNode node,
+    SemanticsData data,
     ui.Image image,
     ByteData byteData,
     RenderView renderView,
   ) async {
     final violations = <Violation>[];
-
-    // Skip disabled nodes, as they are not required to pass contrast checks.
-    final isDisabled = node.flagsCollection.isEnabled == ui.Tristate.isFalse;
-
-    if (node.isInvisible ||
-        node.isMergedIntoParent ||
-        node.flagsCollection.isHidden ||
-        isDisabled) {
-      return violations;
-    }
-
-    final SemanticsData data = node.getSemanticsData();
-    final children = <SemanticsNode>[];
-    node.visitChildren((SemanticsNode child) {
-      children.add(child);
-      return true;
-    });
-    for (final child in children) {
-      violations.addAll(await _evaluateNode(child, image, byteData, renderView));
-    }
-    if (_shouldSkipNode(data)) {
-      return violations;
-    }
     final String text = data.label.isEmpty ? data.value : data.label;
     final Iterable<Element> elements = _collectElementsByText(
       WidgetsBinding.instance.rootElement!,
@@ -434,7 +466,7 @@ class MinimumTextContrastEvaluation extends AccessibilityEvaluation {
     final double contrastRatio = report.contrastRatio();
     final double targetContrastRatio = _targetContrastRatio(fontSize, bold: isBold);
 
-    if (contrastRatio - targetContrastRatio >= _tolerance) {
+    if (contrastRatio - targetContrastRatio >= _ContrastEvaluation._kContrastTolerance) {
       return <Violation>[];
     }
     return <Violation>[
@@ -451,12 +483,6 @@ class MinimumTextContrastEvaluation extends AccessibilityEvaluation {
       ),
     ];
   }
-
-  /// Returns whether node should be skipped.
-  ///
-  /// Skip routes which might have labels, and nodes without any text.
-  bool _shouldSkipNode(SemanticsData data) =>
-      data.flagsCollection.scopesRoute || (data.label.trim().isEmpty && data.value.trim().isEmpty);
 
   /// Returns if a rectangle of node is off the screen.
   ///
@@ -490,7 +516,7 @@ class MinimumTextContrastEvaluation extends AccessibilityEvaluation {
 /// The evaluations are defined by the Web Content Accessibility Guidelines,
 /// https://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast.html
 @internal
-class MinimumNonTextContrastEvaluation extends AccessibilityEvaluation {
+class MinimumNonTextContrastEvaluation extends _ContrastEvaluation {
   /// Create a new [MinimumNonTextContrastEvaluation].
   const MinimumNonTextContrastEvaluation();
 
@@ -499,58 +525,33 @@ class MinimumNonTextContrastEvaluation extends AccessibilityEvaluation {
   /// Defined by http://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast.html
   static const double kMinimumRatioNonText = 3.0;
 
-  static const double _tolerance = -0.01;
-
   @override
-  Future<EvaluationResult> _evaluate(WidgetsBinding binding) async {
-    final violations = <Violation>[];
-    for (final RenderView renderView in binding.renderViews) {
-      final layer = renderView.debugLayer! as OffsetLayer;
-      final SemanticsNode root = renderView.owner!.semanticsOwner!.rootSemanticsNode!;
-      // Needs to be the same pixel ratio otherwise our dimensions won't match
-      // the last transform layer.
-      final double ratio = 1 / renderView.flutterView.devicePixelRatio;
-      final ui.Image image = await layer.toImage(renderView.paintBounds, pixelRatio: ratio);
-      final ByteData? byteData = await image.toByteData();
-      if (byteData != null) {
-        violations.addAll(await _evaluateNode(root, image, byteData, renderView));
-      }
-      image.dispose();
+  bool _shouldSkipNodeEvaluation(SemanticsData data) {
+    if (data.flagsCollection.scopesRoute) {
+      return true;
     }
 
-    return EvaluationResult(violations);
+    final bool isControl =
+        data.flagsCollection.isButton ||
+        data.flagsCollection.isSlider ||
+        data.flagsCollection.isTextField ||
+        data.flagsCollection.isChecked != ui.CheckedState.none ||
+        data.flagsCollection.isToggled != ui.Tristate.none ||
+        data.hasAction(ui.SemanticsAction.tap) ||
+        data.hasAction(ui.SemanticsAction.longPress);
+
+    return !isControl;
   }
 
-  Future<List<Violation>> _evaluateNode(
+  @override
+  Future<List<Violation>> evaluateNodeContent(
     SemanticsNode node,
+    SemanticsData data,
     ui.Image image,
     ByteData byteData,
     RenderView renderView,
   ) async {
     final violations = <Violation>[];
-
-    // Skip disabled nodes, as they are not required to pass contrast checks.
-    final isDisabled = node.flagsCollection.isEnabled == ui.Tristate.isFalse;
-
-    if (node.isInvisible ||
-        node.isMergedIntoParent ||
-        node.flagsCollection.isHidden ||
-        isDisabled) {
-      return violations;
-    }
-
-    final SemanticsData data = node.getSemanticsData();
-    final children = <SemanticsNode>[];
-    node.visitChildren((SemanticsNode child) {
-      children.add(child);
-      return true;
-    });
-    for (final child in children) {
-      violations.addAll(await _evaluateNode(child, image, byteData, renderView));
-    }
-    if (_shouldSkipNode(data)) {
-      return violations;
-    }
     Rect nodeBounds = node.rect;
     SemanticsNode? current = node;
     while (current != null) {
@@ -562,7 +563,7 @@ class MinimumNonTextContrastEvaluation extends AccessibilityEvaluation {
     }
 
     final double devicePixelRatio = renderView.flutterView.devicePixelRatio;
-    final logicalBounds = Rect.fromLTRB(
+    final Rect logicalBounds = Rect.fromLTRB(
       nodeBounds.left / devicePixelRatio,
       nodeBounds.top / devicePixelRatio,
       nodeBounds.right / devicePixelRatio,
@@ -589,7 +590,7 @@ class MinimumNonTextContrastEvaluation extends AccessibilityEvaluation {
     final report = _ContrastReport(colorHistogram);
     final double contrastRatio = report.contrastRatio();
 
-    if (contrastRatio - kMinimumRatioNonText >= _tolerance) {
+    if (contrastRatio - kMinimumRatioNonText >= _ContrastEvaluation._kContrastTolerance) {
       return violations;
     }
 
@@ -600,38 +601,20 @@ class MinimumNonTextContrastEvaluation extends AccessibilityEvaluation {
         'Expected non-text control contrast ratio of at least $kMinimumRatioNonText '
         'but found ${contrastRatio.toStringAsFixed(2)}.\n'
         'The computed colors were:\n'
-        'light - ${report.lightColor}, dark - ${report.darkColor}\n',
+        'light - ${report.lightColor}, dark - ${report.darkColor}\n'
+        'See also: '
+        'https://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast.html',
       ),
     );
     return violations;
   }
 
-  bool _shouldSkipNode(SemanticsData data) {
-    if (data.flagsCollection.scopesRoute) {
-      return true;
-    }
-
-    final bool isControl =
-        data.flagsCollection.isButton ||
-        data.flagsCollection.isSlider ||
-        data.flagsCollection.isTextField ||
-        data.flagsCollection.isChecked != ui.CheckedState.none ||
-        data.flagsCollection.isToggled != ui.Tristate.none ||
-        data.hasAction(ui.SemanticsAction.tap) ||
-        data.hasAction(ui.SemanticsAction.longPress);
-
-    if (!isControl) {
-      return true;
-    }
-    return false;
-  }
-
   bool _isNodeOffScreen(Rect paintBounds, ui.FlutterView window) {
-    final Size windowPhysicalSize = window.physicalSize * window.devicePixelRatio;
+    final Size windowLogicalSize = window.physicalSize / window.devicePixelRatio;
     return paintBounds.top < -50.0 ||
         paintBounds.left < -50.0 ||
-        paintBounds.bottom > windowPhysicalSize.height + 50.0 ||
-        paintBounds.right > windowPhysicalSize.width + 50.0;
+        paintBounds.bottom > windowLogicalSize.height + 50.0 ||
+        paintBounds.right > windowLogicalSize.width + 50.0;
   }
 }
 

--- a/packages/flutter/lib/src/widgets/_accessibility_evaluations.dart
+++ b/packages/flutter/lib/src/widgets/_accessibility_evaluations.dart
@@ -305,6 +305,17 @@ abstract class _ContrastEvaluation extends AccessibilityEvaluation {
     ByteData byteData,
     RenderView renderView,
   );
+
+  /// Returns if a rectangle of node is off the screen.
+  ///
+  /// Allows node to be off screen partially before culling the node.
+  bool _isNodeOffScreen(Rect paintBounds, ui.FlutterView window) {
+    final Size windowLogicalSize = window.physicalSize / window.devicePixelRatio;
+    return paintBounds.top < -50.0 ||
+        paintBounds.left < -50.0 ||
+        paintBounds.bottom > windowLogicalSize.height + 50.0 ||
+        paintBounds.right > windowLogicalSize.width + 50.0;
+  }
 }
 
 /// {@macro flutter.widgets.accessibility_evaluations.internal}
@@ -484,16 +495,6 @@ class MinimumTextContrastEvaluation extends _ContrastEvaluation {
     ];
   }
 
-  /// Returns if a rectangle of node is off the screen.
-  ///
-  /// Allows node to be off screen partially before culling the node.
-  bool _isNodeOffScreen(Rect paintBounds, ui.FlutterView window) {
-    final Size windowPhysicalSize = window.physicalSize * window.devicePixelRatio;
-    return paintBounds.top < -50.0 ||
-        paintBounds.left < -50.0 ||
-        paintBounds.bottom > windowPhysicalSize.height + 50.0 ||
-        paintBounds.right > windowPhysicalSize.width + 50.0;
-  }
 
   /// Returns the required contrast ratio for the [fontSize] and [bold] setting.
   ///
@@ -609,13 +610,7 @@ class MinimumNonTextContrastEvaluation extends _ContrastEvaluation {
     return violations;
   }
 
-  bool _isNodeOffScreen(Rect paintBounds, ui.FlutterView window) {
-    final Size windowLogicalSize = window.physicalSize / window.devicePixelRatio;
-    return paintBounds.top < -50.0 ||
-        paintBounds.left < -50.0 ||
-        paintBounds.bottom > windowLogicalSize.height + 50.0 ||
-        paintBounds.right > windowLogicalSize.width + 50.0;
-  }
+
 }
 
 class _ContrastReport {

--- a/packages/flutter/lib/src/widgets/_accessibility_evaluations.dart
+++ b/packages/flutter/lib/src/widgets/_accessibility_evaluations.dart
@@ -481,7 +481,159 @@ class MinimumTextContrastEvaluation extends AccessibilityEvaluation {
   }
 }
 
-/// A class that reports the contrast ratio of a part of the screen.
+/// {@macro flutter.widgets.accessibility_evaluations.internal}
+///
+/// An evaluation which verifies that all nodes that represent non-text controls
+/// meet minimum contrast levels of 3.0.
+///
+/// The evaluatiosn are defined by the Web Content Accessibility Guidelines,
+/// https://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast.html
+@internal
+class MinimumNonTextContrastEvaluation extends AccessibilityEvaluation {
+  /// Create a new [MinimumNonTextContrastEvaluation].
+  const MinimumNonTextContrastEvaluation();
+
+  /// The minimum contrast ratio for non-text controls.
+  ///
+  /// Defined by http://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast.html
+  static const double kMinimumRatioNonText = 3.0;
+
+  static const double _tolerance = -0.01;
+
+  @override
+  Future<EvaluationResult> _evaluate(WidgetsBinding binding) async {
+    final violations = <Violation>[];
+    for (final RenderView renderView in binding.renderViews) {
+      final layer = renderView.debugLayer! as OffsetLayer;
+      final SemanticsNode root = renderView.owner!.semanticsOwner!.rootSemanticsNode!;
+      // Needs to be the same pixel ratio otherwise our dimensions won't match
+      // the last transform layer.
+      final double ratio = 1 / renderView.flutterView.devicePixelRatio;
+      final ui.Image image = await layer.toImage(renderView.paintBounds, pixelRatio: ratio);
+      final ByteData? byteData = await image.toByteData();
+
+      violations.addAll(await _evaluateNode(root, image, byteData!, renderView));
+      image.dispose();
+    }
+
+    return EvaluationResult(violations);
+  }
+
+  Future<List<Violation>> _evaluateNode(
+    SemanticsNode node,
+    ui.Image image,
+    ByteData byteData,
+    RenderView renderView,
+  ) async {
+    final violations = <Violation>[];
+
+    // Skip disabled nodes, as they are not required to pass contrast checks.
+    final isDisabled = node.flagsCollection.isEnabled == ui.Tristate.isFalse;
+
+    if (node.isInvisible ||
+        node.isMergedIntoParent ||
+        node.flagsCollection.isHidden ||
+        isDisabled) {
+      return violations;
+    }
+
+    final SemanticsData data = node.getSemanticsData();
+    final children = <SemanticsNode>[];
+    node.visitChildren((SemanticsNode child) {
+      children.add(child);
+      return true;
+    });
+    for (final child in children) {
+      violations.addAll(await _evaluateNode(child, image, byteData, renderView));
+    }
+    if (_shouldSkipNode(data)) {
+      return violations;
+    }
+
+    Rect nodeBounds = node.rect;
+    SemanticsNode? current = node;
+    while (current != null) {
+      final Matrix4? transform = current.transform;
+      if (transform != null && current.parent != null) {
+        nodeBounds = MatrixUtils.transformRect(transform, nodeBounds);
+      }
+      current = current.parent;
+    }
+
+    final double devicePixelRatio = renderView.flutterView.devicePixelRatio;
+    final logicalBounds = Rect.fromLTRB(
+      nodeBounds.left / devicePixelRatio,
+      nodeBounds.top / devicePixelRatio,
+      nodeBounds.right / devicePixelRatio,
+      nodeBounds.bottom / devicePixelRatio,
+    );
+
+    final Rect inflatedBounds = logicalBounds.inflate(4.0);
+
+    if (_isNodeOffScreen(inflatedBounds, renderView.flutterView)) {
+      return violations;
+    }
+
+    final Map<Color, int> colorHistogram = _colorsWithinRect(
+      byteData,
+      inflatedBounds,
+      image.width,
+      image.height,
+    );
+
+    if (colorHistogram.length <= 1) {
+      return violations;
+    }
+
+    final report = _ContrastReport(colorHistogram);
+    final double contrastRatio = report.contrastRatio();
+
+    if (contrastRatio - kMinimumRatioNonText >= _tolerance) {
+      return violations;
+    }
+
+    violations.add(
+      Violation(
+        node,
+        '$node:\n'
+        'Expected non-text control contrast ratio of at least $kMinimumRatioNonText '
+        'but found ${contrastRatio.toStringAsFixed(2)}.\n'
+        'The computed colors were:\n'
+        'light - ${report.lightColor}, dark - ${report.darkColor}\n',
+      ),
+    );
+    return violations;
+  }
+
+  bool _shouldSkipNode(SemanticsData data) {
+    if (data.flagsCollection.scopesRoute) {
+      return true;
+    }
+
+    final bool isControl =
+        data.flagsCollection.isButton ||
+        data.flagsCollection.isSlider ||
+        data.flagsCollection.isTextField ||
+        data.flagsCollection.isChecked != ui.CheckedState.none ||
+        data.flagsCollection.isToggled != ui.Tristate.none ||
+        data.hasAction(ui.SemanticsAction.tap) ||
+        data.hasAction(ui.SemanticsAction.longPress);
+
+    if (!isControl) {
+      return true;
+    }
+    return false;
+  }
+
+  bool _isNodeOffScreen(Rect paintBounds, ui.FlutterView window) {
+    final Size windowPhysicalSize = window.physicalSize * window.devicePixelRatio;
+    return paintBounds.top < -50.0 ||
+        paintBounds.left < -50.0 ||
+        paintBounds.bottom > windowPhysicalSize.height + 50.0 ||
+        paintBounds.right > windowPhysicalSize.width + 50.0;
+  }
+}
+
 class _ContrastReport {
   /// Generates a contrast report given a color histogram.
   ///

--- a/packages/flutter/test/widgets/accessibility_evaluations_test.dart
+++ b/packages/flutter/test/widgets/accessibility_evaluations_test.dart
@@ -418,4 +418,200 @@ void main() {
       handle.dispose();
     });
   });
+
+  group('MinimumNonTextContrastEvaluation', () {
+    late final Set<String> originalFeatureFlags;
+    setUpAll(() {
+      originalFeatureFlags = {...debugEnabledFeatureFlags};
+      debugEnabledFeatureFlags.add('accessibility_evaluations');
+    });
+    tearDownAll(() {
+      debugEnabledFeatureFlags.clear();
+      debugEnabledFeatureFlags.addAll(originalFeatureFlags);
+    });
+    const evaluation = MinimumNonTextContrastEvaluation();
+
+    testWidgets('passes for high contrast button', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: SizedBox.square(
+            dimension: 100,
+            child: ColoredBox(
+              color: const Color(0xFFFFFFFF),
+              child: Center(
+                child: Semantics(
+                  button: true,
+                  container: true,
+                  child: const SizedBox.square(
+                    dimension: 50,
+                    child: ColoredBox(color: Color(0xFF000000)),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      final EvaluationResult? result = await tester.runAsync<EvaluationResult>(() async {
+        return await evaluation.evaluate(tester.binding);
+      });
+      expect(result!.violations, isEmpty);
+      handle.dispose();
+    });
+
+    testWidgets('fails for low contrast button', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: SizedBox.square(
+            dimension: 100,
+            child: ColoredBox(
+              color: const Color(0xFFFFFFFF),
+              child: Center(
+                child: Semantics(
+                  button: true,
+                  container: true,
+                  child: const SizedBox.square(
+                    dimension: 50,
+                    child: ColoredBox(color: Color(0xFFEEEEEE)),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      final EvaluationResult? result = await tester.runAsync<EvaluationResult>(() async {
+        return await evaluation.evaluate(tester.binding);
+      });
+      expect(result!.violations, hasLength(1));
+      expect(
+        result.violations.first.reason,
+        contains('Expected non-text control contrast ratio of at least 3.0'),
+      );
+      handle.dispose();
+    });
+
+    testWidgets('passes when transparent and background is uniform', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: SizedBox.square(
+            dimension: 100,
+            child: ColoredBox(
+              color: const Color(0xFFFFFFFF),
+              child: Center(
+                child: Semantics(
+                  button: true,
+                  container: true,
+                  child: const SizedBox.square(dimension: 50),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      final EvaluationResult? result = await tester.runAsync<EvaluationResult>(() async {
+        return await evaluation.evaluate(tester.binding);
+      });
+      expect(result!.violations, isEmpty);
+      handle.dispose();
+    });
+
+    testWidgets('fails for low contrast slider', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: SizedBox.square(
+            dimension: 100,
+            child: ColoredBox(
+              color: const Color(0xFFFFFFFF),
+              child: Center(
+                child: Semantics(
+                  slider: true,
+                  container: true,
+                  child: const SizedBox.square(
+                    dimension: 50,
+                    child: ColoredBox(color: Color(0xFFEEEEEE)),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      final EvaluationResult? result = await tester.runAsync<EvaluationResult>(() async {
+        return await evaluation.evaluate(tester.binding);
+      });
+      expect(result!.violations, hasLength(1));
+      expect(
+        result.violations.first.reason,
+        contains('Expected non-text control contrast ratio of at least 3.0'),
+      );
+      handle.dispose();
+    });
+
+    testWidgets('passes for high contrast textfield', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: SizedBox.square(
+            dimension: 100,
+            child: ColoredBox(
+              color: const Color(0xFFFFFFFF),
+              child: Center(
+                child: Semantics(
+                  textField: true,
+                  container: true,
+                  child: const SizedBox.square(
+                    dimension: 50,
+                    child: ColoredBox(color: Color(0xFF000000)),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      final EvaluationResult? result = await tester.runAsync<EvaluationResult>(() async {
+        return await evaluation.evaluate(tester.binding);
+      });
+      expect(result!.violations, isEmpty);
+      handle.dispose();
+    });
+
+    testWidgets('fails for low contrast node with onTap', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: SizedBox.square(
+            dimension: 100,
+            child: ColoredBox(
+              color: const Color(0xFFFFFFFF),
+              child: Center(
+                child: Semantics(
+                  onTap: () {},
+                  container: true,
+                  child: const SizedBox.square(
+                    dimension: 50,
+                    child: ColoredBox(color: Color(0xFFEEEEEE)),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      final EvaluationResult? result = await tester.runAsync<EvaluationResult>(() async {
+        return await evaluation.evaluate(tester.binding);
+      });
+      expect(result!.violations, hasLength(1));
+      expect(
+        result.violations.first.reason,
+        contains('Expected non-text control contrast ratio of at least 3.0'),
+      );
+      handle.dispose();
+    });
+  });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/170687

This PR is to add an evaluation to ensure non-text controls have enough color contrast.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
