### PR TITLE
Respect tooltip hover delay when moving between targets

### DIFF
--- a/packages/flutter/lib/src/widgets/raw_tooltip.dart
+++ b/packages/flutter/lib/src/widgets/raw_tooltip.dart
@@ -305,6 +305,9 @@ class RawTooltip extends StatefulWidget {
   /// The length of time that a pointer must hover over a tooltip's widget
   /// before the tooltip will be shown.
   ///
+  /// When moving between widgets that each show a tooltip, this delay still
+  /// applies before showing the next tooltip.
+  ///
   /// Defaults to 0 milliseconds (the tooltip is shown immediately upon hover).
   /// {@endtemplate}
   final Duration hoverDelay;

--- a/packages/flutter/lib/src/widgets/raw_tooltip.dart
+++ b/packages/flutter/lib/src/widgets/raw_tooltip.dart
@@ -753,9 +753,7 @@ class RawTooltipState extends State<RawTooltip> with SingleTickerProviderStateMi
       assert(tooltip.mounted);
       tooltip._scheduleDismissTooltip();
     }
-    _scheduleShowTooltip(
-      withDelay: tooltipsToDismiss.isNotEmpty ? Duration.zero : widget.hoverDelay,
-    );
+    _scheduleShowTooltip(withDelay: widget.hoverDelay);
   }
 
   void _handleMouseExit(PointerExitEvent event) {

--- a/packages/flutter/test/widgets/raw_tooltip_test.dart
+++ b/packages/flutter/test/widgets/raw_tooltip_test.dart
@@ -948,10 +948,13 @@ void main() {
     expect(find.text('first tooltip'), findsOneWidget);
     expect(find.text('last tooltip'), findsNothing);
 
-    // Move to the second tooltip and expect it to show up immediately.
+    // Move to the second tooltip and expect it to respect hoverDelay.
     await gesture.moveTo(tester.getCenter(find.byType(RawTooltip).last));
     await tester.pump();
     expect(find.text('first tooltip'), findsNothing);
+    expect(find.text('last tooltip'), findsNothing);
+
+    await tester.pump(hoverDelay);
     expect(find.text('last tooltip'), findsOneWidget);
   });
 

--- a/packages/flutter/test/widgets/raw_tooltip_test.dart
+++ b/packages/flutter/test/widgets/raw_tooltip_test.dart
@@ -892,7 +892,7 @@ void main() {
 
   // Regression test for https://github.com/flutter/flutter/issues/141644.
   // This allows the user to quickly explore the UI via tooltips.
-  testWidgets('Tooltip shows without delay when the mouse moves from another tooltip', (
+  testWidgets('Tooltip respects hover delay when the mouse moves from another tooltip', (
     WidgetTester tester,
   ) async {
     const hoverDelay = Duration(milliseconds: 700);

--- a/packages/flutter/test/widgets/raw_tooltip_test.dart
+++ b/packages/flutter/test/widgets/raw_tooltip_test.dart
@@ -891,8 +891,8 @@ void main() {
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/141644.
-  // This allows the user to quickly explore the UI via tooltips.
-  testWidgets('Tooltip respects hover delay when the mouse moves from another tooltip', (
+  // Moving between tooltip targets should still wait for the configured hoverDelay.
+  testWidgets('Tooltip waits hover delay when moving between tooltip targets', (
     WidgetTester tester,
   ) async {
     const hoverDelay = Duration(milliseconds: 700);


### PR DESCRIPTION
This fixes tooltip hover behavior on web when moving the mouse from one tooltip target to another.

Before this change, the second tooltip could appear immediately because we forced a zero delay if another tooltip was being dismissed. That made tooltips feel jumpy in list-like UIs.

After this change, the next tooltip respects the configured hover delay, so behavior is consistent and predictable.

Fixes https://github.com/flutter/flutter/issues/183882

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

## Testing

- ./bin/flutter test packages/flutter/test/widgets/raw_tooltip_test.dart
- ./bin/flutter test packages/flutter/test/material/tooltip_test.dart

