### PR TITLE
fix(flutter_tools): validate positional arguments in downgrade command

### DIFF
--- a/packages/flutter_tools/lib/src/commands/downgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/downgrade.dart
@@ -78,6 +78,20 @@ class DowngradeCommand extends FlutterCommand {
   @override
   final String category = FlutterCommandCategory.sdk;
 
+  @protected
+  @mustCallSuper
+  @override
+  Future<void> validateCommand() async {
+    await super.validateCommand();
+    if (argResults!.rest.isNotEmpty) {
+      throwToolExit(
+        'The "downgrade" command does not take any positional arguments.\n'
+        'Unexpected argument(s): ${argResults!.rest.join(', ')}\n'
+        'Run "flutter downgrade --help" for more information.',
+      );
+    }
+  }
+
   @override
   Future<FlutterCommandResult> runCommand() async {
     // Commands do not necessarily have access to the correct zone injected

--- a/packages/flutter_tools/test/commands.shard/hermetic/downgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/downgrade_test.dart
@@ -40,6 +40,24 @@ void main() {
     bufferLogger = BufferLogger.test(terminal: terminal);
   });
 
+  testUsingContext('downgrade command fails with positional arguments', () async {
+    final command = DowngradeCommand(
+      persistentToolState: PersistentToolState.test(
+        directory: fileSystem.currentDirectory,
+        logger: bufferLogger,
+      ),
+      terminal: terminal,
+      stdio: stdio,
+      flutterVersion: FakeFlutterVersion(),
+      logger: bufferLogger,
+    );
+
+    expect(
+      () => createTestCommandRunner(command).run(const ['downgrade', 'unexpected-arg']),
+      throwsToolExit(message: 'The "downgrade" command does not take any positional arguments.'),
+    );
+  });
+
   testUsingContext('Downgrade exits on unknown channel', () async {
     final fakeFlutterVersion = FakeFlutterVersion(branch: 'WestSideStory'); // an unknown branch
     fileSystem.currentDirectory


### PR DESCRIPTION
The downgrade command currently silently ignores positional arguments. This PR adds validation to ensure users are notified when they provide unexpected arguments, matching the behavior of other verified commands like flutter doctor.