### PR TITLE
Inject FlutterFramework dependency in iOS Add2App swift packages

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_swift_package.dart
+++ b/packages/flutter_tools/lib/src/commands/build_swift_package.dart
@@ -951,7 +951,7 @@ class FlutterPluginSwiftDependencies {
         if (dependencyData case {'fileSystem': final List<Object?> fileSystemData}) {
           for (final Map<String, Object?> fileSystemData
               in fileSystemData.whereType<Map<String, Object?>>()) {
-            if (fileSystemData['identity'] == 'flutterframework') {
+            if (fileSystemData['identity'] == kFlutterGeneratedFrameworkSwiftPackageTargetName.toLowerCase()) {
               return true;
             }
           }
@@ -988,7 +988,7 @@ class FlutterPluginSwiftDependencies {
       'swift',
       'package',
       'add-dependency',
-      './FlutterFramework',
+      '../FlutterFramework',
       '--type',
       'path',
     ], workingDirectory: workingDirectory.path);
@@ -996,17 +996,17 @@ class FlutterPluginSwiftDependencies {
       throwToolExit('Failed to add FlutterFramework as a dependency. ${result.stderr}');
     }
     for (final targetName in targetNames) {
-      final ProcessResult result = await _utils.processManager.run([
+      final ProcessResult targetResult = await _utils.processManager.run([
         'swift',
         'package',
         'add-target-dependency',
-        'FlutterFramework',
+        kFlutterGeneratedFrameworkSwiftPackageTargetName,
         targetName,
         '--package',
-        'FlutterFramework',
+        kFlutterGeneratedFrameworkSwiftPackageTargetName,
       ], workingDirectory: workingDirectory.path);
-      if (result.exitCode != 0) {
-        throwToolExit('Failed to add FlutterFramework as a target dependency. ${result.stderr}');
+      if (targetResult.exitCode != 0) {
+        throwToolExit('Failed to add FlutterFramework as a target dependency. ${targetResult.stderr}');
       }
     }
   }

--- a/packages/flutter_tools/lib/src/commands/build_swift_package.dart
+++ b/packages/flutter_tools/lib/src/commands/build_swift_package.dart
@@ -680,8 +680,15 @@ class FlutterPluginSwiftDependencies {
       _targetPlatform.supportedPackagePlatform;
 
   @visibleForTesting
-  /// A list of plugin name, path to the copied Swift package, and the plugin's supported version.
-  final List<({String name, String swiftPackagePath, SwiftPackageSupportedPlatform? version})>
+  /// A list of plugin name, path to the copied Swift package, and the plugin's required minimum
+  /// [SwiftPackageSupportedPlatform].
+  final List<
+    ({
+      String name,
+      String swiftPackagePath,
+      SwiftPackageSupportedPlatform? packageMinimumSupportedPlatform,
+    })
+  >
   copiedPlugins = [];
 
   /// Copy plugins from pubcache to [pluginsDirectory] and sets [highestSupportedVersion] to later
@@ -711,7 +718,7 @@ class FlutterPluginSwiftDependencies {
         final ({
           String name,
           String swiftPackagePath,
-          SwiftPackageSupportedPlatform? version,
+          SwiftPackageSupportedPlatform? packageMinimumSupportedPlatform,
           bool restoredFromCache,
         })
         result = await _processPlugin(plugin, pluginsDirectory, cacheDirectory);
@@ -721,7 +728,7 @@ class FlutterPluginSwiftDependencies {
         copiedPlugins.add((
           name: result.name,
           swiftPackagePath: result.swiftPackagePath,
-          version: result.version,
+          packageMinimumSupportedPlatform: result.packageMinimumSupportedPlatform,
         ));
       }
       _highestSupportedVersion = _determineHighestSupportedVersion(copiedPlugins);
@@ -742,7 +749,7 @@ class FlutterPluginSwiftDependencies {
     ({
       String name,
       String swiftPackagePath,
-      SwiftPackageSupportedPlatform? version,
+      SwiftPackageSupportedPlatform? packageMinimumSupportedPlatform,
       bool restoredFromCache,
     })
   >
@@ -756,28 +763,31 @@ class FlutterPluginSwiftDependencies {
     final File cachedManifest = pluginCache.childFile('Package.swift');
     final File cachedVersionFile = pluginCache.childFile('${_targetPlatform.name}.version');
 
-    final ({String name, String swiftPackagePath, SwiftPackageSupportedPlatform? version})? cached =
-        await _restoreFromCache(
-          pluginCache: pluginCache,
-          manifest: manifest,
-          swiftPackagePath: swiftPackagePath,
-          plugin: plugin,
-          cachedManifest: cachedManifest,
-          cachedVersionFile: cachedVersionFile,
-        );
+    final ({
+      String name,
+      String swiftPackagePath,
+      SwiftPackageSupportedPlatform? packageMinimumSupportedPlatform,
+    })?
+    cached = await _restoreFromCache(
+      pluginCache: pluginCache,
+      manifest: manifest,
+      swiftPackagePath: swiftPackagePath,
+      plugin: plugin,
+      cachedManifest: cachedManifest,
+      cachedVersionFile: cachedVersionFile,
+    );
     if (cached != null) {
       return (
         name: cached.name,
         swiftPackagePath: cached.swiftPackagePath,
-        version: cached.version,
+        packageMinimumSupportedPlatform: cached.packageMinimumSupportedPlatform,
         restoredFromCache: true,
       );
     }
 
     final Map<String, Object?> manifestAsJson = await _parseSwiftPackage(manifest);
-    final SwiftPackageSupportedPlatform? parsedPlatform = _parseSwiftPackageSupportedPlatform(
-      manifestAsJson,
-    );
+    final SwiftPackageSupportedPlatform? parsedPlatformVersion =
+        _parseSwiftPackageSupportedPlatform(manifestAsJson);
     final bool flutterDependencyFound = _hasFlutterDependency(manifestAsJson);
     if (!flutterDependencyFound) {
       final List<String> targetNames = _getTargetNames(manifestAsJson);
@@ -795,12 +805,12 @@ class FlutterPluginSwiftDependencies {
       manifest: manifest,
       cachedManifest: cachedManifest,
       cachedVersionFile: cachedVersionFile,
-      parsedPlatform: parsedPlatform,
+      parsedPlatformVersion: parsedPlatformVersion,
     );
     return (
       name: plugin.name,
       swiftPackagePath: swiftPackagePath,
-      version: parsedPlatform,
+      packageMinimumSupportedPlatform: parsedPlatformVersion,
       restoredFromCache: false,
     );
   }
@@ -838,7 +848,13 @@ class FlutterPluginSwiftDependencies {
 
   /// Restores the plugin info from the cache if the original manifest has not changed and the
   /// cached files exist.
-  Future<({String name, String swiftPackagePath, SwiftPackageSupportedPlatform? version})?>
+  Future<
+    ({
+      String name,
+      String swiftPackagePath,
+      SwiftPackageSupportedPlatform? packageMinimumSupportedPlatform,
+    })?
+  >
   _restoreFromCache({
     required Directory pluginCache,
     required File manifest,
@@ -879,7 +895,11 @@ class FlutterPluginSwiftDependencies {
           version: version,
         );
       }
-      return (name: plugin.name, swiftPackagePath: swiftPackagePath, version: parsedPlatform);
+      return (
+        name: plugin.name,
+        swiftPackagePath: swiftPackagePath,
+        packageMinimumSupportedPlatform: parsedPlatform,
+      );
     }
 
     fingerprinter.writeFingerprint();
@@ -892,20 +912,27 @@ class FlutterPluginSwiftDependencies {
     required File manifest,
     required File cachedVersionFile,
     required String basename,
-    required SwiftPackageSupportedPlatform? parsedPlatform,
+    required SwiftPackageSupportedPlatform? parsedPlatformVersion,
   }) {
     // Append the basename to the manifest to force Xcode to re-cache the package when the version changes.
     cachedManifest.writeAsStringSync('${manifest.readAsStringSync()}\n\n// $basename');
-    cachedVersionFile.writeAsStringSync(parsedPlatform?.version.toString() ?? '');
+    cachedVersionFile.writeAsStringSync(parsedPlatformVersion?.version.toString() ?? '');
   }
 
   /// Determine the highest [SwiftPackageSupportedPlatform] from the list of plugins.
   SwiftPackageSupportedPlatform _determineHighestSupportedVersion(
-    List<({String name, String swiftPackagePath, SwiftPackageSupportedPlatform? version})> plugins,
+    List<
+      ({
+        String name,
+        String swiftPackagePath,
+        SwiftPackageSupportedPlatform? packageMinimumSupportedPlatform,
+      })
+    >
+    plugins,
   ) {
     SwiftPackageSupportedPlatform highest = _targetPlatform.supportedPackagePlatform;
     for (final plugin in plugins) {
-      final SwiftPackageSupportedPlatform? pluginVersion = plugin.version;
+      final SwiftPackageSupportedPlatform? pluginVersion = plugin.packageMinimumSupportedPlatform;
       if (pluginVersion != null && pluginVersion.version > highest.version) {
         highest = pluginVersion;
       }
@@ -937,7 +964,12 @@ class FlutterPluginSwiftDependencies {
     if (manifestAsJson case {'platforms': final List<Object?> platformsData}) {
       for (final Map<String, Object?> platformData
           in platformsData.whereType<Map<String, Object?>>()) {
-        return SwiftPackageSupportedPlatform.fromJson(platformData);
+        final SwiftPackageSupportedPlatform? platform = SwiftPackageSupportedPlatform.fromJson(
+          platformData,
+        );
+        if (platform != null && platform.platform == _targetPlatform.swiftPackagePlatform) {
+          return platform;
+        }
       }
     }
     return null;
@@ -951,7 +983,8 @@ class FlutterPluginSwiftDependencies {
         if (dependencyData case {'fileSystem': final List<Object?> fileSystemData}) {
           for (final Map<String, Object?> fileSystemData
               in fileSystemData.whereType<Map<String, Object?>>()) {
-            if (fileSystemData['identity'] == kFlutterGeneratedFrameworkSwiftPackageTargetName.toLowerCase()) {
+            if (fileSystemData['identity'] ==
+                kFlutterGeneratedFrameworkSwiftPackageTargetName.toLowerCase()) {
               return true;
             }
           }
@@ -1006,7 +1039,9 @@ class FlutterPluginSwiftDependencies {
         kFlutterGeneratedFrameworkSwiftPackageTargetName,
       ], workingDirectory: workingDirectory.path);
       if (targetResult.exitCode != 0) {
-        throwToolExit('Failed to add FlutterFramework as a target dependency. ${targetResult.stderr}');
+        throwToolExit(
+          'Failed to add FlutterFramework as a target dependency. ${targetResult.stderr}',
+        );
       }
     }
   }
@@ -1019,7 +1054,11 @@ class FlutterPluginSwiftDependencies {
   }) {
     final List<SwiftPackagePackageDependency> packageDependencies = [];
     final List<SwiftPackageTargetDependency> targetDependencies = [];
-    for (final ({String name, String swiftPackagePath, SwiftPackageSupportedPlatform? version})
+    for (final ({
+          String name,
+          String swiftPackagePath,
+          SwiftPackageSupportedPlatform? packageMinimumSupportedPlatform,
+        })
         plugin
         in copiedPlugins) {
       // Symlink the swift package inside the packagesForConfiguration directory

--- a/packages/flutter_tools/lib/src/commands/build_swift_package.dart
+++ b/packages/flutter_tools/lib/src/commands/build_swift_package.dart
@@ -675,12 +675,13 @@ class FlutterPluginSwiftDependencies {
   /// The highest [SwiftPackageSupportedPlatform] among all of the Flutter SwiftPM plugins.
   /// Defaults to the Flutter framework's [SwiftPackageSupportedPlatform].
   SwiftPackageSupportedPlatform get highestSupportedVersion => _highestSupportedVersion;
-  late SwiftPackageSupportedPlatform _highestSupportedVersion =
+    late SwiftPackageSupportedPlatform _highestSupportedVersion =
       _targetPlatform.supportedPackagePlatform;
 
   @visibleForTesting
   /// A list of [Plugin]s copied and path to the copied Swift package.
-  final List<(Plugin, String)> copiedPlugins = [];
+  final List<({String name, String swiftPackagePath, SwiftPackageSupportedPlatform? version})>
+  copiedPlugins = [];
 
   /// Copy plugins from pubcache to [pluginsDirectory] and sets [highestSupportedVersion] to later
   /// be used when creating the FlutterPluginRegistrant.
@@ -689,22 +690,40 @@ class FlutterPluginSwiftDependencies {
     required List<Plugin> plugins,
     required Directory pluginsDirectory,
   }) async {
-    final Status status = _utils.logger.startProgress('   ├─Processing plugins...');
-    var skipped = false;
+    final Status status = _utils.logger.startProgress('Processing plugins...');
+    var skipped = true;
     try {
-      final List<File> manifests = await _copyPlugins(
-        plugins: plugins,
-        pluginsDirectory: pluginsDirectory,
-      );
-      final Version parsedHighestVersion;
-      (parsedHighestVersion, skipped) = await determineHighestSupportedVersion(
-        cacheDirectory: cacheDirectory,
-        manifests: manifests,
-      );
-      _highestSupportedVersion = SwiftPackageSupportedPlatform(
-        platform: _targetPlatform.swiftPackagePlatform,
-        version: parsedHighestVersion,
-      );
+      ErrorHandlingFileSystem.deleteIfExists(pluginsDirectory, recursive: true);
+    } on FileSystemException catch (e, stackTrace) {
+      // Delete may fail due to Xcode writing hidden files to the directory at the same time.
+      _utils.logger.printTrace('Failed to delete ${pluginsDirectory.path}: $e\n$stackTrace');
+    }
+    try {
+      for (final plugin in plugins) {
+        // If plugin does not support the platform, skip it.
+        if (!plugin.supportSwiftPackageManagerForPlatform(
+          _utils.fileSystem,
+          _targetPlatform.name,
+        )) {
+          continue;
+        }
+        final ({
+          String name,
+          String swiftPackagePath,
+          SwiftPackageSupportedPlatform? version,
+          bool restoredFromCache,
+        })
+        result = await _processPlugin(plugin, pluginsDirectory, cacheDirectory);
+        if (!result.restoredFromCache) {
+          skipped = false;
+        }
+        copiedPlugins.add((
+          name: result.name,
+          swiftPackagePath: result.swiftPackagePath,
+          version: result.version,
+        ));
+      }
+      _highestSupportedVersion = _determineHighestSupportedVersion(copiedPlugins);
     } finally {
       status.stop();
       if (skipped) {
@@ -713,64 +732,124 @@ class FlutterPluginSwiftDependencies {
     }
   }
 
-  /// Copies SwiftPM plugins from pubcache to [pluginsDirectory].
-  Future<List<File>> _copyPlugins({
-    required List<Plugin> plugins,
-    required Directory pluginsDirectory,
-  }) async {
-    final List<File> manifests = [];
-    try {
-      ErrorHandlingFileSystem.deleteIfExists(pluginsDirectory, recursive: true);
-    } on FileSystemException catch (e, stackTrace) {
-      // Delete may fail due to Xcode writing hidden files to the directory at the same time.
-      _utils.logger.printTrace('Failed to delete ${pluginsDirectory.path}: $e\n$stackTrace');
-    }
-    for (final plugin in plugins) {
-      // If plugin does not support the platform, skip it.
-      if (!plugin.supportSwiftPackageManagerForPlatform(_utils.fileSystem, _targetPlatform.name)) {
-        continue;
-      }
+  /// Processes a single plugin by copying it to the [pluginsDirectory] and modifying its Package.swift
+  /// to inject the plugin's version and Flutter framework dependency (if applicable).
+  ///
+  /// The modified manifest is saved to the cache to allow for skipping plugin processing on the
+  /// next run.
+  Future<
+    ({
+      String name,
+      String swiftPackagePath,
+      SwiftPackageSupportedPlatform? version,
+      bool restoredFromCache,
+    })
+  >
+  _processPlugin(Plugin plugin, Directory pluginsDirectory, Directory cacheDirectory) async {
+    // The entire plugin is copied instead of just the Swift package to maintain any relative
+    // links within the plugin.
+    // Example: https://github.com/firebase/flutterfire/blob/198aef8db6c96a08f57d750f1fa756da5e4a68a5/packages/firebase_core/firebase_core/ios/firebase_core/Package.swift#L21-L26
+    final String swiftPackagePath = await _copyPlugin(plugin, pluginsDirectory);
+    final File manifest = _utils.fileSystem.directory(swiftPackagePath).childFile('Package.swift');
 
-      // The entire plugin is copied instead of just the Swift package to maintain any relative
-      // links within the plugin.
-      // Example: https://github.com/firebase/flutterfire/blob/198aef8db6c96a08f57d750f1fa756da5e4a68a5/packages/firebase_core/firebase_core/ios/firebase_core/Package.swift#L21-L26
-      final Directory pluginDestination = pluginsDirectory.childDirectory(plugin.name)
-        ..createSync(recursive: true);
-      copyDirectory(_utils.fileSystem.directory(plugin.path), pluginDestination);
+    final Directory pluginCache = cacheDirectory
+        .childDirectory('Plugins')
+        .childDirectory(plugin.name);
+    final File cachedManifest = pluginCache.childFile('Package.swift');
+    final File cachedVersionFile = pluginCache.childFile('${_targetPlatform.name}.version');
 
-      final String? swiftPackagePath = plugin.pluginSwiftPackagePath(
-        _utils.fileSystem,
-        _targetPlatform.name,
-        overridePath: pluginDestination.path,
+    final ({String name, String swiftPackagePath, SwiftPackageSupportedPlatform? version})? cached =
+        await _restoreFromCache(
+          pluginCache: pluginCache,
+          manifest: manifest,
+          swiftPackagePath: swiftPackagePath,
+          plugin: plugin,
+          cachedManifest: cachedManifest,
+          cachedVersionFile: cachedVersionFile,
+        );
+    if (cached != null) {
+      return (
+        name: cached.name,
+        swiftPackagePath: cached.swiftPackagePath,
+        version: cached.version,
+        restoredFromCache: true,
       );
-      if (swiftPackagePath == null) {
-        throwToolExit("Failed to find copied ${plugin.name}'s Package.swift. $_kFileAnIssue");
-      }
-      copiedPlugins.add((plugin, swiftPackagePath));
-      manifests.add(_utils.fileSystem.directory(swiftPackagePath).childFile('Package.swift'));
     }
-    return manifests;
+
+    final Map<String, Object?> manifestAsJson = await _parseSwiftPackage(manifest);
+    final SwiftPackageSupportedPlatform? parsedPlatform = _parseSwiftPackageSupportedPlatform(
+      manifestAsJson,
+    );
+    final bool flutterDependencyFound = _hasFlutterDependency(manifestAsJson);
+    if (!flutterDependencyFound) {
+      final List<String> targetNames = _getTargetNames(manifestAsJson);
+      if (targetNames.isEmpty) {
+        throwToolExit('Failed to find any targets in ${plugin.name}');
+      }
+      await _injectFlutterDependencies(
+        targetNames: targetNames,
+        workingDirectory: _utils.fileSystem.directory(swiftPackagePath),
+      );
+    }
+
+    _saveManifestInfoToCache(
+      basename: _utils.fileSystem.directory(plugin.path).basename,
+      manifest: manifest,
+      cachedManifest: cachedManifest,
+      cachedVersionFile: cachedVersionFile,
+      parsedPlatform: parsedPlatform,
+    );
+    return (
+      name: plugin.name,
+      swiftPackagePath: swiftPackagePath,
+      version: parsedPlatform,
+      restoredFromCache: false,
+    );
   }
 
-  /// Returns the highest [SwiftPackageSupportedPlatform.version] among the plugins and `true` if
-  /// it was able to get the version from the cache.
-  ///
-  /// Saves the value to a file in [cacheDirectory] for quicker lookup when the list of Swift
-  /// package manifests has not changed.
-  @visibleForTesting
-  Future<(Version, bool)> determineHighestSupportedVersion({
-    required List<File> manifests,
-    required Directory cacheDirectory,
-  }) async {
-    final File savedHighestVersionFile = cacheDirectory.childFile(
-      '${_targetPlatform.name}.version',
+  Future<String> _copyPlugin(Plugin plugin, Directory pluginsDirectory) async {
+    final Directory pluginDestination = pluginsDirectory.childDirectory(plugin.name)
+      ..createSync(recursive: true);
+    copyDirectory(
+      _utils.fileSystem.directory(plugin.path),
+      pluginDestination,
+      shouldCopyDirectory: (directory) {
+        // Skip copying symlinks and build outputs.
+        return !directory.path.contains('.symlinks/plugins') &&
+            !directory.path.contains('example/build/') &&
+            !directory.path.contains('.build/') &&
+            !directory.path.contains('.swiftpm/') &&
+            !directory.path.contains('.dart_tool/');
+      },
     );
+
+    final String? swiftPackagePath = plugin.pluginSwiftPackagePath(
+      _utils.fileSystem,
+      _targetPlatform.name,
+      overridePath: pluginDestination.path,
+    );
+    if (swiftPackagePath == null) {
+      throwToolExit("Failed to find copied ${plugin.name}'s Package.swift. $_kFileAnIssue");
+    }
+    return swiftPackagePath;
+  }
+
+  /// Restores the plugin info from the cache if the original manifest has not changed and the
+  /// cached files exist.
+  Future<({String name, String swiftPackagePath, SwiftPackageSupportedPlatform? version})?>
+  _restoreFromCache({
+    required Directory pluginCache,
+    required File manifest,
+    required String swiftPackagePath,
+    required Plugin plugin,
+    required File cachedManifest,
+    required File cachedVersionFile,
+  }) async {
     final fingerprinter = Fingerprinter(
       fileSystem: _utils.fileSystem,
-      fingerprintPath: cacheDirectory.childFile('flutter_swift_pm_plugins.fingerprint').path,
+      fingerprintPath: pluginCache.childFile('manifest.fingerprint').path,
       paths: [
-        ...manifests.map((manifest) => manifest.path),
-        savedHighestVersionFile.path,
+        manifest.path,
         _utils.fileSystem.path.join(
           _utils.flutterRoot,
           'packages',
@@ -783,74 +862,53 @@ class FlutterPluginSwiftDependencies {
       ],
       logger: _utils.logger,
     );
-    if (fingerprinter.doesFingerprintMatch() && savedHighestVersionFile.existsSync()) {
-      // Use saved version if possible
-      final String versionAsString = savedHighestVersionFile.readAsStringSync();
-      final Version? savedVersion = Version.parse(versionAsString);
-      if (savedVersion != null) {
-        return (savedVersion, true);
+
+    if (fingerprinter.doesFingerprintMatch() &&
+        cachedManifest.existsSync() &&
+        cachedVersionFile.existsSync()) {
+      cachedManifest.copySync(manifest.path);
+
+      SwiftPackageSupportedPlatform? parsedPlatform;
+      final String versionString = cachedVersionFile.readAsStringSync();
+      final Version? version = Version.parse(versionString);
+      if (version != null) {
+        parsedPlatform = SwiftPackageSupportedPlatform(
+          platform: _targetPlatform.swiftPackagePlatform,
+          version: version,
+        );
       }
+      return (name: plugin.name, swiftPackagePath: swiftPackagePath, version: parsedPlatform);
     }
-    Version parsedHighestVersion = _highestSupportedVersion.version;
-    for (final manifest in manifests) {
-      // Parse the plugins for the minimum deployment target.
-      // The FlutterPluginRegistrant needs to match the highest version. Otherwise, it will error.
-      final Version? pluginSupportedVersion = await _parseSwiftPackageSupportedPlatform(manifest);
-      if (pluginSupportedVersion != null && (parsedHighestVersion < pluginSupportedVersion)) {
-        parsedHighestVersion = pluginSupportedVersion;
-      }
-    }
-    savedHighestVersionFile
-      ..createSync(recursive: true)
-      ..writeAsStringSync(parsedHighestVersion.toString());
+
     fingerprinter.writeFingerprint();
-    return (parsedHighestVersion, false);
+    return null;
   }
 
-  /// Parses the [SwiftPackageSupportedPlatform] from the Package.swift using either regex or
-  /// `swift` command line tool.
-  Future<Version?> _parseSwiftPackageSupportedPlatform(File swiftPackageManifest) async {
-    final String manifestContents = swiftPackageManifest.readAsStringSync();
-    if (!manifestContents.contains('platforms')) {
-      return null;
-    }
-    // First, attempt to parse with regex, which is fast
-    // e.g. \.iOS\([\s"]*([\._v\d]*)[\s"]*\) matches .iOS("13.0") or .iOS(.v13) or .iOS(.v10_15)
-    final pattern = RegExp(
-      r'\'
-      '${_targetPlatform.swiftPackagePlatform.displayName}'
-      r'\([\s"]*([\._v\d]*)[\s"]*\)',
-    );
-    final Iterable<RegExpMatch> matches = pattern.allMatches(manifestContents);
-    if (matches.length == 1) {
-      final String? match = matches.first.group(1);
-      if (match != null) {
-        final String normalizedVersionString = match.replaceAll('.v', '').replaceAll('_', '.');
-        final Version? parsedVersion = Version.parse(normalizedVersionString);
-        if (parsedVersion != null) {
-          return parsedVersion;
-        }
-      }
-    }
+  /// Saves the plugin manifest and [SwiftPackageSupportedPlatform] to the cache.
+  void _saveManifestInfoToCache({
+    required File cachedManifest,
+    required File manifest,
+    required File cachedVersionFile,
+    required String basename,
+    required SwiftPackageSupportedPlatform? parsedPlatform,
+  }) {
+    // Append the basename to the manifest to force Xcode to re-cache the package when the version changes.
+    cachedManifest.writeAsStringSync('${manifest.readAsStringSync()}\n\n// $basename');
+    cachedVersionFile.writeAsStringSync(parsedPlatform?.version.toString() ?? '');
+  }
 
-    // If regex matching fails, convert the manifest to json and then parse
-    final Map<String, Object?> manifestAsJson = await _parseSwiftPackage(swiftPackageManifest);
-    if (manifestAsJson case {'platforms': final List<Object?> platformsData}) {
-      for (final Map<String, Object?> platformData
-          in platformsData.whereType<Map<String, Object?>>()) {
-        final SwiftPackageSupportedPlatform? parsedPlatform =
-            SwiftPackageSupportedPlatform.fromJson(platformData);
-        if (parsedPlatform != null &&
-            parsedPlatform.platform == _targetPlatform.swiftPackagePlatform) {
-          return parsedPlatform.version;
-        }
+  /// Determine the highest [SwiftPackageSupportedPlatform] from the list of plugins.
+  SwiftPackageSupportedPlatform _determineHighestSupportedVersion(
+    List<({String name, String swiftPackagePath, SwiftPackageSupportedPlatform? version})> plugins,
+  ) {
+    SwiftPackageSupportedPlatform highest = _targetPlatform.supportedPackagePlatform;
+    for (final plugin in plugins) {
+      final SwiftPackageSupportedPlatform? pluginVersion = plugin.version;
+      if (pluginVersion != null && pluginVersion.version > highest.version) {
+        highest = pluginVersion;
       }
-      return null;
     }
-    throwToolExit(
-      'Unable to parse ${_targetPlatform.name} supported platform version from '
-      '${swiftPackageManifest.path}. $_kFileAnIssue and include the contents of this file.',
-    );
+    return highest;
   }
 
   /// Uses `swift` command line tool to convert Package.swift to json.
@@ -870,6 +928,87 @@ class FlutterPluginSwiftDependencies {
     }
   }
 
+  /// Parses the Swift package manifest to determine the [SwiftPackageSupportedPlatform].
+  SwiftPackageSupportedPlatform? _parseSwiftPackageSupportedPlatform(
+    Map<String, Object?> manifestAsJson,
+  ) {
+    if (manifestAsJson case {'platforms': final List<Object?> platformsData}) {
+      for (final Map<String, Object?> platformData
+          in platformsData.whereType<Map<String, Object?>>()) {
+        return SwiftPackageSupportedPlatform.fromJson(platformData);
+      }
+    }
+    return null;
+  }
+
+  /// Checks if the Swift package has a dependency on the Flutter framework.
+  bool _hasFlutterDependency(Map<String, Object?> manifestAsJson) {
+    if (manifestAsJson case {'dependencies': final List<Object?> dependenciesData}) {
+      for (final Map<String, Object?> dependencyData
+          in dependenciesData.whereType<Map<String, Object?>>()) {
+        if (dependencyData case {'fileSystem': final List<Object?> fileSystemData}) {
+          for (final Map<String, Object?> fileSystemData
+              in fileSystemData.whereType<Map<String, Object?>>()) {
+            if (fileSystemData['identity'] == 'flutterframework') {
+              return true;
+            }
+          }
+        }
+      }
+    }
+    return false;
+  }
+
+  /// Parses the Swift package manifest to extract the names of the regular targets.
+  List<String> _getTargetNames(Map<String, Object?> manifestAsJson) {
+    final List<String> targetNames = [];
+    if (manifestAsJson case {'targets': final List<Object?> targetData}) {
+      for (final Map<String, Object?> target in targetData.whereType<Map<String, Object?>>()) {
+        if (target case {'type': final String targetType, 'name': final String targetName}) {
+          if (targetType == 'regular') {
+            targetNames.add(targetName);
+          }
+        }
+      }
+    }
+    return targetNames;
+  }
+
+  /// Injects the Flutter framework as a dependency into the Swift package using `swift` commands.
+  ///
+  /// This is necessary as adding the FlutterFramework dependency was a secondary requirement that
+  /// some plugins may not have adopted yet.
+  Future<void> _injectFlutterDependencies({
+    required List<String> targetNames,
+    required Directory workingDirectory,
+  }) async {
+    final ProcessResult result = await _utils.processManager.run([
+      'swift',
+      'package',
+      'add-dependency',
+      './FlutterFramework',
+      '--type',
+      'path',
+    ], workingDirectory: workingDirectory.path);
+    if (result.exitCode != 0) {
+      throwToolExit('Failed to add FlutterFramework as a dependency. ${result.stderr}');
+    }
+    for (final targetName in targetNames) {
+      final ProcessResult result = await _utils.processManager.run([
+        'swift',
+        'package',
+        'add-target-dependency',
+        'FlutterFramework',
+        targetName,
+        '--package',
+        'FlutterFramework',
+      ], workingDirectory: workingDirectory.path);
+      if (result.exitCode != 0) {
+        throwToolExit('Failed to add FlutterFramework as a target dependency. ${result.stderr}');
+      }
+    }
+  }
+
   /// Returns dependencies from the SwiftPM-supported plugins for the FlutterPluginRegistrant.
   ///
   /// Also creates the symlinks to the Swift package within [packagesForConfiguration].
@@ -878,11 +1017,13 @@ class FlutterPluginSwiftDependencies {
   }) {
     final List<SwiftPackagePackageDependency> packageDependencies = [];
     final List<SwiftPackageTargetDependency> targetDependencies = [];
-    for (final (plugin, swiftPackagePath) in copiedPlugins) {
+    for (final ({String name, String swiftPackagePath, SwiftPackageSupportedPlatform? version})
+        plugin
+        in copiedPlugins) {
       // Symlink the swift package inside the packagesForConfiguration directory
       final Link symlink = packagesForConfiguration.childLink(plugin.name);
       final String target = _utils.fileSystem.path.relative(
-        swiftPackagePath,
+        plugin.swiftPackagePath,
         from: symlink.parent.path,
       );
       if (symlink.existsSync()) {

--- a/packages/flutter_tools/lib/src/commands/build_swift_package.dart
+++ b/packages/flutter_tools/lib/src/commands/build_swift_package.dart
@@ -704,6 +704,7 @@ class FlutterPluginSwiftDependencies {
       ErrorHandlingFileSystem.deleteIfExists(pluginsDirectory, recursive: true);
     } on FileSystemException catch (e, stackTrace) {
       // Delete may fail due to Xcode writing hidden files to the directory at the same time.
+      // The delete succeeds in deleting the non-XCode generated contents so it's okay to ignore.
       _utils.logger.printTrace('Failed to delete ${pluginsDirectory.path}: $e\n$stackTrace');
     }
     try {

--- a/packages/flutter_tools/lib/src/commands/build_swift_package.dart
+++ b/packages/flutter_tools/lib/src/commands/build_swift_package.dart
@@ -44,6 +44,7 @@ const String _kFileAnIssue =
 const String _kFrameworks = 'Frameworks';
 const String _kPackages = 'Packages';
 const String _kPlugins = 'Plugins';
+const String _kManifests = 'Manifests';
 const String _kCocoaPods = 'CocoaPods';
 const String _kNativeAssets = 'NativeAssets';
 const String kPluginSwiftPackageName = 'FlutterPluginRegistrant';
@@ -675,11 +676,11 @@ class FlutterPluginSwiftDependencies {
   /// The highest [SwiftPackageSupportedPlatform] among all of the Flutter SwiftPM plugins.
   /// Defaults to the Flutter framework's [SwiftPackageSupportedPlatform].
   SwiftPackageSupportedPlatform get highestSupportedVersion => _highestSupportedVersion;
-    late SwiftPackageSupportedPlatform _highestSupportedVersion =
+  late SwiftPackageSupportedPlatform _highestSupportedVersion =
       _targetPlatform.supportedPackagePlatform;
 
   @visibleForTesting
-  /// A list of [Plugin]s copied and path to the copied Swift package.
+  /// A list of plugin name, path to the copied Swift package, and the plugin's supported version.
   final List<({String name, String swiftPackagePath, SwiftPackageSupportedPlatform? version})>
   copiedPlugins = [];
 
@@ -746,14 +747,11 @@ class FlutterPluginSwiftDependencies {
     })
   >
   _processPlugin(Plugin plugin, Directory pluginsDirectory, Directory cacheDirectory) async {
-    // The entire plugin is copied instead of just the Swift package to maintain any relative
-    // links within the plugin.
-    // Example: https://github.com/firebase/flutterfire/blob/198aef8db6c96a08f57d750f1fa756da5e4a68a5/packages/firebase_core/firebase_core/ios/firebase_core/Package.swift#L21-L26
     final String swiftPackagePath = await _copyPlugin(plugin, pluginsDirectory);
     final File manifest = _utils.fileSystem.directory(swiftPackagePath).childFile('Package.swift');
 
     final Directory pluginCache = cacheDirectory
-        .childDirectory('Plugins')
+        .childDirectory(_kManifests)
         .childDirectory(plugin.name);
     final File cachedManifest = pluginCache.childFile('Package.swift');
     final File cachedVersionFile = pluginCache.childFile('${_targetPlatform.name}.version');
@@ -807,9 +805,13 @@ class FlutterPluginSwiftDependencies {
     );
   }
 
+  /// Copies the plugin to the [pluginsDirectory] and returns the path to the copied Swift package.
   Future<String> _copyPlugin(Plugin plugin, Directory pluginsDirectory) async {
     final Directory pluginDestination = pluginsDirectory.childDirectory(plugin.name)
       ..createSync(recursive: true);
+    // The entire plugin is copied instead of just the Swift package to maintain any relative
+    // links within the plugin.
+    // Example: https://github.com/firebase/flutterfire/blob/198aef8db6c96a08f57d750f1fa756da5e4a68a5/packages/firebase_core/firebase_core/ios/firebase_core/Package.swift#L21-L26
     copyDirectory(
       _utils.fileSystem.directory(plugin.path),
       pluginDestination,

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_swift_package_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_swift_package_test.dart
@@ -1676,7 +1676,14 @@ let package = Package(
 ''',
           ),
           const FakeCommand(
-            command: ['swift', 'package', 'add-dependency', './FlutterFramework', '--type', 'path'],
+            command: [
+              'swift',
+              'package',
+              'add-dependency',
+              '../FlutterFramework',
+              '--type',
+              'path',
+            ],
           ),
           const FakeCommand(
             command: [
@@ -1847,7 +1854,14 @@ let package = Package(
 ''',
           ),
           const FakeCommand(
-            command: ['swift', 'package', 'add-dependency', './FlutterFramework', '--type', 'path'],
+            command: [
+              'swift',
+              'package',
+              'add-dependency',
+              '../FlutterFramework',
+              '--type',
+              'path',
+            ],
           ),
           const FakeCommand(
             command: [
@@ -1951,7 +1965,14 @@ let package = Package(
                 '{"platforms": [{"platformName": "ios", "version": "13.0"}], "targets": [{"name": "PluginA", "type": "regular"}], "dependencies": []}',
           ),
           const FakeCommand(
-            command: ['swift', 'package', 'add-dependency', './FlutterFramework', '--type', 'path'],
+            command: [
+              'swift',
+              'package',
+              'add-dependency',
+              '../FlutterFramework',
+              '--type',
+              'path',
+            ],
           ),
           const FakeCommand(
             command: [
@@ -1970,7 +1991,14 @@ let package = Package(
                 '{"platforms": [{"platformName": "ios", "version": "14.0"}], "targets": [{"name": "PluginC", "type": "regular"}], "dependencies": []}',
           ),
           const FakeCommand(
-            command: ['swift', 'package', 'add-dependency', './FlutterFramework', '--type', 'path'],
+            command: [
+              'swift',
+              'package',
+              'add-dependency',
+              '../FlutterFramework',
+              '--type',
+              'path',
+            ],
           ),
           const FakeCommand(
             command: [

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_swift_package_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_swift_package_test.dart
@@ -145,7 +145,7 @@ void main() {
         pluginSwiftDependencies.copiedPlugins.add((
           name: pluginA.name,
           swiftPackagePath: '$pluginsDirectoryPath/PluginA',
-          version: SwiftPackageSupportedPlatform(
+          packageMinimumSupportedPlatform: SwiftPackageSupportedPlatform(
             platform: SwiftPackagePlatform.ios,
             version: Version(13, 0, 0),
           ),
@@ -1780,7 +1780,7 @@ let package = Package(
         pluginSwiftDependencies.copiedPlugins.add((
           name: 'PluginA',
           swiftPackagePath: 'output/FlutterPluginRegistrant/Plugins/PluginA',
-          version: SwiftPackageSupportedPlatform(
+          packageMinimumSupportedPlatform: SwiftPackageSupportedPlatform(
             platform: SwiftPackagePlatform.ios,
             version: Version(13, 0, 0),
           ),
@@ -2053,6 +2053,117 @@ let package = Package(
       });
 
       testWithoutContext(
+        'processPlugins selects the platform version that matches the target platform when multiple platforms are defined',
+        () async {
+          final fs = MemoryFileSystem.test();
+          final logger = BufferLogger.test();
+          const FlutterDarwinPlatform targetPlatform = .ios;
+
+          final pluginA = FakePlugin(name: 'PluginA', darwinPlatform: targetPlatform);
+
+          final Directory appDirectory = fs.directory('/path/to/my_flutter_app')
+            ..createSync(recursive: true);
+          fs.currentDirectory = appDirectory;
+
+          fs.file(commandFilePath).createSync(recursive: true);
+          fs
+              .directory(pluginA.path)
+              .childDirectory('ios')
+              .childDirectory('PluginA')
+              .childFile('Package.swift')
+            ..createSync(recursive: true)
+            ..writeAsStringSync(_pluginManifest(pluginName: 'PluginA'));
+
+          final processManager = FakeProcessManager.list([
+            const FakeCommand(
+              command: ['swift', 'package', 'dump-package'],
+              stdout: '''
+{
+  "platforms": [
+    {
+      "platformName": "macos",
+      "version": "14.0"
+    },
+    {
+      "platformName": "ios",
+      "version": "13.0"
+    }
+  ],
+  "targets": [
+    {
+      "name": "PluginA",
+      "type": "regular"
+    }
+  ],
+  "dependencies": []
+}
+''',
+            ),
+            const FakeCommand(
+              command: [
+                'swift',
+                'package',
+                'add-dependency',
+                '../FlutterFramework',
+                '--type',
+                'path',
+              ],
+            ),
+            const FakeCommand(
+              command: [
+                'swift',
+                'package',
+                'add-target-dependency',
+                'FlutterFramework',
+                'PluginA',
+                '--package',
+                'FlutterFramework',
+              ],
+            ),
+          ]);
+
+          final testUtils = BuildSwiftPackageUtils(
+            analytics: FakeAnalytics(),
+            artifacts: FakeArtifacts(
+              '/path/to/flutter/bin/cache/artifacts/engine/ios/Flutter.xcframework',
+            ),
+            buildSystem: FakeBuildSystem(),
+            cache: FakeCache(fs, '/path/to/flutter'),
+            fileSystem: fs,
+            flutterRoot: '/path/to/flutter',
+            flutterVersion: FakeFlutterVersion(),
+            logger: logger,
+            platform: FakePlatform(),
+            processManager: processManager,
+            project: FakeFlutterProject(directory: appDirectory),
+            templateRenderer: const MustacheTemplateRenderer(),
+            xcode: FakeXcode(),
+          );
+
+          final pluginSwiftDependencies = FlutterPluginSwiftDependencies(
+            targetPlatform: targetPlatform,
+            utils: testUtils,
+          );
+
+          final Directory cacheDir = fs.directory('output/.cache')..createSync(recursive: true);
+          final Directory pluginsDir = appDirectory.childDirectory(
+            'output/FlutterPluginRegistrant/Plugins',
+          )..createSync(recursive: true);
+
+          await pluginSwiftDependencies.processPlugins(
+            cacheDirectory: cacheDir,
+            plugins: [pluginA],
+            pluginsDirectory: pluginsDir,
+          );
+
+          expect(processManager, hasNoRemainingExpectations);
+          expect(pluginSwiftDependencies.copiedPlugins.length, 1);
+          expect(pluginSwiftDependencies.copiedPlugins[0].name, 'PluginA');
+          expect(pluginSwiftDependencies.highestSupportedVersion.version, Version(13, 0, 0));
+        },
+      );
+
+      testWithoutContext(
         'processPlugins skips injecting Flutter dependency if already present',
         () async {
           final fs = MemoryFileSystem.test();
@@ -2189,11 +2300,10 @@ let package = Package(
         );
         final Directory modeDirectory = fs.directory(debugModeDirectoryPath);
         final pluginA = FakePlugin(name: 'PluginA', darwinPlatform: targetPlatform);
-        // pluginSwiftDependencies.copiedPlugins.add((pluginA, '$pluginsDirectoryPath/PluginA'));
         pluginSwiftDependencies.copiedPlugins.add((
           name: pluginA.name,
           swiftPackagePath: '$pluginsDirectoryPath/PluginA',
-          version: SwiftPackageSupportedPlatform(
+          packageMinimumSupportedPlatform: SwiftPackageSupportedPlatform(
             platform: SwiftPackagePlatform.macos,
             version: Version(13, 0, 0),
           ),

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_swift_package_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_swift_package_test.dart
@@ -142,7 +142,14 @@ void main() {
         // Plugin A represents a SwiftPM plugin
         final Directory modeDirectory = fs.directory(debugModeDirectoryPath);
         final pluginA = FakePlugin(name: 'PluginA', darwinPlatform: targetPlatform);
-        pluginSwiftDependencies.copiedPlugins.add((pluginA, '$pluginsDirectoryPath/PluginA'));
+        pluginSwiftDependencies.copiedPlugins.add((
+          name: pluginA.name,
+          swiftPackagePath: '$pluginsDirectoryPath/PluginA',
+          version: SwiftPackageSupportedPlatform(
+            platform: SwiftPackagePlatform.ios,
+            version: Version(13, 0, 0),
+          ),
+        ));
 
         // Plugin B represents a CocoaPod plugin
         final pluginB = FakePlugin(
@@ -434,239 +441,6 @@ let package = Package(
               .childDirectory('../../Frameworks/Flutter.xcframework')
               .resolveSymbolicLinksSync(),
           '/${xcframework.path}',
-        );
-      });
-    });
-
-    group('FlutterPluginDependencies', () {
-      testWithoutContext('processPlugins', () async {
-        final fs = MemoryFileSystem.test();
-        final logger = BufferLogger.test();
-        final processManager = FakeProcessManager.list([]);
-        const FlutterDarwinPlatform targetPlatform = .ios;
-        final testUtils = BuildSwiftPackageUtils(
-          analytics: FakeAnalytics(),
-          artifacts: FakeArtifacts(engineArtifactPath),
-          buildSystem: FakeBuildSystem(),
-          cache: FakeCache(fs, _flutterRoot),
-          fileSystem: fs,
-          flutterRoot: _flutterRoot,
-          flutterVersion: FakeFlutterVersion(),
-          logger: logger,
-          platform: FakePlatform(),
-          processManager: processManager,
-          project: FakeFlutterProject(directory: fs.directory(_flutterAppPath)),
-          templateRenderer: const MustacheTemplateRenderer(),
-          xcode: FakeXcode(),
-        );
-        final pluginSwiftDependencies = FlutterPluginSwiftDependencies(
-          targetPlatform: targetPlatform,
-          utils: testUtils,
-        );
-        final pluginA = FakePlugin(name: 'PluginA', darwinPlatform: targetPlatform);
-        fs.file(
-            fs.path.join(pluginA.pluginSwiftPackagePath(fs, targetPlatform.name)!, 'Package.swift'),
-          )
-          ..createSync(recursive: true)
-          ..writeAsStringSync(_pluginManifest(pluginName: 'PluginA', platforms: '.iOS("15.0")'));
-        final pluginB = FakePlugin(
-          name: 'PluginB',
-          darwinPlatform: targetPlatform,
-          supportsSwiftPM: false,
-        );
-        final pluginC = FakePlugin(name: 'PluginC', darwinPlatform: targetPlatform);
-        fs.file(
-            fs.path.join(pluginC.pluginSwiftPackagePath(fs, targetPlatform.name)!, 'Package.swift'),
-          )
-          ..createSync(recursive: true)
-          ..writeAsStringSync(_pluginManifest(pluginName: 'PluginC'));
-
-        final Directory pluginsDirectory = fs.directory(pluginsDirectoryPath);
-        await pluginSwiftDependencies.processPlugins(
-          cacheDirectory: fs.directory(cacheDirectoryPath),
-          plugins: [pluginA, pluginB, pluginC],
-          pluginsDirectory: pluginsDirectory,
-        );
-        expect(pluginsDirectory.listSync().length, 2);
-        expect(pluginSwiftDependencies.highestSupportedVersion.version, Version(15, 0, 0));
-      });
-
-      testWithoutContext('determineHighestSupportedVersion matches using regex', () async {
-        final fs = MemoryFileSystem.test();
-        final logger = BufferLogger.test();
-        final processManager = FakeProcessManager.list([]);
-        const FlutterDarwinPlatform targetPlatform = .ios;
-        final testUtils = BuildSwiftPackageUtils(
-          analytics: FakeAnalytics(),
-          artifacts: FakeArtifacts(engineArtifactPath),
-          buildSystem: FakeBuildSystem(),
-          cache: FakeCache(fs, _flutterRoot),
-          fileSystem: fs,
-          flutterRoot: _flutterRoot,
-          flutterVersion: FakeFlutterVersion(),
-          logger: logger,
-          platform: FakePlatform(),
-          processManager: processManager,
-          project: FakeFlutterProject(directory: fs.directory(_flutterAppPath)),
-          templateRenderer: const MustacheTemplateRenderer(),
-          xcode: FakeXcode(),
-        );
-        final pluginSwiftDependencies = FlutterPluginSwiftDependencies(
-          targetPlatform: targetPlatform,
-          utils: testUtils,
-        );
-        final Directory cacheDirectory = fs.directory(cacheDirectoryPath);
-        final List<File> manifests = [
-          fs.file('PluginA/Package.swift')
-            ..createSync(recursive: true)
-            ..writeAsStringSync(_pluginManifest(pluginName: 'PluginA', platforms: '.iOS("15.0")')),
-        ];
-        final (Version highestVersion, bool skipped) = await pluginSwiftDependencies
-            .determineHighestSupportedVersion(manifests: manifests, cacheDirectory: cacheDirectory);
-        expect(highestVersion, Version(15, 0, 0));
-        expect(skipped, isFalse);
-
-        manifests.add(
-          fs.file('PluginB/Package.swift')
-            ..createSync(recursive: true)
-            ..writeAsStringSync(
-              _pluginManifest(pluginName: 'PluginB', platforms: '.iOS( .v16 ),\n .macOS("26.0")'),
-            ),
-        );
-        final (Version retryHighestVersion, bool retrySkipped) = await pluginSwiftDependencies
-            .determineHighestSupportedVersion(manifests: manifests, cacheDirectory: cacheDirectory);
-        expect(retryHighestVersion, Version(16, 0, 0));
-        expect(retrySkipped, isFalse);
-      });
-
-      testWithoutContext('determineHighestSupportedVersion matches using swift', () async {
-        final fs = MemoryFileSystem.test();
-        final logger = BufferLogger.test();
-        fs.file(commandFilePath).createSync(recursive: true);
-        final processManager = FakeProcessManager.list([
-          const FakeCommand(
-            command: ['swift', 'package', 'dump-package'],
-            workingDirectory: 'PluginA',
-            stdout: '''
-{
-  "name" : "PluginA",
-  "platforms" : [
-    {
-      "options" : [
-
-      ],
-      "platformName" : "ios",
-      "version" : "15.0"
-    },
-    {
-      "options" : [
-
-      ],
-      "platformName" : "macos",
-      "version" : "26.0"
-    }
-  ]
-}
-''',
-          ),
-        ]);
-        const FlutterDarwinPlatform targetPlatform = .ios;
-        final testUtils = BuildSwiftPackageUtils(
-          analytics: FakeAnalytics(),
-          artifacts: FakeArtifacts(engineArtifactPath),
-          buildSystem: FakeBuildSystem(),
-          cache: FakeCache(fs, _flutterRoot),
-          fileSystem: fs,
-          flutterRoot: _flutterRoot,
-          flutterVersion: FakeFlutterVersion(),
-          logger: logger,
-          platform: FakePlatform(),
-          processManager: processManager,
-          project: FakeFlutterProject(directory: fs.directory(_flutterAppPath)),
-          templateRenderer: const MustacheTemplateRenderer(),
-          xcode: FakeXcode(),
-        );
-        final pluginSwiftDependencies = FlutterPluginSwiftDependencies(
-          targetPlatform: targetPlatform,
-          utils: testUtils,
-        );
-        final Directory cacheDirectory = fs.directory(cacheDirectoryPath);
-        final List<File> manifests = [
-          fs.file('PluginA/Package.swift')
-            ..createSync(recursive: true)
-            ..writeAsStringSync(_pluginManifest(pluginName: 'PluginA', platforms: 'someVar')),
-        ];
-        final (Version highestVersion, bool skipped) = await pluginSwiftDependencies
-            .determineHighestSupportedVersion(manifests: manifests, cacheDirectory: cacheDirectory);
-        expect(highestVersion, Version(15, 0, 0));
-        expect(skipped, isFalse);
-
-        // Verify it uses cache next time it runs (process is not called again)
-        final (Version retryHighestVersion, bool retrySkipped) = await pluginSwiftDependencies
-            .determineHighestSupportedVersion(manifests: manifests, cacheDirectory: cacheDirectory);
-        expect(retryHighestVersion, Version(15, 0, 0));
-        expect(retrySkipped, isTrue);
-      });
-
-      testWithoutContext('generateDependencies', () {
-        final fs = MemoryFileSystem.test();
-        final logger = BufferLogger.test();
-        final processManager = FakeProcessManager.list([]);
-        const FlutterDarwinPlatform targetPlatform = .ios;
-        final testUtils = BuildSwiftPackageUtils(
-          analytics: FakeAnalytics(),
-          artifacts: FakeArtifacts(engineArtifactPath),
-          buildSystem: FakeBuildSystem(),
-          cache: FakeCache(fs, _flutterRoot),
-          fileSystem: fs,
-          flutterRoot: _flutterRoot,
-          flutterVersion: FakeFlutterVersion(),
-          logger: logger,
-          platform: FakePlatform(),
-          processManager: processManager,
-          project: FakeFlutterProject(directory: fs.directory(_flutterAppPath)),
-          templateRenderer: const MustacheTemplateRenderer(),
-          xcode: FakeXcode(),
-        );
-        final pluginSwiftDependencies = FlutterPluginSwiftDependencies(
-          targetPlatform: targetPlatform,
-          utils: testUtils,
-        );
-        final pluginA = FakePlugin(name: 'plugin_a', darwinPlatform: targetPlatform);
-        fs.file(
-            fs.path.join(pluginA.pluginSwiftPackagePath(fs, targetPlatform.name)!, 'Package.swift'),
-          )
-          ..createSync(recursive: true)
-          ..writeAsStringSync(_pluginManifest(pluginName: 'plugin_a'));
-        pluginSwiftDependencies.copiedPlugins.add((pluginA, '$pluginsDirectoryPath/plugin_a'));
-
-        final Directory packagesForConfiguration = fs.directory(
-          '$pluginRegistrantSwiftPackagePath/Release/Packages',
-        );
-
-        final (
-          List<SwiftPackagePackageDependency> pluginPackageDependencies,
-          List<SwiftPackageTargetDependency> pluginTargetDependencies,
-        ) = pluginSwiftDependencies.generateDependencies(
-          packagesForConfiguration: fs.directory(
-            '$pluginRegistrantSwiftPackagePath/Release/Packages',
-          ),
-        );
-        expect(
-          packagesForConfiguration.childLink(pluginA.name).targetSync(),
-          '../../Plugins/plugin_a',
-        );
-        expect(
-          pluginPackageDependencies.first.format().endsWith(
-            '.package(name: "plugin_a", path: "Sources/Packages/plugin_a")',
-          ),
-          isTrue,
-        );
-        expect(
-          pluginTargetDependencies.first.format().endsWith(
-            '.product(name: "plugin-a", package: "plugin_a")',
-          ),
-          isTrue,
         );
       });
     });
@@ -1853,6 +1627,494 @@ let package = Package(
         expect(processManager, hasNoRemainingExpectations);
       });
     });
+
+    group('FlutterPluginSwiftDependencies', () {
+      testWithoutContext('processPlugins installs missing dependencies', () async {
+        final fs = MemoryFileSystem.test();
+        final logger = BufferLogger.test();
+        const FlutterDarwinPlatform targetPlatform = .ios;
+
+        final pluginA = FakePlugin(name: 'PluginA', darwinPlatform: targetPlatform);
+        final pluginB = FakePlugin(
+          name: 'PluginB',
+          darwinPlatform: targetPlatform,
+          supportsSwiftPM: false,
+        );
+
+        final Directory appDirectory = fs.directory('/path/to/my_flutter_app')
+          ..createSync(recursive: true);
+        fs.currentDirectory = appDirectory;
+
+        fs.file(commandFilePath).createSync(recursive: true);
+        fs
+            .directory(pluginA.path)
+            .childDirectory('ios')
+            .childDirectory('PluginA')
+            .childFile('Package.swift')
+          ..createSync(recursive: true)
+          ..writeAsStringSync(_pluginManifest(pluginName: 'PluginA'));
+
+        final processManager = FakeProcessManager.list([
+          const FakeCommand(
+            command: ['swift', 'package', 'dump-package'],
+            stdout: '''
+{
+  "platforms": [
+    {
+      "platformName": "ios",
+      "version": "13.0"
+    }
+  ],
+  "targets": [
+    {
+      "name": "PluginA",
+      "type": "regular"
+    }
+  ],
+  "dependencies": []
+}
+''',
+          ),
+          const FakeCommand(
+            command: ['swift', 'package', 'add-dependency', './FlutterFramework', '--type', 'path'],
+          ),
+          const FakeCommand(
+            command: [
+              'swift',
+              'package',
+              'add-target-dependency',
+              'FlutterFramework',
+              'PluginA',
+              '--package',
+              'FlutterFramework',
+            ],
+          ),
+        ]);
+
+        final testUtils = BuildSwiftPackageUtils(
+          analytics: FakeAnalytics(),
+          artifacts: FakeArtifacts(
+            '/path/to/flutter/bin/cache/artifacts/engine/ios/Flutter.xcframework',
+          ),
+          buildSystem: FakeBuildSystem(),
+          cache: FakeCache(fs, '/path/to/flutter'),
+          fileSystem: fs,
+          flutterRoot: '/path/to/flutter',
+          flutterVersion: FakeFlutterVersion(),
+          logger: logger,
+          platform: FakePlatform(),
+          processManager: processManager,
+          project: FakeFlutterProject(directory: appDirectory),
+          templateRenderer: const MustacheTemplateRenderer(),
+          xcode: FakeXcode(),
+        );
+
+        final pluginSwiftDependencies = FlutterPluginSwiftDependencies(
+          targetPlatform: targetPlatform,
+          utils: testUtils,
+        );
+
+        final Directory cacheDir = fs.directory('output/.cache')..createSync(recursive: true);
+        final Directory pluginsDir = appDirectory.childDirectory(
+          'output/FlutterPluginRegistrant/Plugins',
+        )..createSync(recursive: true);
+
+        await pluginSwiftDependencies.processPlugins(
+          cacheDirectory: cacheDir,
+          plugins: [pluginA, pluginB],
+          pluginsDirectory: pluginsDir,
+        );
+
+        expect(processManager, hasNoRemainingExpectations);
+        expect(pluginSwiftDependencies.copiedPlugins.length, 1);
+        expect(pluginSwiftDependencies.copiedPlugins[0].name, 'PluginA');
+        expect(pluginSwiftDependencies.highestSupportedVersion.version, Version(13, 0, 0));
+
+        final File cachedManifest = cacheDir
+            .childDirectory('Plugins')
+            .childDirectory('PluginA')
+            .childFile('Package.swift');
+        expect(cachedManifest.existsSync(), isTrue);
+      });
+
+      testWithoutContext('generateDependencies', () async {
+        final fs = MemoryFileSystem.test();
+        final logger = BufferLogger.test();
+        final processManager = FakeProcessManager.list([]);
+        const FlutterDarwinPlatform targetPlatform = .ios;
+
+        final Directory appDirectory = fs.directory('/path/to/my_flutter_app')
+          ..createSync(recursive: true);
+        fs.currentDirectory = appDirectory;
+
+        final testUtils = BuildSwiftPackageUtils(
+          analytics: FakeAnalytics(),
+          artifacts: FakeArtifacts(
+            '/path/to/flutter/bin/cache/artifacts/engine/ios/Flutter.xcframework',
+          ),
+          buildSystem: FakeBuildSystem(),
+          cache: FakeCache(fs, '/path/to/flutter'),
+          fileSystem: fs,
+          flutterRoot: '/path/to/flutter',
+          flutterVersion: FakeFlutterVersion(),
+          logger: logger,
+          platform: FakePlatform(),
+          processManager: processManager,
+          project: FakeFlutterProject(directory: appDirectory),
+          templateRenderer: const MustacheTemplateRenderer(),
+          xcode: FakeXcode(),
+        );
+
+        final pluginSwiftDependencies = FlutterPluginSwiftDependencies(
+          targetPlatform: targetPlatform,
+          utils: testUtils,
+        );
+
+        pluginSwiftDependencies.copiedPlugins.add((
+          name: 'PluginA',
+          swiftPackagePath: 'output/FlutterPluginRegistrant/Plugins/PluginA',
+          version: SwiftPackageSupportedPlatform(
+            platform: SwiftPackagePlatform.ios,
+            version: Version(13, 0, 0),
+          ),
+        ));
+
+        final Directory packagesForConfiguration = fs.directory(
+          'output/FlutterPluginRegistrant/Debug/Packages',
+        );
+        packagesForConfiguration.createSync(recursive: true);
+
+        final (
+          List<SwiftPackagePackageDependency> packageDependencies,
+          List<SwiftPackageTargetDependency> targetDependencies,
+        ) = pluginSwiftDependencies.generateDependencies(
+          packagesForConfiguration: packagesForConfiguration,
+        );
+
+        expect(packageDependencies.length, 1);
+        expect(packageDependencies[0].format(), contains('.package(name: "PluginA"'));
+
+        expect(targetDependencies.length, 1);
+        expect(
+          targetDependencies[0].format(),
+          contains('.product(name: "PluginA", package: "PluginA")'),
+        );
+
+        final Link symlink = packagesForConfiguration.childLink('PluginA');
+        expect(symlink.existsSync(), isTrue);
+        expect(symlink.targetSync(), '../../Plugins/PluginA');
+      });
+
+      testWithoutContext('processPlugins uses caching', () async {
+        final fs = MemoryFileSystem.test();
+        final logger = BufferLogger.test();
+        const FlutterDarwinPlatform targetPlatform = .ios;
+
+        final pluginA = FakePlugin(name: 'PluginA', darwinPlatform: targetPlatform);
+
+        final Directory appDirectory = fs.directory('/path/to/my_flutter_app')
+          ..createSync(recursive: true);
+        fs.currentDirectory = appDirectory;
+
+        fs.file(commandFilePath).createSync(recursive: true);
+        fs
+            .directory(pluginA.path)
+            .childDirectory('ios')
+            .childDirectory('PluginA')
+            .childFile('Package.swift')
+          ..createSync(recursive: true)
+          ..writeAsStringSync(_pluginManifest(pluginName: 'PluginA'));
+
+        final processManager = FakeProcessManager.list([
+          const FakeCommand(
+            command: ['swift', 'package', 'dump-package'],
+            stdout: '''
+{
+  "platforms": [
+    {
+      "platformName": "ios",
+      "version": "13.0"
+    }
+  ],
+  "targets": [
+    {
+      "name": "PluginA",
+      "type": "regular"
+    }
+  ],
+  "dependencies": []
+}
+''',
+          ),
+          const FakeCommand(
+            command: ['swift', 'package', 'add-dependency', './FlutterFramework', '--type', 'path'],
+          ),
+          const FakeCommand(
+            command: [
+              'swift',
+              'package',
+              'add-target-dependency',
+              'FlutterFramework',
+              'PluginA',
+              '--package',
+              'FlutterFramework',
+            ],
+          ),
+        ]);
+
+        final testUtils = BuildSwiftPackageUtils(
+          analytics: FakeAnalytics(),
+          artifacts: FakeArtifacts(
+            '/path/to/flutter/bin/cache/artifacts/engine/ios/Flutter.xcframework',
+          ),
+          buildSystem: FakeBuildSystem(),
+          cache: FakeCache(fs, '/path/to/flutter'),
+          fileSystem: fs,
+          flutterRoot: '/path/to/flutter',
+          flutterVersion: FakeFlutterVersion(),
+          logger: logger,
+          platform: FakePlatform(),
+          processManager: processManager,
+          project: FakeFlutterProject(directory: appDirectory),
+          templateRenderer: const MustacheTemplateRenderer(),
+          xcode: FakeXcode(),
+        );
+
+        final pluginSwiftDependencies = FlutterPluginSwiftDependencies(
+          targetPlatform: targetPlatform,
+          utils: testUtils,
+        );
+
+        final Directory cacheDir = fs.directory('output/.cache')..createSync(recursive: true);
+        final Directory pluginsDir = appDirectory.childDirectory(
+          'output/FlutterPluginRegistrant/Plugins',
+        )..createSync(recursive: true);
+
+        // First run will process normally and cache the result
+        await pluginSwiftDependencies.processPlugins(
+          cacheDirectory: cacheDir,
+          plugins: [pluginA],
+          pluginsDirectory: pluginsDir,
+        );
+        expect(processManager, hasNoRemainingExpectations);
+
+        // Clear copied plugins for the second run
+        pluginSwiftDependencies.copiedPlugins.clear();
+
+        // Second run should use cache (ProcessManager has no commands left to consume)
+        await pluginSwiftDependencies.processPlugins(
+          cacheDirectory: cacheDir,
+          plugins: [pluginA],
+          pluginsDirectory: pluginsDir,
+        );
+
+        expect(processManager, hasNoRemainingExpectations);
+        expect(pluginSwiftDependencies.copiedPlugins.length, 1);
+        expect(pluginSwiftDependencies.copiedPlugins[0].name, 'PluginA');
+        expect(pluginSwiftDependencies.highestSupportedVersion.version, Version(13, 0, 0));
+        expect(logger.statusText, contains('Skipping processing plugins. No change detected.'));
+      });
+
+      testWithoutContext('processPlugins determines highest supported version', () async {
+        final fs = MemoryFileSystem.test();
+        final logger = BufferLogger.test();
+        const FlutterDarwinPlatform targetPlatform = .ios;
+
+        final pluginA = FakePlugin(name: 'PluginA', darwinPlatform: targetPlatform);
+        final pluginC = FakePlugin(name: 'PluginC', darwinPlatform: targetPlatform);
+
+        final Directory appDirectory = fs.directory('/path/to/my_flutter_app')
+          ..createSync(recursive: true);
+        fs.currentDirectory = appDirectory;
+
+        fs.file(commandFilePath).createSync(recursive: true);
+        fs
+            .directory(pluginA.path)
+            .childDirectory('ios')
+            .childDirectory('PluginA')
+            .childFile('Package.swift')
+          ..createSync(recursive: true)
+          ..writeAsStringSync(_pluginManifest(pluginName: 'PluginA'));
+
+        fs
+            .directory(pluginC.path)
+            .childDirectory('ios')
+            .childDirectory('PluginC')
+            .childFile('Package.swift')
+          ..createSync(recursive: true)
+          ..writeAsStringSync(_pluginManifest(pluginName: 'PluginC'));
+
+        final processManager = FakeProcessManager.list([
+          const FakeCommand(
+            command: ['swift', 'package', 'dump-package'],
+            stdout:
+                '{"platforms": [{"platformName": "ios", "version": "13.0"}], "targets": [{"name": "PluginA", "type": "regular"}], "dependencies": []}',
+          ),
+          const FakeCommand(
+            command: ['swift', 'package', 'add-dependency', './FlutterFramework', '--type', 'path'],
+          ),
+          const FakeCommand(
+            command: [
+              'swift',
+              'package',
+              'add-target-dependency',
+              'FlutterFramework',
+              'PluginA',
+              '--package',
+              'FlutterFramework',
+            ],
+          ),
+          const FakeCommand(
+            command: ['swift', 'package', 'dump-package'],
+            stdout:
+                '{"platforms": [{"platformName": "ios", "version": "14.0"}], "targets": [{"name": "PluginC", "type": "regular"}], "dependencies": []}',
+          ),
+          const FakeCommand(
+            command: ['swift', 'package', 'add-dependency', './FlutterFramework', '--type', 'path'],
+          ),
+          const FakeCommand(
+            command: [
+              'swift',
+              'package',
+              'add-target-dependency',
+              'FlutterFramework',
+              'PluginC',
+              '--package',
+              'FlutterFramework',
+            ],
+          ),
+        ]);
+
+        final testUtils = BuildSwiftPackageUtils(
+          analytics: FakeAnalytics(),
+          artifacts: FakeArtifacts(
+            '/path/to/flutter/bin/cache/artifacts/engine/ios/Flutter.xcframework',
+          ),
+          buildSystem: FakeBuildSystem(),
+          cache: FakeCache(fs, '/path/to/flutter'),
+          fileSystem: fs,
+          flutterRoot: '/path/to/flutter',
+          flutterVersion: FakeFlutterVersion(),
+          logger: logger,
+          platform: FakePlatform(),
+          processManager: processManager,
+          project: FakeFlutterProject(directory: appDirectory),
+          templateRenderer: const MustacheTemplateRenderer(),
+          xcode: FakeXcode(),
+        );
+
+        final pluginSwiftDependencies = FlutterPluginSwiftDependencies(
+          targetPlatform: targetPlatform,
+          utils: testUtils,
+        );
+
+        final Directory cacheDir = fs.directory('output/.cache')..createSync(recursive: true);
+        final Directory pluginsDir = appDirectory.childDirectory(
+          'output/FlutterPluginRegistrant/Plugins',
+        )..createSync(recursive: true);
+
+        await pluginSwiftDependencies.processPlugins(
+          cacheDirectory: cacheDir,
+          plugins: [pluginA, pluginC],
+          pluginsDirectory: pluginsDir,
+        );
+
+        expect(processManager, hasNoRemainingExpectations);
+        expect(pluginSwiftDependencies.highestSupportedVersion.version, Version(14, 0, 0));
+        expect(pluginSwiftDependencies.copiedPlugins.length, 2);
+      });
+
+      testWithoutContext(
+        'processPlugins skips injecting Flutter dependency if already present',
+        () async {
+          final fs = MemoryFileSystem.test();
+          final logger = BufferLogger.test();
+          const FlutterDarwinPlatform targetPlatform = .ios;
+
+          final pluginA = FakePlugin(name: 'PluginA', darwinPlatform: targetPlatform);
+
+          final Directory appDirectory = fs.directory('/path/to/my_flutter_app')
+            ..createSync(recursive: true);
+          fs.currentDirectory = appDirectory;
+
+          fs.file(commandFilePath).createSync(recursive: true);
+          fs
+              .directory(pluginA.path)
+              .childDirectory('ios')
+              .childDirectory('PluginA')
+              .childFile('Package.swift')
+            ..createSync(recursive: true)
+            ..writeAsStringSync(_pluginManifest(pluginName: 'PluginA'));
+
+          final processManager = FakeProcessManager.list([
+            const FakeCommand(
+              command: ['swift', 'package', 'dump-package'],
+              stdout: '''
+{
+  "platforms": [
+    {
+      "platformName": "ios",
+      "version": "13.0"
+    }
+  ],
+  "targets": [
+    {
+      "name": "PluginA",
+      "type": "regular"
+    }
+  ],
+  "dependencies": [
+    {
+      "fileSystem": [
+        {
+          "identity": "flutterframework"
+        }
+      ]
+    }
+  ]
+}
+''',
+            ),
+          ]);
+
+          final testUtils = BuildSwiftPackageUtils(
+            analytics: FakeAnalytics(),
+            artifacts: FakeArtifacts(
+              '/path/to/flutter/bin/cache/artifacts/engine/ios/Flutter.xcframework',
+            ),
+            buildSystem: FakeBuildSystem(),
+            cache: FakeCache(fs, '/path/to/flutter'),
+            fileSystem: fs,
+            flutterRoot: '/path/to/flutter',
+            flutterVersion: FakeFlutterVersion(),
+            logger: logger,
+            platform: FakePlatform(),
+            processManager: processManager,
+            project: FakeFlutterProject(directory: appDirectory),
+            templateRenderer: const MustacheTemplateRenderer(),
+            xcode: FakeXcode(),
+          );
+
+          final pluginSwiftDependencies = FlutterPluginSwiftDependencies(
+            targetPlatform: targetPlatform,
+            utils: testUtils,
+          );
+
+          final Directory cacheDir = fs.directory('output/.cache')..createSync(recursive: true);
+          final Directory pluginsDir = appDirectory.childDirectory(
+            'output/FlutterPluginRegistrant/Plugins',
+          )..createSync(recursive: true);
+
+          await pluginSwiftDependencies.processPlugins(
+            cacheDirectory: cacheDir,
+            plugins: [pluginA],
+            pluginsDirectory: pluginsDir,
+          );
+
+          expect(processManager, hasNoRemainingExpectations);
+        },
+      );
+    });
   });
 
   group('macos', () {
@@ -1899,7 +2161,15 @@ let package = Package(
         );
         final Directory modeDirectory = fs.directory(debugModeDirectoryPath);
         final pluginA = FakePlugin(name: 'PluginA', darwinPlatform: targetPlatform);
-        pluginSwiftDependencies.copiedPlugins.add((pluginA, '$pluginsDirectoryPath/PluginA'));
+        // pluginSwiftDependencies.copiedPlugins.add((pluginA, '$pluginsDirectoryPath/PluginA'));
+        pluginSwiftDependencies.copiedPlugins.add((
+          name: pluginA.name,
+          swiftPackagePath: '$pluginsDirectoryPath/PluginA',
+          version: SwiftPackageSupportedPlatform(
+            platform: SwiftPackagePlatform.macos,
+            version: Version(13, 0, 0),
+          ),
+        ));
 
         await package.generateSwiftPackage(
           modeDirectory: modeDirectory,
@@ -1974,244 +2244,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PluginAPlugin.register(with: registry.registrar(forPlugin: "PluginAPlugin"))
 }
 ''');
-      });
-    });
-
-    group('FlutterPluginDependencies', () {
-      testWithoutContext('processPlugins', () async {
-        final fs = MemoryFileSystem.test();
-        final logger = BufferLogger.test();
-        final processManager = FakeProcessManager.list([]);
-        const FlutterDarwinPlatform targetPlatform = .macos;
-        final testUtils = BuildSwiftPackageUtils(
-          analytics: FakeAnalytics(),
-          artifacts: FakeArtifacts(engineArtifactPath),
-          buildSystem: FakeBuildSystem(),
-          cache: FakeCache(fs, _flutterRoot),
-          fileSystem: fs,
-          flutterRoot: _flutterRoot,
-          flutterVersion: FakeFlutterVersion(),
-          logger: logger,
-          platform: FakePlatform(),
-          processManager: processManager,
-          project: FakeFlutterProject(directory: fs.directory(_flutterAppPath)),
-          templateRenderer: const MustacheTemplateRenderer(),
-          xcode: FakeXcode(),
-        );
-        final pluginSwiftDependencies = FlutterPluginSwiftDependencies(
-          targetPlatform: targetPlatform,
-          utils: testUtils,
-        );
-        final pluginA = FakePlugin(name: 'PluginA', darwinPlatform: targetPlatform);
-        fs.file(
-            fs.path.join(pluginA.pluginSwiftPackagePath(fs, targetPlatform.name)!, 'Package.swift'),
-          )
-          ..createSync(recursive: true)
-          ..writeAsStringSync(_pluginManifest(pluginName: 'PluginA', platforms: '.macOS("11")'));
-        final pluginB = FakePlugin(
-          name: 'PluginB',
-          darwinPlatform: targetPlatform,
-          supportsSwiftPM: false,
-        );
-        final pluginC = FakePlugin(name: 'PluginC', darwinPlatform: targetPlatform);
-        fs.file(
-            fs.path.join(pluginC.pluginSwiftPackagePath(fs, targetPlatform.name)!, 'Package.swift'),
-          )
-          ..createSync(recursive: true)
-          ..writeAsStringSync(_pluginManifest(pluginName: 'PluginC'));
-
-        final Directory pluginsDirectory = fs.directory(pluginsDirectoryPath);
-        await pluginSwiftDependencies.processPlugins(
-          cacheDirectory: fs.directory(cacheDirectoryPath),
-          plugins: [pluginA, pluginB, pluginC],
-          pluginsDirectory: pluginsDirectory,
-        );
-        expect(pluginsDirectory.listSync().length, 2);
-        expect(pluginSwiftDependencies.highestSupportedVersion.version, Version(11, 0, 0));
-      });
-
-      testWithoutContext('determineHighestSupportedVersion matches using regex', () async {
-        final fs = MemoryFileSystem.test();
-        final logger = BufferLogger.test();
-        final processManager = FakeProcessManager.list([]);
-        const FlutterDarwinPlatform targetPlatform = .macos;
-        final testUtils = BuildSwiftPackageUtils(
-          analytics: FakeAnalytics(),
-          artifacts: FakeArtifacts(engineArtifactPath),
-          buildSystem: FakeBuildSystem(),
-          cache: FakeCache(fs, _flutterRoot),
-          fileSystem: fs,
-          flutterRoot: _flutterRoot,
-          flutterVersion: FakeFlutterVersion(),
-          logger: logger,
-          platform: FakePlatform(),
-          processManager: processManager,
-          project: FakeFlutterProject(directory: fs.directory(_flutterAppPath)),
-          templateRenderer: const MustacheTemplateRenderer(),
-          xcode: FakeXcode(),
-        );
-        final pluginSwiftDependencies = FlutterPluginSwiftDependencies(
-          targetPlatform: targetPlatform,
-          utils: testUtils,
-        );
-        final Directory cacheDirectory = fs.directory(cacheDirectoryPath);
-        final List<File> manifests = [
-          fs.file('PluginA/Package.swift')
-            ..createSync(recursive: true)
-            ..writeAsStringSync(
-              _pluginManifest(pluginName: 'PluginA', platforms: '.macOS("10.16")'),
-            ),
-        ];
-        final (Version highestVersion, bool skipped) = await pluginSwiftDependencies
-            .determineHighestSupportedVersion(manifests: manifests, cacheDirectory: cacheDirectory);
-        expect(highestVersion, Version(10, 16, 0));
-        expect(skipped, isFalse);
-
-        manifests.add(
-          fs.file('PluginB/Package.swift')
-            ..createSync(recursive: true)
-            ..writeAsStringSync(
-              _pluginManifest(
-                pluginName: 'PluginB',
-                platforms: '.iOS( .v16 ),\n .macOS( .v11_15 )',
-              ),
-            ),
-        );
-        final (Version retryHighestVersion, bool retrySkipped) = await pluginSwiftDependencies
-            .determineHighestSupportedVersion(manifests: manifests, cacheDirectory: cacheDirectory);
-        expect(retryHighestVersion, Version(11, 15, 0));
-        expect(retrySkipped, isFalse);
-      });
-
-      testWithoutContext('determineHighestSupportedVersion matches using swift', () async {
-        final fs = MemoryFileSystem.test();
-        final logger = BufferLogger.test();
-        fs.file(commandFilePath).createSync(recursive: true);
-        final processManager = FakeProcessManager.list([
-          const FakeCommand(
-            command: ['swift', 'package', 'dump-package'],
-            workingDirectory: 'PluginA',
-            stdout: '''
-{
-  "name" : "PluginA",
-  "platforms" : [
-    {
-      "options" : [
-
-      ],
-      "platformName" : "ios",
-      "version" : "15.0"
-    },
-    {
-      "options" : [
-
-      ],
-      "platformName" : "macos",
-      "version" : "26.0"
-    }
-  ]
-}
-''',
-          ),
-        ]);
-        const FlutterDarwinPlatform targetPlatform = .macos;
-        final testUtils = BuildSwiftPackageUtils(
-          analytics: FakeAnalytics(),
-          artifacts: FakeArtifacts(engineArtifactPath),
-          buildSystem: FakeBuildSystem(),
-          cache: FakeCache(fs, _flutterRoot),
-          fileSystem: fs,
-          flutterRoot: _flutterRoot,
-          flutterVersion: FakeFlutterVersion(),
-          logger: logger,
-          platform: FakePlatform(),
-          processManager: processManager,
-          project: FakeFlutterProject(directory: fs.directory(_flutterAppPath)),
-          templateRenderer: const MustacheTemplateRenderer(),
-          xcode: FakeXcode(),
-        );
-        final pluginSwiftDependencies = FlutterPluginSwiftDependencies(
-          targetPlatform: targetPlatform,
-          utils: testUtils,
-        );
-        final Directory cacheDirectory = fs.directory(cacheDirectoryPath);
-        final List<File> manifests = [
-          fs.file('PluginA/Package.swift')
-            ..createSync(recursive: true)
-            ..writeAsStringSync(_pluginManifest(pluginName: 'PluginA', platforms: 'someVar')),
-        ];
-        final (Version highestVersion, bool skipped) = await pluginSwiftDependencies
-            .determineHighestSupportedVersion(manifests: manifests, cacheDirectory: cacheDirectory);
-        expect(highestVersion, Version(26, 0, 0));
-        expect(skipped, isFalse);
-
-        // Verify it uses cache next time it runs (process is not called again)
-        final (Version retryHighestVersion, bool retrySkipped) = await pluginSwiftDependencies
-            .determineHighestSupportedVersion(manifests: manifests, cacheDirectory: cacheDirectory);
-        expect(retryHighestVersion, Version(26, 0, 0));
-        expect(retrySkipped, isTrue);
-      });
-
-      testWithoutContext('generateDependencies', () {
-        final fs = MemoryFileSystem.test();
-        final logger = BufferLogger.test();
-        final processManager = FakeProcessManager.list([]);
-        const FlutterDarwinPlatform targetPlatform = .macos;
-        final testUtils = BuildSwiftPackageUtils(
-          analytics: FakeAnalytics(),
-          artifacts: FakeArtifacts(engineArtifactPath),
-          buildSystem: FakeBuildSystem(),
-          cache: FakeCache(fs, _flutterRoot),
-          fileSystem: fs,
-          flutterRoot: _flutterRoot,
-          flutterVersion: FakeFlutterVersion(),
-          logger: logger,
-          platform: FakePlatform(),
-          processManager: processManager,
-          project: FakeFlutterProject(directory: fs.directory(_flutterAppPath)),
-          templateRenderer: const MustacheTemplateRenderer(),
-          xcode: FakeXcode(),
-        );
-        final pluginSwiftDependencies = FlutterPluginSwiftDependencies(
-          targetPlatform: targetPlatform,
-          utils: testUtils,
-        );
-        final pluginA = FakePlugin(name: 'plugin_a', darwinPlatform: targetPlatform);
-        fs.file(
-            fs.path.join(pluginA.pluginSwiftPackagePath(fs, targetPlatform.name)!, 'Package.swift'),
-          )
-          ..createSync(recursive: true)
-          ..writeAsStringSync(_pluginManifest(pluginName: 'plugin_a'));
-        pluginSwiftDependencies.copiedPlugins.add((pluginA, '$pluginsDirectoryPath/plugin_a'));
-
-        final Directory packagesForConfiguration = fs.directory(
-          '$pluginRegistrantSwiftPackagePath/Release/Packages',
-        );
-
-        final (
-          List<SwiftPackagePackageDependency> pluginPackageDependencies,
-          List<SwiftPackageTargetDependency> pluginTargetDependencies,
-        ) = pluginSwiftDependencies.generateDependencies(
-          packagesForConfiguration: fs.directory(
-            '$pluginRegistrantSwiftPackagePath/Release/Packages',
-          ),
-        );
-        expect(
-          packagesForConfiguration.childLink(pluginA.name).targetSync(),
-          '../../Plugins/plugin_a',
-        );
-        expect(
-          pluginPackageDependencies.first.format().endsWith(
-            '.package(name: "plugin_a", path: "Sources/Packages/plugin_a")',
-          ),
-          isTrue,
-        );
-        expect(
-          pluginTargetDependencies.first.format().endsWith(
-            '.product(name: "plugin-a", package: "plugin_a")',
-          ),
-          isTrue,
-        );
       });
     });
 
@@ -2848,7 +2880,7 @@ class FakePlugin extends Fake implements Plugin {
 
   @override
   String? pluginSwiftPackagePath(FileSystem fileSystem, String platform, {String? overridePath}) {
-    return fileSystem.path.join(path, platform, name);
+    return fileSystem.path.join(overridePath ?? path, platform, name);
   }
 
   @override

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_swift_package_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_swift_package_test.dart
@@ -1731,7 +1731,7 @@ let package = Package(
         expect(pluginSwiftDependencies.highestSupportedVersion.version, Version(13, 0, 0));
 
         final File cachedManifest = cacheDir
-            .childDirectory('Plugins')
+            .childDirectory('Manifests')
             .childDirectory('PluginA')
             .childFile('Package.swift');
         expect(cachedManifest.existsSync(), isTrue);


### PR DESCRIPTION
To avoid needing a pre-action script in add2app, all SwiftPM plugins need to have a dependency on the FlutterFramework. However, not all plugins have migrated yet. This PR parses each plugin's Package.swift and injects the FlutterFramework dependency (to the copied version) if it's not already there. Since we need to parse each Package.swift anyways, this also refactors the way we determine the highest deployment version. Previously used a mix of regex and `swift package dump-package` command, now it relies entirely on the `swift` command. 

Needed for https://github.com/flutter/flutter/issues/81867 and https://github.com/flutter/flutter/issues/181222

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
