### PR TITLE
[Android][Accessibility] Guard fontWeightAdjustment access in AccessibilityBridge

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -25,6 +25,7 @@ import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityManager;
 import android.view.accessibility.AccessibilityNodeInfo;
 import android.view.accessibility.AccessibilityNodeProvider;
+import androidx.annotation.DoNotInline;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
@@ -658,8 +659,14 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
     if (rootAccessibilityView == null || rootAccessibilityView.getResources() == null) {
       return;
     }
-    int fontWeightAdjustment =
-        rootAccessibilityView.getResources().getConfiguration().fontWeightAdjustment;
+    int fontWeightAdjustment;
+    try {
+      fontWeightAdjustment = Api31Impl.getFontWeightAdjustment(rootAccessibilityView);
+    } catch (NoSuchFieldError exception) {
+      accessibilityFeatureFlags &= ~AccessibilityFeature.BOLD_TEXT.value;
+      sendLatestAccessibilityFlagsToFlutter();
+      return;
+    }
     boolean shouldBold =
         fontWeightAdjustment != Configuration.FONT_WEIGHT_ADJUSTMENT_UNDEFINED
             && fontWeightAdjustment >= BOLD_TEXT_WEIGHT_ADJUSTMENT;
@@ -680,6 +687,14 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
   @VisibleForTesting
   public AccessibilityNodeInfo obtainAccessibilityNodeInfo(View rootView, int virtualViewId) {
     return AccessibilityNodeInfo.obtain(rootView, virtualViewId);
+  }
+
+  @RequiresApi(API_LEVELS.API_31)
+  private static class Api31Impl {
+    @DoNotInline
+    static int getFontWeightAdjustment(@NonNull View rootAccessibilityView) {
+      return rootAccessibilityView.getResources().getConfiguration().fontWeightAdjustment;
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
- move the API 31 `fontWeightAdjustment` field access behind a dedicated helper in `engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java`
- mark that helper as `@DoNotInline` so the field access stays out of the main code path
- fall back to "bold text unsupported" if an affected runtime still throws `NoSuchFieldError`

## Context
This follows up on flutter/flutter#184286.

AndroidX Compose hardened the same access pattern in July 2024, and this mirrors that shape while keeping the engine change to a single file.

I do not have a public repro project yet, so I am opening this as a draft to get feedback on the patch shape before I spend more time on a standalone reproducer.