### PR TITLE
`Key` → `Object` in internal framework logic

### DIFF
--- a/packages/flutter/lib/src/widgets/animated_switcher.dart
+++ b/packages/flutter/lib/src/widgets/animated_switcher.dart
@@ -218,7 +218,7 @@ class AnimatedSwitcher extends StatefulWidget {
   ///
   /// This is an [AnimatedSwitcherTransitionBuilder] function.
   static Widget defaultTransitionBuilder(Widget child, Animation<double> animation) {
-    return FadeTransition(key: ValueKey<Key?>(child.key), opacity: animation, child: child);
+    return FadeTransition(key: ValueKey<Object?>(child.key), opacity: animation, child: child);
   }
 
   /// The layout builder used as the default value of [layoutBuilder].

--- a/packages/flutter/lib/src/widgets/debug.dart
+++ b/packages/flutter/lib/src/widgets/debug.dart
@@ -175,8 +175,8 @@ bool debugEnhanceBuildTimelineArguments = false;
 /// Show banners for deprecated widgets.
 bool debugHighlightDeprecatedWidgets = false;
 
-Key? _firstNonUniqueKey(Iterable<Widget> widgets) {
-  final Set<Key> keySet = HashSet<Key>();
+Object? _firstNonUniqueKey(Iterable<Widget> widgets) {
+  final Set<Object> keySet = HashSet<Object>();
   for (final widget in widgets) {
     if (widget.key == null) {
       continue;
@@ -213,7 +213,7 @@ Key? _firstNonUniqueKey(Iterable<Widget> widgets) {
 /// Does nothing if asserts are disabled. Always returns false.
 bool debugChildrenHaveDuplicateKeys(Widget parent, Iterable<Widget> children, {String? message}) {
   assert(() {
-    final Key? nonUniqueKey = _firstNonUniqueKey(children);
+    final Object? nonUniqueKey = _firstNonUniqueKey(children);
     if (nonUniqueKey != null) {
       throw FlutterError(
         "${message ?? 'Duplicate keys found.\n'
@@ -240,7 +240,7 @@ bool debugChildrenHaveDuplicateKeys(Widget parent, Iterable<Widget> children, {S
 /// Does nothing if asserts are disabled. Always returns false.
 bool debugItemsHaveDuplicateKeys(Iterable<Widget> items) {
   assert(() {
-    final Key? nonUniqueKey = _firstNonUniqueKey(items);
+    final Object? nonUniqueKey = _firstNonUniqueKey(items);
     if (nonUniqueKey != null) {
       throw FlutterError('Duplicate key found: $nonUniqueKey.');
     }

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -4063,7 +4063,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
       if (child != null) {
         _debugRemoveGlobalKeyReservation(child);
       }
-      final Key? key = newWidget.key;
+      final Object? key = newWidget.key;
       if (key is GlobalKey) {
         assert(owner != null);
         owner!._debugReserveGlobalKeyFor(this, newChild, key);
@@ -4214,9 +4214,9 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
 
     // Scan the old children in the middle of the list.
     final bool haveOldChildren = oldChildrenTop <= oldChildrenBottom;
-    Map<Key, Element>? oldKeyedChildren;
+    Map<Object, Element>? oldKeyedChildren;
     if (haveOldChildren) {
-      oldKeyedChildren = <Key, Element>{};
+      oldKeyedChildren = <Object, Element>{};
       while (oldChildrenTop <= oldChildrenBottom) {
         final Element? oldChild = replaceWithNullIfForgotten(oldChildren[oldChildrenTop]);
         assert(oldChild == null || oldChild._lifecycleState == _ElementLifecycle.active);
@@ -4236,7 +4236,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
       Element? oldChild;
       final Widget newWidget = newWidgets[newChildrenTop];
       if (haveOldChildren) {
-        final Key? key = newWidget.key;
+        final Object? key = newWidget.key;
         if (key != null) {
           oldChild = oldKeyedChildren![key];
           if (oldChild != null) {
@@ -4351,7 +4351,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
       _parentBuildScope = parent.buildScope;
     }
     assert(owner != null);
-    final Key? key = widget.key;
+    final Object? key = widget.key;
     if (key is GlobalKey) {
       owner!._registerGlobalKey(key, this);
     }
@@ -4567,7 +4567,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
     }
 
     try {
-      final Key? key = newWidget.key;
+      final Object? key = newWidget.key;
       final Element? inactiveChild = key is GlobalKey
           ? _retakeInactiveElement(key, newWidget)
           : null;
@@ -4854,7 +4854,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
     assert(owner != null);
     assert(debugMaybeDispatchDisposed(this));
     // Use the private property to avoid a CastError during hot reload.
-    final Key? key = _widget?.key;
+    final Object? key = _widget?.key;
     if (key is GlobalKey) {
       owner!._unregisterGlobalKey(key, this);
     }
@@ -5270,7 +5270,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
     }
     properties.add(ObjectFlagProperty<Widget>('widget', _widget, ifNull: 'no widget'));
     properties.add(
-      DiagnosticsProperty<Key>(
+      DiagnosticsProperty<Object>(
         'key',
         _widget?.key,
         showName: false,

--- a/packages/flutter/lib/src/widgets/page_storage.dart
+++ b/packages/flutter/lib/src/widgets/page_storage.dart
@@ -70,7 +70,7 @@ class _StorageEntryIdentifier {
 class PageStorageBucket {
   static bool _maybeAddKey(BuildContext context, List<PageStorageKey<dynamic>> keys) {
     final Widget widget = context.widget;
-    final Key? key = widget.key;
+    final Object? key = widget.key;
     if (key is PageStorageKey) {
       keys.add(key);
     }

--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -1251,7 +1251,7 @@ class _ReorderableItemState extends State<_ReorderableItem> {
   Offset _targetOffset = Offset.zero;
   AnimationController? _offsetAnimation;
 
-  Key get key => widget.key!;
+  Object get key => widget.key!;
   int get index => widget.index;
 
   bool get dragging => _dragging;
@@ -1737,7 +1737,7 @@ Offset _restrictAxis(Offset offset, Axis scrollDirection) {
 class _ReorderableItemGlobalKey extends GlobalObjectKey {
   const _ReorderableItemGlobalKey(this.subKey, this.index, this.state) : super(subKey);
 
-  final Key subKey;
+  final Object subKey;
   final int index;
   final SliverReorderableListState state;
 

--- a/packages/flutter/lib/src/widgets/scroll_delegate.dart
+++ b/packages/flutter/lib/src/widgets/scroll_delegate.dart
@@ -233,7 +233,7 @@ abstract class SliverChildDelegate {
   }
 }
 
-class _SaltedValueKey extends ValueKey<Key> {
+class _SaltedValueKey extends ValueKey<Object> {
   const _SaltedValueKey(super.value);
 }
 
@@ -528,17 +528,10 @@ class SliverChildBuilderDelegate extends SliverChildDelegate {
 
   @override
   int? findIndexByKey(Key key) {
-    if (findChildIndexCallback == null) {
-      return null;
-    }
-    final Key childKey;
-    if (key is _SaltedValueKey) {
-      final _SaltedValueKey saltedValueKey = key;
-      childKey = saltedValueKey.value;
-    } else {
-      childKey = key;
-    }
-    return findChildIndexCallback!(childKey);
+    return findChildIndexCallback?.call(switch (key) {
+      _SaltedValueKey(:final Key value) => value,
+      _ => key,
+    });
   }
 
   @override
@@ -722,11 +715,11 @@ class SliverChildListDelegate extends SliverChildDelegate {
   //
   // _keyToIndex[null] is used as current index during the lazy loading process
   // in [_findChildIndex]. _keyToIndex should never be used for looking up null key.
-  final Map<Key?, int>? _keyToIndex;
+  final Map<Object?, int>? _keyToIndex;
 
   bool get _isConstantInstance => _keyToIndex == null;
 
-  int? _findChildIndex(Key key) {
+  int? _findChildIndex(Object key) {
     if (_isConstantInstance) {
       return null;
     }
@@ -753,8 +746,8 @@ class SliverChildListDelegate extends SliverChildDelegate {
   }
 
   @override
-  int? findIndexByKey(Key key) {
-    final Key childKey;
+  int? findIndexByKey(Object key) {
+    final Object childKey;
     if (key is _SaltedValueKey) {
       final _SaltedValueKey saltedValueKey = key;
       childKey = saltedValueKey.value;

--- a/packages/flutter/lib/src/widgets/scroll_delegate.dart
+++ b/packages/flutter/lib/src/widgets/scroll_delegate.dart
@@ -746,7 +746,7 @@ class SliverChildListDelegate extends SliverChildDelegate {
   }
 
   @override
-  int? findIndexByKey(Object key) {
+  int? findIndexByKey(Key key) {
     final Object childKey;
     if (key is _SaltedValueKey) {
       final _SaltedValueKey saltedValueKey = key;

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -1000,8 +1000,8 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement
       }
 
       for (final int index in _childElements.keys.toList()) {
-        final Key? key = _childElements[index]!.widget.key;
-        final int? newIndex = key == null ? null : adaptorWidget.delegate.findIndexByKey(key);
+        final Object? key = _childElements[index]!.widget.key;
+        final int? newIndex = (key == null || key is! Key) ? null : adaptorWidget.delegate.findIndexByKey(key);
         final childParentData =
             _childElements[index]!.renderObject?.parentData as SliverMultiBoxAdaptorParentData?;
 

--- a/packages/flutter/lib/src/widgets/slotted_render_object_widget.dart
+++ b/packages/flutter/lib/src/widgets/slotted_render_object_widget.dart
@@ -237,7 +237,7 @@ class SlottedRenderObjectElement<SlotType, ChildType extends RenderObject>
   );
 
   Map<SlotType, Element> _slotToChild = <SlotType, Element>{};
-  Map<Key, Element> _keyedChildren = <Key, Element>{};
+  Map<Object, Element> _keyedChildren = <Object, Element>{};
 
   @override
   SlottedContainerRenderObjectMixin<SlotType, ChildType> get renderObject =>
@@ -288,16 +288,16 @@ class SlottedRenderObjectElement<SlotType, ChildType extends RenderObject>
       'slots must be unique',
     );
 
-    final Map<Key, Element> oldKeyedElements = _keyedChildren;
-    _keyedChildren = <Key, Element>{};
+    final Map<Object, Element> oldKeyedElements = _keyedChildren;
+    _keyedChildren = <Object, Element>{};
     final Map<SlotType, Element> oldSlotToChild = _slotToChild;
     _slotToChild = <SlotType, Element>{};
 
-    Map<Key, List<Element>>? debugDuplicateKeys;
+    Map<Object, List<Element>>? debugDuplicateKeys;
 
     for (final SlotType slot in slottedMultiChildRenderObjectWidgetMixin.slots) {
       final Widget? widget = slottedMultiChildRenderObjectWidgetMixin.childForSlot(slot);
-      final Key? newWidgetKey = widget?.key;
+      final Object? newWidgetKey = widget?.key;
 
       final Element? oldSlotChild = oldSlotToChild[slot];
       final Element? oldKeyChild = oldKeyedElements[newWidgetKey];
@@ -323,7 +323,7 @@ class SlottedRenderObjectElement<SlotType, ChildType extends RenderObject>
           assert(() {
             final Element? existingElement = _keyedChildren[newWidgetKey];
             if (existingElement != null) {
-              (debugDuplicateKeys ??= <Key, List<Element>>{})
+              (debugDuplicateKeys ??= <Object, List<Element>>{})
                   .putIfAbsent(newWidgetKey, () => <Element>[existingElement])
                   .add(newChild);
             }
@@ -341,11 +341,11 @@ class SlottedRenderObjectElement<SlotType, ChildType extends RenderObject>
     );
   }
 
-  bool _debugDuplicateKeys(Map<Key, List<Element>>? debugDuplicateKeys) {
+  bool _debugDuplicateKeys(Map<Object, List<Element>>? debugDuplicateKeys) {
     if (debugDuplicateKeys == null) {
       return true;
     }
-    for (final MapEntry<Key, List<Element>> duplicateKey in debugDuplicateKeys.entries) {
+    for (final MapEntry<Object, List<Element>> duplicateKey in debugDuplicateKeys.entries) {
       throw FlutterError.fromParts(<DiagnosticsNode>[
         ErrorSummary('Multiple widgets used the same key in ${widget.runtimeType}.'),
         ErrorDescription(

--- a/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
@@ -263,11 +263,11 @@ class _TwoDimensionalViewportElement extends RenderObjectElement
 
   // Contains all children, including those that are keyed.
   Map<ChildVicinity, Element> _vicinityToChild = <ChildVicinity, Element>{};
-  Map<Key, Element> _keyToChild = <Key, Element>{};
+  Map<Object, Element> _keyToChild = <Key, Element>{};
   // Used between _startLayout() & _endLayout() to compute the new values for
   // _vicinityToChild and _keyToChild.
   Map<ChildVicinity, Element>? _newVicinityToChild;
-  Map<Key, Element>? _newKeyToChild;
+  Map<Object, Element>? _newKeyToChild;
 
   @override
   void performRebuild() {

--- a/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
@@ -263,7 +263,7 @@ class _TwoDimensionalViewportElement extends RenderObjectElement
 
   // Contains all children, including those that are keyed.
   Map<ChildVicinity, Element> _vicinityToChild = <ChildVicinity, Element>{};
-  Map<Object, Element> _keyToChild = <Key, Element>{};
+  Map<Object, Element> _keyToChild = <Object, Element>{};
   // Used between _startLayout() & _endLayout() to compute the new values for
   // _vicinityToChild and _keyToChild.
   Map<ChildVicinity, Element>? _newVicinityToChild;

--- a/packages/flutter/lib/src/widgets/viewport.dart
+++ b/packages/flutter/lib/src/widgets/viewport.dart
@@ -259,7 +259,7 @@ class Viewport extends MultiChildRenderObjectWidget {
     if (center != null) {
       properties.add(DiagnosticsProperty<Key>('center', center));
     } else if (children.isNotEmpty && children.first.key != null) {
-      properties.add(DiagnosticsProperty<Key>('center', children.first.key, tooltip: 'implicit'));
+      properties.add(DiagnosticsProperty<Object>('center', children.first.key, tooltip: 'implicit'));
     }
     properties.add(DiagnosticsProperty<ScrollCacheExtent>('scrollCacheExtent', scrollCacheExtent));
   }

--- a/packages/flutter/test/widgets/focus_scope_test.dart
+++ b/packages/flutter/test/widgets/focus_scope_test.dart
@@ -1186,7 +1186,7 @@ void main() {
 
       final Element firstScope = tester.element(find.byKey(key1));
       final nodes = <FocusNode>[];
-      final keys = <Key>[];
+      final keys = <Object>[];
       bool visitor(FocusNode node) {
         nodes.add(node);
         keys.add(node.context!.widget.key!);

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -151,9 +151,9 @@ void main() {
     (WidgetTester tester) async {
       final Key key1 = GlobalKey(debugLabel: 'Text1');
       final Key key2 = GlobalKey(debugLabel: 'Text2');
-      Key? rebuiltKeyOfSecondChildBeforeLayout;
-      Key? rebuiltKeyOfFirstChildAfterLayout;
-      Key? rebuiltKeyOfSecondChildAfterLayout;
+      Object? rebuiltKeyOfSecondChildBeforeLayout;
+      Object? rebuiltKeyOfFirstChildAfterLayout;
+      Object? rebuiltKeyOfSecondChildAfterLayout;
       await tester.pumpWidget(
         LayoutBuilder(
           builder: (BuildContext context, BoxConstraints constraints) {
@@ -227,9 +227,9 @@ void main() {
       const Key key1 = GlobalObjectKey('Text1');
       const Key key2 = GlobalObjectKey('Text2');
       const Key key3 = GlobalObjectKey('Text3');
-      Key? rebuiltKeyOfSecondChildBeforeLayout;
-      Key? rebuiltKeyOfSecondChildAfterLayout;
-      Key? rebuiltKeyOfThirdChildAfterLayout;
+      Object? rebuiltKeyOfSecondChildBeforeLayout;
+      Object? rebuiltKeyOfSecondChildAfterLayout;
+      Object? rebuiltKeyOfThirdChildAfterLayout;
       await tester.pumpWidget(
         LayoutBuilder(
           builder: (BuildContext context, BoxConstraints constraints) {
@@ -307,8 +307,8 @@ void main() {
     'GlobalKey correct case 5 - can deal with early rebuild in layoutbuilder - only one global key',
     (WidgetTester tester) async {
       const Key key1 = GlobalObjectKey('Text1');
-      Key? rebuiltKeyOfSecondChildBeforeLayout;
-      Key? rebuiltKeyOfThirdChildAfterLayout;
+      Object? rebuiltKeyOfSecondChildBeforeLayout;
+      Object? rebuiltKeyOfThirdChildAfterLayout;
       await tester.pumpWidget(
         LayoutBuilder(
           builder: (BuildContext context, BoxConstraints constraints) {
@@ -1025,9 +1025,9 @@ void main() {
     (WidgetTester tester) async {
       const Key key1 = GlobalObjectKey('Text1');
       const Key key2 = GlobalObjectKey('Text2');
-      Key? rebuiltKeyOfSecondChildBeforeLayout;
-      Key? rebuiltKeyOfFirstChildAfterLayout;
-      Key? rebuiltKeyOfSecondChildAfterLayout;
+      Object? rebuiltKeyOfSecondChildBeforeLayout;
+      Object? rebuiltKeyOfFirstChildAfterLayout;
+      Object? rebuiltKeyOfSecondChildAfterLayout;
       await tester.pumpWidget(
         LayoutBuilder(
           builder: (BuildContext context, BoxConstraints constraints) {
@@ -1831,7 +1831,7 @@ void main() {
   testWidgets('Element.deactivate reports its deactivation to the InheritedElement it depends on', (
     WidgetTester tester,
   ) async {
-    final removedDependentWidgetKeys = <Key>[];
+    final removedDependentWidgetKeys = <Object>[];
 
     InheritedElement elementCreator(InheritedWidget widget) {
       return _InheritedElementSpy(

--- a/packages/flutter/test/widgets/slivers_keepalive_test.dart
+++ b/packages/flutter/test/widgets/slivers_keepalive_test.dart
@@ -398,15 +398,15 @@ class SwitchingChildBuilderTest extends StatefulWidget {
 
 class _SwitchingChildBuilderTest extends State<SwitchingChildBuilderTest> {
   late List<Widget> children;
-  late Map<Key, int> _mapKeyToIndex;
+  late Map<Object, int> _mapKeyToIndex;
 
   @override
   void initState() {
     super.initState();
     children = widget.children;
-    _mapKeyToIndex = <Key, int>{};
+    _mapKeyToIndex = <Object, int>{};
     for (var index = 0; index < children.length; index += 1) {
-      final Key? key = children[index].key;
+      final Object? key = children[index].key;
       if (key != null) {
         _mapKeyToIndex[key] = index;
       }
@@ -418,9 +418,9 @@ class _SwitchingChildBuilderTest extends State<SwitchingChildBuilderTest> {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.children != widget.children) {
       children = widget.children;
-      _mapKeyToIndex = <Key, int>{};
+      _mapKeyToIndex = <Object, int>{};
       for (var index = 0; index < children.length; index += 1) {
-        final Key? key = children[index].key;
+        final Object? key = children[index].key;
         if (key != null) {
           _mapKeyToIndex[key] = index;
         }

--- a/packages/flutter_driver/test/src/real_tests/stubs/stub_finder_extension.dart
+++ b/packages/flutter_driver/test/src/real_tests/stubs/stub_finder_extension.dart
@@ -13,7 +13,7 @@ class StubFinderExtension extends FinderExtension {
   @override
   Finder createFinder(SerializableFinder finder, CreateFinderFactory finderFactory) {
     return find.byWidgetPredicate((Widget widget) {
-      final Key? key = widget.key;
+      final Object? key = widget.key;
       if (key is! ValueKey<String>) {
         return false;
       }

--- a/packages/flutter_test/lib/src/finders.dart
+++ b/packages/flutter_test/lib/src/finders.dart
@@ -213,7 +213,7 @@ class CommonFinders {
   ///
   /// If the `skipOffstage` argument is true (the default), then this skips
   /// nodes that are [Offstage] or that are from inactive [Route]s.
-  Finder byKey(Key key, {bool skipOffstage = true}) =>
+  Finder byKey(Object key, {bool skipOffstage = true}) =>
       _KeyWidgetFinder(key, skipOffstage: skipOffstage);
 
   /// Finds widgets by searching for widgets implementing a particular type.
@@ -1606,7 +1606,7 @@ class _TextContainingWidgetFinder extends _MatchTextFinder {
 class _KeyWidgetFinder extends MatchFinder {
   _KeyWidgetFinder(this.key, {super.skipOffstage});
 
-  final Key key;
+  final Object key;
 
   @override
   String get description => 'key $key';

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -931,7 +931,7 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
           }
         }
 
-        final Key? key = widget.key;
+        final Object? key = widget.key;
         if (key is ValueKey<dynamic>) {
           final String? keyLabel = switch (key.value) {
             int() || double() || bool() => 'const ${key.runtimeType}(${key.value})',


### PR DESCRIPTION
This is the first step in allowing widgets to use any `Object` as a key.

In order to make the migration easier to review, I've opened this PR, which changes the framework's type annotations as much as possible without changing public widget APIs.

Changes have been made to test files where relevant, including a tweak to the `find.byKey()` method so it accepts any object.

<br>

📜  [Link to Design Doc](https://flutter.dev/go/unwrapping-widget-keys)

design doc issue: #159224