### PR TITLE
Add example app for mustache_template package

### DIFF
--- a/packages/mustache_template/README.md
+++ b/packages/mustache_template/README.md
@@ -1,0 +1,148 @@
+# mustache_template
+
+A Dart implementation of the [Mustache](https://mustache.github.io/) templating language.
+
+## Features
+
+- Variable interpolation with `{{variable}}`
+- Sections for conditionals and loops with `{{#section}}...{{/section}}`
+- Inverted sections with `{{^section}}...{{/section}}`
+- Lambda functions for dynamic content
+- Partials for template composition
+- HTML escaping by default, with `{{{raw}}}` for unescaped output
+
+## Getting Started
+
+Add `mustache_template` to your `pubspec.yaml`:
+
+yaml
+dependencies:
+  mustache_template: ^2.0.0
+
+
+## Usage
+
+### Basic Variable Interpolation
+
+<?code-excerpt "lib/main.dart (basic-variable)"?>
+dart
+/// Demonstrates basic variable interpolation.
+void basicVariableExample() {
+  final template = Template('Hello {{name}}!');
+  final output = template.renderString({'name': 'World'});
+  print(output); // Output: Hello World!
+}
+
+
+### Sections
+
+Sections render blocks of text based on the value of a key. They can be used for conditionals and loops.
+
+<?code-excerpt "lib/main.dart (sections)"?>
+dart
+/// Demonstrates sections for conditionals and loops.
+void sectionsExample() {
+  // Conditional section
+  final conditionalTemplate = Template('''
+{{#showGreeting}}
+Hello, {{name}}!
+{{/showGreeting}}
+''');
+  print(conditionalTemplate.renderString({
+    'showGreeting': true,
+    'name': 'Alice',
+  }));
+
+  // Loop section
+  final loopTemplate = Template('''
+{{#items}}
+- {{name}}: {{price}}
+{{/items}}
+''');
+  print(loopTemplate.renderString({
+    'items': [
+      {'name': 'Apple', 'price': r'$1.00'},
+      {'name': 'Banana', 'price': r'$0.50'},
+    ],
+  }));
+}
+
+
+### Inverted Sections
+
+Inverted sections render when a key is false, null, or an empty list.
+
+<?code-excerpt "lib/main.dart (inverted-sections)"?>
+dart
+/// Demonstrates inverted sections for handling empty or false values.
+void invertedSectionsExample() {
+  final template = Template('''
+{{#items}}
+- {{.}}
+{{/items}}
+{{^items}}
+No items found.
+{{/items}}
+''');
+
+  // With items
+  print(template.renderString({
+    'items': ['One', 'Two'],
+  }));
+
+  // Without items
+  print(template.renderString({
+    'items': <String>[],
+  }));
+}
+
+
+### Lambdas
+
+Lambdas allow dynamic content generation.
+
+<?code-excerpt "lib/main.dart (lambdas)"?>
+dart
+/// Demonstrates lambda functions for dynamic content.
+void lambdasExample() {
+  final template = Template('{{#bold}}Hello{{/bold}}');
+  final output = template.renderString({
+    'bold': (LambdaContext ctx) => '<b>${ctx.renderString()}</b>',
+  });
+  print(output); // Output: <b>Hello</b>
+}
+
+
+### Partials
+
+Partials allow template composition by including other templates.
+
+<?code-excerpt "lib/main.dart (partials)"?>
+dart
+/// Demonstrates partials for template composition.
+void partialsExample() {
+  final baseTemplate = Template(
+    '{{> header}}\nContent here\n{{> footer}}',
+    partialResolver: (String name) {
+      switch (name) {
+        case 'header':
+          return Template('=== Header ===');
+        case 'footer':
+          return Template('=== Footer ===');
+        default:
+          return Template('');
+      }
+    },
+  );
+  print(baseTemplate.renderString({}));
+}
+
+
+## Example
+
+See the [example](example/) directory for a complete example application.
+
+## Additional Resources
+
+- [Mustache Manual](https://mustache.github.io/mustache.5.html)
+- [API Documentation](https://pub.dev/documentation/mustache_template/latest/)

--- a/packages/mustache_template/README.md
+++ b/packages/mustache_template/README.md
@@ -15,31 +15,31 @@ A Dart implementation of the [Mustache](https://mustache.github.io/) templating 
 
 Add `mustache_template` to your `pubspec.yaml`:
 
-yaml
+```yaml
 dependencies:
   mustache_template: ^2.0.0
-
+```
 
 ## Usage
 
 ### Basic Variable Interpolation
 
 <?code-excerpt "lib/main.dart (basic-variable)"?>
-dart
+```dart
 /// Demonstrates basic variable interpolation.
 void basicVariableExample() {
   final template = Template('Hello {{name}}!');
   final output = template.renderString({'name': 'World'});
   print(output); // Output: Hello World!
 }
-
+```
 
 ### Sections
 
 Sections render blocks of text based on the value of a key. They can be used for conditionals and loops.
 
 <?code-excerpt "lib/main.dart (sections)"?>
-dart
+```dart
 /// Demonstrates sections for conditionals and loops.
 void sectionsExample() {
   // Conditional section
@@ -66,14 +66,14 @@ Hello, {{name}}!
     ],
   }));
 }
-
+```
 
 ### Inverted Sections
 
 Inverted sections render when a key is false, null, or an empty list.
 
 <?code-excerpt "lib/main.dart (inverted-sections)"?>
-dart
+```dart
 /// Demonstrates inverted sections for handling empty or false values.
 void invertedSectionsExample() {
   final template = Template('''
@@ -95,14 +95,14 @@ No items found.
     'items': <String>[],
   }));
 }
-
+```
 
 ### Lambdas
 
 Lambdas allow dynamic content generation.
 
 <?code-excerpt "lib/main.dart (lambdas)"?>
-dart
+```dart
 /// Demonstrates lambda functions for dynamic content.
 void lambdasExample() {
   final template = Template('{{#bold}}Hello{{/bold}}');
@@ -111,14 +111,14 @@ void lambdasExample() {
   });
   print(output); // Output: <b>Hello</b>
 }
-
+```
 
 ### Partials
 
 Partials allow template composition by including other templates.
 
 <?code-excerpt "lib/main.dart (partials)"?>
-dart
+```dart
 /// Demonstrates partials for template composition.
 void partialsExample() {
   final baseTemplate = Template(
@@ -136,7 +136,7 @@ void partialsExample() {
   );
   print(baseTemplate.renderString({}));
 }
-
+```
 
 ## Example
 

--- a/packages/mustache_template/example/excerpt_yaml.yaml
+++ b/packages/mustache_template/example/excerpt_yaml.yaml
@@ -1,0 +1,1 @@
+name: mustache_template_example

--- a/packages/mustache_template/example/lib/main.dart
+++ b/packages/mustache_template/example/lib/main.dart
@@ -1,0 +1,118 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// Example demonstrating mustache_template usage.
+library;
+
+import 'package:mustache_template/mustache_template.dart';
+
+void main() {
+  // Basic variable interpolation
+  basicVariableExample();
+
+  // Sections (conditionals and loops)
+  sectionsExample();
+
+  // Inverted sections
+  invertedSectionsExample();
+
+  // Lambdas
+  lambdasExample();
+
+  // Partials
+  partialsExample();
+}
+
+// #docregion basic-variable
+/// Demonstrates basic variable interpolation.
+void basicVariableExample() {
+  final template = Template('Hello {{name}}!');
+  final output = template.renderString({'name': 'World'});
+  print(output); // Output: Hello World!
+}
+// #enddocregion basic-variable
+
+// #docregion sections
+/// Demonstrates sections for conditionals and loops.
+void sectionsExample() {
+  // Conditional section
+  final conditionalTemplate = Template('''
+{{#showGreeting}}
+Hello, {{name}}!
+{{/showGreeting}}
+''');
+  print(conditionalTemplate.renderString({
+    'showGreeting': true,
+    'name': 'Alice',
+  }));
+
+  // Loop section
+  final loopTemplate = Template('''
+{{#items}}
+- {{name}}: {{price}}
+{{/items}}
+''');
+  print(loopTemplate.renderString({
+    'items': [
+      {'name': 'Apple', 'price': r'$1.00'},
+      {'name': 'Banana', 'price': r'$0.50'},
+    ],
+  }));
+}
+// #enddocregion sections
+
+// #docregion inverted-sections
+/// Demonstrates inverted sections for handling empty or false values.
+void invertedSectionsExample() {
+  final template = Template('''
+{{#items}}
+- {{.}}
+{{/items}}
+{{^items}}
+No items found.
+{{/items}}
+''');
+
+  // With items
+  print(template.renderString({
+    'items': ['One', 'Two'],
+  }));
+
+  // Without items
+  print(template.renderString({
+    'items': <String>[],
+  }));
+}
+// #enddocregion inverted-sections
+
+// #docregion lambdas
+/// Demonstrates lambda functions for dynamic content.
+void lambdasExample() {
+  final template = Template('{{#bold}}Hello{{/bold}}');
+  final output = template.renderString({
+    'bold': (LambdaContext ctx) => '<b>${ctx.renderString()}</b>',
+  });
+  print(output); // Output: <b>Hello</b>
+}
+// #enddocregion lambdas
+
+// #docregion partials
+/// Demonstrates partials for template composition.
+void partialsExample() {
+  final baseTemplate = Template(
+    '{{> header}}\nContent here\n{{> footer}}',
+    partialResolver: (String name) {
+      switch (name) {
+        case 'header':
+          return Template('=== Header ===');
+        case 'footer':
+          return Template('=== Footer ===');
+        default:
+          return Template('');
+      }
+    },
+  );
+  print(baseTemplate.renderString({}));
+}
+// #enddocregion partials

--- a/packages/mustache_template/example/pubspec.yaml
+++ b/packages/mustache_template/example/pubspec.yaml
@@ -1,0 +1,10 @@
+name: mustache_template_example
+description: Example app demonstrating mustache_template usage.
+publish_to: none
+
+environment:
+  sdk: ^3.0.0
+
+dependencies:
+  mustache_template:
+    path: ../


### PR DESCRIPTION
This PR adds an example app for the mustache_template package and refactors the README to use code excerpts following the flutter/flutter contribution guidelines. The example app demonstrates key features including basic variable interpolation, sections, inverted sections, lambdas, and partials. The README has been updated to be more high-level while linking to actual runnable code in the example app.

Fixes #183936