### PR TITLE
Improve locked Navigator debug error

### DIFF
--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -3898,7 +3898,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
       'have their RouteSettings defined with names that are defined in the '
       "app's routes table.",
     );
-    assert(!_debugLocked);
+    assert(_debugCheckCanNavigate());
     assert(() {
       _debugLocked = true;
       return true;
@@ -4073,6 +4073,33 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
     }());
   }
 
+  bool _debugCheckCanNavigate() {
+    assert(() {
+      if (_debugLocked) {
+        throw FlutterError.fromParts(<DiagnosticsNode>[
+          ErrorSummary('Navigator operation requested with a locked Navigator.'),
+          ErrorDescription(
+            'A Navigator cannot be used to push, pop, or replace routes while '
+            'it is already updating its history.',
+          ),
+          ErrorHint(
+            'This can happen if a navigation method is called from a pop '
+            'callback such as PopScope.onPopInvokedWithResult. Consider '
+            'scheduling the navigation for the next frame instead of during '
+            'the current navigation update.',
+          ),
+          DiagnosticsProperty<NavigatorState>(
+            'The Navigator was',
+            this,
+            style: DiagnosticsTreeStyle.errorProperty,
+          ),
+        ]);
+      }
+      return true;
+    }());
+    return true;
+  }
+
   @protected
   @override
   void deactivate() {
@@ -4097,7 +4124,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   @protected
   @override
   void dispose() {
-    assert(!_debugLocked);
+    assert(_debugCheckCanNavigate());
     assert(() {
       _debugLocked = true;
       return true;
@@ -4658,7 +4685,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   }
 
   Route<T?>? _routeNamed<T>(String name, {required Object? arguments, bool allowNull = false}) {
-    assert(!_debugLocked);
+    assert(_debugCheckCanNavigate());
     if (allowNull && widget.onGenerateRoute == null) {
       return null;
     }
@@ -5077,7 +5104,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   }
 
   void _pushEntry(_RouteEntry entry) {
-    assert(!_debugLocked);
+    assert(_debugCheckCanNavigate());
     assert(() {
       _debugLocked = true;
       return true;
@@ -5209,7 +5236,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   }
 
   void _pushReplacementEntry<TO extends Object?>(_RouteEntry entry, TO? result) {
-    assert(!_debugLocked);
+    assert(_debugCheckCanNavigate());
     assert(() {
       _debugLocked = true;
       return true;
@@ -5310,7 +5337,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   }
 
   void _pushEntryAndRemoveUntil(_RouteEntry entry, RoutePredicate predicate) {
-    assert(!_debugLocked);
+    assert(_debugCheckCanNavigate());
     assert(() {
       _debugLocked = true;
       return true;
@@ -5347,7 +5374,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   ///    restored during state restoration.
   @optionalTypeArgs
   void replace<T extends Object?>({required Route<dynamic> oldRoute, required Route<T> newRoute}) {
-    assert(!_debugLocked);
+    assert(_debugCheckCanNavigate());
     assert(oldRoute._isInstalledIn(this));
     _replaceEntry(
       _RouteEntry(newRoute, pageBased: false, initialState: _RouteLifecycle.replace),
@@ -5389,7 +5416,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   }
 
   void _replaceEntry(_RouteEntry entry, Route<dynamic> oldRoute) {
-    assert(!_debugLocked);
+    assert(_debugCheckCanNavigate());
     if (oldRoute == entry.route) {
       return;
     }
@@ -5477,7 +5504,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   }
 
   void _replaceEntryBelow(_RouteEntry entry, Route<dynamic> anchorRoute) {
-    assert(!_debugLocked);
+    assert(_debugCheckCanNavigate());
     assert(() {
       _debugLocked = true;
       return true;
@@ -5604,7 +5631,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   /// {@end-tool}
   @optionalTypeArgs
   void pop<T extends Object?>([T? result]) {
-    assert(!_debugLocked);
+    assert(_debugCheckCanNavigate());
     assert(() {
       _debugLocked = true;
       return true;
@@ -5691,7 +5718,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   /// {@macro flutter.widgets.navigator.removeRoute}
   @optionalTypeArgs
   void removeRoute<T extends Object?>(Route<T> route, [T? result]) {
-    assert(!_debugLocked);
+    assert(_debugCheckCanNavigate());
     assert(() {
       _debugLocked = true;
       return true;
@@ -5716,7 +5743,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   /// {@macro flutter.widgets.navigator.removeRouteBelow}
   @optionalTypeArgs
   void removeRouteBelow<T extends Object?>(Route<T> anchorRoute, [T? result]) {
-    assert(!_debugLocked);
+    assert(_debugCheckCanNavigate());
     assert(() {
       _debugLocked = true;
       return true;
@@ -5906,7 +5933,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   @protected
   @override
   Widget build(BuildContext context) {
-    assert(!_debugLocked);
+    assert(_debugCheckCanNavigate());
     assert(_history.isNotEmpty);
 
     // Hides the HeroControllerScope for the widget subtree so that the other

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -4084,9 +4084,8 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
           ),
           ErrorHint(
             'This can happen if a navigation method is called from a pop '
-            'callback such as PopScope.onPopInvokedWithResult. Consider '
-            'scheduling the navigation for the next frame instead of during '
-            'the current navigation update.',
+            'callback. Consider scheduling the navigation for the next frame '
+            'instead of during the current navigation update.',
           ),
           DiagnosticsProperty<NavigatorState>(
             'The Navigator was',

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -6340,6 +6340,65 @@ void main() {
     },
     variant: TargetPlatformVariant.only(TargetPlatform.iOS),
   );
+
+  testWidgets('pushReplacement from onPopInvokedWithResult throws a helpful error', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (BuildContext context) {
+            return Center(
+              child: TextButton(
+                onPressed: () {
+                  Navigator.of(context).push<void>(
+                    MaterialPageRoute<void>(
+                      builder: (BuildContext context) {
+                        return PopScope<void>(
+                          onPopInvokedWithResult: (bool didPop, void result) {
+                            if (!didPop) {
+                              return;
+                            }
+                            Navigator.of(context).pushReplacement<void, void>(
+                              MaterialPageRoute<void>(
+                                builder: (BuildContext context) => const Placeholder(),
+                              ),
+                            );
+                          },
+                          child: Center(
+                            child: TextButton(
+                              onPressed: () {
+                                Navigator.of(context).pop();
+                              },
+                              child: const Text('Pop'),
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+                  );
+                },
+                child: const Text('Push'),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Push'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Pop'));
+    final FlutterError error = tester.takeException()! as FlutterError;
+
+    expect(
+      error.toStringDeep(),
+      contains('Navigator operation requested with a locked Navigator.'),
+    );
+    expect(error.toStringDeep(), contains('PopScope.onPopInvokedWithResult'));
+    expect(error.toStringDeep(), contains('scheduling the navigation for the next frame'));
+  });
 }
 
 typedef AnnouncementCallBack = void Function(Route<dynamic>?);

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -6396,7 +6396,6 @@ void main() {
       error.toStringDeep(),
       contains('Navigator operation requested with a locked Navigator.'),
     );
-    expect(error.toStringDeep(), contains('PopScope.onPopInvokedWithResult'));
     expect(error.toStringDeep(), contains('scheduling the navigation for the next frame'));
   });
 }


### PR DESCRIPTION
## Description
Fixes https://github.com/flutter/flutter/issues/183589.

This issue reports a generic `!_debugLocked` assertion when a route attempts to call
`Navigator.pushReplacement` from `PopScope.onPopInvokedWithResult` while the
navigator is still processing the original pop.

Instead of surfacing the bare assertion, this change routes the locked-navigator
check through a dedicated debug helper that throws a `FlutterError` with:

- a clear summary of what happened,
- an explanation that the navigator is already updating its history, and
- a hint that this commonly happens from pop callbacks like
  `PopScope.onPopInvokedWithResult`, along with guidance to schedule the follow-up
  navigation for the next frame.

The new regression test verifies that this scenario now produces the improved error.

## Tests
- `./bin/flutter test packages/flutter/test/widgets/navigator_test.dart --plain-name "pushReplacement from onPopInvokedWithResult throws a helpful error"` **(blocked locally: this checkout's downloaded Dart/Flutter toolchain initially had missing execute bits on runtime binaries, and `flutter test` still exited with code 255 while building the flutter tool without surfacing a useful stderr message in this environment)**
- `./bin/dart format packages/flutter/lib/src/widgets/navigator.dart packages/flutter/test/widgets/navigator_test.dart`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md

