### PR TITLE
Support different joins for stroked rects in uber_sdf, fix incorrect aa

### DIFF
--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -837,6 +837,7 @@ void Canvas::DrawRect(const Rect& rect, const Paint& paint) {
 
     auto contents = UberSDFContents::MakeRect(
         /*color=*/paint.color, /*stroke_width=*/paint.stroke.width,
+        /*stroke_join=*/paint.stroke.join,
         /*stroked=*/paint.style == Paint::Style::kStroke, &geometry);
 
     const Geometry* geom = contents->GetGeometry();

--- a/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.cc
@@ -24,13 +24,14 @@ using FS = UberSDFPipeline::FragmentShader;
 std::unique_ptr<UberSDFContents> UberSDFContents::MakeRect(
     Color color,
     Scalar stroke_width,
+    Join stroke_join,
     bool stroked,
     const FillRectGeometry* geometry) {
   Rect bounding_box = geometry->GetRect();
-  Scalar aa_padding = geometry->GetAntialiasPadding();
+  Scalar aa_padding = 1.0f;
   return std::make_unique<UberSDFContents>(Type::kRect, bounding_box, color,
-                                           stroke_width, stroked, geometry,
-                                           aa_padding);
+                                           stroke_width, stroke_join, stroked,
+                                           geometry, aa_padding);
 }
 
 std::unique_ptr<UberSDFContents> UberSDFContents::MakeCircle(
@@ -43,14 +44,15 @@ std::unique_ptr<UberSDFContents> UberSDFContents::MakeCircle(
                                      radius * 2, radius * 2);
   Scalar aa_padding = geometry->GetAntialiasPadding();
   return std::unique_ptr<UberSDFContents>(new UberSDFContents(
-      Type::kCircle, bounding_box, color, geometry->GetStrokeWidth(), stroked,
-      geometry, aa_padding));
+      Type::kCircle, bounding_box, color, geometry->GetStrokeWidth(),
+      Join::kMiter, stroked, geometry, aa_padding));
 }
 
 UberSDFContents::UberSDFContents(Type type,
                                  Rect bounding_box,
                                  Color color,
                                  Scalar stroke_width,
+                                 Join stroke_join,
                                  bool stroked,
                                  const Geometry* geometry,
                                  Scalar aa_padding)
@@ -58,6 +60,7 @@ UberSDFContents::UberSDFContents(Type type,
       bounding_box_(bounding_box),
       color_(color),
       stroke_width_(stroke_width),
+      stroke_join_(stroke_join),
       stroked_(stroked),
       geometry_(geometry),
       aa_padding_(aa_padding) {}
@@ -76,6 +79,17 @@ bool UberSDFContents::Render(const ContentContext& renderer,
   frag_info.size =
       Point(bounding_box_.GetWidth() / 2.0f, bounding_box_.GetHeight() / 2.0f);
   frag_info.stroke_width = stroke_width_;
+  switch (stroke_join_) {
+    case Join::kMiter:
+      frag_info.stroke_join = 0.0f;
+      break;
+    case Join::kBevel:
+      frag_info.stroke_join = 1.0f;
+      break;
+    case Join::kRound:
+      frag_info.stroke_join = 2.0f;
+      break;
+  }
   frag_info.aa_pixels = aa_padding_;
   frag_info.stroked = stroked_ ? 1.0f : 0.0f;
   frag_info.type = type_ == Type::kCircle ? 0.0f : 1.0f;

--- a/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.h
+++ b/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.h
@@ -27,6 +27,7 @@ class UberSDFContents : public ColorSourceContents {
   static std::unique_ptr<UberSDFContents> MakeRect(
       Color color,
       Scalar stroke_width,
+      Join stroke_join,
       bool stroked,
       const FillRectGeometry* geometry);
 
@@ -37,6 +38,7 @@ class UberSDFContents : public ColorSourceContents {
                   Rect rect,
                   Color color,
                   Scalar stroke_width,
+                  Join stroke_join,
                   bool stroked,
                   const Geometry* geometry,
                   Scalar aa_padding);
@@ -64,6 +66,8 @@ class UberSDFContents : public ColorSourceContents {
   Color color_;
   /// The width of the stroke.
   Scalar stroke_width_ = 0.0f;
+  /// The join of the stroke.
+  Join stroke_join_ = Join::kMiter;
   /// Whether the geometry is stroked.
   bool stroked_ = false;
   /// The geometry.

--- a/engine/src/flutter/impeller/entity/contents/uber_sdf_contents_unittests.cc
+++ b/engine/src/flutter/impeller/entity/contents/uber_sdf_contents_unittests.cc
@@ -13,8 +13,8 @@ namespace testing {
 TEST(UberSDFContentsTest, ApplyColorFilter) {
   auto rect = Rect::MakeXYWH(100, 100, 200, 200);
   FillRectGeometry geometry(rect);
-  auto contents =
-      UberSDFContents::MakeRect(Color::Red(), 0.0f, false, &geometry);
+  auto contents = UberSDFContents::MakeRect(Color::Red(), 0.0f, Join::kMiter,
+                                            false, &geometry);
 
   ASSERT_EQ(contents->GetColor(), Color::Red());
 

--- a/engine/src/flutter/impeller/entity/entity_unittests.cc
+++ b/engine/src/flutter/impeller/entity/entity_unittests.cc
@@ -1235,8 +1235,8 @@ TEST_P(EntityTest, ContentsGetBoundsForEmptyPathReturnsNullopt) {
 TEST(EntityTest, UberSDFContentsCoverage) {
   auto rect = Rect::MakeXYWH(100, 100, 200, 200);
   FillRectGeometry geometry(rect.Expand(1.0f));
-  auto contents =
-      UberSDFContents::MakeRect(Color::Red(), 0.0f, false, &geometry);
+  auto contents = UberSDFContents::MakeRect(Color::Red(), 0.0f, Join::kMiter,
+                                            false, &geometry);
 
   Entity entity;
   auto coverage = contents->GetCoverage(entity);

--- a/engine/src/flutter/impeller/entity/shaders/uber_sdf.frag
+++ b/engine/src/flutter/impeller/entity/shaders/uber_sdf.frag
@@ -76,6 +76,7 @@ float strokedSDF(vec2 p) {
           distanceFromChamferRect(p, frag_info.size + half_stroke, half_stroke);
     } else {  // Round
       // Rectangle sdf expanded by half_stroke, to give a half_stroke radius
+      // https://www.shadertoy.com/view/NfXSDr
       outer = distanceFromRect(p, frag_info.size) - half_stroke;
     }
     inner = distanceFromRect(p, frag_info.size - half_stroke);

--- a/engine/src/flutter/impeller/entity/shaders/uber_sdf.frag
+++ b/engine/src/flutter/impeller/entity/shaders/uber_sdf.frag
@@ -50,42 +50,44 @@ float distanceFromChamferRect(vec2 p, vec2 b, float chamfer) {
   return length(d);
 }
 
+float filledSDF(vec2 p) {
+  if (frag_info.type < 0.5) {  // Circle
+    return distanceFromCircle(p, frag_info.size.x);
+  } else {  // Rect
+    return distanceFromRect(p, frag_info.size);
+  }
+}
+
+float strokedSDF(vec2 p) {
+  float half_stroke = max(frag_info.stroke_width, 0.0) * 0.5;
+  float outer;
+  float inner;
+
+  if (frag_info.type < 0.5) {  // Circle
+    outer = distanceFromCircle(p, frag_info.size.x + half_stroke);
+    inner = distanceFromCircle(p, frag_info.size.x - half_stroke);
+  } else {                              // Rect
+    if (frag_info.stroke_join < 0.5) {  // Miter
+      // Rectangle expanded by half_stroke
+      outer = distanceFromRect(p, frag_info.size + half_stroke);
+    } else if (frag_info.stroke_join < 1.5) {  // Bevel
+      // Rectangle expanded by half_stroke, with half_stroke chamfer
+      outer =
+          distanceFromChamferRect(p, frag_info.size + half_stroke, half_stroke);
+    } else {  // Round
+      // Rectangle sdf expanded by half_stroke, to give a half_stroke radius
+      outer = distanceFromRect(p, frag_info.size) - half_stroke;
+    }
+    inner = distanceFromRect(p, frag_info.size - half_stroke);
+  }
+
+  return max(outer, -inner);
+}
+
 void main() {
   vec2 p = v_position - frag_info.center;
 
-  float dist;
-
-  if (frag_info.stroked < 0.5) {  // Filled
-    if (frag_info.type < 0.5) {   // Circle
-      dist = distanceFromCircle(p, frag_info.size.x);
-    } else {  // Rect
-      dist = distanceFromRect(p, frag_info.size);
-    }
-  } else {  // Stroked
-    float outer;
-    float inner;
-    float half_stroke = max(frag_info.stroke_width, 0.0) * 0.5;
-
-    if (frag_info.type < 0.5) {  // Circle
-      outer = distanceFromCircle(p, frag_info.size.x + half_stroke);
-      inner = distanceFromCircle(p, frag_info.size.x - half_stroke);
-    } else {                              // Rect
-      if (frag_info.stroke_join < 0.5) {  // Miter
-        // Rectangle expanded by half_stroke
-        outer = distanceFromRect(p, frag_info.size + half_stroke);
-      } else if (frag_info.stroke_join < 1.5) {  // Bevel
-        // Rectangle expanded by half_stroke, with half_stroke chamfer
-        outer = distanceFromChamferRect(p, frag_info.size + half_stroke,
-                                        half_stroke);
-      } else {  // Round
-        // Rectangle sdf expanded by half_stroke, to give a half_stroke radius
-        outer = distanceFromRect(p, frag_info.size) - half_stroke;
-      }
-      inner = distanceFromRect(p, frag_info.size - half_stroke);
-    }
-
-    dist = max(outer, -inner);
-  }
+  float dist = (frag_info.stroked < 0.5) ? filledSDF(p) : strokedSDF(p);
 
   // Anti-aliasing
   // fwidth(dist) gives the change in SDF per pixel.

--- a/engine/src/flutter/impeller/entity/shaders/uber_sdf.frag
+++ b/engine/src/flutter/impeller/entity/shaders/uber_sdf.frag
@@ -12,6 +12,7 @@ uniform FragInfo {
   vec2 center;
   vec2 size;
   float stroke_width;
+  float stroke_join;
   float aa_pixels;
   float stroked;
   float type;
@@ -27,30 +28,70 @@ float distanceFromCircle(vec2 p, float radius) {
 }
 
 float distanceFromRect(vec2 p, vec2 b) {
-  // TODO(gaaclarke): This is may need to be improved for corners. This is just
-  // the simplest thing while we get the plumbing in place.
   vec2 d = abs(p) - b;
   return length(max(d, 0.0)) + min(max(d.x, d.y), 0.0);
+}
+
+float distanceFromChamferRect(vec2 p, vec2 b, float chamfer) {
+  vec2 d = abs(p) - b;
+
+  d = (d.y > d.x) ? d.yx : d.xy;
+  d.y += chamfer;
+
+  const float k = 1.0 - sqrt(2.0);
+  if (d.y < 0.0 && d.y + d.x * k < 0.0) {
+    return d.x;
+  }
+
+  if (d.x < d.y) {
+    return (d.x + d.y) * sqrt(0.5);
+  }
+
+  return length(d);
 }
 
 void main() {
   vec2 p = v_position - frag_info.center;
 
   float dist;
-  if (frag_info.type < 0.5) {
-    dist = distanceFromCircle(p, frag_info.size.x);
-  } else {
-    dist = distanceFromRect(p, frag_info.size);
+
+  if (frag_info.stroked < 0.5) {  // Filled
+    if (frag_info.type < 0.5) {   // Circle
+      dist = distanceFromCircle(p, frag_info.size.x);
+    } else {  // Rect
+      dist = distanceFromRect(p, frag_info.size);
+    }
+  } else {  // Stroked
+    float outer;
+    float inner;
+    float half_stroke = max(frag_info.stroke_width, 0.0) * 0.5;
+
+    if (frag_info.type < 0.5) {  // Circle
+      outer = distanceFromCircle(p, frag_info.size.x + half_stroke);
+      inner = distanceFromCircle(p, frag_info.size.x - half_stroke);
+    } else {                              // Rect
+      if (frag_info.stroke_join < 0.5) {  // Miter
+        // Rectangle expanded by half_stroke
+        outer = distanceFromRect(p, frag_info.size + half_stroke);
+      } else if (frag_info.stroke_join < 1.5) {  // Bevel
+        // Rectangle expanded by half_stroke, with half_stroke chamfer
+        outer = distanceFromChamferRect(p, frag_info.size + half_stroke,
+                                        half_stroke);
+      } else {  // Round
+        // Rectangle sdf expanded by half_stroke, to give a half_stroke radius
+        outer = distanceFromRect(p, frag_info.size) - half_stroke;
+      }
+      inner = distanceFromRect(p, frag_info.size - half_stroke);
+    }
+
+    dist = max(outer, -inner);
   }
 
-  float half_stroke = max(frag_info.stroke_width, 0.0) * 0.5;
-  float sdf_distance = mix(dist, abs(dist) - half_stroke, frag_info.stroked);
-
   // Anti-aliasing
-  // fwidth(sdf_distance) gives the change in SDF per pixel.
-  float fade_size = fwidth(sdf_distance) * frag_info.aa_pixels * 0.5;
+  // fwidth(dist) gives the change in SDF per pixel.
+  float fade_size = fwidth(dist) * frag_info.aa_pixels * 0.5;
 
-  float alpha = 1.0 - smoothstep(-fade_size, fade_size, sdf_distance);
+  float alpha = 1.0 - smoothstep(-fade_size, fade_size, dist);
 
   frag_color = vec4(frag_info.color.rgb, frag_info.color.a * alpha);
   frag_color = IPPremultiply(frag_color);

--- a/engine/src/flutter/impeller/tools/malioc.json
+++ b/engine/src/flutter/impeller/tools/malioc.json
@@ -8680,7 +8680,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 60,
+          "fp16_arithmetic": 54,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -8688,10 +8688,10 @@
               "arith_fma"
             ],
             "longest_path_cycles": [
-              0.46875,
-              0.46875,
-              0.09375,
-              0.3125,
+              0.53125,
+              0.53125,
+              0.296875,
+              0.375,
               0.0,
               0.25,
               0.0
@@ -8710,9 +8710,9 @@
               "arith_fma"
             ],
             "shortest_path_cycles": [
-              0.4375,
-              0.4375,
-              0.03125,
+              0.390625,
+              0.390625,
+              0.0625,
               0.3125,
               0.0,
               0.25,
@@ -8723,10 +8723,10 @@
               "arith_fma"
             ],
             "total_cycles": [
-              0.546875,
-              0.546875,
-              0.109375,
-              0.375,
+              1.0750000476837158,
+              1.0750000476837158,
+              0.484375,
+              0.6875,
               0.0,
               0.25,
               0.0
@@ -8734,7 +8734,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 10,
+          "uniform_registers_used": 16,
           "work_registers_used": 20
         }
       }
@@ -8752,7 +8752,7 @@
               "arithmetic"
             ],
             "longest_path_cycles": [
-              5.940000057220459,
+              9.239999771118164,
               1.0,
               2.0
             ],
@@ -8765,7 +8765,7 @@
               "arithmetic"
             ],
             "shortest_path_cycles": [
-              5.610000133514404,
+              4.619999885559082,
               1.0,
               2.0
             ],
@@ -8773,13 +8773,13 @@
               "arithmetic"
             ],
             "total_cycles": [
-              7.333333492279053,
+              16.33333396911621,
               1.0,
               2.0
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 2,
+          "uniform_registers_used": 3,
           "work_registers_used": 2
         }
       }
@@ -12088,7 +12088,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 48,
+          "fp16_arithmetic": 56,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -12096,10 +12096,10 @@
               "arith_fma"
             ],
             "longest_path_cycles": [
-              0.40625,
-              0.40625,
-              0.078125,
-              0.3125,
+              0.46875,
+              0.46875,
+              0.28125,
+              0.375,
               0.0,
               0.25,
               0.0
@@ -12115,12 +12115,13 @@
             ],
             "shortest_path_bound_pipelines": [
               "arith_total",
-              "arith_fma"
+              "arith_fma",
+              "arith_sfu"
             ],
             "shortest_path_cycles": [
-              0.359375,
-              0.359375,
-              0.046875,
+              0.3125,
+              0.3125,
+              0.078125,
               0.3125,
               0.0,
               0.25,
@@ -12131,10 +12132,10 @@
               "arith_fma"
             ],
             "total_cycles": [
+              1.0,
+              1.0,
               0.46875,
-              0.46875,
-              0.09375,
-              0.375,
+              0.6875,
               0.0,
               0.25,
               0.0
@@ -12142,8 +12143,8 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 12,
-          "work_registers_used": 7
+          "uniform_registers_used": 16,
+          "work_registers_used": 6
         }
       }
     }


### PR DESCRIPTION
Improves (but doesn't completely fix) #184352.

Add stroke join style support for stroked rects and revamp `uber_sdf` stroking logic:
- Adds `stroke_join` input to `uber_sdf` shader
- Changes how `uber_sdf.frag` handles stroked shapes. It calculates the outer and inner SDFs of the stroked shape, then subtracts the inner shape from the outer shape. The old code did something that always ends up with round-joined strokes, and I think this new version is easier to follow.
- `stroke_join` is taken into account to use different outer-edge shapes for stroked rects

Fix incorrect `aa_pixels` used for stroked rects:
- Hard-code a 1.0 value for `UberSDFContents::MakeRect`'s `aa_padding`. This was using `geometry->GetAntialiasPadding()` before, which is misleadingly not the intended AA padding, but instead is the "total padding" for turning a filled rect geometry into the geometry for an sdf-stroked rect (adding a half-stroke-width padding to account for the width of the stroking).

Planning to do in follow-up PRs:
- I think the stroking/AA/geometry logic for UberSDFContents is inconsistent and can be cleaned up significantly. https://github.com/flutter/flutter/issues/184402
- Hairline (stroke_width = 0.0) stroked rects do not show up. See the `CanRenderWideStrokedRectWithoutOverlap` golden images below. This needs a solution. https://github.com/flutter/flutter/issues/184403
- In StrokedRectsRenderCorrectly for the bottom right blue rectangle is still not being rendered correctly. This is a rect with a Miter join, but with a miter limit set to be less than a 90 degree angle, so it falls back to a Bevel join. The SDF doesn't support miter limits, so we'll need to add support for that. https://github.com/flutter/flutter/issues/184404

#### AiksTest.StrokedRectsRenderCorrectly

##### Before:
<img width="484" height="320" alt="image" src="https://github.com/user-attachments/assets/aa395574-7af9-4f19-9afe-151b3726a1ed" />

##### After:
<img width="484" height="320" alt="image" src="https://github.com/user-attachments/assets/4cc13fbe-4a8a-4027-88c8-19a2366148d2" />

##### Non-sdf:
<img width="484" height="320" alt="image" src="https://github.com/user-attachments/assets/135c0cb7-3479-4ac9-8aa3-ec6b77adaff8" />

#### AiksTest.CanRenderWideStrokedRectWithoutOverlap

##### Before:
<img width="404" height="281" alt="image" src="https://github.com/user-attachments/assets/2c5126b1-60b8-437a-bfbb-f93726317057" />

##### After:
<img width="404" height="280" alt="image" src="https://github.com/user-attachments/assets/0d78f1d5-89a6-4705-a2fb-3cebc086a3a9" />

##### Non-sdf:
<img width="404" height="280" alt="image" src="https://github.com/user-attachments/assets/c3f815b0-2eaf-4ecb-a0a2-ceebf18e33e7" />


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
