### PR TITLE
Fixes a flake in reload shaders tests

### DIFF
--- a/engine/src/flutter/testing/dart/vm_service/shader_reload_test.dart
+++ b/engine/src/flutter/testing/dart/vm_service/shader_reload_test.dart
@@ -76,7 +76,7 @@ void main() {
     final Uint8List sourceA = File(shaderSrcA).readAsBytesSync();
     final Uint8List sourceB = File(shaderSrcB).readAsBytesSync();
 
-    fileC.writeAsBytesSync(sourceA, flush: true);
+    _deleteAndWrite(fileC, sourceA);
 
     try {
       final FragmentProgram program = await FragmentProgram.fromAsset(testAssetName);
@@ -84,7 +84,7 @@ void main() {
       final UniformFloatSlot slot = shader.getUniformFloat('iVec2Uniform');
       expect(slot.shaderIndex, 1);
 
-      fileC.writeAsBytesSync(sourceB, flush: true);
+      _deleteAndWrite(fileC, sourceB);
       await _performReload(testAssetName);
       expect(slot.shaderIndex, 5);
     } finally {
@@ -110,7 +110,7 @@ void main() {
     final Uint8List sourceA = File(shaderSrcA).readAsBytesSync();
     final Uint8List sourceB = File(shaderSrcB).readAsBytesSync();
 
-    fileC.writeAsBytesSync(sourceA, flush: true);
+    _deleteAndWrite(fileC, sourceA);
 
     try {
       final FragmentProgram program = await FragmentProgram.fromAsset(testAssetName);
@@ -118,7 +118,7 @@ void main() {
       final UniformFloatSlot slot = shader.getUniformFloat('iMat2Uniform', 3);
       expect(slot.shaderIndex, 6);
 
-      fileC.writeAsBytesSync(sourceB, flush: true);
+      _deleteAndWrite(fileC, sourceB);
       await _performReload(testAssetName);
       expect(slot.shaderIndex, 7);
       // Make sure there is no crash here.
@@ -146,7 +146,7 @@ void main() {
     final Uint8List sourceA = File(shaderSrcA).readAsBytesSync();
     final Uint8List sourceB = File(shaderSrcB).readAsBytesSync();
 
-    fileC.writeAsBytesSync(sourceA, flush: true);
+    _deleteAndWrite(fileC, sourceA);
 
     try {
       final FragmentProgram program = await FragmentProgram.fromAsset(testAssetName);
@@ -154,7 +154,7 @@ void main() {
       final UniformFloatSlot slotA = shader.getUniformFloat('iFloatUniform');
       slotA.set(1.0);
 
-      fileC.writeAsBytesSync(sourceB, flush: true);
+      _deleteAndWrite(fileC, sourceB);
       await _performReload(testAssetName);
 
       final UniformFloatSlot slotB = shader.getUniformFloat('iFloatUniformRenamed');
@@ -184,7 +184,7 @@ void main() {
     final Uint8List sourceA = File(shaderSrcA).readAsBytesSync();
     final Uint8List sourceB = File(shaderSrcB).readAsBytesSync();
 
-    fileC.writeAsBytesSync(sourceA, flush: true);
+    _deleteAndWrite(fileC, sourceA);
 
     try {
       final FragmentProgram program = await FragmentProgram.fromAsset(testAssetName);
@@ -192,7 +192,7 @@ void main() {
       final ImageSamplerSlot slot = shader.getImageSampler('tex_a');
       expect(slot.shaderIndex, 0);
 
-      fileC.writeAsBytesSync(sourceB, flush: true);
+      _deleteAndWrite(fileC, sourceB);
       await _performReload(testAssetName);
       expect(slot.shaderIndex, 1);
     } finally {
@@ -204,3 +204,12 @@ void main() {
 }
 
 void _use(Shader shader) {}
+
+/// Delete the file first, if it exists, to ensure the engine doesn't attempt
+/// to read a memory-mapped file that is actively being truncated and written to.
+void _deleteAndWrite(File file, Uint8List bytes) {
+  if (file.existsSync()) {
+    file.deleteSync();
+  }
+  file.writeAsBytesSync(bytes, flush: true);
+}

--- a/engine/src/flutter/testing/dart/vm_service/shader_reload_test.dart
+++ b/engine/src/flutter/testing/dart/vm_service/shader_reload_test.dart
@@ -76,7 +76,7 @@ void main() {
     final Uint8List sourceA = File(shaderSrcA).readAsBytesSync();
     final Uint8List sourceB = File(shaderSrcB).readAsBytesSync();
 
-    _deleteAndWrite(fileC, sourceA);
+    await _deleteAndWrite(fileC, sourceA);
 
     try {
       final FragmentProgram program = await FragmentProgram.fromAsset(testAssetName);
@@ -84,7 +84,7 @@ void main() {
       final UniformFloatSlot slot = shader.getUniformFloat('iVec2Uniform');
       expect(slot.shaderIndex, 1);
 
-      _deleteAndWrite(fileC, sourceB);
+      await _deleteAndWrite(fileC, sourceB);
       await _performReload(testAssetName);
       expect(slot.shaderIndex, 5);
     } finally {
@@ -110,7 +110,7 @@ void main() {
     final Uint8List sourceA = File(shaderSrcA).readAsBytesSync();
     final Uint8List sourceB = File(shaderSrcB).readAsBytesSync();
 
-    _deleteAndWrite(fileC, sourceA);
+    await _deleteAndWrite(fileC, sourceA);
 
     try {
       final FragmentProgram program = await FragmentProgram.fromAsset(testAssetName);
@@ -118,7 +118,7 @@ void main() {
       final UniformFloatSlot slot = shader.getUniformFloat('iMat2Uniform', 3);
       expect(slot.shaderIndex, 6);
 
-      _deleteAndWrite(fileC, sourceB);
+      await _deleteAndWrite(fileC, sourceB);
       await _performReload(testAssetName);
       expect(slot.shaderIndex, 7);
       // Make sure there is no crash here.
@@ -146,7 +146,7 @@ void main() {
     final Uint8List sourceA = File(shaderSrcA).readAsBytesSync();
     final Uint8List sourceB = File(shaderSrcB).readAsBytesSync();
 
-    _deleteAndWrite(fileC, sourceA);
+    await _deleteAndWrite(fileC, sourceA);
 
     try {
       final FragmentProgram program = await FragmentProgram.fromAsset(testAssetName);
@@ -154,7 +154,7 @@ void main() {
       final UniformFloatSlot slotA = shader.getUniformFloat('iFloatUniform');
       slotA.set(1.0);
 
-      _deleteAndWrite(fileC, sourceB);
+      await _deleteAndWrite(fileC, sourceB);
       await _performReload(testAssetName);
 
       final UniformFloatSlot slotB = shader.getUniformFloat('iFloatUniformRenamed');
@@ -184,7 +184,7 @@ void main() {
     final Uint8List sourceA = File(shaderSrcA).readAsBytesSync();
     final Uint8List sourceB = File(shaderSrcB).readAsBytesSync();
 
-    _deleteAndWrite(fileC, sourceA);
+    await _deleteAndWrite(fileC, sourceA);
 
     try {
       final FragmentProgram program = await FragmentProgram.fromAsset(testAssetName);
@@ -192,7 +192,7 @@ void main() {
       final ImageSamplerSlot slot = shader.getImageSampler('tex_a');
       expect(slot.shaderIndex, 0);
 
-      _deleteAndWrite(fileC, sourceB);
+      await _deleteAndWrite(fileC, sourceB);
       await _performReload(testAssetName);
       expect(slot.shaderIndex, 1);
     } finally {
@@ -207,9 +207,15 @@ void _use(Shader shader) {}
 
 /// Delete the file first, if it exists, to ensure the engine doesn't attempt
 /// to read a memory-mapped file that is actively being truncated and written to.
-void _deleteAndWrite(File file, Uint8List bytes) {
+Future<void> _deleteAndWrite(File file, Uint8List bytes) async {
   if (file.existsSync()) {
     file.deleteSync();
   }
   file.writeAsBytesSync(bytes, flush: true);
+  // Allow time for the macOS file system metadata caching to settle.
+  // Otherwise, the engine's subsequent `fstat` may read a `0` st_size
+  // or `openat` may fail entirely due to APFS asynchronous directory updates.
+  //
+  // renameSync() was tried but it was not sufficient to fix the issue.
+  await Future.delayed(const Duration(milliseconds: 100));
 }

--- a/engine/src/flutter/testing/dart/vm_service/shader_reload_test.dart
+++ b/engine/src/flutter/testing/dart/vm_service/shader_reload_test.dart
@@ -217,5 +217,5 @@ Future<void> _deleteAndWrite(File file, Uint8List bytes) async {
   // or `openat` may fail entirely due to APFS asynchronous directory updates.
   //
   // renameSync() was tried but it was not sufficient to fix the issue.
-  await Future.delayed(const Duration(milliseconds: 100));
+  await Future<void>.delayed(const Duration(milliseconds: 100));
 }


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/184265

This fixes an oddity related to mmap files.  A delay had to be introduced in the test because of oddities with the filesystem.  I tried a few tricks to get it to work without the delay but this is the only way I could get it to work.

testing: has existing test, removes a flake

I tested it manually locally:
```
for i in {1..30}; do echo "Running iteration: $i"; ./testing/run_tests.py --type=dart --dart-filter=shader_reload_test.dart --variant host_debug_unopt_arm64; done
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
