### PR TITLE
Seal the geometry classes

### DIFF
--- a/packages/flutter/lib/src/painting/alignment.dart
+++ b/packages/flutter/lib/src/painting/alignment.dart
@@ -22,7 +22,7 @@ import 'debug.dart';
 /// To convert an [AlignmentGeometry] object of indeterminate type into an
 /// [Alignment] object, call the [resolve] method.
 @immutable
-abstract class AlignmentGeometry {
+sealed class AlignmentGeometry {
   /// Abstract const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
   const AlignmentGeometry();

--- a/packages/flutter/lib/src/painting/border_radius.dart
+++ b/packages/flutter/lib/src/painting/border_radius.dart
@@ -22,7 +22,7 @@ import 'debug.dart';
 /// To convert a [BorderRadiusGeometry] object of indeterminate type into a
 /// [BorderRadius] object, call the [resolve] method.
 @immutable
-abstract class BorderRadiusGeometry {
+sealed class BorderRadiusGeometry {
   /// Abstract const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
   const BorderRadiusGeometry();

--- a/packages/flutter/lib/src/painting/edge_insets.dart
+++ b/packages/flutter/lib/src/painting/edge_insets.dart
@@ -28,7 +28,7 @@ import 'debug.dart';
 ///
 ///  * [Padding], a widget that describes margins using [EdgeInsetsGeometry].
 @immutable
-abstract class EdgeInsetsGeometry {
+sealed class EdgeInsetsGeometry {
   /// Abstract const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
   const EdgeInsetsGeometry();


### PR DESCRIPTION
Abstract private fields are problematic, since they can only be implemented by subtypes within the same library.

The `sealed` class modifier solves this beautifully.

<br>

This PR applies the modifier to the three geometry classes that need it.