### PR TITLE
Fix layout overflowed in small screen in SensitiveContent's example

### DIFF
--- a/examples/api/lib/widgets/sensitive_content/sensitive_content.0.dart
+++ b/examples/api/lib/widgets/sensitive_content/sensitive_content.0.dart
@@ -202,23 +202,25 @@ class _AccountDetailsContent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: <Widget>[
-        Text(
-          'Checking Account',
-          style: TextStyle(fontSize: 20.0, fontWeight: FontWeight.bold),
-        ),
-        SizedBox(height: 12.0),
-        Text('Account number: 123456789'),
-        Text('Routing number: 987654321'),
-        SizedBox(height: 12.0),
-        Text('One-time passcode: 246810'),
-        SizedBox(height: 12.0),
-        Text(
-          'Use ContentSensitivity.sensitive for screens that should be obscured when the app screen is shared.',
-        ),
-      ],
+    return const SingleChildScrollView(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(
+            'Checking Account',
+            style: TextStyle(fontSize: 20.0, fontWeight: FontWeight.bold),
+          ),
+          SizedBox(height: 12.0),
+          Text('Account number: 123456789'),
+          Text('Routing number: 987654321'),
+          SizedBox(height: 12.0),
+          Text('One-time passcode: 246810'),
+          SizedBox(height: 12.0),
+          Text(
+            'Use ContentSensitivity.sensitive for screens that should be obscured when the app screen is shared.',
+          ),
+        ],
+      ),
     );
   }
 }

--- a/examples/api/test/widgets/sensitive_content/sensitive_content.0_test.dart
+++ b/examples/api/test/widgets/sensitive_content/sensitive_content.0_test.dart
@@ -86,4 +86,27 @@ void main() {
     },
     variant: TargetPlatformVariant.only(TargetPlatform.android),
   );
+
+  testWidgets(
+    'Account details widget is scrollable when vertical space is constrained',
+    (WidgetTester tester) async {
+      tester.view.physicalSize = const Size(800.0, 450.0);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(const example.SensitiveContentApp());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(SingleChildScrollView), findsOneWidget);
+      expect(tester.takeException(), isNull);
+
+      await tester.drag(
+        find.byType(SingleChildScrollView),
+        const Offset(0.0, -120.0),
+      );
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+    },
+  );
 }


### PR DESCRIPTION

- After https://github.com/flutter/flutter/pull/183846 was landed on main (https://main-api.flutter.dev/flutter/widgets/SensitiveContent-class.html), I found an overflowed layout issue when the example runs on web in a narrow height.
- This fix is straightforward by adding `SingleChildScrollView` to wrap the account detail widget content.


| before | after |
| --------------- | --------------- |
<img width="400" src="https://github.com/user-attachments/assets/ab6e32d2-3b0f-4277-93c3-5af350c2d0fd"> | <img width="400" src="https://github.com/user-attachments/assets/e0e4d980-16a5-4835-adf7-3cd735a60dff">


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
