### PR TITLE
[flutter_tools] Skip SwiftPM plugin schemes during flutter clean

### DIFF
--- a/packages/flutter_tools/lib/src/commands/clean.dart
+++ b/packages/flutter_tools/lib/src/commands/clean.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:meta/meta.dart';
 
 import '../../src/macos/xcode.dart';
@@ -12,6 +14,7 @@ import '../base/logger.dart';
 import '../build_info.dart';
 import '../globals.dart' as globals;
 import '../ios/xcodeproj.dart';
+import '../macos/swift_package_manager.dart';
 import '../project.dart';
 import '../runner/flutter_command.dart';
 
@@ -97,7 +100,12 @@ class CleanCommand extends FlutterCommand {
           verbose: _verbose,
         );
       } else {
+        final Set<String> swiftPackagePluginSchemes = _swiftPackagePluginSchemes(xcodeProject);
         for (final String scheme in projectInfo.schemes) {
+          if (swiftPackagePluginSchemes.contains(scheme)) {
+            globals.printTrace('Skipping SwiftPM plugin scheme during clean: $scheme');
+            continue;
+          }
           await xcodeProjectInterpreter.cleanWorkspace(
             xcodeWorkspace.path,
             scheme,
@@ -114,6 +122,50 @@ class CleanCommand extends FlutterCommand {
       }
     } finally {
       xcodeStatus.stop();
+    }
+  }
+
+  Set<String> _swiftPackagePluginSchemes(XcodeBasedProject xcodeProject) {
+    final File pluginsDependenciesFile = xcodeProject.parent.flutterPluginsDependenciesFile;
+    if (!pluginsDependenciesFile.existsSync()) {
+      return const <String>{};
+    }
+
+    try {
+      final Object? decoded = json.decode(pluginsDependenciesFile.readAsStringSync());
+      if (decoded is! Map<String, Object?>) {
+        return const <String>{};
+      }
+
+      final Object? swiftPmEnabled = decoded['swift_package_manager_enabled'];
+      if (swiftPmEnabled is! Map<String, Object?> ||
+          swiftPmEnabled[xcodeProject.pluginConfigKey] != true) {
+        return const <String>{};
+      }
+
+      final Object? pluginsObject = decoded['plugins'];
+      if (pluginsObject is! Map<String, Object?>) {
+        return const <String>{};
+      }
+      final Object? platformPlugins = pluginsObject[xcodeProject.pluginConfigKey];
+      if (platformPlugins is! List<Object?>) {
+        return const <String>{};
+      }
+
+      final pluginSchemes = <String>{kFlutterGeneratedPluginSwiftPackageName};
+      for (final Object? plugin in platformPlugins) {
+        if (plugin is! Map<String, Object?>) {
+          continue;
+        }
+        final Object? name = plugin['name'];
+        if (name is String && name.isNotEmpty) {
+          pluginSchemes.add(name);
+        }
+      }
+      return pluginSchemes;
+    } on FormatException catch (error) {
+      globals.printTrace('Unable to parse ${pluginsDependenciesFile.path}: $error');
+      return const <String>{};
     }
   }
 

--- a/packages/flutter_tools/lib/src/commands/clean.dart
+++ b/packages/flutter_tools/lib/src/commands/clean.dart
@@ -153,15 +153,13 @@ class CleanCommand extends FlutterCommand {
       }
 
       final pluginSchemes = <String>{kFlutterGeneratedPluginSwiftPackageName};
-      for (final Object? plugin in platformPlugins) {
-        if (plugin is! Map<String, Object?>) {
-          continue;
-        }
-        final Object? name = plugin['name'];
-        if (name is String && name.isNotEmpty) {
-          pluginSchemes.add(name);
-        }
-      }
+      pluginSchemes.addAll(
+        platformPlugins
+            .whereType<Map<String, Object?>>()
+            .map((Map<String, Object?> plugin) => plugin['name'])
+            .whereType<String>()
+            .where((String name) => name.isNotEmpty),
+      );
       return pluginSchemes;
     } on FormatException catch (error) {
       globals.printTrace('Unable to parse ${pluginsDependenciesFile.path}: $error');

--- a/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
@@ -297,7 +297,18 @@ FlutterProject setupProjectUnderTest(Directory currentDirectory, bool setupXcode
   projectUnderTest.macos.ephemeralDirectory.createSync(recursive: true);
   projectUnderTest.macos.flutterPluginSwiftPackageDirectory.createSync(recursive: true);
   projectUnderTest.windows.ephemeralDirectory.createSync(recursive: true);
-  projectUnderTest.flutterPluginsDependenciesFile.createSync(recursive: true);
+  projectUnderTest.flutterPluginsDependenciesFile.writeAsStringSync('''
+{
+  "plugins": {
+    "ios": [{"name": "swift_package_plugin"}],
+    "macos": [{"name": "swift_package_plugin"}]
+  },
+  "swift_package_manager_enabled": {
+    "ios": true,
+    "macos": true
+  }
+}
+''');
 
   return projectUnderTest;
 }
@@ -314,6 +325,8 @@ class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterprete
     return XcodeProjectInfo(const <String>[], const <String>[], <String>[
       'Runner',
       'custom-scheme',
+      'swift_package_plugin',
+      'FlutterGeneratedPluginSwiftPackage',
     ], BufferLogger.test());
   }
 


### PR DESCRIPTION
`flutter clean` currently iterates every scheme from `xcodebuild -list` and runs `xcodebuild clean` on each one.

When Swift Package Manager plugin integration is enabled, plugin package schemes are also listed. Those schemes are not app schemes and can fail clean. This change keeps the current behavior for explicit `--scheme` clean, but in the default path filters out SwiftPM plugin schemes by reading `.flutter-plugins-dependencies` for the current platform and skipping:

- plugin names listed under `plugins.{ios|macos}` when `swift_package_manager_enabled.{ios|macos}` is `true`
- `FlutterGeneratedPluginSwiftPackage`

A hermetic `clean_test` update verifies that plugin schemes are present in `XcodeProjectInfo` and not passed to `cleanWorkspace`.

Fixes https://github.com/flutter/flutter/issues/183946

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
