### PR TITLE
Revert "Linux reuse sibling (#183653)"

### DIFF
--- a/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.cc
@@ -53,10 +53,6 @@ struct _FlCompositorOpenGL {
   // Last rendered frame.
   FlFramebuffer* framebuffer;
 
-  // Reusable sibling framebuffer for gdk_cairo_draw_from_gl (Wayland).
-  // Avoids per-frame texture churn that GTK/Wayland retains.
-  FlFramebuffer* render_sibling;
-
   // Last rendered frame pixels (only set if shareable is TRUE).
   uint8_t* pixels;
 
@@ -255,12 +251,9 @@ static gboolean fl_compositor_opengl_present_layers(FlCompositor* compositor,
   if (self->framebuffer == nullptr ||
       fl_framebuffer_get_width(self->framebuffer) != width ||
       fl_framebuffer_get_height(self->framebuffer) != height) {
-    // Allocate new framebuffer before disposing old ones to avoid GL texture
-    // ID collision (engine may dispose backing stores later with recycled IDs).
-    FlFramebuffer* new_framebuffer =
-        fl_framebuffer_new(general_format, width, height, self->shareable);
     g_clear_object(&self->framebuffer);
-    self->framebuffer = new_framebuffer;
+    self->framebuffer =
+        fl_framebuffer_new(general_format, width, height, self->shareable);
 
     // If not shareable make buffer to copy frame pixels into.
     if (!self->shareable) {
@@ -430,10 +423,9 @@ static gboolean fl_compositor_opengl_render(FlCompositor* compositor,
   }
 
   if (fl_framebuffer_get_shareable(self->framebuffer)) {
-    g_clear_object(&self->render_sibling);
-    self->render_sibling = fl_framebuffer_create_sibling(self->framebuffer);
-    gdk_cairo_draw_from_gl(cr, window,
-                           fl_framebuffer_get_texture_id(self->render_sibling),
+    g_autoptr(FlFramebuffer) sibling =
+        fl_framebuffer_create_sibling(self->framebuffer);
+    gdk_cairo_draw_from_gl(cr, window, fl_framebuffer_get_texture_id(sibling),
                            GL_TEXTURE, scale_factor, 0, 0, width, height);
   } else {
     GLint saved_texture_binding;
@@ -467,7 +459,6 @@ static void fl_compositor_opengl_dispose(GObject* object) {
 
   g_clear_object(&self->task_runner);
   g_clear_object(&self->opengl_manager);
-  g_clear_object(&self->render_sibling);
   g_clear_object(&self->framebuffer);
   g_clear_pointer(&self->pixels, g_free);
   g_mutex_clear(&self->frame_mutex);


### PR DESCRIPTION
This reverts commit ed5bda45a93f7975aac809de47cc2d672f0fd903.

When running the `examples/multiple_windows` and creating a regular window then closing it causes the content of the main window to stop being updated. The terminal shows:
```
GrGLGpu::flushRenderTargetNoColorWrites glCheckFramebufferStatus 8cd7
---- glGetError 0x506(Unknown) at
        ../../flutter/third_party/skia/src/gpu/ganesh/gl/GrGLGpu.cpp(2271) :
                Clear(clearMask)
---- glGetError 0x506(Unknown) at
        ../../flutter/third_party/skia/src/gpu/ganesh/gl/GrGLOpsRenderPass.cpp(225) :
                DrawRangeElements(glPrimType, minIndexValue, maxIndexValue, indexCount, 0x1403, this->offsetForBaseIndex(baseIndex))
---- glGetError 0x506(Unknown) at
        ../../flutter/third_party/skia/src/gpu/ganesh/gl/GrGLOpsRenderPass.cpp(216) :
                DrawElementsInstancedBaseVertexBaseInstance( glPrimType, indexCount, 0x1403, this->offsetForBaseIndex(baseIndex), 1, baseVertex, 0)
---- glGetError 0x506(Unknown) at
        ../../flutter/third_party/skia/src/gpu/ganesh/gl/GrGLOpsRenderPass.cpp(216) :
                DrawElementsInstancedBaseVertexBaseInstance( glPrimType, indexCount, 0x1403, this->offsetForBaseIndex(baseIndex), 1, baseVertex, 0)
---- glGetError 0x506(Unknown) at
        ../../flutter/third_party/skia/src/gpu/ganesh/gl/GrGLOpsRenderPass.cpp(216) :
                DrawElementsInstancedBaseVertexBaseInstance( glPrimType, indexCount, 0x1403, this->offsetForBaseIndex(baseIndex), 1, baseVertex, 0)
---- glGetError 0x506(Unknown) at
        ../../flutter/third_party/skia/src/gpu/ganesh/gl/GrGLOpsRenderPass.cpp(203) :
                DrawArrays(glPrimType, baseVertex, vertexCount)
---- glGetError 0x506(Unknown) at
        ../../flutter/third_party/skia/src/gpu/ganesh/gl/GrGLOpsRenderPass.cpp(216) :
                DrawElementsInstancedBaseVertexBaseInstance( glPrimType, indexCount, 0x1403, this->offsetForBaseIndex(baseIndex), 1, baseVertex, 0)
---- glGetError 0x506(Unknown) at
        ../../flutter/third_party/skia/src/gpu/ganesh/gl/GrGLOpsRenderPass.cpp(216) :
                DrawElementsInstancedBaseVertexBaseInstance( glPrimType, indexCount, 0x1403, this->offsetForBaseIndex(baseIndex), 1, baseVertex, 0)
---- glGetError 0x506(Unknown) at
        ../../flutter/third_party/skia/src/gpu/ganesh/gl/GrGLTexture.cpp(192) :
                ObjectLabel(0x1702, fID, -1, label.c_str())
```