### PR TITLE
Remove workaround for fake impeller images in iOS simulator.

### DIFF
--- a/engine/src/flutter/display_list/image/dl_image.h
+++ b/engine/src/flutter/display_list/image/dl_image.h
@@ -120,10 +120,6 @@ class DlImage : public SkRefCnt {
   ///             image.
   virtual std::optional<std::string> get_error() const;
 
-#if FML_OS_IOS_SIMULATOR
-  virtual bool IsFakeImage() const { return false; }
-#endif  // FML_OS_IOS_SIMULATOR
-
   bool Equals(const DlImage* other) const {
     if (!other) {
       return false;

--- a/engine/src/flutter/impeller/display_list/dl_image_impeller.cc
+++ b/engine/src/flutter/impeller/display_list/dl_image_impeller.cc
@@ -9,17 +9,6 @@
 
 namespace impeller {
 
-#if FML_OS_IOS_SIMULATOR
-sk_sp<DlImageImpeller> DlImageImpeller::Make(std::shared_ptr<Texture> texture,
-                                             OwningContext owning_context,
-                                             bool is_fake_image) {
-  if (!texture && !is_fake_image) {
-    return nullptr;
-  }
-  return sk_sp<DlImageImpeller>(
-      new DlImageImpeller(std::move(texture), owning_context, is_fake_image));
-}
-#else
 sk_sp<DlImageImpeller> DlImageImpeller::Make(std::shared_ptr<Texture> texture,
                                              OwningContext owning_context) {
   if (!texture) {
@@ -28,7 +17,6 @@ sk_sp<DlImageImpeller> DlImageImpeller::Make(std::shared_ptr<Texture> texture,
   return sk_sp<DlImageImpeller>(
       new DlImageImpeller(std::move(texture), owning_context));
 }
-#endif  // FML_OS_IOS_SIMULATOR
 
 sk_sp<DlImageImpeller> DlImageImpeller::MakeFromYUVTextures(
     AiksContext* aiks_context,
@@ -65,20 +53,8 @@ sk_sp<DlImageImpeller> DlImageImpeller::MakeFromYUVTextures(
 }
 
 DlImageImpeller::DlImageImpeller(std::shared_ptr<Texture> texture,
-                                 OwningContext owning_context
-#ifdef FML_OS_IOS_SIMULATOR
-                                 ,
-                                 bool is_fake_image
-#endif  // FML_OS_IOS_SIMULATOR
-                                 )
-    : texture_(std::move(texture)),
-      owning_context_(owning_context)
-#ifdef FML_OS_IOS_SIMULATOR
-      ,
-      is_fake_image_(is_fake_image)
-#endif  // #ifdef FML_OS_IOS_SIMULATOR
-{
-}
+                                 OwningContext owning_context)
+    : texture_(std::move(texture)), owning_context_(owning_context) {}
 
 // |DlImage|
 DlImageImpeller::~DlImageImpeller() = default;

--- a/engine/src/flutter/impeller/display_list/dl_image_impeller.h
+++ b/engine/src/flutter/impeller/display_list/dl_image_impeller.h
@@ -16,12 +16,7 @@ class DlImageImpeller final : public flutter::DlImage {
  public:
   static sk_sp<DlImageImpeller> Make(
       std::shared_ptr<Texture> texture,
-      OwningContext owning_context = OwningContext::kIO
-#if FML_OS_IOS_SIMULATOR
-      ,
-      bool is_fake_image = false
-#endif  // FML_OS_IOS_SIMULATOR
-  );
+      OwningContext owning_context = OwningContext::kIO);
 
   static sk_sp<DlImageImpeller> MakeFromYUVTextures(
       AiksContext* aiks_context,
@@ -56,25 +51,12 @@ class DlImageImpeller final : public flutter::DlImage {
   // |DlImage|
   OwningContext owning_context() const override { return owning_context_; }
 
-#if FML_OS_IOS_SIMULATOR
-  // |DlImage|
-  bool IsFakeImage() const override { return is_fake_image_; }
-#endif  // FML_OS_IOS_SIMULATOR
-
  private:
   std::shared_ptr<Texture> texture_;
   OwningContext owning_context_;
-#if FML_OS_IOS_SIMULATOR
-  bool is_fake_image_ = false;
-#endif  // FML_OS_IOS_SIMULATOR
 
   explicit DlImageImpeller(std::shared_ptr<Texture> texture,
-                           OwningContext owning_context = OwningContext::kIO
-#if FML_OS_IOS_SIMULATOR
-                           ,
-                           bool is_fake_image = false
-#endif  // FML_OS_IOS_SIMULATOR
-  );
+                           OwningContext owning_context = OwningContext::kIO);
 
   DlImageImpeller(const DlImageImpeller&) = delete;
 

--- a/engine/src/flutter/lib/ui/painting/image_encoding.cc
+++ b/engine/src/flutter/lib/ui/painting/image_encoding.cc
@@ -178,14 +178,6 @@ Dart_Handle EncodeImage(CanvasImage* canvas_image,
   auto callback = std::make_unique<DartPersistentValue>(
       tonic::DartState::Current(), callback_handle);
 
-#if IMPELLER_SUPPORTS_RENDERING && FML_OS_IOS_SIMULATOR
-  if (canvas_image->image()->IsFakeImage()) {
-    sk_sp<SkData> data = SkData::MakeEmpty();
-    InvokeDataCallback(std::move(callback), data);
-    return Dart_Null();
-  }
-#endif  // IMPELLER_SUPPORTS_RENDERING && FML_OS_IOS_SIMULATOR
-
   const auto& task_runners = UIDartState::Current()->GetTaskRunners();
 
   // The static leak checker gets confused by the use of fml::MakeCopyable.

--- a/engine/src/flutter/shell/common/snapshot_controller_impeller.cc
+++ b/engine/src/flutter/shell/common/snapshot_controller_impeller.cc
@@ -136,25 +136,10 @@ void SnapshotControllerImpeller::MakeRasterSnapshot(
                   },
                   [callback]() { callback(nullptr); });
             } else {
-#if FML_OS_IOS_SIMULATOR
-              callback(impeller::DlImageImpeller::Make(
-                  nullptr, DlImage::OwningContext::kRaster,
-                  /*is_fake_image=*/true));
-#else
               callback(nullptr);
-
-#endif  // FML_OS_IOS_SIMULATOR
             }
           })
           .SetIfFalse([&] {
-#if FML_OS_IOS_SIMULATOR
-            if (!GetDelegate().GetAiksContext()) {
-              callback(impeller::DlImageImpeller::Make(
-                  nullptr, DlImage::OwningContext::kRaster,
-                  /*is_fake_image=*/true));
-              return;
-            }
-#endif
             callback(DoMakeRasterSnapshot(display_list, picture_size,
                                           GetDelegate(), pixel_format));
           }));


### PR DESCRIPTION
This is a draft that tests removing the fake impeller images workaround for the iOS simulator, which was originally added in [this PR](https://github.com/flutter/engine/pull/54974)

We've confirmed that this workaround is no longer needed.