### PR TITLE
Remove the cupertino_icons dependency from the spell_check integration test

### DIFF
--- a/dev/integration_tests/spell_check/pubspec.yaml
+++ b/dev/integration_tests/spell_check/pubspec.yaml
@@ -32,10 +32,6 @@ dependencies:
   flutter:
     sdk: flutter
 
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: 1.0.8
-
 
 dev_dependencies:
   flutter_test:
@@ -89,4 +85,4 @@ flutter:
   # For details regarding fonts from package dependencies,
   # see https://flutter.dev/custom-fonts/#from-packages
 
-# PUBSPEC CHECKSUM: ovmend
+# PUBSPEC CHECKSUM: vrimb3


### PR DESCRIPTION
This package will be resolved through the workspace.