### PR TITLE
Encode source file patches as UTF-8 in the code formatter script

### DIFF
--- a/engine/src/flutter/ci/bin/format.dart
+++ b/engine/src/flutter/ci/bin/format.dart
@@ -6,6 +6,7 @@
 //
 // Run with --help for usage.
 
+import 'dart:convert';
 import 'dart:ffi';
 import 'dart:io';
 
@@ -228,13 +229,17 @@ abstract class FormatChecker {
 
   @protected
   Future<bool> applyPatch(List<String> patches) async {
-    final patchPool = ProcessPool(processRunner: _processRunner, printReport: namedReport('patch'));
+    final patchPool = ProcessPool(
+      processRunner: _processRunner,
+      printReport: namedReport('patch'),
+      encoding: Utf8Codec(),
+    );
     final List<WorkerJob> jobs = patches.map<WorkerJob>((String patch) {
       return WorkerJob(<String>[
         'git',
         'apply',
         '--ignore-space-change',
-      ], stdinRaw: codeUnitsAsStream(patch.codeUnits));
+      ], stdin: Stream.value(patch));
     }).toList();
     final List<WorkerJob> completedJobs = await patchPool.runToCompletion(jobs);
     if (patchPool.failedJobs != 0) {

--- a/engine/src/flutter/ci/bin/format.dart
+++ b/engine/src/flutter/ci/bin/format.dart
@@ -232,7 +232,7 @@ abstract class FormatChecker {
     final patchPool = ProcessPool(
       processRunner: _processRunner,
       printReport: namedReport('patch'),
-      encoding: Utf8Codec(),
+      encoding: const Utf8Codec(),
     );
     final List<WorkerJob> jobs = patches.map<WorkerJob>((String patch) {
       return WorkerJob(<String>[

--- a/engine/src/flutter/ci/test/format_test.dart
+++ b/engine/src/flutter/ci/test/format_test.dart
@@ -326,7 +326,7 @@ void main() {
   });
 
   test('Can fix C++ formatting errors with non-ASCII content', () {
-    final FileContentPair ccNonAsciiContentPair = FileContentPair(
+    final ccNonAsciiContentPair = FileContentPair(
       'int main\u221E(){return 0;}\n',
       'int main\u221E() {\n  return 0;\n}\n',
     );

--- a/engine/src/flutter/ci/test/format_test.dart
+++ b/engine/src/flutter/ci/test/format_test.dart
@@ -324,4 +324,27 @@ void main() {
       gnFile.writeAsStringSync(originalContent);
     }
   });
+
+  test('Can fix C++ formatting errors with non-ASCII content', () {
+    final FileContentPair ccNonAsciiContentPair = FileContentPair(
+      'int main\u221E(){return 0;}\n',
+      'int main\u221E() {\n  return 0;\n}\n',
+    );
+    final fixture = TestFileFixture(target.FormatCheck.clang);
+    final ccFile = io.File('${repoDir.path}/non_ascii_test.cc');
+    ccFile.writeAsStringSync(ccNonAsciiContentPair.original);
+    fixture.files.add(ccFile);
+    try {
+      fixture.gitAdd();
+      io.Process.runSync(formatterPath, <String>[
+        '--check',
+        'clang',
+        '--fix',
+      ], workingDirectory: repoDir.path);
+
+      expect(ccFile.readAsStringSync(), ccNonAsciiContentPair.formatted);
+    } finally {
+      fixture.gitRemove();
+    }
+  });
 }


### PR DESCRIPTION
Flutter engine source files can contain non-ASCII characters and are encoded in UTF-8.  Patches generated by diffing against formatted sources should be given to "git apply" as UTF-8.

Fixes https://github.com/flutter/flutter/issues/183464