### PR TITLE
Collect impeller analytics for appbundles

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_aar.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aar.dart
@@ -156,9 +156,6 @@ class BuildAarCommand extends BuildSubCommand {
       buildNumber: buildNumber,
     );
 
-    // When an aar is successfully built, record to analytics whether Impeller
-    // is enabled or disabled. Note that 'computeImpellerEnabled' will default
-    // to false if not enabled explicitly in the manifest.
     final bool impellerEnabled = project.android.computeImpellerEnabled();
     final buildLabel = impellerEnabled
         ? 'manifest-aar-impeller-enabled'

--- a/packages/flutter_tools/lib/src/commands/build_apk.dart
+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
@@ -135,9 +135,6 @@ class BuildApkCommand extends BuildSubCommand {
       configOnly: configOnly,
     );
 
-    // When an app is successfully built, record to analytics whether Impeller
-    // is enabled or disabled. Note that 'computeImpellerEnabled' will default
-    // to false if not enabled explicitly in the manifest.
     final bool impellerEnabled = project.android.computeImpellerEnabled();
     final buildLabel = impellerEnabled ? 'manifest-impeller-enabled' : 'manifest-impeller-disabled';
     globals.analytics.send(Event.flutterBuildInfo(label: buildLabel, buildType: 'android'));

--- a/packages/flutter_tools/lib/src/commands/build_appbundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_appbundle.dart
@@ -172,6 +172,10 @@ class BuildAppBundleCommand extends BuildSubCommand {
       validateDeferredComponents: boolArg('validate-deferred-components'),
       deferredComponentsEnabled: boolArg('deferred-components') && !boolArg('debug'),
     );
+
+    final bool impellerEnabled = project.android.computeImpellerEnabled();
+    final buildLabel = impellerEnabled ? 'manifest-impeller-enabled' : 'manifest-impeller-disabled';
+    globals.analytics.send(Event.flutterBuildInfo(label: buildLabel, buildType: 'android'));
     return FlutterCommandResult.success();
   }
 }

--- a/packages/flutter_tools/test/commands.shard/permeable/build_aar_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_aar_test.dart
@@ -509,7 +509,7 @@ void main() {
       );
 
       testUsingContext(
-        'EnableImpeller="false" reports an disabled event',
+        'EnableImpeller="false" reports a disabled event',
         () async {
           final String projectPath = await createProject(
             tempDir,

--- a/packages/flutter_tools/test/commands.shard/permeable/build_apk_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_apk_test.dart
@@ -412,7 +412,7 @@ void main() {
       );
 
       testUsingContext(
-        'EnableImpeller="false" reports an disabled event',
+        'EnableImpeller="false" reports a disabled event',
         () async {
           final String projectPath = await createProject(
             tempDir,

--- a/packages/flutter_tools/test/commands.shard/permeable/build_appbundle_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_appbundle_test.dart
@@ -177,6 +177,147 @@ void main() {
       },
     );
 
+    group('Impeller AndroidManifest.xml setting', () {
+      // Adds a key-value `<meta-data>` pair to the `<application>` tag in the
+      // corresponding `AndroidManifest.xml` file, right before the closing
+      // `</application>` tag.
+      void writeManifestMetadata({
+        required String projectPath,
+        required String name,
+        required String value,
+      }) {
+        final String manifestPath = globals.fs.path.join(
+          projectPath,
+          'android',
+          'app',
+          'src',
+          'main',
+          'AndroidManifest.xml',
+        );
+
+        // It would be unnecessarily complicated to parse this XML file and
+        // insert the key-value pair, so we just insert it right before the
+        // closing </application> tag.
+        final String oldManifest = globals.fs.file(manifestPath).readAsStringSync();
+        final String newManifest = oldManifest.replaceFirst(
+          '</application>',
+          '    <meta-data\n'
+              '        android:name="$name"\n'
+              '        android:value="$value" />\n'
+              '    </application>',
+        );
+        globals.fs.file(manifestPath).writeAsStringSync(newManifest);
+      }
+
+      testUsingContext(
+        'a default appbundle build reports Impeller as enabled',
+        () async {
+          final String projectPath = await createProject(
+            tempDir,
+            arguments: <String>['--empty', '--no-pub', '--template=app'],
+          );
+
+          final Directory oldCwd = globals.localFileSystem.currentDirectory;
+          try {
+            globals.localFileSystem.currentDirectory = globals.localFileSystem.directory(
+              projectPath,
+            );
+            await runBuildAppBundleCommand(projectPath);
+          } finally {
+            globals.localFileSystem.currentDirectory = oldCwd;
+          }
+
+          expect(
+            fakeAnalytics.sentEvents,
+            contains(
+              Event.flutterBuildInfo(label: 'manifest-impeller-enabled', buildType: 'android'),
+            ),
+          );
+        },
+        overrides: <Type, Generator>{
+          AndroidBuilder: () => FakeAndroidBuilder(),
+          Analytics: () => fakeAnalytics,
+          ProcessInfo: () => processInfo,
+        },
+      );
+
+      testUsingContext(
+        'EnableImpeller="true" reports an enabled event',
+        () async {
+          final String projectPath = await createProject(
+            tempDir,
+            arguments: <String>['--empty', '--no-pub', '--template=app'],
+          );
+
+          writeManifestMetadata(
+            projectPath: projectPath,
+            name: 'io.flutter.embedding.android.EnableImpeller',
+            value: 'true',
+          );
+
+          final Directory oldCwd = globals.localFileSystem.currentDirectory;
+          try {
+            globals.localFileSystem.currentDirectory = globals.localFileSystem.directory(
+              projectPath,
+            );
+            await runBuildAppBundleCommand(projectPath);
+          } finally {
+            globals.localFileSystem.currentDirectory = oldCwd;
+          }
+
+          expect(
+            fakeAnalytics.sentEvents,
+            contains(
+              Event.flutterBuildInfo(label: 'manifest-impeller-enabled', buildType: 'android'),
+            ),
+          );
+        },
+        overrides: <Type, Generator>{
+          AndroidBuilder: () => FakeAndroidBuilder(),
+          Analytics: () => fakeAnalytics,
+          ProcessInfo: () => processInfo,
+        },
+      );
+
+      testUsingContext(
+        'EnableImpeller="false" reports a disabled event',
+        () async {
+          final String projectPath = await createProject(
+            tempDir,
+            arguments: <String>['--empty', '--no-pub', '--template=app'],
+          );
+
+          writeManifestMetadata(
+            projectPath: projectPath,
+            name: 'io.flutter.embedding.android.EnableImpeller',
+            value: 'false',
+          );
+
+          final Directory oldCwd = globals.localFileSystem.currentDirectory;
+          try {
+            globals.localFileSystem.currentDirectory = globals.localFileSystem.directory(
+              projectPath,
+            );
+            await runBuildAppBundleCommand(projectPath);
+          } finally {
+            globals.localFileSystem.currentDirectory = oldCwd;
+          }
+
+          expect(
+            fakeAnalytics.sentEvents,
+            contains(
+              Event.flutterBuildInfo(label: 'manifest-impeller-disabled', buildType: 'android'),
+            ),
+          );
+        },
+        overrides: <Type, Generator>{
+          AndroidBuilder: () => FakeAndroidBuilder(),
+          Analytics: () => fakeAnalytics,
+          ProcessInfo: () => processInfo,
+        },
+      );
+    });
+
     testUsingContext(
       'use of the deferred components feature sends a build info event indicating so',
       () async {


### PR DESCRIPTION
While looking in to https://github.com/flutter/flutter/issues/184127 I noticed we don't collect analytics for impeller when building appbundles. I assume this is a simple oversight, hence this PR.