### PR TITLE
Improve error message when `dart-define` content are not `base64 encoded` and add more test cases

### DIFF
--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -261,8 +261,8 @@ class AssembleCommand extends FlutterCommand {
       }, 'dart-define');
     } on FormatException {
       throwToolExit(
-        'Error parsing assemble command: your generated configuration may be out of date. '
-        "Try re-running 'flutter build ios' or the appropriate build command.",
+        'Error parsing assemble command: The -Pdart-defines argument contains non-base64 encoded data. '
+        'Check your build command and try again.',
       );
     }
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/assemble_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/assemble_test.dart
@@ -314,12 +314,12 @@ void main() {
         '?',
         '#',
       ];
-      for (final invaliDartDefine in invalidDartDefines) {
+      for (final invalidDartDefine in invalidDartDefines) {
         final command = <String>[
           'assemble',
           '--output',
           'Output',
-          '-DartDefines=$invaliDartDefine',
+          '-DartDefines=$invalidDartDefine',
           'debug_macos_bundle_flutter_assets',
         ];
         expect(

--- a/packages/flutter_tools/test/commands.shard/hermetic/assemble_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/assemble_test.dart
@@ -285,20 +285,52 @@ void main() {
         AssembleCommand(buildSystem: TestBuildSystem.all(BuildResult(success: true))),
       );
 
-      final command = <String>[
-        'assemble',
-        '--output',
-        'Output',
-        '-DartDefines=flutter.inspector.structuredErrors%3Dtrue',
-        'debug_macos_bundle_flutter_assets',
+      const invalidDartDefines = [
+        'flutter.inspector.structuredErrors%3Dtrue',
+        '///',
+        '@@@@',
+        "'",
+        '"',
+        '`',
+        r'\',
+        r'$',
+        ';',
+        '/*',
+        '*/',
+        '//',
+        '\n',
+        '\r',
+        '<',
+        '>',
+        '{',
+        '}',
+        '[',
+        ']',
+        '(',
+        ')',
+        '%',
+        '=',
+        '&',
+        '?',
+        '#',
       ];
-      expect(
-        commandRunner.run(command),
-        throwsToolExit(
-          message:
-              'Error parsing assemble command: your generated configuration may be out of date',
-        ),
-      );
+      for (final invaliDartDefine in invalidDartDefines) {
+        final command = <String>[
+          'assemble',
+          '--output',
+          'Output',
+          '-DartDefines=$invaliDartDefine',
+          'debug_macos_bundle_flutter_assets',
+        ];
+        expect(
+          commandRunner.run(command),
+          throwsToolExit(
+            message:
+                'Error parsing assemble command: The -Pdart-defines argument contains non-base64 encoded data. '
+                'Check your build command and try again.',
+          ),
+        );
+      }
     },
     overrides: <Type, Generator>{
       Cache: () => Cache.test(processManager: FakeProcessManager.any()),


### PR DESCRIPTION
Fixes #95116

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
