### PR TITLE
fix: clamp texture dimensions to prevent zero-sized textures (#179572)

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/gles/test/texture_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/texture_gles_unittests.cc
@@ -94,6 +94,19 @@ TEST_P(TextureGLESTest, Binds2DTexture) {
   }
 }
 
+
+TEST_P(TextureGLESTest, ZeroSizedTextureIsClampedValid) {
+  TextureDescriptor desc;
+  desc.storage_mode = StorageMode::kDevicePrivate;
+  desc.size = {0, 0};
+  desc.format = PixelFormat::kR8G8B8A8UNormInt;
+
+  auto texture = GetContext()->GetResourceAllocator()->CreateTexture(desc);
+
+  ASSERT_TRUE(texture);
+  EXPECT_TRUE(TextureGLES::Cast(*texture).IsValid());
+}
+
 TEST_P(TextureGLESTest, Leak) {
   TextureDescriptor desc;
   desc.storage_mode = StorageMode::kDevicePrivate;

--- a/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.cc
@@ -128,7 +128,15 @@ TextureGLES::TextureGLES(std::shared_ptr<ReactorGLES> reactor,
                          bool threadsafe,
                          std::optional<GLuint> fbo,
                          std::optional<HandleGLES> external_handle)
-    : Texture(desc),
+    : Texture([](TextureDescriptor d) {
+        if (d.size.width <= 0) {
+          d.size.width = 1;
+        }
+        if (d.size.height <= 0) {
+          d.size.height = 1;
+        }
+        return d;
+      }(desc)),
       reactor_(std::move(reactor)),
       type_(GetTextureTypeFromDescriptor(
           GetTextureDescriptor(),


### PR DESCRIPTION
Fixes #179572

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

*This PR fixes an issue where VideoPlayer wrapped in a SizedBox with dimensions less than 1 would cause zero or near-zero texture dimensions, breaking Impeller rendering with an "Invalid texture descriptor" error. The fix clamps texture dimensions to at least 1 pixel in the TextureGLES constructor to prevent invalid descriptors from being created.*

*Fixes issue where zero-sized textures could be created when VideoPlayer is wrapped in a SizedBox with dimensions < 1.*

*This change affects the texture creation process in the GLES backend and ensures that all textures have valid dimensions before being used in rendering.*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
