### PR TITLE
Add trailingIconVisibility to ExpansionPanel (#179167)

### DIFF
--- a/examples/api/lib/material/expansion_panel/expansion_panel_list.1.dart
+++ b/examples/api/lib/material/expansion_panel/expansion_panel_list.1.dart
@@ -1,0 +1,127 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+/// Flutter code sample for [ExpansionPanel.trailingIconVisibility].
+
+void main() => runApp(const ExpansionPanelIconVisibilityExampleApp());
+
+class ExpansionPanelIconVisibilityExampleApp extends StatelessWidget {
+  const ExpansionPanelIconVisibilityExampleApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(title: const Text('ExpansionPanel Icon Visibility')),
+        body: const ExpansionPanelIconVisibilityExample(),
+      ),
+    );
+  }
+}
+
+class ExpansionPanelIconVisibilityExample extends StatefulWidget {
+  const ExpansionPanelIconVisibilityExample({super.key});
+
+  @override
+  State<ExpansionPanelIconVisibilityExample> createState() =>
+      _ExpansionPanelIconVisibilityExampleState();
+}
+
+class _ExpansionPanelIconVisibilityExampleState
+    extends State<ExpansionPanelIconVisibilityExample> {
+  ExpansionPanelIconVisibility _visibility =
+      ExpansionPanelIconVisibility.visible;
+  bool _canTapOnHeader = false;
+  final List<bool> _isExpanded = <bool>[false, false, false];
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Column(
+        children: <Widget>[
+          const SizedBox(height: 24),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Column(
+              children: <Widget>[
+                SegmentedButton<ExpansionPanelIconVisibility>(
+                  segments: const <ButtonSegment<ExpansionPanelIconVisibility>>[
+                    ButtonSegment<ExpansionPanelIconVisibility>(
+                      value: ExpansionPanelIconVisibility.visible,
+                      label: Text('Visible'),
+                    ),
+                    ButtonSegment<ExpansionPanelIconVisibility>(
+                      value: ExpansionPanelIconVisibility.hidden,
+                      label: Text('Hidden'),
+                    ),
+                    ButtonSegment<ExpansionPanelIconVisibility>(
+                      value: ExpansionPanelIconVisibility.gone,
+                      label: Text('Gone'),
+                    ),
+                  ],
+                  selected: <ExpansionPanelIconVisibility>{_visibility},
+                  onSelectionChanged:
+                      (Set<ExpansionPanelIconVisibility> selected) {
+                        setState(() {
+                          _visibility = selected.first;
+                        });
+                      },
+                ),
+                const SizedBox(height: 12),
+                SwitchListTile(
+                  title: const Text('canTapOnHeader'),
+                  value: _canTapOnHeader,
+                  onChanged: (bool value) {
+                    setState(() {
+                      _canTapOnHeader = value;
+                    });
+                  },
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 24),
+          ExpansionPanelList(
+            expansionCallback: (int index, bool isExpanded) {
+              setState(() {
+                _isExpanded[index] = isExpanded;
+              });
+            },
+            children: <ExpansionPanel>[
+              for (int i = 0; i < 3; i++)
+                ExpansionPanel(
+                  trailingIconVisibility: _visibility,
+                  canTapOnHeader: _canTapOnHeader,
+                  headerBuilder: (BuildContext context, bool isExpanded) {
+                    return ListTile(
+                      title: Text('Panel ${i + 1}'),
+                      trailing: Container(
+                        width: 8,
+                        height: 8,
+                        decoration: BoxDecoration(
+                          color: Theme.of(context).colorScheme.primary,
+                          shape: BoxShape.circle,
+                        ),
+                      ),
+                    );
+                  },
+                  body: ListTile(
+                    title: Text('Panel ${i + 1} content'),
+                    subtitle: const Text(
+                      'When the icon visibility is hidden, the space is preserved. '
+                      'When gone, the space is removed.',
+                    ),
+                  ),
+                  isExpanded: _isExpanded[i],
+                ),
+            ],
+          ),
+          const SizedBox(height: 24),
+        ],
+      ),
+    );
+  }
+}

--- a/examples/api/test/material/expansion_panel/expansion_panel_list.1_test.dart
+++ b/examples/api/test/material/expansion_panel/expansion_panel_list.1_test.dart
@@ -1,0 +1,73 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/expansion_panel/expansion_panel_list.1.dart'
+    as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('ExpansionPanel icon visibility can be toggled', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const example.ExpansionPanelIconVisibilityExampleApp(),
+    );
+
+    expect(find.byType(ExpandIcon), findsNWidgets(3));
+
+    final Finder visibilityFinder = find
+        .ancestor(
+          of: find.byType(ExpandIcon).first,
+          matching: find.byType(Visibility),
+        )
+        .first;
+
+    Visibility visibility = tester.widget(visibilityFinder);
+    expect(visibility.visible, isTrue);
+
+    await tester.tap(find.text('Hidden'));
+    await tester.pumpAndSettle();
+
+    visibility = tester.widget(visibilityFinder);
+    expect(visibility.visible, isFalse);
+    expect(visibility.maintainSize, isTrue);
+
+    await tester.tap(find.text('Gone'));
+    await tester.pumpAndSettle();
+
+    visibility = tester.widget(visibilityFinder);
+    expect(visibility.visible, isFalse);
+    expect(visibility.maintainSize, isFalse);
+  });
+
+  testWidgets('Expanded panel remains collapsible when icon is hidden', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const example.ExpansionPanelIconVisibilityExampleApp(),
+    );
+
+    await tester.tap(find.byType(ExpandIcon).first);
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.widget<ExpandIcon>(find.byType(ExpandIcon).first).isExpanded,
+      true,
+    );
+
+    await tester.tap(find.text('Hidden'));
+    await tester.pumpAndSettle();
+
+    final Finder visibilityFinder = find
+        .ancestor(
+          of: find.byType(ExpandIcon).first,
+          matching: find.byType(Visibility),
+        )
+        .first;
+
+    final Visibility visibility = tester.widget(visibilityFinder);
+    expect(visibility.visible, isTrue);
+  });
+}

--- a/examples/api/test/material/expansion_panel/expansion_panel_list.1_test.dart
+++ b/examples/api/test/material/expansion_panel/expansion_panel_list.1_test.dart
@@ -37,37 +37,6 @@ void main() {
     await tester.tap(find.text('Gone'));
     await tester.pumpAndSettle();
 
-    visibility = tester.widget(visibilityFinder);
-    expect(visibility.visible, isFalse);
-    expect(visibility.maintainSize, isFalse);
-  });
-
-  testWidgets('Expanded panel remains collapsible when icon is hidden', (
-    WidgetTester tester,
-  ) async {
-    await tester.pumpWidget(
-      const example.ExpansionPanelIconVisibilityExampleApp(),
-    );
-
-    await tester.tap(find.byType(ExpandIcon).first);
-    await tester.pumpAndSettle();
-
-    expect(
-      tester.widget<ExpandIcon>(find.byType(ExpandIcon).first).isExpanded,
-      true,
-    );
-
-    await tester.tap(find.text('Hidden'));
-    await tester.pumpAndSettle();
-
-    final Finder visibilityFinder = find
-        .ancestor(
-          of: find.byType(ExpandIcon).first,
-          matching: find.byType(Visibility),
-        )
-        .first;
-
-    final Visibility visibility = tester.widget(visibilityFinder);
-    expect(visibility.visible, isTrue);
+    expect(find.byType(ExpandIcon), findsNothing);
   });
 }

--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -58,6 +58,20 @@ typedef ExpansionPanelCallback = void Function(int panelIndex, bool isExpanded);
 /// [ExpansionPanel] needs to rebuild.
 typedef ExpansionPanelHeaderBuilder = Widget Function(BuildContext context, bool isExpanded);
 
+/// Controls the visibility of the trailing expand/collapse icon in an
+/// [ExpansionPanel].
+enum ExpansionPanelIconVisibility {
+  /// The icon is visible and interactive.
+  visible,
+
+  /// The icon is hidden, but its layout space is preserved to maintain
+  /// alignment with other panels.
+  hidden,
+
+  /// The icon is hidden and its layout space is removed.
+  gone,
+}
+
 /// A material expansion panel. It has a header and a body and can be either
 /// expanded or collapsed. The body of the panel is only visible when it is
 /// expanded.
@@ -68,6 +82,13 @@ typedef ExpansionPanelHeaderBuilder = Widget Function(BuildContext context, bool
 /// [ExpansionPanelList].
 ///
 /// See [ExpansionPanelList] for a sample implementation.
+///
+/// {@tool dartpad}
+/// This example demonstrates how to use [trailingIconVisibility] to control
+/// the expand/collapse icon.
+///
+/// ** See code in examples/api/lib/material/expansion_panel/expansion_panel_list.1.dart **
+/// {@end-tool}
 ///
 /// See also:
 ///
@@ -84,6 +105,7 @@ class ExpansionPanel {
     this.backgroundColor,
     this.splashColor,
     this.highlightColor,
+    this.trailingIconVisibility = ExpansionPanelIconVisibility.visible,
   });
 
   /// The widget builder that builds the expansion panels' header.
@@ -130,6 +152,22 @@ class ExpansionPanel {
   ///
   /// Defaults to [ThemeData.cardColor].
   final Color? backgroundColor;
+
+  /// Controls the visibility of the trailing expand/collapse icon.
+  ///
+  /// When set to [ExpansionPanelIconVisibility.hidden], the icon is not
+  /// rendered but its layout space is preserved for alignment. When set to
+  /// [ExpansionPanelIconVisibility.gone], both the icon and its space are
+  /// removed.
+  ///
+  /// If the panel is currently expanded, the icon will remain visible
+  /// regardless of this value so that the user can collapse it.
+  ///
+  /// When this is not [ExpansionPanelIconVisibility.visible], the
+  /// [canTapOnHeader] behavior is also disabled, unless the panel is expanded.
+  ///
+  /// Defaults to [ExpansionPanelIconVisibility.visible].
+  final ExpansionPanelIconVisibility trailingIconVisibility;
 }
 
 /// An expansion panel that allows for radio-like functionality.
@@ -153,6 +191,7 @@ class ExpansionPanelRadio extends ExpansionPanel {
     super.backgroundColor,
     super.splashColor,
     super.highlightColor,
+    super.trailingIconVisibility,
   });
 
   /// The value that uniquely identifies a radio panel so that the currently
@@ -394,17 +433,29 @@ class _ExpansionPanelListState extends State<ExpansionPanelList> {
       final ExpansionPanel child = widget.children[index];
       final Widget headerWidget = child.headerBuilder(context, _isChildExpanded(index));
 
-      Widget expandIconPadded = Padding(
-        padding: const EdgeInsetsDirectional.only(end: 8.0),
-        child: IgnorePointer(
-          ignoring: child.canTapOnHeader,
-          child: ExpandIcon(
-            color: widget.expandIconColor,
-            isExpanded: _isChildExpanded(index),
-            padding: _kExpandIconPadding,
-            splashColor: child.splashColor,
-            highlightColor: child.highlightColor,
-            onPressed: (bool isExpanded) => _handlePressed(isExpanded, index),
+      final iconVisible =
+          child.trailingIconVisibility == ExpansionPanelIconVisibility.visible ||
+          _isChildExpanded(index);
+      final iconMaintainSize =
+          child.trailingIconVisibility == ExpansionPanelIconVisibility.hidden;
+
+      Widget expandIconPadded = Visibility(
+        visible: iconVisible,
+        maintainSize: iconMaintainSize,
+        maintainAnimation: iconMaintainSize,
+        maintainState: iconMaintainSize,
+        child: Padding(
+          padding: const EdgeInsetsDirectional.only(end: 8.0),
+          child: IgnorePointer(
+            ignoring: child.canTapOnHeader || (!iconVisible && !_isChildExpanded(index)),
+            child: ExpandIcon(
+              color: widget.expandIconColor,
+              isExpanded: _isChildExpanded(index),
+              padding: _kExpandIconPadding,
+              splashColor: child.splashColor,
+              highlightColor: child.highlightColor,
+              onPressed: (bool isExpanded) => _handlePressed(isExpanded, index),
+            ),
           ),
         ),
       );
@@ -435,7 +486,7 @@ class _ExpansionPanelListState extends State<ExpansionPanelList> {
           expandIconPadded,
         ],
       );
-      if (child.canTapOnHeader) {
+      if (child.canTapOnHeader && iconVisible) {
         header = MergeSemantics(
           child: InkWell(
             splashColor: child.splashColor,

--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -160,12 +160,6 @@ class ExpansionPanel {
   /// [ExpansionPanelIconVisibility.gone], both the icon and its space are
   /// removed.
   ///
-  /// If the panel is currently expanded, the icon will remain visible
-  /// regardless of this value so that the user can collapse it.
-  ///
-  /// When this is not [ExpansionPanelIconVisibility.visible], the
-  /// [canTapOnHeader] behavior is also disabled, unless the panel is expanded.
-  ///
   /// Defaults to [ExpansionPanelIconVisibility.visible].
   final ExpansionPanelIconVisibility trailingIconVisibility;
 }
@@ -433,11 +427,8 @@ class _ExpansionPanelListState extends State<ExpansionPanelList> {
       final ExpansionPanel child = widget.children[index];
       final Widget headerWidget = child.headerBuilder(context, _isChildExpanded(index));
 
-      final iconVisible =
-          child.trailingIconVisibility == ExpansionPanelIconVisibility.visible ||
-          _isChildExpanded(index);
-      final iconMaintainSize =
-          child.trailingIconVisibility == ExpansionPanelIconVisibility.hidden;
+      final iconVisible = child.trailingIconVisibility == .visible;
+      final iconMaintainSize = child.trailingIconVisibility == .hidden;
 
       Widget expandIconPadded = Visibility(
         visible: iconVisible,
@@ -447,7 +438,7 @@ class _ExpansionPanelListState extends State<ExpansionPanelList> {
         child: Padding(
           padding: const EdgeInsetsDirectional.only(end: 8.0),
           child: IgnorePointer(
-            ignoring: child.canTapOnHeader || (!iconVisible && !_isChildExpanded(index)),
+            ignoring: child.canTapOnHeader || !iconVisible,
             child: ExpandIcon(
               color: widget.expandIconColor,
               isExpanded: _isChildExpanded(index),
@@ -486,7 +477,7 @@ class _ExpansionPanelListState extends State<ExpansionPanelList> {
           expandIconPadded,
         ],
       );
-      if (child.canTapOnHeader && iconVisible) {
+      if (child.canTapOnHeader) {
         header = MergeSemantics(
           child: InkWell(
             splashColor: child.splashColor,

--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -438,7 +438,7 @@ class _ExpansionPanelListState extends State<ExpansionPanelList> {
         child: Padding(
           padding: const EdgeInsetsDirectional.only(end: 8.0),
           child: IgnorePointer(
-            ignoring: child.canTapOnHeader || !iconVisible,
+            ignoring: child.canTapOnHeader,
             child: ExpandIcon(
               color: widget.expandIconColor,
               isExpanded: _isChildExpanded(index),
@@ -451,7 +451,7 @@ class _ExpansionPanelListState extends State<ExpansionPanelList> {
         ),
       );
 
-      if (!child.canTapOnHeader) {
+      if (!child.canTapOnHeader && iconVisible) {
         final MaterialLocalizations localizations = MaterialLocalizations.of(context);
         expandIconPadded = Semantics(
           label: _isChildExpanded(index)

--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -85,7 +85,7 @@ enum ExpansionPanelIconVisibility {
 ///
 /// {@tool dartpad}
 /// This example demonstrates how to use [trailingIconVisibility] to control
-/// the expand/collapse icon.
+/// the visibility of the expand/collapse icon.
 ///
 /// ** See code in examples/api/lib/material/expansion_panel/expansion_panel_list.1.dart **
 /// {@end-tool}

--- a/packages/flutter/test/material/expansion_panel_test.dart
+++ b/packages/flutter/test/material/expansion_panel_test.dart
@@ -2087,4 +2087,172 @@ void main() {
     final IgnorePointer ignorePointerTrue = tester.widget(ignorePointerFinder);
     expect(ignorePointerTrue.ignoring, isTrue);
   });
+
+  testWidgets('ExpansionPanel hides icon but preserves space with trailingIconVisibility.hidden', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SingleChildScrollView(
+          child: ExpansionPanelList(
+            children: <ExpansionPanel>[
+              ExpansionPanel(
+                trailingIconVisibility: ExpansionPanelIconVisibility.hidden,
+                headerBuilder: (BuildContext context, bool isExpanded) {
+                  return const ListTile(title: Text('Panel'));
+                },
+                body: const ListTile(title: Text('Content')),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final Finder visibilityFinder = find
+        .ancestor(of: find.byType(ExpandIcon), matching: find.byType(Visibility))
+        .first;
+
+    final Visibility visibility = tester.widget(visibilityFinder);
+    expect(visibility.visible, isFalse);
+    expect(visibility.maintainSize, isTrue);
+    expect(visibility.maintainAnimation, isTrue);
+    expect(visibility.maintainState, isTrue);
+
+    expect(find.byType(ExpandIcon), findsOneWidget);
+  });
+
+  testWidgets('ExpansionPanel removes icon and space with trailingIconVisibility.gone', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SingleChildScrollView(
+          child: ExpansionPanelList(
+            children: <ExpansionPanel>[
+              ExpansionPanel(
+                trailingIconVisibility: ExpansionPanelIconVisibility.gone,
+                headerBuilder: (BuildContext context, bool isExpanded) {
+                  return const ListTile(title: Text('Panel'));
+                },
+                body: const ListTile(title: Text('Content')),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final Finder visibilityFinder = find
+        .ancestor(of: find.byType(ExpandIcon), matching: find.byType(Visibility))
+        .first;
+
+    final Visibility visibility = tester.widget(visibilityFinder);
+    expect(visibility.visible, isFalse);
+    expect(visibility.maintainSize, isFalse);
+    expect(visibility.maintainAnimation, isFalse);
+    expect(visibility.maintainState, isFalse);
+  });
+
+  testWidgets('ExpansionPanel shows icon by default with trailingIconVisibility.visible', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SingleChildScrollView(
+          child: ExpansionPanelList(
+            children: <ExpansionPanel>[
+              ExpansionPanel(
+                headerBuilder: (BuildContext context, bool isExpanded) {
+                  return const ListTile(title: Text('Panel'));
+                },
+                body: const ListTile(title: Text('Content')),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final Finder visibilityFinder = find
+        .ancestor(of: find.byType(ExpandIcon), matching: find.byType(Visibility))
+        .first;
+
+    final Visibility visibility = tester.widget(visibilityFinder);
+    expect(visibility.visible, isTrue);
+  });
+
+  testWidgets('ExpansionPanel disables canTapOnHeader when icon is not visible', (
+    WidgetTester tester,
+  ) async {
+    var callbackInvoked = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SingleChildScrollView(
+          child: ExpansionPanelList(
+            expansionCallback: (int index, bool isExpanded) {
+              callbackInvoked = true;
+            },
+            children: <ExpansionPanel>[
+              ExpansionPanel(
+                canTapOnHeader: true,
+                trailingIconVisibility: ExpansionPanelIconVisibility.hidden,
+                headerBuilder: (BuildContext context, bool isExpanded) {
+                  return const ListTile(title: Text('Panel'));
+                },
+                body: const ListTile(title: Text('Content')),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(InkWell), findsNothing);
+
+    await tester.tap(find.text('Panel'));
+    await tester.pumpAndSettle();
+
+    expect(callbackInvoked, isFalse);
+  });
+
+  testWidgets('ExpansionPanel always shows icon when expanded to allow collapsing', (
+    WidgetTester tester,
+  ) async {
+    Widget buildWidget({bool isExpanded = false}) {
+      return MaterialApp(
+        home: SingleChildScrollView(
+          child: ExpansionPanelList(
+            expansionCallback: (int index, bool isExpanded) {},
+            children: <ExpansionPanel>[
+              ExpansionPanel(
+                trailingIconVisibility: ExpansionPanelIconVisibility.hidden,
+                isExpanded: isExpanded,
+                headerBuilder: (BuildContext context, bool isExpanded) {
+                  return const ListTile(title: Text('Panel'));
+                },
+                body: const ListTile(title: Text('Content')),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildWidget());
+
+    final Finder visibilityFinder = find
+        .ancestor(of: find.byType(ExpandIcon), matching: find.byType(Visibility))
+        .first;
+
+    Visibility visibility = tester.widget(visibilityFinder);
+    expect(visibility.visible, isFalse);
+
+    await tester.pumpWidget(buildWidget(isExpanded: true));
+    await tester.pumpAndSettle();
+
+    visibility = tester.widget(visibilityFinder);
+    expect(visibility.visible, isTrue);
+  });
 }

--- a/packages/flutter/test/material/expansion_panel_test.dart
+++ b/packages/flutter/test/material/expansion_panel_test.dart
@@ -2174,4 +2174,70 @@ void main() {
     expect(visibility.visible, isTrue);
   });
 
+  testWidgets(
+    'ExpansionPanel has semantics label when icon is visible and canTapOnHeader is false',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SingleChildScrollView(
+            child: ExpansionPanelList(
+              children: <ExpansionPanel>[
+                ExpansionPanel(
+                  headerBuilder: (BuildContext context, bool isExpanded) {
+                    return const ListTile(title: Text('Panel'));
+                  },
+                  body: const ListTile(title: Text('Content')),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      final Finder semanticsFinder = find.ancestor(
+        of: find.byType(Visibility),
+        matching: find.byType(Semantics),
+      );
+      expect(semanticsFinder, findsWidgets);
+
+      final Semantics semantics = tester
+          .widgetList<Semantics>(semanticsFinder)
+          .firstWhere(
+            (Semantics s) => s.properties.label != null && s.properties.label!.isNotEmpty,
+          );
+      expect(semantics.properties.label, isNotNull);
+    },
+  );
+
+  testWidgets('ExpansionPanel has no semantics label when icon is hidden', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SingleChildScrollView(
+          child: ExpansionPanelList(
+            children: <ExpansionPanel>[
+              ExpansionPanel(
+                trailingIconVisibility: ExpansionPanelIconVisibility.hidden,
+                headerBuilder: (BuildContext context, bool isExpanded) {
+                  return const ListTile(title: Text('Panel'));
+                },
+                body: const ListTile(title: Text('Content')),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final Finder semanticsFinder = find.ancestor(
+      of: find.byType(Visibility),
+      matching: find.byType(Semantics),
+    );
+    final Iterable<Semantics> semanticsList = tester.widgetList<Semantics>(semanticsFinder);
+    final bool hasExpandCollapseLabel = semanticsList.any(
+      (Semantics s) => s.properties.label != null && s.properties.label!.isNotEmpty,
+    );
+    expect(hasExpandCollapseLabel, isFalse);
+  });
 }

--- a/packages/flutter/test/material/expansion_panel_test.dart
+++ b/packages/flutter/test/material/expansion_panel_test.dart
@@ -2174,40 +2174,37 @@ void main() {
     expect(visibility.visible, isTrue);
   });
 
-  testWidgets(
-    'ExpansionPanel icon has semantics label when visible and canTapOnHeader is false',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          home: SingleChildScrollView(
-            child: ExpansionPanelList(
-              children: <ExpansionPanel>[
-                ExpansionPanel(
-                  headerBuilder: (BuildContext context, bool isExpanded) {
-                    return const ListTile(title: Text('Panel'));
-                  },
-                  body: const ListTile(title: Text('Content')),
-                ),
-              ],
-            ),
+  testWidgets('ExpansionPanel icon has semantics label when visible and canTapOnHeader is false', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SingleChildScrollView(
+          child: ExpansionPanelList(
+            children: <ExpansionPanel>[
+              ExpansionPanel(
+                headerBuilder: (BuildContext context, bool isExpanded) {
+                  return const ListTile(title: Text('Panel'));
+                },
+                body: const ListTile(title: Text('Content')),
+              ),
+            ],
           ),
         ),
-      );
+      ),
+    );
 
-      final Finder semanticsFinder = find.ancestor(
-        of: find.byType(ExpandIcon),
-        matching: find.byType(Semantics),
-      );
-      expect(semanticsFinder, findsWidgets);
+    final Finder semanticsFinder = find.ancestor(
+      of: find.byType(ExpandIcon),
+      matching: find.byType(Semantics),
+    );
+    expect(semanticsFinder, findsWidgets);
 
-      final Semantics semantics = tester
-          .widgetList<Semantics>(semanticsFinder)
-          .firstWhere(
-            (Semantics s) => s.properties.label != null && s.properties.label!.isNotEmpty,
-          );
-      expect(semantics.properties.label, isNotNull);
-    },
-  );
+    final Semantics semantics = tester
+        .widgetList<Semantics>(semanticsFinder)
+        .firstWhere((Semantics s) => s.properties.label != null && s.properties.label!.isNotEmpty);
+    expect(semantics.properties.label, isNotNull);
+  });
 
   testWidgets('ExpansionPanel icon has no semantics label when hidden', (
     WidgetTester tester,

--- a/packages/flutter/test/material/expansion_panel_test.dart
+++ b/packages/flutter/test/material/expansion_panel_test.dart
@@ -2143,15 +2143,7 @@ void main() {
       ),
     );
 
-    final Finder visibilityFinder = find
-        .ancestor(of: find.byType(ExpandIcon), matching: find.byType(Visibility))
-        .first;
-
-    final Visibility visibility = tester.widget(visibilityFinder);
-    expect(visibility.visible, isFalse);
-    expect(visibility.maintainSize, isFalse);
-    expect(visibility.maintainAnimation, isFalse);
-    expect(visibility.maintainState, isFalse);
+    expect(find.byType(ExpandIcon), findsNothing);
   });
 
   testWidgets('ExpansionPanel shows icon by default with trailingIconVisibility.visible', (
@@ -2182,77 +2174,4 @@ void main() {
     expect(visibility.visible, isTrue);
   });
 
-  testWidgets('ExpansionPanel disables canTapOnHeader when icon is not visible', (
-    WidgetTester tester,
-  ) async {
-    var callbackInvoked = false;
-
-    await tester.pumpWidget(
-      MaterialApp(
-        home: SingleChildScrollView(
-          child: ExpansionPanelList(
-            expansionCallback: (int index, bool isExpanded) {
-              callbackInvoked = true;
-            },
-            children: <ExpansionPanel>[
-              ExpansionPanel(
-                canTapOnHeader: true,
-                trailingIconVisibility: ExpansionPanelIconVisibility.hidden,
-                headerBuilder: (BuildContext context, bool isExpanded) {
-                  return const ListTile(title: Text('Panel'));
-                },
-                body: const ListTile(title: Text('Content')),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-
-    expect(find.byType(InkWell), findsNothing);
-
-    await tester.tap(find.text('Panel'));
-    await tester.pumpAndSettle();
-
-    expect(callbackInvoked, isFalse);
-  });
-
-  testWidgets('ExpansionPanel always shows icon when expanded to allow collapsing', (
-    WidgetTester tester,
-  ) async {
-    Widget buildWidget({bool isExpanded = false}) {
-      return MaterialApp(
-        home: SingleChildScrollView(
-          child: ExpansionPanelList(
-            expansionCallback: (int index, bool isExpanded) {},
-            children: <ExpansionPanel>[
-              ExpansionPanel(
-                trailingIconVisibility: ExpansionPanelIconVisibility.hidden,
-                isExpanded: isExpanded,
-                headerBuilder: (BuildContext context, bool isExpanded) {
-                  return const ListTile(title: Text('Panel'));
-                },
-                body: const ListTile(title: Text('Content')),
-              ),
-            ],
-          ),
-        ),
-      );
-    }
-
-    await tester.pumpWidget(buildWidget());
-
-    final Finder visibilityFinder = find
-        .ancestor(of: find.byType(ExpandIcon), matching: find.byType(Visibility))
-        .first;
-
-    Visibility visibility = tester.widget(visibilityFinder);
-    expect(visibility.visible, isFalse);
-
-    await tester.pumpWidget(buildWidget(isExpanded: true));
-    await tester.pumpAndSettle();
-
-    visibility = tester.widget(visibilityFinder);
-    expect(visibility.visible, isTrue);
-  });
 }

--- a/packages/flutter/test/material/expansion_panel_test.dart
+++ b/packages/flutter/test/material/expansion_panel_test.dart
@@ -2175,7 +2175,7 @@ void main() {
   });
 
   testWidgets(
-    'ExpansionPanel has semantics label when icon is visible and canTapOnHeader is false',
+    'ExpansionPanel icon has semantics label when visible and canTapOnHeader is false',
     (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
@@ -2195,7 +2195,7 @@ void main() {
       );
 
       final Finder semanticsFinder = find.ancestor(
-        of: find.byType(Visibility),
+        of: find.byType(ExpandIcon),
         matching: find.byType(Semantics),
       );
       expect(semanticsFinder, findsWidgets);
@@ -2209,7 +2209,7 @@ void main() {
     },
   );
 
-  testWidgets('ExpansionPanel has no semantics label when icon is hidden', (
+  testWidgets('ExpansionPanel icon has no semantics label when hidden', (
     WidgetTester tester,
   ) async {
     await tester.pumpWidget(
@@ -2231,7 +2231,7 @@ void main() {
     );
 
     final Finder semanticsFinder = find.ancestor(
-      of: find.byType(Visibility),
+      of: find.byType(ExpandIcon),
       matching: find.byType(Semantics),
     );
     final Iterable<Semantics> semanticsList = tester.widgetList<Semantics>(semanticsFinder);


### PR DESCRIPTION
Fixes #179167. @dkwingsmt @victorsanni are already following this issue and should be assigned to review this PR. 

Introduces the `ExpansionPanelIconVisibility` enum to control whether the expand icon is visible, hidden (preserving space), or gone (removed from layout) when the panel is collapsed. The icon remains visible when the panel is expanded to ensure the user can still collapse it.


