### PR TITLE
[flutter_tools] Guard daemon input parser against malformed JSON lines

### DIFF
--- a/packages/flutter_tools/lib/src/daemon.dart
+++ b/packages/flutter_tools/lib/src/daemon.dart
@@ -135,17 +135,21 @@ class DaemonInputStreamConverter {
     String jsonString = utf8.decode(combinedChunk).trim();
     if (jsonString.startsWith('[{') && jsonString.endsWith('}]')) {
       jsonString = jsonString.substring(1, jsonString.length - 1);
-      final Map<String, Object?>? value = castStringKeyedMap(json.decode(jsonString));
-      if (value != null) {
-        // Check if we need to consume another binary blob.
-        if (value[_binaryLengthKey] != null) {
-          remainingBinaryLength = value[_binaryLengthKey]! as int;
-          currentBinaryStream = StreamController<List<int>>();
-          state = _InputStreamParseState.binary;
-          _controller.add(DaemonMessage(value, currentBinaryStream.stream));
-        } else {
-          _controller.add(DaemonMessage(value));
+      try {
+        final Map<String, Object?>? value = castStringKeyedMap(json.decode(jsonString));
+        if (value != null) {
+          // Check if we need to consume another binary blob.
+          if (value[_binaryLengthKey] != null) {
+            remainingBinaryLength = value[_binaryLengthKey]! as int;
+            currentBinaryStream = StreamController<List<int>>();
+            state = _InputStreamParseState.binary;
+            _controller.add(DaemonMessage(value, currentBinaryStream.stream));
+          } else {
+            _controller.add(DaemonMessage(value));
+          }
         }
+      } on FormatException {
+        // Ignore malformed JSON lines and continue parsing subsequent messages.
       }
     }
 

--- a/packages/flutter_tools/lib/src/daemon.dart
+++ b/packages/flutter_tools/lib/src/daemon.dart
@@ -148,8 +148,8 @@ class DaemonInputStreamConverter {
             _controller.add(DaemonMessage(value));
           }
         }
-      } on FormatException {
-        // Ignore malformed JSON lines and continue parsing subsequent messages.
+      } on Object {
+        // Ignore malformed daemon JSON lines and continue parsing subsequent messages.
       }
     }
 

--- a/packages/flutter_tools/lib/src/daemon.dart
+++ b/packages/flutter_tools/lib/src/daemon.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io' show stderr;
 import 'dart:typed_data';
 
 import 'package:meta/meta.dart';
@@ -148,8 +149,8 @@ class DaemonInputStreamConverter {
             _controller.add(DaemonMessage(value));
           }
         }
-      } on Object {
-        // Ignore malformed daemon JSON lines and continue parsing subsequent messages.
+      } on Object catch (error) {
+        stderr.writeln('Ignoring malformed daemon JSON line: $jsonString\n$error');
       }
     }
 

--- a/packages/flutter_tools/test/general.shard/daemon_test.dart
+++ b/packages/flutter_tools/test/general.shard/daemon_test.dart
@@ -247,6 +247,25 @@ void main() {
     );
 
     testWithoutContext(
+      'can parse multiple messages while ignoring malformed json data in between',
+      () async {
+        final inputStream = Stream<List<int>>.fromIterable(<List<int>>[
+          testCommandBinary(10),
+          utf8.encode('[{"id":}\n'),
+          testCommandBinary(20),
+        ]);
+        final converter = DaemonInputStreamConverter(inputStream);
+        final Stream<DaemonMessage> outputStream = converter.convertedStream;
+        final List<DaemonMessage> outputs = await outputStream.toList();
+        expect(outputs, hasLength(2));
+        expect(outputs[0].data, testCommand(10));
+        expect(outputs[0].binary, null);
+        expect(outputs[1].data, testCommand(20));
+        expect(outputs[1].binary, null);
+      },
+    );
+
+    testWithoutContext(
       'can parse multiple messages even when they are split in multiple packets',
       () async {
         final List<int> binary1 = testCommandBinary(10);

--- a/packages/flutter_tools/test/general.shard/daemon_test.dart
+++ b/packages/flutter_tools/test/general.shard/daemon_test.dart
@@ -251,7 +251,7 @@ void main() {
       () async {
         final inputStream = Stream<List<int>>.fromIterable(<List<int>>[
           testCommandBinary(10),
-          utf8.encode('[{"id":}\n'),
+          utf8.encode('[{"id":}]\n'),
           testCommandBinary(20),
         ]);
         final converter = DaemonInputStreamConverter(inputStream);


### PR DESCRIPTION
This patch hardens `DaemonInputStreamConverter` against malformed JSON lines in daemon input streams.

Previously, if a line matched the daemon framing (`[{...}]`) but contained malformed JSON, `json.decode` could throw and crash the tool. We now catch `FormatException` for that line and continue parsing subsequent messages.

I also added a regression test that injects malformed JSON between two valid daemon messages and verifies both valid messages are still parsed.

Fixes #183957.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

## Tests

- `dart format packages/flutter_tools/lib/src/daemon.dart packages/flutter_tools/test/general.shard/daemon_test.dart`
- `flutter test packages/flutter_tools/test/general.shard/daemon_test.dart` *(fails in this environment due to local SDK/framework mismatch unrelated to this patch: `DisplayCornerRadii` / `FlutterView` API mismatch)*

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
