### PR TITLE
WIP - Pass the current Element to FlutterError when an exception is thrown inside a widget life-cycle

### DIFF
--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -384,6 +384,7 @@ class FlutterErrorDetails with Diagnosticable {
     this.stackFilter,
     this.informationCollector,
     this.silent = false,
+    this.contextElement,
   });
 
   /// Creates a copy of the error details but with the given fields replaced
@@ -396,6 +397,7 @@ class FlutterErrorDetails with Diagnosticable {
     bool? silent,
     StackTrace? stack,
     IterableFilter<String>? stackFilter,
+    Object? contextElement,
   }) {
     return FlutterErrorDetails(
       context: context ?? this.context,
@@ -405,6 +407,7 @@ class FlutterErrorDetails with Diagnosticable {
       silent: silent ?? this.silent,
       stack: stack ?? this.stack,
       stackFilter: stackFilter ?? this.stackFilter,
+      contextElement: contextElement ?? this.contextElement,
     );
   }
 
@@ -568,6 +571,12 @@ class FlutterErrorDetails with Diagnosticable {
   /// error handler to see the errors even in release builds.
   final bool silent;
 
+  /// The object that was being processed when the exception was fired.
+  ///
+  /// For widget lifecycle errors, this is typically an [Element] or a
+  /// [RenderObject].
+  final Object? contextElement;
+
   /// Converts the [exception] to a string.
   ///
   /// This applies some additional logic to make [AssertionError] exceptions
@@ -654,6 +663,7 @@ class FlutterErrorDetails with Diagnosticable {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<Object>('contextElement', contextElement, defaultValue: null));
     final DiagnosticsNode verb = ErrorDescription(
       'thrown${context != null ? ErrorDescription(" $context") : ""}',
     );

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2217,6 +2217,7 @@ abstract class RenderObject with DiagnosticableTreeMixin implements HitTestTarge
         stack: stack,
         library: 'rendering library',
         context: ErrorDescription('during $method()'),
+        contextElement: this,
         informationCollector: () => <DiagnosticsNode>[
           // debugCreator should always be null outside of debugMode, but we want
           // the tree shaker to notice this.
@@ -6756,4 +6757,10 @@ class DiagnosticsDebugCreator extends DiagnosticsProperty<Object> {
   /// [RenderObject.debugCreator].
   DiagnosticsDebugCreator(Object value)
     : super('debugCreator', value, level: DiagnosticLevel.hidden);
+}
+
+/// Extension that adds the [renderObject] property to [FlutterErrorDetails].
+extension FlutterErrorDetailsRenderObject on FlutterErrorDetails {
+  /// The [RenderObject] that was being processed when the exception was fired.
+  RenderObject? get renderObject => contextElement is RenderObject ? contextElement as RenderObject : null;
 }

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -2757,9 +2757,9 @@ final class BuildScope {
           if (kDebugMode) DiagnosticsDebugCreator(DebugCreator(element)),
           element.describeElement('The element being rebuilt at the time was'),
         ],
+        contextElement: element,
       );
-    }
-    if (isTimelineTracked) {
+    }    if (isTimelineTracked) {
       FlutterTimeline.finishSync();
     }
   }
@@ -5830,6 +5830,7 @@ abstract class ComponentElement extends Element {
           informationCollector: () => <DiagnosticsNode>[
             if (kDebugMode) DiagnosticsDebugCreator(DebugCreator(this)),
           ],
+          contextElement: this,
         ),
       );
     } finally {
@@ -5849,6 +5850,7 @@ abstract class ComponentElement extends Element {
           informationCollector: () => <DiagnosticsNode>[
             if (kDebugMode) DiagnosticsDebugCreator(DebugCreator(this)),
           ],
+          contextElement: this,
         ),
       );
       // _Make sure the old child subtree are deactivated and disposed.
@@ -6718,7 +6720,7 @@ abstract class RenderObjectElement extends Element {
             ),
           ]);
         } on FlutterError catch (error) {
-          _reportException(ErrorSummary('while looking for parent data.'), error, error.stackTrace);
+          _reportException(ErrorSummary('while looking for parent data.'), error, error.stackTrace, contextElement: this);
         }
       }
       return true;
@@ -6893,7 +6895,7 @@ abstract class RenderObjectElement extends Element {
         // while still allowing debuggers to break on exception. Since the tree
         // is in a broken state, adding the ErrorWidget would likely cause more
         // exceptions, which is not good for the debugging experience.
-        _reportException(ErrorSummary('while applying parent data.'), e, e.stackTrace);
+        _reportException(ErrorSummary('while applying parent data.'), e, e.stackTrace, contextElement: this);
       }
       return true;
     }());
@@ -6933,6 +6935,7 @@ abstract class RenderObjectElement extends Element {
                 'a $RenderTreeRootElement to serve as the root of the render tree.',
               ),
             ]),
+            contextElement: this,
           ),
         );
       }
@@ -7251,6 +7254,7 @@ class MultiChildRenderObjectElement extends RenderObjectElement {
               ),
               DiagnosticsDebugCreator(DebugCreator(newChild)),
             ]),
+            contextElement: newChild,
           ),
         );
       }
@@ -7387,6 +7391,7 @@ FlutterErrorDetails _reportException(
   Object exception,
   StackTrace? stack, {
   InformationCollector? informationCollector,
+  Object? contextElement,
 }) {
   final details = FlutterErrorDetails(
     exception: exception,
@@ -7394,6 +7399,7 @@ FlutterErrorDetails _reportException(
     library: 'widgets library',
     context: context,
     informationCollector: informationCollector,
+    contextElement: contextElement,
   );
   FlutterError.reportError(details);
   return details;
@@ -7452,4 +7458,10 @@ class _NullWidget extends Widget {
 
   @override
   Element createElement() => throw UnimplementedError();
+}
+
+/// Extension that adds the [element] property to [FlutterErrorDetails].
+extension FlutterErrorDetailsElement on FlutterErrorDetails {
+  /// The [Element] that was being processed when the exception was fired.
+  Element? get element => contextElement is Element ? contextElement as Element : null;
 }

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -240,6 +240,7 @@ class _LayoutBuilderElement<LayoutInfoType> extends RenderObjectElement {
             informationCollector: () => <DiagnosticsNode>[
               if (kDebugMode) DiagnosticsDebugCreator(DebugCreator(this)),
             ],
+            contextElement: this,
           ),
         );
       }
@@ -255,6 +256,7 @@ class _LayoutBuilderElement<LayoutInfoType> extends RenderObjectElement {
             informationCollector: () => <DiagnosticsNode>[
               if (kDebugMode) DiagnosticsDebugCreator(DebugCreator(this)),
             ],
+            contextElement: this,
           ),
         );
         _child = updateChild(null, built, slot);
@@ -492,6 +494,7 @@ FlutterErrorDetails _reportException(
   Object exception,
   StackTrace stack, {
   InformationCollector? informationCollector,
+  Object? contextElement,
 }) {
   final details = FlutterErrorDetails(
     exception: exception,
@@ -499,6 +502,7 @@ FlutterErrorDetails _reportException(
     library: 'widgets library',
     context: context,
     informationCollector: informationCollector,
+    contextElement: contextElement,
   );
   FlutterError.reportError(details);
   return details;

--- a/packages/flutter/test/widgets/flutter_error_details_element_test.dart
+++ b/packages/flutter/test/widgets/flutter_error_details_element_test.dart
@@ -1,0 +1,139 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('FlutterErrorDetails.element is populated when a StatelessWidget throws in build', (WidgetTester tester) async {
+    Element? capturedElement;
+    final FlutterExceptionHandler? oldOnError = FlutterError.onError;
+    FlutterError.onError = (FlutterErrorDetails details) {
+      capturedElement = details.element;
+    };
+
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: ThrowingStatelessWidget(),
+      ),
+    );
+
+    expect(capturedElement, isA<StatelessElement>());
+    expect(capturedElement!.widget, isA<ThrowingStatelessWidget>());
+
+    FlutterError.onError = oldOnError;
+  });
+
+  testWidgets('FlutterErrorDetails.element is populated when a StatefulWidget throws in build', (WidgetTester tester) async {
+    Element? capturedElement;
+    final FlutterExceptionHandler? oldOnError = FlutterError.onError;
+    FlutterError.onError = (FlutterErrorDetails details) {
+      capturedElement = details.element;
+    };
+
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: ThrowingStatefulWidget(),
+      ),
+    );
+
+    expect(capturedElement, isA<StatefulElement>());
+    expect(capturedElement!.widget, isA<ThrowingStatefulWidget>());
+
+    FlutterError.onError = oldOnError;
+  });
+
+  testWidgets('FlutterErrorDetails.element is populated when LayoutBuilder.builder throws', (WidgetTester tester) async {
+    Element? capturedElement;
+    final FlutterExceptionHandler? oldOnError = FlutterError.onError;
+    FlutterError.onError = (FlutterErrorDetails details) {
+      capturedElement = details.element;
+    };
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: LayoutBuilder(
+          builder: (BuildContext context, BoxConstraints constraints) {
+            throw UnsupportedError('LayoutBuilder error');
+          },
+        ),
+      ),
+    );
+
+    expect(capturedElement, isNotNull);
+    // LayoutBuilder uses a private _LayoutBuilderElement
+    expect(capturedElement!.widget, isA<LayoutBuilder>());
+
+    FlutterError.onError = oldOnError;
+  });
+
+  testWidgets('FlutterErrorDetails.renderObject is populated when RenderObject.paint throws', (WidgetTester tester) async {
+    RenderObject? capturedRenderObject;
+    final FlutterExceptionHandler? oldOnError = FlutterError.onError;
+    FlutterError.onError = (FlutterErrorDetails details) {
+      capturedRenderObject = details.renderObject;
+    };
+
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: ThrowingRenderObjectWidget(),
+      ),
+    );
+
+    // Initial pump might not trigger paint if it's not needed, but here it should.
+    // Wait, paint happens during the frame.
+    
+    expect(capturedRenderObject, isA<ThrowingRenderObject>());
+
+    FlutterError.onError = oldOnError;
+  });
+}
+
+class ThrowingStatelessWidget extends StatelessWidget {
+  const ThrowingStatelessWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    throw UnsupportedError('Stateless build error');
+  }
+}
+
+class ThrowingStatefulWidget extends StatefulWidget {
+  const ThrowingStatefulWidget({super.key});
+
+  @override
+  State<ThrowingStatefulWidget> createState() => _ThrowingStatefulWidgetState();
+}
+
+class _ThrowingStatefulWidgetState extends State<ThrowingStatefulWidget> {
+  @override
+  Widget build(BuildContext context) {
+    throw UnsupportedError('Stateful build error');
+  }
+}
+
+class ThrowingRenderObjectWidget extends LeafRenderObjectWidget {
+  const ThrowingRenderObjectWidget({super.key});
+
+  @override
+  RenderObject createRenderObject(BuildContext context) => ThrowingRenderObject();
+}
+
+class ThrowingRenderObject extends RenderBox {
+  @override
+  void performLayout() {
+    size = constraints.biggest;
+  }
+
+  @override
+  void paint(PaintingContext context, Offset offset) {
+    throw UnsupportedError('RenderObject paint error');
+  }
+}


### PR DESCRIPTION
WIP - experimenting towards https://github.com/flutter/flutter/issues/184148

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
