### PR TITLE
Fix visual misalignment of WidgetSpan when text alignment changes

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1009,6 +1009,12 @@ class RenderParagraph extends RenderBox
     // been invalidated but performLayout wasn't called at this point. Make sure
     // the TextPainter has a valid layout.
     _layoutTextWithConstraints(constraints);
+    // Re-position inline children since the paint offset may have changed when
+    // only a repaint was triggered (e.g. textAlign change). See also:
+    // https://github.com/flutter/flutter/issues/181532
+    if (childCount > 0) {
+      positionInlineChildren(_textPainter.inlinePlaceholderBoxes!);
+    }
     assert(() {
       if (debugRepaintTextRainbowEnabled) {
         final paint = Paint()..color = debugCurrentRepaintColor.toColor();

--- a/packages/flutter/lib/src/widgets/widget_span.dart
+++ b/packages/flutter/lib/src/widgets/widget_span.dart
@@ -420,7 +420,7 @@ class _RenderScaledInlineWidget extends RenderBox with RenderObjectWithChildMixi
 
   @override
   void applyPaintTransform(RenderBox child, Matrix4 transform) {
-    transform.scaleByDouble(scale, scale, scale, 1);
+    transform.scale(scale, scale, 1.0);
   }
 
   @override

--- a/packages/flutter/test/widgets/text_test.dart
+++ b/packages/flutter/test/widgets/text_test.dart
@@ -1813,6 +1813,51 @@ void main() {
 
     semantics.dispose();
   });
+
+  testWidgets(
+    'WidgetSpan is correctly positioned after textAlign triggers only a repaint',
+    (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/181532.
+      // When textAlign changes, only markNeedsPaint() is called, but the paint
+      // offset shifts the text. positionInlineChildren must be called during
+      // paint so WidgetSpan children stay aligned with surrounding text.
+      const double widgetWidth = 30.0;
+      const double widgetHeight = 20.0;
+
+      Widget buildText(TextAlign align) {
+        return Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: SizedBox(
+              width: 300.0,
+              child: Text.rich(
+                TextSpan(
+                  children: <InlineSpan>[
+                    const TextSpan(text: 'before '),
+                    WidgetSpan(
+                      alignment: PlaceholderAlignment.middle,
+                      child: SizedBox(width: widgetWidth, height: widgetHeight),
+                    ),
+                    const TextSpan(text: ' after'),
+                  ],
+                ),
+                textAlign: align,
+              ),
+            ),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(buildText(TextAlign.left));
+      final Offset leftAlignedPosition = tester.getTopLeft(find.byType(SizedBox).last);
+
+      await tester.pumpWidget(buildText(TextAlign.right));
+      final Offset rightAlignedPosition = tester.getTopLeft(find.byType(SizedBox).last);
+
+      // The WidgetSpan should shift horizontally when text alignment changes.
+      expect(rightAlignedPosition.dx, greaterThan(leftAlignedPosition.dx));
+    },
+  );
 }
 
 Future<void> _pumpTextWidget({


### PR DESCRIPTION
**Description:**
Fixes a visual misalignment of WidgetSpan children inside Text.rich() when textAlign changes (e.g. on window resize with centered/right-aligned text).
                                                                                                                                                                                                                              
  When textAlign changes on a RenderParagraph, only markNeedsPaint() is called — not markNeedsLayout(). During paint(), _layoutTextWithConstraints() re-lays out the TextPainter, which updates paintOffset and shifts the    
  visual position of the surrounding text. However, positionInlineChildren — which sets WidgetSpan child offsets based on inlinePlaceholderBoxes — was only ever called in performLayout. As a result, WidgetSpan children    
  remained at stale positions while the surrounding text shifted, producing a visible gap or misalignment between text and inline widgets.                                                                                    
                                                            
  **Changes:**
  - In RenderParagraph.paint(), call positionInlineChildren(_textPainter.inlinePlaceholderBoxes!) after _layoutTextWithConstraints() when inline children are present, so child offsets are kept in sync with the text's paint
   offset on every repaint.                                                                                                                                                                                                   
  - In _RenderScaledInlineWidget.applyPaintTransform(), fix the Z-axis scale value from scale to 1.0 to be consistent with paint() and hitTestChildren(), both of which use Matrix4.diagonal3Values(scale, scale, 1.0).
  - Added a regression test verifying that a WidgetSpan's position shifts correctly when textAlign changes from TextAlign.left to TextAlign.right.                                                                            
                                                                                                                                                                                                                              
  Before: WidgetSpan stays at its original painted position when textAlign changes, causing a visible gap between it and the surrounding TextSpan content.                                                                    
                                                                                                                                                                                                                              
  After: WidgetSpan is correctly repositioned to stay aligned with surrounding text on every repaint.                                                                                                                         
                                                                                                                                                                                                                              
  Issues Fixed                                                                                                                                                                                                                
                                                            
  Fixes https://github.com/flutter/flutter/issues/181532    

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
