### PR TITLE
Expand simple shape path optimization logic and move it from dl_dispatcher to dl_builder

### DIFF
--- a/engine/src/flutter/display_list/display_list_unittests.cc
+++ b/engine/src/flutter/display_list/display_list_unittests.cc
@@ -5097,6 +5097,77 @@ TEST_F(DisplayListTest, DrawRectPathPromoteToDrawRect) {
   ASSERT_TRUE(DisplayListsEQ_Verbose(dl, expect_dl));
 }
 
+TEST_F(DisplayListTest, DrawFilledRectangularLinesPromoteToDrawRect) {
+  DlRect rect = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+
+  // Unclosed set of lines forming 3 sides of a rectangle.
+  DlPath path = DlPathBuilder()
+                    .MoveTo(rect.GetLeftBottom())
+                    .LineTo(rect.GetLeftTop())
+                    .LineTo(rect.GetRightTop())
+                    .LineTo(rect.GetRightBottom())
+                    .TakePath();
+  DlPaint paint = DlPaint().setDrawStyle(DlDrawStyle::kFill);
+
+  DisplayListBuilder builder;
+  builder.DrawPath(path, paint);
+  auto dl = builder.Build();
+
+  DisplayListBuilder expected;
+  expected.DrawRect(rect, paint);
+  auto expect_dl = expected.Build();
+
+  ASSERT_TRUE(DisplayListsEQ_Verbose(dl, expect_dl));
+}
+
+TEST_F(DisplayListTest,
+       DrawStrokedUnclosedRectangularLinesDoesNotPromoteToDrawRect) {
+  DlRect rect = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+
+  // Unclosed set of lines forming 3 sides of a rectangle.
+  DlPath path = DlPathBuilder()
+                    .MoveTo(rect.GetLeftBottom())
+                    .LineTo(rect.GetLeftTop())
+                    .LineTo(rect.GetRightTop())
+                    .LineTo(rect.GetRightBottom())
+                    .TakePath();
+  DlPaint paint = DlPaint().setDrawStyle(DlDrawStyle::kStroke);
+
+  DisplayListBuilder builder;
+  builder.DrawPath(path, paint);
+  auto dl = builder.Build();
+
+  DisplayListBuilder rect_dl_builder;
+  rect_dl_builder.DrawRect(rect, paint);
+  auto rect_dl = rect_dl_builder.Build();
+
+  ASSERT_TRUE(DisplayListsNE_Verbose(dl, rect_dl));
+}
+
+TEST_F(DisplayListTest, DrawStrokedRectangularLinesPromoteToDrawRect) {
+  DlRect rect = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+
+  // Closed set of lines forming a full rectangle.
+  DlPath path = DlPathBuilder()
+                    .MoveTo(rect.GetLeftBottom())
+                    .LineTo(rect.GetLeftTop())
+                    .LineTo(rect.GetRightTop())
+                    .LineTo(rect.GetRightBottom())
+                    .Close()
+                    .TakePath();
+  DlPaint paint = DlPaint().setDrawStyle(DlDrawStyle::kStroke);
+
+  DisplayListBuilder builder;
+  builder.DrawPath(path, paint);
+  auto dl = builder.Build();
+
+  DisplayListBuilder expected;
+  expected.DrawRect(rect, paint);
+  auto expect_dl = expected.Build();
+
+  ASSERT_TRUE(DisplayListsEQ_Verbose(dl, expect_dl));
+}
+
 TEST_F(DisplayListTest, DrawOvalPathPromoteToDrawOval) {
   DlRect rect = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
 
@@ -5126,7 +5197,28 @@ TEST_F(DisplayListTest, DrawRRectPathPromoteToDrawRoundRect) {
   ASSERT_TRUE(DisplayListsEQ_Verbose(dl, expect_dl));
 }
 
-TEST_F(DisplayListTest, DrawRectRoundRectPathPromoteToDrawRect) {
+TEST_F(DisplayListTest, DrawRRectPathUnequalRadiiPromoteToDrawRoundRect) {
+  DlRect rect = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+  DlRoundRect rrect =
+      DlRoundRect::MakeRectRadii(rect, {
+                                           DlSize(0.0f, 0.0f),  // top_left
+                                           DlSize(2.0f, 2.0f),  // top_right
+                                           DlSize(4.0f, 4.0f),  // bottom_right
+                                           DlSize(3.0f, 5.0f),  // bottom_left
+                                       });
+
+  DisplayListBuilder builder;
+  builder.DrawPath(DlPath::MakeRoundRect(rrect), DlPaint());
+  auto dl = builder.Build();
+
+  DisplayListBuilder expected;
+  expected.DrawRoundRect(rrect, DlPaint());
+  auto expect_dl = expected.Build();
+
+  ASSERT_TRUE(DisplayListsEQ_Verbose(dl, expect_dl));
+}
+
+TEST_F(DisplayListTest, DrawRRectPathPromoteToDrawRect) {
   DlRect rect = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
   DlRoundRect rrect = DlRoundRect::MakeRect(rect);
 
@@ -5136,6 +5228,21 @@ TEST_F(DisplayListTest, DrawRectRoundRectPathPromoteToDrawRect) {
 
   DisplayListBuilder expected;
   expected.DrawRect(rect, DlPaint());
+  auto expect_dl = expected.Build();
+
+  ASSERT_TRUE(DisplayListsEQ_Verbose(dl, expect_dl));
+}
+
+TEST_F(DisplayListTest, DrawLinePathPromoteToDrawLine) {
+  DlPoint start = DlPoint::MakeXY(10.0f, 10.0f);
+  DlPoint end = DlPoint::MakeXY(20.0f, 20.0f);
+
+  DisplayListBuilder builder;
+  builder.DrawPath(DlPath::MakeLine(start, end), DlPaint());
+  auto dl = builder.Build();
+
+  DisplayListBuilder expected;
+  expected.DrawLine(start, end, DlPaint());
   auto expect_dl = expected.Build();
 
   ASSERT_TRUE(DisplayListsEQ_Verbose(dl, expect_dl));

--- a/engine/src/flutter/display_list/display_list_unittests.cc
+++ b/engine/src/flutter/display_list/display_list_unittests.cc
@@ -5094,9 +5094,7 @@ TEST_F(DisplayListTest, DrawRectPathPromoteToDrawRect) {
   expected.DrawRect(rect, DlPaint());
   auto expect_dl = expected.Build();
 
-  // Support for this will be re-added soon, until then verify that we
-  // do not promote.
-  ASSERT_TRUE(DisplayListsNE_Verbose(dl, expect_dl));
+  ASSERT_TRUE(DisplayListsEQ_Verbose(dl, expect_dl));
 }
 
 TEST_F(DisplayListTest, DrawOvalPathPromoteToDrawOval) {
@@ -5110,9 +5108,7 @@ TEST_F(DisplayListTest, DrawOvalPathPromoteToDrawOval) {
   expected.DrawOval(rect, DlPaint());
   auto expect_dl = expected.Build();
 
-  // Support for this will be re-added soon, until then verify that we
-  // do not promote.
-  ASSERT_TRUE(DisplayListsNE_Verbose(dl, expect_dl));
+  ASSERT_TRUE(DisplayListsEQ_Verbose(dl, expect_dl));
 }
 
 TEST_F(DisplayListTest, DrawRRectPathPromoteToDrawRoundRect) {
@@ -5127,9 +5123,7 @@ TEST_F(DisplayListTest, DrawRRectPathPromoteToDrawRoundRect) {
   expected.DrawRoundRect(rrect, DlPaint());
   auto expect_dl = expected.Build();
 
-  // Support for this will be re-added soon, until then verify that we
-  // do not promote.
-  ASSERT_TRUE(DisplayListsNE_Verbose(dl, expect_dl));
+  ASSERT_TRUE(DisplayListsEQ_Verbose(dl, expect_dl));
 }
 
 TEST_F(DisplayListTest, DrawRectRoundRectPathPromoteToDrawRect) {
@@ -5144,9 +5138,7 @@ TEST_F(DisplayListTest, DrawRectRoundRectPathPromoteToDrawRect) {
   expected.DrawRect(rect, DlPaint());
   auto expect_dl = expected.Build();
 
-  // Support for this will be re-added soon, until then verify that we
-  // do not promote.
-  ASSERT_TRUE(DisplayListsNE_Verbose(dl, expect_dl));
+  ASSERT_TRUE(DisplayListsEQ_Verbose(dl, expect_dl));
 }
 
 TEST_F(DisplayListTest, DrawOvalRRectPathPromoteToDrawOval) {
@@ -5161,9 +5153,7 @@ TEST_F(DisplayListTest, DrawOvalRRectPathPromoteToDrawOval) {
   expected.DrawOval(rect, DlPaint());
   auto expect_dl = expected.Build();
 
-  // Support for this will be re-added soon, until then verify that we
-  // do not promote.
-  ASSERT_TRUE(DisplayListsNE_Verbose(dl, expect_dl));
+  ASSERT_TRUE(DisplayListsEQ_Verbose(dl, expect_dl));
 }
 
 TEST_F(DisplayListTest, ClipRectRRectPromoteToClipRect) {

--- a/engine/src/flutter/display_list/dl_builder.cc
+++ b/engine/src/flutter/display_list/dl_builder.cc
@@ -1307,8 +1307,9 @@ void DisplayListBuilder::DrawPath(const DlPath& path, const DlPaint& paint) {
     return;
   }
 
-  if (path.IsOval(&rect)) {
-    DrawOval(rect, paint);
+  DlRect oval_bounds;
+  if (path.IsOval(&oval_bounds)) {
+    DrawOval(oval_bounds, paint);
     return;
   }
 

--- a/engine/src/flutter/display_list/dl_builder.cc
+++ b/engine/src/flutter/display_list/dl_builder.cc
@@ -1293,6 +1293,32 @@ void DisplayListBuilder::drawPath(const DlPath& path) {
   }
 }
 void DisplayListBuilder::DrawPath(const DlPath& path, const DlPaint& paint) {
+  DlRect rect;
+  bool closed;
+  if (path.IsRect(&rect, &closed) &&
+      (paint.getDrawStyle() == DlDrawStyle::kFill || closed)) {
+    DrawRect(rect, paint);
+    return;
+  }
+
+  DlRoundRect rrect;
+  if (path.IsRoundRect(&rrect)) {
+    DrawRoundRect(rrect, paint);
+    return;
+  }
+
+  if (path.IsOval(&rect)) {
+    DrawOval(rect, paint);
+    return;
+  }
+
+  DlPoint start;
+  DlPoint end;
+  if (path.IsLine(&start, &end)) {
+    DrawLine(start, end, paint);
+    return;
+  }
+
   SetAttributesFromPaint(paint, DisplayListOpFlags::kDrawPathFlags);
   drawPath(path);
 }

--- a/engine/src/flutter/impeller/display_list/dl_dispatcher.cc
+++ b/engine/src/flutter/impeller/display_list/dl_dispatcher.cc
@@ -590,7 +590,7 @@ void DlDispatcherBase::drawRoundSuperellipse(const DlRoundSuperellipse& rse) {
 void DlDispatcherBase::drawPath(const DlPath& path) {
   AUTO_DEPTH_WATCHER(1u);
 
-  SimplifyOrDrawPath(GetCanvas(), path, paint_);
+  GetCanvas().DrawPath(path, paint_);
 }
 
 void DlDispatcherBase::SimplifyOrDrawPath(Canvas& canvas,


### PR DESCRIPTION
Copies the rect/rrect/oval/line path optimization logic from [`impeller::DlDispatcherBase::SimplifyOrDrawPath`](https://github.com/flutter/flutter/blob/1306bcd2f6219f4dda92deed042c6f838f35fff9/engine/src/flutter/impeller/display_list/dl_dispatcher.cc#L596) to `DisplayListBuilder::DrawPath`.

`impeller::DlDispatcherBase::drawShadow` still uses `impeller::DlDispatcherBase::SimplifyOrDrawPath`, so it can't be completely removed.

The new logic in `DisplayListBuilder::DrawPath` is expanded to include rects that are open and filled, and to include rrects with non-uniform corner radii. This makes it match [Skia graphite's path simpliifcation logic](https://skia.googlesource.com/skia/+/4bbcf0d57a3243ec16f5b8909f761b42661879bd/src/gpu/graphite/Device.cpp#1204).

This allows many common Paths to be drawn with simpler shapes rather than drawPath, helping with https://github.com/flutter/flutter/issues/183044.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
