### PR TITLE
flutter_driver: remove @internal annotation on field

### DIFF
--- a/packages/flutter_driver/lib/src/driver/driver.dart
+++ b/packages/flutter_driver/lib/src/driver/driver.dart
@@ -75,7 +75,6 @@ enum TimelineStream {
 
 /// How long to wait before showing a message saying that
 /// things seem to be taking a long time.
-@internal
 const Duration kUnusuallyLongTimeout = Duration(seconds: 5);
 
 /// A convenient accessor to frequently used finders.


### PR DESCRIPTION
It's being used internally. Not a big issue.

Discovered in https://dart-review.googlesource.com/c/sdk/+/491040
Related to https://github.com/dart-lang/sdk/issues/62987