### PR TITLE
[Impeller] Improve efficiency of growing the glyph cache

### DIFF
--- a/engine/src/flutter/impeller/typographer/backends/skia/typographer_context_skia.cc
+++ b/engine/src/flutter/impeller/typographer/backends/skia/typographer_context_skia.cc
@@ -97,111 +97,50 @@ static SkImageInfo GetImageInfo(const GlyphAtlas& atlas, Size size) {
   FML_UNREACHABLE();
 }
 
-/// Append as many glyphs to the texture as will fit, and return the first index
-/// of [extra_pairs] that did not fit.
-static size_t AppendToExistingAtlas(
-    const std::shared_ptr<GlyphAtlas>& atlas,
-    const std::vector<FontGlyphPair>& extra_pairs,
-    std::vector<Rect>& glyph_positions,
-    const std::vector<Rect>& glyph_sizes,
-    ISize atlas_size,
-    int64_t height_adjustment,
-    const std::shared_ptr<RectanglePacker>& rect_packer) {
-  TRACE_EVENT0("impeller", __FUNCTION__);
-  if (!rect_packer || atlas_size.IsEmpty()) {
-    return 0;
-  }
-
-  for (size_t i = 0; i < extra_pairs.size(); i++) {
-    ISize glyph_size = ISize::Ceil(glyph_sizes[i].GetSize());
-    IPoint16 location_in_atlas;
-    if (!rect_packer->AddRect(glyph_size.width + kPadding,   //
-                              glyph_size.height + kPadding,  //
-                              &location_in_atlas             //
-                              )) {
-      return i;
-    }
-    // Position the glyph in the center of the 1px padding.
-    glyph_positions.push_back(Rect::MakeXYWH(
-        location_in_atlas.x() + 1,                      //
-        location_in_atlas.y() + height_adjustment + 1,  //
-        glyph_size.width,                               //
-        glyph_size.height                               //
-        ));
-  }
-
-  return extra_pairs.size();
-}
-
-static size_t PairsFitInAtlasOfSize(
-    const std::vector<FontGlyphPair>& pairs,
-    const ISize& atlas_size,
-    std::vector<Rect>& glyph_positions,
-    const std::vector<Rect>& glyph_sizes,
-    int64_t height_adjustment,
+bool TypographerContextSkia::AppendSizesAndGrowPacker(
     const std::shared_ptr<RectanglePacker>& rect_packer,
-    size_t start_index) {
-  FML_DCHECK(!atlas_size.IsEmpty());
+    std::vector<NewGlyphData>& glyphs,
+    int max_packer_height) {
+  if (!rect_packer) {
+    // Caller should try again in the "brand new atlas" mode where they
+    // create a brand new packer and expect to create a new texture.
+    return false;
+  }
 
-  for (size_t i = start_index; i < pairs.size(); i++) {
-    ISize glyph_size = ISize::Ceil(glyph_sizes[i].GetSize());
+  FML_DCHECK(rect_packer->width() > 0 && rect_packer->height() > 0);
+  FML_DCHECK(rect_packer->height() <= max_packer_height);
+
+  size_t glyph_index = 0u;
+  while (glyph_index < glyphs.size()) {
+    ISize glyph_size = ISize::Ceil(glyphs[glyph_index].bounds.GetSize());
     IPoint16 location_in_atlas;
-    if (!rect_packer->AddRect(glyph_size.width + kPadding,   //
-                              glyph_size.height + kPadding,  //
-                              &location_in_atlas             //
-                              )) {
-      return i;
+    if (rect_packer->AddRect(glyph_size.width + kPadding,
+                             glyph_size.height + kPadding,
+                             &location_in_atlas)) {
+      // Position the glyph in the center of the 1px padding.
+      glyphs[glyph_index].position =
+          Rect::MakeXYWH(location_in_atlas.x() + 1,  //
+                         location_in_atlas.y() + 1,  //
+                         glyph_size.width,           //
+                         glyph_size.height           //
+          );
+      glyph_index++;
+      continue;
     }
-    glyph_positions.push_back(Rect::MakeXYWH(
-        location_in_atlas.x() + 1,                      //
-        location_in_atlas.y() + height_adjustment + 1,  //
-        glyph_size.width,                               //
-        glyph_size.height                               //
-        ));
+
+    int new_height = std::min(rect_packer->height() * 2, max_packer_height);
+    if (new_height > rect_packer->height()) {
+      rect_packer->GrowTo(rect_packer->width(), new_height);
+      continue;
+    }
+
+    // We failed to add all of the glyphs to the current rectangle packer
+    // even after growing it to the maximum allowed height.
+    return false;
   }
 
-  return pairs.size();
-}
-
-static ISize ComputeNextAtlasSize(
-    const std::shared_ptr<GlyphAtlasContext>& atlas_context,
-    const std::vector<FontGlyphPair>& extra_pairs,
-    std::vector<Rect>& glyph_positions,
-    const std::vector<Rect>& glyph_sizes,
-    size_t glyph_index_start,
-    int64_t max_texture_height) {
-  // Because we can't grow the skyline packer horizontally, pick a reasonable
-  // large width for all atlases.
-  static constexpr int64_t kAtlasWidth = 4096;
-  static constexpr int64_t kMinAtlasHeight = 1024;
-
-  ISize current_size = ISize(kAtlasWidth, kMinAtlasHeight);
-  if (atlas_context->GetAtlasSize().height > current_size.height) {
-    current_size.height = atlas_context->GetAtlasSize().height * 2;
-  }
-
-  auto height_adjustment = atlas_context->GetAtlasSize().height;
-  while (current_size.height <= max_texture_height) {
-    std::shared_ptr<RectanglePacker> rect_packer;
-    if (atlas_context->GetRectPacker() || glyph_index_start) {
-      rect_packer = RectanglePacker::Factory(
-          kAtlasWidth,
-          current_size.height - atlas_context->GetAtlasSize().height);
-    } else {
-      rect_packer = RectanglePacker::Factory(kAtlasWidth, current_size.height);
-    }
-    glyph_positions.erase(glyph_positions.begin() + glyph_index_start,
-                          glyph_positions.end());
-    atlas_context->UpdateRectPacker(rect_packer);
-    auto next_index = PairsFitInAtlasOfSize(
-        extra_pairs, current_size, glyph_positions, glyph_sizes,
-        height_adjustment, rect_packer, glyph_index_start);
-    if (next_index == extra_pairs.size()) {
-      return current_size;
-    }
-    current_size = ISize(current_size.width, current_size.height * 2);
-  }
-  return {};
+  FML_DCHECK(glyph_index == glyphs.size());
+  return true;
 }
 
 static Point SubpixelPositionToPoint(SubpixelPosition pos) {
@@ -262,13 +201,12 @@ static void DrawGlyph(SkCanvas* canvas,
 /// @brief Batch render to a single surface.
 ///
 /// This is only safe for use when updating a fresh texture.
-static bool BulkUpdateAtlasBitmap(const GlyphAtlas& atlas,
-                                  std::shared_ptr<BlitPass>& blit_pass,
-                                  HostBuffer& data_host_buffer,
-                                  const std::shared_ptr<Texture>& texture,
-                                  const std::vector<FontGlyphPair>& new_pairs,
-                                  size_t start_index,
-                                  size_t end_index) {
+bool TypographerContextSkia::BulkUpdateAtlasBitmap(
+    const GlyphAtlas& atlas,
+    std::shared_ptr<BlitPass>& blit_pass,
+    HostBuffer& data_host_buffer,
+    const std::shared_ptr<Texture>& texture,
+    const std::vector<NewGlyphData>& new_glyphs) {
   TRACE_EVENT0("impeller", __FUNCTION__);
 
   bool has_color = atlas.GetType() == GlyphAtlas::Type::kColorBitmap;
@@ -288,8 +226,8 @@ static bool BulkUpdateAtlasBitmap(const GlyphAtlas& atlas,
     return false;
   }
 
-  for (size_t i = start_index; i < end_index; i++) {
-    const FontGlyphPair& pair = new_pairs[i];
+  for (const NewGlyphData& new_glyph : new_glyphs) {
+    const FontGlyphPair& pair = new_glyph.pair;
     auto data = atlas.FindFontGlyphBounds(pair);
     if (!data.has_value()) {
       continue;
@@ -321,19 +259,18 @@ static bool BulkUpdateAtlasBitmap(const GlyphAtlas& atlas,
                                             texture->GetSize().height));
 }
 
-static bool UpdateAtlasBitmap(const GlyphAtlas& atlas,
-                              std::shared_ptr<BlitPass>& blit_pass,
-                              HostBuffer& data_host_buffer,
-                              const std::shared_ptr<Texture>& texture,
-                              const std::vector<FontGlyphPair>& new_pairs,
-                              size_t start_index,
-                              size_t end_index) {
+bool TypographerContextSkia::UpdateAtlasBitmap(
+    const GlyphAtlas& atlas,
+    std::shared_ptr<BlitPass>& blit_pass,
+    HostBuffer& data_host_buffer,
+    const std::shared_ptr<Texture>& texture,
+    const std::vector<NewGlyphData>& new_glyphs) {
   TRACE_EVENT0("impeller", __FUNCTION__);
 
   bool has_color = atlas.GetType() == GlyphAtlas::Type::kColorBitmap;
 
-  for (size_t i = start_index; i < end_index; i++) {
-    const FontGlyphPair& pair = new_pairs[i];
+  for (const NewGlyphData& new_glyph : new_glyphs) {
+    const FontGlyphPair& pair = new_glyph.pair;
     auto data = atlas.FindFontGlyphBounds(pair);
     if (!data.has_value()) {
       continue;
@@ -419,12 +356,11 @@ static Rect ComputeGlyphSize(const SkFont& font,
                         scaled_bounds.fBottom);
 };
 
-std::pair<std::vector<FontGlyphPair>, std::vector<Rect>>
+std::vector<TypographerContextSkia::NewGlyphData>
 TypographerContextSkia::CollectNewGlyphs(
     const std::shared_ptr<GlyphAtlas>& atlas,
     const std::vector<RenderableText>& renderable_texts) {
-  std::vector<FontGlyphPair> new_glyphs;
-  std::vector<Rect> glyph_sizes;
+  std::vector<NewGlyphData> new_glyphs;
   for (const auto& frame : renderable_texts) {
     Rational rounded_scale = TextFrame::RoundScaledFontSize(
         frame.origin_transform.GetMaxBasisLengthXY());
@@ -460,10 +396,13 @@ TypographerContextSkia::CollectNewGlyphs(
             font_glyph_atlas->FindGlyphBounds(subpixel_glyph);
 
         if (!font_glyph_bounds.has_value()) {
-          new_glyphs.push_back(FontGlyphPair{scaled_font, subpixel_glyph});
           auto glyph_bounds = ComputeGlyphSize(
               sk_font, subpixel_glyph, static_cast<Scalar>(scaled_font.scale));
-          glyph_sizes.push_back(glyph_bounds);
+
+          new_glyphs.emplace_back(NewGlyphData{
+              .pair = FontGlyphPair{scaled_font, subpixel_glyph},
+              .bounds = glyph_bounds,
+          });
 
           auto frame_bounds = FrameBounds{
               Rect::MakeLTRB(0, 0, 0, 0),  //
@@ -476,7 +415,7 @@ TypographerContextSkia::CollectNewGlyphs(
       }
     }
   }
-  return {std::move(new_glyphs), std::move(glyph_sizes)};
+  return new_glyphs;
 }
 
 std::shared_ptr<GlyphAtlas> TypographerContextSkia::CreateGlyphAtlas(
@@ -501,9 +440,11 @@ std::shared_ptr<GlyphAtlas> TypographerContextSkia::CreateGlyphAtlas(
   //         with the current atlas and reuse if possible. For each new font and
   //         glyph pair, compute the glyph size at scale.
   // ---------------------------------------------------------------------------
-  auto [new_glyphs, glyph_sizes] =
+  std::vector<NewGlyphData> new_glyphs =
       CollectNewGlyphs(last_atlas, renderable_texts);
   if (new_glyphs.size() == 0) {
+    // All of the glyphs needed in this frame were already found in the
+    // existing atlas, no further work is needed.
     return last_atlas;
   }
 
@@ -513,116 +454,77 @@ std::shared_ptr<GlyphAtlas> TypographerContextSkia::CreateGlyphAtlas(
   // ---------------------------------------------------------------------------
   std::vector<Rect> glyph_positions;
   glyph_positions.reserve(new_glyphs.size());
-  size_t first_missing_index = 0;
+  std::shared_ptr<RectanglePacker> packer = atlas_context->GetRectPacker();
 
-  if (last_atlas->GetTexture()) {
-    // Append all glyphs that fit into the current atlas.
-    first_missing_index = AppendToExistingAtlas(
-        last_atlas, new_glyphs, glyph_positions, glyph_sizes,
-        atlas_context->GetAtlasSize(), atlas_context->GetHeightAdjustment(),
-        atlas_context->GetRectPacker());
+  std::shared_ptr<GlyphAtlas> new_atlas = last_atlas;
+  std::shared_ptr<Texture> last_texture = last_atlas->GetTexture();
+  ISize last_atlas_size = last_texture ? last_texture->GetSize() : ISize();
+  ISize new_atlas_size = last_atlas_size;
 
-    // ---------------------------------------------------------------------------
-    // Step 3a: Record the positions in the glyph atlas of the newly added
-    //          glyphs.
-    // ---------------------------------------------------------------------------
-    for (size_t i = 0; i < first_missing_index; i++) {
-      last_atlas->AddTypefaceGlyphPositionAndBounds(
-          new_glyphs[i], glyph_positions[i], glyph_sizes[i]);
-    }
-
-    std::shared_ptr<CommandBuffer> cmd_buffer = context.CreateCommandBuffer();
-    std::shared_ptr<BlitPass> blit_pass = cmd_buffer->CreateBlitPass();
-
-    fml::ScopedCleanupClosure closure([&]() {
-      blit_pass->EncodeCommands();
-      if (!context.EnqueueCommandBuffer(std::move(cmd_buffer))) {
-        VALIDATION_LOG << "Failed to submit glyph atlas command buffer";
-      }
-    });
-
-    // ---------------------------------------------------------------------------
-    // Step 4a: Draw new font-glyph pairs into the a host buffer and encode
-    // the uploads into the blit pass.
-    // ---------------------------------------------------------------------------
-    if (!UpdateAtlasBitmap(*last_atlas, blit_pass, data_host_buffer,
-                           last_atlas->GetTexture(), new_glyphs, 0,
-                           first_missing_index)) {
-      return nullptr;
-    }
-
-    // If all glyphs fit, just return the old atlas.
-    if (first_missing_index == new_glyphs.size()) {
-      return last_atlas;
-    }
-  }
-
-  int64_t height_adjustment = atlas_context->GetAtlasSize().height;
   const int64_t max_texture_height =
       context.GetResourceAllocator()->GetMaxTextureSizeSupported().height;
 
-  // IF the current atlas size is as big as it can get, then "GC" and create an
-  // atlas with only the required glyphs. OpenGLES cannot reliably perform the
-  // blit required here, as 1) it requires attaching textures as read and write
-  // framebuffers which has substantially smaller size limits that max textures
-  // and 2) is missing a GLES 2.0 implementation and cap check.
-  bool blit_old_atlas = true;
-  std::shared_ptr<GlyphAtlas> new_atlas = last_atlas;
-  if (atlas_context->GetAtlasSize().height >= max_texture_height ||
-      context.GetBackendType() == Context::BackendType::kOpenGLES) {
-    blit_old_atlas = false;
+  // IF we cannot grow the current atlas size to fit all of the new glyphs,
+  // then we will need to "GC" and create an atlas with only the required
+  // glyphs. OpenGLES will always opt out of growing the atlas as it
+  // cannot reliably perform the blit required to keep the glyphs in the
+  // old atlas, as 1) it requires attaching textures as read and write
+  // framebuffers which has substantially smaller size limits that max
+  // textures and 2) is missing a GLES 2.0 implementation and cap check.
+  const bool can_grow_atlas =
+      (context.GetBackendType() != Context::BackendType::kOpenGLES) ||
+      last_texture == nullptr;
+
+  bool atlas_grows = false;
+  bool atlas_refreshes = false;
+
+  // If we cannot grow the atlas, then the first attempt to stuff the
+  // existing atlas with the new glyphs has to indicate that the rectangle
+  // packer is already at its maximum height. Otherwise, we allow the
+  // algorithm to grow the packer to accomodate the new glyphs up to the
+  // maximum texture height.
+  const int64_t max_growth_height =
+      can_grow_atlas ? max_texture_height : last_atlas_size.height;
+
+  if (AppendSizesAndGrowPacker(packer, new_glyphs, max_growth_height)) {
+    // We can fit the new glyphs into the existing atlas, but do we need
+    // to grow the atlas texture to do so?
+    FML_DCHECK(packer);
+    atlas_grows = (packer->height() > last_atlas_size.height);
+    if (atlas_grows) {
+      new_atlas_size = ISize(packer->width(), packer->height());
+      atlas_context->UpdateGlyphAtlas(new_atlas, new_atlas_size);
+    }
+  } else {
+    // We could not append all of the glyphs to the existing atlas,
+    // even after (potentially) growing it. So, we start over with
+    // an empty atlas and try one last time.
     new_atlas = std::make_shared<GlyphAtlas>(
         type, /*initial_generation=*/last_atlas->GetAtlasGeneration() + 1);
-
-    auto [update_glyphs, update_sizes] =
+    std::vector<NewGlyphData> update_glyphs =
         CollectNewGlyphs(new_atlas, renderable_texts);
     new_glyphs = std::move(update_glyphs);
-    glyph_sizes = std::move(update_sizes);
+
+    packer = RectanglePacker::Factory(kAtlasWidth, kMinAtlasHeight);
 
     glyph_positions.clear();
     glyph_positions.reserve(new_glyphs.size());
-    first_missing_index = 0;
 
-    height_adjustment = 0;
-    atlas_context->UpdateRectPacker(nullptr);
-    atlas_context->UpdateGlyphAtlas(new_atlas, {0, 0}, 0);
+    // Since we are recreating an atlas in this instance, we can use the
+    // max_texture_height as the growth limit - the newly created atlas
+    // can be any allocatable height.
+    if (!AppendSizesAndGrowPacker(packer, new_glyphs, max_texture_height)) {
+      // We could not append all of the glyphs even to a brand new empty
+      // atlas of maximum possible height, this frame cannot be updated
+      // for the glyphs in it.
+      return nullptr;
+    }
+
+    new_atlas_size = ISize(packer->width(), packer->height());
+    atlas_context->UpdateRectPacker(packer);
+    atlas_context->UpdateGlyphAtlas(new_atlas, new_atlas_size);
+    atlas_refreshes = true;
   }
-
-  // A new glyph atlas must be created.
-  ISize atlas_size = ComputeNextAtlasSize(atlas_context,        //
-                                          new_glyphs,           //
-                                          glyph_positions,      //
-                                          glyph_sizes,          //
-                                          first_missing_index,  //
-                                          max_texture_height    //
-  );
-
-  atlas_context->UpdateGlyphAtlas(new_atlas, atlas_size, height_adjustment);
-  if (atlas_size.IsEmpty()) {
-    return nullptr;
-  }
-  FML_DCHECK(new_glyphs.size() == glyph_positions.size());
-
-  TextureDescriptor descriptor;
-  switch (type) {
-    case GlyphAtlas::Type::kAlphaBitmap:
-      descriptor.format =
-          context.GetCapabilities()->GetDefaultGlyphAtlasFormat();
-      break;
-    case GlyphAtlas::Type::kColorBitmap:
-      descriptor.format = PixelFormat::kR8G8B8A8UNormInt;
-      break;
-  }
-  descriptor.size = atlas_size;
-  descriptor.storage_mode = StorageMode::kDevicePrivate;
-  descriptor.usage = TextureUsage::kShaderRead;
-  std::shared_ptr<Texture> new_texture =
-      context.GetResourceAllocator()->CreateTexture(descriptor);
-  if (!new_texture) {
-    return nullptr;
-  }
-
-  new_texture->SetLabel("GlyphAtlas");
 
   std::shared_ptr<CommandBuffer> cmd_buffer = context.CreateCommandBuffer();
   std::shared_ptr<BlitPass> blit_pass = cmd_buffer->CreateBlitPass();
@@ -634,39 +536,65 @@ std::shared_ptr<GlyphAtlas> TypographerContextSkia::CreateGlyphAtlas(
     }
   });
 
-  // Now append all remaining glyphs. This should never have any missing data...
-  auto old_texture = new_atlas->GetTexture();
-  new_atlas->SetTexture(std::move(new_texture));
+  // By one of multiple means the new glyphs have been added to a
+  // rectangle packer for an atlas. That atlas may be the existing
+  // atlas with no growth, or to a grown version of the existing atlas,
+  // or to a brand new atlas.
+  if (atlas_grows || atlas_refreshes) {
+    // Either the existing atlas can contain the new glyphs, but needs
+    // to grow in size, or we had to start over with an empty atlas.
+    TextureDescriptor descriptor;
+    switch (type) {
+      case GlyphAtlas::Type::kAlphaBitmap:
+        descriptor.format =
+            context.GetCapabilities()->GetDefaultGlyphAtlasFormat();
+        break;
+      case GlyphAtlas::Type::kColorBitmap:
+        descriptor.format = PixelFormat::kR8G8B8A8UNormInt;
+        break;
+    }
+    descriptor.size = new_atlas_size;
+    descriptor.storage_mode = StorageMode::kDevicePrivate;
+    descriptor.usage = TextureUsage::kShaderRead;
+    std::shared_ptr<Texture> new_texture =
+        context.GetResourceAllocator()->CreateTexture(descriptor);
+    if (!new_texture) {
+      return nullptr;
+    }
+
+    new_texture->SetLabel("GlyphAtlas");
+
+    if (last_texture && !atlas_refreshes) {
+      blit_pass->AddCopy(last_texture, new_texture,
+                         IRect::MakeSize(last_atlas_size), {0, 0});
+    }
+    new_atlas->SetTexture(std::move(new_texture));
+  }
 
   // ---------------------------------------------------------------------------
   // Step 3a: Record the positions in the glyph atlas of the newly added
   //          glyphs.
   // ---------------------------------------------------------------------------
-  for (size_t i = first_missing_index; i < glyph_positions.size(); i++) {
+  for (const auto& new_glyph : new_glyphs) {
     new_atlas->AddTypefaceGlyphPositionAndBounds(
-        new_glyphs[i], glyph_positions[i], glyph_sizes[i]);
+        new_glyph.pair, new_glyph.position, new_glyph.bounds);
   }
 
   // ---------------------------------------------------------------------------
   // Step 4a: Draw new font-glyph pairs into the a host buffer and encode
   // the uploads into the blit pass.
   // ---------------------------------------------------------------------------
-  if (!BulkUpdateAtlasBitmap(*new_atlas, blit_pass, data_host_buffer,
-                             new_atlas->GetTexture(), new_glyphs,
-                             first_missing_index, new_glyphs.size())) {
-    return nullptr;
+  if (atlas_refreshes) {
+    if (!BulkUpdateAtlasBitmap(*new_atlas, blit_pass, data_host_buffer,
+                               new_atlas->GetTexture(), new_glyphs)) {
+      return nullptr;
+    }
+  } else {
+    if (!UpdateAtlasBitmap(*new_atlas, blit_pass, data_host_buffer,
+                           new_atlas->GetTexture(), new_glyphs)) {
+      return nullptr;
+    }
   }
-
-  // Blit the old texture to the top left of the new atlas.
-  if (blit_old_atlas && old_texture) {
-    blit_pass->AddCopy(old_texture, new_atlas->GetTexture(),
-                       IRect::MakeSize(new_atlas->GetTexture()->GetSize()),
-                       {0, 0});
-  }
-
-  // ---------------------------------------------------------------------------
-  // Step 8b: Record the texture in the glyph atlas.
-  // ---------------------------------------------------------------------------
 
   return new_atlas;
 }

--- a/engine/src/flutter/impeller/typographer/backends/skia/typographer_context_skia.h
+++ b/engine/src/flutter/impeller/typographer/backends/skia/typographer_context_skia.h
@@ -30,9 +30,40 @@ class TypographerContextSkia : public TypographerContext {
       const std::vector<RenderableText>& renderable_texts) const override;
 
  private:
-  static std::pair<std::vector<FontGlyphPair>, std::vector<Rect>>
-  CollectNewGlyphs(const std::shared_ptr<GlyphAtlas>& atlas,
-                   const std::vector<RenderableText>& renderable_texts);
+  struct NewGlyphData {
+    FontGlyphPair pair;
+    Rect position;
+    Rect bounds;
+  };
+
+  // Because we can't grow the skyline packer horizontally, pick a reasonable
+  // large width for all atlases.
+  static constexpr int64_t kAtlasWidth = 4096;
+  static constexpr int64_t kMinAtlasHeight = 1024;
+
+  static std::vector<NewGlyphData> CollectNewGlyphs(
+      const std::shared_ptr<GlyphAtlas>& atlas,
+      const std::vector<RenderableText>& renderable_texts);
+
+  /// Append all of the glyphs to the rectangle packer, growing it as needed
+  /// to fit them all and return a boolean indicating success.
+  static bool AppendSizesAndGrowPacker(
+      const std::shared_ptr<RectanglePacker>& rect_packer,
+      std::vector<TypographerContextSkia::NewGlyphData>& glyphs,
+      int max_packer_height);
+
+  static bool UpdateAtlasBitmap(const GlyphAtlas& atlas,
+                                std::shared_ptr<BlitPass>& blit_pass,
+                                HostBuffer& data_host_buffer,
+                                const std::shared_ptr<Texture>& texture,
+                                const std::vector<NewGlyphData>& new_glyphs);
+
+  static bool BulkUpdateAtlasBitmap(
+      const GlyphAtlas& atlas,
+      std::shared_ptr<BlitPass>& blit_pass,
+      HostBuffer& data_host_buffer,
+      const std::shared_ptr<Texture>& texture,
+      const std::vector<NewGlyphData>& new_glyphs);
 
   TypographerContextSkia(const TypographerContextSkia&) = delete;
 

--- a/engine/src/flutter/impeller/typographer/glyph_atlas.cc
+++ b/engine/src/flutter/impeller/typographer/glyph_atlas.cc
@@ -25,20 +25,14 @@ const ISize& GlyphAtlasContext::GetAtlasSize() const {
   return atlas_size_;
 }
 
-int64_t GlyphAtlasContext::GetHeightAdjustment() const {
-  return height_adjustment_;
-}
-
-std::shared_ptr<RectanglePacker> GlyphAtlasContext::GetRectPacker() const {
+std::shared_ptr<RectanglePacker>& GlyphAtlasContext::GetRectPacker() {
   return rect_packer_;
 }
 
 void GlyphAtlasContext::UpdateGlyphAtlas(std::shared_ptr<GlyphAtlas> atlas,
-                                         ISize size,
-                                         int64_t height_adjustment) {
+                                         ISize size) {
   atlas_ = std::move(atlas);
   atlas_size_ = size;
-  height_adjustment_ = height_adjustment;
 }
 
 void GlyphAtlasContext::UpdateRectPacker(

--- a/engine/src/flutter/impeller/typographer/glyph_atlas.h
+++ b/engine/src/flutter/impeller/typographer/glyph_atlas.h
@@ -206,23 +206,11 @@ class GlyphAtlasContext {
 
   //----------------------------------------------------------------------------
   /// @brief      Retrieve the previous (if any) rect packer.
-  std::shared_ptr<RectanglePacker> GetRectPacker() const;
-
-  //----------------------------------------------------------------------------
-  /// @brief      A y-coordinate shift that must be applied to glyphs appended
-  /// to
-  ///             the atlas.
-  ///
-  ///             The rectangle packer is only initialized for unfilled regions
-  ///             of the atlas. The area the rectangle packer covers is offset
-  ///             from the origin by this height adjustment.
-  int64_t GetHeightAdjustment() const;
+  std::shared_ptr<RectanglePacker>& GetRectPacker();
 
   //----------------------------------------------------------------------------
   /// @brief      Update the context with a newly constructed glyph atlas.
-  void UpdateGlyphAtlas(std::shared_ptr<GlyphAtlas> atlas,
-                        ISize size,
-                        int64_t height_adjustment_);
+  void UpdateGlyphAtlas(std::shared_ptr<GlyphAtlas> atlas, ISize size);
 
   void UpdateRectPacker(std::shared_ptr<RectanglePacker> rect_packer);
 
@@ -230,7 +218,6 @@ class GlyphAtlasContext {
   std::shared_ptr<GlyphAtlas> atlas_;
   ISize atlas_size_;
   std::shared_ptr<RectanglePacker> rect_packer_;
-  int64_t height_adjustment_;
 
   GlyphAtlasContext(const GlyphAtlasContext&) = delete;
 

--- a/engine/src/flutter/impeller/typographer/rectangle_packer.cc
+++ b/engine/src/flutter/impeller/typographer/rectangle_packer.cc
@@ -28,10 +28,12 @@ class SkylineRectanglePacker final : public RectanglePacker {
     skyline_.push_back(SkylineSegment{0, 0, width()});
   }
 
+  bool GrowTo(int w, int h) override;
+
   bool AddRect(int w, int h, IPoint16* loc) final;
 
   Scalar PercentFull() const final {
-    return area_so_far_ / (static_cast<float>(width()) * height());
+    return 100.0f * area_so_far_ / (static_cast<float>(width()) * height());
   }
 
  private:
@@ -58,6 +60,53 @@ class SkylineRectanglePacker final : public RectanglePacker {
                        int width,
                        int height);
 };
+
+static constexpr bool kImproveEfficiency = true;
+
+bool SkylineRectanglePacker::GrowTo(int w, int h) {
+  // We might potentially be able to reduce the size of the area if there
+  // are no rectangles already packed at those edges, but really there
+  // should be no reason to shrink the packer area so we just forbit it.
+  int old_width = width();
+  int old_height = height();
+  if (w < old_width || h < old_height) {
+    return false;
+  }
+
+  if (kImproveEfficiency) {
+    // Update the skyline to match the new width before we change it.
+    if (w > old_width) {
+      SkylineSegment& last = skyline_.back();
+      if (last.y_ == 0) {
+        // There was a segment at the end of the list that still started at
+        // the bottom of the area, simply extend it to the new width.
+        last.width_ = w - last.x_;
+      } else {
+        // We have a brand new segment of empty space at the end of the list.
+        skyline_.emplace_back(old_width, 0, w - old_width);
+      }
+    }
+    // We can freely expand the height without invalidating the skyline
+    // segments.
+  } else {
+    // Just reduce the skyline to a single flat plane at the old height
+    // so all new allocations go into the new area we just added. This
+    // technique only works if we are growing it in height as it relies
+    // on recreating the skyline itself as a single "floor".
+    //
+    // This code block matches the old behavior of growing the Impeller
+    // glyph cache in which the old packer was abandoned completely and
+    // a new packer allocated that only saw the new space.
+    FML_DCHECK(h > old_height);
+    skyline_.clear();
+    skyline_.emplace_back(0, old_height, w);
+  }
+
+  width_ = w;
+  height_ = h;
+
+  return true;
+}
 
 bool SkylineRectanglePacker::AddRect(int p_width, int p_height, IPoint16* loc) {
   if (static_cast<unsigned>(p_width) > static_cast<unsigned>(width()) ||

--- a/engine/src/flutter/impeller/typographer/rectangle_packer.h
+++ b/engine/src/flutter/impeller/typographer/rectangle_packer.h
@@ -57,18 +57,25 @@ class RectanglePacker {
   ///
   virtual void Reset() = 0;
 
+  //----------------------------------------------------------------------------
+  /// @brief     Resize the specified area, which must be larger that the
+  ///            existing area.
+  ///
+  ///            None of the previously added rectangles will be disturbed.
+  ///
+  virtual bool GrowTo(int width, int height) = 0;
+
+  int width() const { return width_; }
+  int height() const { return height_; }
+
  protected:
   RectanglePacker(int width, int height) : width_(width), height_(height) {
     FML_DCHECK(width >= 0);
     FML_DCHECK(height >= 0);
   }
 
-  int width() const { return width_; }
-  int height() const { return height_; }
-
- private:
-  const int width_;
-  const int height_;
+  int width_;
+  int height_;
 };
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/typographer/typographer_unittests.cc
+++ b/engine/src/flutter/impeller/typographer/typographer_unittests.cc
@@ -389,7 +389,7 @@ TEST_P(TypographerTest, RectanglePackerAddsNonoverlapingRectangles) {
 
   // Initial area was 200 x 100 = 20_000
   // We added 20x20 = 400. 400 / 20_000 == 0.02 == 2%
-  ASSERT_TRUE(flutter::testing::NumberNear(packer->PercentFull(), 0.02));
+  ASSERT_TRUE(flutter::testing::NumberNear(packer->PercentFull(), 2.0f));
 
   IPoint16 second_output = {-1, -1};
   ASSERT_TRUE(packer->AddRect(140, 90, &second_output));
@@ -402,14 +402,14 @@ TEST_P(TypographerTest, RectanglePackerAddsNonoverlapingRectangles) {
 
   // We added another 90 x 140 = 12_600 units, now taking us to 13_000
   // 13_000 / 20_000 == 0.65 == 65%
-  ASSERT_TRUE(flutter::testing::NumberNear(packer->PercentFull(), 0.65));
+  ASSERT_TRUE(flutter::testing::NumberNear(packer->PercentFull(), 65.0f));
 
   // There's enough area to add this rectangle, but no space big enough for
   // the 50 units of width.
   IPoint16 output;
   ASSERT_FALSE(packer->AddRect(50, 50, &output));
   // Should be unchanged.
-  ASSERT_TRUE(flutter::testing::NumberNear(packer->PercentFull(), 0.65));
+  ASSERT_TRUE(flutter::testing::NumberNear(packer->PercentFull(), 65.0f));
 
   packer->Reset();
   // Should be empty now.
@@ -437,6 +437,79 @@ TEST(TypographerTest, RectanglePackerFillsRows) {
   EXPECT_EQ(loc.y(), 16);
 }
 
+TEST(TypographerTest, RectanglePackerDoesNotShrink) {
+  auto skyline = RectanglePacker::Factory(200, 200);
+
+  EXPECT_FALSE(skyline->GrowTo(199, 200));
+  EXPECT_FALSE(skyline->GrowTo(200, 199));
+  EXPECT_FALSE(skyline->GrowTo(199, 201));
+  EXPECT_FALSE(skyline->GrowTo(201, 199));
+  EXPECT_FALSE(skyline->GrowTo(std::numeric_limits<int>::min(), 200));
+  EXPECT_FALSE(skyline->GrowTo(200, std::numeric_limits<int>::min()));
+  EXPECT_FALSE(skyline->GrowTo(std::numeric_limits<int>::min(), 201));
+  EXPECT_FALSE(skyline->GrowTo(201, std::numeric_limits<int>::min()));
+}
+
+TEST(TypographerTest, RectanglePackerGrowsVertically) {
+  auto skyline = RectanglePacker::Factory(200, 200);
+  IPoint16 loc;
+
+  // We should be able to fit a grid of 10x10 rects of size 20x20
+  for (int i = 0; i < 100; i++) {
+    EXPECT_TRUE(skyline->AddRect(20, 20, &loc)) << "index: " << i;
+  }
+  // We should not able to fit a single additional rect.
+  EXPECT_FALSE(skyline->AddRect(1, 1, &loc));
+
+  EXPECT_TRUE(skyline->GrowTo(200, 400));
+  // We should be able to fit a second grid of 10x10 rects of size 20x20
+  for (int i = 0; i < 100; i++) {
+    EXPECT_TRUE(skyline->AddRect(20, 20, &loc)) << "index: " << i;
+  }
+  // We should not able to fit a single additional rect.
+  EXPECT_FALSE(skyline->AddRect(1, 1, &loc));
+}
+
+TEST(TypographerTest, RectanglePackerGrowsHorizontally) {
+  auto skyline = RectanglePacker::Factory(200, 200);
+  IPoint16 loc;
+
+  // We should be able to fit a grid of 10x10 rects of size 20x20
+  for (int i = 0; i < 100; i++) {
+    EXPECT_TRUE(skyline->AddRect(20, 20, &loc)) << "index: " << i;
+  }
+  // We should not able to fit a single additional rect.
+  EXPECT_FALSE(skyline->AddRect(1, 1, &loc));
+
+  EXPECT_TRUE(skyline->GrowTo(400, 200));
+  // We should be able to fit a second grid of 10x10 rects of size 20x20
+  for (int i = 0; i < 100; i++) {
+    EXPECT_TRUE(skyline->AddRect(20, 20, &loc)) << "index: " << i;
+  }
+  // We should not able to fit a single additional rect.
+  EXPECT_FALSE(skyline->AddRect(1, 1, &loc));
+}
+
+TEST(TypographerTest, RectanglePackerGrowsBothDirections) {
+  auto skyline = RectanglePacker::Factory(200, 200);
+  IPoint16 loc;
+
+  // We should be able to fit a grid of 10x10 rects of size 20x20
+  for (int i = 0; i < 100; i++) {
+    EXPECT_TRUE(skyline->AddRect(20, 20, &loc)) << "index: " << i;
+  }
+  // We should not able to fit a single additional rect.
+  EXPECT_FALSE(skyline->AddRect(1, 1, &loc));
+
+  EXPECT_TRUE(skyline->GrowTo(400, 400));
+  // We should be able to fit 3 more grids of 10x10 rects of size 20x20
+  for (int i = 0; i < 100 * 3; i++) {
+    EXPECT_TRUE(skyline->AddRect(20, 20, &loc)) << "index: " << i;
+  }
+  // We should not able to fit a single additional rect.
+  EXPECT_FALSE(skyline->AddRect(1, 1, &loc));
+}
+
 TEST_P(TypographerTest, GlyphAtlasTextureWillGrowTilMaxTextureSize) {
   if (GetBackend() == PlaygroundBackend::kOpenGLES) {
     GTEST_SKIP() << "Atlas growth isn't supported for OpenGLES currently.";
@@ -456,11 +529,14 @@ TEST_P(TypographerTest, GlyphAtlasTextureWillGrowTilMaxTextureSize) {
       CreateGlyphAtlas(*GetContext(), context.get(), *data_host_buffer,
                        GlyphAtlas::Type::kAlphaBitmap, Matrix(), atlas_context,
                        MakeTextFrameFromTextBlobSkia(blob));
+  constexpr int test_count = 15;
   // Continually append new glyphs until the glyph size grows to the maximum.
   // Note that the sizes here are more or less experimentally determined, but
   // the important expectation is that the atlas size will shrink again after
   // growing to the maximum size.
-  constexpr ISize expected_sizes[13] = {
+  constexpr ISize expected_sizes[test_count] = {
+      {4096, 2048},   //
+      {4096, 2048},   //
       {4096, 4096},   //
       {4096, 4096},   //
       {4096, 8192},   //
@@ -476,9 +552,72 @@ TEST_P(TypographerTest, GlyphAtlasTextureWillGrowTilMaxTextureSize) {
       {4096, 4096}    // Shrinks!
   };
 
+  constexpr std::array<Rect, 2> expected_glyph_sizes[test_count] = {
+      {{
+          Rect::MakeLTRB(-37.5, -1762.5, 1575, 37.5),
+          Rect::MakeLTRB(30.0f, -352.5f, 285.0f, 7.5f),
+      }},
+      {{
+          Rect::MakeLTRB(-38.25, -1797.75, 1606.5, 38.25),
+          Rect::MakeLTRB(30.0f, -352.5f, 285.0f, 7.5f),
+      }},
+      {{
+          Rect::MakeLTRB(-39, -1833, 1638, 39),
+          Rect::MakeLTRB(30.0f, -352.5f, 285.0f, 7.5f),
+      }},
+      {{
+          Rect::MakeLTRB(-39.75, -1868.25, 1669.5, 39.75),
+          Rect::MakeLTRB(30.0f, -352.5f, 285.0f, 7.5f),
+      }},
+      {{
+          Rect::MakeLTRB(-40.5, -1903.5, 1701, 40.5),
+          Rect::MakeLTRB(30.0f, -352.5f, 285.0f, 7.5f),
+      }},
+      {{
+          Rect::MakeLTRB(-41.25, -1938.75, 1732.5, 41.25),
+          Rect::MakeLTRB(30.0f, -352.5f, 285.0f, 7.5f),
+      }},
+      {{
+          Rect::MakeLTRB(-42, -1974, 1764, 42),
+          Rect::MakeLTRB(30.0f, -352.5f, 285.0f, 7.5f),
+      }},
+      {{
+          Rect::MakeLTRB(-42.75, -2009.25, 1795.5, 42.75),
+          Rect::MakeLTRB(30.0f, -352.5f, 285.0f, 7.5f),
+      }},
+      {{
+          Rect::MakeLTRB(-43.5, -2044.5, 1827, 43.5),
+          Rect::MakeLTRB(30.0f, -352.5f, 285.0f, 7.5f),
+      }},
+      {{
+          Rect::MakeLTRB(-44.25, -2079.75, 1858.5, 44.25),
+          Rect::MakeLTRB(30.0f, -352.5f, 285.0f, 7.5f),
+      }},
+      {{
+          Rect::MakeLTRB(-45, -2115, 1890, 45),
+          Rect::MakeLTRB(30.0f, -352.5f, 285.0f, 7.5f),
+      }},
+      {{
+          Rect::MakeLTRB(-45.75, -2150.25, 1921.5, 45.75),
+          Rect::MakeLTRB(30.0f, -352.5f, 285.0f, 7.5f),
+      }},
+      {{
+          Rect::MakeLTRB(-46.5, -2185.5, 1953, 46.5),
+          Rect::MakeLTRB(30.0f, -352.5f, 285.0f, 7.5f),
+      }},
+      {{
+          Rect::MakeLTRB(-47.25, -2220.75, 1984.5, 47.25),
+          Rect::MakeLTRB(30.0f, -352.5f, 285.0f, 7.5f),
+      }},
+      {{
+          Rect::MakeLTRB(-48, -2256, 2016, 48),
+          Rect::MakeLTRB(30.0f, -352.5f, 285.0f, 7.5f),
+      }},
+  };
+
   SkFont sk_font_small = flutter::testing::CreateTestFontOfSize(10);
 
-  for (int i = 0; i < 13; i++) {
+  for (int i = 0; i < test_count; i++) {
     SkTextBlobBuilder builder;
 
     auto add_char = [&](const SkFont& sk_font, char c) {
@@ -496,13 +635,43 @@ TEST_P(TypographerTest, GlyphAtlasTextureWillGrowTilMaxTextureSize) {
     auto blob = builder.make();
 
     Matrix transform = Matrix::MakeScale({50.0f + i, 50.0f + i, 1.0f});
-    atlas =
-        CreateGlyphAtlas(*GetContext(), context.get(), *data_host_buffer,
-                         GlyphAtlas::Type::kAlphaBitmap, transform,
-                         atlas_context, MakeTextFrameFromTextBlobSkia(blob));
+    auto frame = MakeTextFrameFromTextBlobSkia(blob);
+    ASSERT_EQ(frame->GetRunCount(), 2u);
+    atlas = CreateGlyphAtlas(*GetContext(), context.get(), *data_host_buffer,
+                             GlyphAtlas::Type::kAlphaBitmap, transform,
+                             atlas_context, frame);
     ASSERT_TRUE(!!atlas);
+
+    EXPECT_GE(atlas->GetGlyphCount(), 2u);
+    int run_index = 0;
+    int glyph_index = 0;
+    for (const auto& run : frame->GetRuns()) {
+      Rational rounded_scale =
+          TextFrame::RoundScaledFontSize(transform.GetMaxBasisLengthXY());
+      ScaledFont scaled_font = {
+          .font = run.GetFont(),
+          .scale = rounded_scale,
+      };
+      for (const auto& glyph_position : run.GetGlyphPositions()) {
+        SubpixelPosition subpixel = TextFrame::ComputeSubpixelPosition(
+            glyph_position, scaled_font.font.GetAxisAlignment(), transform);
+        SubpixelGlyph subpixel_glyph(glyph_position.glyph, subpixel, {});
+        auto font_glyph_atlas = atlas->GetFontGlyphAtlas(scaled_font);
+        const auto& font_glyph_bounds =
+            font_glyph_atlas->FindGlyphBounds(subpixel_glyph);
+        ASSERT_TRUE(font_glyph_bounds.has_value());
+        EXPECT_EQ(font_glyph_bounds->glyph_bounds,
+                  expected_glyph_sizes[i][glyph_index])
+            << "test index: " << i           //
+            << ", run index: " << run_index  //
+            << ", glyph index: " << glyph_index;
+        glyph_index++;
+      }
+      run_index++;
+    }
     EXPECT_EQ(atlas->GetTexture()->GetTextureDescriptor().size,
-              expected_sizes[i]);
+              expected_sizes[i])
+        << "at index: " << i;
   }
 
   // The final atlas should contain both the "A" glyph (which was not present


### PR DESCRIPTION
Might help with: https://github.com/flutter/flutter/issues/183297
Fixes: https://github.com/flutter/flutter/issues/183139

The glyph cache was only replacing the cache when it was already at maximum size before we got a new set of glyphs to add to it.

This could have potentially led to a failure if the glyph was not at maximum size, but the new set of glyphs would put it over. In that case we could not grow the cache enough for the new glyphs, but we'd already passed the point of reconsideration for replacing it.

The new code will first determine whether we can stuff the glyphs into the old cache, or how they should be positioned if we start over if that fails. At that point all of the decisions will have been made so we know whether we need to regrow or replace the cache so we can proceed without painting ourselves into a "cache updating" corner later.

At the same time, the algorithm provides an opportunity for the rectangle packer to grow its arena of space as it needs to pack more glyphs in. Previously we'd abandon the packer and create a new one for the new space, but abandon the space in the old area of the pre-grown cache. The new code in the SkylinePacker can produce either behavior - abandoning the space by creating a new "skyline floor", or just expanding the height and remembering the previous skyline data. This is the part that fixes https://github.com/flutter/flutter/issues/183139.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.