### PR TITLE
Remove clipboard_utils cross-imports from material and cupertino tests

### DIFF
--- a/packages/flutter/test/cupertino/adaptive_text_selection_toolbar_test.dart
+++ b/packages/flutter/test/cupertino/adaptive_text_selection_toolbar_test.dart
@@ -7,8 +7,8 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/clipboard_utils.dart';
 import '../widgets/text_selection_toolbar_utils.dart';
+import 'clipboard_utils.dart';
 import 'live_text_utils.dart';
 
 void main() {

--- a/packages/flutter/test/cupertino/clipboard_utils.dart
+++ b/packages/flutter/test/cupertino/clipboard_utils.dart
@@ -28,7 +28,6 @@ class MockClipboard {
         return <String, bool>{'value': text != null && text.isNotEmpty};
       case 'Clipboard.setData':
         clipboardData = methodCall.arguments as Map<String, dynamic>;
-        break;
     }
     return null;
   }

--- a/packages/flutter/test/cupertino/clipboard_utils.dart
+++ b/packages/flutter/test/cupertino/clipboard_utils.dart
@@ -1,0 +1,35 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/services.dart';
+
+/// A mock clipboard implementation for testing.
+class MockClipboard {
+  /// Creates a [MockClipboard].
+  MockClipboard({this.hasStringsThrows = false});
+
+  /// Whether [Clipboard.hasStrings] should throw an exception.
+  final bool hasStringsThrows;
+
+  /// The current clipboard data.
+  Map<String, dynamic> clipboardData = <String, dynamic>{'text': null};
+
+  /// Handles a platform method call for clipboard operations.
+  Future<Object?> handleMethodCall(MethodCall methodCall) async {
+    switch (methodCall.method) {
+      case 'Clipboard.getData':
+        return clipboardData;
+      case 'Clipboard.hasStrings':
+        if (hasStringsThrows) {
+          throw Exception();
+        }
+        final text = clipboardData['text'] as String?;
+        return <String, bool>{'value': text != null && text.isNotEmpty};
+      case 'Clipboard.setData':
+        clipboardData = methodCall.arguments as Map<String, dynamic>;
+        break;
+    }
+    return null;
+  }
+}

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -23,9 +23,9 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/clipboard_utils.dart';
 import '../widgets/semantics_tester.dart';
 import '../widgets/text_selection_toolbar_utils.dart';
+import 'clipboard_utils.dart';
 import 'editable_text_utils.dart';
 import 'live_text_utils.dart';
 

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -235,42 +235,40 @@ void main() {
     await Clipboard.setData(const ClipboardData(text: 'Clipboard data'));
   });
 
-  testWidgets(
-    'Live Text button shows and hides correctly when LiveTextStatus changes',
-    (WidgetTester tester) async {
-      final liveTextInputTester = LiveTextInputTester();
-      addTearDown(liveTextInputTester.dispose);
+  testWidgets('Live Text button shows and hides correctly when LiveTextStatus changes', (
+    WidgetTester tester,
+  ) async {
+    final liveTextInputTester = LiveTextInputTester();
+    addTearDown(liveTextInputTester.dispose);
 
-      final controller = TextEditingController(text: '');
-      addTearDown(controller.dispose);
-      const Key key = ValueKey<String>('TextField');
-      final focusNode = FocusNode();
-      addTearDown(focusNode.dispose);
-      final Widget app = CupertinoApp(
-        home: CupertinoPageScaffold(
-          child: Center(
-            child: CupertinoTextField(key: key, controller: controller, focusNode: focusNode),
-          ),
+    final controller = TextEditingController(text: '');
+    addTearDown(controller.dispose);
+    const Key key = ValueKey<String>('TextField');
+    final focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+    final Widget app = CupertinoApp(
+      home: CupertinoPageScaffold(
+        child: Center(
+          child: CupertinoTextField(key: key, controller: controller, focusNode: focusNode),
         ),
-      );
+      ),
+    );
 
-      liveTextInputTester.mockLiveTextInputEnabled = true;
-      await tester.pumpWidget(app);
-      focusNode.requestFocus();
-      await tester.pumpAndSettle();
+    liveTextInputTester.mockLiveTextInputEnabled = true;
+    await tester.pumpWidget(app);
+    focusNode.requestFocus();
+    await tester.pumpAndSettle();
 
-      final Finder textFinder = find.byType(EditableText);
-      await tester.longPress(textFinder);
-      await tester.pumpAndSettle();
-      expect(findLiveTextButton(), kIsWeb ? findsNothing : findsOneWidget);
+    final Finder textFinder = find.byType(EditableText);
+    await tester.longPress(textFinder);
+    await tester.pumpAndSettle();
+    expect(findLiveTextButton(), kIsWeb ? findsNothing : findsOneWidget);
 
-      liveTextInputTester.mockLiveTextInputEnabled = false;
-      await tester.longPress(textFinder);
-      await tester.pumpAndSettle();
-      expect(findLiveTextButton(), findsNothing);
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-  );
+    liveTextInputTester.mockLiveTextInputEnabled = false;
+    await tester.longPress(textFinder);
+    await tester.pumpAndSettle();
+    expect(findLiveTextButton(), findsNothing);
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
 
   testWidgets(
     'Look Up shows up on iOS only',
@@ -533,71 +531,69 @@ void main() {
     );
   });
 
-  testWidgets(
-    'Activates the text field when receives semantics focus on desktops',
-    (WidgetTester tester) async {
-      final semantics = SemanticsTester(tester);
-      final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;
-      final focusNode = FocusNode();
-      addTearDown(focusNode.dispose);
-      await tester.pumpWidget(CupertinoApp(home: CupertinoTextField(focusNode: focusNode)));
-      expect(
-        semantics,
-        hasSemantics(
-          TestSemantics.root(
-            children: <TestSemantics>[
-              TestSemantics(
-                id: 1,
-                textDirection: TextDirection.ltr,
-                children: <TestSemantics>[
-                  TestSemantics(
-                    id: 2,
-                    children: <TestSemantics>[
-                      TestSemantics(
-                        id: 3,
-                        flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
-                        children: <TestSemantics>[
-                          TestSemantics(
-                            id: 4,
-                            inputType: ui.SemanticsInputType.text,
-                            flags: <SemanticsFlag>[
-                              SemanticsFlag.isTextField,
-                              SemanticsFlag.isFocusable,
-                              SemanticsFlag.hasEnabledState,
-                              SemanticsFlag.isEnabled,
-                            ],
-                            actions: <SemanticsAction>[
-                              SemanticsAction.tap,
-                              SemanticsAction.focus,
-                              SemanticsAction.didGainAccessibilityFocus,
-                              SemanticsAction.didLoseAccessibilityFocus,
-                            ],
-                            textDirection: TextDirection.ltr,
-                          ),
-                        ],
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            ],
-          ),
-          ignoreRect: true,
-          ignoreTransform: true,
+  testWidgets('Activates the text field when receives semantics focus on desktops', (
+    WidgetTester tester,
+  ) async {
+    final semantics = SemanticsTester(tester);
+    final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;
+    final focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+    await tester.pumpWidget(CupertinoApp(home: CupertinoTextField(focusNode: focusNode)));
+    expect(
+      semantics,
+      hasSemantics(
+        TestSemantics.root(
+          children: <TestSemantics>[
+            TestSemantics(
+              id: 1,
+              textDirection: TextDirection.ltr,
+              children: <TestSemantics>[
+                TestSemantics(
+                  id: 2,
+                  children: <TestSemantics>[
+                    TestSemantics(
+                      id: 3,
+                      flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
+                      children: <TestSemantics>[
+                        TestSemantics(
+                          id: 4,
+                          inputType: ui.SemanticsInputType.text,
+                          flags: <SemanticsFlag>[
+                            SemanticsFlag.isTextField,
+                            SemanticsFlag.isFocusable,
+                            SemanticsFlag.hasEnabledState,
+                            SemanticsFlag.isEnabled,
+                          ],
+                          actions: <SemanticsAction>[
+                            SemanticsAction.tap,
+                            SemanticsAction.focus,
+                            SemanticsAction.didGainAccessibilityFocus,
+                            SemanticsAction.didLoseAccessibilityFocus,
+                          ],
+                          textDirection: TextDirection.ltr,
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ],
         ),
-      );
+        ignoreRect: true,
+        ignoreTransform: true,
+      ),
+    );
 
-      expect(focusNode.hasFocus, isFalse);
-      semanticsOwner.performAction(4, SemanticsAction.didGainAccessibilityFocus);
-      await tester.pumpAndSettle();
-      expect(focusNode.hasFocus, isTrue);
-      semanticsOwner.performAction(4, SemanticsAction.didLoseAccessibilityFocus);
-      await tester.pumpAndSettle();
-      expect(focusNode.hasFocus, isFalse);
-      semantics.dispose();
-    },
-    variant: TargetPlatformVariant.desktop(),
-  );
+    expect(focusNode.hasFocus, isFalse);
+    semanticsOwner.performAction(4, SemanticsAction.didGainAccessibilityFocus);
+    await tester.pumpAndSettle();
+    expect(focusNode.hasFocus, isTrue);
+    semanticsOwner.performAction(4, SemanticsAction.didLoseAccessibilityFocus);
+    await tester.pumpAndSettle();
+    expect(focusNode.hasFocus, isFalse);
+    semantics.dispose();
+  }, variant: TargetPlatformVariant.desktop());
 
   testWidgets('takes available space horizontally and takes intrinsic space vertically no-strut', (
     WidgetTester tester,
@@ -657,45 +653,41 @@ void main() {
     );
   });
 
-  testWidgets(
-    'selection handles color respects CupertinoTheme',
-    (WidgetTester tester) async {
-      // Regression test for https://github.com/flutter/flutter/issues/74890.
-      const expectedSelectionHandleColor = Color.fromARGB(255, 10, 200, 255);
+  testWidgets('selection handles color respects CupertinoTheme', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/74890.
+    const expectedSelectionHandleColor = Color.fromARGB(255, 10, 200, 255);
 
-      final controller = TextEditingController(text: 'Some text.');
-      addTearDown(controller.dispose);
+    final controller = TextEditingController(text: 'Some text.');
+    addTearDown(controller.dispose);
 
-      await tester.pumpWidget(
-        CupertinoApp(
-          theme: const CupertinoThemeData(selectionHandleColor: CupertinoColors.destructiveRed),
-          home: Center(
-            child: CupertinoTheme(
-              data: const CupertinoThemeData(selectionHandleColor: expectedSelectionHandleColor),
-              child: CupertinoTextField(controller: controller),
-            ),
+    await tester.pumpWidget(
+      CupertinoApp(
+        theme: const CupertinoThemeData(selectionHandleColor: CupertinoColors.destructiveRed),
+        home: Center(
+          child: CupertinoTheme(
+            data: const CupertinoThemeData(selectionHandleColor: expectedSelectionHandleColor),
+            child: CupertinoTextField(controller: controller),
           ),
         ),
-      );
+      ),
+    );
 
-      await tester.tapAt(textOffsetToPosition(tester, 0));
-      await tester.pump();
-      await tester.tapAt(textOffsetToPosition(tester, 0));
-      await tester.pumpAndSettle();
-      final Iterable<RenderBox> boxes = tester.renderObjectList<RenderBox>(
-        find.descendant(
-          of: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_SelectionHandleOverlay'),
-          matching: find.byType(CustomPaint),
-        ),
-      );
-      expect(boxes.length, 2);
+    await tester.tapAt(textOffsetToPosition(tester, 0));
+    await tester.pump();
+    await tester.tapAt(textOffsetToPosition(tester, 0));
+    await tester.pumpAndSettle();
+    final Iterable<RenderBox> boxes = tester.renderObjectList<RenderBox>(
+      find.descendant(
+        of: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_SelectionHandleOverlay'),
+        matching: find.byType(CustomPaint),
+      ),
+    );
+    expect(boxes.length, 2);
 
-      for (final box in boxes) {
-        expect(box, paints..path(color: expectedSelectionHandleColor));
-      }
-    },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-  );
+    for (final box in boxes) {
+      expect(box, paints..path(color: expectedSelectionHandleColor));
+    }
+  }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
   testWidgets('uses DefaultSelectionStyle for selection and cursor colors if provided', (
     WidgetTester tester,
@@ -1931,33 +1923,29 @@ void main() {
     skip: isContextMenuProvidedByPlatform,
   );
 
-  testWidgets(
-    'tap moves cursor to the edge of the word it tapped on',
-    (WidgetTester tester) async {
-      final controller = TextEditingController(text: 'Atwater Peel Sherbrooke Bonaventure');
-      addTearDown(controller.dispose);
-      await tester.pumpWidget(
-        CupertinoApp(
-          home: Center(child: CupertinoTextField(controller: controller)),
-        ),
-      );
+  testWidgets('tap moves cursor to the edge of the word it tapped on', (WidgetTester tester) async {
+    final controller = TextEditingController(text: 'Atwater Peel Sherbrooke Bonaventure');
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(child: CupertinoTextField(controller: controller)),
+      ),
+    );
 
-      final Offset textFieldStart = tester.getTopLeft(find.byType(CupertinoTextField));
+    final Offset textFieldStart = tester.getTopLeft(find.byType(CupertinoTextField));
 
-      await tester.tapAt(textFieldStart + const Offset(50.0, 5.0));
-      await tester.pump();
+    await tester.tapAt(textFieldStart + const Offset(50.0, 5.0));
+    await tester.pump();
 
-      // We moved the cursor.
-      expect(
-        controller.selection,
-        const TextSelection.collapsed(offset: 7, affinity: TextAffinity.upstream),
-      );
+    // We moved the cursor.
+    expect(
+      controller.selection,
+      const TextSelection.collapsed(offset: 7, affinity: TextAffinity.upstream),
+    );
 
-      // But don't trigger the toolbar.
-      expect(find.byType(CupertinoButton), findsNothing);
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-  );
+    // But don't trigger the toolbar.
+    expect(find.byType(CupertinoButton), findsNothing);
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
 
   testWidgets(
     'slow double tap does not trigger double tap',
@@ -1998,155 +1986,149 @@ void main() {
     }),
   );
 
-  testWidgets(
-    'Tapping on a collapsed selection toggles the toolbar',
-    (WidgetTester tester) async {
-      final controller = TextEditingController(
-        text:
-            'Atwater Peel Sherbrooke Bonaventure Angrignon Peel Côte-des-Neigse Atwater Peel Sherbrooke Bonaventure Angrignon Peel Côte-des-Neiges',
-      );
-      addTearDown(controller.dispose);
-      // On iOS/iPadOS, during a tap we select the edge of the word closest to the tap.
-      await tester.pumpWidget(
-        CupertinoApp(
-          home: Center(child: CupertinoTextField(controller: controller, maxLines: 2)),
-        ),
-      );
+  testWidgets('Tapping on a collapsed selection toggles the toolbar', (WidgetTester tester) async {
+    final controller = TextEditingController(
+      text:
+          'Atwater Peel Sherbrooke Bonaventure Angrignon Peel Côte-des-Neigse Atwater Peel Sherbrooke Bonaventure Angrignon Peel Côte-des-Neiges',
+    );
+    addTearDown(controller.dispose);
+    // On iOS/iPadOS, during a tap we select the edge of the word closest to the tap.
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(child: CupertinoTextField(controller: controller, maxLines: 2)),
+      ),
+    );
 
-      final double lineHeight = findRenderEditable(tester).preferredLineHeight;
-      final Offset begPos = textOffsetToPosition(tester, 0);
-      final Offset endPos =
-          textOffsetToPosition(tester, 35) +
-          const Offset(
-            200.0,
-            0.0,
-          ); // Index of 'Bonaventure|' + Offset(200.0,0), which is at the end of the first line.
-      final Offset vPos = textOffsetToPosition(tester, 29); // Index of 'Bonav|enture'.
-      final Offset wPos = textOffsetToPosition(tester, 3); // Index of 'Atw|ater'.
+    final double lineHeight = findRenderEditable(tester).preferredLineHeight;
+    final Offset begPos = textOffsetToPosition(tester, 0);
+    final Offset endPos =
+        textOffsetToPosition(tester, 35) +
+        const Offset(
+          200.0,
+          0.0,
+        ); // Index of 'Bonaventure|' + Offset(200.0,0), which is at the end of the first line.
+    final Offset vPos = textOffsetToPosition(tester, 29); // Index of 'Bonav|enture'.
+    final Offset wPos = textOffsetToPosition(tester, 3); // Index of 'Atw|ater'.
 
-      // This tap just puts the cursor somewhere different than where the double
-      // tap will occur to test that the double tap moves the existing cursor first.
-      await tester.tapAt(wPos);
-      await tester.pump(const Duration(milliseconds: 500));
+    // This tap just puts the cursor somewhere different than where the double
+    // tap will occur to test that the double tap moves the existing cursor first.
+    await tester.tapAt(wPos);
+    await tester.pump(const Duration(milliseconds: 500));
 
-      await tester.tapAt(vPos);
-      await tester.pump(const Duration(milliseconds: 500));
-      // First tap moved the cursor. Here we tap the position where 'v' is located.
-      // On iOS this will select the closest word edge, in this case the cursor is placed
-      // at the end of the word 'Bonaventure|'.
-      expect(controller.selection.isCollapsed, true);
-      expect(controller.selection.baseOffset, 35);
-      expect(find.byType(CupertinoButton), findsNothing);
+    await tester.tapAt(vPos);
+    await tester.pump(const Duration(milliseconds: 500));
+    // First tap moved the cursor. Here we tap the position where 'v' is located.
+    // On iOS this will select the closest word edge, in this case the cursor is placed
+    // at the end of the word 'Bonaventure|'.
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, 35);
+    expect(find.byType(CupertinoButton), findsNothing);
 
-      await tester.tapAt(vPos);
-      await tester.pumpAndSettle(const Duration(milliseconds: 500));
-      // Second tap toggles the toolbar. Here we tap on 'v' again, and select the word edge. Since
-      // the selection has not changed we toggle the toolbar.
-      expect(controller.selection.isCollapsed, true);
-      expect(controller.selection.baseOffset, 35);
-      expectCupertinoToolbarForCollapsedSelection();
+    await tester.tapAt(vPos);
+    await tester.pumpAndSettle(const Duration(milliseconds: 500));
+    // Second tap toggles the toolbar. Here we tap on 'v' again, and select the word edge. Since
+    // the selection has not changed we toggle the toolbar.
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, 35);
+    expectCupertinoToolbarForCollapsedSelection();
 
-      // Tap the 'v' position again to hide the toolbar.
-      await tester.tapAt(vPos);
-      await tester.pumpAndSettle();
-      expect(controller.selection.isCollapsed, true);
-      expect(controller.selection.baseOffset, 35);
-      expect(find.byType(CupertinoButton), findsNothing);
+    // Tap the 'v' position again to hide the toolbar.
+    await tester.tapAt(vPos);
+    await tester.pumpAndSettle();
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, 35);
+    expect(find.byType(CupertinoButton), findsNothing);
 
-      // Long press at the end of the first line to move the cursor to the end of the first line
-      // where the word wrap is. Since there is a word wrap here, and the direction of the text is LTR,
-      // the TextAffinity will be upstream and against the natural direction. The toolbar is also
-      // shown after a long press.
-      await tester.longPressAt(endPos);
-      await tester.pumpAndSettle(const Duration(milliseconds: 500));
-      expect(controller.selection.isCollapsed, true);
-      expect(controller.selection.baseOffset, 46);
-      expect(controller.selection.affinity, TextAffinity.upstream);
-      expectCupertinoToolbarForCollapsedSelection();
+    // Long press at the end of the first line to move the cursor to the end of the first line
+    // where the word wrap is. Since there is a word wrap here, and the direction of the text is LTR,
+    // the TextAffinity will be upstream and against the natural direction. The toolbar is also
+    // shown after a long press.
+    await tester.longPressAt(endPos);
+    await tester.pumpAndSettle(const Duration(milliseconds: 500));
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, 46);
+    expect(controller.selection.affinity, TextAffinity.upstream);
+    expectCupertinoToolbarForCollapsedSelection();
 
-      // Tap at the same position to toggle the toolbar.
-      await tester.tapAt(endPos);
-      await tester.pumpAndSettle();
-      expect(controller.selection.isCollapsed, true);
-      expect(controller.selection.baseOffset, 46);
-      expect(controller.selection.affinity, TextAffinity.upstream);
-      expectNoCupertinoToolbar();
+    // Tap at the same position to toggle the toolbar.
+    await tester.tapAt(endPos);
+    await tester.pumpAndSettle();
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, 46);
+    expect(controller.selection.affinity, TextAffinity.upstream);
+    expectNoCupertinoToolbar();
 
-      // Tap at the beginning of the second line to move the cursor to the front of the first word on the
-      // second line, where the word wrap is. Since there is a word wrap here, and the direction of the text is LTR,
-      // the TextAffinity will be downstream and following the natural direction. The toolbar will be hidden after this tap.
-      await tester.tapAt(begPos + Offset(0.0, lineHeight));
-      await tester.pumpAndSettle();
-      expect(controller.selection.isCollapsed, true);
-      expect(controller.selection.baseOffset, 46);
-      expect(controller.selection.affinity, TextAffinity.downstream);
-      expectNoCupertinoToolbar();
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-  );
+    // Tap at the beginning of the second line to move the cursor to the front of the first word on the
+    // second line, where the word wrap is. Since there is a word wrap here, and the direction of the text is LTR,
+    // the TextAffinity will be downstream and following the natural direction. The toolbar will be hidden after this tap.
+    await tester.tapAt(begPos + Offset(0.0, lineHeight));
+    await tester.pumpAndSettle();
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, 46);
+    expect(controller.selection.affinity, TextAffinity.downstream);
+    expectNoCupertinoToolbar();
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
 
-  testWidgets(
-    'Tapping on a non-collapsed selection toggles the toolbar and retains the selection',
-    (WidgetTester tester) async {
-      final controller = TextEditingController(text: 'Atwater Peel Sherbrooke Bonaventure');
-      addTearDown(controller.dispose);
-      // On iOS/iPadOS, during a tap we select the edge of the word closest to the tap.
-      await tester.pumpWidget(
-        CupertinoApp(
-          home: Center(child: CupertinoTextField(controller: controller)),
-        ),
-      );
+  testWidgets('Tapping on a non-collapsed selection toggles the toolbar and retains the selection', (
+    WidgetTester tester,
+  ) async {
+    final controller = TextEditingController(text: 'Atwater Peel Sherbrooke Bonaventure');
+    addTearDown(controller.dispose);
+    // On iOS/iPadOS, during a tap we select the edge of the word closest to the tap.
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(child: CupertinoTextField(controller: controller)),
+      ),
+    );
 
-      final Offset vPos = textOffsetToPosition(tester, 29); // Index of 'Bonav|enture'.
-      final Offset ePos =
-          textOffsetToPosition(tester, 35) +
-          const Offset(
-            7.0,
-            0.0,
-          ); // Index of 'Bonaventure|' + Offset(7.0,0), which taps slightly to the right of the end of the text.
-      final Offset wPos = textOffsetToPosition(tester, 3); // Index of 'Atw|ater'.
+    final Offset vPos = textOffsetToPosition(tester, 29); // Index of 'Bonav|enture'.
+    final Offset ePos =
+        textOffsetToPosition(tester, 35) +
+        const Offset(
+          7.0,
+          0.0,
+        ); // Index of 'Bonaventure|' + Offset(7.0,0), which taps slightly to the right of the end of the text.
+    final Offset wPos = textOffsetToPosition(tester, 3); // Index of 'Atw|ater'.
 
-      // This tap just puts the cursor somewhere different than where the double
-      // tap will occur to test that the double tap moves the existing cursor first.
-      await tester.tapAt(wPos);
-      await tester.pump(const Duration(milliseconds: 500));
+    // This tap just puts the cursor somewhere different than where the double
+    // tap will occur to test that the double tap moves the existing cursor first.
+    await tester.tapAt(wPos);
+    await tester.pump(const Duration(milliseconds: 500));
 
-      await tester.tapAt(vPos);
-      await tester.pump(const Duration(milliseconds: 50));
-      // First tap moved the cursor.
-      expect(controller.selection.isCollapsed, true);
-      expect(controller.selection.baseOffset, 35);
-      await tester.tapAt(vPos);
-      await tester.pumpAndSettle(const Duration(milliseconds: 500));
+    await tester.tapAt(vPos);
+    await tester.pump(const Duration(milliseconds: 50));
+    // First tap moved the cursor.
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, 35);
+    await tester.tapAt(vPos);
+    await tester.pumpAndSettle(const Duration(milliseconds: 500));
 
-      // Second tap selects the word around the cursor.
-      expect(controller.selection, const TextSelection(baseOffset: 24, extentOffset: 35));
+    // Second tap selects the word around the cursor.
+    expect(controller.selection, const TextSelection(baseOffset: 24, extentOffset: 35));
 
-      expectCupertinoToolbarForPartialSelection();
+    expectCupertinoToolbarForPartialSelection();
 
-      // Tap the selected word to hide the toolbar and retain the selection.
-      await tester.tapAt(vPos);
-      await tester.pumpAndSettle();
-      expect(controller.selection, const TextSelection(baseOffset: 24, extentOffset: 35));
-      expect(find.byType(CupertinoButton), findsNothing);
+    // Tap the selected word to hide the toolbar and retain the selection.
+    await tester.tapAt(vPos);
+    await tester.pumpAndSettle();
+    expect(controller.selection, const TextSelection(baseOffset: 24, extentOffset: 35));
+    expect(find.byType(CupertinoButton), findsNothing);
 
-      // Tap the selected word to show the toolbar and retain the selection.
-      await tester.tapAt(vPos);
-      await tester.pumpAndSettle();
-      expect(controller.selection, const TextSelection(baseOffset: 24, extentOffset: 35));
+    // Tap the selected word to show the toolbar and retain the selection.
+    await tester.tapAt(vPos);
+    await tester.pumpAndSettle();
+    expect(controller.selection, const TextSelection(baseOffset: 24, extentOffset: 35));
 
-      expectCupertinoToolbarForPartialSelection();
+    expectCupertinoToolbarForPartialSelection();
 
-      // Tap past the selected word to move the cursor and hide the toolbar.
-      await tester.tapAt(ePos);
-      await tester.pumpAndSettle();
-      expect(controller.selection.isCollapsed, true);
-      expect(controller.selection.baseOffset, 35);
+    // Tap past the selected word to move the cursor and hide the toolbar.
+    await tester.tapAt(ePos);
+    await tester.pumpAndSettle();
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, 35);
 
-      expect(find.byType(CupertinoButton), findsNothing);
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-  );
+    expect(find.byType(CupertinoButton), findsNothing);
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
 
   testWidgets(
     'double tap selects word for non-Apple platforms',
@@ -2500,191 +2482,181 @@ void main() {
     }),
   );
 
-  testWidgets(
-    'double tapping a space selects the previous word on iOS',
-    (WidgetTester tester) async {
-      final controller = TextEditingController(text: ' blah blah  \n  blah');
-      addTearDown(controller.dispose);
-      await tester.pumpWidget(
-        CupertinoApp(
-          home: Center(child: CupertinoTextField(controller: controller, maxLines: 2)),
-        ),
-      );
+  testWidgets('double tapping a space selects the previous word on iOS', (
+    WidgetTester tester,
+  ) async {
+    final controller = TextEditingController(text: ' blah blah  \n  blah');
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(child: CupertinoTextField(controller: controller, maxLines: 2)),
+      ),
+    );
 
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, -1);
-      expect(controller.value.selection.extentOffset, -1);
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, -1);
+    expect(controller.value.selection.extentOffset, -1);
 
-      // Put the cursor at the end of the field.
-      await tester.tapAt(textOffsetToPosition(tester, 19));
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, 19);
-      expect(controller.value.selection.extentOffset, 19);
+    // Put the cursor at the end of the field.
+    await tester.tapAt(textOffsetToPosition(tester, 19));
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, 19);
+    expect(controller.value.selection.extentOffset, 19);
 
-      // Double tapping the second space selects the previous word.
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.tapAt(textOffsetToPosition(tester, 5));
-      await tester.pump(const Duration(milliseconds: 50));
-      await tester.tapAt(textOffsetToPosition(tester, 5));
-      await tester.pumpAndSettle();
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, 1);
-      expect(controller.value.selection.extentOffset, 5);
+    // Double tapping the second space selects the previous word.
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.tapAt(textOffsetToPosition(tester, 5));
+    await tester.pump(const Duration(milliseconds: 50));
+    await tester.tapAt(textOffsetToPosition(tester, 5));
+    await tester.pumpAndSettle();
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, 1);
+    expect(controller.value.selection.extentOffset, 5);
 
-      // Put the cursor at the end of the field.
-      await tester.tapAt(textOffsetToPosition(tester, 19));
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, 19);
-      expect(controller.value.selection.extentOffset, 19);
+    // Put the cursor at the end of the field.
+    await tester.tapAt(textOffsetToPosition(tester, 19));
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, 19);
+    expect(controller.value.selection.extentOffset, 19);
 
-      // Double tapping the first space selects the space.
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.tapAt(textOffsetToPosition(tester, 0));
-      await tester.pump(const Duration(milliseconds: 50));
-      await tester.tapAt(textOffsetToPosition(tester, 0));
-      await tester.pumpAndSettle();
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, 0);
-      expect(controller.value.selection.extentOffset, 1);
+    // Double tapping the first space selects the space.
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.tapAt(textOffsetToPosition(tester, 0));
+    await tester.pump(const Duration(milliseconds: 50));
+    await tester.tapAt(textOffsetToPosition(tester, 0));
+    await tester.pumpAndSettle();
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, 0);
+    expect(controller.value.selection.extentOffset, 1);
 
-      // Put the cursor at the end of the field.
-      await tester.tapAt(textOffsetToPosition(tester, 19));
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, 19);
-      expect(controller.value.selection.extentOffset, 19);
+    // Put the cursor at the end of the field.
+    await tester.tapAt(textOffsetToPosition(tester, 19));
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, 19);
+    expect(controller.value.selection.extentOffset, 19);
 
-      // Double tapping the last space selects all previous contiguous spaces on
-      // both lines and the previous word.
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.tapAt(textOffsetToPosition(tester, 14));
-      await tester.pump(const Duration(milliseconds: 50));
-      await tester.tapAt(textOffsetToPosition(tester, 14));
-      await tester.pumpAndSettle();
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, 6);
-      expect(controller.value.selection.extentOffset, 14);
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-  );
+    // Double tapping the last space selects all previous contiguous spaces on
+    // both lines and the previous word.
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.tapAt(textOffsetToPosition(tester, 14));
+    await tester.pump(const Duration(milliseconds: 50));
+    await tester.tapAt(textOffsetToPosition(tester, 14));
+    await tester.pumpAndSettle();
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, 6);
+    expect(controller.value.selection.extentOffset, 14);
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
 
-  testWidgets(
-    'double tapping a space selects the space on Mac',
-    (WidgetTester tester) async {
-      final controller = TextEditingController(text: ' blah blah');
-      addTearDown(controller.dispose);
-      await tester.pumpWidget(
-        CupertinoApp(
-          home: Center(child: CupertinoTextField(controller: controller)),
-        ),
-      );
+  testWidgets('double tapping a space selects the space on Mac', (WidgetTester tester) async {
+    final controller = TextEditingController(text: ' blah blah');
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(child: CupertinoTextField(controller: controller)),
+      ),
+    );
 
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, -1);
-      expect(controller.value.selection.extentOffset, -1);
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, -1);
+    expect(controller.value.selection.extentOffset, -1);
 
-      // Put the cursor at the end of the field.
-      await tester.tapAt(textOffsetToPosition(tester, 10));
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, 10);
-      expect(controller.value.selection.extentOffset, 10);
+    // Put the cursor at the end of the field.
+    await tester.tapAt(textOffsetToPosition(tester, 10));
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, 10);
+    expect(controller.value.selection.extentOffset, 10);
 
-      // Double tapping the second space selects it.
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.tapAt(textOffsetToPosition(tester, 5));
-      await tester.pump(const Duration(milliseconds: 50));
-      await tester.tapAt(textOffsetToPosition(tester, 5));
-      await tester.pumpAndSettle();
+    // Double tapping the second space selects it.
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.tapAt(textOffsetToPosition(tester, 5));
+    await tester.pump(const Duration(milliseconds: 50));
+    await tester.tapAt(textOffsetToPosition(tester, 5));
+    await tester.pumpAndSettle();
 
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, 5);
-      expect(controller.value.selection.extentOffset, 6);
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, 5);
+    expect(controller.value.selection.extentOffset, 6);
 
-      // Tap at the end of the text to move the selection to the end. On some
-      // platforms, the context menu "Cut" button blocks this tap, so move it out
-      // of the way by an Offset.
-      await tester.tapAt(textOffsetToPosition(tester, 10) + const Offset(200.0, 0.0));
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, 10);
-      expect(controller.value.selection.extentOffset, 10);
+    // Tap at the end of the text to move the selection to the end. On some
+    // platforms, the context menu "Cut" button blocks this tap, so move it out
+    // of the way by an Offset.
+    await tester.tapAt(textOffsetToPosition(tester, 10) + const Offset(200.0, 0.0));
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, 10);
+    expect(controller.value.selection.extentOffset, 10);
 
-      // Double tapping the first space selects it.
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.tapAt(textOffsetToPosition(tester, 0));
-      await tester.pump(const Duration(milliseconds: 50));
-      await tester.tapAt(textOffsetToPosition(tester, 0));
-      await tester.pumpAndSettle();
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, 0);
-      expect(controller.value.selection.extentOffset, 1);
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.macOS}),
-  );
+    // Double tapping the first space selects it.
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.tapAt(textOffsetToPosition(tester, 0));
+    await tester.pump(const Duration(milliseconds: 50));
+    await tester.tapAt(textOffsetToPosition(tester, 0));
+    await tester.pumpAndSettle();
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, 0);
+    expect(controller.value.selection.extentOffset, 1);
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.macOS}));
 
-  testWidgets(
-    'double clicking a space selects the space on Mac',
-    (WidgetTester tester) async {
-      final controller = TextEditingController(text: ' blah blah');
-      addTearDown(controller.dispose);
-      await tester.pumpWidget(
-        CupertinoApp(
-          home: Center(child: CupertinoTextField(controller: controller)),
-        ),
-      );
+  testWidgets('double clicking a space selects the space on Mac', (WidgetTester tester) async {
+    final controller = TextEditingController(text: ' blah blah');
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(child: CupertinoTextField(controller: controller)),
+      ),
+    );
 
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, -1);
-      expect(controller.value.selection.extentOffset, -1);
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, -1);
+    expect(controller.value.selection.extentOffset, -1);
 
-      // Put the cursor at the end of the field.
-      final TestGesture gesture = await tester.startGesture(
-        textOffsetToPosition(tester, 10),
-        pointer: 7,
-        kind: PointerDeviceKind.mouse,
-      );
-      await tester.pump();
-      await gesture.up();
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, 10);
-      expect(controller.value.selection.extentOffset, 10);
+    // Put the cursor at the end of the field.
+    final TestGesture gesture = await tester.startGesture(
+      textOffsetToPosition(tester, 10),
+      pointer: 7,
+      kind: PointerDeviceKind.mouse,
+    );
+    await tester.pump();
+    await gesture.up();
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, 10);
+    expect(controller.value.selection.extentOffset, 10);
 
-      // Double tapping the second space selects it.
-      await tester.pump(const Duration(milliseconds: 500));
-      await gesture.down(textOffsetToPosition(tester, 5));
-      await tester.pump();
-      await gesture.up();
-      await tester.pump(const Duration(milliseconds: 50));
-      await gesture.down(textOffsetToPosition(tester, 5));
-      await tester.pump();
-      await gesture.up();
-      await tester.pumpAndSettle(kDoubleTapTimeout);
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, 5);
-      expect(controller.value.selection.extentOffset, 6);
+    // Double tapping the second space selects it.
+    await tester.pump(const Duration(milliseconds: 500));
+    await gesture.down(textOffsetToPosition(tester, 5));
+    await tester.pump();
+    await gesture.up();
+    await tester.pump(const Duration(milliseconds: 50));
+    await gesture.down(textOffsetToPosition(tester, 5));
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle(kDoubleTapTimeout);
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, 5);
+    expect(controller.value.selection.extentOffset, 6);
 
-      // Put the cursor at the end of the field.
-      await gesture.down(textOffsetToPosition(tester, 10));
-      await tester.pump();
-      await gesture.up();
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, 10);
-      expect(controller.value.selection.extentOffset, 10);
+    // Put the cursor at the end of the field.
+    await gesture.down(textOffsetToPosition(tester, 10));
+    await tester.pump();
+    await gesture.up();
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, 10);
+    expect(controller.value.selection.extentOffset, 10);
 
-      // Double tapping the first space selects it.
-      await tester.pump(const Duration(milliseconds: 500));
-      await gesture.down(textOffsetToPosition(tester, 0));
-      await tester.pump();
-      await gesture.up();
-      await tester.pump(const Duration(milliseconds: 50));
-      await gesture.down(textOffsetToPosition(tester, 0));
-      await tester.pump();
-      await gesture.up();
-      await tester.pumpAndSettle();
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, 0);
-      expect(controller.value.selection.extentOffset, 1);
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.macOS}),
-  );
+    // Double tapping the first space selects it.
+    await tester.pump(const Duration(milliseconds: 500));
+    await gesture.down(textOffsetToPosition(tester, 0));
+    await tester.pump();
+    await gesture.up();
+    await tester.pump(const Duration(milliseconds: 50));
+    await gesture.down(textOffsetToPosition(tester, 0));
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle();
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, 0);
+    expect(controller.value.selection.extentOffset, 1);
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.macOS}));
 
   testWidgets('An obscured CupertinoTextField is not selectable when disabled', (
     WidgetTester tester,
@@ -3352,59 +3324,55 @@ void main() {
     }),
   );
 
-  testWidgets(
-    'double tap chains work',
-    (WidgetTester tester) async {
-      final controller = TextEditingController(text: 'Atwater Peel Sherbrooke Bonaventure');
-      addTearDown(controller.dispose);
-      await tester.pumpWidget(
-        CupertinoApp(
-          home: Center(child: CupertinoTextField(controller: controller)),
-        ),
-      );
+  testWidgets('double tap chains work', (WidgetTester tester) async {
+    final controller = TextEditingController(text: 'Atwater Peel Sherbrooke Bonaventure');
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(child: CupertinoTextField(controller: controller)),
+      ),
+    );
 
-      final Offset textFieldStart = tester.getTopLeft(find.byType(CupertinoTextField));
+    final Offset textFieldStart = tester.getTopLeft(find.byType(CupertinoTextField));
 
-      await tester.tapAt(textFieldStart + const Offset(50.0, 5.0));
-      await tester.pump(const Duration(milliseconds: 50));
-      expect(
-        controller.selection,
-        const TextSelection.collapsed(offset: 7, affinity: TextAffinity.upstream),
-      );
-      await tester.tapAt(textFieldStart + const Offset(50.0, 5.0));
-      await tester.pumpAndSettle();
-      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
-      expectCupertinoToolbarForPartialSelection();
+    await tester.tapAt(textFieldStart + const Offset(50.0, 5.0));
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(
+      controller.selection,
+      const TextSelection.collapsed(offset: 7, affinity: TextAffinity.upstream),
+    );
+    await tester.tapAt(textFieldStart + const Offset(50.0, 5.0));
+    await tester.pumpAndSettle();
+    expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
+    expectCupertinoToolbarForPartialSelection();
 
-      // Double tap selecting the same word somewhere else is fine.
-      await tester.tapAt(textFieldStart + const Offset(100.0, 5.0));
-      await tester.pump(const Duration(milliseconds: 50));
-      // First tap hides the toolbar, and retains the selection.
-      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
-      expect(find.byType(CupertinoButton), findsNothing);
-      // Second tap shows the toolbar, and retains the selection.
-      await tester.tapAt(textFieldStart + const Offset(100.0, 5.0));
-      // Wait for the consecutive tap timer to timeout so the next
-      // tap is not detected as a triple tap.
-      await tester.pumpAndSettle(kDoubleTapTimeout);
-      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
-      expectCupertinoToolbarForPartialSelection();
+    // Double tap selecting the same word somewhere else is fine.
+    await tester.tapAt(textFieldStart + const Offset(100.0, 5.0));
+    await tester.pump(const Duration(milliseconds: 50));
+    // First tap hides the toolbar, and retains the selection.
+    expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
+    expect(find.byType(CupertinoButton), findsNothing);
+    // Second tap shows the toolbar, and retains the selection.
+    await tester.tapAt(textFieldStart + const Offset(100.0, 5.0));
+    // Wait for the consecutive tap timer to timeout so the next
+    // tap is not detected as a triple tap.
+    await tester.pumpAndSettle(kDoubleTapTimeout);
+    expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
+    expectCupertinoToolbarForPartialSelection();
 
-      await tester.tapAt(textFieldStart + const Offset(150.0, 5.0));
-      await tester.pump(const Duration(milliseconds: 50));
-      // First tap moved the cursor and hides the toolbar.
-      expect(
-        controller.selection,
-        const TextSelection.collapsed(offset: 12, affinity: TextAffinity.upstream),
-      );
-      expect(find.byType(CupertinoButton), findsNothing);
-      await tester.tapAt(textFieldStart + const Offset(150.0, 5.0));
-      await tester.pumpAndSettle();
-      expect(controller.selection, const TextSelection(baseOffset: 8, extentOffset: 12));
-      expectCupertinoToolbarForPartialSelection();
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-  );
+    await tester.tapAt(textFieldStart + const Offset(150.0, 5.0));
+    await tester.pump(const Duration(milliseconds: 50));
+    // First tap moved the cursor and hides the toolbar.
+    expect(
+      controller.selection,
+      const TextSelection.collapsed(offset: 12, affinity: TextAffinity.upstream),
+    );
+    expect(find.byType(CupertinoButton), findsNothing);
+    await tester.tapAt(textFieldStart + const Offset(150.0, 5.0));
+    await tester.pumpAndSettle();
+    expect(controller.selection, const TextSelection(baseOffset: 8, extentOffset: 12));
+    expectCupertinoToolbarForPartialSelection();
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
 
   group('Triple tap/click', () {
     const testValueA =
@@ -3479,65 +3447,63 @@ void main() {
       skip: true, // https://github.com/flutter/flutter/issues/123415
     );
 
-    testWidgets(
-      'Can triple tap to select a paragraph on mobile platforms',
-      (WidgetTester tester) async {
-        final controller = TextEditingController();
-        addTearDown(controller.dispose);
-        final isTargetPlatformApple = defaultTargetPlatform == TargetPlatform.iOS;
+    testWidgets('Can triple tap to select a paragraph on mobile platforms', (
+      WidgetTester tester,
+    ) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+      final isTargetPlatformApple = defaultTargetPlatform == TargetPlatform.iOS;
 
-        await tester.pumpWidget(
-          CupertinoApp(
-            home: Center(
-              child: CupertinoTextField(
-                dragStartBehavior: DragStartBehavior.down,
-                controller: controller,
-                maxLines: null,
-              ),
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: CupertinoTextField(
+              dragStartBehavior: DragStartBehavior.down,
+              controller: controller,
+              maxLines: null,
             ),
           ),
-        );
+        ),
+      );
 
-        await tester.enterText(find.byType(CupertinoTextField), testValueB);
-        // Skip past scrolling animation.
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 200));
-        expect(controller.value.text, testValueB);
+      await tester.enterText(find.byType(CupertinoTextField), testValueB);
+      // Skip past scrolling animation.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(controller.value.text, testValueB);
 
-        final Offset firstLinePos =
-            tester.getTopLeft(find.byType(CupertinoTextField)) + const Offset(50.0, 9.0);
+      final Offset firstLinePos =
+          tester.getTopLeft(find.byType(CupertinoTextField)) + const Offset(50.0, 9.0);
 
-        // Tap on text field to gain focus, and move the selection.
-        final TestGesture gesture = await tester.startGesture(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Tap on text field to gain focus, and move the selection.
+      final TestGesture gesture = await tester.startGesture(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, isTargetPlatformApple ? 5 : 3);
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, isTargetPlatformApple ? 5 : 3);
 
-        // Here we tap on same position again, to register a double tap. This will select
-        // the word at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Here we tap on same position again, to register a double tap. This will select
+      // the word at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 5);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 5);
 
-        // Here we tap on same position again, to register a triple tap. This will select
-        // the paragraph at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pumpAndSettle();
+      // Here we tap on same position again, to register a triple tap. This will select
+      // the paragraph at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 22);
-      },
-      variant: TargetPlatformVariant.mobile(),
-    );
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 22);
+    }, variant: TargetPlatformVariant.mobile());
 
     testWidgets(
       'Triple click at the beginning of a line should not select the previous paragraph',
@@ -3600,67 +3566,65 @@ void main() {
       variant: TargetPlatformVariant.all(excluding: <TargetPlatform>{TargetPlatform.linux}),
     );
 
-    testWidgets(
-      'Triple click at the end of text should select the previous paragraph',
-      (WidgetTester tester) async {
-        // Regression test for https://github.com/flutter/flutter/issues/132126.
-        final controller = TextEditingController();
-        addTearDown(controller.dispose);
+    testWidgets('Triple click at the end of text should select the previous paragraph', (
+      WidgetTester tester,
+    ) async {
+      // Regression test for https://github.com/flutter/flutter/issues/132126.
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
 
-        await tester.pumpWidget(
-          CupertinoApp(
-            home: Center(
-              child: CupertinoTextField(
-                dragStartBehavior: DragStartBehavior.down,
-                controller: controller,
-                maxLines: null,
-              ),
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: CupertinoTextField(
+              dragStartBehavior: DragStartBehavior.down,
+              controller: controller,
+              maxLines: null,
             ),
           ),
-        );
+        ),
+      );
 
-        await tester.enterText(find.byType(CupertinoTextField), testValueB);
-        // Skip past scrolling animation.
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 200));
-        expect(controller.value.text, testValueB);
+      await tester.enterText(find.byType(CupertinoTextField), testValueB);
+      // Skip past scrolling animation.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(controller.value.text, testValueB);
 
-        final Offset endOfTextPos = textOffsetToPosition(tester, 74);
+      final Offset endOfTextPos = textOffsetToPosition(tester, 74);
 
-        // Click on text field to gain focus, and move the selection.
-        final TestGesture gesture = await tester.startGesture(
-          endOfTextPos,
-          kind: PointerDeviceKind.mouse,
-        );
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Click on text field to gain focus, and move the selection.
+      final TestGesture gesture = await tester.startGesture(
+        endOfTextPos,
+        kind: PointerDeviceKind.mouse,
+      );
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, 74);
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, 74);
 
-        // Here we click on same position again, to register a double click.
-        await gesture.down(endOfTextPos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Here we click on same position again, to register a double click.
+      await gesture.down(endOfTextPos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.baseOffset, 74);
-        expect(controller.selection.extentOffset, 74);
+      expect(controller.selection.baseOffset, 74);
+      expect(controller.selection.extentOffset, 74);
 
-        // Here we click on same position again, to register a triple click. This will select
-        // the paragraph at the clicked position.
-        await gesture.down(endOfTextPos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
-        await tester.pumpAndSettle();
+      // Here we click on same position again, to register a triple click. This will select
+      // the paragraph at the clicked position.
+      await gesture.down(endOfTextPos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 57);
-        expect(controller.selection.extentOffset, 74);
-      },
-      variant: TargetPlatformVariant.all(excluding: <TargetPlatform>{TargetPlatform.linux}),
-    );
+      expect(controller.selection.baseOffset, 57);
+      expect(controller.selection.extentOffset, 74);
+    }, variant: TargetPlatformVariant.all(excluding: <TargetPlatform>{TargetPlatform.linux}));
 
     testWidgets(
       'triple tap chains work on Non-Apple mobile platforms',
@@ -3733,79 +3697,75 @@ void main() {
       }),
     );
 
-    testWidgets(
-      'triple tap chains work on Apple platforms',
-      (WidgetTester tester) async {
-        final controller = TextEditingController(
-          text: 'Atwater Peel Sherbrooke Bonaventure\nThe fox jumped over the fence.',
-        );
-        addTearDown(controller.dispose);
-        await tester.pumpWidget(
-          CupertinoApp(
-            home: Center(
-              child: Center(child: CupertinoTextField(controller: controller, maxLines: null)),
-            ),
+    testWidgets('triple tap chains work on Apple platforms', (WidgetTester tester) async {
+      final controller = TextEditingController(
+        text: 'Atwater Peel Sherbrooke Bonaventure\nThe fox jumped over the fence.',
+      );
+      addTearDown(controller.dispose);
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: Center(child: CupertinoTextField(controller: controller, maxLines: null)),
           ),
-        );
+        ),
+      );
 
-        final Offset textfieldStart = tester.getTopLeft(find.byType(CupertinoTextField));
+      final Offset textfieldStart = tester.getTopLeft(find.byType(CupertinoTextField));
 
-        await tester.tapAt(textfieldStart + const Offset(50.0, 9.0));
-        await tester.pump(const Duration(milliseconds: 50));
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, 7);
+      await tester.tapAt(textfieldStart + const Offset(50.0, 9.0));
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, 7);
 
-        await tester.tapAt(textfieldStart + const Offset(50.0, 9.0));
-        await tester.pump();
-        expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
-        expectCupertinoToolbarForPartialSelection();
+      await tester.tapAt(textfieldStart + const Offset(50.0, 9.0));
+      await tester.pump();
+      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
+      expectCupertinoToolbarForPartialSelection();
 
-        await tester.tapAt(textfieldStart + const Offset(50.0, 9.0));
-        await tester.pumpAndSettle(kDoubleTapTimeout);
-        expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 36));
+      await tester.tapAt(textfieldStart + const Offset(50.0, 9.0));
+      await tester.pumpAndSettle(kDoubleTapTimeout);
+      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 36));
 
-        // Triple tap selecting the same paragraph somewhere else is fine.
-        await tester.tapAt(textfieldStart + const Offset(100.0, 9.0));
-        await tester.pump(const Duration(milliseconds: 50));
-        // First tap hides the toolbar and retains the selection.
-        expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 36));
-        expect(find.byType(CupertinoButton), findsNothing);
+      // Triple tap selecting the same paragraph somewhere else is fine.
+      await tester.tapAt(textfieldStart + const Offset(100.0, 9.0));
+      await tester.pump(const Duration(milliseconds: 50));
+      // First tap hides the toolbar and retains the selection.
+      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 36));
+      expect(find.byType(CupertinoButton), findsNothing);
 
-        // Second tap shows the toolbar and selects the word.
-        await tester.tapAt(textfieldStart + const Offset(100.0, 9.0));
-        await tester.pump();
-        expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
-        expectCupertinoToolbarForPartialSelection();
+      // Second tap shows the toolbar and selects the word.
+      await tester.tapAt(textfieldStart + const Offset(100.0, 9.0));
+      await tester.pump();
+      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
+      expectCupertinoToolbarForPartialSelection();
 
-        // Third tap shows the toolbar and selects the paragraph.
-        await tester.tapAt(textfieldStart + const Offset(100.0, 9.0));
-        await tester.pumpAndSettle(kDoubleTapTimeout);
-        expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 36));
-        expectCupertinoToolbarForPartialSelection();
+      // Third tap shows the toolbar and selects the paragraph.
+      await tester.tapAt(textfieldStart + const Offset(100.0, 9.0));
+      await tester.pumpAndSettle(kDoubleTapTimeout);
+      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 36));
+      expectCupertinoToolbarForPartialSelection();
 
-        await tester.tapAt(textfieldStart + const Offset(150.0, 25.0));
-        await tester.pump(const Duration(milliseconds: 50));
-        // First tap moved the cursor and hid the toolbar.
-        expect(
-          controller.selection,
-          const TextSelection.collapsed(offset: 50, affinity: TextAffinity.upstream),
-        );
-        expect(find.byType(CupertinoButton), findsNothing);
+      await tester.tapAt(textfieldStart + const Offset(150.0, 25.0));
+      await tester.pump(const Duration(milliseconds: 50));
+      // First tap moved the cursor and hid the toolbar.
+      expect(
+        controller.selection,
+        const TextSelection.collapsed(offset: 50, affinity: TextAffinity.upstream),
+      );
+      expect(find.byType(CupertinoButton), findsNothing);
 
-        // Second tap selects the word.
-        await tester.tapAt(textfieldStart + const Offset(150.0, 25.0));
-        await tester.pump();
-        expect(controller.selection, const TextSelection(baseOffset: 44, extentOffset: 50));
-        expectCupertinoToolbarForPartialSelection();
+      // Second tap selects the word.
+      await tester.tapAt(textfieldStart + const Offset(150.0, 25.0));
+      await tester.pump();
+      expect(controller.selection, const TextSelection(baseOffset: 44, extentOffset: 50));
+      expectCupertinoToolbarForPartialSelection();
 
-        // Third tap selects the paragraph and shows the toolbar.
-        await tester.tapAt(textfieldStart + const Offset(150.0, 25.0));
-        await tester.pumpAndSettle();
-        expect(controller.selection, const TextSelection(baseOffset: 36, extentOffset: 66));
-        expectCupertinoToolbarForPartialSelection();
-      },
-      variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-    );
+      // Third tap selects the paragraph and shows the toolbar.
+      await tester.tapAt(textfieldStart + const Offset(150.0, 25.0));
+      await tester.pumpAndSettle();
+      expect(controller.selection, const TextSelection(baseOffset: 36, extentOffset: 66));
+      expectCupertinoToolbarForPartialSelection();
+    }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
 
     testWidgets('triple click chains work', (WidgetTester tester) async {
       final controller = TextEditingController(text: testValueA);
@@ -3955,438 +3915,422 @@ void main() {
       );
     }, variant: TargetPlatformVariant.desktop());
 
-    testWidgets(
-      'Can triple tap to select all on a single-line textfield on mobile platforms',
-      (WidgetTester tester) async {
-        final controller = TextEditingController(text: testValueB);
-        addTearDown(controller.dispose);
-        final isTargetPlatformApple = defaultTargetPlatform == TargetPlatform.iOS;
+    testWidgets('Can triple tap to select all on a single-line textfield on mobile platforms', (
+      WidgetTester tester,
+    ) async {
+      final controller = TextEditingController(text: testValueB);
+      addTearDown(controller.dispose);
+      final isTargetPlatformApple = defaultTargetPlatform == TargetPlatform.iOS;
 
-        await tester.pumpWidget(
-          CupertinoApp(
-            home: Center(child: CupertinoTextField(controller: controller)),
-          ),
-        );
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(child: CupertinoTextField(controller: controller)),
+        ),
+      );
 
-        final Offset firstLinePos =
-            tester.getTopLeft(find.byType(CupertinoTextField)) + const Offset(50.0, 9.0);
+      final Offset firstLinePos =
+          tester.getTopLeft(find.byType(CupertinoTextField)) + const Offset(50.0, 9.0);
 
-        // Tap on text field to gain focus, and set selection somewhere on the first word.
-        final TestGesture gesture = await tester.startGesture(firstLinePos, pointer: 7);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Tap on text field to gain focus, and set selection somewhere on the first word.
+      final TestGesture gesture = await tester.startGesture(firstLinePos, pointer: 7);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, isTargetPlatformApple ? 5 : 3);
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, isTargetPlatformApple ? 5 : 3);
 
-        // Here we tap on same position again, to register a double tap. This will select
-        // the word at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Here we tap on same position again, to register a double tap. This will select
+      // the word at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 5);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 5);
 
-        // Here we tap on same position again, to register a triple tap. This will select
-        // the entire text field if it is a single-line field.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pumpAndSettle();
+      // Here we tap on same position again, to register a triple tap. This will select
+      // the entire text field if it is a single-line field.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 74);
-      },
-      variant: TargetPlatformVariant.mobile(),
-    );
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 74);
+    }, variant: TargetPlatformVariant.mobile());
 
-    testWidgets(
-      'Can triple click to select all on a single-line textfield on desktop platforms',
-      (WidgetTester tester) async {
-        final controller = TextEditingController(text: testValueA);
-        addTearDown(controller.dispose);
+    testWidgets('Can triple click to select all on a single-line textfield on desktop platforms', (
+      WidgetTester tester,
+    ) async {
+      final controller = TextEditingController(text: testValueA);
+      addTearDown(controller.dispose);
 
-        await tester.pumpWidget(
-          CupertinoApp(
-            home: Center(
-              child: CupertinoTextField(
-                dragStartBehavior: DragStartBehavior.down,
-                controller: controller,
-              ),
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: CupertinoTextField(
+              dragStartBehavior: DragStartBehavior.down,
+              controller: controller,
             ),
           ),
-        );
+        ),
+      );
 
-        final Offset firstLinePos = textOffsetToPosition(tester, 5);
+      final Offset firstLinePos = textOffsetToPosition(tester, 5);
 
-        // Tap on text field to gain focus, and set selection to 'i|s' on the first line.
-        final TestGesture gesture = await tester.startGesture(
-          firstLinePos,
-          pointer: 7,
-          kind: PointerDeviceKind.mouse,
-        );
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Tap on text field to gain focus, and set selection to 'i|s' on the first line.
+      final TestGesture gesture = await tester.startGesture(
+        firstLinePos,
+        pointer: 7,
+        kind: PointerDeviceKind.mouse,
+      );
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, 5);
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, 5);
 
-        // Here we tap on same position again, to register a double tap. This will select
-        // the word at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Here we tap on same position again, to register a double tap. This will select
+      // the word at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.baseOffset, 4);
-        expect(controller.selection.extentOffset, 6);
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 6);
 
-        // Here we tap on same position again, to register a triple tap. This will select
-        // the entire text field if it is a single-line field.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pumpAndSettle();
+      // Here we tap on same position again, to register a triple tap. This will select
+      // the entire text field if it is a single-line field.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 72);
-      },
-      variant: TargetPlatformVariant.desktop(),
-    );
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 72);
+    }, variant: TargetPlatformVariant.desktop());
 
-    testWidgets(
-      'Can triple click to select a line on Linux',
-      (WidgetTester tester) async {
-        final controller = TextEditingController();
-        addTearDown(controller.dispose);
+    testWidgets('Can triple click to select a line on Linux', (WidgetTester tester) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
 
-        await tester.pumpWidget(
-          CupertinoApp(
-            home: Center(
-              child: CupertinoTextField(
-                dragStartBehavior: DragStartBehavior.down,
-                controller: controller,
-                maxLines: null,
-              ),
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: CupertinoTextField(
+              dragStartBehavior: DragStartBehavior.down,
+              controller: controller,
+              maxLines: null,
             ),
           ),
-        );
+        ),
+      );
 
-        await tester.enterText(find.byType(CupertinoTextField), testValueA);
-        // Skip past scrolling animation.
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 200));
-        expect(controller.value.text, testValueA);
+      await tester.enterText(find.byType(CupertinoTextField), testValueA);
+      // Skip past scrolling animation.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(controller.value.text, testValueA);
 
-        final Offset firstLinePos = textOffsetToPosition(tester, 5);
+      final Offset firstLinePos = textOffsetToPosition(tester, 5);
 
-        // Tap on text field to gain focus, and set selection to 'i|s' on the first line.
-        final TestGesture gesture = await tester.startGesture(
-          firstLinePos,
-          pointer: 7,
-          kind: PointerDeviceKind.mouse,
-        );
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Tap on text field to gain focus, and set selection to 'i|s' on the first line.
+      final TestGesture gesture = await tester.startGesture(
+        firstLinePos,
+        pointer: 7,
+        kind: PointerDeviceKind.mouse,
+      );
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, 5);
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, 5);
 
-        // Here we tap on same position again, to register a double tap. This will select
-        // the word at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Here we tap on same position again, to register a double tap. This will select
+      // the word at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.baseOffset, 4);
-        expect(controller.selection.extentOffset, 6);
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 6);
 
-        // Here we tap on same position again, to register a triple tap. This will select
-        // the paragraph at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pumpAndSettle();
+      // Here we tap on same position again, to register a triple tap. This will select
+      // the paragraph at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 19);
-      },
-      variant: TargetPlatformVariant.only(TargetPlatform.linux),
-    );
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 19);
+    }, variant: TargetPlatformVariant.only(TargetPlatform.linux));
 
-    testWidgets(
-      'Can triple click to select a paragraph',
-      (WidgetTester tester) async {
-        final controller = TextEditingController();
-        addTearDown(controller.dispose);
+    testWidgets('Can triple click to select a paragraph', (WidgetTester tester) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
 
-        await tester.pumpWidget(
-          CupertinoApp(
-            home: Center(
-              child: CupertinoTextField(
-                dragStartBehavior: DragStartBehavior.down,
-                controller: controller,
-                maxLines: null,
-              ),
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: CupertinoTextField(
+              dragStartBehavior: DragStartBehavior.down,
+              controller: controller,
+              maxLines: null,
             ),
           ),
-        );
+        ),
+      );
 
-        await tester.enterText(find.byType(CupertinoTextField), testValueA);
-        // Skip past scrolling animation.
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 200));
-        expect(controller.value.text, testValueA);
+      await tester.enterText(find.byType(CupertinoTextField), testValueA);
+      // Skip past scrolling animation.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(controller.value.text, testValueA);
 
-        final Offset firstLinePos = textOffsetToPosition(tester, 5);
+      final Offset firstLinePos = textOffsetToPosition(tester, 5);
 
-        // Tap on text field to gain focus, and set selection to 'i|s' on the first line.
-        final TestGesture gesture = await tester.startGesture(
-          firstLinePos,
-          pointer: 7,
-          kind: PointerDeviceKind.mouse,
-        );
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Tap on text field to gain focus, and set selection to 'i|s' on the first line.
+      final TestGesture gesture = await tester.startGesture(
+        firstLinePos,
+        pointer: 7,
+        kind: PointerDeviceKind.mouse,
+      );
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, 5);
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, 5);
 
-        // Here we tap on same position again, to register a double tap. This will select
-        // the word at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Here we tap on same position again, to register a double tap. This will select
+      // the word at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.baseOffset, 4);
-        expect(controller.selection.extentOffset, 6);
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 6);
 
-        // Here we tap on same position again, to register a triple tap. This will select
-        // the paragraph at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pumpAndSettle();
+      // Here we tap on same position again, to register a triple tap. This will select
+      // the paragraph at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 20);
-      },
-      variant: TargetPlatformVariant.all(excluding: <TargetPlatform>{TargetPlatform.linux}),
-    );
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 20);
+    }, variant: TargetPlatformVariant.all(excluding: <TargetPlatform>{TargetPlatform.linux}));
 
-    testWidgets(
-      'Can triple click + drag to select line by line on Linux',
-      (WidgetTester tester) async {
-        final controller = TextEditingController();
-        addTearDown(controller.dispose);
+    testWidgets('Can triple click + drag to select line by line on Linux', (
+      WidgetTester tester,
+    ) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
 
-        await tester.pumpWidget(
-          CupertinoApp(
-            home: Center(
-              child: CupertinoTextField(
-                dragStartBehavior: DragStartBehavior.down,
-                controller: controller,
-                maxLines: null,
-              ),
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: CupertinoTextField(
+              dragStartBehavior: DragStartBehavior.down,
+              controller: controller,
+              maxLines: null,
             ),
           ),
-        );
+        ),
+      );
 
-        await tester.enterText(find.byType(CupertinoTextField), testValueA);
-        // Skip past scrolling animation.
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 200));
-        expect(controller.value.text, testValueA);
+      await tester.enterText(find.byType(CupertinoTextField), testValueA);
+      // Skip past scrolling animation.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(controller.value.text, testValueA);
 
-        final Offset firstLinePos = textOffsetToPosition(tester, 5);
+      final Offset firstLinePos = textOffsetToPosition(tester, 5);
 
-        // Tap on text field to gain focus, and set selection to 'i|s' on the first line.
-        final TestGesture gesture = await tester.startGesture(
-          firstLinePos,
-          pointer: 7,
-          kind: PointerDeviceKind.mouse,
-        );
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Tap on text field to gain focus, and set selection to 'i|s' on the first line.
+      final TestGesture gesture = await tester.startGesture(
+        firstLinePos,
+        pointer: 7,
+        kind: PointerDeviceKind.mouse,
+      );
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, 5);
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, 5);
 
-        // Here we tap on same position again, to register a double tap. This will select
-        // the word at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Here we tap on same position again, to register a double tap. This will select
+      // the word at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.baseOffset, 4);
-        expect(controller.selection.extentOffset, 6);
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 6);
 
-        // Here we tap on the same position again, to register a triple tap. This will select
-        // the line at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pumpAndSettle();
+      // Here we tap on the same position again, to register a triple tap. This will select
+      // the line at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 19);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 19);
 
-        // Drag, down after the triple tap, to select line by line.
-        // Moving down will extend the selection to the second line.
-        await gesture.moveTo(firstLinePos + const Offset(0, 10.0));
-        await tester.pumpAndSettle();
+      // Drag, down after the triple tap, to select line by line.
+      // Moving down will extend the selection to the second line.
+      await gesture.moveTo(firstLinePos + const Offset(0, 10.0));
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 35);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 35);
 
-        // Moving down will extend the selection to the third line.
-        await gesture.moveTo(firstLinePos + const Offset(0, 20.0));
-        await tester.pumpAndSettle();
+      // Moving down will extend the selection to the third line.
+      await gesture.moveTo(firstLinePos + const Offset(0, 20.0));
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 54);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 54);
 
-        // Moving down will extend the selection to the last line.
-        await gesture.moveTo(firstLinePos + const Offset(0, 40.0));
-        await tester.pumpAndSettle();
+      // Moving down will extend the selection to the last line.
+      await gesture.moveTo(firstLinePos + const Offset(0, 40.0));
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 72);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 72);
 
-        // Moving up will extend the selection to the third line.
-        await gesture.moveTo(firstLinePos + const Offset(0, 20.0));
-        await tester.pumpAndSettle();
+      // Moving up will extend the selection to the third line.
+      await gesture.moveTo(firstLinePos + const Offset(0, 20.0));
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 54);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 54);
 
-        // Moving up will extend the selection to the second line.
-        await gesture.moveTo(firstLinePos + const Offset(0, 10.0));
-        await tester.pumpAndSettle();
+      // Moving up will extend the selection to the second line.
+      await gesture.moveTo(firstLinePos + const Offset(0, 10.0));
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 35);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 35);
 
-        // Moving up will extend the selection to the first line.
-        await gesture.moveTo(firstLinePos);
-        await tester.pumpAndSettle();
+      // Moving up will extend the selection to the first line.
+      await gesture.moveTo(firstLinePos);
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 19);
-      },
-      variant: TargetPlatformVariant.only(TargetPlatform.linux),
-    );
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 19);
+    }, variant: TargetPlatformVariant.only(TargetPlatform.linux));
 
-    testWidgets(
-      'Can triple click + drag to select paragraph by paragraph',
-      (WidgetTester tester) async {
-        final controller = TextEditingController();
-        addTearDown(controller.dispose);
+    testWidgets('Can triple click + drag to select paragraph by paragraph', (
+      WidgetTester tester,
+    ) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
 
-        await tester.pumpWidget(
-          CupertinoApp(
-            home: Center(
-              child: CupertinoTextField(
-                dragStartBehavior: DragStartBehavior.down,
-                controller: controller,
-                maxLines: null,
-              ),
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: CupertinoTextField(
+              dragStartBehavior: DragStartBehavior.down,
+              controller: controller,
+              maxLines: null,
             ),
           ),
-        );
+        ),
+      );
 
-        await tester.enterText(find.byType(CupertinoTextField), testValueA);
-        // Skip past scrolling animation.
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 200));
-        expect(controller.value.text, testValueA);
+      await tester.enterText(find.byType(CupertinoTextField), testValueA);
+      // Skip past scrolling animation.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(controller.value.text, testValueA);
 
-        final Offset firstLinePos = textOffsetToPosition(tester, 5);
+      final Offset firstLinePos = textOffsetToPosition(tester, 5);
 
-        // Tap on text field to gain focus, and set selection to 'i|s' on the first line.
-        final TestGesture gesture = await tester.startGesture(
-          firstLinePos,
-          pointer: 7,
-          kind: PointerDeviceKind.mouse,
-        );
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Tap on text field to gain focus, and set selection to 'i|s' on the first line.
+      final TestGesture gesture = await tester.startGesture(
+        firstLinePos,
+        pointer: 7,
+        kind: PointerDeviceKind.mouse,
+      );
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, 5);
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, 5);
 
-        // Here we tap on same position again, to register a double tap. This will select
-        // the word at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Here we tap on same position again, to register a double tap. This will select
+      // the word at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.baseOffset, 4);
-        expect(controller.selection.extentOffset, 6);
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 6);
 
-        // Here we tap on the same position again, to register a triple tap. This will select
-        // the paragraph at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pumpAndSettle();
+      // Here we tap on the same position again, to register a triple tap. This will select
+      // the paragraph at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 20);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 20);
 
-        // Drag, down after the triple tap, to select paragraph by paragraph.
-        // Moving down will extend the selection to the second line.
-        await gesture.moveTo(firstLinePos + const Offset(0, 10.0));
-        await tester.pumpAndSettle();
+      // Drag, down after the triple tap, to select paragraph by paragraph.
+      // Moving down will extend the selection to the second line.
+      await gesture.moveTo(firstLinePos + const Offset(0, 10.0));
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 36);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 36);
 
-        // Moving down will extend the selection to the third line.
-        await gesture.moveTo(firstLinePos + const Offset(0, 20.0));
-        await tester.pumpAndSettle();
+      // Moving down will extend the selection to the third line.
+      await gesture.moveTo(firstLinePos + const Offset(0, 20.0));
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 55);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 55);
 
-        // Moving down will extend the selection to the last line.
-        await gesture.moveTo(firstLinePos + const Offset(0, 40.0));
-        await tester.pumpAndSettle();
+      // Moving down will extend the selection to the last line.
+      await gesture.moveTo(firstLinePos + const Offset(0, 40.0));
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 72);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 72);
 
-        // Moving up will extend the selection to the third line.
-        await gesture.moveTo(firstLinePos + const Offset(0, 20.0));
-        await tester.pumpAndSettle();
+      // Moving up will extend the selection to the third line.
+      await gesture.moveTo(firstLinePos + const Offset(0, 20.0));
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 55);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 55);
 
-        // Moving up will extend the selection to the second line.
-        await gesture.moveTo(firstLinePos + const Offset(0, 10.0));
-        await tester.pumpAndSettle();
+      // Moving up will extend the selection to the second line.
+      await gesture.moveTo(firstLinePos + const Offset(0, 10.0));
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 36);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 36);
 
-        // Moving up will extend the selection to the first line.
-        await gesture.moveTo(firstLinePos);
-        await tester.pumpAndSettle();
+      // Moving up will extend the selection to the first line.
+      await gesture.moveTo(firstLinePos);
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 20);
-      },
-      variant: TargetPlatformVariant.all(excluding: <TargetPlatform>{TargetPlatform.linux}),
-    );
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 20);
+    }, variant: TargetPlatformVariant.all(excluding: <TargetPlatform>{TargetPlatform.linux}));
 
     testWidgets(
       'Going past triple click retains the selection on Apple platforms',
@@ -4560,92 +4504,88 @@ void main() {
       }),
     );
 
-    testWidgets(
-      'Double click and triple click alternate on Windows',
-      (WidgetTester tester) async {
-        final controller = TextEditingController(text: testValueA);
-        addTearDown(controller.dispose);
-        await tester.pumpWidget(
-          CupertinoApp(
-            home: Center(
-              child: Center(child: CupertinoTextField(controller: controller, maxLines: null)),
-            ),
+    testWidgets('Double click and triple click alternate on Windows', (WidgetTester tester) async {
+      final controller = TextEditingController(text: testValueA);
+      addTearDown(controller.dispose);
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: Center(child: CupertinoTextField(controller: controller, maxLines: null)),
           ),
-        );
+        ),
+      );
 
-        final Offset textFieldStart = tester.getTopLeft(find.byType(CupertinoTextField));
+      final Offset textFieldStart = tester.getTopLeft(find.byType(CupertinoTextField));
 
-        // First click moves the cursor to the point of the click, not the edge of
-        // the clicked word.
-        final TestGesture gesture = await tester.startGesture(
-          textFieldStart + const Offset(200.0, 9.0),
-          pointer: 7,
-          kind: PointerDeviceKind.mouse,
-        );
-        await tester.pump();
-        await gesture.up();
-        await tester.pump(const Duration(milliseconds: 50));
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, 12);
+      // First click moves the cursor to the point of the click, not the edge of
+      // the clicked word.
+      final TestGesture gesture = await tester.startGesture(
+        textFieldStart + const Offset(200.0, 9.0),
+        pointer: 7,
+        kind: PointerDeviceKind.mouse,
+      );
+      await tester.pump();
+      await gesture.up();
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, 12);
 
-        // Second click selects the word.
-        await gesture.down(textFieldStart + const Offset(200.0, 9.0));
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
-        expect(controller.selection, const TextSelection(baseOffset: 11, extentOffset: 15));
+      // Second click selects the word.
+      await gesture.down(textFieldStart + const Offset(200.0, 9.0));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+      expect(controller.selection, const TextSelection(baseOffset: 11, extentOffset: 15));
 
-        // Triple click selects the paragraph.
-        await gesture.down(textFieldStart + const Offset(200.0, 9.0));
-        await tester.pump();
-        await gesture.up();
-        await tester.pumpAndSettle();
-        expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 20));
+      // Triple click selects the paragraph.
+      await gesture.down(textFieldStart + const Offset(200.0, 9.0));
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
+      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 20));
 
-        // Clicking again selects the word.
-        await gesture.down(textFieldStart + const Offset(200.0, 9.0));
-        await tester.pump();
-        await gesture.up();
-        await tester.pump(const Duration(milliseconds: 50));
-        expect(controller.selection, const TextSelection(baseOffset: 11, extentOffset: 15));
+      // Clicking again selects the word.
+      await gesture.down(textFieldStart + const Offset(200.0, 9.0));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(controller.selection, const TextSelection(baseOffset: 11, extentOffset: 15));
 
-        await gesture.down(textFieldStart + const Offset(200.0, 9.0));
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
-        // Clicking again selects the paragraph.
-        expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 20));
+      await gesture.down(textFieldStart + const Offset(200.0, 9.0));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+      // Clicking again selects the paragraph.
+      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 20));
 
-        await gesture.down(textFieldStart + const Offset(200.0, 9.0));
-        await tester.pump();
-        await gesture.up();
-        await tester.pumpAndSettle();
-        // Clicking again selects the word.
-        expect(controller.selection, const TextSelection(baseOffset: 11, extentOffset: 15));
+      await gesture.down(textFieldStart + const Offset(200.0, 9.0));
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
+      // Clicking again selects the word.
+      expect(controller.selection, const TextSelection(baseOffset: 11, extentOffset: 15));
 
-        await gesture.down(textFieldStart + const Offset(200.0, 9.0));
-        await tester.pump();
-        await gesture.up();
-        await tester.pump(const Duration(milliseconds: 50));
-        // Clicking again selects the paragraph.
-        expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 20));
+      await gesture.down(textFieldStart + const Offset(200.0, 9.0));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump(const Duration(milliseconds: 50));
+      // Clicking again selects the paragraph.
+      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 20));
 
-        await gesture.down(textFieldStart + const Offset(200.0, 9.0));
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
-        // Clicking again selects the word.
-        expect(controller.selection, const TextSelection(baseOffset: 11, extentOffset: 15));
+      await gesture.down(textFieldStart + const Offset(200.0, 9.0));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+      // Clicking again selects the word.
+      expect(controller.selection, const TextSelection(baseOffset: 11, extentOffset: 15));
 
-        await gesture.down(textFieldStart + const Offset(200.0, 9.0));
-        await tester.pump();
-        await gesture.up();
-        await tester.pumpAndSettle();
-        // Clicking again selects the paragraph.
-        expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 20));
-      },
-      variant: TargetPlatformVariant.only(TargetPlatform.windows),
-    );
+      await gesture.down(textFieldStart + const Offset(200.0, 9.0));
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
+      // Clicking again selects the paragraph.
+      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 20));
+    }, variant: TargetPlatformVariant.only(TargetPlatform.windows));
   });
 
   testWidgets('force press selects word', (WidgetTester tester) async {
@@ -4800,213 +4740,203 @@ void main() {
     ),
   );
 
-  testWidgets(
-    'Can drag one handle past the other on iOS',
-    (WidgetTester tester) async {
-      final controller = TextEditingController(text: 'abc def ghi');
-      addTearDown(controller.dispose);
-      // On iOS/iPadOS, during a tap we select the edge of the word closest to the tap.
-      // On macOS, we select the precise position of the tap.
-      final isTargetPlatformIOS = defaultTargetPlatform == TargetPlatform.iOS;
-      // Provide a [TextSelectionControls] that builds selection handles.
-      final TextSelectionControls selectionControls = CupertinoTextSelectionHandleControls();
+  testWidgets('Can drag one handle past the other on iOS', (WidgetTester tester) async {
+    final controller = TextEditingController(text: 'abc def ghi');
+    addTearDown(controller.dispose);
+    // On iOS/iPadOS, during a tap we select the edge of the word closest to the tap.
+    // On macOS, we select the precise position of the tap.
+    final isTargetPlatformIOS = defaultTargetPlatform == TargetPlatform.iOS;
+    // Provide a [TextSelectionControls] that builds selection handles.
+    final TextSelectionControls selectionControls = CupertinoTextSelectionHandleControls();
 
-      await tester.pumpWidget(
-        CupertinoApp(
-          home: Center(
-            child: CupertinoTextField(
-              dragStartBehavior: DragStartBehavior.down,
-              controller: controller,
-              selectionControls: selectionControls,
-              style: const TextStyle(fontSize: 10.0),
-            ),
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(
+          child: CupertinoTextField(
+            dragStartBehavior: DragStartBehavior.down,
+            controller: controller,
+            selectionControls: selectionControls,
+            style: const TextStyle(fontSize: 10.0),
           ),
         ),
-      );
+      ),
+    );
 
-      // Double tap on 'e' to select 'def'.
-      final Offset ePos = textOffsetToPosition(tester, 5);
-      await tester.tapAt(ePos, pointer: 7);
-      await tester.pump(const Duration(milliseconds: 50));
-      expect(controller.selection.isCollapsed, isTrue);
-      expect(controller.selection.baseOffset, isTargetPlatformIOS ? 7 : 5);
-      await tester.tapAt(ePos, pointer: 7);
-      await tester.pumpAndSettle();
-      expect(controller.selection.baseOffset, 4);
-      expect(controller.selection.extentOffset, 7);
+    // Double tap on 'e' to select 'def'.
+    final Offset ePos = textOffsetToPosition(tester, 5);
+    await tester.tapAt(ePos, pointer: 7);
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(controller.selection.isCollapsed, isTrue);
+    expect(controller.selection.baseOffset, isTargetPlatformIOS ? 7 : 5);
+    await tester.tapAt(ePos, pointer: 7);
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 4);
+    expect(controller.selection.extentOffset, 7);
 
-      final RenderEditable renderEditable = findRenderEditable(tester);
-      final List<TextSelectionPoint> endpoints = globalize(
-        renderEditable.getEndpointsForSelection(controller.selection),
-        renderEditable,
-      );
-      expect(endpoints.length, 2);
+    final RenderEditable renderEditable = findRenderEditable(tester);
+    final List<TextSelectionPoint> endpoints = globalize(
+      renderEditable.getEndpointsForSelection(controller.selection),
+      renderEditable,
+    );
+    expect(endpoints.length, 2);
 
-      // On Mac, the toolbar blocks the drag on the right handle, so hide it.
-      final EditableTextState editableTextState = tester.state(find.byType(EditableText));
-      editableTextState.hideToolbar(false);
-      await tester.pumpAndSettle();
+    // On Mac, the toolbar blocks the drag on the right handle, so hide it.
+    final EditableTextState editableTextState = tester.state(find.byType(EditableText));
+    editableTextState.hideToolbar(false);
+    await tester.pumpAndSettle();
 
-      // Drag the right handle until there's only 1 char selected.
-      // We use a small offset because the endpoint is on the very corner
-      // of the handle.
-      final Offset handlePos = endpoints[1].point;
-      Offset newHandlePos = textOffsetToPosition(tester, 5); // Position of 'e'.
-      final TestGesture gesture = await tester.startGesture(handlePos, pointer: 7);
-      await tester.pump();
-      await gesture.moveTo(newHandlePos);
-      await tester.pump();
-      expect(controller.selection.baseOffset, 4);
-      expect(controller.selection.extentOffset, 5);
+    // Drag the right handle until there's only 1 char selected.
+    // We use a small offset because the endpoint is on the very corner
+    // of the handle.
+    final Offset handlePos = endpoints[1].point;
+    Offset newHandlePos = textOffsetToPosition(tester, 5); // Position of 'e'.
+    final TestGesture gesture = await tester.startGesture(handlePos, pointer: 7);
+    await tester.pump();
+    await gesture.moveTo(newHandlePos);
+    await tester.pump();
+    expect(controller.selection.baseOffset, 4);
+    expect(controller.selection.extentOffset, 5);
 
-      newHandlePos = textOffsetToPosition(tester, 2); // Position of 'c'.
-      await gesture.moveTo(newHandlePos);
-      await tester.pump();
-      await gesture.up();
-      await tester.pump();
+    newHandlePos = textOffsetToPosition(tester, 2); // Position of 'c'.
+    await gesture.moveTo(newHandlePos);
+    await tester.pump();
+    await gesture.up();
+    await tester.pump();
 
-      // The selection inverts moving beyond the left handle.
-      expect(controller.selection.baseOffset, 4);
-      expect(controller.selection.extentOffset, 2);
-    },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-  );
+    // The selection inverts moving beyond the left handle.
+    expect(controller.selection.baseOffset, 4);
+    expect(controller.selection.extentOffset, 2);
+  }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
-  testWidgets(
-    'assertion error is not thrown when attempting to drag both selection handles',
-    (WidgetTester tester) async {
-      // Regression test for https://github.com/flutter/flutter/issues/168578.
-      final controller = TextEditingController(text: 'abc def ghi');
-      addTearDown(controller.dispose);
+  testWidgets('assertion error is not thrown when attempting to drag both selection handles', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/168578.
+    final controller = TextEditingController(text: 'abc def ghi');
+    addTearDown(controller.dispose);
 
-      await tester.pumpWidget(
-        CupertinoApp(
-          home: Center(
-            child: CupertinoTextField(
-              dragStartBehavior: DragStartBehavior.down,
-              controller: controller,
-              style: const TextStyle(fontSize: 10.0),
-            ),
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(
+          child: CupertinoTextField(
+            dragStartBehavior: DragStartBehavior.down,
+            controller: controller,
+            style: const TextStyle(fontSize: 10.0),
           ),
         ),
-      );
+      ),
+    );
 
-      // Double tap on 'e' to select 'def'.
-      final Offset ePos = textOffsetToPosition(tester, 5);
-      await tester.tapAt(ePos, pointer: 7);
-      await tester.pump(const Duration(milliseconds: 50));
-      expect(controller.selection.isCollapsed, isTrue);
-      expect(controller.selection.baseOffset, 7);
-      await tester.tapAt(ePos, pointer: 7);
-      await tester.pumpAndSettle();
-      expect(controller.selection.baseOffset, 4);
-      expect(controller.selection.extentOffset, 7);
+    // Double tap on 'e' to select 'def'.
+    final Offset ePos = textOffsetToPosition(tester, 5);
+    await tester.tapAt(ePos, pointer: 7);
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(controller.selection.isCollapsed, isTrue);
+    expect(controller.selection.baseOffset, 7);
+    await tester.tapAt(ePos, pointer: 7);
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 4);
+    expect(controller.selection.extentOffset, 7);
 
-      final RenderEditable renderEditable = findRenderEditable(tester);
-      final List<TextSelectionPoint> endpoints = globalize(
-        renderEditable.getEndpointsForSelection(controller.selection),
-        renderEditable,
-      );
-      expect(endpoints.length, 2);
+    final RenderEditable renderEditable = findRenderEditable(tester);
+    final List<TextSelectionPoint> endpoints = globalize(
+      renderEditable.getEndpointsForSelection(controller.selection),
+      renderEditable,
+    );
+    expect(endpoints.length, 2);
 
-      // Drag the end handle to 'g'.
-      final Offset endHandlePos = endpoints[1].point;
-      Offset newHandlePos = textOffsetToPosition(tester, 9); // Position of 'g'.
-      final TestGesture endHandleGesture = await tester.startGesture(endHandlePos, pointer: 7);
-      await tester.pump();
-      await endHandleGesture.moveTo(newHandlePos);
-      await tester.pump();
-      expect(controller.selection.baseOffset, 4);
-      expect(controller.selection.extentOffset, 9);
+    // Drag the end handle to 'g'.
+    final Offset endHandlePos = endpoints[1].point;
+    Offset newHandlePos = textOffsetToPosition(tester, 9); // Position of 'g'.
+    final TestGesture endHandleGesture = await tester.startGesture(endHandlePos, pointer: 7);
+    await tester.pump();
+    await endHandleGesture.moveTo(newHandlePos);
+    await tester.pump();
+    expect(controller.selection.baseOffset, 4);
+    expect(controller.selection.extentOffset, 9);
 
-      // Attempt to drag the start handle to the start of the text.
-      final Offset startHandlePos = endpoints[0].point;
-      newHandlePos = textOffsetToPosition(tester, 0);
-      final TestGesture startHandleGesture = await tester.startGesture(startHandlePos, pointer: 8);
-      await tester.pump();
-      await startHandleGesture.moveTo(newHandlePos);
-      await tester.pump();
-      await startHandleGesture.up();
-      await tester.pump();
+    // Attempt to drag the start handle to the start of the text.
+    final Offset startHandlePos = endpoints[0].point;
+    newHandlePos = textOffsetToPosition(tester, 0);
+    final TestGesture startHandleGesture = await tester.startGesture(startHandlePos, pointer: 8);
+    await tester.pump();
+    await startHandleGesture.moveTo(newHandlePos);
+    await tester.pump();
+    await startHandleGesture.up();
+    await tester.pump();
 
-      // Drag the end handle to the end of the text after releasing the start handle.
-      newHandlePos = textOffsetToPosition(tester, 11); // Position of 'i'.
-      await tester.pump();
-      await endHandleGesture.moveTo(newHandlePos);
-      await tester.pump();
-      await endHandleGesture.up();
-      await tester.pump();
+    // Drag the end handle to the end of the text after releasing the start handle.
+    newHandlePos = textOffsetToPosition(tester, 11); // Position of 'i'.
+    await tester.pump();
+    await endHandleGesture.moveTo(newHandlePos);
+    await tester.pump();
+    await endHandleGesture.up();
+    await tester.pump();
 
-      expect(tester.takeException(), isNull);
-      expect(controller.selection.baseOffset, 4);
-      expect(controller.selection.extentOffset, 11);
-    },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-  );
+    expect(tester.takeException(), isNull);
+    expect(controller.selection.baseOffset, 4);
+    expect(controller.selection.extentOffset, 11);
+  }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
-  testWidgets(
-    'Can only drag one handle at a time on iOS',
-    (WidgetTester tester) async {
-      final controller = TextEditingController(text: 'abc def ghi');
-      addTearDown(controller.dispose);
+  testWidgets('Can only drag one handle at a time on iOS', (WidgetTester tester) async {
+    final controller = TextEditingController(text: 'abc def ghi');
+    addTearDown(controller.dispose);
 
-      await tester.pumpWidget(
-        CupertinoApp(
-          home: Center(
-            child: CupertinoTextField(
-              dragStartBehavior: DragStartBehavior.down,
-              controller: controller,
-              style: const TextStyle(fontSize: 10.0),
-            ),
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(
+          child: CupertinoTextField(
+            dragStartBehavior: DragStartBehavior.down,
+            controller: controller,
+            style: const TextStyle(fontSize: 10.0),
           ),
         ),
-      );
+      ),
+    );
 
-      // Double tap on 'e' to select 'def'.
-      final Offset ePos = textOffsetToPosition(tester, 5);
-      await tester.tapAt(ePos, pointer: 7);
-      await tester.pump(const Duration(milliseconds: 50));
-      expect(controller.selection.isCollapsed, isTrue);
-      expect(controller.selection.baseOffset, 7);
-      await tester.tapAt(ePos, pointer: 7);
-      await tester.pumpAndSettle();
-      expect(controller.selection.baseOffset, 4);
-      expect(controller.selection.extentOffset, 7);
+    // Double tap on 'e' to select 'def'.
+    final Offset ePos = textOffsetToPosition(tester, 5);
+    await tester.tapAt(ePos, pointer: 7);
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(controller.selection.isCollapsed, isTrue);
+    expect(controller.selection.baseOffset, 7);
+    await tester.tapAt(ePos, pointer: 7);
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 4);
+    expect(controller.selection.extentOffset, 7);
 
-      final RenderEditable renderEditable = findRenderEditable(tester);
-      final List<TextSelectionPoint> endpoints = globalize(
-        renderEditable.getEndpointsForSelection(controller.selection),
-        renderEditable,
-      );
-      expect(endpoints.length, 2);
+    final RenderEditable renderEditable = findRenderEditable(tester);
+    final List<TextSelectionPoint> endpoints = globalize(
+      renderEditable.getEndpointsForSelection(controller.selection),
+      renderEditable,
+    );
+    expect(endpoints.length, 2);
 
-      // Drag the end handle to the end of the text.
-      final Offset endHandlePos = endpoints[1].point;
-      Offset newHandlePos = textOffsetToPosition(tester, 11); // Position of 'i'.
-      final TestGesture endHandleGesture = await tester.startGesture(endHandlePos, pointer: 7);
-      await tester.pump();
-      await endHandleGesture.moveTo(newHandlePos);
-      await tester.pump();
-      expect(controller.selection.baseOffset, 4);
-      expect(controller.selection.extentOffset, 11);
+    // Drag the end handle to the end of the text.
+    final Offset endHandlePos = endpoints[1].point;
+    Offset newHandlePos = textOffsetToPosition(tester, 11); // Position of 'i'.
+    final TestGesture endHandleGesture = await tester.startGesture(endHandlePos, pointer: 7);
+    await tester.pump();
+    await endHandleGesture.moveTo(newHandlePos);
+    await tester.pump();
+    expect(controller.selection.baseOffset, 4);
+    expect(controller.selection.extentOffset, 11);
 
-      // Attempt to drag the start handle to the start of the text.
-      final Offset startHandlePos = endpoints[0].point;
-      newHandlePos = textOffsetToPosition(tester, 0);
-      final TestGesture startHandleGesture = await tester.startGesture(startHandlePos, pointer: 8);
-      await tester.pump();
-      await startHandleGesture.moveTo(newHandlePos);
-      await tester.pump();
-      await startHandleGesture.up();
-      await endHandleGesture.up();
-      await tester.pump();
+    // Attempt to drag the start handle to the start of the text.
+    final Offset startHandlePos = endpoints[0].point;
+    newHandlePos = textOffsetToPosition(tester, 0);
+    final TestGesture startHandleGesture = await tester.startGesture(startHandlePos, pointer: 8);
+    await tester.pump();
+    await startHandleGesture.moveTo(newHandlePos);
+    await tester.pump();
+    await startHandleGesture.up();
+    await endHandleGesture.up();
+    await tester.pump();
 
-      // The start handle does not cause the selection to change.
-      expect(controller.selection.baseOffset, 4);
-      expect(controller.selection.extentOffset, 11);
-    },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-  );
+    // The start handle does not cause the selection to change.
+    expect(controller.selection.baseOffset, 4);
+    expect(controller.selection.extentOffset, 11);
+  }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
   testWidgets(
     'Can only drag one selection handle at a time on Android web',
@@ -5623,61 +5553,59 @@ void main() {
     variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
   );
 
-  testWidgets(
-    'Can move cursor when dragging, when tap is on collapsed selection (iOS)',
-    (WidgetTester tester) async {
-      final controller = TextEditingController();
-      addTearDown(controller.dispose);
+  testWidgets('Can move cursor when dragging, when tap is on collapsed selection (iOS)', (
+    WidgetTester tester,
+  ) async {
+    final controller = TextEditingController();
+    addTearDown(controller.dispose);
 
-      await tester.pumpWidget(
-        CupertinoApp(
-          home: CupertinoPageScaffold(
-            child: CupertinoTextField(
-              dragStartBehavior: DragStartBehavior.down,
-              controller: controller,
-            ),
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: CupertinoPageScaffold(
+          child: CupertinoTextField(
+            dragStartBehavior: DragStartBehavior.down,
+            controller: controller,
           ),
         ),
-      );
+      ),
+    );
 
-      const testValue = 'abc def ghi';
-      await tester.enterText(find.byType(CupertinoTextField), testValue);
-      await tester.pumpAndSettle(const Duration(milliseconds: 200));
+    const testValue = 'abc def ghi';
+    await tester.enterText(find.byType(CupertinoTextField), testValue);
+    await tester.pumpAndSettle(const Duration(milliseconds: 200));
 
-      final Offset ePos = textOffsetToPosition(tester, testValue.indexOf('e'));
-      final Offset iPos = textOffsetToPosition(tester, testValue.indexOf('i'));
+    final Offset ePos = textOffsetToPosition(tester, testValue.indexOf('e'));
+    final Offset iPos = textOffsetToPosition(tester, testValue.indexOf('i'));
 
-      // Tap on text field to gain focus, and set selection to '|g'. On iOS
-      // the selection is set to the word edge closest to the tap position.
-      // We await for [kDoubleTapTimeout] after the up event, so our next down
-      // event does not register as a double tap.
-      final TestGesture gesture = await tester.startGesture(ePos);
-      await tester.pump();
-      await gesture.up();
-      await tester.pumpAndSettle(kDoubleTapTimeout);
+    // Tap on text field to gain focus, and set selection to '|g'. On iOS
+    // the selection is set to the word edge closest to the tap position.
+    // We await for [kDoubleTapTimeout] after the up event, so our next down
+    // event does not register as a double tap.
+    final TestGesture gesture = await tester.startGesture(ePos);
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle(kDoubleTapTimeout);
 
-      expect(controller.selection.isCollapsed, true);
-      expect(controller.selection.baseOffset, 7);
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, 7);
 
-      // If the position we tap during a drag start is on the collapsed selection, then
-      // we can move the cursor with a drag.
-      // Here we tap on '|g', where our selection was previously, and move to '|i'.
-      await gesture.down(textOffsetToPosition(tester, 7));
-      await tester.pump();
-      await gesture.moveTo(iPos);
-      await tester.pumpAndSettle();
+    // If the position we tap during a drag start is on the collapsed selection, then
+    // we can move the cursor with a drag.
+    // Here we tap on '|g', where our selection was previously, and move to '|i'.
+    await gesture.down(textOffsetToPosition(tester, 7));
+    await tester.pump();
+    await gesture.moveTo(iPos);
+    await tester.pumpAndSettle();
 
-      expect(controller.selection.isCollapsed, true);
-      expect(controller.selection.baseOffset, testValue.indexOf('i'));
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, testValue.indexOf('i'));
 
-      // End gesture and skip the magnifier hide animation, so it can release
-      // resources.
-      await gesture.up();
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 150));
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-  );
+    // End gesture and skip the magnifier hide animation, so it can release
+    // resources.
+    await gesture.up();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 150));
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
 
   testWidgets(
     'Can move cursor when dragging, when tap is on collapsed selection (iOS) - multiline',
@@ -9472,77 +9400,75 @@ void main() {
       );
     });
 
-    testWidgets(
-      'Can drag handles to show, unshow, and update magnifier',
-      (WidgetTester tester) async {
-        final controller = TextEditingController();
-        addTearDown(controller.dispose);
-        await tester.pumpWidget(
-          CupertinoApp(
-            home: CupertinoPageScaffold(
-              child: Builder(
-                builder: (BuildContext context) => CupertinoTextField(
-                  dragStartBehavior: DragStartBehavior.down,
-                  controller: controller,
-                  magnifierConfiguration: TextMagnifierConfiguration(
-                    magnifierBuilder:
-                        (
-                          _,
-                          MagnifierController controller,
-                          ValueNotifier<MagnifierInfo> localMagnifierInfo,
-                        ) {
-                          magnifierInfo = localMagnifierInfo;
-                          return fakeMagnifier;
-                        },
-                  ),
+    testWidgets('Can drag handles to show, unshow, and update magnifier', (
+      WidgetTester tester,
+    ) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: CupertinoPageScaffold(
+            child: Builder(
+              builder: (BuildContext context) => CupertinoTextField(
+                dragStartBehavior: DragStartBehavior.down,
+                controller: controller,
+                magnifierConfiguration: TextMagnifierConfiguration(
+                  magnifierBuilder:
+                      (
+                        _,
+                        MagnifierController controller,
+                        ValueNotifier<MagnifierInfo> localMagnifierInfo,
+                      ) {
+                        magnifierInfo = localMagnifierInfo;
+                        return fakeMagnifier;
+                      },
                 ),
               ),
             ),
           ),
-        );
+        ),
+      );
 
-        const testValue = 'abc def ghi';
-        await tester.enterText(find.byType(CupertinoTextField), testValue);
+      const testValue = 'abc def ghi';
+      await tester.enterText(find.byType(CupertinoTextField), testValue);
 
-        // Double tap the 'e' to select 'def'.
-        await tester.tapAt(textOffsetToPosition(tester, testValue.indexOf('e')));
-        await tester.pump(const Duration(milliseconds: 30));
-        await tester.tapAt(textOffsetToPosition(tester, testValue.indexOf('e')));
-        await tester.pump(const Duration(milliseconds: 30));
+      // Double tap the 'e' to select 'def'.
+      await tester.tapAt(textOffsetToPosition(tester, testValue.indexOf('e')));
+      await tester.pump(const Duration(milliseconds: 30));
+      await tester.tapAt(textOffsetToPosition(tester, testValue.indexOf('e')));
+      await tester.pump(const Duration(milliseconds: 30));
 
-        final TextSelection selection = controller.selection;
+      final TextSelection selection = controller.selection;
 
-        final RenderEditable renderEditable = findRenderEditable(tester);
-        final List<TextSelectionPoint> endpoints = globalize(
-          renderEditable.getEndpointsForSelection(selection),
-          renderEditable,
-        );
+      final RenderEditable renderEditable = findRenderEditable(tester);
+      final List<TextSelectionPoint> endpoints = globalize(
+        renderEditable.getEndpointsForSelection(selection),
+        renderEditable,
+      );
 
-        // Drag the right handle 2 letters to the right.
-        final Offset handlePos = endpoints.last.point + const Offset(1.0, 1.0);
-        final TestGesture gesture = await tester.startGesture(handlePos, pointer: 7);
+      // Drag the right handle 2 letters to the right.
+      final Offset handlePos = endpoints.last.point + const Offset(1.0, 1.0);
+      final TestGesture gesture = await tester.startGesture(handlePos, pointer: 7);
 
-        Offset? firstDragGesturePosition;
+      Offset? firstDragGesturePosition;
 
-        await gesture.moveTo(textOffsetToPosition(tester, testValue.length - 2));
-        await tester.pump();
+      await gesture.moveTo(textOffsetToPosition(tester, testValue.length - 2));
+      await tester.pump();
 
-        expect(find.byKey(fakeMagnifier.key!), findsOneWidget);
-        firstDragGesturePosition = magnifierInfo.value.globalGesturePosition;
+      expect(find.byKey(fakeMagnifier.key!), findsOneWidget);
+      firstDragGesturePosition = magnifierInfo.value.globalGesturePosition;
 
-        await gesture.moveTo(textOffsetToPosition(tester, testValue.length));
-        await tester.pump();
+      await gesture.moveTo(textOffsetToPosition(tester, testValue.length));
+      await tester.pump();
 
-        // Expect the position the magnifier gets to have moved.
-        expect(firstDragGesturePosition, isNot(magnifierInfo.value.globalGesturePosition));
+      // Expect the position the magnifier gets to have moved.
+      expect(firstDragGesturePosition, isNot(magnifierInfo.value.globalGesturePosition));
 
-        await gesture.up();
-        await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(find.byKey(fakeMagnifier.key!), findsNothing);
-      },
-      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-    );
+      expect(find.byKey(fakeMagnifier.key!), findsNothing);
+    }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
     testWidgets(
       'Can drag to show, unshow, and update magnifier',
@@ -9652,243 +9578,237 @@ void main() {
       }),
     );
 
-    testWidgets(
-      'Can long press to show, unshow, and update magnifier on non-Apple platforms',
-      (WidgetTester tester) async {
-        final controller = TextEditingController();
-        addTearDown(controller.dispose);
-        final isTargetPlatformAndroid = defaultTargetPlatform == TargetPlatform.android;
-        await tester.pumpWidget(
-          CupertinoApp(
-            home: Center(
-              child: CupertinoTextField(
-                dragStartBehavior: DragStartBehavior.down,
-                controller: controller,
-                magnifierConfiguration: TextMagnifierConfiguration(
-                  magnifierBuilder:
-                      (
-                        _,
-                        MagnifierController controller,
-                        ValueNotifier<MagnifierInfo> localMagnifierInfo,
-                      ) {
-                        magnifierInfo = localMagnifierInfo;
-                        return fakeMagnifier;
-                      },
-                ),
+    testWidgets('Can long press to show, unshow, and update magnifier on non-Apple platforms', (
+      WidgetTester tester,
+    ) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+      final isTargetPlatformAndroid = defaultTargetPlatform == TargetPlatform.android;
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: CupertinoTextField(
+              dragStartBehavior: DragStartBehavior.down,
+              controller: controller,
+              magnifierConfiguration: TextMagnifierConfiguration(
+                magnifierBuilder:
+                    (
+                      _,
+                      MagnifierController controller,
+                      ValueNotifier<MagnifierInfo> localMagnifierInfo,
+                    ) {
+                      magnifierInfo = localMagnifierInfo;
+                      return fakeMagnifier;
+                    },
               ),
             ),
           ),
-        );
+        ),
+      );
 
-        const testValue = 'abc def ghi';
-        await tester.enterText(find.byType(CupertinoTextField), testValue);
-        await tester.pumpAndSettle();
+      const testValue = 'abc def ghi';
+      await tester.enterText(find.byType(CupertinoTextField), testValue);
+      await tester.pumpAndSettle();
 
-        // Tap at 'e' to move the cursor before the 'e'.
-        await tester.tapAt(textOffsetToPosition(tester, testValue.indexOf('e')));
-        await tester.pumpAndSettle(const Duration(milliseconds: 300));
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, isTargetPlatformAndroid ? 5 : 4);
-        expect(find.byKey(fakeMagnifier.key!), findsNothing);
+      // Tap at 'e' to move the cursor before the 'e'.
+      await tester.tapAt(textOffsetToPosition(tester, testValue.indexOf('e')));
+      await tester.pumpAndSettle(const Duration(milliseconds: 300));
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, isTargetPlatformAndroid ? 5 : 4);
+      expect(find.byKey(fakeMagnifier.key!), findsNothing);
 
-        // Long press the 'e' to select 'def' and show the magnifier.
-        final TestGesture gesture = await tester.startGesture(
-          textOffsetToPosition(tester, testValue.indexOf('e')),
-        );
-        await tester.pumpAndSettle(const Duration(milliseconds: 1000));
-        expect(controller.selection.baseOffset, 4);
-        expect(controller.selection.extentOffset, 7);
-        expect(find.byKey(fakeMagnifier.key!), findsOneWidget);
+      // Long press the 'e' to select 'def' and show the magnifier.
+      final TestGesture gesture = await tester.startGesture(
+        textOffsetToPosition(tester, testValue.indexOf('e')),
+      );
+      await tester.pumpAndSettle(const Duration(milliseconds: 1000));
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 7);
+      expect(find.byKey(fakeMagnifier.key!), findsOneWidget);
 
-        final Offset firstLongPressGesturePosition = magnifierInfo.value.globalGesturePosition;
+      final Offset firstLongPressGesturePosition = magnifierInfo.value.globalGesturePosition;
 
-        // Move the gesture to 'h' to extend the selection to 'ghi'.
-        await gesture.moveTo(textOffsetToPosition(tester, testValue.indexOf('h')));
-        await tester.pumpAndSettle();
-        expect(controller.selection.baseOffset, 4);
-        expect(controller.selection.extentOffset, 11);
-        expect(find.byKey(fakeMagnifier.key!), findsOneWidget);
-        // Expect the position the magnifier gets to have moved.
-        expect(firstLongPressGesturePosition, isNot(magnifierInfo.value.globalGesturePosition));
+      // Move the gesture to 'h' to extend the selection to 'ghi'.
+      await gesture.moveTo(textOffsetToPosition(tester, testValue.indexOf('h')));
+      await tester.pumpAndSettle();
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 11);
+      expect(find.byKey(fakeMagnifier.key!), findsOneWidget);
+      // Expect the position the magnifier gets to have moved.
+      expect(firstLongPressGesturePosition, isNot(magnifierInfo.value.globalGesturePosition));
 
-        // End the long press to hide the magnifier.
-        await gesture.up();
-        await tester.pumpAndSettle();
-        expect(find.byKey(fakeMagnifier.key!), findsNothing);
-      },
-      variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.android}),
-    );
+      // End the long press to hide the magnifier.
+      await gesture.up();
+      await tester.pumpAndSettle();
+      expect(find.byKey(fakeMagnifier.key!), findsNothing);
+    }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.android}));
 
-    testWidgets(
-      'Can long press to show, unshow, and update magnifier on iOS',
-      (WidgetTester tester) async {
-        final controller = TextEditingController();
-        addTearDown(controller.dispose);
-        final isTargetPlatformAndroid = defaultTargetPlatform == TargetPlatform.android;
-        await tester.pumpWidget(
-          CupertinoApp(
-            home: Center(
-              child: CupertinoTextField(
-                dragStartBehavior: DragStartBehavior.down,
-                controller: controller,
-                magnifierConfiguration: TextMagnifierConfiguration(
-                  magnifierBuilder:
-                      (
-                        _,
-                        MagnifierController controller,
-                        ValueNotifier<MagnifierInfo> localMagnifierInfo,
-                      ) {
-                        magnifierInfo = localMagnifierInfo;
-                        return fakeMagnifier;
-                      },
-                ),
+    testWidgets('Can long press to show, unshow, and update magnifier on iOS', (
+      WidgetTester tester,
+    ) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+      final isTargetPlatformAndroid = defaultTargetPlatform == TargetPlatform.android;
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: CupertinoTextField(
+              dragStartBehavior: DragStartBehavior.down,
+              controller: controller,
+              magnifierConfiguration: TextMagnifierConfiguration(
+                magnifierBuilder:
+                    (
+                      _,
+                      MagnifierController controller,
+                      ValueNotifier<MagnifierInfo> localMagnifierInfo,
+                    ) {
+                      magnifierInfo = localMagnifierInfo;
+                      return fakeMagnifier;
+                    },
               ),
             ),
           ),
-        );
+        ),
+      );
 
-        const testValue = 'abc def ghi';
-        await tester.enterText(find.byType(CupertinoTextField), testValue);
-        await tester.pumpAndSettle();
+      const testValue = 'abc def ghi';
+      await tester.enterText(find.byType(CupertinoTextField), testValue);
+      await tester.pumpAndSettle();
 
-        // Tap at 'e' to set the selection to position 5 on Android.
-        // Tap at 'e' to set the selection to the closest word edge, which is position 4 on iOS.
-        await tester.tapAt(textOffsetToPosition(tester, testValue.indexOf('e')));
-        await tester.pumpAndSettle(const Duration(milliseconds: 300));
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, isTargetPlatformAndroid ? 5 : 7);
-        expect(find.byKey(fakeMagnifier.key!), findsNothing);
+      // Tap at 'e' to set the selection to position 5 on Android.
+      // Tap at 'e' to set the selection to the closest word edge, which is position 4 on iOS.
+      await tester.tapAt(textOffsetToPosition(tester, testValue.indexOf('e')));
+      await tester.pumpAndSettle(const Duration(milliseconds: 300));
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, isTargetPlatformAndroid ? 5 : 7);
+      expect(find.byKey(fakeMagnifier.key!), findsNothing);
 
-        // Long press the 'e' to move the cursor in front of the 'e' and show the magnifier.
-        final TestGesture gesture = await tester.startGesture(
-          textOffsetToPosition(tester, testValue.indexOf('e')),
-        );
-        await tester.pumpAndSettle(const Duration(milliseconds: 1000));
-        expect(controller.selection.baseOffset, 5);
-        expect(controller.selection.extentOffset, 5);
-        expect(find.byKey(fakeMagnifier.key!), findsOneWidget);
+      // Long press the 'e' to move the cursor in front of the 'e' and show the magnifier.
+      final TestGesture gesture = await tester.startGesture(
+        textOffsetToPosition(tester, testValue.indexOf('e')),
+      );
+      await tester.pumpAndSettle(const Duration(milliseconds: 1000));
+      expect(controller.selection.baseOffset, 5);
+      expect(controller.selection.extentOffset, 5);
+      expect(find.byKey(fakeMagnifier.key!), findsOneWidget);
 
-        final Offset firstLongPressGesturePosition = magnifierInfo.value.globalGesturePosition;
+      final Offset firstLongPressGesturePosition = magnifierInfo.value.globalGesturePosition;
 
-        // Move the gesture to 'h' to update the magnifier and move the cursor to 'h'.
-        await gesture.moveTo(textOffsetToPosition(tester, testValue.indexOf('h')));
-        await tester.pumpAndSettle();
-        expect(controller.selection.baseOffset, 9);
-        expect(controller.selection.extentOffset, 9);
-        expect(find.byKey(fakeMagnifier.key!), findsOneWidget);
-        // Expect the position the magnifier gets to have moved.
-        expect(firstLongPressGesturePosition, isNot(magnifierInfo.value.globalGesturePosition));
+      // Move the gesture to 'h' to update the magnifier and move the cursor to 'h'.
+      await gesture.moveTo(textOffsetToPosition(tester, testValue.indexOf('h')));
+      await tester.pumpAndSettle();
+      expect(controller.selection.baseOffset, 9);
+      expect(controller.selection.extentOffset, 9);
+      expect(find.byKey(fakeMagnifier.key!), findsOneWidget);
+      // Expect the position the magnifier gets to have moved.
+      expect(firstLongPressGesturePosition, isNot(magnifierInfo.value.globalGesturePosition));
 
-        // End the long press to hide the magnifier.
-        await gesture.up();
-        await tester.pumpAndSettle();
-        expect(find.byKey(fakeMagnifier.key!), findsNothing);
-      },
-      variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-    );
+      // End the long press to hide the magnifier.
+      await gesture.up();
+      await tester.pumpAndSettle();
+      expect(find.byKey(fakeMagnifier.key!), findsNothing);
+    }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
 
-    testWidgets(
-      'Can double tap and drag to show, unshow, and update magnifier',
-      (WidgetTester tester) async {
-        final controller = TextEditingController();
-        addTearDown(controller.dispose);
-        MagnifierController? magnifierController;
-        await tester.pumpWidget(
-          CupertinoApp(
-            home: Center(
-              child: CupertinoTextField(
-                dragStartBehavior: DragStartBehavior.down,
-                controller: controller,
-                magnifierConfiguration: TextMagnifierConfiguration(
-                  magnifierBuilder:
-                      (
-                        BuildContext context,
-                        MagnifierController controller,
-                        ValueNotifier<MagnifierInfo> localMagnifierInfo,
-                      ) {
-                        magnifierController = controller;
-                        return CupertinoTextMagnifier(
-                          controller: controller,
-                          magnifierInfo: localMagnifierInfo,
-                        );
-                      },
-                ),
+    testWidgets('Can double tap and drag to show, unshow, and update magnifier', (
+      WidgetTester tester,
+    ) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+      MagnifierController? magnifierController;
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: CupertinoTextField(
+              dragStartBehavior: DragStartBehavior.down,
+              controller: controller,
+              magnifierConfiguration: TextMagnifierConfiguration(
+                magnifierBuilder:
+                    (
+                      BuildContext context,
+                      MagnifierController controller,
+                      ValueNotifier<MagnifierInfo> localMagnifierInfo,
+                    ) {
+                      magnifierController = controller;
+                      return CupertinoTextMagnifier(
+                        controller: controller,
+                        magnifierInfo: localMagnifierInfo,
+                      );
+                    },
               ),
             ),
           ),
-        );
+        ),
+      );
 
-        const testValue = 'one two three four five six seven';
-        await tester.enterText(find.byType(CupertinoTextField), testValue);
-        await tester.pumpAndSettle();
+      const testValue = 'one two three four five six seven';
+      await tester.enterText(find.byType(CupertinoTextField), testValue);
+      await tester.pumpAndSettle();
 
-        // Tap at 'e' to set the selection to the closest word edge, which is position 3 on iOS.
-        final Offset initialPosition = textOffsetToPosition(tester, testValue.indexOf('e'));
-        await tester.tapAt(initialPosition);
-        await tester.pumpAndSettle(const Duration(milliseconds: 300));
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, 3);
-        expect(magnifierController, isNull);
+      // Tap at 'e' to set the selection to the closest word edge, which is position 3 on iOS.
+      final Offset initialPosition = textOffsetToPosition(tester, testValue.indexOf('e'));
+      await tester.tapAt(initialPosition);
+      await tester.pumpAndSettle(const Duration(milliseconds: 300));
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, 3);
+      expect(magnifierController, isNull);
 
-        // Double tap the 'e' to select 'one'.
-        final TestGesture gesture = await tester.startGesture(initialPosition);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
-        await gesture.down(initialPosition);
-        await tester.pumpAndSettle();
-        expect(controller.selection.isCollapsed, false);
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 3);
-        expect(magnifierController, isNull);
+      // Double tap the 'e' to select 'one'.
+      final TestGesture gesture = await tester.startGesture(initialPosition);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+      await gesture.down(initialPosition);
+      await tester.pumpAndSettle();
+      expect(controller.selection.isCollapsed, false);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 3);
+      expect(magnifierController, isNull);
 
-        // Drag immediately after the double tap to select 'one two three four' and show the magnifier.
-        await gesture.moveTo(textOffsetToPosition(tester, 16));
-        await tester.pumpAndSettle();
+      // Drag immediately after the double tap to select 'one two three four' and show the magnifier.
+      await gesture.moveTo(textOffsetToPosition(tester, 16));
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.isCollapsed, false);
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 18);
-        expect(magnifierController, isNotNull);
-        expect(magnifierController!.shown, true);
+      expect(controller.selection.isCollapsed, false);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 18);
+      expect(magnifierController, isNotNull);
+      expect(magnifierController!.shown, true);
 
-        // Dragging down at the same position should hide the cupertino magnifier when it
-        // exceeds its `hideBelowThreshold`.
-        await gesture.moveTo(textOffsetToPosition(tester, 16) + const Offset(0.0, 50.0));
-        await tester.pumpAndSettle();
-        expect(controller.selection.isCollapsed, false);
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 18);
-        expect(magnifierController, isNotNull);
-        expect(magnifierController!.shown, false);
+      // Dragging down at the same position should hide the cupertino magnifier when it
+      // exceeds its `hideBelowThreshold`.
+      await gesture.moveTo(textOffsetToPosition(tester, 16) + const Offset(0.0, 50.0));
+      await tester.pumpAndSettle();
+      expect(controller.selection.isCollapsed, false);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 18);
+      expect(magnifierController, isNotNull);
+      expect(magnifierController!.shown, false);
 
-        // Keep draging to select 'one two three four five' while the position continues to
-        // exceed the `hideBelowThreshold` keeping the magnifier hidden.
-        await gesture.moveTo(textOffsetToPosition(tester, 20) + const Offset(0.0, 50.0));
-        await tester.pumpAndSettle();
-        expect(controller.selection.isCollapsed, false);
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 23);
-        expect(magnifierController, isNotNull);
-        expect(magnifierController!.shown, false);
+      // Keep draging to select 'one two three four five' while the position continues to
+      // exceed the `hideBelowThreshold` keeping the magnifier hidden.
+      await gesture.moveTo(textOffsetToPosition(tester, 20) + const Offset(0.0, 50.0));
+      await tester.pumpAndSettle();
+      expect(controller.selection.isCollapsed, false);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 23);
+      expect(magnifierController, isNotNull);
+      expect(magnifierController!.shown, false);
 
-        // Remove offset that is used to exceed threshold, this should reveal the magnifier.
-        await gesture.moveTo(textOffsetToPosition(tester, 20));
-        await tester.pumpAndSettle();
-        expect(controller.selection.isCollapsed, false);
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 23);
-        expect(magnifierController, isNotNull);
-        expect(magnifierController!.shown, true);
+      // Remove offset that is used to exceed threshold, this should reveal the magnifier.
+      await gesture.moveTo(textOffsetToPosition(tester, 20));
+      await tester.pumpAndSettle();
+      expect(controller.selection.isCollapsed, false);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 23);
+      expect(magnifierController, isNotNull);
+      expect(magnifierController!.shown, true);
 
-        // End the drag to hide the magnifier.
-        await gesture.up();
-        await tester.pumpAndSettle();
-        expect(magnifierController, isNotNull);
-        expect(magnifierController!.shown, false);
-      },
-      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-    );
+      // End the drag to hide the magnifier.
+      await gesture.up();
+      await tester.pumpAndSettle();
+      expect(magnifierController, isNotNull);
+      expect(magnifierController!.shown, false);
+    }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
     testWidgets(
       'cancelling long press hides magnifier',
@@ -10611,95 +10531,90 @@ void main() {
     semantics.dispose();
   }, variant: TargetPlatformVariant.all());
 
-  testWidgets(
-    'when disabled does not listen to onFocus events or gain focus',
-    (WidgetTester tester) async {
-      final semantics = SemanticsTester(tester);
-      final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;
-      final focusNode = FocusNode();
-      addTearDown(focusNode.dispose);
-      await tester.pumpWidget(
-        CupertinoApp(home: CupertinoTextField(focusNode: focusNode, enabled: false)),
-      );
-      expect(
-        semantics,
-        hasSemantics(
-          TestSemantics.root(
-            children: <TestSemantics>[
-              TestSemantics(
-                id: 1,
-                textDirection: TextDirection.ltr,
-                children: <TestSemantics>[
-                  TestSemantics(
-                    id: 2,
-                    children: <TestSemantics>[
-                      TestSemantics(
-                        id: 3,
-                        flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
-                        children: <TestSemantics>[
-                          TestSemantics(
-                            id: 4,
-                            inputType: ui.SemanticsInputType.text,
-                            flags: <SemanticsFlag>[
-                              SemanticsFlag.isTextField,
-                              SemanticsFlag.isFocusable,
-                              SemanticsFlag.hasEnabledState,
-                              SemanticsFlag.isReadOnly,
+  testWidgets('when disabled does not listen to onFocus events or gain focus', (
+    WidgetTester tester,
+  ) async {
+    final semantics = SemanticsTester(tester);
+    final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;
+    final focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+    await tester.pumpWidget(
+      CupertinoApp(home: CupertinoTextField(focusNode: focusNode, enabled: false)),
+    );
+    expect(
+      semantics,
+      hasSemantics(
+        TestSemantics.root(
+          children: <TestSemantics>[
+            TestSemantics(
+              id: 1,
+              textDirection: TextDirection.ltr,
+              children: <TestSemantics>[
+                TestSemantics(
+                  id: 2,
+                  children: <TestSemantics>[
+                    TestSemantics(
+                      id: 3,
+                      flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
+                      children: <TestSemantics>[
+                        TestSemantics(
+                          id: 4,
+                          inputType: ui.SemanticsInputType.text,
+                          flags: <SemanticsFlag>[
+                            SemanticsFlag.isTextField,
+                            SemanticsFlag.isFocusable,
+                            SemanticsFlag.hasEnabledState,
+                            SemanticsFlag.isReadOnly,
+                          ],
+                          actions: <SemanticsAction>[
+                            if (defaultTargetPlatform == TargetPlatform.linux ||
+                                defaultTargetPlatform == TargetPlatform.windows ||
+                                defaultTargetPlatform == TargetPlatform.macOS) ...<SemanticsAction>[
+                              SemanticsAction.didGainAccessibilityFocus,
+                              SemanticsAction.didLoseAccessibilityFocus,
                             ],
-                            actions: <SemanticsAction>[
-                              if (defaultTargetPlatform == TargetPlatform.linux ||
-                                  defaultTargetPlatform == TargetPlatform.windows ||
-                                  defaultTargetPlatform ==
-                                      TargetPlatform.macOS) ...<SemanticsAction>[
-                                SemanticsAction.didGainAccessibilityFocus,
-                                SemanticsAction.didLoseAccessibilityFocus,
-                              ],
-                            ],
-                          ),
-                        ],
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            ],
-          ),
-          ignoreRect: true,
-          ignoreTransform: true,
+                          ],
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ],
         ),
-      );
+        ignoreRect: true,
+        ignoreTransform: true,
+      ),
+    );
 
-      expect(focusNode.hasFocus, isFalse);
-      semanticsOwner.performAction(4, SemanticsAction.focus);
-      await tester.pumpAndSettle();
-      expect(focusNode.hasFocus, isFalse);
-      semantics.dispose();
-    },
-    variant: TargetPlatformVariant.all(),
-  );
+    expect(focusNode.hasFocus, isFalse);
+    semanticsOwner.performAction(4, SemanticsAction.focus);
+    await tester.pumpAndSettle();
+    expect(focusNode.hasFocus, isFalse);
+    semantics.dispose();
+  }, variant: TargetPlatformVariant.all());
 
-  testWidgets(
-    'when receives SemanticsAction.focus while already focused, shows keyboard',
-    (WidgetTester tester) async {
-      final semantics = SemanticsTester(tester);
-      final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;
-      final focusNode = FocusNode();
-      addTearDown(focusNode.dispose);
-      await tester.pumpWidget(CupertinoApp(home: CupertinoTextField(focusNode: focusNode)));
-      focusNode.requestFocus();
-      await tester.pumpAndSettle();
+  testWidgets('when receives SemanticsAction.focus while already focused, shows keyboard', (
+    WidgetTester tester,
+  ) async {
+    final semantics = SemanticsTester(tester);
+    final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;
+    final focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+    await tester.pumpWidget(CupertinoApp(home: CupertinoTextField(focusNode: focusNode)));
+    focusNode.requestFocus();
+    await tester.pumpAndSettle();
 
-      tester.testTextInput.log.clear();
-      expect(focusNode.hasFocus, isTrue);
-      semanticsOwner.performAction(4, SemanticsAction.focus);
-      await tester.pumpAndSettle();
-      expect(focusNode.hasFocus, isTrue);
-      expect(tester.testTextInput.log.single.method, 'TextInput.show');
+    tester.testTextInput.log.clear();
+    expect(focusNode.hasFocus, isTrue);
+    semanticsOwner.performAction(4, SemanticsAction.focus);
+    await tester.pumpAndSettle();
+    expect(focusNode.hasFocus, isTrue);
+    expect(tester.testTextInput.log.single.method, 'TextInput.show');
 
-      semantics.dispose();
-    },
-    variant: TargetPlatformVariant.all(),
-  );
+    semantics.dispose();
+  }, variant: TargetPlatformVariant.all());
 
   testWidgets(
     'when receives SemanticsAction.focus while focused but read-only, does not show keyboard',

--- a/packages/flutter/test/cupertino/text_selection_test.dart
+++ b/packages/flutter/test/cupertino/text_selection_test.dart
@@ -15,7 +15,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/clipboard_utils.dart';
+import 'clipboard_utils.dart';
 import 'editable_text_utils.dart' show findRenderEditable, textOffsetToPosition;
 
 class _LongCupertinoLocalizationsDelegate extends LocalizationsDelegate<CupertinoLocalizations> {

--- a/packages/flutter/test/material/adaptive_text_selection_toolbar_test.dart
+++ b/packages/flutter/test/material/adaptive_text_selection_toolbar_test.dart
@@ -7,8 +7,8 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import '../widgets/clipboard_utils.dart';
 import '../widgets/text_selection_toolbar_utils.dart';
+import 'clipboard_utils.dart';
 import 'editable_text_utils.dart';
 import 'live_text_utils.dart';
 

--- a/packages/flutter/test/material/adaptive_text_selection_toolbar_test.dart
+++ b/packages/flutter/test/material/adaptive_text_selection_toolbar_test.dart
@@ -390,61 +390,59 @@ void main() {
       skip: kIsWeb, // [intended]
     );
 
-    testWidgets(
-      'getAdaptiveButtons builds the correct button widgets per-platform',
-      (WidgetTester tester) async {
-        const buttonText = 'Click me';
+    testWidgets('getAdaptiveButtons builds the correct button widgets per-platform', (
+      WidgetTester tester,
+    ) async {
+      const buttonText = 'Click me';
 
-        await tester.pumpWidget(
-          MaterialApp(
-            home: Scaffold(
-              body: Center(
-                child: Builder(
-                  builder: (BuildContext context) {
-                    final buttonItems = <ContextMenuButtonItem>[
-                      ContextMenuButtonItem(label: buttonText, onPressed: () {}),
-                    ];
-                    return ListView(
-                      children: AdaptiveTextSelectionToolbar.getAdaptiveButtons(
-                        context,
-                        buttonItems,
-                      ).toList(),
-                    );
-                  },
-                ),
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: Builder(
+                builder: (BuildContext context) {
+                  final buttonItems = <ContextMenuButtonItem>[
+                    ContextMenuButtonItem(label: buttonText, onPressed: () {}),
+                  ];
+                  return ListView(
+                    children: AdaptiveTextSelectionToolbar.getAdaptiveButtons(
+                      context,
+                      buttonItems,
+                    ).toList(),
+                  );
+                },
               ),
             ),
           ),
-        );
+        ),
+      );
 
-        expect(find.text(buttonText), findsOneWidget);
+      expect(find.text(buttonText), findsOneWidget);
 
-        switch (defaultTargetPlatform) {
-          case TargetPlatform.fuchsia:
-          case TargetPlatform.android:
-            expect(find.byType(TextSelectionToolbarTextButton), findsOneWidget);
-            expect(find.byType(CupertinoTextSelectionToolbarButton), findsNothing);
-            expect(find.byType(DesktopTextSelectionToolbarButton), findsNothing);
-            expect(find.byType(CupertinoDesktopTextSelectionToolbarButton), findsNothing);
-          case TargetPlatform.iOS:
-            expect(find.byType(TextSelectionToolbarTextButton), findsNothing);
-            expect(find.byType(CupertinoTextSelectionToolbarButton), findsOneWidget);
-            expect(find.byType(DesktopTextSelectionToolbarButton), findsNothing);
-            expect(find.byType(CupertinoDesktopTextSelectionToolbarButton), findsNothing);
-          case TargetPlatform.macOS:
-            expect(find.byType(TextSelectionToolbarTextButton), findsNothing);
-            expect(find.byType(CupertinoTextSelectionToolbarButton), findsNothing);
-            expect(find.byType(DesktopTextSelectionToolbarButton), findsNothing);
-            expect(find.byType(CupertinoDesktopTextSelectionToolbarButton), findsOneWidget);
-          case TargetPlatform.linux:
-          case TargetPlatform.windows:
-            expect(find.byType(TextSelectionToolbarTextButton), findsNothing);
-            expect(find.byType(CupertinoTextSelectionToolbarButton), findsNothing);
-            expect(find.byType(DesktopTextSelectionToolbarButton), findsOneWidget);
-            expect(find.byType(CupertinoDesktopTextSelectionToolbarButton), findsNothing);
-        }
-      },
-      variant: TargetPlatformVariant.all(),
-    );
+      switch (defaultTargetPlatform) {
+        case TargetPlatform.fuchsia:
+        case TargetPlatform.android:
+          expect(find.byType(TextSelectionToolbarTextButton), findsOneWidget);
+          expect(find.byType(CupertinoTextSelectionToolbarButton), findsNothing);
+          expect(find.byType(DesktopTextSelectionToolbarButton), findsNothing);
+          expect(find.byType(CupertinoDesktopTextSelectionToolbarButton), findsNothing);
+        case TargetPlatform.iOS:
+          expect(find.byType(TextSelectionToolbarTextButton), findsNothing);
+          expect(find.byType(CupertinoTextSelectionToolbarButton), findsOneWidget);
+          expect(find.byType(DesktopTextSelectionToolbarButton), findsNothing);
+          expect(find.byType(CupertinoDesktopTextSelectionToolbarButton), findsNothing);
+        case TargetPlatform.macOS:
+          expect(find.byType(TextSelectionToolbarTextButton), findsNothing);
+          expect(find.byType(CupertinoTextSelectionToolbarButton), findsNothing);
+          expect(find.byType(DesktopTextSelectionToolbarButton), findsNothing);
+          expect(find.byType(CupertinoDesktopTextSelectionToolbarButton), findsOneWidget);
+        case TargetPlatform.linux:
+        case TargetPlatform.windows:
+          expect(find.byType(TextSelectionToolbarTextButton), findsNothing);
+          expect(find.byType(CupertinoTextSelectionToolbarButton), findsNothing);
+          expect(find.byType(DesktopTextSelectionToolbarButton), findsOneWidget);
+          expect(find.byType(CupertinoDesktopTextSelectionToolbarButton), findsNothing);
+      }
+    }, variant: TargetPlatformVariant.all());
   });
 }

--- a/packages/flutter/test/material/clipboard_utils.dart
+++ b/packages/flutter/test/material/clipboard_utils.dart
@@ -28,7 +28,6 @@ class MockClipboard {
         return <String, bool>{'value': text != null && text.isNotEmpty};
       case 'Clipboard.setData':
         clipboardData = methodCall.arguments as Map<String, dynamic>;
-        break;
     }
     return null;
   }

--- a/packages/flutter/test/material/clipboard_utils.dart
+++ b/packages/flutter/test/material/clipboard_utils.dart
@@ -1,0 +1,35 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/services.dart';
+
+/// A mock clipboard implementation for testing.
+class MockClipboard {
+  /// Creates a [MockClipboard].
+  MockClipboard({this.hasStringsThrows = false});
+
+  /// Whether [Clipboard.hasStrings] should throw an exception.
+  final bool hasStringsThrows;
+
+  /// The current clipboard data.
+  Map<String, dynamic> clipboardData = <String, dynamic>{'text': null};
+
+  /// Handles a platform method call for clipboard operations.
+  Future<Object?> handleMethodCall(MethodCall methodCall) async {
+    switch (methodCall.method) {
+      case 'Clipboard.getData':
+        return clipboardData;
+      case 'Clipboard.hasStrings':
+        if (hasStringsThrows) {
+          throw Exception();
+        }
+        final text = clipboardData['text'] as String?;
+        return <String, bool>{'value': text != null && text.isNotEmpty};
+      case 'Clipboard.setData':
+        clipboardData = methodCall.arguments as Map<String, dynamic>;
+        break;
+    }
+    return null;
+  }
+}

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -13,7 +13,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import '../widgets/clipboard_utils.dart';
+import 'clipboard_utils.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/packages/flutter/test/material/input_date_picker_form_field_test.dart
+++ b/packages/flutter/test/material/input_date_picker_form_field_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/clipboard_utils.dart';
+import 'clipboard_utils.dart';
 
 class TestMaterialLocalizations extends DefaultMaterialLocalizations {
   @override

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -9,7 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/clipboard_utils.dart';
+import 'clipboard_utils.dart';
 import '../widgets/semantics_tester.dart';
 
 void main() {

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -9,8 +9,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'clipboard_utils.dart';
 import '../widgets/semantics_tester.dart';
+import 'clipboard_utils.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/packages/flutter/test/material/selectable_text_test.dart
+++ b/packages/flutter/test/material/selectable_text_test.dart
@@ -20,8 +20,8 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
-import '../widgets/clipboard_utils.dart';
 import '../widgets/semantics_tester.dart';
+import 'clipboard_utils.dart';
 import 'editable_text_utils.dart' show textOffsetToPosition;
 
 class MaterialLocalizationsDelegate extends LocalizationsDelegate<MaterialLocalizations> {

--- a/packages/flutter/test/material/selectable_text_test.dart
+++ b/packages/flutter/test/material/selectable_text_test.dart
@@ -2928,132 +2928,108 @@ void main() {
     expect(tester.takeException(), isNotNull);
   });
 
-  testWidgets(
-    'tap moves cursor to the edge of the word it tapped',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        const MaterialApp(
-          home: Material(
-            child: Center(child: SelectableText('Atwater Peel Sherbrooke Bonaventure')),
-          ),
-        ),
-      );
+  testWidgets('tap moves cursor to the edge of the word it tapped', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Material(child: Center(child: SelectableText('Atwater Peel Sherbrooke Bonaventure'))),
+      ),
+    );
 
-      final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
+    final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
 
-      await tester.tapAt(selectableTextStart + const Offset(50.0, 5.0));
-      await tester.pump();
+    await tester.tapAt(selectableTextStart + const Offset(50.0, 5.0));
+    await tester.pump();
 
-      final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
-      final TextEditingController controller = editableTextWidget.controller;
-      // We moved the cursor.
-      expect(
-        controller.selection,
-        const TextSelection.collapsed(offset: 7, affinity: TextAffinity.upstream),
-      );
+    final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
+    final TextEditingController controller = editableTextWidget.controller;
+    // We moved the cursor.
+    expect(
+      controller.selection,
+      const TextSelection.collapsed(offset: 7, affinity: TextAffinity.upstream),
+    );
 
-      // But don't trigger the toolbar.
-      expect(find.byType(CupertinoButton), findsNothing);
-    },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-  );
+    // But don't trigger the toolbar.
+    expect(find.byType(CupertinoButton), findsNothing);
+  }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
-  testWidgets(
-    'tap moves cursor to the position tapped (Android)',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        const MaterialApp(
-          home: Material(
-            child: Center(child: SelectableText('Atwater Peel Sherbrooke Bonaventure')),
-          ),
-        ),
-      );
+  testWidgets('tap moves cursor to the position tapped (Android)', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Material(child: Center(child: SelectableText('Atwater Peel Sherbrooke Bonaventure'))),
+      ),
+    );
 
-      final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
+    final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
 
-      await tester.tapAt(selectableTextStart + const Offset(50.0, 5.0));
-      await tester.pump();
+    await tester.tapAt(selectableTextStart + const Offset(50.0, 5.0));
+    await tester.pump();
 
-      final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
-      final TextEditingController controller = editableTextWidget.controller;
+    final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
+    final TextEditingController controller = editableTextWidget.controller;
 
-      // We moved the cursor.
-      expect(
-        controller.selection,
-        const TextSelection.collapsed(offset: 4, affinity: TextAffinity.upstream),
-      );
+    // We moved the cursor.
+    expect(
+      controller.selection,
+      const TextSelection.collapsed(offset: 4, affinity: TextAffinity.upstream),
+    );
 
-      // But don't trigger the toolbar.
-      expect(find.byType(TextButton), findsNothing);
-    },
-    variant: TargetPlatformVariant.all(excluding: const <TargetPlatform>{TargetPlatform.iOS}),
-  );
+    // But don't trigger the toolbar.
+    expect(find.byType(TextButton), findsNothing);
+  }, variant: TargetPlatformVariant.all(excluding: const <TargetPlatform>{TargetPlatform.iOS}));
 
-  testWidgets(
-    'two slow taps do not trigger a word selection on iOS',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        const MaterialApp(
-          home: Material(
-            child: Center(child: SelectableText('Atwater Peel Sherbrooke Bonaventure')),
-          ),
-        ),
-      );
+  testWidgets('two slow taps do not trigger a word selection on iOS', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Material(child: Center(child: SelectableText('Atwater Peel Sherbrooke Bonaventure'))),
+      ),
+    );
 
-      final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
+    final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
 
-      await tester.tapAt(selectableTextStart + const Offset(50.0, 5.0));
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.tapAt(selectableTextStart + const Offset(50.0, 5.0));
-      await tester.pump();
+    await tester.tapAt(selectableTextStart + const Offset(50.0, 5.0));
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.tapAt(selectableTextStart + const Offset(50.0, 5.0));
+    await tester.pump();
 
-      final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
-      final TextEditingController controller = editableTextWidget.controller;
+    final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
+    final TextEditingController controller = editableTextWidget.controller;
 
-      // Plain collapsed selection.
-      expect(
-        controller.selection,
-        const TextSelection.collapsed(offset: 7, affinity: TextAffinity.upstream),
-      );
+    // Plain collapsed selection.
+    expect(
+      controller.selection,
+      const TextSelection.collapsed(offset: 7, affinity: TextAffinity.upstream),
+    );
 
-      // No toolbar.
-      expect(find.byType(CupertinoButton), findsNothing);
-    },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-  );
+    // No toolbar.
+    expect(find.byType(CupertinoButton), findsNothing);
+  }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
-  testWidgets(
-    'two slow taps do not trigger a word selection',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        const MaterialApp(
-          home: Material(
-            child: Center(child: SelectableText('Atwater Peel Sherbrooke Bonaventure')),
-          ),
-        ),
-      );
+  testWidgets('two slow taps do not trigger a word selection', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Material(child: Center(child: SelectableText('Atwater Peel Sherbrooke Bonaventure'))),
+      ),
+    );
 
-      final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
+    final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
 
-      await tester.tapAt(selectableTextStart + const Offset(50.0, 5.0));
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.tapAt(selectableTextStart + const Offset(50.0, 5.0));
-      await tester.pump();
+    await tester.tapAt(selectableTextStart + const Offset(50.0, 5.0));
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.tapAt(selectableTextStart + const Offset(50.0, 5.0));
+    await tester.pump();
 
-      final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
-      final TextEditingController controller = editableTextWidget.controller;
+    final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
+    final TextEditingController controller = editableTextWidget.controller;
 
-      // Plain collapsed selection.
-      expect(
-        controller.selection,
-        const TextSelection.collapsed(offset: 4, affinity: TextAffinity.upstream),
-      );
+    // Plain collapsed selection.
+    expect(
+      controller.selection,
+      const TextSelection.collapsed(offset: 4, affinity: TextAffinity.upstream),
+    );
 
-      // No toolbar.
-      expect(find.byType(CupertinoButton), findsNothing);
-    },
-    variant: TargetPlatformVariant.all(excluding: <TargetPlatform>{TargetPlatform.iOS}),
-  );
+    // No toolbar.
+    expect(find.byType(CupertinoButton), findsNothing);
+  }, variant: TargetPlatformVariant.all(excluding: <TargetPlatform>{TargetPlatform.iOS}));
 
   testWidgets(
     'double tap selects word and first tap of double tap moves cursor',
@@ -3251,86 +3227,74 @@ void main() {
     }),
   );
 
-  testWidgets(
-    'tap after a double tap select is not affected (iOS)',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        const MaterialApp(
-          home: Material(
-            child: Center(child: SelectableText('Atwater Peel Sherbrooke Bonaventure')),
-          ),
-        ),
-      );
+  testWidgets('tap after a double tap select is not affected (iOS)', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Material(child: Center(child: SelectableText('Atwater Peel Sherbrooke Bonaventure'))),
+      ),
+    );
 
-      final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
+    final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
 
-      await tester.tapAt(selectableTextStart + const Offset(150.0, 5.0));
-      await tester.pump(const Duration(milliseconds: 50));
+    await tester.tapAt(selectableTextStart + const Offset(150.0, 5.0));
+    await tester.pump(const Duration(milliseconds: 50));
 
-      final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
-      final TextEditingController controller = editableTextWidget.controller;
+    final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
+    final TextEditingController controller = editableTextWidget.controller;
 
-      // First tap moved the cursor.
-      expect(
-        controller.selection,
-        const TextSelection.collapsed(offset: 12, affinity: TextAffinity.upstream),
-      );
-      await tester.tapAt(selectableTextStart + const Offset(150.0, 5.0));
-      await tester.pump(const Duration(milliseconds: 500));
+    // First tap moved the cursor.
+    expect(
+      controller.selection,
+      const TextSelection.collapsed(offset: 12, affinity: TextAffinity.upstream),
+    );
+    await tester.tapAt(selectableTextStart + const Offset(150.0, 5.0));
+    await tester.pump(const Duration(milliseconds: 500));
 
-      await tester.tapAt(selectableTextStart + const Offset(100.0, 5.0));
-      await tester.pump();
+    await tester.tapAt(selectableTextStart + const Offset(100.0, 5.0));
+    await tester.pump();
 
-      // Plain collapsed selection at the edge of first word. In iOS 12, the
-      // first tap after a double tap ends up putting the cursor at where
-      // you tapped instead of the edge like every other single tap. This is
-      // likely a bug in iOS 12 and not present in other versions.
-      expect(controller.selection, const TextSelection.collapsed(offset: 7));
+    // Plain collapsed selection at the edge of first word. In iOS 12, the
+    // first tap after a double tap ends up putting the cursor at where
+    // you tapped instead of the edge like every other single tap. This is
+    // likely a bug in iOS 12 and not present in other versions.
+    expect(controller.selection, const TextSelection.collapsed(offset: 7));
 
-      // No toolbar.
-      expect(find.byType(CupertinoButton), findsNothing);
-    },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-  );
+    // No toolbar.
+    expect(find.byType(CupertinoButton), findsNothing);
+  }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
-  testWidgets(
-    'tap after a double tap select is not affected (macOS)',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        const MaterialApp(
-          home: Material(
-            child: Center(child: SelectableText('Atwater Peel Sherbrooke Bonaventure')),
-          ),
-        ),
-      );
+  testWidgets('tap after a double tap select is not affected (macOS)', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Material(child: Center(child: SelectableText('Atwater Peel Sherbrooke Bonaventure'))),
+      ),
+    );
 
-      final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
+    final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
 
-      await tester.tapAt(selectableTextStart + const Offset(150.0, 5.0));
-      await tester.pump(const Duration(milliseconds: 50));
+    await tester.tapAt(selectableTextStart + const Offset(150.0, 5.0));
+    await tester.pump(const Duration(milliseconds: 50));
 
-      final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
-      final TextEditingController controller = editableTextWidget.controller;
+    final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
+    final TextEditingController controller = editableTextWidget.controller;
 
-      // First tap moved the cursor.
-      expect(
-        controller.selection,
-        const TextSelection.collapsed(offset: 11, affinity: TextAffinity.upstream),
-      );
-      await tester.tapAt(selectableTextStart + const Offset(150.0, 5.0));
-      await tester.pump(const Duration(milliseconds: 500));
+    // First tap moved the cursor.
+    expect(
+      controller.selection,
+      const TextSelection.collapsed(offset: 11, affinity: TextAffinity.upstream),
+    );
+    await tester.tapAt(selectableTextStart + const Offset(150.0, 5.0));
+    await tester.pump(const Duration(milliseconds: 500));
 
-      await tester.tapAt(selectableTextStart + const Offset(100.0, 5.0));
-      await tester.pump();
+    await tester.tapAt(selectableTextStart + const Offset(100.0, 5.0));
+    await tester.pump();
 
-      // Collapse selection.
-      expect(controller.selection, const TextSelection.collapsed(offset: 7));
+    // Collapse selection.
+    expect(controller.selection, const TextSelection.collapsed(offset: 7));
 
-      // No toolbar.
-      expect(find.byType(CupertinoButton), findsNothing);
-    },
-    variant: TargetPlatformVariant.only(TargetPlatform.macOS),
-  );
+    // No toolbar.
+    expect(find.byType(CupertinoButton), findsNothing);
+  }, variant: TargetPlatformVariant.only(TargetPlatform.macOS));
 
   testWidgets(
     'long press selects word and shows toolbar (iOS)',
@@ -3382,73 +3346,69 @@ void main() {
     expectMaterialSelectionToolbar();
   });
 
-  testWidgets(
-    'long press selects word and shows custom toolbar (Cupertino)',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Material(
-            child: Center(
-              child: SelectableText(
-                'Atwater Peel Sherbrooke Bonaventure',
-                selectionControls: cupertinoTextSelectionControls,
-              ),
+  testWidgets('long press selects word and shows custom toolbar (Cupertino)', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(
+            child: SelectableText(
+              'Atwater Peel Sherbrooke Bonaventure',
+              selectionControls: cupertinoTextSelectionControls,
             ),
           ),
         ),
-      );
+      ),
+    );
 
-      final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
+    final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
 
-      await tester.longPressAt(selectableTextStart + const Offset(50.0, 5.0));
-      await tester.pump();
+    await tester.longPressAt(selectableTextStart + const Offset(50.0, 5.0));
+    await tester.pump();
 
-      final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
-      final TextEditingController controller = editableTextWidget.controller;
+    final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
+    final TextEditingController controller = editableTextWidget.controller;
 
-      // The long pressed word is selected.
-      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
+    // The long pressed word is selected.
+    expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
 
-      // Toolbar shows one button (copy).
-      expect(find.byType(CupertinoButton), findsNWidgets(1));
-      expect(find.text('Copy'), findsOneWidget);
-    },
-    variant: TargetPlatformVariant.all(),
-  );
+    // Toolbar shows one button (copy).
+    expect(find.byType(CupertinoButton), findsNWidgets(1));
+    expect(find.text('Copy'), findsOneWidget);
+  }, variant: TargetPlatformVariant.all());
 
-  testWidgets(
-    'long press selects word and shows custom toolbar (Material)',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Material(
-            child: Center(
-              child: SelectableText(
-                'Atwater Peel Sherbrooke Bonaventure',
-                selectionControls: materialTextSelectionControls,
-              ),
+  testWidgets('long press selects word and shows custom toolbar (Material)', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(
+            child: SelectableText(
+              'Atwater Peel Sherbrooke Bonaventure',
+              selectionControls: materialTextSelectionControls,
             ),
           ),
         ),
-      );
+      ),
+    );
 
-      final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
+    final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
 
-      await tester.longPressAt(selectableTextStart + const Offset(50.0, 5.0));
-      await tester.pump();
+    await tester.longPressAt(selectableTextStart + const Offset(50.0, 5.0));
+    await tester.pump();
 
-      final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
-      final TextEditingController controller = editableTextWidget.controller;
+    final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
+    final TextEditingController controller = editableTextWidget.controller;
 
-      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
+    expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
 
-      // Collapsed toolbar shows 2 buttons: copy, select all
-      expect(find.byType(TextButton), findsNWidgets(2));
-      expect(find.text('Copy'), findsOneWidget);
-      expect(find.text('Select all'), findsOneWidget);
-    },
-    variant: TargetPlatformVariant.all(),
-  );
+    // Collapsed toolbar shows 2 buttons: copy, select all
+    expect(find.byType(TextButton), findsNWidgets(2));
+    expect(find.text('Copy'), findsOneWidget);
+    expect(find.text('Select all'), findsOneWidget);
+  }, variant: TargetPlatformVariant.all());
 
   testWidgets('textSelectionControls is passed to EditableText', (WidgetTester tester) async {
     await tester.pumpWidget(
@@ -3468,145 +3428,129 @@ void main() {
     expect(widget.selectionControls, equals(materialTextSelectionControls));
   });
 
-  testWidgets(
-    'PageView beats SelectableText drag gestures (iOS)',
-    (WidgetTester tester) async {
-      // This is a regression test for
-      // https://github.com/flutter/flutter/issues/130198.
-      final pageController = PageController();
-      addTearDown(pageController.dispose);
-      const testValue = 'abc def ghi jkl mno pqr stu vwx yz';
+  testWidgets('PageView beats SelectableText drag gestures (iOS)', (WidgetTester tester) async {
+    // This is a regression test for
+    // https://github.com/flutter/flutter/issues/130198.
+    final pageController = PageController();
+    addTearDown(pageController.dispose);
+    const testValue = 'abc def ghi jkl mno pqr stu vwx yz';
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Material(
-            child: PageView(
-              controller: pageController,
-              children: const <Widget>[
-                Center(child: SelectableText(testValue)),
-                SizedBox(height: 200.0, child: Center(child: Text('Page 2'))),
-              ],
-            ),
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: PageView(
+            controller: pageController,
+            children: const <Widget>[
+              Center(child: SelectableText(testValue)),
+              SizedBox(height: 200.0, child: Center(child: Text('Page 2'))),
+            ],
           ),
         ),
-      );
+      ),
+    );
 
-      await skipPastScrollingAnimation(tester);
+    await skipPastScrollingAnimation(tester);
 
-      final Offset gPos = textOffsetToPosition(tester, testValue.indexOf('g'));
-      final Offset pPos = textOffsetToPosition(tester, testValue.indexOf('p'));
+    final Offset gPos = textOffsetToPosition(tester, testValue.indexOf('g'));
+    final Offset pPos = textOffsetToPosition(tester, testValue.indexOf('p'));
 
-      // A double tap + drag should take precedence over parent drags.
-      final TestGesture gesture = await tester.startGesture(gPos);
-      await tester.pump();
-      await gesture.up();
-      await tester.pump();
-      await gesture.down(gPos);
-      await tester.pumpAndSettle();
-      await gesture.moveTo(pPos);
-      await tester.pump();
-      await gesture.up();
-      await tester.pumpAndSettle();
-      final TextEditingValue currentValue = tester
-          .state<EditableTextState>(find.byType(EditableText))
-          .textEditingValue;
-      expect(
-        currentValue.selection,
-        TextSelection(baseOffset: testValue.indexOf('g'), extentOffset: testValue.indexOf('p') + 3),
-      );
+    // A double tap + drag should take precedence over parent drags.
+    final TestGesture gesture = await tester.startGesture(gPos);
+    await tester.pump();
+    await gesture.up();
+    await tester.pump();
+    await gesture.down(gPos);
+    await tester.pumpAndSettle();
+    await gesture.moveTo(pPos);
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle();
+    final TextEditingValue currentValue = tester
+        .state<EditableTextState>(find.byType(EditableText))
+        .textEditingValue;
+    expect(
+      currentValue.selection,
+      TextSelection(baseOffset: testValue.indexOf('g'), extentOffset: testValue.indexOf('p') + 3),
+    );
 
-      expect(pageController.page, isNotNull);
-      expect(pageController.page, 0.0);
-      // A horizontal drag directly on the SelectableText should move the page
-      // view to the next page.
-      final Rect selectableTextRect = tester.getRect(find.byType(SelectableText));
-      await tester.dragFrom(
-        selectableTextRect.centerRight - const Offset(0.1, 0.0),
-        const Offset(-500.0, 0.0),
-      );
-      await tester.pumpAndSettle();
-      expect(pageController.page, isNotNull);
-      expect(pageController.page, 1.0);
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-  );
+    expect(pageController.page, isNotNull);
+    expect(pageController.page, 0.0);
+    // A horizontal drag directly on the SelectableText should move the page
+    // view to the next page.
+    final Rect selectableTextRect = tester.getRect(find.byType(SelectableText));
+    await tester.dragFrom(
+      selectableTextRect.centerRight - const Offset(0.1, 0.0),
+      const Offset(-500.0, 0.0),
+    );
+    await tester.pumpAndSettle();
+    expect(pageController.page, isNotNull);
+    expect(pageController.page, 1.0);
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
 
-  testWidgets(
-    'long press tap cannot initiate a double tap on macOS',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        const MaterialApp(
-          home: Material(
-            child: Center(child: SelectableText('Atwater Peel Sherbrooke Bonaventure')),
-          ),
-        ),
-      );
+  testWidgets('long press tap cannot initiate a double tap on macOS', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Material(child: Center(child: SelectableText('Atwater Peel Sherbrooke Bonaventure'))),
+      ),
+    );
 
-      final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
+    final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
 
-      await tester.longPressAt(selectableTextStart + const Offset(50.0, 5.0));
-      await tester.pump(const Duration(milliseconds: 50));
+    await tester.longPressAt(selectableTextStart + const Offset(50.0, 5.0));
+    await tester.pump(const Duration(milliseconds: 50));
 
-      // Hide the toolbar so it doesn't interfere with taps on the text.
-      final EditableTextState editableTextState = tester.state<EditableTextState>(
-        find.byType(EditableText),
-      );
-      editableTextState.hideToolbar();
-      await tester.pumpAndSettle();
+    // Hide the toolbar so it doesn't interfere with taps on the text.
+    final EditableTextState editableTextState = tester.state<EditableTextState>(
+      find.byType(EditableText),
+    );
+    editableTextState.hideToolbar();
+    await tester.pumpAndSettle();
 
-      await tester.tapAt(selectableTextStart + const Offset(50.0, 5.0));
-      await tester.pump();
+    await tester.tapAt(selectableTextStart + const Offset(50.0, 5.0));
+    await tester.pump();
 
-      final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
-      final TextEditingController controller = editableTextWidget.controller;
+    final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
+    final TextEditingController controller = editableTextWidget.controller;
 
-      // Move the cursor to the tapped position.
-      expect(
-        controller.selection,
-        const TextSelection.collapsed(offset: 4, affinity: TextAffinity.upstream),
-      );
+    // Move the cursor to the tapped position.
+    expect(
+      controller.selection,
+      const TextSelection.collapsed(offset: 4, affinity: TextAffinity.upstream),
+    );
 
-      expect(find.byType(CupertinoButton), findsNothing);
-    },
-    variant: TargetPlatformVariant.only(TargetPlatform.macOS),
-  );
+    expect(find.byType(CupertinoButton), findsNothing);
+  }, variant: TargetPlatformVariant.only(TargetPlatform.macOS));
 
-  testWidgets(
-    'long press tap cannot initiate a double tap on iOS',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        const MaterialApp(
-          home: Material(
-            child: Center(child: SelectableText('Atwater Peel Sherbrooke Bonaventure')),
-          ),
-        ),
-      );
+  testWidgets('long press tap cannot initiate a double tap on iOS', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Material(child: Center(child: SelectableText('Atwater Peel Sherbrooke Bonaventure'))),
+      ),
+    );
 
-      final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
+    final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
 
-      await tester.longPressAt(selectableTextStart + const Offset(50.0, 5.0));
-      await tester.pump(const Duration(milliseconds: 50));
+    await tester.longPressAt(selectableTextStart + const Offset(50.0, 5.0));
+    await tester.pump(const Duration(milliseconds: 50));
 
-      // Hide the toolbar so it doesn't interfere with taps on the text.
-      final EditableTextState editableTextState = tester.state<EditableTextState>(
-        find.byType(EditableText),
-      );
-      editableTextState.hideToolbar();
-      await tester.pumpAndSettle();
+    // Hide the toolbar so it doesn't interfere with taps on the text.
+    final EditableTextState editableTextState = tester.state<EditableTextState>(
+      find.byType(EditableText),
+    );
+    editableTextState.hideToolbar();
+    await tester.pumpAndSettle();
 
-      await tester.tapAt(selectableTextStart + const Offset(50.0, 5.0));
-      await tester.pump();
+    await tester.tapAt(selectableTextStart + const Offset(50.0, 5.0));
+    await tester.pump();
 
-      final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
-      final TextEditingController controller = editableTextWidget.controller;
+    final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
+    final TextEditingController controller = editableTextWidget.controller;
 
-      // Move the cursor to the edge of the same word and toggle the toolbar.
-      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
+    // Move the cursor to the edge of the same word and toggle the toolbar.
+    expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
 
-      expect(find.byType(CupertinoButton), findsNWidgets(4));
-    },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-  );
+    expect(find.byType(CupertinoButton), findsNWidgets(4));
+  }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
   testWidgets(
     'long press drag extends the selection to the word under the drag and shows toolbar on lift on non-Apple platforms',
@@ -3727,58 +3671,54 @@ void main() {
     variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
   );
 
-  testWidgets(
-    'long press drag moves the cursor under the drag and shows toolbar on lift (macOS)',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        const MaterialApp(
-          home: Material(
-            child: Center(child: SelectableText('Atwater Peel Sherbrooke Bonaventure')),
-          ),
-        ),
-      );
+  testWidgets('long press drag moves the cursor under the drag and shows toolbar on lift (macOS)', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Material(child: Center(child: SelectableText('Atwater Peel Sherbrooke Bonaventure'))),
+      ),
+    );
 
-      final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
+    final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
 
-      final TestGesture gesture = await tester.startGesture(
-        selectableTextStart + const Offset(50.0, 5.0),
-      );
-      await tester.pump(const Duration(milliseconds: 500));
+    final TestGesture gesture = await tester.startGesture(
+      selectableTextStart + const Offset(50.0, 5.0),
+    );
+    await tester.pump(const Duration(milliseconds: 500));
 
-      final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
-      final TextEditingController controller = editableTextWidget.controller;
+    final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
+    final TextEditingController controller = editableTextWidget.controller;
 
-      // The long pressed word is selected.
-      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
-      // Cursor move doesn't trigger a toolbar initially.
-      expect(find.byType(CupertinoButton), findsNothing);
+    // The long pressed word is selected.
+    expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
+    // Cursor move doesn't trigger a toolbar initially.
+    expect(find.byType(CupertinoButton), findsNothing);
 
-      await gesture.moveBy(const Offset(50, 0));
-      await tester.pump();
+    await gesture.moveBy(const Offset(50, 0));
+    await tester.pump();
 
-      // The selection position is now moved with the drag.
-      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 8));
-      // Still no toolbar.
-      expect(find.byType(CupertinoButton), findsNothing);
+    // The selection position is now moved with the drag.
+    expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 8));
+    // Still no toolbar.
+    expect(find.byType(CupertinoButton), findsNothing);
 
-      await gesture.moveBy(const Offset(50, 0));
-      await tester.pump();
+    await gesture.moveBy(const Offset(50, 0));
+    await tester.pump();
 
-      // The selection position is now moved with the drag.
-      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 12));
-      // Still no toolbar.
-      expect(find.byType(CupertinoButton), findsNothing);
+    // The selection position is now moved with the drag.
+    expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 12));
+    // Still no toolbar.
+    expect(find.byType(CupertinoButton), findsNothing);
 
-      await gesture.up();
-      await tester.pump();
+    await gesture.up();
+    await tester.pump();
 
-      // The selection isn't affected by the gesture lift.
-      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 12));
-      // The toolbar now shows up.
-      expectCupertinoSelectionToolbar();
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.macOS}),
-  );
+    // The selection isn't affected by the gesture lift.
+    expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 12));
+    // The toolbar now shows up.
+    expectCupertinoSelectionToolbar();
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.macOS}));
 
   testWidgets(
     'long press drag can edge scroll when inside a scrollable',
@@ -3854,69 +3794,67 @@ void main() {
     variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
   );
 
-  testWidgets(
-    'Desktop mouse drag can edge scroll when inside a horizontal scrollable',
-    (WidgetTester tester) async {
-      // This is a regression test for https://github.com/flutter/flutter/issues/129590.
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Material(
-            child: Center(
-              child: SizedBox(
-                width: 300.0,
-                child: SingleChildScrollView(
-                  scrollDirection: Axis.horizontal,
-                  child: SelectableText(
-                    'Atwater Peel Sherbrooke Bonaventure Angrignon Peel Côte-des-Neiges ' * 2,
-                    maxLines: 1,
-                  ),
+  testWidgets('Desktop mouse drag can edge scroll when inside a horizontal scrollable', (
+    WidgetTester tester,
+  ) async {
+    // This is a regression test for https://github.com/flutter/flutter/issues/129590.
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(
+            child: SizedBox(
+              width: 300.0,
+              child: SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: SelectableText(
+                  'Atwater Peel Sherbrooke Bonaventure Angrignon Peel Côte-des-Neiges ' * 2,
+                  maxLines: 1,
                 ),
               ),
             ),
           ),
         ),
-      );
+      ),
+    );
 
-      final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
+    final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
 
-      final TestGesture gesture = await tester.startGesture(
-        selectableTextStart + const Offset(200.0, 0.0),
-      );
-      await tester.pump();
+    final TestGesture gesture = await tester.startGesture(
+      selectableTextStart + const Offset(200.0, 0.0),
+    );
+    await tester.pump();
 
-      final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
-      final TextEditingController controller = editableTextWidget.controller;
+    final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
+    final TextEditingController controller = editableTextWidget.controller;
 
-      await gesture.moveBy(const Offset(100, 0));
-      // To the edge of the screen basically.
-      await tester.pump();
-      expect(controller.selection, const TextSelection(baseOffset: 14, extentOffset: 21));
-      // Keep moving out.
-      await gesture.moveBy(const Offset(100, 0));
-      await tester.pump();
-      expect(controller.selection, const TextSelection(baseOffset: 14, extentOffset: 28));
-      await gesture.moveBy(const Offset(1600, 0));
-      await tester.pump();
-      expect(controller.selection, const TextSelection(baseOffset: 14, extentOffset: 134));
+    await gesture.moveBy(const Offset(100, 0));
+    // To the edge of the screen basically.
+    await tester.pump();
+    expect(controller.selection, const TextSelection(baseOffset: 14, extentOffset: 21));
+    // Keep moving out.
+    await gesture.moveBy(const Offset(100, 0));
+    await tester.pump();
+    expect(controller.selection, const TextSelection(baseOffset: 14, extentOffset: 28));
+    await gesture.moveBy(const Offset(1600, 0));
+    await tester.pump();
+    expect(controller.selection, const TextSelection(baseOffset: 14, extentOffset: 134));
 
-      await gesture.up();
-      await tester.pumpAndSettle();
+    await gesture.up();
+    await tester.pumpAndSettle();
 
-      // The selection isn't affected by the gesture lift.
-      expect(controller.selection, const TextSelection(baseOffset: 14, extentOffset: 134));
+    // The selection isn't affected by the gesture lift.
+    expect(controller.selection, const TextSelection(baseOffset: 14, extentOffset: 134));
 
-      final RenderEditable renderEditable = findRenderEditable(tester);
-      final List<TextSelectionPoint> endpoints = globalize(
-        renderEditable.getEndpointsForSelection(controller.selection),
-        renderEditable,
-      );
-      expect(endpoints.isNotEmpty, isTrue);
-      expect(endpoints.length, 2);
-      expect(endpoints[0].point.dx, isNegative);
-      expect(endpoints[1].point.dx, isPositive);
-    },
-    variant: TargetPlatformVariant.desktop(),
-  );
+    final RenderEditable renderEditable = findRenderEditable(tester);
+    final List<TextSelectionPoint> endpoints = globalize(
+      renderEditable.getEndpointsForSelection(controller.selection),
+      renderEditable,
+    );
+    expect(endpoints.isNotEmpty, isTrue);
+    expect(endpoints.length, 2);
+    expect(endpoints[0].point.dx, isNegative);
+    expect(endpoints[1].point.dx, isPositive);
+  }, variant: TargetPlatformVariant.desktop());
 
   testWidgets(
     'long press drag can edge scroll',
@@ -4002,84 +3940,76 @@ void main() {
     }),
   );
 
-  testWidgets(
-    'long tap still selects after a double tap select (iOS)',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        const MaterialApp(
-          home: Material(
-            child: Center(child: SelectableText('Atwater Peel Sherbrooke Bonaventure')),
-          ),
-        ),
-      );
+  testWidgets('long tap still selects after a double tap select (iOS)', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Material(child: Center(child: SelectableText('Atwater Peel Sherbrooke Bonaventure'))),
+      ),
+    );
 
-      final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
+    final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
 
-      await tester.tapAt(selectableTextStart + const Offset(150.0, 5.0));
-      await tester.pump(const Duration(milliseconds: 50));
+    await tester.tapAt(selectableTextStart + const Offset(150.0, 5.0));
+    await tester.pump(const Duration(milliseconds: 50));
 
-      final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
-      final TextEditingController controller = editableTextWidget.controller;
+    final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
+    final TextEditingController controller = editableTextWidget.controller;
 
-      // First tap moved the cursor to the beginning of the second word.
-      expect(
-        controller.selection,
-        const TextSelection.collapsed(offset: 12, affinity: TextAffinity.upstream),
-      );
-      await tester.tapAt(selectableTextStart + const Offset(150.0, 5.0));
-      await tester.pump(const Duration(milliseconds: 500));
+    // First tap moved the cursor to the beginning of the second word.
+    expect(
+      controller.selection,
+      const TextSelection.collapsed(offset: 12, affinity: TextAffinity.upstream),
+    );
+    await tester.tapAt(selectableTextStart + const Offset(150.0, 5.0));
+    await tester.pump(const Duration(milliseconds: 500));
 
-      await tester.longPressAt(selectableTextStart + const Offset(100.0, 5.0));
-      await tester.pump();
+    await tester.longPressAt(selectableTextStart + const Offset(100.0, 5.0));
+    await tester.pump();
 
-      // Selected the "word" where the tap happened, which is the first space.
-      // Because the "word" is a whitespace, the selection will shift to the
-      // previous "word" that is not a whitespace.
-      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
+    // Selected the "word" where the tap happened, which is the first space.
+    // Because the "word" is a whitespace, the selection will shift to the
+    // previous "word" that is not a whitespace.
+    expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
 
-      expectCupertinoSelectionToolbar();
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-  );
+    expectCupertinoSelectionToolbar();
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
 
-  testWidgets(
-    'long tap still selects after a double tap select (macOS)',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        const MaterialApp(
-          home: Material(
-            child: Center(child: SelectableText('Atwater Peel Sherbrooke Bonaventure')),
-          ),
-        ),
-      );
+  testWidgets('long tap still selects after a double tap select (macOS)', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Material(child: Center(child: SelectableText('Atwater Peel Sherbrooke Bonaventure'))),
+      ),
+    );
 
-      final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
+    final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
 
-      await tester.tapAt(selectableTextStart + const Offset(150.0, 5.0));
-      await tester.pump(const Duration(milliseconds: 50));
+    await tester.tapAt(selectableTextStart + const Offset(150.0, 5.0));
+    await tester.pump(const Duration(milliseconds: 50));
 
-      final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
-      final TextEditingController controller = editableTextWidget.controller;
+    final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
+    final TextEditingController controller = editableTextWidget.controller;
 
-      // First tap moves the cursor to the tapped position.
-      expect(
-        controller.selection,
-        const TextSelection.collapsed(offset: 11, affinity: TextAffinity.upstream),
-      );
-      await tester.tapAt(selectableTextStart + const Offset(150.0, 5.0));
-      await tester.pump(const Duration(milliseconds: 500));
+    // First tap moves the cursor to the tapped position.
+    expect(
+      controller.selection,
+      const TextSelection.collapsed(offset: 11, affinity: TextAffinity.upstream),
+    );
+    await tester.tapAt(selectableTextStart + const Offset(150.0, 5.0));
+    await tester.pump(const Duration(milliseconds: 500));
 
-      await tester.longPressAt(selectableTextStart + const Offset(100.0, 5.0));
-      await tester.pump();
+    await tester.longPressAt(selectableTextStart + const Offset(100.0, 5.0));
+    await tester.pump();
 
-      // Selected the "word" where the tap happened, which is the first space.
-      expect(controller.selection, const TextSelection(baseOffset: 7, extentOffset: 8));
+    // Selected the "word" where the tap happened, which is the first space.
+    expect(controller.selection, const TextSelection(baseOffset: 7, extentOffset: 8));
 
-      // The toolbar shows up.
-      expectCupertinoSelectionToolbar();
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.macOS}),
-  );
+    // The toolbar shows up.
+    expectCupertinoSelectionToolbar();
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.macOS}));
   //convert
   testWidgets(
     'double tap after a long tap is not affected',
@@ -4252,109 +4182,101 @@ void main() {
     expect(find.byType(TextButton), findsNothing);
   });
 
-  testWidgets(
-    'force press selects word',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        const MaterialApp(
-          home: Material(child: SelectableText('Atwater Peel Sherbrooke Bonaventure')),
-        ),
-      );
+  testWidgets('force press selects word', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Material(child: SelectableText('Atwater Peel Sherbrooke Bonaventure')),
+      ),
+    );
 
-      final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
+    final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
 
-      final int pointerValue = tester.nextPointer;
-      final Offset offset = selectableTextStart + const Offset(150.0, 5.0);
-      final TestGesture gesture = await tester.createGesture();
-      await gesture.downWithCustomEvent(
-        offset,
-        PointerDownEvent(
-          pointer: pointerValue,
-          position: offset,
-          pressure: 0.0,
-          pressureMax: 6.0,
-          pressureMin: 0.0,
-        ),
-      );
+    final int pointerValue = tester.nextPointer;
+    final Offset offset = selectableTextStart + const Offset(150.0, 5.0);
+    final TestGesture gesture = await tester.createGesture();
+    await gesture.downWithCustomEvent(
+      offset,
+      PointerDownEvent(
+        pointer: pointerValue,
+        position: offset,
+        pressure: 0.0,
+        pressureMax: 6.0,
+        pressureMin: 0.0,
+      ),
+    );
 
-      await gesture.updateWithCustomEvent(
-        PointerMoveEvent(
-          pointer: pointerValue,
-          position: selectableTextStart + const Offset(150.0, 5.0),
-          pressure: 0.5,
-          pressureMin: 0,
-        ),
-      );
+    await gesture.updateWithCustomEvent(
+      PointerMoveEvent(
+        pointer: pointerValue,
+        position: selectableTextStart + const Offset(150.0, 5.0),
+        pressure: 0.5,
+        pressureMin: 0,
+      ),
+    );
 
-      final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
-      final TextEditingController controller = editableTextWidget.controller;
+    final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
+    final TextEditingController controller = editableTextWidget.controller;
 
-      // We expect the force press to select a word at the given location.
-      expect(controller.selection, const TextSelection(baseOffset: 8, extentOffset: 12));
+    // We expect the force press to select a word at the given location.
+    expect(controller.selection, const TextSelection(baseOffset: 8, extentOffset: 12));
 
-      await gesture.up();
-      await tester.pump();
-      expectCupertinoSelectionToolbar();
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-  );
+    await gesture.up();
+    await tester.pump();
+    expectCupertinoSelectionToolbar();
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
 
-  testWidgets(
-    'tap on non-force-press-supported devices work',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        const MaterialApp(
-          home: Material(child: SelectableText('Atwater Peel Sherbrooke Bonaventure')),
-        ),
-      );
+  testWidgets('tap on non-force-press-supported devices work', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Material(child: SelectableText('Atwater Peel Sherbrooke Bonaventure')),
+      ),
+    );
 
-      final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
+    final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
 
-      final int pointerValue = tester.nextPointer;
-      final Offset offset = selectableTextStart + const Offset(150.0, 5.0);
-      final TestGesture gesture = await tester.createGesture();
-      await gesture.downWithCustomEvent(
-        offset,
-        PointerDownEvent(
-          pointer: pointerValue,
-          position: offset,
-          // iPhone 6 and below report 0 across the board.
-          pressure: 0,
-          pressureMax: 0,
-          pressureMin: 0,
-        ),
-      );
+    final int pointerValue = tester.nextPointer;
+    final Offset offset = selectableTextStart + const Offset(150.0, 5.0);
+    final TestGesture gesture = await tester.createGesture();
+    await gesture.downWithCustomEvent(
+      offset,
+      PointerDownEvent(
+        pointer: pointerValue,
+        position: offset,
+        // iPhone 6 and below report 0 across the board.
+        pressure: 0,
+        pressureMax: 0,
+        pressureMin: 0,
+      ),
+    );
 
-      await gesture.updateWithCustomEvent(
-        PointerMoveEvent(
-          pointer: pointerValue,
-          position: selectableTextStart + const Offset(150.0, 5.0),
-          pressure: 0.5,
-          pressureMin: 0,
-        ),
-      );
-      await gesture.up();
+    await gesture.updateWithCustomEvent(
+      PointerMoveEvent(
+        pointer: pointerValue,
+        position: selectableTextStart + const Offset(150.0, 5.0),
+        pressure: 0.5,
+        pressureMin: 0,
+      ),
+    );
+    await gesture.up();
 
-      final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
-      final TextEditingController controller = editableTextWidget.controller;
+    final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
+    final TextEditingController controller = editableTextWidget.controller;
 
-      // The event should fallback to a normal tap and move the cursor.
-      // Single taps selects the edge of the word.
-      expect(
-        controller.selection,
-        const TextSelection.collapsed(offset: 12, affinity: TextAffinity.upstream),
-      );
+    // The event should fallback to a normal tap and move the cursor.
+    // Single taps selects the edge of the word.
+    expect(
+      controller.selection,
+      const TextSelection.collapsed(offset: 12, affinity: TextAffinity.upstream),
+    );
 
-      await tester.pump();
-      // Single taps shouldn't trigger the toolbar.
-      expect(find.byType(CupertinoButton), findsNothing);
+    await tester.pump();
+    // Single taps shouldn't trigger the toolbar.
+    expect(find.byType(CupertinoButton), findsNothing);
 
-      // TODO(gspencergoog): Add in TargetPlatform.macOS in the line below when we
-      // figure out what global state is leaking.
-      // https://github.com/flutter/flutter/issues/43445
-    },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-  );
+    // TODO(gspencergoog): Add in TargetPlatform.macOS in the line below when we
+    // figure out what global state is leaking.
+    // https://github.com/flutter/flutter/issues/43445
+  }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
   testWidgets('default SelectableText debugFillProperties', (WidgetTester tester) async {
     final builder = DiagnosticPropertiesBuilder();

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -1641,51 +1641,47 @@ void main() {
     expect(cursorOffsetSpaces.dx >= 0, isTrue);
   });
 
-  testWidgets(
-    'mobile obscureText control test',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        overlay(
-          child: const TextField(
-            obscureText: true,
-            decoration: InputDecoration(hintText: 'Placeholder'),
-          ),
+  testWidgets('mobile obscureText control test', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      overlay(
+        child: const TextField(
+          obscureText: true,
+          decoration: InputDecoration(hintText: 'Placeholder'),
         ),
-      );
-      await tester.showKeyboard(find.byType(TextField));
+      ),
+    );
+    await tester.showKeyboard(find.byType(TextField));
 
-      const testValue = 'ABC';
-      tester.testTextInput.updateEditingValue(
-        const TextEditingValue(
-          text: testValue,
-          selection: TextSelection.collapsed(offset: testValue.length),
-        ),
-      );
+    const testValue = 'ABC';
+    tester.testTextInput.updateEditingValue(
+      const TextEditingValue(
+        text: testValue,
+        selection: TextSelection.collapsed(offset: testValue.length),
+      ),
+    );
 
-      await tester.pump();
+    await tester.pump();
 
-      // Enter a character into the obscured field and verify that the character
-      // is temporarily shown to the user and then changed to a bullet.
-      const newChar = 'X';
-      tester.testTextInput.updateEditingValue(
-        const TextEditingValue(
-          text: testValue + newChar,
-          selection: TextSelection.collapsed(offset: testValue.length + 1),
-        ),
-      );
+    // Enter a character into the obscured field and verify that the character
+    // is temporarily shown to the user and then changed to a bullet.
+    const newChar = 'X';
+    tester.testTextInput.updateEditingValue(
+      const TextEditingValue(
+        text: testValue + newChar,
+        selection: TextSelection.collapsed(offset: testValue.length + 1),
+      ),
+    );
 
-      await tester.pump();
+    await tester.pump();
 
-      String editText = (findRenderEditable(tester).text! as TextSpan).text!;
-      expect(editText.substring(editText.length - 1), newChar);
+    String editText = (findRenderEditable(tester).text! as TextSpan).text!;
+    expect(editText.substring(editText.length - 1), newChar);
 
-      await tester.pump(const Duration(seconds: 2));
+    await tester.pump(const Duration(seconds: 2));
 
-      editText = (findRenderEditable(tester).text! as TextSpan).text!;
-      expect(editText.substring(editText.length - 1), '\u2022');
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.android}),
-  );
+    editText = (findRenderEditable(tester).text! as TextSpan).text!;
+    expect(editText.substring(editText.length - 1), '\u2022');
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.android}));
 
   testWidgets(
     'desktop obscureText control test',
@@ -2480,56 +2476,54 @@ void main() {
     expect(controller.selection.extentOffset, testValue.indexOf('g'));
   });
 
-  testWidgets(
-    'Can move cursor when dragging, when tap is on collapsed selection (iOS)',
-    (WidgetTester tester) async {
-      final TextEditingController controller = _textEditingController();
+  testWidgets('Can move cursor when dragging, when tap is on collapsed selection (iOS)', (
+    WidgetTester tester,
+  ) async {
+    final TextEditingController controller = _textEditingController();
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Material(
-            child: TextField(dragStartBehavior: DragStartBehavior.down, controller: controller),
-          ),
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: TextField(dragStartBehavior: DragStartBehavior.down, controller: controller),
         ),
-      );
+      ),
+    );
 
-      const testValue = 'abc def ghi';
-      await tester.enterText(find.byType(TextField), testValue);
-      await skipPastScrollingAnimation(tester);
+    const testValue = 'abc def ghi';
+    await tester.enterText(find.byType(TextField), testValue);
+    await skipPastScrollingAnimation(tester);
 
-      final Offset ePos = textOffsetToPosition(tester, testValue.indexOf('e'));
-      final Offset iPos = textOffsetToPosition(tester, testValue.indexOf('i'));
+    final Offset ePos = textOffsetToPosition(tester, testValue.indexOf('e'));
+    final Offset iPos = textOffsetToPosition(tester, testValue.indexOf('i'));
 
-      // Tap on text field to gain focus, and set selection to '|g'. On iOS
-      // the selection is set to the word edge closest to the tap position.
-      // We await for kDoubleTapTimeout after the up event, so our next down event
-      // does not register as a double tap.
-      final TestGesture gesture = await tester.startGesture(ePos);
-      await tester.pump();
-      await gesture.up();
-      await tester.pumpAndSettle(kDoubleTapTimeout);
+    // Tap on text field to gain focus, and set selection to '|g'. On iOS
+    // the selection is set to the word edge closest to the tap position.
+    // We await for kDoubleTapTimeout after the up event, so our next down event
+    // does not register as a double tap.
+    final TestGesture gesture = await tester.startGesture(ePos);
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle(kDoubleTapTimeout);
 
-      expect(controller.selection.isCollapsed, true);
-      expect(controller.selection.baseOffset, 7);
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, 7);
 
-      // If the position we tap during a drag start is on the collapsed selection, then
-      // we can move the cursor with a drag.
-      // Here we tap on '|g', where our selection was previously, and move to '|i'.
-      await gesture.down(textOffsetToPosition(tester, 7));
-      await tester.pump();
-      await gesture.moveTo(iPos);
-      await tester.pumpAndSettle();
+    // If the position we tap during a drag start is on the collapsed selection, then
+    // we can move the cursor with a drag.
+    // Here we tap on '|g', where our selection was previously, and move to '|i'.
+    await gesture.down(textOffsetToPosition(tester, 7));
+    await tester.pump();
+    await gesture.moveTo(iPos);
+    await tester.pumpAndSettle();
 
-      expect(controller.selection.isCollapsed, true);
-      expect(controller.selection.baseOffset, testValue.indexOf('i'));
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, testValue.indexOf('i'));
 
-      // End gesture and skip the magnifier hide animation, so it can release
-      // resources.
-      await gesture.up();
-      await tester.pumpAndSettle();
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-  );
+    // End gesture and skip the magnifier hide animation, so it can release
+    // resources.
+    await gesture.up();
+    await tester.pumpAndSettle();
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
 
   testWidgets(
     'Cursor should not move on a quick touch drag when touch does not begin on previous selection (iOS)',
@@ -3404,141 +3398,135 @@ void main() {
     ),
   );
 
-  testWidgets(
-    'assertion error is not thrown when attempting to drag both selection handles',
-    (WidgetTester tester) async {
-      // Regression test for https://github.com/flutter/flutter/issues/168578.
-      final controller = TextEditingController(text: 'abc def ghi');
-      addTearDown(controller.dispose);
+  testWidgets('assertion error is not thrown when attempting to drag both selection handles', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/168578.
+    final controller = TextEditingController(text: 'abc def ghi');
+    addTearDown(controller.dispose);
 
-      await tester.pumpWidget(
-        overlay(
-          child: Center(
-            child: TextField(
-              dragStartBehavior: DragStartBehavior.down,
-              controller: controller,
-              style: const TextStyle(fontSize: 10.0),
-            ),
+    await tester.pumpWidget(
+      overlay(
+        child: Center(
+          child: TextField(
+            dragStartBehavior: DragStartBehavior.down,
+            controller: controller,
+            style: const TextStyle(fontSize: 10.0),
           ),
         ),
-      );
+      ),
+    );
 
-      // Double tap on 'e' to select 'def'.
-      final Offset ePos = textOffsetToPosition(tester, 5);
-      await tester.tapAt(ePos, pointer: 7);
-      await tester.pump(const Duration(milliseconds: 50));
-      expect(controller.selection.isCollapsed, isTrue);
-      expect(controller.selection.baseOffset, 5);
-      await tester.tapAt(ePos, pointer: 7);
-      await tester.pumpAndSettle();
-      expect(controller.selection.baseOffset, 4);
-      expect(controller.selection.extentOffset, 7);
+    // Double tap on 'e' to select 'def'.
+    final Offset ePos = textOffsetToPosition(tester, 5);
+    await tester.tapAt(ePos, pointer: 7);
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(controller.selection.isCollapsed, isTrue);
+    expect(controller.selection.baseOffset, 5);
+    await tester.tapAt(ePos, pointer: 7);
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 4);
+    expect(controller.selection.extentOffset, 7);
 
-      final RenderEditable renderEditable = findRenderEditable(tester);
-      final List<TextSelectionPoint> endpoints = globalize(
-        renderEditable.getEndpointsForSelection(controller.selection),
-        renderEditable,
-      );
-      expect(endpoints.length, 2);
+    final RenderEditable renderEditable = findRenderEditable(tester);
+    final List<TextSelectionPoint> endpoints = globalize(
+      renderEditable.getEndpointsForSelection(controller.selection),
+      renderEditable,
+    );
+    expect(endpoints.length, 2);
 
-      // Drag the end handle to 'g'.
-      final Offset endHandlePos = endpoints[1].point + const Offset(1.0, 1.0);
-      Offset newHandlePos = textOffsetToPosition(tester, 9); // Position of 'g'.
-      final TestGesture endHandleGesture = await tester.startGesture(endHandlePos, pointer: 7);
-      await tester.pump();
-      await endHandleGesture.moveTo(newHandlePos);
-      await tester.pump();
-      expect(controller.selection.baseOffset, 4);
-      expect(controller.selection.extentOffset, 9);
+    // Drag the end handle to 'g'.
+    final Offset endHandlePos = endpoints[1].point + const Offset(1.0, 1.0);
+    Offset newHandlePos = textOffsetToPosition(tester, 9); // Position of 'g'.
+    final TestGesture endHandleGesture = await tester.startGesture(endHandlePos, pointer: 7);
+    await tester.pump();
+    await endHandleGesture.moveTo(newHandlePos);
+    await tester.pump();
+    expect(controller.selection.baseOffset, 4);
+    expect(controller.selection.extentOffset, 9);
 
-      // Attempt to drag the start handle to the start of the text.
-      final Offset startHandlePos = endpoints[0].point + const Offset(1.0, 1.0);
-      newHandlePos = textOffsetToPosition(tester, 0);
-      final TestGesture startHandleGesture = await tester.startGesture(startHandlePos, pointer: 8);
-      await tester.pump();
-      await startHandleGesture.moveTo(newHandlePos);
-      await tester.pump();
-      await startHandleGesture.up();
-      await tester.pump();
+    // Attempt to drag the start handle to the start of the text.
+    final Offset startHandlePos = endpoints[0].point + const Offset(1.0, 1.0);
+    newHandlePos = textOffsetToPosition(tester, 0);
+    final TestGesture startHandleGesture = await tester.startGesture(startHandlePos, pointer: 8);
+    await tester.pump();
+    await startHandleGesture.moveTo(newHandlePos);
+    await tester.pump();
+    await startHandleGesture.up();
+    await tester.pump();
 
-      // Drag the end handle to the end of the text after releasing the start handle.
-      newHandlePos = textOffsetToPosition(tester, 11); // Position of 'i'.
-      await tester.pump();
-      await endHandleGesture.moveTo(newHandlePos);
-      await tester.pump();
-      await endHandleGesture.up();
-      await tester.pump();
+    // Drag the end handle to the end of the text after releasing the start handle.
+    newHandlePos = textOffsetToPosition(tester, 11); // Position of 'i'.
+    await tester.pump();
+    await endHandleGesture.moveTo(newHandlePos);
+    await tester.pump();
+    await endHandleGesture.up();
+    await tester.pump();
 
-      expect(tester.takeException(), isNull);
-      expect(controller.selection.baseOffset, 0);
-      expect(controller.selection.extentOffset, 11);
-    },
-    variant: TargetPlatformVariant.only(TargetPlatform.android),
-  );
+    expect(tester.takeException(), isNull);
+    expect(controller.selection.baseOffset, 0);
+    expect(controller.selection.extentOffset, 11);
+  }, variant: TargetPlatformVariant.only(TargetPlatform.android));
 
-  testWidgets(
-    'Can only drag one selection handle at a time on iOS',
-    (WidgetTester tester) async {
-      final controller = TextEditingController(text: 'abc def ghi');
-      addTearDown(controller.dispose);
+  testWidgets('Can only drag one selection handle at a time on iOS', (WidgetTester tester) async {
+    final controller = TextEditingController(text: 'abc def ghi');
+    addTearDown(controller.dispose);
 
-      await tester.pumpWidget(
-        overlay(
-          child: Center(
-            child: TextField(
-              dragStartBehavior: DragStartBehavior.down,
-              controller: controller,
-              style: const TextStyle(fontSize: 10.0),
-            ),
+    await tester.pumpWidget(
+      overlay(
+        child: Center(
+          child: TextField(
+            dragStartBehavior: DragStartBehavior.down,
+            controller: controller,
+            style: const TextStyle(fontSize: 10.0),
           ),
         ),
-      );
+      ),
+    );
 
-      // Double tap on 'e' to select 'def'.
-      final Offset ePos = textOffsetToPosition(tester, 5);
-      await tester.tapAt(ePos, pointer: 7);
-      await tester.pump(const Duration(milliseconds: 50));
-      expect(controller.selection.isCollapsed, isTrue);
-      expect(controller.selection.baseOffset, 7);
-      await tester.tapAt(ePos, pointer: 7);
-      await tester.pumpAndSettle();
-      expect(controller.selection.baseOffset, 4);
-      expect(controller.selection.extentOffset, 7);
+    // Double tap on 'e' to select 'def'.
+    final Offset ePos = textOffsetToPosition(tester, 5);
+    await tester.tapAt(ePos, pointer: 7);
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(controller.selection.isCollapsed, isTrue);
+    expect(controller.selection.baseOffset, 7);
+    await tester.tapAt(ePos, pointer: 7);
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 4);
+    expect(controller.selection.extentOffset, 7);
 
-      final RenderEditable renderEditable = findRenderEditable(tester);
-      final List<TextSelectionPoint> endpoints = globalize(
-        renderEditable.getEndpointsForSelection(controller.selection),
-        renderEditable,
-      );
-      expect(endpoints.length, 2);
+    final RenderEditable renderEditable = findRenderEditable(tester);
+    final List<TextSelectionPoint> endpoints = globalize(
+      renderEditable.getEndpointsForSelection(controller.selection),
+      renderEditable,
+    );
+    expect(endpoints.length, 2);
 
-      // Drag the end handle to the end of the text.
-      final Offset endHandlePos = endpoints[1].point;
-      Offset newHandlePos = textOffsetToPosition(tester, 11); // Position of 'i'.
-      final TestGesture endHandleGesture = await tester.startGesture(endHandlePos, pointer: 7);
-      await tester.pump();
-      await endHandleGesture.moveTo(newHandlePos);
-      await tester.pump();
-      expect(controller.selection.baseOffset, 4);
-      expect(controller.selection.extentOffset, 11);
+    // Drag the end handle to the end of the text.
+    final Offset endHandlePos = endpoints[1].point;
+    Offset newHandlePos = textOffsetToPosition(tester, 11); // Position of 'i'.
+    final TestGesture endHandleGesture = await tester.startGesture(endHandlePos, pointer: 7);
+    await tester.pump();
+    await endHandleGesture.moveTo(newHandlePos);
+    await tester.pump();
+    expect(controller.selection.baseOffset, 4);
+    expect(controller.selection.extentOffset, 11);
 
-      // Attempt to drag the start handle to the start of the text.
-      final Offset startHandlePos = endpoints[0].point;
-      newHandlePos = textOffsetToPosition(tester, 0);
-      final TestGesture startHandleGesture = await tester.startGesture(startHandlePos, pointer: 8);
-      await tester.pump();
-      await startHandleGesture.moveTo(newHandlePos);
-      await tester.pump();
-      await startHandleGesture.up();
-      await endHandleGesture.up();
-      await tester.pump();
+    // Attempt to drag the start handle to the start of the text.
+    final Offset startHandlePos = endpoints[0].point;
+    newHandlePos = textOffsetToPosition(tester, 0);
+    final TestGesture startHandleGesture = await tester.startGesture(startHandlePos, pointer: 8);
+    await tester.pump();
+    await startHandleGesture.moveTo(newHandlePos);
+    await tester.pump();
+    await startHandleGesture.up();
+    await endHandleGesture.up();
+    await tester.pump();
 
-      // The start handle does not cause the selection to change.
-      expect(controller.selection.baseOffset, 4);
-      expect(controller.selection.extentOffset, 11);
-    },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-  );
+    // The start handle does not cause the selection to change.
+    expect(controller.selection.baseOffset, 4);
+    expect(controller.selection.extentOffset, 11);
+  }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
   testWidgets(
     'Can only drag one selection handle at a time on Android web',
@@ -4825,55 +4813,53 @@ void main() {
     skip: isContextMenuProvidedByPlatform,
   );
 
-  testWidgets(
-    'create selection overlay if none exists when toggleToolbar is called',
-    (WidgetTester tester) async {
-      // Regression test for https://github.com/flutter/flutter/issues/111660
-      final Widget testWidget = MaterialApp(
-        home: Scaffold(
-          appBar: AppBar(
-            title: const Text('Test'),
-            actions: <Widget>[
-              PopupMenuButton<String>(
-                itemBuilder: (BuildContext context) {
-                  return <String>{'About'}.map((String value) {
-                    return PopupMenuItem<String>(value: value, child: Text(value));
-                  }).toList();
-                },
-              ),
-            ],
-          ),
-          body: const TextField(),
+  testWidgets('create selection overlay if none exists when toggleToolbar is called', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/111660
+    final Widget testWidget = MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(
+          title: const Text('Test'),
+          actions: <Widget>[
+            PopupMenuButton<String>(
+              itemBuilder: (BuildContext context) {
+                return <String>{'About'}.map((String value) {
+                  return PopupMenuItem<String>(value: value, child: Text(value));
+                }).toList();
+              },
+            ),
+          ],
         ),
-      );
+        body: const TextField(),
+      ),
+    );
 
-      await tester.pumpWidget(testWidget);
+    await tester.pumpWidget(testWidget);
 
-      // Tap on TextField.
-      final Offset textFieldStart = tester.getTopLeft(find.byType(TextField));
-      final TestGesture gesture = await tester.startGesture(textFieldStart);
-      await tester.pump(const Duration(milliseconds: 300));
-      await gesture.up();
-      await tester.pumpAndSettle();
+    // Tap on TextField.
+    final Offset textFieldStart = tester.getTopLeft(find.byType(TextField));
+    final TestGesture gesture = await tester.startGesture(textFieldStart);
+    await tester.pump(const Duration(milliseconds: 300));
+    await gesture.up();
+    await tester.pumpAndSettle();
 
-      // Tap on 3 dot menu.
-      await tester.tap(find.byType(PopupMenuButton<String>));
-      await tester.pumpAndSettle();
+    // Tap on 3 dot menu.
+    await tester.tap(find.byType(PopupMenuButton<String>));
+    await tester.pumpAndSettle();
 
-      // Tap on TextField.
-      await gesture.down(textFieldStart);
-      await tester.pump(const Duration(milliseconds: 300));
-      await gesture.up();
-      await tester.pumpAndSettle();
+    // Tap on TextField.
+    await gesture.down(textFieldStart);
+    await tester.pump(const Duration(milliseconds: 300));
+    await gesture.up();
+    await tester.pumpAndSettle();
 
-      // Tap on TextField again.
-      await tester.tapAt(textFieldStart);
-      await tester.pumpAndSettle();
+    // Tap on TextField again.
+    await tester.tapAt(textFieldStart);
+    await tester.pumpAndSettle();
 
-      expect(tester.takeException(), isNull);
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-  );
+    expect(tester.takeException(), isNull);
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
 
   testWidgets('TextField height with minLines unset', (WidgetTester tester) async {
     await tester.pumpWidget(textFieldBuilder());
@@ -10115,36 +10101,32 @@ void main() {
     expect(tester.takeException(), isNotNull);
   });
 
-  testWidgets(
-    'tap moves cursor to the edge of the word it tapped',
-    (WidgetTester tester) async {
-      final TextEditingController controller = _textEditingController(
-        text: 'Atwater Peel Sherbrooke Bonaventure',
-      );
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Material(
-            child: Center(child: TextField(controller: controller)),
-          ),
+  testWidgets('tap moves cursor to the edge of the word it tapped', (WidgetTester tester) async {
+    final TextEditingController controller = _textEditingController(
+      text: 'Atwater Peel Sherbrooke Bonaventure',
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(child: TextField(controller: controller)),
         ),
-      );
+      ),
+    );
 
-      final Offset textfieldStart = tester.getTopLeft(find.byType(TextField));
+    final Offset textfieldStart = tester.getTopLeft(find.byType(TextField));
 
-      await tester.tapAt(textfieldStart + const Offset(50.0, 9.0));
-      await tester.pump();
+    await tester.tapAt(textfieldStart + const Offset(50.0, 9.0));
+    await tester.pump();
 
-      // We moved the cursor.
-      expect(
-        controller.selection,
-        const TextSelection.collapsed(offset: 7, affinity: TextAffinity.upstream),
-      );
+    // We moved the cursor.
+    expect(
+      controller.selection,
+      const TextSelection.collapsed(offset: 7, affinity: TextAffinity.upstream),
+    );
 
-      // But don't trigger the toolbar.
-      expectNoCupertinoToolbar();
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-  );
+    // But don't trigger the toolbar.
+    expectNoCupertinoToolbar();
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
 
   testWidgets(
     'tap with a mouse does not move cursor to the edge of the word',
@@ -10253,199 +10235,191 @@ void main() {
     }),
   );
 
-  testWidgets(
-    'Tapping on a collapsed selection toggles the toolbar',
-    (WidgetTester tester) async {
-      final TextEditingController controller = _textEditingController(
-        text:
-            'Atwater Peel Sherbrooke Bonaventure Angrignon Peel Côte-des-Neigse Atwater Peel Sherbrooke Bonaventure Angrignon Peel Côte-des-Neiges',
-      );
-      // On iOS/iPadOS, during a tap we select the edge of the word closest to the tap.
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Material(
-            child: Center(child: TextField(controller: controller, maxLines: 2)),
-          ),
+  testWidgets('Tapping on a collapsed selection toggles the toolbar', (WidgetTester tester) async {
+    final TextEditingController controller = _textEditingController(
+      text:
+          'Atwater Peel Sherbrooke Bonaventure Angrignon Peel Côte-des-Neigse Atwater Peel Sherbrooke Bonaventure Angrignon Peel Côte-des-Neiges',
+    );
+    // On iOS/iPadOS, during a tap we select the edge of the word closest to the tap.
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(child: TextField(controller: controller, maxLines: 2)),
         ),
-      );
+      ),
+    );
 
-      final double lineHeight = findRenderEditable(tester).preferredLineHeight;
-      final Offset begPos = textOffsetToPosition(tester, 0);
-      final Offset endPos =
-          textOffsetToPosition(tester, 35) +
-          const Offset(
-            200.0,
-            0.0,
-          ); // Index of 'Bonaventure|' + Offset(200.0,0), which is at the end of the first line.
-      final Offset vPos = textOffsetToPosition(tester, 29); // Index of 'Bonav|enture'.
-      final Offset wPos = textOffsetToPosition(tester, 3); // Index of 'Atw|ater'.
+    final double lineHeight = findRenderEditable(tester).preferredLineHeight;
+    final Offset begPos = textOffsetToPosition(tester, 0);
+    final Offset endPos =
+        textOffsetToPosition(tester, 35) +
+        const Offset(
+          200.0,
+          0.0,
+        ); // Index of 'Bonaventure|' + Offset(200.0,0), which is at the end of the first line.
+    final Offset vPos = textOffsetToPosition(tester, 29); // Index of 'Bonav|enture'.
+    final Offset wPos = textOffsetToPosition(tester, 3); // Index of 'Atw|ater'.
 
-      // This tap just puts the cursor somewhere different than where the double
-      // tap will occur to test that the double tap moves the existing cursor first.
-      await tester.tapAt(wPos);
-      await tester.pump(const Duration(milliseconds: 500));
+    // This tap just puts the cursor somewhere different than where the double
+    // tap will occur to test that the double tap moves the existing cursor first.
+    await tester.tapAt(wPos);
+    await tester.pump(const Duration(milliseconds: 500));
 
-      await tester.tapAt(vPos);
-      await tester.pump(const Duration(milliseconds: 500));
-      // First tap moved the cursor. Here we tap the position where 'v' is located.
-      // On iOS this will select the closest word edge, in this case the cursor is placed
-      // at the end of the word 'Bonaventure|'.
-      expect(controller.selection.isCollapsed, true);
-      expect(controller.selection.baseOffset, 35);
-      expectNoCupertinoToolbar();
+    await tester.tapAt(vPos);
+    await tester.pump(const Duration(milliseconds: 500));
+    // First tap moved the cursor. Here we tap the position where 'v' is located.
+    // On iOS this will select the closest word edge, in this case the cursor is placed
+    // at the end of the word 'Bonaventure|'.
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, 35);
+    expectNoCupertinoToolbar();
 
-      await tester.tapAt(vPos);
-      await tester.pumpAndSettle(const Duration(milliseconds: 500));
-      // Second tap toggles the toolbar. Here we tap on 'v' again, and select the word edge. Since
-      // the selection has not changed we toggle the toolbar.
-      expect(controller.selection.isCollapsed, true);
-      expect(controller.selection.baseOffset, 35);
-      expectCupertinoToolbarForCollapsedSelection();
+    await tester.tapAt(vPos);
+    await tester.pumpAndSettle(const Duration(milliseconds: 500));
+    // Second tap toggles the toolbar. Here we tap on 'v' again, and select the word edge. Since
+    // the selection has not changed we toggle the toolbar.
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, 35);
+    expectCupertinoToolbarForCollapsedSelection();
 
-      // Tap the 'v' position again to hide the toolbar.
-      await tester.tapAt(vPos);
-      await tester.pumpAndSettle();
-      expect(controller.selection.isCollapsed, true);
-      expect(controller.selection.baseOffset, 35);
-      expectNoCupertinoToolbar();
+    // Tap the 'v' position again to hide the toolbar.
+    await tester.tapAt(vPos);
+    await tester.pumpAndSettle();
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, 35);
+    expectNoCupertinoToolbar();
 
-      // Long press at the end of the first line to move the cursor to the end of the first line
-      // where the word wrap is. Since there is a word wrap here, and the direction of the text is LTR,
-      // the TextAffinity will be upstream and against the natural direction. The toolbar is also
-      // shown after a long press.
-      await tester.longPressAt(endPos);
-      await tester.pumpAndSettle(const Duration(milliseconds: 500));
-      expect(controller.selection.isCollapsed, true);
-      expect(controller.selection.baseOffset, 46);
-      expect(controller.selection.affinity, TextAffinity.upstream);
-      expectCupertinoToolbarForCollapsedSelection();
+    // Long press at the end of the first line to move the cursor to the end of the first line
+    // where the word wrap is. Since there is a word wrap here, and the direction of the text is LTR,
+    // the TextAffinity will be upstream and against the natural direction. The toolbar is also
+    // shown after a long press.
+    await tester.longPressAt(endPos);
+    await tester.pumpAndSettle(const Duration(milliseconds: 500));
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, 46);
+    expect(controller.selection.affinity, TextAffinity.upstream);
+    expectCupertinoToolbarForCollapsedSelection();
 
-      // Tap at the same position to toggle the toolbar.
-      await tester.tapAt(endPos);
-      await tester.pumpAndSettle();
-      expect(controller.selection.isCollapsed, true);
-      expect(controller.selection.baseOffset, 46);
-      expect(controller.selection.affinity, TextAffinity.upstream);
-      expectNoCupertinoToolbar();
+    // Tap at the same position to toggle the toolbar.
+    await tester.tapAt(endPos);
+    await tester.pumpAndSettle();
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, 46);
+    expect(controller.selection.affinity, TextAffinity.upstream);
+    expectNoCupertinoToolbar();
 
-      // Tap at the beginning of the second line to move the cursor to the front of the first word on the
-      // second line, where the word wrap is. Since there is a word wrap here, and the direction of the text is LTR,
-      // the TextAffinity will be downstream and following the natural direction. The toolbar will be hidden after this tap.
-      await tester.tapAt(begPos + Offset(0.0, lineHeight));
-      await tester.pumpAndSettle();
-      expect(controller.selection.isCollapsed, true);
-      expect(controller.selection.baseOffset, 46);
-      expect(controller.selection.affinity, TextAffinity.downstream);
-      expectNoCupertinoToolbar();
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-  );
+    // Tap at the beginning of the second line to move the cursor to the front of the first word on the
+    // second line, where the word wrap is. Since there is a word wrap here, and the direction of the text is LTR,
+    // the TextAffinity will be downstream and following the natural direction. The toolbar will be hidden after this tap.
+    await tester.tapAt(begPos + Offset(0.0, lineHeight));
+    await tester.pumpAndSettle();
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, 46);
+    expect(controller.selection.affinity, TextAffinity.downstream);
+    expectNoCupertinoToolbar();
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
 
-  testWidgets(
-    'Tapping on a non-collapsed selection toggles the toolbar and retains the selection',
-    (WidgetTester tester) async {
-      final TextEditingController controller = _textEditingController(
-        text: 'Atwater Peel Sherbrooke Bonaventure',
-      );
-      // On iOS/iPadOS, during a tap we select the edge of the word closest to the tap.
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Material(
-            child: Center(child: TextField(controller: controller)),
-          ),
+  testWidgets('Tapping on a non-collapsed selection toggles the toolbar and retains the selection', (
+    WidgetTester tester,
+  ) async {
+    final TextEditingController controller = _textEditingController(
+      text: 'Atwater Peel Sherbrooke Bonaventure',
+    );
+    // On iOS/iPadOS, during a tap we select the edge of the word closest to the tap.
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(child: TextField(controller: controller)),
         ),
-      );
+      ),
+    );
 
-      final Offset vPos = textOffsetToPosition(tester, 29); // Index of 'Bonav|enture'.
-      final Offset ePos =
-          textOffsetToPosition(tester, 35) +
-          const Offset(
-            7.0,
-            0.0,
-          ); // Index of 'Bonaventure|' + Offset(7.0,0), which taps slightly to the right of the end of the text.
-      final Offset wPos = textOffsetToPosition(tester, 3); // Index of 'Atw|ater'.
+    final Offset vPos = textOffsetToPosition(tester, 29); // Index of 'Bonav|enture'.
+    final Offset ePos =
+        textOffsetToPosition(tester, 35) +
+        const Offset(
+          7.0,
+          0.0,
+        ); // Index of 'Bonaventure|' + Offset(7.0,0), which taps slightly to the right of the end of the text.
+    final Offset wPos = textOffsetToPosition(tester, 3); // Index of 'Atw|ater'.
 
-      // This tap just puts the cursor somewhere different than where the double
-      // tap will occur to test that the double tap moves the existing cursor first.
-      await tester.tapAt(wPos);
-      await tester.pump(const Duration(milliseconds: 500));
+    // This tap just puts the cursor somewhere different than where the double
+    // tap will occur to test that the double tap moves the existing cursor first.
+    await tester.tapAt(wPos);
+    await tester.pump(const Duration(milliseconds: 500));
 
-      await tester.tapAt(vPos);
-      await tester.pump(const Duration(milliseconds: 50));
-      // First tap moved the cursor.
-      expect(controller.selection.isCollapsed, true);
-      expect(controller.selection.baseOffset, 35);
-      await tester.tapAt(vPos);
-      await tester.pumpAndSettle(const Duration(milliseconds: 500));
+    await tester.tapAt(vPos);
+    await tester.pump(const Duration(milliseconds: 50));
+    // First tap moved the cursor.
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, 35);
+    await tester.tapAt(vPos);
+    await tester.pumpAndSettle(const Duration(milliseconds: 500));
 
-      // Second tap selects the word around the cursor.
-      expect(controller.selection, const TextSelection(baseOffset: 24, extentOffset: 35));
+    // Second tap selects the word around the cursor.
+    expect(controller.selection, const TextSelection(baseOffset: 24, extentOffset: 35));
 
-      // The toolbar shows up.
-      expectCupertinoToolbarForPartialSelection();
+    // The toolbar shows up.
+    expectCupertinoToolbarForPartialSelection();
 
-      // Tap the selected word to hide the toolbar and retain the selection.
-      await tester.tapAt(vPos);
-      await tester.pumpAndSettle();
-      expect(controller.selection, const TextSelection(baseOffset: 24, extentOffset: 35));
-      expectNoCupertinoToolbar();
+    // Tap the selected word to hide the toolbar and retain the selection.
+    await tester.tapAt(vPos);
+    await tester.pumpAndSettle();
+    expect(controller.selection, const TextSelection(baseOffset: 24, extentOffset: 35));
+    expectNoCupertinoToolbar();
 
-      // Tap the selected word to show the toolbar and retain the selection.
-      await tester.tapAt(vPos);
-      await tester.pumpAndSettle();
-      expect(controller.selection, const TextSelection(baseOffset: 24, extentOffset: 35));
-      expectCupertinoToolbarForPartialSelection();
+    // Tap the selected word to show the toolbar and retain the selection.
+    await tester.tapAt(vPos);
+    await tester.pumpAndSettle();
+    expect(controller.selection, const TextSelection(baseOffset: 24, extentOffset: 35));
+    expectCupertinoToolbarForPartialSelection();
 
-      // Tap past the selected word to move the cursor and hide the toolbar.
-      await tester.tapAt(ePos);
-      await tester.pumpAndSettle();
-      expect(controller.selection.isCollapsed, true);
-      expect(controller.selection.baseOffset, 35);
-      expectNoCupertinoToolbar();
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-  );
+    // Tap past the selected word to move the cursor and hide the toolbar.
+    await tester.tapAt(ePos);
+    await tester.pumpAndSettle();
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, 35);
+    expectNoCupertinoToolbar();
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
 
-  testWidgets(
-    'double tap selects word and first tap of double tap moves cursor (iOS)',
-    (WidgetTester tester) async {
-      final TextEditingController controller = _textEditingController(
-        text: 'Atwater Peel Sherbrooke Bonaventure',
-      );
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Material(
-            child: Center(child: TextField(controller: controller)),
-          ),
+  testWidgets('double tap selects word and first tap of double tap moves cursor (iOS)', (
+    WidgetTester tester,
+  ) async {
+    final TextEditingController controller = _textEditingController(
+      text: 'Atwater Peel Sherbrooke Bonaventure',
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(child: TextField(controller: controller)),
         ),
-      );
+      ),
+    );
 
-      final Offset pPos = textOffsetToPosition(tester, 9); // Index of 'P|eel'.
-      final Offset wPos = textOffsetToPosition(tester, 3); // Index of 'Atw|ater'.
+    final Offset pPos = textOffsetToPosition(tester, 9); // Index of 'P|eel'.
+    final Offset wPos = textOffsetToPosition(tester, 3); // Index of 'Atw|ater'.
 
-      // This tap just puts the cursor somewhere different than where the double
-      // tap will occur to test that the double tap moves the existing cursor first.
-      await tester.tapAt(wPos);
-      await tester.pump(const Duration(milliseconds: 500));
+    // This tap just puts the cursor somewhere different than where the double
+    // tap will occur to test that the double tap moves the existing cursor first.
+    await tester.tapAt(wPos);
+    await tester.pump(const Duration(milliseconds: 500));
 
-      await tester.tapAt(pPos);
-      await tester.pump(const Duration(milliseconds: 50));
-      // First tap moved the cursor.
-      expect(
-        controller.selection,
-        const TextSelection.collapsed(offset: 12, affinity: TextAffinity.upstream),
-      );
-      await tester.tapAt(pPos);
-      await tester.pumpAndSettle();
+    await tester.tapAt(pPos);
+    await tester.pump(const Duration(milliseconds: 50));
+    // First tap moved the cursor.
+    expect(
+      controller.selection,
+      const TextSelection.collapsed(offset: 12, affinity: TextAffinity.upstream),
+    );
+    await tester.tapAt(pPos);
+    await tester.pumpAndSettle();
 
-      // Second tap selects the word around the cursor.
-      expect(controller.selection, const TextSelection(baseOffset: 8, extentOffset: 12));
+    // Second tap selects the word around the cursor.
+    expect(controller.selection, const TextSelection(baseOffset: 8, extentOffset: 12));
 
-      // The toolbar shows up.
-      expectCupertinoToolbarForPartialSelection();
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-  );
+    // The toolbar shows up.
+    expectCupertinoToolbarForPartialSelection();
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
 
   testWidgets('iOS selectWordEdge works correctly', (WidgetTester tester) async {
     final TextEditingController controller = _textEditingController(text: 'blah1 blah2');
@@ -10814,62 +10788,60 @@ void main() {
       }),
     );
 
-    testWidgets(
-      'Can triple tap to select a paragraph on mobile platforms',
-      (WidgetTester tester) async {
-        final TextEditingController controller = _textEditingController();
-        final isTargetPlatformApple = defaultTargetPlatform == TargetPlatform.iOS;
+    testWidgets('Can triple tap to select a paragraph on mobile platforms', (
+      WidgetTester tester,
+    ) async {
+      final TextEditingController controller = _textEditingController();
+      final isTargetPlatformApple = defaultTargetPlatform == TargetPlatform.iOS;
 
-        await tester.pumpWidget(
-          MaterialApp(
-            home: Material(
-              child: TextField(
-                dragStartBehavior: DragStartBehavior.down,
-                controller: controller,
-                maxLines: null,
-              ),
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: TextField(
+              dragStartBehavior: DragStartBehavior.down,
+              controller: controller,
+              maxLines: null,
             ),
           ),
-        );
+        ),
+      );
 
-        await tester.enterText(find.byType(TextField), testValueB);
-        await skipPastScrollingAnimation(tester);
-        expect(controller.value.text, testValueB);
+      await tester.enterText(find.byType(TextField), testValueB);
+      await skipPastScrollingAnimation(tester);
+      expect(controller.value.text, testValueB);
 
-        final Offset firstLinePos =
-            tester.getTopLeft(find.byType(TextField)) + const Offset(50.0, 9.0);
+      final Offset firstLinePos =
+          tester.getTopLeft(find.byType(TextField)) + const Offset(50.0, 9.0);
 
-        // Tap on text field to gain focus, and move the selection.
-        final TestGesture gesture = await tester.startGesture(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Tap on text field to gain focus, and move the selection.
+      final TestGesture gesture = await tester.startGesture(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, isTargetPlatformApple ? 5 : 3);
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, isTargetPlatformApple ? 5 : 3);
 
-        // Here we tap on same position again, to register a double tap. This will select
-        // the word at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Here we tap on same position again, to register a double tap. This will select
+      // the word at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 5);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 5);
 
-        // Here we tap on same position again, to register a triple tap. This will select
-        // the paragraph at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pumpAndSettle();
+      // Here we tap on same position again, to register a triple tap. This will select
+      // the paragraph at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 22);
-      },
-      variant: TargetPlatformVariant.mobile(),
-    );
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 22);
+    }, variant: TargetPlatformVariant.mobile());
 
     testWidgets(
       'Triple click at the beginning of a line should not select the previous paragraph',
@@ -10929,64 +10901,62 @@ void main() {
       variant: TargetPlatformVariant.all(excluding: <TargetPlatform>{TargetPlatform.linux}),
     );
 
-    testWidgets(
-      'Triple click at the end of text should select the previous paragraph',
-      (WidgetTester tester) async {
-        // Regression test for https://github.com/flutter/flutter/issues/132126.
-        final TextEditingController controller = _textEditingController();
+    testWidgets('Triple click at the end of text should select the previous paragraph', (
+      WidgetTester tester,
+    ) async {
+      // Regression test for https://github.com/flutter/flutter/issues/132126.
+      final TextEditingController controller = _textEditingController();
 
-        await tester.pumpWidget(
-          MaterialApp(
-            home: Material(
-              child: TextField(
-                dragStartBehavior: DragStartBehavior.down,
-                controller: controller,
-                maxLines: null,
-              ),
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: TextField(
+              dragStartBehavior: DragStartBehavior.down,
+              controller: controller,
+              maxLines: null,
             ),
           ),
-        );
+        ),
+      );
 
-        await tester.enterText(find.byType(TextField), testValueB);
-        await skipPastScrollingAnimation(tester);
-        expect(controller.value.text, testValueB);
+      await tester.enterText(find.byType(TextField), testValueB);
+      await skipPastScrollingAnimation(tester);
+      expect(controller.value.text, testValueB);
 
-        final Offset endOfTextPos = textOffsetToPosition(tester, 74);
+      final Offset endOfTextPos = textOffsetToPosition(tester, 74);
 
-        // Click on text field to gain focus, and move the selection.
-        final TestGesture gesture = await tester.startGesture(
-          endOfTextPos,
-          kind: PointerDeviceKind.mouse,
-        );
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Click on text field to gain focus, and move the selection.
+      final TestGesture gesture = await tester.startGesture(
+        endOfTextPos,
+        kind: PointerDeviceKind.mouse,
+      );
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, 74);
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, 74);
 
-        // Here we click on same position again, to register a double click.
-        await gesture.down(endOfTextPos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Here we click on same position again, to register a double click.
+      await gesture.down(endOfTextPos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.baseOffset, 74);
-        expect(controller.selection.extentOffset, 74);
+      expect(controller.selection.baseOffset, 74);
+      expect(controller.selection.extentOffset, 74);
 
-        // Here we click on same position again, to register a triple click. This will select
-        // the paragraph at the clicked position.
-        await gesture.down(endOfTextPos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
-        await tester.pumpAndSettle();
+      // Here we click on same position again, to register a triple click. This will select
+      // the paragraph at the clicked position.
+      await gesture.down(endOfTextPos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 57);
-        expect(controller.selection.extentOffset, 74);
-      },
-      variant: TargetPlatformVariant.all(excluding: <TargetPlatform>{TargetPlatform.linux}),
-    );
+      expect(controller.selection.baseOffset, 57);
+      expect(controller.selection.extentOffset, 74);
+    }, variant: TargetPlatformVariant.all(excluding: <TargetPlatform>{TargetPlatform.linux}));
 
     testWidgets(
       'triple tap chains work on Non-Apple mobile platforms',
@@ -11060,75 +11030,71 @@ void main() {
       }),
     );
 
-    testWidgets(
-      'triple tap chains work on Apple platforms',
-      (WidgetTester tester) async {
-        final TextEditingController controller = _textEditingController(
-          text: 'Atwater Peel Sherbrooke Bonaventure\nThe fox jumped over the fence.',
-        );
-        await tester.pumpWidget(
-          MaterialApp(
-            theme: ThemeData(useMaterial3: false),
-            home: Material(
-              child: Center(child: TextField(controller: controller, maxLines: null)),
-            ),
+    testWidgets('triple tap chains work on Apple platforms', (WidgetTester tester) async {
+      final TextEditingController controller = _textEditingController(
+        text: 'Atwater Peel Sherbrooke Bonaventure\nThe fox jumped over the fence.',
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(useMaterial3: false),
+          home: Material(
+            child: Center(child: TextField(controller: controller, maxLines: null)),
           ),
-        );
+        ),
+      );
 
-        final Offset textfieldStart = tester.getTopLeft(find.byType(TextField));
+      final Offset textfieldStart = tester.getTopLeft(find.byType(TextField));
 
-        await tester.tapAt(textfieldStart + const Offset(50.0, 9.0));
-        await tester.pump(const Duration(milliseconds: 50));
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, 7);
-        await tester.tapAt(textfieldStart + const Offset(50.0, 9.0));
-        await tester.pump();
-        expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
-        expectCupertinoToolbarForPartialSelection();
+      await tester.tapAt(textfieldStart + const Offset(50.0, 9.0));
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, 7);
+      await tester.tapAt(textfieldStart + const Offset(50.0, 9.0));
+      await tester.pump();
+      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
+      expectCupertinoToolbarForPartialSelection();
 
-        await tester.tapAt(textfieldStart + const Offset(50.0, 9.0));
-        await tester.pumpAndSettle(kDoubleTapTimeout);
-        expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 36));
-        // Triple tap selecting the same paragraph somewhere else is fine.
-        await tester.tapAt(textfieldStart + const Offset(100.0, 9.0));
-        await tester.pump(const Duration(milliseconds: 50));
-        // First tap hides the toolbar and retains the selection.
-        expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 36));
-        expectNoCupertinoToolbar();
-        // Second tap shows the toolbar and selects the word.
-        await tester.tapAt(textfieldStart + const Offset(100.0, 9.0));
-        await tester.pump();
-        expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
-        expectCupertinoToolbarForPartialSelection();
+      await tester.tapAt(textfieldStart + const Offset(50.0, 9.0));
+      await tester.pumpAndSettle(kDoubleTapTimeout);
+      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 36));
+      // Triple tap selecting the same paragraph somewhere else is fine.
+      await tester.tapAt(textfieldStart + const Offset(100.0, 9.0));
+      await tester.pump(const Duration(milliseconds: 50));
+      // First tap hides the toolbar and retains the selection.
+      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 36));
+      expectNoCupertinoToolbar();
+      // Second tap shows the toolbar and selects the word.
+      await tester.tapAt(textfieldStart + const Offset(100.0, 9.0));
+      await tester.pump();
+      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
+      expectCupertinoToolbarForPartialSelection();
 
-        // Third tap shows the toolbar and selects the paragraph.
-        await tester.tapAt(textfieldStart + const Offset(100.0, 9.0));
-        await tester.pumpAndSettle(kDoubleTapTimeout);
-        expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 36));
-        expectCupertinoToolbarForPartialSelection();
+      // Third tap shows the toolbar and selects the paragraph.
+      await tester.tapAt(textfieldStart + const Offset(100.0, 9.0));
+      await tester.pumpAndSettle(kDoubleTapTimeout);
+      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 36));
+      expectCupertinoToolbarForPartialSelection();
 
-        await tester.tapAt(textfieldStart + const Offset(150.0, 50.0));
-        await tester.pump(const Duration(milliseconds: 50));
-        // First tap moved the cursor and hid the toolbar.
-        expect(
-          controller.selection,
-          const TextSelection.collapsed(offset: 50, affinity: TextAffinity.upstream),
-        );
-        expectNoCupertinoToolbar();
-        // Second tap selects the word.
-        await tester.tapAt(textfieldStart + const Offset(150.0, 50.0));
-        await tester.pump();
-        expect(controller.selection, const TextSelection(baseOffset: 44, extentOffset: 50));
-        expectCupertinoToolbarForPartialSelection();
+      await tester.tapAt(textfieldStart + const Offset(150.0, 50.0));
+      await tester.pump(const Duration(milliseconds: 50));
+      // First tap moved the cursor and hid the toolbar.
+      expect(
+        controller.selection,
+        const TextSelection.collapsed(offset: 50, affinity: TextAffinity.upstream),
+      );
+      expectNoCupertinoToolbar();
+      // Second tap selects the word.
+      await tester.tapAt(textfieldStart + const Offset(150.0, 50.0));
+      await tester.pump();
+      expect(controller.selection, const TextSelection(baseOffset: 44, extentOffset: 50));
+      expectCupertinoToolbarForPartialSelection();
 
-        // Third tap selects the paragraph and shows the toolbar.
-        await tester.tapAt(textfieldStart + const Offset(150.0, 50.0));
-        await tester.pumpAndSettle();
-        expect(controller.selection, const TextSelection(baseOffset: 36, extentOffset: 66));
-        expectCupertinoToolbarForPartialSelection();
-      },
-      variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-    );
+      // Third tap selects the paragraph and shows the toolbar.
+      await tester.tapAt(textfieldStart + const Offset(150.0, 50.0));
+      await tester.pumpAndSettle();
+      expect(controller.selection, const TextSelection(baseOffset: 36, extentOffset: 66));
+      expectCupertinoToolbarForPartialSelection();
+    }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
 
     testWidgets('triple click chains work', (WidgetTester tester) async {
       final TextEditingController controller = _textEditingController(text: testValueA);
@@ -11272,425 +11238,409 @@ void main() {
       );
     }, variant: TargetPlatformVariant.desktop());
 
-    testWidgets(
-      'Can triple tap to select all on a single-line textfield on mobile platforms',
-      (WidgetTester tester) async {
-        final TextEditingController controller = _textEditingController(text: testValueB);
-        final isTargetPlatformApple = defaultTargetPlatform == TargetPlatform.iOS;
+    testWidgets('Can triple tap to select all on a single-line textfield on mobile platforms', (
+      WidgetTester tester,
+    ) async {
+      final TextEditingController controller = _textEditingController(text: testValueB);
+      final isTargetPlatformApple = defaultTargetPlatform == TargetPlatform.iOS;
 
-        await tester.pumpWidget(
-          MaterialApp(
-            home: Material(child: TextField(controller: controller)),
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(child: TextField(controller: controller)),
+        ),
+      );
+
+      final Offset firstLinePos =
+          tester.getTopLeft(find.byType(TextField)) + const Offset(50.0, 9.0);
+
+      // Tap on text field to gain focus, and set selection somewhere on the first word.
+      final TestGesture gesture = await tester.startGesture(firstLinePos, pointer: 7);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, isTargetPlatformApple ? 5 : 3);
+
+      // Here we tap on same position again, to register a double tap. This will select
+      // the word at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 5);
+
+      // Here we tap on same position again, to register a triple tap. This will select
+      // the entire text field if it is a single-line field.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 74);
+    }, variant: TargetPlatformVariant.mobile());
+
+    testWidgets('Can triple click to select all on a single-line textfield on desktop platforms', (
+      WidgetTester tester,
+    ) async {
+      final TextEditingController controller = _textEditingController(text: testValueA);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: TextField(dragStartBehavior: DragStartBehavior.down, controller: controller),
           ),
-        );
+        ),
+      );
 
-        final Offset firstLinePos =
-            tester.getTopLeft(find.byType(TextField)) + const Offset(50.0, 9.0);
+      final Offset firstLinePos = textOffsetToPosition(tester, 5);
 
-        // Tap on text field to gain focus, and set selection somewhere on the first word.
-        final TestGesture gesture = await tester.startGesture(firstLinePos, pointer: 7);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Tap on text field to gain focus, and set selection to 'i|s' on the first line.
+      final TestGesture gesture = await tester.startGesture(
+        firstLinePos,
+        pointer: 7,
+        kind: PointerDeviceKind.mouse,
+      );
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, isTargetPlatformApple ? 5 : 3);
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, 5);
 
-        // Here we tap on same position again, to register a double tap. This will select
-        // the word at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Here we tap on same position again, to register a double tap. This will select
+      // the word at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 5);
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 6);
 
-        // Here we tap on same position again, to register a triple tap. This will select
-        // the entire text field if it is a single-line field.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pumpAndSettle();
+      // Here we tap on same position again, to register a triple tap. This will select
+      // the entire text field if it is a single-line field.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 74);
-      },
-      variant: TargetPlatformVariant.mobile(),
-    );
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 72);
+    }, variant: TargetPlatformVariant.desktop());
 
-    testWidgets(
-      'Can triple click to select all on a single-line textfield on desktop platforms',
-      (WidgetTester tester) async {
-        final TextEditingController controller = _textEditingController(text: testValueA);
+    testWidgets('Can triple click to select a line on Linux', (WidgetTester tester) async {
+      final TextEditingController controller = _textEditingController();
 
-        await tester.pumpWidget(
-          MaterialApp(
-            home: Material(
-              child: TextField(dragStartBehavior: DragStartBehavior.down, controller: controller),
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: TextField(
+              dragStartBehavior: DragStartBehavior.down,
+              controller: controller,
+              maxLines: null,
             ),
           ),
-        );
+        ),
+      );
 
-        final Offset firstLinePos = textOffsetToPosition(tester, 5);
+      await tester.enterText(find.byType(TextField), testValueA);
+      await skipPastScrollingAnimation(tester);
+      expect(controller.value.text, testValueA);
 
-        // Tap on text field to gain focus, and set selection to 'i|s' on the first line.
-        final TestGesture gesture = await tester.startGesture(
-          firstLinePos,
-          pointer: 7,
-          kind: PointerDeviceKind.mouse,
-        );
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      final Offset firstLinePos = textOffsetToPosition(tester, 5);
 
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, 5);
+      // Tap on text field to gain focus, and set selection to 'i|s' on the first line.
+      final TestGesture gesture = await tester.startGesture(
+        firstLinePos,
+        pointer: 7,
+        kind: PointerDeviceKind.mouse,
+      );
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        // Here we tap on same position again, to register a double tap. This will select
-        // the word at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, 5);
 
-        expect(controller.selection.baseOffset, 4);
-        expect(controller.selection.extentOffset, 6);
+      // Here we tap on same position again, to register a double tap. This will select
+      // the word at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        // Here we tap on same position again, to register a triple tap. This will select
-        // the entire text field if it is a single-line field.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pumpAndSettle();
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 6);
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 72);
-      },
-      variant: TargetPlatformVariant.desktop(),
-    );
+      // Here we tap on same position again, to register a triple tap. This will select
+      // the paragraph at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
 
-    testWidgets(
-      'Can triple click to select a line on Linux',
-      (WidgetTester tester) async {
-        final TextEditingController controller = _textEditingController();
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 19);
+    }, variant: TargetPlatformVariant.only(TargetPlatform.linux));
 
-        await tester.pumpWidget(
-          MaterialApp(
-            home: Material(
-              child: TextField(
-                dragStartBehavior: DragStartBehavior.down,
-                controller: controller,
-                maxLines: null,
-              ),
+    testWidgets('Can triple click to select a paragraph', (WidgetTester tester) async {
+      final TextEditingController controller = _textEditingController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: TextField(
+              dragStartBehavior: DragStartBehavior.down,
+              controller: controller,
+              maxLines: null,
             ),
           ),
-        );
+        ),
+      );
 
-        await tester.enterText(find.byType(TextField), testValueA);
-        await skipPastScrollingAnimation(tester);
-        expect(controller.value.text, testValueA);
+      await tester.enterText(find.byType(TextField), testValueA);
+      await skipPastScrollingAnimation(tester);
+      expect(controller.value.text, testValueA);
 
-        final Offset firstLinePos = textOffsetToPosition(tester, 5);
+      final Offset firstLinePos = textOffsetToPosition(tester, 5);
 
-        // Tap on text field to gain focus, and set selection to 'i|s' on the first line.
-        final TestGesture gesture = await tester.startGesture(
-          firstLinePos,
-          pointer: 7,
-          kind: PointerDeviceKind.mouse,
-        );
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Tap on text field to gain focus, and set selection to 'i|s' on the first line.
+      final TestGesture gesture = await tester.startGesture(
+        firstLinePos,
+        pointer: 7,
+        kind: PointerDeviceKind.mouse,
+      );
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, 5);
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, 5);
 
-        // Here we tap on same position again, to register a double tap. This will select
-        // the word at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Here we tap on same position again, to register a double tap. This will select
+      // the word at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.baseOffset, 4);
-        expect(controller.selection.extentOffset, 6);
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 6);
 
-        // Here we tap on same position again, to register a triple tap. This will select
-        // the paragraph at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pumpAndSettle();
+      // Here we tap on same position again, to register a triple tap. This will select
+      // the paragraph at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 19);
-      },
-      variant: TargetPlatformVariant.only(TargetPlatform.linux),
-    );
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 20);
+    }, variant: TargetPlatformVariant.all(excluding: <TargetPlatform>{TargetPlatform.linux}));
 
-    testWidgets(
-      'Can triple click to select a paragraph',
-      (WidgetTester tester) async {
-        final TextEditingController controller = _textEditingController();
+    testWidgets('Can triple click + drag to select line by line on Linux', (
+      WidgetTester tester,
+    ) async {
+      final TextEditingController controller = _textEditingController();
 
-        await tester.pumpWidget(
-          MaterialApp(
-            home: Material(
-              child: TextField(
-                dragStartBehavior: DragStartBehavior.down,
-                controller: controller,
-                maxLines: null,
-              ),
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(useMaterial3: false),
+          home: Material(
+            child: TextField(
+              dragStartBehavior: DragStartBehavior.down,
+              controller: controller,
+              maxLines: null,
             ),
           ),
-        );
+        ),
+      );
 
-        await tester.enterText(find.byType(TextField), testValueA);
-        await skipPastScrollingAnimation(tester);
-        expect(controller.value.text, testValueA);
+      await tester.enterText(find.byType(TextField), testValueA);
+      await skipPastScrollingAnimation(tester);
+      expect(controller.value.text, testValueA);
 
-        final Offset firstLinePos = textOffsetToPosition(tester, 5);
+      final Offset firstLinePos = textOffsetToPosition(tester, 5);
+      final double lineHeight = findRenderEditable(tester).preferredLineHeight;
 
-        // Tap on text field to gain focus, and set selection to 'i|s' on the first line.
-        final TestGesture gesture = await tester.startGesture(
-          firstLinePos,
-          pointer: 7,
-          kind: PointerDeviceKind.mouse,
-        );
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Tap on text field to gain focus, and set selection to 'i|s' on the first line.
+      final TestGesture gesture = await tester.startGesture(
+        firstLinePos,
+        pointer: 7,
+        kind: PointerDeviceKind.mouse,
+      );
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, 5);
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, 5);
 
-        // Here we tap on same position again, to register a double tap. This will select
-        // the word at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Here we tap on same position again, to register a double tap. This will select
+      // the word at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.baseOffset, 4);
-        expect(controller.selection.extentOffset, 6);
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 6);
 
-        // Here we tap on same position again, to register a triple tap. This will select
-        // the paragraph at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pumpAndSettle();
+      // Here we tap on the same position again, to register a triple tap. This will select
+      // the line at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 20);
-      },
-      variant: TargetPlatformVariant.all(excluding: <TargetPlatform>{TargetPlatform.linux}),
-    );
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 19);
 
-    testWidgets(
-      'Can triple click + drag to select line by line on Linux',
-      (WidgetTester tester) async {
-        final TextEditingController controller = _textEditingController();
+      // Drag, down after the triple tap, to select line by line.
+      // Moving down will extend the selection to the second line.
+      await gesture.moveTo(firstLinePos + Offset(0, lineHeight));
+      await tester.pumpAndSettle();
 
-        await tester.pumpWidget(
-          MaterialApp(
-            theme: ThemeData(useMaterial3: false),
-            home: Material(
-              child: TextField(
-                dragStartBehavior: DragStartBehavior.down,
-                controller: controller,
-                maxLines: null,
-              ),
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 35);
+
+      // Moving down will extend the selection to the third line.
+      await gesture.moveTo(firstLinePos + Offset(0, lineHeight * 2));
+      await tester.pumpAndSettle();
+
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 54);
+
+      // Moving down will extend the selection to the last line.
+      await gesture.moveTo(firstLinePos + Offset(0, lineHeight * 4));
+      await tester.pumpAndSettle();
+
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 72);
+
+      // Moving up will extend the selection to the third line.
+      await gesture.moveTo(firstLinePos + Offset(0, lineHeight * 2));
+      await tester.pumpAndSettle();
+
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 54);
+
+      // Moving up will extend the selection to the second line.
+      await gesture.moveTo(firstLinePos + Offset(0, lineHeight * 1));
+      await tester.pumpAndSettle();
+
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 35);
+
+      // Moving up will extend the selection to the first line.
+      await gesture.moveTo(firstLinePos);
+      await tester.pumpAndSettle();
+
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 19);
+    }, variant: TargetPlatformVariant.only(TargetPlatform.linux));
+
+    testWidgets('Can triple click + drag to select paragraph by paragraph', (
+      WidgetTester tester,
+    ) async {
+      final TextEditingController controller = _textEditingController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(useMaterial3: false),
+          home: Material(
+            child: TextField(
+              dragStartBehavior: DragStartBehavior.down,
+              controller: controller,
+              maxLines: null,
             ),
           ),
-        );
+        ),
+      );
 
-        await tester.enterText(find.byType(TextField), testValueA);
-        await skipPastScrollingAnimation(tester);
-        expect(controller.value.text, testValueA);
+      await tester.enterText(find.byType(TextField), testValueA);
+      await skipPastScrollingAnimation(tester);
+      expect(controller.value.text, testValueA);
 
-        final Offset firstLinePos = textOffsetToPosition(tester, 5);
-        final double lineHeight = findRenderEditable(tester).preferredLineHeight;
+      final Offset firstLinePos = textOffsetToPosition(tester, 5);
+      final double lineHeight = findRenderEditable(tester).preferredLineHeight;
 
-        // Tap on text field to gain focus, and set selection to 'i|s' on the first line.
-        final TestGesture gesture = await tester.startGesture(
-          firstLinePos,
-          pointer: 7,
-          kind: PointerDeviceKind.mouse,
-        );
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Tap on text field to gain focus, and set selection to 'i|s' on the first line.
+      final TestGesture gesture = await tester.startGesture(
+        firstLinePos,
+        pointer: 7,
+        kind: PointerDeviceKind.mouse,
+      );
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, 5);
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, 5);
 
-        // Here we tap on same position again, to register a double tap. This will select
-        // the word at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Here we tap on same position again, to register a double tap. This will select
+      // the word at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.baseOffset, 4);
-        expect(controller.selection.extentOffset, 6);
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 6);
 
-        // Here we tap on the same position again, to register a triple tap. This will select
-        // the line at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pumpAndSettle();
+      // Here we tap on the same position again, to register a triple tap. This will select
+      // the paragraph at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 19);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 20);
 
-        // Drag, down after the triple tap, to select line by line.
-        // Moving down will extend the selection to the second line.
-        await gesture.moveTo(firstLinePos + Offset(0, lineHeight));
-        await tester.pumpAndSettle();
+      // Drag, down after the triple tap, to select paragraph by paragraph.
+      // Moving down will extend the selection to the second line.
+      await gesture.moveTo(firstLinePos + Offset(0, lineHeight));
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 35);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 36);
 
-        // Moving down will extend the selection to the third line.
-        await gesture.moveTo(firstLinePos + Offset(0, lineHeight * 2));
-        await tester.pumpAndSettle();
+      // Moving down will extend the selection to the third line.
+      await gesture.moveTo(firstLinePos + Offset(0, lineHeight * 2));
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 54);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 55);
 
-        // Moving down will extend the selection to the last line.
-        await gesture.moveTo(firstLinePos + Offset(0, lineHeight * 4));
-        await tester.pumpAndSettle();
+      // Moving down will extend the selection to the last line.
+      await gesture.moveTo(firstLinePos + Offset(0, lineHeight * 4));
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 72);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 72);
 
-        // Moving up will extend the selection to the third line.
-        await gesture.moveTo(firstLinePos + Offset(0, lineHeight * 2));
-        await tester.pumpAndSettle();
+      // Moving up will extend the selection to the third line.
+      await gesture.moveTo(firstLinePos + Offset(0, lineHeight * 2));
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 54);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 55);
 
-        // Moving up will extend the selection to the second line.
-        await gesture.moveTo(firstLinePos + Offset(0, lineHeight * 1));
-        await tester.pumpAndSettle();
+      // Moving up will extend the selection to the second line.
+      await gesture.moveTo(firstLinePos + Offset(0, lineHeight));
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 35);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 36);
 
-        // Moving up will extend the selection to the first line.
-        await gesture.moveTo(firstLinePos);
-        await tester.pumpAndSettle();
+      // Moving up will extend the selection to the first line.
+      await gesture.moveTo(firstLinePos);
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 19);
-      },
-      variant: TargetPlatformVariant.only(TargetPlatform.linux),
-    );
-
-    testWidgets(
-      'Can triple click + drag to select paragraph by paragraph',
-      (WidgetTester tester) async {
-        final TextEditingController controller = _textEditingController();
-
-        await tester.pumpWidget(
-          MaterialApp(
-            theme: ThemeData(useMaterial3: false),
-            home: Material(
-              child: TextField(
-                dragStartBehavior: DragStartBehavior.down,
-                controller: controller,
-                maxLines: null,
-              ),
-            ),
-          ),
-        );
-
-        await tester.enterText(find.byType(TextField), testValueA);
-        await skipPastScrollingAnimation(tester);
-        expect(controller.value.text, testValueA);
-
-        final Offset firstLinePos = textOffsetToPosition(tester, 5);
-        final double lineHeight = findRenderEditable(tester).preferredLineHeight;
-
-        // Tap on text field to gain focus, and set selection to 'i|s' on the first line.
-        final TestGesture gesture = await tester.startGesture(
-          firstLinePos,
-          pointer: 7,
-          kind: PointerDeviceKind.mouse,
-        );
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
-
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, 5);
-
-        // Here we tap on same position again, to register a double tap. This will select
-        // the word at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
-
-        expect(controller.selection.baseOffset, 4);
-        expect(controller.selection.extentOffset, 6);
-
-        // Here we tap on the same position again, to register a triple tap. This will select
-        // the paragraph at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pumpAndSettle();
-
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 20);
-
-        // Drag, down after the triple tap, to select paragraph by paragraph.
-        // Moving down will extend the selection to the second line.
-        await gesture.moveTo(firstLinePos + Offset(0, lineHeight));
-        await tester.pumpAndSettle();
-
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 36);
-
-        // Moving down will extend the selection to the third line.
-        await gesture.moveTo(firstLinePos + Offset(0, lineHeight * 2));
-        await tester.pumpAndSettle();
-
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 55);
-
-        // Moving down will extend the selection to the last line.
-        await gesture.moveTo(firstLinePos + Offset(0, lineHeight * 4));
-        await tester.pumpAndSettle();
-
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 72);
-
-        // Moving up will extend the selection to the third line.
-        await gesture.moveTo(firstLinePos + Offset(0, lineHeight * 2));
-        await tester.pumpAndSettle();
-
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 55);
-
-        // Moving up will extend the selection to the second line.
-        await gesture.moveTo(firstLinePos + Offset(0, lineHeight));
-        await tester.pumpAndSettle();
-
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 36);
-
-        // Moving up will extend the selection to the first line.
-        await gesture.moveTo(firstLinePos);
-        await tester.pumpAndSettle();
-
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 20);
-      },
-      variant: TargetPlatformVariant.all(excluding: <TargetPlatform>{TargetPlatform.linux}),
-    );
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 20);
+    }, variant: TargetPlatformVariant.all(excluding: <TargetPlatform>{TargetPlatform.linux}));
 
     testWidgets(
       'Going past triple click retains the selection on Apple platforms',
@@ -11862,91 +11812,87 @@ void main() {
       }),
     );
 
-    testWidgets(
-      'Double click and triple click alternate on Windows',
-      (WidgetTester tester) async {
-        final TextEditingController controller = _textEditingController(text: testValueA);
-        await tester.pumpWidget(
-          MaterialApp(
-            home: Material(
-              child: Center(child: TextField(controller: controller, maxLines: null)),
-            ),
+    testWidgets('Double click and triple click alternate on Windows', (WidgetTester tester) async {
+      final TextEditingController controller = _textEditingController(text: testValueA);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Center(child: TextField(controller: controller, maxLines: null)),
           ),
-        );
+        ),
+      );
 
-        final Offset textFieldStart = tester.getTopLeft(find.byType(TextField));
+      final Offset textFieldStart = tester.getTopLeft(find.byType(TextField));
 
-        // First click moves the cursor to the point of the click, not the edge of
-        // the clicked word.
-        final TestGesture gesture = await tester.startGesture(
-          textFieldStart + const Offset(210.0, 9.0),
-          pointer: 7,
-          kind: PointerDeviceKind.mouse,
-        );
-        await tester.pump();
-        await gesture.up();
-        await tester.pump(const Duration(milliseconds: 50));
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, 13);
+      // First click moves the cursor to the point of the click, not the edge of
+      // the clicked word.
+      final TestGesture gesture = await tester.startGesture(
+        textFieldStart + const Offset(210.0, 9.0),
+        pointer: 7,
+        kind: PointerDeviceKind.mouse,
+      );
+      await tester.pump();
+      await gesture.up();
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, 13);
 
-        // Second click selects the word.
-        await gesture.down(textFieldStart + const Offset(210.0, 9.0));
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
-        expect(controller.selection, const TextSelection(baseOffset: 11, extentOffset: 15));
+      // Second click selects the word.
+      await gesture.down(textFieldStart + const Offset(210.0, 9.0));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+      expect(controller.selection, const TextSelection(baseOffset: 11, extentOffset: 15));
 
-        // Triple click selects the paragraph.
-        await gesture.down(textFieldStart + const Offset(210.0, 9.0));
-        await tester.pump();
-        await gesture.up();
-        await tester.pumpAndSettle();
-        expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 20));
+      // Triple click selects the paragraph.
+      await gesture.down(textFieldStart + const Offset(210.0, 9.0));
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
+      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 20));
 
-        // Clicking again selects the word.
-        await gesture.down(textFieldStart + const Offset(210.0, 9.0));
-        await tester.pump();
-        await gesture.up();
-        await tester.pump(const Duration(milliseconds: 50));
-        expect(controller.selection, const TextSelection(baseOffset: 11, extentOffset: 15));
+      // Clicking again selects the word.
+      await gesture.down(textFieldStart + const Offset(210.0, 9.0));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(controller.selection, const TextSelection(baseOffset: 11, extentOffset: 15));
 
-        await gesture.down(textFieldStart + const Offset(210.0, 9.0));
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
-        // Clicking again selects the paragraph.
-        expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 20));
+      await gesture.down(textFieldStart + const Offset(210.0, 9.0));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+      // Clicking again selects the paragraph.
+      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 20));
 
-        await gesture.down(textFieldStart + const Offset(210.0, 9.0));
-        await tester.pump();
-        await gesture.up();
-        await tester.pumpAndSettle();
-        // Clicking again selects the word.
-        expect(controller.selection, const TextSelection(baseOffset: 11, extentOffset: 15));
+      await gesture.down(textFieldStart + const Offset(210.0, 9.0));
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
+      // Clicking again selects the word.
+      expect(controller.selection, const TextSelection(baseOffset: 11, extentOffset: 15));
 
-        await gesture.down(textFieldStart + const Offset(210.0, 9.0));
-        await tester.pump();
-        await gesture.up();
-        await tester.pump(const Duration(milliseconds: 50));
-        // Clicking again selects the paragraph.
-        expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 20));
+      await gesture.down(textFieldStart + const Offset(210.0, 9.0));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump(const Duration(milliseconds: 50));
+      // Clicking again selects the paragraph.
+      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 20));
 
-        await gesture.down(textFieldStart + const Offset(210.0, 9.0));
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
-        // Clicking again selects the word.
-        expect(controller.selection, const TextSelection(baseOffset: 11, extentOffset: 15));
+      await gesture.down(textFieldStart + const Offset(210.0, 9.0));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+      // Clicking again selects the word.
+      expect(controller.selection, const TextSelection(baseOffset: 11, extentOffset: 15));
 
-        await gesture.down(textFieldStart + const Offset(210.0, 9.0));
-        await tester.pump();
-        await gesture.up();
-        await tester.pumpAndSettle();
-        // Clicking again selects the paragraph.
-        expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 20));
-      },
-      variant: TargetPlatformVariant.only(TargetPlatform.windows),
-    );
+      await gesture.down(textFieldStart + const Offset(210.0, 9.0));
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
+      // Clicking again selects the paragraph.
+      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 20));
+    }, variant: TargetPlatformVariant.only(TargetPlatform.windows));
   });
 
   testWidgets(
@@ -12338,71 +12284,67 @@ void main() {
     }),
   );
 
-  testWidgets(
-    'Toolbar hides on scroll start and re-appears on scroll end on Android',
-    (WidgetTester tester) async {
-      final TextEditingController controller = _textEditingController(
-        text: 'Atwater Peel Sherbrooke Bonaventure ' * 20,
-      );
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Material(
-            child: Center(child: TextField(controller: controller)),
-          ),
+  testWidgets('Toolbar hides on scroll start and re-appears on scroll end on Android', (
+    WidgetTester tester,
+  ) async {
+    final TextEditingController controller = _textEditingController(
+      text: 'Atwater Peel Sherbrooke Bonaventure ' * 20,
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(child: TextField(controller: controller)),
         ),
-      );
+      ),
+    );
 
-      final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
-      final RenderEditable renderEditable = state.renderEditable;
+    final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
+    final RenderEditable renderEditable = state.renderEditable;
 
-      final Offset textfieldStart = tester.getTopLeft(find.byType(TextField));
+    final Offset textfieldStart = tester.getTopLeft(find.byType(TextField));
 
-      await tester.longPressAt(textfieldStart + const Offset(50.0, 9.0));
-      await tester.pumpAndSettle();
+    await tester.longPressAt(textfieldStart + const Offset(50.0, 9.0));
+    await tester.pumpAndSettle();
 
-      // Long press should select word at position and show toolbar.
-      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
+    // Long press should select word at position and show toolbar.
+    expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
 
-      final targetPlatformIsiOS = defaultTargetPlatform == TargetPlatform.iOS;
-      final Finder contextMenuButtonFinder = targetPlatformIsiOS
-          ? find.byType(CupertinoButton)
-          : find.byType(TextButton);
-      // Context menu shows 5 buttons: cut, copy, paste, select all, share on Android.
-      // Context menu shows 6 buttons: cut, copy, paste, select all, lookup, share on iOS.
-      final numberOfContextMenuButtons = targetPlatformIsiOS ? 6 : 5;
+    final targetPlatformIsiOS = defaultTargetPlatform == TargetPlatform.iOS;
+    final Finder contextMenuButtonFinder = targetPlatformIsiOS
+        ? find.byType(CupertinoButton)
+        : find.byType(TextButton);
+    // Context menu shows 5 buttons: cut, copy, paste, select all, share on Android.
+    // Context menu shows 6 buttons: cut, copy, paste, select all, lookup, share on iOS.
+    final numberOfContextMenuButtons = targetPlatformIsiOS ? 6 : 5;
 
-      expect(
-        contextMenuButtonFinder,
-        isContextMenuProvidedByPlatform ? findsNothing : findsNWidgets(numberOfContextMenuButtons),
-      );
+    expect(
+      contextMenuButtonFinder,
+      isContextMenuProvidedByPlatform ? findsNothing : findsNWidgets(numberOfContextMenuButtons),
+    );
 
-      // Scroll to the left, the toolbar should be hidden since we are scrolling.
-      final TestGesture gesture = await tester.startGesture(
-        tester.getCenter(find.byType(TextField)),
-      );
-      await tester.pump();
-      await gesture.moveTo(tester.getBottomLeft(find.byType(TextField)));
-      await tester.pumpAndSettle();
-      expect(contextMenuButtonFinder, findsNothing);
+    // Scroll to the left, the toolbar should be hidden since we are scrolling.
+    final TestGesture gesture = await tester.startGesture(tester.getCenter(find.byType(TextField)));
+    await tester.pump();
+    await gesture.moveTo(tester.getBottomLeft(find.byType(TextField)));
+    await tester.pumpAndSettle();
+    expect(contextMenuButtonFinder, findsNothing);
 
-      // Scroll back to center, the toolbar should still be hidden since
-      // we are still scrolling.
-      await gesture.moveTo(tester.getCenter(find.byType(TextField)));
-      await tester.pumpAndSettle();
-      expect(contextMenuButtonFinder, findsNothing);
+    // Scroll back to center, the toolbar should still be hidden since
+    // we are still scrolling.
+    await gesture.moveTo(tester.getCenter(find.byType(TextField)));
+    await tester.pumpAndSettle();
+    expect(contextMenuButtonFinder, findsNothing);
 
-      // Release finger to end scroll, toolbar should now be visible.
-      await gesture.up();
-      await tester.pumpAndSettle();
-      expect(
-        contextMenuButtonFinder,
-        isContextMenuProvidedByPlatform ? findsNothing : findsNWidgets(numberOfContextMenuButtons),
-      );
-      expect(renderEditable.selectionStartInViewport.value, true);
-      expect(renderEditable.selectionEndInViewport.value, true);
-    },
-    variant: TargetPlatformVariant.only(TargetPlatform.android),
-  );
+    // Release finger to end scroll, toolbar should now be visible.
+    await gesture.up();
+    await tester.pumpAndSettle();
+    expect(
+      contextMenuButtonFinder,
+      isContextMenuProvidedByPlatform ? findsNothing : findsNWidgets(numberOfContextMenuButtons),
+    );
+    expect(renderEditable.selectionStartInViewport.value, true);
+    expect(renderEditable.selectionEndInViewport.value, true);
+  }, variant: TargetPlatformVariant.only(TargetPlatform.android));
 
   testWidgets(
     'Toolbar hides on parent scrollable scroll start and re-appears on scroll end on Android and iOS',
@@ -13627,64 +13569,60 @@ void main() {
     expectNoCupertinoToolbar();
   }, variant: TargetPlatformVariant.desktop());
 
-  testWidgets(
-    'double tap chains work',
-    (WidgetTester tester) async {
-      final TextEditingController controller = _textEditingController(
-        text: 'Atwater Peel Sherbrooke Bonaventure',
-      );
-      await tester.pumpWidget(
-        MaterialApp(
-          theme: ThemeData(useMaterial3: false),
-          home: Material(
-            child: Center(child: TextField(controller: controller)),
-          ),
+  testWidgets('double tap chains work', (WidgetTester tester) async {
+    final TextEditingController controller = _textEditingController(
+      text: 'Atwater Peel Sherbrooke Bonaventure',
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: Material(
+          child: Center(child: TextField(controller: controller)),
         ),
-      );
+      ),
+    );
 
-      final Offset textfieldStart = tester.getTopLeft(find.byType(TextField));
+    final Offset textfieldStart = tester.getTopLeft(find.byType(TextField));
 
-      await tester.tapAt(textfieldStart + const Offset(50.0, 9.0));
-      await tester.pump(const Duration(milliseconds: 50));
-      expect(
-        controller.selection,
-        const TextSelection.collapsed(offset: 7, affinity: TextAffinity.upstream),
-      );
-      await tester.tapAt(textfieldStart + const Offset(50.0, 9.0));
-      await tester.pumpAndSettle();
-      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
-      expectCupertinoToolbarForPartialSelection();
+    await tester.tapAt(textfieldStart + const Offset(50.0, 9.0));
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(
+      controller.selection,
+      const TextSelection.collapsed(offset: 7, affinity: TextAffinity.upstream),
+    );
+    await tester.tapAt(textfieldStart + const Offset(50.0, 9.0));
+    await tester.pumpAndSettle();
+    expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
+    expectCupertinoToolbarForPartialSelection();
 
-      // Double tap selecting the same word somewhere else is fine.
-      await tester.tapAt(textfieldStart + const Offset(100.0, 9.0));
-      await tester.pump(const Duration(milliseconds: 50));
-      // First tap hides the toolbar and retains the selection.
-      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
-      expectNoCupertinoToolbar();
+    // Double tap selecting the same word somewhere else is fine.
+    await tester.tapAt(textfieldStart + const Offset(100.0, 9.0));
+    await tester.pump(const Duration(milliseconds: 50));
+    // First tap hides the toolbar and retains the selection.
+    expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
+    expectNoCupertinoToolbar();
 
-      // Second tap shows the toolbar and retains the selection.
-      await tester.tapAt(textfieldStart + const Offset(100.0, 9.0));
-      // Wait for the consecutive tap timer to timeout so the next
-      // tap is not detected as a triple tap.
-      await tester.pumpAndSettle(kDoubleTapTimeout);
-      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
-      expectCupertinoToolbarForPartialSelection();
+    // Second tap shows the toolbar and retains the selection.
+    await tester.tapAt(textfieldStart + const Offset(100.0, 9.0));
+    // Wait for the consecutive tap timer to timeout so the next
+    // tap is not detected as a triple tap.
+    await tester.pumpAndSettle(kDoubleTapTimeout);
+    expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
+    expectCupertinoToolbarForPartialSelection();
 
-      await tester.tapAt(textfieldStart + const Offset(150.0, 9.0));
-      await tester.pump(const Duration(milliseconds: 50));
-      // First tap moved the cursor and hid the toolbar.
-      expect(
-        controller.selection,
-        const TextSelection.collapsed(offset: 12, affinity: TextAffinity.upstream),
-      );
-      expectNoCupertinoToolbar();
-      await tester.tapAt(textfieldStart + const Offset(150.0, 9.0));
-      await tester.pumpAndSettle();
-      expect(controller.selection, const TextSelection(baseOffset: 8, extentOffset: 12));
-      expectCupertinoToolbarForPartialSelection();
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-  );
+    await tester.tapAt(textfieldStart + const Offset(150.0, 9.0));
+    await tester.pump(const Duration(milliseconds: 50));
+    // First tap moved the cursor and hid the toolbar.
+    expect(
+      controller.selection,
+      const TextSelection.collapsed(offset: 12, affinity: TextAffinity.upstream),
+    );
+    expectNoCupertinoToolbar();
+    await tester.tapAt(textfieldStart + const Offset(150.0, 9.0));
+    await tester.pumpAndSettle();
+    expect(controller.selection, const TextSelection(baseOffset: 8, extentOffset: 12));
+    expectCupertinoToolbarForPartialSelection();
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
 
   testWidgets(
     'double click chains work',
@@ -13760,73 +13698,71 @@ void main() {
     }),
   );
 
-  testWidgets(
-    'double tapping a space selects the previous word on iOS',
-    (WidgetTester tester) async {
-      final TextEditingController controller = _textEditingController(text: ' blah blah  \n  blah');
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Material(
-            child: Center(child: TextField(maxLines: null, controller: controller)),
-          ),
+  testWidgets('double tapping a space selects the previous word on iOS', (
+    WidgetTester tester,
+  ) async {
+    final TextEditingController controller = _textEditingController(text: ' blah blah  \n  blah');
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(child: TextField(maxLines: null, controller: controller)),
         ),
-      );
+      ),
+    );
 
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, -1);
-      expect(controller.value.selection.extentOffset, -1);
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, -1);
+    expect(controller.value.selection.extentOffset, -1);
 
-      // Put the cursor at the end of the field.
-      await tester.tapAt(textOffsetToPosition(tester, 19));
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, 19);
-      expect(controller.value.selection.extentOffset, 19);
+    // Put the cursor at the end of the field.
+    await tester.tapAt(textOffsetToPosition(tester, 19));
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, 19);
+    expect(controller.value.selection.extentOffset, 19);
 
-      // Double tapping does the same thing.
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.tapAt(textOffsetToPosition(tester, 5));
-      await tester.pump(const Duration(milliseconds: 50));
-      await tester.tapAt(textOffsetToPosition(tester, 5));
-      await tester.pumpAndSettle();
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.extentOffset, 5);
-      expect(controller.value.selection.baseOffset, 1);
+    // Double tapping does the same thing.
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.tapAt(textOffsetToPosition(tester, 5));
+    await tester.pump(const Duration(milliseconds: 50));
+    await tester.tapAt(textOffsetToPosition(tester, 5));
+    await tester.pumpAndSettle();
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.extentOffset, 5);
+    expect(controller.value.selection.baseOffset, 1);
 
-      // Put the cursor at the end of the field.
-      await tester.tapAt(textOffsetToPosition(tester, 19));
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, 19);
-      expect(controller.value.selection.extentOffset, 19);
+    // Put the cursor at the end of the field.
+    await tester.tapAt(textOffsetToPosition(tester, 19));
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, 19);
+    expect(controller.value.selection.extentOffset, 19);
 
-      // Double tapping does the same thing for the first space.
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.tapAt(textOffsetToPosition(tester, 0));
-      await tester.pump(const Duration(milliseconds: 50));
-      await tester.tapAt(textOffsetToPosition(tester, 0));
-      await tester.pumpAndSettle();
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, 0);
-      expect(controller.value.selection.extentOffset, 1);
+    // Double tapping does the same thing for the first space.
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.tapAt(textOffsetToPosition(tester, 0));
+    await tester.pump(const Duration(milliseconds: 50));
+    await tester.tapAt(textOffsetToPosition(tester, 0));
+    await tester.pumpAndSettle();
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, 0);
+    expect(controller.value.selection.extentOffset, 1);
 
-      // Put the cursor at the end of the field.
-      await tester.tapAt(textOffsetToPosition(tester, 19));
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, 19);
-      expect(controller.value.selection.extentOffset, 19);
+    // Put the cursor at the end of the field.
+    await tester.tapAt(textOffsetToPosition(tester, 19));
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, 19);
+    expect(controller.value.selection.extentOffset, 19);
 
-      // Double tapping the last space selects all previous contiguous spaces on
-      // both lines and the previous word.
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.tapAt(textOffsetToPosition(tester, 14));
-      await tester.pump(const Duration(milliseconds: 50));
-      await tester.tapAt(textOffsetToPosition(tester, 14));
-      await tester.pumpAndSettle();
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, 6);
-      expect(controller.value.selection.extentOffset, 14);
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-  );
+    // Double tapping the last space selects all previous contiguous spaces on
+    // both lines and the previous word.
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.tapAt(textOffsetToPosition(tester, 14));
+    await tester.pump(const Duration(milliseconds: 50));
+    await tester.tapAt(textOffsetToPosition(tester, 14));
+    await tester.pumpAndSettle();
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, 6);
+    expect(controller.value.selection.extentOffset, 14);
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
 
   testWidgets(
     'selecting a space selects the space on non-iOS platforms',
@@ -14057,107 +13993,99 @@ void main() {
     }),
   );
 
-  testWidgets(
-    'force press selects word',
-    (WidgetTester tester) async {
-      final TextEditingController controller = _textEditingController(
-        text: 'Atwater Peel Sherbrooke Bonaventure',
-      );
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Material(child: TextField(controller: controller)),
-        ),
-      );
+  testWidgets('force press selects word', (WidgetTester tester) async {
+    final TextEditingController controller = _textEditingController(
+      text: 'Atwater Peel Sherbrooke Bonaventure',
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(child: TextField(controller: controller)),
+      ),
+    );
 
-      final Offset textfieldStart = tester.getTopLeft(find.byType(TextField));
+    final Offset textfieldStart = tester.getTopLeft(find.byType(TextField));
 
-      final int pointerValue = tester.nextPointer;
-      final Offset offset = textfieldStart + const Offset(150.0, 9.0);
-      final TestGesture gesture = await tester.createGesture();
-      await gesture.downWithCustomEvent(
-        offset,
-        PointerDownEvent(
-          pointer: pointerValue,
-          position: offset,
-          pressure: 0.0,
-          pressureMax: 6.0,
-          pressureMin: 0.0,
-        ),
-      );
+    final int pointerValue = tester.nextPointer;
+    final Offset offset = textfieldStart + const Offset(150.0, 9.0);
+    final TestGesture gesture = await tester.createGesture();
+    await gesture.downWithCustomEvent(
+      offset,
+      PointerDownEvent(
+        pointer: pointerValue,
+        position: offset,
+        pressure: 0.0,
+        pressureMax: 6.0,
+        pressureMin: 0.0,
+      ),
+    );
 
-      await gesture.updateWithCustomEvent(
-        PointerMoveEvent(
-          pointer: pointerValue,
-          position: textfieldStart + const Offset(150.0, 9.0),
-          pressure: 0.5,
-          pressureMin: 0,
-        ),
-      );
-      // We expect the force press to select a word at the given location.
-      expect(controller.selection, const TextSelection(baseOffset: 8, extentOffset: 12));
+    await gesture.updateWithCustomEvent(
+      PointerMoveEvent(
+        pointer: pointerValue,
+        position: textfieldStart + const Offset(150.0, 9.0),
+        pressure: 0.5,
+        pressureMin: 0,
+      ),
+    );
+    // We expect the force press to select a word at the given location.
+    expect(controller.selection, const TextSelection(baseOffset: 8, extentOffset: 12));
 
-      await gesture.up();
-      await tester.pumpAndSettle();
-      expectCupertinoToolbarForPartialSelection();
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-  );
+    await gesture.up();
+    await tester.pumpAndSettle();
+    expectCupertinoToolbarForPartialSelection();
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
 
-  testWidgets(
-    'tap on non-force-press-supported devices work',
-    (WidgetTester tester) async {
-      final TextEditingController controller = _textEditingController(
-        text: 'Atwater Peel Sherbrooke Bonaventure',
-      );
-      await tester.pumpWidget(Container(key: GlobalKey()));
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Material(child: TextField(controller: controller)),
-        ),
-      );
+  testWidgets('tap on non-force-press-supported devices work', (WidgetTester tester) async {
+    final TextEditingController controller = _textEditingController(
+      text: 'Atwater Peel Sherbrooke Bonaventure',
+    );
+    await tester.pumpWidget(Container(key: GlobalKey()));
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(child: TextField(controller: controller)),
+      ),
+    );
 
-      final Offset textfieldStart = tester.getTopLeft(find.byType(TextField));
+    final Offset textfieldStart = tester.getTopLeft(find.byType(TextField));
 
-      final int pointerValue = tester.nextPointer;
-      final Offset offset = textfieldStart + const Offset(150.0, 9.0);
-      final TestGesture gesture = await tester.createGesture();
-      await gesture.downWithCustomEvent(
-        offset,
-        PointerDownEvent(
-          pointer: pointerValue,
-          position: offset,
-          // iPhone 6 and below report 0 across the board.
-          pressure: 0,
-          pressureMax: 0,
-          pressureMin: 0,
-        ),
-      );
+    final int pointerValue = tester.nextPointer;
+    final Offset offset = textfieldStart + const Offset(150.0, 9.0);
+    final TestGesture gesture = await tester.createGesture();
+    await gesture.downWithCustomEvent(
+      offset,
+      PointerDownEvent(
+        pointer: pointerValue,
+        position: offset,
+        // iPhone 6 and below report 0 across the board.
+        pressure: 0,
+        pressureMax: 0,
+        pressureMin: 0,
+      ),
+    );
 
-      await gesture.updateWithCustomEvent(
-        PointerMoveEvent(
-          pointer: pointerValue,
-          position: textfieldStart + const Offset(150.0, 9.0),
-          pressure: 0.5,
-          pressureMin: 0,
-        ),
-      );
-      await gesture.up();
-      // The event should fallback to a normal tap and move the cursor.
-      // Single taps selects the edge of the word.
-      expect(
-        controller.selection,
-        const TextSelection.collapsed(offset: 12, affinity: TextAffinity.upstream),
-      );
+    await gesture.updateWithCustomEvent(
+      PointerMoveEvent(
+        pointer: pointerValue,
+        position: textfieldStart + const Offset(150.0, 9.0),
+        pressure: 0.5,
+        pressureMin: 0,
+      ),
+    );
+    await gesture.up();
+    // The event should fallback to a normal tap and move the cursor.
+    // Single taps selects the edge of the word.
+    expect(
+      controller.selection,
+      const TextSelection.collapsed(offset: 12, affinity: TextAffinity.upstream),
+    );
 
-      await tester.pump();
-      // Single taps shouldn't trigger the toolbar.
-      expectNoCupertinoToolbar();
+    await tester.pump();
+    // Single taps shouldn't trigger the toolbar.
+    expectNoCupertinoToolbar();
 
-      // TODO(gspencergoog): Add in TargetPlatform.macOS in the line below when we figure out what global state is leaking.
-      // https://github.com/flutter/flutter/issues/43445
-    },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-  );
+    // TODO(gspencergoog): Add in TargetPlatform.macOS in the line below when we figure out what global state is leaking.
+    // https://github.com/flutter/flutter/issues/43445
+  }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
   testWidgets('default TextField debugFillProperties', (WidgetTester tester) async {
     final builder = DiagnosticPropertiesBuilder();
@@ -14565,43 +14493,41 @@ void main() {
     }),
   );
 
-  testWidgets(
-    'iPad Scribble selection change shows selection handles',
-    (WidgetTester tester) async {
-      const testText = 'lorem ipsum';
-      final TextEditingController controller = _textEditingController(text: testText);
+  testWidgets('iPad Scribble selection change shows selection handles', (
+    WidgetTester tester,
+  ) async {
+    const testText = 'lorem ipsum';
+    final TextEditingController controller = _textEditingController(text: testText);
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Material(child: TextField(controller: controller)),
-        ),
-      );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(child: TextField(controller: controller)),
+      ),
+    );
 
-      await tester.showKeyboard(find.byType(EditableText));
-      await tester.testTextInput.startScribbleInteraction();
-      tester.testTextInput.updateEditingValue(
-        const TextEditingValue(
-          text: testText,
-          selection: TextSelection(baseOffset: 2, extentOffset: 7),
-        ),
-      );
-      await tester.pumpAndSettle();
+    await tester.showKeyboard(find.byType(EditableText));
+    await tester.testTextInput.startScribbleInteraction();
+    tester.testTextInput.updateEditingValue(
+      const TextEditingValue(
+        text: testText,
+        selection: TextSelection(baseOffset: 2, extentOffset: 7),
+      ),
+    );
+    await tester.pumpAndSettle();
 
-      final List<FadeTransition> transitions = find
-          .byType(FadeTransition)
-          .evaluate()
-          .map((Element e) => e.widget)
-          .cast<FadeTransition>()
-          .toList();
-      expect(transitions.length, 2);
-      final FadeTransition left = transitions[0];
-      final FadeTransition right = transitions[1];
+    final List<FadeTransition> transitions = find
+        .byType(FadeTransition)
+        .evaluate()
+        .map((Element e) => e.widget)
+        .cast<FadeTransition>()
+        .toList();
+    expect(transitions.length, 2);
+    final FadeTransition left = transitions[0];
+    final FadeTransition right = transitions[1];
 
-      expect(left.opacity.value, equals(1.0));
-      expect(right.opacity.value, equals(1.0));
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-  );
+    expect(left.opacity.value, equals(1.0));
+    expect(right.opacity.value, equals(1.0));
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
 
   testWidgets('Tap shows handles but not toolbar', (WidgetTester tester) async {
     final TextEditingController controller = _textEditingController(text: 'abc def ghi');
@@ -17418,49 +17344,41 @@ void main() {
     });
 
     group('defaults', () {
-      testWidgets(
-        'should build Magnifier on Android',
-        (WidgetTester tester) async {
-          await tester.pumpWidget(const MaterialApp(home: Scaffold(body: TextField())));
+      testWidgets('should build Magnifier on Android', (WidgetTester tester) async {
+        await tester.pumpWidget(const MaterialApp(home: Scaffold(body: TextField())));
 
-          final BuildContext context = tester.firstElement(find.byType(TextField));
-          final EditableText editableText = tester.widget(find.byType(EditableText));
-          final magnifierInfo = ValueNotifier<MagnifierInfo>(MagnifierInfo.empty);
-          addTearDown(magnifierInfo.dispose);
+        final BuildContext context = tester.firstElement(find.byType(TextField));
+        final EditableText editableText = tester.widget(find.byType(EditableText));
+        final magnifierInfo = ValueNotifier<MagnifierInfo>(MagnifierInfo.empty);
+        addTearDown(magnifierInfo.dispose);
 
-          expect(
-            editableText.magnifierConfiguration.magnifierBuilder(
-              context,
-              MagnifierController(),
-              magnifierInfo,
-            ),
-            isA<TextMagnifier>(),
-          );
-        },
-        variant: TargetPlatformVariant.only(TargetPlatform.android),
-      );
+        expect(
+          editableText.magnifierConfiguration.magnifierBuilder(
+            context,
+            MagnifierController(),
+            magnifierInfo,
+          ),
+          isA<TextMagnifier>(),
+        );
+      }, variant: TargetPlatformVariant.only(TargetPlatform.android));
 
-      testWidgets(
-        'should build CupertinoMagnifier on iOS',
-        (WidgetTester tester) async {
-          await tester.pumpWidget(const MaterialApp(home: Scaffold(body: TextField())));
+      testWidgets('should build CupertinoMagnifier on iOS', (WidgetTester tester) async {
+        await tester.pumpWidget(const MaterialApp(home: Scaffold(body: TextField())));
 
-          final BuildContext context = tester.firstElement(find.byType(TextField));
-          final EditableText editableText = tester.widget(find.byType(EditableText));
-          final magnifierInfo = ValueNotifier<MagnifierInfo>(MagnifierInfo.empty);
-          addTearDown(magnifierInfo.dispose);
+        final BuildContext context = tester.firstElement(find.byType(TextField));
+        final EditableText editableText = tester.widget(find.byType(EditableText));
+        final magnifierInfo = ValueNotifier<MagnifierInfo>(MagnifierInfo.empty);
+        addTearDown(magnifierInfo.dispose);
 
-          expect(
-            editableText.magnifierConfiguration.magnifierBuilder(
-              context,
-              MagnifierController(),
-              magnifierInfo,
-            ),
-            isA<CupertinoTextMagnifier>(),
-          );
-        },
-        variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-      );
+        expect(
+          editableText.magnifierConfiguration.magnifierBuilder(
+            context,
+            MagnifierController(),
+            magnifierInfo,
+          ),
+          isA<CupertinoTextMagnifier>(),
+        );
+      }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
       testWidgets(
         'should build nothing on all platforms but iOS and Android',
@@ -17739,110 +17657,108 @@ void main() {
       }),
     );
 
-    testWidgets(
-      'Can double tap and drag to show, unshow, and update magnifier',
-      (WidgetTester tester) async {
-        final TextEditingController controller = _textEditingController();
-        MagnifierController? magnifierController;
-        await tester.pumpWidget(
-          MaterialApp(
-            home: Material(
-              child: Center(
-                child: TextField(
-                  dragStartBehavior: DragStartBehavior.down,
-                  controller: controller,
-                  magnifierConfiguration: TextMagnifierConfiguration(
-                    magnifierBuilder:
-                        (
-                          BuildContext context,
-                          MagnifierController controller,
-                          ValueNotifier<MagnifierInfo> localMagnifierInfo,
-                        ) {
-                          magnifierController = controller;
-                          return TextMagnifier.adaptiveMagnifierConfiguration.magnifierBuilder(
-                            context,
-                            controller,
-                            localMagnifierInfo,
-                          );
-                        },
-                  ),
+    testWidgets('Can double tap and drag to show, unshow, and update magnifier', (
+      WidgetTester tester,
+    ) async {
+      final TextEditingController controller = _textEditingController();
+      MagnifierController? magnifierController;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Center(
+              child: TextField(
+                dragStartBehavior: DragStartBehavior.down,
+                controller: controller,
+                magnifierConfiguration: TextMagnifierConfiguration(
+                  magnifierBuilder:
+                      (
+                        BuildContext context,
+                        MagnifierController controller,
+                        ValueNotifier<MagnifierInfo> localMagnifierInfo,
+                      ) {
+                        magnifierController = controller;
+                        return TextMagnifier.adaptiveMagnifierConfiguration.magnifierBuilder(
+                          context,
+                          controller,
+                          localMagnifierInfo,
+                        );
+                      },
                 ),
               ),
             ),
           ),
-        );
+        ),
+      );
 
-        const testValue = 'one two three four five six seven';
-        await tester.enterText(find.byType(TextField), testValue);
-        await skipPastScrollingAnimation(tester);
+      const testValue = 'one two three four five six seven';
+      await tester.enterText(find.byType(TextField), testValue);
+      await skipPastScrollingAnimation(tester);
 
-        // Tap at 'e' to set the selection to the closest word edge, which is position 3 on iOS.
-        final Offset initialPosition = textOffsetToPosition(tester, testValue.indexOf('e'));
-        await tester.tapAt(initialPosition);
-        await tester.pumpAndSettle(const Duration(milliseconds: 300));
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, 3);
-        expect(magnifierController, isNull);
+      // Tap at 'e' to set the selection to the closest word edge, which is position 3 on iOS.
+      final Offset initialPosition = textOffsetToPosition(tester, testValue.indexOf('e'));
+      await tester.tapAt(initialPosition);
+      await tester.pumpAndSettle(const Duration(milliseconds: 300));
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, 3);
+      expect(magnifierController, isNull);
 
-        // Double tap the 'e' to select 'one'.
-        final TestGesture gesture = await tester.startGesture(initialPosition);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
-        await gesture.down(initialPosition);
-        await tester.pumpAndSettle();
-        expect(controller.selection.isCollapsed, false);
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 3);
-        expect(magnifierController, isNull);
+      // Double tap the 'e' to select 'one'.
+      final TestGesture gesture = await tester.startGesture(initialPosition);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+      await gesture.down(initialPosition);
+      await tester.pumpAndSettle();
+      expect(controller.selection.isCollapsed, false);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 3);
+      expect(magnifierController, isNull);
 
-        // Drag immediately after the double tap to select 'one two three four' and show the magnifier.
-        await gesture.moveTo(textOffsetToPosition(tester, 16));
-        await tester.pumpAndSettle();
+      // Drag immediately after the double tap to select 'one two three four' and show the magnifier.
+      await gesture.moveTo(textOffsetToPosition(tester, 16));
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.isCollapsed, false);
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 18);
-        expect(magnifierController, isNotNull);
-        expect(magnifierController!.shown, true);
+      expect(controller.selection.isCollapsed, false);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 18);
+      expect(magnifierController, isNotNull);
+      expect(magnifierController!.shown, true);
 
-        // Dragging down at the same position should hide the cupertino magnifier when it
-        // exceeds its `hideBelowThreshold`.
-        await gesture.moveTo(textOffsetToPosition(tester, 16) + const Offset(0.0, 50.0));
-        await tester.pumpAndSettle();
-        expect(controller.selection.isCollapsed, false);
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 18);
-        expect(magnifierController, isNotNull);
-        expect(magnifierController!.shown, false);
+      // Dragging down at the same position should hide the cupertino magnifier when it
+      // exceeds its `hideBelowThreshold`.
+      await gesture.moveTo(textOffsetToPosition(tester, 16) + const Offset(0.0, 50.0));
+      await tester.pumpAndSettle();
+      expect(controller.selection.isCollapsed, false);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 18);
+      expect(magnifierController, isNotNull);
+      expect(magnifierController!.shown, false);
 
-        // Keep draging to select 'one two three four five' while the position continues to
-        // exceed the `hideBelowThreshold` keeping the magnifier hidden.
-        await gesture.moveTo(textOffsetToPosition(tester, 20) + const Offset(0.0, 50.0));
-        await tester.pumpAndSettle();
-        expect(controller.selection.isCollapsed, false);
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 23);
-        expect(magnifierController, isNotNull);
-        expect(magnifierController!.shown, false);
+      // Keep draging to select 'one two three four five' while the position continues to
+      // exceed the `hideBelowThreshold` keeping the magnifier hidden.
+      await gesture.moveTo(textOffsetToPosition(tester, 20) + const Offset(0.0, 50.0));
+      await tester.pumpAndSettle();
+      expect(controller.selection.isCollapsed, false);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 23);
+      expect(magnifierController, isNotNull);
+      expect(magnifierController!.shown, false);
 
-        // Remove offset that is used to exceed threshold, this should reveal the magnifier.
-        await gesture.moveTo(textOffsetToPosition(tester, 20));
-        await tester.pumpAndSettle();
-        expect(controller.selection.isCollapsed, false);
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 23);
-        expect(magnifierController, isNotNull);
-        expect(magnifierController!.shown, true);
+      // Remove offset that is used to exceed threshold, this should reveal the magnifier.
+      await gesture.moveTo(textOffsetToPosition(tester, 20));
+      await tester.pumpAndSettle();
+      expect(controller.selection.isCollapsed, false);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 23);
+      expect(magnifierController, isNotNull);
+      expect(magnifierController!.shown, true);
 
-        // End the drag to hide the magnifier.
-        await gesture.up();
-        await tester.pumpAndSettle();
-        expect(magnifierController, isNotNull);
-        expect(magnifierController!.shown, false);
-      },
-      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-    );
+      // End the drag to hide the magnifier.
+      await gesture.up();
+      await tester.pumpAndSettle();
+      expect(magnifierController, isNotNull);
+      expect(magnifierController!.shown, false);
+    }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
     testWidgets(
       'cancelling long press hides magnifier',
@@ -18710,66 +18626,60 @@ void main() {
     EditableText.debugDeterministicCursor = false;
   }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
-  testWidgets(
-    'Cursor should not blink when long-pressing to show floating cursor.',
-    (WidgetTester tester) async {
-      final TextEditingController controller = _textEditingController(text: 'abcdefghijklmnopqr');
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Material(
-            child: Center(
-              child: TextField(
-                autofocus: true,
-                controller: controller,
-                cursorOpacityAnimates: false,
-              ),
-            ),
+  testWidgets('Cursor should not blink when long-pressing to show floating cursor.', (
+    WidgetTester tester,
+  ) async {
+    final TextEditingController controller = _textEditingController(text: 'abcdefghijklmnopqr');
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(
+            child: TextField(autofocus: true, controller: controller, cursorOpacityAnimates: false),
           ),
         ),
-      );
-      final EditableTextState state = tester.state(find.byType(EditableText));
-      Future<void> checkCursorBlinking({bool isBlinking = true}) async {
-        var initialShowCursor = true;
-        if (isBlinking) {
-          initialShowCursor = state.renderEditable.showCursor.value;
-        }
-        await tester.pump(state.cursorBlinkInterval);
-        expect(
-          state.cursorCurrentlyVisible,
-          equals(isBlinking ? !initialShowCursor : initialShowCursor),
-        );
-        await tester.pump(state.cursorBlinkInterval);
-        expect(state.cursorCurrentlyVisible, equals(initialShowCursor));
-        await tester.pump(state.cursorBlinkInterval);
-        expect(
-          state.cursorCurrentlyVisible,
-          equals(isBlinking ? !initialShowCursor : initialShowCursor),
-        );
-        await tester.pump(state.cursorBlinkInterval);
-        expect(state.cursorCurrentlyVisible, equals(initialShowCursor));
+      ),
+    );
+    final EditableTextState state = tester.state(find.byType(EditableText));
+    Future<void> checkCursorBlinking({bool isBlinking = true}) async {
+      var initialShowCursor = true;
+      if (isBlinking) {
+        initialShowCursor = state.renderEditable.showCursor.value;
       }
-
-      // Wait for autofocus.
-      await tester.pumpAndSettle();
-      // Before long-pressing, the cursor should blink.
-      await checkCursorBlinking();
-
-      final TestGesture gesture = await tester.startGesture(
-        tester.getTopLeft(find.byType(TextField)),
+      await tester.pump(state.cursorBlinkInterval);
+      expect(
+        state.cursorCurrentlyVisible,
+        equals(isBlinking ? !initialShowCursor : initialShowCursor),
       );
-      await tester.pump(kLongPressTimeout);
-      // When long-pressing, the cursor shouldn't blink.
-      await checkCursorBlinking(isBlinking: false);
-      await gesture.moveBy(const Offset(20, 0));
-      await tester.pump();
-      // When long-pressing and dragging to move the cursor, the cursor shouldn't blink.
-      await checkCursorBlinking(isBlinking: false);
-      await gesture.up();
-      // After finishing the long-press, the cursor should blink.
-      await checkCursorBlinking();
-    },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-  );
+      await tester.pump(state.cursorBlinkInterval);
+      expect(state.cursorCurrentlyVisible, equals(initialShowCursor));
+      await tester.pump(state.cursorBlinkInterval);
+      expect(
+        state.cursorCurrentlyVisible,
+        equals(isBlinking ? !initialShowCursor : initialShowCursor),
+      );
+      await tester.pump(state.cursorBlinkInterval);
+      expect(state.cursorCurrentlyVisible, equals(initialShowCursor));
+    }
+
+    // Wait for autofocus.
+    await tester.pumpAndSettle();
+    // Before long-pressing, the cursor should blink.
+    await checkCursorBlinking();
+
+    final TestGesture gesture = await tester.startGesture(
+      tester.getTopLeft(find.byType(TextField)),
+    );
+    await tester.pump(kLongPressTimeout);
+    // When long-pressing, the cursor shouldn't blink.
+    await checkCursorBlinking(isBlinking: false);
+    await gesture.moveBy(const Offset(20, 0));
+    await tester.pump();
+    // When long-pressing and dragging to move the cursor, the cursor shouldn't blink.
+    await checkCursorBlinking(isBlinking: false);
+    await gesture.up();
+    // After finishing the long-press, the cursor should blink.
+    await checkCursorBlinking();
+  }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
   testWidgets('when enabled listens to onFocus events and gains focus', (
     WidgetTester tester,
@@ -18843,107 +18753,103 @@ void main() {
     semantics.dispose();
   }, variant: TargetPlatformVariant.all());
 
-  testWidgets(
-    'when disabled does not listen to onFocus events or gain focus',
-    (WidgetTester tester) async {
-      final semantics = SemanticsTester(tester);
-      final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;
-      final focusNode = FocusNode();
-      addTearDown(focusNode.dispose);
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Material(
-            child: Center(child: TextField(focusNode: focusNode, enabled: false)),
-          ),
+  testWidgets('when disabled does not listen to onFocus events or gain focus', (
+    WidgetTester tester,
+  ) async {
+    final semantics = SemanticsTester(tester);
+    final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;
+    final focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(child: TextField(focusNode: focusNode, enabled: false)),
         ),
-      );
-      expect(
-        semantics,
-        hasSemantics(
-          TestSemantics.root(
-            children: <TestSemantics>[
-              TestSemantics(
-                id: 1,
-                textDirection: TextDirection.ltr,
-                children: <TestSemantics>[
-                  TestSemantics(
-                    id: 2,
-                    children: <TestSemantics>[
-                      TestSemantics(
-                        id: 3,
-                        flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
-                        children: <TestSemantics>[
-                          TestSemantics(
-                            id: 4,
-                            inputType: ui.SemanticsInputType.text,
-                            currentValueLength: 0,
-                            flags: <SemanticsFlag>[
-                              SemanticsFlag.isTextField,
-                              SemanticsFlag.isFocusable,
-                              SemanticsFlag.hasEnabledState,
-                              SemanticsFlag.isReadOnly,
-                            ],
-                            actions: <SemanticsAction>[
-                              if (defaultTargetPlatform == TargetPlatform.windows ||
-                                  defaultTargetPlatform == TargetPlatform.macOS ||
-                                  defaultTargetPlatform == TargetPlatform.linux)
-                                SemanticsAction.didGainAccessibilityFocus,
-                              if (defaultTargetPlatform == TargetPlatform.windows ||
-                                  defaultTargetPlatform == TargetPlatform.macOS ||
-                                  defaultTargetPlatform == TargetPlatform.linux)
-                                SemanticsAction.didLoseAccessibilityFocus,
-                            ],
-                          ),
-                        ],
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            ],
-          ),
-          ignoreRect: true,
-          ignoreTransform: true,
+      ),
+    );
+    expect(
+      semantics,
+      hasSemantics(
+        TestSemantics.root(
+          children: <TestSemantics>[
+            TestSemantics(
+              id: 1,
+              textDirection: TextDirection.ltr,
+              children: <TestSemantics>[
+                TestSemantics(
+                  id: 2,
+                  children: <TestSemantics>[
+                    TestSemantics(
+                      id: 3,
+                      flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
+                      children: <TestSemantics>[
+                        TestSemantics(
+                          id: 4,
+                          inputType: ui.SemanticsInputType.text,
+                          currentValueLength: 0,
+                          flags: <SemanticsFlag>[
+                            SemanticsFlag.isTextField,
+                            SemanticsFlag.isFocusable,
+                            SemanticsFlag.hasEnabledState,
+                            SemanticsFlag.isReadOnly,
+                          ],
+                          actions: <SemanticsAction>[
+                            if (defaultTargetPlatform == TargetPlatform.windows ||
+                                defaultTargetPlatform == TargetPlatform.macOS ||
+                                defaultTargetPlatform == TargetPlatform.linux)
+                              SemanticsAction.didGainAccessibilityFocus,
+                            if (defaultTargetPlatform == TargetPlatform.windows ||
+                                defaultTargetPlatform == TargetPlatform.macOS ||
+                                defaultTargetPlatform == TargetPlatform.linux)
+                              SemanticsAction.didLoseAccessibilityFocus,
+                          ],
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ],
         ),
-      );
+        ignoreRect: true,
+        ignoreTransform: true,
+      ),
+    );
 
-      expect(focusNode.hasFocus, isFalse);
-      semanticsOwner.performAction(4, SemanticsAction.focus);
-      await tester.pumpAndSettle();
-      expect(focusNode.hasFocus, isFalse);
-      semantics.dispose();
-    },
-    variant: TargetPlatformVariant.all(),
-  );
+    expect(focusNode.hasFocus, isFalse);
+    semanticsOwner.performAction(4, SemanticsAction.focus);
+    await tester.pumpAndSettle();
+    expect(focusNode.hasFocus, isFalse);
+    semantics.dispose();
+  }, variant: TargetPlatformVariant.all());
 
-  testWidgets(
-    'when receives SemanticsAction.focus while already focused, shows keyboard',
-    (WidgetTester tester) async {
-      final semantics = SemanticsTester(tester);
-      final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;
-      final focusNode = FocusNode();
-      addTearDown(focusNode.dispose);
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Material(
-            child: Center(child: TextField(focusNode: focusNode)),
-          ),
+  testWidgets('when receives SemanticsAction.focus while already focused, shows keyboard', (
+    WidgetTester tester,
+  ) async {
+    final semantics = SemanticsTester(tester);
+    final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;
+    final focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(child: TextField(focusNode: focusNode)),
         ),
-      );
-      focusNode.requestFocus();
-      await tester.pumpAndSettle();
+      ),
+    );
+    focusNode.requestFocus();
+    await tester.pumpAndSettle();
 
-      tester.testTextInput.log.clear();
-      expect(focusNode.hasFocus, isTrue);
-      semanticsOwner.performAction(4, SemanticsAction.focus);
-      await tester.pumpAndSettle();
-      expect(focusNode.hasFocus, isTrue);
-      expect(tester.testTextInput.log.single.method, 'TextInput.show');
+    tester.testTextInput.log.clear();
+    expect(focusNode.hasFocus, isTrue);
+    semanticsOwner.performAction(4, SemanticsAction.focus);
+    await tester.pumpAndSettle();
+    expect(focusNode.hasFocus, isTrue);
+    expect(tester.testTextInput.log.single.method, 'TextInput.show');
 
-      semantics.dispose();
-    },
-    variant: TargetPlatformVariant.all(),
-  );
+    semantics.dispose();
+  }, variant: TargetPlatformVariant.all());
 
   testWidgets(
     'when receives SemanticsAction.focus while focused but read-only, does not show keyboard',

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -24,10 +24,10 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/clipboard_utils.dart';
 import '../widgets/feedback_tester.dart';
 import '../widgets/semantics_tester.dart';
 import '../widgets/text_selection_toolbar_utils.dart';
+import 'clipboard_utils.dart';
 import 'editable_text_utils.dart';
 import 'live_text_utils.dart';
 import 'process_text_utils.dart';

--- a/packages/flutter/test/material/text_form_field_test.dart
+++ b/packages/flutter/test/material/text_form_field_test.dart
@@ -12,7 +12,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/clipboard_utils.dart';
+import 'clipboard_utils.dart';
 import 'editable_text_utils.dart';
 
 void main() {

--- a/packages/flutter/test/material/text_selection_test.dart
+++ b/packages/flutter/test/material/text_selection_test.dart
@@ -770,80 +770,76 @@ void main() {
     variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.android}),
   );
 
-  testWidgets(
-    'does not crash when long press is cancelled after unmounting',
-    (WidgetTester tester) async {
-      // Regression test for b/425840577.
-      final scrollController = ScrollController();
-      addTearDown(scrollController.dispose);
+  testWidgets('does not crash when long press is cancelled after unmounting', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for b/425840577.
+    final scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Material(
-            child: CustomScrollView(
-              controller: scrollController,
-              slivers: <Widget>[
-                SliverList(
-                  delegate: SliverChildBuilderDelegate(
-                    (_, int index) => index == 0 ? const TextField() : const SizedBox(height: 50),
-                    childCount: 200,
-                    addAutomaticKeepAlives: false,
-                  ),
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: CustomScrollView(
+            controller: scrollController,
+            slivers: <Widget>[
+              SliverList(
+                delegate: SliverChildBuilderDelegate(
+                  (_, int index) => index == 0 ? const TextField() : const SizedBox(height: 50),
+                  childCount: 200,
+                  addAutomaticKeepAlives: false,
                 ),
-              ],
-            ),
+              ),
+            ],
           ),
         ),
-      );
+      ),
+    );
 
-      final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
-      // Start a long press, don't release it, and don't completely reach kLongPressTimeout so the
-      // gesture is not accepted and is cancelled when the recognizer is disposed.
-      await tester.startGesture(tester.getCenter(find.byType(TextField)));
-      await tester.pump(const Duration(milliseconds: 200));
-      await tester.pumpAndSettle();
+    final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
+    // Start a long press, don't release it, and don't completely reach kLongPressTimeout so the
+    // gesture is not accepted and is cancelled when the recognizer is disposed.
+    await tester.startGesture(tester.getCenter(find.byType(TextField)));
+    await tester.pump(const Duration(milliseconds: 200));
+    await tester.pumpAndSettle();
 
-      // While attempting to long press, scroll the TextField out of view
-      // to dispose of it and its gesture recognizers.
-      scrollController.jumpTo(8000.0);
-      await tester.pump();
-      expect(state.mounted, isFalse);
-      // Should reach the end of the test without any failures.
-    },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-  );
+    // While attempting to long press, scroll the TextField out of view
+    // to dispose of it and its gesture recognizers.
+    scrollController.jumpTo(8000.0);
+    await tester.pump();
+    expect(state.mounted, isFalse);
+    // Should reach the end of the test without any failures.
+  }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
   // Regression test for https://github.com/flutter/flutter/issues/37032.
-  testWidgets(
-    "selection handle's GestureDetector should not cover the entire screen",
-    (WidgetTester tester) async {
-      final controller = TextEditingController(text: 'a');
-      addTearDown(controller.dispose);
+  testWidgets("selection handle's GestureDetector should not cover the entire screen", (
+    WidgetTester tester,
+  ) async {
+    final controller = TextEditingController(text: 'a');
+    addTearDown(controller.dispose);
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(body: TextField(autofocus: true, controller: controller)),
-        ),
-      );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: TextField(autofocus: true, controller: controller)),
+      ),
+    );
 
-      await tester.pumpAndSettle();
+    await tester.pumpAndSettle();
 
-      final Finder gestureDetector = find.descendant(
-        of: find.byType(CompositedTransformFollower),
-        matching: find.descendant(
-          of: find.byType(FadeTransition),
-          matching: find.byType(RawGestureDetector),
-        ),
-      );
+    final Finder gestureDetector = find.descendant(
+      of: find.byType(CompositedTransformFollower),
+      matching: find.descendant(
+        of: find.byType(FadeTransition),
+        matching: find.byType(RawGestureDetector),
+      ),
+    );
 
-      expect(gestureDetector, findsOneWidget);
-      // The GestureDetector's size should not exceed that of the TextField.
-      final Rect hitRect = tester.getRect(gestureDetector);
-      final Rect textFieldRect = tester.getRect(find.byType(TextField));
+    expect(gestureDetector, findsOneWidget);
+    // The GestureDetector's size should not exceed that of the TextField.
+    final Rect hitRect = tester.getRect(gestureDetector);
+    final Rect textFieldRect = tester.getRect(find.byType(TextField));
 
-      expect(hitRect.size.width, lessThanOrEqualTo(textFieldRect.size.width));
-      expect(hitRect.size.height, lessThanOrEqualTo(textFieldRect.size.height));
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-  );
+    expect(hitRect.size.width, lessThanOrEqualTo(textFieldRect.size.width));
+    expect(hitRect.size.height, lessThanOrEqualTo(textFieldRect.size.height));
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
 }

--- a/packages/flutter/test/material/text_selection_test.dart
+++ b/packages/flutter/test/material/text_selection_test.dart
@@ -12,7 +12,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/clipboard_utils.dart';
+import 'clipboard_utils.dart';
 import 'editable_text_utils.dart' show findRenderEditable, globalize, textOffsetToPosition;
 
 void main() {


### PR DESCRIPTION
Part of #182636.                                                                                                                                                                                         
                                                                
`MockClipboard` is a small (30-line) test utility with a trivial implementation, so duplication is the appropriate strategy per the issue guidelines. The file is copied into both `test/material/` and  
`test/cupertino/`, and all imports are updated to reference the local copy.
                                                                                                                                                                                                         
## Pre-launch Checklist                                         

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.                                                                                                                           
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].                                                                                                                                                                                
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).                                                                                                                                  
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.                                                                                                             
- [x] All existing and new tests are passing.                   
                                                                                          

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
