### PR TITLE
[web] Enable address bar collapse on mobile by switching touch input

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine.dart
@@ -15,6 +15,7 @@
 // ignore: unnecessary_library_directive
 library engine;
 
+export 'engine/address_bar_controller.dart';
 export 'engine/alarm_clock.dart';
 export 'engine/app_bootstrap.dart';
 export 'engine/arena.dart';

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/address_bar_controller.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/address_bar_controller.dart
@@ -2,23 +2,20 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
 
 import 'package:ui/ui.dart' as ui;
 import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 import 'dom.dart';
 import 'platform_dispatcher.dart';
+import 'pointer_binding.dart';
 import 'pointer_converter.dart';
+import 'semantics.dart';
 import 'view_embedder/embedding_strategy/full_page_embedding_strategy.dart';
 import 'window.dart';
-
-typedef _ListenerRecord = ({
-  DomEventTarget target,
-  String type,
-  DomEventListener listener,
-  JSAny options,
-});
 
 /// Enables mobile browser address bar collapse for Flutter web apps.
 ///
@@ -27,81 +24,71 @@ typedef _ListenerRecord = ({
 /// and adds a spacer to make `<body>` scrollable, allowing the browser
 /// to collapse the address bar on scroll.
 ///
-/// ## Touch input switching
-///
-/// `touch-action: pan-y` causes the browser to fire `pointercancel`
-/// during vertical scrolling, breaking [PointerBinding]'s gesture stream.
-/// This class blocks touch-type Pointer Events at the capture phase and
-/// handles finger input via Touch Events instead. Mouse and pen Pointer
-/// Events pass through to [PointerBinding] unchanged.
-///
-/// ## Scroll position management
-///
-/// On iOS, a single scroll-snap target at the midpoint of a large spacer
-/// prevents momentum scrolling while keeping scrollTop far from 0.
-///
-/// On Android, two scroll-snap targets (top and bottom) form a binary
-/// state: the snap direction matches the user's scroll direction, which
-/// is required because Chrome uses final scroll direction (not gesture
-/// direction) for address bar detection. The top target is offset by 1px
-/// from scrollTop=0 to prevent pull-to-refresh.
-///
-/// Only active for full-page embedding on mobile. On desktop or with a
-/// custom host element, the constructor and [dispose] are no-ops.
+/// When active, finger input is taken from Touch Events (which keep firing
+/// during scrolling) rather than touch-type Pointer Events (whose stream breaks
+/// because `pan-y` fires `pointercancel` on vertical scrolls). Each touch is
+/// converted to pointer data and handed to `PointerBinding`'s `ClickDebouncer`
+/// directly; the native touch-type pointer events it replaces are stopped in
+/// the window capture phase so `PointerBinding` does not process them too.
 ///
 /// See also:
 ///
 ///  * https://github.com/flutter/flutter/issues/69529
 class AddressBarController {
-  AddressBarController(this._view) : _pointerDataConverter = PointerDataConverter() {
-    if (!_isSupported) {
+  AddressBarController(EngineFlutterView view)
+    : _view = view,
+      _isActive = _computeIsSupported(view) {
+    if (!_isActive) {
       return;
     }
 
-    domDocument.body!.style
-      ..overflowY = 'auto'
-      ..setProperty('touch-action', 'pan-y');
-
-    _setupSpacer();
-    _blockTouchPointerEvents();
-    _setupTouchHandlers();
+    _setupScrollMachinery();
+    _setupTouchTranslation();
+    _setupTouchPointerEventSuppression();
   }
 
   final EngineFlutterView _view;
-  final PointerDataConverter _pointerDataConverter;
+
+  final bool _isActive;
+
+  final List<_SavedStyle> _savedStyles = <_SavedStyle>[];
 
   static bool get _isIOs => ui_web.browser.operatingSystem == ui_web.OperatingSystem.iOs;
   static bool get _isAndroid => ui_web.browser.operatingSystem == ui_web.OperatingSystem.android;
 
-  bool get _isSupported =>
-      (_isIOs || _isAndroid) && _view.embeddingStrategy is FullPageEmbeddingStrategy;
+  /// Whether the current operating system is one the address bar collapse
+  /// targets (iOS or Android).
+  ///
+  /// [FullPageDimensionsProvider] reads this so its `innerHeight`-based height
+  /// measurement is gated on exactly the operating systems this controller
+  /// activates for, rather than on the broader [ui_web.BrowserDetection.isMobile]
+  /// (which also includes [ui_web.OperatingSystem.unknown]).
+  static bool get isSupportedOperatingSystem => _isIOs || _isAndroid;
 
-  final Set<int> _activeTouchIds = <int>{};
-  final List<_ListenerRecord> _listeners = [];
+  static bool _computeIsSupported(EngineFlutterView view) =>
+      isSupportedOperatingSystem && view.embeddingStrategy is FullPageEmbeddingStrategy;
 
   DomElement? _spacerElement;
 
   void dispose() {
-    if (!_isSupported) {
+    if (!_isActive) {
       return;
     }
-    for (final _ListenerRecord r in _listeners) {
-      r.target.removeEventListener(r.type, r.listener, r.options);
-    }
-    _listeners.clear();
-    _spacerElement?.remove();
-    domDocument.body!.style
-      ..overflowY = 'hidden'
-      ..setProperty('touch-action', 'none');
-    domDocument.documentElement!.style
-      ..setProperty('scroll-snap-type', '')
-      ..setProperty('scrollbar-width', '');
+    _cancelActiveTouches();
+    _removeListeners();
+    _teardownScrollMachinery();
   }
 
-  void _setupSpacer() {
-    domDocument.documentElement!.style
-      ..setProperty('scroll-snap-type', 'y mandatory')
-      ..setProperty('scrollbar-width', 'none');
+  /// Makes the page scrollable so the browser collapses the address bar on
+  /// scroll: a scrollable, `pan-y` `<body>`; scroll-snapping on `<html>`; and an
+  /// off-screen spacer carrying the snap targets.
+  void _setupScrollMachinery() {
+    final DomCSSStyleDeclaration bodyStyle = domDocument.body!.style;
+    _setStyle(bodyStyle, 'overflow-y', 'auto');
+    _setStyle(bodyStyle, 'touch-action', 'pan-y');
+
+    final DomCSSStyleDeclaration htmlStyle = domDocument.documentElement!.style;
+    _setStyle(htmlStyle, 'scrollbar-width', 'none');
 
     final DomElement spacer = createDomElement('flt-scroll-spacer');
     spacer.style
@@ -114,26 +101,58 @@ class AddressBarController {
     _spacerElement = spacer;
 
     if (_isAndroid) {
-      // Two snap targets: snap direction matches user's scroll direction,
-      // which Chrome requires for correct address bar detection.
-      // Top snap at 1px prevents scrollTop=0 (pull-to-refresh).
-      // collapseMargin keeps the bottom snap reachable after the address
-      // bar collapses and the viewport grows (~80px).
+      // Two snap targets: snap direction matches the user's scroll direction,
+      // which Chrome requires for correct address bar detection, with
+      // `proximity` strictness (`mandatory` re-snaps every frame and drops scroll
+      // frames). Top snap at 1px prevents scrollTop=0 (pull-to-refresh).
+      // collapseMargin keeps the bottom snap reachable after the address bar
+      // collapses and the viewport grows (~80px). 100vh (the large viewport
+      // height) keeps the spacer taller than the viewport across rotations.
+      _setStyle(htmlStyle, 'scroll-snap-type', 'y proximity');
       const snapDistance = 100;
       const collapseMargin = 100;
-      final int viewportHeight = domWindow.innerHeight!.toInt();
-      spacer.style.height = '${viewportHeight + snapDistance + 1 + collapseMargin}px';
+      spacer.style.height = 'calc(100vh + ${snapDistance + 1 + collapseMargin}px)';
       spacer.append(_createSnapTarget(1));
       spacer.append(_createSnapTarget(snapDistance + 1));
     } else if (_isIOs) {
-      // Single snap target at midpoint prevents momentum scrolling
-      // and keeps scrollTop far from 0 (no pull-to-refresh).
+      // Single `mandatory` snap target at the midpoint prevents momentum
+      // scrolling and keeps scrollTop far from 0 (no pull-to-refresh).
+      _setStyle(htmlStyle, 'scroll-snap-type', 'y mandatory');
       const spacerHeight = 10000;
       spacer.style.height = '${spacerHeight}px';
       spacer.append(_createSnapTarget(spacerHeight ~/ 2));
     }
 
     domDocument.documentElement!.append(spacer);
+  }
+
+  /// Reverses [_setupScrollMachinery]: removes the spacer and restores the
+  /// styles it changed.
+  void _teardownScrollMachinery() {
+    _spacerElement?.remove();
+    _restoreStyles();
+  }
+
+  /// Sets [property] on [style] to [value], recording its prior value so
+  /// [_restoreStyles] can put it back. Every `<body>`/`<html>` style mutation
+  /// routes through here so the restore set can never drift from what setup
+  /// changed.
+  void _setStyle(DomCSSStyleDeclaration style, String property, String value) {
+    _savedStyles.add((
+      style: style,
+      property: property,
+      previousValue: style.getPropertyValue(property),
+    ));
+    style.setProperty(property, value);
+  }
+
+  /// Restores every property changed via [_setStyle] to its prior value;
+  /// `setProperty` with an empty value removes a property that was unset.
+  void _restoreStyles() {
+    for (final _SavedStyle saved in _savedStyles) {
+      saved.style.setProperty(saved.property, saved.previousValue);
+    }
+    _savedStyles.clear();
   }
 
   DomElement _createSnapTarget(int topOffset) {
@@ -148,120 +167,255 @@ class AddressBarController {
     return target;
   }
 
-  /// Blocks touch-type Pointer Events from reaching [PointerBinding].
-  ///
-  /// Only `pointerType === 'touch'` is blocked. Mouse and pen events pass
-  /// through to [PointerBinding] unchanged, preserving pressure, tilt, and
-  /// other Pointer Event features.
-  void _blockTouchPointerEvents() {
-    final DomElement root = _view.dom.rootElement;
-    const pointerEventTypes = <String>[
-      'pointerdown',
-      'pointermove',
-      'pointerup',
-      'pointercancel',
-      'pointerleave',
-    ];
-    final JSAny options = DomEventListenerOptions(capture: true);
-    for (final type in pointerEventTypes) {
-      final DomEventListener listener = createDomEventListener((DomEvent event) {
-        final pe = event as DomPointerEvent;
-        if (pe.pointerType == 'touch') {
-          event.stopImmediatePropagation();
-        }
-      });
-      root.addEventListener(type, listener, options);
-      _listeners.add((target: root, type: type, listener: listener, options: options));
-    }
-  }
+  final List<_ListenerRegistration> _listenerRegistrations = <_ListenerRegistration>[];
+  final Set<int> _activeTouchIds = <int>{};
+  final PointerDataConverter _pointerDataConverter = PointerDataConverter();
 
-  void _setupTouchHandlers() {
-    final DomElement root = _view.dom.rootElement;
-    final JSAny options = DomEventListenerOptions(passive: true);
+  static const Map<String, String> _touchToPointerEventType = <String, String>{
+    'touchstart': 'pointerdown',
+    'touchmove': 'pointermove',
+    'touchend': 'pointerup',
+    'touchcancel': 'pointercancel',
+  };
 
-    void listen(String type, DartDomEventListener handler) {
-      final DomEventListener listener = createDomEventListener(handler);
-      root.addEventListener(type, listener, options);
-      _listeners.add((target: root, type: type, listener: listener, options: options));
-    }
-
-    listen('touchstart', (DomEvent event) {
-      final te = event as DomTouchEvent;
-      final num ts = te.timeStamp!;
-      for (final DomTouch touch in te.changedTouches) {
-        final int id = touch.identifier!.toInt();
-        _activeTouchIds.add(id);
-        _sendPointerData(ui.PointerChange.down, ts, id, touch.clientX, touch.clientY, 1);
-      }
-    });
-
-    listen('touchmove', (DomEvent event) {
-      final te = event as DomTouchEvent;
-      final num ts = te.timeStamp!;
-      for (final DomTouch touch in te.changedTouches) {
-        final int id = touch.identifier!.toInt();
-        if (!_activeTouchIds.contains(id)) {
-          continue;
-        }
-        _sendPointerData(ui.PointerChange.move, ts, id, touch.clientX, touch.clientY, 1);
-      }
-    });
-
-    listen('touchend', (DomEvent event) {
-      final te = event as DomTouchEvent;
-      final num ts = te.timeStamp!;
-      for (final DomTouch touch in te.changedTouches) {
-        final int id = touch.identifier!.toInt();
-        if (!_activeTouchIds.remove(id)) {
-          continue;
-        }
-        _sendPointerData(ui.PointerChange.up, ts, id, touch.clientX, touch.clientY, 0);
-      }
-    });
-
-    listen('touchcancel', (DomEvent event) {
-      final te = event as DomTouchEvent;
-      final num ts = te.timeStamp!;
-      for (final DomTouch touch in te.changedTouches) {
-        final int id = touch.identifier!.toInt();
-        if (!_activeTouchIds.remove(id)) {
-          continue;
-        }
-        _sendPointerData(ui.PointerChange.cancel, ts, id, touch.clientX, touch.clientY, 0);
-      }
-    });
-  }
-
-  // In full-page mode the host element is position:fixed at (0,0),
-  // so clientX/clientY are already root-relative.
-  void _sendPointerData(
-    ui.PointerChange change,
-    num eventTimeStamp,
-    int device,
-    double clientX,
-    double clientY,
-    int buttons,
+  /// Registers [handler] for [type] on [target] and tracks it so
+  /// [_removeListeners] can detach it.
+  void _addListener(
+    DomEventTarget target,
+    String type,
+    DartDomEventListener handler,
+    DomEventListenerOptions options,
   ) {
-    final int ms = eventTimeStamp.toInt();
-    final timeStamp = Duration(
-      milliseconds: ms,
-      microseconds: ((eventTimeStamp - ms) * Duration.microsecondsPerMillisecond).toInt(),
-    );
-    final data = <ui.PointerData>[];
+    final DomEventListener listener = createDomEventListener(handler);
+    target.addEventListener(type, listener, options);
+    _listenerRegistrations.add((target: target, type: type, listener: listener, options: options));
+  }
+
+  /// Reverses every [_addListener] from [_setupTouchTranslation] and
+  /// [_setupTouchPointerEventSuppression].
+  void _removeListeners() {
+    for (final _ListenerRegistration registration in _listenerRegistrations) {
+      registration.target.removeEventListener(
+        registration.type,
+        registration.listener,
+        registration.options,
+      );
+    }
+    _listenerRegistrations.clear();
+  }
+
+  /// Registers passive Touch Event listeners on the view root that feed
+  /// [_translateTouchEvent].
+  void _setupTouchTranslation() {
+    _touchToPointerEventType.forEach((String touchEventType, String pointerEventType) {
+      _addListener(
+        _view.dom.rootElement,
+        touchEventType,
+        (DomEvent event) => _translateTouchEvent(event as DomTouchEvent, pointerEventType),
+        DomEventListenerOptions(passive: true),
+      );
+    });
+  }
+
+  /// Stops the native touch-type pointer events that the translation replaces,
+  /// so `PointerBinding` does not process each touch a second time.
+  ///
+  /// The capture phase on the window runs before any engine listener,
+  /// regardless of registration order.
+  void _setupTouchPointerEventSuppression() {
+    for (final pointerEventType in <String>[..._touchToPointerEventType.values, 'pointerleave']) {
+      _addListener(
+        domWindow,
+        pointerEventType,
+        _suppressTouchPointerEvent,
+        DomEventListenerOptions(capture: true),
+      );
+    }
+  }
+
+  /// Stops every native touch-type pointer event inside the view, and records
+  /// pen (stylus) contacts. Mouse events pass through untouched.
+  void _suppressTouchPointerEvent(DomEvent event) {
+    final pointerEvent = event as DomPointerEvent;
+    final String? pointerType = pointerEvent.pointerType;
+    if (pointerType != 'touch' && pointerType != 'pen') {
+      return;
+    }
+    final DomEventTarget? target = pointerEvent.target;
+    if (target == null || !_view.dom.rootElement.contains(target as DomNode)) {
+      return;
+    }
+    switch (pointerType) {
+      case 'pen':
+        _trackPenContact(pointerEvent);
+      case 'touch':
+        pointerEvent.stopPropagation();
+        if (pointerEvent.type == 'pointerdown' && target == _view.dom.rootElement) {
+          // Suppresses the browser's default focus change; the view focus is
+          // requested from _translateTouchEvent instead.
+          pointerEvent.preventDefault();
+        }
+    }
+  }
+
+  /// Positions of active stylus contacts, keyed by `pointerId`.
+  final Map<int, ui.Offset> _activePenContacts = <int, ui.Offset>{};
+
+  /// Records a stylus contact's position on `pointerdown` and clears it on
+  /// `pointerup`/`pointercancel`/`pointerleave`, for [_coincidesWithActivePen].
+  /// The pen's own Pointer events are left for `PointerBinding` to handle.
+  void _trackPenContact(DomPointerEvent event) {
+    final int? id = event.pointerId?.toInt();
+    if (id == null) {
+      return;
+    }
+    switch (event.type) {
+      case 'pointerdown':
+        _activePenContacts[id] = ui.Offset(event.clientX, event.clientY);
+      case 'pointerup' || 'pointercancel' || 'pointerleave':
+        _activePenContacts.remove(id);
+    }
+  }
+
+  /// Whether [touch] coincides with an active stylus contact.
+  ///
+  /// One stylus contact fires both a `pen` Pointer event (kept, handled by
+  /// `PointerBinding`) and a Touch event reporting the same position; the
+  /// coinciding touch is skipped so one contact does not become two pointers.
+  bool _coincidesWithActivePen(DomTouch touch) {
+    const tolerance = 1.0;
+    for (final ui.Offset pen in _activePenContacts.values) {
+      if ((pen.dx - touch.clientX).abs() <= tolerance &&
+          (pen.dy - touch.clientY).abs() <= tolerance) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /// Converts a Touch Event into pointer data and hands it to PointerBinding's
+  /// `ClickDebouncer` — the same entry the native pointer events would reach —
+  /// without dispatching synthetic DOM events.
+  void _translateTouchEvent(DomTouchEvent event, String pointerType) {
+    // Report the event to semantics — it disables browser gestures while
+    // pointer events are flowing and auto-enables semantics on interaction —
+    // exactly as PointerBinding's listener wrapper does for the events it
+    // handles. If semantics consumes the event, do not forward it.
+    if (!EngineSemantics.instance.receiveGlobalEvent(event)) {
+      return;
+    }
+    final ui.PointerChange change = switch (pointerType) {
+      'pointerdown' => ui.PointerChange.down,
+      'pointermove' => ui.PointerChange.move,
+      'pointerup' => ui.PointerChange.up,
+      _ => ui.PointerChange.cancel,
+    };
+    final bool isDown = change == ui.PointerChange.down || change == ui.PointerChange.move;
+    final DomElement root = _view.dom.rootElement;
     final double dpr = _view.devicePixelRatio;
-    _pointerDataConverter.convert(
-      data,
-      viewId: _view.viewId,
-      change: change,
-      timeStamp: timeStamp,
-      signalKind: ui.PointerSignalKind.none,
-      device: device,
-      physicalX: clientX * dpr,
-      physicalY: clientY * dpr,
-      buttons: buttons,
-      pressure: buttons > 0 ? 1.0 : 0.0,
-      pressureMax: 1.0,
-    );
-    EnginePlatformDispatcher.instance.invokeOnPointerDataPacket(ui.PointerDataPacket(data: data));
+    final Duration timeStamp = _durationFromMilliseconds(event.timeStamp!);
+    for (final DomTouch touch in event.changedTouches) {
+      final int device = touch.identifier!.toInt();
+      if (change == ui.PointerChange.down) {
+        // The pen's pointerdown precedes this touchstart on the targeted
+        // engines, so a coinciding contact is already recorded.
+        if (_coincidesWithActivePen(touch)) {
+          continue;
+        }
+        // A repeated touchstart for an already-active id would emit a second
+        // down; skip it, as the native pointer path's sanitizer did.
+        if (!_activeTouchIds.add(device)) {
+          continue;
+        }
+      } else if (change == ui.PointerChange.move) {
+        if (!_activeTouchIds.contains(device)) {
+          continue;
+        }
+      } else if (!_activeTouchIds.remove(device)) {
+        continue;
+      }
+      final data = <ui.PointerData>[];
+      _pointerDataConverter.convert(
+        data,
+        viewId: _view.viewId,
+        change: change,
+        timeStamp: timeStamp,
+        device: device,
+        // In full-page mode the host is position:fixed at (0,0), so clientX/Y
+        // are already root-relative. Reading getBoundingClientRect here to
+        // re-derive the origin would force a synchronous layout flush on every
+        // touchmove; during the address bar collapse the viewport resizes each
+        // frame, so those reads thrash layout and stall the scroll.
+        physicalX: touch.clientX * dpr,
+        physicalY: touch.clientY * dpr,
+        buttons: isDown ? 1 : 0,
+        pressure: isDown ? 1.0 : 0.0,
+        pressureMax: 1.0,
+      );
+      PointerBinding.clickDebouncer.onPointerData(
+        _debounceEvent(pointerType, touch.target ?? root, event.timeStamp!),
+        data,
+      );
+      if (change == ui.PointerChange.down && touch.target == root) {
+        _requestViewFocus();
+      }
+    }
+  }
+
+  /// A minimal pointer-event-shaped object carrying only the fields
+  /// `ClickDebouncer` reads (type, target, timeStamp); it is never dispatched.
+  DomEvent _debounceEvent(String type, DomEventTarget target, num timeStamp) {
+    final event = JSObject();
+    event['type'] = type.toJS;
+    event['target'] = target as JSObject;
+    event['timeStamp'] = timeStamp.toJS;
+    return event as DomEvent;
+  }
+
+  /// Focuses the view, replicating the side effect of PointerBinding's
+  /// pointerdown handler, which no longer runs for touch input.
+  void _requestViewFocus() {
+    Timer(Duration.zero, () {
+      EnginePlatformDispatcher.instance.requestViewFocusChange(
+        viewId: _view.viewId,
+        state: ui.ViewFocusState.focused,
+        direction: ui.ViewFocusDirection.undefined,
+      );
+    });
+  }
+
+  static Duration _durationFromMilliseconds(num milliseconds) {
+    final int ms = milliseconds.toInt();
+    final int micro = ((milliseconds - ms) * Duration.microsecondsPerMillisecond).toInt();
+    return Duration(milliseconds: ms, microseconds: micro);
+  }
+
+  /// Cancels touches still down so the framework does not keep phantom
+  /// pointers after translation stops.
+  void _cancelActiveTouches() {
+    if (_activeTouchIds.isEmpty) {
+      return;
+    }
+    final DomElement root = _view.dom.rootElement;
+    for (final int device in _activeTouchIds) {
+      final data = <ui.PointerData>[];
+      // The converter substitutes the pointer's last known location for cancel.
+      _pointerDataConverter.convert(data, viewId: _view.viewId, device: device, pressureMax: 1.0);
+      // Route through the same ClickDebouncer entry as live touches. A cancel
+      // issued mid-debounce is then queued behind the still-pending `down` and
+      // flushed in order; sending it straight to the dispatcher would race
+      // ahead of that queued `down` and leave the framework a phantom pointer.
+      PointerBinding.clickDebouncer.onPointerData(_debounceEvent('pointercancel', root, 0), data);
+    }
+    _activeTouchIds.clear();
   }
 }
+
+typedef _ListenerRegistration = ({
+  DomEventTarget target,
+  String type,
+  DomEventListener listener,
+  DomEventListenerOptions options,
+});
+
+typedef _SavedStyle = ({DomCSSStyleDeclaration style, String property, String previousValue});

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/address_bar_controller.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/address_bar_controller.dart
@@ -20,24 +20,38 @@ typedef _ListenerRecord = ({
   JSAny options,
 });
 
-/// Enables iOS browser address bar collapse for Flutter web apps.
+/// Enables mobile browser address bar collapse for Flutter web apps.
 ///
-/// The browser collapses the address bar only when it detects a
-/// user-initiated scroll, which requires `touch-action` to not be `none`.
-/// However, changing `touch-action` causes the browser to fire
-/// `pointercancel` during vertical scroll, breaking [PointerBinding]'s
-/// gesture stream.
+/// Flutter web sets `touch-action: none` on `<body>`, preventing the
+/// browser from detecting scrolls. This class sets `touch-action: pan-y`
+/// and adds a spacer to make `<body>` scrollable, allowing the browser
+/// to collapse the address bar on scroll.
 ///
-/// This class works around the issue by blocking touch-type Pointer Events
-/// and handling finger input via Touch Events instead. Touch Events are
-/// independent of Pointer Events and continue after `pointercancel`.
-/// Mouse and pen Pointer Events are not blocked — [PointerBinding] handles
-/// them normally.
+/// ## Touch input switching
 ///
-/// Only active for full-page embedding on iOS. On other platforms or with
-/// a custom host element, the constructor is a no-op.
+/// `touch-action: pan-y` causes the browser to fire `pointercancel`
+/// during vertical scrolling, breaking [PointerBinding]'s gesture stream.
+/// This class blocks touch-type Pointer Events at the capture phase and
+/// handles finger input via Touch Events instead. Mouse and pen Pointer
+/// Events pass through to [PointerBinding] unchanged.
 ///
-/// See https://github.com/flutter/flutter/issues/69529
+/// ## Scroll position management
+///
+/// On iOS, a single scroll-snap target at the midpoint of a large spacer
+/// prevents momentum scrolling while keeping scrollTop far from 0.
+///
+/// On Android, two scroll-snap targets (top and bottom) form a binary
+/// state: the snap direction matches the user's scroll direction, which
+/// is required because Chrome uses final scroll direction (not gesture
+/// direction) for address bar detection. The top target is offset by 1px
+/// from scrollTop=0 to prevent pull-to-refresh.
+///
+/// Only active for full-page embedding on mobile. On desktop or with a
+/// custom host element, the constructor and [dispose] are no-ops.
+///
+/// See also:
+///
+///  * https://github.com/flutter/flutter/issues/69529
 class AddressBarController {
   AddressBarController(this._view) : _pointerDataConverter = PointerDataConverter() {
     if (!_isSupported) {
@@ -53,14 +67,14 @@ class AddressBarController {
     _setupTouchHandlers();
   }
 
-  static const int spacerHeight = 10000;
-
   final EngineFlutterView _view;
   final PointerDataConverter _pointerDataConverter;
 
+  static bool get _isIOs => ui_web.browser.operatingSystem == ui_web.OperatingSystem.iOs;
+  static bool get _isAndroid => ui_web.browser.operatingSystem == ui_web.OperatingSystem.android;
+
   bool get _isSupported =>
-      ui_web.browser.operatingSystem == ui_web.OperatingSystem.iOs &&
-      _view.embeddingStrategy is FullPageEmbeddingStrategy;
+      (_isIOs || _isAndroid) && _view.embeddingStrategy is FullPageEmbeddingStrategy;
 
   final Set<int> _activeTouchIds = <int>{};
   final List<_ListenerRecord> _listeners = [];
@@ -84,11 +98,6 @@ class AddressBarController {
       ..setProperty('scrollbar-width', '');
   }
 
-  /// Appends a tall invisible element under `<html>` to provide scroll room.
-  ///
-  /// `scroll-snap-type: y mandatory` on `<html>` with a snap point at the
-  /// center prevents iOS Safari from momentum-scrolling, which would block
-  /// touch event delivery until momentum stops.
   void _setupSpacer() {
     domDocument.documentElement!.style
       ..setProperty('scroll-snap-type', 'y mandatory')
@@ -100,21 +109,43 @@ class AddressBarController {
       ..top = '0'
       ..left = '0'
       ..width = '1px'
-      ..height = '${spacerHeight}px'
       ..pointerEvents = 'none'
       ..opacity = '0';
     _spacerElement = spacer;
-    domDocument.documentElement!.append(spacer);
 
-    final DomElement snapTarget = createDomElement('flt-scroll-snap-target');
-    snapTarget.style
+    if (_isAndroid) {
+      // Two snap targets: snap direction matches user's scroll direction,
+      // which Chrome requires for correct address bar detection.
+      // Top snap at 1px prevents scrollTop=0 (pull-to-refresh).
+      // collapseMargin keeps the bottom snap reachable after the address
+      // bar collapses and the viewport grows (~80px).
+      const snapDistance = 100;
+      const collapseMargin = 100;
+      final int viewportHeight = domWindow.innerHeight!.toInt();
+      spacer.style.height = '${viewportHeight + snapDistance + 1 + collapseMargin}px';
+      spacer.append(_createSnapTarget(1));
+      spacer.append(_createSnapTarget(snapDistance + 1));
+    } else if (_isIOs) {
+      // Single snap target at midpoint prevents momentum scrolling
+      // and keeps scrollTop far from 0 (no pull-to-refresh).
+      const spacerHeight = 10000;
+      spacer.style.height = '${spacerHeight}px';
+      spacer.append(_createSnapTarget(spacerHeight ~/ 2));
+    }
+
+    domDocument.documentElement!.append(spacer);
+  }
+
+  DomElement _createSnapTarget(int topOffset) {
+    final DomElement target = createDomElement('flt-scroll-snap-target');
+    target.style
       ..position = 'absolute'
-      ..top = '${spacerHeight ~/ 2}px'
+      ..top = '${topOffset}px'
       ..left = '0'
       ..width = '1px'
       ..height = '1px'
       ..setProperty('scroll-snap-align', 'start');
-    spacer.append(snapTarget);
+    return target;
   }
 
   /// Blocks touch-type Pointer Events from reaching [PointerBinding].

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/address_bar_controller.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/address_bar_controller.dart
@@ -191,8 +191,7 @@ class AddressBarController {
       for (final DomTouch touch in te.changedTouches) {
         final int id = touch.identifier!.toInt();
         _activeTouchIds.add(id);
-        final ui.Offset offset = _touchOffset(touch);
-        _sendPointerData(ui.PointerChange.down, ts, id, offset, 1);
+        _sendPointerData(ui.PointerChange.down, ts, id, touch.clientX, touch.clientY, 1);
       }
     });
 
@@ -204,8 +203,7 @@ class AddressBarController {
         if (!_activeTouchIds.contains(id)) {
           continue;
         }
-        final ui.Offset offset = _touchOffset(touch);
-        _sendPointerData(ui.PointerChange.move, ts, id, offset, 1);
+        _sendPointerData(ui.PointerChange.move, ts, id, touch.clientX, touch.clientY, 1);
       }
     });
 
@@ -217,8 +215,7 @@ class AddressBarController {
         if (!_activeTouchIds.remove(id)) {
           continue;
         }
-        final ui.Offset offset = _touchOffset(touch);
-        _sendPointerData(ui.PointerChange.up, ts, id, offset, 0);
+        _sendPointerData(ui.PointerChange.up, ts, id, touch.clientX, touch.clientY, 0);
       }
     });
 
@@ -230,22 +227,19 @@ class AddressBarController {
         if (!_activeTouchIds.remove(id)) {
           continue;
         }
-        final ui.Offset offset = _touchOffset(touch);
-        _sendPointerData(ui.PointerChange.cancel, ts, id, offset, 0);
+        _sendPointerData(ui.PointerChange.cancel, ts, id, touch.clientX, touch.clientY, 0);
       }
     });
   }
 
-  ui.Offset _touchOffset(DomTouch touch) {
-    final DomRect rect = _view.dom.rootElement.getBoundingClientRect();
-    return ui.Offset(touch.clientX - rect.x, touch.clientY - rect.y);
-  }
-
+  // In full-page mode the host element is position:fixed at (0,0),
+  // so clientX/clientY are already root-relative.
   void _sendPointerData(
     ui.PointerChange change,
     num eventTimeStamp,
     int device,
-    ui.Offset offset,
+    double clientX,
+    double clientY,
     int buttons,
   ) {
     final int ms = eventTimeStamp.toInt();
@@ -262,8 +256,8 @@ class AddressBarController {
       timeStamp: timeStamp,
       signalKind: ui.PointerSignalKind.none,
       device: device,
-      physicalX: offset.dx * dpr,
-      physicalY: offset.dy * dpr,
+      physicalX: clientX * dpr,
+      physicalY: clientY * dpr,
       buttons: buttons,
       pressure: buttons > 0 ? 1.0 : 0.0,
       pressureMax: 1.0,

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/address_bar_controller.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/address_bar_controller.dart
@@ -1,0 +1,242 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:js_interop';
+
+import 'package:ui/ui.dart' as ui;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
+
+import 'dom.dart';
+import 'platform_dispatcher.dart';
+import 'pointer_converter.dart';
+import 'view_embedder/embedding_strategy/full_page_embedding_strategy.dart';
+import 'window.dart';
+
+typedef _ListenerRecord = ({
+  DomEventTarget target,
+  String type,
+  DomEventListener listener,
+  JSAny options,
+});
+
+/// Enables iOS browser address bar collapse for Flutter web apps.
+///
+/// The browser collapses the address bar only when it detects a
+/// user-initiated scroll, which requires `touch-action` to not be `none`.
+/// However, changing `touch-action` causes the browser to fire
+/// `pointercancel` during vertical scroll, breaking [PointerBinding]'s
+/// gesture stream.
+///
+/// This class works around the issue by blocking touch-type Pointer Events
+/// and handling finger input via Touch Events instead. Touch Events are
+/// independent of Pointer Events and continue after `pointercancel`.
+/// Mouse and pen Pointer Events are not blocked — [PointerBinding] handles
+/// them normally.
+///
+/// Only active for full-page embedding on iOS. On other platforms or with
+/// a custom host element, the constructor is a no-op.
+///
+/// See https://github.com/flutter/flutter/issues/69529
+class AddressBarController {
+  AddressBarController(this._view) : _pointerDataConverter = PointerDataConverter() {
+    if (!_isSupported) {
+      return;
+    }
+
+    domDocument.body!.style
+      ..overflowY = 'auto'
+      ..setProperty('touch-action', 'pan-y');
+
+    _setupSpacer();
+    _blockTouchPointerEvents();
+    _setupTouchHandlers();
+  }
+
+  static const int spacerHeight = 10000;
+
+  final EngineFlutterView _view;
+  final PointerDataConverter _pointerDataConverter;
+
+  bool get _isSupported =>
+      ui_web.browser.operatingSystem == ui_web.OperatingSystem.iOs &&
+      _view.embeddingStrategy is FullPageEmbeddingStrategy;
+
+  final Set<int> _activeTouchIds = <int>{};
+  final List<_ListenerRecord> _listeners = [];
+
+  DomElement? _spacerElement;
+
+  void dispose() {
+    if (!_isSupported) {
+      return;
+    }
+    for (final _ListenerRecord r in _listeners) {
+      r.target.removeEventListener(r.type, r.listener, r.options);
+    }
+    _listeners.clear();
+    _spacerElement?.remove();
+    domDocument.body!.style
+      ..overflowY = 'hidden'
+      ..setProperty('touch-action', 'none');
+    domDocument.documentElement!.style
+      ..setProperty('scroll-snap-type', '')
+      ..setProperty('scrollbar-width', '');
+  }
+
+  /// Appends a tall invisible element under `<html>` to provide scroll room.
+  ///
+  /// `scroll-snap-type: y mandatory` on `<html>` with a snap point at the
+  /// center prevents iOS Safari from momentum-scrolling, which would block
+  /// touch event delivery until momentum stops.
+  void _setupSpacer() {
+    domDocument.documentElement!.style
+      ..setProperty('scroll-snap-type', 'y mandatory')
+      ..setProperty('scrollbar-width', 'none');
+
+    final DomElement spacer = createDomElement('flt-scroll-spacer');
+    spacer.style
+      ..position = 'absolute'
+      ..top = '0'
+      ..left = '0'
+      ..width = '1px'
+      ..height = '${spacerHeight}px'
+      ..pointerEvents = 'none'
+      ..opacity = '0';
+    _spacerElement = spacer;
+    domDocument.documentElement!.append(spacer);
+
+    final DomElement snapTarget = createDomElement('flt-scroll-snap-target');
+    snapTarget.style
+      ..position = 'absolute'
+      ..top = '${spacerHeight ~/ 2}px'
+      ..left = '0'
+      ..width = '1px'
+      ..height = '1px'
+      ..setProperty('scroll-snap-align', 'start');
+    spacer.append(snapTarget);
+  }
+
+  /// Blocks touch-type Pointer Events from reaching [PointerBinding].
+  ///
+  /// Only `pointerType === 'touch'` is blocked. Mouse and pen events pass
+  /// through to [PointerBinding] unchanged, preserving pressure, tilt, and
+  /// other Pointer Event features.
+  void _blockTouchPointerEvents() {
+    final DomElement root = _view.dom.rootElement;
+    const pointerEventTypes = <String>[
+      'pointerdown',
+      'pointermove',
+      'pointerup',
+      'pointercancel',
+      'pointerleave',
+    ];
+    final JSAny options = DomEventListenerOptions(capture: true);
+    for (final type in pointerEventTypes) {
+      final DomEventListener listener = createDomEventListener((DomEvent event) {
+        final pe = event as DomPointerEvent;
+        if (pe.pointerType == 'touch') {
+          event.stopImmediatePropagation();
+        }
+      });
+      root.addEventListener(type, listener, options);
+      _listeners.add((target: root, type: type, listener: listener, options: options));
+    }
+  }
+
+  void _setupTouchHandlers() {
+    final DomElement root = _view.dom.rootElement;
+    final JSAny options = DomEventListenerOptions(passive: true);
+
+    void listen(String type, DartDomEventListener handler) {
+      final DomEventListener listener = createDomEventListener(handler);
+      root.addEventListener(type, listener, options);
+      _listeners.add((target: root, type: type, listener: listener, options: options));
+    }
+
+    listen('touchstart', (DomEvent event) {
+      final te = event as DomTouchEvent;
+      final num ts = te.timeStamp!;
+      for (final DomTouch touch in te.changedTouches) {
+        final int id = touch.identifier!.toInt();
+        _activeTouchIds.add(id);
+        final ui.Offset offset = _touchOffset(touch);
+        _sendPointerData(ui.PointerChange.down, ts, id, offset, 1);
+      }
+    });
+
+    listen('touchmove', (DomEvent event) {
+      final te = event as DomTouchEvent;
+      final num ts = te.timeStamp!;
+      for (final DomTouch touch in te.changedTouches) {
+        final int id = touch.identifier!.toInt();
+        if (!_activeTouchIds.contains(id)) {
+          continue;
+        }
+        final ui.Offset offset = _touchOffset(touch);
+        _sendPointerData(ui.PointerChange.move, ts, id, offset, 1);
+      }
+    });
+
+    listen('touchend', (DomEvent event) {
+      final te = event as DomTouchEvent;
+      final num ts = te.timeStamp!;
+      for (final DomTouch touch in te.changedTouches) {
+        final int id = touch.identifier!.toInt();
+        if (!_activeTouchIds.remove(id)) {
+          continue;
+        }
+        final ui.Offset offset = _touchOffset(touch);
+        _sendPointerData(ui.PointerChange.up, ts, id, offset, 0);
+      }
+    });
+
+    listen('touchcancel', (DomEvent event) {
+      final te = event as DomTouchEvent;
+      final num ts = te.timeStamp!;
+      for (final DomTouch touch in te.changedTouches) {
+        final int id = touch.identifier!.toInt();
+        if (!_activeTouchIds.remove(id)) {
+          continue;
+        }
+        final ui.Offset offset = _touchOffset(touch);
+        _sendPointerData(ui.PointerChange.cancel, ts, id, offset, 0);
+      }
+    });
+  }
+
+  ui.Offset _touchOffset(DomTouch touch) {
+    final DomRect rect = _view.dom.rootElement.getBoundingClientRect();
+    return ui.Offset(touch.clientX - rect.x, touch.clientY - rect.y);
+  }
+
+  void _sendPointerData(
+    ui.PointerChange change,
+    num eventTimeStamp,
+    int device,
+    ui.Offset offset,
+    int buttons,
+  ) {
+    final int ms = eventTimeStamp.toInt();
+    final timeStamp = Duration(
+      milliseconds: ms,
+      microseconds: ((eventTimeStamp - ms) * Duration.microsecondsPerMillisecond).toInt(),
+    );
+    final data = <ui.PointerData>[];
+    final double dpr = _view.devicePixelRatio;
+    _pointerDataConverter.convert(
+      data,
+      viewId: _view.viewId,
+      change: change,
+      timeStamp: timeStamp,
+      signalKind: ui.PointerSignalKind.none,
+      device: device,
+      physicalX: offset.dx * dpr,
+      physicalY: offset.dy * dpr,
+      buttons: buttons,
+      pressure: buttons > 0 ? 1.0 : 0.0,
+      pressureMax: 1.0,
+    );
+    EnginePlatformDispatcher.instance.invokeOnPointerDataPacket(ui.PointerDataPacket(data: data));
+  }
+}

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/address_bar_controller.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/address_bar_controller.dart
@@ -204,14 +204,14 @@ class AddressBarController {
 
   void _setupTouchTranslation() {
     final options = DomEventListenerOptions(passive: true);
-    _touchEventChanges.forEach((String touchEventType, ui.PointerChange change) {
+    for (final MapEntry<String, ui.PointerChange> entry in _touchEventChanges.entries) {
       _addListener(
         _view.dom.rootElement,
-        touchEventType,
-        (DomEvent event) => _translateTouchEvent(event as DomTouchEvent, change),
+        entry.key,
+        (DomEvent event) => _translateTouchEvent(event as DomTouchEvent, entry.value),
         options,
       );
-    });
+    }
     // On the window, where [PointerBinding] also listens for moves in full-page
     // mode.
     _addListener(domWindow, 'pointerrawupdate', _translateRawUpdate, options);

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/address_bar_controller.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/address_bar_controller.dart
@@ -1,0 +1,401 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:ui/ui.dart' as ui;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
+
+import 'dom.dart';
+import 'platform_dispatcher.dart';
+import 'pointer_binding.dart';
+import 'pointer_converter.dart';
+import 'semantics.dart';
+import 'view_embedder/embedding_strategy/full_page_embedding_strategy.dart';
+import 'window.dart';
+
+/// Enables mobile browser address bar collapse for Flutter web apps.
+///
+/// Flutter web sets `touch-action: none` on `<body>`, preventing the browser
+/// from detecting scrolls. On Android and iOS, for a full-page app, this class
+/// sets `touch-action: pan-y` and adds a spacer to make the page scrollable,
+/// which is what the browser needs before it will collapse its address bar.
+///
+/// Under `pan-y` the browser fires `pointercancel` and stops reporting a finger
+/// as soon as it claims a vertical drag for scrolling, but Touch Events keep
+/// firing. So for touch input this class translates Touch Events into pointer
+/// data and sends it to the framework itself. The browser throttles `touchmove`
+/// while it is scrolling, so movement is taken from `pointerrawupdate` where it
+/// can be — the browser has to fire it, and only one finger can be down, since a
+/// raw update carries no id to match it to a contact. Mouse and stylus Pointer
+/// Events are not intercepted and still go through `PointerBinding`.
+///
+/// The view is painted to the viewport with the address bar collapsed, so its
+/// size does not change as the bar animates. What the bar covers is reported
+/// through [EngineFlutterView.updateChromeInsets] as padding instead.
+///
+/// See: https://github.com/flutter/flutter/issues/69529
+class AddressBarController {
+  AddressBarController(EngineFlutterView view)
+    : _view = view,
+      _isActive = _computeIsSupported(view) {
+    if (!_isActive) {
+      return;
+    }
+
+    _setupScrollMachinery();
+    _setupTouchTranslation();
+    _setupNativePointerEventInterception();
+    _measureChromeInsets(0);
+  }
+
+  final EngineFlutterView _view;
+
+  final bool _isActive;
+
+  static bool get isSupportedOperatingSystem => switch (ui_web.browser.operatingSystem) {
+    ui_web.OperatingSystem.android || ui_web.OperatingSystem.iOs => true,
+    _ => false,
+  };
+
+  static bool _computeIsSupported(EngineFlutterView view) =>
+      isSupportedOperatingSystem && view.embeddingStrategy is FullPageEmbeddingStrategy;
+
+  DomElement? _spacerElement;
+
+  void dispose() {
+    _cancelActiveTouches();
+    _removeListeners();
+    _spacerElement?.remove();
+  }
+
+  /// Makes the page scrollable so the browser collapses the address bar on
+  /// scroll.
+  void _setupScrollMachinery() {
+    final DomCSSStyleDeclaration bodyStyle = domDocument.body!.style;
+    // Propagates to the viewport, undoing the embedding strategy's `hidden`.
+    bodyStyle.setProperty('overflow-y', 'auto');
+    bodyStyle.setProperty('touch-action', 'pan-y');
+    bodyStyle.setProperty('height', '100vh');
+
+    final DomElement spacer = createDomElement('flt-scroll-spacer');
+    spacer.style
+      ..position = 'absolute'
+      ..top = '0'
+      ..left = '0'
+      ..width = '1px'
+      ..pointerEvents = 'none'
+      ..opacity = '0';
+    _spacerElement = spacer;
+
+    final DomCSSStyleDeclaration htmlStyle = domDocument.documentElement!.style;
+    htmlStyle.setProperty('scrollbar-width', 'none');
+
+    switch (ui_web.browser.operatingSystem) {
+      case ui_web.OperatingSystem.android:
+        // Chrome does not collapse the address bar under `mandatory`. The range
+        // must also stay short: `100lvh` is the viewport with the chrome hidden
+        // and the scrollport is the viewport with it showing, so this is the
+        // chrome's height plus a pixel. Anything taller keeps scrolling the page
+        // after the chrome is gone.
+        htmlStyle.setProperty('scroll-snap-type', 'y proximity');
+        spacer.style.height = 'calc(100lvh + 1px)';
+        spacer.append(_createSnapTarget(1));
+      case ui_web.OperatingSystem.iOs:
+        // On iOS the snapping is for the scroll range, not the bar: `mandatory`
+        // parks the page in the middle of a tall spacer, out of reach of
+        // pull-to-refresh and rubber-banding (`overscroll-behavior` does not
+        // prevent them there), and it cuts Safari's momentum scrolling short.
+        htmlStyle.setProperty('scroll-snap-type', 'y mandatory');
+        const spacerHeight = 10000;
+        spacer.style.height = '${spacerHeight}px';
+        spacer.append(_createSnapTarget(spacerHeight ~/ 2));
+      default:
+      // not supported
+    }
+
+    domDocument.documentElement!.append(spacer);
+  }
+
+  /// Called by [EngineFlutterView] on every browser resize, after it has
+  /// recomputed `viewInsets`.
+  void handleBrowserResize(ViewPadding viewInsets) {
+    if (!_isActive) {
+      return;
+    }
+    _measureChromeInsets(viewInsets.bottom);
+  }
+
+  void _measureChromeInsets(double keyboardInset) {
+    final double dpr = _view.devicePixelRatio;
+    final double bodyHeight = domDocument.body!.getBoundingClientRect().height;
+    // The body's box is the viewport with the bar collapsed and the layout
+    // viewport is the viewport with it showing, neither of which the keyboard
+    // changes, so their difference is the strip the bar covers when it is out.
+    final double barHeight =
+        math.max(0.0, bodyHeight - domDocument.documentElement!.clientHeight) * dpr;
+    // What it covers at this moment. The visual viewport is preferred over
+    // `innerHeight`, which keeps the value it had when the gesture started until
+    // the finger lifts. It shrinks for the keyboard too, which is already
+    // reported as an inset, and for a pinch zoom, which `scale` takes back out.
+    final DomVisualViewport? viewport = domWindow.visualViewport;
+    final double visibleHeight = viewport == null
+        ? domWindow.innerHeight!
+        : viewport.height! * (viewport.scale ?? 1);
+    final double covered = math.max(0.0, (bodyHeight - visibleHeight) * dpr - keyboardInset);
+    _view.updateChromeInsets(
+      padding: ViewPadding(bottom: math.min(covered, barHeight), left: 0, right: 0, top: 0),
+      viewPadding: ViewPadding(bottom: barHeight, left: 0, right: 0, top: 0),
+    );
+  }
+
+  DomElement _createSnapTarget(int topOffset) {
+    final DomElement target = createDomElement('flt-scroll-snap-target');
+    target.style
+      ..position = 'absolute'
+      ..top = '${topOffset}px'
+      ..left = '0'
+      ..width = '1px'
+      ..height = '1px'
+      ..setProperty('scroll-snap-align', 'start');
+    return target;
+  }
+
+  final List<_ListenerRegistration> _listenerRegistrations = <_ListenerRegistration>[];
+
+  final Set<int> _activeTouchIds = <int>{};
+  final PointerDataConverter _pointerDataConverter = PointerDataConverter();
+
+  static const Map<String, ui.PointerChange> _touchEventChanges = <String, ui.PointerChange>{
+    'touchstart': ui.PointerChange.down,
+    'touchmove': ui.PointerChange.move,
+    'touchend': ui.PointerChange.up,
+    'touchcancel': ui.PointerChange.cancel,
+  };
+
+  /// The pointer events the Touch Event translation replaces.
+  static const List<String> _interceptedPointerEventTypes = <String>[
+    'pointerdown',
+    'pointermove',
+    'pointerup',
+    'pointercancel',
+    'pointerleave',
+  ];
+
+  void _addListener(
+    DomEventTarget target,
+    String type,
+    DartDomEventListener handler,
+    DomEventListenerOptions options,
+  ) {
+    final DomEventListener listener = createDomEventListener(handler);
+    target.addEventListener(type, listener, options);
+    _listenerRegistrations.add((target: target, type: type, listener: listener));
+  }
+
+  void _removeListeners() {
+    for (final _ListenerRegistration registration in _listenerRegistrations) {
+      registration.target.removeEventListener(registration.type, registration.listener);
+    }
+    _listenerRegistrations.clear();
+  }
+
+  void _setupTouchTranslation() {
+    final options = DomEventListenerOptions(passive: true);
+    _touchEventChanges.forEach((String touchEventType, ui.PointerChange change) {
+      _addListener(
+        _view.dom.rootElement,
+        touchEventType,
+        (DomEvent event) => _translateTouchEvent(event as DomTouchEvent, change),
+        options,
+      );
+    });
+    // On the window, where [PointerBinding] also listens for moves in full-page
+    // mode.
+    _addListener(domWindow, 'pointerrawupdate', _translateRawUpdate, options);
+  }
+
+  /// The contact whose movement `pointerrawupdate` is reporting, making its
+  /// `touchmove` redundant. Which browsers send raw updates is decided by what
+  /// arrives rather than by feature detection.
+  int? _rawUpdatedContact;
+
+  void _translateRawUpdate(DomEvent event) {
+    final pointerEvent = event as DomPointerEvent;
+    // Only while a single finger is down. A raw update carries no id this
+    // translation can match to a contact, so with more than one down there is no
+    // telling which finger moved; their `touchmove`s, which do carry ids, take
+    // over.
+    if (pointerEvent.pointerType != 'touch' || _activeTouchIds.length != 1) {
+      return;
+    }
+    // Not reported to semantics: it neither consumes `pointerrawupdate` nor
+    // counts it towards the gesture mode, and the contact's Touch Events are
+    // reported already.
+    final int device = _activeTouchIds.first;
+    _rawUpdatedContact = device;
+    final data = <ui.PointerData>[];
+    final double dpr = _view.devicePixelRatio;
+    _pointerDataConverter.convert(
+      data,
+      viewId: _view.viewId,
+      change: ui.PointerChange.move,
+      timeStamp: _durationFromMilliseconds(pointerEvent.timeStamp!),
+      device: device,
+      physicalX: pointerEvent.clientX * dpr,
+      physicalY: pointerEvent.clientY * dpr,
+      buttons: 1,
+      pressure: pointerEvent.pressure ?? _fingerPressure,
+      pressureMax: 1.0,
+    );
+    PointerBinding.clickDebouncer.onPointerData(pointerEvent, data);
+  }
+
+  /// Stops the touch-type pointer events that the Touch Event translation
+  /// replaces from reaching [PointerBinding].
+  ///
+  /// `stopImmediatePropagation`, not `stopPropagation`: [PointerBinding] listens
+  /// on this element too, and only the immediate form withholds the events from
+  /// it, which works because [EngineFlutterView] constructs this controller
+  /// first. Stopping here also keeps them from the window, where
+  /// [PointerBinding] takes moves and ups. The bubble phase, rather than capture
+  /// on the window, leaves platform views and native text fields their events.
+  void _setupNativePointerEventInterception() {
+    // Not passive: the handler calls `preventDefault`.
+    final options = DomEventListenerOptions(passive: false);
+    for (final String pointerEventType in _interceptedPointerEventTypes) {
+      _addListener(_view.dom.rootElement, pointerEventType, _interceptNativePointerEvent, options);
+    }
+  }
+
+  /// The withheld pointer events, kept for the translation to hand to
+  /// [ClickDebouncer] as the source of the data it derives from them.
+  ///
+  /// The browser fires each one just before the Touch event it is translated
+  /// from, so the entry is always this gesture's.
+  final Map<String, DomEvent> _withheldPointerEvents = <String, DomEvent>{};
+
+  void _interceptNativePointerEvent(DomEvent event) {
+    final pointerEvent = event as DomPointerEvent;
+    if (pointerEvent.pointerType != 'touch') {
+      return;
+    }
+    if (pointerEvent.type == 'pointerdown') {
+      _withheldPointerEvents.clear();
+    }
+    _withheldPointerEvents[pointerEvent.type] = pointerEvent;
+    if (pointerEvent.type == 'pointerdown' &&
+        pointerEvent.target == _view.dom.rootElement &&
+        EngineSemantics.instance.receiveGlobalEvent(event)) {
+      // What PointerBinding's pointerdown handler does, which this interception
+      // stops from running, under the semantics gate that wraps it there:
+      // suppress the browser's focus handling and ask for the view's focus a
+      // turn later.
+      pointerEvent.preventDefault();
+      Timer(Duration.zero, () {
+        EnginePlatformDispatcher.instance.requestViewFocusChange(
+          viewId: _view.viewId,
+          state: ui.ViewFocusState.focused,
+          direction: ui.ViewFocusDirection.undefined,
+        );
+      });
+    }
+    pointerEvent.stopImmediatePropagation();
+  }
+
+  void _translateTouchEvent(DomTouchEvent event, ui.PointerChange change) {
+    // As in _translateRawUpdate, except that only a new contact is withheld: one
+    // already reported as down has to be closed out, or the framework keeps
+    // waiting for a finger that is gone.
+    final bool accepted = EngineSemantics.instance.receiveGlobalEvent(event);
+    if (!accepted && change == ui.PointerChange.down) {
+      return;
+    }
+    final bool isDown = change == ui.PointerChange.down || change == ui.PointerChange.move;
+    final double dpr = _view.devicePixelRatio;
+    final Duration timeStamp = _durationFromMilliseconds(event.timeStamp!);
+    for (final DomTouch touch in event.changedTouches) {
+      final int device = touch.identifier!.toInt();
+      if (change == ui.PointerChange.down) {
+        if (_activeTouchIds.contains(device)) {
+          continue;
+        }
+        _activeTouchIds.add(device);
+        if (_activeTouchIds.length > 1) {
+          _rawUpdatedContact = null;
+        }
+      } else if (!_activeTouchIds.contains(device)) {
+        continue;
+      } else if (change == ui.PointerChange.move) {
+        if (device == _rawUpdatedContact) {
+          // Already reported by `pointerrawupdate`, with less latency. Cleared
+          // as it is consumed, so that a gesture whose raw updates stop coming
+          // falls back to the next `touchmove`.
+          _rawUpdatedContact = null;
+          continue;
+        }
+      } else {
+        _activeTouchIds.remove(device);
+        _rawUpdatedContact = null;
+      }
+      final data = <ui.PointerData>[];
+      _pointerDataConverter.convert(
+        data,
+        viewId: _view.viewId,
+        change: change,
+        timeStamp: timeStamp,
+        device: device,
+        // In full-page mode the host is position:fixed at (0,0), so clientX/Y
+        // are already root-relative.
+        physicalX: touch.clientX * dpr,
+        physicalY: touch.clientY * dpr,
+        buttons: isDown ? 1 : 0,
+        pressure: isDown ? _fingerPressure : 0.0,
+        pressureMax: 1.0,
+      );
+      // The withheld pointer event this data stands in for, so that the
+      // debouncer sees the type and target it keys on. The Touch event is the
+      // fallback for a phase the browser did not report as a pointer event, and
+      // is inert to the debouncer.
+      final DomEvent source = switch (change) {
+        ui.PointerChange.down => _withheldPointerEvents['pointerdown'] ?? event,
+        ui.PointerChange.up => _withheldPointerEvents['pointerup'] ?? event,
+        ui.PointerChange.cancel => _withheldPointerEvents['pointercancel'] ?? event,
+        _ => event,
+      };
+      PointerBinding.clickDebouncer.onPointerData(source, data);
+    }
+  }
+
+  /// What a touch-type Pointer Event reports for a finger on hardware that
+  /// cannot measure pressure.
+  static const double _fingerPressure = 0.5;
+
+  static Duration _durationFromMilliseconds(num milliseconds) {
+    final int ms = milliseconds.toInt();
+    final int micro = ((milliseconds - ms) * Duration.microsecondsPerMillisecond).toInt();
+    return Duration(milliseconds: ms, microseconds: micro);
+  }
+
+  /// Cancels touches still down, so no phantom pointers outlive the translation.
+  void _cancelActiveTouches() {
+    if (_activeTouchIds.isEmpty) {
+      return;
+    }
+    final data = <ui.PointerData>[];
+    for (final int device in _activeTouchIds) {
+      // `convert` defaults to a cancel, for which it substitutes the pointer's
+      // last known location.
+      _pointerDataConverter.convert(data, viewId: _view.viewId, device: device);
+    }
+    _activeTouchIds.clear();
+    _rawUpdatedContact = null;
+    // `flushAndSend` flushes first, so a pending `down` reaches the framework
+    // before the cancel that closes it out.
+    PointerBinding.clickDebouncer.flushAndSend(data);
+  }
+}
+
+typedef _ListenerRegistration = ({DomEventTarget target, String type, DomEventListener listener});

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/dom.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/dom.dart
@@ -387,6 +387,7 @@ extension type DomEvent._(JSObject _) implements JSObject {
 
   external void preventDefault();
   external void stopPropagation();
+  external void stopImmediatePropagation();
 
   @JS('initEvent')
   external void _initEvent(String type, [bool bubbles, bool cancelable]);

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/dom.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/dom.dart
@@ -387,7 +387,6 @@ extension type DomEvent._(JSObject _) implements JSObject {
 
   external void preventDefault();
   external void stopPropagation();
-  external void stopImmediatePropagation();
 
   @JS('initEvent')
   external void _initEvent(String type, [bool bubbles, bool cancelable]);
@@ -2006,6 +2005,7 @@ extension type DomTouch._(JSObject _) implements JSObject {
   external double? get identifier;
   external double get clientX;
   external double get clientY;
+  external DomEventTarget? get target;
 
   DomPoint get client => DomPoint(clientX, clientY);
 }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/dom.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/dom.dart
@@ -468,6 +468,7 @@ extension type DomEvent._(JSObject _) implements JSObject {
 
   external void preventDefault();
   external void stopPropagation();
+  external void stopImmediatePropagation();
 
   @JS('initEvent')
   external void _initEvent(String type, [bool bubbles, bool cancelable]);

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/full_page_dimensions_provider.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/full_page_dimensions_provider.dart
@@ -3,7 +3,9 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:math' as math;
 
+import 'package:ui/src/engine/address_bar_controller.dart';
 import 'package:ui/src/engine/display.dart';
 import 'package:ui/src/engine/dom.dart';
 import 'package:ui/src/engine/window.dart';
@@ -70,22 +72,19 @@ class FullPageDimensionsProvider extends DimensionsProvider {
 
     if (viewport != null) {
       if (ui_web.browser.operatingSystem == ui_web.OperatingSystem.iOs) {
-        // Chrome on iOS reports incorrect viewport.width when the app starts
-        // in portrait and is rotated to landscape.  clientWidth is reliable.
-        // See: https://github.com/flutter/flutter/issues/81430
+        // Chrome on iOS reports an incorrect viewport.width when the app
+        // starts in portrait orientation and the phone is rotated to
+        // landscape, so the width is read from documentElement's clientWidth.
         windowInnerWidth = domDocument.documentElement!.clientWidth * devicePixelRatio;
       } else {
         windowInnerWidth = viewport.width! * devicePixelRatio;
       }
 
-      if (ui_web.browser.isMobile) {
-        // innerHeight tracks address bar collapse without firing
-        // intermediate values during the animation, unlike viewport.height.
-        // See: https://github.com/flutter/flutter/issues/69529
-        windowInnerHeight = domWindow.innerHeight! * devicePixelRatio;
-      } else {
-        windowInnerHeight = viewport.height! * devicePixelRatio;
-      }
+      windowInnerHeight = _physicalInnerHeight(
+        viewport,
+        devicePixelRatio,
+        preferInnerHeight: AddressBarController.isSupportedOperatingSystem,
+      );
     } else {
       windowInnerWidth = domWindow.innerWidth! * devicePixelRatio;
       windowInnerHeight = domWindow.innerHeight! * devicePixelRatio;
@@ -100,17 +99,37 @@ class FullPageDimensionsProvider extends DimensionsProvider {
     late double windowInnerHeight;
 
     if (viewport != null) {
-      if (ui_web.browser.isMobile && !isEditingOnMobile) {
-        // Match computePhysicalSize() which uses innerHeight on mobile.
-        windowInnerHeight = domWindow.innerHeight! * devicePixelRatio;
-      } else {
-        windowInnerHeight = viewport.height! * devicePixelRatio;
-      }
+      // Match computePhysicalSize; while editing, the visual viewport shrinks
+      // for the keyboard, so its height is used instead of innerHeight.
+      windowInnerHeight = _physicalInnerHeight(
+        viewport,
+        devicePixelRatio,
+        preferInnerHeight: AddressBarController.isSupportedOperatingSystem && !isEditingOnMobile,
+      );
     } else {
       windowInnerHeight = domWindow.innerHeight! * devicePixelRatio;
     }
-    final double bottomPadding = physicalHeight - windowInnerHeight;
+    // The address bar can collapse while editing, growing the viewport past
+    // the preserved physical height.
+    final double bottomPadding = math.max(0.0, physicalHeight - windowInnerHeight);
 
     return ViewPadding(bottom: bottomPadding, left: 0, right: 0, top: 0);
+  }
+
+  /// The physical height of the view, read from either `window.innerHeight` or
+  /// the visual viewport.
+  ///
+  /// On mobile, `innerHeight` tracks the address bar collapse without firing the
+  /// intermediate values that `visualViewport.height` produces during the
+  /// animation, so it is preferred when [preferInnerHeight] is true. The visual
+  /// viewport height is used otherwise (e.g. while editing, when it shrinks for
+  /// the on-screen keyboard).
+  double _physicalInnerHeight(
+    DomVisualViewport viewport,
+    double devicePixelRatio, {
+    required bool preferInnerHeight,
+  }) {
+    final double height = preferInnerHeight ? domWindow.innerHeight! : viewport.height!;
+    return height * devicePixelRatio;
   }
 }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/full_page_dimensions_provider.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/full_page_dimensions_provider.dart
@@ -74,13 +74,16 @@ class FullPageDimensionsProvider extends DimensionsProvider {
         // in portrait and is rotated to landscape.  clientWidth is reliable.
         // See: https://github.com/flutter/flutter/issues/81430
         windowInnerWidth = domDocument.documentElement!.clientWidth * devicePixelRatio;
+      } else {
+        windowInnerWidth = viewport.width! * devicePixelRatio;
+      }
 
-        // innerHeight tracks address bar collapse and is not affected by
-        // the on-screen keyboard (unlike viewport.height).
+      if (ui_web.browser.isMobile) {
+        // innerHeight tracks address bar collapse without firing
+        // intermediate values during the animation, unlike viewport.height.
         // See: https://github.com/flutter/flutter/issues/69529
         windowInnerHeight = domWindow.innerHeight! * devicePixelRatio;
       } else {
-        windowInnerWidth = viewport.width! * devicePixelRatio;
         windowInnerHeight = viewport.height! * devicePixelRatio;
       }
     } else {
@@ -97,9 +100,8 @@ class FullPageDimensionsProvider extends DimensionsProvider {
     late double windowInnerHeight;
 
     if (viewport != null) {
-      if (ui_web.browser.operatingSystem == ui_web.OperatingSystem.iOs && !isEditingOnMobile) {
-        // Match computePhysicalSize() which uses innerHeight on iOS.
-        // See: https://github.com/flutter/flutter/issues/69529
+      if (ui_web.browser.isMobile && !isEditingOnMobile) {
+        // Match computePhysicalSize() which uses innerHeight on mobile.
         windowInnerHeight = domWindow.innerHeight! * devicePixelRatio;
       } else {
         windowInnerHeight = viewport.height! * devicePixelRatio;

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/full_page_dimensions_provider.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/full_page_dimensions_provider.dart
@@ -70,18 +70,15 @@ class FullPageDimensionsProvider extends DimensionsProvider {
 
     if (viewport != null) {
       if (ui_web.browser.operatingSystem == ui_web.OperatingSystem.iOs) {
-        /// Chrome on iOS reports incorrect viewport.height when app
-        /// starts in portrait orientation and the phone is rotated to
-        /// landscape.
-        ///
-        /// We instead use documentElement clientWidth/Height to read
-        /// accurate physical size. VisualViewport api is only used during
-        /// text editing to make sure inset is correctly reported to
-        /// framework.
-        final double docWidth = domDocument.documentElement!.clientWidth;
-        final double docHeight = domDocument.documentElement!.clientHeight;
-        windowInnerWidth = docWidth * devicePixelRatio;
-        windowInnerHeight = docHeight * devicePixelRatio;
+        // Chrome on iOS reports incorrect viewport.width when the app starts
+        // in portrait and is rotated to landscape.  clientWidth is reliable.
+        // See: https://github.com/flutter/flutter/issues/81430
+        windowInnerWidth = domDocument.documentElement!.clientWidth * devicePixelRatio;
+
+        // innerHeight tracks address bar collapse and is not affected by
+        // the on-screen keyboard (unlike viewport.height).
+        // See: https://github.com/flutter/flutter/issues/69529
+        windowInnerHeight = domWindow.innerHeight! * devicePixelRatio;
       } else {
         windowInnerWidth = viewport.width! * devicePixelRatio;
         windowInnerHeight = viewport.height! * devicePixelRatio;
@@ -101,7 +98,9 @@ class FullPageDimensionsProvider extends DimensionsProvider {
 
     if (viewport != null) {
       if (ui_web.browser.operatingSystem == ui_web.OperatingSystem.iOs && !isEditingOnMobile) {
-        windowInnerHeight = domDocument.documentElement!.clientHeight * devicePixelRatio;
+        // Match computePhysicalSize() which uses innerHeight on iOS.
+        // See: https://github.com/flutter/flutter/issues/69529
+        windowInnerHeight = domWindow.innerHeight! * devicePixelRatio;
       } else {
         windowInnerHeight = viewport.height! * devicePixelRatio;
       }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/full_page_dimensions_provider.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/full_page_dimensions_provider.dart
@@ -4,11 +4,11 @@
 
 import 'dart:async';
 
+import 'package:ui/src/engine/address_bar_controller.dart';
 import 'package:ui/src/engine/display.dart';
 import 'package:ui/src/engine/dom.dart';
 import 'package:ui/src/engine/window.dart';
 import 'package:ui/ui.dart' as ui show Size;
-import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 import 'dimensions_provider.dart';
 
@@ -69,19 +69,18 @@ class FullPageDimensionsProvider extends DimensionsProvider {
     final double devicePixelRatio = EngineFlutterDisplay.instance.devicePixelRatio;
 
     if (viewport != null) {
-      if (ui_web.browser.operatingSystem == ui_web.OperatingSystem.iOs) {
-        /// Chrome on iOS reports incorrect viewport.height when app
-        /// starts in portrait orientation and the phone is rotated to
-        /// landscape.
-        ///
-        /// We instead use documentElement clientWidth/Height to read
-        /// accurate physical size. VisualViewport api is only used during
-        /// text editing to make sure inset is correctly reported to
-        /// framework.
-        final double docWidth = domDocument.documentElement!.clientWidth;
-        final double docHeight = domDocument.documentElement!.clientHeight;
-        windowInnerWidth = docWidth * devicePixelRatio;
-        windowInnerHeight = docHeight * devicePixelRatio;
+      if (AddressBarController.isSupportedOperatingSystem) {
+        // The view's box is `<body>`, which is laid out against the layout
+        // viewport, not the visual one. It also avoids Chrome on iOS reporting
+        // an incorrect width when the app starts in portrait and is rotated.
+        windowInnerWidth = domDocument.documentElement!.clientWidth * devicePixelRatio;
+        // [AddressBarController] pins `<body>` to the viewport with the address
+        // bar collapsed, so its box is the view's box and holds still while the
+        // bar animates. A height that followed the bar would relayout the whole
+        // app on every frame of its animation, in the middle of the scroll that
+        // caused it; what the bar covers is reported as padding instead.
+        final double boxHeight = domDocument.body!.getBoundingClientRect().height;
+        windowInnerHeight = (boxHeight > 0 ? boxHeight : domWindow.innerHeight!) * devicePixelRatio;
       } else {
         windowInnerWidth = viewport.width! * devicePixelRatio;
         windowInnerHeight = viewport.height! * devicePixelRatio;
@@ -100,8 +99,13 @@ class FullPageDimensionsProvider extends DimensionsProvider {
     late double windowInnerHeight;
 
     if (viewport != null) {
-      if (ui_web.browser.operatingSystem == ui_web.OperatingSystem.iOs && !isEditingOnMobile) {
-        windowInnerHeight = domDocument.documentElement!.clientHeight * devicePixelRatio;
+      if (AddressBarController.isSupportedOperatingSystem && !isEditingOnMobile) {
+        // The same measurement as [computePhysicalSize], so the address bar
+        // produces no inset of its own; what it covers is reported as padding
+        // instead. An inset asks the app to shrink, and this one would ask that
+        // on every frame of the bar's animation.
+        final double boxHeight = domDocument.body!.getBoundingClientRect().height;
+        windowInnerHeight = (boxHeight > 0 ? boxHeight : domWindow.innerHeight!) * devicePixelRatio;
       } else {
         windowInnerHeight = viewport.height! * devicePixelRatio;
       }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/window.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/window.dart
@@ -264,6 +264,7 @@ class EngineFlutterView implements ui.FlutterView {
   @override
   ViewPadding get viewInsets => _viewInsets;
   ViewPadding _viewInsets = ui.ViewPadding.zero as ViewPadding;
+  bool _hasNotifiedMetrics = false;
 
   @override
   ViewPadding get viewPadding => _viewConfiguration.viewPadding;
@@ -320,6 +321,8 @@ class EngineFlutterView implements ui.FlutterView {
   void _handleBrowserResize(ui.Size? _) {
     StyleManager.scaleSemanticsHost(dom.semanticsHost, devicePixelRatio);
     final ui.Size newPhysicalSize = _computePhysicalSize();
+    final ui.Size previousPhysicalSize = _physicalSize ?? ui.Size.zero;
+    final ViewPadding previousViewInsets = _viewInsets;
     if (_shouldPreservePhysicalSizeOnResize && !_isRotation(newPhysicalSize)) {
       _computeOnScreenKeyboardInsets(true);
     } else {
@@ -327,7 +330,16 @@ class EngineFlutterView implements ui.FlutterView {
       // When physical size changes this value has to be recalculated.
       _computeOnScreenKeyboardInsets(false);
     }
-    platformDispatcher.invokeOnMetricsChanged();
+    final bool sizeChanged = newPhysicalSize != previousPhysicalSize;
+    final bool insetsChanged =
+        _viewInsets.bottom != previousViewInsets.bottom ||
+        _viewInsets.top != previousViewInsets.top ||
+        _viewInsets.left != previousViewInsets.left ||
+        _viewInsets.right != previousViewInsets.right;
+    if (sizeChanged || insetsChanged || !_hasNotifiedMetrics) {
+      _hasNotifiedMetrics = true;
+      platformDispatcher.invokeOnMetricsChanged();
+    }
   }
 
   /// Uses the previous physical size and current innerHeight/innerWidth

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/window.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/window.dart
@@ -69,8 +69,8 @@ class EngineFlutterView implements ui.FlutterView {
     // The embeddingStrategy will take care of cleaning up the rootElement on
     // hot restart.
     embeddingStrategy.attachViewRoot(dom.rootElement);
-    pointerBinding = PointerBinding(this);
     addressBarController = AddressBarController(this);
+    pointerBinding = PointerBinding(this);
     _resizeSubscription = onResize.listen(_handleBrowserResize);
     _globalHtmlAttributes.applyAttributes(
       viewId: viewId,
@@ -111,8 +111,8 @@ class EngineFlutterView implements ui.FlutterView {
     isDisposed = true;
     _resizeSubscription.cancel();
     dimensionsProvider.close();
-    pointerBinding.dispose();
     addressBarController.dispose();
+    pointerBinding.dispose();
     dom.rootElement.remove();
     // TODO(harryterkelsen): What should we do about this in multi-view?
     renderer.clearFragmentProgramCache();
@@ -264,7 +264,10 @@ class EngineFlutterView implements ui.FlutterView {
   @override
   ViewPadding get viewInsets => _viewInsets;
   ViewPadding _viewInsets = ui.ViewPadding.zero as ViewPadding;
-  bool _hasNotifiedMetrics = false;
+
+  ui.Size? _lastNotifiedPhysicalSize;
+  ViewPadding? _lastNotifiedViewInsets;
+  double? _lastNotifiedDevicePixelRatio;
 
   @override
   ViewPadding get viewPadding => _viewConfiguration.viewPadding;
@@ -321,8 +324,6 @@ class EngineFlutterView implements ui.FlutterView {
   void _handleBrowserResize(ui.Size? _) {
     StyleManager.scaleSemanticsHost(dom.semanticsHost, devicePixelRatio);
     final ui.Size newPhysicalSize = _computePhysicalSize();
-    final ui.Size previousPhysicalSize = _physicalSize ?? ui.Size.zero;
-    final ViewPadding previousViewInsets = _viewInsets;
     if (_shouldPreservePhysicalSizeOnResize && !_isRotation(newPhysicalSize)) {
       _computeOnScreenKeyboardInsets(true);
     } else {
@@ -330,14 +331,23 @@ class EngineFlutterView implements ui.FlutterView {
       // When physical size changes this value has to be recalculated.
       _computeOnScreenKeyboardInsets(false);
     }
-    final bool sizeChanged = newPhysicalSize != previousPhysicalSize;
+    // The browser can fire resize events while none of the metrics the
+    // framework observes changed (e.g. while the address bar animates);
+    // notify only when something changed since the last notification
+    // (`handleFrameworkResize` refreshes `_physicalSize` in between).
+    final ViewPadding? lastInsets = _lastNotifiedViewInsets;
+    final sizeChanged = _physicalSize != _lastNotifiedPhysicalSize;
     final bool insetsChanged =
-        _viewInsets.bottom != previousViewInsets.bottom ||
-        _viewInsets.top != previousViewInsets.top ||
-        _viewInsets.left != previousViewInsets.left ||
-        _viewInsets.right != previousViewInsets.right;
-    if (sizeChanged || insetsChanged || !_hasNotifiedMetrics) {
-      _hasNotifiedMetrics = true;
+        lastInsets == null ||
+        _viewInsets.bottom != lastInsets.bottom ||
+        _viewInsets.top != lastInsets.top ||
+        _viewInsets.left != lastInsets.left ||
+        _viewInsets.right != lastInsets.right;
+    final dprChanged = devicePixelRatio != _lastNotifiedDevicePixelRatio;
+    if (sizeChanged || insetsChanged || dprChanged) {
+      _lastNotifiedPhysicalSize = _physicalSize;
+      _lastNotifiedViewInsets = _viewInsets;
+      _lastNotifiedDevicePixelRatio = devicePixelRatio;
       platformDispatcher.invokeOnMetricsChanged();
     }
   }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/window.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/window.dart
@@ -10,6 +10,7 @@ import 'package:ui/ui.dart' as ui;
 import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 import '../engine.dart' show DimensionsProvider, registerHotRestartListener, renderer;
+import 'address_bar_controller.dart';
 import 'browser_detection.dart';
 import 'display.dart';
 import 'dom.dart';
@@ -69,6 +70,7 @@ class EngineFlutterView implements ui.FlutterView {
     // hot restart.
     embeddingStrategy.attachViewRoot(dom.rootElement);
     pointerBinding = PointerBinding(this);
+    addressBarController = AddressBarController(this);
     _resizeSubscription = onResize.listen(_handleBrowserResize);
     _globalHtmlAttributes.applyAttributes(
       viewId: viewId,
@@ -110,6 +112,7 @@ class EngineFlutterView implements ui.FlutterView {
     _resizeSubscription.cancel();
     dimensionsProvider.close();
     pointerBinding.dispose();
+    addressBarController.dispose();
     dom.rootElement.remove();
     // TODO(harryterkelsen): What should we do about this in multi-view?
     renderer.clearFragmentProgramCache();
@@ -153,6 +156,8 @@ class EngineFlutterView implements ui.FlutterView {
   late final DomManager dom = DomManager(devicePixelRatio: devicePixelRatio);
 
   late final PointerBinding pointerBinding;
+
+  late final AddressBarController addressBarController;
 
   @override
   ViewConstraints get physicalConstraints {

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/window.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/window.dart
@@ -10,6 +10,7 @@ import 'package:ui/ui.dart' as ui;
 import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 import '../engine.dart' show DimensionsProvider, registerHotRestartListener, renderer;
+import 'address_bar_controller.dart';
 import 'browser_detection.dart';
 import 'display.dart';
 import 'dom.dart';
@@ -68,6 +69,7 @@ class EngineFlutterView implements ui.FlutterView {
     // The embeddingStrategy will take care of cleaning up the rootElement on
     // hot restart.
     embeddingStrategy.attachViewRoot(dom.rootElement);
+    addressBarController = AddressBarController(this);
     pointerBinding = PointerBinding(this);
     _resizeSubscription = onResize.listen(_handleBrowserResize);
     _globalHtmlAttributes.applyAttributes(
@@ -94,7 +96,7 @@ class EngineFlutterView implements ui.FlutterView {
 
   late final StreamSubscription<ui.Size?> _resizeSubscription;
 
-  final ViewConfiguration _viewConfiguration = const ViewConfiguration();
+  ViewConfiguration _viewConfiguration = const ViewConfiguration();
 
   /// Whether this [EngineFlutterView] has been disposed or not.
   bool isDisposed = false;
@@ -109,6 +111,7 @@ class EngineFlutterView implements ui.FlutterView {
     isDisposed = true;
     _resizeSubscription.cancel();
     dimensionsProvider.close();
+    addressBarController.dispose();
     pointerBinding.dispose();
     dom.rootElement.remove();
     // TODO(harryterkelsen): What should we do about this in multi-view?
@@ -153,6 +156,8 @@ class EngineFlutterView implements ui.FlutterView {
   late final DomManager dom = DomManager(devicePixelRatio: devicePixelRatio);
 
   late final PointerBinding pointerBinding;
+
+  late final AddressBarController addressBarController;
 
   @override
   ViewConstraints get physicalConstraints {
@@ -260,6 +265,14 @@ class EngineFlutterView implements ui.FlutterView {
   ViewPadding get viewInsets => _viewInsets;
   ViewPadding _viewInsets = ui.ViewPadding.zero as ViewPadding;
 
+  /// Reports the strip of the view that browser chrome can cover: [padding] is
+  /// what it covers now, [viewPadding] what it covers when it is showing.
+  ///
+  /// Does not notify; [_handleBrowserResize] does that.
+  void updateChromeInsets({required ViewPadding padding, required ViewPadding viewPadding}) {
+    _viewConfiguration = _viewConfiguration.copyWith(padding: padding, viewPadding: viewPadding);
+  }
+
   @override
   ViewPadding get viewPadding => _viewConfiguration.viewPadding;
 
@@ -322,6 +335,10 @@ class EngineFlutterView implements ui.FlutterView {
       // When physical size changes this value has to be recalculated.
       _computeOnScreenKeyboardInsets(false);
     }
+    // From here rather than a resize subscription of the controller's own,
+    // which would be registered first and run before `_viewInsets` is
+    // recomputed.
+    addressBarController.handleBrowserResize(_viewInsets);
     platformDispatcher.invokeOnMetricsChanged();
   }
 

--- a/engine/src/flutter/lib/web_ui/test/engine/address_bar_controller_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/address_bar_controller_test.dart
@@ -1,0 +1,597 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/src/engine.dart';
+import 'package:ui/ui.dart' as ui;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
+
+/// Desktop Safari and Firefox do not expose the `Touch`/`TouchEvent`
+/// constructors, so tests that synthesize Touch Events can only run on
+/// Chromium-based browsers. The browsers this code path targets (mobile
+/// Safari and mobile Chrome) both support Touch Events.
+final bool touchConstructorsSupported =
+    globalContext.has('Touch') && globalContext.has('TouchEvent');
+
+EnginePlatformDispatcher get dispatcher => EnginePlatformDispatcher.instance;
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+void testMain() {
+  EngineFlutterWindow createFullPageView() => EngineFlutterView.implicit(dispatcher, null);
+
+  DomTouch createTouch({
+    required int identifier,
+    required DomEventTarget target,
+    required double clientX,
+    required double clientY,
+  }) {
+    return createDomTouch(<String, dynamic>{
+      'identifier': identifier,
+      'target': target,
+      'clientX': clientX,
+      'clientY': clientY,
+    });
+  }
+
+  DomTouchEvent createTouchEvent(String type, List<DomTouch> touches) {
+    return DomTouchEvent(
+      type,
+      <String, dynamic>{'bubbles': true, 'cancelable': true, 'changedTouches': touches}.toJSAnyDeep,
+    );
+  }
+
+  void dispatchTouch(
+    DomElement target,
+    String type,
+    int identifier, {
+    double x = 10,
+    double y = 10,
+  }) {
+    target.dispatchEvent(
+      createTouchEvent(type, <DomTouch>[
+        createTouch(identifier: identifier, target: target, clientX: x, clientY: y),
+      ]),
+    );
+  }
+
+  DomElement? findSpacer() => domDocument.documentElement!.querySelector('flt-scroll-spacer');
+
+  group('$AddressBarController lifecycle', () {
+    EngineFlutterView? view;
+
+    // Dispose through tearDown so a failing expectation cannot leak the
+    // view's DOM (e.g. the spacer) into the following tests.
+    tearDown(() {
+      view?.dispose();
+      PointerBinding.debugResetGlobalState();
+      view = null;
+      ui_web.browser.debugOperatingSystemOverride = null;
+    });
+
+    test('does nothing on a desktop OS', () {
+      ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.macOs;
+      view = createFullPageView();
+
+      expect(findSpacer(), isNull);
+      expect(domDocument.body!.style.getPropertyValue('touch-action'), 'none');
+    });
+
+    test('does nothing for a custom element view, even on mobile', () {
+      ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.android;
+      final DomElement host = createDomHTMLDivElement();
+      domDocument.body!.append(host);
+      addTearDown(() => host.remove());
+      view = EngineFlutterView(dispatcher, host);
+
+      expect(findSpacer(), isNull);
+    });
+
+    test('on Android, makes the page scrollable with two top snap targets', () {
+      ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.android;
+      view = createFullPageView();
+
+      expect(domDocument.body!.style.overflowY, 'auto');
+      expect(domDocument.body!.style.getPropertyValue('touch-action'), 'pan-y');
+      // `proximity` is the default snap strictness, so the browser drops it when
+      // serializing `y proximity`, leaving `y`.
+      expect(domDocument.documentElement!.style.getPropertyValue('scroll-snap-type'), 'y');
+
+      final DomElement? spacer = findSpacer();
+      expect(spacer, isNotNull);
+      // 100vh + snapDistance (100) + 1px pull-to-refresh guard +
+      // collapseMargin (100). Browsers normalize the order of calc() terms,
+      // so the assertion cannot compare the full string.
+      expect(spacer!.style.height, allOf(contains('100vh'), contains('201px')));
+
+      final List<DomElement> snapTargets = spacer.children.toList();
+      expect(snapTargets, hasLength(2));
+      expect(snapTargets[0].style.top, '1px');
+      expect(snapTargets[1].style.top, '101px');
+      for (final snapTarget in snapTargets) {
+        expect(snapTarget.style.getPropertyValue('scroll-snap-align'), 'start');
+      }
+    });
+
+    test('on iOS, uses a single mid-point snap target', () {
+      ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.iOs;
+      view = createFullPageView();
+
+      expect(domDocument.body!.style.overflowY, 'auto');
+      expect(domDocument.body!.style.getPropertyValue('touch-action'), 'pan-y');
+      expect(
+        domDocument.documentElement!.style.getPropertyValue('scroll-snap-type'),
+        'y mandatory',
+      );
+
+      final DomElement? spacer = findSpacer();
+      expect(spacer, isNotNull);
+      expect(spacer!.style.height, '10000px');
+
+      final List<DomElement> snapTargets = spacer.children.toList();
+      expect(snapTargets, hasLength(1));
+      expect(snapTargets[0].style.top, '5000px');
+    });
+
+    test('dispose removes the spacer and restores full-page styles', () {
+      ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.android;
+      view = createFullPageView();
+      expect(findSpacer(), isNotNull);
+
+      view!.dispose();
+
+      expect(findSpacer(), isNull);
+      expect(domDocument.body!.style.overflowY, 'hidden');
+      expect(domDocument.body!.style.getPropertyValue('touch-action'), 'none');
+      expect(domDocument.documentElement!.style.getPropertyValue('scroll-snap-type'), '');
+      expect(domDocument.documentElement!.style.getPropertyValue('scrollbar-width'), '');
+    });
+  });
+
+  group('$AddressBarController touch input pipeline', () {
+    late EngineFlutterWindow view;
+    late List<ui.PointerDataPacket> packets;
+
+    setUp(() {
+      ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.android;
+      view = createFullPageView();
+      packets = <ui.PointerDataPacket>[];
+      dispatcher.onPointerDataPacket = packets.add;
+    });
+
+    tearDown(() {
+      dispatcher.onPointerDataPacket = null;
+      view.dispose();
+      PointerBinding.debugResetGlobalState();
+      ui_web.browser.debugOperatingSystemOverride = null;
+    });
+
+    test('touchstart produces an add and a touch-kind down', () {
+      final DomElement root = view.dom.rootElement;
+      final double dpr = view.devicePixelRatio;
+      dispatchTouch(root, 'touchstart', 7, y: 20);
+
+      final List<ui.PointerData> data = allPointerDataOf(packets);
+      expect(data, hasLength(2));
+      expect(data[0].change, ui.PointerChange.add);
+      expect(data[1].change, ui.PointerChange.down);
+      expect(data[1].kind, ui.PointerDeviceKind.touch);
+      expect(data[1].device, 7);
+      expect(data[1].physicalX, 10 * dpr);
+      expect(data[1].physicalY, 20 * dpr);
+      expect(data[1].buttons, 1);
+
+      // End the gesture so no pointer state leaks into other tests.
+      dispatchTouch(root, 'touchend', 7, y: 20);
+    });
+
+    test('a full tap gesture ends with up and a synthesized remove', () {
+      final DomElement root = view.dom.rootElement;
+      dispatchTouch(root, 'touchstart', 11);
+      dispatchTouch(root, 'touchmove', 11, y: 30);
+      dispatchTouch(root, 'touchend', 11, y: 30);
+
+      final List<ui.PointerChange> changes = allPointerDataOf(
+        packets,
+      ).map((ui.PointerData data) => data.change).toList();
+      expect(changes, <ui.PointerChange>[
+        ui.PointerChange.add,
+        ui.PointerChange.down,
+        ui.PointerChange.move,
+        ui.PointerChange.up,
+        ui.PointerChange.remove,
+      ]);
+    });
+
+    test('touchcancel sends cancel', () {
+      final DomElement root = view.dom.rootElement;
+      dispatchTouch(root, 'touchstart', 21);
+      dispatchTouch(root, 'touchcancel', 21);
+
+      final List<ui.PointerChange> changes = allPointerDataOf(
+        packets,
+      ).map((ui.PointerData data) => data.change).toList();
+      expect(changes, <ui.PointerChange>[
+        ui.PointerChange.add,
+        ui.PointerChange.down,
+        ui.PointerChange.cancel,
+        ui.PointerChange.remove,
+      ]);
+    });
+
+    test('move, end, and cancel of unknown identifiers are ignored', () {
+      final DomElement root = view.dom.rootElement;
+      dispatchTouch(root, 'touchmove', 99);
+      dispatchTouch(root, 'touchend', 99);
+      dispatchTouch(root, 'touchcancel', 99);
+
+      expect(packets, isEmpty);
+    });
+
+    test('multi-touch produces an independent pointer per identifier', () {
+      final DomElement root = view.dom.rootElement;
+      root.dispatchEvent(
+        createTouchEvent('touchstart', <DomTouch>[
+          createTouch(identifier: 31, target: root, clientX: 10, clientY: 10),
+          createTouch(identifier: 32, target: root, clientX: 50, clientY: 50),
+        ]),
+      );
+
+      final List<ui.PointerData> data = allPointerDataOf(packets);
+      final Iterable<ui.PointerData> downs = data.where(
+        (ui.PointerData datum) => datum.change == ui.PointerChange.down,
+      );
+      expect(downs.map((ui.PointerData datum) => datum.device), <int>[31, 32]);
+
+      root.dispatchEvent(
+        createTouchEvent('touchend', <DomTouch>[
+          createTouch(identifier: 31, target: root, clientX: 10, clientY: 10),
+          createTouch(identifier: 32, target: root, clientX: 50, clientY: 50),
+        ]),
+      );
+    });
+
+    test('positions stay client-relative while the page is scrolled', () {
+      final DomElement root = view.dom.rootElement;
+      final double dpr = view.devicePixelRatio;
+      // The spacer keeps the page scrolled away from 0 on devices (~5000 on
+      // iOS); positions must not skew by the scroll offset.
+      domDocument.documentElement!.scrollTop = 60;
+      addTearDown(() {
+        domDocument.documentElement!.scrollTop = 0;
+      });
+
+      dispatchTouch(root, 'touchstart', 81, y: 20);
+      dispatchTouch(root, 'touchend', 81, y: 20);
+
+      final List<ui.PointerData> data = allPointerDataOf(packets);
+      expect(data[1].change, ui.PointerChange.down);
+      expect(data[1].physicalX, 10 * dpr);
+      expect(data[1].physicalY, 20 * dpr);
+    });
+
+    test('a touch on a child element gets view-relative coordinates', () {
+      // The pointer position is the finger's location in the view, regardless
+      // of which descendant the touch lands on (not relative to that element).
+      final DomElement child = createDomElement('div');
+      child.style
+        ..position = 'absolute'
+        ..left = '40px'
+        ..top = '30px';
+      view.dom.rootElement.append(child);
+      addTearDown(() => child.remove());
+
+      final double dpr = view.devicePixelRatio;
+      final DomRect rootRect = view.dom.rootElement.getBoundingClientRect();
+
+      dispatchTouch(child, 'touchstart', 95, x: 60, y: 50);
+
+      final ui.PointerData down = allPointerDataOf(
+        packets,
+      ).firstWhere((ui.PointerData d) => d.change == ui.PointerChange.down);
+      expect(down.physicalX, closeTo((60 - rootRect.x) * dpr, 0.5));
+      expect(down.physicalY, closeTo((50 - rootRect.y) * dpr, 0.5));
+
+      dispatchTouch(child, 'touchend', 95, x: 60, y: 50);
+    });
+
+    test('a touch coinciding with an active stylus is skipped', () {
+      final DomElement root = view.dom.rootElement;
+      // A stylus surfaces as a 'pen' Pointer event (which PointerBinding
+      // handles) plus a Touch event at the same point. The touch must not be
+      // translated into a second pointer.
+      root.dispatchEvent(
+        createDomPointerEvent('pointerdown', <String, dynamic>{
+          'bubbles': true,
+          'pointerId': 5,
+          'pointerType': 'pen',
+          'button': 0,
+          'buttons': 1,
+          'clientX': 30.0,
+          'clientY': 40.0,
+        }),
+      );
+      // Ignore any pointer data PointerBinding emitted for the pen itself.
+      packets.clear();
+
+      dispatchTouch(root, 'touchstart', 71, x: 30, y: 40);
+      expect(packets, isEmpty);
+
+      // A finger at a different point is still translated.
+      dispatchTouch(root, 'touchstart', 72, x: 200, y: 200);
+      expect(
+        allPointerDataOf(packets).where((ui.PointerData d) => d.change == ui.PointerChange.down),
+        isNotEmpty,
+      );
+      dispatchTouch(root, 'touchend', 72, x: 200, y: 200);
+
+      // Release the pen so no pointer state leaks into other tests.
+      root.dispatchEvent(
+        createDomPointerEvent('pointerup', <String, dynamic>{
+          'bubbles': true,
+          'pointerId': 5,
+          'pointerType': 'pen',
+          'button': 0,
+          'buttons': 0,
+          'clientX': 30.0,
+          'clientY': 40.0,
+        }),
+      );
+    });
+
+    test('a touch at a lifted stylus position is translated again', () {
+      final DomElement root = view.dom.rootElement;
+      // Pen down at (30, 40): a coinciding touch is skipped as a duplicate.
+      root.dispatchEvent(
+        createDomPointerEvent('pointerdown', <String, dynamic>{
+          'bubbles': true,
+          'pointerId': 8,
+          'pointerType': 'pen',
+          'button': 0,
+          'buttons': 1,
+          'clientX': 30.0,
+          'clientY': 40.0,
+        }),
+      );
+      packets.clear();
+      dispatchTouch(root, 'touchstart', 81, x: 30, y: 40);
+      expect(packets, isEmpty);
+      dispatchTouch(root, 'touchend', 81, x: 30, y: 40);
+
+      // Lifting the pen clears the tracked contact.
+      root.dispatchEvent(
+        createDomPointerEvent('pointerup', <String, dynamic>{
+          'bubbles': true,
+          'pointerId': 8,
+          'pointerType': 'pen',
+          'button': 0,
+          'buttons': 0,
+          'clientX': 30.0,
+          'clientY': 40.0,
+        }),
+      );
+      packets.clear();
+
+      // A touch at the same point is no longer treated as a stylus duplicate.
+      dispatchTouch(root, 'touchstart', 82, x: 30, y: 40);
+      expect(
+        allPointerDataOf(packets).where((ui.PointerData d) => d.change == ui.PointerChange.down),
+        isNotEmpty,
+      );
+      dispatchTouch(root, 'touchend', 82, x: 30, y: 40);
+    });
+
+    test('dispose synthesizes cancel for active touches', () {
+      dispatchTouch(view.dom.rootElement, 'touchstart', 51);
+      packets.clear();
+
+      view.dispose();
+
+      final List<ui.PointerChange> changes = allPointerDataOf(
+        packets,
+      ).map((ui.PointerData data) => data.change).toList();
+      expect(changes, <ui.PointerChange>[ui.PointerChange.cancel, ui.PointerChange.remove]);
+    });
+
+    test('a cancel issued while debouncing flushes in order behind the down', () async {
+      // With semantics on, a tap on a tappable element is held by the
+      // ClickDebouncer. If the view is disposed during that window, the cancel
+      // must queue behind the still-pending `down` and flush in order. Routing
+      // it straight to the dispatcher would race ahead of the queued `down` and
+      // strand the framework with a phantom pointer.
+      EngineSemantics.instance.semanticsEnabled = true;
+      addTearDown(() => EngineSemantics.instance.semanticsEnabled = false);
+      view.dom.rootElement.setAttribute('flt-tappable', '');
+
+      dispatchTouch(view.dom.rootElement, 'touchstart', 61);
+      // The debouncer holds the down; nothing reaches the framework yet.
+      expect(packets, isEmpty);
+
+      view.dispose();
+      // The cancel is queued behind the down, not sent ahead of it.
+      expect(packets, isEmpty);
+
+      // Let the 200ms debounce timer flush the queued sequence.
+      await Future<void>.delayed(const Duration(milliseconds: 250));
+
+      final List<ui.PointerChange> changes = allPointerDataOf(
+        packets,
+      ).map((ui.PointerData data) => data.change).toList();
+      expect(changes, <ui.PointerChange>[
+        ui.PointerChange.add,
+        ui.PointerChange.down,
+        ui.PointerChange.cancel,
+        ui.PointerChange.remove,
+      ]);
+    });
+  }, skip: !touchConstructorsSupported);
+
+  group('$AddressBarController switched-mode pointer events', () {
+    late EngineFlutterWindow view;
+    late List<ui.PointerDataPacket> packets;
+    late DomElement child;
+
+    setUp(() {
+      ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.android;
+      view = createFullPageView();
+      child = createDomElement('div');
+      view.dom.rootElement.append(child);
+      packets = <ui.PointerDataPacket>[];
+      dispatcher.onPointerDataPacket = packets.add;
+    });
+
+    tearDown(() {
+      dispatcher.onPointerDataPacket = null;
+      child.remove();
+      view.dispose();
+      PointerBinding.debugResetGlobalState();
+      ui_web.browser.debugOperatingSystemOverride = null;
+    });
+
+    test('touch-type pointer events are dropped by PointerBinding', () {
+      child.dispatchEvent(
+        createDomPointerEvent('pointerdown', <String, dynamic>{
+          'bubbles': true,
+          'pointerId': 12,
+          'button': 0,
+          'buttons': 1,
+          'clientX': 10.0,
+          'clientY': 10.0,
+          'pointerType': 'touch',
+        }),
+      );
+
+      expect(packets, isEmpty);
+    });
+
+    test('touch pointerdown on the root element keeps the focus side effects', () {
+      final DomPointerEvent event = createDomPointerEvent('pointerdown', <String, dynamic>{
+        'bubbles': true,
+        'cancelable': true,
+        'pointerId': 13,
+        'button': 0,
+        'buttons': 1,
+        'clientX': 10.0,
+        'clientY': 10.0,
+        'pointerType': 'touch',
+      });
+      view.dom.rootElement.dispatchEvent(event);
+
+      expect(packets, isEmpty);
+      expect(event.defaultPrevented, isTrue);
+    });
+
+    test('mouse pointer events pass through to PointerBinding', () {
+      child.dispatchEvent(
+        createDomPointerEvent('pointerdown', <String, dynamic>{
+          'bubbles': true,
+          'pointerId': 1,
+          'button': 0,
+          'buttons': 1,
+          'clientX': 10.0,
+          'clientY': 10.0,
+          'pointerType': 'mouse',
+        }),
+      );
+
+      final List<ui.PointerData> data = allPointerDataOf(packets);
+      expect(data, isNotEmpty);
+      expect(data.last.change, ui.PointerChange.down);
+      expect(data.last.kind, ui.PointerDeviceKind.mouse);
+
+      // Release the mouse button so no pointer state leaks into other tests.
+      child.dispatchEvent(
+        createDomPointerEvent('pointerup', <String, dynamic>{
+          'bubbles': true,
+          'pointerId': 1,
+          'button': 0,
+          'buttons': 0,
+          'clientX': 10.0,
+          'clientY': 10.0,
+          'pointerType': 'mouse',
+        }),
+      );
+    });
+  });
+
+  group('$AddressBarController semantics integration', () {
+    final testTime = DateTime(2018, 12, 17);
+    late EngineFlutterWindow view;
+    late List<ui.PointerChange> pointerChanges;
+    late List<({ui.SemanticsAction type, int nodeId})> semanticsActions;
+
+    setUp(() {
+      ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.android;
+      view = createFullPageView();
+      pointerChanges = <ui.PointerChange>[];
+      semanticsActions = <({ui.SemanticsAction type, int nodeId})>[];
+      dispatcher.onPointerDataPacket = (ui.PointerDataPacket packet) {
+        for (final ui.PointerData data in packet.data) {
+          pointerChanges.add(data.change);
+        }
+      };
+      dispatcher.onSemanticsActionEvent = (ui.SemanticsActionEvent event) {
+        semanticsActions.add((type: event.type, nodeId: event.nodeId));
+      };
+      EngineSemantics.instance
+        ..debugOverrideTimestampFunction(() => testTime)
+        ..semanticsEnabled = true;
+    });
+
+    tearDown(() {
+      EngineSemantics.instance.semanticsEnabled = false;
+      dispatcher.onPointerDataPacket = null;
+      dispatcher.onSemanticsActionEvent = null;
+      view.dispose();
+      PointerBinding.debugResetGlobalState();
+      ui_web.browser.debugOperatingSystemOverride = null;
+    });
+
+    test('a touch tap on a tappable node sends one tap action and no pointer events', () async {
+      final DomElement tappable = createDomElement('flt-semantics');
+      tappable.setAttribute('flt-tappable', '');
+      view.dom.semanticsHost.appendChild(tappable);
+
+      dispatchTouch(tappable, 'touchstart', 61);
+      // The ClickDebouncer starts debouncing at the end of the event loop.
+      await Future<void>.delayed(Duration.zero);
+      expect(PointerBinding.clickDebouncer.isDebouncing, isTrue);
+
+      dispatchTouch(tappable, 'touchend', 61);
+      final DomEvent click = createDomMouseEvent('click', <Object?, Object?>{
+        'clientX': 10,
+        'clientY': 10,
+      });
+      PointerBinding.clickDebouncer.onClick(click, view.viewId, 42, true);
+
+      expect(semanticsActions, <({ui.SemanticsAction type, int nodeId})>[
+        (type: ui.SemanticsAction.tap, nodeId: 42),
+      ]);
+      // The debounced touch-derived pointer events were dropped in favor of
+      // the tap action, so the button is not activated twice.
+      expect(pointerChanges, isEmpty);
+    });
+
+    test('touch events flip the gesture mode to pointerEvents', () {
+      final DomElement root = view.dom.rootElement;
+      EngineSemantics.instance.debugResetGestureMode();
+      expect(EngineSemantics.instance.gestureMode, GestureMode.browserGestures);
+
+      dispatchTouch(root, 'touchstart', 71);
+
+      expect(EngineSemantics.instance.gestureMode, GestureMode.pointerEvents);
+
+      dispatchTouch(root, 'touchend', 71);
+    });
+  }, skip: !touchConstructorsSupported);
+}
+
+List<ui.PointerData> allPointerDataOf(List<ui.PointerDataPacket> packets) =>
+    packets.expand((ui.PointerDataPacket packet) => packet.data).toList();

--- a/engine/src/flutter/lib/web_ui/test/engine/address_bar_controller_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/address_bar_controller_test.dart
@@ -1,0 +1,280 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/src/engine.dart';
+import 'package:ui/ui.dart' as ui;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
+
+/// Desktop Safari and Firefox do not expose the `Touch`/`TouchEvent`
+/// constructors. The browsers this code path targets, mobile Safari and mobile
+/// Chrome, both do.
+final bool touchConstructorsSupported =
+    globalContext.has('Touch') && globalContext.has('TouchEvent');
+
+EnginePlatformDispatcher get dispatcher => EnginePlatformDispatcher.instance;
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+void testMain() {
+  EngineFlutterWindow createFullPageView() => EngineFlutterView.implicit(dispatcher, null);
+
+  void dispatchTouch(DomElement target, String type, int identifier, {double y = 10}) {
+    final DomTouch touch = createDomTouch(<String, dynamic>{
+      'identifier': identifier,
+      'target': target,
+      'clientX': 10,
+      'clientY': y,
+    });
+    target.dispatchEvent(
+      DomTouchEvent(
+        type,
+        <String, dynamic>{
+          'bubbles': true,
+          'changedTouches': <DomTouch>[touch],
+        }.toJSAnyDeep,
+      ),
+    );
+  }
+
+  DomPointerEvent createPointer(String type, {double y = 10, String pointerType = 'touch'}) {
+    return createDomPointerEvent(type, <String, dynamic>{
+      'bubbles': true,
+      'cancelable': true,
+      'pointerId': 1,
+      'pointerType': pointerType,
+      'button': 0,
+      'buttons': 1,
+      'clientX': 10,
+      'clientY': y,
+      'pressure': 0.5,
+    });
+  }
+
+  DomElement? findSpacer() => domDocument.documentElement!.querySelector('flt-scroll-spacer');
+
+  group('$AddressBarController lifecycle', () {
+    EngineFlutterView? view;
+
+    // Dispose through tearDown so a failing expectation cannot leak the spacer
+    // into the following tests.
+    tearDown(() {
+      view?.dispose();
+      PointerBinding.debugResetGlobalState();
+      view = null;
+      ui_web.browser.debugOperatingSystemOverride = null;
+    });
+
+    test('does nothing outside Android and iOS', () {
+      for (final ui_web.OperatingSystem os in ui_web.OperatingSystem.values) {
+        if (os == ui_web.OperatingSystem.android || os == ui_web.OperatingSystem.iOs) {
+          continue;
+        }
+        ui_web.browser.debugOperatingSystemOverride = os;
+        view = createFullPageView();
+
+        expect(findSpacer(), isNull, reason: '$os');
+        expect(domDocument.body!.style.getPropertyValue('touch-action'), 'none', reason: '$os');
+
+        view!.dispose();
+        PointerBinding.debugResetGlobalState();
+        view = null;
+      }
+    });
+
+    test('does nothing for a custom element view, even on mobile', () {
+      ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.android;
+      final DomElement host = createDomHTMLDivElement();
+      domDocument.body!.append(host);
+      addTearDown(() => host.remove());
+      view = EngineFlutterView(dispatcher, host);
+
+      expect(findSpacer(), isNull);
+    });
+
+    test('makes the page scrollable, with a snap target', () {
+      ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.android;
+      view = createFullPageView();
+
+      expect(domDocument.body!.style.overflowY, 'auto');
+      expect(domDocument.body!.style.getPropertyValue('touch-action'), 'pan-y');
+      expect(domDocument.body!.style.height, '100vh');
+
+      final DomElement? spacer = findSpacer();
+      expect(spacer, isNotNull);
+      expect(spacer!.children, hasLength(1));
+      expect(spacer.children.single.style.getPropertyValue('scroll-snap-align'), 'start');
+    });
+
+    test('snaps by proximity on Android and mandatorily on iOS', () {
+      // `proximity` is the default strictness, so the browser drops it when
+      // serializing `y proximity`, leaving `y`.
+      ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.android;
+      view = createFullPageView();
+      expect(domDocument.documentElement!.style.getPropertyValue('scroll-snap-type'), 'y');
+
+      view!.dispose();
+      PointerBinding.debugResetGlobalState();
+      ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.iOs;
+      view = createFullPageView();
+      expect(
+        domDocument.documentElement!.style.getPropertyValue('scroll-snap-type'),
+        'y mandatory',
+      );
+    });
+  });
+
+  group('$AddressBarController touch input pipeline', () {
+    late EngineFlutterWindow view;
+    late DomElement root;
+    late double dpr;
+    late List<ui.PointerDataPacket> packets;
+
+    setUp(() {
+      ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.android;
+      view = createFullPageView();
+      root = view.dom.rootElement;
+      dpr = view.devicePixelRatio;
+      packets = <ui.PointerDataPacket>[];
+      dispatcher.onPointerDataPacket = packets.add;
+    });
+
+    tearDown(() {
+      dispatcher.onPointerDataPacket = null;
+      view.dispose();
+      PointerBinding.debugResetGlobalState();
+      ui_web.browser.debugOperatingSystemOverride = null;
+    });
+
+    test('a tap produces a touch-kind pointer sequence', () {
+      dispatchTouch(root, 'touchstart', 7, y: 20);
+      dispatchTouch(root, 'touchend', 7, y: 20);
+
+      final List<ui.PointerData> data = allPointerDataOf(packets);
+      expect(data.map((ui.PointerData d) => d.change), <ui.PointerChange>[
+        ui.PointerChange.add,
+        ui.PointerChange.down,
+        ui.PointerChange.up,
+        ui.PointerChange.remove,
+      ]);
+      expect(data[1].kind, ui.PointerDeviceKind.touch);
+      expect(data[1].device, 7);
+      expect(data[1].physicalX, 10 * dpr);
+      expect(data[1].physicalY, 20 * dpr);
+    });
+
+    test('touchmove carries the movement where no raw update arrives', () {
+      // Safari does not implement `pointerrawupdate`.
+      dispatchTouch(root, 'touchstart', 13);
+      dispatchTouch(root, 'touchmove', 13, y: 30);
+
+      expect(movesOf(packets), hasLength(1));
+      expect(movesOf(packets).single.physicalY, 30 * dpr);
+    });
+
+    test('a raw update takes the contact over from touchmove', () {
+      // Both report the same movement, the `touchmove` late.
+      dispatchTouch(root, 'touchstart', 14);
+      root.dispatchEvent(createPointer('pointerrawupdate', y: 30));
+      dispatchTouch(root, 'touchmove', 14, y: 30);
+
+      expect(movesOf(packets), hasLength(1));
+      expect(movesOf(packets).single.physicalY, 30 * dpr);
+    });
+
+    test('movement outlives the pointercancel the browser fires', () {
+      // Under `pan-y` the browser takes a vertical drag over and cancels the
+      // pointer. `pointermove` stops there; `pointerrawupdate` does not.
+      dispatchTouch(root, 'touchstart', 12);
+      root.dispatchEvent(createPointer('pointercancel', y: 20));
+      root.dispatchEvent(createPointer('pointerrawupdate', y: 40));
+
+      expect(movesOf(packets), hasLength(1));
+      expect(movesOf(packets).single.physicalY, 40 * dpr);
+    });
+
+    test('positions do not skew by the page scroll offset', () {
+      // The spacer keeps the page scrolled away from 0 on devices.
+      domDocument.documentElement!.scrollTop = 60;
+      addTearDown(() {
+        domDocument.documentElement!.scrollTop = 0;
+      });
+
+      dispatchTouch(root, 'touchstart', 81, y: 20);
+      final ui.PointerData down = allPointerDataOf(packets).last;
+      expect(down.physicalX, 10 * dpr);
+      expect(down.physicalY, 20 * dpr);
+    });
+
+    test('touch events flip the gesture mode to pointerEvents', () {
+      EngineSemantics.instance.debugResetGestureMode();
+      addTearDown(EngineSemantics.instance.debugResetGestureMode);
+      expect(EngineSemantics.instance.gestureMode, GestureMode.browserGestures);
+
+      dispatchTouch(root, 'touchstart', 71);
+
+      expect(EngineSemantics.instance.gestureMode, GestureMode.pointerEvents);
+    });
+  }, skip: !touchConstructorsSupported);
+
+  group('$AddressBarController switched-mode pointer events', () {
+    late EngineFlutterWindow view;
+    late DomElement child;
+    late List<ui.PointerDataPacket> packets;
+
+    setUp(() {
+      ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.android;
+      view = createFullPageView();
+      child = createDomElement('div');
+      view.dom.rootElement.append(child);
+      packets = <ui.PointerDataPacket>[];
+      dispatcher.onPointerDataPacket = packets.add;
+    });
+
+    tearDown(() {
+      dispatcher.onPointerDataPacket = null;
+      child.remove();
+      view.dispose();
+      PointerBinding.debugResetGlobalState();
+      ui_web.browser.debugOperatingSystemOverride = null;
+    });
+
+    test('touch pointer events are withheld from PointerBinding, not from the view', () {
+      final received = <String>[];
+      child.addEventListener(
+        'pointerdown',
+        createDomEventListener((DomEvent event) => received.add(event.type)),
+      );
+
+      child.dispatchEvent(createPointer('pointerdown'));
+
+      // Platform views and native text fields are descendants of the view root,
+      // so the interception has to run after them.
+      expect(received, <String>['pointerdown']);
+      expect(packets, isEmpty);
+    });
+
+    test('mouse pointer events pass through to PointerBinding', () {
+      child.dispatchEvent(createPointer('pointerdown', pointerType: 'mouse'));
+
+      final List<ui.PointerData> data = allPointerDataOf(packets);
+      expect(data, isNotEmpty);
+      expect(data.last.change, ui.PointerChange.down);
+      expect(data.last.kind, ui.PointerDeviceKind.mouse);
+    });
+  });
+}
+
+List<ui.PointerData> allPointerDataOf(List<ui.PointerDataPacket> packets) =>
+    packets.expand((ui.PointerDataPacket packet) => packet.data).toList();
+
+List<ui.PointerData> movesOf(List<ui.PointerDataPacket> packets) => allPointerDataOf(
+  packets,
+).where((ui.PointerData data) => data.change == ui.PointerChange.move).toList();

--- a/engine/src/flutter/lib/web_ui/test/engine/view_embedder/dimensions_provider/full_page_dimensions_provider_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/view_embedder/dimensions_provider/full_page_dimensions_provider_test.dart
@@ -8,6 +8,7 @@ import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui show Size;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 void main() {
   internalBootstrapBrowserTest(() => doTests);
@@ -57,6 +58,12 @@ void doTests() {
       expect(computed.bottom, expectedBottom);
       expect(computed.left, 0);
     });
+
+    test('clamped to zero when the viewport outgrows the preserved height', () {
+      final ViewPadding computed = provider.computeKeyboardInsets(10, true);
+
+      expect(computed.bottom, 0);
+    });
   });
 
   group('onResize Stream', () {
@@ -100,6 +107,69 @@ void doTests() {
 
       expect(provider.onResize.isEmpty, completion(isTrue));
       expect(completer.future, completion(isTrue));
+    });
+  });
+
+  group('mobile platform overrides', () {
+    late FullPageDimensionsProvider provider;
+
+    setUp(() {
+      provider = FullPageDimensionsProvider();
+    });
+
+    tearDown(() {
+      ui_web.browser.debugOperatingSystemOverride = null;
+      EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(null);
+    });
+
+    test('on mobile, physical height is computed from window.innerHeight', () {
+      ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.android;
+      const dpr = 2.5;
+      EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(dpr);
+      final expected = ui.Size(
+        domWindow.visualViewport!.width! * dpr,
+        domWindow.innerHeight! * dpr,
+      );
+
+      expect(provider.computePhysicalSize(), expected);
+    });
+
+    test('on iOS, physical width is computed from documentElement.clientWidth', () {
+      ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.iOs;
+      const dpr = 2.5;
+      EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(dpr);
+      final expected = ui.Size(
+        domDocument.documentElement!.clientWidth * dpr,
+        domWindow.innerHeight! * dpr,
+      );
+
+      expect(provider.computePhysicalSize(), expected);
+    });
+
+    test('on mobile, keyboard insets stay zero while not editing', () {
+      ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.android;
+      const dpr = 2.5;
+      EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(dpr);
+
+      // computeKeyboardInsets must use the same height source as
+      // computePhysicalSize, otherwise every address bar movement would
+      // produce a phantom bottom inset.
+      final double physicalHeight = provider.computePhysicalSize().height;
+      final ViewPadding insets = provider.computeKeyboardInsets(physicalHeight, false);
+
+      expect(insets.bottom, 0);
+    });
+
+    test('on mobile while editing, insets come from the visualViewport height', () {
+      ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.android;
+      const dpr = 2.5;
+      EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(dpr);
+      const double keyboardGap = 100;
+      final double physicalHeight = (domWindow.visualViewport!.height! + keyboardGap) * dpr;
+
+      final ViewPadding insets = provider.computeKeyboardInsets(physicalHeight, true);
+
+      expect(insets.bottom, keyboardGap * dpr);
     });
   });
 }

--- a/engine/src/flutter/lib/web_ui/test/engine/view_embedder/dimensions_provider/full_page_dimensions_provider_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/view_embedder/dimensions_provider/full_page_dimensions_provider_test.dart
@@ -8,6 +8,7 @@ import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui show Size;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 void main() {
   internalBootstrapBrowserTest(() => doTests);
@@ -100,6 +101,58 @@ void doTests() {
 
       expect(provider.onResize.isEmpty, completion(isTrue));
       expect(completer.future, completion(isTrue));
+    });
+  });
+
+  group('mobile platform overrides', () {
+    late FullPageDimensionsProvider provider;
+
+    setUp(() {
+      provider = FullPageDimensionsProvider();
+    });
+
+    tearDown(() {
+      ui_web.browser.debugOperatingSystemOverride = null;
+      EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(null);
+    });
+
+    test('on mobile, the view is measured from the body box', () {
+      // [AddressBarController] pins the body to the viewport with the address
+      // bar collapsed, so the box holds still while the bar animates.
+      ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.android;
+      const dpr = 2.5;
+      EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(dpr);
+      domDocument.body!.style.height = '640px';
+      addTearDown(() => domDocument.body!.style.removeProperty('height'));
+
+      final expected = ui.Size(domDocument.documentElement!.clientWidth * dpr, 640 * dpr);
+      expect(provider.computePhysicalSize(), expected);
+    });
+
+    test('on mobile, keyboard insets stay zero while not editing', () {
+      ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.android;
+      const dpr = 2.5;
+      EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(dpr);
+
+      // computeKeyboardInsets must use the same height source as
+      // computePhysicalSize, otherwise every address bar movement would
+      // produce a phantom bottom inset.
+      final double physicalHeight = provider.computePhysicalSize().height;
+      final ViewPadding insets = provider.computeKeyboardInsets(physicalHeight, false);
+
+      expect(insets.bottom, 0);
+    });
+
+    test('on mobile while editing, insets come from the visualViewport height', () {
+      ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.android;
+      const dpr = 2.5;
+      EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(dpr);
+      const double keyboardGap = 100;
+      final double physicalHeight = (domWindow.visualViewport!.height! + keyboardGap) * dpr;
+
+      final ViewPadding insets = provider.computeKeyboardInsets(physicalHeight, true);
+
+      expect(insets.bottom, keyboardGap * dpr);
     });
   });
 }

--- a/engine/src/flutter/lib/web_ui/test/engine/window_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/window_test.dart
@@ -821,4 +821,72 @@ void testMain() {
       expect(myWindow.physicalSize, initialPhysicalSize);
     });
   });
+
+  group('browser resize metrics deduplication', () {
+    final DomEventTarget resizeEventTarget = domWindow.visualViewport ?? domWindow;
+    late int metricsChangedCount;
+
+    Future<void> dispatchResizeEvent() async {
+      resizeEventTarget.dispatchEvent(createDomEvent('Event', 'resize'));
+      // Resize events are delivered through an asynchronous broadcast stream.
+      await Future<void>.delayed(Duration.zero);
+    }
+
+    setUp(() {
+      metricsChangedCount = 0;
+      dispatcher.onMetricsChanged = () {
+        metricsChangedCount++;
+      };
+    });
+
+    tearDown(() {
+      dispatcher.onMetricsChanged = null;
+      myWindow.debugPhysicalSizeOverride = null;
+      EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(null);
+    });
+
+    test('notifies only once for redundant resize events', () async {
+      await dispatchResizeEvent();
+      expect(metricsChangedCount, 1);
+
+      await dispatchResizeEvent();
+      await dispatchResizeEvent();
+      expect(metricsChangedCount, 1);
+    });
+
+    test('notifies again when the physical size changes', () async {
+      await dispatchResizeEvent();
+      expect(metricsChangedCount, 1);
+
+      // Sizes taller than the viewport keep the computed keyboard insets
+      // non-negative.
+      myWindow.debugPhysicalSizeOverride = const ui.Size(5000.0, 5000.0);
+      await dispatchResizeEvent();
+      expect(metricsChangedCount, 2);
+
+      await dispatchResizeEvent();
+      expect(metricsChangedCount, 2);
+
+      myWindow.debugPhysicalSizeOverride = const ui.Size(6000.0, 6000.0);
+      await dispatchResizeEvent();
+      expect(metricsChangedCount, 3);
+    });
+
+    test('notifies when the device pixel ratio changes', () async {
+      // Freeze the physical size so only the device-pixel-ratio change can
+      // drive the notification. Without this the dpr-scaled physical size would
+      // change too, and `sizeChanged` alone would satisfy the gate — masking
+      // whether the `dprChanged` clause works.
+      myWindow.debugPhysicalSizeOverride = const ui.Size(5000.0, 5000.0);
+      await dispatchResizeEvent();
+      expect(metricsChangedCount, 1);
+
+      EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(3.7);
+      await dispatchResizeEvent();
+      expect(metricsChangedCount, 2);
+
+      await dispatchResizeEvent();
+      expect(metricsChangedCount, 2);
+    });
+  });
 }


### PR DESCRIPTION
> [!NOTE]
> This is a proof-of-concept for discussion, not a merge-ready PR.
> Looking for feedback on the approach before investing further.
> An opt-in flag, and any change to the existing input path (`PointerBinding`), are out of scope here.

## Summary

Addresses https://github.com/flutter/flutter/issues/69529

On mobile the browser address bar never collapses because Flutter web sets `touch-action: none` on body, so the browser never sees a scroll. Four things, on Android and iOS, and only when Flutter owns the whole page:

1. `touch-action: pan-y` on body, so the browser reads a vertical drag as a scroll.
2. A spacer under `<html>`, giving the document real overflow — a scroll for the browser to consume and spend on its address bar.
3. Everything that scroll would otherwise do to the app, held off: it must not move, resize, pull to refresh or carry momentum. Only the bar reacts.
4. The touch input stream rebuilt from Touch Events and `pointerrawupdate`, because `pan-y` makes the browser cancel the touch Pointer Events mid-drag.

iOS Safari

https://github.com/user-attachments/assets/fa0e0e42-c97d-441a-8725-327bfe0241ec

Android Chrome (Secure context)

https://github.com/user-attachments/assets/c5322d76-eb6d-4461-bcfd-bd06b0a053e0

## Design decisions

1. `touch-action: pan-y` on mobile.
   * The address bar doesn't collapse without it, and everything else here follows from the browser claiming the drag and ending the touch pointer stream.
2. Touch input through Touch Events.
   * Not a preference between the two APIs: under `pan-y` the touch Pointer Event stream ends mid-drag, so it cannot carry touch input at all.
   * Touch Events cost `pointerType` and tilt, and leave multi-touch movement on the throttled `touchmove`.

## Details

### Touch input

Touch-type Pointer Events are withheld from `PointerBinding` and Touch Events are translated into `PointerData` in their place. The withholding happens in the bubble phase on the view root via `stopImmediatePropagation` — the controller is constructed before `PointerBinding`, so its listener runs first. It is deliberately not a capture listener on the window: platform views and native text fields are descendants of the view root and see the events before anything is stopped.

`pointerrawupdate` ([MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/pointerrawupdate_event), [Pointer Events Level 3](https://www.w3.org/TR/pointerevents3/)) is the more precise movement source, since the browser throttles `touchmove` while it is scrolling. Safari doesn't implement it and Chrome withholds it outside a secure context, so `touchmove` is the fallback.

Two things follow from the spec. It never fires for the changes that fire `pointerdown`/`pointerup`, so the contact's lifetime comes from Touch Events. And it carries no id that can be matched to a Touch contact, so it is used only while a single finger is down; with more than one, the `touchmove`s, which do carry ids, drive the movement.

### scroll-snap

Android uses `y proximity` with a `calc(100lvh + 1px)` spacer: Chrome won't collapse the bar under `mandatory`, and a longer scroll range would keep scrolling the page after the browser chrome is already gone.

On iOS the snapping is not about the bar but about the scroll range. `y mandatory` parks the page on a snap target in the middle of a 10000px spacer, thousands of pixels from either end, which keeps pull-to-refresh and rubber-banding out of reach and stops Safari's momentum scrolling from carrying on past the gesture. Under `proximity` both come back.

<details>
<summary>Test app (lib/main.dart)</summary>

```dart
import 'package:material_ui/material_ui.dart';

void main() {
  runApp(const WebScrollTestApp());
}

class WebScrollTestApp extends StatelessWidget {
  const WebScrollTestApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      title: 'Address Bar Controller Test',
      home: const TestMenu(),
    );
  }
}

class TestMenu extends StatelessWidget {
  const TestMenu({super.key});

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(title: const Text('Tests')),
      body: ListView(
        padding: const .all(16),
        children: [
          _TestTile(
            title: 'Basic Vertical ListView',
            subtitle: 'Address bar should collapse when scrolling down',
            destination: const BasicVerticalListTest(),
          ),
          _TestTile(
            title: 'Nested Scrollables',
            subtitle: 'Horizontal PageView inside a vertical ListView',
            destination: const NestedScrollTest(),
          ),
          _TestTile(
            title: 'Interactive Widgets',
            subtitle: 'Buttons, sliders, text fields inside a scroll view',
            destination: const InteractiveWidgetsTest(),
          ),
          _TestTile(
            title: 'Tap-Only Page (No Scroll)',
            subtitle: 'Non-scrollable page with tappable buttons',
            destination: const TapOnlyTest(),
          ),
        ],
      ),
    );
  }
}

class _TestTile extends StatelessWidget {
  const _TestTile({
    required this.title,
    required this.subtitle,
    required this.destination,
  });

  final String title;
  final String subtitle;
  final Widget destination;

  @override
  Widget build(BuildContext context) {
    return Card(
      child: ListTile(
        title: Text(title),
        subtitle: Text(subtitle),
        trailing: const Icon(Icons.arrow_forward_ios, size: 16),
        onTap: () {
          Navigator.of(context)
              .push(MaterialPageRoute<void>(builder: (_) => destination));
        },
      ),
    );
  }
}

class BasicVerticalListTest extends StatelessWidget {
  const BasicVerticalListTest({super.key});

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(title: const Text('Basic Vertical List')),
      body: ListView.builder(
        itemCount: 100,
        itemBuilder: (context, index) => ListTile(
          leading: CircleAvatar(child: Text('${index + 1}')),
          title: Text('Item ${index + 1}'),
          subtitle: Text('Scroll to collapse the address bar'),
          tileColor: index.isEven ? null : Colors.grey.shade50,
        ),
      ),
    );
  }
}

class NestedScrollTest extends StatelessWidget {
  const NestedScrollTest({super.key});

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(title: const Text('Nested Scrollables')),
      body: ListView(
        children: [
          const Padding(
            padding: .all(16),
            child: Text(
              'Vertical scroll should collapse address bar.\n'
              'Horizontal swipe should switch pages without interfering.',
              style: TextStyle(fontSize: 14, color: Colors.grey),
            ),
          ),
          // Horizontal PageView
          SizedBox(
            height: 200,
            child: PageView.builder(
              itemCount: 10,
              itemBuilder: (context, index) => Card(
                margin: const .symmetric(horizontal: 16, vertical: 8),
                color:
                    Colors.primaries[index % Colors.primaries.length].shade200,
                child: Center(
                  child: Text(
                    'Page ${index + 1}',
                    style: const TextStyle(
                      fontSize: 24,
                      fontWeight: FontWeight.bold,
                    ),
                  ),
                ),
              ),
            ),
          ),
          // More vertical content
          for (int i = 0; i < 50; i++)
            ListTile(
              leading: CircleAvatar(
                backgroundColor: Colors.teal.shade100,
                child: Text('${i + 1}'),
              ),
              title: Text('List item ${i + 1}'),
            ),
        ],
      ),
    );
  }
}

class InteractiveWidgetsTest extends StatefulWidget {
  const InteractiveWidgetsTest({super.key});

  @override
  State<InteractiveWidgetsTest> createState() => _InteractiveWidgetsTestState();
}

class _InteractiveWidgetsTestState extends State<InteractiveWidgetsTest> {
  double _sliderValue = 0.5;
  bool _switchValue = false;
  int _tapCount = 0;
  final _textController = TextEditingController();

  @override
  void dispose() {
    _textController.dispose();
    super.dispose();
  }

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(title: const Text('Interactive Widgets')),
      body: ListView(
        padding: const .all(16),
        children: [
          const Text(
            'All widgets below should remain fully interactive '
            'even with the address bar controller active.',
            style: TextStyle(color: Colors.grey),
          ),
          const SizedBox(height: 16),

          // Tap counter
          Card(
            child: Padding(
              padding: const .all(16),
              child: Column(
                children: [
                  Text(
                    'Tap count: $_tapCount',
                    style: const TextStyle(fontSize: 18),
                  ),
                  const SizedBox(height: 8),
                  Row(
                    mainAxisAlignment: MainAxisAlignment.center,
                    children: [
                      ElevatedButton(
                        onPressed: () => setState(() => _tapCount++),
                        child: const Text('Tap me'),
                      ),
                      const SizedBox(width: 12),
                      OutlinedButton(
                        onPressed: () => setState(() => _tapCount = 0),
                        child: const Text('Reset'),
                      ),
                    ],
                  ),
                ],
              ),
            ),
          ),
          const SizedBox(height: 12),

          // Slider
          Card(
            child: Padding(
              padding: const .all(16),
              child: Column(
                children: [
                  Text('Slider: ${_sliderValue.toStringAsFixed(2)}'),
                  Slider(
                    value: _sliderValue,
                    onChanged: (v) => setState(() => _sliderValue = v),
                  ),
                ],
              ),
            ),
          ),
          const SizedBox(height: 12),

          // Switch
          Card(
            child: SwitchListTile(
              title: const Text('Toggle switch'),
              value: _switchValue,
              onChanged: (v) => setState(() => _switchValue = v),
            ),
          ),
          const SizedBox(height: 12),

          // TextField
          Card(
            child: Padding(
              padding: const .all(16),
              child: TextField(
                controller: _textController,
                decoration: const InputDecoration(
                  labelText: 'Type something',
                  border: OutlineInputBorder(),
                ),
              ),
            ),
          ),
          const SizedBox(height: 12),

          // GestureDetector with long press
          Card(
            child: GestureDetector(
              onLongPress: () {
                ScaffoldMessenger.of(context).showSnackBar(
                  const SnackBar(content: Text('Long press detected!')),
                );
              },
              child: Container(
                padding: const .all(24),
                alignment: Alignment.center,
                child: const Text('Long press me'),
              ),
            ),
          ),

          // Spacer items to make scrollable
          for (int i = 0; i < 30; i++)
            ListTile(
              title: Text('Filler item ${i + 1}'),
              tileColor: i.isEven ? Colors.grey.shade50 : null,
            ),
        ],
      ),
    );
  }
}

class TapOnlyTest extends StatefulWidget {
  const TapOnlyTest({super.key});

  @override
  State<TapOnlyTest> createState() => _TapOnlyTestState();
}

class _TapOnlyTestState extends State<TapOnlyTest> {
  Color _color = Colors.blue;
  int _counter = 0;

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(title: const Text('Tap Only (No Scroll)')),
      body: Center(
        child: Column(
          mainAxisAlignment: MainAxisAlignment.center,
          children: [
            const Text(
              'This page has no scrollable content.\n'
              'Taps, drags, and other gestures should work normally.',
              textAlign: TextAlign.center,
              style: TextStyle(color: Colors.grey),
            ),
            const SizedBox(height: 32),
            GestureDetector(
              onTap: () {
                setState(() {
                  _counter++;
                  _color = Colors.primaries[_counter % Colors.primaries.length];
                });
              },
              child: AnimatedContainer(
                duration: const Duration(milliseconds: 300),
                width: 150,
                height: 150,
                decoration: BoxDecoration(
                  color: _color,
                  borderRadius: BorderRadius.circular(24),
                ),
                alignment: Alignment.center,
                child: Text(
                  '$_counter',
                  style: const TextStyle(
                    color: Colors.white,
                    fontSize: 48,
                    fontWeight: FontWeight.bold,
                  ),
                ),
              ),
            ),
            const SizedBox(height: 24),
            const Text('Tap the box to change color'),
          ],
        ),
      ),
    );
  }
} 
```
</details>

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
