### PR TITLE
Fix Autocomplete Tab focus traversal with disabled fields

### DIFF
--- a/packages/flutter/lib/src/material/autocomplete.dart
+++ b/packages/flutter/lib/src/material/autocomplete.dart
@@ -287,6 +287,7 @@ class _AutocompleteOptionsListState<T extends Object> extends State<_Autocomplet
           button: true,
           child: InkWell(
             key: GlobalObjectKey(option),
+            canRequestFocus: false,
             onTap: () {
               widget.onSelected(option);
             },

--- a/packages/flutter/test/material/autocomplete_test.dart
+++ b/packages/flutter/test/material/autocomplete_test.dart
@@ -538,6 +538,59 @@ void main() {
     checkOptionHighlight(tester, 'northern white rhinoceros', null);
   });
 
+  testWidgets('Tab moves focus to the next enabled widget when options are shown', (
+    WidgetTester tester,
+  ) async {
+    final firstFieldFocusNode = FocusNode();
+    final autocompleteFocusNode = FocusNode();
+    final trailingAutocompleteFocusNode = FocusNode();
+    addTearDown(firstFieldFocusNode.dispose);
+    addTearDown(autocompleteFocusNode.dispose);
+    addTearDown(trailingAutocompleteFocusNode.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Column(
+            children: <Widget>[
+              TextFormField(focusNode: firstFieldFocusNode),
+              Autocomplete<String>(
+                focusNode: autocompleteFocusNode,
+                optionsBuilder: (TextEditingValue textEditingValue) {
+                  return kOptions.where((String option) {
+                    return option.contains(textEditingValue.text.toLowerCase());
+                  });
+                },
+              ),
+              TextFormField(enabled: false),
+              TextFormField(enabled: false),
+              Autocomplete<String>(
+                focusNode: trailingAutocompleteFocusNode,
+                optionsBuilder: (TextEditingValue textEditingValue) {
+                  return kOptions.where((String option) {
+                    return option.contains(textEditingValue.text.toLowerCase());
+                  });
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    firstFieldFocusNode.requestFocus();
+    await tester.pump();
+    expect(firstFieldFocusNode.hasFocus, isTrue);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+    expect(autocompleteFocusNode.hasFocus, isTrue);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+    expect(trailingAutocompleteFocusNode.hasFocus, isTrue);
+  });
+
   group('optionsViewOpenDirection', () {
     testWidgets('default (down)', (WidgetTester tester) async {
       await tester.pumpWidget(

--- a/packages/flutter/test/material/autocomplete_test.dart
+++ b/packages/flutter/test/material/autocomplete_test.dart
@@ -544,9 +544,13 @@ void main() {
     final firstFieldFocusNode = FocusNode();
     final autocompleteFocusNode = FocusNode();
     final trailingAutocompleteFocusNode = FocusNode();
+    final autocompleteController = TextEditingController();
+    final trailingAutocompleteController = TextEditingController();
     addTearDown(firstFieldFocusNode.dispose);
     addTearDown(autocompleteFocusNode.dispose);
     addTearDown(trailingAutocompleteFocusNode.dispose);
+    addTearDown(autocompleteController.dispose);
+    addTearDown(trailingAutocompleteController.dispose);
 
     await tester.pumpWidget(
       MaterialApp(
@@ -556,20 +560,30 @@ void main() {
               TextFormField(focusNode: firstFieldFocusNode),
               Autocomplete<String>(
                 focusNode: autocompleteFocusNode,
-                optionsBuilder: (TextEditingValue textEditingValue) {
-                  return kOptions.where((String option) {
-                    return option.contains(textEditingValue.text.toLowerCase());
-                  });
+                textEditingController: autocompleteController,
+                optionsBuilder: (TextEditingValue textEditingValue) => <String>['apple'],
+                fieldViewBuilder: (
+                  BuildContext context,
+                  TextEditingController textEditingController,
+                  FocusNode focusNode,
+                  VoidCallback onFieldSubmitted,
+                ) {
+                  return TextFormField(controller: textEditingController, focusNode: focusNode);
                 },
               ),
               TextFormField(enabled: false),
               TextFormField(enabled: false),
               Autocomplete<String>(
                 focusNode: trailingAutocompleteFocusNode,
-                optionsBuilder: (TextEditingValue textEditingValue) {
-                  return kOptions.where((String option) {
-                    return option.contains(textEditingValue.text.toLowerCase());
-                  });
+                textEditingController: trailingAutocompleteController,
+                optionsBuilder: (TextEditingValue textEditingValue) => <String>['banana'],
+                fieldViewBuilder: (
+                  BuildContext context,
+                  TextEditingController textEditingController,
+                  FocusNode focusNode,
+                  VoidCallback onFieldSubmitted,
+                ) {
+                  return TextFormField(controller: textEditingController, focusNode: focusNode);
                 },
               ),
             ],


### PR DESCRIPTION
## What this PR changes

This prevents the default Material `Autocomplete` options from participating in Tab focus traversal.

The options are built with `InkWell`, which can request focus during Tab traversal. When disabled fields sit after the autocomplete field, traversal can stay inside autocomplete interaction instead of moving to the next enabled control.

This change sets `canRequestFocus: false` on each option row so Tab keeps moving through the form while arrow keys continue to control option highlighting.

I also added a regression test in `autocomplete_test.dart` that covers traversal from an autocomplete field to the next enabled widget when disabled fields are in between.

Fixes https://github.com/flutter/flutter/issues/183456

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

## Validation

- `./bin/flutter analyze packages/flutter/lib/src/material/autocomplete.dart packages/flutter/test/material/autocomplete_test.dart`
- `./bin/flutter test packages/flutter/test/material/autocomplete_test.dart --plain-name "Tab moves focus to the next enabled widget when options are shown"`