### PR TITLE
RawAutocomplete: Add controller param for caller-managed options

### DIFF
--- a/packages/flutter/lib/src/widgets/autocomplete.dart
+++ b/packages/flutter/lib/src/widgets/autocomplete.dart
@@ -388,6 +388,7 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
   // Set the initial value to null so when this widget gets focused for the first
   // time it will try to run the options view builder.
   String? _lastFieldText;
+  bool _userHidOptions = false;
   final ValueNotifier<int> _highlightedOptionIndex = ValueNotifier<int>(0);
 
   static const Map<ShortcutActivator, Intent> _appleShortcuts = <ShortcutActivator, Intent>{
@@ -426,8 +427,9 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
   void _onFocusChange() {
     if (_focusNode.hasFocus != _hasFocus) {
       _hasFocus = _focusNode.hasFocus;
-      // Gaining focus can open the options view (if there are options). Losing
-      // focus always closes it.
+      if (_hasFocus) {
+        _userHidOptions = false;
+      }
       _updateOptionsViewVisibility();
     }
   }
@@ -435,7 +437,7 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
   /// Shows the options view when the field is focused and there is at least one
   /// option to display; otherwise hides the options view.
   void _updateOptionsViewVisibility() {
-    if (_canShowOptionsView) {
+    if (_canShowOptionsView && !_userHidOptions) {
       _optionsViewController.show();
     } else if (_optionsViewController.isShowing) {
       _optionsViewController.hide();
@@ -479,13 +481,11 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
     }
     final TextEditingValue value = _textEditingController.value;
 
-    // Makes sure that options change only when content of the field changes.
-    var shouldUpdateOptions = false;
     if (value.text != _lastFieldText) {
-      shouldUpdateOptions = true;
-      _onChangedCallId += 1;
+      _userHidOptions = false;
     }
     _lastFieldText = value.text;
+    _onChangedCallId += 1;
     final int callId = _onChangedCallId;
     final Iterable<T> options = await widget.optionsBuilder(value);
 
@@ -494,7 +494,7 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
     }
 
     // Makes sure that previous call results do not replace new ones.
-    if (callId != _onChangedCallId || !shouldUpdateOptions) {
+    if (callId != _onChangedCallId) {
       return;
     }
     if (_options.isEmpty != options.isEmpty) {
@@ -567,6 +567,7 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
 
   void _highlightOption(int index) {
     assert(_canShowOptionsView);
+    _userHidOptions = false;
     _updateOptionsViewVisibility();
     assert(_optionsViewController.isShowing);
     _updateHighlight(index);
@@ -574,6 +575,7 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
 
   Object? _hideOptions(DismissIntent intent) {
     if (_optionsViewController.isShowing) {
+      _userHidOptions = true;
       _optionsViewController.hide();
       return null;
     } else {

--- a/packages/flutter/lib/src/widgets/autocomplete.dart
+++ b/packages/flutter/lib/src/widgets/autocomplete.dart
@@ -679,12 +679,12 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
       widget.textEditingController?.addListener(_onChangedField);
     }
     if (!identical(oldWidget.focusNode, widget.focusNode)) {
-      oldWidget.focusNode?.removeListener(_updateOptionsViewVisibility);
+      oldWidget.focusNode?.removeListener(_onFocusChange);
       if (oldWidget.focusNode == null) {
         _internalFocusNode?.dispose();
         _internalFocusNode = null;
       }
-      widget.focusNode?.addListener(_updateOptionsViewVisibility);
+      widget.focusNode?.addListener(_onFocusChange);
     }
   }
 
@@ -692,7 +692,7 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
   void dispose() {
     widget.textEditingController?.removeListener(_onChangedField);
     _internalTextEditingController?.dispose();
-    widget.focusNode?.removeListener(_updateOptionsViewVisibility);
+    widget.focusNode?.removeListener(_onFocusChange);
     _internalFocusNode?.dispose();
     _highlightedOptionIndex.dispose();
     super.dispose();

--- a/packages/flutter/lib/src/widgets/autocomplete.dart
+++ b/packages/flutter/lib/src/widgets/autocomplete.dart
@@ -121,20 +121,57 @@ enum OptionsViewOpenDirection {
   mostSpace,
 }
 
+/// A controller for a [RawAutocomplete] widget
+/// that allows the caller to manage the options list directly
+/// instead of using a [RawAutocomplete.optionsBuilder] callback.
+///
+/// This is useful when the options depend on criteria beyond just the
+/// [TextEditingValue], which is the only input
+/// that [RawAutocomplete.optionsBuilder] receives.
+///
+/// Provide an [AutocompleteController] to [RawAutocomplete.controller] and
+/// set [options] to update the displayed options. The widget will react to
+/// changes in the controller's options and show/hide the options view
+/// accordingly.
+///
+/// Remember to [dispose] of the [AutocompleteController] when it is no
+/// longer needed. This will ensure all resources used by the object are
+/// discarded.
+///
+/// See also:
+///
+///  * [RawAutocomplete.controller], which accepts this controller.
+///  * [RawAutocomplete.optionsBuilder], the callback-based alternative.
+class AutocompleteController<T extends Object> extends ChangeNotifier {
+  /// The current list of selectable options.
+  Iterable<T> get options => _options;
+  Iterable<T> _options = Iterable<T>.empty();
+  set options(Iterable<T> value) {
+    if (value == _options) {
+      return;
+    }
+    _options = value;
+    notifyListeners();
+  }
+}
+
 // TODO(justinmc): Mention AutocompleteCupertino when it is implemented.
 /// {@template flutter.widgets.RawAutocomplete.RawAutocomplete}
 /// A widget for helping the user make a selection by entering some text and
 /// choosing from among a list of options.
 ///
-/// The user's text input is received in a field built with the
-/// [fieldViewBuilder] parameter. The options to be displayed are determined
-/// using [optionsBuilder] and rendered with [optionsViewBuilder].
+/// The text input is rendered with [fieldViewBuilder].
+/// The options to be displayed are determined using [optionsBuilder]
+/// and rendered with [optionsViewBuilder].
 ///
 /// The options view opens when the field gains focus or when the field's text
-/// changes, as long as [optionsBuilder] returns at least one option. The options
-/// view closes when the user selects an option, when there are no matching
+/// changes, as long as there is at least one option. The options
+/// view closes when the user selects an option, when there are no
 /// options, or when the field loses focus.
 /// {@endtemplate}
+///
+/// Alternatively, provide a [controller] to manage the options list directly
+/// instead of using [optionsBuilder].
 ///
 /// This is a core framework widget with very basic UI.
 ///
@@ -171,12 +208,16 @@ enum OptionsViewOpenDirection {
 class RawAutocomplete<T extends Object> extends StatefulWidget {
   /// Create an instance of RawAutocomplete.
   ///
-  /// [displayStringForOption], [optionsBuilder] and [optionsViewBuilder] must
-  /// not be null.
+  /// Exactly one of [optionsBuilder] or [controller] must be provided.
+  /// When [optionsBuilder] is provided, the widget internally calls it when the
+  /// text field's [TextEditingValue] changes and manages the result.
+  /// When [controller] is provided, the caller sets
+  /// [AutocompleteController.options] directly and the widget reacts.
   const RawAutocomplete({
     super.key,
     required this.optionsViewBuilder,
-    required this.optionsBuilder,
+    this.optionsBuilder,
+    this.controller,
     this.optionsViewOpenDirection = OptionsViewOpenDirection.down,
     this.displayStringForOption = defaultStringForOption,
     this.fieldViewBuilder,
@@ -193,6 +234,10 @@ class RawAutocomplete<T extends Object> extends StatefulWidget {
        assert(
          !(textEditingController != null && initialValue != null),
          'textEditingController and initialValue cannot be simultaneously defined.',
+       ),
+       assert(
+         (optionsBuilder == null) != (controller == null),
+         'Exactly one of optionsBuilder or controller must be provided.',
        );
 
   /// {@template flutter.widgets.RawAutocomplete.fieldViewBuilder}
@@ -277,7 +322,21 @@ class RawAutocomplete<T extends Object> extends StatefulWidget {
   /// A function that returns the current selectable options objects given the
   /// current TextEditingValue.
   /// {@endtemplate}
-  final AutocompleteOptionsBuilder<T> optionsBuilder;
+  ///
+  /// Mutually exclusive with [controller]. Exactly one must be provided.
+  final AutocompleteOptionsBuilder<T>? optionsBuilder;
+
+  /// {@template flutter.widgets.RawAutocomplete.controller}
+  /// A controller that allows the caller to manage the options list directly.
+  ///
+  /// When provided, the caller sets [AutocompleteController.options]
+  /// directly and the widget reacts to changes. This is useful when the
+  /// options depend on criteria beyond just the [TextEditingValue], which is
+  /// the only input that [optionsBuilder] receives.
+  /// {@endtemplate}
+  ///
+  /// Mutually exclusive with [optionsBuilder]. Exactly one must be provided.
+  final AutocompleteController<T>? controller;
 
   /// The [TextEditingController] that is used for the text field.
   ///
@@ -383,7 +442,14 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
     DismissIntent: CallbackAction<DismissIntent>(onInvoke: _hideOptions),
   };
 
-  Iterable<T> _options = Iterable<T>.empty();
+  AutocompleteController<T>? _internalController;
+  AutocompleteController<T> get _controller {
+    return widget.controller ??
+        (_internalController ??= AutocompleteController<T>()..addListener(_handleOptionsChanged));
+  }
+
+  Iterable<T> get _options => _controller.options;
+  bool _lastOptionsWereEmpty = true;
   T? _selection;
   // Set the initial value to null so when this widget gets focused for the first
   // time it will try to run the options view builder.
@@ -485,28 +551,47 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
       _userHidOptions = false;
     }
     _lastFieldText = value.text;
-    _onChangedCallId += 1;
-    final int callId = _onChangedCallId;
-    final Iterable<T> options = await widget.optionsBuilder(value);
 
-    if (!mounted) {
-      return;
-    }
+    if (widget.optionsBuilder case final optionsBuilder?) {
+      _onChangedCallId += 1;
+      final int callId = _onChangedCallId;
+      final Iterable<T> options = await optionsBuilder(value);
 
-    // Makes sure that previous call results do not replace new ones.
-    if (callId != _onChangedCallId) {
-      return;
+      if (!mounted) {
+        return;
+      }
+
+      // Makes sure that previous call results do not replace new ones.
+      if (callId != _onChangedCallId) {
+        return;
+      }
+      _controller.options = options; // triggers _handleOptionsChanged via listener
+    } else {
+      // External controller: caller manages options separately.
+      // Still update selection validity and visibility for text changes.
+      _updateSelectionValidity();
     }
-    if (_options.isEmpty != options.isEmpty) {
-      _announceSemantics(options.isNotEmpty);
+  }
+
+  // No setState here: the overlay content rebuilds because
+  // _updateOptionsViewVisibility calls show()/hide() on the
+  // OverlayPortalController, which calls setState on _OverlayPortalState.
+  void _handleOptionsChanged() {
+    final bool optionsWereEmpty = _lastOptionsWereEmpty;
+    _lastOptionsWereEmpty = _options.isEmpty;
+    if (optionsWereEmpty != _options.isEmpty) {
+      _announceSemantics(_options.isNotEmpty);
     }
-    _options = options;
     _updateHighlight(_highlightedOptionIndex.value);
+    _updateSelectionValidity();
+  }
+
+  void _updateSelectionValidity() {
     final T? selection = _selection;
-    if (selection != null && value.text != widget.displayStringForOption(selection)) {
+    if (selection != null &&
+        _textEditingController.text != widget.displayStringForOption(selection)) {
       _selection = null;
     }
-
     _updateOptionsViewVisibility();
   }
 
@@ -661,6 +746,10 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
   @override
   void initState() {
     super.initState();
+    if (widget.controller != null) {
+      widget.controller!.addListener(_handleOptionsChanged);
+      _lastOptionsWereEmpty = widget.controller!.options.isEmpty;
+    }
     final TextEditingController initialController =
         widget.textEditingController ??
         (_internalTextEditingController = TextEditingController.fromValue(widget.initialValue));
@@ -672,6 +761,17 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
   @override
   void didUpdateWidget(RawAutocomplete<T> oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (!identical(oldWidget.controller, widget.controller)) {
+      oldWidget.controller?.removeListener(_handleOptionsChanged);
+      if (oldWidget.controller == null) {
+        _internalController?.dispose();
+        _internalController = null;
+      }
+      if (widget.controller != null) {
+        widget.controller!.addListener(_handleOptionsChanged);
+        _lastOptionsWereEmpty = widget.controller!.options.isEmpty;
+      }
+    }
     if (!identical(oldWidget.textEditingController, widget.textEditingController)) {
       oldWidget.textEditingController?.removeListener(_onChangedField);
       if (oldWidget.textEditingController == null) {
@@ -692,6 +792,8 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
 
   @override
   void dispose() {
+    widget.controller?.removeListener(_handleOptionsChanged);
+    _internalController?.dispose();
     widget.textEditingController?.removeListener(_onChangedField);
     _internalTextEditingController?.dispose();
     widget.focusNode?.removeListener(_onFocusChange);

--- a/packages/flutter/test/widgets/autocomplete_test.dart
+++ b/packages/flutter/test/widgets/autocomplete_test.dart
@@ -4087,4 +4087,157 @@ void main() {
     // Now text up to cursor is "go", which matches more options.
     expect(lastOptions, <String>['dingo', 'flamingo', 'goose']);
   });
+
+  group('AutocompleteController', () {
+    testWidgets('shows, updates, and hides options view', (WidgetTester tester) async {
+      final GlobalKey fieldKey = GlobalKey();
+      final GlobalKey optionsKey = GlobalKey();
+      final controller = AutocompleteController<String>();
+      addTearDown(controller.dispose);
+      late FocusNode focusNode;
+      late Iterable<String> lastOptions;
+
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: RawAutocomplete<String>(
+            controller: controller,
+            fieldViewBuilder:
+                (
+                  BuildContext context,
+                  TextEditingController fieldTextEditingController,
+                  FocusNode fieldFocusNode,
+                  VoidCallback onFieldSubmitted,
+                ) {
+                  focusNode = fieldFocusNode;
+                  return TestTextField(
+                    key: fieldKey,
+                    focusNode: focusNode,
+                    controller: fieldTextEditingController,
+                  );
+                },
+            optionsViewBuilder:
+                (
+                  BuildContext context,
+                  AutocompleteOnSelected<String> onSelected,
+                  Iterable<String> options,
+                ) {
+                  lastOptions = options;
+                  return Container(key: optionsKey);
+                },
+          ),
+        ),
+      );
+
+      // Set options and focus — options view shows.
+      controller.options = kOptions;
+      focusNode.requestFocus();
+      await tester.pump();
+      expect(find.byKey(optionsKey), findsOneWidget);
+      expect(lastOptions.length, kOptions.length);
+
+      // Update to a subset.
+      controller.options = <String>['aardvark', 'bobcat'];
+      await tester.pump();
+      expect(lastOptions.length, 2);
+      expect(lastOptions.elementAt(0), 'aardvark');
+      expect(lastOptions.elementAt(1), 'bobcat');
+
+      // Set to empty — options view hides.
+      controller.options = <String>[];
+      await tester.pump();
+      expect(find.byKey(optionsKey), findsNothing);
+    });
+
+    testWidgets('options stay hidden after Escape until text change or re-focus', (
+      WidgetTester tester,
+    ) async {
+      final GlobalKey fieldKey = GlobalKey();
+      final GlobalKey optionsKey = GlobalKey();
+      final controller = AutocompleteController<String>();
+      addTearDown(controller.dispose);
+      late FocusNode focusNode;
+
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: RawAutocomplete<String>(
+            controller: controller,
+            fieldViewBuilder:
+                (
+                  BuildContext context,
+                  TextEditingController fieldTextEditingController,
+                  FocusNode fieldFocusNode,
+                  VoidCallback onFieldSubmitted,
+                ) {
+                  focusNode = fieldFocusNode;
+                  return TestTextField(
+                    key: fieldKey,
+                    focusNode: focusNode,
+                    controller: fieldTextEditingController,
+                  );
+                },
+            optionsViewBuilder:
+                (
+                  BuildContext context,
+                  AutocompleteOnSelected<String> onSelected,
+                  Iterable<String> options,
+                ) {
+                  return Container(key: optionsKey);
+                },
+          ),
+        ),
+      );
+
+      // Show options.
+      controller.options = kOptions;
+      focusNode.requestFocus();
+      await tester.pump();
+      expect(find.byKey(optionsKey), findsOneWidget);
+
+      // Dismiss with Escape.
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pump();
+      expect(find.byKey(optionsKey), findsNothing);
+
+      // New options from controller don't reopen the view.
+      controller.options = <String>['aardvark', 'bobcat'];
+      await tester.pump();
+      expect(find.byKey(optionsKey), findsNothing);
+
+      // Typing new text reopens it.
+      await tester.enterText(find.byKey(fieldKey), 'a');
+      await tester.pump();
+      expect(find.byKey(optionsKey), findsOneWidget);
+    });
+
+    testWidgets('assertion: exactly one of optionsBuilder or controller', (
+      WidgetTester tester,
+    ) async {
+      final controller = AutocompleteController<String>();
+      addTearDown(controller.dispose);
+
+      Widget optionsViewBuilder(
+        BuildContext context,
+        AutocompleteOnSelected<String> onSelected,
+        Iterable<String> options,
+      ) {
+        return Container();
+      }
+
+      // Both provided.
+      expect(
+        () => RawAutocomplete<String>(
+          optionsBuilder: (TextEditingValue value) => <String>[],
+          controller: controller,
+          optionsViewBuilder: optionsViewBuilder,
+        ),
+        throwsAssertionError,
+      );
+
+      // Neither provided.
+      expect(
+        () => RawAutocomplete<String>(optionsViewBuilder: optionsViewBuilder),
+        throwsAssertionError,
+      );
+    });
+  });
 }

--- a/packages/flutter/test/widgets/autocomplete_test.dart
+++ b/packages/flutter/test/widgets/autocomplete_test.dart
@@ -4024,4 +4024,67 @@ void main() {
     // The text field should be updated to 'test'.
     expect(textCtrl.text, 'test');
   });
+
+  testWidgets('options update when selection changes', (WidgetTester tester) async {
+    final GlobalKey fieldKey = GlobalKey();
+    final GlobalKey optionsKey = GlobalKey();
+    late FocusNode focusNode;
+    late TextEditingController textEditingController;
+    Iterable<String>? lastOptions;
+
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: RawAutocomplete<String>(
+          optionsBuilder: (TextEditingValue textEditingValue) {
+            // An optionsBuilder that uses the selection, not just the text.
+            final int offset = textEditingValue.selection.baseOffset;
+            final String textUpToCursor = textEditingValue.text.substring(
+              0,
+              offset.clamp(0, textEditingValue.text.length),
+            );
+            return kOptions.where((String option) {
+              return option.contains(textUpToCursor.toLowerCase());
+            });
+          },
+          fieldViewBuilder:
+              (
+                BuildContext context,
+                TextEditingController fieldTextEditingController,
+                FocusNode fieldFocusNode,
+                VoidCallback onFieldSubmitted,
+              ) {
+                focusNode = fieldFocusNode;
+                textEditingController = fieldTextEditingController;
+                return TestTextField(
+                  key: fieldKey,
+                  focusNode: focusNode,
+                  controller: textEditingController,
+                );
+              },
+          optionsViewBuilder:
+              (
+                BuildContext context,
+                AutocompleteOnSelected<String> onSelected,
+                Iterable<String> options,
+              ) {
+                lastOptions = options;
+                return Container(key: optionsKey);
+              },
+        ),
+      ),
+    );
+
+    focusNode.requestFocus();
+    await tester.enterText(find.byKey(fieldKey), 'goose');
+    await tester.pump();
+    expect(find.byKey(optionsKey), findsOneWidget);
+    // Full text "goose" matches only "goose".
+    expect(lastOptions, <String>['goose']);
+
+    // Move the cursor to just after "go".
+    textEditingController.selection = const TextSelection.collapsed(offset: 2);
+    await tester.pump();
+    // Now text up to cursor is "go", which matches more options.
+    expect(lastOptions, <String>['dingo', 'flamingo', 'goose']);
+  });
 }


### PR DESCRIPTION
Fixes #159443.

This lets `RawAutocomplete`'s callers just specify the autocomplete options directly, on their own schedule, rather than via `optionsBuilder` which is only called on text-field-value changes. This is non-breaking: callers opt in with `RawAutocomplete`'s new `controller` param.

In a separate commit, this also fixes a behavior that seems undesirable: for callers who use `optionsBuilder`, the passed callback was only being called when the text field's `TextEditingValue.text` changed. Now the callback is also called when the selection or composing range changes.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
