### PR TITLE
Refactor: Removes Geometry field from ColorSourceContents

### DIFF
--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -33,6 +33,7 @@
 #include "impeller/entity/contents/framebuffer_blend_contents.h"
 #include "impeller/entity/contents/line_contents.h"
 #include "impeller/entity/contents/shadow_vertices_contents.h"
+#include "impeller/entity/contents/solid_color_contents.h"
 #include "impeller/entity/contents/solid_rrect_blur_contents.h"
 #include "impeller/entity/contents/solid_rsuperellipse_blur_contents.h"
 #include "impeller/entity/contents/text_contents.h"
@@ -1266,8 +1267,7 @@ void Canvas::DrawVertices(const std::shared_ptr<VerticesGeometry>& vertices,
   src_paint.color = paint.color.WithAlpha(1.0);
 
   std::shared_ptr<ColorSourceContents> src_contents =
-      src_paint.CreateContents();
-  src_contents->SetGeometry(vertices.get());
+      src_paint.CreateContents(vertices.get());
 
   // If the color source has an intrinsic size, then we use that to
   // create the src contents as a simplification. Otherwise we use
@@ -1291,10 +1291,8 @@ void Canvas::DrawVertices(const std::shared_ptr<VerticesGeometry>& vertices,
       src_coverage = cvg.value();
     }
   }
-  src_contents = src_paint.CreateContents();
-
   clip_geometry_.push_back(Geometry::MakeRect(Rect::Round(src_coverage)));
-  src_contents->SetGeometry(clip_geometry_.back().get());
+  src_contents = src_paint.CreateContents(clip_geometry_.back().get());
 
   auto contents = std::make_shared<VerticesSimpleBlendContents>();
   contents->SetBlendMode(blend_mode);
@@ -1302,7 +1300,8 @@ void Canvas::DrawVertices(const std::shared_ptr<VerticesGeometry>& vertices,
   contents->SetGeometry(vertices);
   contents->SetLazyTextureCoverage(src_coverage);
   contents->SetLazyTexture(
-      [src_contents, src_coverage](const ContentContext& renderer) {
+      [src_contents, src_coverage](
+          const ContentContext& renderer) -> std::shared_ptr<Texture> {
         // Applying the src coverage as the coverage limit prevents the 1px
         // coverage pad from adding a border that is picked up by developer
         // specified UVs.
@@ -1912,10 +1911,10 @@ void Canvas::AddRenderEntityWithFiltersToCurrentPass(Entity& entity,
                                                      const Geometry* geometry,
                                                      const Paint& paint,
                                                      bool reuse_depth) {
-  std::shared_ptr<ColorSourceContents> contents = paint.CreateContents();
+  std::shared_ptr<ColorSourceContents> contents =
+      paint.CreateContents(geometry);
   if (!paint.color_filter && !paint.invert_colors && !paint.image_filter &&
       !paint.mask_blur_descriptor.has_value()) {
-    contents->SetGeometry(geometry);
     entity.SetContents(std::move(contents));
     AddRenderEntityToCurrentPass(entity, reuse_depth);
     return;
@@ -1939,17 +1938,51 @@ void Canvas::AddRenderEntityWithFiltersToCurrentPass(Entity& entity,
   }
 
   bool can_apply_mask_filter = geometry->CanApplyMaskFilter();
-  contents->SetGeometry(geometry);
 
   if (can_apply_mask_filter && paint.mask_blur_descriptor.has_value()) {
     // If there's a mask blur and we need to apply the color filter on the GPU,
     // we need to be careful to only apply the color filter to the source
     // colors. CreateMaskBlur is able to handle this case.
-    FillRectGeometry out_rect(Rect{});
-    auto filter_contents = paint.mask_blur_descriptor->CreateMaskBlur(
-        contents, needs_color_filter ? paint.color_filter : nullptr,
-        needs_color_filter ? paint.invert_colors : false, &out_rect);
-    entity.SetContents(std::move(filter_contents));
+    // 1. Create a white mask of the original geometry.
+    auto mask = std::make_shared<SolidColorContents>(geometry);
+    mask->SetColor(Color::White());
+
+    // 2. Blur the mask.
+    auto blurred_mask = FilterContents::MakeGaussianBlur(
+        FilterInput::Make(mask), paint.mask_blur_descriptor->sigma,
+        paint.mask_blur_descriptor->sigma, Entity::TileMode::kDecal,
+        /*bounds=*/std::nullopt, paint.mask_blur_descriptor->style, geometry);
+
+    // 3. Get expanded bounds.
+    std::optional<Rect> expanded_bounds = blurred_mask->GetCoverage({});
+    if (!expanded_bounds.has_value()) {
+      expanded_bounds = Rect();
+    }
+    FillRectGeometry out_rect(expanded_bounds.value());
+
+    // 4. Create expanded color source contents.
+    std::shared_ptr<ColorSourceContents> expanded_contents =
+        paint.CreateContents(&out_rect);
+    std::shared_ptr<Contents> final_contents = expanded_contents;
+
+    // 5. Apply color filter to expanded contents if needed.
+    if (needs_color_filter) {
+      if (paint.color_filter) {
+        final_contents = WrapWithGPUColorFilter(
+            paint.color_filter, FilterInput::Make(std::move(final_contents)),
+            ColorFilterContents::AbsorbOpacity::kYes);
+      }
+      if (paint.invert_colors) {
+        final_contents =
+            WrapWithInvertColors(FilterInput::Make(std::move(final_contents)),
+                                 ColorFilterContents::AbsorbOpacity::kYes);
+      }
+    }
+
+    // 6. Composite the color source with the blurred mask.
+    entity.SetContents(ColorFilterContents::MakeBlend(
+        BlendMode::kSrcIn,
+        {FilterInput::Make(blurred_mask), FilterInput::Make(final_contents)}));
     AddRenderEntityToCurrentPass(entity, reuse_depth);
     return;
   }

--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -1940,8 +1940,9 @@ void Canvas::AddRenderEntityWithFiltersToCurrentPass(Entity& entity,
   bool can_apply_mask_filter = geometry->CanApplyMaskFilter();
 
   if (can_apply_mask_filter && paint.mask_blur_descriptor.has_value()) {
+    FillRectGeometry out_rect(Rect{});
     auto filter = paint.mask_blur_descriptor->CreateMaskBlur(
-        paint, geometry, contents, needs_color_filter);
+        paint, geometry, contents, needs_color_filter, &out_rect);
     entity.SetContents(std::move(filter));
     AddRenderEntityToCurrentPass(entity, reuse_depth);
     return;

--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -1939,6 +1939,17 @@ void Canvas::AddRenderEntityWithFiltersToCurrentPass(Entity& entity,
 
   bool can_apply_mask_filter = geometry->CanApplyMaskFilter();
 
+  if (can_apply_mask_filter && paint.mask_blur_descriptor.has_value() &&
+      contents->IsSolidColor()) {
+    auto filter = FilterContents::MakeGaussianBlur(
+        FilterInput::Make(contents), paint.mask_blur_descriptor->sigma,
+        paint.mask_blur_descriptor->sigma, Entity::TileMode::kDecal,
+        /*bounds=*/std::nullopt, paint.mask_blur_descriptor->style, geometry);
+    entity.SetContents(std::move(filter));
+    AddRenderEntityToCurrentPass(entity, reuse_depth);
+    return;
+  }
+
   if (can_apply_mask_filter && paint.mask_blur_descriptor.has_value()) {
     // If there's a mask blur and we need to apply the color filter on the GPU,
     // we need to be careful to only apply the color filter to the source

--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -1940,6 +1940,9 @@ void Canvas::AddRenderEntityWithFiltersToCurrentPass(Entity& entity,
   bool can_apply_mask_filter = geometry->CanApplyMaskFilter();
 
   if (can_apply_mask_filter && paint.mask_blur_descriptor.has_value()) {
+    // If there's a mask blur and we need to apply the color filter on the GPU,
+    // we need to be careful to only apply the color filter to the source
+    // colors. CreateMaskBlur is able to handle this case.
     FillRectGeometry out_rect(Rect{});
     auto filter = paint.mask_blur_descriptor->CreateMaskBlur(
         paint, geometry, contents, needs_color_filter, &out_rect);

--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -1939,61 +1939,10 @@ void Canvas::AddRenderEntityWithFiltersToCurrentPass(Entity& entity,
 
   bool can_apply_mask_filter = geometry->CanApplyMaskFilter();
 
-  if (can_apply_mask_filter && paint.mask_blur_descriptor.has_value() &&
-      contents->IsSolidColor()) {
-    auto filter = FilterContents::MakeGaussianBlur(
-        FilterInput::Make(contents), paint.mask_blur_descriptor->sigma,
-        paint.mask_blur_descriptor->sigma, Entity::TileMode::kDecal,
-        /*bounds=*/std::nullopt, paint.mask_blur_descriptor->style, geometry);
-    entity.SetContents(std::move(filter));
-    AddRenderEntityToCurrentPass(entity, reuse_depth);
-    return;
-  }
-
   if (can_apply_mask_filter && paint.mask_blur_descriptor.has_value()) {
-    // If there's a mask blur and we need to apply the color filter on the GPU,
-    // we need to be careful to only apply the color filter to the source
-    // colors. CreateMaskBlur is able to handle this case.
-    // 1. Create a white mask of the original geometry.
-    auto mask = std::make_shared<SolidColorContents>(geometry);
-    mask->SetColor(Color::White());
-
-    // 2. Blur the mask.
-    auto blurred_mask = FilterContents::MakeGaussianBlur(
-        FilterInput::Make(mask), paint.mask_blur_descriptor->sigma,
-        paint.mask_blur_descriptor->sigma, Entity::TileMode::kDecal,
-        /*bounds=*/std::nullopt, paint.mask_blur_descriptor->style, geometry);
-
-    // 3. Get expanded bounds.
-    std::optional<Rect> expanded_bounds = blurred_mask->GetCoverage({});
-    if (!expanded_bounds.has_value()) {
-      expanded_bounds = Rect();
-    }
-    FillRectGeometry out_rect(expanded_bounds.value());
-
-    // 4. Create expanded color source contents.
-    std::shared_ptr<ColorSourceContents> expanded_contents =
-        paint.CreateContents(&out_rect);
-    std::shared_ptr<Contents> final_contents = expanded_contents;
-
-    // 5. Apply color filter to expanded contents if needed.
-    if (needs_color_filter) {
-      if (paint.color_filter) {
-        final_contents = WrapWithGPUColorFilter(
-            paint.color_filter, FilterInput::Make(std::move(final_contents)),
-            ColorFilterContents::AbsorbOpacity::kYes);
-      }
-      if (paint.invert_colors) {
-        final_contents =
-            WrapWithInvertColors(FilterInput::Make(std::move(final_contents)),
-                                 ColorFilterContents::AbsorbOpacity::kYes);
-      }
-    }
-
-    // 6. Composite the color source with the blurred mask.
-    entity.SetContents(ColorFilterContents::MakeBlend(
-        BlendMode::kSrcIn,
-        {FilterInput::Make(blurred_mask), FilterInput::Make(final_contents)}));
+    auto filter = paint.mask_blur_descriptor->CreateMaskBlur(
+        paint, geometry, contents, needs_color_filter);
+    entity.SetContents(std::move(filter));
     AddRenderEntityToCurrentPass(entity, reuse_depth);
     return;
   }

--- a/engine/src/flutter/impeller/display_list/paint.cc
+++ b/engine/src/flutter/impeller/display_list/paint.cc
@@ -59,9 +59,10 @@ void Paint::ConvertStops(const flutter::DlGradientColorSourceBase* gradient,
   }
 }
 
-std::shared_ptr<ColorSourceContents> Paint::CreateContents() const {
+std::shared_ptr<ColorSourceContents> Paint::CreateContents(
+    const Geometry* geometry) const {
   if (color_source == nullptr) {
-    auto contents = std::make_shared<SolidColorContents>();
+    auto contents = std::make_shared<SolidColorContents>(geometry);
     contents->SetColor(color);
     return contents;
   }
@@ -80,7 +81,7 @@ std::shared_ptr<ColorSourceContents> Paint::CreateContents() const {
       auto tile_mode = static_cast<Entity::TileMode>(linear->tile_mode());
       auto effect_transform = linear->matrix();
 
-      auto contents = std::make_shared<LinearGradientContents>();
+      auto contents = std::make_shared<LinearGradientContents>(geometry);
       contents->SetOpacityFactor(color.alpha);
       contents->SetColors(std::move(colors));
       contents->SetStops(std::move(stops));
@@ -109,7 +110,7 @@ std::shared_ptr<ColorSourceContents> Paint::CreateContents() const {
           static_cast<Entity::TileMode>(radialGradient->tile_mode());
       auto effect_transform = radialGradient->matrix();
 
-      auto contents = std::make_shared<RadialGradientContents>();
+      auto contents = std::make_shared<RadialGradientContents>(geometry);
       contents->SetOpacityFactor(color.alpha);
       contents->SetColors(std::move(colors));
       contents->SetStops(std::move(stops));
@@ -141,8 +142,7 @@ std::shared_ptr<ColorSourceContents> Paint::CreateContents() const {
           static_cast<Entity::TileMode>(conical_gradient->tile_mode());
       auto effect_transform = conical_gradient->matrix();
 
-      std::shared_ptr<ConicalGradientContents> contents =
-          std::make_shared<ConicalGradientContents>();
+      auto contents = std::make_shared<ConicalGradientContents>(geometry);
       contents->SetOpacityFactor(color.alpha);
       contents->SetColors(std::move(colors));
       contents->SetStops(std::move(stops));
@@ -175,7 +175,7 @@ std::shared_ptr<ColorSourceContents> Paint::CreateContents() const {
           static_cast<Entity::TileMode>(sweepGradient->tile_mode());
       auto effect_transform = sweepGradient->matrix();
 
-      auto contents = std::make_shared<SweepGradientContents>();
+      auto contents = std::make_shared<SweepGradientContents>(geometry);
       contents->SetOpacityFactor(color.alpha);
       contents->SetCenterAndAngles(center, start_angle, end_angle);
       contents->SetColors(std::move(colors));
@@ -200,7 +200,7 @@ std::shared_ptr<ColorSourceContents> Paint::CreateContents() const {
       // See https://github.com/flutter/flutter/issues/165205
       flutter::DlMatrix effect_transform = image_color_source->matrix().To3x3();
 
-      auto contents = std::make_shared<TiledTextureContents>();
+      auto contents = std::make_shared<TiledTextureContents>(geometry);
       contents->SetOpacityFactor(color.alpha);
       contents->SetTexture(texture);
       contents->SetTileModes(x_tile_mode, y_tile_mode);
@@ -245,14 +245,14 @@ std::shared_ptr<ColorSourceContents> Paint::CreateContents() const {
       for (auto& sampler : samplers) {
         if (sampler == nullptr) {
           VALIDATION_LOG << "Runtime effect sampler is null";
-          auto contents = std::make_shared<SolidColorContents>();
+          auto contents = std::make_shared<SolidColorContents>(geometry);
           contents->SetColor(Color::BlackTransparent());
           return contents;
         }
         auto* image = sampler->asImage();
         if (!sampler->asImage()) {
           VALIDATION_LOG << "Runtime effect sampler is not an image";
-          auto contents = std::make_shared<SolidColorContents>();
+          auto contents = std::make_shared<SolidColorContents>(geometry);
           contents->SetColor(Color::BlackTransparent());
           return contents;
         }
@@ -264,7 +264,7 @@ std::shared_ptr<ColorSourceContents> Paint::CreateContents() const {
         });
       }
 
-      auto contents = std::make_shared<RuntimeEffectContents>();
+      auto contents = std::make_shared<RuntimeEffectContents>(geometry);
       contents->SetOpacityFactor(color.alpha);
       contents->SetRuntimeStage(std::move(runtime_stage));
       contents->SetUniformData(std::move(uniform_data));
@@ -369,8 +369,6 @@ std::shared_ptr<FilterContents> Paint::MaskBlurDescriptor::CreateMaskBlur(
       GaussianBlurFilterContents::ScaleSigma(sigma.sigma));
   texture_contents->SetSourceRect(
       texture_contents->GetSourceRect().Expand(expand_amount, expand_amount));
-  auto mask = std::make_shared<SolidColorContents>();
-  mask->SetColor(Color::White());
   std::optional<Rect> coverage = texture_contents->GetCoverage({});
   Geometry* geometry = nullptr;
   if (coverage) {
@@ -379,7 +377,8 @@ std::shared_ptr<FilterContents> Paint::MaskBlurDescriptor::CreateMaskBlur(
     *rect_geom = FillRectGeometry(coverage.value());
     geometry = rect_geom;
   }
-  mask->SetGeometry(geometry);
+  auto mask = std::make_shared<SolidColorContents>(geometry);
+  mask->SetColor(Color::White());
   auto descriptor = texture_contents->GetSamplerDescriptor();
   texture_contents->SetSamplerDescriptor(descriptor);
   std::shared_ptr<FilterContents> blurred_mask =
@@ -390,63 +389,6 @@ std::shared_ptr<FilterContents> Paint::MaskBlurDescriptor::CreateMaskBlur(
   return ColorFilterContents::MakeBlend(
       BlendMode::kSrcIn,
       {FilterInput::Make(blurred_mask), FilterInput::Make(texture_contents)});
-}
-
-std::shared_ptr<FilterContents> Paint::MaskBlurDescriptor::CreateMaskBlur(
-    std::shared_ptr<ColorSourceContents> color_source_contents,
-    const flutter::DlColorFilter* color_filter,
-    bool invert_colors,
-    FillRectGeometry* rect_geom) const {
-  // If it's a solid color then we can just get  away with doing one Gaussian
-  // blur. The color filter will always be applied on the CPU.
-  if (color_source_contents->IsSolidColor()) {
-    return FilterContents::MakeGaussianBlur(
-        FilterInput::Make(color_source_contents), sigma, sigma,
-        Entity::TileMode::kDecal, /*bounds=*/std::nullopt, style,
-        color_source_contents->GetGeometry());
-  }
-
-  /// 1. Create an opaque white mask of the original geometry.
-
-  auto mask = std::make_shared<SolidColorContents>();
-  mask->SetColor(Color::White());
-  mask->SetGeometry(color_source_contents->GetGeometry());
-
-  /// 2. Blur the mask.
-
-  auto blurred_mask = FilterContents::MakeGaussianBlur(
-      FilterInput::Make(mask), sigma, sigma, Entity::TileMode::kDecal,
-      /*bounds=*/std::nullopt, style, color_source_contents->GetGeometry());
-
-  /// 3. Replace the geometry of the original color source with a rectangle that
-  ///    covers the full region of the blurred mask. Note that geometry is in
-  ///    local bounds.
-
-  auto expanded_local_bounds = blurred_mask->GetCoverage({});
-  if (!expanded_local_bounds.has_value()) {
-    expanded_local_bounds = Rect();
-  }
-  *rect_geom = FillRectGeometry(expanded_local_bounds.value());
-  color_source_contents->SetGeometry(rect_geom);
-  std::shared_ptr<Contents> color_contents = color_source_contents;
-
-  /// 4. Apply the user set color filter on the GPU, if applicable.
-  if (color_filter) {
-    color_contents =
-        WrapWithGPUColorFilter(color_filter, FilterInput::Make(color_contents),
-                               ColorFilterContents::AbsorbOpacity::kYes);
-  }
-  if (invert_colors) {
-    color_contents =
-        WrapWithInvertColors(FilterInput::Make(color_contents),
-                             ColorFilterContents::AbsorbOpacity::kYes);
-  }
-
-  /// 5. Composite the color source with the blurred mask.
-
-  return ColorFilterContents::MakeBlend(
-      BlendMode::kSrcIn,
-      {FilterInput::Make(blurred_mask), FilterInput::Make(color_contents)});
 }
 
 std::shared_ptr<FilterContents> Paint::MaskBlurDescriptor::CreateMaskBlur(

--- a/engine/src/flutter/impeller/display_list/paint.cc
+++ b/engine/src/flutter/impeller/display_list/paint.cc
@@ -396,7 +396,7 @@ std::shared_ptr<Contents> Paint::MaskBlurDescriptor::CreateMaskBlur(
     const Geometry* geometry,
     std::shared_ptr<ColorSourceContents> contents,
     bool needs_color_filter,
-    FillRectGeometry* out_rect) const {
+    FillRectGeometry* out_geom) const {
   // If it's a solid color then we can just get  away with doing one Gaussian
   // blur. The color filter will always be applied on the CPU.
   if (contents->IsSolidColor()) {
@@ -417,14 +417,14 @@ std::shared_ptr<Contents> Paint::MaskBlurDescriptor::CreateMaskBlur(
   /// 3. Replace the geometry of the original color source with a rectangle that
   ///    covers the full region of the blurred mask. Note that geometry is in
   ///    local bounds.
-  std::optional<Rect> expanded_bounds = blurred_mask->GetCoverage({});
-  if (!expanded_bounds.has_value()) {
-    expanded_bounds = Rect();
+  std::optional<Rect> expanded_local_bounds = blurred_mask->GetCoverage({});
+  if (!expanded_local_bounds.has_value()) {
+    expanded_local_bounds = Rect();
   }
-  *out_rect = FillRectGeometry(expanded_bounds.value());
+  *out_geom = FillRectGeometry(expanded_local_bounds.value());
 
   std::shared_ptr<ColorSourceContents> expanded_contents =
-      paint.CreateContents(out_rect);
+      paint.CreateContents(out_geom);
   std::shared_ptr<Contents> final_contents = expanded_contents;
 
   /// 4. Apply the user set color filter on the GPU, if applicable.

--- a/engine/src/flutter/impeller/display_list/paint.cc
+++ b/engine/src/flutter/impeller/display_list/paint.cc
@@ -391,6 +391,61 @@ std::shared_ptr<FilterContents> Paint::MaskBlurDescriptor::CreateMaskBlur(
       {FilterInput::Make(blurred_mask), FilterInput::Make(texture_contents)});
 }
 
+std::shared_ptr<Contents> Paint::MaskBlurDescriptor::CreateMaskBlur(
+    const Paint& paint,
+    const Geometry* geometry,
+    std::shared_ptr<ColorSourceContents> contents,
+    bool needs_color_filter) const {
+  // If it's a solid color then we can just get  away with doing one Gaussian
+  // blur. The color filter will always be applied on the CPU.
+  if (contents->IsSolidColor()) {
+    return FilterContents::MakeGaussianBlur(
+        FilterInput::Make(contents), sigma, sigma, Entity::TileMode::kDecal,
+        /*bounds=*/std::nullopt, style, geometry);
+  }
+
+  /// 1. Create an opaque white mask of the original geometry.
+  auto mask = std::make_shared<SolidColorContents>(geometry);
+  mask->SetColor(Color::White());
+
+  /// 2. Blur the mask.
+  auto blurred_mask = FilterContents::MakeGaussianBlur(
+      FilterInput::Make(mask), sigma, sigma, Entity::TileMode::kDecal,
+      /*bounds=*/std::nullopt, style, geometry);
+
+  /// 3. Replace the geometry of the original color source with a rectangle that
+  ///    covers the full region of the blurred mask. Note that geometry is in
+  ///    local bounds.
+  std::optional<Rect> expanded_bounds = blurred_mask->GetCoverage({});
+  if (!expanded_bounds.has_value()) {
+    expanded_bounds = Rect();
+  }
+  FillRectGeometry out_rect(expanded_bounds.value());
+
+  std::shared_ptr<ColorSourceContents> expanded_contents =
+      paint.CreateContents(&out_rect);
+  std::shared_ptr<Contents> final_contents = expanded_contents;
+
+  /// 4. Apply the user set color filter on the GPU, if applicable.
+  if (needs_color_filter) {
+    if (paint.color_filter) {
+      final_contents = WrapWithGPUColorFilter(
+          paint.color_filter, FilterInput::Make(std::move(final_contents)),
+          ColorFilterContents::AbsorbOpacity::kYes);
+    }
+    if (paint.invert_colors) {
+      final_contents =
+          WrapWithInvertColors(FilterInput::Make(std::move(final_contents)),
+                               ColorFilterContents::AbsorbOpacity::kYes);
+    }
+  }
+
+  /// 5. Composite the color source with the blurred mask.
+  return ColorFilterContents::MakeBlend(
+      BlendMode::kSrcIn,
+      {FilterInput::Make(blurred_mask), FilterInput::Make(final_contents)});
+}
+
 std::shared_ptr<FilterContents> Paint::MaskBlurDescriptor::CreateMaskBlur(
     const FilterInput::Ref& input,
     bool is_solid_color,

--- a/engine/src/flutter/impeller/display_list/paint.cc
+++ b/engine/src/flutter/impeller/display_list/paint.cc
@@ -395,7 +395,8 @@ std::shared_ptr<Contents> Paint::MaskBlurDescriptor::CreateMaskBlur(
     const Paint& paint,
     const Geometry* geometry,
     std::shared_ptr<ColorSourceContents> contents,
-    bool needs_color_filter) const {
+    bool needs_color_filter,
+    FillRectGeometry* out_rect) const {
   // If it's a solid color then we can just get  away with doing one Gaussian
   // blur. The color filter will always be applied on the CPU.
   if (contents->IsSolidColor()) {
@@ -420,10 +421,10 @@ std::shared_ptr<Contents> Paint::MaskBlurDescriptor::CreateMaskBlur(
   if (!expanded_bounds.has_value()) {
     expanded_bounds = Rect();
   }
-  FillRectGeometry out_rect(expanded_bounds.value());
+  *out_rect = FillRectGeometry(expanded_bounds.value());
 
   std::shared_ptr<ColorSourceContents> expanded_contents =
-      paint.CreateContents(&out_rect);
+      paint.CreateContents(out_rect);
   std::shared_ptr<Contents> final_contents = expanded_contents;
 
   /// 4. Apply the user set color filter on the GPU, if applicable.

--- a/engine/src/flutter/impeller/display_list/paint.h
+++ b/engine/src/flutter/impeller/display_list/paint.h
@@ -57,12 +57,6 @@ struct Paint {
     bool respect_ctm = true;
 
     std::shared_ptr<FilterContents> CreateMaskBlur(
-        std::shared_ptr<ColorSourceContents> color_source_contents,
-        const flutter::DlColorFilter* color_filter,
-        bool invert_colors,
-        FillRectGeometry* rect_geom) const;
-
-    std::shared_ptr<FilterContents> CreateMaskBlur(
         std::shared_ptr<TextureContents> texture_contents,
         FillRectGeometry* rect_geom) const;
 
@@ -106,7 +100,8 @@ struct Paint {
   /// @brief   Whether this paint has a color filter that can apply opacity
   bool HasColorFilter() const;
 
-  std::shared_ptr<ColorSourceContents> CreateContents() const;
+  std::shared_ptr<ColorSourceContents> CreateContents(
+      const Geometry* geometry) const;
 
   std::shared_ptr<Contents> WithMaskBlur(std::shared_ptr<Contents> input,
                                          bool is_solid_color,

--- a/engine/src/flutter/impeller/display_list/paint.h
+++ b/engine/src/flutter/impeller/display_list/paint.h
@@ -64,6 +64,12 @@ struct Paint {
         const FilterInput::Ref& input,
         bool is_solid_color,
         const Matrix& ctm) const;
+
+    std::shared_ptr<Contents> CreateMaskBlur(
+        const Paint& paint,
+        const Geometry* geometry,
+        std::shared_ptr<ColorSourceContents> contents,
+        bool needs_color_filter) const;
   };
 
   Color color = Color::Black();

--- a/engine/src/flutter/impeller/display_list/paint.h
+++ b/engine/src/flutter/impeller/display_list/paint.h
@@ -69,7 +69,8 @@ struct Paint {
         const Paint& paint,
         const Geometry* geometry,
         std::shared_ptr<ColorSourceContents> contents,
-        bool needs_color_filter) const;
+        bool needs_color_filter,
+        FillRectGeometry* out_rect) const;
   };
 
   Color color = Color::Black();

--- a/engine/src/flutter/impeller/display_list/paint.h
+++ b/engine/src/flutter/impeller/display_list/paint.h
@@ -70,7 +70,7 @@ struct Paint {
         const Geometry* geometry,
         std::shared_ptr<ColorSourceContents> contents,
         bool needs_color_filter,
-        FillRectGeometry* out_rect) const;
+        FillRectGeometry* out_geom) const;
   };
 
   Color color = Color::Black();

--- a/engine/src/flutter/impeller/entity/contents/circle_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/circle_contents.cc
@@ -76,4 +76,8 @@ std::optional<Rect> CircleContents::GetCoverage(const Entity& entity) const {
   return geometry_->GetCoverage(entity.GetTransform());
 }
 
+const Geometry* CircleContents::GetGeometry() const {
+  return geometry_.get();
+}
+
 }  // namespace impeller

--- a/engine/src/flutter/impeller/entity/contents/circle_contents.h
+++ b/engine/src/flutter/impeller/entity/contents/circle_contents.h
@@ -23,6 +23,8 @@ class CircleContents : public ColorSourceContents {
 
   std::optional<Rect> GetCoverage(const Entity& entity) const override;
 
+  const Geometry* GetGeometry() const override;
+
  private:
   explicit CircleContents(std::unique_ptr<CircleGeometry> geometry,
                           Color color,

--- a/engine/src/flutter/impeller/entity/contents/color_source_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/color_source_contents.cc
@@ -13,14 +13,6 @@ ColorSourceContents::ColorSourceContents() = default;
 
 ColorSourceContents::~ColorSourceContents() = default;
 
-void ColorSourceContents::SetGeometry(const Geometry* geometry) {
-  geometry_ = geometry;
-}
-
-const Geometry* ColorSourceContents::GetGeometry() const {
-  return geometry_;
-}
-
 void ColorSourceContents::SetOpacityFactor(Scalar alpha) {
   opacity_ = alpha;
 }
@@ -43,8 +35,9 @@ bool ColorSourceContents::IsSolidColor() const {
 
 std::optional<Rect> ColorSourceContents::GetCoverage(
     const Entity& entity) const {
-  return geometry_->GetCoverage(entity.GetTransform());
-};
+  const Geometry* geometry = GetGeometry();
+  return geometry ? geometry->GetCoverage(entity.GetTransform()) : std::nullopt;
+}
 
 void ColorSourceContents::SetInheritedOpacity(Scalar opacity) {
   inherited_opacity_ = opacity;

--- a/engine/src/flutter/impeller/entity/contents/color_source_contents.h
+++ b/engine/src/flutter/impeller/entity/contents/color_source_contents.h
@@ -50,15 +50,7 @@ class ColorSourceContents : public Contents {
 
   ~ColorSourceContents() override;
 
-  //----------------------------------------------------------------------------
-  /// @brief  Set the geometry that this contents will use to render.
-  ///
-  void SetGeometry(const Geometry* geometry);
-
-  //----------------------------------------------------------------------------
-  /// @brief  Get the geometry that this contents will use to render.
-  ///
-  const Geometry* GetGeometry() const;
+  virtual const Geometry* GetGeometry() const = 0;
 
   //----------------------------------------------------------------------------
   /// @brief  Set the effect transform for this color source.
@@ -278,7 +270,6 @@ class ColorSourceContents : public Contents {
   }
 
  private:
-  const Geometry* geometry_ = nullptr;
   Matrix inverse_matrix_;
   Scalar opacity_ = 1.0;
   Scalar inherited_opacity_ = 1.0;

--- a/engine/src/flutter/impeller/entity/contents/color_source_contents.h
+++ b/engine/src/flutter/impeller/entity/contents/color_source_contents.h
@@ -50,6 +50,9 @@ class ColorSourceContents : public Contents {
 
   ~ColorSourceContents() override;
 
+  //----------------------------------------------------------------------------
+  /// @brief  Get the geometry that this contents will use to render.
+  ///
   virtual const Geometry* GetGeometry() const = 0;
 
   //----------------------------------------------------------------------------

--- a/engine/src/flutter/impeller/entity/contents/conical_gradient_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/conical_gradient_contents.cc
@@ -36,9 +36,14 @@ ConicalKind GetConicalKind(Point center,
 
 }  // namespace
 
-ConicalGradientContents::ConicalGradientContents() = default;
+ConicalGradientContents::ConicalGradientContents(const Geometry* geometry)
+    : geometry_(geometry) {}
 
 ConicalGradientContents::~ConicalGradientContents() = default;
+
+const Geometry* ConicalGradientContents::GetGeometry() const {
+  return geometry_;
+}
 
 void ConicalGradientContents::SetCenterAndRadius(Point center, Scalar radius) {
   center_ = center;

--- a/engine/src/flutter/impeller/entity/contents/conical_gradient_contents.h
+++ b/engine/src/flutter/impeller/entity/contents/conical_gradient_contents.h
@@ -16,9 +16,11 @@ namespace impeller {
 
 class ConicalGradientContents final : public ColorSourceContents {
  public:
-  ConicalGradientContents();
+  explicit ConicalGradientContents(const Geometry* geometry);
 
   ~ConicalGradientContents() override;
+
+  const Geometry* GetGeometry() const override;
 
   // |Contents|
   bool Render(const ContentContext& renderer,
@@ -56,6 +58,7 @@ class ConicalGradientContents final : public ColorSourceContents {
                      const Entity& entity,
                      RenderPass& pass) const;
 
+  const Geometry* geometry_ = nullptr;
   Point center_;
   Scalar radius_ = 0.0f;
   std::vector<Color> colors_;

--- a/engine/src/flutter/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -613,9 +613,8 @@ static std::optional<Entity> PipelineBlend(
     // If a foreground color is set, blend it in.
 
     if (foreground_color.has_value()) {
-      auto contents = std::make_shared<SolidColorContents>();
       FillRectGeometry geom(Rect::MakeSize(pass.GetRenderTargetSize()));
-      contents->SetGeometry(&geom);
+      auto contents = std::make_shared<SolidColorContents>(&geom);
       contents->SetColor(foreground_color.value());
 
       Entity foreground_entity;

--- a/engine/src/flutter/impeller/entity/contents/filters/runtime_effect_filter_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/filters/runtime_effect_filter_contents.cc
@@ -153,12 +153,11 @@ std::optional<Entity> RuntimeEffectFilterContents::RenderFilter(
        uniforms = uniforms_, texture_inputs = texture_input_copy](
           const ContentContext& renderer, const Entity& entity,
           RenderPass& pass) -> bool {
-    RuntimeEffectContents contents;
     FillRectGeometry geom(Rect::MakeSize(input_snapshot->texture->GetSize()));
+    RuntimeEffectContents contents(&geom);
     contents.SetRuntimeStage(runtime_stage);
     contents.SetUniformData(uniforms);
     contents.SetTextureInputs(texture_inputs);
-    contents.SetGeometry(&geom);
     Entity offset_entity = entity.Clone();
     offset_entity.SetTransform(entity.GetTransform() * snapshot_transform);
     return contents.Render(renderer, offset_entity, pass);

--- a/engine/src/flutter/impeller/entity/contents/framebuffer_blend_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/framebuffer_blend_contents.cc
@@ -13,6 +13,10 @@ FramebufferBlendContents::FramebufferBlendContents() = default;
 
 FramebufferBlendContents::~FramebufferBlendContents() = default;
 
+const Geometry* FramebufferBlendContents::GetGeometry() const {
+  return nullptr;
+}
+
 void FramebufferBlendContents::SetBlendMode(BlendMode blend_mode) {
   blend_mode_ = blend_mode;
 }

--- a/engine/src/flutter/impeller/entity/contents/framebuffer_blend_contents.h
+++ b/engine/src/flutter/impeller/entity/contents/framebuffer_blend_contents.h
@@ -36,6 +36,8 @@ class FramebufferBlendContents final : public ColorSourceContents {
 
   ~FramebufferBlendContents() override;
 
+  const Geometry* GetGeometry() const override;
+
   void SetBlendMode(BlendMode blend_mode);
 
   void SetChildContents(std::shared_ptr<Contents> child_contents);

--- a/engine/src/flutter/impeller/entity/contents/linear_gradient_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/linear_gradient_contents.cc
@@ -15,9 +15,14 @@
 
 namespace impeller {
 
-LinearGradientContents::LinearGradientContents() = default;
+LinearGradientContents::LinearGradientContents(const Geometry* geometry)
+    : geometry_(geometry) {}
 
 LinearGradientContents::~LinearGradientContents() = default;
+
+const Geometry* LinearGradientContents::GetGeometry() const {
+  return geometry_;
+}
 
 void LinearGradientContents::SetEndPoints(Point start_point, Point end_point) {
   start_point_ = start_point;

--- a/engine/src/flutter/impeller/entity/contents/linear_gradient_contents.h
+++ b/engine/src/flutter/impeller/entity/contents/linear_gradient_contents.h
@@ -16,9 +16,11 @@ namespace impeller {
 
 class LinearGradientContents final : public ColorSourceContents {
  public:
-  LinearGradientContents();
+  explicit LinearGradientContents(const Geometry* geometry);
 
   ~LinearGradientContents() override;
+
+  const Geometry* GetGeometry() const override;
 
   // |Contents|
   bool IsOpaque(const Matrix& transform) const override;
@@ -63,6 +65,7 @@ class LinearGradientContents final : public ColorSourceContents {
 
   bool CanApplyFastGradient() const;
 
+  const Geometry* geometry_ = nullptr;
   Point start_point_;
   Point end_point_;
   std::vector<Color> colors_;

--- a/engine/src/flutter/impeller/entity/contents/radial_gradient_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/radial_gradient_contents.cc
@@ -14,9 +14,14 @@
 
 namespace impeller {
 
-RadialGradientContents::RadialGradientContents() = default;
+RadialGradientContents::RadialGradientContents(const Geometry* geometry)
+    : geometry_(geometry) {}
 
 RadialGradientContents::~RadialGradientContents() = default;
+
+const Geometry* RadialGradientContents::GetGeometry() const {
+  return geometry_;
+}
 
 void RadialGradientContents::SetCenterAndRadius(Point center, Scalar radius) {
   center_ = center;

--- a/engine/src/flutter/impeller/entity/contents/radial_gradient_contents.h
+++ b/engine/src/flutter/impeller/entity/contents/radial_gradient_contents.h
@@ -16,9 +16,11 @@ namespace impeller {
 
 class RadialGradientContents final : public ColorSourceContents {
  public:
-  RadialGradientContents();
+  explicit RadialGradientContents(const Geometry* geometry);
 
   ~RadialGradientContents() override;
+
+  const Geometry* GetGeometry() const override;
 
   // |Contents|
   bool IsOpaque(const Matrix& transform) const override;
@@ -57,6 +59,7 @@ class RadialGradientContents final : public ColorSourceContents {
                      const Entity& entity,
                      RenderPass& pass) const;
 
+  const Geometry* geometry_ = nullptr;
   Point center_;
   Scalar radius_;
   std::vector<Color> colors_;

--- a/engine/src/flutter/impeller/entity/contents/runtime_effect_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/runtime_effect_contents.cc
@@ -68,6 +68,15 @@ BufferView RuntimeEffectContents::EmplaceUniform(
       });
 }
 
+RuntimeEffectContents::RuntimeEffectContents(const Geometry* geometry)
+    : geometry_(geometry) {}
+
+RuntimeEffectContents::~RuntimeEffectContents() = default;
+
+const Geometry* RuntimeEffectContents::GetGeometry() const {
+  return geometry_;
+}
+
 void RuntimeEffectContents::SetRuntimeStage(
     std::shared_ptr<RuntimeStage> runtime_stage) {
   runtime_stage_ = std::move(runtime_stage);

--- a/engine/src/flutter/impeller/entity/contents/runtime_effect_contents.h
+++ b/engine/src/flutter/impeller/entity/contents/runtime_effect_contents.h
@@ -17,6 +17,9 @@ namespace impeller {
 
 class RuntimeEffectContents final : public ColorSourceContents {
  public:
+  explicit RuntimeEffectContents(const Geometry* geometry);
+
+  ~RuntimeEffectContents() override;
   struct TextureInput {
     SamplerDescriptor sampler_descriptor;
     std::shared_ptr<Texture> texture;
@@ -27,6 +30,8 @@ class RuntimeEffectContents final : public ColorSourceContents {
   void SetUniformData(std::shared_ptr<std::vector<uint8_t>> uniform_data);
 
   void SetTextureInputs(std::vector<TextureInput> texture_inputs);
+
+  const Geometry* GetGeometry() const override;
 
   // |Contents|
   bool Render(const ContentContext& renderer,
@@ -59,6 +64,7 @@ class RuntimeEffectContents final : public ColorSourceContents {
       ContentContextOptions options,
       bool async) const;
 
+  const Geometry* geometry_ = nullptr;
   std::shared_ptr<RuntimeStage> runtime_stage_;
   std::shared_ptr<std::vector<uint8_t>> uniform_data_;
   std::vector<TextureInput> texture_inputs_;

--- a/engine/src/flutter/impeller/entity/contents/solid_color_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/solid_color_contents.cc
@@ -11,7 +11,8 @@
 
 namespace impeller {
 
-SolidColorContents::SolidColorContents() = default;
+SolidColorContents::SolidColorContents(const Geometry* geometry)
+    : geometry_(geometry) {}
 
 SolidColorContents::~SolidColorContents() = default;
 
@@ -21,6 +22,10 @@ void SolidColorContents::SetColor(Color color) {
 
 Color SolidColorContents::GetColor() const {
   return color_.WithAlpha(color_.alpha * GetOpacityFactor());
+}
+
+const Geometry* SolidColorContents::GetGeometry() const {
+  return geometry_;
 }
 
 bool SolidColorContents::IsSolidColor() const {
@@ -72,8 +77,12 @@ bool SolidColorContents::Render(const ContentContext& renderer,
 std::optional<Color> SolidColorContents::AsBackgroundColor(
     const Entity& entity,
     ISize target_size) const {
+  const Geometry* geometry = GetGeometry();
+  if (geometry == nullptr) {
+    return std::nullopt;
+  }
   Rect target_rect = Rect::MakeSize(target_size);
-  return GetGeometry()->CoversArea(entity.GetTransform(), target_rect)
+  return geometry->CoversArea(entity.GetTransform(), target_rect)
              ? GetColor()
              : std::optional<Color>();
 }

--- a/engine/src/flutter/impeller/entity/contents/solid_color_contents.h
+++ b/engine/src/flutter/impeller/entity/contents/solid_color_contents.h
@@ -13,7 +13,7 @@ namespace impeller {
 
 class SolidColorContents final : public ColorSourceContents {
  public:
-  SolidColorContents();
+  explicit SolidColorContents(const Geometry* geometry);
 
   ~SolidColorContents() override;
 
@@ -23,6 +23,8 @@ class SolidColorContents final : public ColorSourceContents {
 
   // |ColorSourceContents|
   bool IsSolidColor() const override;
+
+  const Geometry* GetGeometry() const override;
 
   // |Contents|
   bool IsOpaque(const Matrix& transform) const override;
@@ -43,6 +45,7 @@ class SolidColorContents final : public ColorSourceContents {
       const ColorFilterProc& color_filter_proc) override;
 
  private:
+  const Geometry* geometry_ = nullptr;
   Color color_;
 
   SolidColorContents(const SolidColorContents&) = delete;

--- a/engine/src/flutter/impeller/entity/contents/sweep_gradient_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/sweep_gradient_contents.cc
@@ -14,9 +14,14 @@
 
 namespace impeller {
 
-SweepGradientContents::SweepGradientContents() = default;
+SweepGradientContents::SweepGradientContents(const Geometry* geometry)
+    : geometry_(geometry) {}
 
 SweepGradientContents::~SweepGradientContents() = default;
+
+const Geometry* SweepGradientContents::GetGeometry() const {
+  return geometry_;
+}
 
 void SweepGradientContents::SetCenterAndAngles(Point center,
                                                Degrees start_angle,

--- a/engine/src/flutter/impeller/entity/contents/sweep_gradient_contents.h
+++ b/engine/src/flutter/impeller/entity/contents/sweep_gradient_contents.h
@@ -17,9 +17,11 @@ namespace impeller {
 
 class SweepGradientContents final : public ColorSourceContents {
  public:
-  SweepGradientContents();
+  explicit SweepGradientContents(const Geometry* geometry);
 
   ~SweepGradientContents() override;
+
+  const Geometry* GetGeometry() const override;
 
   // |Contents|
   bool IsOpaque(const Matrix& transform) const override;
@@ -58,6 +60,7 @@ class SweepGradientContents final : public ColorSourceContents {
                      const Entity& entity,
                      RenderPass& pass) const;
 
+  const Geometry* geometry_ = nullptr;
   Point center_;
   Scalar bias_;
   Scalar scale_;

--- a/engine/src/flutter/impeller/entity/contents/tiled_texture_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/tiled_texture_contents.cc
@@ -34,9 +34,14 @@ static std::optional<SamplerAddressMode> TileModeToAddressMode(
   }
 }
 
-TiledTextureContents::TiledTextureContents() = default;
+TiledTextureContents::TiledTextureContents(const Geometry* geometry)
+    : geometry_(geometry) {}
 
 TiledTextureContents::~TiledTextureContents() = default;
+
+const Geometry* TiledTextureContents::GetGeometry() const {
+  return geometry_;
+}
 
 void TiledTextureContents::SetTexture(std::shared_ptr<Texture> texture) {
   texture_ = std::move(texture);

--- a/engine/src/flutter/impeller/entity/contents/tiled_texture_contents.h
+++ b/engine/src/flutter/impeller/entity/contents/tiled_texture_contents.h
@@ -18,9 +18,11 @@ namespace impeller {
 
 class TiledTextureContents final : public ColorSourceContents {
  public:
-  TiledTextureContents();
+  explicit TiledTextureContents(const Geometry* geometry);
 
   ~TiledTextureContents() override;
+
+  const Geometry* GetGeometry() const override;
 
   using ColorFilterProc =
       std::function<std::shared_ptr<ColorFilterContents>(FilterInput::Ref)>;
@@ -66,6 +68,7 @@ class TiledTextureContents final : public ColorSourceContents {
 
   bool UsesEmulatedTileMode(const Capabilities& capabilities) const;
 
+  const Geometry* geometry_ = nullptr;
   std::shared_ptr<Texture> texture_;
   SamplerDescriptor sampler_descriptor_ = {};
   Entity::TileMode x_tile_mode_ = Entity::TileMode::kClamp;

--- a/engine/src/flutter/impeller/entity/contents/tiled_texture_contents_unittests.cc
+++ b/engine/src/flutter/impeller/entity/contents/tiled_texture_contents_unittests.cc
@@ -28,9 +28,8 @@ TEST_P(EntityTest, TiledTextureContentsRendersWithCorrectPipeline) {
       GetContext()->GetResourceAllocator()->CreateTexture(texture_desc);
 
   auto geom = Geometry::MakeCover();
-  TiledTextureContents contents;
+  TiledTextureContents contents(geom.get());
   contents.SetTexture(texture);
-  contents.SetGeometry(geom.get());
 
   auto content_context = GetContentContext();
   auto buffer = content_context->GetContext()->CreateCommandBuffer();

--- a/engine/src/flutter/impeller/entity/entity_unittests.cc
+++ b/engine/src/flutter/impeller/entity/entity_unittests.cc
@@ -120,11 +120,9 @@ TEST_P(EntityTest, ThreeStrokesInOnePath) {
 
   Entity entity;
   entity.SetTransform(Matrix::MakeScale(GetContentScale()));
-  auto contents = std::make_unique<SolidColorContents>();
-
   std::unique_ptr<Geometry> geom =
       Geometry::MakeStrokePath(path, {.width = 5.0f});
-  contents->SetGeometry(geom.get());
+  auto contents = std::make_unique<SolidColorContents>(geom.get());
   contents->SetColor(Color::Red());
   entity.SetContents(std::move(contents));
   ASSERT_TRUE(OpenPlaygroundHere(std::move(entity)));
@@ -143,10 +141,9 @@ TEST_P(EntityTest, StrokeWithTextureContents) {
 
   Entity entity;
   entity.SetTransform(Matrix::MakeScale(GetContentScale()));
-  auto contents = std::make_unique<TiledTextureContents>();
   std::unique_ptr<Geometry> geom =
       Geometry::MakeStrokePath(path, {.width = 100.0f});
-  contents->SetGeometry(geom.get());
+  auto contents = std::make_unique<TiledTextureContents>(geom.get());
   contents->SetTexture(bridge);
   contents->SetTileModes(Entity::TileMode::kClamp, Entity::TileMode::kClamp);
   entity.SetContents(std::move(contents));
@@ -186,10 +183,9 @@ TEST_P(EntityTest, TriangleInsideASquare) {
 
     Entity entity;
     entity.SetTransform(Matrix::MakeScale(GetContentScale()));
-    auto contents = std::make_unique<SolidColorContents>();
     std::unique_ptr<Geometry> geom =
         Geometry::MakeStrokePath(path, {.width = 20.0});
-    contents->SetGeometry(geom.get());
+    auto contents = std::make_unique<SolidColorContents>(geom.get());
     contents->SetColor(Color::Red());
     entity.SetContents(std::move(contents));
 
@@ -223,7 +219,6 @@ TEST_P(EntityTest, StrokeCapAndJoinTest) {
     auto world_matrix = Matrix::MakeScale(GetContentScale());
     auto render_path = [width = width, &context, &pass, &world_matrix](
                            const flutter::DlPath& path, Cap cap, Join join) {
-      auto contents = std::make_unique<SolidColorContents>();
       std::unique_ptr<Geometry> geom =
           Geometry::MakeStrokePath(path, {
                                              .width = width,
@@ -231,7 +226,7 @@ TEST_P(EntityTest, StrokeCapAndJoinTest) {
                                              .join = join,
                                              .miter_limit = miter_limit,
                                          });
-      contents->SetGeometry(geom.get());
+      auto contents = std::make_unique<SolidColorContents>(geom.get());
       contents->SetColor(Color::Red());
 
       Entity entity;
@@ -240,12 +235,10 @@ TEST_P(EntityTest, StrokeCapAndJoinTest) {
 
       auto coverage = entity.GetCoverage();
       if (coverage.has_value()) {
-        auto bounds_contents = std::make_unique<SolidColorContents>();
-
         std::unique_ptr<Geometry> geom = Geometry::MakeFillPath(
             flutter::DlPath::MakeRect(entity.GetCoverage().value()));
 
-        bounds_contents->SetGeometry(geom.get());
+        auto bounds_contents = std::make_unique<SolidColorContents>(geom.get());
         bounds_contents->SetColor(Color::Green().WithAlpha(0.5));
         Entity bounds_entity;
         bounds_entity.SetContents(std::move(bounds_contents));
@@ -389,9 +382,8 @@ TEST_P(EntityTest, CubicCurveTest) {
 
   std::unique_ptr<Geometry> geom = Geometry::MakeFillPath(path);
 
-  auto contents = std::make_shared<SolidColorContents>();
+  auto contents = std::make_shared<SolidColorContents>(geom.get());
   contents->SetColor(Color::Red());
-  contents->SetGeometry(geom.get());
 
   entity.SetContents(contents);
   ASSERT_TRUE(OpenPlaygroundHere(std::move(entity)));
@@ -440,9 +432,8 @@ TEST_P(EntityTest, CanDrawCorrectlyWithRotatedTransform) {
 
     std::unique_ptr<Geometry> geom = Geometry::MakeFillPath(path);
 
-    auto contents = std::make_shared<SolidColorContents>();
+    auto contents = std::make_shared<SolidColorContents>(geom.get());
     contents->SetColor(Color::Red());
-    contents->SetGeometry(geom.get());
 
     entity.SetContents(contents);
     return entity.Render(context, pass);
@@ -677,9 +668,8 @@ TEST_P(EntityTest, CubicCurveAndOverlapTest) {
 
   std::unique_ptr<Geometry> geom = Geometry::MakeFillPath(path);
 
-  auto contents = std::make_shared<SolidColorContents>();
+  auto contents = std::make_shared<SolidColorContents>(geom.get());
   contents->SetColor(Color::Red());
-  contents->SetGeometry(geom.get());
 
   entity.SetContents(contents);
   ASSERT_TRUE(OpenPlaygroundHere(std::move(entity)));
@@ -908,9 +898,8 @@ TEST_P(EntityTest, BezierCircleScaled) {
 
     std::unique_ptr<Geometry> geom = Geometry::MakeFillPath(path);
 
-    auto contents = std::make_shared<SolidColorContents>();
+    auto contents = std::make_shared<SolidColorContents>(geom.get());
     contents->SetColor(Color::Red());
-    contents->SetGeometry(geom.get());
 
     entity.SetContents(contents);
     return entity.Render(context, pass);
@@ -1047,12 +1036,10 @@ TEST_P(EntityTest, GaussianBlurFilter) {
       input = texture;
       input_size = input_rect.GetSize();
     } else {
-      auto fill = std::make_shared<SolidColorContents>();
-      fill->SetColor(input_color);
       solid_color_input =
           Geometry::MakeFillPath(flutter::DlPath::MakeRect(input_rect));
-
-      fill->SetGeometry(solid_color_input.get());
+      auto fill = std::make_shared<SolidColorContents>(solid_color_input.get());
+      fill->SetColor(input_color);
 
       input = fill;
       input_size = input_rect.GetSize();
@@ -1099,11 +1086,9 @@ TEST_P(EntityTest, GaussianBlurFilter) {
     // Renders a red "cover" rectangle that shows the original position of the
     // unfiltered input.
     Entity cover_entity;
-    std::unique_ptr<Geometry> geom =
-        Geometry::MakeFillPath(flutter::DlPath::MakeRect(input_rect));
-    auto contents = std::make_shared<SolidColorContents>();
+    auto geom = Geometry::MakeFillPath(flutter::DlPath::MakeRect(input_rect));
+    auto contents = std::make_shared<SolidColorContents>(geom.get());
     contents->SetColor(cover_color);
-    contents->SetGeometry(geom.get());
     cover_entity.SetContents(std::move(contents));
     cover_entity.SetTransform(ctm);
     cover_entity.Render(context, pass);
@@ -1116,9 +1101,8 @@ TEST_P(EntityTest, GaussianBlurFilter) {
       std::unique_ptr<Geometry> geom =
           Geometry::MakeFillPath(flutter::DlPath::MakeRect(
               target_contents->GetCoverage(entity).value()));
-      auto contents = std::make_shared<SolidColorContents>();
+      auto contents = std::make_shared<SolidColorContents>(geom.get());
       contents->SetColor(bounds_color);
-      contents->SetGeometry(geom.get());
 
       bounds_entity.SetContents(contents);
       bounds_entity.SetTransform(Matrix());
@@ -1210,11 +1194,9 @@ TEST_P(EntityTest, MorphologyFilter) {
     // Renders a red "cover" rectangle that shows the original position of  the
     // unfiltered input.
     Entity cover_entity;
-    std::unique_ptr<Geometry> geom =
-        Geometry::MakeFillPath(flutter::DlPath::MakeRect(input_rect));
-    auto cover_contents = std::make_shared<SolidColorContents>();
+    auto geom = Geometry::MakeFillPath(flutter::DlPath::MakeRect(input_rect));
+    auto cover_contents = std::make_shared<SolidColorContents>(geom.get());
     cover_contents->SetColor(cover_color);
-    cover_contents->SetGeometry(geom.get());
     cover_entity.SetContents(cover_contents);
     cover_entity.SetTransform(ctm);
     cover_entity.Render(context, pass);
@@ -1223,9 +1205,9 @@ TEST_P(EntityTest, MorphologyFilter) {
     Entity bounds_entity;
     std::unique_ptr<Geometry> bounds_geom = Geometry::MakeFillPath(
         flutter::DlPath::MakeRect(contents->GetCoverage(entity).value()));
-    auto bounds_contents = std::make_shared<SolidColorContents>();
+    auto bounds_contents =
+        std::make_shared<SolidColorContents>(bounds_geom.get());
     bounds_contents->SetColor(bounds_color);
-    bounds_contents->SetGeometry(bounds_geom.get());
     bounds_entity.SetContents(std::move(bounds_contents));
     bounds_entity.SetTransform(Matrix());
 
@@ -1245,7 +1227,7 @@ TEST_P(EntityTest, SetBlendMode) {
 
 TEST_P(EntityTest, ContentsGetBoundsForEmptyPathReturnsNullopt) {
   Entity entity;
-  entity.SetContents(std::make_shared<SolidColorContents>());
+  entity.SetContents(std::make_shared<SolidColorContents>(nullptr));
   ASSERT_FALSE(entity.GetCoverage().has_value());
 }
 
@@ -1261,8 +1243,7 @@ TEST_P(EntityTest, SolidStrokeCoverageIsCorrect) {
         });
 
     Entity entity;
-    auto contents = std::make_unique<SolidColorContents>();
-    contents->SetGeometry(geometry.get());
+    auto contents = std::make_unique<SolidColorContents>(geometry.get());
     contents->SetColor(Color::Black());
     entity.SetContents(std::move(contents));
     auto actual = entity.GetCoverage();
@@ -1284,8 +1265,7 @@ TEST_P(EntityTest, SolidStrokeCoverageIsCorrect) {
         });
 
     Entity entity;
-    auto contents = std::make_unique<SolidColorContents>();
-    contents->SetGeometry(geometry.get());
+    auto contents = std::make_unique<SolidColorContents>(geometry.get());
     contents->SetColor(Color::Black());
     entity.SetContents(std::move(contents));
     auto actual = entity.GetCoverage();
@@ -1308,8 +1288,7 @@ TEST_P(EntityTest, SolidStrokeCoverageIsCorrect) {
         });
 
     Entity entity;
-    auto contents = std::make_unique<SolidColorContents>();
-    contents->SetGeometry(geometry.get());
+    auto contents = std::make_unique<SolidColorContents>(geometry.get());
     contents->SetColor(Color::Black());
     entity.SetContents(std::move(contents));
     auto actual = entity.GetCoverage();
@@ -1321,10 +1300,9 @@ TEST_P(EntityTest, SolidStrokeCoverageIsCorrect) {
 }
 
 TEST_P(EntityTest, BorderMaskBlurCoverageIsCorrect) {
-  auto fill = std::make_shared<SolidColorContents>();
   auto geom = Geometry::MakeFillPath(
       flutter::DlPath::MakeRect(Rect::MakeXYWH(0, 0, 300, 400)));
-  fill->SetGeometry(geom.get());
+  auto fill = std::make_shared<SolidColorContents>(geom.get());
   fill->SetColor(Color::CornflowerBlue());
   auto border_mask_blur = FilterContents::MakeBorderMaskBlur(
       FilterInput::Make(fill), Radius{3}, Radius{4});
@@ -1351,11 +1329,10 @@ TEST_P(EntityTest, BorderMaskBlurCoverageIsCorrect) {
 TEST_P(EntityTest, SolidFillCoverageIsCorrect) {
   // No transform
   {
-    auto fill = std::make_shared<SolidColorContents>();
-    fill->SetColor(Color::CornflowerBlue());
     auto expected = Rect::MakeLTRB(100, 110, 200, 220);
     auto geom = Geometry::MakeFillPath(flutter::DlPath::MakeRect(expected));
-    fill->SetGeometry(geom.get());
+    auto fill = std::make_shared<SolidColorContents>(geom.get());
+    fill->SetColor(Color::CornflowerBlue());
 
     auto coverage = fill->GetCoverage({});
     ASSERT_TRUE(coverage.has_value());
@@ -1364,11 +1341,10 @@ TEST_P(EntityTest, SolidFillCoverageIsCorrect) {
 
   // Entity transform
   {
-    auto fill = std::make_shared<SolidColorContents>();
     auto geom = Geometry::MakeFillPath(
         flutter::DlPath::MakeRect(Rect::MakeLTRB(100, 110, 200, 220)));
+    auto fill = std::make_shared<SolidColorContents>(geom.get());
     fill->SetColor(Color::CornflowerBlue());
-    fill->SetGeometry(geom.get());
 
     Entity entity;
     entity.SetTransform(Matrix::MakeTranslation(Vector2(4, 5)));
@@ -1382,11 +1358,10 @@ TEST_P(EntityTest, SolidFillCoverageIsCorrect) {
 
   // No coverage for fully transparent colors
   {
-    auto fill = std::make_shared<SolidColorContents>();
     auto geom = Geometry::MakeFillPath(
         flutter::DlPath::MakeRect(Rect::MakeLTRB(100, 110, 200, 220)));
+    auto fill = std::make_shared<SolidColorContents>(geom.get());
     fill->SetColor(Color::WhiteTransparent());
-    fill->SetGeometry(geom.get());
 
     auto coverage = fill->GetCoverage({});
     ASSERT_FALSE(coverage.has_value());
@@ -1432,10 +1407,9 @@ TEST_P(EntityTest, RRectShadowTest) {
 
     auto coverage = entity.GetCoverage();
     if (show_coverage && coverage.has_value()) {
-      auto bounds_contents = std::make_unique<SolidColorContents>();
       auto geom = Geometry::MakeFillPath(
           flutter::DlPath::MakeRect(entity.GetCoverage().value()));
-      bounds_contents->SetGeometry(geom.get());
+      auto bounds_contents = std::make_unique<SolidColorContents>(geom.get());
       bounds_contents->SetColor(coverage_color.Premultiply());
       Entity bounds_entity;
       bounds_entity.SetContents(std::move(bounds_contents));
@@ -1449,10 +1423,9 @@ TEST_P(EntityTest, RRectShadowTest) {
 
 TEST_P(EntityTest, ColorMatrixFilterCoverageIsCorrect) {
   // Set up a simple color background.
-  auto fill = std::make_shared<SolidColorContents>();
   auto geom = Geometry::MakeFillPath(
       flutter::DlPath::MakeRect(Rect::MakeXYWH(0, 0, 300, 400)));
-  fill->SetGeometry(geom.get());
+  auto fill = std::make_shared<SolidColorContents>(geom.get());
   fill->SetColor(Color::Coral());
 
   // Set the color matrix filter.
@@ -1539,8 +1512,7 @@ TEST_P(EntityTest, LinearToSrgbFilterCoverageIsCorrect) {
   // Set up a simple color background.
   auto geom = Geometry::MakeFillPath(
       flutter::DlPath::MakeRect(Rect::MakeXYWH(0, 0, 300, 400)));
-  auto fill = std::make_shared<SolidColorContents>();
-  fill->SetGeometry(geom.get());
+  auto fill = std::make_shared<SolidColorContents>(geom.get());
   fill->SetColor(Color::MintCream());
 
   auto filter =
@@ -1590,10 +1562,9 @@ TEST_P(EntityTest, LinearToSrgbFilter) {
 
 TEST_P(EntityTest, SrgbToLinearFilterCoverageIsCorrect) {
   // Set up a simple color background.
-  auto fill = std::make_shared<SolidColorContents>();
   auto geom = Geometry::MakeFillPath(
       flutter::DlPath::MakeRect(Rect::MakeXYWH(0, 0, 300, 400)));
-  fill->SetGeometry(geom.get());
+  auto fill = std::make_shared<SolidColorContents>(geom.get());
   fill->SetColor(Color::DeepPink());
 
   auto filter =
@@ -1771,8 +1742,7 @@ TEST_P(EntityTest, RuntimeEffect) {
   auto callback = [&](ContentContext& context, RenderPass& pass) -> bool {
     EXPECT_EQ(runtime_stage->IsDirty(), expect_dirty);
 
-    auto contents = std::make_shared<RuntimeEffectContents>();
-    contents->SetGeometry(geom.get());
+    auto contents = std::make_shared<RuntimeEffectContents>(geom.get());
     contents->SetRuntimeStage(runtime_stage);
 
     struct FragUniforms {
@@ -1832,9 +1802,8 @@ TEST_P(EntityTest, RuntimeEffectCanSuccessfullyRender) {
   ASSERT_TRUE(runtime_stage);
   ASSERT_TRUE(runtime_stage->IsDirty());
 
-  auto contents = std::make_shared<RuntimeEffectContents>();
   auto geom = Geometry::MakeCover();
-  contents->SetGeometry(geom.get());
+  auto contents = std::make_shared<RuntimeEffectContents>(geom.get());
   contents->SetRuntimeStage(runtime_stage);
 
   struct FragUniforms {
@@ -1880,7 +1849,8 @@ TEST_P(EntityTest, RuntimeEffectCanPrecache) {
   ASSERT_TRUE(runtime_stage);
   ASSERT_TRUE(runtime_stage->IsDirty());
 
-  auto contents = std::make_shared<RuntimeEffectContents>();
+  auto geom = Geometry::MakeCover();
+  auto contents = std::make_shared<RuntimeEffectContents>(geom.get());
   contents->SetRuntimeStage(runtime_stage);
 
   EXPECT_TRUE(contents->BootstrapShader(*GetContentContext()));
@@ -1898,9 +1868,8 @@ TEST_P(EntityTest, RuntimeEffectSetsRightSizeWhenUniformIsStruct) {
   ASSERT_TRUE(runtime_stage);
   ASSERT_TRUE(runtime_stage->IsDirty());
 
-  auto contents = std::make_shared<RuntimeEffectContents>();
   auto geom = Geometry::MakeCover();
-  contents->SetGeometry(geom.get());
+  auto contents = std::make_shared<RuntimeEffectContents>(geom.get());
   contents->SetRuntimeStage(runtime_stage);
 
   struct FragUniforms {
@@ -2032,9 +2001,8 @@ TEST_P(EntityTest, CoverageForStrokePathWithNegativeValuesInTransform) {
 
 TEST_P(EntityTest, SolidColorContentsIsOpaque) {
   Matrix matrix;
-  SolidColorContents contents;
   auto geom = Geometry::MakeRect(Rect::MakeLTRB(0, 0, 10, 10));
-  contents.SetGeometry(geom.get());
+  SolidColorContents contents(geom.get());
 
   contents.SetColor(Color::CornflowerBlue());
   EXPECT_TRUE(contents.IsOpaque(matrix));
@@ -2042,19 +2010,18 @@ TEST_P(EntityTest, SolidColorContentsIsOpaque) {
   EXPECT_FALSE(contents.IsOpaque(matrix));
 
   // Create stroked path that required alpha coverage.
-  geom = Geometry::MakeStrokePath(flutter::DlPath::MakeLine({0, 0}, {100, 100}),
-                                  {.width = 0.05});
-  contents.SetGeometry(geom.get());
-  contents.SetColor(Color::CornflowerBlue());
+  auto geom2 = Geometry::MakeStrokePath(
+      flutter::DlPath::MakeLine({0, 0}, {100, 100}), {.width = 0.05});
+  SolidColorContents contents2(geom2.get());
+  contents2.SetColor(Color::CornflowerBlue());
 
-  EXPECT_FALSE(contents.IsOpaque(matrix));
+  EXPECT_FALSE(contents2.IsOpaque(matrix));
 }
 
 TEST_P(EntityTest, ConicalGradientContentsIsOpaque) {
   Matrix matrix;
-  ConicalGradientContents contents;
   auto geom = Geometry::MakeRect(Rect::MakeLTRB(0, 0, 10, 10));
-  contents.SetGeometry(geom.get());
+  ConicalGradientContents contents(geom.get());
 
   contents.SetColors({Color::CornflowerBlue()});
   EXPECT_FALSE(contents.IsOpaque(matrix));
@@ -2062,20 +2029,19 @@ TEST_P(EntityTest, ConicalGradientContentsIsOpaque) {
   EXPECT_FALSE(contents.IsOpaque(matrix));
 
   // Create stroked path that required alpha coverage.
-  geom = Geometry::MakeStrokePath(
+  auto geom2 = Geometry::MakeStrokePath(
       flutter::DlPathBuilder{}.MoveTo({0, 0}).LineTo({100, 100}).TakePath(),
       {.width = 0.05f});
-  contents.SetGeometry(geom.get());
-  contents.SetColors({Color::CornflowerBlue()});
+  ConicalGradientContents contents2(geom2.get());
+  contents2.SetColors({Color::CornflowerBlue()});
 
-  EXPECT_FALSE(contents.IsOpaque(matrix));
+  EXPECT_FALSE(contents2.IsOpaque(matrix));
 }
 
 TEST_P(EntityTest, LinearGradientContentsIsOpaque) {
   Matrix matrix;
-  LinearGradientContents contents;
   auto geom = Geometry::MakeRect(Rect::MakeLTRB(0, 0, 10, 10));
-  contents.SetGeometry(geom.get());
+  LinearGradientContents contents(geom.get());
 
   contents.SetColors({Color::CornflowerBlue()});
   EXPECT_TRUE(contents.IsOpaque(matrix));
@@ -2086,20 +2052,19 @@ TEST_P(EntityTest, LinearGradientContentsIsOpaque) {
   EXPECT_FALSE(contents.IsOpaque(matrix));
 
   // Create stroked path that required alpha coverage.
-  geom = Geometry::MakeStrokePath(
+  auto geom2 = Geometry::MakeStrokePath(
       flutter::DlPathBuilder{}.MoveTo({0, 0}).LineTo({100, 100}).TakePath(),
       {.width = 0.05f});
-  contents.SetGeometry(geom.get());
-  contents.SetColors({Color::CornflowerBlue()});
+  LinearGradientContents contents2(geom2.get());
+  contents2.SetColors({Color::CornflowerBlue()});
 
-  EXPECT_FALSE(contents.IsOpaque(matrix));
+  EXPECT_FALSE(contents2.IsOpaque(matrix));
 }
 
 TEST_P(EntityTest, RadialGradientContentsIsOpaque) {
   Matrix matrix;
-  RadialGradientContents contents;
   auto geom = Geometry::MakeRect(Rect::MakeLTRB(0, 0, 10, 10));
-  contents.SetGeometry(geom.get());
+  RadialGradientContents contents(geom.get());
 
   contents.SetColors({Color::CornflowerBlue()});
   EXPECT_TRUE(contents.IsOpaque(matrix));
@@ -2110,20 +2075,19 @@ TEST_P(EntityTest, RadialGradientContentsIsOpaque) {
   EXPECT_FALSE(contents.IsOpaque(matrix));
 
   // Create stroked path that required alpha coverage.
-  geom = Geometry::MakeStrokePath(
+  auto geom2 = Geometry::MakeStrokePath(
       flutter::DlPathBuilder{}.MoveTo({0, 0}).LineTo({100, 100}).TakePath(),
       {.width = 0.05});
-  contents.SetGeometry(geom.get());
-  contents.SetColors({Color::CornflowerBlue()});
+  RadialGradientContents contents2(geom2.get());
+  contents2.SetColors({Color::CornflowerBlue()});
 
-  EXPECT_FALSE(contents.IsOpaque(matrix));
+  EXPECT_FALSE(contents2.IsOpaque(matrix));
 }
 
 TEST_P(EntityTest, SweepGradientContentsIsOpaque) {
   Matrix matrix;
-  RadialGradientContents contents;
   auto geom = Geometry::MakeRect(Rect::MakeLTRB(0, 0, 10, 10));
-  contents.SetGeometry(geom.get());
+  SweepGradientContents contents(geom.get());
 
   contents.SetColors({Color::CornflowerBlue()});
   EXPECT_TRUE(contents.IsOpaque(matrix));
@@ -2134,19 +2098,20 @@ TEST_P(EntityTest, SweepGradientContentsIsOpaque) {
   EXPECT_FALSE(contents.IsOpaque(matrix));
 
   // Create stroked path that required alpha coverage.
-  geom = Geometry::MakeStrokePath(
+  auto geom2 = Geometry::MakeStrokePath(
       flutter::DlPathBuilder{}.MoveTo({0, 0}).LineTo({100, 100}).TakePath(),
       {.width = 0.05f});
-  contents.SetGeometry(geom.get());
-  contents.SetColors({Color::CornflowerBlue()});
+  SweepGradientContents contents2(geom2.get());
+  contents2.SetColors({Color::CornflowerBlue()});
 
-  EXPECT_FALSE(contents.IsOpaque(matrix));
+  EXPECT_FALSE(contents2.IsOpaque(matrix));
 }
 
 TEST_P(EntityTest, TiledTextureContentsIsOpaque) {
   Matrix matrix;
   auto bay_bridge = CreateTextureForFixture("bay_bridge.jpg");
-  TiledTextureContents contents;
+  auto geom = Geometry::MakeCover();
+  TiledTextureContents contents(geom.get());
   contents.SetTexture(bay_bridge);
   // This is a placeholder test. Images currently never decompress as opaque
   // (whether in Flutter or the playground), and so this should currently always
@@ -2165,14 +2130,12 @@ TEST_P(EntityTest, PointFieldGeometryCoverage) {
 TEST_P(EntityTest, ColorFilterContentsWithLargeGeometry) {
   Entity entity;
   entity.SetTransform(Matrix::MakeScale(GetContentScale()));
-  auto src_contents = std::make_shared<SolidColorContents>();
   auto src_geom = Geometry::MakeRect(Rect::MakeLTRB(-300, -500, 30000, 50000));
-  src_contents->SetGeometry(src_geom.get());
+  auto src_contents = std::make_shared<SolidColorContents>(src_geom.get());
   src_contents->SetColor(Color::Red());
 
-  auto dst_contents = std::make_shared<SolidColorContents>();
   auto dst_geom = Geometry::MakeRect(Rect::MakeLTRB(300, 500, 20000, 30000));
-  dst_contents->SetGeometry(dst_geom.get());
+  auto dst_contents = std::make_shared<SolidColorContents>(dst_geom.get());
   dst_contents->SetColor(Color::Blue());
 
   auto contents = ColorFilterContents::MakeBlend(
@@ -2454,9 +2417,8 @@ TEST_P(EntityTest, CanRenderEmptyPathsWithoutCrashing) {
 
   EXPECT_TRUE(path.GetBounds().IsEmpty());
 
-  auto contents = std::make_shared<SolidColorContents>();
   std::unique_ptr<Geometry> geom = Geometry::MakeFillPath(path);
-  contents->SetGeometry(geom.get());
+  auto contents = std::make_shared<SolidColorContents>(geom.get());
   contents->SetColor(Color::Red());
 
   Entity entity;
@@ -2483,12 +2445,11 @@ TEST_P(EntityTest, DrawSuperEllipse) {
     ImGui::ColorEdit4("Color", reinterpret_cast<float*>(&color));
     ImGui::End();
 
-    auto contents = std::make_shared<SolidColorContents>();
     std::unique_ptr<SuperellipseGeometry> geom =
         std::make_unique<SuperellipseGeometry>(Point{400, 400}, radius, degree,
                                                alpha, beta);
+    auto contents = std::make_shared<SolidColorContents>(geom.get());
     contents->SetColor(color);
-    contents->SetGeometry(geom.get());
 
     Entity entity;
     entity.SetContents(contents);
@@ -2598,9 +2559,8 @@ TEST_P(EntityTest, DrawRoundSuperEllipse) {
       geom = Geometry::MakeStrokePath(path, {.width = 2.0f});
     }
 
-    auto contents = std::make_shared<SolidColorContents>();
+    auto contents = std::make_shared<SolidColorContents>(geom.get());
     contents->SetColor(Color::Red());
-    contents->SetGeometry(geom.get());
 
     Entity entity;
     entity.SetContents(contents);
@@ -2649,9 +2609,8 @@ TEST_P(EntityTest, DrawRoundSuperEllipseWithLargeN) {
         std::make_unique<RoundSuperellipseGeometry>(rect, corner_radius);
     // Fill
     {
-      auto contents = std::make_shared<SolidColorContents>();
+      auto contents = std::make_shared<SolidColorContents>(fill_geom.get());
       contents->SetColor(Color::Red());
-      contents->SetGeometry(fill_geom.get());
 
       Entity entity;
       entity.SetContents(contents);
@@ -2665,9 +2624,8 @@ TEST_P(EntityTest, DrawRoundSuperEllipseWithLargeN) {
         RoundSuperellipse::MakeRectRadius(rect, corner_radius));
     auto stroke_geom = Geometry::MakeStrokePath(path, {.width = 2 / scale});
     {
-      auto contents = std::make_shared<SolidColorContents>();
+      auto contents = std::make_shared<SolidColorContents>(stroke_geom.get());
       contents->SetColor(Color::Blue());
-      contents->SetGeometry(stroke_geom.get());
 
       Entity entity;
       entity.SetContents(contents);
@@ -2786,7 +2744,8 @@ TEST_P(EntityTest, CanDrawRoundSuperEllipseWithJustEnoughRadius) {
 }
 
 TEST_P(EntityTest, SolidColorApplyColorFilter) {
-  auto contents = SolidColorContents();
+  auto geom = Geometry::MakeCover();
+  auto contents = SolidColorContents(geom.get());
   contents.SetColor(Color::CornflowerBlue().WithAlpha(0.75));
   auto result = contents.ApplyColorFilter([](const Color& color) {
     return color.Blend(Color::LimeGreen().WithAlpha(0.75), BlendMode::kScreen);
@@ -2798,7 +2757,8 @@ TEST_P(EntityTest, SolidColorApplyColorFilter) {
 
 #define APPLY_COLOR_FILTER_GRADIENT_TEST(name)                                 \
   TEST_P(EntityTest, name##GradientApplyColorFilter) {                         \
-    auto contents = name##GradientContents();                                  \
+    auto geom = Geometry::MakeCover();                                         \
+    auto contents = name##GradientContents(geom.get());                        \
     contents.SetColors({Color::CornflowerBlue().WithAlpha(0.75)});             \
     auto result = contents.ApplyColorFilter([](const Color& color) {           \
       return color.Blend(Color::LimeGreen().WithAlpha(0.75),                   \

--- a/engine/src/flutter/shell/common/snapshot_controller_impeller.cc
+++ b/engine/src/flutter/shell/common/snapshot_controller_impeller.cc
@@ -246,7 +246,7 @@ void SnapshotControllerImpeller::CacheRuntimeStage(
   if (!context) {
     return;
   }
-  impeller::RuntimeEffectContents runtime_effect;
+  impeller::RuntimeEffectContents runtime_effect(nullptr);
   runtime_effect.SetRuntimeStage(runtime_stage);
   runtime_effect.BootstrapShader(context->GetContentContext());
 }


### PR DESCRIPTION
This refactor lays the groundwork for future SDF contents and cleans up the existing circle SDF contents which need to maintain the identity of what sort of geometry they have.  Having the geometry at the ColorSourceContents layer strips it of its identity (ex CircleGeometry vs RectGeometry).

## state before the change
<img width="568" height="567" alt="RPBHQiCm34NVynLwJBRc1yeOBO7rQJ3Q3nYg8p8pnmwoMbgs_VkSB4wRU4ysrhq7wSeRByXoQasMuT4Ben9G1hs77RcMXA_mbG4yGeLsstNc-eh-yqKR8SuBMCFHEPFz9ERAMI4hVZJlI2ft9iQ6yl2ivTfxzwHaAE_9re77mq6yWZ_D2hh0AdhyIDMi3CtO9JInp_LOZuq7N-MCuuCxiRgvdhxBSa7A5k27IJ6nqW5JSjBF" src="https://github.com/user-attachments/assets/ca45c829-59cd-4ca4-8c4d-fea821ea6050" />


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
