### PR TITLE
Use clearer return value for idle and timeout callbacks.

### DIFF
--- a/engine/src/flutter/shell/platform/linux/fl_binary_messenger_test.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_binary_messenger_test.cc
@@ -506,7 +506,7 @@ TEST(FlBinaryMessengerTest, ControlChannelErrorResponse) {
         g_idle_add(
             [](gpointer user_data) {
               g_main_loop_quit(static_cast<GMainLoop*>(user_data));
-              return FALSE;
+              return G_SOURCE_REMOVE;
             },
             loop);
 

--- a/engine/src/flutter/shell/platform/linux/fl_task_runner.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_task_runner.cc
@@ -88,7 +88,7 @@ static gboolean fl_task_runner_on_expired_timeout(gpointer data) {
 
   g_object_unref(self);
 
-  return FALSE;
+  return G_SOURCE_REMOVE;
 }
 
 // Returns the absolute time of next expired task (in microseconds, based on

--- a/engine/src/flutter/shell/platform/linux/fl_view.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_view.cc
@@ -133,12 +133,12 @@ static gboolean redraw_cb(gpointer user_data) {
       // size of the render area.
       gtk_window_resize(GTK_WINDOW(toplevel), 1, 1);
     }
-    return FALSE;
+    return G_SOURCE_REMOVE;
   }
 
   gtk_widget_queue_draw(GTK_WIDGET(self->render_area));
 
-  return FALSE;
+  return G_SOURCE_REMOVE;
 }
 
 // Signal handler for GtkWidget::delete-event


### PR DESCRIPTION
Use G_SOURCE_REMOVE (which is just FALSE) to make clearer what happens at the end of these callbacks.
