### PR TITLE
[Flutter GPU] Improve context initialization error messages

### DIFF
--- a/engine/src/flutter/lib/gpu/context.cc
+++ b/engine/src/flutter/lib/gpu/context.cc
@@ -41,14 +41,23 @@ std::shared_ptr<impeller::Context> Context::GetDefaultContext(
   }
 
   auto dart_state = flutter::UIDartState::Current();
+  if (!dart_state->IsImpellerEnabled()) {
+    out_error =
+        "Flutter GPU requires the Impeller rendering backend, but Impeller is "
+        "not enabled. Impeller can be enabled by adding the FLTEnableImpeller "
+        "key set to true in the Info.plist on iOS/macOS, or the "
+        "io.flutter.embedding.android.EnableImpeller metadata key to true in "
+        "the AndroidManifest.xml on Android.";
+    return nullptr;
+  }
   if (!dart_state->IsFlutterGPUEnabled()) {
     out_error =
         "Flutter GPU must be enabled via the Flutter GPU manifest "
         "setting. This can be done either via command line argument "
         "--enable-flutter-gpu or "
-        "by adding the FLTEnableFlutterGPU key set to true on iOS or "
-        "io.flutter.embedding.android.EnableFlutterGPU metadata key to true on "
-        "Android.";
+        "by adding the FLTEnableFlutterGPU key set to true in the Info.plist "
+        "on iOS/macOS, or the io.flutter.embedding.android.EnableFlutterGPU "
+        "metadata key to true in the AndroidManifest.xml on Android.";
     return nullptr;
   }
   // Grab the Impeller context from the IO manager.

--- a/engine/src/flutter/lib/gpu/context.cc
+++ b/engine/src/flutter/lib/gpu/context.cc
@@ -44,10 +44,8 @@ std::shared_ptr<impeller::Context> Context::GetDefaultContext(
   if (!dart_state->IsImpellerEnabled()) {
     out_error =
         "Flutter GPU requires the Impeller rendering backend, but Impeller is "
-        "not enabled. Impeller can be enabled by adding the FLTEnableImpeller "
-        "key set to true in the Info.plist on iOS/macOS, or the "
-        "io.flutter.embedding.android.EnableImpeller metadata key to true in "
-        "the AndroidManifest.xml on Android.";
+        "not enabled. For more details about where Impeller is available and "
+        "how to enable it, see: https://docs.flutter.dev/perf/impeller";
     return nullptr;
   }
   if (!dart_state->IsFlutterGPUEnabled()) {

--- a/engine/src/flutter/testing/dart/gpu_test.dart
+++ b/engine/src/flutter/testing/dart/gpu_test.dart
@@ -148,21 +148,49 @@ void drawTriangle(RenderPassState state, Vector4 color) {
 void main() async {
   final ImageComparer comparer = await ImageComparer.create();
 
-  test('gpu.context throws exception for incompatible embedders', () async {
+  test('gpu.context throws exception when Impeller is not enabled', () async {
     try {
       // ignore: unnecessary_statements
       gpu.gpuContext; // Force the context to instantiate.
       if (!impellerEnabled) {
-        fail('Exception not thrown, but no Impeller context available.');
+        fail('Exception not thrown, but Impeller is not enabled.');
       }
     } catch (e) {
       if (impellerEnabled) {
-        fail('Exception thrown even though Impeller is enabled.');
+        fail('Exception thrown even though Impeller is enabled: $e');
       }
-      expect(
-        e.toString(),
-        contains('Exception: Flutter GPU must be enabled via the Flutter GPU manifest setting'),
-      );
+      expect(e.toString(), contains('Flutter GPU requires the Impeller rendering backend'));
+    }
+  });
+
+  test('gpu.context throws exception when Flutter GPU is not enabled', () async {
+    try {
+      // ignore: unnecessary_statements
+      gpu.gpuContext; // Force the context to instantiate.
+      if (!flutterGpuEnabled) {
+        fail('Exception not thrown, but Flutter GPU is not enabled.');
+      }
+    } catch (e) {
+      if (flutterGpuEnabled && impellerEnabled) {
+        fail('Exception thrown even though Flutter GPU and Impeller are both enabled: $e');
+      }
+      if (impellerEnabled) {
+        expect(
+          e.toString(),
+          contains('Flutter GPU must be enabled via the Flutter GPU manifest setting'),
+        );
+      }
+    }
+  });
+
+  test('gpu.context is available when Impeller and Flutter GPU are enabled', () async {
+    try {
+      // ignore: unnecessary_statements
+      gpu.gpuContext; // Force the context to instantiate.
+    } catch (e) {
+      if (impellerEnabled && flutterGpuEnabled) {
+        fail('Exception thrown even though Impeller and Flutter GPU are enabled: $e');
+      }
     }
   });
 

--- a/engine/src/flutter/testing/dart/gpu_test.dart
+++ b/engine/src/flutter/testing/dart/gpu_test.dart
@@ -615,7 +615,7 @@ void main() async {
     },
     // TODO(b-luk): https://github.com/flutter/flutter/issues/183530 Re-enable for opengles.
     skip:
-        !(impellerEnabled && gpu.gpuContext.doesSupportOffscreenMSAA) ||
+        !(impellerEnabled && flutterGpuEnabled && gpu.gpuContext.doesSupportOffscreenMSAA) ||
         impellerBackend == 'opengles',
   );
 
@@ -636,7 +636,7 @@ void main() async {
         );
       }
     },
-    skip: !(impellerEnabled && !gpu.gpuContext.doesSupportOffscreenMSAA),
+    skip: !(impellerEnabled && flutterGpuEnabled && !gpu.gpuContext.doesSupportOffscreenMSAA),
   );
 
   // Renders a hollow green triangle pointing downwards.

--- a/engine/src/flutter/testing/dart/gpu_test.dart
+++ b/engine/src/flutter/testing/dart/gpu_test.dart
@@ -199,7 +199,7 @@ void main() async {
   test('GpuContext.minimumUniformByteAlignment', () async {
     final int alignment = gpu.gpuContext.minimumUniformByteAlignment;
     expect(alignment, greaterThanOrEqualTo(16));
-  }, skip: !impellerEnabled || !flutterGpuEnabled);
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   test('HostBuffer.emplace', () async {
     final gpu.HostBuffer hostBuffer = gpu.gpuContext.createHostBuffer();
@@ -215,7 +215,7 @@ void main() async {
     );
     expect(view1.offsetInBytes, equals(gpu.gpuContext.minimumUniformByteAlignment));
     expect(view1.lengthInBytes, 4);
-  }, skip: !impellerEnabled || !flutterGpuEnabled);
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   test('HostBuffer.reset', () async {
     final gpu.HostBuffer hostBuffer = gpu.gpuContext.createHostBuffer();
@@ -233,7 +233,7 @@ void main() async {
     );
     expect(view1.offsetInBytes, 0);
     expect(view1.lengthInBytes, 4);
-  }, skip: !impellerEnabled || !flutterGpuEnabled);
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   test('HostBuffer reuses DeviceBuffers after N frames', () async {
     final gpu.HostBuffer hostBuffer = gpu.gpuContext.createHostBuffer();
@@ -250,7 +250,7 @@ void main() async {
     );
 
     expect(view0.buffer, equals(view1.buffer));
-  }, skip: !impellerEnabled || !flutterGpuEnabled);
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   test('GpuContext.createDeviceBuffer', () async {
     final gpu.DeviceBuffer deviceBuffer = gpu.gpuContext.createDeviceBuffer(
@@ -259,7 +259,7 @@ void main() async {
     );
 
     expect(deviceBuffer.sizeInBytes, 4);
-  }, skip: !impellerEnabled || !flutterGpuEnabled);
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   test('DeviceBuffer.overwrite', () async {
     final gpu.DeviceBuffer deviceBuffer = gpu.gpuContext.createDeviceBuffer(
@@ -272,7 +272,7 @@ void main() async {
     );
     deviceBuffer.flush();
     expect(success, true);
-  }, skip: !impellerEnabled || !flutterGpuEnabled);
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   test('DeviceBuffer.overwrite fails when out of bounds', () async {
     final gpu.DeviceBuffer deviceBuffer = gpu.gpuContext.createDeviceBuffer(
@@ -286,7 +286,7 @@ void main() async {
     );
     deviceBuffer.flush();
     expect(success, false);
-  }, skip: !impellerEnabled || !flutterGpuEnabled);
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   test(
     'DeviceBuffer.overwrite throws for negative destination offset',
@@ -307,7 +307,7 @@ void main() async {
         expect(e.toString(), contains('destinationOffsetInBytes must be positive'));
       }
     },
-    skip: !impellerEnabled || !flutterGpuEnabled,
+    skip: !(impellerEnabled && flutterGpuEnabled),
   );
 
   test('GpuContext.createTexture', () async {
@@ -326,7 +326,7 @@ void main() async {
     expect(!texture.enableShaderWriteUsage, true);
     expect(texture.bytesPerTexel, 4);
     expect(texture.getBaseMipLevelSizeInBytes(), 40000);
-  }, skip: !impellerEnabled || !flutterGpuEnabled);
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   test(
     'GpuContext.createTexture fails if invalid sampleCount and texture type is passed.',
@@ -344,7 +344,7 @@ void main() async {
         expect(e.toString(), contains('Texture creation failed'));
       }
     },
-    skip: !impellerEnabled || !flutterGpuEnabled,
+    skip: !(impellerEnabled && flutterGpuEnabled),
   );
 
   test('Texture.overwrite', () async {
@@ -355,7 +355,7 @@ void main() async {
     texture.overwrite(
       Int32List.fromList(<int>[red.value, green.value, green.value, red.value]).buffer.asByteData(),
     );
-  }, skip: !impellerEnabled || !flutterGpuEnabled);
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   test('Texture.overwrite throws for wrong buffer size', () async {
     final gpu.Texture texture = gpu.gpuContext.createTexture(gpu.StorageMode.hostVisible, 100, 100);
@@ -374,7 +374,7 @@ void main() async {
         ),
       );
     }
-  }, skip: !impellerEnabled || !flutterGpuEnabled);
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   test('Texture.asImage returns a valid ui.Image handle', () async {
     final gpu.Texture texture = gpu.gpuContext.createTexture(gpu.StorageMode.hostVisible, 100, 100);
@@ -382,7 +382,7 @@ void main() async {
     final ui.Image image = texture.asImage();
     expect(image.width, 100);
     expect(image.height, 100);
-  }, skip: !impellerEnabled || !flutterGpuEnabled);
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   test('Texture.asImage throws when not shader readable', () async {
     final gpu.Texture texture = gpu.gpuContext.createTexture(
@@ -401,7 +401,7 @@ void main() async {
         contains('Only shader readable Flutter GPU textures can be used as UI Images'),
       );
     }
-  }, skip: !impellerEnabled || !flutterGpuEnabled);
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   test(
     'RenderPass.setStencilReference doesnt throw for valid values',
@@ -411,7 +411,7 @@ void main() async {
       state.renderPass.setStencilReference(0);
       state.renderPass.setStencilReference(2 << 30);
     },
-    skip: !impellerEnabled || !flutterGpuEnabled,
+    skip: !(impellerEnabled && flutterGpuEnabled),
   );
 
   test(
@@ -433,7 +433,7 @@ void main() async {
         expect(e.toString(), contains('The stencil reference value must be in the range'));
       }
     },
-    skip: !impellerEnabled || !flutterGpuEnabled,
+    skip: !(impellerEnabled && flutterGpuEnabled),
   );
 
   test(
@@ -454,7 +454,7 @@ void main() async {
         targetFace: gpu.StencilFace.back,
       );
     },
-    skip: !impellerEnabled || !flutterGpuEnabled,
+    skip: !(impellerEnabled && flutterGpuEnabled),
   );
 
   test(
@@ -488,7 +488,7 @@ void main() async {
         expect(e.toString(), contains('The stencil write mask must be in the range'));
       }
     },
-    skip: !impellerEnabled || !flutterGpuEnabled,
+    skip: !(impellerEnabled && flutterGpuEnabled),
   );
 
   test(
@@ -517,7 +517,7 @@ void main() async {
         );
       }
     },
-    skip: !impellerEnabled || !flutterGpuEnabled,
+    skip: !(impellerEnabled && flutterGpuEnabled),
   );
 
   // Performs no draw calls. Just clears the render target to a solid green color.
@@ -528,7 +528,7 @@ void main() async {
 
     final ui.Image image = state.renderTexture.asImage();
     await comparer.addGoldenImage(image, 'flutter_gpu_test_clear_color.png');
-  }, skip: !impellerEnabled || !flutterGpuEnabled);
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   // Regression test for https://github.com/flutter/flutter/issues/157324
   test('Can bind uniforms in range', () async {
@@ -563,7 +563,7 @@ void main() async {
     } catch (e) {
       expect(e.toString(), contains('Failed to bind uniform'));
     }
-  }, skip: !impellerEnabled || !flutterGpuEnabled);
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   // Renders a green triangle pointing downwards.
   test(
@@ -577,7 +577,7 @@ void main() async {
       await comparer.addGoldenImage(image, 'flutter_gpu_test_triangle.png');
     },
     // TODO(b-luk): https://github.com/flutter/flutter/issues/183530 Re-enable for opengles.
-    skip: !impellerEnabled || !flutterGpuEnabled || impellerBackend == 'opengles',
+    skip: !(impellerEnabled && flutterGpuEnabled) || impellerBackend == 'opengles',
   );
 
   // Renders a green triangle pointing downwards using polygon mode line.
@@ -625,7 +625,7 @@ void main() async {
       await comparer.addGoldenImage(image, 'flutter_gpu_test_triangle_polygon_mode.png');
     },
     // TODO(b-luk): https://github.com/flutter/flutter/issues/183530 Re-enable for opengles.
-    skip: !impellerEnabled || !flutterGpuEnabled || impellerBackend == 'opengles',
+    skip: !(impellerEnabled && flutterGpuEnabled) || impellerBackend == 'opengles',
   );
 
   // Renders a green triangle pointing downwards, with 4xMSAA.
@@ -744,7 +744,7 @@ void main() async {
       await comparer.addGoldenImage(image, 'flutter_gpu_test_triangle_stencil.png');
     },
     // TODO(b-luk): https://github.com/flutter/flutter/issues/183530 Re-enable for opengles.
-    skip: !impellerEnabled || !flutterGpuEnabled || impellerBackend == 'opengles',
+    skip: !(impellerEnabled && flutterGpuEnabled) || impellerBackend == 'opengles',
   );
 
   test(
@@ -799,7 +799,7 @@ void main() async {
       await comparer.addGoldenImage(image, 'flutter_gpu_test_cull_mode.png');
     },
     // TODO(b-luk): https://github.com/flutter/flutter/issues/183530 Re-enable for opengles.
-    skip: !impellerEnabled || !flutterGpuEnabled || impellerBackend == 'opengles',
+    skip: !(impellerEnabled && flutterGpuEnabled) || impellerBackend == 'opengles',
   );
 
   // Renders a hexagon using line strip primitive type.
@@ -858,7 +858,7 @@ void main() async {
       await comparer.addGoldenImage(image, 'flutter_gpu_test_hexgon_line_strip.png');
     },
     // TODO(b-luk): https://github.com/flutter/flutter/issues/183530 Re-enable for opengles.
-    skip: !impellerEnabled || !flutterGpuEnabled || impellerBackend == 'opengles',
+    skip: !(impellerEnabled && flutterGpuEnabled) || impellerBackend == 'opengles',
   );
 
   // Renders the middle part triangle using scissor.
@@ -905,15 +905,19 @@ void main() async {
       await comparer.addGoldenImage(image, 'flutter_gpu_test_scissor.png');
     },
     // TODO(b-luk): https://github.com/flutter/flutter/issues/183530 Re-enable for opengles.
-    skip: !impellerEnabled || !flutterGpuEnabled || impellerBackend == 'opengles',
+    skip: !(impellerEnabled && flutterGpuEnabled) || impellerBackend == 'opengles',
   );
 
-  test('RenderPass.setScissor doesnt throw for valid values', () async {
-    final RenderPassState state = createSimpleRenderPass();
+  test(
+    'RenderPass.setScissor doesnt throw for valid values',
+    () async {
+      final RenderPassState state = createSimpleRenderPass();
 
-    state.renderPass.setScissor(gpu.Scissor(x: 25, width: 50, height: 100));
-    state.renderPass.setScissor(gpu.Scissor(width: 50, height: 100));
-  }, skip: !impellerEnabled || !flutterGpuEnabled);
+      state.renderPass.setScissor(gpu.Scissor(x: 25, width: 50, height: 100));
+      state.renderPass.setScissor(gpu.Scissor(width: 50, height: 100));
+    },
+    skip: !(impellerEnabled && flutterGpuEnabled),
+  );
 
   test('RenderPass.setScissor throws for invalid values', () async {
     final RenderPassState state = createSimpleRenderPass();
@@ -931,7 +935,7 @@ void main() async {
     } catch (e) {
       expect(e.toString(), contains('Invalid values for scissor. All values should be positive.'));
     }
-  }, skip: !impellerEnabled || !flutterGpuEnabled);
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   test(
     'RenderPass.setViewport doesnt throw for valid values',
@@ -941,7 +945,7 @@ void main() async {
       state.renderPass.setViewport(gpu.Viewport(x: 25, width: 50, height: 100));
       state.renderPass.setViewport(gpu.Viewport(width: 50, height: 100));
     },
-    skip: !impellerEnabled || !flutterGpuEnabled,
+    skip: !(impellerEnabled && flutterGpuEnabled),
   );
 
   test('RenderPass.setViewport throws for invalid values', () async {
@@ -960,7 +964,7 @@ void main() async {
     } catch (e) {
       expect(e.toString(), contains('Invalid values for viewport. All values should be positive.'));
     }
-  }, skip: !impellerEnabled || !flutterGpuEnabled);
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   // Renders the middle part triangle using viewport.
   test(
@@ -1006,6 +1010,6 @@ void main() async {
       await comparer.addGoldenImage(image, 'flutter_gpu_test_viewport.png');
     },
     // TODO(b-luk): https://github.com/flutter/flutter/issues/183530 Re-enable for opengles.
-    skip: !impellerEnabled || !flutterGpuEnabled || impellerBackend == 'opengles',
+    skip: !(impellerEnabled && flutterGpuEnabled) || impellerBackend == 'opengles',
   );
 }

--- a/engine/src/flutter/testing/dart/gpu_test.dart
+++ b/engine/src/flutter/testing/dart/gpu_test.dart
@@ -156,10 +156,12 @@ void main() async {
         fail('Exception not thrown, but Impeller is not enabled.');
       }
     } catch (e) {
-      if (impellerEnabled) {
-        fail('Exception thrown even though Impeller is enabled: $e');
+      if (impellerEnabled && flutterGpuEnabled) {
+        fail('Exception thrown even though Impeller and Flutter GPU are both enabled: $e');
       }
-      expect(e.toString(), contains('Flutter GPU requires the Impeller rendering backend'));
+      if (!impellerEnabled) {
+        expect(e.toString(), contains('Flutter GPU requires the Impeller rendering backend'));
+      }
     }
   });
 
@@ -197,7 +199,7 @@ void main() async {
   test('GpuContext.minimumUniformByteAlignment', () async {
     final int alignment = gpu.gpuContext.minimumUniformByteAlignment;
     expect(alignment, greaterThanOrEqualTo(16));
-  }, skip: !impellerEnabled);
+  }, skip: !impellerEnabled || !flutterGpuEnabled);
 
   test('HostBuffer.emplace', () async {
     final gpu.HostBuffer hostBuffer = gpu.gpuContext.createHostBuffer();
@@ -213,7 +215,7 @@ void main() async {
     );
     expect(view1.offsetInBytes, equals(gpu.gpuContext.minimumUniformByteAlignment));
     expect(view1.lengthInBytes, 4);
-  }, skip: !impellerEnabled);
+  }, skip: !impellerEnabled || !flutterGpuEnabled);
 
   test('HostBuffer.reset', () async {
     final gpu.HostBuffer hostBuffer = gpu.gpuContext.createHostBuffer();
@@ -231,7 +233,7 @@ void main() async {
     );
     expect(view1.offsetInBytes, 0);
     expect(view1.lengthInBytes, 4);
-  }, skip: !impellerEnabled);
+  }, skip: !impellerEnabled || !flutterGpuEnabled);
 
   test('HostBuffer reuses DeviceBuffers after N frames', () async {
     final gpu.HostBuffer hostBuffer = gpu.gpuContext.createHostBuffer();
@@ -248,7 +250,7 @@ void main() async {
     );
 
     expect(view0.buffer, equals(view1.buffer));
-  }, skip: !impellerEnabled);
+  }, skip: !impellerEnabled || !flutterGpuEnabled);
 
   test('GpuContext.createDeviceBuffer', () async {
     final gpu.DeviceBuffer deviceBuffer = gpu.gpuContext.createDeviceBuffer(
@@ -257,7 +259,7 @@ void main() async {
     );
 
     expect(deviceBuffer.sizeInBytes, 4);
-  }, skip: !impellerEnabled);
+  }, skip: !impellerEnabled || !flutterGpuEnabled);
 
   test('DeviceBuffer.overwrite', () async {
     final gpu.DeviceBuffer deviceBuffer = gpu.gpuContext.createDeviceBuffer(
@@ -270,7 +272,7 @@ void main() async {
     );
     deviceBuffer.flush();
     expect(success, true);
-  }, skip: !impellerEnabled);
+  }, skip: !impellerEnabled || !flutterGpuEnabled);
 
   test('DeviceBuffer.overwrite fails when out of bounds', () async {
     final gpu.DeviceBuffer deviceBuffer = gpu.gpuContext.createDeviceBuffer(
@@ -284,25 +286,29 @@ void main() async {
     );
     deviceBuffer.flush();
     expect(success, false);
-  }, skip: !impellerEnabled);
+  }, skip: !impellerEnabled || !flutterGpuEnabled);
 
-  test('DeviceBuffer.overwrite throws for negative destination offset', () async {
-    final gpu.DeviceBuffer deviceBuffer = gpu.gpuContext.createDeviceBuffer(
-      gpu.StorageMode.hostVisible,
-      4,
-    );
-
-    try {
-      deviceBuffer.overwrite(
-        Int8List.fromList(<int>[0, 1, 2, 3]).buffer.asByteData(),
-        destinationOffsetInBytes: -1,
+  test(
+    'DeviceBuffer.overwrite throws for negative destination offset',
+    () async {
+      final gpu.DeviceBuffer deviceBuffer = gpu.gpuContext.createDeviceBuffer(
+        gpu.StorageMode.hostVisible,
+        4,
       );
-      deviceBuffer.flush();
-      fail('Exception not thrown for negative destination offset.');
-    } catch (e) {
-      expect(e.toString(), contains('destinationOffsetInBytes must be positive'));
-    }
-  }, skip: !impellerEnabled);
+
+      try {
+        deviceBuffer.overwrite(
+          Int8List.fromList(<int>[0, 1, 2, 3]).buffer.asByteData(),
+          destinationOffsetInBytes: -1,
+        );
+        deviceBuffer.flush();
+        fail('Exception not thrown for negative destination offset.');
+      } catch (e) {
+        expect(e.toString(), contains('destinationOffsetInBytes must be positive'));
+      }
+    },
+    skip: !impellerEnabled || !flutterGpuEnabled,
+  );
 
   test('GpuContext.createTexture', () async {
     final gpu.Texture texture = gpu.gpuContext.createTexture(gpu.StorageMode.hostVisible, 100, 100);
@@ -320,7 +326,7 @@ void main() async {
     expect(!texture.enableShaderWriteUsage, true);
     expect(texture.bytesPerTexel, 4);
     expect(texture.getBaseMipLevelSizeInBytes(), 40000);
-  }, skip: !impellerEnabled);
+  }, skip: !impellerEnabled || !flutterGpuEnabled);
 
   test(
     'GpuContext.createTexture fails if invalid sampleCount and texture type is passed.',
@@ -338,7 +344,7 @@ void main() async {
         expect(e.toString(), contains('Texture creation failed'));
       }
     },
-    skip: !impellerEnabled,
+    skip: !impellerEnabled || !flutterGpuEnabled,
   );
 
   test('Texture.overwrite', () async {
@@ -349,7 +355,7 @@ void main() async {
     texture.overwrite(
       Int32List.fromList(<int>[red.value, green.value, green.value, red.value]).buffer.asByteData(),
     );
-  }, skip: !impellerEnabled);
+  }, skip: !impellerEnabled || !flutterGpuEnabled);
 
   test('Texture.overwrite throws for wrong buffer size', () async {
     final gpu.Texture texture = gpu.gpuContext.createTexture(gpu.StorageMode.hostVisible, 100, 100);
@@ -368,7 +374,7 @@ void main() async {
         ),
       );
     }
-  }, skip: !impellerEnabled);
+  }, skip: !impellerEnabled || !flutterGpuEnabled);
 
   test('Texture.asImage returns a valid ui.Image handle', () async {
     final gpu.Texture texture = gpu.gpuContext.createTexture(gpu.StorageMode.hostVisible, 100, 100);
@@ -376,7 +382,7 @@ void main() async {
     final ui.Image image = texture.asImage();
     expect(image.width, 100);
     expect(image.height, 100);
-  }, skip: !impellerEnabled);
+  }, skip: !impellerEnabled || !flutterGpuEnabled);
 
   test('Texture.asImage throws when not shader readable', () async {
     final gpu.Texture texture = gpu.gpuContext.createTexture(
@@ -395,104 +401,124 @@ void main() async {
         contains('Only shader readable Flutter GPU textures can be used as UI Images'),
       );
     }
-  }, skip: !impellerEnabled);
+  }, skip: !impellerEnabled || !flutterGpuEnabled);
 
-  test('RenderPass.setStencilReference doesnt throw for valid values', () async {
-    final RenderPassState state = createSimpleRenderPass();
+  test(
+    'RenderPass.setStencilReference doesnt throw for valid values',
+    () async {
+      final RenderPassState state = createSimpleRenderPass();
 
-    state.renderPass.setStencilReference(0);
-    state.renderPass.setStencilReference(2 << 30);
-  }, skip: !impellerEnabled);
+      state.renderPass.setStencilReference(0);
+      state.renderPass.setStencilReference(2 << 30);
+    },
+    skip: !impellerEnabled || !flutterGpuEnabled,
+  );
 
-  test('RenderPass.setStencilReference throws for invalid values', () async {
-    final RenderPassState state = createSimpleRenderPass();
+  test(
+    'RenderPass.setStencilReference throws for invalid values',
+    () async {
+      final RenderPassState state = createSimpleRenderPass();
 
-    try {
-      state.renderPass.setStencilReference(-1);
-      fail('Exception not thrown for out of bounds stencil reference.');
-    } catch (e) {
-      expect(e.toString(), contains('The stencil reference value must be in the range'));
-    }
+      try {
+        state.renderPass.setStencilReference(-1);
+        fail('Exception not thrown for out of bounds stencil reference.');
+      } catch (e) {
+        expect(e.toString(), contains('The stencil reference value must be in the range'));
+      }
 
-    try {
-      state.renderPass.setStencilReference(2 << 31);
-      fail('Exception not thrown for out of bounds stencil reference.');
-    } catch (e) {
-      expect(e.toString(), contains('The stencil reference value must be in the range'));
-    }
-  }, skip: !impellerEnabled);
+      try {
+        state.renderPass.setStencilReference(2 << 31);
+        fail('Exception not thrown for out of bounds stencil reference.');
+      } catch (e) {
+        expect(e.toString(), contains('The stencil reference value must be in the range'));
+      }
+    },
+    skip: !impellerEnabled || !flutterGpuEnabled,
+  );
 
-  test('RenderPass.setStencilConfig doesnt throw for valid values', () async {
-    final RenderPassState state = createSimpleRenderPass();
+  test(
+    'RenderPass.setStencilConfig doesnt throw for valid values',
+    () async {
+      final RenderPassState state = createSimpleRenderPass();
 
-    state.renderPass.setStencilConfig(gpu.StencilConfig());
-    state.renderPass.setStencilConfig(
-      gpu.StencilConfig(
-        compareFunction: gpu.CompareFunction.notEqual,
-        depthFailureOperation: gpu.StencilOperation.decrementWrap,
-        depthStencilPassOperation: gpu.StencilOperation.incrementWrap,
-        stencilFailureOperation: gpu.StencilOperation.invert,
-        readMask: 0,
-        writeMask: 0,
-      ),
-      targetFace: gpu.StencilFace.back,
-    );
-  }, skip: !impellerEnabled);
-
-  test('RenderPass.setStencilConfig throws for invalid masks', () async {
-    final RenderPassState state = createSimpleRenderPass();
-
-    try {
-      state.renderPass.setStencilConfig(gpu.StencilConfig(readMask: -1));
-      fail('Exception not thrown for invalid stencil read mask.');
-    } catch (e) {
-      expect(e.toString(), contains('The stencil read mask must be in the range'));
-    }
-    try {
-      state.renderPass.setStencilConfig(gpu.StencilConfig(readMask: 0xFFFFFFFF + 1));
-      fail('Exception not thrown for invalid stencil read mask.');
-    } catch (e) {
-      expect(e.toString(), contains('The stencil read mask must be in the range'));
-    }
-
-    try {
-      state.renderPass.setStencilConfig(gpu.StencilConfig(writeMask: -1));
-      fail('Exception not thrown for invalid stencil write mask.');
-    } catch (e) {
-      expect(e.toString(), contains('The stencil write mask must be in the range'));
-    }
-    try {
-      state.renderPass.setStencilConfig(gpu.StencilConfig(writeMask: 0xFFFFFFFF + 1));
-      fail('Exception not thrown for invalid stencil write mask.');
-    } catch (e) {
-      expect(e.toString(), contains('The stencil write mask must be in the range'));
-    }
-  }, skip: !impellerEnabled);
-
-  test('RenderPass.bindTexture throws for deviceTransient Textures', () async {
-    final RenderPassState state = createSimpleRenderPass();
-
-    final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
-    // Although this is a non-texture uniform slot, it'll work fine for the
-    // purposes of testing this error.
-    final gpu.UniformSlot vertInfo = pipeline.vertexShader.getUniformSlot('VertInfo');
-
-    final gpu.Texture texture = gpu.gpuContext.createTexture(
-      gpu.StorageMode.deviceTransient,
-      100,
-      100,
-    );
-
-    try {
-      state.renderPass.bindTexture(vertInfo, texture);
-      fail('Exception not thrown when binding a transient texture.');
-    } catch (e) {
-      expect(
-        e.toString(),
-        contains('Textures with StorageMode.deviceTransient cannot be bound to a RenderPass'),
+      state.renderPass.setStencilConfig(gpu.StencilConfig());
+      state.renderPass.setStencilConfig(
+        gpu.StencilConfig(
+          compareFunction: gpu.CompareFunction.notEqual,
+          depthFailureOperation: gpu.StencilOperation.decrementWrap,
+          depthStencilPassOperation: gpu.StencilOperation.incrementWrap,
+          stencilFailureOperation: gpu.StencilOperation.invert,
+          readMask: 0,
+          writeMask: 0,
+        ),
+        targetFace: gpu.StencilFace.back,
       );
-    }
-  }, skip: !impellerEnabled);
+    },
+    skip: !impellerEnabled || !flutterGpuEnabled,
+  );
+
+  test(
+    'RenderPass.setStencilConfig throws for invalid masks',
+    () async {
+      final RenderPassState state = createSimpleRenderPass();
+
+      try {
+        state.renderPass.setStencilConfig(gpu.StencilConfig(readMask: -1));
+        fail('Exception not thrown for invalid stencil read mask.');
+      } catch (e) {
+        expect(e.toString(), contains('The stencil read mask must be in the range'));
+      }
+      try {
+        state.renderPass.setStencilConfig(gpu.StencilConfig(readMask: 0xFFFFFFFF + 1));
+        fail('Exception not thrown for invalid stencil read mask.');
+      } catch (e) {
+        expect(e.toString(), contains('The stencil read mask must be in the range'));
+      }
+
+      try {
+        state.renderPass.setStencilConfig(gpu.StencilConfig(writeMask: -1));
+        fail('Exception not thrown for invalid stencil write mask.');
+      } catch (e) {
+        expect(e.toString(), contains('The stencil write mask must be in the range'));
+      }
+      try {
+        state.renderPass.setStencilConfig(gpu.StencilConfig(writeMask: 0xFFFFFFFF + 1));
+        fail('Exception not thrown for invalid stencil write mask.');
+      } catch (e) {
+        expect(e.toString(), contains('The stencil write mask must be in the range'));
+      }
+    },
+    skip: !impellerEnabled || !flutterGpuEnabled,
+  );
+
+  test(
+    'RenderPass.bindTexture throws for deviceTransient Textures',
+    () async {
+      final RenderPassState state = createSimpleRenderPass();
+
+      final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
+      // Although this is a non-texture uniform slot, it'll work fine for the
+      // purposes of testing this error.
+      final gpu.UniformSlot vertInfo = pipeline.vertexShader.getUniformSlot('VertInfo');
+
+      final gpu.Texture texture = gpu.gpuContext.createTexture(
+        gpu.StorageMode.deviceTransient,
+        100,
+        100,
+      );
+
+      try {
+        state.renderPass.bindTexture(vertInfo, texture);
+        fail('Exception not thrown when binding a transient texture.');
+      } catch (e) {
+        expect(
+          e.toString(),
+          contains('Textures with StorageMode.deviceTransient cannot be bound to a RenderPass'),
+        );
+      }
+    },
+    skip: !impellerEnabled || !flutterGpuEnabled,
+  );
 
   // Performs no draw calls. Just clears the render target to a solid green color.
   test('Can render clear color', () async {
@@ -502,7 +528,7 @@ void main() async {
 
     final ui.Image image = state.renderTexture.asImage();
     await comparer.addGoldenImage(image, 'flutter_gpu_test_clear_color.png');
-  }, skip: !impellerEnabled);
+  }, skip: !impellerEnabled || !flutterGpuEnabled);
 
   // Regression test for https://github.com/flutter/flutter/issues/157324
   test('Can bind uniforms in range', () async {
@@ -537,7 +563,7 @@ void main() async {
     } catch (e) {
       expect(e.toString(), contains('Failed to bind uniform'));
     }
-  }, skip: !impellerEnabled);
+  }, skip: !impellerEnabled || !flutterGpuEnabled);
 
   // Renders a green triangle pointing downwards.
   test(
@@ -551,7 +577,7 @@ void main() async {
       await comparer.addGoldenImage(image, 'flutter_gpu_test_triangle.png');
     },
     // TODO(b-luk): https://github.com/flutter/flutter/issues/183530 Re-enable for opengles.
-    skip: !impellerEnabled || impellerBackend == 'opengles',
+    skip: !impellerEnabled || !flutterGpuEnabled || impellerBackend == 'opengles',
   );
 
   // Renders a green triangle pointing downwards using polygon mode line.
@@ -599,7 +625,7 @@ void main() async {
       await comparer.addGoldenImage(image, 'flutter_gpu_test_triangle_polygon_mode.png');
     },
     // TODO(b-luk): https://github.com/flutter/flutter/issues/183530 Re-enable for opengles.
-    skip: !impellerEnabled || impellerBackend == 'opengles',
+    skip: !impellerEnabled || !flutterGpuEnabled || impellerBackend == 'opengles',
   );
 
   // Renders a green triangle pointing downwards, with 4xMSAA.
@@ -718,7 +744,7 @@ void main() async {
       await comparer.addGoldenImage(image, 'flutter_gpu_test_triangle_stencil.png');
     },
     // TODO(b-luk): https://github.com/flutter/flutter/issues/183530 Re-enable for opengles.
-    skip: !impellerEnabled || impellerBackend == 'opengles',
+    skip: !impellerEnabled || !flutterGpuEnabled || impellerBackend == 'opengles',
   );
 
   test(
@@ -773,7 +799,7 @@ void main() async {
       await comparer.addGoldenImage(image, 'flutter_gpu_test_cull_mode.png');
     },
     // TODO(b-luk): https://github.com/flutter/flutter/issues/183530 Re-enable for opengles.
-    skip: !impellerEnabled || impellerBackend == 'opengles',
+    skip: !impellerEnabled || !flutterGpuEnabled || impellerBackend == 'opengles',
   );
 
   // Renders a hexagon using line strip primitive type.
@@ -832,7 +858,7 @@ void main() async {
       await comparer.addGoldenImage(image, 'flutter_gpu_test_hexgon_line_strip.png');
     },
     // TODO(b-luk): https://github.com/flutter/flutter/issues/183530 Re-enable for opengles.
-    skip: !impellerEnabled || impellerBackend == 'opengles',
+    skip: !impellerEnabled || !flutterGpuEnabled || impellerBackend == 'opengles',
   );
 
   // Renders the middle part triangle using scissor.
@@ -879,7 +905,7 @@ void main() async {
       await comparer.addGoldenImage(image, 'flutter_gpu_test_scissor.png');
     },
     // TODO(b-luk): https://github.com/flutter/flutter/issues/183530 Re-enable for opengles.
-    skip: !impellerEnabled || impellerBackend == 'opengles',
+    skip: !impellerEnabled || !flutterGpuEnabled || impellerBackend == 'opengles',
   );
 
   test('RenderPass.setScissor doesnt throw for valid values', () async {
@@ -887,7 +913,7 @@ void main() async {
 
     state.renderPass.setScissor(gpu.Scissor(x: 25, width: 50, height: 100));
     state.renderPass.setScissor(gpu.Scissor(width: 50, height: 100));
-  }, skip: !impellerEnabled);
+  }, skip: !impellerEnabled || !flutterGpuEnabled);
 
   test('RenderPass.setScissor throws for invalid values', () async {
     final RenderPassState state = createSimpleRenderPass();
@@ -905,14 +931,18 @@ void main() async {
     } catch (e) {
       expect(e.toString(), contains('Invalid values for scissor. All values should be positive.'));
     }
-  }, skip: !impellerEnabled);
+  }, skip: !impellerEnabled || !flutterGpuEnabled);
 
-  test('RenderPass.setViewport doesnt throw for valid values', () async {
-    final RenderPassState state = createSimpleRenderPass();
+  test(
+    'RenderPass.setViewport doesnt throw for valid values',
+    () async {
+      final RenderPassState state = createSimpleRenderPass();
 
-    state.renderPass.setViewport(gpu.Viewport(x: 25, width: 50, height: 100));
-    state.renderPass.setViewport(gpu.Viewport(width: 50, height: 100));
-  }, skip: !impellerEnabled);
+      state.renderPass.setViewport(gpu.Viewport(x: 25, width: 50, height: 100));
+      state.renderPass.setViewport(gpu.Viewport(width: 50, height: 100));
+    },
+    skip: !impellerEnabled || !flutterGpuEnabled,
+  );
 
   test('RenderPass.setViewport throws for invalid values', () async {
     final RenderPassState state = createSimpleRenderPass();
@@ -930,7 +960,7 @@ void main() async {
     } catch (e) {
       expect(e.toString(), contains('Invalid values for viewport. All values should be positive.'));
     }
-  }, skip: !impellerEnabled);
+  }, skip: !impellerEnabled || !flutterGpuEnabled);
 
   // Renders the middle part triangle using viewport.
   test(
@@ -976,6 +1006,6 @@ void main() async {
       await comparer.addGoldenImage(image, 'flutter_gpu_test_viewport.png');
     },
     // TODO(b-luk): https://github.com/flutter/flutter/issues/183530 Re-enable for opengles.
-    skip: !impellerEnabled || impellerBackend == 'opengles',
+    skip: !impellerEnabled || !flutterGpuEnabled || impellerBackend == 'opengles',
   );
 }

--- a/engine/src/flutter/testing/dart/impeller_enabled.dart
+++ b/engine/src/flutter/testing/dart/impeller_enabled.dart
@@ -6,6 +6,8 @@ import 'dart:io';
 
 bool get impellerEnabled => Platform.executableArguments.contains('--enable-impeller');
 
+bool get flutterGpuEnabled => Platform.executableArguments.contains('--enable-flutter-gpu');
+
 String? get impellerBackend {
   if (!impellerEnabled) {
     return null;

--- a/engine/src/flutter/testing/run_tests.py
+++ b/engine/src/flutter/testing/run_tests.py
@@ -652,12 +652,14 @@ class FlutterTesterOptions():
       self,
       multithreaded: bool = False,
       impeller_backend: str = '',
+      enable_flutter_gpu: bool = True,
       enable_vm_service: bool = False,
       enable_microtask_profiling: bool = False,
       expect_failure: bool = False
   ) -> None:
     self.multithreaded = multithreaded
     self.impeller_backend = impeller_backend
+    self.enable_flutter_gpu = enable_flutter_gpu
     self.enable_vm_service = enable_vm_service
     self.enable_microtask_profiling = enable_microtask_profiling
     self.expect_failure = expect_failure
@@ -667,9 +669,9 @@ class FlutterTesterOptions():
       command_args.append('--disable-vm-service')
 
     if self.impeller_backend != '':
-      command_args += [
-          '--enable-impeller', '--enable-flutter-gpu', f'--impeller-backend={self.impeller_backend}'
-      ]
+      command_args += ['--enable-impeller', f'--impeller-backend={self.impeller_backend}']
+      if self.enable_flutter_gpu:
+        command_args.append('--enable-flutter-gpu')
     else:
       command_args += ['--no-enable-impeller']
 
@@ -686,7 +688,8 @@ class FlutterTesterOptions():
 
   def impeller_enabled(self) -> str:
     if self.impeller_backend != '':
-      return f'impeller {self.impeller_backend}'
+      gpu_str = ' flutter_gpu' if self.enable_flutter_gpu else ''
+      return f'impeller {self.impeller_backend}{gpu_str}'
     return 'skia software'
 
   def tester_name(self) -> str:
@@ -968,6 +971,21 @@ def gather_dart_tests(
                 enable_microtask_profiling=dart_test_basename == 'microtask_profiling_test.dart',
             )
         )
+
+  # Run gpu_test.dart with Impeller enabled but Flutter GPU disabled to test
+  # the "Flutter GPU must be enabled" error message.
+  gpu_test_file = os.path.join(dart_tests_dir, 'gpu_test.dart')
+  if test_filter is None or 'gpu_test.dart' in test_filter:
+    for impeller in impeller_backends:
+      if impeller == '':
+        continue
+      yield gather_dart_test(
+          build_dir, gpu_test_file,
+          FlutterTesterOptions(
+              impeller_backend=impeller,
+              enable_flutter_gpu=False,
+          )
+      )
 
 
 def gather_dart_smoke_test(


### PR DESCRIPTION
When Flutter GPU initialization fails because Impeller is not enabled, display a specific error message about enabling Impeller rather than the generic "Flutter GPU must be enabled" message.

Resolves https://github.com/flutter/flutter/issues/173648