### PR TITLE
Adds github action to reset cicd when new branches come

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,0 +1,23 @@
+# Copyright 2024 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+name: Remove outdated CICD Label
+
+on:
+  pull_request_target:
+    types: [synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  remove_label:
+    if: contains(github.event.pull_request.labels.*.name, 'CICD')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove outdated CICD label
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} --remove-label "CICD"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -18,6 +18,6 @@ jobs:
     steps:
       - name: Remove outdated CICD label
         run: |
-          gh pr edit ${{ github.event.pull_request.number }} --remove-label "CICD"
+          gh pr edit ${{ github.event.pull_request.number }} -R flutter/flutter --remove-label "CICD"
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -10,14 +10,56 @@ on:
 
 permissions:
   pull-requests: write
+  issues: write
 
 jobs:
-  remove_label:
+  remove_cicd_label:
     if: contains(github.event.pull_request.labels.*.name, 'CICD')
     runs-on: ubuntu-latest
     steps:
-      - name: Remove outdated CICD label
+      - name: Check if label was added before push
+        id: check_timing
         run: |
-          gh pr edit ${{ github.event.pull_request.number }} -R flutter/flutter --remove-label "CICD"
+          # Get push time (commit date of the head SHA)
+          PUSH_TIME=$(gh api repos/${{ github.repository }}/commits/${{ github.event.pull_request.head.sha }} --jq '.commit.committer.date')
+          echo "Push time: $PUSH_TIME"
+
+          # Get latest CICD labeling event time from the last 100 events
+          LABEL_TIME=$(gh api graphql -f query='
+            query($owner: String!, $repo: String!, $pr: Int!) {
+              repository(owner: $owner, name: $repo) {
+                pullRequest(number: $pr) {
+                  timelineItems(last: 100, itemTypes: [LABELED_EVENT]) {
+                    nodes {
+                      ... on LabeledEvent {
+                        label { name }
+                        createdAt
+                      }
+                    }
+                  }
+                }
+              }
+            }' -f owner=${{ github.repository_owner }} -f repo=${{ github.event.repository.name }} -F pr=${{ github.event.pull_request.number }} \
+            --jq '.data.repository.pullRequest.timelineItems.nodes | map(select(.label.name == "CICD")) | last | .createdAt')
+          echo "Label time: $LABEL_TIME"
+
+          if [[ -z "$LABEL_TIME" ]]; then
+            # Label exists on PR (checked by job 'if') but not in last 100 events -> must be very old
+            echo "should_remove=true" >> "$GITHUB_OUTPUT"
+            echo "Result: Label found on PR but not in recent timeline events. Assuming it is old."
+          elif [[ "$LABEL_TIME" < "$PUSH_TIME" ]]; then
+            echo "should_remove=true" >> "$GITHUB_OUTPUT"
+            echo "Result: Label added at $LABEL_TIME is older than push at $PUSH_TIME. Removing."
+          else
+            echo "should_remove=false" >> "$GITHUB_OUTPUT"
+            echo "Result: Label added at $LABEL_TIME is newer than or same as push at $PUSH_TIME. Skipping removal."
+          fi
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Remove outdated CICD label
+        if: steps.check_timing.outputs.should_remove == 'true'
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} -R ${{ github.repository }} --remove-label "CICD"
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
