### PR TITLE
Add a platform OpenGL context.

### DIFF
--- a/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.cc
@@ -110,7 +110,7 @@ static gchar* get_program_log(GLuint program) {
 }
 
 static void setup_shader(FlCompositorOpenGL* self) {
-  if (!fl_opengl_manager_make_current(self->opengl_manager)) {
+  if (!fl_opengl_manager_make_platform_current(self->opengl_manager)) {
     g_warning(
         "Failed to setup compositor shaders, unable to make OpenGL context "
         "current");
@@ -169,7 +169,7 @@ static void setup_shader(FlCompositorOpenGL* self) {
 }
 
 static void cleanup_shader(FlCompositorOpenGL* self) {
-  if (!fl_opengl_manager_make_current(self->opengl_manager)) {
+  if (!fl_opengl_manager_make_platform_current(self->opengl_manager)) {
     g_warning(
         "Failed to cleanup compositor shaders, unable to make OpenGL context "
         "current");

--- a/engine/src/flutter/shell/platform/linux/fl_opengl_manager.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_opengl_manager.cc
@@ -69,12 +69,24 @@ static void fl_opengl_manager_init(FlOpenGLManager* self) {
   eglChooseConfig(self->display, config_attributes, &config, 1, &num_config);
 
   const EGLint context_attributes[] = {EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE};
+
   self->render_context = eglCreateContext(self->display, config, EGL_NO_CONTEXT,
                                           context_attributes);
+  if (self->render_context == EGL_NO_CONTEXT) {
+    g_warning("Failed to create EGL context for rendering");
+  }
+
   self->resource_context = eglCreateContext(
       self->display, config, self->render_context, context_attributes);
+  if (self->resource_context == EGL_NO_CONTEXT) {
+    g_warning("Failed to create EGL context for resource sharing");
+  }
+
   self->platform_context = eglCreateContext(
       self->display, config, self->render_context, context_attributes);
+  if (self->platform_context == EGL_NO_CONTEXT) {
+    g_warning("Failed to create EGL context for platform thread");
+  }
 }
 
 FlOpenGLManager* fl_opengl_manager_new() {

--- a/engine/src/flutter/shell/platform/linux/fl_opengl_manager.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_opengl_manager.cc
@@ -16,11 +16,14 @@ struct _FlOpenGLManager {
   // Display being rendered to.
   EGLDisplay display;
 
-  // Context used by Flutter to render.
+  // Context used by the Flutter engine for rendering.
   EGLContext render_context;
 
-  // Context used by Flutter to share resources.
+  // Context used by the Flutter engine to share resources.
   EGLContext resource_context;
+
+  // Context used by platform thread.
+  EGLContext platform_context;
 };
 
 G_DEFINE_TYPE(FlOpenGLManager, fl_opengl_manager, G_TYPE_OBJECT)
@@ -30,6 +33,7 @@ static void fl_opengl_manager_dispose(GObject* object) {
 
   eglDestroyContext(self->display, self->render_context);
   eglDestroyContext(self->display, self->resource_context);
+  eglDestroyContext(self->display, self->platform_context);
   eglTerminate(self->display);
 
   G_OBJECT_CLASS(fl_opengl_manager_parent_class)->dispose(object);
@@ -69,6 +73,8 @@ static void fl_opengl_manager_init(FlOpenGLManager* self) {
                                           context_attributes);
   self->resource_context = eglCreateContext(
       self->display, config, self->render_context, context_attributes);
+  self->platform_context = eglCreateContext(
+      self->display, config, self->render_context, context_attributes);
 }
 
 FlOpenGLManager* fl_opengl_manager_new() {
@@ -85,6 +91,11 @@ gboolean fl_opengl_manager_make_current(FlOpenGLManager* self) {
 gboolean fl_opengl_manager_make_resource_current(FlOpenGLManager* self) {
   return eglMakeCurrent(self->display, EGL_NO_SURFACE, EGL_NO_SURFACE,
                         self->resource_context) == EGL_TRUE;
+}
+
+gboolean fl_opengl_manager_make_platform_current(FlOpenGLManager* self) {
+  return eglMakeCurrent(self->display, EGL_NO_SURFACE, EGL_NO_SURFACE,
+                        self->platform_context) == EGL_TRUE;
 }
 
 gboolean fl_opengl_manager_clear_current(FlOpenGLManager* self) {

--- a/engine/src/flutter/shell/platform/linux/fl_opengl_manager.h
+++ b/engine/src/flutter/shell/platform/linux/fl_opengl_manager.h
@@ -45,6 +45,16 @@ gboolean fl_opengl_manager_make_current(FlOpenGLManager* manager);
 gboolean fl_opengl_manager_make_resource_current(FlOpenGLManager* manager);
 
 /**
+ * fl_opengl_manager_make_platform_current:
+ * @manager: an #FlOpenGLManager.
+ *
+ * Makes the platform rendering context current.
+ *
+ * Returns: %TRUE if the context made current.
+ */
+gboolean fl_opengl_manager_make_platform_current(FlOpenGLManager* manager);
+
+/**
  * fl_opengl_manager_clear_current:
  * @manager: an #FlOpenGLManager.
  *


### PR DESCRIPTION
Switch the compositor from using the engine OpenGL context to a new context for the platform thread. When creating windows with the new multi-window API (calls come from Dart code) the FlView would try and make shaders but fail since the engine context was already current.

This would show when running the multiple_windows example as: ** (com.example.multiple_windows:1244082): WARNING **: 14:09:30.400: Failed to setup compositor shaders, unable to make OpenGL context current
