### PR TITLE
Text hint should not be ignored in `MinimumTextContrastGuideline`

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -759,13 +759,13 @@ class _RenderDecoration extends RenderBox
     final RenderBox? helperError = childForSlot(_DecorationSlot.helperError);
     return <RenderBox>[
       ?icon,
-      ?hint,
       ?input,
       ?prefixIcon,
       ?suffixIcon,
       ?prefix,
       ?suffix,
       ?label,
+      ?hint,
       ?helperError,
       ?counter,
       ?container,

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -726,14 +726,26 @@ class _RenderDecoration extends RenderBox
     required bool isFocused,
     required bool expands,
     required bool material3,
+    required bool enabled,
     TextAlignVertical? textAlignVertical,
   }) : _decoration = decoration,
        _textDirection = textDirection,
        _textBaseline = textBaseline,
        _textAlignVertical = textAlignVertical,
        _isFocused = isFocused,
+       _enabled = enabled,
        _expands = expands,
        _material3 = material3;
+
+  bool get enabled => _enabled;
+  bool _enabled;
+  set enabled(bool value) {
+    if (_enabled == value) {
+      return;
+    }
+    _enabled = value;
+    markNeedsSemanticsUpdate();
+  }
 
   // TODO(bleroux): consider defining this value as a Material token and making it
   // configurable by InputDecorationThemeData.
@@ -1734,11 +1746,15 @@ class _RenderDecoration extends RenderBox
   @override
   void describeSemanticsConfiguration(SemanticsConfiguration config) {
     config.childConfigurationsDelegate = _childSemanticsConfigurationDelegate;
+    if (!_enabled) {
+      config.isEnabled = false;
+    }
   }
 }
 
 class _Decorator extends SlottedMultiChildRenderObjectWidget<_DecorationSlot, RenderBox> {
   const _Decorator({
+    required this.enabled,
     required this.textAlignVertical,
     required this.decoration,
     required this.textDirection,
@@ -1747,6 +1763,7 @@ class _Decorator extends SlottedMultiChildRenderObjectWidget<_DecorationSlot, Re
     required this.expands,
   });
 
+  final bool enabled;
   final _Decoration decoration;
   final TextDirection textDirection;
   final TextBaseline textBaseline;
@@ -1784,6 +1801,7 @@ class _Decorator extends SlottedMultiChildRenderObjectWidget<_DecorationSlot, Re
       isFocused: isFocused,
       expands: expands,
       material3: Theme.of(context).useMaterial3,
+      enabled: enabled,
     );
   }
 
@@ -1795,7 +1813,8 @@ class _Decorator extends SlottedMultiChildRenderObjectWidget<_DecorationSlot, Re
       ..isFocused = isFocused
       ..textAlignVertical = textAlignVertical
       ..textBaseline = textBaseline
-      ..textDirection = textDirection;
+      ..textDirection = textDirection
+      ..enabled = enabled;
   }
 }
 
@@ -2644,6 +2663,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
     }
 
     final decorator = _Decorator(
+      enabled: decoration.enabled,
       decoration: _Decoration(
         contentPadding: contentPadding,
         isCollapsed: decoration.isCollapsed!,

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -759,13 +759,13 @@ class _RenderDecoration extends RenderBox
     final RenderBox? helperError = childForSlot(_DecorationSlot.helperError);
     return <RenderBox>[
       ?icon,
+      ?hint,
       ?input,
       ?prefixIcon,
       ?suffixIcon,
       ?prefix,
       ?suffix,
       ?label,
-      ?hint,
       ?helperError,
       ?counter,
       ?container,

--- a/packages/flutter_test/lib/src/accessibility.dart
+++ b/packages/flutter_test/lib/src/accessibility.dart
@@ -367,7 +367,7 @@ class MinimumTextContrastGuideline extends AccessibilityGuideline {
       return result;
     }
     final String text = data.label.isEmpty ? data.value : data.label;
-    final Iterable<Element> elements = find.text(text).evaluate();
+    final Iterable<Element> elements = find.text(text).hitTestable().evaluate();
     for (final element in elements) {
       result += await _evaluateElement(node, element, tester, image, byteData, renderView);
     }

--- a/packages/flutter_test/lib/src/accessibility.dart
+++ b/packages/flutter_test/lib/src/accessibility.dart
@@ -355,6 +355,10 @@ class MinimumTextContrastGuideline extends AccessibilityGuideline {
     }
 
     final SemanticsData data = node.getSemanticsData();
+    if (shouldSkipDisabledNode(data)) {
+      return result;
+    }
+
     final children = <SemanticsNode>[];
     node.visitChildren((SemanticsNode child) {
       children.add(child);
@@ -474,6 +478,9 @@ class MinimumTextContrastGuideline extends AccessibilityGuideline {
       'https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html',
     );
   }
+
+  bool shouldSkipDisabledNode(SemanticsData data) =>
+      data.flagsCollection.isEnabled == ui.Tristate.isFalse;
 
   /// Returns whether node should be skipped.
   ///

--- a/packages/flutter_test/lib/src/accessibility.dart
+++ b/packages/flutter_test/lib/src/accessibility.dart
@@ -367,7 +367,7 @@ class MinimumTextContrastGuideline extends AccessibilityGuideline {
       return result;
     }
     final String text = data.label.isEmpty ? data.value : data.label;
-    final Iterable<Element> elements = find.text(text).hitTestable().evaluate();
+    final Iterable<Element> elements = find.text(text).evaluate();
     for (final element in elements) {
       result += await _evaluateElement(node, element, tester, image, byteData, renderView);
     }

--- a/packages/flutter_test/test/accessibility_test.dart
+++ b/packages/flutter_test/test/accessibility_test.dart
@@ -248,6 +248,28 @@ void main() {
       handle.dispose();
     });
 
+    testWidgets('Material text field - hint text contrast', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        _boilerplate(
+          Container(
+            width: 200.0,
+            color: Colors.white,
+            child: TextField(
+              decoration: InputDecoration(
+                hintText: 'Type something here...',
+                hintStyle: TextStyle(color: Colors.black.withAlpha(32)),
+                border: const OutlineInputBorder(),
+              ),
+              keyboardType: TextInputType.text,
+            ),
+          ),
+        ),
+      );
+      await expectLater(tester, doesNotMeetGuideline(textContrastGuideline));
+      handle.dispose();
+    });
+
     testWidgets('Material2: yellow text on yellow background fails with correct message', (
       WidgetTester tester,
     ) async {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/172009

This PR is to fix the issue where TextField hint was ignored from `MinimumTextContrastGuideline`. 

`InputDecorator`'s custom children sequence mapped the input (the text field editor) before the hint. During simulated pointer tap-tests (used internally by .hitTestable()), the input layer intercepted the hit and prevented the algorithm from evaluating the hint text visually layered beneath it. 

First attempt: I originally tried to [swap `hint` and `input` child sequencing](https://github.com/flutter/flutter/pull/184099/changes/976b3b58530ac23707d56cd1efe40785dd93f7f9) in `_RenderDecoration.children`, it fixes the pointer-based simulated hits for the .hitTestable(). However, it breaks tests (such as InputDatePickerFormField) that rely on pointer events intended exclusively for the input field being intercepted by the editor layer.

By removing `.hitTestable()` from the contrast evaluation in `accessibility.dart`, we decouple visual visibility from pointer-level touch physics entirely. Visually accessible text is correctly surfaced exclusively via the semantics tree, avoiding unneeded regressions for existing pointer-driven test suites elsewhere. However, removing `hitTestable()` will cause the disabled textfield is evaluated as well and thus cause failure on the text contrast.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing