### PR TITLE
[fuchsia] Replace ambient-replace-as-executable with VmexResource.

### DIFF
--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/meta/common.shard.cml
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/meta/common.shard.cml
@@ -30,6 +30,7 @@
                 "fuchsia.device.NameProvider",  // For fdio uname()
                 "fuchsia.feedback.CrashReporter",
                 "fuchsia.intl.PropertyProvider",  // For dartVM timezone support
+                "fuchsia.kernel.VmexResource",  // Also used in AOT for FFI callback thunks.
                 "fuchsia.net.name.Lookup",  // For fdio sockets
                 "fuchsia.posix.socket.Provider",  // For fdio sockets
             ],

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/meta/dart_jit_product_runner.cml
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/meta/dart_jit_product_runner.cml
@@ -8,8 +8,6 @@
         binary: "bin/app",
         forward_stdout_to: "log",
         forward_stderr_to: "log",
-        // Needed for JIT builds.
-        job_policy_ambient_mark_vmo_exec: "true",
     },
     capabilities: [
         {

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/meta/dart_jit_runner.cml
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/meta/dart_jit_runner.cml
@@ -8,8 +8,6 @@
         binary: "bin/app",
         forward_stdout_to: "log",
         forward_stderr_to: "log",
-        // Needed for JIT builds.
-        job_policy_ambient_mark_vmo_exec: "true",
     },
     capabilities: [
         {

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_aot_runner/meta/dart-aot-runner-integration-test.cml
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_aot_runner/meta/dart-aot-runner-integration-test.cml
@@ -27,6 +27,7 @@
                 "fuchsia.vulkan.loader.Loader",
                 "fuchsia.posix.socket.Provider",
                 "fuchsia.intl.PropertyProvider",
+                "fuchsia.kernel.VmexResource",
             ],
             from: "parent",
             to: "#realm_builder",

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_jit_runner/meta/dart-jit-runner-integration-test.cml
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_jit_runner/meta/dart-jit-runner-integration-test.cml
@@ -26,6 +26,7 @@
                 "fuchsia.vulkan.loader.Loader",
                 "fuchsia.posix.socket.Provider",
                 "fuchsia.intl.PropertyProvider",
+                "fuchsia.kernel.VmexResource",
             ],
             from: "parent",
             to: "#realm_builder",

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/meta/common.shard.cml
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/meta/common.shard.cml
@@ -35,6 +35,7 @@
                 "fuchsia.feedback.CrashReporter",
                 "fuchsia.fonts.Provider",
                 "fuchsia.intl.PropertyProvider",
+                "fuchsia.kernel.VmexResource", // Also used in AOT for FFI callback thunks.
                 "fuchsia.media.ProfileProvider",
                 "fuchsia.memorypressure.Provider",
                 "fuchsia.scheduler.RoleManager",

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/meta/flutter_jit_product_runner.cml
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/meta/flutter_jit_product_runner.cml
@@ -8,8 +8,6 @@
         binary: "bin/app",
         forward_stdout_to: "log",
         forward_stderr_to: "log",
-        // Needed for JIT builds.
-        job_policy_ambient_mark_vmo_exec: "true"
     },
     capabilities: [
         {

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/meta/flutter_jit_runner.cml
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/meta/flutter_jit_runner.cml
@@ -8,8 +8,6 @@
         binary: "bin/app",
         forward_stdout_to: "log",
         forward_stderr_to: "log",
-        // Needed for JIT builds.
-        job_policy_ambient_mark_vmo_exec: "true"
     },
     capabilities: [
         {

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/embedder/meta/flutter-embedder-test.cml
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/embedder/meta/flutter-embedder-test.cml
@@ -22,6 +22,7 @@
             // Offer capabilities needed by components in this test realm.
             // Keep it minimal, describe only what's actually needed.
             protocol: [
+                "fuchsia.kernel.VmexResource",
                 "fuchsia.sysmem.Allocator",
                 "fuchsia.sysmem2.Allocator",
                 "fuchsia.tracing.provider.Registry",

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/mouse-input/meta/mouse-input-test.cml
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/mouse-input/meta/mouse-input-test.cml
@@ -32,6 +32,7 @@
             protocol: [
                 "fuchsia.kernel.RootJobForInspect",
                 "fuchsia.kernel.Stats",
+                "fuchsia.kernel.VmexResource",
                 "fuchsia.scheduler.ProfileProvider",
                 "fuchsia.sysmem.Allocator",
                 "fuchsia.sysmem2.Allocator",

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/text-input/meta/text-input-test.cml
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/text-input/meta/text-input-test.cml
@@ -30,6 +30,7 @@
             protocol: [
                 "fuchsia.kernel.RootJobForInspect",
                 "fuchsia.kernel.Stats",
+                "fuchsia.kernel.VmexResource",
                 "fuchsia.scheduler.ProfileProvider",
                 "fuchsia.sysmem.Allocator",
                 "fuchsia.sysmem2.Allocator",

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/touch-input/meta/touch-input-test.cml
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/touch-input/meta/touch-input-test.cml
@@ -32,6 +32,7 @@
             protocol: [
                 "fuchsia.kernel.RootJobForInspect",
                 "fuchsia.kernel.Stats",
+                "fuchsia.kernel.VmexResource",
                 "fuchsia.scheduler.ProfileProvider",
                 "fuchsia.sysmem.Allocator",
                 "fuchsia.sysmem2.Allocator",

--- a/engine/src/flutter/testing/fuchsia/meta/test_suite.cml
+++ b/engine/src/flutter/testing/fuchsia/meta/test_suite.cml
@@ -13,17 +13,23 @@
     },
     program: {
         // TODO(fxbug.dev/80338): Switch to gtest_runner after the filters in
-        // `gtest_filters.yaml` are supported by `--test-filter` and
-        // deprecated-ambient-replace-as-executable is available.
-        // Equivalent to the "deprecated-ambient-replace-as-executable" sandbox
-        // feature in cfv1.
-        runner: "elf_test_ambient_exec_runner",
+        // `gtest_filters.yaml` are supported by `--test-filter`.
+        runner: "elf_test_runner",
         binary: "bin/app",
 
         // Part of //sdk/lib/diagnostics/syslog/elf_stdio.shard.cml.
         forward_stderr_to: "log",
         forward_stdout_to: "log",
     },
+    offer: [
+        {
+            protocol: [
+                "fuchsia.kernel.VmexResource",
+            ],
+            from: "parent",
+            to: "#realm_builder",
+        },
+    ],
     capabilities: [
         { protocol: "fuchsia.test.Suite" },
     ],
@@ -36,6 +42,7 @@
     use: [
         {
             protocol: [
+                "fuchsia.kernel.VmexResource",
                 "fuchsia.process.Launcher",
                 "fuchsia.tracing.provider.Registry",
                 "fuchsia.vulkan.loader.Loader",

--- a/engine/src/flutter/testing/fuchsia/run_tests.py
+++ b/engine/src/flutter/testing/fuchsia/run_tests.py
@@ -93,6 +93,8 @@ def main() -> int:
   logging.info('Running tests in %s', OUT_DIR)
   force_running_unattended()
   sys.argv.append('--out-dir=' + OUT_DIR)
+  # VmexResource not available in default realm
+  sys.argv.append('--test-realm=/core/testing/chromium-tests')
   if VARIANT.endswith('_arm64') or VARIANT.endswith('_arm64_tester'):
     sys.argv.append('--product=terminal.qemu-arm64')
 


### PR DESCRIPTION
Add the VmexResource to AOT configurations to be able to copy the FFI trampolines.

Bug: https://dartbug.com/52579
