### PR TITLE
Remove the default_git_folder GN argument

### DIFF
--- a/engine/src/flutter/tools/gn
+++ b/engine/src/flutter/tools/gn
@@ -591,11 +591,6 @@ def to_gn_args(args):
 
   gn_args['concurrent_toolchain_jobs'] = get_concurrent_jobs('1GB', '100MB')
 
-  # Hardcoding this avoids invoking a relatively expensive python script from
-  # GN, but removes the ability to use git-worktrees in the Dart checkout from
-  # within the Engine repo, but it's unlikely anyone is using that.
-  gn_args['default_git_folder'] = os.path.join(get_dart_path(), '.git')
-
   # By default, the Dart GN build will invoke a relatively expensive python
   # script to calculate an SDK "hash" that ensures compatibility between the
   # Dart VM and the Dart front-end. This default hash calculation allows some


### PR DESCRIPTION
This was removed from the Dart SDK in https://dart.googlesource.com/sdk/+/0a376fb28dbd5ff2e368b595beafdbc6ab959ca8