### PR TITLE
Only dispatch predictive back to the deepest observer

### DIFF
--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -104,10 +104,11 @@ abstract mixin class WidgetsBindingObserver {
 
   /// Called at the start of a predictive back gesture.
   ///
-  /// Observers are notified in registration order until one returns true or all
-  /// observers have been notified. If an observer returns true then that
-  /// observer, and only that observer, will be notified of subsequent events in
-  /// this same gesture (for example [handleUpdateBackGestureProgress], etc.).
+  /// Observers are notified in reverse registration order until one returns
+  /// true or all observers have been notified. If an observer returns true then
+  /// that observer, and only that observer, will be notified of subsequent
+  /// events in this same gesture (for example
+  /// [handleUpdateBackGestureProgress], etc.).
   ///
   /// Observers are expected to return true if they were able to handle the
   /// notification, for example by starting a predictive back animation, and

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -1139,10 +1139,11 @@ mixin WidgetsBinding
   bool _handleStartBackGesture(Map<String?, Object?> arguments) {
     _backGestureObservers.clear();
     final backEvent = PredictiveBackEvent.fromMap(arguments);
-    for (final observer in List<WidgetsBindingObserver>.of(_observers)) {
+    for (final observer in List<WidgetsBindingObserver>.of(_observers).reversed) {
       try {
         if (observer.handleStartBackGesture(backEvent)) {
           _backGestureObservers.add(observer);
+          break;
         }
       } catch (exception, stack) {
         FlutterError.reportError(

--- a/packages/flutter/test/widgets/binding_test.dart
+++ b/packages/flutter/test/widgets/binding_test.dart
@@ -241,6 +241,39 @@ class LoggingObserver with WidgetsBindingObserver {
 }
 
 // Implements to make sure all methods get coverage.
+class SelectiveLoggingObserver with WidgetsBindingObserver {
+  SelectiveLoggingObserver({
+    required this.name,
+    required this.log,
+    required this.handlesBackGesture,
+  });
+
+  final String name;
+  final List<String> log;
+  final bool handlesBackGesture;
+
+  @override
+  bool handleStartBackGesture(PredictiveBackEvent backEvent) {
+    log.add('$name.handleStartBackGesture');
+    return handlesBackGesture;
+  }
+
+  @override
+  void handleUpdateBackGestureProgress(PredictiveBackEvent backEvent) {
+    log.add('$name.handleUpdateBackGestureProgress');
+  }
+
+  @override
+  void handleCommitBackGesture() {
+    log.add('$name.handleCommitBackGesture');
+  }
+
+  @override
+  void handleCancelBackGesture() {
+    log.add('$name.handleCancelBackGesture');
+  }
+}
+
 class RentrantObserver implements WidgetsBindingObserver {
   RentrantObserver() {
     WidgetsBinding.instance.addObserver(this);
@@ -1122,6 +1155,70 @@ void main() {
       WidgetsBinding.instance.handleMemoryPressure();
       expect(log, contains('didHaveMemoryPressure'));
       expect(errors, hasLength(1));
+    });
+
+    testWidgets('only the deepest observer handles a predictive back gesture', (
+      WidgetTester tester,
+    ) async {
+      final log = <String>[];
+      final outerObserver = SelectiveLoggingObserver(
+        name: 'outer',
+        log: log,
+        handlesBackGesture: true,
+      );
+      final innerObserver = SelectiveLoggingObserver(
+        name: 'inner',
+        log: log,
+        handlesBackGesture: true,
+      );
+      WidgetsBinding.instance.addObserver(outerObserver);
+      WidgetsBinding.instance.addObserver(innerObserver);
+      addTearDown(() {
+        WidgetsBinding.instance.removeObserver(outerObserver);
+        WidgetsBinding.instance.removeObserver(innerObserver);
+      });
+
+      final ByteData startMessage = const StandardMethodCodec().encodeMethodCall(
+        const MethodCall('startBackGesture', <String, dynamic>{
+          'touchOffset': <double>[5.0, 300.0],
+          'progress': 0.0,
+          'swipeEdge': 0,
+        }),
+      );
+      await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+        'flutter/backgesture',
+        startMessage,
+        (ByteData? _) {},
+      );
+
+      final ByteData updateMessage = const StandardMethodCodec().encodeMethodCall(
+        const MethodCall('updateBackGestureProgress', <String, dynamic>{
+          'x': 100.0,
+          'y': 300.0,
+          'progress': 0.35,
+          'swipeEdge': 0,
+        }),
+      );
+      await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+        'flutter/backgesture',
+        updateMessage,
+        (ByteData? _) {},
+      );
+
+      final ByteData commitMessage = const StandardMethodCodec().encodeMethodCall(
+        const MethodCall('commitBackGesture'),
+      );
+      await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+        'flutter/backgesture',
+        commitMessage,
+        (ByteData? _) {},
+      );
+
+      expect(log, <String>[
+        'inner.handleStartBackGesture',
+        'inner.handleUpdateBackGestureProgress',
+        'inner.handleCommitBackGesture',
+      ]);
     });
 
     testWidgets('handleUpdateBackGestureProgress', (WidgetTester tester) async {


### PR DESCRIPTION
## Issue
Fixes #183597.

Predictive back gestures currently notify every `WidgetsBindingObserver` that reports it can handle the gesture. In nested navigation scenarios, that allows multiple active routes to participate in the same gesture, which can pop more than the deepest navigator.

## What this PR changes
- dispatches `startBackGesture` in reverse observer order so the most recently registered observer gets first chance to claim the gesture
- stops after the first observer claims the gesture, so only one observer owns a predictive back gesture
- adds a regression test covering two nested back-gesture observers and verifies only the deepest observer receives update/commit callbacks

## Outcome
Predictive back gestures now stay scoped to the deepest active observer instead of being broadcast to every eligible observer.

## Tests
- `./bin/flutter test packages/flutter/test/widgets/binding_test.dart --plain-name 'only the deepest observer handles a predictive back gesture'`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md

