### PR TITLE
Add lint rule for debug-only RenderObject getters

### DIFF
--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -19,6 +19,7 @@ import 'package:path/path.dart' as path;
 
 import 'allowlist.dart';
 import 'custom_rules/analyze.dart';
+import 'custom_rules/avoid_debug_only_rendering_getters.dart';
 import 'custom_rules/avoid_future_catcherror.dart';
 import 'custom_rules/no_double_clamp.dart';
 import 'custom_rules/no_stop_watches.dart';
@@ -200,6 +201,7 @@ Future<void> run(List<String> arguments) async {
     // lints are easier to write when they can assume, for example, there is no
     // inheritance cycles.
     final rules = <AnalyzeRule>[
+      avoidDebugOnlyRenderingGetters,
       noDoubleClamp,
       noStopwatches,
       renderBoxIntrinsicCalculation,

--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -735,8 +735,8 @@ class _DeprecationMessagesVisitor extends RecursiveAstVisitor<void> {
     super.visitAnnotation(node);
     final bool shouldCheckAnnotation =
         node.name.name == 'Deprecated' &&
-        !hasInlineIgnore(node, parseResult, ignoreDeprecration) &&
-        !hasInlineIgnore(node, parseResult, legacyDeprecation);
+        !hasInlineIgnore(node, parseResult.content, parseResult.lineInfo, ignoreDeprecration) &&
+        !hasInlineIgnore(node, parseResult.content, parseResult.lineInfo, legacyDeprecation);
     if (!shouldCheckAnnotation) {
       return;
     }
@@ -1049,8 +1049,8 @@ class _TestSkipLinesVisitor<T> extends RecursiveAstVisitor<T> {
     r'// .*https+?://github.com/.*/issues/\d+',
   );
   bool _hasValidJustificationComment(Label skipLabel) {
-    return hasInlineIgnore(skipLabel, parseResult, _skipTestIntentionalPattern) ||
-        hasInlineIgnore(skipLabel, parseResult, _skipTestTrackingBugPattern);
+    return hasInlineIgnore(skipLabel, parseResult.content, parseResult.lineInfo, _skipTestIntentionalPattern) ||
+        hasInlineIgnore(skipLabel, parseResult.content, parseResult.lineInfo, _skipTestTrackingBugPattern);
   }
 
   @override

--- a/dev/bots/custom_rules/avoid_debug_only_rendering_getters.dart
+++ b/dev/bots/custom_rules/avoid_debug_only_rendering_getters.dart
@@ -122,12 +122,15 @@ class _Visitor extends RecursiveAstVisitor<void> {
 
   /// Returns true if [enclosingElement] is `RenderObject` or a subclass of it.
   static bool _isRenderObjectSubclass(InterfaceElement enclosingElement) {
-    if (enclosingElement.name == 'RenderObject') {
+    bool isRenderObjectType(InterfaceElement element) {
+      return element.name == 'RenderObject' &&
+          element.library.source.uri.toString() == 'package:flutter/src/rendering/object.dart';
+    }
+
+    if (isRenderObjectType(enclosingElement)) {
       return true;
     }
-    return enclosingElement.allSupertypes.any(
-      (InterfaceType supertype) => supertype.element.name == 'RenderObject',
-    );
+    return enclosingElement.allSupertypes.any((InterfaceType supertype) => isRenderObjectType(supertype.element));
   }
 
   /// Returns true if [node] is inside an `assert(...)` statement or an

--- a/dev/bots/custom_rules/avoid_debug_only_rendering_getters.dart
+++ b/dev/bots/custom_rules/avoid_debug_only_rendering_getters.dart
@@ -1,0 +1,169 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
+
+import '../utils.dart';
+import 'analyze.dart';
+
+// The comment pattern representing the "flutter_ignore" inline directive that
+// indicates the line should be exempt from the debug-only getter check.
+final Pattern _ignoreDirective = RegExp(
+  r'// flutter_ignore: .*debug_only_rendering_getter .*\(see analyze\.dart\)',
+);
+
+/// Verify that debug-only getters on RenderObject are not used outside of
+/// asserts or debug-only contexts.
+///
+/// The following getters on RenderObject return meaningless values in release
+/// builds and should only be used in asserts or debug-only code:
+///
+///  * `debugNeedsLayout`
+///  * `debugNeedsPaint`
+///  * `debugNeedsCompositedLayerUpdate`
+///  * `debugNeedsSemanticsUpdate`
+final AnalyzeRule avoidDebugOnlyRenderingGetters = _AvoidDebugOnlyRenderingGetters();
+
+const Set<String> _debugOnlyGetters = <String>{
+  'debugNeedsLayout',
+  'debugNeedsPaint',
+  'debugNeedsCompositedLayerUpdate',
+  'debugNeedsSemanticsUpdate',
+};
+
+class _AvoidDebugOnlyRenderingGetters implements AnalyzeRule {
+  final Map<ResolvedUnitResult, List<AstNode>> _errors = <ResolvedUnitResult, List<AstNode>>{};
+
+  @override
+  void applyTo(ResolvedUnitResult unit) {
+    final visitor = _Visitor(unit);
+    unit.unit.visitChildren(visitor);
+    final List<AstNode> violationsInUnit = visitor.offendingNodes;
+    if (violationsInUnit.isNotEmpty) {
+      _errors.putIfAbsent(unit, () => <AstNode>[]).addAll(violationsInUnit);
+    }
+  }
+
+  @override
+  void reportViolations(String workingDirectory) {
+    if (_errors.isEmpty) {
+      return;
+    }
+
+    foundError(<String>[
+      for (final MapEntry<ResolvedUnitResult, List<AstNode>> entry in _errors.entries)
+        for (final AstNode node in entry.value)
+          '${locationInFile(entry.key, node, workingDirectory)}: ${node.parent}',
+      '\n${bold}Debug-only getters on RenderObject (debugNeedsLayout, debugNeedsPaint, debugNeedsCompositedLayerUpdate, debugNeedsSemanticsUpdate) are only meaningful in debug mode. Only use them in asserts.$reset',
+    ]);
+  }
+
+  @override
+  String toString() => 'Avoid debug-only RenderObject getters outside of asserts';
+}
+
+class _Visitor extends RecursiveAstVisitor<void> {
+  _Visitor(this.compilationUnit);
+
+  final ResolvedUnitResult compilationUnit;
+  final List<AstNode> offendingNodes = <AstNode>[];
+
+  // We don't care about directives or comments.
+  @override
+  void visitImportDirective(ImportDirective node) {}
+
+  @override
+  void visitExportDirective(ExportDirective node) {}
+
+  @override
+  void visitComment(Comment node) {}
+
+  @override
+  void visitSimpleIdentifier(SimpleIdentifier node) {
+    if (!_debugOnlyGetters.contains(node.name)) {
+      return;
+    }
+
+    // Check that the getter belongs to a RenderObject subclass.
+    final Element? element = node.element;
+    if (element is! PropertyAccessorElement) {
+      return;
+    }
+    final Element enclosingElement = element.enclosingElement;
+    if (enclosingElement is! InterfaceElement) {
+      return;
+    }
+    if (!_isRenderObjectSubclass(enclosingElement)) {
+      return;
+    }
+
+    // Allow usage inside assert statements.
+    if (_isInAssert(node)) {
+      return;
+    }
+
+    // Allow usage inside the debug getter definitions themselves.
+    if (_isInDebugGetterDefinition(node)) {
+      return;
+    }
+
+    // Allow usage with a trailing flutter_ignore comment.
+    if (_hasTrailingFlutterIgnore(node)) {
+      return;
+    }
+
+    offendingNodes.add(node);
+  }
+
+  /// Returns true if [enclosingElement] is `RenderObject` or a subclass of it.
+  static bool _isRenderObjectSubclass(InterfaceElement enclosingElement) {
+    if (enclosingElement.name == 'RenderObject') {
+      return true;
+    }
+    return enclosingElement.allSupertypes.any(
+      (InterfaceType supertype) => supertype.element.name == 'RenderObject',
+    );
+  }
+
+  /// Returns true if [node] is inside an `assert(...)` statement or an
+  /// `assert(() { ... }())` closure.
+  static bool _isInAssert(AstNode node) {
+    AstNode? current = node.parent;
+    while (current != null) {
+      if (current is Assertion) {
+        return true;
+      }
+      current = current.parent;
+    }
+    return false;
+  }
+
+  /// Returns true if [node] is inside the definition of one of the debug-only
+  /// getters (i.e., the getter body itself in RenderObject).
+  static bool _isInDebugGetterDefinition(AstNode node) {
+    AstNode? current = node.parent;
+    while (current != null) {
+      if (current is MethodDeclaration &&
+          current.isGetter &&
+          _debugOnlyGetters.contains(current.name.lexeme)) {
+        return true;
+      }
+      current = current.parent;
+    }
+    return false;
+  }
+
+  bool _hasTrailingFlutterIgnore(AstNode node) {
+    return compilationUnit.content
+        .substring(
+          node.offset + node.length,
+          compilationUnit.lineInfo.getOffsetOfLineAfter(node.offset + node.length),
+        )
+        .contains(_ignoreDirective);
+  }
+}

--- a/dev/bots/custom_rules/avoid_debug_only_rendering_getters.dart
+++ b/dev/bots/custom_rules/avoid_debug_only_rendering_getters.dart
@@ -14,7 +14,7 @@ import 'analyze.dart';
 // The comment pattern representing the "flutter_ignore" inline directive that
 // indicates the line should be exempt from the debug-only getter check.
 final Pattern _ignoreDirective = RegExp(
-  r'// flutter_ignore: .*debug_only_rendering_getter .*\(see analyze\.dart\)',
+  r'// flutter_ignore: .*debug_only_rendering_getter.*\(see analyze\.dart\)',
 );
 
 /// Verify that debug-only getters on RenderObject are not used outside of
@@ -112,8 +112,8 @@ class _Visitor extends RecursiveAstVisitor<void> {
       return;
     }
 
-    // Allow usage with a trailing flutter_ignore comment.
-    if (_hasTrailingFlutterIgnore(node)) {
+    // Allow usage with a flutter_ignore comment.
+    if (hasInlineIgnore(node, compilationUnit.content, compilationUnit.lineInfo, _ignoreDirective)) {
       return;
     }
 
@@ -124,7 +124,7 @@ class _Visitor extends RecursiveAstVisitor<void> {
   static bool _isRenderObjectSubclass(InterfaceElement enclosingElement) {
     bool isRenderObjectType(InterfaceElement element) {
       return element.name == 'RenderObject' &&
-          element.library.source.uri.toString() == 'package:flutter/src/rendering/object.dart';
+          element.library.uri.toString() == 'package:flutter/src/rendering/object.dart';
     }
 
     if (isRenderObjectType(enclosingElement)) {
@@ -159,14 +159,5 @@ class _Visitor extends RecursiveAstVisitor<void> {
       current = current.parent;
     }
     return false;
-  }
-
-  bool _hasTrailingFlutterIgnore(AstNode node) {
-    return compilationUnit.content
-        .substring(
-          node.offset + node.length,
-          compilationUnit.lineInfo.getOffsetOfLineAfter(node.offset + node.length),
-        )
-        .contains(_ignoreDirective);
   }
 }

--- a/dev/bots/custom_rules/avoid_debug_only_rendering_getters.dart
+++ b/dev/bots/custom_rules/avoid_debug_only_rendering_getters.dart
@@ -122,15 +122,12 @@ class _Visitor extends RecursiveAstVisitor<void> {
 
   /// Returns true if [enclosingElement] is `RenderObject` or a subclass of it.
   static bool _isRenderObjectSubclass(InterfaceElement enclosingElement) {
-    bool isRenderObjectType(InterfaceElement element) {
-      return element.name == 'RenderObject' &&
-          element.library.uri.toString() == 'package:flutter/src/rendering/object.dart';
-    }
-
-    if (isRenderObjectType(enclosingElement)) {
+    if (enclosingElement.name == 'RenderObject') {
       return true;
     }
-    return enclosingElement.allSupertypes.any((InterfaceType supertype) => isRenderObjectType(supertype.element));
+    return enclosingElement.allSupertypes.any(
+      (InterfaceType supertype) => supertype.element.name == 'RenderObject',
+    );
   }
 
   /// Returns true if [node] is inside an `assert(...)` statement or an

--- a/dev/bots/test/analyze-test-input/root/packages/flutter/lib/debug_only_rendering_getters.dart
+++ b/dev/bots/test/analyze-test-input/root/packages/flutter/lib/debug_only_rendering_getters.dart
@@ -1,0 +1,42 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// ignore_for_file: unnecessary_statements
+
+import '../../foo/fake_render_object.dart';
+
+class MyRenderObject extends RenderObject {
+  void testDebugGettersInAssert() {
+    // OK: inside assert.
+    assert(!debugNeedsLayout);
+    assert(!debugNeedsPaint);
+    assert(!debugNeedsCompositedLayerUpdate);
+    assert(!debugNeedsSemanticsUpdate);
+  }
+
+  void testDebugGettersInAssertClosure() {
+    // OK: inside assert closure.
+    assert(() {
+      return !debugNeedsPaint;
+    }());
+  }
+
+  void testDebugGettersWithIgnore() {
+    // OK: flutter_ignore directive.
+    debugNeedsLayout; // flutter_ignore: debug_only_rendering_getter (see analyze.dart)
+  }
+}
+
+void testExternalAccess(MyRenderObject obj) {
+  // Bad: outside assert.
+  obj.debugNeedsLayout; // ERROR: obj.debugNeedsLayout
+  obj.debugNeedsPaint; // ERROR: obj.debugNeedsPaint
+  obj.debugNeedsCompositedLayerUpdate; // ERROR: obj.debugNeedsCompositedLayerUpdate
+  obj.debugNeedsSemanticsUpdate; // ERROR: obj.debugNeedsSemanticsUpdate
+}
+
+void testExternalAccessInAssert(MyRenderObject obj) {
+  // OK: inside assert.
+  assert(!obj.debugNeedsLayout);
+}

--- a/dev/bots/test/analyze-test-input/root/packages/foo/fake_render_object.dart
+++ b/dev/bots/test/analyze-test-input/root/packages/foo/fake_render_object.dart
@@ -1,0 +1,10 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+abstract class RenderObject {
+  bool get debugNeedsLayout => false;
+  bool get debugNeedsPaint => false;
+  bool get debugNeedsCompositedLayerUpdate => false;
+  bool get debugNeedsSemanticsUpdate => false;
+}

--- a/dev/bots/test/analyze_test.dart
+++ b/dev/bots/test/analyze_test.dart
@@ -8,6 +8,7 @@ import 'package:path/path.dart' as path;
 
 import '../analyze.dart';
 import '../custom_rules/analyze.dart';
+import '../custom_rules/avoid_debug_only_rendering_getters.dart';
 import '../custom_rules/no_double_clamp.dart';
 import '../custom_rules/no_stop_watches.dart';
 import '../custom_rules/render_box_intrinsics.dart';
@@ -374,6 +375,31 @@ void main() {
         endsWith: <String>[
           '',
           'Typically the get* methods should be used to obtain the intrinsics of a RenderBox.',
+        ],
+      ),
+    );
+  });
+
+  test('analyze.dart - debug-only RenderObject getters', () async {
+    final String result = await capture(
+      () => analyzeWithRules(
+        testRootPath,
+        <AnalyzeRule>[avoidDebugOnlyRenderingGetters],
+        includePaths: <String>['packages/flutter/lib'],
+      ),
+      shouldHaveErrors: true,
+    );
+
+    final fixture = File(
+      path.join(testRootPath, 'packages', 'flutter', 'lib', 'debug_only_rendering_getters.dart'),
+    );
+    expect(
+      result,
+      matchesErrorsInFile(
+        fixture,
+        endsWith: <String>[
+          '',
+          'Debug-only getters on RenderObject (debugNeedsLayout, debugNeedsPaint, debugNeedsCompositedLayerUpdate, debugNeedsSemanticsUpdate) are only meaningful in debug mode. Only use them in asserts.',
         ],
       ),
     );

--- a/dev/bots/utils.dart
+++ b/dev/bots/utils.dart
@@ -365,12 +365,12 @@ String locationInFile(ResolvedUnitResult unit, AstNode node, String workingDirec
 /// or after the line that needs to be exemped.
 bool hasInlineIgnore(
   AstNode node,
-  ParseStringResult compilationUnit,
+  String content,
+  LineInfo lineInfo,
   Pattern ignoreDirectivePattern,
 ) {
-  final LineInfo lineInfo = compilationUnit.lineInfo;
   // In case the node has multiple lines, match from its start offset.
-  final String textAfterNode = compilationUnit.content.substring(
+  final String textAfterNode = content.substring(
     node.offset,
     // This assumes every line ends with a newline character (including the last
     // line) and the new line character is not included to match the given pattern.
@@ -384,7 +384,7 @@ bool hasInlineIgnore(
   if (lineNumber <= 0) {
     return false;
   }
-  return compilationUnit.content
+  return content
       .substring(lineInfo.getOffsetOfLine(lineNumber - 1), lineInfo.getOffsetOfLine(lineNumber))
       .trimLeft()
       .contains(ignoreDirectivePattern);

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -2233,7 +2233,7 @@ mixin WidgetInspectorService {
       return null;
     }
 
-    if (renderObject.debugNeedsLayout) {
+    if (renderObject.debugNeedsLayout) { // flutter_ignore: debug_only_rendering_getter (see analyze.dart)
       final PipelineOwner owner = renderObject.owner!;
       assert(!owner.debugDoingLayout);
       owner
@@ -2245,7 +2245,7 @@ mixin WidgetInspectorService {
       // in the layout phase and therefore can't be painted. It is clearer to
       // return null indicating that a screenshot is unavailable than to return
       // an empty image.
-      if (renderObject.debugNeedsLayout) {
+      if (renderObject.debugNeedsLayout) { // flutter_ignore: debug_only_rendering_getter (see analyze.dart)
         return null;
       }
     }
@@ -2321,7 +2321,7 @@ mixin WidgetInspectorService {
           }
 
           try {
-            if (!renderObject.debugNeedsLayout) {
+            if (!renderObject.debugNeedsLayout) { // flutter_ignore: debug_only_rendering_getter (see analyze.dart)
               // ignore: invalid_use_of_protected_member
               final Constraints constraints = renderObject.constraints;
               final constraintsProperty = <String, Object>{


### PR DESCRIPTION
Adds a custom analyze rule that warns when debug-only RenderObject getters (`debugNeedsLayout`, `debugNeedsPaint`, `debugNeedsCompositedLayerUpdate`, `debugNeedsSemanticsUpdate`) are used outside of `assert` statements.

These getters are only meaningful in debug mode — in release builds they silently return `false`. Using them in non-assert code can lead to subtle bugs where the app behaves differently in debug vs release mode.

Legitimate non-assert usages (e.g. in `WidgetInspectorService`, which only runs in debug/profile mode) can be suppressed with a `// flutter_ignore: debug_only_rendering_getter (see analyze.dart)` comment.

Follow-up to #183697, fixes #183696.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md