### PR TITLE
[web] Add browser scroll controller and BrowserScrollPhysics

### DIFF
--- a/dev/bots/suite_runners/run_web_tests.dart
+++ b/dev/bots/suite_runners/run_web_tests.dart
@@ -55,6 +55,7 @@ class WebTestsSuite {
       // VM-specific functionality.
       'test/services/message_codecs_vm_test.dart',
       'test/examples/sector_layout_test.dart',
+      'test/widgets/browser_scroll_test.dart',
 
       // These tests are broken and need to be fixed.
       // TODO(yjbanov): https://github.com/flutter/flutter/issues/71604
@@ -70,6 +71,7 @@ class WebTestsSuite {
       // VM-specific functionality.
       'test/services/message_codecs_vm_test.dart',
       'test/examples/sector_layout_test.dart',
+      'test/widgets/browser_scroll_test.dart',
 
       // These tests are broken and need to be fixed.
       // TODO(jacksongardner): https://github.com/flutter/flutter/issues/71604

--- a/engine/src/flutter/lib/web_ui/lib/src/engine.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine.dart
@@ -19,6 +19,7 @@ export 'engine/alarm_clock.dart';
 export 'engine/app_bootstrap.dart';
 export 'engine/arena.dart';
 export 'engine/browser_detection.dart';
+export 'engine/browser_scroll_controller.dart';
 export 'engine/canvaskit/canvas.dart';
 export 'engine/canvaskit/canvaskit_api.dart';
 export 'engine/canvaskit/color_filter.dart';

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/browser_scroll_controller.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/browser_scroll_controller.dart
@@ -1,0 +1,138 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:js_interop';
+
+import 'dom.dart';
+import 'view_embedder/embedding_strategy/embedding_strategy.dart';
+import 'window.dart';
+
+/// Manages browser-driven scrolling for a Flutter view.
+///
+/// When enabled, the view's root element (`<flutter-view>`) becomes a real
+/// scrollable DOM element. The browser handles wheel, touch, keyboard,
+/// momentum, and scroll chaining natively. This controller listens for the
+/// resulting `scroll` event and reports the new position to the framework
+/// via [FlutterView.onBrowserScroll].
+///
+/// The framework communicates content extent via the dart:ui API on
+/// [FlutterView].
+class BrowserScrollController {
+  BrowserScrollController(this._view);
+
+  final EngineFlutterView _view;
+
+  bool _enabled = false;
+  bool get enabled => _enabled;
+
+  JSFunction? _scrollListener;
+  double? _lastProgrammaticScrollTop;
+
+  /// Enables browser-driven scrolling for this view.
+  void enable() {
+    if (_enabled) {
+      return;
+    }
+
+    final EmbeddingStrategy strategy = _view.embeddingStrategy;
+    if (!strategy.supportsBrowserScrolling) {
+      return;
+    }
+
+    _enabled = true;
+    strategy.enableBrowserScrolling(_view.dom.rootElement);
+    _attachScrollListener();
+  }
+
+  /// Disables browser-driven scrolling for this view.
+  void disable() {
+    if (!_enabled) {
+      return;
+    }
+
+    _enabled = false;
+    _detachScrollListener();
+    _view.embeddingStrategy.disableBrowserScrolling(_view.dom.rootElement);
+  }
+
+  /// Updates the total scroll content height. Called when the framework
+  /// reports a new content extent.
+  void updateContentHeight(double height) {
+    _view.embeddingStrategy.updateScrollContentHeight(height);
+  }
+
+  /// Instantly scrolls the root element to [offset].
+  ///
+  /// Notifies the framework directly so its [ScrollPosition.pixels] stays
+  /// in sync. The DOM `scroll` event echo is suppressed via
+  /// [_lastProgrammaticScrollTop] to avoid a duplicate notification.
+  void scrollTo(double offset) {
+    if (_enabled) {
+      final DomElement root = _view.dom.rootElement;
+      root.scrollTop = offset;
+      final double newTop = root.scrollTop;
+      _lastProgrammaticScrollTop = newTop;
+      _sendScrollPositionToFramework(newTop);
+    }
+  }
+
+  void smoothScrollTo(double offset) {
+    if (_enabled) {
+      _view.dom.rootElement.scrollTo(top: offset, behavior: 'smooth');
+    }
+  }
+
+  /// Scrolls the root element by [delta] pixels.
+  ///
+  /// Calls [_sendScrollPositionToFramework] directly rather than relying on
+  /// the DOM `scroll` event, so the framework sees the new position even
+  /// though [_lastProgrammaticScrollTop] would otherwise suppress the echo.
+  ///
+  /// Used by the framework to forward inner-scrollable overscroll into the
+  /// outer browser viewport.
+  void scrollBy(double delta) {
+    if (_enabled) {
+      final DomElement root = _view.dom.rootElement;
+      root.scrollTop = root.scrollTop + delta;
+      final double newTop = root.scrollTop;
+      _lastProgrammaticScrollTop = newTop;
+      _sendScrollPositionToFramework(newTop);
+    }
+  }
+
+  void _attachScrollListener() {
+    final DomElement scrollTarget = _view.dom.rootElement;
+
+    void onScroll() {
+      final double scrollTop = scrollTarget.scrollTop;
+      // Suppress echo when the framework just wrote scrollTop programmatically.
+      if (_lastProgrammaticScrollTop != null &&
+          (scrollTop - _lastProgrammaticScrollTop!).abs() < 1.0) {
+        _lastProgrammaticScrollTop = null;
+        return;
+      }
+      _lastProgrammaticScrollTop = null;
+      _sendScrollPositionToFramework(scrollTop);
+    }
+
+    _scrollListener = onScroll.toJS;
+    scrollTarget.addEventListener('scroll', _scrollListener);
+  }
+
+  void _detachScrollListener() {
+    final JSFunction? listener = _scrollListener;
+    if (listener != null) {
+      _view.dom.rootElement.removeEventListener('scroll', listener);
+      _scrollListener = null;
+    }
+  }
+
+  void _sendScrollPositionToFramework(double scrollTop) {
+    _view.onBrowserScroll?.call(scrollTop);
+  }
+
+  void dispose() {
+    disable();
+  }
+}

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/dom.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/dom.dart
@@ -528,6 +528,13 @@ extension type DomElement._(JSObject _) implements DomNode {
   external double scrollLeft;
   external DomTokenList get classList;
 
+  @JS('scrollTo')
+  external void _scrollTo([JSAny? options]);
+
+  void scrollTo({required double top, String behavior = 'auto'}) {
+    _scrollTo(<String, dynamic>{'top': top, 'behavior': behavior}.toJSAnyDeep);
+  }
+
   /// Scrolls the element into the visible area of the browser window.
   ///
   /// See: https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/pointer_binding.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/pointer_binding.dart
@@ -28,9 +28,6 @@ const bool _debugLogPointerEvents = false;
 /// Set this to true to log all the events sent to the Flutter framework.
 const bool _debugLogFlutterEvents = false;
 
-// Note: debugResetIframeDetectionCache() and debugSetIframeEmbeddingForTests()
-// are now in dom.dart as shared utilities.
-
 /// Resets full-page app detection override for tests.
 @visibleForTesting
 void debugResetFullPageAppCache() {
@@ -562,13 +559,11 @@ abstract class _BaseAdapter {
   DomWheelEvent? _lastWheelEvent;
   bool _lastWheelEventWasTrackpad = false;
 
-  /// Two flags to track scroll handling for the two-flag system:
-  /// 1. _lastWheelEventAllowedDefault: true if a scrollable is at boundary
-  /// 2. _lastWheelEventHandledByWidget: true if a scrollable consumed the event
-  ///
-  /// This enables proper handling of nested scrollables:
-  /// - If inner scrollable handles the event, don't scroll parent page
-  /// - If all scrollables are at boundary, scroll parent page
+  // Two flags to disambiguate nested scrollable wheel handling:
+  // _lastWheelEventAllowedDefault: set when a scrollable is at boundary.
+  // _lastWheelEventHandledByWidget: set when a scrollable consumed the event.
+  // If inner scrollable handles the event, don't scroll parent page.
+  // If all scrollables are at boundary, allow parent page to scroll.
   bool _lastWheelEventAllowedDefault = false;
   bool _lastWheelEventHandledByWidget = false;
 
@@ -788,12 +783,9 @@ mixin _WheelEventListenerMixin on _BaseAdapter {
         scrollDeltaX: deltaX,
         scrollDeltaY: deltaY,
         onRespond: ({bool allowPlatformDefault = false}) {
-          // Track both: platform default and widget handling
           if (allowPlatformDefault) {
-            // Widget is at boundary, wants platform to handle
             _lastWheelEventAllowedDefault = true;
           } else {
-            // Widget explicitly handled this event
             _lastWheelEventHandledByWidget = true;
           }
         },
@@ -823,39 +815,40 @@ mixin _WheelEventListenerMixin on _BaseAdapter {
       print(event.type);
     }
 
-    // Reset flags before dispatching to framework
-    _lastWheelEventAllowedDefault = false;
-    _lastWheelEventHandledByWidget = false;
-
     final wheelEvent = event as DomWheelEvent;
 
-    // Dispatch to framework (this triggers onRespond callbacks synchronously)
+    _lastWheelEventAllowedDefault = false;
+    _lastWheelEventHandledByWidget = false;
     _callback(event, _convertWheelEventToPointerData(wheelEvent));
 
-    // Determine if we should prevent default
+    if (_view.browserScrollController.enabled) {
+      // If a nested Flutter scrollable consumed this wheel event, block the
+      // browser from also scrolling <flutter-view>.
+      // Otherwise (outermost BrowserScrollPhysics declined, or no scrollable
+      // at target), skip preventDefault so the browser handles the wheel
+      // natively via overflow: auto on <flutter-view>. This delivers real
+      // browser-native wheel physics and lets the browser chain the scroll
+      // to a parent document when <flutter-view> hits its boundary.
+      if (_lastWheelEventHandledByWidget) {
+        event.preventDefault();
+      }
+      return;
+    }
+
     final bool isInIframe = isEmbeddedInIframe();
 
-    // Special handling only for full-page Flutter apps running inside an iframe.
-    // Custom element apps (Flutter embedded as a component) should let the
-    // browser handle normal scroll flow.
+    // Full-page app in an iframe: skip preventDefault when all scrollables
+    // are at boundary so the browser bubbles scroll to the parent window.
+    // Fixes GitHub issue #156985
     if (isInIframe && _isFullPageApp) {
-      // Full-page app in an iframe: only preventDefault when Flutter handles
-      // the scroll. When scrollables are at boundary, skip preventDefault to
-      // let the browser naturally bubble the scroll to the parent window.
-      //
-      // Fixes GitHub issue #156985
       final bool shouldScrollParent =
           _lastWheelEventAllowedDefault && !_lastWheelEventHandledByWidget;
       if (!shouldScrollParent) {
         event.preventDefault();
       }
     } else {
-      // Original behavior for:
-      // 1. Apps NOT in an iframe (normal page)
-      // 2. Multi-view mode inside an iframe
-      //
-      // Only preventDefault when a scrollable widget handles the event.
-      // This preserves native scroll behavior when Flutter can't scroll.
+      // Non-iframe or custom-element: only preventDefault when a widget
+      // handled the event, preserving native scroll at boundaries.
       if (!_lastWheelEventAllowedDefault) {
         event.preventDefault();
       }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/embedding_strategy/custom_element_embedding_strategy.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/embedding_strategy/custom_element_embedding_strategy.dart
@@ -50,4 +50,16 @@ class CustomElementEmbeddingStrategy implements EmbeddingStrategy {
     registerElementForCleanup(rootElement);
     _rootElement = rootElement;
   }
+
+  @override
+  bool get supportsBrowserScrolling => false;
+
+  @override
+  void enableBrowserScrolling(DomElement rootElement) {}
+
+  @override
+  void disableBrowserScrolling(DomElement rootElement) {}
+
+  @override
+  void updateScrollContentHeight(double height) {}
 }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/embedding_strategy/embedding_strategy.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/embedding_strategy/embedding_strategy.dart
@@ -44,4 +44,22 @@ abstract class EmbeddingStrategy {
 
   /// Attaches the view root element into the hostElement.
   void attachViewRoot(DomElement rootElement);
+
+  /// Whether browser-driven scrolling is supported by this embedding strategy.
+  bool get supportsBrowserScrolling => false;
+
+  /// Enables browser-driven scrolling for the outermost scrollable.
+  ///
+  /// When enabled, [rootElement] becomes a real scrollable DOM element,
+  /// allowing the browser to handle scroll physics, momentum, and scroll
+  /// chaining natively. The framework syncs its scroll position from the
+  /// browser's scroll events.
+  void enableBrowserScrolling(DomElement rootElement) {}
+
+  /// Disables browser-driven scrolling, restoring the original styles.
+  void disableBrowserScrolling(DomElement rootElement) {}
+
+  /// Updates the scroll content height so the browser knows how much
+  /// content is available to scroll through.
+  void updateScrollContentHeight(double height) {}
 }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/embedding_strategy/full_page_embedding_strategy.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/embedding_strategy/full_page_embedding_strategy.dart
@@ -27,6 +27,18 @@ class FullPageEmbeddingStrategy implements EmbeddingStrategy {
   DomEventTarget get globalEventTarget => domWindow;
 
   @override
+  bool get supportsBrowserScrolling => true;
+
+  DomElement? _scrollHeightPlaceholder;
+
+  // Per-child inline style snapshot taken on enable so disable can restore
+  // the exact pre-enable state. Needed because some engine-managed children
+  // such as <flt-semantics-host> carry inline `position: absolute` that
+  // otherwise falls through to `static` when we clear the style.
+  final Map<DomElement, Map<String, String>> _savedChildStyles =
+      <DomElement, Map<String, String>>{};
+
+  @override
   void setLocale(ui.Locale locale) {
     domDocument.documentElement!.setAttribute('lang', locale.toLanguageTag());
   }
@@ -44,6 +56,111 @@ class FullPageEmbeddingStrategy implements EmbeddingStrategy {
     hostElement.append(rootElement);
 
     registerElementForCleanup(rootElement);
+  }
+
+  @override
+  void enableBrowserScrolling(DomElement rootElement) {
+    setElementStyle(hostElement, 'position', 'static');
+    setElementStyle(hostElement, 'overflow', 'hidden');
+    setElementStyle(hostElement, 'padding', '0');
+    setElementStyle(hostElement, 'margin', '0');
+    setElementStyle(hostElement, 'width', '100%');
+    setElementStyle(hostElement, 'height', '100%');
+
+    // Override body's touch-action from 'none' to 'pan-y'. The browser
+    // computes effective touch-action as the intersection of an element
+    // and all its ancestors. If body keeps 'none', no descendant can
+    // touch-scroll regardless of its own touch-action value.
+    setElementStyle(hostElement, 'touch-action', 'pan-y');
+
+    // Make <flutter-view> the scrollable element. This is critical: the
+    // flutter-view must be the scrollable so that wheel events, which land
+    // on it, trigger native scrolling. If we made the body scrollable but
+    // flutter-view was fixed on top, wheel events would go to flutter-view
+    // and the body would never scroll.
+    rootElement.style
+      ..position = 'fixed'
+      ..top = '0'
+      ..right = '0'
+      ..bottom = '0'
+      ..left = '0'
+      ..overflow = 'auto';
+
+    // Allow the browser to handle vertical touch-drag as native scroll.
+    // Horizontal and other gestures still flow to Flutter as pointer events.
+    setElementStyle(rootElement, 'touch-action', 'pan-y');
+
+    // Make all existing children of flutter-view sticky so they stay
+    // visible at the top of the viewport while the element scrolls.
+    // This includes <flt-glass-pane>, <flt-text-editing-host>, and
+    // <flt-semantics-host>.
+    //
+    // Snapshot each child's inline position/top/left first so disable can
+    // restore them. <flt-semantics-host> in particular ships with inline
+    // `position: absolute` set by StyleManager; clearing to empty would
+    // drop it through to `static` and break its transform scaling.
+    for (final DomElement child in rootElement.children) {
+      _savedChildStyles[child] = <String, String>{
+        'position': child.style.position,
+        'top': child.style.top,
+        'left': child.style.left,
+      };
+      child.style
+        ..position = 'sticky'
+        ..top = '0'
+        ..left = '0';
+    }
+
+    // Create a placeholder element inside flutter-view that sets the
+    // scroll height. This gives flutter-view real content to scroll against.
+    // It must be positioned absolutely so it doesn't push the sticky
+    // children down, and its height defines the total scrollable area.
+    _scrollHeightPlaceholder = domDocument.createElement('div');
+    _scrollHeightPlaceholder!.setAttribute('flt-scroll-placeholder', '');
+    _scrollHeightPlaceholder!.style
+      ..width = '1px'
+      ..pointerEvents = 'none'
+      ..position = 'absolute'
+      ..top = '0'
+      ..left = '0';
+
+    rootElement.append(_scrollHeightPlaceholder!);
+
+    registerElementForCleanup(_scrollHeightPlaceholder!);
+  }
+
+  @override
+  void disableBrowserScrolling(DomElement rootElement) {
+    _setHostStyles();
+
+    rootElement.style
+      ..position = 'absolute'
+      ..top = '0'
+      ..right = '0'
+      ..bottom = '0'
+      ..left = '0'
+      ..overflow = '';
+
+    setElementStyle(rootElement, 'touch-action', '');
+
+    for (final DomElement child in rootElement.children) {
+      final Map<String, String>? saved = _savedChildStyles[child];
+      child.style
+        ..position = saved?['position'] ?? ''
+        ..top = saved?['top'] ?? ''
+        ..left = saved?['left'] ?? '';
+    }
+    _savedChildStyles.clear();
+
+    _scrollHeightPlaceholder?.remove();
+    _scrollHeightPlaceholder = null;
+  }
+
+  @override
+  void updateScrollContentHeight(double height) {
+    if (_scrollHeightPlaceholder != null) {
+      _scrollHeightPlaceholder!.style.height = '${height}px';
+    }
   }
 
   // Sets the global styles for a flutter app.

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/window.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/window.dart
@@ -11,6 +11,7 @@ import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 import '../engine.dart' show DimensionsProvider, registerHotRestartListener, renderer;
 import 'browser_detection.dart';
+import 'browser_scroll_controller.dart';
 import 'display.dart';
 import 'dom.dart';
 import 'initialization.dart';
@@ -110,6 +111,7 @@ class EngineFlutterView implements ui.FlutterView {
     _resizeSubscription.cancel();
     dimensionsProvider.close();
     pointerBinding.dispose();
+    browserScrollController.dispose();
     dom.rootElement.remove();
     // TODO(harryterkelsen): What should we do about this in multi-view?
     renderer.clearFragmentProgramCache();
@@ -164,6 +166,42 @@ class EngineFlutterView implements ui.FlutterView {
   final JsViewConstraints? _jsViewConstraints;
 
   late final EngineSemanticsOwner semantics = EngineSemanticsOwner(viewId, dom.semanticsHost);
+
+  late final BrowserScrollController browserScrollController = BrowserScrollController(this);
+
+  // Browser-driven scrolling API (dart:ui surface)
+
+  @override
+  bool get supportsBrowserScrolling => embeddingStrategy.supportsBrowserScrolling;
+
+  @override
+  void enableBrowserScrolling() => browserScrollController.enable();
+
+  @override
+  void disableBrowserScrolling() => browserScrollController.disable();
+
+  @override
+  void browserScrollTo(double offset) => browserScrollController.scrollTo(offset);
+
+  @override
+  void browserSmoothScrollTo(double offset) => browserScrollController.smoothScrollTo(offset);
+
+  @override
+  void browserScrollBy(double delta) => browserScrollController.scrollBy(delta);
+
+  @override
+  void updateBrowserScrollContentHeight(double height) =>
+      browserScrollController.updateContentHeight(height);
+
+  ui.BrowserScrollCallback? _onBrowserScroll;
+
+  @override
+  ui.BrowserScrollCallback? get onBrowserScroll => _onBrowserScroll;
+
+  @override
+  set onBrowserScroll(ui.BrowserScrollCallback? callback) {
+    _onBrowserScroll = callback;
+  }
 
   @override
   ui.Size get physicalSize {

--- a/engine/src/flutter/lib/web_ui/lib/window.dart
+++ b/engine/src/flutter/lib/web_ui/lib/window.dart
@@ -11,6 +11,8 @@ abstract class Display {
   double get refreshRate;
 }
 
+typedef BrowserScrollCallback = void Function(double offset);
+
 abstract class FlutterView {
   PlatformDispatcher get platformDispatcher;
   int get viewId;
@@ -27,6 +29,20 @@ abstract class FlutterView {
   DisplayCornerRadii? get displayCornerRadii;
   void render(Scene scene, {Size? size});
   void updateSemantics(SemanticsUpdate update) => platformDispatcher.updateSemantics(update);
+
+  // Browser-driven scrolling API (web-only, no-op on other platforms).
+
+  bool get supportsBrowserScrolling => false;
+
+  void enableBrowserScrolling() {}
+  void disableBrowserScrolling() {}
+  void browserScrollTo(double offset) {}
+  void browserSmoothScrollTo(double offset) {}
+  void browserScrollBy(double delta) {}
+  void updateBrowserScrollContentHeight(double height) {}
+
+  BrowserScrollCallback? get onBrowserScroll => null;
+  set onBrowserScroll(BrowserScrollCallback? callback) {}
 }
 
 abstract class SingletonFlutterWindow extends FlutterView {

--- a/engine/src/flutter/lib/web_ui/test/engine/browser_scroll_controller_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/browser_scroll_controller_test.dart
@@ -1,0 +1,189 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/src/engine.dart';
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+void testMain() {
+  late EngineFlutterView view;
+  late BrowserScrollController controller;
+  late DomElement hostElement;
+
+  setUp(() {
+    hostElement = createDomHTMLDivElement();
+    domDocument.body!.append(hostElement);
+    view = EngineFlutterView(EnginePlatformDispatcher.instance, hostElement);
+    controller = view.browserScrollController;
+  });
+
+  tearDown(() {
+    view.dispose();
+    hostElement.remove();
+  });
+
+  group('enable/disable', () {
+    test('starts disabled', () {
+      expect(controller.enabled, isFalse);
+    });
+
+    test('does not enable when strategy does not support it', () {
+      controller.enable();
+      expect(controller.enabled, isFalse);
+    });
+
+    test('disable when already disabled is a no-op', () {
+      controller.disable();
+      expect(controller.enabled, isFalse);
+    });
+  });
+
+  group('dispose', () {
+    test('disable is called on dispose', () {
+      controller.dispose();
+      expect(controller.enabled, isFalse);
+    });
+
+    test('can dispose when already disabled', () {
+      controller.dispose();
+      controller.dispose();
+      expect(controller.enabled, isFalse);
+    });
+  });
+
+  // The full-page strategy is the only one that returns
+  // supportsBrowserScrolling == true, so the controller's actual scroll
+  // listener wiring and notification contract can only be exercised here.
+  // Body styles get mutated by enableBrowserScrolling, so each test saves
+  // and restores them to avoid cross-test contamination.
+  group('full-page', () {
+    late EngineFlutterView fullPageView;
+    late BrowserScrollController fullPageController;
+    late Map<String, String> savedBodyStyles;
+
+    setUp(() {
+      savedBodyStyles = <String, String>{};
+      for (final prop in const <String>[
+        'position',
+        'top',
+        'right',
+        'bottom',
+        'left',
+        'overflow',
+        'padding',
+        'margin',
+        'width',
+        'height',
+        'touch-action',
+        'user-select',
+        '-webkit-user-select',
+      ]) {
+        savedBodyStyles[prop] = domDocument.body!.style.getPropertyValue(prop);
+      }
+      // Null hostElement -> FullPageEmbeddingStrategy.
+      fullPageView = EngineFlutterView.implicit(EnginePlatformDispatcher.instance, null);
+      fullPageController = fullPageView.browserScrollController;
+    });
+
+    tearDown(() {
+      fullPageView.dispose();
+      for (final MapEntry<String, String> entry in savedBodyStyles.entries) {
+        if (entry.value.isEmpty) {
+          domDocument.body!.style.removeProperty(entry.key);
+        } else {
+          domDocument.body!.style.setProperty(entry.key, entry.value);
+        }
+      }
+    });
+
+    test('enable activates browser scrolling on full-page view', () {
+      expect(fullPageController.enabled, isFalse);
+      fullPageController.enable();
+      expect(fullPageController.enabled, isTrue);
+      // The strategy makes flutter-view the scrollable element.
+      expect(fullPageView.dom.rootElement.style.overflow, 'auto');
+    });
+
+    test('updateContentHeight sets placeholder height', () {
+      fullPageController.enable();
+      final DomElement? placeholder = fullPageView.dom.rootElement.querySelector(
+        '[flt-scroll-placeholder]',
+      );
+      expect(placeholder, isNotNull);
+
+      fullPageController.updateContentHeight(3000);
+      expect(placeholder!.style.height, '3000px');
+    });
+
+    test('scroll event invokes onBrowserScroll callback', () {
+      fullPageController.enable();
+      fullPageController.updateContentHeight(3000);
+
+      final received = <double>[];
+      fullPageView.onBrowserScroll = received.add;
+
+      // Simulate the browser firing a scroll event after a user-driven move.
+      fullPageView.dom.rootElement.scrollTop = 150;
+      fullPageView.dom.rootElement.dispatchEvent(createDomEvent('Event', 'scroll'));
+
+      expect(received, hasLength(1));
+      expect(received.first, closeTo(150, 0.5));
+    });
+
+    test('scrollTo writes scrollTop and notifies framework directly', () async {
+      fullPageController.enable();
+      fullPageController.updateContentHeight(3000);
+
+      final received = <double>[];
+      fullPageView.onBrowserScroll = received.add;
+
+      fullPageController.scrollTo(150);
+
+      // The direct notification fires synchronously, so the framework's
+      // ScrollPosition.pixels stays in sync even though the browser's echo
+      // scroll event is suppressed.
+      expect(received, hasLength(1));
+      expect(received.first, closeTo(150, 0.5));
+      expect(fullPageView.dom.rootElement.scrollTop, closeTo(150, 0.5));
+
+      // Flush the queue to confirm the browser's echoed scroll event does
+      // not double-notify.
+      await Future<void>.delayed(Duration.zero);
+      expect(received, hasLength(1));
+    });
+
+    test('scrollBy writes scrollTop and notifies framework', () {
+      fullPageController.enable();
+      fullPageController.updateContentHeight(3000);
+      fullPageController.scrollTo(100);
+
+      final received = <double>[];
+      fullPageView.onBrowserScroll = received.add;
+
+      fullPageController.scrollBy(50);
+
+      expect(received, hasLength(1));
+      expect(received.first, closeTo(150, 0.5));
+      expect(fullPageView.dom.rootElement.scrollTop, closeTo(150, 0.5));
+    });
+
+    test('disable removes scroll listener', () {
+      fullPageController.enable();
+      fullPageController.updateContentHeight(3000);
+      fullPageController.disable();
+
+      final received = <double>[];
+      fullPageView.onBrowserScroll = received.add;
+
+      fullPageView.dom.rootElement.scrollTop = 150;
+      fullPageView.dom.rootElement.dispatchEvent(createDomEvent('Event', 'scroll'));
+
+      expect(received, isEmpty);
+    });
+  });
+}

--- a/engine/src/flutter/lib/web_ui/test/engine/view_embedder/embedding_strategy/embedding_strategy_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/view_embedder/embedding_strategy/embedding_strategy_test.dart
@@ -31,4 +31,130 @@ void doTests() {
       expect(strategy, isA<CustomElementEmbeddingStrategy>());
     });
   });
+
+  group('Browser scrolling support', () {
+    test('FullPageEmbeddingStrategy supports browser scrolling', () {
+      final strategy = EmbeddingStrategy.create();
+      expect(strategy.supportsBrowserScrolling, isTrue);
+    });
+
+    test('CustomElementEmbeddingStrategy does not support browser scrolling', () {
+      final DomElement element = createDomElement('some-element');
+      final strategy = EmbeddingStrategy.create(hostElement: element);
+      expect(strategy.supportsBrowserScrolling, isFalse);
+    });
+
+    test('FullPage enableBrowserScrolling sets overflow:auto on rootElement', () {
+      final strategy = EmbeddingStrategy.create() as FullPageEmbeddingStrategy;
+      final DomElement rootElement = createDomElement('flutter-view');
+      domDocument.body!.append(rootElement);
+
+      strategy.enableBrowserScrolling(rootElement);
+
+      expect(rootElement.style.overflow, 'auto');
+
+      strategy.disableBrowserScrolling(rootElement);
+      rootElement.remove();
+    });
+
+    test('FullPage enableBrowserScrolling sets touch-action:pan-y on rootElement', () {
+      final strategy = EmbeddingStrategy.create() as FullPageEmbeddingStrategy;
+      final DomElement rootElement = createDomElement('flutter-view');
+      domDocument.body!.append(rootElement);
+
+      strategy.enableBrowserScrolling(rootElement);
+
+      final String touchAction = rootElement.style.getPropertyValue('touch-action');
+      expect(touchAction, 'pan-y');
+
+      strategy.disableBrowserScrolling(rootElement);
+      rootElement.remove();
+    });
+
+    test('FullPage enableBrowserScrolling creates scroll height placeholder', () {
+      final strategy = EmbeddingStrategy.create() as FullPageEmbeddingStrategy;
+      final DomElement rootElement = createDomElement('flutter-view');
+      domDocument.body!.append(rootElement);
+
+      strategy.enableBrowserScrolling(rootElement);
+
+      final DomElement? placeholder = rootElement.querySelector('[flt-scroll-placeholder]');
+      expect(placeholder, isNotNull);
+
+      strategy.disableBrowserScrolling(rootElement);
+      rootElement.remove();
+    });
+
+    test('FullPage updateScrollContentHeight sets placeholder height', () {
+      final strategy = EmbeddingStrategy.create() as FullPageEmbeddingStrategy;
+      final DomElement rootElement = createDomElement('flutter-view');
+      domDocument.body!.append(rootElement);
+
+      strategy.enableBrowserScrolling(rootElement);
+      strategy.updateScrollContentHeight(5000);
+
+      final DomElement? placeholder = rootElement.querySelector('[flt-scroll-placeholder]');
+      expect(placeholder, isNotNull);
+      expect(placeholder!.style.height, '5000px');
+
+      strategy.disableBrowserScrolling(rootElement);
+      rootElement.remove();
+    });
+
+    test('FullPage updateScrollContentHeight is no-op before enable', () {
+      final strategy = EmbeddingStrategy.create() as FullPageEmbeddingStrategy;
+      strategy.updateScrollContentHeight(5000);
+    });
+
+    test('FullPage disableBrowserScrolling restores inline child styles', () {
+      final strategy = EmbeddingStrategy.create() as FullPageEmbeddingStrategy;
+      final DomElement rootElement = createDomElement('flutter-view');
+      domDocument.body!.append(rootElement);
+
+      // Mimic StyleManager.styleSemanticsHost applying inline position.
+      final DomElement semanticsHost = createDomElement('flt-semantics-host');
+      semanticsHost.style.position = 'absolute';
+      rootElement.append(semanticsHost);
+
+      // Mimic a child without inline position.
+      final DomElement glassPane = createDomElement('flt-glass-pane');
+      rootElement.append(glassPane);
+
+      strategy.enableBrowserScrolling(rootElement);
+      expect(semanticsHost.style.position, 'sticky');
+      expect(glassPane.style.position, 'sticky');
+
+      strategy.disableBrowserScrolling(rootElement);
+      expect(semanticsHost.style.position, 'absolute');
+      expect(glassPane.style.position, '');
+
+      rootElement.remove();
+    });
+
+    test('FullPage disableBrowserScrolling restores hostElement touch-action', () {
+      final strategy = EmbeddingStrategy.create() as FullPageEmbeddingStrategy;
+      final DomElement rootElement = createDomElement('flutter-view');
+      domDocument.body!.append(rootElement);
+
+      strategy.enableBrowserScrolling(rootElement);
+      expect(strategy.hostElement.style.getPropertyValue('touch-action'), 'pan-y');
+
+      strategy.disableBrowserScrolling(rootElement);
+      // _setHostStyles, called from disable, restores touch-action: none.
+      // The class invariant for non-browser-scroll mode is none, matching
+      // the constructor.
+      expect(strategy.hostElement.style.getPropertyValue('touch-action'), 'none');
+
+      rootElement.remove();
+    });
+
+    test('CustomElement enableBrowserScrolling is a no-op', () {
+      final DomElement element = createDomElement('some-element');
+      final strategy = EmbeddingStrategy.create(hostElement: element);
+      final DomElement rootElement = createDomElement('flutter-view');
+
+      strategy.enableBrowserScrolling(rootElement);
+      expect(strategy.supportsBrowserScrolling, isFalse);
+    });
+  });
 }

--- a/packages/flutter/lib/foundation.dart
+++ b/packages/flutter/lib/foundation.dart
@@ -12,6 +12,8 @@ library foundation;
 export 'package:meta/meta.dart'
     show
         awaitNotRequired,
+        // ignore: experimental_member_use
+        experimental,
         factory,
         immutable,
         internal,

--- a/packages/flutter/lib/src/widgets/_browser_scroll_view_io.dart
+++ b/packages/flutter/lib/src/widgets/_browser_scroll_view_io.dart
@@ -1,0 +1,70 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui' show FlutterView;
+
+import 'package:flutter/foundation.dart';
+
+/// Non-web implementation of browser scroll view bindings.
+///
+/// On non-web platforms, browser scrolling is not available. All methods
+/// record their calls so tests can verify outbound communication. The
+/// [onBrowserScroll] callback is stored locally so tests can simulate
+/// browser scroll events.
+class BrowserScrollViewBinding {
+  /// Creates a binding for the given [FlutterView].
+  BrowserScrollViewBinding(this.view);
+
+  /// The [FlutterView] this binding is associated with.
+  final FlutterView view;
+
+  /// Whether the engine supports browser-driven scrolling for this view.
+  ///
+  /// Always false on non-web platforms in production, so apps that ship
+  /// to iOS/Android/desktop don't accidentally engage [BrowserScrollPhysics]
+  /// against a binding the engine cannot drive. Tests can flip
+  /// [debugForceSupportedForTests] to true to exercise the browser-scroll
+  /// code path against the recording stub.
+  bool get supported => debugForceSupportedForTests;
+
+  /// Test-only override that makes [supported] return true on non-web.
+  /// Reset to false in tearDown to avoid leaking across tests.
+  @visibleForTesting
+  static bool debugForceSupportedForTests = false;
+
+  /// Recorded method calls for test assertions.
+  ///
+  /// Each entry is a map with `method` and optional `args` keys.
+  final List<Map<String, Object?>> calls = <Map<String, Object?>>[];
+
+  /// Records a method call.
+  void _record(String method, [Object? args]) {
+    calls.add(<String, Object?>{'method': method, if (args != null) 'args': args});
+  }
+
+  /// No-op on non-web platforms. Records the call.
+  void enableBrowserScrolling() => _record('enableBrowserScrolling');
+
+  /// No-op on non-web platforms. Records the call.
+  void disableBrowserScrolling() => _record('disableBrowserScrolling');
+
+  /// No-op on non-web platforms. Records the call.
+  void browserScrollTo(double offset) => _record('browserScrollTo', offset);
+
+  /// No-op on non-web platforms. Records the call.
+  void browserSmoothScrollTo(double offset) => _record('browserSmoothScrollTo', offset);
+
+  /// No-op on non-web platforms. Records the call.
+  void browserScrollBy(double delta) => _record('browserScrollBy', delta);
+
+  /// No-op on non-web platforms. Records the call.
+  void updateBrowserScrollContentHeight(double height) =>
+      _record('updateBrowserScrollContentHeight', height);
+
+  /// The callback invoked when the browser reports a scroll position change.
+  ///
+  /// On non-web platforms, this callback is stored locally so tests can
+  /// simulate browser scroll events.
+  void Function(double offset)? onBrowserScroll;
+}

--- a/packages/flutter/lib/src/widgets/_browser_scroll_view_web.dart
+++ b/packages/flutter/lib/src/widgets/_browser_scroll_view_web.dart
@@ -1,0 +1,64 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui' show FlutterView;
+
+/// Web implementation of browser scroll view bindings.
+///
+/// On web, [FlutterView] is backed by `EngineFlutterView` which provides
+/// browser scroll methods via the dart:ui API surface. This class uses
+/// dynamic dispatch to call those methods, since the native dart:ui
+/// `FlutterView` class does not declare them.
+class BrowserScrollViewBinding {
+  /// Creates a binding for the given [FlutterView].
+  BrowserScrollViewBinding(this.view);
+
+  /// The [FlutterView] this binding is associated with.
+  final FlutterView view;
+
+  // Use dynamic to call web-only FlutterView methods that the native
+  // analyzer cannot resolve.
+  dynamic get _webView => view;
+
+  /// Whether the engine supports browser-driven scrolling for this view.
+  ///
+  /// Returns false for embedding strategies (e.g. custom-element) that
+  /// the engine does not enable, even on web.
+  // ignore: avoid_dynamic_calls
+  bool get supported => _webView.supportsBrowserScrolling as bool;
+
+  /// Enables browser-driven scrolling on the view.
+  // ignore: avoid_dynamic_calls
+  void enableBrowserScrolling() => _webView.enableBrowserScrolling();
+
+  /// Disables browser-driven scrolling on the view.
+  // ignore: avoid_dynamic_calls
+  void disableBrowserScrolling() => _webView.disableBrowserScrolling();
+
+  /// Instantly scrolls the browser to the given offset.
+  // ignore: avoid_dynamic_calls
+  void browserScrollTo(double offset) => _webView.browserScrollTo(offset);
+
+  /// Smoothly scrolls the browser to the given offset.
+  // ignore: avoid_dynamic_calls
+  void browserSmoothScrollTo(double offset) => _webView.browserSmoothScrollTo(offset);
+
+  /// Scrolls the browser by the given delta.
+  // ignore: avoid_dynamic_calls
+  void browserScrollBy(double delta) => _webView.browserScrollBy(delta);
+
+  /// Updates the browser scroll content height.
+  void updateBrowserScrollContentHeight(double height) =>
+      // ignore: avoid_dynamic_calls
+      _webView.updateBrowserScrollContentHeight(height);
+
+  /// The callback invoked when the browser reports a scroll position change.
+  void Function(double offset)? get onBrowserScroll =>
+      // ignore: avoid_dynamic_calls
+      _webView.onBrowserScroll as void Function(double)?;
+
+  set onBrowserScroll(void Function(double offset)? callback) {
+    _webView.onBrowserScroll = callback; // ignore: avoid_dynamic_calls
+  }
+}

--- a/packages/flutter/lib/src/widgets/browser_scroll.dart
+++ b/packages/flutter/lib/src/widgets/browser_scroll.dart
@@ -1,0 +1,100 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// @docImport 'scroll_physics.dart';
+library;
+
+import 'package:flutter/foundation.dart';
+
+import 'framework.dart';
+import 'notification_listener.dart';
+import 'scroll_configuration.dart';
+import 'scroll_metrics.dart';
+import 'scroll_notification.dart';
+import 'scrollable.dart';
+
+/// A wrapper widget that enables browser-driven scrolling, forwards
+/// touch-driven overscroll to the browser, and disables Flutter scrollbars.
+///
+/// Place this above the outermost scrollable. It sets
+/// [ScrollBehavior.enableBrowserScrolling] to true, which causes
+/// [ScrollableState] to set up browser scrolling via dart:ui and automatically
+/// apply [BrowserScrollPhysics]. This widget adds two things on top:
+///
+/// 1. Catches [OverscrollNotification] from touch drag gestures and forwards
+///    them to the browser via `scrollBy`, except at the edges where
+///    [RefreshIndicator] or load-more indicators need the notification.
+/// 2. Disables Flutter-drawn scrollbars since the browser provides its own.
+///
+/// Programmatic scrolling with [ScrollController.animateTo] and
+/// [ScrollController.jumpTo] works automatically when browser scrolling is
+/// active. Both are routed through the browser's native scroll mechanism,
+/// so they respect the actual content height even under lazy layout.
+///
+/// Known limitations:
+///
+/// * Only one [BrowserScrollable] can drive the browser at a time. Mounting
+///   a second one while another holds the slot leaves the second on
+///   Dart-driven physics. This shows up with `Navigator.push` to a route
+///   whose body is wrapped in [BrowserScrollable]: the pushed page is
+///   rejected because the route below it still owns the slot. Slot
+///   reclaim is on the roadmap; for now, build flows that have a single
+///   browser-scroll route at a time.
+/// * Only the full-page embedding strategy supports browser scrolling.
+///   Custom-element views report unsupported, which means the wrapped
+///   scrollable falls back to Dart-driven scrolling (no [BrowserScrollPhysics]
+///   is applied).
+/// * On iOS Safari, touch-drag inside a cross-origin iframe nested under
+///   this widget waits for the iframe's internal momentum to finish before
+///   chaining to the parent page. This is a browser-level behavior that
+///   cannot be intercepted from the parent document.
+///
+/// Example:
+/// ```dart
+/// // ignore_for_file: experimental_member_use
+/// BrowserScrollable(
+///   child: ListView.builder(
+///     itemCount: 100,
+///     itemBuilder: (context, index) => ListTile(title: Text('Item $index')),
+///   ),
+/// )
+/// ```
+@experimental
+class BrowserScrollable extends StatelessWidget {
+  /// Creates a widget that enables browser-driven scrolling for its child.
+  const BrowserScrollable({super.key, required this.child});
+
+  /// The child widget, typically a scrollable like [ListView].
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return NotificationListener<OverscrollNotification>(
+      onNotification: _handleOverscrollNotification,
+      child: ScrollConfiguration(
+        behavior: ScrollConfiguration.of(
+          context,
+        ).copyWith(scrollbars: false, enableBrowserScrolling: true),
+        child: child,
+      ),
+    );
+  }
+
+  static bool _handleOverscrollNotification(OverscrollNotification notification) {
+    final double delta = notification.overscroll;
+    final ScrollMetrics metrics = notification.metrics;
+
+    if (delta < 0 && metrics.pixels <= metrics.minScrollExtent) {
+      return false;
+    }
+    if (delta > 0 && metrics.pixels >= metrics.maxScrollExtent) {
+      return false;
+    }
+
+    if (delta.abs() > 0.5) {
+      ScrollableState.browserScrollViewBinding?.browserScrollBy(delta);
+    }
+    return true;
+  }
+}

--- a/packages/flutter/lib/src/widgets/scroll_configuration.dart
+++ b/packages/flutter/lib/src/widgets/scroll_configuration.dart
@@ -74,6 +74,29 @@ class ScrollBehavior {
   /// Creates a description of how [Scrollable] widgets should behave.
   const ScrollBehavior();
 
+  /// Whether the outermost scrollable should delegate scrolling to the
+  /// browser's native scroll engine.
+  ///
+  /// When true, [ScrollableState] sets up browser scrolling via the dart:ui
+  /// API to sync positions with the browser and automatically applies
+  /// [BrowserScrollPhysics]. The browser handles scroll physics,
+  /// draws the native scrollbar, and chains overflow to parent pages. Flutter
+  /// still lays out and paints content, but the browser owns the scroll
+  /// position.
+  ///
+  /// The dart:ui browser scroll API is only functional on web. On other
+  /// platforms the binding calls are no-ops, but [BrowserScrollPhysics] is
+  /// still applied to the physics chain so that the behavior can be tested
+  /// without running in a browser.
+  ///
+  /// If multiple nested [Scrollable]s inherit this flag, only the outermost
+  /// one claims the browser-scroll binding. Inner scrollables use their
+  /// normal physics.
+  ///
+  /// Defaults to false.
+  @experimental
+  bool get enableBrowserScrolling => false;
+
   /// Creates a copy of this ScrollBehavior, making it possible to
   /// easily toggle `scrollbar` and `overscrollIndicator` effects.
   ///
@@ -91,6 +114,7 @@ class ScrollBehavior {
     ScrollPhysics? physics,
     TargetPlatform? platform,
     ScrollViewKeyboardDismissBehavior? keyboardDismissBehavior,
+    bool? enableBrowserScrolling,
   }) {
     return _WrappedScrollBehavior(
       delegate: this,
@@ -102,6 +126,7 @@ class ScrollBehavior {
       physics: physics,
       platform: platform,
       keyboardDismissBehavior: keyboardDismissBehavior,
+      enableBrowserScrolling: enableBrowserScrolling,
     );
   }
 
@@ -289,8 +314,10 @@ class _WrappedScrollBehavior implements ScrollBehavior {
     this.physics,
     this.platform,
     this.keyboardDismissBehavior,
+    bool? enableBrowserScrolling,
   }) : _dragDevices = dragDevices,
-       _pointerAxisModifiers = pointerAxisModifiers;
+       _pointerAxisModifiers = pointerAxisModifiers,
+       _enableBrowserScrolling = enableBrowserScrolling;
 
   final ScrollBehavior delegate;
   final bool scrollbars;
@@ -301,6 +328,10 @@ class _WrappedScrollBehavior implements ScrollBehavior {
   final Set<PointerDeviceKind>? _dragDevices;
   final MultitouchDragStrategy? multitouchDragStrategy;
   final Set<LogicalKeyboardKey>? _pointerAxisModifiers;
+  final bool? _enableBrowserScrolling;
+
+  @override
+  bool get enableBrowserScrolling => _enableBrowserScrolling ?? delegate.enableBrowserScrolling;
 
   @override
   Set<PointerDeviceKind> get dragDevices => _dragDevices ?? delegate.dragDevices;
@@ -340,6 +371,7 @@ class _WrappedScrollBehavior implements ScrollBehavior {
     ScrollPhysics? physics,
     TargetPlatform? platform,
     ScrollViewKeyboardDismissBehavior? keyboardDismissBehavior,
+    bool? enableBrowserScrolling,
   }) {
     return delegate.copyWith(
       scrollbars: scrollbars ?? this.scrollbars,
@@ -350,6 +382,7 @@ class _WrappedScrollBehavior implements ScrollBehavior {
       physics: physics ?? this.physics,
       platform: platform ?? this.platform,
       keyboardDismissBehavior: keyboardDismissBehavior ?? this.keyboardDismissBehavior,
+      enableBrowserScrolling: enableBrowserScrolling ?? this.enableBrowserScrolling,
     );
   }
 
@@ -378,6 +411,7 @@ class _WrappedScrollBehavior implements ScrollBehavior {
         !setEquals<LogicalKeyboardKey>(oldDelegate.pointerAxisModifiers, pointerAxisModifiers) ||
         oldDelegate.physics != physics ||
         oldDelegate.platform != platform ||
+        oldDelegate._enableBrowserScrolling != _enableBrowserScrolling ||
         delegate.shouldNotify(oldDelegate.delegate);
   }
 

--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -984,3 +984,56 @@ class NeverScrollableScrollPhysics extends ScrollPhysics {
   @override
   bool get allowImplicitScrolling => false;
 }
+
+/// A [ScrollPhysics] that accepts user scroll gestures but converts all
+/// movement into overscroll, designed for use when the browser drives the
+/// outermost scroll on Flutter Web.
+///
+/// By accepting gestures, the outer scrollable participates in gesture
+/// disambiguation. On touch devices this is critical: if no scrollable
+/// accepted the vertical drag, the gesture would be lost. Once accepted,
+/// all deltas are returned as overscroll via [applyBoundaryConditions],
+/// which the framework catches and forwards to the browser via the
+/// `FlutterView.browserScrollBy` dart:ui API.
+///
+/// For desktop wheel events, the engine handles scroll chaining by
+/// selectively calling `preventDefault()` based on whether a nested
+/// scrollable consumed the event.
+///
+/// When [ScrollBehavior.enableBrowserScrolling] is true, [ScrollableState]
+/// automatically injects this physics for the outermost scrollable and uses
+/// the [FlutterView] browser scroll API to sync positions with the browser.
+/// Programmatic scrolling via [ScrollController.animateTo] and
+/// [ScrollController.jumpTo] is automatically routed through the browser
+/// when this physics is active.
+///
+/// Developers should not need to set this physics manually. Use
+/// [BrowserScrollable] to opt in to browser-driven scrolling.
+@experimental
+class BrowserScrollPhysics extends ScrollPhysics {
+  /// Creates scroll physics that delegates scrolling to the browser.
+  const BrowserScrollPhysics({super.parent});
+
+  @override
+  BrowserScrollPhysics applyTo(ScrollPhysics? ancestor) {
+    return BrowserScrollPhysics(parent: buildParent(ancestor));
+  }
+
+  @override
+  bool get allowImplicitScrolling => false;
+
+  @override
+  double applyPhysicsToUserOffset(ScrollMetrics position, double offset) {
+    return offset;
+  }
+
+  @override
+  double applyBoundaryConditions(ScrollMetrics position, double value) {
+    return value - position.pixels;
+  }
+
+  @override
+  Simulation? createBallisticSimulation(ScrollMetrics position, double velocity) {
+    return null;
+  }
+}

--- a/packages/flutter/lib/src/widgets/scroll_position_with_single_context.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position_with_single_context.dart
@@ -9,6 +9,7 @@
 /// @docImport 'viewport.dart';
 library;
 
+import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
@@ -16,12 +17,14 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/physics.dart';
 import 'package:flutter/rendering.dart';
 
+import '_browser_scroll_view_io.dart' if (dart.library.js_interop) '_browser_scroll_view_web.dart';
 import 'basic.dart';
 import 'scroll_activity.dart';
 import 'scroll_context.dart';
 import 'scroll_notification.dart';
 import 'scroll_physics.dart';
 import 'scroll_position.dart';
+import 'scrollable.dart';
 
 /// A scroll position that manages scroll activities for a single
 /// [ScrollContext].
@@ -78,6 +81,32 @@ class ScrollPositionWithSingleContext extends ScrollPosition implements ScrollAc
   /// transfer to a next activity.
   double _heldPreviousVelocity = 0.0;
 
+  // Tracks the in-flight browser smooth scroll started by [animateTo]. The
+  // completer resolves when the browser reports (via forcePixels) that the
+  // scroll position has reached the requested target, or when superseded by
+  // a later [animateTo]/[jumpTo], or when the safety timeout fires.
+  Completer<void>? _pendingBrowserSmoothScrollCompleter;
+  double? _pendingBrowserSmoothScrollTarget;
+  // Absolute safety ceiling for the Future. Runs from animateTo start.
+  Timer? _pendingBrowserSmoothScrollTimer;
+  // Resets on every forcePixels tick; fires when the browser stops reporting
+  // updates, meaning the scroll has settled at a clamped or interrupted
+  // position without reaching the requested target.
+  Timer? _pendingBrowserSmoothScrollIdleTimer;
+
+  void _completePendingBrowserSmoothScroll() {
+    _pendingBrowserSmoothScrollTimer?.cancel();
+    _pendingBrowserSmoothScrollTimer = null;
+    _pendingBrowserSmoothScrollIdleTimer?.cancel();
+    _pendingBrowserSmoothScrollIdleTimer = null;
+    final Completer<void>? completer = _pendingBrowserSmoothScrollCompleter;
+    _pendingBrowserSmoothScrollCompleter = null;
+    _pendingBrowserSmoothScrollTarget = null;
+    if (completer != null && !completer.isCompleted) {
+      completer.complete();
+    }
+  }
+
   @override
   AxisDirection get axisDirection => context.axisDirection;
 
@@ -85,6 +114,27 @@ class ScrollPositionWithSingleContext extends ScrollPosition implements ScrollAc
   double setPixels(double newPixels) {
     assert(activity!.isScrolling);
     return super.setPixels(newPixels);
+  }
+
+  @override
+  void forcePixels(double value) {
+    super.forcePixels(value);
+    final double? target = _pendingBrowserSmoothScrollTarget;
+    if (target == null) {
+      return;
+    }
+    // Exact-hit: browser's smooth scroll reached the requested target.
+    if ((value - target).abs() < 1.0) {
+      _completePendingBrowserSmoothScroll();
+      return;
+    }
+    // Scroll is progressing but hasn't hit the target. Reset an idle timer
+    // that fires once the browser stops reporting new positions, meaning it
+    // settled at a clamped or interrupted offset.
+    _pendingBrowserSmoothScrollIdleTimer?.cancel();
+    _pendingBrowserSmoothScrollIdleTimer = Timer(const Duration(milliseconds: 100), () {
+      _completePendingBrowserSmoothScroll();
+    });
   }
 
   @override
@@ -128,7 +178,44 @@ class ScrollPositionWithSingleContext extends ScrollPosition implements ScrollAc
   @override
   void applyUserOffset(double delta) {
     updateUserScrollDirection(delta > 0.0 ? ScrollDirection.forward : ScrollDirection.reverse);
-    setPixels(pixels - physics.applyPhysicsToUserOffset(this, delta));
+
+    final BrowserScrollViewBinding? binding = ScrollableState.browserScrollViewBinding;
+    final double proposed = pixels - physics.applyPhysicsToUserOffset(this, delta);
+
+    // Manual boundary forwarding only applies to inner scrollables with
+    // normal physics. The outer scrollable runs BrowserScrollPhysics, which
+    // returns the entire delta as overscroll. setPixels would emit an
+    // OverscrollNotification that BrowserScrollable forwards to the browser
+    // already; doing it manually here would double-forward at the boundary.
+    if (binding != null && physics is! BrowserScrollPhysics) {
+      // When browser scrolling is active for an inner scrollable, clamp
+      // pixels at each boundary and forward the excess to the browser so
+      // the outer page scrolls.
+      //
+      // At maxScrollExtent (bottom): clamping prevents the inner list from
+      // rubber-band bouncing while the parent simultaneously scrolls.
+      //
+      // At minScrollExtent (top): clamping keeps pixels at the boundary
+      // while didOverscrollBy dispatches an OverscrollNotification, which
+      // RefreshIndicator needs to reveal itself. This mirrors how
+      // RefreshIndicator works with ClampingScrollPhysics on Android: the
+      // indicator accumulates the overscroll amount from the notification,
+      // not from pixels going negative.
+      if (proposed > maxScrollExtent) {
+        final double excess = proposed - maxScrollExtent;
+        setPixels(maxScrollExtent);
+        binding.browserScrollBy(excess);
+      } else if (proposed < minScrollExtent) {
+        final double excess = proposed - minScrollExtent;
+        setPixels(minScrollExtent);
+        didOverscrollBy(excess);
+        binding.browserScrollBy(excess);
+      } else {
+        setPixels(proposed);
+      }
+    } else {
+      setPixels(proposed);
+    }
   }
 
   @override
@@ -175,6 +262,43 @@ class ScrollPositionWithSingleContext extends ScrollPosition implements ScrollAc
 
   @override
   Future<void> animateTo(double to, {required Duration duration, required Curve curve}) {
+    // When browser scrolling is active on the outermost scrollable, pixels
+    // never moves through normal Dart physics (BrowserScrollPhysics returns
+    // the entire delta as overscroll). Delegate to the browser's smooth scroll
+    // so the developer's controller.animateTo() call works transparently.
+    final BrowserScrollViewBinding? binding = ScrollableState.browserScrollViewBinding;
+    if (binding != null && physics is BrowserScrollPhysics) {
+      // A new animateTo supersedes any still-pending smooth scroll.
+      _completePendingBrowserSmoothScroll();
+
+      if (nearEqual(to, pixels, physics.toleranceFor(this).distance)) {
+        // Already at target; skip the browser animation entirely.
+        return Future<void>.value();
+      }
+
+      final completer = Completer<void>();
+      _pendingBrowserSmoothScrollCompleter = completer;
+      _pendingBrowserSmoothScrollTarget = to;
+
+      // Grow the browser's scroll placeholder if [to] is past the revealed
+      // content. Without this, the browser clamps the smooth scroll at the
+      // current scrollHeight and the animation settles short of the target.
+      ScrollableState.prepareActiveBrowserScrollForTarget(to);
+      binding.browserSmoothScrollTo(to);
+
+      // Absolute safety ceiling. The browser can clamp targets past
+      // scrollHeight or be interrupted by user input. Idle detection in
+      // forcePixels usually resolves first; this is the backstop when
+      // onBrowserScroll never fires at all.
+      _pendingBrowserSmoothScrollTimer = Timer(const Duration(seconds: 1), () {
+        if (_pendingBrowserSmoothScrollCompleter == completer) {
+          _completePendingBrowserSmoothScroll();
+        }
+      });
+
+      return completer.future;
+    }
+
     if (nearEqual(to, pixels, physics.toleranceFor(this).distance)) {
       // Skip the animation, go straight to the position as we are already close.
       jumpTo(to);
@@ -195,6 +319,17 @@ class ScrollPositionWithSingleContext extends ScrollPosition implements ScrollAc
 
   @override
   void jumpTo(double value) {
+    // When browser scrolling is active on the outermost scrollable, delegate
+    // to the browser's instant scroll so controller.jumpTo() works transparently.
+    final BrowserScrollViewBinding? binding = ScrollableState.browserScrollViewBinding;
+    if (binding != null && physics is BrowserScrollPhysics) {
+      // jumpTo supersedes any pending animateTo; complete its future.
+      _completePendingBrowserSmoothScroll();
+      ScrollableState.prepareActiveBrowserScrollForTarget(value);
+      binding.browserScrollTo(value);
+      return;
+    }
+
     goIdle();
     if (pixels != value) {
       final double oldPixels = pixels;
@@ -277,6 +412,7 @@ class ScrollPositionWithSingleContext extends ScrollPosition implements ScrollAc
 
   @override
   void dispose() {
+    _completePendingBrowserSmoothScroll();
     _currentDrag?.dispose();
     _currentDrag = null;
     super.dispose();

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -23,6 +23,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 
+import '_browser_scroll_view_io.dart' if (dart.library.js_interop) '_browser_scroll_view_web.dart';
 import 'basic.dart';
 import 'framework.dart';
 import 'gesture_detector.dart';
@@ -614,11 +615,213 @@ class ScrollableState extends State<Scrollable>
   ScrollController? _fallbackScrollController;
   DeviceGestureSettings? _mediaQueryGestureSettings;
 
+  // BROWSER-DRIVEN SCROLLING
+
+  // Only one ScrollableState should own the browser-scroll view API at a time.
+  // The first instance to claim it wins; nested scrollables that inherit
+  // enableBrowserScrolling from an ancestor ScrollConfiguration are skipped.
+  static ScrollableState? _activeBrowserScrollInstance;
+
+  /// The [BrowserScrollViewBinding] used by the active browser-scroll owner.
+  ///
+  /// Used by [ScrollPositionWithSingleContext] to delegate
+  /// [ScrollController.animateTo] and [ScrollController.jumpTo] to the browser
+  /// when [BrowserScrollPhysics] is active. Only non-null while browser
+  /// scrolling is active.
+  @internal
+  static BrowserScrollViewBinding? browserScrollViewBinding;
+
+  /// Grows the browser scroll placeholder to at least [target] so a
+  /// subsequent programmatic scroll is not clamped by the "revealed
+  /// content" strategy.
+  ///
+  /// Called by [ScrollPositionWithSingleContext] before dispatching
+  /// `browserSmoothScrollTo` or `browserScrollTo` with a potentially
+  /// large target. No-op when no browser-scroll owner is active.
+  @internal
+  static void prepareActiveBrowserScrollForTarget(double target) {
+    _activeBrowserScrollInstance?._prepareBrowserScrollForTarget(target);
+  }
+
+  BrowserScrollViewBinding? _viewBinding;
+
+  bool _browserScrollEnabled = false;
+  bool _browserScrollActive = false;
+  bool _isBrowserDriving = false;
+  double _maxReachedPixels = 0;
+  bool _reachedBottom = false;
+  double _lastReportedHeight = 0;
+
+  void _setupBrowserScroll() {
+    final bool shouldBeActive =
+        _configuration.enableBrowserScrolling && (_viewBinding?.supported ?? false);
+
+    if (shouldBeActive && !_browserScrollActive) {
+      // Only the first ScrollableState to claim the binding wins. Nested
+      // scrollables that inherit enableBrowserScrolling from their ancestor
+      // ScrollConfiguration are silently skipped.
+      if (_activeBrowserScrollInstance != null && _activeBrowserScrollInstance != this) {
+        return;
+      }
+      _activeBrowserScrollInstance = this;
+      browserScrollViewBinding = _viewBinding;
+      _browserScrollActive = true;
+      _viewBinding!.onBrowserScroll = _syncScrollFromBrowser;
+      _effectiveScrollController.addListener(_onBrowserScrollPositionChanged);
+      if (!_browserScrollEnabled) {
+        _enableBrowserScrolling();
+      }
+    } else if (!shouldBeActive && _browserScrollActive) {
+      _teardownBrowserScroll();
+    }
+  }
+
+  void _teardownBrowserScroll() {
+    if (!_browserScrollActive) {
+      return;
+    }
+    _effectiveScrollController.removeListener(_onBrowserScrollPositionChanged);
+    _viewBinding?.onBrowserScroll = null;
+    if (_browserScrollEnabled) {
+      _disableBrowserScrolling();
+    }
+    _browserScrollActive = false;
+    if (_activeBrowserScrollInstance == this) {
+      _activeBrowserScrollInstance = null;
+      browserScrollViewBinding = null;
+    }
+    _maxReachedPixels = 0;
+    _reachedBottom = false;
+    _lastReportedHeight = 0;
+  }
+
+  void _enableBrowserScrolling() {
+    _viewBinding!.enableBrowserScrolling();
+    _browserScrollEnabled = true;
+
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      _reportBrowserContentExtent();
+    });
+  }
+
+  void _disableBrowserScrolling() {
+    _browserScrollEnabled = false;
+    _viewBinding!.disableBrowserScrolling();
+  }
+
+  void _syncScrollFromBrowser(double scrollTop) {
+    if (!_effectiveScrollController.hasClients) {
+      return;
+    }
+
+    final ScrollPosition pos = _effectiveScrollController.position;
+    final double clampedOffset = clampDouble(scrollTop, pos.minScrollExtent, pos.maxScrollExtent);
+
+    if ((pos.pixels - clampedOffset).abs() > 0.5) {
+      _isBrowserDriving = true;
+      // Use forcePixels instead of jumpTo to avoid cancelling any active
+      // drag activity. jumpTo calls goIdle+goBallistic which would kill
+      // the drag gesture and stop further scroll updates.
+      // ignore: invalid_use_of_protected_member
+      pos.forcePixels(clampedOffset);
+      _isBrowserDriving = false;
+    }
+  }
+
+  void _onBrowserScrollPositionChanged() {
+    if (!_effectiveScrollController.hasClients || !_browserScrollEnabled) {
+      return;
+    }
+
+    final ScrollPosition pos = _effectiveScrollController.position;
+
+    // When the browser drives scrolling, it sends onScroll which calls
+    // forcePixels. We must not echo that back as a scrollTo or we'd create
+    // a feedback loop. Only sync the DOM scrollTop when Flutter is driving
+    // the scroll, e.g. programmatic jumpTo or ensureVisible.
+    if (!_isBrowserDriving) {
+      _viewBinding?.browserScrollTo(pos.pixels);
+    }
+
+    _reportBrowserContentExtent();
+  }
+
+  void _prepareBrowserScrollForTarget(double target) {
+    if (!_browserScrollActive || !_effectiveScrollController.hasClients) {
+      return;
+    }
+    final ScrollPosition pos = _effectiveScrollController.position;
+    // Clamp against Flutter's estimated maxScrollExtent. Never grow the
+    // placeholder past content that Flutter can actually paint.
+    final double clamped = math.min(target, pos.maxScrollExtent);
+    if (clamped > _maxReachedPixels) {
+      _maxReachedPixels = clamped;
+      _reportBrowserContentExtent();
+    }
+  }
+
+  void _reportBrowserContentExtent() {
+    if (!_effectiveScrollController.hasClients || !_browserScrollEnabled) {
+      return;
+    }
+
+    final ScrollPosition pos = _effectiveScrollController.position;
+
+    if (pos.pixels > _maxReachedPixels) {
+      _maxReachedPixels = pos.pixels;
+    }
+    // Never let _maxReachedPixels exceed the actual content extent. The lazy
+    // ListView's estimate fed into _prepareBrowserScrollForTarget can be too
+    // high; once it converges downward, shrink so the placeholder matches
+    // real content. Otherwise the browser scrolls past Flutter's painted
+    // range and creates a dead zone above the visible bottom.
+    if (_maxReachedPixels > pos.maxScrollExtent) {
+      _maxReachedPixels = pos.maxScrollExtent;
+    }
+
+    // Invalidate the bottom-reached latch when content has grown past the
+    // previously known bottom. Otherwise an infinite list or load-more
+    // pattern stays gated at the old bottom forever, because lookahead
+    // remains zero and the placeholder never grows.
+    if (pos.maxScrollExtent > _maxReachedPixels + 1.0) {
+      _reachedBottom = false;
+    }
+    if (pos.pixels >= pos.maxScrollExtent - 1.0) {
+      _reachedBottom = true;
+    }
+
+    // The placeholder height is based on the furthest point the user has
+    // scrolled to, plus a lookahead buffer so there's always room to scroll
+    // forward without hitting the placeholder bottom prematurely. Once the
+    // user has reached the actual content bottom, the lookahead drops to
+    // zero permanently because we know the true content size at that point.
+    final double lookahead;
+    if (_reachedBottom) {
+      lookahead = 0;
+    } else {
+      final double remainingContent = pos.maxScrollExtent - _maxReachedPixels;
+      lookahead = clampDouble(remainingContent, 0, pos.viewportDimension);
+    }
+    final double totalHeight = _maxReachedPixels + pos.viewportDimension + lookahead;
+
+    if ((totalHeight - _lastReportedHeight).abs() < 1.0) {
+      return;
+    }
+
+    _lastReportedHeight = totalHeight;
+    _viewBinding?.updateBrowserScrollContentHeight(totalHeight);
+  }
+
   // Only call this from places that will definitely trigger a rebuild.
   void _updatePosition() {
     _configuration = widget.scrollBehavior ?? ScrollConfiguration.of(context);
-    final ScrollPhysics? physicsFromWidget =
+    ScrollPhysics? physicsFromWidget =
         widget.physics ?? widget.scrollBehavior?.getScrollPhysics(context);
+    if (_configuration.enableBrowserScrolling &&
+        (_viewBinding?.supported ?? false) &&
+        (_activeBrowserScrollInstance == null || _activeBrowserScrollInstance == this)) {
+      physicsFromWidget = const BrowserScrollPhysics().applyTo(physicsFromWidget);
+    }
     _physics = _configuration.getScrollPhysics(context);
     _physics = physicsFromWidget?.applyTo(_physics) ?? _physics;
 
@@ -669,9 +872,13 @@ class ScrollableState extends State<Scrollable>
   @override
   void didChangeDependencies() {
     _mediaQueryGestureSettings = MediaQuery.maybeGestureSettingsOf(context);
-    _devicePixelRatio =
-        MediaQuery.maybeDevicePixelRatioOf(context) ?? View.of(context).devicePixelRatio;
+    final FlutterView flutterView = View.of(context);
+    if (_viewBinding?.view != flutterView) {
+      _viewBinding = BrowserScrollViewBinding(flutterView);
+    }
+    _devicePixelRatio = MediaQuery.maybeDevicePixelRatioOf(context) ?? flutterView.devicePixelRatio;
     _updatePosition();
+    _setupBrowserScroll();
     super.didChangeDependencies();
   }
 
@@ -703,7 +910,9 @@ class ScrollableState extends State<Scrollable>
   void didUpdateWidget(Scrollable oldWidget) {
     super.didUpdateWidget(oldWidget);
 
-    if (widget.controller != oldWidget.controller) {
+    final controllerChanged = widget.controller != oldWidget.controller;
+    if (controllerChanged) {
+      _teardownBrowserScroll();
       if (oldWidget.controller == null) {
         // The old controller was null, meaning the fallback cannot be null.
         // Dispose of the fallback.
@@ -727,12 +936,20 @@ class ScrollableState extends State<Scrollable>
 
     if (_shouldUpdatePosition(oldWidget)) {
       _updatePosition();
+      // Position update can change physics or scrollBehavior, both of which
+      // affect whether browser scrolling should be active. Re-evaluate the
+      // setup so a runtime toggle of scrollBehavior.enableBrowserScrolling
+      // also activates or tears down the engine binding.
+      _setupBrowserScroll();
+    } else if (controllerChanged) {
+      _setupBrowserScroll();
     }
   }
 
   @protected
   @override
   void dispose() {
+    _teardownBrowserScroll();
     if (widget.controller != null) {
       widget.controller!.detach(position);
     } else {
@@ -954,6 +1171,14 @@ class ScrollableState extends State<Scrollable>
   void _receivedPointerSignal(PointerSignalEvent event) {
     if (event is PointerScrollEvent && _position != null) {
       if (_physics != null && !_physics!.shouldAcceptUserOffset(position)) {
+        return;
+      }
+      // With BrowserScrollPhysics the browser owns wheel scrolling on
+      // <flutter-view> via overflow: auto. Decline to register here so
+      // PointerSignalResolver auto-responds with allowPlatformDefault=true.
+      // That tells the web engine to skip preventDefault on the wheel event
+      // and let the browser scroll natively.
+      if (_physics is BrowserScrollPhysics) {
         return;
       }
       final double delta = _pointerSignalEventDelta(event);

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -34,6 +34,7 @@ export 'src/widgets/banner.dart';
 export 'src/widgets/basic.dart';
 export 'src/widgets/binding.dart';
 export 'src/widgets/bottom_navigation_bar_item.dart';
+export 'src/widgets/browser_scroll.dart';
 export 'src/widgets/color_filter.dart';
 export 'src/widgets/container.dart';
 export 'src/widgets/context_menu_button_item.dart';

--- a/packages/flutter/test/widgets/browser_scroll_test.dart
+++ b/packages/flutter/test/widgets/browser_scroll_test.dart
@@ -1,0 +1,1147 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// The test harness uses `BrowserScrollViewBinding.calls`, which only exists in
+// the IO stub (`_browser_scroll_view_io.dart`). On web the binding delegates
+// to the real engine via `FlutterView` method calls and has no recorded calls
+// list. Skip the file on web.
+@TestOn('!chrome')
+library;
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/src/widgets/_browser_scroll_view_io.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Widget _buildTestApp(ScrollController controller) {
+  return Directionality(
+    textDirection: TextDirection.ltr,
+    child: MediaQuery(
+      data: const MediaQueryData(),
+      child: BrowserScrollable(
+        child: ListView.builder(
+          controller: controller,
+          itemCount: 20,
+          itemBuilder: (context, index) => SizedBox(height: 200.0, child: Text('Item $index')),
+        ),
+      ),
+    ),
+  );
+}
+
+Widget _buildTestAppNoPrimaryNoController() {
+  return Directionality(
+    textDirection: TextDirection.ltr,
+    child: MediaQuery(
+      data: const MediaQueryData(),
+      child: BrowserScrollable(
+        child: ListView.builder(
+          primary: false,
+          itemCount: 20,
+          itemBuilder: (context, index) => SizedBox(height: 200.0, child: Text('Item $index')),
+        ),
+      ),
+    ),
+  );
+}
+
+void _simulateOnScroll(double offset) {
+  ScrollableState.browserScrollViewBinding?.onBrowserScroll?.call(offset);
+}
+
+List<Map<String, Object?>> _bindingCalls() {
+  return ScrollableState.browserScrollViewBinding?.calls ?? <Map<String, Object?>>[];
+}
+
+List<Map<String, Object?>> _callsOf(String method) {
+  return _bindingCalls().where((c) => c['method'] == method).toList();
+}
+
+void _clearCalls() {
+  ScrollableState.browserScrollViewBinding?.calls.clear();
+}
+
+void main() {
+  setUpAll(() {
+    BrowserScrollViewBinding.debugForceSupportedForTests = true;
+  });
+
+  tearDownAll(() {
+    BrowserScrollViewBinding.debugForceSupportedForTests = false;
+  });
+
+  group('ScrollableState browser-scroll integration – placeholder height', () {
+    late ScrollController controller;
+
+    setUp(() {
+      controller = ScrollController();
+    });
+
+    tearDown(() {
+      controller.dispose();
+    });
+
+    testWidgets('reports initial height via binding', (tester) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      _simulateOnScroll(0);
+      await tester.pump();
+
+      if (controller.hasClients) {
+        expect(controller.position.pixels, closeTo(0.0, 1.0));
+      }
+    });
+
+    testWidgets('reports content height to engine', (tester) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      _simulateOnScroll(0);
+      await tester.pump();
+
+      final List<Map<String, Object?>> heights = _callsOf('updateBrowserScrollContentHeight');
+      expect(heights, isNotEmpty);
+
+      final double viewport = tester.getSize(find.byType(ListView)).height;
+      final lastHeight = heights.last['args']! as double;
+      expect(lastHeight, closeTo(viewport * 2, 2.0));
+    });
+
+    testWidgets('content height grows as user scrolls down', (tester) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      _simulateOnScroll(500);
+      await tester.pump();
+
+      _simulateOnScroll(1000);
+      await tester.pump();
+
+      final List<double> heights = _callsOf(
+        'updateBrowserScrollContentHeight',
+      ).map((c) => c['args']! as double).toList();
+      if (heights.length >= 2) {
+        expect(heights.last, greaterThanOrEqualTo(heights.first));
+      }
+    });
+
+    testWidgets('duplicate heights within tolerance are not re-reported', (tester) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      _simulateOnScroll(100);
+      await tester.pump();
+
+      final int countAfterFirst = _callsOf('updateBrowserScrollContentHeight').length;
+
+      _simulateOnScroll(100);
+      await tester.pump();
+
+      expect(_callsOf('updateBrowserScrollContentHeight').length, countAfterFirst);
+    });
+
+    testWidgets('onScroll syncs Flutter position to browser scrollTop', (tester) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      _simulateOnScroll(300);
+      await tester.pump();
+
+      if (controller.hasClients) {
+        final ScrollPosition pos = controller.position;
+        expect(pos.pixels, closeTo(300.0, 1.0));
+      }
+    });
+
+    testWidgets('onScroll clamps to maxScrollExtent', (tester) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      _simulateOnScroll(999999);
+      await tester.pump();
+
+      if (controller.hasClients) {
+        final ScrollPosition pos = controller.position;
+        expect(pos.pixels, lessThanOrEqualTo(pos.maxScrollExtent + 1.0));
+      }
+    });
+
+    testWidgets('mounts and unmounts cleanly', (tester) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      await tester.pumpWidget(const SizedBox.shrink());
+    });
+
+    testWidgets('dispose triggers disableBrowserScrolling and clears binding', (tester) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      expect(ScrollableState.browserScrollViewBinding, isNotNull);
+
+      // Capture the binding before it is cleared on teardown, so we can inspect
+      // its call log after the widget is disposed.
+      // ignore: specify_nonobvious_local_variable_types
+      final binding = ScrollableState.browserScrollViewBinding!;
+      binding.calls.clear();
+
+      // Replace the widget tree with something that has no BrowserScrollable.
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+
+      // The static binding must be cleared on teardown.
+      expect(ScrollableState.browserScrollViewBinding, isNull);
+
+      // disableBrowserScrolling must have been recorded by the captured binding.
+      expect(
+        binding.calls.where((Map<String, Object?> c) => c['method'] == 'disableBrowserScrolling'),
+        isNotEmpty,
+      );
+    });
+
+    testWidgets('controller swap re-registers callback', (tester) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      final controller2 = ScrollController();
+      addTearDown(controller2.dispose);
+
+      await tester.pumpWidget(_buildTestApp(controller2));
+      await tester.pump();
+
+      _simulateOnScroll(100);
+      await tester.pump();
+
+      if (controller2.hasClients) {
+        expect(controller2.position.pixels, closeTo(100.0, 1.0));
+      }
+    });
+
+    testWidgets('disabling enableBrowserScrolling tears down callback', (tester) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      _simulateOnScroll(200);
+      await tester.pump();
+
+      expect(controller.position.pixels, closeTo(200.0, 1.0));
+
+      // Rebuild with enableBrowserScrolling: false.
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: ScrollConfiguration(
+              behavior: const ScrollBehavior().copyWith(enableBrowserScrolling: false),
+              child: ListView.builder(
+                controller: controller,
+                itemCount: 20,
+                itemBuilder: (context, index) =>
+                    SizedBox(height: 200.0, child: Text('Item $index')),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // The callback should be null now, so simulateOnScroll should do nothing.
+      final double pixelsBefore = controller.position.pixels;
+      _simulateOnScroll(0);
+      await tester.pump();
+      expect(controller.position.pixels, pixelsBefore);
+    });
+  });
+
+  group('ScrollableState browser-scroll – primary:false fallback controller', () {
+    testWidgets('works with primary:false and no explicit controller', (tester) async {
+      await tester.pumpWidget(_buildTestAppNoPrimaryNoController());
+      await tester.pump();
+
+      _simulateOnScroll(400);
+      await tester.pump();
+
+      final Finder listFinder = find.byType(ListView);
+      final ScrollableState scrollable = tester.state(
+        find.descendant(of: listFinder, matching: find.byType(Scrollable)),
+      );
+      expect(scrollable.position.pixels, closeTo(400.0, 1.0));
+    });
+  });
+
+  group('BrowserScrollable – OverscrollNotification edge passthrough', () {
+    late ScrollController controller;
+
+    setUp(() {
+      controller = ScrollController();
+    });
+
+    tearDown(() {
+      controller.dispose();
+    });
+
+    testWidgets('consumes OverscrollNotification when not at edge', (tester) async {
+      final leaked = <OverscrollNotification>[];
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: NotificationListener<OverscrollNotification>(
+              onNotification: (OverscrollNotification n) {
+                leaked.add(n);
+                return false;
+              },
+              child: BrowserScrollable(
+                child: ListView.builder(
+                  controller: controller,
+                  itemCount: 20,
+                  itemBuilder: (context, index) =>
+                      SizedBox(height: 200.0, child: Text('Item $index')),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      _simulateOnScroll(500);
+      await tester.pump();
+
+      leaked.clear();
+      _clearCalls();
+
+      final ScrollPosition pos = controller.position;
+      OverscrollNotification(
+        overscroll: 50.0,
+        metrics: pos.copyWith(),
+        context: tester.element(find.byType(ListView)),
+      ).dispatch(tester.element(find.byType(ListView)));
+      await tester.pump();
+
+      expect(leaked, isEmpty);
+      expect(_callsOf('browserScrollBy'), isNotEmpty);
+    });
+
+    testWidgets('lets OverscrollNotification bubble at top edge', (tester) async {
+      final leaked = <OverscrollNotification>[];
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: NotificationListener<OverscrollNotification>(
+              onNotification: (OverscrollNotification n) {
+                leaked.add(n);
+                return false;
+              },
+              child: BrowserScrollable(
+                child: ListView.builder(
+                  controller: controller,
+                  itemCount: 20,
+                  itemBuilder: (context, index) =>
+                      SizedBox(height: 200.0, child: Text('Item $index')),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      _simulateOnScroll(0);
+      await tester.pump();
+
+      leaked.clear();
+      _clearCalls();
+
+      final ScrollPosition pos = controller.position;
+      OverscrollNotification(
+        overscroll: -30.0,
+        metrics: pos.copyWith(),
+        context: tester.element(find.byType(ListView)),
+      ).dispatch(tester.element(find.byType(ListView)));
+      await tester.pump();
+
+      expect(leaked, hasLength(1));
+      expect(leaked.first.overscroll, -30.0);
+      expect(_callsOf('browserScrollBy'), isEmpty);
+    });
+
+    testWidgets('lets OverscrollNotification bubble at bottom edge', (tester) async {
+      final leaked = <OverscrollNotification>[];
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: NotificationListener<OverscrollNotification>(
+              onNotification: (OverscrollNotification n) {
+                leaked.add(n);
+                return false;
+              },
+              child: BrowserScrollable(
+                child: ListView.builder(
+                  controller: controller,
+                  itemCount: 20,
+                  itemBuilder: (context, index) =>
+                      SizedBox(height: 200.0, child: Text('Item $index')),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final double maxExtent = controller.position.maxScrollExtent;
+      _simulateOnScroll(maxExtent);
+      await tester.pump();
+
+      leaked.clear();
+      _clearCalls();
+
+      final ScrollPosition pos = controller.position;
+      OverscrollNotification(
+        overscroll: 40.0,
+        metrics: pos.copyWith(),
+        context: tester.element(find.byType(ListView)),
+      ).dispatch(tester.element(find.byType(ListView)));
+      await tester.pump();
+
+      expect(leaked, hasLength(1));
+      expect(leaked.first.overscroll, 40.0);
+      expect(_callsOf('browserScrollBy'), isEmpty);
+    });
+
+    testWidgets('forwards overscroll just inside the bottom edge', (tester) async {
+      // Regression: the edge-guard uses `>=`, so a fractional gap below the
+      // maxScrollExtent must NOT count as "at edge". An overscroll with
+      // pixels = maxExtent - 0.01 and positive delta should forward to the
+      // browser rather than bubble for RefreshIndicator-style handlers.
+      // A tight 0.01 gap also catches refactors that fuzz the edge check
+      // with an epsilon larger than 0.01.
+      final leaked = <OverscrollNotification>[];
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: NotificationListener<OverscrollNotification>(
+              onNotification: (OverscrollNotification n) {
+                leaked.add(n);
+                return false;
+              },
+              child: BrowserScrollable(
+                child: ListView.builder(
+                  controller: controller,
+                  itemCount: 20,
+                  itemBuilder: (context, index) =>
+                      SizedBox(height: 200.0, child: Text('Item $index')),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final double maxExtent = controller.position.maxScrollExtent;
+      _simulateOnScroll(maxExtent - 0.01);
+      await tester.pump();
+
+      leaked.clear();
+      _clearCalls();
+
+      final ScrollPosition pos = controller.position;
+      OverscrollNotification(
+        overscroll: 40.0,
+        metrics: pos.copyWith(pixels: maxExtent - 0.01),
+        context: tester.element(find.byType(ListView)),
+      ).dispatch(tester.element(find.byType(ListView)));
+      await tester.pump();
+
+      // Not at the exact edge, so BrowserScrollable should forward.
+      expect(leaked, isEmpty);
+      expect(_callsOf('browserScrollBy'), isNotEmpty);
+    });
+  });
+
+  group('ScrollableState browser-scroll – programmatic scrolling', () {
+    late ScrollController controller;
+
+    setUp(() {
+      controller = ScrollController();
+    });
+
+    tearDown(() {
+      controller.dispose();
+    });
+
+    testWidgets('jumpTo delegates to browser and does not move pixels directly', (tester) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      _clearCalls();
+
+      controller.jumpTo(500);
+      await tester.pump();
+
+      // pixels stays at 0 until the browser fires onBrowserScroll back
+      expect(controller.position.pixels, closeTo(0.0, 1.0));
+
+      final List<Map<String, Object?>> scrollToCalls = _callsOf('browserScrollTo');
+      expect(scrollToCalls, isNotEmpty);
+      expect(scrollToCalls.last['args']! as double, closeTo(500.0, 1.0));
+
+      // simulate the browser responding, which syncs pixels
+      _simulateOnScroll(500);
+      await tester.pump();
+      expect(controller.position.pixels, closeTo(500.0, 1.0));
+    });
+
+    testWidgets('jumpTo delegates to browser and does not move pixels directly – via controller', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      _clearCalls();
+
+      // jumpTo on the outermost BrowserScrollPhysics scrollable must delegate
+      // to the browser rather than moving pixels in Dart directly.
+      controller.jumpTo(300);
+      await tester.pump();
+
+      // pixels does not change until the browser fires onBrowserScroll back.
+      expect(controller.position.pixels, closeTo(0.0, 1.0));
+
+      final List<Map<String, Object?>> scrollToCalls = _callsOf('browserScrollTo');
+      expect(scrollToCalls, isNotEmpty);
+      expect(scrollToCalls.last['args']! as double, closeTo(300.0, 1.0));
+
+      // simulate the browser responding, which syncs pixels
+      _simulateOnScroll(300);
+      await tester.pump();
+      expect(controller.position.pixels, closeTo(300.0, 1.0));
+    });
+
+    testWidgets('animateTo delegates to browser smooth scroll', (tester) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      _clearCalls();
+
+      controller.animateTo(400, duration: const Duration(milliseconds: 200), curve: Curves.easeOut);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.pump(const Duration(milliseconds: 150));
+
+      // pixels stays at 0 until the browser fires onBrowserScroll back
+      expect(controller.position.pixels, closeTo(0.0, 1.0));
+
+      final List<Map<String, Object?>> smoothCalls = _callsOf('browserSmoothScrollTo');
+      expect(smoothCalls, isNotEmpty);
+      expect(smoothCalls.last['args']! as double, closeTo(400.0, 1.0));
+    });
+
+    testWidgets('animateTo Future resolves when browser reaches target', (tester) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      _clearCalls();
+
+      var completed = false;
+      final Future<void> done = controller
+          .animateTo(400, duration: const Duration(milliseconds: 200), curve: Curves.easeOut)
+          .whenComplete(() => completed = true);
+
+      await tester.pump();
+      // Before the browser reports back, the Future must NOT be complete. It
+      // is important that `await animateTo(...)` reflects scroll settle, not
+      // the dispatch of the scroll command.
+      expect(completed, isFalse);
+      expect(controller.position.pixels, closeTo(0.0, 1.0));
+
+      // Simulate the browser's smooth-scroll settling at the target.
+      _simulateOnScroll(400);
+      await tester.pump();
+      await done;
+
+      expect(completed, isTrue);
+      expect(controller.position.pixels, closeTo(400.0, 1.0));
+    });
+
+    testWidgets('animateTo Future resolves when jumpTo supersedes it', (tester) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      _clearCalls();
+
+      var animateCompleted = false;
+      final Future<void> done = controller
+          .animateTo(1000, duration: const Duration(milliseconds: 300), curve: Curves.easeOut)
+          .whenComplete(() => animateCompleted = true);
+
+      await tester.pump();
+      expect(animateCompleted, isFalse);
+
+      // A jumpTo before the browser settles must supersede the pending
+      // animation and complete its Future.
+      controller.jumpTo(200);
+      await tester.pump();
+      await done;
+
+      expect(animateCompleted, isTrue);
+    });
+
+    testWidgets('animateTo Future resolves when a later animateTo supersedes it', (tester) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      _clearCalls();
+
+      var firstCompleted = false;
+      final Future<void> firstDone = controller
+          .animateTo(1000, duration: const Duration(milliseconds: 300), curve: Curves.easeOut)
+          .whenComplete(() => firstCompleted = true);
+
+      await tester.pump();
+      expect(firstCompleted, isFalse);
+
+      // A second animateTo replaces the first; the first Future must resolve
+      // so awaiting code doesn't hang.
+      controller.animateTo(600, duration: const Duration(milliseconds: 300), curve: Curves.easeOut);
+      await tester.pump();
+      await firstDone;
+
+      expect(firstCompleted, isTrue);
+    });
+
+    testWidgets('animateTo to current pixels resolves immediately', (tester) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      // Sync pixels to a known value.
+      _simulateOnScroll(150);
+      await tester.pump();
+      expect(controller.position.pixels, closeTo(150.0, 1.0));
+
+      _clearCalls();
+
+      // Asking to animate to where we already are should return a resolved
+      // future without dispatching a smooth scroll.
+      await controller.animateTo(
+        150,
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeOut,
+      );
+
+      expect(_callsOf('browserSmoothScrollTo'), isEmpty);
+    });
+
+    testWidgets('animateTo grows the placeholder to cover the target', (tester) async {
+      // A long ListView so maxScrollExtent far exceeds the initial placeholder
+      // height (which is 2 viewports before any scrolling has happened).
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: BrowserScrollable(
+              child: ListView.builder(
+                controller: controller,
+                itemCount: 100,
+                itemBuilder: (context, index) =>
+                    SizedBox(height: 200.0, child: Text('Item $index')),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final double viewport = controller.position.viewportDimension;
+      final double maxExtent = controller.position.maxScrollExtent;
+      final double target = maxExtent * 0.9; // well past the initial placeholder
+
+      _clearCalls();
+
+      controller.animateTo(
+        target,
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeOut,
+      );
+      await tester.pump();
+
+      // The framework must have bumped the reported content height to cover
+      // the target before dispatching browserSmoothScrollTo, otherwise the
+      // browser would clamp the smooth scroll short.
+      final List<double> heights = _callsOf(
+        'updateBrowserScrollContentHeight',
+      ).map((c) => c['args']! as double).toList();
+      expect(heights, isNotEmpty);
+      expect(heights.last, greaterThanOrEqualTo(target + viewport - 1.0));
+
+      final List<Map<String, Object?>> smoothCalls = _callsOf('browserSmoothScrollTo');
+      expect(smoothCalls, isNotEmpty);
+      expect(smoothCalls.last['args']! as double, closeTo(target, 1.0));
+    });
+
+    testWidgets('animateTo past maxScrollExtent clamps placeholder growth', (tester) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      final double viewport = controller.position.viewportDimension;
+      final double maxExtent = controller.position.maxScrollExtent;
+
+      _clearCalls();
+
+      // Ask to go far past the real content end.
+      controller.animateTo(
+        maxExtent * 10,
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeOut,
+      );
+      await tester.pump();
+
+      final List<double> heights = _callsOf(
+        'updateBrowserScrollContentHeight',
+      ).map((c) => c['args']! as double).toList();
+      if (heights.isNotEmpty) {
+        // Placeholder never grows past maxScrollExtent + viewport; we must
+        // not promise more scroll area than Flutter can paint.
+        expect(heights.last, lessThanOrEqualTo(maxExtent + viewport + 1.0));
+      }
+    });
+
+    testWidgets('jumpTo grows the placeholder to cover the target', (tester) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: BrowserScrollable(
+              child: ListView.builder(
+                controller: controller,
+                itemCount: 100,
+                itemBuilder: (context, index) =>
+                    SizedBox(height: 200.0, child: Text('Item $index')),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final double viewport = controller.position.viewportDimension;
+      final double maxExtent = controller.position.maxScrollExtent;
+      final double target = maxExtent * 0.9;
+
+      _clearCalls();
+
+      controller.jumpTo(target);
+      await tester.pump();
+
+      final List<double> heights = _callsOf(
+        'updateBrowserScrollContentHeight',
+      ).map((c) => c['args']! as double).toList();
+      expect(heights, isNotEmpty);
+      expect(heights.last, greaterThanOrEqualTo(target + viewport - 1.0));
+    });
+
+    testWidgets('ensureVisible triggers scroll', (tester) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: BrowserScrollable(
+              child: ListView.builder(
+                controller: controller,
+                itemCount: 50,
+                itemBuilder: (context, index) => SizedBox(
+                  height: 200.0,
+                  key: index == 40 ? const Key('target') : null,
+                  child: Text('Item $index'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      _simulateOnScroll(2000);
+      await tester.pump();
+
+      _clearCalls();
+
+      final Finder target = find.byKey(const Key('target'));
+      if (target.evaluate().isNotEmpty) {
+        await Scrollable.ensureVisible(target.evaluate().first);
+        await tester.pump();
+
+        expect(controller.position.pixels, greaterThan(0));
+        expect(_callsOf('browserScrollTo'), isNotEmpty);
+      }
+    });
+
+    testWidgets('focus traversal triggers scroll for offscreen widget', (tester) async {
+      final List<FocusNode> focusNodes = List.generate(30, (_) => FocusNode());
+      addTearDown(() {
+        for (final node in focusNodes) {
+          node.dispose();
+        }
+      });
+
+      await tester.pumpWidget(
+        WidgetsApp(
+          color: const Color(0xFF000000),
+          builder: (context, child) => BrowserScrollable(
+            child: ListView.builder(
+              controller: controller,
+              itemCount: 30,
+              itemBuilder: (context, index) => Focus(
+                focusNode: focusNodes[index],
+                child: SizedBox(height: 200.0, child: Text('Button $index')),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      focusNodes[0].requestFocus();
+      await tester.pump();
+
+      _clearCalls();
+
+      for (var i = 0; i < 10; i++) {
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+      }
+
+      // Focus traversal delegates programmatic scroll to the browser via jumpTo.
+      // pixels stays at 0 until onBrowserScroll fires; the browser call is the
+      // observable effect.
+      expect(
+        _callsOf('browserScrollTo'),
+        isNotEmpty,
+        reason: 'Focus traversal to offscreen widget should send browserScrollTo to engine',
+      );
+    });
+  });
+
+  group('ScrollableState browser-scroll – nested scrollable isolation', () {
+    late ScrollController outerController;
+
+    setUp(() {
+      outerController = ScrollController();
+    });
+
+    tearDown(() {
+      outerController.dispose();
+    });
+
+    testWidgets('only the outermost scrollable owns the binding', (tester) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: BrowserScrollable(
+              child: ListView(
+                controller: outerController,
+                children: [
+                  const SizedBox(height: 100),
+                  SizedBox(
+                    height: 300,
+                    child: ListView.builder(
+                      itemCount: 50,
+                      itemBuilder: (context, index) =>
+                          SizedBox(height: 40, child: Text('Inner $index')),
+                    ),
+                  ),
+                  const SizedBox(height: 1000),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      _clearCalls();
+
+      outerController.jumpTo(200);
+      await tester.pump();
+
+      // jumpTo on the outermost scrollable delegates to the browser and does
+      // not move pixels directly; pixels updates when onBrowserScroll fires.
+      final List<Map<String, Object?>> scrollToCalls = _callsOf('browserScrollTo');
+      expect(scrollToCalls, isNotEmpty);
+      expect(scrollToCalls.last['args']! as double, closeTo(200.0, 1.0));
+
+      _simulateOnScroll(200);
+      await tester.pump();
+      expect(outerController.position.pixels, closeTo(200.0, 1.0));
+    });
+
+    testWidgets('inner scrollable at boundary forwards delta to engine via browserScrollBy', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: BrowserScrollable(
+              child: ListView(
+                controller: outerController,
+                children: [
+                  const SizedBox(height: 100),
+                  SizedBox(
+                    height: 300,
+                    child: ListView.builder(
+                      itemCount: 50,
+                      itemBuilder: (context, index) =>
+                          SizedBox(height: 40, child: Text('Inner $index')),
+                    ),
+                  ),
+                  const SizedBox(height: 1000),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final Finder innerListFinder = find.byType(Scrollable).at(1);
+      final ScrollableState innerScrollable = tester.state(innerListFinder);
+      final ScrollPosition innerPos = innerScrollable.position;
+
+      // Scroll the inner list to its bottom boundary.
+      innerPos.jumpTo(innerPos.maxScrollExtent);
+      await tester.pump();
+
+      _clearCalls();
+
+      // Drag the inner list past its bottom boundary.
+      // applyUserOffset detects wasAtMax and calls browserScrollBy.
+      await tester.drag(find.byType(Scrollable).at(1), const Offset(0, -60));
+      await tester.pump();
+
+      final List<Map<String, Object?>> scrollByCalls = _callsOf('browserScrollBy');
+      expect(
+        scrollByCalls,
+        isNotEmpty,
+        reason: 'Inner scrollable at bottom boundary should forward delta to engine',
+      );
+    });
+
+    testWidgets('scrollable without BrowserScrollable binding scrolls normally in Dart', (
+      tester,
+    ) async {
+      // Build a plain scrollable with NO BrowserScrollable wrapper.
+      // applyUserOffset should take the "no browser binding" path and move
+      // pixels directly in Dart.
+      final controller2 = ScrollController();
+      addTearDown(controller2.dispose);
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: ListView.builder(
+              controller: controller2,
+              itemCount: 20,
+              itemBuilder: (context, index) => SizedBox(height: 200.0, child: Text('Item $index')),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // No browser binding should be set.
+      expect(ScrollableState.browserScrollViewBinding, isNull);
+
+      // A drag should move pixels directly via normal Dart physics.
+      await tester.drag(find.byType(Scrollable), const Offset(0, -300));
+      await tester.pump();
+
+      expect(controller2.position.pixels, greaterThan(0.0));
+    });
+
+    testWidgets('inner scrollable scrolls independently without BrowserScrollPhysics', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: BrowserScrollable(
+              child: ListView(
+                controller: outerController,
+                children: [
+                  const SizedBox(height: 100),
+                  SizedBox(
+                    height: 300,
+                    child: ListView.builder(
+                      itemCount: 50,
+                      itemBuilder: (context, index) =>
+                          SizedBox(height: 40, child: Text('Inner $index')),
+                    ),
+                  ),
+                  const SizedBox(height: 1000),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final Finder innerListFinder = find.byType(Scrollable).at(1);
+      final ScrollableState innerScrollable = tester.state(innerListFinder);
+      final ScrollPosition innerPos = innerScrollable.position;
+
+      expect(innerPos.pixels, 0.0);
+
+      innerPos.jumpTo(100);
+      await tester.pump();
+
+      expect(innerPos.pixels, closeTo(100.0, 1.0));
+    });
+  });
+
+  group('ScrollableState browser-scroll – wheel events', () {
+    late ScrollController controller;
+
+    setUp(() {
+      controller = ScrollController();
+    });
+
+    tearDown(() {
+      controller.dispose();
+    });
+
+    testWidgets(
+      'wheel on outer BrowserScrollable does not move pixels and allows browser default',
+      (tester) async {
+        await tester.pumpWidget(_buildTestApp(controller));
+        await tester.pump();
+
+        _clearCalls();
+
+        final respondCalls = <bool>[];
+        final Offset location = tester.getCenter(find.byType(ListView));
+        final testPointer = TestPointer(1, PointerDeviceKind.mouse);
+        testPointer.hover(location);
+
+        final event = PointerScrollEvent(
+          position: location,
+          scrollDelta: const Offset(0.0, 100.0),
+          onRespond: ({required bool allowPlatformDefault}) {
+            respondCalls.add(allowPlatformDefault);
+          },
+        );
+
+        await tester.sendEventToBinding(event);
+        await tester.pump();
+
+        // Pixels must not move: the framework declined to handle the wheel
+        // because BrowserScrollPhysics is active; the browser owns this
+        // wheel event.
+        expect(controller.position.pixels, 0.0);
+
+        // The resolver auto-responds true when no widget registers. This is
+        // the signal the engine watches to decide whether to preventDefault.
+        expect(
+          respondCalls,
+          equals(<bool>[true]),
+          reason:
+              'Outer BrowserScrollPhysics declined the wheel event. '
+              'PointerSignalResolver should auto-respond allowPlatformDefault=true '
+              'so the web engine skips preventDefault and lets the browser '
+              'scroll <flutter-view> natively.',
+        );
+
+        // The framework did not push a programmatic scroll to the engine.
+        expect(_callsOf('browserScrollTo'), isEmpty);
+        expect(_callsOf('browserSmoothScrollTo'), isEmpty);
+      },
+    );
+
+    testWidgets('wheel on nested inner Scrollable moves the inner, not the outer', (tester) async {
+      final innerController = ScrollController();
+      addTearDown(innerController.dispose);
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: BrowserScrollable(
+              child: ListView(
+                controller: controller,
+                children: <Widget>[
+                  SizedBox(
+                    height: 400.0,
+                    child: ListView.builder(
+                      key: const Key('inner'),
+                      controller: innerController,
+                      itemCount: 30,
+                      itemBuilder: (context, index) =>
+                          SizedBox(height: 50.0, child: Text('Inner $index')),
+                    ),
+                  ),
+                  const SizedBox(height: 2000.0, child: Text('Outer tail')),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      _clearCalls();
+
+      final respondCalls = <bool>[];
+      final Offset location = tester.getCenter(find.byKey(const Key('inner')));
+      final testPointer = TestPointer(1, PointerDeviceKind.mouse);
+      testPointer.hover(location);
+
+      final event = PointerScrollEvent(
+        position: location,
+        scrollDelta: const Offset(0.0, 80.0),
+        onRespond: ({required bool allowPlatformDefault}) {
+          respondCalls.add(allowPlatformDefault);
+        },
+      );
+
+      await tester.sendEventToBinding(event);
+      await tester.pump();
+
+      // Inner scrollable handled the wheel.
+      expect(innerController.offset, closeTo(80.0, 1.0));
+      expect(controller.position.pixels, 0.0);
+
+      // Inner called respond(allowPlatformDefault=false) so the engine will
+      // preventDefault and the browser won't also scroll <flutter-view>.
+      expect(respondCalls, equals(<bool>[false]));
+    });
+  });
+}

--- a/packages/flutter/test/widgets/scroll_physics_test.dart
+++ b/packages/flutter/test/widgets/scroll_physics_test.dart
@@ -364,4 +364,63 @@ FlutterError
     );
     await tester.fling(find.text('Index 2'), const Offset(0.0, -300.0), 10000.0);
   });
+
+  group('BrowserScrollPhysics', () {
+    test('applyTo returns BrowserScrollPhysics', () {
+      const physics = BrowserScrollPhysics();
+      final ScrollPhysics result = physics.applyTo(const ClampingScrollPhysics());
+      expect(result, isA<BrowserScrollPhysics>());
+    });
+
+    test('does not allow implicit scrolling', () {
+      const physics = BrowserScrollPhysics();
+      expect(physics.allowImplicitScrolling, isFalse);
+    });
+
+    test('applyPhysicsToUserOffset returns full offset', () {
+      const physics = BrowserScrollPhysics();
+      final metrics = FixedScrollMetrics(
+        minScrollExtent: 0,
+        maxScrollExtent: 1000,
+        pixels: 500,
+        viewportDimension: 600,
+        axisDirection: AxisDirection.down,
+        devicePixelRatio: 1.0,
+      );
+      expect(physics.applyPhysicsToUserOffset(metrics, 42.0), 42.0);
+      expect(physics.applyPhysicsToUserOffset(metrics, -10.0), -10.0);
+    });
+
+    test('applyBoundaryConditions returns entire delta as overscroll', () {
+      const physics = BrowserScrollPhysics();
+      final metrics = FixedScrollMetrics(
+        minScrollExtent: 0,
+        maxScrollExtent: 1000,
+        pixels: 500,
+        viewportDimension: 600,
+        axisDirection: AxisDirection.down,
+        devicePixelRatio: 1.0,
+      );
+      // value=550 means delta of 50 from current pixels=500
+      expect(physics.applyBoundaryConditions(metrics, 550), 50.0);
+      // value=400 means delta of -100 from current pixels=500
+      expect(physics.applyBoundaryConditions(metrics, 400), -100.0);
+      // value=500 means delta of 0
+      expect(physics.applyBoundaryConditions(metrics, 500), 0.0);
+    });
+
+    test('createBallisticSimulation returns null', () {
+      const physics = BrowserScrollPhysics();
+      final metrics = FixedScrollMetrics(
+        minScrollExtent: 0,
+        maxScrollExtent: 1000,
+        pixels: 500,
+        viewportDimension: 600,
+        axisDirection: AxisDirection.down,
+        devicePixelRatio: 1.0,
+      );
+      expect(physics.createBallisticSimulation(metrics, 100.0), isNull);
+      expect(physics.createBallisticSimulation(metrics, 0.0), isNull);
+    });
+  });
 }

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -233,6 +233,21 @@ class _TestFlutterView implements FlutterView {
 
   @override
   void updateSemantics(ui.SemanticsUpdate update) {}
+
+  // Browser-driven scrolling APIs. These are declared on FlutterView in the
+  // web dart:ui but not on the native dart:ui, so we cannot annotate them with
+  // @override (it would fail the native analyzer). They are no-ops in tests
+  // because the engine-side implementation lives in the web embedder. Tests
+  // interact with browser scrolling via
+  // ScrollableState.browserScrollViewBinding instead.
+  bool get supportsBrowserScrolling => false;
+  void enableBrowserScrolling() {}
+  void disableBrowserScrolling() {}
+  void browserScrollTo(double offset) {}
+  void browserSmoothScrollTo(double offset) {}
+  void browserScrollBy(double delta) {}
+  void updateBrowserScrollContentHeight(double height) {}
+  void Function(double offset)? onBrowserScroll;
 }
 
 mixin _ChildWindowHierarchyMixin {


### PR DESCRIPTION
  **Design doc**                             
[Browser-Driven Scrolling](https://docs.google.com/document/d/14NSGIMbVnx_BOr1eFqRI_ir-Pb6SMK_mGVrqUSX7Fnk/edit?usp=sharing)

  **Summary**                             
 Introduces BrowserScrollable for Flutter Web: the outermost scrollable delegates to the browser's native scroll   engine, and the framework listens to scroll events to keep its ScrollController in sync.                                                                
                                                                     
  **Approach**                            
  - **Engine**: `BrowserScrollController` listens for scroll events on the flutter-view element and forwards positions to the framework via `dart:ui`. `FullPageEmbeddingStrategy.enableBrowserScrolling` makes flutter-view a scroll container with `overflow: auto` and `touch-action: pan-y`, sticks fixed children, and inserts a placeholder for scroll height.         
  - **Framework**: `BrowserScrollable` wraps a child `Scrollable`, opts it into `BrowserScrollPhysics`, forwards `OverscrollNotification`s  to `browserScrollBy`, and reports content extent to the engine.
  `BrowserScrollPhysics` returns the full delta as overscroll so the parent picks it up; no ballistic simulation.                       
  - **Echo suppression**: programmatic `scrollTo`/`scrollBy` notify the framework directly and suppress the browser's echoed scroll event.  
  
  **Limitations**                                                       
  - Single `BrowserScrollable` per view (no slot-reclaim retry).     
  - `Navigator.push` not yet supported.  
  - On iOS Safari, when the user touch-drags inside a cross-origin iframe and the content reaches its boundary, two things happen: the iframe visually overscroll-bounces, and the parent page does not start scrolling until the iframe's internal momentum finishes settling. Android does not have this delay or bounce, the parent page picks up scrolling as soon as the iframe hits its boundary.
                                                                       
  **Demo**        
  - Before: https://flutter-demo-19-before.web.app/                    
  - After: https://flutter-demo-19.web.app/                   
                                                                       
  **Source code**:
  https://github.com/flutter-zl/browser_scroll_comprehensive_demo 

