### PR TITLE
[a11y] fix selected tristate flags mismatch

### DIFF
--- a/engine/src/flutter/shell/platform/common/accessibility_bridge.cc
+++ b/engine/src/flutter/shell/platform/common/accessibility_bridge.cc
@@ -442,8 +442,9 @@ void AccessibilityBridge::SetBooleanAttributesFromFlutterUpdate(
   // TODO(chunhtai): figure out if there is a node that does not clip overflow.
   node_data.AddBoolAttribute(ax::mojom::BoolAttribute::kClipsChildren,
                              !node.children_in_traversal_order.empty());
-  node_data.AddBoolAttribute(ax::mojom::BoolAttribute::kSelected,
-                             flags->is_selected == FlutterTristate::kFlutterTristateTrue);
+  node_data.AddBoolAttribute(
+      ax::mojom::BoolAttribute::kSelected,
+      flags->is_selected == FlutterTristate::kFlutterTristateTrue);
   node_data.AddBoolAttribute(ax::mojom::BoolAttribute::kEditableRoot,
                              flags->is_text_field && !flags->is_read_only);
   // Mark nodes as line breaking so that screen readers don't

--- a/engine/src/flutter/shell/platform/common/accessibility_bridge.cc
+++ b/engine/src/flutter/shell/platform/common/accessibility_bridge.cc
@@ -443,7 +443,7 @@ void AccessibilityBridge::SetBooleanAttributesFromFlutterUpdate(
   node_data.AddBoolAttribute(ax::mojom::BoolAttribute::kClipsChildren,
                              !node.children_in_traversal_order.empty());
   node_data.AddBoolAttribute(ax::mojom::BoolAttribute::kSelected,
-                             flags->is_selected);
+                             flags->is_selected == FlutterTristate::kFlutterTristateTrue);
   node_data.AddBoolAttribute(ax::mojom::BoolAttribute::kEditableRoot,
                              flags->is_text_field && !flags->is_read_only);
   // Mark nodes as line breaking so that screen readers don't

--- a/engine/src/flutter/shell/platform/common/accessibility_bridge_unittests.cc
+++ b/engine/src/flutter/shell/platform/common/accessibility_bridge_unittests.cc
@@ -596,7 +596,8 @@ TEST(AccessibilityBridgeTest, IsSelectedAttribute) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
 
-  FlutterSemanticsNode2 node0 = CreateSemanticsNode(0, "node 0");
+  std::vector<int32_t> children{1, 2};
+  FlutterSemanticsNode2 node0 = CreateSemanticsNode(0, "node 0", &children);
   auto flags0 = FlutterSemanticsFlags{
       .is_selected = FlutterTristate::kFlutterTristateNone,
   };

--- a/engine/src/flutter/shell/platform/common/accessibility_bridge_unittests.cc
+++ b/engine/src/flutter/shell/platform/common/accessibility_bridge_unittests.cc
@@ -592,5 +592,47 @@ TEST(AccessibilityBridgeTest, LineBreakingObjectTest) {
       ax::mojom::BoolAttribute::kIsLineBreakingObject));
 }
 
+TEST(AccessibilityBridgeTest, IsSelectedAttribute) {
+  std::shared_ptr<TestAccessibilityBridge> bridge =
+      std::make_shared<TestAccessibilityBridge>();
+
+  FlutterSemanticsNode2 node0 = CreateSemanticsNode(0, "node 0");
+  auto flags0 = FlutterSemanticsFlags{
+      .is_selected = FlutterTristate::kFlutterTristateNone,
+  };
+  node0.flags2 = &flags0;
+
+  FlutterSemanticsNode2 node1 = CreateSemanticsNode(1, "node 1");
+  auto flags1 = FlutterSemanticsFlags{
+      .is_selected = FlutterTristate::kFlutterTristateTrue,
+  };
+  node1.flags2 = &flags1;
+
+  FlutterSemanticsNode2 node2 = CreateSemanticsNode(2, "node 2");
+  auto flags2 = FlutterSemanticsFlags{
+      .is_selected = FlutterTristate::kFlutterTristateFalse,
+  };
+  node2.flags2 = &flags2;
+
+  bridge->AddFlutterSemanticsNodeUpdate(node0);
+  bridge->AddFlutterSemanticsNodeUpdate(node1);
+  bridge->AddFlutterSemanticsNodeUpdate(node2);
+  bridge->CommitUpdates();
+
+  auto delegate0 = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
+  auto delegate1 = bridge->GetFlutterPlatformNodeDelegateFromID(1).lock();
+  auto delegate2 = bridge->GetFlutterPlatformNodeDelegateFromID(2).lock();
+
+  // For kFlutterTristateNone, selected should be false.
+  EXPECT_FALSE(delegate0->GetData().GetBoolAttribute(
+      ax::mojom::BoolAttribute::kSelected));
+  // For kFlutterTristateTrue, selected should be true.
+  EXPECT_TRUE(delegate1->GetData().GetBoolAttribute(
+      ax::mojom::BoolAttribute::kSelected));
+  // For kFlutterTristateFalse, selected should be false.
+  EXPECT_FALSE(delegate2->GetData().GetBoolAttribute(
+      ax::mojom::BoolAttribute::kSelected));
+}
+
 }  // namespace testing
 }  // namespace flutter


### PR DESCRIPTION
fix https://github.com/flutter/flutter/issues/184058 
The issue and solution was both pointed out in https://github.com/flutter/flutter/issues/184058  


## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
