### PR TITLE
Add title evaluation

### DIFF
--- a/packages/flutter/lib/src/widgets/_accessibility_evaluations.dart
+++ b/packages/flutter/lib/src/widgets/_accessibility_evaluations.dart
@@ -13,6 +13,7 @@ import 'binding.dart';
 import 'editable_text.dart';
 import 'framework.dart';
 import 'text.dart';
+import 'title.dart';
 
 const String _kAccessibilityEvaluationsDisabledErrorMessage = '''
 Accessibility evaluations APIs are not enabled.
@@ -824,5 +825,43 @@ class UnlabeledLeafNodeEvaluation extends AccessibilityEvaluation {
     }
 
     return violations;
+  }
+}
+
+/// {@macro flutter.widgets.accessibility_evaluations.internal}
+///
+/// An evaluation which enforces that the application has at least one [Title]
+/// widget to set the web page title.
+@internal
+class TitleEvaluation extends AccessibilityEvaluation {
+  /// Create a new [TitleEvaluation].
+  const TitleEvaluation();
+
+  @override
+  FutureOr<EvaluationResult> _evaluate(WidgetsBinding binding) {
+    final violations = <Violation>[];
+
+    if (binding.rootElement != null && !_hasTitleWidget(binding.rootElement!)) {
+      final SemanticsNode rootNode =
+          binding.renderViews.first.owner!.semanticsOwner!.rootSemanticsNode!;
+      violations.add(
+        Violation(rootNode, 'Expected to find at least one Title widget, but none was found.'),
+      );
+    }
+
+    return EvaluationResult(violations);
+  }
+
+  bool _hasTitleWidget(Element element) {
+    if (element.widget is Title) {
+      return true;
+    }
+    var found = false;
+    element.visitChildren((Element child) {
+      if (!found) {
+        found = _hasTitleWidget(child);
+      }
+    });
+    return found;
   }
 }

--- a/packages/flutter/test/widgets/accessibility_evaluations_test.dart
+++ b/packages/flutter/test/widgets/accessibility_evaluations_test.dart
@@ -614,4 +614,95 @@ void main() {
       handle.dispose();
     });
   });
+
+  group('TitleEvaluation', () {
+    late final Set<String> originalFeatureFlags;
+    setUpAll(() {
+      originalFeatureFlags = <String>{...debugEnabledFeatureFlags};
+      debugEnabledFeatureFlags.add('accessibility_evaluations');
+    });
+    tearDownAll(() {
+      debugEnabledFeatureFlags.clear();
+      debugEnabledFeatureFlags.addAll(originalFeatureFlags);
+    });
+
+    const evaluation = TitleEvaluation();
+
+    testWidgets('passes if there is at least one title widget', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: Title(title: 'Title', color: const Color(0xFF000000), child: const SizedBox()),
+        ),
+      );
+      final EvaluationResult? result = await tester.runAsync<EvaluationResult>(() async {
+        return await evaluation.evaluate(tester.binding);
+      });
+      expect(result!.violations, isEmpty);
+      handle.dispose();
+    });
+
+    testWidgets('passes if title widget is deeply nested (recursive check)', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: SizedBox(
+            child: Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Center(
+                child: Title(title: 'Nested Title', color: const Color(0xFF000000), child: const SizedBox()),
+              ),
+            ),
+          ),
+        ),
+      );
+      final EvaluationResult? result = await tester.runAsync<EvaluationResult>(() async {
+        return await evaluation.evaluate(tester.binding);
+      });
+      expect(result!.violations, isEmpty);
+      handle.dispose();
+    });
+
+    testWidgets('fails if there is no title widget', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        const Directionality(textDirection: TextDirection.ltr, child: SizedBox()),
+      );
+      final EvaluationResult? result = await tester.runAsync<EvaluationResult>(() async {
+        return await evaluation.evaluate(tester.binding);
+      });
+      expect(result!.violations, hasLength(1));
+      expect(
+        result.violations.first.reason,
+        contains('Expected to find at least one Title widget, but none was found.'),
+      );
+      handle.dispose();
+    });
+
+    testWidgets('fails if title widget is missing in deeply nested tree', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        const Directionality(
+          textDirection: TextDirection.ltr,
+          child: SizedBox(
+            child: Padding(
+              padding: EdgeInsets.all(8.0),
+              child: Center(
+                child: Text('No title here'),
+              ),
+            ),
+          ),
+        ),
+      );
+      final EvaluationResult? result = await tester.runAsync<EvaluationResult>(() async {
+        return await evaluation.evaluate(tester.binding);
+      });
+      expect(result!.violations, hasLength(1));
+      expect(
+        result.violations.first.reason,
+        contains('Expected to find at least one Title widget, but none was found.'),
+      );
+      handle.dispose();
+    });
+  });
 }

--- a/packages/flutter/test/widgets/accessibility_evaluations_test.dart
+++ b/packages/flutter/test/widgets/accessibility_evaluations_test.dart
@@ -642,7 +642,9 @@ void main() {
       handle.dispose();
     });
 
-    testWidgets('passes if title widget is deeply nested (recursive check)', (WidgetTester tester) async {
+    testWidgets('passes if title widget is deeply nested (recursive check)', (
+      WidgetTester tester,
+    ) async {
       final SemanticsHandle handle = tester.ensureSemantics();
       await tester.pumpWidget(
         TestWidgetsApp(
@@ -650,7 +652,11 @@ void main() {
             child: Padding(
               padding: const EdgeInsets.all(8.0),
               child: Center(
-                child: Title(title: 'Nested Title', color: const Color(0xFF000000), child: const SizedBox()),
+                child: Title(
+                  title: 'Nested Title',
+                  color: const Color(0xFF000000),
+                  child: const SizedBox(),
+                ),
               ),
             ),
           ),
@@ -679,7 +685,9 @@ void main() {
       handle.dispose();
     });
 
-    testWidgets('fails if title widget is missing in deeply nested tree', (WidgetTester tester) async {
+    testWidgets('fails if title widget is missing in deeply nested tree', (
+      WidgetTester tester,
+    ) async {
       final SemanticsHandle handle = tester.ensureSemantics();
       await tester.pumpWidget(
         const Directionality(
@@ -687,9 +695,7 @@ void main() {
           child: SizedBox(
             child: Padding(
               padding: EdgeInsets.all(8.0),
-              child: Center(
-                child: Text('No title here'),
-              ),
+              child: Center(child: Text('No title here')),
             ),
           ),
         ),


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/170715

This PR is to add an Evaluation for a11y to ensure a web app has at least one `Title` widget.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
