### PR TITLE
Replace deprecated Color.alpha usage in Title

### DIFF
--- a/packages/flutter/lib/src/widgets/title.dart
+++ b/packages/flutter/lib/src/widgets/title.dart
@@ -13,17 +13,16 @@ class Title extends StatefulWidget {
   /// Creates a widget that describes this app to the Android operating system.
   ///
   /// [title] will default to the empty string if not supplied.
-  /// [color] must be an opaque color (i.e. color.alpha must be 255 (0xFF)).
+  /// [color] must be an opaque color (i.e. color.a must be 1.0).
   /// [color] and [child] are required arguments.
   Title({super.key, this.title = '', required this.color, required this.child})
-    : assert(color.alpha == 0xFF);
+    : assert(color.a == 1.0);
 
   /// A one-line description of this app for use in the window manager.
   final String title;
 
   /// A color that the window manager should use to identify this app. Must be
-  /// an opaque color (i.e. color.alpha must be 255 (0xFF)), and must not be
-  /// null.
+  /// an opaque color (i.e. color.a must be 1.0), and must not be null.
   final Color color;
 
   /// The widget below this widget in the tree.

--- a/packages/flutter/test/widgets/title_test.dart
+++ b/packages/flutter/test/widgets/title_test.dart
@@ -25,6 +25,7 @@ void main() {
 
   testWidgets('should not allow non-opaque color', (WidgetTester tester) async {
     expect(() => Title(color: const Color(0x00000000), child: Container()), throwsAssertionError);
+    expect(() => Title(color: const Color(0x7F000000), child: Container()), throwsAssertionError);
   });
 
   testWidgets('should not pass "null" to setApplicationSwitcherDescription', (


### PR DESCRIPTION
This updates `Title` to stop using the deprecated `Color.alpha` getter.

The constructor assert now checks `color.a == 1.0`, and the related API docs were updated to match.

Fixes https://github.com/flutter/flutter/issues/184002

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

Test command run:
- `flutter test packages/flutter/test/widgets/title_test.dart` *(fails in this local environment with `ui.DisplayCornerRadii` compile errors in framework test setup; no change-specific test failure observed).*

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
