### PR TITLE
Update merge semantics logic to merge sibling nodes

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -6295,10 +6295,10 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
     // At this point, the cachedSemanticsNode should be latest semantics node
     // representing this render object and _producedSiblingNodesAndOwners contains the latest
     // sibling nodes.
+    semanticsNodes.add(node);
     if (!_needsMergingSiblingNodesIntoSelf) {
       semanticsNodes.addAll(_producedSiblingNodesAndOwners.keys);
     }
-    semanticsNodes.add(node);
     built = true;
   }
 

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -3942,7 +3942,6 @@ abstract class RenderObject with DiagnosticableTreeMixin implements HitTestTarge
     SemanticsConfiguration config,
     Iterable<SemanticsNode> children,
   ) {
-    assert(node == _semantics.cachedSemanticsNode);
     // TODO(a14n): remove the following cast by updating type of parameter in either updateWith or assembleSemanticsNode
     node.updateWith(config: config, childrenInInversePaintOrder: children as List<SemanticsNode>);
   }
@@ -6248,42 +6247,36 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
       });
     }
     if (configProvider.effective.isSemanticBoundary) {
-      renderObject.assembleSemanticsNode(node, configProvider.effective, children);
-    } else {
-      if (configProvider.effective.isMergingSemanticsOfDescendants && semanticsNodes.length > 1) {
-
-
-        final SemanticsConfiguration housingConfig = SemanticsConfiguration()
-          ..absorb(configProvider.effective)
-          ..isMergingSemanticsOfDescendants = false;
-
-        final SemanticsNode mergeHousingNode = SemanticsNode(showOnScreen: renderObject.showOnScreen)
-          ..updateWith(
-            config: housingConfig,
-            childrenInInversePaintOrder: children,
-          )
-          ..isMergedIntoParent = true;
+      if (configProvider.effective.isMergingSemanticsOfDescendants && semanticsNodes.isNotEmpty) {
+        // This node needs to merge the sibling nodes in the sub tree.
+        //
+        // Create an inner node to hold the configuration and children, and the cachedSemanticsNode will
+        // hold the inner node and the sibling nodes so that all of them can be merged together.
+        final innerNode = SemanticsNode(showOnScreen: renderObject.showOnScreen);
+        renderObject.assembleSemanticsNode(innerNode, configProvider.effective, children);
 
         final config = SemanticsConfiguration()
+          ..isSemanticBoundary = true
           ..isMergingSemanticsOfDescendants = true;
-        if (configProvider.effective.isSemanticBoundary) {
-          config.isSemanticBoundary = true;
-        }
 
         node.updateWith(
           config: config,
-          childrenInInversePaintOrder: <SemanticsNode>[mergeHousingNode],
+          childrenInInversePaintOrder: <SemanticsNode>[innerNode, ...semanticsNodes],
         );
+        // Clear the sibling nodes since they are now attached under the node.
+        semanticsNodes.clear();
       } else {
-        node.updateWith(config: configProvider.effective, childrenInInversePaintOrder: children);
+        renderObject.assembleSemanticsNode(node, configProvider.effective, children);
       }
+    } else {
+      assert(!configProvider.effective.isMergingSemanticsOfDescendants);
+      node.updateWith(config: configProvider.effective, childrenInInversePaintOrder: children);
     }
   }
 
   void _produceSemanticsNode({required Set<int> usedSemanticsIds}) {
     assert(!built);
     final SemanticsNode node = cachedSemanticsNode ??= _createSemanticsNode();
-    semanticsNodes.add(node);
     node
       ..isMergedIntoParent = (parentData?.mergeIntoParent ?? false)
       ..tags = parentData?.tagsForChildren;
@@ -6291,6 +6284,7 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
 
     _mergeSiblingGroup(usedSemanticsIds);
     _buildSemanticsSubtree(usedSemanticsIds: usedSemanticsIds);
+    semanticsNodes.add(node);
     built = true;
   }
 

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -6291,6 +6291,10 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
 
     _mergeSiblingGroup(usedSemanticsIds);
     _buildSemanticsSubtree(usedSemanticsIds: usedSemanticsIds);
+
+    // At this point, the cachedSemanticsNode should be latest semantics node
+    // represeting this render object and _producedSiblingNodesAndOwners contains the latest
+    // sibling nodes.
     if (!_needsMergingSiblingNodesIntoSelf) {
       semanticsNodes.addAll(_producedSiblingNodesAndOwners.keys);
     }

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -5675,6 +5675,11 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
 
   bool get isRoot => parent == null;
 
+  bool get _needsMergingSiblingNodesIntoSelf {
+    return configProvider.effective.isMergingSemanticsOfDescendants &&
+        _producedSiblingNodesAndOwners.isNotEmpty;
+  }
+
   bool get shouldFormSemanticsNode {
     if (configProvider.effective.isSemanticBoundary) {
       return true;
@@ -6194,8 +6199,6 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
       }
     }
     if (!built) {
-      semanticsNodes.clear();
-      _producedSiblingNodesAndOwners.clear();
       _produceSemanticsNode(usedSemanticsIds: usedSemanticsIds);
     }
     assert(built);
@@ -6247,7 +6250,7 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
       });
     }
     if (configProvider.effective.isSemanticBoundary) {
-      if (configProvider.effective.isMergingSemanticsOfDescendants && semanticsNodes.isNotEmpty) {
+      if (_needsMergingSiblingNodesIntoSelf) {
         // This node needs to merge the sibling nodes in the sub tree.
         //
         // Create an inner node to hold the configuration and children, and the cachedSemanticsNode will
@@ -6261,10 +6264,11 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
 
         node.updateWith(
           config: config,
-          childrenInInversePaintOrder: <SemanticsNode>[innerNode, ...semanticsNodes],
+          childrenInInversePaintOrder: <SemanticsNode>[
+            innerNode,
+            ..._producedSiblingNodesAndOwners.keys,
+          ],
         );
-        // Clear the sibling nodes since they are now attached under the node.
-        semanticsNodes.clear();
       } else {
         renderObject.assembleSemanticsNode(node, configProvider.effective, children);
       }
@@ -6276,6 +6280,9 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
 
   void _produceSemanticsNode({required Set<int> usedSemanticsIds}) {
     assert(!built);
+    semanticsNodes.clear();
+    _producedSiblingNodesAndOwners.clear();
+
     final SemanticsNode node = cachedSemanticsNode ??= _createSemanticsNode();
     node
       ..isMergedIntoParent = (parentData?.mergeIntoParent ?? false)
@@ -6284,6 +6291,9 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
 
     _mergeSiblingGroup(usedSemanticsIds);
     _buildSemanticsSubtree(usedSemanticsIds: usedSemanticsIds);
+    if (!_needsMergingSiblingNodesIntoSelf) {
+      semanticsNodes.addAll(_producedSiblingNodesAndOwners.keys);
+    }
     semanticsNodes.add(node);
     built = true;
   }
@@ -6338,7 +6348,6 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
         }
         node.updateWith(config: configuration, childrenInInversePaintOrder: childrenNodes);
         _producedSiblingNodesAndOwners[node] = group;
-        semanticsNodes.add(node);
 
         final Set<SemanticsTag> tags = group
             .map<Set<SemanticsTag>?>(

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -6250,7 +6250,33 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
     if (configProvider.effective.isSemanticBoundary) {
       renderObject.assembleSemanticsNode(node, configProvider.effective, children);
     } else {
-      node.updateWith(config: configProvider.effective, childrenInInversePaintOrder: children);
+      if (configProvider.effective.isMergingSemanticsOfDescendants && semanticsNodes.length > 1) {
+
+
+        final SemanticsConfiguration housingConfig = SemanticsConfiguration()
+          ..absorb(configProvider.effective)
+          ..isMergingSemanticsOfDescendants = false;
+
+        final SemanticsNode mergeHousingNode = SemanticsNode(showOnScreen: renderObject.showOnScreen)
+          ..updateWith(
+            config: housingConfig,
+            childrenInInversePaintOrder: children,
+          )
+          ..isMergedIntoParent = true;
+
+        final config = SemanticsConfiguration()
+          ..isMergingSemanticsOfDescendants = true;
+        if (configProvider.effective.isSemanticBoundary) {
+          config.isSemanticBoundary = true;
+        }
+
+        node.updateWith(
+          config: config,
+          childrenInInversePaintOrder: <SemanticsNode>[mergeHousingNode],
+        );
+      } else {
+        node.updateWith(config: configProvider.effective, childrenInInversePaintOrder: children);
+      }
     }
   }
 

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -6293,7 +6293,7 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
     _buildSemanticsSubtree(usedSemanticsIds: usedSemanticsIds);
 
     // At this point, the cachedSemanticsNode should be latest semantics node
-    // represeting this render object and _producedSiblingNodesAndOwners contains the latest
+    // representing this render object and _producedSiblingNodesAndOwners contains the latest
     // sibling nodes.
     if (!_needsMergingSiblingNodesIntoSelf) {
       semanticsNodes.addAll(_producedSiblingNodesAndOwners.keys);

--- a/packages/flutter/test/widgets/semantics_child_configs_delegate_test.dart
+++ b/packages/flutter/test/widgets/semantics_child_configs_delegate_test.dart
@@ -67,8 +67,8 @@ void main() {
       hasSemantics(
         TestSemantics.root(
           children: <TestSemantics>[
-            TestSemantics.rootChild(label: 'parent\n2'),
             TestSemantics.rootChild(label: '1\n3'),
+            TestSemantics.rootChild(label: 'parent\n2'),
           ],
         ),
         ignoreId: true,

--- a/packages/flutter/test/widgets/semantics_child_configs_delegate_test.dart
+++ b/packages/flutter/test/widgets/semantics_child_configs_delegate_test.dart
@@ -67,8 +67,8 @@ void main() {
       hasSemantics(
         TestSemantics.root(
           children: <TestSemantics>[
-            TestSemantics.rootChild(label: '1\n3'),
             TestSemantics.rootChild(label: 'parent\n2'),
+            TestSemantics.rootChild(label: '1\n3'),
           ],
         ),
         ignoreId: true,

--- a/packages/flutter/test/widgets/semantics_merge_test.dart
+++ b/packages/flutter/test/widgets/semantics_merge_test.dart
@@ -196,18 +196,36 @@ void main() {
     semantics.dispose();
   });
 
-  testWidgets('MergeSemantics with TextField prefix and suffix', (WidgetTester tester) async {
-    final controller = TextEditingController(text: '123');
-    addTearDown(controller.dispose);
+  testWidgets('MergeSemantics with child delegate', (WidgetTester tester) async {
+    final semantics = SemanticsTester(tester);
+    ChildSemanticsConfigurationsResult delegate(List<SemanticsConfiguration> configs) {
+      final builder = ChildSemanticsConfigurationsResultBuilder();
+      final sibling = <SemanticsConfiguration>[];
+      for (final config in configs) {
+        if (config.value == '123') {
+          builder.markAsMergeUp(config);
+        } else {
+          sibling.add(config);
+        }
+      }
+      builder.markAsSiblingMergeGroup(sibling);
+      return builder.build();
+    }
+
     await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: MergeSemantics(
-            child: Semantics(
-              label: 'Room Height',
-              child: TextField(
-                controller: controller,
-                decoration: const InputDecoration(prefixText: 'height', suffixText: 'feet'),
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: MergeSemantics(
+          child: Semantics(
+            label: 'Room Height',
+            child: TestConfigDelegate(
+              delegate: delegate,
+              child: Column(
+                children: <Widget>[
+                  Semantics(label: 'height', child: const SizedBox(width: 100, height: 100)),
+                  Semantics(value: '123', child: const SizedBox(width: 100, height: 100)),
+                  Semantics(label: 'feet', child: const SizedBox(width: 100, height: 100)),
+                ],
               ),
             ),
           ),
@@ -219,5 +237,39 @@ void main() {
     final SemanticsData data = node.getSemanticsData();
     expect(data.label, 'Room Height\nheight\nfeet');
     expect(data.value, '123');
+
+    semantics.dispose();
   });
+}
+
+class TestConfigDelegate extends SingleChildRenderObjectWidget {
+  const TestConfigDelegate({super.key, required this.delegate, super.child});
+  final ChildSemanticsConfigurationsDelegate delegate;
+
+  @override
+  RenderTestConfigDelegate createRenderObject(BuildContext context) =>
+      RenderTestConfigDelegate(delegate: delegate);
+
+  @override
+  void updateRenderObject(BuildContext context, RenderTestConfigDelegate renderObject) {
+    renderObject.delegate = delegate;
+  }
+}
+
+class RenderTestConfigDelegate extends RenderProxyBox {
+  RenderTestConfigDelegate({ChildSemanticsConfigurationsDelegate? delegate}) : _delegate = delegate;
+
+  ChildSemanticsConfigurationsDelegate? get delegate => _delegate;
+  ChildSemanticsConfigurationsDelegate? _delegate;
+  set delegate(ChildSemanticsConfigurationsDelegate? value) {
+    if (value != _delegate) {
+      markNeedsSemanticsUpdate();
+    }
+    _delegate = value;
+  }
+
+  @override
+  void describeSemanticsConfiguration(SemanticsConfiguration config) {
+    config.childConfigurationsDelegate = delegate;
+  }
 }

--- a/packages/flutter/test/widgets/semantics_merge_test.dart
+++ b/packages/flutter/test/widgets/semantics_merge_test.dart
@@ -195,4 +195,29 @@ void main() {
 
     semantics.dispose();
   });
+
+  testWidgets('MergeSemantics with TextField prefix and suffix', (WidgetTester tester) async {
+    final controller = TextEditingController(text: '123');
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: MergeSemantics(
+            child: Semantics(
+              label: 'Room Height',
+              child: TextField(
+                controller: controller,
+                decoration: const InputDecoration(prefixText: 'height', suffixText: 'feet'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final SemanticsNode node = tester.getSemantics(find.byType(MergeSemantics));
+    final SemanticsData data = node.getSemanticsData();
+    expect(data.label, 'Room Height\nheight\nfeet');
+    expect(data.value, '123');
+  });
 }


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

fixes https://github.com/flutter/flutter/issues/160281

The issue is that merge semantics flag is set on semantics node. and is process only when sending semantics node to engine.

This become a issue when a render object creates more than one semantics node (self node + sibling nodes) to be attached to parent semantics node. If this renderobject has isMergingSemanticsOfDescendants = true, the end result should be merging all nodes into one semantics node to be attached to parent. Currently the renderobject will set the flag isMergingSemanticsOfDescendants only on the self node which causes  sibling nodes to not merge together.

To correctly fix the issue, the renderobject will create a new node to host both self node and sibling nodes. it will then set isMergingSemanticsOfDescendants on this new node

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
