### PR TITLE
Use `Material.of(context)` to clean up tests

### DIFF
--- a/packages/flutter/test/material/calendar_date_picker_test.dart
+++ b/packages/flutter/test/material/calendar_date_picker_test.dart
@@ -1613,8 +1613,7 @@ void main() {
         ),
       );
 
-      final Finder findDatePicker = find.byType(CalendarDatePicker);
-      MaterialInkController inkFeatures = Material.of(tester.element(findDatePicker));
+      final Object inkFeatures = Material.of(tester.element(find.byType(CalendarDatePicker)));
       expect(
         inkFeatures,
         isNot(
@@ -1627,7 +1626,6 @@ void main() {
       await gesture.addPointer();
       await gesture.moveTo(tester.getCenter(find.text('25')));
       await tester.pumpAndSettle();
-      inkFeatures = Material.of(tester.element(findDatePicker));
       expect(
         inkFeatures,
         paints

--- a/packages/flutter/test/material/calendar_date_picker_test.dart
+++ b/packages/flutter/test/material/calendar_date_picker_test.dart
@@ -1613,9 +1613,8 @@ void main() {
         ),
       );
 
-      RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-        (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-      );
+      final Finder findDatePicker = find.byType(CalendarDatePicker);
+      MaterialInkController inkFeatures = Material.of(tester.element(findDatePicker));
       expect(
         inkFeatures,
         isNot(
@@ -1628,9 +1627,7 @@ void main() {
       await gesture.addPointer();
       await gesture.moveTo(tester.getCenter(find.text('25')));
       await tester.pumpAndSettle();
-      inkFeatures = tester.allRenderObjects.firstWhere(
-        (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-      );
+      inkFeatures = Material.of(tester.element(findDatePicker));
       expect(
         inkFeatures,
         paints

--- a/packages/flutter/test/material/carousel_test.dart
+++ b/packages/flutter/test/material/carousel_test.dart
@@ -93,9 +93,11 @@ void main() {
     expect(material.elevation, 10.0);
     expect(material.shape, const StadiumBorder());
 
-    RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
+    final Finder findInkWell = find.descendant(
+      of: carouselViewMaterial,
+      matching: find.byType(InkWell),
     );
+    MaterialInkController inkFeatures = Material.of(tester.element(findInkWell));
 
     // On hovered.
     final TestGesture gesture = await hoverPointerOverCarouselItem(tester, key);
@@ -106,9 +108,7 @@ void main() {
     await tester.pumpAndSettle();
     await gesture.down(tester.getCenter(find.byKey(key)));
     await tester.pumpAndSettle();
-    inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
+    inkFeatures = Material.of(tester.element(findInkWell));
     expect(
       inkFeatures,
       paints

--- a/packages/flutter/test/material/carousel_test.dart
+++ b/packages/flutter/test/material/carousel_test.dart
@@ -93,11 +93,10 @@ void main() {
     expect(material.elevation, 10.0);
     expect(material.shape, const StadiumBorder());
 
-    final Finder findInkWell = find.descendant(
-      of: carouselViewMaterial,
-      matching: find.byType(InkWell),
+    final BuildContext context = tester.element(
+      find.descendant(of: carouselViewMaterial, matching: find.byType(InkWell)),
     );
-    MaterialInkController inkFeatures = Material.of(tester.element(findInkWell));
+    final MaterialInkController inkFeatures = Material.of(context);
 
     // On hovered.
     final TestGesture gesture = await hoverPointerOverCarouselItem(tester, key);
@@ -108,7 +107,6 @@ void main() {
     await tester.pumpAndSettle();
     await gesture.down(tester.getCenter(find.byKey(key)));
     await tester.pumpAndSettle();
-    inkFeatures = Material.of(tester.element(findInkWell));
     expect(
       inkFeatures,
       paints

--- a/packages/flutter/test/material/chip_test.dart
+++ b/packages/flutter/test/material/chip_test.dart
@@ -5518,9 +5518,7 @@ void main() {
       ),
     );
 
-    RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
+    MaterialInkController inkFeatures = Material.of(tester.element(find.byType(Ink)));
     expect(inkFeatures, isNot(paints..rect(color: theme.hoverColor)));
     expect(inkFeatures, paintsExactlyCountTimes(#clipPath, 0));
 
@@ -5531,9 +5529,7 @@ void main() {
     addTearDown(hoverGesture.removePointer);
     await tester.pumpAndSettle();
 
-    inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
+    inkFeatures = Material.of(tester.element(find.byType(Ink)));
     expect(inkFeatures, paints..rect(color: theme.hoverColor));
     expect(inkFeatures, paintsExactlyCountTimes(#clipPath, 1));
 

--- a/packages/flutter/test/material/chip_test.dart
+++ b/packages/flutter/test/material/chip_test.dart
@@ -5518,7 +5518,7 @@ void main() {
       ),
     );
 
-    MaterialInkController inkFeatures = Material.of(tester.element(find.byType(Ink)));
+    final MaterialInkController inkFeatures = Material.of(tester.element(find.byType(Ink)));
     expect(inkFeatures, isNot(paints..rect(color: theme.hoverColor)));
     expect(inkFeatures, paintsExactlyCountTimes(#clipPath, 0));
 
@@ -5529,7 +5529,6 @@ void main() {
     addTearDown(hoverGesture.removePointer);
     await tester.pumpAndSettle();
 
-    inkFeatures = Material.of(tester.element(find.byType(Ink)));
     expect(inkFeatures, paints..rect(color: theme.hoverColor));
     expect(inkFeatures, paintsExactlyCountTimes(#clipPath, 1));
 

--- a/packages/flutter/test/material/date_picker_theme_test.dart
+++ b/packages/flutter/test/material/date_picker_theme_test.dart
@@ -613,9 +613,8 @@ void main() {
     expect(arrowIcon.color, datePickerTheme.subHeaderForegroundColor);
 
     // Test the day overlay color.
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
+    final BuildContext context = tester.element(find.byType(DatePickerDialog));
+    final MaterialInkController inkFeatures = Material.of(context);
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
     await gesture.addPointer();
     await gesture.moveTo(tester.getCenter(find.text('25')));
@@ -773,9 +772,8 @@ void main() {
     expect(selectedDate.style?.fontSize, datePickerTheme.rangePickerHeaderHeadlineStyle?.fontSize);
 
     // Test the day overlay color.
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
+    final BuildContext context = tester.element(find.byType(DatePickerDialog));
+    final MaterialInkController inkFeatures = Material.of(context);
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
     await gesture.addPointer();
     await gesture.moveTo(tester.getCenter(find.text('16')));
@@ -842,9 +840,8 @@ void main() {
     expect(selectedDate.style?.fontSize, datePickerTheme.rangePickerHeaderHeadlineStyle?.fontSize);
 
     // Test the day overlay color.
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
+    final BuildContext context = tester.element(find.byType(DatePickerDialog));
+    final MaterialInkController inkFeatures = Material.of(context);
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
     await gesture.addPointer();
     await gesture.moveTo(tester.getCenter(find.text('16')));
@@ -1102,9 +1099,8 @@ void main() {
     );
 
     // Test the hover overlay color.
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
+    final BuildContext context = tester.element(find.byType(DatePickerDialog));
+    final MaterialInkController inkFeatures = Material.of(context);
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
     await gesture.addPointer();
     await gesture.moveTo(tester.getCenter(find.text('2022')));
@@ -1181,9 +1177,8 @@ void main() {
     );
 
     // Test the hover overlay color.
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
+    final BuildContext context = tester.element(find.byType(DatePickerDialog));
+    final MaterialInkController inkFeatures = Material.of(context);
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
     await gesture.addPointer();
     await gesture.moveTo(tester.getCenter(find.text('18')));

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -188,18 +188,11 @@ void main() {
       return iconRichText.text.style;
     }
 
-    RenderObject overlayPainter(WidgetTester tester, TestMenu menuItem) {
-      return tester.renderObject(
-        find
-            .descendant(
-              of: findMenuItemButton(menuItem.label),
-              matching: find.byElementPredicate(
-                (Element element) =>
-                    element.renderObject.runtimeType.toString() == '_RenderInkFeatures',
-              ),
-            )
-            .last,
+    MaterialInkController overlayPainter(WidgetTester tester, TestMenu menuItem) {
+      final BuildContext context = tester.element(
+        find.descendant(of: findMenuItemButton(menuItem.label), matching: find.byType(InkWell)),
       );
+      return Material.of(context);
     }
 
     testWidgets('defaults are correct', (WidgetTester tester) async {

--- a/packages/flutter/test/material/elevated_button_test.dart
+++ b/packages/flutter/test/material/elevated_button_test.dart
@@ -75,10 +75,10 @@ void main() {
     // Material 3 uses the InkSparkle which uses a shader, so we can't capture
     // the effect with paint methods.
     if (!material3) {
-      final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-        (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
+      expect(
+        Material.of(tester.element(find.text('button'))),
+        paints..circle(color: colorScheme.onPrimary.withOpacity(0.24)),
       );
-      expect(inkFeatures, paints..circle(color: colorScheme.onPrimary.withOpacity(0.24)));
     }
 
     // Only elevation changes when enabled and pressed.
@@ -391,11 +391,7 @@ void main() {
       ),
     );
 
-    RenderObject overlayColor() {
-      return tester.allRenderObjects.firstWhere(
-        (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-      );
-    }
+    Object overlayColor() => Material.of(tester.element(find.text('ElevatedButton')));
 
     double elevation() {
       return tester
@@ -876,10 +872,7 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.byType(ElevatedButton)));
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-    expect(inkFeatures, paints..rect(color: hoverColor));
+    expect(Material.of(tester.element(find.text('button'))), paints..rect(color: hoverColor));
   });
 
   testWidgets('Does ElevatedButton work with focus', (WidgetTester tester) async {
@@ -906,10 +899,7 @@ void main() {
     focusNode.requestFocus();
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-    expect(inkFeatures, paints..rect(color: focusColor));
+    expect(Material.of(tester.element(find.text('button'))), paints..rect(color: focusColor));
 
     focusNode.dispose();
   });
@@ -940,10 +930,7 @@ void main() {
     FocusManager.instance.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-    expect(inkFeatures, paints..rect(color: focusColor));
+    expect(Material.of(tester.element(find.text('button'))), paints..rect(color: focusColor));
 
     focusNode.dispose();
   });

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -1621,12 +1621,9 @@ void main() {
       await tester.pump(); // Start the splash animation.
       await tester.pump(const Duration(milliseconds: 100)); // Splash is underway.
 
-      final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-        (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-      );
       // Check if the ink splash is drawn on top of the background color.
       expect(
-        inkFeatures,
+        Material.of(tester.element(find.byKey(expansionTileKey))),
         paints
           ..path(color: collapsedBackgroundColor)
           ..circle(color: theme.splashColor),

--- a/packages/flutter/test/material/filled_button_test.dart
+++ b/packages/flutter/test/material/filled_button_test.dart
@@ -501,11 +501,7 @@ void main() {
       ),
     );
 
-    RenderObject overlayColor() {
-      return tester.allRenderObjects.firstWhere(
-        (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-      );
-    }
+    MaterialInkController overlayColor() => Material.of(tester.element(find.text('FilledButton')));
 
     double elevation() {
       return tester
@@ -573,11 +569,7 @@ void main() {
       ),
     );
 
-    RenderObject overlayColor() {
-      return tester.allRenderObjects.firstWhere(
-        (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-      );
-    }
+    MaterialInkController overlayColor() => Material.of(tester.element(find.text('FilledButton')));
 
     double elevation() {
       return tester
@@ -1058,10 +1050,7 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.byType(FilledButton)));
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-    expect(inkFeatures, paints..rect(color: hoverColor));
+    expect(Material.of(tester.element(find.text('button'))), paints..rect(color: hoverColor));
   });
 
   testWidgets('Does FilledButton work with focus', (WidgetTester tester) async {
@@ -1088,10 +1077,7 @@ void main() {
     focusNode.requestFocus();
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-    expect(inkFeatures, paints..rect(color: focusColor));
+    expect(Material.of(tester.element(find.text('button'))), paints..rect(color: focusColor));
     focusNode.dispose();
   });
 
@@ -1121,10 +1107,7 @@ void main() {
     FocusManager.instance.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-    expect(inkFeatures, paints..rect(color: focusColor));
+    expect(Material.of(tester.element(find.text('button'))), paints..rect(color: focusColor));
     focusNode.dispose();
   });
 

--- a/packages/flutter/test/material/icon_button_test.dart
+++ b/packages/flutter/test/material/icon_button_test.dart
@@ -34,10 +34,8 @@ void main() {
     mockOnPressedFunction = MockOnPressedFunction();
   });
 
-  RenderObject getOverlayColor(WidgetTester tester) {
-    return tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
+  MaterialInkController getOverlayColor(WidgetTester tester) {
+    return Material.of(tester.element(find.byType(Icon)));
   }
 
   Finder findTooltipContainer(String tooltipText) {
@@ -3067,7 +3065,7 @@ void main() {
     await gesture.down(topLeft);
     await tester.pumpAndSettle();
     expect(
-      getOverlayColor(tester),
+      Material.of(tester.element(find.byType(ColoredBox))),
       paints
         ..rect(color: const Color(0xFFFF0000)) // ColoredBox.
         ..rect(color: const Color(0xFF00FF00)), // IconButton overlay.
@@ -3383,6 +3381,7 @@ void main() {
     addTearDown(focusNode.dispose);
 
     const Color focusColor = Colors.orange;
+    final Finder findIcon = find.byIcon(Icons.headphones);
 
     await tester.pumpWidget(
       MaterialApp(
@@ -3409,15 +3408,13 @@ void main() {
       SemanticsActionEvent(
         type: SemanticsAction.focus,
         viewId: tester.view.viewId,
-        nodeId: tester.semantics.find(find.byIcon(Icons.headphones)).id,
+        nodeId: tester.semantics.find(findIcon).id,
       ),
     );
     await tester.pumpAndSettle();
 
     // Make sure no focus highlight was drawn.
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) {
-      return object.runtimeType.toString() == '_RenderInkFeatures';
-    });
+    final MaterialInkController inkFeatures = Material.of(tester.element(findIcon));
     expect(focusNode.hasFocus, isTrue);
     expect(FocusManager.instance.highlightMode, equals(FocusHighlightMode.touch));
     expect(inkFeatures, isNot(paints..rect(color: focusColor)));

--- a/packages/flutter/test/material/icon_button_theme_test.dart
+++ b/packages/flutter/test/material/icon_button_theme_test.dart
@@ -8,12 +8,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  RenderObject getOverlayColor(WidgetTester tester) {
-    return tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-  }
-
   test('IconButtonThemeData lerp special cases', () {
     expect(IconButtonThemeData.lerp(null, null, 0), null);
     const data = IconButtonThemeData();
@@ -306,6 +300,7 @@ void main() {
         ),
       ),
     );
+    final MaterialInkController controller = Material.of(tester.element(find.byType(Icon)));
 
     // Hovered.
     final Offset center = tester.getCenter(find.byType(IconButton));
@@ -313,13 +308,13 @@ void main() {
     await gesture.addPointer();
     await gesture.moveTo(center);
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect(color: overlayColor.withOpacity(0.08)));
+    expect(controller, paints..rect(color: overlayColor.withOpacity(0.08)));
 
     // Highlighted (pressed).
     await gesture.down(center);
     await tester.pumpAndSettle();
     expect(
-      getOverlayColor(tester),
+      controller,
       paints
         ..rect(color: overlayColor.withOpacity(0.08))
         ..rect(color: overlayColor.withOpacity(0.1)),
@@ -333,6 +328,6 @@ void main() {
     // Focused.
     await tester.sendKeyEvent(LogicalKeyboardKey.tab);
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect(color: overlayColor.withOpacity(0.1)));
+    expect(controller, paints..rect(color: overlayColor.withOpacity(0.1)));
   });
 }

--- a/packages/flutter/test/material/ink_well_test.dart
+++ b/packages/flutter/test/material/ink_well_test.dart
@@ -13,10 +13,9 @@ import '../widgets/feedback_tester.dart';
 import '../widgets/semantics_tester.dart';
 
 void main() {
-  RenderObject getInkFeatures(WidgetTester tester) {
-    return tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
+  RenderObject getInkFeatures(WidgetTester tester, {Type type = InkWell}) {
+    final BuildContext context = tester.element(find.byType(type));
+    return Material.of(context) as RenderObject;
   }
 
   testWidgets('InkWell gestures control test', (WidgetTester tester) async {
@@ -619,7 +618,7 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
-    final RenderObject inkFeatures = getInkFeatures(tester);
+    final RenderObject inkFeatures = getInkFeatures(tester, type: InkResponse);
     expect(inkFeatures, paintsExactlyCountTimes(#drawCircle, 0));
     focusNode.requestFocus();
     await tester.pumpAndSettle();
@@ -839,7 +838,7 @@ void main() {
 
     await tester.pumpWidget(boilerplate(10));
     await tester.pumpAndSettle();
-    final RenderObject inkFeatures = getInkFeatures(tester);
+    final RenderObject inkFeatures = getInkFeatures(tester, type: InkResponse);
     expect(inkFeatures, paintsExactlyCountTimes(#drawCircle, 0));
 
     focusNode.requestFocus();
@@ -879,7 +878,7 @@ void main() {
 
     await tester.pumpWidget(boilerplate(BoxShape.circle));
     await tester.pumpAndSettle();
-    final RenderObject inkFeatures = getInkFeatures(tester);
+    final RenderObject inkFeatures = getInkFeatures(tester, type: InkResponse);
     expect(inkFeatures, paintsExactlyCountTimes(#drawCircle, 0));
     expect(inkFeatures, paintsExactlyCountTimes(#drawRRect, 0));
 

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -328,12 +328,6 @@ TextStyle? getIconStyle(WidgetTester tester, IconData icon) {
   return iconRichText.text.style;
 }
 
-RenderObject getOverlayColor(WidgetTester tester) {
-  return tester.allRenderObjects.firstWhere(
-    (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-  );
-}
-
 void main() {
   // TODO(bleroux): migrate all M2 tests to M3.
   // See https://github.com/flutter/flutter/issues/139076
@@ -10350,7 +10344,8 @@ void main() {
     await gesture.addPointer();
     await gesture.moveTo(center);
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect(color: overlayColor));
+    final BuildContext context = tester.element(find.byType(InputDecorator));
+    expect(Material.of(context), paints..rect(color: overlayColor));
   });
 
   testWidgets('Suffix IconButton inherits IconButtonTheme', (WidgetTester tester) async {
@@ -10398,7 +10393,8 @@ void main() {
     await gesture.addPointer();
     await gesture.moveTo(center);
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect(color: overlayColor));
+    final BuildContext context = tester.element(find.byType(InputDecorator));
+    expect(Material.of(context), paints..rect(color: overlayColor));
   });
 
   testWidgets('Prefix IconButton color respects IconButtonTheme foreground color states', (

--- a/packages/flutter/test/material/material_button_test.dart
+++ b/packages/flutter/test/material/material_button_test.dart
@@ -123,10 +123,7 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.byType(MaterialButton)));
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-    expect(inkFeatures, paints..rect(color: hoverColor));
+    expect(Material.of(tester.element(find.text('button'))), paints..rect(color: hoverColor));
   });
 
   testWidgets('Does MaterialButton work with focus', (WidgetTester tester) async {
@@ -149,10 +146,7 @@ void main() {
     focusNode.requestFocus();
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-    expect(inkFeatures, paints..rect(color: focusColor));
+    expect(Material.of(tester.element(find.text('button'))), paints..rect(color: focusColor));
 
     focusNode.dispose();
   });
@@ -193,6 +187,7 @@ void main() {
     );
     await tester.pumpAndSettle();
     FocusManager.instance.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
+    final MaterialInkController inkFeatures = Material.of(tester.element(find.text('button')));
 
     // Base elevation
     Material material = tester.widget<Material>(rawButtonMaterial);
@@ -202,9 +197,6 @@ void main() {
     focusNode.requestFocus();
     await tester.pumpAndSettle();
     material = tester.widget<Material>(rawButtonMaterial);
-    RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
     expect(inkFeatures, paints..rect(color: focusColor));
     expect(focusNode.hasPrimaryFocus, isTrue);
     expect(material.elevation, equals(focusElevation));
@@ -216,9 +208,6 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.byType(MaterialButton)));
     await tester.pumpAndSettle();
     material = tester.widget<Material>(rawButtonMaterial);
-    inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
     expect(
       inkFeatures,
       paints
@@ -236,9 +225,6 @@ void main() {
     addTearDown(gesture2.removePointer);
     await tester.pumpAndSettle();
     material = tester.widget<Material>(rawButtonMaterial);
-    inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
     expect(
       inkFeatures,
       paints

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -181,12 +181,6 @@ void main() {
     );
   }
 
-  RenderObject getOverlayColor(WidgetTester tester) {
-    return tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-  }
-
   TextStyle iconStyle(WidgetTester tester, IconData icon) {
     final RichText iconRichText = tester.widget<RichText>(
       find.descendant(of: find.byIcon(icon), matching: find.byType(RichText)),
@@ -3353,6 +3347,7 @@ void main() {
           ),
         ),
       );
+      final MaterialInkController controller = Material.of(tester.element(find.text('MenuItem')));
 
       // Hovered.
       final Offset center = tester.getCenter(find.byType(MenuItemButton));
@@ -3360,13 +3355,13 @@ void main() {
       await gesture.addPointer();
       await gesture.moveTo(center);
       await tester.pumpAndSettle();
-      expect(getOverlayColor(tester), paints..rect(color: overlayColor.withOpacity(0.08)));
+      expect(controller, paints..rect(color: overlayColor.withOpacity(0.08)));
 
       // Highlighted (pressed).
       await gesture.down(center);
       await tester.pumpAndSettle();
       expect(
-        getOverlayColor(tester),
+        controller,
         paints
           ..rect(color: overlayColor.withOpacity(0.08))
           ..rect(color: overlayColor.withOpacity(0.08))
@@ -5035,6 +5030,7 @@ void main() {
           ),
         ),
       );
+      final MaterialInkController controller = Material.of(tester.element(find.text('Submenu')));
 
       // Hovered.
       final Offset center = tester.getCenter(find.byType(SubmenuButton));
@@ -5042,13 +5038,13 @@ void main() {
       await gesture.addPointer();
       await gesture.moveTo(center);
       await tester.pumpAndSettle();
-      expect(getOverlayColor(tester), paints..rect(color: overlayColor.withOpacity(0.08)));
+      expect(controller, paints..rect(color: overlayColor.withOpacity(0.08)));
 
       // Highlighted (pressed).
       await gesture.down(center);
       await tester.pumpAndSettle();
       expect(
-        getOverlayColor(tester),
+        controller,
         paints
           ..rect(color: overlayColor.withOpacity(0.08))
           ..rect(color: overlayColor.withOpacity(0.08))

--- a/packages/flutter/test/material/navigation_bar_test.dart
+++ b/packages/flutter/test/material/navigation_bar_test.dart
@@ -720,9 +720,7 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.byIcon(Icons.access_alarm)));
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
+    final MaterialInkController inkFeatures = Material.of(tester.element(find.text('AC')));
     var indicatorCenter = const Offset(600, 30);
     const includedIndicatorSize = Size(64, 32);
     const excludedIndicatorSize = Size(74, 40);
@@ -1164,6 +1162,8 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.byType(NavigationIndicator).last));
     await tester.pumpAndSettle();
 
+    // This test extracts the controller from the allRenderObjects iterable
+    // in order to prevent some wonkiness when running via skwasm.
     final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
       (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
     );
@@ -1318,9 +1318,7 @@ void main() {
       await gesture.moveTo(tester.getCenter(find.byIcon(Icons.access_alarm)));
       await tester.pumpAndSettle();
 
-      final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-        (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-      );
+      final MaterialInkController inkFeatures = Material.of(tester.element(find.text('AC')));
       var indicatorCenter = const Offset(600, 33);
       const includedIndicatorSize = Size(64, 32);
       const excludedIndicatorSize = Size(74, 40);

--- a/packages/flutter/test/material/navigation_bar_theme_test.dart
+++ b/packages/flutter/test/material/navigation_bar_theme_test.dart
@@ -285,6 +285,8 @@ void main() {
       await gesture.moveTo(tester.getCenter(find.byType(NavigationIndicator).last));
       await tester.pumpAndSettle();
 
+      // This test extracts the controller from the allRenderObjects iterable
+      // in order to prevent some wonkiness when running via skwasm.
       final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
         (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
       );

--- a/packages/flutter/test/material/navigation_rail_test.dart
+++ b/packages/flutter/test/material/navigation_rail_test.dart
@@ -11,6 +11,14 @@ import 'package:flutter_test/flutter_test.dart';
 import '../widgets/semantics_tester.dart';
 
 void main() {
+  MaterialInkController inkController(WidgetTester tester) {
+    final BuildContext context = tester.element(
+      find.descendant(of: find.byType(NavigationRail), matching: find.byType(Expanded)),
+    );
+
+    return Material.of(context);
+  }
+
   testWidgets('Custom selected and unselected textStyles are honored', (WidgetTester tester) async {
     const selectedTextStyle = TextStyle(fontWeight: FontWeight.w300, fontSize: 17.0);
     const unselectedTextStyle = TextStyle(fontWeight: FontWeight.w800, fontSize: 11.0);
@@ -3095,15 +3103,12 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.byIcon(Icons.favorite_border)));
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
     const indicatorRect = Rect.fromLTRB(12.0, 0.0, 68.0, 32.0);
     const includedRect = indicatorRect;
     final Rect excludedRect = includedRect.inflate(10);
 
     expect(
-      inkFeatures,
+      inkController(tester),
       paints
         ..clipPath(
           pathMatcher: isPathThat(
@@ -3157,15 +3162,12 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.byIcon(Icons.favorite_border)));
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
     const indicatorRect = Rect.fromLTRB(12.0, 6.0, 68.0, 38.0);
     const includedRect = indicatorRect;
     final Rect excludedRect = includedRect.inflate(10);
 
     expect(
-      inkFeatures,
+      inkController(tester),
       paints
         ..clipPath(
           pathMatcher: isPathThat(
@@ -3223,15 +3225,12 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.byIcon(Icons.favorite_border)));
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
     const indicatorRect = Rect.fromLTRB(22.0, 16.0, 78.0, 48.0);
     const includedRect = indicatorRect;
     final Rect excludedRect = includedRect.inflate(10);
 
     expect(
-      inkFeatures,
+      inkController(tester),
       paints
         ..clipPath(
           pathMatcher: isPathThat(
@@ -3288,15 +3287,12 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.byIcon(Icons.favorite_border)));
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
     const indicatorRect = Rect.fromLTRB(-3.0, 6.0, 53.0, 38.0);
     const includedRect = indicatorRect;
     final Rect excludedRect = includedRect.inflate(10);
 
     expect(
-      inkFeatures,
+      inkController(tester),
       paints
         ..clipPath(
           pathMatcher: isPathThat(
@@ -3355,15 +3351,12 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.byIcon(Icons.favorite_border)));
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
     const indicatorRect = Rect.fromLTRB(132.0, 16.0, 188.0, 48.0);
     const includedRect = indicatorRect;
     final Rect excludedRect = includedRect.inflate(10);
 
     expect(
-      inkFeatures,
+      inkController(tester),
       paints
         ..clipPath(
           pathMatcher: isPathThat(
@@ -3418,10 +3411,6 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.byIcon(Icons.favorite_border)));
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-
     // Default values from M3 specification.
     const railMinWidth = 80.0;
     const indicatorHeight = 32.0;
@@ -3441,7 +3430,7 @@ void main() {
     const double indicatorHorizontalPadding = (railMinWidth - indicatorWidth) / 2; // 12.0
 
     expect(
-      inkFeatures,
+      inkController(tester),
       paints
         ..clipPath(
           pathMatcher: isPathThat(
@@ -3508,10 +3497,6 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.byIcon(Icons.favorite_border)));
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-
     // Default values from M3 specification.
     const railMinWidth = 80.0;
     const indicatorHeight = 32.0;
@@ -3541,7 +3526,7 @@ void main() {
     const double secondIndicatorVerticalOffset = (iconSize - indicatorHeight) / 2;
 
     expect(
-      inkFeatures,
+      inkController(tester),
       paints
         ..clipPath(
           pathMatcher: isPathThat(
@@ -3607,10 +3592,6 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.byIcon(Icons.favorite_border)));
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-
     // Default values from M3 specification.
     const railMinExtendedWidth = 256.0;
     const indicatorHeight = 32.0;
@@ -3639,7 +3620,7 @@ void main() {
     const double secondIndicatorVerticalOffset = verticalDestinationSpacingM3 / 2;
 
     expect(
-      inkFeatures,
+      inkController(tester),
       paints
         ..clipPath(
           pathMatcher: isPathThat(
@@ -3892,11 +3873,8 @@ void main() {
     await gesture.addPointer();
     await gesture.moveTo(tester.getCenter(find.byIcon(Icons.favorite_border)));
     await tester.pumpAndSettle();
-    RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
 
-    expect(inkFeatures, paints..rect(color: Colors.transparent));
+    expect(inkController(tester), paints..rect(color: Colors.transparent));
 
     await gesture.down(tester.getCenter(find.byIcon(Icons.favorite_border)));
     await tester.pump(); // Start the splash and highlight animations.
@@ -3904,10 +3882,7 @@ void main() {
       const Duration(milliseconds: 800),
     ); // Wait for splash and highlight to be well under way.
 
-    inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-    expect(inkFeatures, paints..circle(color: Colors.transparent));
+    expect(inkController(tester), paints..circle(color: Colors.transparent));
   });
 
   testWidgets('Navigation rail can have expanded widgets inside', (WidgetTester tester) async {

--- a/packages/flutter/test/material/outlined_button_test.dart
+++ b/packages/flutter/test/material/outlined_button_test.dart
@@ -85,10 +85,8 @@ void main() {
     // Material 3 uses the InkSparkle which uses a shader, so we can't capture
     // the effect with paint methods.
     if (!material3) {
-      final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-        (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-      );
-      expect(inkFeatures, paints..circle(color: colorScheme.primary.withOpacity(0.12)));
+      final BuildContext context = tester.element(find.text('button'));
+      expect(Material.of(context), paints..circle(color: colorScheme.primary.withOpacity(0.12)));
     }
 
     await gesture.up();
@@ -376,10 +374,8 @@ void main() {
       ),
     );
 
-    RenderObject overlayColor() {
-      return tester.allRenderObjects.firstWhere(
-        (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-      );
+    MaterialInkController overlayColor() {
+      return Material.of(tester.element(find.text('OutlinedButton')));
     }
 
     // Hovered.
@@ -437,10 +433,7 @@ void main() {
     await gesture.addPointer();
     await gesture.moveTo(tester.getCenter(find.byType(OutlinedButton)));
     await tester.pumpAndSettle();
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-    expect(inkFeatures, paints..rect(color: hoverColor));
+    expect(Material.of(tester.element(find.text('button'))), paints..rect(color: hoverColor));
   });
 
   testWidgets('Does OutlinedButton work with focus', (WidgetTester tester) async {
@@ -471,10 +464,7 @@ void main() {
     focusNode.requestFocus();
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-    expect(inkFeatures, paints..rect(color: focusColor));
+    expect(Material.of(tester.element(find.text('button'))), paints..rect(color: focusColor));
 
     final Finder buttonMaterial = find.descendant(
       of: find.byType(OutlinedButton),
@@ -516,10 +506,7 @@ void main() {
     FocusManager.instance.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-    expect(inkFeatures, paints..rect(color: focusColor));
+    expect(Material.of(tester.element(find.text('button'))), paints..rect(color: focusColor));
 
     final Finder buttonMaterial = find.descendant(
       of: find.byType(OutlinedButton),

--- a/packages/flutter/test/material/search_anchor_test.dart
+++ b/packages/flutter/test/material/search_anchor_test.dart
@@ -556,24 +556,19 @@ void main() {
       ),
     );
 
-    RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
+    MaterialInkController inkFeatures() => Material.of(tester.element(find.byType(SearchBar)));
 
     // On hovered.
     final TestGesture gesture = await _pointGestureToSearchBar(tester);
     await tester.pumpAndSettle();
-    expect(inkFeatures, paints..rect(color: hoveredColor.withOpacity(1.0)));
+    expect(inkFeatures(), paints..rect(color: hoveredColor.withOpacity(1.0)));
 
     // On pressed.
     await tester.pumpAndSettle();
     await gesture.down(tester.getCenter(find.byType(SearchBar)));
     await tester.pumpAndSettle();
-    inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
     expect(
-      inkFeatures,
+      inkFeatures(),
       paints
         ..rect()
         ..rect(color: pressedColor.withOpacity(1.0)),
@@ -586,11 +581,8 @@ void main() {
     // Remove the pointer so we are no longer hovering.
     await gesture.removePointer();
     await tester.pump();
-    inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
     expect(
-      inkFeatures,
+      inkFeatures(),
       paints
         ..rect()
         ..rect(color: focusedColor.withOpacity(1.0)),

--- a/packages/flutter/test/material/segmented_button_test.dart
+++ b/packages/flutter/test/material/segmented_button_test.dart
@@ -18,12 +18,6 @@ import 'package:flutter_test/flutter_test.dart';
 import '../widgets/semantics_tester.dart';
 
 void main() {
-  RenderObject getOverlayColor(WidgetTester tester) {
-    return tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-  }
-
   Widget boilerplate({required Widget child}) {
     return Directionality(
       textDirection: TextDirection.ltr,
@@ -691,6 +685,7 @@ void main() {
       ),
     );
 
+    final MaterialInkController controller = Material.of(tester.element(find.text('2')));
     final Material material = tester.widget<Material>(
       find.descendant(of: find.byType(TextButton).last, matching: find.byType(Material)),
     );
@@ -701,17 +696,14 @@ void main() {
     await gesture.addPointer();
     await gesture.moveTo(center);
     await tester.pumpAndSettle();
-    expect(
-      getOverlayColor(tester),
-      paints..rect(color: theme.colorScheme.onSurface.withOpacity(0.08)),
-    );
+    expect(controller, paints..rect(color: theme.colorScheme.onSurface.withOpacity(0.08)));
     expect(material.textStyle?.color, theme.colorScheme.onSurface);
 
     // Highlighted (pressed).
     await gesture.down(center);
     await tester.pumpAndSettle();
     expect(
-      getOverlayColor(tester),
+      controller,
       paints
         ..rect()
         ..rect(color: theme.colorScheme.onSurface.withOpacity(0.1)),
@@ -873,7 +865,8 @@ void main() {
     await gesture.addPointer();
     await gesture.down(tester.getCenter(find.text('1')));
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect(color: foregroundColor.withOpacity(0.08)));
+    final BuildContext context = tester.element(find.text('1'));
+    expect(Material.of(context), paints..rect(color: foregroundColor.withOpacity(0.08)));
   });
 
   testWidgets('Disabled SegmentedButton has correct states when rebuilding', (
@@ -1062,26 +1055,28 @@ void main() {
       ),
     );
 
+    Object inkController(String text) => Material.of(tester.element(find.text(text)));
+
     // Hovered selected segment,
     Offset center = tester.getCenter(find.text('Option 1'));
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
     await gesture.addPointer();
     await gesture.moveTo(center);
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect(color: overlayColor.withOpacity(0.08)));
+    expect(inkController('Option 1'), paints..rect(color: overlayColor.withOpacity(0.08)));
 
     // Hovered unselected segment,
     center = tester.getCenter(find.text('Option 2'));
     await gesture.moveTo(center);
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect(color: overlayColor.withOpacity(0.08)));
+    expect(inkController('Option 2'), paints..rect(color: overlayColor.withOpacity(0.08)));
 
     // Highlighted unselected segment (pressed).
     center = tester.getCenter(find.text('Option 1'));
     await gesture.down(center);
     await tester.pumpAndSettle();
     expect(
-      getOverlayColor(tester),
+      inkController('Option 1'),
       paints
         ..rect(color: overlayColor.withOpacity(0.08))
         ..rect(color: overlayColor.withOpacity(0.1)),
@@ -1097,7 +1092,7 @@ void main() {
     await gesture.down(center);
     await tester.pumpAndSettle();
     expect(
-      getOverlayColor(tester),
+      inkController('Option 2'),
       paints
         ..rect(color: overlayColor.withOpacity(0.08))
         ..rect(color: overlayColor.withOpacity(0.1)),
@@ -1111,12 +1106,12 @@ void main() {
     // Focused unselected segment.
     await tester.sendKeyEvent(LogicalKeyboardKey.tab);
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect(color: overlayColor.withOpacity(0.1)));
+    expect(inkController('Option 1'), paints..rect(color: overlayColor.withOpacity(0.1)));
 
     // Focused selected segment.
     await tester.sendKeyEvent(LogicalKeyboardKey.tab);
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect(color: overlayColor.withOpacity(0.1)));
+    expect(inkController('Option 2'), paints..rect(color: overlayColor.withOpacity(0.1)));
   });
 
   testWidgets('SegmentedButton.styleFrom with transparent overlayColor', (
@@ -1139,6 +1134,7 @@ void main() {
         ),
       ),
     );
+    final MaterialInkController controller = Material.of(tester.element(find.text('Option')));
 
     // Hovered,
     final Offset center = tester.getCenter(find.text('Option'));
@@ -1146,13 +1142,13 @@ void main() {
     await gesture.addPointer();
     await gesture.moveTo(center);
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect(color: overlayColor));
+    expect(controller, paints..rect(color: overlayColor));
 
     // Highlighted (pressed).
     await gesture.down(center);
     await tester.pumpAndSettle();
     expect(
-      getOverlayColor(tester),
+      controller,
       paints
         ..rect(color: overlayColor)
         ..rect(color: overlayColor),
@@ -1166,7 +1162,7 @@ void main() {
     // Focused.
     await tester.sendKeyEvent(LogicalKeyboardKey.tab);
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect(color: overlayColor));
+    expect(controller, paints..rect(color: overlayColor));
   });
 
   // This is a regression test for https://github.com/flutter/flutter/issues/144990.

--- a/packages/flutter/test/material/segmented_button_theme_test.dart
+++ b/packages/flutter/test/material/segmented_button_theme_test.dart
@@ -9,12 +9,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  RenderObject getOverlayColor(WidgetTester tester) {
-    return tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-  }
-
   test('SegmentedButtonThemeData copyWith, ==, hashCode basics', () {
     expect(const SegmentedButtonThemeData(), const SegmentedButtonThemeData().copyWith());
     expect(
@@ -516,6 +510,7 @@ void main() {
           ),
         ),
       );
+      Object inkController(String buttonText) => Material.of(tester.element(find.text(buttonText)));
 
       // Hovered selected segment,
       Offset center = tester.getCenter(find.text('Option 1'));
@@ -523,20 +518,20 @@ void main() {
       await gesture.addPointer();
       await gesture.moveTo(center);
       await tester.pumpAndSettle();
-      expect(getOverlayColor(tester), paints..rect(color: overlayColor.withOpacity(0.08)));
+      expect(inkController('Option 1'), paints..rect(color: overlayColor.withOpacity(0.08)));
 
       // Hovered unselected segment,
       center = tester.getCenter(find.text('Option 2'));
       await gesture.moveTo(center);
       await tester.pumpAndSettle();
-      expect(getOverlayColor(tester), paints..rect(color: overlayColor.withOpacity(0.08)));
+      expect(inkController('Option 2'), paints..rect(color: overlayColor.withOpacity(0.08)));
 
       // Highlighted unselected segment (pressed).
       center = tester.getCenter(find.text('Option 1'));
       await gesture.down(center);
       await tester.pumpAndSettle();
       expect(
-        getOverlayColor(tester),
+        inkController('Option 1'),
         paints
           ..rect(color: overlayColor.withOpacity(0.08))
           ..rect(color: overlayColor.withOpacity(0.1)),
@@ -552,7 +547,7 @@ void main() {
       await gesture.down(center);
       await tester.pumpAndSettle();
       expect(
-        getOverlayColor(tester),
+        inkController('Option 2'),
         paints
           ..rect(color: overlayColor.withOpacity(0.08))
           ..rect(color: overlayColor.withOpacity(0.1)),
@@ -566,12 +561,12 @@ void main() {
       // Focused unselected segment.
       await tester.sendKeyEvent(LogicalKeyboardKey.tab);
       await tester.pumpAndSettle();
-      expect(getOverlayColor(tester), paints..rect(color: overlayColor.withOpacity(0.1)));
+      expect(inkController('Option 1'), paints..rect(color: overlayColor.withOpacity(0.1)));
 
       // Focused selected segment.
       await tester.sendKeyEvent(LogicalKeyboardKey.tab);
       await tester.pumpAndSettle();
-      expect(getOverlayColor(tester), paints..rect(color: overlayColor.withOpacity(0.1)));
+      expect(inkController('Option 2'), paints..rect(color: overlayColor.withOpacity(0.1)));
     },
   );
 }

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -567,22 +567,21 @@ void main() {
       buildFrame(tabs: tabs, value: selectedValue, useMaterial3: theme.useMaterial3),
     );
 
-    RenderObject overlayColor() {
-      return tester.allRenderObjects.firstWhere(
-        (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-      );
-    }
+    Object inkController(String text) => Material.of(tester.element(find.text(text)));
 
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
     await gesture.addPointer();
     await gesture.moveTo(tester.getCenter(find.text(selectedValue)));
     await tester.pumpAndSettle();
-    expect(overlayColor(), paints..rect(color: theme.colorScheme.primary.withOpacity(0.08)));
+    expect(
+      inkController(selectedValue),
+      paints..rect(color: theme.colorScheme.primary.withOpacity(0.08)),
+    );
 
     await gesture.down(tester.getCenter(find.text(selectedValue)));
     await tester.pumpAndSettle();
     expect(
-      overlayColor(),
+      inkController(selectedValue),
       paints
         ..rect()
         ..rect(color: theme.colorScheme.primary.withOpacity(0.1)),
@@ -592,16 +591,22 @@ void main() {
 
     await gesture.moveTo(tester.getCenter(find.text(unselectedValue)));
     await tester.pumpAndSettle();
-    expect(overlayColor(), paints..rect(color: theme.colorScheme.onSurface.withOpacity(0.08)));
+    expect(
+      inkController(unselectedValue),
+      paints..rect(color: theme.colorScheme.onSurface.withOpacity(0.08)),
+    );
 
     await gesture.moveTo(tester.getCenter(find.text(selectedValue)));
     await tester.pumpAndSettle();
-    expect(overlayColor(), paints..rect(color: theme.colorScheme.primary.withOpacity(0.08)));
+    expect(
+      inkController(unselectedValue),
+      paints..rect(color: theme.colorScheme.primary.withOpacity(0.08)),
+    );
 
     await gesture.down(tester.getCenter(find.text(selectedValue)));
     await tester.pumpAndSettle();
     expect(
-      overlayColor(),
+      inkController(unselectedValue),
       paints
         ..rect()
         ..rect(color: theme.colorScheme.primary.withOpacity(0.1)),
@@ -625,22 +630,21 @@ void main() {
       ),
     );
 
-    RenderObject overlayColor() {
-      return tester.allRenderObjects.firstWhere(
-        (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-      );
-    }
+    Object inkController(String text) => Material.of(tester.element(find.text(text)));
 
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
     await gesture.addPointer();
     await gesture.moveTo(tester.getCenter(find.text(selectedValue)));
     await tester.pumpAndSettle();
-    expect(overlayColor(), paints..rect(color: theme.colorScheme.onSurface.withOpacity(0.08)));
+    expect(
+      inkController(selectedValue),
+      paints..rect(color: theme.colorScheme.onSurface.withOpacity(0.08)),
+    );
 
     await gesture.down(tester.getCenter(find.text(selectedValue)));
     await tester.pumpAndSettle();
     expect(
-      overlayColor(),
+      inkController(selectedValue),
       paints
         ..rect()
         ..rect(color: theme.colorScheme.onSurface.withOpacity(0.1)),
@@ -650,12 +654,15 @@ void main() {
 
     await gesture.moveTo(tester.getCenter(find.text(unselectedValue)));
     await tester.pumpAndSettle();
-    expect(overlayColor(), paints..rect(color: theme.colorScheme.onSurface.withOpacity(0.08)));
+    expect(
+      inkController(unselectedValue),
+      paints..rect(color: theme.colorScheme.onSurface.withOpacity(0.08)),
+    );
 
     await gesture.down(tester.getCenter(find.text(selectedValue)));
     await tester.pumpAndSettle();
     expect(
-      overlayColor(),
+      inkController(unselectedValue),
       paints
         ..rect()
         ..rect(color: theme.colorScheme.onSurface.withOpacity(0.1)),
@@ -5113,11 +5120,8 @@ void main() {
       await gesture.addPointer();
       await gesture.moveTo(tester.getCenter(find.byType(Tab)));
       await tester.pumpAndSettle();
-      final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-        (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-      );
       expect(
-        inkFeatures,
+        Material.of(tester.element(find.text('A'))),
         paints..rect(
           rect: const Rect.fromLTRB(0.0, 276.0, 800.0, 324.0),
           color: const Color(0xff00ff00),
@@ -5154,10 +5158,8 @@ void main() {
           tester.getRect(find.byType(InkWell)).center,
         );
         await tester.pump(const Duration(milliseconds: 200)); // unconfirmed splash is well underway
-        final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-          (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-        );
-        expect(inkFeatures, paints..circle(x: 400, y: 24, color: splashColor));
+        final BuildContext context = tester.element(find.text('A'));
+        expect(Material.of(context), paints..circle(x: 400, y: 24, color: splashColor));
         await gesture.up();
       },
     );
@@ -6663,7 +6665,7 @@ void main() {
               return Colors.black54;
             }),
             splashBorderRadius: BorderRadius.circular(radius),
-            tabs: const <Widget>[Tab(child: Text(''))],
+            tabs: const <Widget>[Tab(child: Text('Tab'))],
           ),
         ),
       ),
@@ -6675,11 +6677,8 @@ void main() {
     );
     await gesture.moveTo(tester.getCenter(find.byType(Tab)));
     await tester.pumpAndSettle();
-    final RenderObject object = tester.allRenderObjects.firstWhere(
-      (RenderObject element) => element.runtimeType.toString() == '_RenderInkFeatures',
-    );
     expect(
-      object,
+      Material.of(tester.element(find.text('Tab'))),
       paints..rrect(
         color: hoverColor,
         rrect: RRect.fromRectAndRadius(
@@ -6879,9 +6878,7 @@ void main() {
     await tester.pumpWidget(buildFrame(tabs: tabs, value: 'C', useMaterial3: theme.useMaterial3));
 
     await tester.pumpAndSettle();
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
+    final MaterialInkController inkFeatures = Material.of(tester.element(find.text('C')));
     expect(inkFeatures, isNot(paints..rect(color: theme.colorScheme.onSurface.withOpacity(0.08))));
     expect(inkFeatures, isNot(paints..rect(color: theme.colorScheme.primary.withOpacity(0.08))));
 
@@ -6910,9 +6907,7 @@ void main() {
     );
 
     await tester.pumpAndSettle();
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
+    final MaterialInkController inkFeatures = Material.of(tester.element(find.text('B')));
     expect(inkFeatures, isNot(paints..rect(color: theme.colorScheme.onSurface.withOpacity(0.1))));
     expect(inkFeatures, isNot(paints..rect(color: theme.colorScheme.primary.withOpacity(0.1))));
 
@@ -6938,9 +6933,7 @@ void main() {
     );
 
     await tester.pumpAndSettle();
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
+    final MaterialInkController inkFeatures = Material.of(tester.element(find.text('B')));
     expect(inkFeatures, isNot(paints..rect(color: theme.colorScheme.primary.withOpacity(0.1))));
 
     // Press unselected tab.

--- a/packages/flutter/test/material/text_button_test.dart
+++ b/packages/flutter/test/material/text_button_test.dart
@@ -75,10 +75,8 @@ void main() {
     // Material 3 uses the InkSparkle which uses a shader, so we can't capture
     // the effect with paint methods.
     if (!material3) {
-      final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-        (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-      );
-      expect(inkFeatures, paints..circle(color: colorScheme.primary.withOpacity(0.12)));
+      final BuildContext context = tester.element(find.text('button'));
+      expect(Material.of(context), paints..circle(color: colorScheme.primary.withOpacity(0.12)));
     }
 
     await gesture.up();
@@ -471,11 +469,7 @@ void main() {
       ),
     );
 
-    RenderObject overlayColor() {
-      return tester.allRenderObjects.firstWhere(
-        (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-      );
-    }
+    MaterialInkController overlayColor() => Material.of(tester.element(find.text('TextButton')));
 
     // Hovered.
     final Offset center = tester.getCenter(find.byType(TextButton));
@@ -690,10 +684,7 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.byType(TextButton)));
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-    expect(inkFeatures, paints..rect(color: hoverColor));
+    expect(Material.of(tester.element(find.byType(Container))), paints..rect(color: hoverColor));
   });
 
   testWidgets('Does TextButton work with focus', (WidgetTester tester) async {
@@ -723,10 +714,7 @@ void main() {
     focusNode.requestFocus();
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-    expect(inkFeatures, paints..rect(color: focusColor));
+    expect(Material.of(tester.element(find.text('button'))), paints..rect(color: focusColor));
 
     focusNode.dispose();
   });
@@ -2486,12 +2474,6 @@ void main() {
       ),
     );
 
-    RenderObject overlayColor() {
-      return tester.allRenderObjects.firstWhere(
-        (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-      );
-    }
-
     final Offset center = tester.getCenter(find.byType(TextButton));
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.stylus);
     await gesture.addPointer();
@@ -2501,7 +2483,8 @@ void main() {
 
     await gesture.moveTo(center);
     await tester.pumpAndSettle();
-    expect(overlayColor(), paints..rect(color: theme.colorScheme.primary.withOpacity(0.08)));
+    final BuildContext context = tester.element(find.text('TextButton'));
+    expect(Material.of(context), paints..rect(color: theme.colorScheme.primary.withOpacity(0.08)));
     expect(hasBeenHovered, isTrue);
   });
 

--- a/packages/flutter/test/material/toggle_buttons_test.dart
+++ b/packages/flutter/test/material/toggle_buttons_test.dart
@@ -658,6 +658,7 @@ void main() {
     );
 
     final Offset center = tester.getCenter(find.text('First child'));
+    final MaterialInkController inkFeatures = Material.of(tester.element(find.text('First child')));
 
     // hoverColor
     final TestGesture hoverGesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
@@ -666,9 +667,6 @@ void main() {
     await tester.pumpAndSettle();
     await hoverGesture.moveTo(Offset.zero);
 
-    RenderObject inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) {
-      return object.runtimeType.toString() == '_RenderInkFeatures';
-    });
     expect(inkFeatures, paints..rect(color: theme.colorScheme.onSurface.withOpacity(0.04)));
 
     // splashColor
@@ -676,9 +674,6 @@ void main() {
     await touchGesture.down(center); // The button is on hovered and pressed
     await tester.pumpAndSettle();
 
-    inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) {
-      return object.runtimeType.toString() == '_RenderInkFeatures';
-    });
     expect(inkFeatures, paints..circle(color: theme.colorScheme.onSurface.withOpacity(0.16)));
 
     await touchGesture.up();
@@ -690,9 +685,6 @@ void main() {
     FocusManager.instance.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
     focusNode.requestFocus();
     await tester.pumpAndSettle();
-    inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) {
-      return object.runtimeType.toString() == '_RenderInkFeatures';
-    });
     expect(inkFeatures, paints..rect(color: theme.colorScheme.onSurface.withOpacity(0.12)));
 
     await hoverGesture.removePointer();
@@ -715,6 +707,7 @@ void main() {
     );
 
     final Offset center = tester.getCenter(find.text('First child'));
+    final MaterialInkController inkFeatures = Material.of(tester.element(find.text('First child')));
 
     // hoverColor
     final TestGesture hoverGesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
@@ -722,9 +715,6 @@ void main() {
     await hoverGesture.moveTo(center);
     await tester.pumpAndSettle();
 
-    RenderObject inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) {
-      return object.runtimeType.toString() == '_RenderInkFeatures';
-    });
     expect(inkFeatures, paints..rect(color: theme.colorScheme.primary.withOpacity(0.04)));
     await hoverGesture.moveTo(Offset.zero);
 
@@ -733,9 +723,6 @@ void main() {
     await touchGesture.down(center); // The button is on hovered and pressed
     await tester.pumpAndSettle();
 
-    inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) {
-      return object.runtimeType.toString() == '_RenderInkFeatures';
-    });
     expect(inkFeatures, paints..circle(color: theme.colorScheme.primary.withOpacity(0.16)));
 
     await touchGesture.up();
@@ -747,9 +734,6 @@ void main() {
     FocusManager.instance.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
     focusNode.requestFocus();
     await tester.pumpAndSettle();
-    inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) {
-      return object.runtimeType.toString() == '_RenderInkFeatures';
-    });
     expect(inkFeatures, paints..rect(color: theme.colorScheme.primary.withOpacity(0.12)));
 
     await hoverGesture.removePointer();
@@ -780,16 +764,13 @@ void main() {
     );
 
     final Offset center = tester.getCenter(find.text('First child'));
+    final MaterialInkController inkFeatures = Material.of(tester.element(find.text('First child')));
 
     // splashColor
     final TestGesture touchGesture = await tester.createGesture();
     await touchGesture.down(center);
     await tester.pumpAndSettle();
 
-    RenderObject inkFeatures;
-    inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) {
-      return object.runtimeType.toString() == '_RenderInkFeatures';
-    });
     expect(inkFeatures, paints..circle(color: splashColor));
 
     await touchGesture.up();
@@ -801,9 +782,6 @@ void main() {
     await hoverGesture.moveTo(center);
     await tester.pumpAndSettle();
 
-    inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) {
-      return object.runtimeType.toString() == '_RenderInkFeatures';
-    });
     expect(inkFeatures, paints..rect(color: hoverColor));
     await hoverGesture.moveTo(Offset.zero);
 
@@ -811,9 +789,6 @@ void main() {
     FocusManager.instance.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
     focusNode.requestFocus();
     await tester.pumpAndSettle();
-    inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) {
-      return object.runtimeType.toString() == '_RenderInkFeatures';
-    });
     expect(inkFeatures, paints..rect(color: focusColor));
 
     await hoverGesture.removePointer();

--- a/packages/flutter/test/material/toggle_buttons_theme_test.dart
+++ b/packages/flutter/test/material/toggle_buttons_theme_test.dart
@@ -447,6 +447,7 @@ void main() {
     );
 
     final Offset center = tester.getCenter(find.text('First child'));
+    final MaterialInkController inkFeatures = Material.of(tester.element(find.text('First child')));
 
     // splashColor
     // highlightColor
@@ -454,10 +455,6 @@ void main() {
     await touchGesture.down(center);
     await tester.pumpAndSettle();
 
-    RenderObject inkFeatures;
-    inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) {
-      return object.runtimeType.toString() == '_RenderInkFeatures';
-    });
     expect(inkFeatures, paints..circle(color: splashColor));
 
     await touchGesture.up();
@@ -469,9 +466,6 @@ void main() {
     await hoverGesture.moveTo(center);
     await tester.pumpAndSettle();
 
-    inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) {
-      return object.runtimeType.toString() == '_RenderInkFeatures';
-    });
     expect(inkFeatures, paints..rect(color: hoverColor));
     await hoverGesture.moveTo(Offset.zero);
 
@@ -479,9 +473,6 @@ void main() {
     FocusManager.instance.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
     focusNode.requestFocus();
     await tester.pumpAndSettle();
-    inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) {
-      return object.runtimeType.toString() == '_RenderInkFeatures';
-    });
     expect(inkFeatures, paints..rect(color: focusColor));
 
     await hoverGesture.removePointer();


### PR DESCRIPTION
This pull request is the first step toward moving [**MaterialInkController**](https://main-api.flutter.dev/flutter/material/MaterialInkController-class.html) out of the Material library.

And even if we don't end up moving anything, we could still land this PR on its own as a nice cleanup!

<br>

related:
- [flutter.dev/go/layered-material-widgets](https://flutter.dev/go/layered-material-widgets)
- #150139
