### PR TITLE
Reland "Fix Slider semantics node size" with some changes 

### DIFF
--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -1901,6 +1901,9 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
   /// Calculates the local coordinate center of the [Slider] thumb given its
   /// physical placement on the track from 0.0 (left) to 1.0 (right).
+  ///
+  /// The [visualPosition] is provided by the caller so semantics can use the
+  /// raw logical value while paint can use the smoothly animated value.
   Offset _calcThumbCenter({ required Rect trackRect, required double visualPosition }) {
     final double padding = _sliderTheme.trackShape!.isRounded ? trackRect.height : 0.0;
     final double thumbPosition = isDiscrete

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -995,6 +995,7 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
         onChangeEnd: _handleDragEnd,
         state: this,
         semanticFormatterCallback: widget.semanticFormatterCallback,
+        onDidGainAccessibilityFocus: handleDidGainAccessibilityFocus,
         hasFocus: _focused,
         hovering: _hovering,
         allowedInteraction: effectiveAllowedInteraction,
@@ -1013,22 +1014,17 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
       child: result,
     );
 
-    return Semantics(
-      label: widget.label,
-      container: true,
-      slider: true,
-      onDidGainAccessibilityFocus: handleDidGainAccessibilityFocus,
-      child: FocusableActionDetector(
-        actions: _actionMap,
-        shortcuts: shortcutMap,
-        focusNode: focusNode,
-        autofocus: widget.autofocus,
-        enabled: _enabled,
-        onShowFocusHighlight: _handleFocusHighlightChanged,
-        onShowHoverHighlight: _handleHoverChanged,
-        mouseCursor: effectiveMouseCursor,
-        child: result,
-      ),
+    return FocusableActionDetector(
+      actions: _actionMap,
+      shortcuts: shortcutMap,
+      focusNode: focusNode,
+      autofocus: widget.autofocus,
+      enabled: _enabled,
+      onShowFocusHighlight: _handleFocusHighlightChanged,
+      onShowHoverHighlight: _handleHoverChanged,
+      mouseCursor: effectiveMouseCursor,
+      includeFocusSemantics: false,
+      child: result,
     );
   }
 
@@ -1086,6 +1082,7 @@ class _SliderRenderObjectWidget extends LeafRenderObjectWidget {
     required this.onChangeEnd,
     required this.state,
     required this.semanticFormatterCallback,
+    required this.onDidGainAccessibilityFocus,
     required this.hasFocus,
     required this.hovering,
     required this.allowedInteraction,
@@ -1102,6 +1099,7 @@ class _SliderRenderObjectWidget extends LeafRenderObjectWidget {
   final ValueChanged<double>? onChangeStart;
   final ValueChanged<double>? onChangeEnd;
   final SemanticFormatterCallback? semanticFormatterCallback;
+  final VoidCallback? onDidGainAccessibilityFocus;
   final _SliderState state;
   final bool hasFocus;
   final bool hovering;
@@ -1123,6 +1121,7 @@ class _SliderRenderObjectWidget extends LeafRenderObjectWidget {
       state: state,
       textDirection: Directionality.of(context),
       semanticFormatterCallback: semanticFormatterCallback,
+      onDidGainAccessibilityFocus: onDidGainAccessibilityFocus,
       platform: Theme.of(context).platform,
       hasFocus: hasFocus,
       hovering: hovering,
@@ -1148,6 +1147,7 @@ class _SliderRenderObjectWidget extends LeafRenderObjectWidget {
       ..onChangeEnd = onChangeEnd
       ..textDirection = Directionality.of(context)
       ..semanticFormatterCallback = semanticFormatterCallback
+      ..onDidGainAccessibilityFocus = onDidGainAccessibilityFocus
       ..platform = Theme.of(context).platform
       ..hasFocus = hasFocus
       ..hovering = hovering
@@ -1170,6 +1170,7 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     required TargetPlatform platform,
     required ValueChanged<double>? onChanged,
     required SemanticFormatterCallback? semanticFormatterCallback,
+    required this.onDidGainAccessibilityFocus,
     required this.onChangeStart,
     required this.onChangeEnd,
     required _SliderState state,
@@ -1259,6 +1260,7 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   late HorizontalDragGestureRecognizer _drag;
   late TapGestureRecognizer _tap;
   bool _active = false;
+  VoidCallback? onDidGainAccessibilityFocus;
   double _currentDragValue = 0.0;
   Rect? overlayRect;
 
@@ -1755,21 +1757,12 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       sliderTheme: _sliderTheme,
       isDiscrete: isDiscrete,
     );
-    final double padding = _sliderTheme.trackShape!.isRounded ? trackRect.height : 0.0;
-    final double thumbPosition = isDiscrete
-        ? trackRect.left + visualPosition * (trackRect.width - padding) + padding / 2
-        : trackRect.left + visualPosition * trackRect.width;
-    // Apply padding to trackRect.left and trackRect.right if the track height is
-    // greater than the thumb radius to ensure the thumb is drawn within the track.
-    final Size thumbPreferredSize = _sliderTheme.thumbShape!.getPreferredSize(
-      isInteractive,
-      isDiscrete,
+
+    final Offset thumbCenter = _calcThumbCenter(
+      trackRect: trackRect,
+      visualPosition: visualPosition,
     );
-    final double thumbPadding = (padding > thumbPreferredSize.width / 2 ? padding / 2 : 0);
-    final thumbCenter = Offset(
-      clampDouble(thumbPosition, trackRect.left + thumbPadding, trackRect.right - thumbPadding),
-      trackRect.center.dy,
-    );
+
     if (isInteractive) {
       final Size overlaySize = sliderTheme.overlayShape!.getPreferredSize(isInteractive, false);
       overlayRect = Rect.fromCircle(center: thumbCenter, radius: overlaySize.width / 2.0);
@@ -1906,26 +1899,75 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     );
   }
 
+  /// Calculates the local coordinate center of the [Slider] thumb given its
+  /// physical placement on the track from 0.0 (left) to 1.0 (right).
+  Offset _calcThumbCenter({ required Rect trackRect, required double visualPosition }) {
+    final double padding = _sliderTheme.trackShape!.isRounded ? trackRect.height : 0.0;
+    final double thumbPosition = isDiscrete
+        ? trackRect.left + visualPosition * (trackRect.width - padding) + padding / 2
+        : trackRect.left + visualPosition * trackRect.width;
+    // Apply padding to trackRect.left and trackRect.right if the track height is
+    // greater than the thumb radius to ensure the thumb is drawn within the track.
+    final Size thumbPreferredSize = _sliderTheme.thumbShape!.getPreferredSize(
+      isInteractive,
+      isDiscrete,
+    );
+    final double thumbPadding = padding > thumbPreferredSize.width / 2 ? padding / 2 : 0;
+    return Offset(
+      clampDouble(thumbPosition, trackRect.left + thumbPadding, trackRect.right - thumbPadding),
+      trackRect.center.dy,
+    );
+  }
+
+  Offset get _semanticThumbCenter {
+    final double visualPosition = switch (textDirection) {
+      TextDirection.rtl => 1.0 - _value,
+      TextDirection.ltr => _value,
+    };
+    return _calcThumbCenter(trackRect: _trackRect, visualPosition: visualPosition);
+  }
+
+  @override
+  void assembleSemanticsNode(
+    SemanticsNode node,
+    SemanticsConfiguration config,
+    Iterable<SemanticsNode> children,
+  ) {
+    node.rect = Rect.fromCenter(
+      center: _semanticThumbCenter,
+      width: kMinInteractiveDimension,
+      height: kMinInteractiveDimension,
+    );
+
+    node.updateWith(config: config);
+  }
+
   @override
   void describeSemanticsConfiguration(SemanticsConfiguration config) {
     super.describeSemanticsConfiguration(config);
 
-    // The Slider widget has its own Focus widget with semantics information,
+    // The Slider widget has its own Focus widget.
+    // We mark the Focus widget with "includeFocusSemantics: false"
     // and we want that semantics node to collect the semantics information here
-    // so that it's all in the same node: otherwise Talkback sees that the node
-    // has focusable children, and it won't focus the Slider's Focus widget
-    // because it thinks the Focus widget's node doesn't have anything to say
-    // (which it doesn't, but this child does). Aggregating the semantic
-    // information into one node means that Talkback will recognize that it has
-    // something to say and focus it when it receives keyboard focus.
-    // (See https://github.com/flutter/flutter/issues/57038 for context).
-    config.isSemanticBoundary = false;
+    // so that it's all in the same node.
+    config.isSemanticBoundary = true;
 
     config.isEnabled = isInteractive;
+    if (label != null) {
+      config.label = label!;
+    }
+    config.isSlider = true;
+    config.isFocusable = isInteractive;
+    config.isFocused = hasFocus;
+
+    if (onDidGainAccessibilityFocus != null) {
+      config.onDidGainAccessibilityFocus = onDidGainAccessibilityFocus;
+    }
     config.textDirection = textDirection;
     if (isInteractive) {
       config.onIncrease = increaseAction;
       config.onDecrease = decreaseAction;
+      config.onFocus = onFocusAction;
     }
 
     if (semanticFormatterCallback != null) {
@@ -1946,6 +1988,17 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   }
 
   double get _semanticActionUnit => divisions != null ? 1.0 / divisions! : _adjustmentUnit;
+
+  void onFocusAction() {
+    if (isInteractive) {
+      if (!_state.mounted) {
+        return;
+      }
+      if (!hasFocus) {
+        _state.focusNode.requestFocus();
+      }
+    }
+  }
 
   void increaseAction() {
     if (isInteractive) {

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -1904,7 +1904,7 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///
   /// The [visualPosition] is provided by the caller so semantics can use the
   /// raw logical value while paint can use the smoothly animated value.
-  Offset _calcThumbCenter({ required Rect trackRect, required double visualPosition }) {
+  Offset _calcThumbCenter({required Rect trackRect, required double visualPosition}) {
     final double padding = _sliderTheme.trackShape!.isRounded ? trackRect.height : 0.0;
     final double thumbPosition = isDiscrete
         ? trackRect.left + visualPosition * (trackRect.width - padding) + padding / 2

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -1337,22 +1337,27 @@ void main() {
                         children: <TestSemantics>[
                           TestSemantics(
                             id: 4,
-                            flags: <SemanticsFlag>[
-                              SemanticsFlag.hasEnabledState,
-                              SemanticsFlag.isEnabled,
-                              SemanticsFlag.isFocusable,
-                              SemanticsFlag.isSlider,
+                            children: <TestSemantics>[
+                              TestSemantics(id: 6),
+                              TestSemantics(
+                                id: 5,
+                                flags: <SemanticsFlag>[
+                                  SemanticsFlag.hasEnabledState,
+                                  SemanticsFlag.isEnabled,
+                                  SemanticsFlag.isFocusable,
+                                  SemanticsFlag.isSlider,
+                                ],
+                                actions: <SemanticsAction>[
+                                  SemanticsAction.increase,
+                                  SemanticsAction.decrease,
+                                  SemanticsAction.focus,
+                                ],
+                                value: '50%',
+                                increasedValue: '55%',
+                                decreasedValue: '45%',
+                                textDirection: TextDirection.ltr,
+                              ),
                             ],
-                            actions: <SemanticsAction>[
-                              SemanticsAction.focus,
-                              SemanticsAction.increase,
-                              SemanticsAction.decrease,
-                            ],
-                            value: '50%',
-                            increasedValue: '55%',
-                            decreasedValue: '45%',
-                            textDirection: TextDirection.ltr,
-                            children: <TestSemantics>[TestSemantics(id: 5)],
                           ),
                         ],
                       ),
@@ -1394,19 +1399,22 @@ void main() {
                         flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
                         children: <TestSemantics>[
                           TestSemantics(
-                            id: 4,
-                            flags: <SemanticsFlag>[
-                              SemanticsFlag.hasEnabledState,
-                              // isFocusable is delayed by 1 frame.
-                              SemanticsFlag.isFocusable,
-                              SemanticsFlag.isSlider,
+                            id: 7,
+                            children: <TestSemantics>[
+                              TestSemantics(id: 6),
+                              TestSemantics(
+                                id: 5,
+                                flags: <SemanticsFlag>[
+                                  SemanticsFlag.hasEnabledState,
+                                  SemanticsFlag.isFocusable,
+                                  SemanticsFlag.isSlider,
+                                ],
+                                value: '50%',
+                                increasedValue: '55%',
+                                decreasedValue: '45%',
+                                textDirection: TextDirection.ltr,
+                              ),
                             ],
-                            actions: <SemanticsAction>[SemanticsAction.focus],
-                            value: '50%',
-                            increasedValue: '55%',
-                            decreasedValue: '45%',
-                            textDirection: TextDirection.ltr,
-                            children: <TestSemantics>[TestSemantics(id: 5)],
                           ),
                         ],
                       ),
@@ -1439,16 +1447,22 @@ void main() {
                         flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
                         children: <TestSemantics>[
                           TestSemantics(
-                            id: 4,
-                            flags: <SemanticsFlag>[
-                              SemanticsFlag.hasEnabledState,
-                              SemanticsFlag.isSlider,
+                            id: 7,
+                            children: <TestSemantics>[
+                              TestSemantics(id: 6),
+                              TestSemantics(
+                                id: 5,
+                                flags: <SemanticsFlag>[
+                                  SemanticsFlag.hasEnabledState,
+                                  SemanticsFlag.isFocusable,
+                                  SemanticsFlag.isSlider,
+                                ],
+                                value: '50%',
+                                increasedValue: '55%',
+                                decreasedValue: '45%',
+                                textDirection: TextDirection.ltr,
+                              ),
                             ],
-                            value: '50%',
-                            increasedValue: '55%',
-                            decreasedValue: '45%',
-                            textDirection: TextDirection.ltr,
-                            children: <TestSemantics>[TestSemantics(id: 5)],
                           ),
                         ],
                       ),
@@ -1508,23 +1522,27 @@ void main() {
                         children: <TestSemantics>[
                           TestSemantics(
                             id: 4,
-                            flags: <SemanticsFlag>[
-                              SemanticsFlag.hasEnabledState,
-                              SemanticsFlag.isEnabled,
-                              SemanticsFlag.isFocusable,
-                              SemanticsFlag.isSlider,
+                            children: <TestSemantics>[
+                              TestSemantics(id: 6),
+                              TestSemantics(
+                                id: 5,
+                                flags: <SemanticsFlag>[
+                                  SemanticsFlag.hasEnabledState,
+                                  SemanticsFlag.isEnabled,
+                                  SemanticsFlag.isFocusable,
+                                  SemanticsFlag.isSlider,
+                                ],
+                                actions: <SemanticsAction>[
+                                  SemanticsAction.increase,
+                                  SemanticsAction.decrease,
+                                  SemanticsAction.focus,
+                                ],
+                                value: '50%',
+                                increasedValue: '60%',
+                                decreasedValue: '40%',
+                                textDirection: TextDirection.ltr,
+                              ),
                             ],
-                            actions: <SemanticsAction>[
-                              if (defaultTargetPlatform != TargetPlatform.iOS)
-                                SemanticsAction.focus,
-                              SemanticsAction.increase,
-                              SemanticsAction.decrease,
-                            ],
-                            value: '50%',
-                            increasedValue: '60%',
-                            decreasedValue: '40%',
-                            textDirection: TextDirection.ltr,
-                            children: <TestSemantics>[TestSemantics(id: 5)],
                           ),
                         ],
                       ),
@@ -1566,16 +1584,22 @@ void main() {
                         flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
                         children: <TestSemantics>[
                           TestSemantics(
-                            id: 6,
-                            flags: <SemanticsFlag>[
-                              SemanticsFlag.hasEnabledState,
-                              SemanticsFlag.isSlider,
+                            id: 7,
+                            children: <TestSemantics>[
+                              TestSemantics(id: 9),
+                              TestSemantics(
+                                id: 8,
+                                flags: <SemanticsFlag>[
+                                  SemanticsFlag.hasEnabledState,
+                                  SemanticsFlag.isFocusable,
+                                  SemanticsFlag.isSlider,
+                                ],
+                                value: '50%',
+                                increasedValue: '60%',
+                                decreasedValue: '40%',
+                                textDirection: TextDirection.ltr,
+                              ),
                             ],
-                            value: '50%',
-                            increasedValue: '60%',
-                            decreasedValue: '40%',
-                            textDirection: TextDirection.ltr,
-                            children: <TestSemantics>[TestSemantics(id: 7)],
                           ),
                         ],
                       ),
@@ -1632,23 +1656,28 @@ void main() {
                         children: <TestSemantics>[
                           TestSemantics(
                             id: 4,
-                            flags: <SemanticsFlag>[
-                              SemanticsFlag.hasEnabledState,
-                              SemanticsFlag.isEnabled,
-                              SemanticsFlag.isFocusable,
-                              SemanticsFlag.isSlider,
+                            children: <TestSemantics>[
+                              TestSemantics(id: 6),
+                              TestSemantics(
+                                id: 5,
+                                flags: <SemanticsFlag>[
+                                  SemanticsFlag.hasEnabledState,
+                                  SemanticsFlag.isEnabled,
+                                  SemanticsFlag.isFocusable,
+                                  SemanticsFlag.isSlider,
+                                ],
+                                actions: <SemanticsAction>[
+                                  SemanticsAction.increase,
+                                  SemanticsAction.decrease,
+                                  SemanticsAction.didGainAccessibilityFocus,
+                                  SemanticsAction.focus,
+                                ],
+                                value: '50%',
+                                increasedValue: '55%',
+                                decreasedValue: '45%',
+                                textDirection: TextDirection.ltr,
+                              ),
                             ],
-                            actions: <SemanticsAction>[
-                              SemanticsAction.focus,
-                              SemanticsAction.increase,
-                              SemanticsAction.decrease,
-                              SemanticsAction.didGainAccessibilityFocus,
-                            ],
-                            value: '50%',
-                            increasedValue: '55%',
-                            decreasedValue: '45%',
-                            textDirection: TextDirection.ltr,
-                            children: <TestSemantics>[TestSemantics(id: 5)],
                           ),
                         ],
                       ),
@@ -1690,22 +1719,25 @@ void main() {
                         flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
                         children: <TestSemantics>[
                           TestSemantics(
-                            id: 4,
-                            flags: <SemanticsFlag>[
-                              SemanticsFlag.hasEnabledState,
-                              // isFocusable is delayed by 1 frame.
-                              SemanticsFlag.isFocusable,
-                              SemanticsFlag.isSlider,
+                            id: 7,
+                            children: <TestSemantics>[
+                              TestSemantics(id: 6),
+                              TestSemantics(
+                                id: 5,
+                                flags: <SemanticsFlag>[
+                                  SemanticsFlag.hasEnabledState,
+                                  SemanticsFlag.isFocusable,
+                                  SemanticsFlag.isSlider,
+                                ],
+                                actions: <SemanticsAction>[
+                                  SemanticsAction.didGainAccessibilityFocus,
+                                ],
+                                value: '50%',
+                                increasedValue: '55%',
+                                decreasedValue: '45%',
+                                textDirection: TextDirection.ltr,
+                              ),
                             ],
-                            actions: <SemanticsAction>[
-                              SemanticsAction.focus,
-                              SemanticsAction.didGainAccessibilityFocus,
-                            ],
-                            value: '50%',
-                            increasedValue: '55%',
-                            decreasedValue: '45%',
-                            textDirection: TextDirection.ltr,
-                            children: <TestSemantics>[TestSemantics(id: 5)],
                           ),
                         ],
                       ),
@@ -1715,6 +1747,7 @@ void main() {
               ),
             ],
           ),
+
           ignoreRect: true,
           ignoreTransform: true,
         ),
@@ -1738,17 +1771,25 @@ void main() {
                         flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
                         children: <TestSemantics>[
                           TestSemantics(
-                            id: 4,
-                            flags: <SemanticsFlag>[
-                              SemanticsFlag.hasEnabledState,
-                              SemanticsFlag.isSlider,
+                            id: 7,
+                            children: <TestSemantics>[
+                              TestSemantics(id: 6),
+                              TestSemantics(
+                                id: 5,
+                                flags: <SemanticsFlag>[
+                                  SemanticsFlag.hasEnabledState,
+                                  SemanticsFlag.isFocusable,
+                                  SemanticsFlag.isSlider,
+                                ],
+                                actions: <SemanticsAction>[
+                                  SemanticsAction.didGainAccessibilityFocus,
+                                ],
+                                value: '50%',
+                                increasedValue: '55%',
+                                decreasedValue: '45%',
+                                textDirection: TextDirection.ltr,
+                              ),
                             ],
-                            actions: <SemanticsAction>[SemanticsAction.didGainAccessibilityFocus],
-                            value: '50%',
-                            increasedValue: '55%',
-                            decreasedValue: '45%',
-                            textDirection: TextDirection.ltr,
-                            children: <TestSemantics>[TestSemantics(id: 5)],
                           ),
                         ],
                       ),
@@ -1807,22 +1848,27 @@ void main() {
                       children: <TestSemantics>[
                         TestSemantics(
                           id: 4,
-                          flags: <SemanticsFlag>[
-                            SemanticsFlag.hasEnabledState,
-                            SemanticsFlag.isEnabled,
-                            SemanticsFlag.isFocusable,
-                            SemanticsFlag.isSlider,
+                          children: <TestSemantics>[
+                            TestSemantics(
+                              id: 5,
+                              flags: <SemanticsFlag>[
+                                SemanticsFlag.hasEnabledState,
+                                SemanticsFlag.isEnabled,
+                                SemanticsFlag.isFocusable,
+                                SemanticsFlag.isSlider,
+                              ],
+                              actions: <SemanticsAction>[
+                                SemanticsAction.increase,
+                                SemanticsAction.decrease,
+                                SemanticsAction.focus,
+                              ],
+                              value: '40',
+                              increasedValue: '60',
+                              decreasedValue: '20',
+                              textDirection: TextDirection.ltr,
+                            ),
+                            TestSemantics(id: 6),
                           ],
-                          actions: <SemanticsAction>[
-                            SemanticsAction.focus,
-                            SemanticsAction.increase,
-                            SemanticsAction.decrease,
-                          ],
-                          value: '40',
-                          increasedValue: '60',
-                          decreasedValue: '20',
-                          textDirection: TextDirection.ltr,
-                          children: <TestSemantics>[TestSemantics(id: 5)],
                         ),
                       ],
                     ),
@@ -1880,23 +1926,28 @@ void main() {
                       children: <TestSemantics>[
                         TestSemantics(
                           id: 4,
-                          flags: <SemanticsFlag>[
-                            SemanticsFlag.hasEnabledState,
-                            SemanticsFlag.isEnabled,
-                            SemanticsFlag.isFocusable,
-                            SemanticsFlag.isSlider,
+                          children: <TestSemantics>[
+                            TestSemantics(
+                              id: 5,
+                              flags: <SemanticsFlag>[
+                                SemanticsFlag.hasEnabledState,
+                                SemanticsFlag.isEnabled,
+                                SemanticsFlag.isFocusable,
+                                SemanticsFlag.isSlider,
+                              ],
+                              actions: <SemanticsAction>[
+                                SemanticsAction.increase,
+                                SemanticsAction.decrease,
+                                SemanticsAction.focus,
+                              ],
+                              label: 'Bingo',
+                              value: '40',
+                              increasedValue: '60',
+                              decreasedValue: '20',
+                              textDirection: TextDirection.ltr,
+                            ),
+                            TestSemantics(id: 6),
                           ],
-                          actions: <SemanticsAction>[
-                            SemanticsAction.focus,
-                            SemanticsAction.increase,
-                            SemanticsAction.decrease,
-                          ],
-                          value: '40',
-                          increasedValue: '60',
-                          decreasedValue: '20',
-                          textDirection: TextDirection.ltr,
-                          label: label,
-                          children: <TestSemantics>[TestSemantics(id: 5)],
                         ),
                       ],
                     ),
@@ -2829,23 +2880,28 @@ void main() {
                         children: <TestSemantics>[
                           TestSemantics(
                             id: 4,
-                            flags: <SemanticsFlag>[
-                              SemanticsFlag.hasEnabledState,
-                              SemanticsFlag.isEnabled,
-                              SemanticsFlag.isFocusable,
-                              SemanticsFlag.isSlider,
+                            children: <TestSemantics>[
+                              TestSemantics(id: 6),
+                              TestSemantics(
+                                id: 5,
+                                flags: <SemanticsFlag>[
+                                  SemanticsFlag.hasEnabledState,
+                                  SemanticsFlag.isEnabled,
+                                  SemanticsFlag.isFocusable,
+                                  SemanticsFlag.isSlider,
+                                ],
+                                actions: <SemanticsAction>[
+                                  SemanticsAction.focus,
+                                  SemanticsAction.increase,
+                                  SemanticsAction.decrease,
+                                  SemanticsAction.didGainAccessibilityFocus,
+                                ],
+                                value: '50%',
+                                increasedValue: '55%',
+                                decreasedValue: '45%',
+                                textDirection: TextDirection.ltr,
+                              ),
                             ],
-                            actions: <SemanticsAction>[
-                              SemanticsAction.focus,
-                              SemanticsAction.increase,
-                              SemanticsAction.decrease,
-                              SemanticsAction.didGainAccessibilityFocus,
-                            ],
-                            value: '50%',
-                            increasedValue: '55%',
-                            decreasedValue: '45%',
-                            textDirection: TextDirection.ltr,
-                            children: <TestSemantics>[TestSemantics(id: 5)],
                           ),
                         ],
                       ),
@@ -2861,7 +2917,7 @@ void main() {
       );
 
       expect(focusNode.hasFocus, isFalse);
-      semanticsOwner.performAction(4, SemanticsAction.didGainAccessibilityFocus);
+      semanticsOwner.performAction(5, SemanticsAction.didGainAccessibilityFocus);
       await tester.pumpAndSettle();
       expect(focusNode.hasFocus, isTrue);
       semantics.dispose();

--- a/packages/flutter/test/widgets/semantics_debugger_test.dart
+++ b/packages/flutter/test/widgets/semantics_debugger_test.dart
@@ -312,7 +312,7 @@ void main() {
   });
 
   testWidgets('SemanticsDebugger slider', (WidgetTester tester) async {
-    var value = 0.75;
+    var value = 0.5;
 
     await tester.pumpWidget(
       MaterialApp(
@@ -354,12 +354,12 @@ void main() {
     switch (defaultTargetPlatform) {
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
-        expect(value, equals(0.65));
+        expect(value, equals(0.4));
       case TargetPlatform.linux:
       case TargetPlatform.windows:
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
-        expect(value, equals(0.70));
+        expect(value, equals(0.45));
     }
   }, variant: TargetPlatformVariant.all());
 

--- a/packages/flutter_test/test/controller_test.dart
+++ b/packages/flutter_test/test/controller_test.dart
@@ -799,7 +799,7 @@ void main() {
         await tester.pumpWidget(const MaterialApp(home: _SemanticsTestWidget()));
 
         // We're expecting the traversal to start where the slider is.
-        final expectedMatchers = <Matcher>[...fullTraversalMatchers]..removeRange(0, 9);
+        final expectedMatchers = <Matcher>[...fullTraversalMatchers]..removeRange(0, 8);
 
         expect(
           tester.semantics.simulatedAccessibilityTraversal(start: find.byType(Slider)),
@@ -890,7 +890,7 @@ void main() {
         // We're expecting the traversal to end where the slider is, inclusive.
         final Iterable<Matcher> expectedMatchers = <Matcher>[
           ...fullTraversalMatchers,
-        ].getRange(0, 10);
+        ].getRange(0, 9);
 
         expect(
           tester.semantics.simulatedAccessibilityTraversal(end: find.byType(Slider)),
@@ -961,7 +961,7 @@ void main() {
         // We're expecting the traversal to start at the text field and end at the slider.
         final Iterable<Matcher> expectedMatchers = <Matcher>[
           ...fullTraversalMatchers,
-        ].getRange(1, 10);
+        ].getRange(1, 9);
 
         expect(
           tester.semantics.simulatedAccessibilityTraversal(
@@ -1250,7 +1250,10 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(invoked, isTrue);
-        expect(tester.semantics.find(find.byType(Slider)).value, equals(expected));
+        expect(
+          find.semantics.byFlag(SemanticsFlag.isSlider).evaluate().single.value,
+          equals(expected),
+        );
       });
 
       testWidgets('showOnScreen sends showOnScreen action', (WidgetTester tester) async {


### PR DESCRIPTION
This is a reland of  a old PR https://github.com/flutter/flutter/pull/115285 with some changes: 
1. the node has onFocusAction 
2. update tests to reflect the semantics tree changes.  
3. the `semantics` and `paint()` reuse the _calcThumbCenter function. in the formly reverted PR https://github.com/flutter/flutter/pull/115285 the semantics only get the value of the thumbcenter after it's updated in paint() , I think it's what caused the g3 test failures in g3 and caused the revert.  


The semantics tree changes was caused because the semantics node was higher than the overlay before, and after the PR, the semantics node is formed as a leaf node and not merged with the overlay node, the extra overlay node won't change user experience but it will change some test result, 



fixes https://github.com/flutter/flutter/issues/114225

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
