### PR TITLE
fix gaussian blur getting clipped with negative scale

### DIFF
--- a/engine/src/flutter/impeller/display_list/aiks_dl_blur_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_blur_unittests.cc
@@ -1509,5 +1509,25 @@ TEST_P(AiksTest, CanRenderNestedBackdropBlur) {
   ASSERT_TRUE(OpenPlaygroundHere(callback));
 }
 
+TEST_P(AiksTest, GaussianBlurFlipped) {
+  DisplayListBuilder builder;
+  builder.Scale(GetContentScale().x, GetContentScale().y);
+
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 350, 350),
+                   DlPaint().setColor(DlColor::kWhite()));
+
+  builder.Save();
+  builder.Scale(-1, 1);
+  DlPaint paint;
+  paint.setImageFilter(DlBlurImageFilter::Make(10, 10, DlTileMode::kDecal));
+  builder.SaveLayer(DlRect::MakeLTRB(-150, 100, 150, 200), &paint);
+  builder.DrawRect(DlRect::MakeLTRB(-150, 0, 150, 300),
+                   DlPaint().setColor(DlColor::kRed()));
+  builder.Restore();
+  builder.Restore();
+
+  ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/engine/src/flutter/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -816,9 +816,9 @@ std::optional<Rect> GaussianBlurFilterContents::GetFilterSourceCoverage(
   Vector2 scaled_sigma = {ScaleSigma(sigma_.x), ScaleSigma(sigma_.y)};
   Vector2 blur_radius = {CalculateBlurRadius(scaled_sigma.x),
                          CalculateBlurRadius(scaled_sigma.y)};
-  Vector3 blur_radii =
-      effect_transform.Basis() * Vector3{blur_radius.x, blur_radius.y, 0.0};
-  return output_limit.Expand(Point(blur_radii.x, blur_radii.y));
+  Vector2 transformed_blur_radius =
+      effect_transform.TransformDirection(blur_radius).Abs();
+  return output_limit.Expand(transformed_blur_radius);
 }
 
 std::optional<Rect> GaussianBlurFilterContents::GetFilterCoverage(

--- a/engine/src/flutter/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -816,9 +816,10 @@ std::optional<Rect> GaussianBlurFilterContents::GetFilterSourceCoverage(
   Vector2 scaled_sigma = {ScaleSigma(sigma_.x), ScaleSigma(sigma_.y)};
   Vector2 blur_radius = {CalculateBlurRadius(scaled_sigma.x),
                          CalculateBlurRadius(scaled_sigma.y)};
-  Vector2 transformed_blur_radius =
-      effect_transform.TransformDirection(blur_radius).Abs();
-  return output_limit.Expand(transformed_blur_radius);
+  Vector3 blur_radii =
+      (effect_transform.Basis() * Vector3{blur_radius.x, blur_radius.y, 0.0})
+          .Abs();
+  return output_limit.Expand(Point(blur_radii.x, blur_radii.y));
 }
 
 std::optional<Rect> GaussianBlurFilterContents::GetFilterCoverage(

--- a/engine/src/flutter/impeller/entity/contents/filters/gaussian_blur_filter_contents_unittests.cc
+++ b/engine/src/flutter/impeller/entity/contents/filters/gaussian_blur_filter_contents_unittests.cc
@@ -243,8 +243,10 @@ TEST(GaussianBlurFilterContentsTest, FilterSourceCoverageNegativeScale) {
       /*effect_transform=*/Matrix::MakeScale({-2.0, 2.0, 1.0}),
       /*output_limit=*/Rect::MakeLTRB(100, 100, 200, 200));
   ASSERT_TRUE(coverage.has_value());
-  EXPECT_RECT_NEAR(coverage.value(),
-                   Rect::MakeLTRB(100 - 2, 100 - 2, 200 + 2, 200 + 2));
+  if (coverage.has_value()) {
+    EXPECT_RECT_NEAR(coverage.value(),
+                     Rect::MakeLTRB(100 - 2, 100 - 2, 200 + 2, 200 + 2));
+  }
 }
 
 TEST(GaussianBlurFilterContentsTest, CalculateSigmaValues) {

--- a/engine/src/flutter/impeller/entity/contents/filters/gaussian_blur_filter_contents_unittests.cc
+++ b/engine/src/flutter/impeller/entity/contents/filters/gaussian_blur_filter_contents_unittests.cc
@@ -242,11 +242,9 @@ TEST(GaussianBlurFilterContentsTest, FilterSourceCoverageNegativeScale) {
   std::optional<Rect> coverage = contents->GetFilterSourceCoverage(
       /*effect_transform=*/Matrix::MakeScale({-2.0, 2.0, 1.0}),
       /*output_limit=*/Rect::MakeLTRB(100, 100, 200, 200));
-  EXPECT_TRUE(coverage.has_value());
-  if (coverage.has_value()) {
-    EXPECT_RECT_NEAR(coverage.value(),
-                     Rect::MakeLTRB(100 - 2, 100 - 2, 200 + 2, 200 + 2));
-  }
+  ASSERT_TRUE(coverage.has_value());
+  EXPECT_RECT_NEAR(coverage.value(),
+                   Rect::MakeLTRB(100 - 2, 100 - 2, 200 + 2, 200 + 2));
 }
 
 TEST(GaussianBlurFilterContentsTest, CalculateSigmaValues) {

--- a/engine/src/flutter/impeller/entity/contents/filters/gaussian_blur_filter_contents_unittests.cc
+++ b/engine/src/flutter/impeller/entity/contents/filters/gaussian_blur_filter_contents_unittests.cc
@@ -229,6 +229,26 @@ TEST(GaussianBlurFilterContentsTest, FilterSourceCoverage) {
   }
 }
 
+TEST(GaussianBlurFilterContentsTest, FilterSourceCoverageNegativeScale) {
+  fml::StatusOr<Scalar> sigma_radius_1 =
+      CalculateSigmaForBlurRadius(1.0, Matrix());
+  ASSERT_TRUE(sigma_radius_1.ok());
+  auto contents = std::make_unique<GaussianBlurFilterContents>(
+      sigma_radius_1.value(), sigma_radius_1.value(), Entity::TileMode::kDecal,
+      /*bounds=*/std::nullopt, FilterContents::BlurStyle::kNormal,
+      /*mask_geometry=*/nullptr);
+
+  // Negative scale should still result in an expanded coverage rect.
+  std::optional<Rect> coverage = contents->GetFilterSourceCoverage(
+      /*effect_transform=*/Matrix::MakeScale({-2.0, 2.0, 1.0}),
+      /*output_limit=*/Rect::MakeLTRB(100, 100, 200, 200));
+  EXPECT_TRUE(coverage.has_value());
+  if (coverage.has_value()) {
+    EXPECT_RECT_NEAR(coverage.value(),
+                     Rect::MakeLTRB(100 - 2, 100 - 2, 200 + 2, 200 + 2));
+  }
+}
+
 TEST(GaussianBlurFilterContentsTest, CalculateSigmaValues) {
   EXPECT_EQ(GaussianBlurFilterContents::CalculateScale(1.0f), 1);
   EXPECT_EQ(GaussianBlurFilterContents::CalculateScale(2.0f), 1);


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/183884

GaussianBlurFilterContents::GetFilterSourceCoverage decides how much to expand the bounding rect to account for the applied blur. If given a matrix with a negative scale, `GetFilterSourceCoverage` would shrink the bounding rect instead of expanding it - giving the appearance of the "offset" described in https://github.com/flutter/flutter/issues/183884

Added a unittest and golden test to verify the change.

Repro app on MacOS with --enable-impeller at HEAD:

<img width="799" height="626" alt="Screenshot 2026-03-23 at 2 28 06 PM" src="https://github.com/user-attachments/assets/ed26b264-a1b2-481e-aa54-9be6858b35f5" />


Repro app with this change with --enable-impeller:

<img width="799" height="626" alt="Screenshot 2026-03-23 at 2 27 10 PM" src="https://github.com/user-attachments/assets/2f8edf40-e4da-4833-88ca-1ff6180c25ac" />


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
