### PR TITLE
Fix _scheduleSystemFontsUpdate assertion during non-idle scheduler phase

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -145,3 +145,4 @@ Kamil Kras <vemu.kkras@gmail.com>
 Piotr Rogulski <piter.rogulski@gmail.com>
 Michal Kucharski <michal.kucharski17@gmail.com>
 Alexander Dmitriev <veselblu@yandex.ru>
+Solvejet <karan@solvejet.net>

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -4700,15 +4700,16 @@ mixin RelayoutWhenSystemFontsChangeMixin on RenderObject {
 
   bool _hasPendingSystemFontsDidChangeCallBack = false;
   void _scheduleSystemFontsUpdate() {
-    assert(
-      SchedulerBinding.instance.schedulerPhase == SchedulerPhase.idle,
-      '${objectRuntimeType(this, "RelayoutWhenSystemFontsChangeMixin")}._scheduleSystemFontsUpdate() '
-      'called during ${SchedulerBinding.instance.schedulerPhase}.',
-    );
     if (_hasPendingSystemFontsDidChangeCallBack) {
       return;
     }
     _hasPendingSystemFontsDidChangeCallBack = true;
+
+    // The system fonts notification can arrive during any scheduler phase
+    // (e.g. midFrameMicrotasks on web when fonts load asynchronously).
+    // scheduleFrameCallback is safe to call during any phase; if called
+    // mid-frame, the callback runs in the next frame's transient callback
+    // phase since handleBeginFrame snapshots and replaces _transientCallbacks.
     SchedulerBinding.instance.scheduleFrameCallback((Duration timeStamp) {
       assert(_hasPendingSystemFontsDidChangeCallBack);
       _hasPendingSystemFontsDidChangeCallBack = false;

--- a/packages/flutter/test/painting/system_fonts_test.dart
+++ b/packages/flutter/test/painting/system_fonts_test.dart
@@ -220,6 +220,37 @@ void main() {
     await verifyMarkedNeedsLayoutDuringTransientCallbacksPhase(tester, renderObject);
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/151873
+  testWidgets('System fonts update during non-idle scheduler phase does not assert', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const MaterialApp(home: Text('Hello')));
+
+    // Simulate a fontsChange system message arriving during a non-idle
+    // scheduler phase (e.g. midFrameMicrotasks on web when fonts load
+    // asynchronously). Previously this caused an assertion failure in
+    // _scheduleSystemFontsUpdate because it assumed the scheduler was idle.
+    tester.binding.scheduleFrameCallback((Duration timeStamp) {
+      // We're now inside transientCallbacks phase (not idle).
+      // Trigger a fonts change notification from here.
+      const data = <String, dynamic>{'type': 'fontsChange'};
+      tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+        'flutter/system',
+        SystemChannels.system.codec.encodeMessage(data),
+        (ByteData? data) {},
+      );
+    });
+
+    // Pump to execute the frame callback. This should not throw.
+    await tester.pump();
+
+    // Pump again to let the scheduled frame callback run.
+    await tester.pump();
+
+    // Verify the text widget still renders correctly after the fonts update.
+    expect(find.text('Hello'), findsOneWidget);
+  });
+
   testWidgets('TimePicker relayout upon system fonts changes', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(


### PR DESCRIPTION
## Description

Fixes the assertion failure in RelayoutWhenSystemFontsChangeMixin._scheduleSystemFontsUpdate() when the system fonts notification arrives during a non-idle scheduler phase.

## Problem

On web, when fonts load asynchronously (e.g. via google_fonts), the platform sends a fontsChange system message that can arrive during SchedulerPhase.midFrameMicrotasks. The _scheduleSystemFontsUpdate method asserted schedulerPhase == idle, causing:

`Failed assertion: SchedulerBinding.instance.schedulerPhase == SchedulerPhase.idle`

## Fix

Remove the idle-phase assertion

scheduleFrameCallback is safe to call during any phase — if called mid-frame, the callback naturally runs in the next frame's transient callback phase (since handleBeginFrame snapshots and replaces _transientCallbacks before iterating)

The _hasPendingSystemFontsDidChangeCallBack flag prevents duplicate scheduling

## Test

Added regression test that triggers a fontsChange platform message during transientCallbacks phase.

Fixes #151873