### PR TITLE
Add `start` and `end` parameters to `EdgeInsetsGeometry.only`

### DIFF
--- a/packages/flutter/lib/fix_data/fix_painting.yaml
+++ b/packages/flutter/lib/fix_data/fix_painting.yaml
@@ -18,6 +18,17 @@
 # * Fixes in this file are from the Painting library. *
 version: 1
 transforms:
+  # Change made in https://github.com/flutter/flutter/pull/183699
+  - title: "Migrate to 'EdgeInsetsDirectional.only'"
+    date: 2023-06-09
+    element:
+      uris: [ 'painting.dart' ]
+      constructor: 'directional'
+      inClass: 'EdgeInsetsGeometry'
+    changes:
+      - kind: 'rename'
+        newName: 'only'
+
   # Change made in https://github.com/flutter/flutter/pull/128522
   - title: "Migrate to 'textScaler'"
     date: 2023-06-09

--- a/packages/flutter/lib/src/painting/edge_insets.dart
+++ b/packages/flutter/lib/src/painting/edge_insets.dart
@@ -36,9 +36,15 @@ abstract class EdgeInsetsGeometry {
   /// Creates insets where all the offsets are `value`.
   const factory EdgeInsetsGeometry.all(double value) = EdgeInsets.all;
 
-  /// Creates [EdgeInsets] with only the given values non-zero.
-  const factory EdgeInsetsGeometry.only({double left, double right, double top, double bottom}) =
-      EdgeInsets.only;
+  /// Creates an [EdgeInsetsGeometry] object with only the given values non-zero.
+  const factory EdgeInsetsGeometry.only({
+    double left,
+    double right,
+    double start,
+    double end,
+    double top,
+    double bottom,
+  }) = _MixedEdgeInsets.only;
 
   /// Creates [EdgeInsetsDirectional] with only the given values non-zero.
   const factory EdgeInsetsGeometry.directional({
@@ -982,6 +988,20 @@ class _MixedEdgeInsets extends EdgeInsetsGeometry {
     this._top,
     this._bottom,
   );
+
+  const _MixedEdgeInsets.only({
+    double left = 0.0,
+    double right = 0.0,
+    double start = 0.0,
+    double end = 0.0,
+    double top = 0.0,
+    double bottom = 0.0,
+  }) : _left = left,
+       _right = right,
+       _start = start,
+       _end = end,
+       _top = top,
+       _bottom = bottom;
 
   @override
   final double _left;

--- a/packages/flutter/lib/src/painting/edge_insets.dart
+++ b/packages/flutter/lib/src/painting/edge_insets.dart
@@ -37,6 +37,14 @@ abstract class EdgeInsetsGeometry {
   const factory EdgeInsetsGeometry.all(double value) = EdgeInsets.all;
 
   /// Creates an [EdgeInsetsGeometry] object with only the given values non-zero.
+  ///
+  /// The `left`, `right`, `top`, and `bottom` parameters set values with respect to
+  /// [EdgeInsets].
+  ///
+  /// The other two parameters set the padding based on the ambient [Directionality].
+  /// When using [TextDirection.ltr], `start` adds to the left padding and `end` adds to
+  /// the right padding. And for [TextDirection.rtl], `start` corresponds to the right and
+  /// `end` corresponds to the left.
   const factory EdgeInsetsGeometry.only({
     double left,
     double right,

--- a/packages/flutter/lib/src/painting/edge_insets.dart
+++ b/packages/flutter/lib/src/painting/edge_insets.dart
@@ -47,6 +47,11 @@ abstract class EdgeInsetsGeometry {
   }) = _MixedEdgeInsets.only;
 
   /// Creates [EdgeInsetsDirectional] with only the given values non-zero.
+  @Deprecated(
+    'Use EdgeInsetsGeometry.only instead. '
+    'The .only() constructor allows setting start and end values. '
+    'This feature was deprecated after 3.43.0-0.1.pre.',
+  )
   const factory EdgeInsetsGeometry.directional({
     double start,
     double end,

--- a/packages/flutter/test/painting/edge_insets_test.dart
+++ b/packages/flutter/test/painting/edge_insets_test.dart
@@ -77,6 +77,23 @@ void main() {
     expect(symmetric.resolve(TextDirection.rtl), equals(const EdgeInsets.fromLTRB(10, 20, 10, 20)));
   });
 
+  test('EdgeInsetsGeometry.only() constructor', () {
+    const singleValue = EdgeInsetsGeometry.only(start: 10);
+    expect(singleValue.resolve(TextDirection.ltr), equals(const EdgeInsets.only(left: 10)));
+    expect(singleValue.resolve(TextDirection.rtl), equals(const EdgeInsets.only(right: 10)));
+
+    const allValues = EdgeInsetsGeometry.only(
+      left: 10,
+      right: 10,
+      start: 10,
+      end: 10,
+      top: 10,
+      bottom: 10,
+    );
+    expect(allValues.resolve(TextDirection.ltr), equals(const EdgeInsets.fromLTRB(20, 10, 20, 10)));
+    expect(allValues.resolve(TextDirection.rtl), equals(const EdgeInsets.fromLTRB(20, 10, 20, 10)));
+  });
+
   test('EdgeInsets control test', () {
     const insets = EdgeInsets.fromLTRB(5.0, 7.0, 11.0, 13.0);
 

--- a/packages/flutter/test_fixes/painting/painting.dart
+++ b/packages/flutter/test_fixes/painting/painting.dart
@@ -5,6 +5,9 @@
 import 'package:flutter/painting.dart';
 
 void main() {
+  // Change made in https://github.com/flutter/flutter/pull/183699
+  const EdgeInsetsGeometry onlyStart = .directional(start: 10);
+
   // Change made in https://github.com/flutter/flutter/pull/121152
   final EdgeInsets insets = EdgeInsets.fromWindowPadding(ViewPadding.zero, 3.0);
 

--- a/packages/flutter/test_fixes/painting/painting.dart.expect
+++ b/packages/flutter/test_fixes/painting/painting.dart.expect
@@ -5,6 +5,9 @@
 import 'package:flutter/painting.dart';
 
 void main() {
+  // Change made in https://github.com/flutter/flutter/pull/183699
+  const EdgeInsetsGeometry onlyStart = .only(start: 10);
+
   // Change made in https://github.com/flutter/flutter/pull/121152
   final EdgeInsets insets = EdgeInsets.fromViewPadding(ViewPadding.zero, 3.0);
 


### PR DESCRIPTION
This pull request updates the [**EdgeInsetsGeometry.only**](https://main-api.flutter.dev/flutter/painting/EdgeInsetsGeometry/EdgeInsetsGeometry.only.html) constructor to include `start` and `end` parameters.

<br>

With this change, the following will work as intended:

```dart
Padding(
  padding: .only(start: 10),
  child: // ...
)
```