### PR TITLE
[flutter_tools] Avoid attaching LLDB to app extensions

### DIFF
--- a/packages/flutter_tools/lib/src/ios/core_devices.dart
+++ b/packages/flutter_tools/lib/src/ios/core_devices.dart
@@ -129,10 +129,13 @@ class IOSCoreDeviceLauncher {
       IOSCoreDeviceRunningProcess process,
     ) {
       final String? executable = process.executable;
-      if (executable == null || !executable.startsWith('$installationURL/')) {
+      final String installationPrefix = installationURL.endsWith('/')
+          ? installationURL
+          : '$installationURL/';
+      if (executable == null || !executable.startsWith(installationPrefix)) {
         return false;
       }
-      final String relativeExecutablePath = executable.substring(installationURL.length + 1);
+      final String relativeExecutablePath = executable.substring(installationPrefix.length);
       return !relativeExecutablePath.contains('/');
     }).firstOrNull;
 

--- a/packages/flutter_tools/lib/src/ios/core_devices.dart
+++ b/packages/flutter_tools/lib/src/ios/core_devices.dart
@@ -119,15 +119,22 @@ class IOSCoreDeviceLauncher {
       return launchResult;
     }
 
-    // Find the process that was launched using the installationURL.
+    // Prefer the main app executable directly inside the installed app bundle.
+    // Matching any process whose executable merely contains the installation
+    // URL can pick an app extension inside `Runner.app/PlugIns/*.appex/*` and
+    // attach LLDB to the wrong process.
     final List<IOSCoreDeviceRunningProcess> processes = await _coreDeviceControl
         .getRunningProcesses(deviceId: deviceId);
-    final IOSCoreDeviceRunningProcess? launchedProcess = processes
-        .where(
-          (IOSCoreDeviceRunningProcess process) =>
-              process.executable != null && process.executable!.contains(installationURL),
-        )
-        .firstOrNull;
+    final IOSCoreDeviceRunningProcess? launchedProcess = processes.where((
+      IOSCoreDeviceRunningProcess process,
+    ) {
+      final String? executable = process.executable;
+      if (executable == null || !executable.startsWith('$installationURL/')) {
+        return false;
+      }
+      final String relativeExecutablePath = executable.substring(installationURL.length + 1);
+      return !relativeExecutablePath.contains('/');
+    }).firstOrNull;
 
     final int? processId = launchedProcess?.processIdentifier;
     if (launchedProcess == null || processId == null) {

--- a/packages/flutter_tools/test/general.shard/ios/core_devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/core_devices_test.dart
@@ -181,7 +181,7 @@ void main() {
             'info': <String, Object?>{'outcome': 'success'},
             'result': <String, Object?>{
               'installedApplications': [
-                <String, Object?>{'installationURL': '/asdf'},
+                <String, Object?>{'installationURL': '/app/Runner.app'},
               ],
             },
           }),
@@ -194,7 +194,7 @@ void main() {
           runningProcesses: [
             IOSCoreDeviceRunningProcess.fromJson(const <String, Object?>{
               'processIdentifier': 123,
-              'executable': '/asdf',
+              'executable': '/app/Runner.app/Runner',
             }),
           ],
         );
@@ -223,13 +223,66 @@ void main() {
         expect(fakeLLDB.attemptedToAttach, isTrue);
       });
 
+      testWithoutContext('attaches to main app instead of extension process', () async {
+        final fakeCoreDeviceControl = FakeIOSCoreDeviceControl(
+          installResult: IOSCoreDeviceInstallResult.fromJson(const <String, Object?>{
+            'info': <String, Object?>{'outcome': 'success'},
+            'result': <String, Object?>{
+              'installedApplications': [
+                <String, Object?>{'installationURL': '/app/Runner.app'},
+              ],
+            },
+          }),
+          launchResult: IOSCoreDeviceLaunchResult.fromJson(const <String, Object?>{
+            'info': <String, Object?>{'outcome': 'success'},
+            'result': <String, Object?>{
+              'process': <String, Object?>{'processIdentifier': 123},
+            },
+          }),
+          runningProcesses: [
+            IOSCoreDeviceRunningProcess.fromJson(const <String, Object?>{
+              'processIdentifier': 999,
+              'executable': '/app/Runner.app/PlugIns/Widgets.appex/Widgets',
+            }),
+            IOSCoreDeviceRunningProcess.fromJson(const <String, Object?>{
+              'processIdentifier': 123,
+              'executable': '/app/Runner.app/Runner',
+            }),
+          ],
+        );
+        final processManager = FakeProcessManager.any();
+        final logger = BufferLogger.test();
+        final processUtils = ProcessUtils(processManager: processManager, logger: logger);
+        final fakeLLDB = FakeLLDB();
+        final launcher = IOSCoreDeviceLauncher(
+          coreDeviceControl: fakeCoreDeviceControl,
+          logger: logger,
+          xcodeDebug: FakeXcodeDebug(),
+          fileSystem: MemoryFileSystem.test(),
+          processUtils: processUtils,
+          lldb: fakeLLDB,
+        );
+
+        final bool result = await launcher.launchAppWithLLDBDebugger(
+          deviceId: 'device-id',
+          bundlePath: 'bundle-path',
+          bundleId: 'bundle-id',
+          launchArguments: <String>[],
+          shutdownHooks: FakeShutdownHooks(),
+        );
+
+        expect(result, isTrue);
+        expect(fakeLLDB.attemptedToAttach, isTrue);
+        expect(fakeLLDB.appProcessId, 123);
+      });
+
       testWithoutContext('fails on install', () async {
         final fakeCoreDeviceControl = FakeIOSCoreDeviceControl(
           installResult: IOSCoreDeviceInstallResult.fromJson(const <String, Object?>{
             'info': <String, Object?>{'outcome': 'success'},
             'result': <String, Object?>{
               'installedApplications': [
-                <String, Object?>{'installationURL': '/asdf'},
+                <String, Object?>{'installationURL': '/app/Runner.app'},
               ],
             },
           }),
@@ -242,7 +295,7 @@ void main() {
           runningProcesses: [
             IOSCoreDeviceRunningProcess.fromJson(const <String, Object?>{
               'processIdentifier': 123,
-              'executable': '/asdf',
+              'executable': '/app/Runner.app/Runner',
             }),
           ],
           installSuccess: false,
@@ -287,7 +340,7 @@ void main() {
           runningProcesses: [
             IOSCoreDeviceRunningProcess.fromJson(const <String, Object?>{
               'processIdentifier': 123,
-              'executable': '/asdf',
+              'executable': '/app/Runner.app/Runner',
             }),
           ],
         );
@@ -323,7 +376,7 @@ void main() {
             'info': <String, Object?>{'outcome': 'success'},
             'result': <String, Object?>{
               'installedApplications': [
-                <String, Object?>{'installationURL': '/asdf'},
+                <String, Object?>{'installationURL': '/app/Runner.app'},
               ],
             },
           }),
@@ -336,7 +389,7 @@ void main() {
           runningProcesses: [
             IOSCoreDeviceRunningProcess.fromJson(const <String, Object?>{
               'processIdentifier': 123,
-              'executable': '/asdf',
+              'executable': '/app/Runner.app/Runner',
             }),
           ],
           launchSuccess: false,
@@ -373,7 +426,7 @@ void main() {
             'info': <String, Object?>{'outcome': 'success'},
             'result': <String, Object?>{
               'installedApplications': [
-                <String, Object?>{'installationURL': '/asdf'},
+                <String, Object?>{'installationURL': '/app/Runner.app'},
               ],
             },
           }),
@@ -417,7 +470,7 @@ void main() {
             'info': <String, Object?>{'outcome': 'success'},
             'result': <String, Object?>{
               'installedApplications': [
-                <String, Object?>{'installationURL': '/asdf'},
+                <String, Object?>{'installationURL': '/app/Runner.app'},
               ],
             },
           }),
@@ -428,7 +481,9 @@ void main() {
             },
           }),
           runningProcesses: [
-            IOSCoreDeviceRunningProcess.fromJson(const <String, Object?>{'executable': '/asdf'}),
+            IOSCoreDeviceRunningProcess.fromJson(const <String, Object?>{
+              'executable': '/app/Runner.app/Runner',
+            }),
           ],
         );
 
@@ -463,7 +518,7 @@ void main() {
             'info': <String, Object?>{'outcome': 'success'},
             'result': <String, Object?>{
               'installedApplications': [
-                <String, Object?>{'installationURL': '/asdf'},
+                <String, Object?>{'installationURL': '/app/Runner.app'},
               ],
             },
           }),
@@ -476,7 +531,7 @@ void main() {
           runningProcesses: [
             IOSCoreDeviceRunningProcess.fromJson(const <String, Object?>{
               'processIdentifier': 123,
-              'executable': '/asdf',
+              'executable': '/app/Runner.app/Runner',
             }),
           ],
         );
@@ -3962,6 +4017,7 @@ class FakeLLDB extends Fake implements LLDB {
     required LLDBLogForwarder lldbLogForwarder,
   }) async {
     attemptedToAttach = true;
+    _processId = appProcessId;
     return attachSuccess;
   }
 

--- a/packages/flutter_tools/test/general.shard/ios/core_devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/core_devices_test.dart
@@ -276,6 +276,59 @@ void main() {
         expect(fakeLLDB.appProcessId, 123);
       });
 
+      testWithoutContext('handles trailing slash in installationURL', () async {
+        final fakeCoreDeviceControl = FakeIOSCoreDeviceControl(
+          installResult: IOSCoreDeviceInstallResult.fromJson(const <String, Object?>{
+            'info': <String, Object?>{'outcome': 'success'},
+            'result': <String, Object?>{
+              'installedApplications': [
+                <String, Object?>{'installationURL': '/app/Runner.app/'},
+              ],
+            },
+          }),
+          launchResult: IOSCoreDeviceLaunchResult.fromJson(const <String, Object?>{
+            'info': <String, Object?>{'outcome': 'success'},
+            'result': <String, Object?>{
+              'process': <String, Object?>{'processIdentifier': 123},
+            },
+          }),
+          runningProcesses: [
+            IOSCoreDeviceRunningProcess.fromJson(const <String, Object?>{
+              'processIdentifier': 999,
+              'executable': '/app/Runner.app/PlugIns/Widgets.appex/Widgets',
+            }),
+            IOSCoreDeviceRunningProcess.fromJson(const <String, Object?>{
+              'processIdentifier': 123,
+              'executable': '/app/Runner.app/Runner',
+            }),
+          ],
+        );
+        final processManager = FakeProcessManager.any();
+        final logger = BufferLogger.test();
+        final processUtils = ProcessUtils(processManager: processManager, logger: logger);
+        final fakeLLDB = FakeLLDB();
+        final launcher = IOSCoreDeviceLauncher(
+          coreDeviceControl: fakeCoreDeviceControl,
+          logger: logger,
+          xcodeDebug: FakeXcodeDebug(),
+          fileSystem: MemoryFileSystem.test(),
+          processUtils: processUtils,
+          lldb: fakeLLDB,
+        );
+
+        final bool result = await launcher.launchAppWithLLDBDebugger(
+          deviceId: 'device-id',
+          bundlePath: 'bundle-path',
+          bundleId: 'bundle-id',
+          launchArguments: <String>[],
+          shutdownHooks: FakeShutdownHooks(),
+        );
+
+        expect(result, isTrue);
+        expect(fakeLLDB.attemptedToAttach, isTrue);
+        expect(fakeLLDB.appProcessId, 123);
+      });
+
       testWithoutContext('fails on install', () async {
         final fakeCoreDeviceControl = FakeIOSCoreDeviceControl(
           installResult: IOSCoreDeviceInstallResult.fromJson(const <String, Object?>{


### PR DESCRIPTION
## Description

Fixes a physical-iOS `flutter run` LLDB attach bug when the app bundle also contains an extension, such as `Runner.app/PlugIns/Widgets.appex`.

`launchAppWithLLDBDebugger` previously selected the first running process whose executable path merely contained the installed app URL. That can match an extension executable before the main app executable, causing LLDB to attach to the wrong process and the launch to hang.

This change narrows the selection to the main app executable directly inside the installed app bundle, avoiding nested `.appex` processes.

Fixes https://github.com/flutter/flutter/issues/183613

## Tests

- `cd packages/flutter_tools && ../../bin/flutter test test/general.shard/ios/core_devices_test.dart`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md

