### PR TITLE
fixes crash when invisible semantics nodes dropped from semantics tree

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1612,12 +1612,15 @@ base class PipelineOwner with DiagnosticableTreeMixin {
           if (!node._semantics.geometry!.isVisible && !node._semantics.isRoot) {
             final _RenderObjectSemantics parentInSemanticsTree =
                 node._semantics.parentInSemanticsTree!;
-            parentInSemanticsTree.computeAncestorInfo(treeShapeToken);
-            final _RenderObjectSemantics? firstAncestorNodeWithCleanGeometry =
-                parentInSemanticsTree.firstAncestorNodeWithCleanGeometry;
-            // firstAncestorNodeWithCleanGeometry can be null if this is a blocked branch.
-            if (firstAncestorNodeWithCleanGeometry != null) {
-              targets.add(firstAncestorNodeWithCleanGeometry);
+            if (!parentInSemanticsTree.geometryDirty) {
+              targets.add(parentInSemanticsTree);
+            } else {
+              final _RenderObjectSemantics? firstAncestorNodeWithCleanGeometry =
+                  parentInSemanticsTree.firstAncestorNodeWithCleanGeometry;
+              // firstAncestorNodeWithCleanGeometry can be null if this is a blocked branch.
+              if (firstAncestorNodeWithCleanGeometry != null) {
+                targets.add(firstAncestorNodeWithCleanGeometry);
+              }
             }
           }
           targets.add(node._semantics);

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1600,7 +1600,7 @@ base class PipelineOwner with DiagnosticableTreeMixin {
       for (final RenderObject node in nodesToProcess.reversed) {
         node._semantics.computeAncestorInfo(treeShapeToken);
         final targets = <_RenderObjectSemantics>[];
-        if (node._semantics.geometry == null) {
+        if (node._semantics.geometryDirty) {
           if (node._semantics.firstAncestorNodeWithCleanGeometry != null) {
             targets.add(node._semantics.firstAncestorNodeWithCleanGeometry!);
           }
@@ -1609,10 +1609,16 @@ base class PipelineOwner with DiagnosticableTreeMixin {
           // geometry becomes invisible after the ensureGeometry call above,
           // the parent of this node will have to update its semantics subtree to remove
           // this node from its children.
-          if (!node._semantics.geometry!.isVisible &&
-              !node._semantics.isRoot &&
-              node._semantics.parentInSemanticsTree != null) {
-            targets.add(node._semantics.parentInSemanticsTree!);
+          if (!node._semantics.geometry!.isVisible && !node._semantics.isRoot) {
+            final _RenderObjectSemantics parentInSemanticsTree =
+                node._semantics.parentInSemanticsTree!;
+            parentInSemanticsTree.computeAncestorInfo(treeShapeToken);
+            final _RenderObjectSemantics? firstAncestorNodeWithCleanGeometry =
+                parentInSemanticsTree.firstAncestorNodeWithCleanGeometry;
+            // firstAncestorNodeWithCleanGeometry can be null if this is a blocked branch.
+            if (firstAncestorNodeWithCleanGeometry != null) {
+              targets.add(firstAncestorNodeWithCleanGeometry);
+            }
           }
           targets.add(node._semantics);
         }
@@ -5648,8 +5654,11 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
     if (next == null) {
       return;
     }
-    next.computeAncestorInfo(treeShapeToken);
-    firstAncestorNodeWithCleanGeometry ??= next.firstAncestorNodeWithCleanGeometry;
+
+    if (firstAncestorNodeWithCleanGeometry == null) {
+      next.computeAncestorInfo(treeShapeToken);
+      firstAncestorNodeWithCleanGeometry = next.firstAncestorNodeWithCleanGeometry;
+    }
   }
 
   /// If this forms a semantics node, all of the properties in config are

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1610,16 +1610,18 @@ base class PipelineOwner with DiagnosticableTreeMixin {
           // the parent of this node will have to update its semantics subtree to remove
           // this node from its children.
           if (!node._semantics.geometry!.isVisible && !node._semantics.isRoot) {
-            final _RenderObjectSemantics parentInSemanticsTree =
-                node._semantics.parentInSemanticsTree!;
-            if (!parentInSemanticsTree.geometryDirty) {
-              targets.add(parentInSemanticsTree);
-            } else {
-              final _RenderObjectSemantics? firstAncestorNodeWithCleanGeometry =
-                  parentInSemanticsTree.firstAncestorNodeWithCleanGeometry;
-              // firstAncestorNodeWithCleanGeometry can be null if this is a blocked branch.
-              if (firstAncestorNodeWithCleanGeometry != null) {
-                targets.add(firstAncestorNodeWithCleanGeometry);
+            final _RenderObjectSemantics? parentInSemanticsTree =
+                node._semantics.parentInSemanticsTree;
+            if (parentInSemanticsTree != null) {
+              if (!parentInSemanticsTree.geometryDirty) {
+                targets.add(parentInSemanticsTree);
+              } else {
+                final _RenderObjectSemantics? firstAncestorNodeWithCleanGeometry =
+                    parentInSemanticsTree.firstAncestorNodeWithCleanGeometry;
+                // firstAncestorNodeWithCleanGeometry can be null if this is a blocked branch.
+                if (firstAncestorNodeWithCleanGeometry != null) {
+                  targets.add(firstAncestorNodeWithCleanGeometry);
+                }
               }
             }
           }

--- a/packages/flutter/test/rendering/semantics_layout_sized_test.dart
+++ b/packages/flutter/test/rendering/semantics_layout_sized_test.dart
@@ -156,8 +156,6 @@ void main() {
     newChild.isSemanticBoundary = true;
     grandParent.add(newChild);
 
-    // Flushing semantics now will run through flushSemantics.
-    // firstAncestorNodeWithCleanGeometry will be null at line 1618.
     pumpFrame(phase: EnginePhase.flushSemantics);
   });
 }

--- a/packages/flutter/test/rendering/semantics_layout_sized_test.dart
+++ b/packages/flutter/test/rendering/semantics_layout_sized_test.dart
@@ -123,6 +123,55 @@ void main() {
     // State after removal: exposes originalChild again.
     expect(parentSemantics.childrenCount, 1);
   });
+
+  test('Skip update for invisible child being dropped from tree', () {
+    final child = RenderTestLayoutSemanticsBoundary();
+    child.isSemanticBoundary = true;
+    child.targetSize = Size.zero; // Geometry will be invisible.
+
+    final parent = RenderTestParentUsesSize(child: child);
+    parent.isSemanticBoundary = true;
+    parent.explicitChildNode = true;
+
+    final grandParent = RenderTestLastChildSemanticsMultiChildParent(children: <RenderBox>[parent]);
+    grandParent.explicitChildNode = true;
+
+    TestRenderingFlutterBinding.instance.pipelineOwner.ensureSemantics();
+    layout(grandParent, phase: EnginePhase.flushSemantics);
+
+    // Initial state: grandParent visits parent (because parent is the last child).
+    // parent visits child. Thus all nodes are in the semantics tree.
+    expect(grandParent.debugSemantics!.childrenCount, 1);
+
+    // To trigger the scenario, we need grandParent to drop parent,
+    // explicitly marking parent and child as needing semantics update.
+    parent.markNeedsLayout();
+    child.markNeedsLayout();
+
+    // Adding a new child to grandParent makes it the new `lastChild`.
+    // Because grandParent only visits `lastChild` in `visitChildrenForSemantics`,
+    // the original `parent` and `child` will be dropped from the semantics tree
+    // without their parentDataDirty flags being cleared during the update phase.
+    final newChild = RenderTestLayoutSemanticsBoundary();
+    newChild.isSemanticBoundary = true;
+    grandParent.add(newChild);
+
+    // Flushing semantics now will run through flushSemantics.
+    // firstAncestorNodeWithCleanGeometry will be null at line 1618.
+    pumpFrame(phase: EnginePhase.flushSemantics);
+  });
+}
+
+class RenderTestParentUsesSize extends RenderTestParent {
+  RenderTestParentUsesSize({super.child});
+
+  @override
+  void performLayout() {
+    if (child != null) {
+      child!.layout(constraints.loosen(), parentUsesSize: true);
+    }
+    size = constraints.biggest;
+  }
 }
 
 class RenderTestParent extends RenderBox with RenderObjectWithChildMixin<RenderBox> {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

fixes https://github.com/flutter/flutter/issues/184036

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
