### PR TITLE
Fix selection highlight artifacts for faded selectable text

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1017,6 +1017,19 @@ class RenderParagraph extends RenderBox
       return true;
     }());
 
+    if (_lastSelectableFragments != null) {
+      if (_needsClipping) {
+        context.canvas.save();
+        context.canvas.clipRect(offset & size);
+      }
+      for (final _SelectableFragment fragment in _lastSelectableFragments!) {
+        fragment.paintSelection(context, offset);
+      }
+      if (_needsClipping) {
+        context.canvas.restore();
+      }
+    }
+
     if (_needsClipping) {
       final Rect bounds = offset & size;
       if (_overflowShader != null) {
@@ -1027,12 +1040,6 @@ class RenderParagraph extends RenderBox
         context.canvas.save();
       }
       context.canvas.clipRect(bounds);
-    }
-
-    if (_lastSelectableFragments != null) {
-      for (final _SelectableFragment fragment in _lastSelectableFragments!) {
-        fragment.paint(context, offset);
-      }
     }
 
     assert(() {
@@ -1053,6 +1060,12 @@ class RenderParagraph extends RenderBox
         context.canvas.drawRect(Offset.zero & size, paint);
       }
       context.canvas.restore();
+    }
+
+    if (_lastSelectableFragments != null) {
+      for (final _SelectableFragment fragment in _lastSelectableFragments!) {
+        fragment.paintHandles(context, offset);
+      }
     }
   }
 
@@ -3577,7 +3590,7 @@ class _SelectableFragment
     return _rect.size;
   }
 
-  void paint(PaintingContext context, Offset offset) {
+  void paintSelection(PaintingContext context, Offset offset) {
     if (_textSelectionStart == null || _textSelectionEnd == null) {
       return;
     }
@@ -3592,6 +3605,12 @@ class _SelectableFragment
       for (final TextBox textBox in paragraph.getBoxesForSelection(selection)) {
         context.canvas.drawRect(textBox.toRect().shift(offset), selectionPaint);
       }
+    }
+  }
+
+  void paintHandles(PaintingContext context, Offset offset) {
+    if (_textSelectionStart == null || _textSelectionEnd == null) {
+      return;
     }
     if (_startHandleLayerLink != null && value.startSelectionPoint != null) {
       context.pushLayer(

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -1037,11 +1037,11 @@ void main() {
       const selectionColor = Color(0xAF6694e8);
       final paragraph = RenderParagraph(
         const TextSpan(text: 'a\na\na\na'),
-        textDirection: TextDirection.ltr,
+        textDirection: .ltr,
         registrar: registrar,
         selectionColor: selectionColor,
         maxLines: 3,
-        overflow: TextOverflow.fade,
+        overflow: .fade,
       );
       layout(paragraph, constraints: const BoxConstraints(maxWidth: 100.0));
       expect(paragraph.debugHasOverflowShader, isTrue);
@@ -1631,11 +1631,7 @@ class MockCanvas extends Fake implements Canvas {
   }
 
   @override
-  void clipRect(
-    Rect rect, {
-    ui.ClipOp clipOp = ui.ClipOp.intersect,
-    bool doAntiAlias = true,
-  }) {
+  void clipRect(Rect rect, {ui.ClipOp clipOp = ui.ClipOp.intersect, bool doAntiAlias = true}) {
     operations.add('clipRect');
   }
 

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' as ui show BoxHeightStyle, BoxWidthStyle, Paragraph, TextBox;
+import 'dart:ui' as ui show BoxHeightStyle, BoxWidthStyle, ClipOp, Paragraph, TextBox;
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
@@ -1031,6 +1031,44 @@ void main() {
       expect(paintingContext.canvas.drawnRectPaint!.color, isSameColorAs(selectionColor));
     });
 
+    // Regression test for https://github.com/flutter/flutter/issues/182776.
+    test('paints selection highlights outside fade layer and handles after text', () async {
+      final registrar = TestSelectionRegistrar();
+      const selectionColor = Color(0xAF6694e8);
+      final paragraph = RenderParagraph(
+        const TextSpan(text: 'a\na\na\na'),
+        textDirection: TextDirection.ltr,
+        registrar: registrar,
+        selectionColor: selectionColor,
+        maxLines: 3,
+        overflow: TextOverflow.fade,
+      );
+      layout(paragraph, constraints: const BoxConstraints(maxWidth: 100.0));
+      expect(paragraph.debugHasOverflowShader, isTrue);
+
+      for (final Selectable selectable in registrar.selectables) {
+        selectable.dispatchSelectionEvent(const SelectAllSelectionEvent());
+        selectable.pushHandleLayers(LayerLink(), LayerLink());
+      }
+
+      final paintingContext = MockPaintingContext();
+      paragraph.paint(paintingContext, Offset.zero);
+
+      final List<String> operations = paintingContext.operations;
+      final int saveLayerIndex = operations.indexOf('saveLayer');
+      final int paragraphIndex = operations.indexOf('paragraph');
+      final int shaderRectIndex = operations.indexOf('shaderRect');
+      final int firstPushLayerIndex = operations.indexOf('pushLayer');
+
+      expect(saveLayerIndex, isNonNegative);
+      expect(paragraphIndex, greaterThan(saveLayerIndex));
+      expect(shaderRectIndex, greaterThan(paragraphIndex));
+      expect(firstPushLayerIndex, greaterThan(shaderRectIndex));
+      expect(operations.take(saveLayerIndex), contains('selectionRect'));
+      expect(operations.skip(saveLayerIndex), isNot(contains('selectionRect')));
+      expect(paintingContext.pushedLayers.whereType<LeaderLayer>(), hasLength(2));
+    });
+
     // Regression test for https://github.com/flutter/flutter/issues/126652.
     test('paints selection when tap at chinese character', () async {
       final registrar = TestSelectionRegistrar();
@@ -1575,32 +1613,82 @@ void main() {
 }
 
 class MockCanvas extends Fake implements Canvas {
+  MockCanvas(this.operations);
+
+  final List<String> operations;
   Rect? drawnRect;
   Paint? drawnRectPaint;
   List<Type> drawnItemTypes = <Type>[];
+
+  @override
+  void save() {
+    operations.add('save');
+  }
+
+  @override
+  void saveLayer(Rect? bounds, Paint paint) {
+    operations.add('saveLayer');
+  }
+
+  @override
+  void clipRect(
+    Rect rect, {
+    ui.ClipOp clipOp = ui.ClipOp.intersect,
+    bool doAntiAlias = true,
+  }) {
+    operations.add('clipRect');
+  }
 
   @override
   void drawRect(Rect rect, Paint paint) {
     drawnRect = rect;
     drawnRectPaint = paint;
     drawnItemTypes.add(Rect);
+    operations.add(paint.shader == null ? 'selectionRect' : 'shaderRect');
   }
 
   @override
   void drawParagraph(ui.Paragraph paragraph, Offset offset) {
     drawnItemTypes.add(ui.Paragraph);
+    operations.add('paragraph');
+  }
+
+  @override
+  void restore() {
+    operations.add('restore');
+  }
+
+  @override
+  void translate(double dx, double dy) {
+    operations.add('translate');
   }
 
   void clear() {
     drawnRect = null;
     drawnRectPaint = null;
     drawnItemTypes.clear();
+    operations.clear();
   }
 }
 
 class MockPaintingContext extends Fake implements PaintingContext {
+  final List<String> operations = <String>[];
+
   @override
-  final MockCanvas canvas = MockCanvas();
+  late final MockCanvas canvas = MockCanvas(operations);
+
+  final List<ContainerLayer> pushedLayers = <ContainerLayer>[];
+
+  @override
+  void pushLayer(
+    ContainerLayer childLayer,
+    PaintingContextCallback painter,
+    Offset offset, {
+    Rect? childPaintBounds,
+  }) {
+    operations.add('pushLayer');
+    pushedLayers.add(childLayer);
+  }
 }
 
 class TestSelectionRegistrar extends SelectionRegistrar {


### PR DESCRIPTION
## Summary

Fixes a rendering artifact when selecting text inside `SelectionArea` for a `Text`/`RichText` that uses `TextOverflow.fade`.

Previously, `RenderParagraph` painted selection highlights into the same saveLayer used for the fade overflow shader. That caused the fade compositing path to affect the selection rects and produced dark border/line artifacts during selection.

This change separates selection highlight painting from the faded text layer so the fade shader only applies to the text content.

Fixes: https://github.com/flutter/flutter/issues/182776

## Changes

- Paint `RenderParagraph` selection highlights outside the overflow fade saveLayer

## Screenshots

| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/22c3c8a1-3d17-40f3-8b77-fc48e9e91a25) | ![After](https://github.com/user-attachments/assets/dbca31d9-edb0-4dea-a617-0bf8c2b809a8) |