### PR TITLE
Rick roll triagers on/near April 1st

### DIFF
--- a/docs/triage/README.md
+++ b/docs/triage/README.md
@@ -206,8 +206,8 @@ for (url in urls) {
 }
 
 targets.forEach((target) => window.open(target));
-const today = new Date();
-if (today.getMonth() === 3 && today.getDate() === 1) {
+function isNearAprilFools(){const e=new Date;e.setHours(0,0,0,0);const t=e.getFullYear(),n=new Date(t,3,1);return Math.abs(e-n)/864e5<=7}
+if (isNearAprilFools()) {
   window.open('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
 }
 ```

--- a/docs/triage/README.md
+++ b/docs/triage/README.md
@@ -206,6 +206,10 @@ for (url in urls) {
 }
 
 targets.forEach((target) => window.open(target));
+const today = new Date();
+if (today.getMonth() === 3 && today.getDate() === 1) {
+  window.open('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+}
 ```
 
 </details>


### PR DESCRIPTION
Triagers use this script to open all GitHub issues/PRs in new tabs. When the date is near April Fool's Day, then one of the tabs will be the rick roll video.

## Open questions

 * Does anyone still use this script or am I mostly rickrolling myself? Lots of people using AI for triage now.
 * Currently this will rick roll people +/- 1 week from April Fool's Day. Is that too much?
 * Should I be disciplined for wasting company resources by submitting this PR?