### PR TITLE
ci: Remove `bringup` from orchestrator for windows_arm_host_engine on Linux

### DIFF
--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -556,9 +556,7 @@ targets:
     drone_dimensions:
       - os=Windows
 
-  # TODO(gustl22): Remove, once orchestrator is green on Linux
-  # https://github.com/flutter/flutter/pull/176385
-  - name: Windows windows_arm_host_engine
+  - name: Linux windows_arm_host_engine
     recipe: engine_v2/engine_v2
     timeout: 120
     enabled_branches:
@@ -566,22 +564,6 @@ targets:
       - master
     properties:
       release_build: "true"
-      add_recipes_cq: "true"
-      config_name: windows_arm_host_engine
-    drone_dimensions:
-      - os=Windows
-
-  # TODO(gustl22): Remove `bringup: true` and add `release_build: true`.
-  # https://github.com/flutter/flutter/pull/176385
-  - name: Linux windows_arm_host_engine
-    recipe: engine_v2/engine_v2
-    timeout: 120
-    bringup: true
-    enabled_branches:
-      # Don't run this on release branches
-      - master
-    properties:
-      release_build: "false"
       add_recipes_cq: "true"
       config_name: windows_arm_host_engine
     # Do not remove(https://github.com/flutter/flutter/issues/144644)


### PR DESCRIPTION
In order to save resources on windows runners the orchestrator for windows_arm_host_engine is moved to Linux.
See: https://github.com/flutter/flutter/pull/176385#issuecomment-3730556941

The orchestrator seems to be successful on Linux (last column):
https://flutter-dashboard.appspot.com/#/build?showMac=false&showiOS=false&showAndroid=false&showBringup=true&repo=flutter&branch=master
<img width="571" height="634" alt="image" src="https://github.com/user-attachments/assets/3795023d-02a7-4e6e-8b19-57994e1e5e0b" />

Follows on: #181075
Towards: #62597
Ref PR: #168941

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
