### PR TITLE
[android][a11y] set "android.widget.ProgressBar" according to semantics role

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -2409,6 +2409,16 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
     Role(int value) {
       this.value = value;
     }
+
+    @NonNull
+    public static Role fromInt(int value) {
+      for (Role role : Role.values()) {
+        if (role.value == value) {
+          return role;
+        }
+      }
+      return Role.NONE;
+    }
   }
 
   // Actions that are triggered by Android OS, as opposed to user-triggered actions.

--- a/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -855,8 +855,8 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
       result.setClassName("android.widget.ProgressBar");
       if (semanticsNode.value != null) {
         try {
-          float min = 0.0f;
-          float max = 100.0f;
+          float min = Float.NEGATIVE_INFINITY;
+          float max = Float.POSITIVE_INFINITY;
           if (semanticsNode.minValue != null) {
             min = Float.parseFloat(semanticsNode.minValue);
           }

--- a/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -851,26 +851,43 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
       // TODO(jonahwilliams): Figure out a way conform to the expected id from TalkBack's
       // CustomLabelManager. talkback/src/main/java/labeling/CustomLabelManager.java#L525
     }
-    if (semanticsNode.role == Role.PROGRESS_BAR.value) {
-      result.setClassName("android.widget.ProgressBar");
-      if (semanticsNode.value != null) {
-        try {
+    switch (Role.fromInt(semanticsNode.role)) {
+      case PROGRESS_BAR:
+        result.setClassName("android.widget.ProgressBar");
+        if (semanticsNode.value != null) {
+
           float min = Float.NEGATIVE_INFINITY;
           float max = Float.POSITIVE_INFINITY;
           if (semanticsNode.minValue != null) {
-            min = Float.parseFloat(semanticsNode.minValue);
+            try {
+              min = Float.parseFloat(semanticsNode.minValue);
+            } catch (NumberFormatException e) {
+              // Fallback to default min.
+            }
           }
           if (semanticsNode.maxValue != null) {
-            max = Float.parseFloat(semanticsNode.maxValue);
+            try {
+              max = Float.parseFloat(semanticsNode.maxValue);
+            } catch (NumberFormatException e) {
+              // Fallback to default max.
+            }
           }
-          float parsedValue = Float.parseFloat(semanticsNode.value);
-          result.setRangeInfo(
-              AccessibilityNodeInfo.RangeInfo.obtain(
-                  AccessibilityNodeInfo.RangeInfo.RANGE_TYPE_FLOAT, min, max, parsedValue));
-        } catch (NumberFormatException e) {
-          // Keep as indeterminate format.
+          try {
+            float parsedValue = Float.parseFloat(semanticsNode.value);
+            result.setRangeInfo(
+                AccessibilityNodeInfo.RangeInfo.obtain(
+                    AccessibilityNodeInfo.RangeInfo.RANGE_TYPE_FLOAT, min, max, parsedValue));
+          } catch (NumberFormatException e) {
+            // Keep as indeterminate format. There is no RANGE_TYPE_INDETERMINATE, so we
+            // fallback to RANGE_TYPE_FLOAT with 0.0.
+            result.setRangeInfo(
+                AccessibilityNodeInfo.RangeInfo.obtain(
+                    AccessibilityNodeInfo.RangeInfo.RANGE_TYPE_FLOAT, 0.0f, 0.0f, 0.0f));
+          }
         }
-      }
+        break;
+      default:
+        break;
     }
     if (semanticsNode.hasAction(Action.DISMISS)) {
       result.setDismissable(true);

--- a/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -853,6 +853,24 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
     }
     if (semanticsNode.role == Role.PROGRESS_BAR.value) {
       result.setClassName("android.widget.ProgressBar");
+      if (semanticsNode.hasValue()) {
+        try {
+          float min = 0.0f;
+          float max = 100.0f;
+          if (semanticsNode.minValue != null) {
+            min = Float.parseFloat(semanticsNode.minValue);
+          }
+          if (semanticsNode.maxValue != null) {
+            max = Float.parseFloat(semanticsNode.maxValue);
+          }
+          float parsedValue = Float.parseFloat(semanticsNode.getValue());
+          result.setRangeInfo(
+              AccessibilityNodeInfo.RangeInfo.obtain(
+                  AccessibilityNodeInfo.RangeInfo.RANGE_TYPE_FLOAT, min, max, parsedValue));
+        } catch (NumberFormatException e) {
+          // Keep as indeterminate format.
+        }
+      }
     }
     if (semanticsNode.hasAction(Action.DISMISS)) {
       result.setDismissable(true);
@@ -2569,6 +2587,9 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
     // The locale of the content of this node.
     @Nullable private String locale;
 
+    @Nullable private String minValue;
+    @Nullable private String maxValue;
+
     // The role of this node.
     private int role;
 
@@ -2802,6 +2823,8 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
       tooltip = getStringFromBuffer(buffer, strings);
       linkUrl = getStringFromBuffer(buffer, strings);
       locale = getStringFromBuffer(buffer, strings);
+      minValue = getStringFromBuffer(buffer, strings);
+      maxValue = getStringFromBuffer(buffer, strings);
 
       headingLevel = buffer.getInt();
       textDirection = TextDirection.fromInt(buffer.getInt());

--- a/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -851,7 +851,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
       // TODO(jonahwilliams): Figure out a way conform to the expected id from TalkBack's
       // CustomLabelManager. talkback/src/main/java/labeling/CustomLabelManager.java#L525
     }
-    if (semanticsNode.role == 23 /* ProgressBar */) {
+    if (semanticsNode.role == Role.PROGRESS_BAR.value) {
       result.setClassName("android.widget.ProgressBar");
     }
     if (semanticsNode.hasAction(Action.DISMISS)) {
@@ -2330,6 +2330,50 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
     public final int value;
 
     Action(int value) {
+      this.value = value;
+    }
+  }
+
+  // Must match SemanticsRole in semantics.dart
+  // https://github.com/flutter/flutter/blob/main/engine/src/flutter/lib/ui/semantics.dart
+  enum Role {
+    NONE(0),
+    TAB(1),
+    TAB_BAR(2),
+    TAB_PANEL(3),
+    DIALOG(4),
+    ALERT_DIALOG(5),
+    TABLE(6),
+    CELL(7),
+    ROW(8),
+    COLUMN_HEADER(9),
+    DRAG_HANDLE(10),
+    SPIN_BUTTON(11),
+    COMBO_BOX(12),
+    MENU_BAR(13),
+    MENU(14),
+    MENU_ITEM(15),
+    MENU_ITEM_CHECKBOX(16),
+    MENU_ITEM_RADIO(17),
+    LIST(18),
+    LIST_ITEM(19),
+    FORM(20),
+    TOOLTIP(21),
+    LOADING_SPINNER(22),
+    PROGRESS_BAR(23),
+    HOTKEY(24),
+    RADIO_GROUP(25),
+    STATUS(26),
+    ALERT(27),
+    COMPLEMENTARY(28),
+    CONTENT_INFO(29),
+    MAIN(30),
+    NAVIGATION(31),
+    REGION(32);
+
+    final int value;
+
+    Role(int value) {
       this.value = value;
     }
   }

--- a/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -853,7 +853,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
     }
     if (semanticsNode.role == Role.PROGRESS_BAR.value) {
       result.setClassName("android.widget.ProgressBar");
-      if (semanticsNode.hasValue()) {
+      if (semanticsNode.value != null) {
         try {
           float min = 0.0f;
           float max = 100.0f;
@@ -863,7 +863,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
           if (semanticsNode.maxValue != null) {
             max = Float.parseFloat(semanticsNode.maxValue);
           }
-          float parsedValue = Float.parseFloat(semanticsNode.getValue());
+          float parsedValue = Float.parseFloat(semanticsNode.value);
           result.setRangeInfo(
               AccessibilityNodeInfo.RangeInfo.obtain(
                   AccessibilityNodeInfo.RangeInfo.RANGE_TYPE_FLOAT, min, max, parsedValue));

--- a/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -851,7 +851,8 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
       // TODO(jonahwilliams): Figure out a way conform to the expected id from TalkBack's
       // CustomLabelManager. talkback/src/main/java/labeling/CustomLabelManager.java#L525
     }
-    switch (Role.fromInt(semanticsNode.role)) {
+    Role role = Role.values()[semanticsNode.role];
+    switch (role) {
       case PROGRESS_BAR:
         result.setClassName("android.widget.ProgressBar");
         if (semanticsNode.value != null) {
@@ -877,10 +878,10 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
                 AccessibilityNodeInfo.RangeInfo.obtain(
                     AccessibilityNodeInfo.RangeInfo.RANGE_TYPE_FLOAT, min, max, parsedValue));
           } catch (NumberFormatException e) {
-            // Fallback to RANGE_TYPE_FLOAT with 0.0.
+            // Fallback to RANGE_TYPE_INDETERMINATE.
             result.setRangeInfo(
                 AccessibilityNodeInfo.RangeInfo.obtain(
-                    AccessibilityNodeInfo.RangeInfo.RANGE_TYPE_FLOAT, 0.0f, 0.0f, 0.0f));
+                    AccessibilityNodeInfo.RangeInfo.RANGE_TYPE_INDETERMINATE, 0.0f, 0.0f, 0.0f));
           }
         }
         break;
@@ -2408,16 +2409,6 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
 
     Role(int value) {
       this.value = value;
-    }
-
-    @NonNull
-    public static Role fromInt(int value) {
-      for (Role role : Role.values()) {
-        if (role.value == value) {
-          return role;
-        }
-      }
-      return Role.NONE;
     }
   }
 

--- a/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -2524,6 +2524,8 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
 
     // The locale of the content of this node.
     @Nullable private String locale;
+
+    // The role of this node.
     private int role;
 
     // The heading level for this node (0 means not a heading).

--- a/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -878,10 +878,16 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
                 AccessibilityNodeInfo.RangeInfo.obtain(
                     AccessibilityNodeInfo.RangeInfo.RANGE_TYPE_FLOAT, min, max, parsedValue));
           } catch (NumberFormatException e) {
-            // Fallback to RANGE_TYPE_INDETERMINATE.
-            result.setRangeInfo(
-                AccessibilityNodeInfo.RangeInfo.obtain(
-                    AccessibilityNodeInfo.RangeInfo.RANGE_TYPE_INDETERMINATE, 0.0f, 0.0f, 0.0f));
+            if (Build.VERSION.SDK_INT >= API_LEVELS.API_36) {
+              result.setRangeInfo(
+                  AccessibilityNodeInfo.RangeInfo.obtain(
+                      AccessibilityNodeInfo.RangeInfo.RANGE_TYPE_INDETERMINATE, 0.0f, 0.0f, 0.0f));
+            } else {
+              // Fallback to RANGE_TYPE_FLOAT with 0.0.
+              result.setRangeInfo(
+                  AccessibilityNodeInfo.RangeInfo.obtain(
+                      AccessibilityNodeInfo.RangeInfo.RANGE_TYPE_FLOAT, 0.0f, 0.0f, 0.0f));
+            }
           }
         }
         break;

--- a/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -851,6 +851,9 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
       // TODO(jonahwilliams): Figure out a way conform to the expected id from TalkBack's
       // CustomLabelManager. talkback/src/main/java/labeling/CustomLabelManager.java#L525
     }
+    if (semanticsNode.role == 23 /* ProgressBar */) {
+      result.setClassName("android.widget.ProgressBar");
+    }
     if (semanticsNode.hasAction(Action.DISMISS)) {
       result.setDismissable(true);
       result.addAction(AccessibilityNodeInfo.ACTION_DISMISS);
@@ -2521,6 +2524,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
 
     // The locale of the content of this node.
     @Nullable private String locale;
+    private int role;
 
     // The heading level for this node (0 means not a heading).
     private int headingLevel;
@@ -2730,6 +2734,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
       scrollPosition = buffer.getFloat();
       scrollExtentMax = buffer.getFloat();
       scrollExtentMin = buffer.getFloat();
+      role = buffer.getInt();
 
       identifier = getStringFromBuffer(buffer, strings);
 

--- a/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -855,7 +855,6 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
       case PROGRESS_BAR:
         result.setClassName("android.widget.ProgressBar");
         if (semanticsNode.value != null) {
-
           float min = Float.NEGATIVE_INFINITY;
           float max = Float.POSITIVE_INFINITY;
           if (semanticsNode.minValue != null) {
@@ -878,8 +877,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
                 AccessibilityNodeInfo.RangeInfo.obtain(
                     AccessibilityNodeInfo.RangeInfo.RANGE_TYPE_FLOAT, min, max, parsedValue));
           } catch (NumberFormatException e) {
-            // Keep as indeterminate format. There is no RANGE_TYPE_INDETERMINATE, so we
-            // fallback to RANGE_TYPE_FLOAT with 0.0.
+            // Fallback to RANGE_TYPE_FLOAT with 0.0.
             result.setRangeInfo(
                 AccessibilityNodeInfo.RangeInfo.obtain(
                     AccessibilityNodeInfo.RangeInfo.RANGE_TYPE_FLOAT, 0.0f, 0.0f, 0.0f));

--- a/engine/src/flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.cc
@@ -243,6 +243,8 @@ void PlatformViewAndroidDelegate::UpdateSemantics(
       putStringIntoBuffer(node.tooltip, buffer_int32, &position, strings);
       putStringIntoBuffer(node.linkUrl, buffer_int32, &position, strings);
       putStringIntoBuffer(node.locale, buffer_int32, &position, strings);
+      putStringIntoBuffer(node.minValue, buffer_int32, &position, strings);
+      putStringIntoBuffer(node.maxValue, buffer_int32, &position, strings);
 
       buffer_int32[position++] = node.headingLevel;
       buffer_int32[position++] = node.textDirection;

--- a/engine/src/flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.cc
@@ -214,6 +214,7 @@ void PlatformViewAndroidDelegate::UpdateSemantics(
       buffer_float32[position++] = static_cast<float>(node.scrollPosition);
       buffer_float32[position++] = static_cast<float>(node.scrollExtentMax);
       buffer_float32[position++] = static_cast<float>(node.scrollExtentMin);
+      buffer_int32[position++] = static_cast<int32_t>(node.role);
 
       putStringIntoBuffer(node.identifier, buffer_int32, &position, strings);
 

--- a/engine/src/flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.h
+++ b/engine/src/flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.h
@@ -17,7 +17,7 @@ namespace flutter {
 class PlatformViewAndroidDelegate {
  public:
   static constexpr size_t kBytesPerNode =
-      70 * sizeof(int32_t);  // The # fields in SemanticsNode
+      71 * sizeof(int32_t);  // The # fields in SemanticsNode
   static constexpr size_t kBytesPerChild = sizeof(int32_t);
   static constexpr size_t kBytesPerCustomAction = sizeof(int32_t);
   static constexpr size_t kBytesPerAction = 4 * sizeof(int32_t);

--- a/engine/src/flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.h
+++ b/engine/src/flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.h
@@ -17,7 +17,7 @@ namespace flutter {
 class PlatformViewAndroidDelegate {
  public:
   static constexpr size_t kBytesPerNode =
-      71 * sizeof(int32_t);  // The # fields in SemanticsNode
+      73 * sizeof(int32_t);  // The # fields in SemanticsNode
   static constexpr size_t kBytesPerChild = sizeof(int32_t);
   static constexpr size_t kBytesPerCustomAction = sizeof(int32_t);
   static constexpr size_t kBytesPerAction = 4 * sizeof(int32_t);

--- a/engine/src/flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate_unittests.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate_unittests.cc
@@ -45,6 +45,7 @@ TEST(PlatformViewShell, UpdateSemanticsDoesFlutterViewUpdateSemantics) {
   buffer_float32[position++] = static_cast<float>(node0.scrollPosition);
   buffer_float32[position++] = static_cast<float>(node0.scrollExtentMax);
   buffer_float32[position++] = static_cast<float>(node0.scrollExtentMin);
+  buffer_int32[position++] = static_cast<int32_t>(node0.role);
   buffer_int32[position++] = expected_strings.size();  // node0.identifier
   expected_strings.push_back(node0.identifier);
   buffer_int32[position++] = expected_strings.size();  // node0.label
@@ -116,6 +117,7 @@ TEST(PlatformViewShell, UpdateSemanticsDoesUpdateLinkUrl) {
   buffer_float32[position++] = static_cast<float>(node0.scrollPosition);
   buffer_float32[position++] = static_cast<float>(node0.scrollExtentMax);
   buffer_float32[position++] = static_cast<float>(node0.scrollExtentMin);
+  buffer_int32[position++] = static_cast<int32_t>(node0.role);
   buffer_int32[position++] = expected_strings.size();  // node0.identifier
   expected_strings.push_back(node0.identifier);
   buffer_int32[position++] = expected_strings.size();  // node0.label
@@ -188,6 +190,7 @@ TEST(PlatformViewShell, UpdateSemanticsDoesUpdateLocale) {
   buffer_float32[position++] = static_cast<float>(node0.scrollPosition);
   buffer_float32[position++] = static_cast<float>(node0.scrollExtentMax);
   buffer_float32[position++] = static_cast<float>(node0.scrollExtentMin);
+  buffer_int32[position++] = static_cast<int32_t>(node0.role);
   buffer_int32[position++] = expected_strings.size();  // node0.identifier
   expected_strings.push_back(node0.identifier);
   buffer_int32[position++] = expected_strings.size();  // node0.label
@@ -275,6 +278,7 @@ TEST(PlatformViewShell,
   buffer_float32[position++] = static_cast<float>(node0.scrollPosition);
   buffer_float32[position++] = static_cast<float>(node0.scrollExtentMax);
   buffer_float32[position++] = static_cast<float>(node0.scrollExtentMin);
+  buffer_int32[position++] = static_cast<int32_t>(node0.role);
   buffer_int32[position++] = expected_strings.size();  // node0.identifier
   expected_strings.push_back(node0.identifier);
   buffer_int32[position++] = expected_strings.size();  // node0.label

--- a/engine/src/flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate_unittests.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate_unittests.cc
@@ -63,6 +63,8 @@ TEST(PlatformViewShell, UpdateSemanticsDoesFlutterViewUpdateSemantics) {
   expected_strings.push_back(node0.tooltip);
   buffer_int32[position++] = -1;  // node0.linkUrl
   buffer_int32[position++] = -1;  // node0.locale
+  buffer_int32[position++] = -1;  // node0.minValue
+  buffer_int32[position++] = -1;  // node0.maxValue
   buffer_int32[position++] = node0.headingLevel;
   buffer_int32[position++] = node0.textDirection;
   buffer_float32[position++] = node0.rect.left();
@@ -135,6 +137,8 @@ TEST(PlatformViewShell, UpdateSemanticsDoesUpdateLinkUrl) {
   buffer_int32[position++] = expected_strings.size();  // node0.linkUrl
   expected_strings.push_back(node0.linkUrl);
   buffer_int32[position++] = -1;  // node0.locale
+  buffer_int32[position++] = -1;  // node0.minValue
+  buffer_int32[position++] = -1;  // node0.maxValue
   buffer_int32[position++] = node0.headingLevel;
   buffer_int32[position++] = node0.textDirection;
   buffer_float32[position++] = node0.rect.left();
@@ -208,6 +212,8 @@ TEST(PlatformViewShell, UpdateSemanticsDoesUpdateLocale) {
   buffer_int32[position++] = -1;  // node0.linkUrl
   buffer_int32[position++] = expected_strings.size();
   expected_strings.push_back(node0.locale);  // node0.locale
+  buffer_int32[position++] = -1;             // node0.minValue
+  buffer_int32[position++] = -1;             // node0.maxValue
   buffer_int32[position++] = node0.headingLevel;
   buffer_int32[position++] = node0.textDirection;
   buffer_float32[position++] = node0.rect.left();
@@ -307,6 +313,8 @@ TEST(PlatformViewShell,
   buffer_int32[position++] = -1;  // node0.tooltip
   buffer_int32[position++] = -1;  // node0.linkUrl
   buffer_int32[position++] = -1;  // node0.locale
+  buffer_int32[position++] = -1;  // node0.minValue
+  buffer_int32[position++] = -1;  // node0.maxValue
   buffer_int32[position++] = node0.headingLevel;
   buffer_int32[position++] = node0.textDirection;
   buffer_float32[position++] = node0.rect.left();

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -2434,9 +2434,9 @@ public class AccessibilityBridgeTest {
     AccessibilityNodeInfo nodeInfo = accessibilityBridge.createAccessibilityNodeInfo(0);
     assertEquals("android.widget.ProgressBar", nodeInfo.getClassName().toString());
     assertNotNull(nodeInfo.getRangeInfo());
-    assertEquals(0.0f, nodeInfo.getRangeInfo().getMin());
-    assertEquals(100.0f, nodeInfo.getRangeInfo().getMax());
-    assertEquals(50.0f, nodeInfo.getRangeInfo().getCurrent());
+    assertEquals(0.0f, nodeInfo.getRangeInfo().getMin(), 1e-4f);
+    assertEquals(100.0f, nodeInfo.getRangeInfo().getMax(), 1e-4f);
+    assertEquals(50.0f, nodeInfo.getRangeInfo().getCurrent(), 1e-4f);
   }
 
   @Config(sdk = API_LEVELS.API_32)

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -2491,6 +2491,8 @@ public class AccessibilityBridgeTest {
     assertEquals(50.0f, nodeInfo.getRangeInfo().getCurrent(), 1e-4f);
   }
 
+  @Config(sdk = API_LEVELS.API_34)
+  @TargetApi(API_LEVELS.API_34)
   @Test
   public void itAddsRangeInfoToProgressBar_unparseableValue() {
     AccessibilityBridge accessibilityBridge = setUpBridge();
@@ -2504,6 +2506,31 @@ public class AccessibilityBridgeTest {
     AccessibilityNodeInfo nodeInfo = accessibilityBridge.createAccessibilityNodeInfo(0);
     assertEquals("android.widget.ProgressBar", nodeInfo.getClassName().toString());
     assertNotNull(nodeInfo.getRangeInfo());
+    assertEquals(
+        AccessibilityNodeInfo.RangeInfo.RANGE_TYPE_FLOAT, nodeInfo.getRangeInfo().getType());
+    assertEquals(0.0f, nodeInfo.getRangeInfo().getMin(), 1e-4f);
+    assertEquals(0.0f, nodeInfo.getRangeInfo().getMax(), 1e-4f);
+    assertEquals(0.0f, nodeInfo.getRangeInfo().getCurrent(), 1e-4f);
+  }
+
+  @Config(sdk = API_LEVELS.API_36)
+  @TargetApi(API_LEVELS.API_36)
+  @Test
+  public void itAddsRangeInfoToProgressBar_unparseableValueAPI36() {
+    AccessibilityBridge accessibilityBridge = setUpBridge();
+    TestSemanticsNode testSemanticsNode = new TestSemanticsNode();
+    testSemanticsNode.role = 23; // SemanticsRole::kProgressBar
+    testSemanticsNode.value = "a";
+    testSemanticsNode.minValue = "0";
+    testSemanticsNode.maxValue = "100";
+    TestSemanticsUpdate testSemanticsUpdate = testSemanticsNode.toUpdate();
+    testSemanticsUpdate.sendUpdateToBridge(accessibilityBridge);
+    AccessibilityNodeInfo nodeInfo = accessibilityBridge.createAccessibilityNodeInfo(0);
+    assertEquals("android.widget.ProgressBar", nodeInfo.getClassName().toString());
+    assertNotNull(nodeInfo.getRangeInfo());
+    assertEquals(
+        AccessibilityNodeInfo.RangeInfo.RANGE_TYPE_INDETERMINATE,
+        nodeInfo.getRangeInfo().getType());
     assertEquals(0.0f, nodeInfo.getRangeInfo().getMin(), 1e-4f);
     assertEquals(0.0f, nodeInfo.getRangeInfo().getMax(), 1e-4f);
     assertEquals(0.0f, nodeInfo.getRangeInfo().getCurrent(), 1e-4f);

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -2421,6 +2421,24 @@ public class AccessibilityBridgeTest {
     assertEquals("android.widget.ProgressBar", nodeInfo.getClassName().toString());
   }
 
+  @Test
+  public void itAddsRangeInfoToProgressBar() {
+    AccessibilityBridge accessibilityBridge = setUpBridge();
+    TestSemanticsNode testSemanticsNode = new TestSemanticsNode();
+    testSemanticsNode.role = 23; // SemanticsRole::kProgressBar
+    testSemanticsNode.value = "50";
+    testSemanticsNode.minValue = "0";
+    testSemanticsNode.maxValue = "100";
+    TestSemanticsUpdate testSemanticsUpdate = testSemanticsNode.toUpdate();
+    testSemanticsUpdate.sendUpdateToBridge(accessibilityBridge);
+    AccessibilityNodeInfo nodeInfo = accessibilityBridge.createAccessibilityNodeInfo(0);
+    assertEquals("android.widget.ProgressBar", nodeInfo.getClassName().toString());
+    assertNotNull(nodeInfo.getRangeInfo());
+    assertEquals(0.0f, nodeInfo.getRangeInfo().getMin());
+    assertEquals(100.0f, nodeInfo.getRangeInfo().getMax());
+    assertEquals(50.0f, nodeInfo.getRangeInfo().getCurrent());
+  }
+
   @Config(sdk = API_LEVELS.API_32)
   @TargetApi(API_LEVELS.API_32)
   @Test
@@ -2939,6 +2957,8 @@ public class AccessibilityBridgeTest {
     String tooltip = null;
     String linkUrl = null;
     String locale = null;
+    String minValue = null;
+    String maxValue = null;
     int role = 0;
     int headingLevel = 0;
     int textDirection = 0;
@@ -3024,6 +3044,18 @@ public class AccessibilityBridgeTest {
         bytes.putInt(-1);
       } else {
         strings.add(locale);
+        bytes.putInt(strings.size() - 1);
+      }
+      if (minValue == null) {
+        bytes.putInt(-1);
+      } else {
+        strings.add(minValue);
+        bytes.putInt(strings.size() - 1);
+      }
+      if (maxValue == null) {
+        bytes.putInt(-1);
+      } else {
+        strings.add(maxValue);
         bytes.putInt(strings.size() - 1);
       }
       bytes.putInt(headingLevel);

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -2410,6 +2410,17 @@ public class AccessibilityBridgeTest {
     assertEquals("android.widget.HorizontalScrollView", nodeInfo.getClassName().toString());
   }
 
+  @Test
+  public void itAddsProgressBarToClassName() {
+    AccessibilityBridge accessibilityBridge = setUpBridge();
+    TestSemanticsNode testSemanticsNode = new TestSemanticsNode();
+    testSemanticsNode.role = 23; // SemanticsRole::kProgressBar
+    TestSemanticsUpdate testSemanticsUpdate = testSemanticsNode.toUpdate();
+    testSemanticsUpdate.sendUpdateToBridge(accessibilityBridge);
+    AccessibilityNodeInfo nodeInfo = accessibilityBridge.createAccessibilityNodeInfo(0);
+    assertEquals("android.widget.ProgressBar", nodeInfo.getClassName().toString());
+  }
+
   @Config(sdk = API_LEVELS.API_32)
   @TargetApi(API_LEVELS.API_32)
   @Test
@@ -2928,6 +2939,7 @@ public class AccessibilityBridgeTest {
     String tooltip = null;
     String linkUrl = null;
     String locale = null;
+    int role = 0;
     int headingLevel = 0;
     int textDirection = 0;
     float left = 0.0f;
@@ -2984,6 +2996,7 @@ public class AccessibilityBridgeTest {
       bytes.putFloat(scrollPosition);
       bytes.putFloat(scrollExtentMax);
       bytes.putFloat(scrollExtentMin);
+      bytes.putInt(role);
       if (identifier == null) {
         bytes.putInt(-1);
       } else {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -2439,6 +2439,76 @@ public class AccessibilityBridgeTest {
     assertEquals(50.0f, nodeInfo.getRangeInfo().getCurrent(), 1e-4f);
   }
 
+  @Test
+  public void itAddsRangeInfoToProgressBar_missingMinAndMaxValue() {
+    AccessibilityBridge accessibilityBridge = setUpBridge();
+    TestSemanticsNode testSemanticsNode = new TestSemanticsNode();
+    testSemanticsNode.role = 23; // SemanticsRole::kProgressBar
+    testSemanticsNode.value = "50";
+    TestSemanticsUpdate testSemanticsUpdate = testSemanticsNode.toUpdate();
+    testSemanticsUpdate.sendUpdateToBridge(accessibilityBridge);
+    AccessibilityNodeInfo nodeInfo = accessibilityBridge.createAccessibilityNodeInfo(0);
+    assertEquals("android.widget.ProgressBar", nodeInfo.getClassName().toString());
+    assertNotNull(nodeInfo.getRangeInfo());
+    assertEquals(Float.NEGATIVE_INFINITY, nodeInfo.getRangeInfo().getMin(), 1e-4f);
+    assertEquals(Float.POSITIVE_INFINITY, nodeInfo.getRangeInfo().getMax(), 1e-4f);
+    assertEquals(50.0f, nodeInfo.getRangeInfo().getCurrent(), 1e-4f);
+  }
+
+  @Test
+  public void itAddsRangeInfoToProgressBar_unparseableMinValue() {
+    AccessibilityBridge accessibilityBridge = setUpBridge();
+    TestSemanticsNode testSemanticsNode = new TestSemanticsNode();
+    testSemanticsNode.role = 23; // SemanticsRole::kProgressBar
+    testSemanticsNode.value = "50";
+    testSemanticsNode.minValue = "a";
+    testSemanticsNode.maxValue = "100";
+    TestSemanticsUpdate testSemanticsUpdate = testSemanticsNode.toUpdate();
+    testSemanticsUpdate.sendUpdateToBridge(accessibilityBridge);
+    AccessibilityNodeInfo nodeInfo = accessibilityBridge.createAccessibilityNodeInfo(0);
+    assertEquals("android.widget.ProgressBar", nodeInfo.getClassName().toString());
+    assertNotNull(nodeInfo.getRangeInfo());
+    assertEquals(Float.NEGATIVE_INFINITY, nodeInfo.getRangeInfo().getMin(), 1e-4f);
+    assertEquals(100.0f, nodeInfo.getRangeInfo().getMax(), 1e-4f);
+    assertEquals(50.0f, nodeInfo.getRangeInfo().getCurrent(), 1e-4f);
+  }
+
+  @Test
+  public void itAddsRangeInfoToProgressBar_unparseableMaxValue() {
+    AccessibilityBridge accessibilityBridge = setUpBridge();
+    TestSemanticsNode testSemanticsNode = new TestSemanticsNode();
+    testSemanticsNode.role = 23; // SemanticsRole::kProgressBar
+    testSemanticsNode.value = "50";
+    testSemanticsNode.minValue = "0";
+    testSemanticsNode.maxValue = "a";
+    TestSemanticsUpdate testSemanticsUpdate = testSemanticsNode.toUpdate();
+    testSemanticsUpdate.sendUpdateToBridge(accessibilityBridge);
+    AccessibilityNodeInfo nodeInfo = accessibilityBridge.createAccessibilityNodeInfo(0);
+    assertEquals("android.widget.ProgressBar", nodeInfo.getClassName().toString());
+    assertNotNull(nodeInfo.getRangeInfo());
+    assertEquals(0.0f, nodeInfo.getRangeInfo().getMin(), 1e-4f);
+    assertEquals(Float.POSITIVE_INFINITY, nodeInfo.getRangeInfo().getMax(), 1e-4f);
+    assertEquals(50.0f, nodeInfo.getRangeInfo().getCurrent(), 1e-4f);
+  }
+
+  @Test
+  public void itAddsRangeInfoToProgressBar_unparseableValue() {
+    AccessibilityBridge accessibilityBridge = setUpBridge();
+    TestSemanticsNode testSemanticsNode = new TestSemanticsNode();
+    testSemanticsNode.role = 23; // SemanticsRole::kProgressBar
+    testSemanticsNode.value = "a";
+    testSemanticsNode.minValue = "0";
+    testSemanticsNode.maxValue = "100";
+    TestSemanticsUpdate testSemanticsUpdate = testSemanticsNode.toUpdate();
+    testSemanticsUpdate.sendUpdateToBridge(accessibilityBridge);
+    AccessibilityNodeInfo nodeInfo = accessibilityBridge.createAccessibilityNodeInfo(0);
+    assertEquals("android.widget.ProgressBar", nodeInfo.getClassName().toString());
+    assertNotNull(nodeInfo.getRangeInfo());
+    assertEquals(0.0f, nodeInfo.getRangeInfo().getMin(), 1e-4f);
+    assertEquals(0.0f, nodeInfo.getRangeInfo().getMax(), 1e-4f);
+    assertEquals(0.0f, nodeInfo.getRangeInfo().getCurrent(), 1e-4f);
+  }
+
   @Config(sdk = API_LEVELS.API_32)
   @TargetApi(API_LEVELS.API_32)
   @Test


### PR DESCRIPTION
when testing https://github.com/flutter/flutter/issues/182491 I found out the ProgressBar class is not set on android, setting the class name will make the talkback announce "progress bar".

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
