### PR TITLE
fix(web_ui): move prepareToDraw after raster to improve concurrency and stability

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/compositing/rasterizer.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/compositing/rasterizer.dart
@@ -80,13 +80,13 @@ abstract class ViewRasterizer {
     final bitmapSize = BitmapSize.fromSize(frameSize);
 
     currentFrameSize = bitmapSize;
-    await prepareToDraw();
     viewEmbedder.frameSize = currentFrameSize;
     final Frame compositorFrame = context.acquireFrame(viewEmbedder);
 
     compositorFrame.raster(layerTree, currentFrameSize, recorder);
     _lastRenderedLayerTree = layerTree;
 
+    await prepareToDraw();
     await viewEmbedder.submitFrame(recorder);
   }
 

--- a/engine/src/flutter/lib/web_ui/test/ui/rasterizer_order_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/ui/rasterizer_order_test.dart
@@ -1,0 +1,174 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/src/engine.dart';
+import 'package:ui/ui.dart' as ui;
+
+import '../common/test_initialization.dart';
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+class MockViewEmbedder extends PlatformViewEmbedder {
+  MockViewEmbedder(super.sceneHost, super.rasterizer);
+
+  bool optimizeCompositionCalled = false;
+  BitmapSize? frameSizeDuringOptimize;
+  BitmapSize? _capturedFrameSize;
+
+  @override
+  set frameSize(BitmapSize size) {
+    _capturedFrameSize = size;
+    super.frameSize = size;
+  }
+
+  @override
+  void optimizeComposition() {
+    optimizeCompositionCalled = true;
+    frameSizeDuringOptimize = _capturedFrameSize;
+  }
+
+  @override
+  Future<void> submitFrame(FrameTimingRecorder? recorder) async {
+    await rasterizer.rasterize(<DisplayCanvas>[], <ui.Picture>[], recorder);
+  }
+
+  @override
+  Iterable<LayerCanvas> getOptimizedCanvases() => <LayerCanvas>[];
+}
+
+class OrderVerifyingRasterizer extends ViewRasterizer {
+  OrderVerifyingRasterizer(super.view);
+
+  bool prepareToDrawCalled = false;
+  bool rasterizeCalled = false;
+
+  // We track the state of these flags when each method is called
+  bool? optimizeCompositionCalledDuringPrepare;
+  bool? prepareToDrawCalledDuringRasterize;
+  BitmapSize? sizeDuringPrepare;
+  BitmapSize? sizeDuringRasterize;
+
+  late final MockViewEmbedder _viewEmbedder = MockViewEmbedder(sceneElement, this);
+
+  @override
+  MockViewEmbedder get viewEmbedder => _viewEmbedder;
+
+  @override
+  DisplayCanvasFactory<DisplayCanvas> get displayFactory => throw UnimplementedError();
+
+  @override
+  Future<void> prepareToDraw() async {
+    prepareToDrawCalled = true;
+    sizeDuringPrepare = currentFrameSize;
+    optimizeCompositionCalledDuringPrepare = viewEmbedder.optimizeCompositionCalled;
+  }
+
+  @override
+  Future<void> rasterize(
+    List<DisplayCanvas> displayCanvases,
+    List<ui.Picture> pictures,
+    FrameTimingRecorder? recorder,
+  ) async {
+    rasterizeCalled = true;
+    sizeDuringRasterize = currentFrameSize;
+    prepareToDrawCalledDuringRasterize = prepareToDrawCalled;
+  }
+}
+
+void testMain() {
+  group('Rasterizer order', () {
+    setUpUnitTests();
+
+    test('calls prepareToDraw after raster (optimizeComposition) and before rasterize', () async {
+      final view = EngineFlutterView(
+        EnginePlatformDispatcher.instance,
+        domDocument.createElement('div'),
+      );
+      final rasterizer = OrderVerifyingRasterizer(view);
+
+      final rootLayer = RootLayer();
+      final layerTree = LayerTree(rootLayer);
+
+      // physicalSize must be non-empty for draw() to proceed
+      view.debugPhysicalSizeOverride = const ui.Size(100, 100);
+      view.debugForceResize();
+
+      await rasterizer.draw(layerTree, null);
+
+      final MockViewEmbedder mockEmbedder = rasterizer.viewEmbedder;
+
+      expect(
+        mockEmbedder.optimizeCompositionCalled,
+        isTrue,
+        reason: 'optimizeComposition should be called',
+      );
+      expect(rasterizer.prepareToDrawCalled, isTrue, reason: 'prepareToDraw should be called');
+      expect(rasterizer.rasterizeCalled, isTrue, reason: 'rasterize should be called');
+
+      expect(
+        rasterizer.optimizeCompositionCalledDuringPrepare,
+        isTrue,
+        reason: 'optimizeComposition (part of raster) should have been called before prepareToDraw',
+      );
+
+      expect(
+        rasterizer.prepareToDrawCalledDuringRasterize,
+        isTrue,
+        reason: 'prepareToDraw should have been called before rasterize (part of submitFrame)',
+      );
+    });
+
+    test('currentFrameSize is updated before prepareToDraw', () async {
+      final view = EngineFlutterView(
+        EnginePlatformDispatcher.instance,
+        domDocument.createElement('div'),
+      );
+      final rasterizer = OrderVerifyingRasterizer(view);
+
+      final rootLayer = RootLayer();
+      final layerTree = LayerTree(rootLayer);
+
+      view.debugPhysicalSizeOverride = const ui.Size(123, 456);
+      view.debugForceResize();
+
+      await rasterizer.draw(layerTree, null);
+
+      expect(rasterizer.sizeDuringPrepare, const BitmapSize(123, 456));
+    });
+
+    test('renders two frames at different sizes and uses the correct size for each', () async {
+      final view = EngineFlutterView(
+        EnginePlatformDispatcher.instance,
+        domDocument.createElement('div'),
+      );
+      final rasterizer = OrderVerifyingRasterizer(view);
+      final MockViewEmbedder mockEmbedder = rasterizer.viewEmbedder;
+
+      final rootLayer = RootLayer();
+      final layerTree = LayerTree(rootLayer);
+
+      // Frame 1: 100x200
+      view.debugPhysicalSizeOverride = const ui.Size(100, 200);
+      view.debugForceResize();
+      await rasterizer.draw(layerTree, null);
+
+      expect(mockEmbedder.frameSizeDuringOptimize, const BitmapSize(100, 200));
+      expect(rasterizer.sizeDuringPrepare, const BitmapSize(100, 200));
+      expect(rasterizer.sizeDuringRasterize, const BitmapSize(100, 200));
+
+      // Frame 2: 300x400
+      view.debugPhysicalSizeOverride = const ui.Size(300, 400);
+      view.debugForceResize();
+      await rasterizer.draw(layerTree, null);
+
+      expect(mockEmbedder.frameSizeDuringOptimize, const BitmapSize(300, 400));
+      expect(rasterizer.sizeDuringPrepare, const BitmapSize(300, 400));
+      expect(rasterizer.sizeDuringRasterize, const BitmapSize(300, 400));
+    });
+  });
+}

--- a/engine/src/flutter/lib/web_ui/test/ui/rasterizer_resize_golden_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/ui/rasterizer_resize_golden_test.dart
@@ -1,0 +1,66 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:math' as math;
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/src/engine.dart';
+import 'package:ui/ui.dart' as ui;
+import 'package:web_engine_tester/golden_tester.dart';
+
+import '../common/test_initialization.dart';
+import 'utils.dart';
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+void testMain() {
+  group('Rasterizer resize', () {
+    setUpUnitTests(withImplicitView: true, setUpTestViewDimensions: false);
+
+    test('renders correctly after resizing the view', () async {
+      final view = implicitView as EngineFlutterView;
+
+      // 1. Initial size 200x200
+      view.debugPhysicalSizeOverride = const ui.Size(200, 200);
+      view.debugForceResize();
+
+      Future<void> drawCenteredCircle(ui.Size size, ui.Color color) async {
+        final recorder = ui.PictureRecorder();
+        final canvas = ui.Canvas(recorder);
+        canvas.drawCircle(
+          ui.Offset(size.width / 2, size.height / 2),
+          math.min(size.width, size.height) / 4,
+          ui.Paint()..color = color,
+        );
+        final ui.Picture picture = recorder.endRecording();
+        final sb = ui.SceneBuilder();
+        sb.addPicture(ui.Offset.zero, picture);
+        await renderer.renderScene(sb.build(), view);
+      }
+
+      // Draw first frame at 200x200. This ensures the rasterizer is initialized
+      // and has a "current" size.
+      await drawCenteredCircle(const ui.Size(200, 200), const ui.Color(0xFFFF0000));
+
+      // 2. Resize to 400x400 and draw again.
+      // This tests that the second frame correctly uses the new size for
+      // measurement and painting, even if it happens immediately after the resize.
+      view.debugPhysicalSizeOverride = const ui.Size(400, 400);
+      view.debugForceResize();
+
+      // Draw second frame at 400x400 with a green circle.
+      // If the reordering was incorrect, the circle might be centered at (100, 100)
+      // instead of (200, 200), or it might be clipped.
+      await drawCenteredCircle(const ui.Size(400, 400), const ui.Color(0xFF00FF00));
+
+      await matchGoldenFile(
+        'ui_resize_centered_circle.png',
+        region: const ui.Rect.fromLTWH(0, 0, 400, 400),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Moving prepareToDraw after the synchronous raster recording phase ensures that the UI state is captured immediately. This prevents potential race conditions in Skwasm where resizing the surface immediately before measuring and painting could lead to uninitialized Skia resources or incorrect rendering states.

By deferring physical surface sizing until after the pictures are recorded, we also allow asynchronous surface preparation to better overlap with other work, improving overall frame performance.

Fixes https://github.com/flutter/flutter/issues/182354

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
