### PR TITLE
docs: add custom transitionBuilder example to AnimatedSwitcher

### DIFF
--- a/packages/flutter/lib/src/widgets/animated_switcher.dart
+++ b/packages/flutter/lib/src/widgets/animated_switcher.dart
@@ -182,7 +182,26 @@ class AnimatedSwitcher extends StatefulWidget {
   /// the transition is rebuilt for the current child and all previous children
   /// using the new [transitionBuilder]. The function must not return null.
   ///
-  /// The default is [AnimatedSwitcher.defaultTransitionBuilder].
+ /// The default is [AnimatedSwitcher.defaultTransitionBuilder].
+  ///
+  /// The following example uses a [SlideTransition] instead of the default
+  /// [FadeTransition]:
+  ///
+  /// ```dart
+  /// AnimatedSwitcher(
+  ///   duration: const Duration(milliseconds: 400),
+  ///   transitionBuilder: (Widget child, Animation<double> animation) {
+  ///     return SlideTransition(
+  ///       position: Tween<Offset>(
+  ///         begin: const Offset(1.0, 0.0),
+  ///         end: Offset.zero,
+  ///       ).animate(animation),
+  ///       child: child,
+  ///     );
+  ///   },
+  ///   child: Text('$_count', key: ValueKey<int>(_count)),
+  /// )
+  /// ```
   ///
   /// The animation provided to the builder has the [duration] and
   /// [switchInCurve] or [switchOutCurve] applied as provided when the

--- a/packages/flutter/lib/src/widgets/animated_switcher.dart
+++ b/packages/flutter/lib/src/widgets/animated_switcher.dart
@@ -184,10 +184,13 @@ class AnimatedSwitcher extends StatefulWidget {
   ///
  /// The default is [AnimatedSwitcher.defaultTransitionBuilder].
   ///
-  /// The following example uses a [SlideTransition] instead of the default
+ /// The following example uses a [SlideTransition] instead of the default
   /// [FadeTransition]:
   ///
   /// ```dart
+  /// // Somewhere in your StatefulWidget:
+  /// // int _count = 0;
+  ///
   /// AnimatedSwitcher(
   ///   duration: const Duration(milliseconds: 400),
   ///   transitionBuilder: (Widget child, Animation<double> animation) {
@@ -199,10 +202,14 @@ class AnimatedSwitcher extends StatefulWidget {
   ///       child: child,
   ///     );
   ///   },
-  ///   child: Text('$_count', key: ValueKey<int>(_count)),
+  ///   child: Text(
+  ///     '$_count',
+  ///     // A unique key is required to trigger the transition
+  ///     // when the child value changes.
+  ///     key: ValueKey<int>(_count),
+  ///   ),
   /// )
   /// ```
-  ///
   /// The animation provided to the builder has the [duration] and
   /// [switchInCurve] or [switchOutCurve] applied as provided when the
   /// corresponding [child] was first provided.


### PR DESCRIPTION
## Description

Adds a `SlideTransition` usage example to the `transitionBuilder` parameter
docs in `AnimatedSwitcher`. The existing docs only mention the default
`FadeTransition` but don't show how to override it — this is one of the most
common sources of confusion for developers using `AnimatedSwitcher`.

## Related Issues

Docs-only improvement, no linked issue.

## Tests

No logic change. Existing tests unaffected.
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
