### PR TITLE
fix: guard against OOB read in FlutterStandardCodecHelper string decode path (iOS/macOS)

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/common/framework/Source/FlutterStandardCodecHelper.cc
+++ b/engine/src/flutter/shell/platform/darwin/common/framework/Source/FlutterStandardCodecHelper.cc
@@ -65,6 +65,12 @@ uint32_t FlutterStandardCodecHelperReadSize(unsigned long* location,
 static CFDataRef ReadDataNoCopy(unsigned long* location,
                                 unsigned long length,
                                 CFDataRef data) {
+  CFIndex data_length = CFDataGetLength(data);
+  if ((CFIndex)*location > data_length ||
+      length > (unsigned long)(data_length - (CFIndex)*location)) {
+    *location += length;
+    return nil;
+  }
   CFDataRef result = CFDataCreateWithBytesNoCopy(
       kCFAllocatorDefault, CFDataGetBytePtr(data) + *location, length,
       kCFAllocatorNull);
@@ -76,6 +82,9 @@ CFStringRef FlutterStandardCodecHelperReadUTF8(unsigned long* location,
                                                CFDataRef data) {
   uint32_t size = FlutterStandardCodecHelperReadSize(location, data);
   CFDataRef bytes = ReadDataNoCopy(location, size, data);
+  if (!bytes) {
+    return nil;
+  }
   CFStringRef result = CFStringCreateFromExternalRepresentation(
       kCFAllocatorDefault, bytes, kCFStringEncodingUTF8);
   return static_cast<CFStringRef>(CFAutorelease(result));

--- a/engine/src/flutter/shell/platform/darwin/common/framework/Source/flutter_standard_codec_unittest.mm
+++ b/engine/src/flutter/shell/platform/darwin/common/framework/Source/flutter_standard_codec_unittest.mm
@@ -366,7 +366,7 @@ TEST(FlutterStandardCodec, ReaderDoesNotCrashOnTruncatedString) {
   FlutterStandardReader* reader =
       [[FlutterStandardReader alloc] initWithData:data];
   id result = [reader readValue];
-  ASSERT_TRUE(result == nil || [result isKindOfClass:[NSString class]]);
+  ASSERT_TRUE(result == nil);
 }
 
 TEST(FlutterStandardCodec, MessageCodecDoesNotCrashOnTruncatedString) {
@@ -374,7 +374,7 @@ TEST(FlutterStandardCodec, MessageCodecDoesNotCrashOnTruncatedString) {
   NSData* message = [NSData dataWithBytes:bytes length:sizeof(bytes)];
   FlutterStandardMessageCodec* codec = [FlutterStandardMessageCodec sharedInstance];
   id decoded = [codec decode:message];
-  ASSERT_TRUE(decoded == nil || [decoded isKindOfClass:[NSString class]]);
+  ASSERT_TRUE(decoded == nil);
 }
 
 TEST(FlutterStandardCodec, ReaderDoesNotCrashOnStringExactlyAtBufferEnd) {
@@ -382,5 +382,5 @@ TEST(FlutterStandardCodec, ReaderDoesNotCrashOnStringExactlyAtBufferEnd) {
   NSData* full = [codec encode:@"hello"];
   NSData* truncated = [full subdataWithRange:NSMakeRange(0, full.length - 1)];
   id decoded = [codec decode:truncated];
-  ASSERT_TRUE(decoded == nil || [decoded isKindOfClass:[NSString class]]);
+  ASSERT_TRUE(decoded == nil);
 }

--- a/engine/src/flutter/shell/platform/darwin/common/framework/Source/flutter_standard_codec_unittest.mm
+++ b/engine/src/flutter/shell/platform/darwin/common/framework/Source/flutter_standard_codec_unittest.mm
@@ -359,3 +359,28 @@ TEST(FlutterStandardCodec, HandlesSubclasses) {
   ASSERT_TRUE([pair.left isEqual:decoded.left]);
   ASSERT_TRUE([pair.right isEqual:decoded.right]);
 }
+
+TEST(FlutterStandardCodec, ReaderDoesNotCrashOnTruncatedString) {
+  const uint8_t bytes[] = {0x07, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+  NSData* data = [NSData dataWithBytes:bytes length:sizeof(bytes)];
+  FlutterStandardReader* reader =
+      [[FlutterStandardReader alloc] initWithData:data];
+  id result = [reader readValue];
+  ASSERT_TRUE(result == nil || [result isKindOfClass:[NSString class]]);
+}
+
+TEST(FlutterStandardCodec, MessageCodecDoesNotCrashOnTruncatedString) {
+  const uint8_t bytes[] = {0x07, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+  NSData* message = [NSData dataWithBytes:bytes length:sizeof(bytes)];
+  FlutterStandardMessageCodec* codec = [FlutterStandardMessageCodec sharedInstance];
+  id decoded = [codec decode:message];
+  ASSERT_TRUE(decoded == nil || [decoded isKindOfClass:[NSString class]]);
+}
+
+TEST(FlutterStandardCodec, ReaderDoesNotCrashOnStringExactlyAtBufferEnd) {
+  FlutterStandardMessageCodec* codec = [FlutterStandardMessageCodec sharedInstance];
+  NSData* full = [codec encode:@"hello"];
+  NSData* truncated = [full subdataWithRange:NSMakeRange(0, full.length - 1)];
+  id decoded = [codec decode:truncated];
+  ASSERT_TRUE(decoded == nil || [decoded isKindOfClass:[NSString class]]);
+}


### PR DESCRIPTION
Fixes a crash in `FlutterStandardCodecHelper` on iOS and macOS where a crafted platform channel message could cause the codec to read memory beyond the end of the buffer.

`ReadDataNoCopy` was calling `CFDataCreateWithBytesNoCopy` using the length field directly from the wire without first checking that enough bytes remain. That function doesn't validate the pointer arithmetic, so a message with an inflated size — for example a `kString` type byte followed by `0xFF 0xFF 0xFF 0xFF 0xFF` encoding a claimed length of 4 GiB — would wrap a huge range of unowned heap memory in a `CFData`. When `CFStringCreateFromExternalRepresentation` then tried to scan that "string" it would read far past the actual buffer and crash.

The typed-data decode path already had this issue documented and worked around: there's a comment in `FlutterStandardCodec.mm` (around `ReadTypedDataOfType`) that says `CFDataCreateBytesNoCopy crashes` and uses `subdataWithRange:` instead. That fix was never applied to the string path (`ReadDataNoCopy` / `FlutterStandardCodecHelperReadUTF8`), which is what this PR addresses.

The change is small — a bounds check at the top of `ReadDataNoCopy` and a nil guard in  `FlutterStandardCodecHelperReadUTF8`. Three regression tests are added covering the inflated-size case, a normally-encoded string truncated by one byte, and the `FlutterStandardMessageCodec` layer decode.

## Pre-launch Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.
