### PR TITLE
Refactor layout dimensions

### DIFF
--- a/packages/flutter/lib/src/material/carousel.dart
+++ b/packages/flutter/lib/src/material/carousel.dart
@@ -814,11 +814,6 @@ class _RenderSliverFixedExtentCarousel extends RenderSliverFixedExtentBoxAdaptor
     return maxExtent;
   }
 
-  @override
-  void performLayout() {
-    super.performLayout();
-  }
-
   /// The layout offset for the child with the given index.
   @override
   double indexToLayoutOffset(

--- a/packages/flutter/lib/src/material/carousel.dart
+++ b/packages/flutter/lib/src/material/carousel.dart
@@ -814,16 +814,8 @@ class _RenderSliverFixedExtentCarousel extends RenderSliverFixedExtentBoxAdaptor
     return maxExtent;
   }
 
-  late SliverLayoutDimensions _currentLayoutDimensions;
-
   @override
   void performLayout() {
-    _currentLayoutDimensions = SliverLayoutDimensions(
-      scrollOffset: constraints.scrollOffset,
-      precedingScrollExtent: constraints.precedingScrollExtent,
-      viewportMainAxisExtent: constraints.viewportMainAxisExtent,
-      crossAxisExtent: constraints.crossAxisExtent,
-    );
     super.performLayout();
   }
 
@@ -851,7 +843,7 @@ class _RenderSliverFixedExtentCarousel extends RenderSliverFixedExtentBoxAdaptor
       minExtent,
     );
     if (index == firstVisibleIndex) {
-      final double firstVisibleItemExtent = _buildItemExtent(index, _currentLayoutDimensions);
+      final double firstVisibleItemExtent = _buildItemExtent(index, layoutDimensions);
 
       // If the first item is collapsed to be less than `effectiveMinExtent`,
       // then it should stop changing its size and should start to scroll off screen.
@@ -1012,8 +1004,6 @@ class _RenderSliverWeightedCarousel extends RenderSliverFixedExtentBoxAdaptor {
     markNeedsLayout();
   }
 
-  late SliverLayoutDimensions _currentLayoutDimensions;
-
   // This is to implement the itemExtentBuilder callback to return each item extent
   // while scrolling.
   //
@@ -1153,7 +1143,7 @@ class _RenderSliverWeightedCarousel extends RenderSliverFixedExtentBoxAdaptor {
     }
     double visibleItemsTotalExtent = _distanceToLeadingEdge;
     for (int i = _firstVisibleItemIndex + 1; i < index; i++) {
-      visibleItemsTotalExtent += _buildItemExtent(i, _currentLayoutDimensions);
+      visibleItemsTotalExtent += _buildItemExtent(i, layoutDimensions);
     }
     return constraints.scrollOffset + visibleItemsTotalExtent;
   }
@@ -1183,7 +1173,7 @@ class _RenderSliverWeightedCarousel extends RenderSliverFixedExtentBoxAdaptor {
     if (childCount != null) {
       double visibleItemsTotalExtent = _distanceToLeadingEdge;
       for (int i = _firstVisibleItemIndex + 1; i < childCount; i++) {
-        visibleItemsTotalExtent += _buildItemExtent(i, _currentLayoutDimensions);
+        visibleItemsTotalExtent += _buildItemExtent(i, layoutDimensions);
         if (visibleItemsTotalExtent >= constraints.viewportMainAxisExtent) {
           return i;
         }
@@ -1205,7 +1195,7 @@ class _RenderSliverWeightedCarousel extends RenderSliverFixedExtentBoxAdaptor {
   }
 
   BoxConstraints _getChildConstraints(int index) {
-    final double extent = itemExtentBuilder!(index, _currentLayoutDimensions)!;
+    final double extent = itemExtentBuilder!(index, layoutDimensions)!;
     return constraints.asBoxConstraints(minExtent: extent, maxExtent: extent);
   }
 
@@ -1230,12 +1220,6 @@ class _RenderSliverWeightedCarousel extends RenderSliverFixedExtentBoxAdaptor {
     final double remainingExtent = constraints.remainingCacheExtent;
     assert(remainingExtent >= 0.0);
     final double targetEndScrollOffset = scrollOffset + remainingExtent;
-    _currentLayoutDimensions = SliverLayoutDimensions(
-      scrollOffset: constraints.scrollOffset,
-      precedingScrollExtent: constraints.precedingScrollExtent,
-      viewportMainAxisExtent: constraints.viewportMainAxisExtent,
-      crossAxisExtent: constraints.crossAxisExtent,
-    );
     // TODO(Piinks): Clean up when deprecation expires.
     const double deprecatedExtraItemExtent = -1;
 
@@ -1344,7 +1328,7 @@ class _RenderSliverWeightedCarousel extends RenderSliverFixedExtentBoxAdaptor {
 
       trailingScrollOffset += math.max(
         weights.last * extentUnit,
-        _buildItemExtent(lastIndex, _currentLayoutDimensions),
+        _buildItemExtent(lastIndex, layoutDimensions),
       );
       trailingScrollOffset += extraLayoutOffset;
     } else {

--- a/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
+++ b/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
@@ -84,7 +84,7 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
         if (childCount != null && i > childCount - 1) {
           break;
         }
-        itemExtent = itemExtentBuilder!(i, _currentLayoutDimensions);
+        itemExtent = itemExtentBuilder!(i, layoutDimensions);
         if (itemExtent == null) {
           break;
         }
@@ -228,7 +228,7 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
       var offset = 0.0;
       double? itemExtent;
       for (var i = 0; i < childManager.childCount; i++) {
-        itemExtent = itemExtentBuilder!(i, _currentLayoutDimensions);
+        itemExtent = itemExtentBuilder!(i, layoutDimensions);
         if (itemExtent == null) {
           break;
         }
@@ -250,7 +250,7 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
       if (childCount != null && index > childCount - 1) {
         break;
       }
-      itemExtent = callback(index, _currentLayoutDimensions);
+      itemExtent = callback(index, layoutDimensions);
       if (itemExtent == null) {
         break;
       }
@@ -265,12 +265,34 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
     if (itemExtentBuilder == null) {
       extent = itemExtent!;
     } else {
-      extent = itemExtentBuilder!(index, _currentLayoutDimensions)!;
+      extent = itemExtentBuilder!(index, layoutDimensions)!;
     }
     return constraints.asBoxConstraints(minExtent: extent, maxExtent: extent);
   }
 
-  late SliverLayoutDimensions _currentLayoutDimensions;
+  /// The layout dimensions for the sliver.
+  ///
+  /// If the sliver has not been laid out yet, this returns a
+  /// [SliverLayoutDimensions] based on the current [constraints].
+  SliverLayoutDimensions get layoutDimensions {
+    return _currentLayoutDimensions ??
+        SliverLayoutDimensions(
+          scrollOffset: constraints.scrollOffset,
+          precedingScrollExtent: constraints.precedingScrollExtent,
+          viewportMainAxisExtent: constraints.viewportMainAxisExtent,
+          crossAxisExtent: constraints.crossAxisExtent,
+        );
+  }
+
+  @override
+  double paintExtentOf(RenderBox child) {
+    if (itemExtentBuilder == null) {
+      return itemExtent!;
+    }
+    return itemExtentBuilder!(indexOf(child), layoutDimensions)!;
+  }
+
+  SliverLayoutDimensions? _currentLayoutDimensions;
 
   @override
   void performLayout() {

--- a/packages/flutter/lib/src/rendering/sliver_tree.dart
+++ b/packages/flutter/lib/src/rendering/sliver_tree.dart
@@ -12,7 +12,6 @@ import 'package:flutter/foundation.dart';
 import 'box.dart';
 import 'layer.dart';
 import 'object.dart';
-import 'sliver.dart';
 import 'sliver_fixed_extent_list.dart';
 import 'sliver_multi_box_adaptor.dart';
 

--- a/packages/flutter/lib/src/rendering/sliver_tree.dart
+++ b/packages/flutter/lib/src/rendering/sliver_tree.dart
@@ -190,11 +190,6 @@ class RenderTreeSliver extends RenderSliverVariedExtentList {
     super.dispose();
   }
 
-  // TODO(Piinks): This should be made a public getter on the super class.
-  // Multiple subclasses are making use of it now, yak shave that refactor
-  // separately.
-  late SliverLayoutDimensions _currentLayoutDimensions;
-
   @override
   void performLayout() {
     assert(
@@ -203,12 +198,6 @@ class RenderTreeSliver extends RenderSliverVariedExtentList {
       'The current axis direction is: ${constraints.axisDirection}.',
     );
     _updateAnimationCache();
-    _currentLayoutDimensions = SliverLayoutDimensions(
-      scrollOffset: constraints.scrollOffset,
-      precedingScrollExtent: constraints.precedingScrollExtent,
-      viewportMainAxisExtent: constraints.viewportMainAxisExtent,
-      crossAxisExtent: constraints.crossAxisExtent,
-    );
     super.performLayout();
   }
 
@@ -240,7 +229,7 @@ class RenderTreeSliver extends RenderSliverVariedExtentList {
         break;
       }
 
-      itemExtent = itemExtentBuilder(index, _currentLayoutDimensions);
+      itemExtent = itemExtentBuilder(index, layoutDimensions);
       if (itemExtent == null) {
         break;
       }
@@ -272,7 +261,7 @@ class RenderTreeSliver extends RenderSliverVariedExtentList {
     // We animate only a portion of children that would be visible/in the cache
     // extent, unless all children would fit on the screen.
     while (currentIndex <= lastIndex && currentPosition < targetPosition) {
-      final double itemExtent = itemExtentBuilder(currentIndex, _currentLayoutDimensions)!;
+      final double itemExtent = itemExtentBuilder(currentIndex, layoutDimensions)!;
       totalAnimatingOffset += itemExtent;
       currentPosition += itemExtent;
       currentIndex++;
@@ -306,7 +295,7 @@ class RenderTreeSliver extends RenderSliverVariedExtentList {
         break;
       }
 
-      itemExtent = itemExtentBuilder(currentIndex, _currentLayoutDimensions);
+      itemExtent = itemExtentBuilder(currentIndex, layoutDimensions);
       if (itemExtent == null) {
         break;
       }
@@ -386,10 +375,10 @@ class RenderTreeSliver extends RenderSliverVariedExtentList {
       final int parentIndex = math.max(segment.leadingIndex - 1, 0);
       final double leadingOffset =
           indexToLayoutOffset(0.0, parentIndex) +
-          (parentIndex == 0 ? 0.0 : itemExtentBuilder(parentIndex, _currentLayoutDimensions)!);
+          (parentIndex == 0 ? 0.0 : itemExtentBuilder(parentIndex, layoutDimensions)!);
       final double trailingOffset =
           indexToLayoutOffset(0.0, segment.trailingIndex) +
-          itemExtentBuilder(segment.trailingIndex, _currentLayoutDimensions)!;
+          itemExtentBuilder(segment.trailingIndex, layoutDimensions)!;
       final rect = Rect.fromPoints(
         Offset(0.0, leadingOffset),
         Offset(constraints.crossAxisExtent, trailingOffset),

--- a/packages/flutter/test/widgets/slivers_test.dart
+++ b/packages/flutter/test/widgets/slivers_test.dart
@@ -1612,7 +1612,7 @@ void main() {
   });
 
   testWidgets('RenderSliverFixedExtentBoxAdaptor.layoutDimensions reflects the current constraints', (WidgetTester tester) async {
-    final ScrollController controller = ScrollController();
+    final controller = ScrollController();
     addTearDown(controller.dispose);
     await tester.pumpWidget(
       Directionality(

--- a/packages/flutter/test/widgets/slivers_test.dart
+++ b/packages/flutter/test/widgets/slivers_test.dart
@@ -1611,41 +1611,46 @@ void main() {
     expect(controller.position.maxScrollExtent, 0.0);
   });
 
-  testWidgets('RenderSliverFixedExtentBoxAdaptor.layoutDimensions reflects the current constraints', (WidgetTester tester) async {
-    final controller = ScrollController();
-    addTearDown(controller.dispose);
-    await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: CustomScrollView(
-          controller: controller,
-          slivers: <Widget>[
-            SliverFixedExtentList(
-              itemExtent: 100.0,
-              delegate: SliverChildBuilderDelegate(
-                (BuildContext context, int index) => SizedBox(height: 100.0, child: Text('Item $index')),
-                childCount: 20,
+  testWidgets(
+    'RenderSliverFixedExtentBoxAdaptor.layoutDimensions reflects the current constraints',
+    (WidgetTester tester) async {
+      final controller = ScrollController();
+      addTearDown(controller.dispose);
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: CustomScrollView(
+            controller: controller,
+            slivers: <Widget>[
+              SliverFixedExtentList(
+                itemExtent: 100.0,
+                delegate: SliverChildBuilderDelegate(
+                  (BuildContext context, int index) =>
+                      SizedBox(height: 100.0, child: Text('Item $index')),
+                  childCount: 20,
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
-      ),
-    );
+      );
 
-    final RenderSliverFixedExtentBoxAdaptor renderSliver = tester.renderObject<RenderSliverFixedExtentBoxAdaptor>(find.byType(SliverFixedExtentList));
-    expect(renderSliver.layoutDimensions.scrollOffset, 0.0);
-    expect(renderSliver.layoutDimensions.precedingScrollExtent, 0.0);
-    expect(renderSliver.layoutDimensions.viewportMainAxisExtent, 600.0);
-    expect(renderSliver.layoutDimensions.crossAxisExtent, 800.0);
+      final RenderSliverFixedExtentBoxAdaptor renderSliver = tester
+          .renderObject<RenderSliverFixedExtentBoxAdaptor>(find.byType(SliverFixedExtentList));
+      expect(renderSliver.layoutDimensions.scrollOffset, 0.0);
+      expect(renderSliver.layoutDimensions.precedingScrollExtent, 0.0);
+      expect(renderSliver.layoutDimensions.viewportMainAxisExtent, 600.0);
+      expect(renderSliver.layoutDimensions.crossAxisExtent, 800.0);
 
-    controller.jumpTo(150.0);
-    await tester.pump();
+      controller.jumpTo(150.0);
+      await tester.pump();
 
-    expect(renderSliver.layoutDimensions.scrollOffset, 150.0);
-    expect(renderSliver.layoutDimensions.precedingScrollExtent, 0.0);
-    expect(renderSliver.layoutDimensions.viewportMainAxisExtent, 600.0);
-    expect(renderSliver.layoutDimensions.crossAxisExtent, 800.0);
-  });
+      expect(renderSliver.layoutDimensions.scrollOffset, 150.0);
+      expect(renderSliver.layoutDimensions.precedingScrollExtent, 0.0);
+      expect(renderSliver.layoutDimensions.viewportMainAxisExtent, 600.0);
+      expect(renderSliver.layoutDimensions.crossAxisExtent, 800.0);
+    },
+  );
 }
 
 bool isRight(Offset a, Offset b) => b.dx > a.dx;

--- a/packages/flutter/test/widgets/slivers_test.dart
+++ b/packages/flutter/test/widgets/slivers_test.dart
@@ -1610,6 +1610,42 @@ void main() {
     // Verify correct scroll extent
     expect(controller.position.maxScrollExtent, 0.0);
   });
+
+  testWidgets('RenderSliverFixedExtentBoxAdaptor.layoutDimensions reflects the current constraints', (WidgetTester tester) async {
+    final ScrollController controller = ScrollController();
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: CustomScrollView(
+          controller: controller,
+          slivers: <Widget>[
+            SliverFixedExtentList(
+              itemExtent: 100.0,
+              delegate: SliverChildBuilderDelegate(
+                (BuildContext context, int index) => SizedBox(height: 100.0, child: Text('Item $index')),
+                childCount: 20,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    final RenderSliverFixedExtentBoxAdaptor renderSliver = tester.renderObject<RenderSliverFixedExtentBoxAdaptor>(find.byType(SliverFixedExtentList));
+    expect(renderSliver.layoutDimensions.scrollOffset, 0.0);
+    expect(renderSliver.layoutDimensions.precedingScrollExtent, 0.0);
+    expect(renderSliver.layoutDimensions.viewportMainAxisExtent, 600.0);
+    expect(renderSliver.layoutDimensions.crossAxisExtent, 800.0);
+
+    controller.jumpTo(150.0);
+    await tester.pump();
+
+    expect(renderSliver.layoutDimensions.scrollOffset, 150.0);
+    expect(renderSliver.layoutDimensions.precedingScrollExtent, 0.0);
+    expect(renderSliver.layoutDimensions.viewportMainAxisExtent, 600.0);
+    expect(renderSliver.layoutDimensions.crossAxisExtent, 800.0);
+  });
 }
 
 bool isRight(Offset a, Offset b) => b.dx > a.dx;


### PR DESCRIPTION
This PR completes an old TODO by refactoring how `SliverLayoutDimensions` are accessed and managed within `RenderSliverFixedExtentBoxAdaptor` and its subclasses.

Previously, several subclasses of RenderSliverFixedExtentBoxAdaptor (such as `RenderTreeSliver` and `RenderCarousel`) were manually maintaining their own local `layoutDimensions` fields and updating them during `performLayout`. This PR centralizes that logic into the base class, providing a unified and public way to access these dimensions.

* `RenderSliverFixedExtentBoxAdaptor` (base class):
  * Introduced a public `layoutDimensions` getter. This getter returns the dimensions from the most recent layout pass, or a default based on current constraints if layout is still in progress.
  * Added a `paintExtentOf` override to simplify extent calculations for subclasses.
    * This is not strictly part of the refactor. RenderSliverMultiBoxAdaptor already defines paintExtentOf, but this provides an optimization for RenderSliverFixedExtentBoxAdaptor by using itemExtent or itemExtentBuilder instead of relying on child.hasSize. This is especially useful for calculating visibility without a full layout.
  * Moved the management of the internal `_currentLayoutDimensions` field to the base class.
* `RenderTreeSliver`:
     * Removed the redundant local layoutDimensions field and its manual assignment.
     * Removed the "yak shave" TODO that previously noted this refactor was needed.
 * `RenderCarousel` & `_RenderSliverWeightedCarousel`:
     * Removed redundant local layoutDimensions fields and manual assignments in
         performLayout.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
