### PR TITLE
SelectableRegion should passthrough constraints to child unmodified

### DIFF
--- a/packages/flutter/lib/src/widgets/_platform_selectable_region_context_menu_web.dart
+++ b/packages/flutter/lib/src/widgets/_platform_selectable_region_context_menu_web.dart
@@ -144,6 +144,7 @@ class PlatformSelectableRegionContextMenu extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Stack(
+      fit: StackFit.passthrough,
       children: <Widget>[
         const Positioned.fill(child: HtmlElementView(viewType: _viewType)),
         child,

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -5430,15 +5430,18 @@ void main() {
 
   // Regression test for https://github.com/flutter/flutter/issues/121053.
   testWidgets(
-    'Ensure SelectionArea does not affect the layout of its children',
+    'Ensure SelectableRegion does not affect the layout of its children',
     (WidgetTester tester) async {
       await tester.pumpWidget(
-        const MaterialApp(
+        TestWidgetsApp(
           home: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: <Widget>[
-              SelectionArea(child: Text('row 1')),
-              Text('row 2'),
+              SelectableRegion(
+                selectionControls: emptyTextSelectionControls,
+                child: const Text('row 1'),
+              ),
+              const Text('row 2'),
             ],
           ),
         ),
@@ -5446,7 +5449,44 @@ void main() {
       await tester.pumpAndSettle();
       final double xOffset1 = tester.getTopLeft(find.text('row 1')).dx;
       final double xOffset2 = tester.getTopLeft(find.text('row 2')).dx;
+      final Size size1 = tester.getSize(find.text('row 1'));
+      final Size size2 = tester.getSize(find.text('row 2'));
       expect(xOffset1, xOffset2);
+      expect(size1, size2);
+    },
+    variant: TargetPlatformVariant.all(),
+  );
+
+  // Regression test for https://github.com/flutter/flutter/issues/171632.
+  testWidgets(
+    'SelectableRegion preserves constraints from parent rather than loosening them',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: Center(
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(minWidth: 300.0, minHeight: 400.0),
+              child: SelectableRegion(
+                selectionControls: emptyTextSelectionControls,
+                child: Container(
+                  key: const Key('container'),
+                  constraints: const BoxConstraints(maxWidth: 200.0, maxHeight: 200.0),
+                  child: const Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: <Widget>[Text('Row 1')],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Because min constraints win, the container size should be forced to 300x400.
+      final Size containerSize = tester.getSize(find.byKey(const Key('container')));
+      expect(containerSize.width, 300.0);
+      expect(containerSize.height, 400.0);
     },
     variant: TargetPlatformVariant.all(),
   );


### PR DESCRIPTION
Fixes #171632

Before this change the internal `Stack` that wraps a `SelectableRegion` to provide the native browser menu on the web through a platform view used the default `StackFit.loose` this means constraints passed to children are loosened. This caused the issue because it discarded incoming minimum layout constraints from the parent (setting them to zero). This prevented the child of SelectableRegion from expanding to fill their parent's bounds, allowing them to shrink to their intrinsic sizes instead.

After this change the internal `Stack` used by `SelectableRegion` now uses `StackFit.passthrough` to pass the constraints unmodified to its children. This fixes the issue by forwarding both minimum and maximum constraints unmodified, guaranteeing that child of `SelectableRegion` resolves to the same dimensions on the web and native.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.