### PR TITLE
Remove trivial test utility cross-imports from material and cupertino…

### DIFF
--- a/packages/flutter/test/cupertino/list_tile_tester.dart
+++ b/packages/flutter/test/cupertino/list_tile_tester.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/widgets.dart';
 
-/// A minimal ListTile widget for testing purposes.
+/// A minimal CupertinoListTile widget for testing purposes.
 class TestListTile extends StatelessWidget {
   /// Creates a minimal list tile for testing.
   const TestListTile({super.key, this.title, this.onTap});

--- a/packages/flutter/test/cupertino/list_tile_tester.dart
+++ b/packages/flutter/test/cupertino/list_tile_tester.dart
@@ -1,0 +1,32 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+
+/// A minimal ListTile widget for testing purposes.
+class TestListTile extends StatelessWidget {
+  /// Creates a minimal list tile for testing.
+  const TestListTile({super.key, this.title, this.onTap});
+
+  /// The primary content of the list tile.
+  final Widget? title;
+
+  /// Called when the user taps this list tile.
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final Widget content = Container(
+      constraints: const BoxConstraints(minHeight: 56.0),
+      padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 4.0),
+      child: title,
+    );
+
+    if (onTap != null) {
+      return GestureDetector(onTap: onTap, behavior: HitTestBehavior.opaque, child: content);
+    }
+
+    return content;
+  }
+}

--- a/packages/flutter/test/cupertino/switch_test.dart
+++ b/packages/flutter/test/cupertino/switch_test.dart
@@ -17,7 +17,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/list_tile_tester.dart';
+import 'list_tile_tester.dart';
 import '../widgets/semantics_tester.dart';
 
 void main() {

--- a/packages/flutter/test/cupertino/switch_test.dart
+++ b/packages/flutter/test/cupertino/switch_test.dart
@@ -17,8 +17,8 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'list_tile_tester.dart';
 import '../widgets/semantics_tester.dart';
+import 'list_tile_tester.dart';
 
 void main() {
   testWidgets('Switch can toggle on tap', (WidgetTester tester) async {

--- a/packages/flutter/test/material/material_test.dart
+++ b/packages/flutter/test/material/material_test.dart
@@ -13,7 +13,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 import '../widgets/multi_view_testing.dart';
-import '../widgets/test_border.dart' show TestBorder;
+import 'test_border.dart' show TestBorder;
 
 class NotifyMaterial extends StatelessWidget {
   const NotifyMaterial({super.key});

--- a/packages/flutter/test/material/process_text_utils.dart
+++ b/packages/flutter/test/material/process_text_utils.dart
@@ -1,0 +1,52 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+/// The ID of a fake text processing action.
+const String fakeAction1Id = 'fakeActivity.fakeAction1';
+
+/// The ID of another fake text processing action.
+const String fakeAction2Id = 'fakeActivity.fakeAction2';
+
+/// The label of a fake text processing action.
+const String fakeAction1Label = 'Action1';
+
+/// The label of another fake text processing action.
+const String fakeAction2Label = 'Action2';
+
+/// A mock handler for text processing for tests.
+class MockProcessTextHandler {
+  /// The ID of the last action that was called.
+  String? lastCalledActionId;
+
+  /// The text that was passed to the last action that was called.
+  String? lastTextToProcess;
+
+  /// A mock of the native text processing method call handler.
+  Future<Object?> handleMethodCall(MethodCall call) async {
+    if (call.method == 'ProcessText.queryTextActions') {
+      // Simulate that only the Android engine will return a non-null result.
+      if (defaultTargetPlatform == TargetPlatform.android) {
+        return <String, String>{fakeAction1Id: fakeAction1Label, fakeAction2Id: fakeAction2Label};
+      }
+    }
+    if (call.method == 'ProcessText.processTextAction') {
+      final args = call.arguments as List<dynamic>;
+      final actionId = args[0] as String;
+      final textToProcess = args[1] as String;
+      lastCalledActionId = actionId;
+      lastTextToProcess = textToProcess;
+
+      if (actionId == fakeAction1Id) {
+        // Simulates an action that returns a transformed text.
+        return '$textToProcess!!!';
+      }
+      // Simulates an action that failed or does not transform text.
+      return null;
+    }
+    return null;
+  }
+}

--- a/packages/flutter/test/material/selection_area_test.dart
+++ b/packages/flutter/test/material/selection_area_test.dart
@@ -10,7 +10,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/process_text_utils.dart';
+import 'process_text_utils.dart';
 
 Offset textOffsetToPosition(RenderParagraph paragraph, int offset) {
   const caret = Rect.fromLTWH(0.0, 0.0, 2.0, 20.0);

--- a/packages/flutter/test/material/test_border.dart
+++ b/packages/flutter/test/material/test_border.dart
@@ -1,0 +1,40 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+
+/// A function that logs a string.
+typedef Logger = void Function(String caller);
+
+/// A [ShapeBorder] for testing that logs its method calls.
+class TestBorder extends ShapeBorder {
+  /// Creates a [TestBorder] that logs to [onLog].
+  const TestBorder(this.onLog);
+
+  /// The callback that is called when a method on this border is called.
+  final Logger onLog;
+
+  @override
+  EdgeInsetsGeometry get dimensions => const EdgeInsetsDirectional.only(start: 1.0);
+
+  @override
+  ShapeBorder scale(double t) => TestBorder(onLog);
+
+  @override
+  Path getInnerPath(Rect rect, {TextDirection? textDirection}) {
+    onLog('getInnerPath $rect $textDirection');
+    return Path();
+  }
+
+  @override
+  Path getOuterPath(Rect rect, {TextDirection? textDirection}) {
+    onLog('getOuterPath $rect $textDirection');
+    return Path();
+  }
+
+  @override
+  void paint(Canvas canvas, Rect rect, {TextDirection? textDirection}) {
+    onLog('paint $rect $textDirection');
+  }
+}

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -26,11 +26,11 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../widgets/clipboard_utils.dart';
 import '../widgets/feedback_tester.dart';
-import '../widgets/process_text_utils.dart';
 import '../widgets/semantics_tester.dart';
 import '../widgets/text_selection_toolbar_utils.dart';
 import 'editable_text_utils.dart';
 import 'live_text_utils.dart';
+import 'process_text_utils.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();


### PR DESCRIPTION
Removes cross-directory test imports of four trivial test utilities from material and cupertino tests.
                                                                                                                                                                                                         
Part of #182636.
                                                                                                                                                                                                         
All four utilities are small (20-40 lines) with trivial implementations, so duplication is the appropriate strategy per the issue guidelines:                                                            
 
- `test_border.dart` (36 lines) → `test/material/` (1 file updated)                                                                                                                                      
- `sliver_test_utils.dart` (20 lines) → `test/material/` (1 file updated)
- `process_text_utils.dart` (40 lines) → `test/material/` (2 files updated)                                                                                                                              
- `list_tile_tester.dart` (30 lines) → `test/cupertino/` (1 file updated)                                                                                                                                
 
## Pre-launch Checklist                                                                                                                                                                                  
                                                                
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.                                                                                                         
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.                                                                                                                           
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].                                                                                           
- [x] I signed the [CLA].                                                                                                                                                                                
- [x] I listed at least one issue that this PR fixes in the description above.                                                                                                                           
- [x] I updated/added relevant documentation (doc comments with `///`).                                                                                                                                  
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].                                                                                                                    
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.                                                                                                             
- [x] All existing and new tests are passing. 

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
