### PR TITLE
Use operator<=> instead of std::less for UniqueID.

### DIFF
--- a/engine/src/flutter/impeller/base/comparable.h
+++ b/engine/src/flutter/impeller/base/comparable.h
@@ -18,13 +18,7 @@ struct UniqueID {
 
   UniqueID();
 
-  constexpr bool operator==(const UniqueID& other) const {
-    return id == other.id;
-  }
-
-  constexpr bool operator<(const UniqueID& other) const {
-    return id < other.id;
-  }
+  constexpr auto operator<=>(const UniqueID&) const = default;
 };
 
 class ComparableBase {};

--- a/engine/src/flutter/impeller/base/comparable.h
+++ b/engine/src/flutter/impeller/base/comparable.h
@@ -21,6 +21,10 @@ struct UniqueID {
   constexpr bool operator==(const UniqueID& other) const {
     return id == other.id;
   }
+
+  constexpr bool operator<(const UniqueID& other) const {
+    return id < other.id;
+  }
 };
 
 class ComparableBase {};
@@ -98,14 +102,6 @@ template <>
 struct hash<impeller::UniqueID> {
   constexpr std::size_t operator()(const impeller::UniqueID& id) {
     return id.id;
-  }
-};
-
-template <>
-struct less<impeller::UniqueID> {
-  constexpr bool operator()(const impeller::UniqueID& lhs,
-                            const impeller::UniqueID& rhs) const {
-    return lhs.id < rhs.id;
   }
 };
 


### PR DESCRIPTION
Internally when this is compiled with C++20, the compiler could not find the implementation for `std::less<UniqueID, UniqueID>`. Overridding `operator<=>` instead as that is the best practice in modern C++.
