### PR TITLE
fix(web): call ui.Picture.onDispose for the original picture only

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/picture.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/picture.dart
@@ -17,21 +17,18 @@ import 'surface.dart';
 
 /// Implements [ui.Picture] on top of [SkPicture].
 class CkPicture implements LayerPicture, StackTraceDebugger {
-  CkPicture(SkPicture skPicture) {
-    _ref = CkCountedRef<CkPicture, SkPicture>(
-      skPicture,
-      this,
-      'Picture',
-      onDisposed: (CkPicture picture) => ui.Picture.onDispose?.call(picture),
-    );
+  CkPicture(SkPicture skPicture) : _isClone = false {
+    _ref = CkCountedRef<CkPicture, SkPicture>(skPicture, this, 'Picture');
     _initStackTrace();
   }
 
-  CkPicture._clone(CkCountedRef<CkPicture, SkPicture> ref) {
+  CkPicture._clone(CkCountedRef<CkPicture, SkPicture> ref) : _isClone = true {
     _ref = ref;
     ref.ref(this);
     _initStackTrace();
   }
+
+  final bool _isClone;
 
   late final CkCountedRef<CkPicture, SkPicture> _ref;
 
@@ -97,6 +94,9 @@ class CkPicture implements LayerPicture, StackTraceDebugger {
       _debugDisposalStackTrace = StackTrace.current;
       return true;
     }());
+    if (!_isClone) {
+      ui.Picture.onDispose?.call(this);
+    }
     _isDisposed = true;
     _ref.unref(this);
   }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/picture.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/picture.dart
@@ -7,22 +7,23 @@ import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 import 'package:ui/ui.dart' as ui;
 
 class SkwasmPicture implements LayerPicture, StackTraceDebugger {
-  SkwasmPicture.fromHandle(PictureHandle handle) {
+  SkwasmPicture.fromHandle(PictureHandle handle) : _isClone = false {
     box = CountedRef<SkwasmPicture, PictureHandle>(
       handle,
       this,
       'Picture',
       onDispose: (PictureHandle h) => pictureDispose(h),
-      onDisposed: (SkwasmPicture picture) => ui.Picture.onDispose?.call(picture),
     );
     _init();
     ui.Picture.onCreate?.call(this);
   }
 
-  SkwasmPicture.cloneOf(this.box) {
+  SkwasmPicture.cloneOf(this.box) : _isClone = true {
     box.ref(this);
     _init();
   }
+
+  final bool _isClone;
 
   void _init() {
     assert(() {
@@ -49,6 +50,9 @@ class SkwasmPicture implements LayerPicture, StackTraceDebugger {
   void dispose() {
     if (_disposed) {
       return;
+    }
+    if (!_isClone) {
+      ui.Picture.onDispose?.call(this);
     }
     _disposed = true;
     box.unref(this);

--- a/engine/src/flutter/lib/web_ui/test/ui/native_resource_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/ui/native_resource_test.dart
@@ -93,14 +93,17 @@ Future<void> testMain() async {
       expect(createCount, 1);
       expect(disposeCount, 0);
 
+      // The original picture should call onDispose when it is disposed,
+      // regardless of whether there are live clones.
       picture1.dispose();
       expect(createCount, 1);
-      expect(disposeCount, 0);
+      expect(disposeCount, 1);
 
+      // Disposing the clone should not call onDispose again.
       picture2.dispose();
       expect(createCount, 1);
       expect(disposeCount, 1);
-      expect(lastDisposedPicture, same(picture2));
+      expect(lastDisposedPicture, same(picture1));
 
       ui.Picture.onCreate = null;
       ui.Picture.onDispose = null;


### PR DESCRIPTION
This reverts a recent change where ui.Picture.onDispose is only called when the original picture and all clones have been disposed. This change broke leak tracker tests.

Fixes https://github.com/flutter/flutter/issues/184312

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
