### PR TITLE
feat(web): unify CanvasKit and Skwasm garbage collection

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine.dart
@@ -79,6 +79,7 @@ export 'engine/lazy_path.dart';
 export 'engine/mouse/context_menu.dart';
 export 'engine/mouse/cursor.dart';
 export 'engine/mouse/prevent_default.dart';
+export 'engine/native_memory.dart';
 export 'engine/navigation/history.dart';
 export 'engine/noto_font.dart';
 export 'engine/noto_font_encoding.dart';

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/color_filter.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/color_filter.dart
@@ -15,12 +15,12 @@ import 'package:ui/ui.dart' as ui;
 ///   the lifecycle of its [SkColorFilter].
 class ManagedSkColorFilter {
   ManagedSkColorFilter(CkColorFilter ckColorFilter) : colorFilter = ckColorFilter {
-    _ref = UniqueRef<SkColorFilter>(this, colorFilter._initRawColorFilter(), 'ColorFilter');
+    _ref = CkUniqueRef<SkColorFilter>(this, colorFilter._initRawColorFilter(), 'ColorFilter');
   }
 
   final CkColorFilter colorFilter;
 
-  late final UniqueRef<SkColorFilter> _ref;
+  late final CkUniqueRef<SkColorFilter> _ref;
 
   SkColorFilter get skiaObject => _ref.nativeObject;
 

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/image.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/image.dart
@@ -401,8 +401,14 @@ Future<Uint8List> readChunked(
 /// A [ui.Image] backed by an `SkImage` from Skia.
 class CkImage implements ui.Image, StackTraceDebugger {
   CkImage(SkImage skImage, {this.imageSource}) {
-    box = CountedRef<CkImage, SkImage>(skImage, this, 'SkImage');
+    box = CkCountedRef<CkImage, SkImage>(
+      skImage,
+      this,
+      'SkImage',
+      onDisposed: (CkImage image) => ui.Image.onDispose?.call(image),
+    );
     _init();
+    ui.Image.onCreate?.call(this);
     imageSource?.refCount++;
   }
 
@@ -417,7 +423,6 @@ class CkImage implements ui.Image, StackTraceDebugger {
       _debugStackTrace = StackTrace.current;
       return true;
     }());
-    ui.Image.onCreate?.call(this);
   }
 
   @override
@@ -426,7 +431,7 @@ class CkImage implements ui.Image, StackTraceDebugger {
 
   // Use ref counting because `SkImage` may be deleted either due to this object
   // being garbage-collected, or by an explicit call to [delete].
-  late final CountedRef<CkImage, SkImage> box;
+  late final CkCountedRef<CkImage, SkImage> box;
 
   /// If this [CkImage] is backed by an image source (either VideoFrame, <img>
   /// element, or ImageBitmap), this is the backing image source. We read pixels
@@ -436,7 +441,7 @@ class CkImage implements ui.Image, StackTraceDebugger {
 
   /// The underlying Skia image object.
   ///
-  /// Do not store the returned value. It is memory-managed by [CountedRef].
+  /// Do not store the returned value. It is memory-managed by [CkCountedRef].
   /// Storing it may result in use-after-free bugs.
   SkImage get skImage => box.nativeObject;
 
@@ -450,7 +455,6 @@ class CkImage implements ui.Image, StackTraceDebugger {
   @override
   void dispose() {
     assert(!_disposed, 'Cannot dispose an image that has already been disposed.');
-    ui.Image.onDispose?.call(this);
     _disposed = true;
     box.unref(this);
 

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/image.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/image.dart
@@ -463,19 +463,7 @@ class CkImage implements ui.Image, StackTraceDebugger {
   }
 
   @override
-  bool get debugDisposed {
-    bool? result;
-    assert(() {
-      result = _disposed;
-      return true;
-    }());
-
-    if (result != null) {
-      return result!;
-    }
-
-    throw StateError('Image.debugDisposed is only available when asserts are enabled.');
-  }
+  bool get debugDisposed => box.debugDisposed;
 
   @override
   CkImage clone() {

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/image.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/image.dart
@@ -463,7 +463,19 @@ class CkImage implements ui.Image, StackTraceDebugger {
   }
 
   @override
-  bool get debugDisposed => box.debugDisposed;
+  bool get debugDisposed {
+    bool? result;
+    assert(() {
+      result = _disposed;
+      return true;
+    }());
+
+    if (result != null) {
+      return result!;
+    }
+
+    throw StateError('Image.debugDisposed is only available when asserts are enabled.');
+  }
 
   @override
   CkImage clone() {

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/image_wasm_codecs.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/image_wasm_codecs.dart
@@ -22,10 +22,10 @@ class CkAnimatedImage implements ui.Codec {
   /// Decodes an image from a list of encoded bytes.
   CkAnimatedImage.decodeFromBytes(this._bytes, this.src, {this.targetWidth, this.targetHeight}) {
     final SkAnimatedImage skAnimatedImage = createSkAnimatedImage();
-    _ref = UniqueRef<SkAnimatedImage>(this, skAnimatedImage, 'Codec');
+    _ref = CkUniqueRef<SkAnimatedImage>(this, skAnimatedImage, 'Codec');
   }
 
-  late final UniqueRef<SkAnimatedImage> _ref;
+  late final CkUniqueRef<SkAnimatedImage> _ref;
   final String src;
   final Uint8List _bytes;
   int _frameCount = 0;

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/native_memory.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/native_memory.dart
@@ -3,224 +3,34 @@
 // found in the LICENSE file.
 
 import 'dart:js_interop';
-import 'package:meta/meta.dart';
-import 'package:ui/src/engine.dart';
 
-/// Collects native objects that weren't explicitly disposed of using
-/// [UniqueRef.dispose] or [CountedRef.unref].
-///
-/// We use this to delete Skia objects when their "Ck" wrapper is garbage
-/// collected.
-///
-/// Example sequence of events:
-///
-/// 1. A (CkPaint, SkPaint) pair created.
-/// 2. The paint is used to paint some picture.
-/// 3. CkPaint is dropped by the app.
-/// 4. GC decides to perform a GC cycle and collects CkPaint.
-/// 5. The finalizer function is called with the SkPaint as the sole argument.
-/// 6. We call `delete` on SkPaint.
-DomFinalizationRegistry _finalizationRegistry = DomFinalizationRegistry(
-  ((ExternalDartReference<UniqueRef<JSObject>> boxedUniq) => boxedUniq.toDartObject.collect()).toJS,
-);
+import '../native_memory.dart';
+import 'canvaskit_api.dart';
 
-NativeMemoryFinalizationRegistry nativeMemoryFinalizationRegistry =
-    NativeMemoryFinalizationRegistry();
-
-/// An indirection to [DomFinalizationRegistry] to enable tests provide a
-/// mock implementation of a finalization registry.
-class NativeMemoryFinalizationRegistry {
-  void register(Object owner, UniqueRef<JSObject> ref) {
-    if (browserSupportsFinalizationRegistry) {
-      _finalizationRegistry.register(owner.toExternalReference, ref.toExternalReference);
-    }
-  }
-}
+export '../native_memory.dart' show StackTraceDebugger;
 
 /// Manages the lifecycle of a C++ object referenced by a single Dart object.
-///
-/// It is expected that when the C++ object is no longer needed [dispose] is
-/// called.
-///
-/// To prevent memory leaks, the underlying C++ object is deleted by the GC if
-/// it wasn't previously disposed of explicitly.
-class UniqueRef<T extends JSObject> {
-  UniqueRef(Object owner, T nativeObject, this._debugOwnerLabel) {
-    _nativeObject = nativeObject;
-    if (Instrumentation.enabled) {
-      Instrumentation.instance.incrementCounter('$_debugOwnerLabel Created');
-    }
-    nativeMemoryFinalizationRegistry.register(owner, this);
-  }
-
-  T? _nativeObject;
-  final String _debugOwnerLabel;
-
-  /// Returns the underlying native object reference, if it has not been
-  /// disposed of yet.
-  ///
-  /// The returned reference must not be stored. I should only be borrowed
-  /// temporarily. Storing this reference may result in dangling pointer errors.
-  T get nativeObject {
-    assert(!isDisposed, 'The native object of $_debugOwnerLabel was disposed.');
-    return _nativeObject!;
-  }
-
-  /// Returns whether the underlying native object has been disposed and
-  /// therefore can no longer be used.
-  bool get isDisposed => _nativeObject == null;
-
-  /// Disposes the underlying native object.
-  ///
-  /// The underlying object may be deleted or its ref count may be bumped down.
-  /// The exact action taken depends on the sharing model of that particular
-  /// object. For example, an [SkImage] may not be immediately deleted if a
-  /// [SkPicture] exists that still references it. On the other hand, [SkPaint]
-  /// is deleted eagerly.
-  void dispose() {
-    assert(!isDisposed, 'A native object reference cannot be disposed more than once.');
-    if (Instrumentation.enabled) {
-      Instrumentation.instance.incrementCounter('$_debugOwnerLabel Deleted');
-    }
-    final object = nativeObject as SkDeletable;
-    if (!object.isDeleted()) {
-      object.delete();
-    }
-    _nativeObject = null;
-  }
-
-  /// Called by the garbage [Collector] when the owner of this handle is
-  /// collected.
-  ///
-  /// Garbage collection is used as a back-up for the cases when the handle
-  /// isn't disposed of explicitly by calling [dispose]. It most likely
-  /// indicates a memory leak or inefficiency in the framework or application
-  /// code.
-  @visibleForTesting
-  void collect() {
-    if (!isDisposed) {
-      if (Instrumentation.enabled) {
-        Instrumentation.instance.incrementCounter('$_debugOwnerLabel Leaked');
-      }
-      dispose();
-    }
-  }
-}
-
-/// Interface that classes wrapping [UniqueRef] must implement.
-///
-/// Used to collect stack traces in debug mode.
-abstract class StackTraceDebugger {
-  /// The stack trace pointing to code location that created or upreffed a
-  /// [CountedRef].
-  StackTrace get debugStackTrace;
+class CkUniqueRef<T extends JSObject> extends UniqueRef<T> {
+  CkUniqueRef(super.owner, super.nativeObject, super.debugOwnerLabel)
+    : super(
+        onDispose: (T obj) {
+          final deletable = obj as SkDeletable;
+          if (!deletable.isDeleted()) {
+            deletable.delete();
+          }
+        },
+      );
 }
 
 /// Manages the lifecycle of a C++ object referenced by multiple Dart objects.
-///
-/// Uses reference counting to manage the lifecycle of the C++ object.
-///
-/// If the C++ object has a unique owner, use [UniqueRef] instead.
-///
-/// The [ref] method can be used to increment the refcount to tell this box to
-/// keep the underlying C++ object alive.
-///
-/// The [unref] method can be used to decrement the refcount indicating that a
-/// referring object no longer needs it. When the refcount drops to zero the
-/// underlying C++ object is deleted.
-///
-/// In addition to ref counting, this object is also managed by GC. When this
-/// reference is garbage collected, the underlying C++ object is automatically
-/// deleted. This is mostly done to prevent memory leaks in production. Well
-/// behaving framework and app code are expected to rely on [ref] and [unref]
-/// for timely collection of resources.
-class CountedRef<R extends StackTraceDebugger, T extends JSObject> {
-  /// Creates a counted reference.
-  CountedRef(T nativeObject, R debugReferrer, String debugLabel) {
-    _ref = UniqueRef<T>(this, nativeObject, debugLabel);
-    assert(() {
-      debugReferrers.add(debugReferrer);
-      return true;
-    }());
-    assert(refCount == debugReferrers.length);
-  }
-
-  /// The native object reference whose lifecycle is being managed by this ref
-  /// count.
-  ///
-  /// Do not store this value outside this class.
-  late final UniqueRef<T> _ref;
-
-  /// Returns the underlying native object reference, if it has not been
-  /// disposed of yet.
-  ///
-  /// The returned reference must not be stored. I should only be borrowed
-  /// temporarily. Storing this reference may result in dangling pointer errors.
-  T get nativeObject => _ref.nativeObject;
-
-  /// The number of objects sharing references to this box.
-  ///
-  /// When this count reaches zero, the underlying [nativeObject] is scheduled
-  /// for deletion.
-  int get refCount => _refCount;
-  int _refCount = 1;
-
-  /// Whether the underlying [nativeObject] has been disposed and is no longer
-  /// accessible.
-  bool get isDisposed => _ref.isDisposed;
-
-  /// When assertions are enabled, stores all objects that share this box.
-  ///
-  /// The length of this list is always identical to [refCount].
-  ///
-  /// This list can be used for debugging ref counting issues.
-  final Set<R> debugReferrers = <R>{};
-
-  /// If asserts are enabled, the [StackTrace]s representing when a reference
-  /// was created.
-  List<StackTrace> debugGetStackTraces() {
-    List<StackTrace>? result;
-    assert(() {
-      result = debugReferrers.map<StackTrace>((R referrer) => referrer.debugStackTrace).toList();
-      return true;
-    }());
-
-    if (result != null) {
-      return result!;
-    }
-
-    throw UnsupportedError('');
-  }
-
-  /// Increases the reference count of this box because a new object began
-  /// sharing ownership of the underlying [nativeObject].
-  void ref(R debugReferrer) {
-    assert(!_ref.isDisposed, 'Cannot increment ref count on a deleted handle.');
-    assert(_refCount > 0);
-    assert(
-      debugReferrers.add(debugReferrer),
-      'Attempted to increment ref count by the same referrer more than once.',
-    );
-    _refCount += 1;
-    assert(refCount == debugReferrers.length);
-  }
-
-  /// Decrements the reference count for the [nativeObject].
-  ///
-  /// Does nothing if the object has already been deleted.
-  ///
-  /// If this causes the reference count to drop to zero, deletes the
-  /// [nativeObject].
-  void unref(R debugReferrer) {
-    assert(!_ref.isDisposed, 'Attempted to unref an already deleted native object.');
-    assert(
-      debugReferrers.remove(debugReferrer),
-      'Attempted to decrement ref count by the same referrer more than once.',
-    );
-    _refCount -= 1;
-    assert(refCount == debugReferrers.length);
-    if (_refCount == 0) {
-      _ref.dispose();
-    }
-  }
+class CkCountedRef<R extends StackTraceDebugger, T extends JSObject> extends CountedRef<R, T> {
+  CkCountedRef(super.nativeObject, super.debugReferrer, super.debugLabel, {super.onDisposed})
+    : super(
+        onDispose: (T obj) {
+          final deletable = obj as SkDeletable;
+          if (!deletable.isDeleted()) {
+            deletable.delete();
+          }
+        },
+      );
 }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/painting.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/painting.dart
@@ -350,7 +350,7 @@ class CkFragmentShader implements ui.FragmentShader, CkShader {
   final CkFragmentProgram _program;
 
   @visibleForTesting
-  UniqueRef<SkShader>? ref;
+  CkUniqueRef<SkShader>? ref;
 
   @override
   bool get isGradient => false;
@@ -371,7 +371,7 @@ class CkFragmentShader implements ui.FragmentShader, CkShader {
       );
     }
 
-    ref = UniqueRef<SkShader>(this, result, 'FragmentShader');
+    ref = CkUniqueRef<SkShader>(this, result, 'FragmentShader');
     return result;
   }
 

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/path.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/path.dart
@@ -38,10 +38,10 @@ class CkPath implements DisposablePath {
   }
 
   CkPath._(SkPathBuilder nativeObject, this._fillType) {
-    _ref = UniqueRef<SkPathBuilder>(this, nativeObject, 'PathBuilder');
+    _ref = CkUniqueRef<SkPathBuilder>(this, nativeObject, 'PathBuilder');
   }
 
-  late final UniqueRef<SkPathBuilder> _ref;
+  late final CkUniqueRef<SkPathBuilder> _ref;
 
   SkPathBuilder get _skiaPathBuilder => _ref.nativeObject;
 

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/path_metrics.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/path_metrics.dart
@@ -23,12 +23,12 @@ class CkPathMetrics extends IterableBase<ui.PathMetric> implements DisposablePat
 
 class CkContourMeasureIter implements DisposablePathMetricIterator {
   CkContourMeasureIter(this._metrics) {
-    _skPathRef = UniqueRef<SkPath>(
+    _skPathRef = CkUniqueRef<SkPath>(
       this,
       _metrics._path.snapshotSkPath(),
       'SkContourMeasureIter:SkPath',
     );
-    _ref = UniqueRef<SkContourMeasureIter>(
+    _ref = CkUniqueRef<SkContourMeasureIter>(
       this,
       SkContourMeasureIter(_skPathRef.nativeObject, _metrics._forceClosed, 1.0),
       'CkContourMeasureIter:SkContourMeasureIter',
@@ -42,8 +42,8 @@ class CkContourMeasureIter implements DisposablePathMetricIterator {
   }
 
   final CkPathMetrics _metrics;
-  late final UniqueRef<SkContourMeasureIter> _ref;
-  late final UniqueRef<SkPath> _skPathRef;
+  late final CkUniqueRef<SkContourMeasureIter> _ref;
+  late final CkUniqueRef<SkPath> _skPathRef;
 
   SkContourMeasureIter get skiaObject => _ref.nativeObject;
 
@@ -83,7 +83,7 @@ class CkContourMeasureIter implements DisposablePathMetricIterator {
 
 class CkContourMeasure implements DisposablePathMetric {
   CkContourMeasure(this._metrics, SkContourMeasure skiaObject, this.contourIndex) {
-    _ref = UniqueRef<SkContourMeasure>(this, skiaObject, 'PathMetric');
+    _ref = CkUniqueRef<SkContourMeasure>(this, skiaObject, 'PathMetric');
   }
 
   /// The path metrics used to create this measure.
@@ -91,7 +91,7 @@ class CkContourMeasure implements DisposablePathMetric {
   /// This is used to resurrect the object if it is deleted prematurely.
   final CkPathMetrics _metrics;
 
-  late final UniqueRef<SkContourMeasure> _ref;
+  late final CkUniqueRef<SkContourMeasure> _ref;
 
   SkContourMeasure get skiaObject => _ref.nativeObject;
 

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/picture.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/picture.dart
@@ -44,7 +44,19 @@ class CkPicture implements LayerPicture, StackTraceDebugger {
   int get approximateBytesUsed => skiaObject.approximateBytesUsed();
 
   @override
-  bool get debugDisposed => _ref.debugDisposed;
+  bool get debugDisposed {
+    bool? result;
+    assert(() {
+      result = _isDisposed;
+      return true;
+    }());
+
+    if (result != null) {
+      return result!;
+    }
+
+    throw StateError('Picture.debugDisposed is only available when asserts are enabled.');
+  }
 
   /// This is set to true when [dispose] is called and is never reset back to
   /// false.

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/picture.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/picture.dart
@@ -44,19 +44,7 @@ class CkPicture implements LayerPicture, StackTraceDebugger {
   int get approximateBytesUsed => skiaObject.approximateBytesUsed();
 
   @override
-  bool get debugDisposed {
-    bool? result;
-    assert(() {
-      result = _isDisposed;
-      return true;
-    }());
-
-    if (result != null) {
-      return result!;
-    }
-
-    throw StateError('Picture.debugDisposed is only available when asserts are enabled.');
-  }
+  bool get debugDisposed => _ref.debugDisposed;
 
   /// This is set to true when [dispose] is called and is never reset back to
   /// false.

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/picture.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/picture.dart
@@ -17,19 +17,23 @@ import 'surface.dart';
 
 /// Implements [ui.Picture] on top of [SkPicture].
 class CkPicture implements LayerPicture, StackTraceDebugger {
-  CkPicture(SkPicture skPicture) : _isClone = false {
-    _ref = CountedRef<CkPicture, SkPicture>(skPicture, this, 'Picture');
+  CkPicture(SkPicture skPicture) {
+    _ref = CkCountedRef<CkPicture, SkPicture>(
+      skPicture,
+      this,
+      'Picture',
+      onDisposed: (CkPicture picture) => ui.Picture.onDispose?.call(picture),
+    );
     _initStackTrace();
   }
 
-  CkPicture._clone(CountedRef<CkPicture, SkPicture> ref) : _isClone = true {
+  CkPicture._clone(CkCountedRef<CkPicture, SkPicture> ref) {
     _ref = ref;
     ref.ref(this);
     _initStackTrace();
   }
 
-  late final CountedRef<CkPicture, SkPicture> _ref;
-  final bool _isClone;
+  late final CkCountedRef<CkPicture, SkPicture> _ref;
 
   SkPicture get skiaObject => _ref.nativeObject;
 
@@ -93,9 +97,6 @@ class CkPicture implements LayerPicture, StackTraceDebugger {
       _debugDisposalStackTrace = StackTrace.current;
       return true;
     }());
-    if (!_isClone) {
-      ui.Picture.onDispose?.call(this);
-    }
     _isDisposed = true;
     _ref.unref(this);
   }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/shader.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/shader.dart
@@ -39,10 +39,10 @@ abstract class CkShader implements ui.Shader {
 /// [SkShader] object, ignoring contextual filter quality.
 abstract class SimpleCkShader implements CkShader {
   SimpleCkShader() {
-    _ref = UniqueRef<SkShader>(this, createSkiaObject(), debugOwnerLabel);
+    _ref = CkUniqueRef<SkShader>(this, createSkiaObject(), debugOwnerLabel);
   }
 
-  late final UniqueRef<SkShader> _ref;
+  late final CkUniqueRef<SkShader> _ref;
 
   @override
   SkShader getSkShader(ui.FilterQuality contextualQuality) => _ref.nativeObject;
@@ -258,7 +258,7 @@ class CkImageShader implements ui.ImageShader, CkShader {
   /// This reference changes when [withQuality] is called with different filter
   /// quality levels.
   @visibleForTesting
-  UniqueRef<SkShader>? ref;
+  CkUniqueRef<SkShader>? ref;
 
   /// The filter quality at which the latest [SkShader] was initialized.
   @visibleForTesting
@@ -303,7 +303,7 @@ class CkImageShader implements ui.ImageShader, CkShader {
 
     currentQuality = quality;
     ref?.dispose();
-    ref = UniqueRef<SkShader>(this, skShader, 'ImageShader');
+    ref = CkUniqueRef<SkShader>(this, skShader, 'ImageShader');
   }
 
   bool _isDisposed = false;

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/shader.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/shader.dart
@@ -309,7 +309,19 @@ class CkImageShader implements ui.ImageShader, CkShader {
   bool _isDisposed = false;
 
   @override
-  bool get debugDisposed => _isDisposed;
+  bool get debugDisposed {
+    bool? result;
+    assert(() {
+      result = _isDisposed;
+      return true;
+    }());
+
+    if (result != null) {
+      return result!;
+    }
+
+    throw StateError('debugDisposed is only available when asserts are enabled.');
+  }
 
   @override
   void dispose() {

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/text.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/text.dart
@@ -794,10 +794,10 @@ SkFontStyle toSkFontStyle(ui.FontWeight? fontWeight, ui.FontStyle? fontStyle) {
 /// The CanvasKit implementation of [ui.Paragraph].
 class CkParagraph implements ui.Paragraph {
   CkParagraph(SkParagraph skParagraph, this._paragraphStyle) {
-    _ref = UniqueRef<SkParagraph>(this, skParagraph, 'Paragraph');
+    _ref = CkUniqueRef<SkParagraph>(this, skParagraph, 'Paragraph');
   }
 
-  late final UniqueRef<SkParagraph> _ref;
+  late final CkUniqueRef<SkParagraph> _ref;
 
   SkParagraph get skiaObject => _ref.nativeObject;
 

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/vertices.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/vertices.dart
@@ -80,7 +80,7 @@ class CkVertices implements ui.Vertices {
         _colors,
         _indices,
       );
-      _ref = UniqueRef<SkVertices>(this, skVertices, 'Vertices');
+      _ref = CkUniqueRef<SkVertices>(this, skVertices, 'Vertices');
     } else {
       _ref = null;
     }
@@ -91,7 +91,7 @@ class CkVertices implements ui.Vertices {
   final Float32List? _textureCoordinates;
   final Uint32List? _colors;
   final Uint16List? _indices;
-  late final UniqueRef<SkVertices>? _ref;
+  late final CkUniqueRef<SkVertices>? _ref;
 
   SkVertices get skiaObject => _ref!.nativeObject;
 

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/native_memory.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/native_memory.dart
@@ -1,0 +1,243 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:js_interop';
+
+import 'package:meta/meta.dart';
+
+import 'dom.dart';
+import 'profiler.dart';
+
+/// An interface for a finalizer that can be used to run a cleanup function when
+/// an object is garbage collected.
+abstract class Finalizer {
+  /// Attaches this finalizer to [target].
+  void attach(Object target, Object value, {Object? detach});
+
+  /// Detaches this finalizer from whatever [detach] was used to attach it.
+  void detach(Object detach);
+}
+
+/// A finalizer that can be used to run a cleanup function when an object is
+/// garbage collected.
+///
+/// This is a wrapper around [DomFinalizationRegistry] that provides a more
+/// Dart-friendly API, similar to [NativeFinalizer] from `dart:ffi`.
+class NativeMemoryFinalizer implements Finalizer {
+  NativeMemoryFinalizer(void Function(Object) cleanup)
+    : _registry = DomFinalizationRegistry(
+        ((ExternalDartReference value) {
+          final Object? object = value.toDartObject;
+          if (object != null) {
+            cleanup(object);
+          }
+        }).toJS,
+      );
+
+  final DomFinalizationRegistry _registry;
+
+  /// Attaches this finalizer to [target].
+  ///
+  /// When [target] is garbage collected, the cleanup function of this
+  /// finalizer will be called with [value] as the argument.
+  ///
+  /// If [detach] is provided, it can be used to detach the finalizer later
+  /// using [this.detach].
+  @override
+  void attach(Object target, Object value, {Object? detach}) {
+    if (browserSupportsFinalizationRegistry) {
+      if (detach != null) {
+        _registry.registerWithToken(
+          target.toExternalReference,
+          value.toExternalReference,
+          detach.toExternalReference,
+        );
+      } else {
+        _registry.register(target.toExternalReference, value.toExternalReference);
+      }
+    }
+  }
+
+  /// Detaches this finalizer from whatever [detach] was used to attach it.
+  @override
+  void detach(Object detach) {
+    if (browserSupportsFinalizationRegistry) {
+      _registry.unregister(detach.toExternalReference);
+    }
+  }
+}
+
+/// Interface that objects wrapping [UniqueRef] or [CountedRef] must implement
+/// to support debugging.
+abstract class StackTraceDebugger {
+  /// The stack trace pointing to code location that created or upreffed a
+  /// [CountedRef].
+  StackTrace get debugStackTrace;
+}
+
+/// Manages the lifecycle of a native object referenced by a single Dart object.
+///
+/// It is expected that when the native object is no longer needed [dispose] is
+/// called.
+///
+/// To prevent memory leaks, the underlying native object is disposed by the GC
+/// if it wasn't previously disposed of explicitly.
+class UniqueRef<T> {
+  UniqueRef(
+    Object owner,
+    T nativeObject,
+    this._debugOwnerLabel, {
+    required void Function(T) onDispose,
+  }) : _nativeObject = nativeObject,
+       _onDispose = onDispose {
+    if (Instrumentation.enabled) {
+      Instrumentation.instance.incrementCounter('$_debugOwnerLabel Created');
+    }
+    finalizer.attach(owner, this, detach: this);
+  }
+
+  /// The finalizer used by all [UniqueRef] instances.
+  ///
+  /// This can be overridden in tests to verify finalization behavior.
+  @visibleForTesting
+  static Finalizer finalizer = NativeMemoryFinalizer(
+    (Object ref) => (ref as UniqueRef<dynamic>).collect(),
+  );
+
+  T? _nativeObject;
+  final String _debugOwnerLabel;
+  final void Function(T) _onDispose;
+
+  /// Returns the underlying native object reference, if it has not been
+  /// disposed of yet.
+  T get nativeObject {
+    assert(!isDisposed, 'The native object of $_debugOwnerLabel was disposed.');
+    return _nativeObject!;
+  }
+
+  /// Returns whether the underlying native object has been disposed and
+  /// therefore can no longer be used.
+  bool get isDisposed => _nativeObject == null;
+
+  /// Disposes the underlying native object.
+  void dispose() {
+    assert(!isDisposed, 'A native object reference cannot be disposed more than once.');
+    finalizer.detach(this);
+    if (Instrumentation.enabled) {
+      Instrumentation.instance.incrementCounter('$_debugOwnerLabel Deleted');
+    }
+    final object = _nativeObject as T;
+    _onDispose(object);
+    _nativeObject = null;
+  }
+
+  /// Called by the garbage collector when the owner of this handle is
+  /// collected.
+  @visibleForTesting
+  void collect() {
+    if (!isDisposed) {
+      if (Instrumentation.enabled) {
+        Instrumentation.instance.incrementCounter('$_debugOwnerLabel Leaked');
+      }
+      dispose();
+    }
+  }
+}
+
+/// Manages the lifecycle of a native object referenced by multiple Dart objects.
+///
+/// Uses reference counting to manage the lifecycle of the native object.
+///
+/// If the native object has a unique owner, use [UniqueRef] instead.
+///
+/// The [ref] method can be used to increment the refcount to tell this box to
+/// keep the underlying native object alive.
+///
+/// The [unref] method can be used to decrement the refcount indicating that a
+/// referring object no longer needs it. When the refcount drops to zero the
+/// underlying native object is disposed.
+class CountedRef<R extends StackTraceDebugger, T> {
+  /// Creates a counted reference.
+  CountedRef(
+    T nativeObject,
+    R debugReferrer,
+    String debugLabel, {
+    required void Function(T) onDispose,
+    this.onDisposed,
+  }) {
+    _ref = UniqueRef<T>(this, nativeObject, debugLabel, onDispose: onDispose);
+    assert(() {
+      debugReferrers.add(debugReferrer);
+      return true;
+    }());
+    assert(refCount == debugReferrers.length);
+  }
+
+  /// The native object reference whose lifecycle is being managed by this ref
+  /// count.
+  late final UniqueRef<T> _ref;
+
+  /// A callback that is called when the reference count drops to zero and the
+  /// underlying native object is disposed.
+  final void Function(R)? onDisposed;
+
+  /// Returns the underlying native object reference, if it has not been
+  /// disposed of yet.
+  T get nativeObject => _ref.nativeObject;
+
+  /// The number of objects sharing references to this box.
+  int get refCount => _refCount;
+  int _refCount = 1;
+
+  /// Whether the underlying [nativeObject] has been disposed and is no longer
+  /// accessible.
+  bool get isDisposed => _ref.isDisposed;
+
+  /// When assertions are enabled, stores all objects that share this box.
+  final Set<R> debugReferrers = <R>{};
+
+  /// If asserts are enabled, the [StackTrace]s representing when a reference
+  /// was created.
+  List<StackTrace> debugGetStackTraces() {
+    List<StackTrace>? result;
+    assert(() {
+      result = debugReferrers.map<StackTrace>((R referrer) => referrer.debugStackTrace).toList();
+      return true;
+    }());
+
+    if (result != null) {
+      return result!;
+    }
+
+    throw UnsupportedError('StackTrace collection only supported in debug mode.');
+  }
+
+  /// Increases the reference count of this box because a new object began
+  /// sharing ownership of the underlying [nativeObject].
+  void ref(R debugReferrer) {
+    assert(!_ref.isDisposed, 'Cannot increment ref count on a deleted handle.');
+    assert(_refCount > 0);
+    assert(
+      debugReferrers.add(debugReferrer),
+      'Attempted to increment ref count by the same referrer more than once.',
+    );
+    _refCount += 1;
+    assert(refCount == debugReferrers.length);
+  }
+
+  /// Decrements the reference count for the [nativeObject].
+  void unref(R debugReferrer) {
+    assert(!_ref.isDisposed, 'Attempted to unref an already deleted native object.');
+    assert(
+      debugReferrers.remove(debugReferrer),
+      'Attempted to decrement ref count by the same referrer more than once.',
+    );
+    _refCount -= 1;
+    assert(refCount == debugReferrers.length);
+    if (_refCount == 0) {
+      onDisposed?.call(debugReferrer);
+      _ref.dispose();
+    }
+  }
+}

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/native_memory.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/native_memory.dart
@@ -120,6 +120,23 @@ class UniqueRef<T> {
   /// therefore can no longer be used.
   bool get isDisposed => _nativeObject == null;
 
+  /// Whether the underlying native object has been disposed.
+  ///
+  /// This is only available in debug mode.
+  bool get debugDisposed {
+    bool? result;
+    assert(() {
+      result = isDisposed;
+      return true;
+    }());
+
+    if (result != null) {
+      return result!;
+    }
+
+    throw StateError('debugDisposed is only available when asserts are enabled.');
+  }
+
   /// Disposes the underlying native object.
   void dispose() {
     assert(!isDisposed, 'A native object reference cannot be disposed more than once.');
@@ -193,6 +210,11 @@ class CountedRef<R extends StackTraceDebugger, T> {
   /// Whether the underlying [nativeObject] has been disposed and is no longer
   /// accessible.
   bool get isDisposed => _ref.isDisposed;
+
+  /// Whether the underlying native object has been disposed.
+  ///
+  /// This is only available in debug mode.
+  bool get debugDisposed => _ref.debugDisposed;
 
   /// When assertions are enabled, stores all objects that share this box.
   final Set<R> debugReferrers = <R>{};

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/filters.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/filters.dart
@@ -446,7 +446,7 @@ class SkwasmMatrixColorFilter extends SkwasmColorFilter {
 
 class SkwasmMaskFilter extends SkwasmObjectWrapper<RawMaskFilter> {
   SkwasmMaskFilter._(MaskFilterHandle handle)
-    : super(handle, (MaskFilterHandle h) => maskFilterDispose(h));
+    : super(handle, (MaskFilterHandle h) => maskFilterDispose(h), 'MaskFilter');
 
   factory SkwasmMaskFilter.fromUiMaskFilter(ui.MaskFilter maskFilter) => SkwasmMaskFilter._(
     maskFilterCreateBlur(maskFilter.webOnlyBlurStyle.index, maskFilter.webOnlySigma),

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/filters.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/filters.dart
@@ -445,14 +445,10 @@ class SkwasmMatrixColorFilter extends SkwasmColorFilter {
 }
 
 class SkwasmMaskFilter extends SkwasmObjectWrapper<RawMaskFilter> {
-  SkwasmMaskFilter._(MaskFilterHandle handle) : super(handle, _registry);
+  SkwasmMaskFilter._(MaskFilterHandle handle)
+    : super(handle, (MaskFilterHandle h) => maskFilterDispose(h));
 
   factory SkwasmMaskFilter.fromUiMaskFilter(ui.MaskFilter maskFilter) => SkwasmMaskFilter._(
     maskFilterCreateBlur(maskFilter.webOnlyBlurStyle.index, maskFilter.webOnlySigma),
   );
-
-  static final SkwasmFinalizationRegistry<RawMaskFilter> _registry =
-      SkwasmFinalizationRegistry<RawMaskFilter>(
-        (MaskFilterHandle handle) => maskFilterDispose(handle),
-      );
 }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/font_collection.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/font_collection.dart
@@ -20,10 +20,8 @@ String _robotoUrl =
     '${configuration.fontFallbackBaseUrl}roboto/v32/KFOmCnqEu92Fr1Me4GZLCzYlKw.woff2';
 
 class SkwasmTypeface extends SkwasmObjectWrapper<RawTypeface> {
-  SkwasmTypeface(SkDataHandle data) : super(typefaceCreate(data), _registry);
-
-  static final SkwasmFinalizationRegistry<RawTypeface> _registry =
-      SkwasmFinalizationRegistry<RawTypeface>((TypefaceHandle handle) => typefaceDispose(handle));
+  SkwasmTypeface(SkDataHandle data)
+    : super(typefaceCreate(data), (TypefaceHandle h) => typefaceDispose(h));
 }
 
 class SkwasmFontCollection implements FlutterFontCollection {

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/font_collection.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/font_collection.dart
@@ -21,7 +21,7 @@ String _robotoUrl =
 
 class SkwasmTypeface extends SkwasmObjectWrapper<RawTypeface> {
   SkwasmTypeface(SkDataHandle data)
-    : super(typefaceCreate(data), (TypefaceHandle h) => typefaceDispose(h));
+    : super(typefaceCreate(data), (TypefaceHandle h) => typefaceDispose(h), 'Typeface');
 }
 
 class SkwasmFontCollection implements FlutterFontCollection {

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/image.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/image.dart
@@ -10,9 +10,22 @@ import 'package:ui/src/engine.dart';
 import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 import 'package:ui/ui.dart' as ui;
 
-class SkwasmImage extends SkwasmObjectWrapper<RawImage> implements ui.Image {
-  SkwasmImage(ImageHandle handle) : super(handle, _registry) {
+class SkwasmImage implements ui.Image, StackTraceDebugger {
+  SkwasmImage(ImageHandle handle) {
+    box = CountedRef<SkwasmImage, ImageHandle>(
+      handle,
+      this,
+      'SkImage',
+      onDispose: (ImageHandle h) => imageDispose(h),
+      onDisposed: (SkwasmImage image) => ui.Image.onDispose?.call(image),
+    );
+    _init();
     ui.Image.onCreate?.call(this);
+  }
+
+  SkwasmImage.cloneOf(this.box) {
+    box.ref(this);
+    _init();
   }
 
   factory SkwasmImage.fromPixels(
@@ -38,14 +51,28 @@ class SkwasmImage extends SkwasmObjectWrapper<RawImage> implements ui.Image {
     return SkwasmImage(imageHandle);
   }
 
-  static final SkwasmFinalizationRegistry<RawImage> _registry =
-      SkwasmFinalizationRegistry<RawImage>((ImageHandle handle) => imageDispose(handle));
+  void _init() {
+    assert(() {
+      _debugStackTrace = StackTrace.current;
+      return true;
+    }());
+  }
+
+  @override
+  StackTrace get debugStackTrace => _debugStackTrace;
+  late StackTrace _debugStackTrace;
+
+  late final CountedRef<SkwasmImage, ImageHandle> box;
 
   @override
   void dispose() {
-    super.dispose();
-    ui.Image.onDispose?.call(this);
+    box.unref(this);
   }
+
+  ImageHandle get handle => box.nativeObject;
+
+  @override
+  bool get debugDisposed => box.isDisposed;
 
   @override
   int get width => imageGetWidth(handle);
@@ -88,16 +115,13 @@ class SkwasmImage extends SkwasmObjectWrapper<RawImage> implements ui.Image {
   ui.ColorSpace get colorSpace => ui.ColorSpace.sRGB;
 
   @override
-  SkwasmImage clone() {
-    imageRef(handle);
-    return SkwasmImage(handle);
-  }
+  SkwasmImage clone() => SkwasmImage.cloneOf(box);
 
   @override
   bool isCloneOf(ui.Image other) => other is SkwasmImage && handle == other.handle;
 
   @override
-  List<StackTrace>? debugGetOpenHandleStackTraces() => null;
+  List<StackTrace>? debugGetOpenHandleStackTraces() => box.debugGetStackTraces();
 
   @override
   String toString() => '[$width\u00D7$height]';

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/image.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/image.dart
@@ -64,15 +64,33 @@ class SkwasmImage implements ui.Image, StackTraceDebugger {
 
   late final CountedRef<SkwasmImage, ImageHandle> box;
 
+  bool _disposed = false;
+
   @override
   void dispose() {
+    if (_disposed) {
+      return;
+    }
+    _disposed = true;
     box.unref(this);
   }
 
   ImageHandle get handle => box.nativeObject;
 
   @override
-  bool get debugDisposed => box.debugDisposed;
+  bool get debugDisposed {
+    bool? result;
+    assert(() {
+      result = _disposed;
+      return true;
+    }());
+
+    if (result != null) {
+      return result!;
+    }
+
+    throw StateError('Image.debugDisposed is only available when asserts are enabled.');
+  }
 
   @override
   int get width => imageGetWidth(handle);

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/image.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/image.dart
@@ -72,7 +72,7 @@ class SkwasmImage implements ui.Image, StackTraceDebugger {
   ImageHandle get handle => box.nativeObject;
 
   @override
-  bool get debugDisposed => box.isDisposed;
+  bool get debugDisposed => box.debugDisposed;
 
   @override
   int get width => imageGetWidth(handle);

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/memory.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/memory.dart
@@ -3,48 +3,20 @@
 // found in the LICENSE file.
 
 import 'dart:ffi';
-import 'dart:js_interop';
 
-import 'package:ui/src/engine.dart';
+import 'package:ui/src/engine/native_memory.dart';
 
-class SkwasmObjectWrapper<T extends NativeType> {
-  SkwasmObjectWrapper(this.handle, this.registry) {
-    registry.register(this);
+abstract class SkwasmObjectWrapper<T extends NativeType> {
+  SkwasmObjectWrapper(this.handle, void Function(Pointer<T>) dispose) {
+    _ref = UniqueRef<Pointer<T>>(this, handle, 'SkwasmObject', onDispose: dispose);
   }
-  final SkwasmFinalizationRegistry<T> registry;
+
+  late final UniqueRef<Pointer<T>> _ref;
   final Pointer<T> handle;
-  bool _isDisposed = false;
 
   void dispose() {
-    assert(!_isDisposed);
-    registry.evict(this);
-    _isDisposed = true;
+    _ref.dispose();
   }
 
-  bool get debugDisposed => _isDisposed;
-}
-
-typedef DisposeFunction<T extends NativeType> = void Function(Pointer<T>);
-
-class SkwasmFinalizationRegistry<T extends NativeType> {
-  SkwasmFinalizationRegistry(this.dispose)
-    : registry = DomFinalizationRegistry(
-        ((ExternalDartReference<int> address) => dispose(
-          Pointer<T>.fromAddress(address.toDartObject),
-        )).toJS,
-      );
-
-  final DomFinalizationRegistry registry;
-  final DisposeFunction<T> dispose;
-
-  void register(SkwasmObjectWrapper<T> wrapper) {
-    final ExternalDartReference jsWrapper = wrapper.toExternalReference;
-    registry.registerWithToken(jsWrapper, wrapper.handle.address.toExternalReference, jsWrapper);
-  }
-
-  void evict(SkwasmObjectWrapper<T> wrapper) {
-    final ExternalDartReference jsWrapper = wrapper.toExternalReference;
-    registry.unregister(jsWrapper);
-    dispose(wrapper.handle);
-  }
+  bool get debugDisposed => _ref.isDisposed;
 }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/memory.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/memory.dart
@@ -7,12 +7,13 @@ import 'dart:ffi';
 import 'package:ui/src/engine/native_memory.dart';
 
 abstract class SkwasmObjectWrapper<T extends NativeType> {
-  SkwasmObjectWrapper(this.handle, void Function(Pointer<T>) dispose) {
+  SkwasmObjectWrapper(Pointer<T> handle, void Function(Pointer<T>) dispose) {
     _ref = UniqueRef<Pointer<T>>(this, handle, 'SkwasmObject', onDispose: dispose);
   }
 
   late final UniqueRef<Pointer<T>> _ref;
-  final Pointer<T> handle;
+
+  Pointer<T> get handle => _ref.nativeObject;
 
   void dispose() {
     _ref.dispose();

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/memory.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/memory.dart
@@ -6,9 +6,14 @@ import 'dart:ffi';
 
 import 'package:ui/src/engine/native_memory.dart';
 
+/// A wrapper for a native Skia object that is owned by the Skwasm renderer.
 abstract class SkwasmObjectWrapper<T extends NativeType> {
-  SkwasmObjectWrapper(Pointer<T> handle, void Function(Pointer<T>) dispose) {
-    _ref = UniqueRef<Pointer<T>>(this, handle, 'SkwasmObject', onDispose: dispose);
+  SkwasmObjectWrapper(
+    Pointer<T> handle,
+    void Function(Pointer<T>) dispose,
+    String debugOwnerLabel,
+  ) {
+    _ref = UniqueRef<Pointer<T>>(this, handle, debugOwnerLabel, onDispose: dispose);
   }
 
   late final UniqueRef<Pointer<T>> _ref;

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/memory.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/memory.dart
@@ -19,5 +19,5 @@ abstract class SkwasmObjectWrapper<T extends NativeType> {
     _ref.dispose();
   }
 
-  bool get debugDisposed => _ref.isDisposed;
+  bool get debugDisposed => _ref.debugDisposed;
 }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
@@ -90,12 +90,8 @@ class SkwasmLineMetrics implements ui.LineMetrics {
 }
 
 class SkwasmParagraph extends SkwasmObjectWrapper<RawParagraph> implements ui.Paragraph {
-  SkwasmParagraph(ParagraphHandle handle) : super(handle, _registry);
-
-  static final SkwasmFinalizationRegistry<RawParagraph> _registry =
-      SkwasmFinalizationRegistry<RawParagraph>(
-        (ParagraphHandle handle) => paragraphDispose(handle),
-      );
+  SkwasmParagraph(ParagraphHandle handle)
+    : super(handle, (ParagraphHandle h) => paragraphDispose(h));
 
   bool _hasCheckedForMissingCodePoints = false;
 
@@ -311,14 +307,10 @@ void withScopedFontList(
 }
 
 class SkwasmNativeTextStyle extends SkwasmObjectWrapper<RawTextStyle> {
-  SkwasmNativeTextStyle(TextStyleHandle handle) : super(handle, _registry);
+  SkwasmNativeTextStyle(TextStyleHandle handle)
+    : super(handle, (TextStyleHandle h) => textStyleDispose(h));
 
   factory SkwasmNativeTextStyle.defaultTextStyle() => SkwasmNativeTextStyle(textStyleCreate());
-
-  static final SkwasmFinalizationRegistry<RawTextStyle> _registry =
-      SkwasmFinalizationRegistry<RawTextStyle>(
-        (TextStyleHandle handle) => textStyleDispose(handle),
-      );
 
   SkwasmNativeTextStyle copy() {
     return SkwasmNativeTextStyle(textStyleCopy(handle));
@@ -929,14 +921,9 @@ class SkwasmParagraphBuilder extends SkwasmObjectWrapper<RawParagraphBuilder>
     ParagraphBuilderHandle handle,
     this.style,
     SkwasmNativeTextStyle baseTextStyle,
-  ) : super(handle, _registry) {
+  ) : super(handle, (ParagraphBuilderHandle h) => paragraphBuilderDispose(h)) {
     textStyleStack.add(baseTextStyle);
   }
-
-  static final SkwasmFinalizationRegistry<RawParagraphBuilder> _registry =
-      SkwasmFinalizationRegistry<RawParagraphBuilder>(
-        (ParagraphBuilderHandle handle) => paragraphBuilderDispose(handle),
-      );
 
   final SkwasmParagraphStyle style;
   final List<SkwasmNativeTextStyle> textStyleStack = <SkwasmNativeTextStyle>[];

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
@@ -91,7 +91,7 @@ class SkwasmLineMetrics implements ui.LineMetrics {
 
 class SkwasmParagraph extends SkwasmObjectWrapper<RawParagraph> implements ui.Paragraph {
   SkwasmParagraph(ParagraphHandle handle)
-    : super(handle, (ParagraphHandle h) => paragraphDispose(h));
+    : super(handle, (ParagraphHandle h) => paragraphDispose(h), 'Paragraph');
 
   bool _hasCheckedForMissingCodePoints = false;
 
@@ -308,7 +308,7 @@ void withScopedFontList(
 
 class SkwasmNativeTextStyle extends SkwasmObjectWrapper<RawTextStyle> {
   SkwasmNativeTextStyle(TextStyleHandle handle)
-    : super(handle, (TextStyleHandle h) => textStyleDispose(h));
+    : super(handle, (TextStyleHandle h) => textStyleDispose(h), 'TextStyle');
 
   factory SkwasmNativeTextStyle.defaultTextStyle() => SkwasmNativeTextStyle(textStyleCreate());
 
@@ -921,7 +921,7 @@ class SkwasmParagraphBuilder extends SkwasmObjectWrapper<RawParagraphBuilder>
     ParagraphBuilderHandle handle,
     this.style,
     SkwasmNativeTextStyle baseTextStyle,
-  ) : super(handle, (ParagraphBuilderHandle h) => paragraphBuilderDispose(h)) {
+  ) : super(handle, (ParagraphBuilderHandle h) => paragraphBuilderDispose(h), 'ParagraphBuilder') {
     textStyleStack.add(baseTextStyle);
   }
 

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/path.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/path.dart
@@ -23,11 +23,7 @@ class SkwasmPath extends SkwasmObjectWrapper<RawPath> implements LayerPath, Disp
     return SkwasmPath.fromHandle(pathCopy(source.handle));
   }
 
-  SkwasmPath.fromHandle(PathHandle handle) : super(handle, _registry);
-
-  static final SkwasmFinalizationRegistry<RawPath> _registry = SkwasmFinalizationRegistry<RawPath>(
-    (PathHandle handle) => pathDispose(handle),
-  );
+  SkwasmPath.fromHandle(PathHandle handle) : super(handle, (PathHandle h) => pathDispose(h));
 
   @override
   ui.PathFillType get fillType => ui.PathFillType.values[pathGetFillType(handle)];

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/path.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/path.dart
@@ -23,7 +23,8 @@ class SkwasmPath extends SkwasmObjectWrapper<RawPath> implements LayerPath, Disp
     return SkwasmPath.fromHandle(pathCopy(source.handle));
   }
 
-  SkwasmPath.fromHandle(PathHandle handle) : super(handle, (PathHandle h) => pathDispose(h));
+  SkwasmPath.fromHandle(PathHandle handle)
+    : super(handle, (PathHandle h) => pathDispose(h), 'Path');
 
   @override
   ui.PathFillType get fillType => ui.PathFillType.values[pathGetFillType(handle)];

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/path_metrics.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/path_metrics.dart
@@ -25,6 +25,7 @@ class SkwasmPathMetricIterator extends SkwasmObjectWrapper<RawContourMeasureIter
     : super(
         contourMeasureIterCreate(path.handle, forceClosed, 1.0),
         (ContourMeasureIterHandle h) => contourMeasureIterDispose(h),
+        'PathMetricIterator',
       );
 
   SkwasmPathMetric? _current;
@@ -59,7 +60,7 @@ class SkwasmPathMetricIterator extends SkwasmObjectWrapper<RawContourMeasureIter
 class SkwasmPathMetric extends SkwasmObjectWrapper<RawContourMeasure>
     implements DisposablePathMetric {
   SkwasmPathMetric(ContourMeasureHandle handle, this.contourIndex)
-    : super(handle, (ContourMeasureHandle h) => contourMeasureDispose(h));
+    : super(handle, (ContourMeasureHandle h) => contourMeasureDispose(h), 'PathMetric');
 
   @override
   final int contourIndex;

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/path_metrics.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/path_metrics.dart
@@ -22,11 +22,9 @@ class SkwasmPathMetrics extends IterableBase<ui.PathMetric> implements Disposabl
 class SkwasmPathMetricIterator extends SkwasmObjectWrapper<RawContourMeasureIter>
     implements DisposablePathMetricIterator {
   SkwasmPathMetricIterator(SkwasmPath path, bool forceClosed)
-    : super(contourMeasureIterCreate(path.handle, forceClosed, 1.0), _registry);
-
-  static final SkwasmFinalizationRegistry<RawContourMeasureIter> _registry =
-      SkwasmFinalizationRegistry<RawContourMeasureIter>(
-        (ContourMeasureIterHandle handle) => contourMeasureIterDispose(handle),
+    : super(
+        contourMeasureIterCreate(path.handle, forceClosed, 1.0),
+        (ContourMeasureIterHandle h) => contourMeasureIterDispose(h),
       );
 
   SkwasmPathMetric? _current;
@@ -60,12 +58,8 @@ class SkwasmPathMetricIterator extends SkwasmObjectWrapper<RawContourMeasureIter
 
 class SkwasmPathMetric extends SkwasmObjectWrapper<RawContourMeasure>
     implements DisposablePathMetric {
-  SkwasmPathMetric(ContourMeasureHandle handle, this.contourIndex) : super(handle, _registry);
-
-  static final SkwasmFinalizationRegistry<RawContourMeasure> _registry =
-      SkwasmFinalizationRegistry<RawContourMeasure>(
-        (ContourMeasureHandle handle) => contourMeasureDispose(handle),
-      );
+  SkwasmPathMetric(ContourMeasureHandle handle, this.contourIndex)
+    : super(handle, (ContourMeasureHandle h) => contourMeasureDispose(h));
 
   @override
   final int contourIndex;

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/picture.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/picture.dart
@@ -81,10 +81,13 @@ class SkwasmPicture implements LayerPicture, StackTraceDebugger {
   bool get debugDisposed {
     bool? result;
     assert(() {
-      result = box.isDisposed;
+      result = isDisposed;
       return true;
     }());
-    return result ?? box.isDisposed;
+    if (result != null) {
+      return result!;
+    }
+    throw StateError('Picture.debugDisposed is only available when asserts are enabled.');
   }
 }
 

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/picture.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/picture.dart
@@ -6,13 +6,38 @@ import 'package:ui/src/engine.dart';
 import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 import 'package:ui/ui.dart' as ui;
 
-class SkwasmPicture extends SkwasmObjectWrapper<RawPicture> implements LayerPicture {
-  SkwasmPicture.fromHandle(PictureHandle handle, {this.isClone = false}) : super(handle, _registry);
+class SkwasmPicture implements LayerPicture, StackTraceDebugger {
+  SkwasmPicture.fromHandle(PictureHandle handle) {
+    box = CountedRef<SkwasmPicture, PictureHandle>(
+      handle,
+      this,
+      'Picture',
+      onDispose: (PictureHandle h) => pictureDispose(h),
+      onDisposed: (SkwasmPicture picture) => ui.Picture.onDispose?.call(picture),
+    );
+    _init();
+    ui.Picture.onCreate?.call(this);
+  }
 
-  final bool isClone;
+  SkwasmPicture.cloneOf(this.box) {
+    box.ref(this);
+    _init();
+  }
 
-  static final SkwasmFinalizationRegistry<RawPicture> _registry =
-      SkwasmFinalizationRegistry<RawPicture>((PictureHandle handle) => pictureDispose(handle));
+  void _init() {
+    assert(() {
+      _debugStackTrace = StackTrace.current;
+      return true;
+    }());
+  }
+
+  @override
+  StackTrace get debugStackTrace => _debugStackTrace;
+  late StackTrace _debugStackTrace;
+
+  late final CountedRef<SkwasmPicture, PictureHandle> box;
+
+  PictureHandle get handle => box.nativeObject;
 
   @override
   Future<ui.Image> toImage(int width, int height) async => toImageSync(width, height);
@@ -22,10 +47,7 @@ class SkwasmPicture extends SkwasmObjectWrapper<RawPicture> implements LayerPict
 
   @override
   void dispose() {
-    super.dispose();
-    if (!isClone) {
-      ui.Picture.onDispose?.call(this);
-    }
+    box.unref(this);
   }
 
   @override
@@ -45,10 +67,7 @@ class SkwasmPicture extends SkwasmObjectWrapper<RawPicture> implements LayerPict
   }
 
   @override
-  LayerPicture clone() {
-    pictureRef(handle);
-    return SkwasmPicture.fromHandle(handle, isClone: true);
-  }
+  LayerPicture clone() => SkwasmPicture.cloneOf(box);
 
   @override
   String toString() {
@@ -56,24 +75,29 @@ class SkwasmPicture extends SkwasmObjectWrapper<RawPicture> implements LayerPict
   }
 
   @override
-  bool get isDisposed => debugDisposed;
+  bool get isDisposed => box.isDisposed;
+
+  @override
+  bool get debugDisposed {
+    bool? result;
+    assert(() {
+      result = box.isDisposed;
+      return true;
+    }());
+    return result ?? box.isDisposed;
+  }
 }
 
 class SkwasmPictureRecorder extends SkwasmObjectWrapper<RawPictureRecorder>
     implements LayerPictureRecorder {
-  SkwasmPictureRecorder() : super(pictureRecorderCreate(), _registry);
-
-  static final SkwasmFinalizationRegistry<RawPictureRecorder> _registry =
-      SkwasmFinalizationRegistry<RawPictureRecorder>(
-        (PictureRecorderHandle handle) => pictureRecorderDispose(handle),
-      );
+  SkwasmPictureRecorder()
+    : super(pictureRecorderCreate(), (PictureRecorderHandle h) => pictureRecorderDispose(h));
 
   @override
   SkwasmPicture endRecording() {
     isRecording = false;
 
     final picture = SkwasmPicture.fromHandle(pictureRecorderEndRecording(handle));
-    ui.Picture.onCreate?.call(picture);
     dispose();
     return picture;
   }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/picture.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/picture.dart
@@ -78,17 +78,7 @@ class SkwasmPicture implements LayerPicture, StackTraceDebugger {
   bool get isDisposed => box.isDisposed;
 
   @override
-  bool get debugDisposed {
-    bool? result;
-    assert(() {
-      result = isDisposed;
-      return true;
-    }());
-    if (result != null) {
-      return result!;
-    }
-    throw StateError('Picture.debugDisposed is only available when asserts are enabled.');
-  }
+  bool get debugDisposed => box.debugDisposed;
 }
 
 class SkwasmPictureRecorder extends SkwasmObjectWrapper<RawPictureRecorder>

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/picture.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/picture.dart
@@ -47,6 +47,10 @@ class SkwasmPicture implements LayerPicture, StackTraceDebugger {
 
   @override
   void dispose() {
+    if (_disposed) {
+      return;
+    }
+    _disposed = true;
     box.unref(this);
   }
 
@@ -75,10 +79,24 @@ class SkwasmPicture implements LayerPicture, StackTraceDebugger {
   }
 
   @override
-  bool get isDisposed => box.isDisposed;
+  bool get isDisposed => _disposed;
+
+  bool _disposed = false;
 
   @override
-  bool get debugDisposed => box.debugDisposed;
+  bool get debugDisposed {
+    bool? result;
+    assert(() {
+      result = _disposed;
+      return true;
+    }());
+
+    if (result != null) {
+      return result!;
+    }
+
+    throw StateError('Picture.debugDisposed is only available when asserts are enabled.');
+  }
 }
 
 class SkwasmPictureRecorder extends SkwasmObjectWrapper<RawPictureRecorder>

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/picture.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/picture.dart
@@ -84,7 +84,11 @@ class SkwasmPicture implements LayerPicture, StackTraceDebugger {
 class SkwasmPictureRecorder extends SkwasmObjectWrapper<RawPictureRecorder>
     implements LayerPictureRecorder {
   SkwasmPictureRecorder()
-    : super(pictureRecorderCreate(), (PictureRecorderHandle h) => pictureRecorderDispose(h));
+    : super(
+        pictureRecorderCreate(),
+        (PictureRecorderHandle h) => pictureRecorderDispose(h),
+        'PictureRecorder',
+      );
 
   @override
   SkwasmPicture endRecording() {

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/shaders.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/shaders.dart
@@ -21,10 +21,7 @@ abstract class SkwasmShader implements ui.Shader {
 // An implementation that handles the storage, disposal, and finalization of
 // a native shader handle.
 class SkwasmNativeShader extends SkwasmObjectWrapper<RawShader> implements SkwasmShader {
-  SkwasmNativeShader(ShaderHandle handle) : super(handle, _registry);
-
-  static final SkwasmFinalizationRegistry<RawShader> _registry =
-      SkwasmFinalizationRegistry<RawShader>((ShaderHandle handle) => shaderDispose(handle));
+  SkwasmNativeShader(ShaderHandle handle) : super(handle, (ShaderHandle h) => shaderDispose(h));
 
   @override
   bool get isGradient => false;
@@ -216,7 +213,7 @@ class SkwasmImageShader extends SkwasmNativeShader implements ui.ImageShader {
 class SkwasmFragmentProgram extends SkwasmObjectWrapper<RawRuntimeEffect>
     implements ui.FragmentProgram {
   SkwasmFragmentProgram._(this.name, RuntimeEffectHandle handle, this._shaderData)
-    : super(handle, _registry);
+    : super(handle, (RuntimeEffectHandle h) => runtimeEffectDispose(h));
 
   factory SkwasmFragmentProgram.fromBytes(String name, Uint8List bytes) {
     final shaderData = ShaderData.fromBytes(bytes);
@@ -234,11 +231,6 @@ class SkwasmFragmentProgram extends SkwasmObjectWrapper<RawRuntimeEffect>
     skStringFree(sourceString);
     return SkwasmFragmentProgram._(name, handle, shaderData);
   }
-
-  static final SkwasmFinalizationRegistry<RawRuntimeEffect> _registry =
-      SkwasmFinalizationRegistry<RawRuntimeEffect>(
-        (RuntimeEffectHandle handle) => runtimeEffectDispose(handle),
-      );
 
   final String name;
   int get floatUniformCount => _shaderData.floatCount;
@@ -261,12 +253,8 @@ class SkwasmFragmentProgram extends SkwasmObjectWrapper<RawRuntimeEffect>
 }
 
 class SkwasmShaderData extends SkwasmObjectWrapper<RawUniformData> {
-  SkwasmShaderData(int size) : super(uniformDataCreate(size), _registry);
-
-  static final SkwasmFinalizationRegistry<RawUniformData> _registry =
-      SkwasmFinalizationRegistry<RawUniformData>(
-        (UniformDataHandle handle) => uniformDataDispose(handle),
-      );
+  SkwasmShaderData(int size)
+    : super(uniformDataCreate(size), (UniformDataHandle h) => uniformDataDispose(h));
 
   Pointer<Void> get pointer => uniformDataGetPointer(handle);
 }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/shaders.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/shaders.dart
@@ -314,7 +314,19 @@ class SkwasmFragmentShader implements SkwasmShader, ui.FragmentShader {
   }
 
   @override
-  bool get debugDisposed => _isDisposed;
+  bool get debugDisposed {
+    bool? result;
+    assert(() {
+      result = _isDisposed;
+      return true;
+    }());
+
+    if (result != null) {
+      return result!;
+    }
+
+    throw StateError('debugDisposed is only available when asserts are enabled.');
+  }
 
   @override
   void setFloat(int index, double value) {

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/shaders.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/shaders.dart
@@ -21,7 +21,8 @@ abstract class SkwasmShader implements ui.Shader {
 // An implementation that handles the storage, disposal, and finalization of
 // a native shader handle.
 class SkwasmNativeShader extends SkwasmObjectWrapper<RawShader> implements SkwasmShader {
-  SkwasmNativeShader(ShaderHandle handle) : super(handle, (ShaderHandle h) => shaderDispose(h));
+  SkwasmNativeShader(ShaderHandle handle)
+    : super(handle, (ShaderHandle h) => shaderDispose(h), 'Shader');
 
   @override
   bool get isGradient => false;
@@ -213,7 +214,7 @@ class SkwasmImageShader extends SkwasmNativeShader implements ui.ImageShader {
 class SkwasmFragmentProgram extends SkwasmObjectWrapper<RawRuntimeEffect>
     implements ui.FragmentProgram {
   SkwasmFragmentProgram._(this.name, RuntimeEffectHandle handle, this._shaderData)
-    : super(handle, (RuntimeEffectHandle h) => runtimeEffectDispose(h));
+    : super(handle, (RuntimeEffectHandle h) => runtimeEffectDispose(h), 'FragmentProgram');
 
   factory SkwasmFragmentProgram.fromBytes(String name, Uint8List bytes) {
     final shaderData = ShaderData.fromBytes(bytes);
@@ -254,7 +255,7 @@ class SkwasmFragmentProgram extends SkwasmObjectWrapper<RawRuntimeEffect>
 
 class SkwasmShaderData extends SkwasmObjectWrapper<RawUniformData> {
   SkwasmShaderData(int size)
-    : super(uniformDataCreate(size), (UniformDataHandle h) => uniformDataDispose(h));
+    : super(uniformDataCreate(size), (UniformDataHandle h) => uniformDataDispose(h), 'ShaderData');
 
   Pointer<Void> get pointer => uniformDataGetPointer(handle);
 }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/vertices.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/vertices.dart
@@ -71,8 +71,5 @@ class SkwasmVertices extends SkwasmObjectWrapper<RawVertices> implements ui.Vert
     );
   });
 
-  SkwasmVertices._(VerticesHandle handle) : super(handle, _registry);
-
-  static final SkwasmFinalizationRegistry<RawVertices> _registry =
-      SkwasmFinalizationRegistry<RawVertices>((VerticesHandle handle) => verticesDispose(handle));
+  SkwasmVertices._(VerticesHandle handle) : super(handle, (VerticesHandle h) => verticesDispose(h));
 }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/vertices.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/vertices.dart
@@ -71,5 +71,6 @@ class SkwasmVertices extends SkwasmObjectWrapper<RawVertices> implements ui.Vert
     );
   });
 
-  SkwasmVertices._(VerticesHandle handle) : super(handle, (VerticesHandle h) => verticesDispose(h));
+  SkwasmVertices._(VerticesHandle handle)
+    : super(handle, (VerticesHandle h) => verticesDispose(h), 'Vertices');
 }

--- a/engine/src/flutter/lib/web_ui/test/canvaskit/fragment_program_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/canvaskit/fragment_program_test.dart
@@ -285,7 +285,7 @@ void testMain() {
       expect(reason: 'SkShaders are created lazily', shader.ref, isNull);
 
       final SkShader skShader = shader.getSkShader(ui.FilterQuality.none);
-      final UniqueRef<SkShader> ref = shader.ref!;
+      final CkUniqueRef<SkShader> ref = shader.ref!;
       expect(skShader, same(ref.nativeObject));
       expect(ref.isDisposed, false);
 
@@ -300,10 +300,10 @@ void testMain() {
       shader.setFloat(0, 5);
 
       final SkShader skShader1 = shader.getSkShader(ui.FilterQuality.none);
-      final UniqueRef<SkShader> ref1 = shader.ref!;
+      final CkUniqueRef<SkShader> ref1 = shader.ref!;
 
       final SkShader skShader2 = shader.getSkShader(ui.FilterQuality.none);
-      final UniqueRef<SkShader> ref2 = shader.ref!;
+      final CkUniqueRef<SkShader> ref2 = shader.ref!;
       expect(ref1, isNot(same(ref2)));
       expect(
         reason:

--- a/engine/src/flutter/lib/web_ui/test/canvaskit/native_memory_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/canvaskit/native_memory_test.dart
@@ -17,30 +17,30 @@ void main() {
 void testMain() {
   setUpCanvasKitTest();
 
-  late _MockNativeMemoryFinalizationRegistry mockFinalizationRegistry;
+  late _MockFinalizer mockFinalizer;
+  final Finalizer originalFinalizer = UniqueRef.finalizer;
 
   setUp(() {
     TestSkDeletableMock.deleteCount = 0;
-    nativeMemoryFinalizationRegistry = mockFinalizationRegistry =
-        _MockNativeMemoryFinalizationRegistry();
+    UniqueRef.finalizer = mockFinalizer = _MockFinalizer();
   });
 
   tearDown(() {
-    nativeMemoryFinalizationRegistry = NativeMemoryFinalizationRegistry();
+    UniqueRef.finalizer = originalFinalizer;
   });
 
-  group(UniqueRef, () {
+  group(CkUniqueRef, () {
     test('create-dispose-collect cycle', () {
-      expect(mockFinalizationRegistry.registeredPairs, hasLength(0));
+      expect(mockFinalizer.registeredPairs, hasLength(0));
       final owner = Object();
       final nativeObject = TestSkDeletable();
-      final ref = UniqueRef<TestSkDeletable>(owner, nativeObject, 'TestSkDeletable');
+      final ref = CkUniqueRef<TestSkDeletable>(owner, nativeObject, 'TestSkDeletable');
       expect(ref.isDisposed, isFalse);
       expect(ref.nativeObject, same(nativeObject));
       expect(TestSkDeletableMock.deleteCount, 0);
-      expect(mockFinalizationRegistry.registeredPairs, hasLength(1));
-      expect(mockFinalizationRegistry.registeredPairs.single.owner, same(owner));
-      expect(mockFinalizationRegistry.registeredPairs.single.ref, same(ref));
+      expect(mockFinalizer.registeredPairs, hasLength(1));
+      expect(mockFinalizer.registeredPairs.single.target, same(owner));
+      expect(mockFinalizer.registeredPairs.single.value, same(ref));
 
       ref.dispose();
       expect(TestSkDeletableMock.deleteCount, 1);
@@ -57,24 +57,22 @@ void testMain() {
       );
       expect(TestSkDeletableMock.deleteCount, 1);
 
-      // Simulate a GC
-      mockFinalizationRegistry.registeredPairs.single.ref.collect();
       expect(
-        reason: 'Manually disposed object should not be deleted again by GC.',
-        TestSkDeletableMock.deleteCount,
-        1,
+        reason: 'Manually disposed object should be detached from the registry.',
+        mockFinalizer.registeredPairs,
+        isEmpty,
       );
     });
 
     test('create-collect cycle', () {
-      expect(mockFinalizationRegistry.registeredPairs, hasLength(0));
+      expect(mockFinalizer.registeredPairs, hasLength(0));
       final owner = Object();
       final nativeObject = TestSkDeletable();
-      final ref = UniqueRef<TestSkDeletable>(owner, nativeObject, 'TestSkDeletable');
+      final ref = CkUniqueRef<TestSkDeletable>(owner, nativeObject, 'TestSkDeletable');
       expect(ref.isDisposed, isFalse);
       expect(ref.nativeObject, same(nativeObject));
       expect(TestSkDeletableMock.deleteCount, 0);
-      expect(mockFinalizationRegistry.registeredPairs, hasLength(1));
+      expect(mockFinalizer.registeredPairs, hasLength(1));
 
       ref.collect();
       expect(TestSkDeletableMock.deleteCount, 1);
@@ -92,7 +90,7 @@ void testMain() {
       final nativeObject = TestSkDeletable();
 
       expect(Instrumentation.instance.debugCounters, <String, int>{});
-      final ref = UniqueRef<TestSkDeletable>(owner, nativeObject, 'TestSkDeletable');
+      final ref = CkUniqueRef<TestSkDeletable>(owner, nativeObject, 'TestSkDeletable');
       expect(Instrumentation.instance.debugCounters, <String, int>{'TestSkDeletable Created': 1});
       ref.dispose();
       expect(Instrumentation.instance.debugCounters, <String, int>{
@@ -109,7 +107,7 @@ void testMain() {
       final nativeObject = TestSkDeletable();
 
       expect(Instrumentation.instance.debugCounters, <String, int>{});
-      final ref = UniqueRef<TestSkDeletable>(owner, nativeObject, 'TestSkDeletable');
+      final ref = CkUniqueRef<TestSkDeletable>(owner, nativeObject, 'TestSkDeletable');
       expect(Instrumentation.instance.debugCounters, <String, int>{'TestSkDeletable Created': 1});
       ref.collect();
       expect(Instrumentation.instance.debugCounters, <String, int>{
@@ -120,9 +118,9 @@ void testMain() {
     });
   });
 
-  group(CountedRef, () {
+  group(CkCountedRef, () {
     test('single owner', () {
-      expect(mockFinalizationRegistry.registeredPairs, hasLength(0));
+      expect(mockFinalizer.registeredPairs, hasLength(0));
       final nativeObject = TestSkDeletable();
       final owner = TestCountedRefOwner(nativeObject);
       expect(owner.ref.debugReferrers, hasLength(1));
@@ -130,7 +128,7 @@ void testMain() {
       expect(owner.ref.refCount, 1);
       expect(owner.ref.nativeObject, nativeObject);
       expect(TestSkDeletableMock.deleteCount, 0);
-      expect(mockFinalizationRegistry.registeredPairs, hasLength(1));
+      expect(mockFinalizer.registeredPairs, hasLength(1));
 
       owner.dispose();
       expect(owner.ref.debugReferrers, isEmpty);
@@ -150,7 +148,7 @@ void testMain() {
     });
 
     test('multiple owners', () {
-      expect(mockFinalizationRegistry.registeredPairs, hasLength(0));
+      expect(mockFinalizer.registeredPairs, hasLength(0));
       final nativeObject = TestSkDeletable();
       final owner1 = TestCountedRefOwner(nativeObject);
       expect(owner1.ref.debugReferrers, hasLength(1));
@@ -158,7 +156,7 @@ void testMain() {
       expect(owner1.ref.refCount, 1);
       expect(owner1.ref.nativeObject, nativeObject);
       expect(TestSkDeletableMock.deleteCount, 0);
-      expect(mockFinalizationRegistry.registeredPairs, hasLength(1));
+      expect(mockFinalizer.registeredPairs, hasLength(1));
 
       final TestCountedRefOwner owner2 = owner1.clone();
       expect(owner2.ref, same(owner1.ref));
@@ -172,7 +170,7 @@ void testMain() {
         reason:
             'Second owner does not add more native object owners. '
             'The underlying shared UniqueRef is the only one.',
-        mockFinalizationRegistry.registeredPairs,
+        mockFinalizer.registeredPairs,
         hasLength(1),
       );
 
@@ -205,12 +203,10 @@ void testMain() {
         throwsA(isA<AssertionError>()),
       );
 
-      // Simulate a GC
-      mockFinalizationRegistry.registeredPairs.single.ref.collect();
       expect(
-        reason: 'Manually disposed object should not be deleted again by GC.',
-        TestSkDeletableMock.deleteCount,
-        1,
+        reason: 'Manually disposed object should be detached from the registry.',
+        mockFinalizer.registeredPairs,
+        isEmpty,
       );
     });
   });
@@ -266,7 +262,7 @@ class TestCountedRefOwner implements StackTraceDebugger {
       _debugStackTrace = StackTrace.current;
       return true;
     }());
-    ref = CountedRef<TestCountedRefOwner, TestSkDeletable>(
+    ref = CkCountedRef<TestCountedRefOwner, TestSkDeletable>(
       nativeObject,
       this,
       'TestCountedRefOwner',
@@ -285,7 +281,7 @@ class TestCountedRefOwner implements StackTraceDebugger {
   StackTrace get debugStackTrace => _debugStackTrace;
   late StackTrace _debugStackTrace;
 
-  late final CountedRef<TestCountedRefOwner, TestSkDeletable> ref;
+  late final CkCountedRef<TestCountedRefOwner, TestSkDeletable> ref;
 
   void dispose() {
     ref.unref(this);
@@ -294,18 +290,24 @@ class TestCountedRefOwner implements StackTraceDebugger {
   TestCountedRefOwner clone() => TestCountedRefOwner.cloneOf(ref);
 }
 
-class _MockNativeMemoryFinalizationRegistry implements NativeMemoryFinalizationRegistry {
+class _MockFinalizer implements Finalizer {
   final List<_MockPair> registeredPairs = <_MockPair>[];
 
   @override
-  void register(Object owner, UniqueRef<JSObject> ref) {
-    registeredPairs.add(_MockPair(owner, ref));
+  void attach(Object target, Object value, {Object? detach}) {
+    registeredPairs.add(_MockPair(target, value, detach));
+  }
+
+  @override
+  void detach(Object detach) {
+    registeredPairs.removeWhere((pair) => pair.detach == detach);
   }
 }
 
 class _MockPair {
-  _MockPair(this.owner, this.ref);
+  _MockPair(this.target, this.value, this.detach);
 
-  Object owner;
-  UniqueRef<JSObject> ref;
+  Object target;
+  Object value;
+  Object? detach;
 }

--- a/engine/src/flutter/lib/web_ui/test/canvaskit/shader_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/canvaskit/shader_test.dart
@@ -68,7 +68,7 @@ void testMain() {
               as CkImageShader;
       expect(imageShader, isA<CkImageShader>());
 
-      final UniqueRef<SkShader> ref = imageShader.ref!;
+      final CkUniqueRef<SkShader> ref = imageShader.ref!;
       expect(imageShader.debugDisposed, false);
       expect(imageShader.getSkShader(ui.FilterQuality.none), same(ref.nativeObject));
       expect(ref.isDisposed, false);
@@ -95,19 +95,19 @@ void testMain() {
               as CkImageShader;
       expect(imageShader, isA<CkImageShader>());
 
-      final UniqueRef<SkShader> ref1 = imageShader.ref!;
+      final CkUniqueRef<SkShader> ref1 = imageShader.ref!;
       expect(imageShader.getSkShader(ui.FilterQuality.none), same(ref1.nativeObject));
 
       // Request the same quality as the default quality (none).
       expect(imageShader.getSkShader(ui.FilterQuality.none), isNotNull);
-      final UniqueRef<SkShader> ref2 = imageShader.ref!;
+      final CkUniqueRef<SkShader> ref2 = imageShader.ref!;
       expect(ref1, same(ref2));
       expect(ref1.isDisposed, false);
       expect(image.debugDisposed, false);
 
       // Change quality to medium.
       expect(imageShader.getSkShader(ui.FilterQuality.medium), isNotNull);
-      final UniqueRef<SkShader> ref3 = imageShader.ref!;
+      final CkUniqueRef<SkShader> ref3 = imageShader.ref!;
       expect(ref1, isNot(same(ref3)));
       expect(
         ref1.isDisposed,
@@ -119,7 +119,7 @@ void testMain() {
 
       // Ask for medium again.
       expect(imageShader.getSkShader(ui.FilterQuality.medium), isNotNull);
-      final UniqueRef<SkShader> ref4 = imageShader.ref!;
+      final CkUniqueRef<SkShader> ref4 = imageShader.ref!;
       expect(ref4, same(ref3));
       expect(ref3.isDisposed, false);
       expect(image.debugDisposed, false);

--- a/engine/src/flutter/lib/web_ui/test/engine/native_memory_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/native_memory_test.dart
@@ -37,12 +37,13 @@ void testMain() {
       expect(ref.isDisposed, isFalse);
       expect(ref.nativeObject, nativeObject);
       expect(disposed, isFalse);
-      expect(mockFinalizer.attachedTargets, contains(owner));
+      expect(mockFinalizer.registeredPairs.single.target, same(owner));
+      expect(mockFinalizer.registeredPairs.single.value, same(ref));
 
       ref.dispose();
       expect(ref.isDisposed, isTrue);
       expect(disposed, isTrue);
-      expect(mockFinalizer.attachedTargets, isEmpty);
+      expect(mockFinalizer.registeredPairs, isEmpty);
     });
 
     test('collect calls onDispose', () {
@@ -65,7 +66,8 @@ void testMain() {
   group(CountedRef, () {
     test('reference counting', () {
       final nativeObject = _MockNativeObject();
-      var disposed = false;
+      var nativeDisposed = false;
+      var wrapperDisposed = false;
       final referrer1 = _MockStackTraceDebugger();
       final referrer2 = _MockStackTraceDebugger();
 
@@ -73,22 +75,26 @@ void testMain() {
         nativeObject,
         referrer1,
         'TestObject',
-        onDispose: (obj) => disposed = true,
+        onDispose: (obj) => nativeDisposed = true,
+        onDisposed: (referrer) => wrapperDisposed = true,
       );
 
       expect(ref.refCount, 1);
-      expect(disposed, isFalse);
+      expect(nativeDisposed, isFalse);
+      expect(wrapperDisposed, isFalse);
 
       ref.ref(referrer2);
       expect(ref.refCount, 2);
 
       ref.unref(referrer1);
       expect(ref.refCount, 1);
-      expect(disposed, isFalse);
+      expect(nativeDisposed, isFalse);
+      expect(wrapperDisposed, isFalse);
 
       ref.unref(referrer2);
       expect(ref.refCount, 0);
-      expect(disposed, isTrue);
+      expect(nativeDisposed, isTrue);
+      expect(wrapperDisposed, isTrue);
     });
   });
 }
@@ -101,19 +107,17 @@ class _MockStackTraceDebugger implements StackTraceDebugger {
 }
 
 class _MockFinalizer implements Finalizer {
-  final Set<Object> attachedTargets = <Object>{};
+  final List<({Object target, Object value, Object? detach})> _registeredPairs = [];
+
+  List<({Object target, Object value, Object? detach})> get registeredPairs => _registeredPairs;
 
   @override
   void attach(Object target, Object value, {Object? detach}) {
-    attachedTargets.add(target);
+    _registeredPairs.add((target: target, value: value, detach: detach));
   }
 
   @override
   void detach(Object detach) {
-    // In our implementation, detach is called with the UniqueRef itself
-    // We need to find which target it was attached to.
-    // For simplicity in this mock, we'll just clear everything or
-    // track by detach token if we want to be precise.
-    attachedTargets.clear();
+    _registeredPairs.removeWhere((pair) => pair.detach == detach);
   }
 }

--- a/engine/src/flutter/lib/web_ui/test/engine/native_memory_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/native_memory_test.dart
@@ -1,0 +1,119 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/src/engine.dart';
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+void testMain() {
+  late _MockFinalizer mockFinalizer;
+  final Finalizer originalFinalizer = UniqueRef.finalizer;
+
+  setUp(() {
+    UniqueRef.finalizer = mockFinalizer = _MockFinalizer();
+  });
+
+  tearDown(() {
+    UniqueRef.finalizer = originalFinalizer;
+  });
+
+  group(UniqueRef, () {
+    test('create-dispose cycle', () {
+      final owner = Object();
+      final nativeObject = _MockNativeObject();
+      var disposed = false;
+      final ref = UniqueRef<_MockNativeObject>(
+        owner,
+        nativeObject,
+        'TestObject',
+        onDispose: (obj) => disposed = true,
+      );
+
+      expect(ref.isDisposed, isFalse);
+      expect(ref.nativeObject, nativeObject);
+      expect(disposed, isFalse);
+      expect(mockFinalizer.attachedTargets, contains(owner));
+
+      ref.dispose();
+      expect(ref.isDisposed, isTrue);
+      expect(disposed, isTrue);
+      expect(mockFinalizer.attachedTargets, isEmpty);
+    });
+
+    test('collect calls onDispose', () {
+      final owner = Object();
+      final nativeObject = _MockNativeObject();
+      var disposed = false;
+      final ref = UniqueRef<_MockNativeObject>(
+        owner,
+        nativeObject,
+        'TestObject',
+        onDispose: (obj) => disposed = true,
+      );
+
+      ref.collect();
+      expect(ref.isDisposed, isTrue);
+      expect(disposed, isTrue);
+    });
+  });
+
+  group(CountedRef, () {
+    test('reference counting', () {
+      final nativeObject = _MockNativeObject();
+      var disposed = false;
+      final referrer1 = _MockStackTraceDebugger();
+      final referrer2 = _MockStackTraceDebugger();
+
+      final ref = CountedRef<_MockStackTraceDebugger, _MockNativeObject>(
+        nativeObject,
+        referrer1,
+        'TestObject',
+        onDispose: (obj) => disposed = true,
+      );
+
+      expect(ref.refCount, 1);
+      expect(disposed, isFalse);
+
+      ref.ref(referrer2);
+      expect(ref.refCount, 2);
+
+      ref.unref(referrer1);
+      expect(ref.refCount, 1);
+      expect(disposed, isFalse);
+
+      ref.unref(referrer2);
+      expect(ref.refCount, 0);
+      expect(disposed, isTrue);
+    });
+  });
+}
+
+class _MockNativeObject {}
+
+class _MockStackTraceDebugger implements StackTraceDebugger {
+  @override
+  StackTrace get debugStackTrace => StackTrace.current;
+}
+
+class _MockFinalizer implements Finalizer {
+  final Set<Object> attachedTargets = <Object>{};
+
+  @override
+  void attach(Object target, Object value, {Object? detach}) {
+    attachedTargets.add(target);
+  }
+
+  @override
+  void detach(Object detach) {
+    // In our implementation, detach is called with the UniqueRef itself
+    // We need to find which target it was attached to.
+    // For simplicity in this mock, we'll just clear everything or
+    // track by detach token if we want to be precise.
+    attachedTargets.clear();
+  }
+}

--- a/engine/src/flutter/lib/web_ui/test/skwasm/native_memory_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/skwasm/native_memory_test.dart
@@ -1,0 +1,64 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:typed_data';
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
+import 'package:ui/ui.dart' as ui;
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+void testMain() {
+  group('Skwasm native memory', () {
+    test('SkwasmImage.clone share same handle and box', () {
+      final pixels = Uint8List(4);
+      final image = SkwasmImage.fromPixels(pixels, 1, 1, ui.PixelFormat.rgba8888);
+
+      final SkwasmImage clone = image.clone();
+      expect(clone.handle, image.handle);
+      expect(clone.box, image.box);
+      expect(image.box.refCount, 2);
+
+      image.dispose();
+      expect(clone.debugDisposed, isFalse);
+      expect(clone.box.refCount, 1);
+
+      clone.dispose();
+      expect(clone.debugDisposed, isTrue);
+      expect(clone.box.refCount, 0);
+    });
+
+    test('SkwasmPicture.clone share same handle and box', () {
+      final recorder = ui.PictureRecorder();
+      final canvas = ui.Canvas(recorder);
+      canvas.drawRect(const ui.Rect.fromLTRB(0, 0, 10, 10), ui.Paint());
+      final picture = recorder.endRecording() as SkwasmPicture;
+
+      final clone = picture.clone() as SkwasmPicture;
+      expect(clone.handle, picture.handle);
+      expect(clone.box, picture.box);
+      expect(picture.box.refCount, 2);
+
+      picture.dispose();
+      expect(clone.isDisposed, isFalse);
+      expect(clone.box.refCount, 1);
+
+      clone.dispose();
+      expect(clone.isDisposed, isTrue);
+      expect(clone.box.refCount, 0);
+    });
+
+    test('SkwasmPath uses UniqueRef', () {
+      final path = SkwasmPath();
+      expect(path.debugDisposed, isFalse);
+
+      path.dispose();
+      expect(path.debugDisposed, isTrue);
+    });
+  });
+}

--- a/engine/src/flutter/lib/web_ui/test/ui/native_resource_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/ui/native_resource_test.dart
@@ -1,0 +1,109 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/src/engine.dart';
+import 'package:ui/ui.dart' as ui;
+
+import '../common/test_initialization.dart';
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+Future<void> testMain() async {
+  setUpUnitTests();
+
+  group('ui.Image native resource tracking', () {
+    test('onCreate and onDispose are balanced for cloned images', () {
+      var createCount = 0;
+      var disposeCount = 0;
+      ui.Image? lastCreatedImage;
+      ui.Image? lastDisposedImage;
+
+      ui.Image.onCreate = (ui.Image image) {
+        createCount++;
+        lastCreatedImage = image;
+      };
+      ui.Image.onDispose = (ui.Image image) {
+        disposeCount++;
+        lastDisposedImage = image;
+      };
+
+      final recorder = ui.PictureRecorder();
+      final canvas = ui.Canvas(recorder);
+      canvas.drawRect(const ui.Rect.fromLTRB(0, 0, 1, 1), ui.Paint());
+      final ui.Picture picture = recorder.endRecording();
+      final ui.Image image1 = picture.toImageSync(1, 1);
+
+      expect(createCount, 1);
+      expect(disposeCount, 0);
+      expect(lastCreatedImage, same(image1));
+
+      final ui.Image image2 = image1.clone();
+      // Should NOT call onCreate for clones if we are tracking native resources
+      expect(createCount, 1);
+      expect(disposeCount, 0);
+
+      image1.dispose();
+      // Should NOT call onDispose yet as image2 is still alive
+      expect(createCount, 1);
+      expect(disposeCount, 0);
+
+      image2.dispose();
+      // NOW it should call onDispose
+      expect(createCount, 1);
+      expect(disposeCount, 1);
+      expect(lastDisposedImage, same(image2));
+
+      picture.dispose();
+      ui.Image.onCreate = null;
+      ui.Image.onDispose = null;
+    });
+  });
+
+  group('ui.Picture native resource tracking', () {
+    test('onCreate and onDispose are balanced for cloned pictures', () {
+      var createCount = 0;
+      var disposeCount = 0;
+      ui.Picture? lastCreatedPicture;
+      ui.Picture? lastDisposedPicture;
+
+      ui.Picture.onCreate = (ui.Picture picture) {
+        createCount++;
+        lastCreatedPicture = picture;
+      };
+      ui.Picture.onDispose = (ui.Picture picture) {
+        disposeCount++;
+        lastDisposedPicture = picture;
+      };
+
+      final recorder = ui.PictureRecorder();
+      final canvas = ui.Canvas(recorder);
+      canvas.drawRect(const ui.Rect.fromLTRB(0, 0, 10, 10), ui.Paint());
+      final ui.Picture picture1 = recorder.endRecording();
+
+      expect(createCount, 1);
+      expect(disposeCount, 0);
+      expect(lastCreatedPicture, same(picture1));
+
+      final LayerPicture picture2 = (picture1 as LayerPicture).clone();
+      expect(createCount, 1);
+      expect(disposeCount, 0);
+
+      picture1.dispose();
+      expect(createCount, 1);
+      expect(disposeCount, 0);
+
+      picture2.dispose();
+      expect(createCount, 1);
+      expect(disposeCount, 1);
+      expect(lastDisposedPicture, same(picture2));
+
+      ui.Picture.onCreate = null;
+      ui.Picture.onDispose = null;
+    });
+  });
+}


### PR DESCRIPTION
Introduce a shared memory management system in `lib/src/engine/native_memory.dart` that both CanvasKit and Skwasm renderers now utilize. This unification replaces renderer-specific finalization logic with a consistent, efficient, and type-safe approach.

Key changes:
- Created `NativeMemoryFinalizer`, `UniqueRef`, and `CountedRef` as generic base classes for native resource management.
- Refactored CanvasKit to use `CkUniqueRef` and `CkCountedRef`, which specialize the base classes for Skia objects.
- Refactored Skwasm to use the unified `UniqueRef` and `CountedRef` abstractions, enabling proper `ui.Image` and `ui.Picture` cloning via reference counting.
- Improved efficiency by using tokens to detach manually disposed objects from the `DomFinalizationRegistry`.
- Added a `Finalizer` interface to support mocking and verification of finalization behavior in tests.
- Comprehensive test coverage across generic engine logic and renderer-specific implementations.

Testing:
- Generic memory management tests: `test/engine/native_memory_test.dart`
- CanvasKit-specific tests: `test/canvaskit/native_memory_test.dart`
- Skwasm-specific tests: `test/skwasm/native_memory_test.dart`

Fixes https://github.com/flutter/flutter/issues/175628

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
