### PR TITLE
[wimp] MSAA support

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
@@ -265,8 +265,9 @@ void(glDepthRange)(GLdouble n, GLdouble f);
   PROC(UniformBlockBinding);               \
   PROC(BindBufferRange);                   \
   PROC(WaitSync);                          \
-  PROC(RenderbufferStorageMultisample)     \
-  PROC(BlitFramebuffer);
+  PROC(RenderbufferStorageMultisample);    \
+  PROC(BlitFramebuffer);                   \
+  PROC(InvalidateFramebuffer);
 
 #define FOR_EACH_IMPELLER_EXT_PROC(PROC)    \
   PROC(DebugMessageControlKHR);             \

--- a/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -527,28 +527,39 @@ void RenderPassGLES::ResetGLState(const ProcTableGLES& gl) {
       !gl.GetCapabilities()->SupportsImplicitResolvingMSAA() &&
       !is_wrapped_fbo) {
     FML_DCHECK(pass_data.resolve_attachment != pass_data.color_attachment);
-    // Perform multisample resolve via blit.
-    // Create and bind a resolve FBO.
-    GLuint resolve_fbo;
-    gl.GenFramebuffers(1u, &resolve_fbo);
-    gl.BindFramebuffer(GL_FRAMEBUFFER, resolve_fbo);
+    TextureGLES& resolve_gles =
+        TextureGLES::Cast(*pass_data.resolve_attachment);
+    std::optional<GLuint> resolve_fbo_opt;
 
-    if (!TextureGLES::Cast(*pass_data.resolve_attachment)
-             .SetAsFramebufferAttachment(
-                 GL_FRAMEBUFFER, TextureGLES::AttachmentType::kColor0)) {
-      return false;
+    if (!resolve_gles.GetCachedFBO().IsDead()) {
+      resolve_fbo_opt = reactor.GetGLHandle(resolve_gles.GetCachedFBO());
     }
 
-    auto status = gl.CheckFramebufferStatusDebug(GL_FRAMEBUFFER);
-    if (status != GL_FRAMEBUFFER_COMPLETE) {
-      VALIDATION_LOG << "Could not create a complete frambuffer: "
-                     << DebugToFramebufferError(status);
-      return false;
+    if (!resolve_fbo_opt.has_value()) {
+      HandleGLES cached_fbo =
+          reactor.CreateUntrackedHandle(HandleType::kFrameBuffer);
+      resolve_gles.SetCachedFBO(cached_fbo);
+      resolve_fbo_opt = reactor.GetGLHandle(cached_fbo);
+      gl.BindFramebuffer(GL_FRAMEBUFFER, resolve_fbo_opt.value());
+
+      if (!resolve_gles.SetAsFramebufferAttachment(
+              GL_FRAMEBUFFER, TextureGLES::AttachmentType::kColor0)) {
+        return false;
+      }
+
+      auto status = gl.CheckFramebufferStatusDebug(GL_FRAMEBUFFER);
+      if (status != GL_FRAMEBUFFER_COMPLETE) {
+        VALIDATION_LOG << "Could not create a complete frambuffer: "
+                       << DebugToFramebufferError(status);
+        return false;
+      }
+    } else {
+      gl.BindFramebuffer(GL_FRAMEBUFFER, resolve_fbo_opt.value());
     }
 
     // Bind MSAA renderbuffer to read framebuffer.
     gl.BindFramebuffer(GL_READ_FRAMEBUFFER, fbo.value());
-    gl.BindFramebuffer(GL_DRAW_FRAMEBUFFER, resolve_fbo);
+    gl.BindFramebuffer(GL_DRAW_FRAMEBUFFER, resolve_fbo_opt.value());
 
     RenderPassGLES::ResetGLState(gl);
     auto size = pass_data.color_attachment->GetSize();
@@ -566,7 +577,6 @@ void RenderPassGLES::ResetGLState(const ProcTableGLES& gl) {
 
     gl.BindFramebuffer(GL_DRAW_FRAMEBUFFER, GL_NONE);
     gl.BindFramebuffer(GL_READ_FRAMEBUFFER, GL_NONE);
-    gl.DeleteFramebuffers(1u, &resolve_fbo);
     // Rebind the original FBO so that we can discard it below.
     gl.BindFramebuffer(GL_FRAMEBUFFER, fbo.value());
   }
@@ -575,7 +585,31 @@ void RenderPassGLES::ResetGLState(const ProcTableGLES& gl) {
   gl.GetIntegerv(GL_FRAMEBUFFER_BINDING, &framebuffer_id);
   const bool is_default_fbo = framebuffer_id == 0;
 
-  if (gl.DiscardFramebufferEXT.IsAvailable()) {
+  if (gl.InvalidateFramebuffer.IsAvailable()) {
+    std::array<GLenum, 3> attachments;
+    size_t attachment_count = 0;
+
+    bool angle_safe = gl.GetCapabilities()->IsANGLE() ? !is_default_fbo : true;
+
+    if (pass_data.discard_color_attachment) {
+      attachments[attachment_count++] =
+          (is_default_fbo ? GL_COLOR_EXT : GL_COLOR_ATTACHMENT0);
+    }
+
+    if (pass_data.discard_depth_attachment && angle_safe) {
+      attachments[attachment_count++] =
+          (is_default_fbo ? GL_DEPTH_EXT : GL_DEPTH_ATTACHMENT);
+    }
+
+    if (pass_data.discard_stencil_attachment && angle_safe) {
+      attachments[attachment_count++] =
+          (is_default_fbo ? GL_STENCIL_EXT : GL_STENCIL_ATTACHMENT);
+    }
+    gl.InvalidateFramebuffer(GL_FRAMEBUFFER,     // target
+                             attachment_count,   // attachments to discard
+                             attachments.data()  // size
+    );
+  } else if (gl.DiscardFramebufferEXT.IsAvailable()) {
     std::array<GLenum, 3> attachments;
     size_t attachment_count = 0;
 

--- a/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles_unittests.cc
@@ -69,7 +69,8 @@ TEST_P(RenderPassGLESWithDiscardFrameBufferExtTest, DiscardFramebufferExt) {
   auto mock_gl_impl = std::make_unique<NiceMock<MockGLESImpl>>();
   auto& mock_gl_impl_ref = *mock_gl_impl;
   auto mock_gl =
-      MockGLES::Init(std::move(mock_gl_impl), {{"GL_EXT_discard_framebuffer"}});
+      MockGLES::Init(std::move(mock_gl_impl), {{"GL_EXT_discard_framebuffer"}},
+                     "OpenGL ES 2.0");
 
   auto context = CreateFakeGLESContext();
   auto dummy_worker = std::make_shared<MockWorker>();
@@ -113,6 +114,107 @@ INSTANTIATE_TEST_SUITE_P(
     [](const ::testing::TestParamInfo<DiscardFrameBufferParams>& info) {
       return (info.param.frame_buffer_id == 0) ? "Default" : "NonDefault";
     });
+
+TEST_P(RenderPassGLESWithDiscardFrameBufferExtTest, InvalidateFramebuffer) {
+  auto mock_gl_impl = std::make_unique<NiceMock<MockGLESImpl>>();
+  auto& mock_gl_impl_ref = *mock_gl_impl;
+  auto mock_gl =
+      MockGLES::Init(std::move(mock_gl_impl), std::nullopt, "OpenGL ES 3.0");
+
+  auto context = CreateFakeGLESContext();
+  auto dummy_worker = std::make_shared<MockWorker>();
+  context->AddReactorWorker(dummy_worker);
+  auto reactor = context->GetReactor();
+
+  const auto command_buffer =
+      std::static_pointer_cast<Context>(context)->CreateCommandBuffer();
+  auto render_target = RenderTarget{};
+  const auto description = TextureDescriptor{
+      .format = PixelFormat::kR8G8B8A8UNormInt, .size = {10, 10}};
+
+  const auto& test_params = GetParam();
+  auto framebuffer_texture =
+      TextureGLES::WrapFBO(reactor, description, test_params.frame_buffer_id);
+
+  auto color_attachment = ColorAttachment{Attachment{
+      .texture = framebuffer_texture, .store_action = StoreAction::kDontCare}};
+  render_target.SetColorAttachment(color_attachment, 0);
+  const auto render_pass = command_buffer->CreateRenderPass(render_target);
+
+  EXPECT_CALL(mock_gl_impl_ref, GetIntegerv(GL_FRAMEBUFFER_BINDING, _))
+      .WillOnce(SetArgPointee<1>(test_params.frame_buffer_id));
+
+  // InvalidateFramebuffer should be called instead of DiscardFramebufferEXT
+  EXPECT_CALL(mock_gl_impl_ref, InvalidateFramebuffer(GL_FRAMEBUFFER, _, _))
+      .With(Args<2, 1>(ElementsAreArray(test_params.expected_attachments)))
+      .Times(1);
+  EXPECT_CALL(mock_gl_impl_ref, DiscardFramebufferEXT(GL_FRAMEBUFFER, _, _))
+      .Times(0);
+
+  ASSERT_TRUE(render_pass->EncodeCommands());
+  ASSERT_TRUE(reactor->React());
+}
+
+TEST(RenderPassGLESTest, ResolvingMultisampleTextureCachesResolveFBO) {
+  auto mock_gl_impl = std::make_unique<NiceMock<MockGLESImpl>>();
+  auto& mock_gl_impl_ref = *mock_gl_impl;
+  // Make sure implicit resolving isn't supported so we go down explicit path.
+  auto mock_gl =
+      MockGLES::Init(std::move(mock_gl_impl), std::nullopt, "OpenGL ES 3.0");
+
+  auto context = CreateFakeGLESContext();
+  auto dummy_worker = std::make_shared<MockWorker>();
+  context->AddReactorWorker(dummy_worker);
+  auto reactor = context->GetReactor();
+
+  const auto command_buffer =
+      std::static_pointer_cast<Context>(context)->CreateCommandBuffer();
+
+  const auto msaa_desc =
+      TextureDescriptor{.type = TextureType::kTexture2DMultisample,
+                        .format = PixelFormat::kR8G8B8A8UNormInt,
+                        .size = {10, 10},
+                        .usage = TextureUsage::kRenderTarget,
+                        .sample_count = SampleCount::kCount4};
+  const auto resolve_desc =
+      TextureDescriptor{.storage_mode = StorageMode::kDevicePrivate,
+                        .type = TextureType::kTexture2D,
+                        .format = PixelFormat::kR8G8B8A8UNormInt,
+                        .size = {10, 10},
+                        .usage = TextureUsage::kRenderTarget,
+                        .sample_count = SampleCount::kCount1};
+
+  auto msaa_tex = std::make_shared<TextureGLES>(reactor, msaa_desc);
+  auto resolve_tex = std::make_shared<TextureGLES>(reactor, resolve_desc);
+
+  auto render_target = RenderTarget{};
+  auto color_attachment = ColorAttachment{Attachment{
+      .texture = msaa_tex,
+      .resolve_texture = resolve_tex,
+      .load_action = LoadAction::kClear,
+      .store_action = StoreAction::kMultisampleResolve,
+  }};
+  color_attachment.clear_color = Color::Black();
+  render_target.SetColorAttachment(color_attachment, 0);
+
+  EXPECT_CALL(mock_gl_impl_ref, CheckFramebufferStatus(_))
+      .WillRepeatedly(Return(GL_FRAMEBUFFER_COMPLETE));
+
+  // Expect GenFramebuffers is called exactly once for the offscreen FBO,
+  // and exactly once for the resolve FBO over two passes.
+  EXPECT_CALL(mock_gl_impl_ref, GenFramebuffers(_, _)).Times(2);
+
+  {
+    const auto render_pass = command_buffer->CreateRenderPass(render_target);
+    ASSERT_TRUE(render_pass->EncodeCommands());
+    ASSERT_TRUE(reactor->React());
+  }
+  {
+    const auto render_pass2 = command_buffer->CreateRenderPass(render_target);
+    ASSERT_TRUE(render_pass2->EncodeCommands());
+    ASSERT_TRUE(reactor->React());
+  }
+}
 
 }  // namespace testing
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.cc
@@ -22,6 +22,7 @@ static std::weak_ptr<MockGLES> g_mock_gles;
 static std::vector<const char*> g_extensions;
 
 static const char* g_version;
+static std::string g_extensions_string;
 
 template <typename T, typename U>
 struct CheckSameSignature : std::false_type {};
@@ -65,6 +66,9 @@ const unsigned char* mockGetString(GLenum name) {
       return reinterpret_cast<const unsigned char*>(kMockVendor);
     case GL_VERSION:
       return reinterpret_cast<const unsigned char*>(g_version);
+    case GL_EXTENSIONS:
+      return reinterpret_cast<const unsigned char*>(
+          g_extensions_string.c_str());
     case GL_SHADING_LANGUAGE_VERSION:
       return reinterpret_cast<const unsigned char*>(
           kMockShadingLanguageVersion);
@@ -317,14 +321,31 @@ void mockDiscardFramebufferEXT(GLenum target,
 static_assert(CheckSameSignature<decltype(mockDiscardFramebufferEXT),  //
                                  decltype(glDiscardFramebufferEXT)>::value);
 
+void mockInvalidateFramebuffer(GLenum target,
+                               GLsizei numAttachments,
+                               const GLenum* attachments) {
+  return CallMockMethod(&IMockGLESImpl::InvalidateFramebuffer, target,
+                        numAttachments, attachments);
+}
+
+static_assert(CheckSameSignature<decltype(mockInvalidateFramebuffer),  //
+                                 decltype(glInvalidateFramebuffer)>::value);
+
 // static
 std::shared_ptr<MockGLES> MockGLES::Init(
     std::unique_ptr<MockGLESImpl> impl,
-    const std::optional<std::vector<const char*>>& extensions) {
+    const std::optional<std::vector<const char*>>& extensions,
+    const char* version_string) {
   FML_CHECK(g_test_lock.try_lock())
       << "MockGLES is already being used by another test.";
   g_extensions = extensions.value_or(kExtensions);
-  g_version = "OpenGL ES 3.0";
+  g_extensions_string.clear();
+  for (const auto& ext : g_extensions) {
+    if (!g_extensions_string.empty())
+      g_extensions_string += " ";
+    g_extensions_string += ext;
+  }
+  g_version = version_string;
   auto mock_gles = std::shared_ptr<MockGLES>(new MockGLES());
   mock_gles->impl_ = std::move(impl);
   g_mock_gles = mock_gles;
@@ -339,6 +360,12 @@ std::shared_ptr<MockGLES> MockGLES::Init(
   FML_CHECK(g_test_lock.try_lock())
       << "MockGLES is already being used by another test.";
   g_extensions = extensions.value_or(kExtensions);
+  g_extensions_string.clear();
+  for (const auto& ext : g_extensions) {
+    if (!g_extensions_string.empty())
+      g_extensions_string += " ";
+    g_extensions_string += ext;
+  }
   g_version = version_string;
   auto mock_gles = std::shared_ptr<MockGLES>(new MockGLES(std::move(resolver)));
   g_mock_gles = mock_gles;
@@ -406,6 +433,8 @@ const ProcTableGLES::Resolver kMockResolverGLES = [](const char* name) {
     return reinterpret_cast<void*>(mockBindFramebuffer);
   } else if (strcmp(name, "glDiscardFramebufferEXT") == 0) {
     return reinterpret_cast<void*>(mockDiscardFramebufferEXT);
+  } else if (strcmp(name, "glInvalidateFramebuffer") == 0) {
+    return reinterpret_cast<void*>(mockInvalidateFramebuffer);
   } else {
     return reinterpret_cast<void*>(&doNothing);
   }

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.cc
@@ -363,8 +363,9 @@ std::shared_ptr<MockGLES> MockGLES::Init(
   g_extensions = extensions.value_or(kExtensions);
   g_extensions_string.clear();
   for (const auto& ext : g_extensions) {
-    if (!g_extensions_string.empty())
+    if (!g_extensions_string.empty()) {
       g_extensions_string += " ";
+    }
     g_extensions_string += ext;
   }
   g_version = version_string;

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.cc
@@ -341,8 +341,9 @@ std::shared_ptr<MockGLES> MockGLES::Init(
   g_extensions = extensions.value_or(kExtensions);
   g_extensions_string.clear();
   for (const auto& ext : g_extensions) {
-    if (!g_extensions_string.empty())
+    if (!g_extensions_string.empty()) {
       g_extensions_string += " ";
+    }
     g_extensions_string += ext;
   }
   g_version = version_string;

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.h
@@ -96,6 +96,9 @@ class IMockGLESImpl {
   virtual void DiscardFramebufferEXT(GLenum target,
                                      GLsizei numAttachments,
                                      const GLenum* attachments) {};
+  virtual void InvalidateFramebuffer(GLenum target,
+                                     GLsizei numAttachments,
+                                     const GLenum* attachments) {};
   virtual void GetIntegerv(GLenum name, GLint* attachments) {};
 };
 
@@ -231,6 +234,12 @@ class MockGLESImpl : public IMockGLESImpl {
                GLsizei numAttachments,
                const GLenum* attachments),
               (override));
+  MOCK_METHOD(void,
+              InvalidateFramebuffer,
+              (GLenum target,
+               GLsizei numAttachments,
+               const GLenum* attachments),
+              (override));
   MOCK_METHOD(void, GetIntegerv, (GLenum name, GLint* value), (override));
 };
 
@@ -246,7 +255,8 @@ class MockGLES final {
  public:
   static std::shared_ptr<MockGLES> Init(
       std::unique_ptr<MockGLESImpl> impl,
-      const std::optional<std::vector<const char*>>& extensions = std::nullopt);
+      const std::optional<std::vector<const char*>>& extensions = std::nullopt,
+      const char* version_string = "OpenGL ES 3.0");
 
   /// @brief      Returns an initialized |MockGLES| instance.
   ///

--- a/engine/src/flutter/skwasm/library_skwasm_support.js
+++ b/engine/src/flutter/skwasm/library_skwasm_support.js
@@ -305,13 +305,13 @@ mergeInto(LibraryManager.library, {
     };
 
     // GL Context
-    _skwasm_getGlContextForCanvas = function (canvas, surfaceHandle) {
+    _skwasm_getGlContextForCanvas = function (canvas, antialias, surfaceHandle) {
       var contextAttributes = {
         majorVersion: 2,
         alpha: true,
         depth: true,
         stencil: true,
-        antialias: false,
+        antialias: antialias,
         premultipliedAlpha: true,
         preserveDrawingBuffer: false,
         powerPreference: 'default',

--- a/engine/src/flutter/skwasm/skwasm_support.h
+++ b/engine/src/flutter/skwasm/skwasm_support.h
@@ -22,6 +22,7 @@ class DisplayList;
 
 extern "C" {
 extern bool skwasm_isSingleThreaded();
+extern bool skwasm_isWimp();
 extern void skwasm_setAssociatedObjectOnThread(unsigned long thread_id,
                                                void* pointer,
                                                SkwasmObject object);
@@ -35,6 +36,7 @@ extern void skwasm_dispatchRenderPictures(unsigned long thread_id,
                                           int count,
                                           uint32_t callback_id);
 extern uint32_t skwasm_getGlContextForCanvas(SkwasmObject canvas,
+                                             bool antialias,
                                              Skwasm::Surface* surface);
 extern void skwasm_reportInitialized(Skwasm::Surface* surface,
                                      uint32_t callback_id,

--- a/engine/src/flutter/skwasm/surface.cc
+++ b/engine/src/flutter/skwasm/surface.cc
@@ -96,7 +96,8 @@ void Skwasm::Surface::ReceiveCanvasOnWorker(SkwasmObject canvas,
   }
   canvas_width_ = 1;
   canvas_height_ = 1;
-  gl_context_ = skwasm_getGlContextForCanvas(canvas, this);
+  bool antialias = skwasm_isWimp();
+  gl_context_ = skwasm_getGlContextForCanvas(canvas, antialias, this);
   if (!gl_context_) {
     printf("Failed to create context!\n");
     return;


### PR DESCRIPTION
* Use MSAA for default framebuffer by using the antialias flag when creating our WebGL context
* Cache and reuse the MSAA resolve attachment for intermediate targets.
* Use `glInvalidateFramebuffer` when it's available. We use the `glDiscardFramebufferEXT` when it's available, but that isn't available on WebGL, so we want to use `glInvalidateFramebuffer` in that case.