### PR TITLE
Fix web proxy incorrectly merging multiple Set-Cookie headers

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/proxy_middleware.dart
+++ b/packages/flutter_tools/lib/src/isolated/proxy_middleware.dart
@@ -10,6 +10,76 @@ import '../web/devfs_proxy.dart';
 
 const _kLogEntryPrefix = '[proxyMiddleware]';
 
+/// Known Set-Cookie attribute names (lowercase) that may appear before '='
+/// in a cookie header value (e.g. "Max-Age=3600").
+const Set<String> _kCookieAttributes = <String>{
+  'domain',
+  'expires',
+  'httponly',
+  'max-age',
+  'partitioned',
+  'path',
+  'samesite',
+  'secure',
+};
+
+/// Splits a merged Set-Cookie header value into individual cookie strings.
+///
+/// HTTP allows multiple Set-Cookie headers, but some libraries merge them into
+/// a single comma-separated string. This is problematic because cookie values
+/// and Expires dates can contain commas. This function re-splits them by
+/// detecting where a new cookie name starts after a comma.
+List<String> splitSetCookieHeader(String headerValue) {
+  if (headerValue.isEmpty) {
+    return <String>[];
+  }
+
+  final List<String> cookies = <String>[];
+  final StringBuffer currentCookie = StringBuffer();
+
+  for (final String part in headerValue.split(',')) {
+    final String trimmedPart = part.trim();
+    if (currentCookie.isEmpty) {
+      currentCookie.write(trimmedPart);
+    } else if (_isNewCookie(trimmedPart)) {
+      cookies.add(currentCookie.toString());
+      currentCookie.clear();
+      currentCookie.write(trimmedPart);
+    } else {
+      currentCookie.write(', $trimmedPart');
+    }
+  }
+
+  if (currentCookie.isNotEmpty) {
+    cookies.add(currentCookie.toString());
+  }
+
+  return cookies;
+}
+
+/// Returns true if [part] looks like the start of a new cookie (name=value)
+/// rather than a continuation of a previous cookie's attribute (e.g. an
+/// Expires date that contains a comma).
+bool _isNewCookie(String part) {
+  final int equalsIndex = part.indexOf('=');
+  if (equalsIndex <= 0) {
+    return false;
+  }
+
+  final String beforeEquals = part.substring(0, equalsIndex);
+  final int lastSemicolon = beforeEquals.lastIndexOf(';');
+  final int lastSpace = beforeEquals.lastIndexOf(' ');
+  final int tokenStart = (lastSemicolon > lastSpace ? lastSemicolon : lastSpace) + 1;
+  final String token = beforeEquals.substring(tokenStart).trim().toLowerCase();
+
+  if (token.isEmpty || _kCookieAttributes.contains(token)) {
+    return false;
+  }
+
+  // RFC 6265 cookie-name is a token; allow common characters including dots.
+  return RegExp(r'^[a-zA-Z0-9_.\-]+$').hasMatch(token);
+}
+
 /// Creates a new [shelf.Request] by proxying an [originalRequest] to a [finalTargetUrl].
 ///
 /// The new request will have the same method, headers, body, and context as the
@@ -47,13 +117,32 @@ Future<shelf.Response> _applyProxyRules(
       final shelf.Response proxyResponse = await handler(proxyBackendRequest);
       logger.printStatus('$_kLogEntryPrefix Matched "$requestPath". Requesting "$finalTargetUrl"');
       logger.printTrace('$_kLogEntryPrefix Matched with proxy rule: $rule');
-      return proxyResponse;
+      return _fixSetCookieHeaders(proxyResponse);
     } on Exception catch (e) {
       logger.printError('$_kLogEntryPrefix Error for $finalTargetUrl: $e. Allowing fall-through.');
       return innerHandler(request);
     }
   }
   return innerHandler(request);
+}
+
+/// Fixes Set-Cookie headers that were incorrectly merged into a single value.
+///
+/// The shelf_proxy package merges multiple Set-Cookie headers into one
+/// comma-separated string, but Set-Cookie cannot be safely combined this way
+/// because cookie values and Expires dates can contain commas.
+shelf.Response _fixSetCookieHeaders(shelf.Response response) {
+  final String? setCookieHeader = response.headers['set-cookie'];
+  if (setCookieHeader == null) {
+    return response;
+  }
+
+  final List<String> cookies = splitSetCookieHeader(setCookieHeader);
+  if (cookies.length <= 1) {
+    return response;
+  }
+
+  return response.change(headers: <String, Object>{...response.headers, 'set-cookie': cookies});
 }
 
 /// Creates a [shelf.Middleware] that proxies requests based on a list of [ProxyRule]s.

--- a/packages/flutter_tools/lib/src/isolated/proxy_middleware.dart
+++ b/packages/flutter_tools/lib/src/isolated/proxy_middleware.dart
@@ -76,8 +76,8 @@ bool _isNewCookie(String part) {
     return false;
   }
 
-  // RFC 6265 cookie-name is a token; allow common characters including dots.
-  return RegExp(r'^[a-zA-Z0-9_.\-]+$').hasMatch(token);
+  // RFC 6265 cookie-name is a token (RFC 2616 §2.2); allow all valid token characters.
+  return RegExp(r"^[!#$%&'*+.^_`|~0-9a-zA-Z-]+$").hasMatch(token);
 }
 
 /// Creates a new [shelf.Request] by proxying an [originalRequest] to a [finalTargetUrl].

--- a/packages/flutter_tools/test/general.shard/web/proxy_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/proxy_test.dart
@@ -540,5 +540,15 @@ void main() {
         '__Secure-id=xyz; Secure',
       ]);
     });
+
+    test('handles cookie names with RFC 6265 special characters', () {
+      final List<String> result = splitSetCookieHeader(
+        "my!cookie=abc; Path=/, other.cookie\$|~=xyz",
+      );
+      expect(result, <String>[
+        'my!cookie=abc; Path=/',
+        'other.cookie\$|~=xyz',
+      ]);
+    });
   });
 }

--- a/packages/flutter_tools/test/general.shard/web/proxy_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/proxy_test.dart
@@ -445,4 +445,100 @@ void main() {
       },
     );
   });
+
+  group('splitSetCookieHeader', () {
+    test('returns single cookie unchanged', () {
+      final List<String> result = splitSetCookieHeader('sessionid=abc123; Path=/; HttpOnly');
+      expect(result, <String>['sessionid=abc123; Path=/; HttpOnly']);
+    });
+
+    test('splits two simple cookies', () {
+      final List<String> result = splitSetCookieHeader(
+        'csrftoken=abc; Path=/; SameSite=Lax, sessionid=xyz; Path=/; HttpOnly; SameSite=Lax',
+      );
+      expect(result, <String>[
+        'csrftoken=abc; Path=/; SameSite=Lax',
+        'sessionid=xyz; Path=/; HttpOnly; SameSite=Lax',
+      ]);
+    });
+
+    test('handles cookies with Expires containing comma in date', () {
+      final List<String> result = splitSetCookieHeader(
+        'token=abc; Expires=Thu, 01 Jan 2025 00:00:00 GMT; Path=/, session=xyz; Path=/',
+      );
+      expect(result, <String>[
+        'token=abc; Expires=Thu, 01 Jan 2025 00:00:00 GMT; Path=/',
+        'session=xyz; Path=/',
+      ]);
+    });
+
+    test('handles multiple cookies with Expires dates', () {
+      final List<String> result = splitSetCookieHeader(
+        'a=1; Expires=Mon, 01 Jan 2024 00:00:00 GMT, b=2; Expires=Tue, 02 Jan 2024 00:00:00 GMT',
+      );
+      expect(result, <String>[
+        'a=1; Expires=Mon, 01 Jan 2024 00:00:00 GMT',
+        'b=2; Expires=Tue, 02 Jan 2024 00:00:00 GMT',
+      ]);
+    });
+
+    test('handles cookies with Max-Age attribute', () {
+      final List<String> result = splitSetCookieHeader(
+        'cookie1=value1; Max-Age=3600; Path=/, cookie2=value2; Max-Age=7200',
+      );
+      expect(result, <String>[
+        'cookie1=value1; Max-Age=3600; Path=/',
+        'cookie2=value2; Max-Age=7200',
+      ]);
+    });
+
+    test('handles cookies with Domain attribute', () {
+      final List<String> result = splitSetCookieHeader(
+        'a=1; Domain=.example.com; Path=/, b=2; Domain=.test.com',
+      );
+      expect(result, <String>[
+        'a=1; Domain=.example.com; Path=/',
+        'b=2; Domain=.test.com',
+      ]);
+    });
+
+    test('handles three or more cookies', () {
+      final List<String> result = splitSetCookieHeader(
+        'a=1; Path=/, b=2; Path=/, c=3; Path=/',
+      );
+      expect(result, <String>['a=1; Path=/', 'b=2; Path=/', 'c=3; Path=/']);
+    });
+
+    test('returns empty list for empty string', () {
+      final List<String> result = splitSetCookieHeader('');
+      expect(result, <String>[]);
+    });
+
+    test('handles cookies with Secure and HttpOnly flags', () {
+      final List<String> result = splitSetCookieHeader(
+        'token=abc; Secure; HttpOnly; Path=/, other=xyz; Secure',
+      );
+      expect(result, <String>[
+        'token=abc; Secure; HttpOnly; Path=/',
+        'other=xyz; Secure',
+      ]);
+    });
+
+    test('handles cookie names with dots', () {
+      final List<String> result = splitSetCookieHeader(
+        'app.session=123; Path=/, other.id=456',
+      );
+      expect(result, <String>['app.session=123; Path=/', 'other.id=456']);
+    });
+
+    test('handles cookie names with __Host- prefix', () {
+      final List<String> result = splitSetCookieHeader(
+        '__Host-app.session=abc; Path=/, __Secure-id=xyz; Secure',
+      );
+      expect(result, <String>[
+        '__Host-app.session=abc; Path=/',
+        '__Secure-id=xyz; Secure',
+      ]);
+    });
+  });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/178582

## Description

Fixes the web dev server proxy incorrectly merging multiple `Set-Cookie` headers into one comma-separated value.

When a backend sends multiple `Set-Cookie` headers:
```
Set-Cookie: csrftoken=abc; Path=/; SameSite=Lax
Set-Cookie: sessionid=xyz; Path=/; HttpOnly; SameSite=Lax
```

The `shelf_proxy` package merges them into a single header:
```
Set-Cookie: csrftoken=abc; Path=/; SameSite=Lax,sessionid=xyz; Path=/; HttpOnly; SameSite=Lax
```

This violates the HTTP specification. Browsers treat this as one invalid cookie and fail to set either cookie.

## Fix

Added a `splitSetCookieHeader` function that re-splits the merged header value by detecting where new cookie names begin after commas. This correctly handles `Expires` dates and other attributes that contain commas.

The fix applies to proxy responses automatically via the existing `_applyProxyRules` flow.

## Test plan

- Added 11 unit tests covering: single cookies, multiple cookies, cookies with `Expires` dates (containing commas), `Max-Age`, `Domain`, `SameSite`, `Secure`/`HttpOnly` flags, cookie names with dots, and `__Host-`/`__Secure-` prefixes.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests