### PR TITLE
[DO_NOT_LAND][ios][pv]add integration test with a drawing website for touch fallthrough bug

### DIFF
--- a/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
+++ b/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
@@ -123,6 +123,33 @@ static const CGFloat kStandardTimeOut = 60.0;
   XCTAssertTrue([successText waitForExistenceWithTimeout:60]);
 }
 
+
+- (void)testPlatformViewDrawingWebViewCannotBeDrownWhenContextMenuIsShown {
+  XCUIElement *entranceButton = self.app.buttons[@"drawing web view behind context menu test"];
+  XCTAssertTrue([entranceButton waitForExistenceWithTimeout:kStandardTimeOut]);
+  [entranceButton tap];
+
+  XCUIElement *platformView = self.app.webViews[@"platform_view[0]"];
+  XCTAssertTrue([platformView waitForExistenceWithTimeout:kStandardTimeOut]);
+
+  // expand the context menu.
+  XCUIElement *showMenuButton = self.app.buttons[@"Show menu"];
+  XCTAssertTrue([showMenuButton waitForExistenceWithTimeout:kStandardTimeOut]);
+  [showMenuButton tap];
+
+  // draw on the canvas
+  XCUICoordinate *center = [self.app coordinateWithNormalizedOffset:CGVectorMake(0.5, 0.5)];
+  XCUICoordinate *end = [center coordinateWithOffset:CGVectorMake(0.0, 100.0)];
+  [center pressForDuration:0.1 thenDragToCoordinate:end];
+  
+  // Dismiss the context menu (so that we can find web view under the accessibility tree).
+  [center tap];
+
+  // Verify that the web view does not have any pixels drawn
+  XCUIElement *pixelCountLabel = self.app.staticTexts[@"pixel count: 0"];
+  XCTAssertTrue([pixelCountLabel waitForExistenceWithTimeout:kStandardTimeOut]);
+}
+
 - (void)testPlatformViewFakeAdMobBannerTappableForScrollableListScenario {
   XCUIElement *entranceButton = self.app.buttons[@"admob banner in scrollable list test"];
   XCTAssertTrue([entranceButton waitForExistenceWithTimeout:kStandardTimeOut]);

--- a/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
+++ b/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
@@ -124,7 +124,7 @@ static const CGFloat kStandardTimeOut = 60.0;
 }
 
 
-- (void)testPlatformViewDrawingWebViewCannotBeDrownWhenContextMenuIsShown {
+- (void)testPlatformViewDrawingWebViewCannotBeDrawnWhenContextMenuIsShown {
   XCUIElement *entranceButton = self.app.buttons[@"drawing web view behind context menu test"];
   XCTAssertTrue([entranceButton waitForExistenceWithTimeout:kStandardTimeOut]);
   [entranceButton tap];
@@ -136,14 +136,19 @@ static const CGFloat kStandardTimeOut = 60.0;
   XCUIElement *showMenuButton = self.app.buttons[@"Show menu"];
   XCTAssertTrue([showMenuButton waitForExistenceWithTimeout:kStandardTimeOut]);
   [showMenuButton tap];
+  XCUIElement *menuItem = self.app.buttons[@"menu button 1"];
+  XCTAssertTrue([menuItem waitForExistenceWithTimeout:kStandardTimeOut]);
 
   // draw on the canvas
   XCUICoordinate *center = [self.app coordinateWithNormalizedOffset:CGVectorMake(0.5, 0.5)];
   XCUICoordinate *end = [center coordinateWithOffset:CGVectorMake(0.0, 100.0)];
   [center pressForDuration:0.1 thenDragToCoordinate:end];
-  
+
   // Dismiss the context menu (so that we can find web view under the accessibility tree).
-  [center tap];
+  // Since context menu is on top right, we tap on the bottom left corner to avoid tapping within the menu area.
+  XCUICoordinate *bottomLeft = [self.app coordinateWithNormalizedOffset:CGVectorMake(0.05, 0.95)];
+  [bottomLeft tap];
+  XCTAssertTrue([menuItem waitForNonExistenceWithTimeout:kStandardTimeOut]);
 
   // Verify that the web view does not have any pixels drawn
   XCUIElement *pixelCountLabel = self.app.staticTexts[@"pixel count: 0"];

--- a/dev/integration_tests/ios_platform_view_tests/ios/Runner.xcodeproj/project.pbxproj
+++ b/dev/integration_tests/ios_platform_view_tests/ios/Runner.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		E09898DE2853DBE800064317 /* ViewFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = E09898DD2853DBE800064317 /* ViewFactory.m */; };
 		E09898E12853DC3C00064317 /* TextFieldFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = E09898E02853DC3C00064317 /* TextFieldFactory.m */; };
 		E09898E92853E9F000064317 /* PlatformViewUITests.m in Sources */ = {isa = PBXBuildFile; fileRef = E09898E82853E9F000064317 /* PlatformViewUITests.m */; };
+		E0DC4BCE2F69D8FA00CBE9CF /* drawing_website.html in Resources */ = {isa = PBXBuildFile; fileRef = E0DC4BCD2F69D8FA00CBE9CF /* drawing_website.html */; };
+		E0DC4BD12F69D91800CBE9CF /* DrawingWebViewFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = E0DC4BD02F69D91800CBE9CF /* DrawingWebViewFactory.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -75,6 +77,9 @@
 		E09898E02853DC3C00064317 /* TextFieldFactory.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TextFieldFactory.m; sourceTree = "<group>"; };
 		E09898E62853E9F000064317 /* PlatformViewUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PlatformViewUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E09898E82853E9F000064317 /* PlatformViewUITests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PlatformViewUITests.m; sourceTree = "<group>"; };
+		E0DC4BCD2F69D8FA00CBE9CF /* drawing_website.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = drawing_website.html; sourceTree = "<group>"; };
+		E0DC4BCF2F69D90D00CBE9CF /* DrawingWebViewFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DrawingWebViewFactory.h; sourceTree = "<group>"; };
+		E0DC4BD02F69D91800CBE9CF /* DrawingWebViewFactory.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DrawingWebViewFactory.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -138,10 +143,13 @@
 				E09898DD2853DBE800064317 /* ViewFactory.m */,
 				E090076F2F3A6FE400B349AE /* WebViewFactory.h */,
 				E09007702F3A6FE400B349AE /* WebViewFactory.m */,
+				E0DC4BCF2F69D90D00CBE9CF /* DrawingWebViewFactory.h */,
+				E0DC4BD02F69D91800CBE9CF /* DrawingWebViewFactory.m */,
 				E090082E2F47BE8500B349AE /* LinkNavigationWebView.h */,
 				E090082F2F47BE8500B349AE /* LinkNavigationWebView.m */,
 				E09008282F47BAFB00B349AE /* FakeAdMobBannerFactory.h */,
 				E09008292F47BAFB00B349AE /* FakeAdMobBannerFactory.m */,
+				E0DC4BCD2F69D8FA00CBE9CF /* drawing_website.html */,
 				97C146FA1CF9000F007C117D /* Main.storyboard */,
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
@@ -252,6 +260,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E0DC4BCE2F69D8FA00CBE9CF /* drawing_website.html in Resources */,
 				97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */,
 				3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */,
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
@@ -314,6 +323,7 @@
 				E090082A2F47BAFB00B349AE /* FakeAdMobBannerFactory.m in Sources */,
 				E0440002299C782300D02513 /* ButtonFactory.m in Sources */,
 				E09898E12853DC3C00064317 /* TextFieldFactory.m in Sources */,
+				E0DC4BD12F69D91800CBE9CF /* DrawingWebViewFactory.m in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 				E09898DE2853DBE800064317 /* ViewFactory.m in Sources */,
 			);

--- a/dev/integration_tests/ios_platform_view_tests/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/dev/integration_tests/ios_platform_view_tests/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -58,6 +58,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/dev/integration_tests/ios_platform_view_tests/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/dev/integration_tests/ios_platform_view_tests/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -58,7 +58,6 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/dev/integration_tests/ios_platform_view_tests/ios/Runner/AppDelegate.m
+++ b/dev/integration_tests/ios_platform_view_tests/ios/Runner/AppDelegate.m
@@ -8,6 +8,7 @@
 #import "TextFieldFactory.h"
 #import "ButtonFactory.h"
 #import "WebViewFactory.h"
+#import "DrawingWebViewFactory.h"
 #import "FakeAdMobBannerFactory.h"
 
 @implementation AppDelegate
@@ -21,6 +22,7 @@
   [registrar registerViewFactory:[[TextFieldFactory alloc] init] withId:@"platform_text_field"];
   [registrar registerViewFactory:[[ButtonFactory alloc] init] withId:@"platform_button"];
   [registrar registerViewFactory:[[WebViewFactory alloc] init] withId:@"platform_web_view"];
+  [registrar registerViewFactory:[[DrawingWebViewFactory alloc] init] withId:@"platform_drawing_web_view"];
   [registrar registerViewFactory:[[FakeAdMobBannerFactory alloc] init] withId:@"platform_fake_admob_banner"];
   return [super application:application didFinishLaunchingWithOptions:launchOptions];
 }

--- a/dev/integration_tests/ios_platform_view_tests/ios/Runner/DrawingWebViewFactory.h
+++ b/dev/integration_tests/ios_platform_view_tests/ios/Runner/DrawingWebViewFactory.h
@@ -1,0 +1,14 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Flutter/Flutter.h>
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface DrawingWebViewFactory: NSObject<FlutterPlatformViewFactory>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/dev/integration_tests/ios_platform_view_tests/ios/Runner/DrawingWebViewFactory.m
+++ b/dev/integration_tests/ios_platform_view_tests/ios/Runner/DrawingWebViewFactory.m
@@ -1,0 +1,38 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "DrawingWebViewFactory.h"
+#import <WebKit/WebKit.h>
+
+@interface DrawingWebViewPlatformView: NSObject<FlutterPlatformView>
+@property (strong, nonatomic) WKWebView *platformView;
+@end
+
+@implementation DrawingWebViewPlatformView
+
+- (instancetype)init
+{
+  self = [super init];
+  if (self) {
+    _platformView = [[WKWebView alloc] init];
+    NSString *htmlPath = [[NSBundle mainBundle] pathForResource:@"drawing_website" ofType:@"html"];
+    NSURL *htmlURL = [NSURL fileURLWithPath:htmlPath];
+    [self.platformView loadFileURL:htmlURL allowingReadAccessToURL: [htmlURL URLByDeletingLastPathComponent]];
+  }
+  return self;
+}
+
+- (UIView *)view {
+  return self.platformView;
+}
+
+@end
+
+@implementation DrawingWebViewFactory
+
+- (NSObject<FlutterPlatformView> *)createWithFrame:(CGRect)frame viewIdentifier:(int64_t)viewId arguments:(id)args {
+  return [[DrawingWebViewPlatformView alloc] init];
+}
+
+@end

--- a/dev/integration_tests/ios_platform_view_tests/ios/Runner/DrawingWebViewFactory.m
+++ b/dev/integration_tests/ios_platform_view_tests/ios/Runner/DrawingWebViewFactory.m
@@ -18,7 +18,7 @@
     _platformView = [[WKWebView alloc] init];
     NSString *htmlPath = [[NSBundle mainBundle] pathForResource:@"drawing_website" ofType:@"html"];
     NSURL *htmlURL = [NSURL fileURLWithPath:htmlPath];
-    [self.platformView loadFileURL:htmlURL allowingReadAccessToURL: [htmlURL URLByDeletingLastPathComponent]];
+    [self.platformView loadFileURL:htmlURL allowingReadAccessToURL:[htmlURL URLByDeletingLastPathComponent]];
   }
   return self;
 }

--- a/dev/integration_tests/ios_platform_view_tests/ios/Runner/drawing_website.html
+++ b/dev/integration_tests/ios_platform_view_tests/ios/Runner/drawing_website.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no'>
+  <style>
+    body { margin: 0; overflow: hidden; background-color: white; touch-action: none; }
+    canvas { display: block; width: 100vw; height: 100vh; }
+    #label { position: absolute; top: 10px; left: 10px; font-size: 20px; font-family: sans-serif; pointer-events: none; }
+  </style>
+</head>
+<body>
+  <div id='label'>pixel count: 0</div>
+  <canvas id='canvas'></canvas>
+  <script>
+    const canvas = document.getElementById('canvas');
+    const ctx = canvas.getContext('2d');
+    const label = document.getElementById('label');
+    let pixelCount = 0;
+    function resize() {
+      canvas.width = window.innerWidth;
+      canvas.height = window.innerHeight;
+    }
+    window.addEventListener('resize', resize);
+    resize();
+    function drawPixel(x, y) {
+      ctx.fillStyle = 'black';
+      ctx.fillRect(x, y, 2, 2);
+      pixelCount++;
+      label.innerText = 'pixel count: ' + pixelCount;
+    }
+    function handleTouch(e) {
+      e.preventDefault();
+      for (let i = 0; i < e.changedTouches.length; i++) {
+        const touch = e.changedTouches[i];
+        drawPixel(touch.clientX, touch.clientY);
+      }
+    }
+    canvas.addEventListener('touchstart', handleTouch, {passive: false});
+    canvas.addEventListener('touchmove', handleTouch, {passive: false});
+  </script>
+</body>
+</html>

--- a/dev/integration_tests/ios_platform_view_tests/lib/main.dart
+++ b/dev/integration_tests/ios_platform_view_tests/lib/main.dart
@@ -103,6 +103,18 @@ class _MyHomePageState extends State<MyHomePage> {
             },
           ),
           TextButton(
+            key: const ValueKey<String>('drawing_web_view_behind_context_menu_test'),
+            child: const Text('drawing web view behind context menu test'),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute<DrawingWebViewBehindContextMenuTestPage>(
+                  builder: (BuildContext context) => const DrawingWebViewBehindContextMenuTestPage(),
+                ),
+              );
+            },
+          ),
+          TextButton(
             key: const ValueKey<String>('admob_banner_in_scrollable_list_test'),
             child: const Text('admob banner in scrollable list test'),
             onPressed: () {
@@ -274,6 +286,50 @@ class _WebViewBehindContextMenuTestPageState extends State<WebViewBehindContextM
           dimension: 500.0,
           child: UiKitView(
             viewType: 'platform_web_view',
+            creationParamsCodec: StandardMessageCodec(),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// A page to test a web view with drawing website cannot be drawn when a context menu is shown.
+/// See [this issue](https://github.com/flutter/flutter/issues/179916).
+class DrawingWebViewBehindContextMenuTestPage extends StatefulWidget {
+  const DrawingWebViewBehindContextMenuTestPage({super.key});
+
+  @override
+  State<DrawingWebViewBehindContextMenuTestPage> createState() => _DrawingWebViewBehindContextMenuTestPageState();
+}
+
+class _DrawingWebViewBehindContextMenuTestPageState extends State<DrawingWebViewBehindContextMenuTestPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Drawing web view behind context menu test'),
+        actions: <Widget>[
+          PopupMenuButton<String>(
+            icon: const Icon(Icons.more_vert),
+            onSelected: (String value) {},
+            itemBuilder: (BuildContext context) {
+              return <PopupMenuEntry<String>>[
+                const PopupMenuItem<String>(value: 'button 1', child: Text('menu button 1')),
+                const PopupMenuItem<String>(value: 'button 2', child: Text('menu button 2')),
+                const PopupMenuItem<String>(value: 'button 3', child: Text('menu button 3')),
+                const PopupMenuItem<String>(value: 'button 4', child: Text('menu button 4')),
+                const PopupMenuItem<String>(value: 'button 5', child: Text('menu button 5')),
+              ];
+            },
+          ),
+        ],
+      ),
+      body: const Center(
+        child: SizedBox.square(
+          dimension: 500.0,
+          child: UiKitView(
+            viewType: 'platform_drawing_web_view',
             creationParamsCodec: StandardMessageCodec(),
           ),
         ),


### PR DESCRIPTION
## Do Not Land

I created this as a separate PR to allow code review in parallel. Also want to avoid distraction to the review of original PR (https://github.com/flutter/flutter/pull/183484) which is much more involved. 

*The CI will fail* because https://github.com/flutter/flutter/pull/183484 is still in progress. Once review is done, I will cherry-pick it into original PR and close this PR. 

This PR contains integration tests for drawing website touch fall-through bug. The current buggy behavior is that touches still fall-through even when context menu is shown: 

https://github.com/user-attachments/assets/f6759e85-16fa-4d7d-9390-d2574bb478be



*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

https://github.com/flutter/flutter/issues/179916

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
