### PR TITLE
For ShapeBorder instances with preferPaintInterior=true, use paintInterior rather than drawing the path from getOuterPath.

### DIFF
--- a/examples/api/test/widgets/scrollbar/raw_scrollbar.shape.0_test.dart
+++ b/examples/api/test/widgets/scrollbar/raw_scrollbar.shape.0_test.dart
@@ -25,7 +25,19 @@ void main() {
     expect(
       find.byType(RawScrollbar),
       paints
-        ..path(color: Colors.blue)
+        // Scrollbar thumb background fill.
+        ..rrect(
+          rrect: RRect.fromLTRBR(
+            785.0,
+            0.0,
+            800.0,
+            180.0,
+            const Radius.circular(7.5),
+          ),
+          style: PaintingStyle.fill,
+          color: Colors.blue,
+        )
+        // Scrollbar thumb border.
         ..rrect(
           rrect: RRect.fromLTRBR(
             786.5,
@@ -34,6 +46,8 @@ void main() {
             178.5,
             const Radius.circular(6),
           ),
+          style: PaintingStyle.stroke,
+          strokeWidth: 3.0,
           color: Colors.brown,
         ),
     );

--- a/packages/flutter/lib/src/cupertino/checkbox.dart
+++ b/packages/flutter/lib/src/cupertino/checkbox.dart
@@ -571,7 +571,11 @@ class _CheckboxPainter extends ToggleablePainter {
       colors: <Color>[topColor, bottomColor],
     );
     final gradientPaint = Paint()..shader = fillGradient.createShader(outer);
-    canvas.drawPath(shape.getOuterPath(outer), gradientPaint);
+    if (shape.preferPaintInterior) {
+      shape.paintInterior(canvas, outer, gradientPaint);
+    } else {
+      canvas.drawPath(shape.getOuterPath(outer), gradientPaint);
+    }
   }
 
   void _drawBox(Canvas canvas, Rect outer, Paint paint, BorderSide? side, bool value) {
@@ -587,6 +591,8 @@ class _CheckboxPainter extends ToggleablePainter {
           isActive ? _kDarkGradientOpacities[1] : _kDisabledDarkGradientOpacities[1],
         ),
       );
+    } else if (shape.preferPaintInterior) {
+      shape.paintInterior(canvas, outer, paint);
     } else {
       canvas.drawPath(shape.getOuterPath(outer), paint);
     }
@@ -641,7 +647,11 @@ class _CheckboxPainter extends ToggleablePainter {
         ..color = brightness == Brightness.light
             ? CupertinoColors.black.withOpacity(_kPressedOverlayOpacity)
             : CupertinoColors.white.withOpacity(_kPressedOverlayOpacity);
-      canvas.drawPath(shape.getOuterPath(outer), pressedPaint);
+      if (shape.preferPaintInterior) {
+        shape.paintInterior(canvas, outer, pressedPaint);
+      } else {
+        canvas.drawPath(shape.getOuterPath(outer), pressedPaint);
+      }
     }
     if (isFocused) {
       final Rect focusOuter = outer.inflate(1);

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -737,7 +737,11 @@ class _CheckboxPainter extends ToggleablePainter {
   }
 
   void _drawBox(Canvas canvas, Rect outer, Paint paint, BorderSide? side) {
-    canvas.drawPath(shape.getOuterPath(outer), paint);
+    if (shape.preferPaintInterior) {
+      shape.paintInterior(canvas, outer, paint);
+    } else {
+      canvas.drawPath(shape.getOuterPath(outer), paint);
+    }
     if (side != null) {
       shape.copyWith(side: side).paint(canvas, outer);
     }

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -2178,8 +2178,12 @@ class _RenderChip extends RenderBox with SlottedContainerRenderObjectMixin<_Chip
         final darkenPaint = Paint()
           ..color = selectionScrimTween.evaluate(checkmarkAnimation)!
           ..blendMode = BlendMode.srcATop;
-        final Path path = avatarBorder!.getOuterPath(avatarRect);
-        context.canvas.drawPath(path, darkenPaint);
+        if (avatarBorder!.preferPaintInterior) {
+          avatarBorder!.paintInterior(context.canvas, avatarRect, darkenPaint);
+        } else {
+          final Path path = avatarBorder!.getOuterPath(avatarRect);
+          context.canvas.drawPath(path, darkenPaint);
+        }
       }
       // Need to make the check mark be a little smaller than the avatar.
       final double checkSize = avatar.size.height * 0.75;

--- a/packages/flutter/lib/src/material/input_border.dart
+++ b/packages/flutter/lib/src/material/input_border.dart
@@ -702,8 +702,8 @@ class ShapedInputBorder extends InputBorder {
 
   @override
   void paintInterior(Canvas canvas, Rect rect, Paint paint, {TextDirection? textDirection}) {
-    if (shape is OutlinedBorder) {
-      (shape as OutlinedBorder).paintInterior(canvas, rect, paint, textDirection: textDirection);
+    if (shape.preferPaintInterior) {
+      shape.paintInterior(canvas, rect, paint, textDirection: textDirection);
     } else {
       // Fallback for shapes that don't support paintInterior.
       canvas.drawPath(shape.getOuterPath(rect, textDirection: textDirection), paint);

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -141,12 +141,14 @@ class _InputBorderPainter extends CustomPainter {
     final Rect canvasRect = Offset.zero & size;
     final Color blendedFillColor = blendedColor;
     if (blendedFillColor.alpha > 0) {
-      canvas.drawPath(
-        borderValue.getOuterPath(canvasRect, textDirection: textDirection),
-        Paint()
-          ..color = blendedFillColor
-          ..style = PaintingStyle.fill,
-      );
+      final paint = Paint()
+        ..color = blendedFillColor
+        ..style = PaintingStyle.fill;
+      if (borderValue.preferPaintInterior) {
+        borderValue.paintInterior(canvas, canvasRect, paint, textDirection: textDirection);
+      } else {
+        canvas.drawPath(borderValue.getOuterPath(canvasRect, textDirection: textDirection), paint);
+      }
     }
 
     borderValue.paint(

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -639,8 +639,12 @@ class ScrollbarPainter extends ChangeNotifier implements CustomPainter {
         return;
       }
       // Custom-shaped thumb
-      final Path outerPath = shape!.getOuterPath(_thumbRect!);
-      canvas.drawPath(outerPath, _paintThumb);
+      if (shape!.preferPaintInterior) {
+        shape!.paintInterior(canvas, _thumbRect!, _paintThumb);
+      } else {
+        final Path outerPath = shape!.getOuterPath(_thumbRect!);
+        canvas.drawPath(outerPath, _paintThumb);
+      }
       shape!.paint(canvas, _thumbRect!);
     }
   }

--- a/packages/flutter/test/cupertino/checkbox_test.dart
+++ b/packages/flutter/test/cupertino/checkbox_test.dart
@@ -751,11 +751,11 @@ void main() {
 
     await tester.pumpWidget(buildApp(enabled: true));
     await tester.pumpAndSettle();
-    expect(getCheckboxRenderer(), paints..path(color: activeEnabledFillColor));
+    expect(getCheckboxRenderer(), paints..rrect(color: activeEnabledFillColor));
 
     await tester.pumpWidget(buildApp(enabled: false));
     await tester.pumpAndSettle();
-    expect(getCheckboxRenderer(), paints..path(color: activeDisabledFillColor));
+    expect(getCheckboxRenderer(), paints..rrect(color: activeDisabledFillColor));
   });
 
   testWidgets('Checkbox fill color take precedence over active/inactive colors', (
@@ -793,11 +793,11 @@ void main() {
 
     await tester.pumpWidget(buildApp(enabled: true));
     await tester.pumpAndSettle();
-    expect(getCheckboxRenderer(), paints..path(color: activeEnabledFillColor));
+    expect(getCheckboxRenderer(), paints..rrect(color: activeEnabledFillColor));
 
     await tester.pumpWidget(buildApp(enabled: false));
     await tester.pumpAndSettle();
-    expect(getCheckboxRenderer(), paints..path(color: activeDisabledFillColor));
+    expect(getCheckboxRenderer(), paints..rrect(color: activeDisabledFillColor));
   });
 
   testWidgets('Checkbox fill color resolves in hovered/focused states', (
@@ -842,7 +842,7 @@ void main() {
     focusNode.requestFocus();
     await tester.pumpAndSettle();
     expect(focusNode.hasPrimaryFocus, isTrue);
-    expect(getCheckboxRenderer(), paints..path(color: focusedFillColor));
+    expect(getCheckboxRenderer(), paints..rrect(color: focusedFillColor));
 
     // Start hovering.
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
@@ -851,7 +851,7 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.byType(CupertinoCheckbox)));
     await tester.pumpAndSettle();
 
-    expect(getCheckboxRenderer(), paints..path(color: hoveredFillColor));
+    expect(getCheckboxRenderer(), paints..rrect(color: hoveredFillColor));
   });
 
   testWidgets('Checkbox configures focus color', (WidgetTester tester) async {

--- a/packages/flutter/test/cupertino/checkbox_test.dart
+++ b/packages/flutter/test/cupertino/checkbox_test.dart
@@ -891,10 +891,10 @@ void main() {
     expect(
       find.byType(CupertinoCheckbox),
       paints
-        ..path(color: defaultActiveFillColor)
+        ..rrect(color: defaultActiveFillColor)
         ..rrect()
         ..path(color: defaultCheckColor)
-        ..path(color: defaultFocusColor, strokeWidth: 3.5, style: PaintingStyle.stroke),
+        ..rrect(color: defaultFocusColor, strokeWidth: 3.5, style: PaintingStyle.stroke),
       reason: 'Checkbox shows the correct focus color',
     );
 
@@ -904,10 +904,10 @@ void main() {
     expect(
       find.byType(CupertinoCheckbox),
       paints
-        ..path(color: defaultActiveFillColor)
+        ..rrect(color: defaultActiveFillColor)
         ..rrect()
         ..path(color: defaultCheckColor)
-        ..path(color: testFocusColor, strokeWidth: 3.5, style: PaintingStyle.stroke),
+        ..rrect(color: testFocusColor, strokeWidth: 3.5, style: PaintingStyle.stroke),
       reason: 'Checkbox can configure a focus color',
     );
   });
@@ -932,9 +932,9 @@ void main() {
     expect(
       find.byType(CupertinoCheckbox),
       paints
-        ..path(color: defaultInactiveFillColor)
+        ..rrect(color: defaultInactiveFillColor)
         ..drrect()
-        ..path(color: pressedDarkShadow),
+        ..rrect(color: pressedDarkShadow),
       reason: 'Inactive pressed checkbox is slightly darkened',
     );
 
@@ -952,10 +952,10 @@ void main() {
     expect(
       find.byType(CupertinoCheckbox),
       paints
-        ..path(color: defaultActiveFillColor)
+        ..rrect(color: defaultActiveFillColor)
         ..rrect()
         ..path(color: defaultCheckColor)
-        ..path(color: pressedDarkShadow),
+        ..rrect(color: pressedDarkShadow),
       reason: 'Active pressed checkbox is slightly darkened',
     );
 
@@ -986,9 +986,9 @@ void main() {
     expect(
       find.byType(CupertinoCheckbox),
       paints
-        ..path(color: defaultInactiveFillColor)
+        ..rrect(color: defaultInactiveFillColor)
         ..drrect()
-        ..path(color: pressedLightShadow),
+        ..rrect(color: pressedLightShadow),
       reason: 'Inactive pressed checkbox is slightly lightened',
     );
 
@@ -1007,10 +1007,10 @@ void main() {
     expect(
       find.byType(CupertinoCheckbox),
       paints
-        ..path(color: defaultActiveFillColor)
+        ..rrect(color: defaultActiveFillColor)
         ..rrect()
         ..path(color: checkColor)
-        ..path(color: pressedLightShadow),
+        ..rrect(color: pressedLightShadow),
       reason: 'Active pressed checkbox is slightly lightened',
     );
 

--- a/packages/flutter/test/material/checkbox_list_tile_test.dart
+++ b/packages/flutter/test/material/checkbox_list_tile_test.dart
@@ -85,7 +85,7 @@ void main() {
     expect(
       getCheckboxListTileRenderer(),
       paints
-        ..path(color: checkBoxBorderColor)
+        ..rrect(color: checkBoxBorderColor)
         ..path(color: checkBoxCheckColor),
     );
 
@@ -96,7 +96,7 @@ void main() {
     expect(
       getCheckboxListTileRenderer(),
       paints
-        ..path(color: checkBoxBorderColor)
+        ..rrect(color: checkBoxBorderColor)
         ..path(color: checkBoxCheckColor),
     );
   });
@@ -122,7 +122,7 @@ void main() {
     expect(
       getCheckboxListTileRenderer(),
       paints
-        ..path(color: checkBoxBorderColor)
+        ..rrect(color: checkBoxBorderColor)
         ..path(color: checkBoxCheckColor),
     );
 
@@ -133,7 +133,7 @@ void main() {
     expect(
       getCheckboxListTileRenderer(),
       paints
-        ..path(color: checkBoxBorderColor)
+        ..rrect(color: checkBoxBorderColor)
         ..path(color: checkBoxCheckColor),
     );
   });
@@ -164,11 +164,11 @@ void main() {
 
     await tester.pumpWidget(buildFrame(const Color(0xFF000000), null));
     await tester.pumpAndSettle();
-    expect(getCheckboxListTileRenderer(), paints..path(color: const Color(0xFF000000)));
+    expect(getCheckboxListTileRenderer(), paints..rrect(color: const Color(0xFF000000)));
 
     await tester.pumpWidget(buildFrame(const Color(0xFF000000), const Color(0xFFFFFFFF)));
     await tester.pumpAndSettle();
-    expect(getCheckboxListTileRenderer(), paints..path(color: const Color(0xFFFFFFFF)));
+    expect(getCheckboxListTileRenderer(), paints..rrect(color: const Color(0xFFFFFFFF)));
   });
 
   testWidgets('CheckboxListTile can autofocus unless disabled.', (WidgetTester tester) async {
@@ -683,11 +683,11 @@ void main() {
 
     await tester.pumpWidget(buildFrame(enabled: true));
     await tester.pumpAndSettle();
-    expect(getCheckboxRenderer(), paints..path(color: activeEnabledFillColor));
+    expect(getCheckboxRenderer(), paints..rrect(color: activeEnabledFillColor));
 
     await tester.pumpWidget(buildFrame(enabled: false));
     await tester.pumpAndSettle();
-    expect(getCheckboxRenderer(), paints..path(color: activeDisabledFillColor));
+    expect(getCheckboxRenderer(), paints..rrect(color: activeDisabledFillColor));
   });
 
   testWidgets('CheckboxListTile respects fillColor in hovered state', (WidgetTester tester) async {
@@ -726,7 +726,7 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.byType(Checkbox)));
     await tester.pumpAndSettle();
 
-    expect(getCheckboxRenderer(), paints..path(color: hoveredFillColor));
+    expect(getCheckboxRenderer(), paints..rrect(color: hoveredFillColor));
   });
 
   testWidgets('CheckboxListTile respects hoverColor', (WidgetTester tester) async {
@@ -757,7 +757,7 @@ void main() {
     expect(
       Material.of(tester.element(find.byType(Checkbox))),
       paints
-        ..path(style: PaintingStyle.fill)
+        ..rrect(style: PaintingStyle.fill)
         ..path(style: PaintingStyle.stroke, strokeWidth: 2.0),
     );
 
@@ -771,7 +771,7 @@ void main() {
       Material.of(tester.element(find.byType(Checkbox))),
       paints
         ..circle(color: Colors.orange[500])
-        ..path(style: PaintingStyle.fill)
+        ..rrect(style: PaintingStyle.fill)
         ..path(style: PaintingStyle.stroke, strokeWidth: 2.0),
     );
 
@@ -781,7 +781,7 @@ void main() {
     expect(
       Material.of(tester.element(find.byType(Checkbox))),
       paints
-        ..path(style: PaintingStyle.fill)
+        ..rrect(style: PaintingStyle.fill)
         ..path(style: PaintingStyle.stroke, strokeWidth: 2.0),
     );
   });
@@ -1128,7 +1128,7 @@ void main() {
     expect(
       Material.of(tester.element(find.byType(Checkbox))),
       paints
-        ..path(color: themeData.colorScheme.error)
+        ..rrect(color: themeData.colorScheme.error)
         ..path(color: themeData.colorScheme.onError),
     );
 
@@ -1142,7 +1142,7 @@ void main() {
       Material.of(tester.element(find.byType(Checkbox))),
       paints
         ..circle(color: themeData.colorScheme.error.withOpacity(0.08))
-        ..path(color: themeData.colorScheme.error),
+        ..rrect(color: themeData.colorScheme.error),
     );
   });
 

--- a/packages/flutter/test/material/checkbox_test.dart
+++ b/packages/flutter/test/material/checkbox_test.dart
@@ -433,7 +433,7 @@ void main() {
     expect(
       getCheckboxRenderer(),
       paints
-        ..path(color: theme.colorScheme.secondary)
+        ..rrect(color: theme.colorScheme.secondary)
         ..path(color: const Color(0xFFFFFFFF)),
     ); // checkmark is rendered as a path
 
@@ -455,7 +455,7 @@ void main() {
     expect(
       getCheckboxRenderer(),
       paints
-        ..path(color: theme.colorScheme.secondary)
+        ..rrect(color: theme.colorScheme.secondary)
         ..path(color: const Color(0xFFFFFFFF)),
     ); // checkmark is rendered as a path
 
@@ -499,7 +499,7 @@ void main() {
     expect(
       getCheckboxRenderer(),
       paints
-        ..path(color: theme.colorScheme.primary)
+        ..rrect(color: theme.colorScheme.primary)
         ..path(color: theme.colorScheme.onPrimary),
     ); // checkmark is rendered as a path
 
@@ -521,7 +521,7 @@ void main() {
     expect(
       getCheckboxRenderer(),
       paints
-        ..path(color: theme.colorScheme.primary)
+        ..rrect(color: theme.colorScheme.primary)
         ..path(color: theme.colorScheme.onPrimary),
     ); // checkmark is rendered as a path
 
@@ -563,7 +563,7 @@ void main() {
     expect(
       getCheckboxRenderer(),
       paints
-        ..path(color: borderColor)
+        ..rrect(color: borderColor)
         ..path(color: checkColor),
     ); // paints's color is 0xFFFFFFFF (default color)
 
@@ -574,7 +574,7 @@ void main() {
     expect(
       getCheckboxRenderer(),
       paints
-        ..path(color: borderColor)
+        ..rrect(color: borderColor)
         ..path(color: checkColor),
     ); // paints's color is 0xFF000000 (params)
 
@@ -629,7 +629,7 @@ void main() {
     expect(
       getCheckboxRenderer(),
       paints
-        ..path(color: borderColor)
+        ..rrect(color: borderColor)
         ..path(color: checkColor),
     ); // paints's color is 0xFFFFFFFF (default color)
 
@@ -640,7 +640,7 @@ void main() {
     expect(
       getCheckboxRenderer(),
       paints
-        ..path(color: borderColor)
+        ..rrect(color: borderColor)
         ..path(color: checkColor),
     ); // paints's color is 0xFF000000 (params)
 
@@ -704,7 +704,7 @@ void main() {
       Material.of(tester.element(find.byType(Checkbox))),
       paints
         ..circle(color: Colors.orange[500])
-        ..path(color: const Color(0xff2196f3))
+        ..rrect(color: const Color(0xff2196f3))
         ..path(color: Colors.white),
     );
 
@@ -782,7 +782,7 @@ void main() {
       Material.of(tester.element(find.byType(Checkbox))),
       paints
         ..circle(color: Colors.orange[500])
-        ..path(color: theme.colorScheme.primary)
+        ..rrect(color: theme.colorScheme.primary)
         ..path(color: theme.colorScheme.onPrimary),
     );
 
@@ -922,7 +922,7 @@ void main() {
     expect(
       Material.of(tester.element(find.byType(Checkbox))),
       paints
-        ..path(color: const Color(0xff2196f3))
+        ..rrect(color: const Color(0xff2196f3))
         ..path(color: const Color(0xffffffff), style: PaintingStyle.stroke, strokeWidth: 2.0),
     );
 
@@ -937,7 +937,7 @@ void main() {
       Material.of(tester.element(find.byType(Checkbox))),
       paints
         ..circle(color: Colors.orange[500])
-        ..path(color: const Color(0xff2196f3))
+        ..rrect(color: const Color(0xff2196f3))
         ..path(color: const Color(0xffffffff), style: PaintingStyle.stroke, strokeWidth: 2.0),
     );
 
@@ -947,7 +947,7 @@ void main() {
     expect(
       Material.of(tester.element(find.byType(Checkbox))),
       paints
-        ..path(color: const Color(0x61000000))
+        ..rrect(color: const Color(0x61000000))
         ..path(color: const Color(0xffffffff), style: PaintingStyle.stroke, strokeWidth: 2.0),
     );
   });
@@ -988,7 +988,7 @@ void main() {
     expect(
       Material.of(tester.element(find.byType(Checkbox))),
       paints
-        ..path(color: const Color(0xff6750a4))
+        ..rrect(color: const Color(0xff6750a4))
         ..path(color: theme.colorScheme.onPrimary, style: PaintingStyle.stroke, strokeWidth: 2.0),
     );
 
@@ -1003,7 +1003,7 @@ void main() {
       Material.of(tester.element(find.byType(Checkbox))),
       paints
         ..circle(color: Colors.orange[500])
-        ..path(color: const Color(0xff6750a4))
+        ..rrect(color: const Color(0xff6750a4))
         ..path(color: theme.colorScheme.onPrimary, style: PaintingStyle.stroke, strokeWidth: 2.0),
     );
 
@@ -1013,7 +1013,7 @@ void main() {
     expect(
       Material.of(tester.element(find.byType(Checkbox))),
       paints
-        ..path(color: theme.colorScheme.onSurface.withOpacity(0.38))
+        ..rrect(color: theme.colorScheme.onSurface.withOpacity(0.38))
         ..path(color: theme.colorScheme.surface, style: PaintingStyle.stroke, strokeWidth: 2.0),
     );
   });
@@ -2136,7 +2136,7 @@ void main() {
       Material.of(tester.element(find.byType(Checkbox))),
       paints
         ..circle(color: themeData.colorScheme.error.withOpacity(0.1))
-        ..path(color: themeData.colorScheme.error)
+        ..rrect(color: themeData.colorScheme.error)
         ..path(color: themeData.colorScheme.onError),
     );
 
@@ -2148,7 +2148,7 @@ void main() {
     expect(
       Material.of(tester.element(find.byType(Checkbox))),
       paints
-        ..path(color: themeData.colorScheme.error)
+        ..rrect(color: themeData.colorScheme.error)
         ..path(color: themeData.colorScheme.onError),
     );
 
@@ -2163,7 +2163,7 @@ void main() {
       Material.of(tester.element(find.byType(Checkbox))),
       paints
         ..circle(color: themeData.colorScheme.error.withOpacity(0.08))
-        ..path(color: themeData.colorScheme.error),
+        ..rrect(color: themeData.colorScheme.error),
     );
 
     // Start pressing
@@ -2175,7 +2175,7 @@ void main() {
       Material.of(tester.element(find.byType(Checkbox))),
       paints
         ..circle(color: themeData.colorScheme.error.withOpacity(0.1))
-        ..path(color: themeData.colorScheme.error),
+        ..rrect(color: themeData.colorScheme.error),
     );
     await gestureLongPress.up();
     await tester.pump();

--- a/packages/flutter/test/material/checkbox_test.dart
+++ b/packages/flutter/test/material/checkbox_test.dart
@@ -423,7 +423,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(
       getCheckboxRenderer(),
-      paints..path(color: Colors.transparent),
+      paints..rrect(color: Colors.transparent),
     ); // paint transparent border
     expect(getCheckboxRenderer(), isNot(paints..line())); // null is rendered as a line (a "dash")
     expect(getCheckboxRenderer(), paints..drrect()); // empty checkbox
@@ -441,7 +441,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(
       getCheckboxRenderer(),
-      paints..path(color: Colors.transparent),
+      paints..rrect(color: Colors.transparent),
     ); // paint transparent border
     expect(getCheckboxRenderer(), isNot(paints..line())); // null is rendered as a line (a "dash")
     expect(getCheckboxRenderer(), paints..drrect()); // empty checkbox
@@ -489,7 +489,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(
       getCheckboxRenderer(),
-      paints..path(color: Colors.transparent),
+      paints..rrect(color: Colors.transparent),
     ); // paint transparent border
     expect(getCheckboxRenderer(), isNot(paints..line())); // null is rendered as a line (a "dash")
     expect(getCheckboxRenderer(), paints..drrect()); // empty checkbox
@@ -507,7 +507,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(
       getCheckboxRenderer(),
-      paints..path(color: Colors.transparent),
+      paints..rrect(color: Colors.transparent),
     ); // paint transparent border
     expect(getCheckboxRenderer(), isNot(paints..line())); // null is rendered as a line (a "dash")
     expect(getCheckboxRenderer(), paints..drrect()); // empty checkbox
@@ -586,14 +586,14 @@ void main() {
     await tester.pumpAndSettle();
     expect(
       getCheckboxRenderer(),
-      paints..path(color: activeColor),
+      paints..rrect(color: activeColor),
     ); // paints's color is 0xFF00FF00 (theme)
 
     activeColor = const Color(0xFF000000);
 
     await tester.pumpWidget(buildFrame(activeColor: activeColor));
     await tester.pumpAndSettle();
-    expect(getCheckboxRenderer(), paints..path(color: activeColor));
+    expect(getCheckboxRenderer(), paints..rrect(color: activeColor));
   });
 
   testWidgets('Material3 - Checkbox color rendering', (WidgetTester tester) async {
@@ -652,14 +652,14 @@ void main() {
     await tester.pumpAndSettle();
     expect(
       getCheckboxRenderer(),
-      paints..path(color: activeColor),
+      paints..rrect(color: activeColor),
     ); // paints's color is 0xFF00FF00 (theme)
 
     activeColor = const Color(0xFF000000);
 
     await tester.pumpWidget(buildFrame(activeColor: activeColor));
     await tester.pumpAndSettle();
-    expect(getCheckboxRenderer(), paints..path(color: activeColor));
+    expect(getCheckboxRenderer(), paints..rrect(color: activeColor));
   });
 
   testWidgets('Material2 - Checkbox is focusable and has correct focus color', (
@@ -1368,11 +1368,11 @@ void main() {
 
     await tester.pumpWidget(buildFrame(enabled: true));
     await tester.pumpAndSettle();
-    expect(getCheckboxRenderer(), paints..path(color: activeEnabledFillColor));
+    expect(getCheckboxRenderer(), paints..rrect(color: activeEnabledFillColor));
 
     await tester.pumpWidget(buildFrame(enabled: false));
     await tester.pumpAndSettle();
-    expect(getCheckboxRenderer(), paints..path(color: activeDisabledFillColor));
+    expect(getCheckboxRenderer(), paints..rrect(color: activeDisabledFillColor));
   });
 
   testWidgets('Checkbox fill color resolves in hovered/focused states', (
@@ -1423,7 +1423,7 @@ void main() {
     await tester.pumpWidget(buildFrame());
     await tester.pumpAndSettle();
     expect(focusNode.hasPrimaryFocus, isTrue);
-    expect(getCheckboxRenderer(), paints..path(color: focusedFillColor));
+    expect(getCheckboxRenderer(), paints..rrect(color: focusedFillColor));
 
     // Start hovering
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
@@ -1432,7 +1432,7 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.byType(Checkbox)));
     await tester.pumpAndSettle();
 
-    expect(getCheckboxRenderer(), paints..path(color: hoveredFillColor));
+    expect(getCheckboxRenderer(), paints..rrect(color: hoveredFillColor));
   });
 
   testWidgets('Checkbox respects shape and side', (WidgetTester tester) async {
@@ -1934,12 +1934,12 @@ void main() {
     await tester.pumpWidget(buildApp(value: true));
     await tester.pumpAndSettle();
     expect(getCheckboxRenderer(), paints..drrect(color: Colors.transparent));
-    expect(getCheckboxRenderer(), paints..path(color: activeColor)); // checkbox fill
+    expect(getCheckboxRenderer(), paints..rrect(color: activeColor)); // checkbox fill
 
     await tester.pumpWidget(buildApp());
     await tester.pumpAndSettle();
     expect(getCheckboxRenderer(), paints..drrect(color: Colors.transparent));
-    expect(getCheckboxRenderer(), paints..path(color: activeColor)); // checkbox fill
+    expect(getCheckboxRenderer(), paints..rrect(color: activeColor)); // checkbox fill
   });
 
   testWidgets('Material2 - Checkbox WidgetStateBorderSide applies unconditionally', (
@@ -2420,12 +2420,12 @@ void main() {
     await tester.pumpWidget(buildApp());
     await tester.pumpAndSettle();
     expect(getCheckboxRenderer(), paints..drrect(color: theme.unselectedWidgetColor));
-    expect(getCheckboxRenderer(), paints..path(color: inactiveBackgroundColor));
+    expect(getCheckboxRenderer(), paints..rrect(color: inactiveBackgroundColor));
 
     await tester.pumpWidget(buildApp(enabled: false));
     await tester.pumpAndSettle();
     expect(getCheckboxRenderer(), paints..drrect(color: theme.disabledColor));
-    expect(getCheckboxRenderer(), paints..path(color: inactiveBackgroundColor));
+    expect(getCheckboxRenderer(), paints..rrect(color: inactiveBackgroundColor));
   });
 
   testWidgets('Material3 - Checkbox respects fillColor when it is unchecked', (
@@ -2463,7 +2463,7 @@ void main() {
     await tester.pumpWidget(buildApp());
     await tester.pumpAndSettle();
     expect(getCheckboxRenderer(), paints..drrect(color: theme.colorScheme.onSurfaceVariant));
-    expect(getCheckboxRenderer(), paints..path(color: inactiveBackgroundColor));
+    expect(getCheckboxRenderer(), paints..rrect(color: inactiveBackgroundColor));
 
     await tester.pumpWidget(buildApp(enabled: false));
     await tester.pumpAndSettle();
@@ -2471,7 +2471,7 @@ void main() {
       getCheckboxRenderer(),
       paints..drrect(color: theme.colorScheme.onSurface.withOpacity(0.38)),
     );
-    expect(getCheckboxRenderer(), paints..path(color: inactiveBackgroundColor));
+    expect(getCheckboxRenderer(), paints..rrect(color: inactiveBackgroundColor));
   });
 
   testWidgets('Checkbox renders at zero area', (WidgetTester tester) async {

--- a/packages/flutter/test/material/checkbox_theme_test.dart
+++ b/packages/flutter/test/material/checkbox_theme_test.dart
@@ -136,7 +136,7 @@ void main() {
     // Checkbox.
     await tester.pumpWidget(buildCheckbox());
     await tester.pumpAndSettle();
-    expect(_getCheckboxMaterial(tester), paints..path(color: defaultFillColor));
+    expect(_getCheckboxMaterial(tester), paints..rrect(color: defaultFillColor));
     // Size from MaterialTapTargetSize.shrinkWrap with added VisualDensity.
     expect(
       tester.getSize(find.byType(Checkbox)),
@@ -146,11 +146,11 @@ void main() {
     // Selected checkbox.
     await tester.pumpWidget(buildCheckbox(selected: true));
     await tester.pumpAndSettle();
-    expect(_getCheckboxMaterial(tester), paints..path(color: selectedFillColor));
+    expect(_getCheckboxMaterial(tester), paints..rrect(color: selectedFillColor));
     expect(
       _getCheckboxMaterial(tester),
       paints
-        ..path(color: selectedFillColor)
+        ..rrect(color: selectedFillColor)
         ..path(color: defaultCheckColor),
     );
 
@@ -174,7 +174,7 @@ void main() {
     expect(
       _getCheckboxMaterial(tester),
       paints
-        ..path(color: selectedFillColor)
+        ..rrect(color: selectedFillColor)
         ..path(color: focusedCheckColor),
     );
   });
@@ -254,7 +254,7 @@ void main() {
     // Checkbox.
     await tester.pumpWidget(buildCheckbox());
     await tester.pumpAndSettle();
-    expect(_getCheckboxMaterial(tester), paints..path(color: defaultFillColor));
+    expect(_getCheckboxMaterial(tester), paints..rrect(color: defaultFillColor));
     // Size from MaterialTapTargetSize.shrinkWrap with added VisualDensity.
     expect(
       tester.getSize(find.byType(Checkbox)),
@@ -264,11 +264,11 @@ void main() {
     // Selected checkbox.
     await tester.pumpWidget(buildCheckbox(selected: true));
     await tester.pumpAndSettle();
-    expect(_getCheckboxMaterial(tester), paints..path(color: selectedFillColor));
+    expect(_getCheckboxMaterial(tester), paints..rrect(color: selectedFillColor));
     expect(
       _getCheckboxMaterial(tester),
       paints
-        ..path(color: selectedFillColor)
+        ..rrect(color: selectedFillColor)
         ..path(color: checkColor),
     );
 
@@ -318,12 +318,12 @@ void main() {
     // Unselected checkbox.
     await tester.pumpWidget(buildCheckbox());
     await tester.pumpAndSettle();
-    expect(_getCheckboxMaterial(tester), paints..path(color: themeDefaultFillColor));
+    expect(_getCheckboxMaterial(tester), paints..rrect(color: themeDefaultFillColor));
 
     // Selected checkbox.
     await tester.pumpWidget(buildCheckbox(selected: true));
     await tester.pumpAndSettle();
-    expect(_getCheckboxMaterial(tester), paints..path(color: selectedFillColor));
+    expect(_getCheckboxMaterial(tester), paints..rrect(color: selectedFillColor));
   });
 
   testWidgets('Checkbox theme overlay color resolves in active/pressed states', (
@@ -412,11 +412,11 @@ void main() {
 
     await tester.pumpWidget(buildCheckbox(active: true));
     await tester.pumpAndSettle();
-    expect(_getCheckboxMaterial(tester), paints..path(color: localThemeFillColor));
+    expect(_getCheckboxMaterial(tester), paints..rrect(color: localThemeFillColor));
     expect(
       _getCheckboxMaterial(tester),
       paints
-        ..path(color: localThemeFillColor)
+        ..rrect(color: localThemeFillColor)
         ..path(color: localThemeCheckColor),
     );
   });

--- a/packages/flutter/test/material/chip_test.dart
+++ b/packages/flutter/test/material/chip_test.dart
@@ -3534,15 +3534,17 @@ void main() {
         }),
       ),
     );
+    const avatarX = 16.0;
+    const avatarY = 16.0;
+    const avatarRadius = 12.0;
     const selectScrimColor = Color(0x60191919);
     expect(
       rawChip,
-      paints..circle(
-        color: selectScrimColor,
-        x: 16.0,
-        y: 16.0,
-        radius: 12.0,
-      ),
+      paints
+        // CircleAvatar background.
+        ..circle(x: avatarX, y: avatarY, radius: avatarRadius)
+        // Selection scrim overlay.
+        ..circle(color: selectScrimColor, x: avatarX, y: avatarY, radius: avatarRadius),
     );
   });
 
@@ -3567,15 +3569,17 @@ void main() {
         }),
       ),
     );
+    const avatarX = 18.0;
+    const avatarY = 18.0;
+    const avatarRadius = 10.0;
     const selectScrimColor = Color(0x60191919);
     expect(
       rawChip,
-      paints..circle(
-        color: selectScrimColor,
-        x: 18.0,
-        y: 18.0,
-        radius: 10.0,
-      ),
+      paints
+        // CircleAvatar background.
+        ..circle(x: avatarX, y: avatarY, radius: avatarRadius)
+        // Selection scrim overlay.
+        ..circle(color: selectScrimColor, x: avatarX, y: avatarY, radius: avatarRadius),
     );
   });
 

--- a/packages/flutter/test/material/chip_test.dart
+++ b/packages/flutter/test/material/chip_test.dart
@@ -3537,10 +3537,11 @@ void main() {
     const selectScrimColor = Color(0x60191919);
     expect(
       rawChip,
-      paints..path(
+      paints..circle(
         color: selectScrimColor,
-        includes: <Offset>[const Offset(10, 10)],
-        excludes: <Offset>[const Offset(4, 4)],
+        x: 16.0,
+        y: 16.0,
+        radius: 12.0,
       ),
     );
   });
@@ -3569,10 +3570,11 @@ void main() {
     const selectScrimColor = Color(0x60191919);
     expect(
       rawChip,
-      paints..path(
+      paints..circle(
         color: selectScrimColor,
-        includes: <Offset>[const Offset(11, 11)],
-        excludes: <Offset>[const Offset(4, 4)],
+        x: 18.0,
+        y: 18.0,
+        radius: 10.0,
       ),
     );
   });

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -1339,8 +1339,7 @@ void main() {
     expect(
       Material.of(tester.element(find.byType(Checkbox).last)),
       paints
-        ..path()
-        ..path(color: fillColor)
+        ..rrect(color: fillColor)
         ..path(color: checkColor),
     );
   });

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -2654,7 +2654,7 @@ void main() {
     final ThemeData theme = Theme.of(tester.element(find.byType(InputDecorator)));
     expect(
       findInputDecoratorBorderPainter(),
-      paints..path(style: PaintingStyle.fill, color: theme.colorScheme.surfaceContainerHighest),
+      paints..rrect(style: PaintingStyle.fill, color: theme.colorScheme.surfaceContainerHighest),
     );
 
     // Focus color from Decoration.
@@ -2670,7 +2670,7 @@ void main() {
 
     expect(
       findInputDecoratorBorderPainter(),
-      paints..path(style: PaintingStyle.fill, color: const Color(0xff00ffff)),
+      paints..rrect(style: PaintingStyle.fill, color: const Color(0xff00ffff)),
     );
 
     // Focus color from focusColor property.
@@ -2687,7 +2687,7 @@ void main() {
 
     expect(
       findInputDecoratorBorderPainter(),
-      paints..path(style: PaintingStyle.fill, color: const Color(0xff00ff00)),
+      paints..rrect(style: PaintingStyle.fill, color: const Color(0xff00ff00)),
     );
   });
 
@@ -2715,7 +2715,7 @@ void main() {
     ).colorScheme.surfaceContainerHighest;
     expect(
       findInputDecoratorBorderPainter(),
-      paints..path(style: PaintingStyle.fill, color: defaultBorderColor),
+      paints..rrect(style: PaintingStyle.fill, color: defaultBorderColor),
     );
 
     // Replace focusNode and request focus.
@@ -2727,7 +2727,7 @@ void main() {
     await tester.pump(); // Wait for requestFocus to take effect.
     expect(
       findInputDecoratorBorderPainter(),
-      paints..path(style: PaintingStyle.fill, color: const Color(0xff00ff00)),
+      paints..rrect(style: PaintingStyle.fill, color: const Color(0xff00ff00)),
     );
 
     // Replace focusNode and request focus.
@@ -2740,7 +2740,7 @@ void main() {
     await tester.pump(); // Wait for unfocus to take effect.
     expect(
       findInputDecoratorBorderPainter(),
-      paints..path(style: PaintingStyle.fill, color: defaultBorderColor),
+      paints..rrect(style: PaintingStyle.fill, color: defaultBorderColor),
     );
   });
 
@@ -2830,7 +2830,7 @@ void main() {
     final ThemeData theme = Theme.of(tester.element(find.byType(InputDecorator)));
     expect(
       findInputDecoratorBorderPainter(),
-      paints..path(
+      paints..rrect(
         style: PaintingStyle.fill,
         color: Color.alphaBlend(theme.hoverColor, theme.colorScheme.surfaceContainerHighest),
       ),
@@ -2848,7 +2848,7 @@ void main() {
     );
     expect(
       findInputDecoratorBorderPainter(),
-      paints..path(
+      paints..rrect(
         style: PaintingStyle.fill,
         color: Color.alphaBlend(hoverColor, theme.colorScheme.surfaceContainerHighest),
       ),

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -1976,30 +1976,22 @@ void main() {
 
       final RenderBox box = tester.renderObject(find.byType(InputDecorator));
 
-      // Fill is the border's outer path, a rounded rectangle.
       expect(
         box,
-        paints..path(
-          style: PaintingStyle.fill,
-          color: const Color(0xFF00FF00),
-          includes: <Offset>[const Offset(800.0 / 2.0, 56 / 2.0)],
-          excludes: <Offset>[
-            const Offset(1.0, 6.0), // outside the rounded corner, top left.
-            const Offset(800.0 - 1.0, 6.0), // top right.
-            const Offset(1.0, 56.0 - 6.0), // bottom left.
-            const Offset(800 - 1.0, 56.0 - 6.0), // bottom right.
-          ],
-        ),
-      );
-
-      // Border outline. The rrect is the -center- of the 1.0 stroked outline.
-      expect(
-        box,
-        paints..rrect(
-          style: PaintingStyle.stroke,
-          strokeWidth: 1.0,
-          rrect: RRect.fromLTRBR(0.5, 0.5, 799.5, 55.5, const Radius.circular(11.5)),
-        ),
+        paints
+          // The border's outer path, a rounded rectangle.
+          ..rrect(
+            style: PaintingStyle.fill,
+            color: const Color(0xFF00FF00),
+            rrect: const BorderRadius.all(Radius.circular(12.0))
+              .toRRect(const Rect.fromLTWH(0, 0, 800.0, 56.0)),
+          )
+          // Border outline. The rrect is the -center- of the 1.0 stroked outline.
+          ..rrect(
+            style: PaintingStyle.stroke,
+            strokeWidth: 1.0,
+            rrect: RRect.fromLTRBR(0.5, 0.5, 799.5, 55.5, const Radius.circular(11.5)),
+          ),
       );
     });
 
@@ -14544,30 +14536,22 @@ void main() {
 
       final RenderBox box = tester.renderObject(find.byType(InputDecorator));
 
-      // Fill is the border's outer path, a rounded rectangle
       expect(
         box,
-        paints..path(
-          style: PaintingStyle.fill,
-          color: const Color(0xFF00FF00),
-          includes: <Offset>[const Offset(800.0 / 2.0, 56 / 2.0)],
-          excludes: <Offset>[
-            const Offset(1.0, 6.0), // outside the rounded corner, top left
-            const Offset(800.0 - 1.0, 6.0), // top right
-            const Offset(1.0, 56.0 - 6.0), // bottom left
-            const Offset(800 - 1.0, 56.0 - 6.0), // bottom right
-          ],
-        ),
-      );
-
-      // Border outline. The rrect is the -center- of the 1.0 stroked outline.
-      expect(
-        box,
-        paints..rrect(
-          style: PaintingStyle.stroke,
-          strokeWidth: 1.0,
-          rrect: RRect.fromLTRBR(0.5, 0.5, 799.5, 55.5, const Radius.circular(11.5)),
-        ),
+        paints
+          // The border's outer path, a rounded rectangle.
+          ..rrect(
+            style: PaintingStyle.fill,
+            color: const Color(0xFF00FF00),
+            rrect: const BorderRadius.all(Radius.circular(12.0))
+              .toRRect(const Rect.fromLTWH(0, 0, 800.0, 56.0)),
+          )
+          // Border outline. The rrect is the -center- of the 1.0 stroked outline.
+          ..rrect(
+            style: PaintingStyle.stroke,
+            strokeWidth: 1.0,
+            rrect: RRect.fromLTRBR(0.5, 0.5, 799.5, 55.5, const Radius.circular(11.5)),
+          ),
       );
     });
 
@@ -15169,61 +15153,15 @@ void main() {
         findBorderPainter(),
         paints
           ..save()
-          ..path(
+          ..rrect(
             style: PaintingStyle.fill,
             color: const Color(0xFF00FF00),
-            includes: const <Offset>[
-              // The border should draw along the four edges of the
-              // InputDecorator.
-
-              // Top center
-              Offset(inputDecoratorWidth / 2.0, 0.0),
-              // Bottom center
-              Offset(inputDecoratorWidth / 2.0, inputDecoratorHeight),
-              // Left center
-              Offset(0.0, inputDecoratorHeight / 2.0),
-              // Right center
-              Offset(inputDecoratorWidth, inputDecoratorHeight / 2.0),
-
-              // The border path should contain points where each rounded corner
-              // ends.
-
-              // Bottom-right arc
-              Offset(inputDecoratorWidth, inputDecoratorHeight - largerBorderRadiusScaled),
-              Offset(inputDecoratorWidth - largerBorderRadiusScaled, inputDecoratorHeight),
-              // Top-right arc
-              Offset(inputDecoratorWidth, 0.0 + largerBorderRadiusScaled),
-              Offset(inputDecoratorWidth - largerBorderRadiusScaled, 0.0),
-              // Bottom-left arc
-              Offset(0.0, inputDecoratorHeight - smallerBorderRadiusScaled),
-              Offset(0.0 + smallerBorderRadiusScaled, inputDecoratorHeight),
-              // Top-left arc
-              Offset(0.0, 0.0 + smallerBorderRadiusScaled),
-              Offset(0.0 + smallerBorderRadiusScaled, 0.0),
-            ],
-            excludes: const <Offset>[
-              // The border should not contain the corner points, since the border
-              // is rounded.
-
-              // Top-left
-              Offset.zero,
-              // Top-right
-              Offset(inputDecoratorWidth, 0.0),
-              // Bottom-left
-              Offset(0.0, inputDecoratorHeight),
-              // Bottom-right
-              Offset(inputDecoratorWidth, inputDecoratorHeight),
-
-              // Corners with larger border ratio should not contain points outside
-              // of the larger radius.
-
-              // Bottom-right arc
-              Offset(inputDecoratorWidth, inputDecoratorHeight - smallerBorderRadiusScaled),
-              Offset(inputDecoratorWidth - smallerBorderRadiusScaled, inputDecoratorWidth),
-              // Top-left arc
-              Offset(inputDecoratorWidth, 0.0 + smallerBorderRadiusScaled),
-              Offset(inputDecoratorWidth - smallerBorderRadiusScaled, 0.0),
-            ],
+            rrect: const BorderRadius.only(
+              topLeft: Radius.circular(smallerBorderRadius),
+              bottomLeft: Radius.circular(smallerBorderRadius),
+              topRight: Radius.circular(largerBorderRadius),
+              bottomRight: Radius.circular(largerBorderRadius),
+            ).toRRect(const Rect.fromLTWH(0, 0, inputDecoratorWidth, inputDecoratorHeight)),
           )
           ..restore(),
       );
@@ -15269,57 +15207,11 @@ void main() {
         findBorderPainter(),
         paints
           ..save()
-          ..path(
+          ..rrect(
             style: PaintingStyle.fill,
             color: const Color(0xFF00FF00),
-            includes: <Offset>[
-              // The border should draw along the four edges of the
-              // InputDecorator.
-
-              // Top center
-              const Offset(inputDecoratorWidth / 2.0, 0.0),
-              // Bottom center
-              const Offset(inputDecoratorWidth / 2.0, inputDecoratorHeight),
-              // Left center
-              const Offset(0.0, inputDecoratorHeight / 2.0),
-              // Right center
-              const Offset(inputDecoratorWidth, inputDecoratorHeight / 2.0),
-
-              // The border path should contain points where each rounded corner
-              // ends.
-
-              // Bottom-right arc
-              const Offset(inputDecoratorWidth, inputDecoratorHeight - borderRadiusScaled),
-              const Offset(inputDecoratorWidth - borderRadiusScaled, inputDecoratorHeight),
-              // Top-right arc
-              const Offset(inputDecoratorWidth, 0.0 + borderRadiusScaled),
-              const Offset(inputDecoratorWidth - borderRadiusScaled, 0.0),
-              // Bottom-left arc
-              const Offset(0.0, inputDecoratorHeight - borderRadiusScaled),
-              const Offset(0.0 + borderRadiusScaled, inputDecoratorHeight),
-              // Top-left arc
-              const Offset(0.0, 0.0 + borderRadiusScaled),
-              const Offset(0.0 + borderRadiusScaled, 0.0),
-
-              // Gap edges
-              // gap start x = radius - radius * cos(arc sweep)
-              // gap start y = radius - radius * sin(arc sweep)
-              const Offset(39.49999999999999, 32.284366616798906),
-              Offset(39.49999999999999 + labelRect.width, 0.0),
-            ],
-            excludes: const <Offset>[
-              // The border should not contain the corner points, since the border
-              // is rounded.
-
-              // Top-left
-              Offset.zero,
-              // Top-right
-              Offset(inputDecoratorWidth, 0.0),
-              // Bottom-left
-              Offset(0.0, inputDecoratorHeight),
-              // Bottom-right
-              Offset(inputDecoratorWidth, inputDecoratorHeight),
-            ],
+            rrect: const BorderRadius.all(Radius.circular(borderRadius))
+              .toRRect(const Rect.fromLTWH(0, 0, inputDecoratorWidth, inputDecoratorHeight)),
           )
           ..restore(),
       );

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -1876,8 +1876,9 @@ void main() {
           ..rrect(
             style: PaintingStyle.fill,
             color: const Color(0xFF00FF00),
-            rrect: const BorderRadius.all(Radius.circular(12.0))
-              .toRRect(const Rect.fromLTWH(0, 0, 800.0, 56.0)),
+            rrect: const BorderRadius.all(
+              Radius.circular(12.0),
+            ).toRRect(const Rect.fromLTWH(0, 0, 800.0, 56.0)),
           )
           // Border outline. The rrect is the -center- of the 1.0 stroked outline.
           ..rrect(
@@ -14449,8 +14450,9 @@ void main() {
           ..rrect(
             style: PaintingStyle.fill,
             color: const Color(0xFF00FF00),
-            rrect: const BorderRadius.all(Radius.circular(12.0))
-              .toRRect(const Rect.fromLTWH(0, 0, 800.0, 56.0)),
+            rrect: const BorderRadius.all(
+              Radius.circular(12.0),
+            ).toRRect(const Rect.fromLTWH(0, 0, 800.0, 56.0)),
           )
           // Border outline. The rrect is the -center- of the 1.0 stroked outline.
           ..rrect(
@@ -15100,8 +15102,9 @@ void main() {
           ..rrect(
             style: PaintingStyle.fill,
             color: const Color(0xFF00FF00),
-            rrect: const BorderRadius.all(Radius.circular(borderRadius))
-              .toRRect(const Rect.fromLTWH(0, 0, inputDecoratorWidth, inputDecoratorHeight)),
+            rrect: const BorderRadius.all(
+              Radius.circular(borderRadius),
+            ).toRRect(const Rect.fromLTWH(0, 0, inputDecoratorWidth, inputDecoratorHeight)),
           )
           ..restore(),
       );

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -387,7 +387,7 @@ void main() {
           expect(
             findBorderPainter(),
             paints
-              ..path(style: PaintingStyle.fill, color: theme.colorScheme.surfaceContainerHighest),
+              ..rrect(style: PaintingStyle.fill, color: theme.colorScheme.surfaceContainerHighest),
           );
         });
 
@@ -444,7 +444,7 @@ void main() {
           final ThemeData theme = Theme.of(tester.element(findDecorator()));
           expect(
             findBorderPainter(),
-            paints..path(
+            paints..rrect(
               style: PaintingStyle.fill,
               color: theme.colorScheme.onSurface.withOpacity(0.04),
             ),
@@ -506,7 +506,7 @@ void main() {
           expect(theme.hoverColor, Colors.black.withOpacity(0.04));
           expect(
             findBorderPainter(),
-            paints..path(
+            paints..rrect(
               style: PaintingStyle.fill,
               color: Color.alphaBlend(theme.hoverColor, theme.colorScheme.surfaceContainerHighest),
             ),
@@ -568,7 +568,7 @@ void main() {
           expect(
             findBorderPainter(),
             paints
-              ..path(style: PaintingStyle.fill, color: theme.colorScheme.surfaceContainerHighest),
+              ..rrect(style: PaintingStyle.fill, color: theme.colorScheme.surfaceContainerHighest),
           );
         });
 
@@ -594,7 +594,7 @@ void main() {
           expect(
             findBorderPainter(),
             paints
-              ..path(style: PaintingStyle.fill, color: Color.alphaBlend(hoverColor, focusColor)),
+              ..rrect(style: PaintingStyle.fill, color: Color.alphaBlend(hoverColor, focusColor)),
           );
         });
 
@@ -672,7 +672,7 @@ void main() {
           expect(
             findBorderPainter(),
             paints
-              ..path(style: PaintingStyle.fill, color: theme.colorScheme.surfaceContainerHighest),
+              ..rrect(style: PaintingStyle.fill, color: theme.colorScheme.surfaceContainerHighest),
           );
         });
 
@@ -1731,76 +1731,19 @@ void main() {
         ),
       );
 
-      // Skia determines the scale based on the ratios of radii to the total
-      // height or width allowed. In this case, it is the right side of the
-      // border, which have two corners with largerBorderRadius that add up
-      // to be 400.0.
-      const double denominator = largerBorderRadius * 2.0;
-
-      const double largerBorderRadiusScaled =
-          largerBorderRadius / denominator * inputDecoratorHeight;
-      const double smallerBorderRadiusScaled =
-          smallerBorderRadius / denominator * inputDecoratorHeight;
-
       expect(
         findBorderPainter(),
         paints
           ..save()
-          ..path(
+          ..rrect(
             style: PaintingStyle.fill,
             color: const Color(0xFF00FF00),
-            includes: const <Offset>[
-              // The border should draw along the four edges of the
-              // InputDecorator.
-
-              // Top center.
-              Offset(inputDecoratorWidth / 2.0, 0.0),
-              // Bottom center.
-              Offset(inputDecoratorWidth / 2.0, inputDecoratorHeight),
-              // Left center.
-              Offset(0.0, inputDecoratorHeight / 2.0),
-              // Right center.
-              Offset(inputDecoratorWidth, inputDecoratorHeight / 2.0),
-
-              // The border path should contain points where each rounded corner
-              // ends.
-
-              // Bottom-right arc.
-              Offset(inputDecoratorWidth, inputDecoratorHeight - largerBorderRadiusScaled),
-              Offset(inputDecoratorWidth - largerBorderRadiusScaled, inputDecoratorHeight),
-              // Top-right arc.
-              Offset(inputDecoratorWidth, 0.0 + largerBorderRadiusScaled),
-              Offset(inputDecoratorWidth - largerBorderRadiusScaled, 0.0),
-              // Bottom-left arc.
-              Offset(0.0, inputDecoratorHeight - smallerBorderRadiusScaled),
-              Offset(0.0 + smallerBorderRadiusScaled, inputDecoratorHeight),
-              // Top-left arc.
-              Offset(0.0, 0.0 + smallerBorderRadiusScaled),
-              Offset(0.0 + smallerBorderRadiusScaled, 0.0),
-            ],
-            excludes: const <Offset>[
-              // The border should not contain the corner points, since the border
-              // is rounded.
-
-              // Top-left.
-              Offset.zero,
-              // Top-right.
-              Offset(inputDecoratorWidth, 0.0),
-              // Bottom-left.
-              Offset(0.0, inputDecoratorHeight),
-              // Bottom-right.
-              Offset(inputDecoratorWidth, inputDecoratorHeight),
-
-              // Corners with larger border ratio should not contain points outside
-              // of the larger radius.
-
-              // Bottom-right arc.
-              Offset(inputDecoratorWidth, inputDecoratorHeight - smallerBorderRadiusScaled),
-              Offset(inputDecoratorWidth - smallerBorderRadiusScaled, inputDecoratorWidth),
-              // Top-left arc.
-              Offset(inputDecoratorWidth, 0.0 + smallerBorderRadiusScaled),
-              Offset(inputDecoratorWidth - smallerBorderRadiusScaled, 0.0),
-            ],
+            rrect: const BorderRadius.only(
+              topLeft: Radius.circular(smallerBorderRadius),
+              bottomLeft: Radius.circular(smallerBorderRadius),
+              topRight: Radius.circular(largerBorderRadius),
+              bottomRight: Radius.circular(largerBorderRadius),
+            ).toRRect(const Rect.fromLTWH(0, 0, inputDecoratorWidth, inputDecoratorHeight)),
           )
           ..restore(),
       );
@@ -1830,67 +1773,17 @@ void main() {
         ),
       );
 
-      const double denominator = borderRadius * 2.0;
-      const double borderRadiusScaled = borderRadius / denominator * inputDecoratorHeight;
-
       expect(find.text(labelText), findsOneWidget);
-      final Rect labelRect = tester.getRect(find.text(labelText));
-
       expect(
         findBorderPainter(),
         paints
           ..save()
-          ..path(
+          ..rrect(
             style: PaintingStyle.fill,
             color: const Color(0xFF00FF00),
-            includes: <Offset>[
-              // The border should draw along the four edges of the
-              // InputDecorator.
-
-              // Top center.
-              const Offset(inputDecoratorWidth / 2.0, 0.0),
-              // Bottom center.
-              const Offset(inputDecoratorWidth / 2.0, inputDecoratorHeight),
-              // Left center.
-              const Offset(0.0, inputDecoratorHeight / 2.0),
-              // Right center.
-              const Offset(inputDecoratorWidth, inputDecoratorHeight / 2.0),
-
-              // The border path should contain points where each rounded corner
-              // ends.
-
-              // Bottom-right arc.
-              const Offset(inputDecoratorWidth, inputDecoratorHeight - borderRadiusScaled),
-              const Offset(inputDecoratorWidth - borderRadiusScaled, inputDecoratorHeight),
-              // Top-right arc.
-              const Offset(inputDecoratorWidth, 0.0 + borderRadiusScaled),
-              const Offset(inputDecoratorWidth - borderRadiusScaled, 0.0),
-              // Bottom-left arc.
-              const Offset(0.0, inputDecoratorHeight - borderRadiusScaled),
-              const Offset(0.0 + borderRadiusScaled, inputDecoratorHeight),
-              // Top-left arc.
-              const Offset(0.0, 0.0 + borderRadiusScaled),
-              const Offset(0.0 + borderRadiusScaled, 0.0),
-
-              // Gap edges:
-              // gap start x = radius - radius * cos(arc sweep).
-              // gap start y = radius - radius * sin(arc sweep).
-              const Offset(39.49999999999999, 32.284366616798906),
-              Offset(39.49999999999999 + labelRect.width, 0.0),
-            ],
-            excludes: const <Offset>[
-              // The border should not contain the corner points, since the border
-              // is rounded.
-
-              // Top-left.
-              Offset.zero,
-              // Top-right.
-              Offset(inputDecoratorWidth, 0.0),
-              // Bottom-left.
-              Offset(0.0, inputDecoratorHeight),
-              // Bottom-right.
-              Offset(inputDecoratorWidth, inputDecoratorHeight),
-            ],
+            rrect: const BorderRadius.all(
+              Radius.circular(borderRadius),
+            ).toRRect(const Rect.fromLTWH(0, 0, inputDecoratorWidth, inputDecoratorHeight)),
           )
           ..restore(),
       );
@@ -2024,6 +1917,19 @@ void main() {
         expect(
           box,
           paints
+            // Background fill of the InputDecorator.
+            ..rrect(
+              style: PaintingStyle.fill,
+              color: const Color(0xFF00FF00),
+              rrect: RRect.fromLTRBR(
+                0,
+                0,
+                inputDecoratorWidth,
+                inputDecoratorHeight,
+                const Radius.circular(borderRadius),
+              ),
+            )
+            // The stroked OutlineInputBorder.
             ..rrect(style: PaintingStyle.stroke, strokeWidth: borderWidth, rrect: expectedRRect),
         );
       }
@@ -10095,7 +10001,7 @@ void main() {
         ),
       );
 
-      expect(findBorderPainter(), paints..path(style: PaintingStyle.fill, color: fillColor));
+      expect(findBorderPainter(), paints..rrect(style: PaintingStyle.fill, color: fillColor));
     });
 
     testWidgets('activeIndicatorBorder', (WidgetTester tester) async {
@@ -10132,7 +10038,7 @@ void main() {
       final Color focusColor = theme.colorScheme.surfaceContainerHighest;
       expect(
         findBorderPainter(),
-        paints..path(style: PaintingStyle.fill, color: Color.alphaBlend(hoverColor, focusColor)),
+        paints..rrect(style: PaintingStyle.fill, color: Color.alphaBlend(hoverColor, focusColor)),
       );
     });
 
@@ -15138,17 +15044,6 @@ void main() {
         ),
       );
 
-      // Skia determines the scale based on the ratios of radii to the total
-      // height or width allowed. In this case, it is the right side of the
-      // border, which have two corners with largerBorderRadius that add up
-      // to be 400.0.
-      const double denominator = largerBorderRadius * 2.0;
-
-      const double largerBorderRadiusScaled =
-          largerBorderRadius / denominator * inputDecoratorHeight;
-      const double smallerBorderRadiusScaled =
-          smallerBorderRadius / denominator * inputDecoratorHeight;
-
       expect(
         findBorderPainter(),
         paints
@@ -15197,12 +15092,7 @@ void main() {
         ),
       );
 
-      const double denominator = borderRadius * 2.0;
-      const double borderRadiusScaled = borderRadius / denominator * inputDecoratorHeight;
-
       expect(find.text(labelText), findsOneWidget);
-      final Rect labelRect = tester.getRect(find.text(labelText));
-
       expect(
         findBorderPainter(),
         paints

--- a/packages/flutter/test/widgets/scrollbar_test.dart
+++ b/packages/flutter/test/widgets/scrollbar_test.dart
@@ -1802,16 +1802,10 @@ The provided ScrollController cannot be shared by multiple ScrollView widgets.''
     expect(
       find.byType(RawScrollbar),
       paints
-        ..path(
-          includes: const <Offset>[
-            Offset(782.0, 180.0),
-            Offset(782.0, 180.0 - 18.0),
-            Offset(782.0 + 18.0, 180),
-            Offset(782.0, 180.0 + 18.0),
-            Offset(782.0 - 18.0, 180),
-          ],
-        )
-        ..circle(x: 782.0, y: 180.0, radius: 17.0, strokeWidth: 2.0),
+        // Scrollbar thumb background fill.
+        ..circle(x: 782.0, y: 180.0, radius: 18.0, style: PaintingStyle.fill)
+        // Scrollbar thumb border (stroke).
+        ..circle(x: 782.0, y: 180.0, radius: 17.0, style: PaintingStyle.stroke, strokeWidth: 2.0),
     );
   });
 
@@ -1873,10 +1867,14 @@ The provided ScrollController cannot be shared by multiple ScrollView widgets.''
     expect(
       find.byType(RawScrollbar),
       paints
+        // Scrollbar track.
         ..rect(rect: const Rect.fromLTRB(780.0, 0.0, 800.0, 600.0))
-        ..path(
-          includes: const <Offset>[Offset(800.0, 0.0)],
-          excludes: const <Offset>[Offset(780.0, 0.0)],
+        // Scrollbar thumb background fill.
+        ..rrect(
+          rrect: RRect.fromRectAndCorners(
+            const Rect.fromLTRB(780.0, 0.0, 800.0, 360.0),
+            topLeft: const Radius.circular(8.0),
+          ),
         ),
     );
   });


### PR DESCRIPTION
For ShapeBorder instances with preferPaintInterior=true, use paintInterior rather than drawing the path from getOuterPath.

From https://api.flutter.dev/flutter/painting/ShapeBorder/paintInterior.html:
> On [ShapeBorder](https://api.flutter.dev/flutter/painting/ShapeBorder-class.html) subclasses whose [preferPaintInterior](https://api.flutter.dev/flutter/painting/ShapeBorder/preferPaintInterior.html) method returns true, this should be faster than using [Canvas.drawPath](https://api.flutter.dev/flutter/dart-ui/Canvas/drawPath.html) with the path provided by [getOuterPath](https://api.flutter.dev/flutter/painting/ShapeBorder/getOuterPath.html).

> [paintInterior](https://api.flutter.dev/flutter/painting/ShapeBorder/paintInterior.html) is semantically equivalent to (i.e. renders the same pixels as) calling [Canvas.drawPath](https://api.flutter.dev/flutter/dart-ui/Canvas/drawPath.html) with the same [Paint](https://api.flutter.dev/flutter/dart-ui/Paint-class.html) and the [Path](https://api.flutter.dev/flutter/dart-ui/Path-class.html) returned from [getOuterPath](https://api.flutter.dev/flutter/painting/ShapeBorder/getOuterPath.html)

Part of #183044

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
