### PR TITLE
Fix merge changelog workflow.

### DIFF
--- a/.github/workflows/merge-changelog.yml
+++ b/.github/workflows/merge-changelog.yml
@@ -31,18 +31,10 @@ jobs:
 
       # avoid downloading hundreds of other branches/history
       # utilizing `fetch-depth:0` in actions/checkout would clone everything.
-      - name: Fetch Stable Branch Only
-        run: git fetch upstream stable:stable --depth=1
-
-      - name: Read CHANGELOG.md from the stable branch
-        id: read_stable_changelog
+      - name: Fetch upstream branches
         run: |
-          # upstream/stable is locally mapped to stable
-          # use the local stable ref from above
-          CHANGELOG_CONTENT=$(git show stable:CHANGELOG.md)
-          echo "CHANGELOG_CONTENT<<EOF" >> $GITHUB_ENV
-          echo "$CHANGELOG_CONTENT" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
+          git fetch upstream stable:stable --depth=1
+          git fetch upstream master --depth=1
 
       - name: Prepare PR branch and commit changes
         id: prepare_pr_branch
@@ -51,13 +43,27 @@ jobs:
         run: |
           PR_BRANCH="sync-changelog-stable-to-master-$(date +%s)"
           echo "pr_branch_name=$PR_BRANCH" >> "$GITHUB_OUTPUT"
-          git checkout -b "$PR_BRANCH" master
-          echo "${{ env.CHANGELOG_CONTENT }}" > CHANGELOG.md
+
+          # Base the branch on upstream's master to avoid issues if the fork's master is out of date
+          git checkout -b "$PR_BRANCH" upstream/master
+
+          # Retrieve the file from stable directly into the working directory
+          git show stable:CHANGELOG.md > CHANGELOG.md
+
+          # Stop if no changes are detected
+          if git diff --quiet CHANGELOG.md; then
+            echo "No changes detected. Skipping PR creation."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
           git add CHANGELOG.md
           git commit -m "Sync CHANGELOG.md from stable"
           git push origin "$PR_BRANCH"
 
       - name: Create Pull Request
+        if: steps.prepare_pr_branch.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ secrets.FLUTTERACTIONSBOT_CP_TOKEN }}
         run: |


### PR DESCRIPTION
* Avoids doing literal string substitutions of `env.CHANGELOG_CONTENT`, which prevents escaping issues.
* Base the branch off of `upstream/master` instead of the (rarely updated) master branch from the bot's fork.
* Handle the case where there are no changelog changes more gracefully (succeed with a no-op).

https://github.com/flutter/flutter/issues/178913