### PR TITLE
[web] Handle variation selectors in font fallback

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/font_fallback_service.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/font_fallback_service.dart
@@ -67,6 +67,18 @@ class FallbackFontService {
   /// single [FallbackFontComponent] before marking it as unsupported.
   static const int _maxFontsPerComponent = 5;
 
+  /// First code point in the Unicode Variation Selectors block (VS1).
+  static const int _kVariationSelectorStart = 0xFE00;
+
+  /// Last code point in the Unicode Variation Selectors block (VS16).
+  static const int _kVariationSelectorEnd = 0xFE0F;
+
+  /// Text-presentation variation selector (VS15).
+  static const int _kTextPresentationSelector = 0xFE0E;
+
+  /// Whether VS15 has been observed in the input.
+  bool _hasSeenTextPresentationSelector = false;
+
   /// Adds a list of missing code points to be processed.
   void addMissingCodePoints(List<int> codePoints) {
     var added = false;
@@ -82,6 +94,14 @@ class FallbackFontService {
     // determine which fallback font component covers them and whether that
     // component is already satisfied by a registered font.
     for (final codePoint in codePoints) {
+      // Variation selectors have no glyph in the fallback data.
+      if (codePoint >= _kVariationSelectorStart && codePoint <= _kVariationSelectorEnd) {
+        if (codePoint == _kTextPresentationSelector) {
+          _hasSeenTextPresentationSelector = true;
+        }
+        continue;
+      }
+
       // Skip if we already know this character can't be rendered or if it's
       // already scheduled for processing.
       if (!_unsupportedCodePoints.contains(codePoint) &&
@@ -220,22 +240,42 @@ class FallbackFontService {
       _unsupportedCodePoints.addAll(newlyUnsupported);
     }
 
-    if (gapComponentCounts.isEmpty) {
-      _checkIdle();
-      return;
-    }
-
     // Resolve the Gap: Run the greedy algorithm on unique components.
     // This finds the smallest set of fonts that will resolve all current "Gaps".
     final List<NotoFont> newFonts = _findFontsForComponents(gapComponentCounts);
 
-    if (newFonts.isEmpty) {
-      _checkIdle();
-      return;
-    }
-
     // Fire and Forget: Start downloads for the selected fonts.
     newFonts.forEach(_startDownloadTask);
+
+    // Also schedule the text-presentation companion when VS15 was observed.
+    if (_hasSeenTextPresentationSelector) {
+      final NotoFont? textPresentationFont = _findTextPresentationFont();
+      if (textPresentationFont != null) {
+        _startDownloadTask(textPresentationFont);
+      }
+    }
+
+    _checkIdle();
+  }
+
+  /// Returns a Noto Emoji shard covering an unprocessed code point that has
+  /// not yet been registered, downloaded, or marked unavailable.
+  NotoFont? _findTextPresentationFont() {
+    final FontFallbackManager manager = renderer.fontCollection.fontFallbackManager!;
+    for (final int cp in _unprocessedCodePoints) {
+      for (final NotoFont font in manager.codePointToComponents.lookup(cp).fonts) {
+        if (!font.name.startsWith('Noto Emoji')) {
+          continue;
+        }
+        if (_pendingFonts.contains(font) ||
+            _permanentlyUnavailableFonts.contains(font) ||
+            _registeredFonts.contains(font)) {
+          continue;
+        }
+        return font;
+      }
+    }
+    return null;
   }
 
   /// Wraps the download and registration process in a managed task.
@@ -633,6 +673,7 @@ class FallbackFontService {
     _failedFontsPerComponent.clear();
     _totalPermanentFailures = 0;
     _isBroken = false;
+    _hasSeenTextPresentationSelector = false;
     _processTimer?.cancel();
     _processTimer = null;
     _notifyTimer?.cancel();

--- a/engine/src/flutter/lib/web_ui/test/ui/fallback_fonts_golden_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/ui/fallback_fonts_golden_test.dart
@@ -198,6 +198,74 @@ void testMain() {
       // TODO(hterkelsen): https://github.com/flutter/flutter/issues/71520
     });
 
+    // https://github.com/flutter/flutter/issues/157831
+    test('can render emoji with text variation selector (VS15)', () async {
+      expect(renderer.fontCollection.fontFallbackManager!.globalFontFallbacks, <String>['Roboto']);
+
+      final text = String.fromCharCodes(<int>[
+        0x2648, 0xFE0E, // ♈︎
+        0x264B, 0xFE0E, // ♋︎
+        0x000A, // newline
+        0x2650, 0xFE0E, // ♐︎
+      ]);
+      var pb = ui.ParagraphBuilder(ui.ParagraphStyle());
+      pb.addText(text);
+      pb.build().layout(const ui.ParagraphConstraints(width: 1000));
+
+      await FallbackFontService.instance.waitForIdle();
+
+      expect(downloadedFontFamilies, isNotEmpty);
+
+      final recorder = ui.PictureRecorder();
+      final canvas = ui.Canvas(recorder);
+
+      pb = ui.ParagraphBuilder(ui.ParagraphStyle());
+      pb.pushStyle(ui.TextStyle(fontSize: 32));
+      pb.addText(text);
+      pb.pop();
+      final ui.Paragraph paragraph = pb.build();
+      paragraph.layout(const ui.ParagraphConstraints(width: 1000));
+
+      canvas.drawParagraph(paragraph, ui.Offset.zero);
+      await drawPictureUsingCurrentRenderer(recorder.endRecording());
+
+      await matchGoldenFile('ui_font_fallback_emoji_vs15.png', region: kDefaultRegion);
+    });
+
+    // https://github.com/flutter/flutter/issues/157831
+    test('can render emoji with color variation selector (VS16)', () async {
+      expect(renderer.fontCollection.fontFallbackManager!.globalFontFallbacks, <String>['Roboto']);
+
+      final text = String.fromCharCodes(<int>[
+        0x2648, 0xFE0F, // ♈️
+        0x264B, 0xFE0F, // ♋️
+        0x000A, // newline
+        0x2650, 0xFE0F, // ♐️
+      ]);
+      var pb = ui.ParagraphBuilder(ui.ParagraphStyle());
+      pb.addText(text);
+      pb.build().layout(const ui.ParagraphConstraints(width: 1000));
+
+      await FallbackFontService.instance.waitForIdle();
+
+      expect(downloadedFontFamilies, isNotEmpty);
+
+      final recorder = ui.PictureRecorder();
+      final canvas = ui.Canvas(recorder);
+
+      pb = ui.ParagraphBuilder(ui.ParagraphStyle());
+      pb.pushStyle(ui.TextStyle(fontSize: 32));
+      pb.addText(text);
+      pb.pop();
+      final ui.Paragraph paragraph = pb.build();
+      paragraph.layout(const ui.ParagraphConstraints(width: 1000));
+
+      canvas.drawParagraph(paragraph, ui.Offset.zero);
+      await drawPictureUsingCurrentRenderer(recorder.endRecording());
+
+      await matchGoldenFile('ui_font_fallback_emoji_vs16.png', region: kDefaultRegion);
+    });
+
     /// Attempts to render [text] and verifies that [expectedFamilies] are downloaded.
     ///
     /// Then it does the same, but asserts that the families aren't downloaded again


### PR DESCRIPTION
fix https://github.com/flutter/flutter/issues/157831

Emoji containing `U+FE0F` (Variation Selector 16) are rendered as broken or monochrome glyphs on Flutter web.　This is because the font fallback system selects Noto Sans Symbols instead of Noto Color Emoji.

I updated `_selectFont` so that Noto Color Emoji takes precedence over Noto Sans Symbols when both are available.

I also added golden tests to verify the rendering.

| | before | after |
| :---: | :---: | :---: |
| keycap | <img width="100" height="100" alt="before_keycap" src="https://github.com/user-attachments/assets/adaa30cf-2b7a-45a9-bc44-24068643c018" /> | <img width="100" height="100" alt="after_keycap" src="https://github.com/user-attachments/assets/c9306a0f-e7ab-46a8-9da8-4a22f8f3f8b5" /> |
| symbol | <img width="100" height="100" alt="before_symbol" src="https://github.com/user-attachments/assets/79ea9d96-4e68-4891-914f-005a7eb18514" /> | <img width="100" height="100" alt="after_symbol" src="https://github.com/user-attachments/assets/b7d275f6-5f0b-4d08-87a6-f1a987f16075" /> |

Additionally, for inputs containing `U+FE0E` (Variation Selector 15), `Noto Emoji` should be selected to render text presentation correctly. However, Noto Emoji does not appear to be included in `font_fallback_data.dart`, so it is not picked as a fallback.

<img width="100" height="100" alt="ui_font_fallback_symbol_emoji_text" src="https://github.com/user-attachments/assets/577e289d-77b8-432d-9e48-a5f8ba42d75d" />

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
