### PR TITLE
[web] Fix occasional failure to find Chrome tab

### DIFF
--- a/dev/devicelab/lib/framework/browser.dart
+++ b/dev/devicelab/lib/framework/browser.dart
@@ -287,11 +287,16 @@ String _findSystemChromeExecutable() {
 Future<WipConnection> _connectToChromeDebugPort(int port, String? tabUrl) async {
   final Uri devtoolsUri = await _getRemoteDebuggerUrl(Uri.parse('http://localhost:$port'));
   print('Connecting to DevTools: $devtoolsUri');
+
+  final String url = tabUrl ?? 'http://localhost';
   final chromeConnection = ChromeConnection('localhost', port);
-  final Iterable<ChromeTab> tabs = (await chromeConnection.getTabs()).where((ChromeTab tab) {
-    return tab.url.startsWith(tabUrl ?? 'http://localhost');
-  });
-  final ChromeTab tab = tabs.single;
+  final ChromeTab? tab = await chromeConnection.getTab(
+    (ChromeTab tab) => tab.url.startsWith(url),
+    retryFor: const Duration(seconds: 5),
+  );
+  if (tab == null) {
+    throw Exception('Chrome failed to open a tab for $url');
+  }
   final WipConnection debugConnection = await tab.connect();
   print('Connected to Chrome tab: ${tab.title} (${tab.url})');
   return debugConnection;

--- a/engine/src/flutter/lib/web_ui/dev/chrome.dart
+++ b/engine/src/flutter/lib/web_ui/dev/chrome.dart
@@ -389,8 +389,12 @@ Future<void> setupChromiumTab(Uri url, Completer<String> exceptionCompleter) asy
   final chromeConnection = wip.ChromeConnection('localhost', kDevtoolsPort);
   final wip.ChromeTab? chromeTab = await chromeConnection.getTab(
     (wip.ChromeTab chromeTab) => chromeTab.url == url.toString(),
+    retryFor: const Duration(seconds: 5),
   );
-  final wip.WipConnection wipConnection = await chromeTab!.connect();
+  if (chromeTab == null) {
+    throw Exception('Chrome failed to open a tab for $url');
+  }
+  final wip.WipConnection wipConnection = await chromeTab.connect();
 
   await wipConnection.runtime.enable();
 


### PR DESCRIPTION
I got the following error several times locally:
```
Failed to load "<name>_test.dart": Failed to run browser process: Null check operator used on a null value.
  ../../dev/chrome.dart 400:58          setupChromiumTab
  ===== asynchronous gap ===========================
  ../../dev/chrome.dart 129:9           new Chrome.<fn>
  ===== asynchronous gap ===========================
  ../../dev/browser_process.dart 25:33  new BrowserProcess.<fn>
```

For some reason, newer versions of Chrome allow the WIP connection to be established before tabs have had a chance to launch. This results in the code failing to find any tabs to connect to. The fix in this PR is to retry for a few seconds until tabs are available.

We had a similar [report](https://github.com/flutter/flutter/issues/183335) of this issue happening in the `web_benchmark` package. A similar fix will be implemented there.