### PR TITLE
fix(web): fix crash in Skwasm when transferring non-transferable texture sources

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
@@ -465,7 +465,7 @@ class SkwasmRenderer extends Renderer {
     required int height,
     required bool transferOwnership,
   }) async {
-    if (!transferOwnership) {
+    if (!transferOwnership || (isMultiThreaded && !_isTransferable(textureSource))) {
       textureSource = (await createImageBitmap(textureSource, (
         x: 0,
         y: 0,
@@ -482,6 +482,9 @@ class SkwasmRenderer extends Renderer {
       ),
     );
   }
+
+  bool _isTransferable(JSAny object) =>
+      object.isA<DomImageBitmap>() || object.isA<VideoFrame>() || object.isA<DomOffscreenCanvas>();
 
   @override
   void dumpDebugInfo() {

--- a/engine/src/flutter/lib/web_ui/test/ui/image_texture_source_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/ui/image_texture_source_test.dart
@@ -1,0 +1,78 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/src/engine.dart';
+import 'package:ui/ui.dart' as ui;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
+
+import '../common/test_initialization.dart';
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+Future<void> testMain() async {
+  setUpUnitTests(withImplicitView: true);
+
+  test('createImageFromTextureSource with HTMLImageElement and transferOwnership: true', () async {
+    final DomHTMLImageElement image = createDomHTMLImageElement();
+    // Use a data URL to avoid network issues in tests
+    const transparentImage =
+        'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+    image.src = transparentImage;
+
+    final completer = Completer<void>();
+    image.addEventListener(
+      'load',
+      createDomEventListener((DomEvent event) {
+        completer.complete();
+      }),
+    );
+    await completer.future;
+
+    final ui.Image uiImage = await ui_web.createImageFromTextureSource(
+      image,
+      width: 1,
+      height: 1,
+      transferOwnership: true,
+    );
+
+    expect(uiImage.width, 1);
+    expect(uiImage.height, 1);
+    uiImage.dispose();
+  });
+
+  test('createImageFromTextureSource with ImageBitmap and transferOwnership: true', () async {
+    final DomHTMLImageElement image = createDomHTMLImageElement();
+    const transparentImage =
+        'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+    image.src = transparentImage;
+
+    final completer = Completer<void>();
+    image.addEventListener(
+      'load',
+      createDomEventListener((DomEvent event) {
+        completer.complete();
+      }),
+    );
+    await completer.future;
+
+    final DomImageBitmap bitmap = await createImageBitmap(image, (x: 0, y: 0, width: 1, height: 1));
+
+    final ui.Image uiImage = await ui_web.createImageFromTextureSource(
+      bitmap,
+      width: 1,
+      height: 1,
+      transferOwnership: true,
+    );
+
+    expect(uiImage.width, 1);
+    expect(uiImage.height, 1);
+    uiImage.dispose();
+  });
+}


### PR DESCRIPTION
The engine was previously attempting to transfer non-transferable objects like `HTMLImageElement` to the web worker via `postMessage` when `transferOwnership` was set to `true`. This resulted in a `DataCloneError`.

This change adds a check to see if the texture source is a transferable type when in multi-threaded mode. If not, it converts it to an `ImageBitmap` using `createImageBitmap` before transferring.

A new test `test/ui/image_texture_source_test.dart` has been added to verify this behavior across all renderers.

Fixes https://github.com/flutter/flutter/issues/183166

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
