### PR TITLE
[web] Make it safe to call dispose multiple times on a CkSurface

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/surface.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/surface.dart
@@ -223,6 +223,7 @@ abstract class CkSurface extends Surface {
   @override
   void dispose() {
     _skSurface?.dispose();
+    _skSurface = null;
   }
 
   @override

--- a/engine/src/flutter/lib/web_ui/test/canvaskit/surface_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/canvaskit/surface_test.dart
@@ -139,6 +139,17 @@ void testMain() {
       final SkSurface? skSurface2 = surface.skSurface;
       expect(skSurface1, same(skSurface2));
     });
+
+    test('CkSurface dispose is idempotent', () async {
+      CkSurface.debugForceGLFailure = true;
+      final surface = CkOffscreenSurface(OffscreenCanvasProvider());
+      await surface.initialized;
+
+      // Check that it is safe to call dispose multiple times on the same
+      // surface.
+      surface.dispose();
+      surface.dispose();
+    });
   });
 }
 


### PR DESCRIPTION
References to a CkSurface instance may be held by multiple users.  Specifically, the PlatformViewEmbedder and the DisplayCanvasFactory can use the same surface, and both classes will dispose that surface during a hot restart.

This PR changes CkSurface.dispose to set _skSurface to null so that future calls to dispose will do nothing.

See https://github.com/flutter/flutter/issues/183923