### PR TITLE
Warn about the use of TestSemantics

### DIFF
--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -25,6 +25,10 @@ const String _matcherHelp =
 /// This class should be avoided due to a high frequency of breakages caused by
 /// small semantics tree changes. Instead, prefer [SemanticsController.find],
 /// accessible via [WidgetTester.semantics].
+@Deprecated(
+  'Use `SemanticsController.find`, `isSemantics`, or `matchesSemantics` instead. '
+  'This feature was deprecated after v3.43.0-0.3.pre.',
+)
 class TestSemantics {
   /// Creates an object with some test semantics data.
   ///
@@ -40,6 +44,10 @@ class TestSemantics {
   ///
   ///  * [TestSemantics.fullScreen] 800x600, the test screen's size in logical
   ///    pixels, useful for other full-screen widgets.
+  @Deprecated(
+    'Use `SemanticsController.find`, `isSemantics`, or `matchesSemantics` instead. '
+    'This feature was deprecated after v3.43.0-0.3.pre.',
+  )
   TestSemantics({
     this.id,
     this.flags = 0,
@@ -77,6 +85,10 @@ class TestSemantics {
 
   /// Creates an object with some test semantics data, with the [id] and [rect]
   /// set to the appropriate values for the root node.
+  @Deprecated(
+    'Use `SemanticsController.find`, `isSemantics`, or `matchesSemantics` instead. '
+    'This feature was deprecated after v3.43.0-0.3.pre.',
+  )
   TestSemantics.root({
     this.flags = 0,
     this.actions = 0,
@@ -122,6 +134,10 @@ class TestSemantics {
   /// The [rect] field is required and has no default. The
   /// [TestSemantics.fullScreen] property may be useful as a value; it describes
   /// an 800x600 rectangle, which is the test screen's size in logical pixels.
+  @Deprecated(
+    'Use `SemanticsController.find`, `isSemantics`, or `matchesSemantics` instead. '
+    'This feature was deprecated after v3.43.0-0.3.pre.',
+  )
   TestSemantics.rootChild({
     this.id,
     this.flags = 0,

--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -15,10 +15,16 @@ export 'package:flutter/rendering.dart' show SemanticsData;
 const String _matcherHelp =
     'Try dumping the semantics with debugDumpSemanticsTree(DebugSemanticsDumpOrder.inverseHitTest) from the package:flutter/rendering.dart library to see what the semantics tree looks like.';
 
+// TODO(justinmc): Remove this per
+// https://github.com/flutter/flutter/issues/184367.
 /// Test semantics data that is compared against real semantics tree.
 ///
 /// Useful with [hasSemantics] and [SemanticsTester] to test the contents of the
 /// semantics tree.
+///
+/// This class should be avoided due a high frequency of breakages caused by
+/// small semantics tree changes. Instead prefer [SemanticsController.find],
+/// accessible via [WidgetTester.semantics].
 class TestSemantics {
   /// Creates an object with some test semantics data.
   ///

--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -24,7 +24,8 @@ const String _matcherHelp =
 ///
 /// This class should be avoided due to a high frequency of breakages caused by
 /// small semantics tree changes. Instead, prefer [SemanticsController.find],
-/// accessible via [WidgetTester.semantics].
+/// accessible via [WidgetTester.semantics], or the matchers [isSemantics] and
+/// [matchesSemantics].
 @Deprecated(
   'Use `SemanticsController.find`, `isSemantics`, or `matchesSemantics` instead. '
   'This feature was deprecated after v3.43.0-0.3.pre.',

--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -22,8 +22,8 @@ const String _matcherHelp =
 /// Useful with [hasSemantics] and [SemanticsTester] to test the contents of the
 /// semantics tree.
 ///
-/// This class should be avoided due a high frequency of breakages caused by
-/// small semantics tree changes. Instead prefer [SemanticsController.find],
+/// This class should be avoided due to a high frequency of breakages caused by
+/// small semantics tree changes. Instead, prefer [SemanticsController.find],
 /// accessible via [WidgetTester.semantics].
 class TestSemantics {
   /// Creates an object with some test semantics data.


### PR DESCRIPTION
As decided in https://github.com/flutter/flutter/pull/183790#issuecomment-4158558039, we should avoid using TestSemantics. Let's communicate that for now until we can remove the class entirely.

Part of https://github.com/flutter/flutter/issues/184367.