### PR TITLE
Clarify contributor access wording shown as Write in GitHub

### DIFF
--- a/docs/contributing/Contributor-access.md
+++ b/docs/contributing/Contributor-access.md
@@ -32,8 +32,7 @@ Part of being a contributor is making sure our documentation is up to date, incl
 
 ### Privileges
 
-Being in the GitHub "flutter-hackers" group gives you the following.
-In the GitHub UI, this membership appears as "Write" access on pull requests.
+Being in the GitHub "flutter-hackers" group gives you the following privileges (in the GitHub UI, this membership appears as "Write" access on pull requests):
 
 
 * The ability to merge your own PRs once they are reviewed (see [Tree Hygiene](Tree-hygiene.md)).

--- a/docs/contributing/Contributor-access.md
+++ b/docs/contributing/Contributor-access.md
@@ -32,7 +32,9 @@ Part of being a contributor is making sure our documentation is up to date, incl
 
 ### Privileges
 
-Being in the GitHub "flutter-hackers" group gives you the following:
+Being in the GitHub "flutter-hackers" group gives you the following.
+In the GitHub UI, this membership appears as "Write" access on pull requests.
+
 
 * The ability to merge your own PRs once they are reviewed (see [Tree Hygiene](Tree-hygiene.md)).
 

--- a/docs/contributing/Contributor-access.md
+++ b/docs/contributing/Contributor-access.md
@@ -32,7 +32,7 @@ Part of being a contributor is making sure our documentation is up to date, incl
 
 ### Privileges
 
-Being in the GitHub "flutter-hackers" group gives you the following privileges (in the GitHub UI, this membership appears as "Write" access on pull requests):
+Being in the GitHub "flutter-hackers" group gives you the following privileges (shown as "Write" access in the GitHub UI):
 
 
 * The ability to merge your own PRs once they are reviewed (see [Tree Hygiene](Tree-hygiene.md)).


### PR DESCRIPTION
This updates the contributor access doc to clarify wording that is currently confusing in GitHub PR UI.

The doc refers to membership in the flutter-hackers group and commit access. On PR pages, GitHub shows this as Write access. This change adds that mapping directly in the privileges section so readers can connect the two terms.

Fixes https://github.com/flutter/flutter/issues/183881

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

## Testing

- Not run. Documentation-only change. Test-exempt.
