### PR TITLE
Fix selecting backwards when involving widget spans

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1860,7 +1860,14 @@ class _SelectableFragment
     transform.invert();
     final Offset localPosition = MatrixUtils.transformPoint(transform, globalPosition);
     if (_rect.isEmpty) {
-      return SelectionUtils.getResultBasedOnRect(_rect, localPosition);
+      final SelectionResult result = SelectionUtils.getResultBasedOnRect(_rect, localPosition);
+      _setSelectionPosition(
+        result == SelectionResult.next
+            ? TextPosition(offset: range.end)
+            : TextPosition(offset: range.start, affinity: TextAffinity.upstream),
+        isEnd: isEnd,
+      );
+      return result;
     }
     final Offset adjustedOffset = SelectionUtils.adjustDragOffset(
       _rect,
@@ -1926,7 +1933,14 @@ class _SelectableFragment
     transform.invert();
     final Offset localPosition = MatrixUtils.transformPoint(transform, globalPosition);
     if (_rect.isEmpty) {
-      return SelectionUtils.getResultBasedOnRect(_rect, localPosition);
+      final SelectionResult result = SelectionUtils.getResultBasedOnRect(_rect, localPosition);
+      _setSelectionPosition(
+        result == SelectionResult.next
+            ? TextPosition(offset: range.end)
+            : TextPosition(offset: range.start, affinity: TextAffinity.upstream),
+        isEnd: isEnd,
+      );
+      return result;
     }
     final Offset adjustedOffset = SelectionUtils.adjustDragOffset(
       _rect,
@@ -2834,7 +2848,14 @@ class _SelectableFragment
     transform.invert();
     final Offset localPosition = MatrixUtils.transformPoint(transform, globalPosition);
     if (_rect.isEmpty) {
-      return SelectionUtils.getResultBasedOnRect(_rect, localPosition);
+      final SelectionResult result = SelectionUtils.getResultBasedOnRect(_rect, localPosition);
+      _setSelectionPosition(
+        result == SelectionResult.next
+            ? TextPosition(offset: range.end)
+            : TextPosition(offset: range.start, affinity: TextAffinity.upstream),
+        isEnd: isEnd,
+      );
+      return result;
     }
     final Offset adjustedOffset = SelectionUtils.adjustDragOffset(
       _rect,

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -3267,13 +3267,11 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
       final SelectionResult childResult = dispatchSelectionEventToChild(child, event);
       switch (childResult) {
         case SelectionResult.next:
-          if (forward == null) {
-            forward = true;
-            newIndex = index;
-          } else if (!forward) {
+          if (forward == false) {
             hasFoundEdgeIndex = true;
             result = SelectionResult.end;
           } else {
+            forward = true;
             newIndex = index;
           }
         case SelectionResult.none:
@@ -3289,13 +3287,11 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
             result = SelectionResult.previous;
             break;
           }
-          if (forward == null) {
-            forward = false;
-            newIndex = index;
-          } else if (forward) {
+          if (forward ?? false) {
             hasFoundEdgeIndex = true;
             result = SelectionResult.end;
           } else {
+            forward = false;
             newIndex = index;
           }
         case SelectionResult.pending:
@@ -3306,7 +3302,7 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
       if (hasFoundEdgeIndex) {
         break;
       }
-      index += forward == null ? 1 : (forward ? 1 : -1);
+      index += (forward ?? true) ? 1 : -1;
     }
 
     if (newIndex == -1) {

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -3260,21 +3260,15 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
     // If we already have an opposite edge initialized, start our sweep from there
     // to ensure all items between the two edges are properly visited.
     final int oppositeEdgeIndex = isEnd ? currentSelectionStartIndex : currentSelectionEndIndex;
-    final startIndex = oppositeEdgeIndex != -1 ? oppositeEdgeIndex : 0;
-    int? step;
+    var index = oppositeEdgeIndex != -1 ? oppositeEdgeIndex : 0;
 
-    for (
-      var index = startIndex;
-      index >= 0 && index < selectables.length && !hasFoundEdgeIndex;
-      index += step ?? 1
-    ) {
+    while (index >= 0 && index < selectables.length) {
       final Selectable child = selectables[index];
       final SelectionResult childResult = dispatchSelectionEventToChild(child, event);
       switch (childResult) {
         case SelectionResult.next:
           if (forward == null) {
             forward = true;
-            step = 1;
             newIndex = index;
           } else if (!forward) {
             hasFoundEdgeIndex = true;
@@ -3297,7 +3291,7 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
           }
           if (forward == null) {
             forward = false;
-            step = -1;
+            newIndex = index;
           } else if (forward) {
             hasFoundEdgeIndex = true;
             result = SelectionResult.end;
@@ -3309,6 +3303,10 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
           result = SelectionResult.pending;
           hasFoundEdgeIndex = true;
       }
+      if (hasFoundEdgeIndex) {
+        break;
+      }
+      index += forward == null ? 1 : (forward ? 1 : -1);
     }
 
     if (newIndex == -1) {

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -3249,6 +3249,85 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
   /// Ideally, this method should only be called twice at the beginning of the
   /// drag selection, once for start edge update event, once for end edge update
   /// event.
+  SelectionResult _initSelectionA(SelectionEdgeUpdateEvent event, {required bool isEnd}) {
+    assert(
+      (isEnd && currentSelectionEndIndex == -1) || (!isEnd && currentSelectionStartIndex == -1),
+    );
+    var newIndex = -1;
+    var hasFoundEdgeIndex = false;
+    SelectionResult? result;
+    bool? forward;
+    // If we already have an opposite edge initialized, start our sweep from there
+    // to ensure all items between the two edges are properly visited.
+    final int oppositeEdgeIndex = isEnd ? currentSelectionStartIndex : currentSelectionEndIndex;
+    final startIndex = oppositeEdgeIndex != -1 ? oppositeEdgeIndex : 0;
+    int? step;
+
+    // for (var index = 0; index < selectables.length && !hasFoundEdgeIndex; index += 1) {
+    for (
+      var index = startIndex;
+      index >= 0 && index < selectables.length && !hasFoundEdgeIndex;
+      index += step ?? 1
+    ) {
+      final Selectable child = selectables[index];
+      final SelectionResult childResult = dispatchSelectionEventToChild(child, event);
+      switch (childResult) {
+        case SelectionResult.next:
+          if (forward == null) {
+            forward = true;
+            step = 1;
+            newIndex = index;
+          } else if (!forward) {
+            hasFoundEdgeIndex = true;
+            result = SelectionResult.end;
+          } else {
+            newIndex = index;
+          }
+        case SelectionResult.none:
+          newIndex = index;
+        case SelectionResult.end:
+          newIndex = index;
+          result = SelectionResult.end;
+          hasFoundEdgeIndex = true;
+        case SelectionResult.previous:
+          if (index == 0) {
+            hasFoundEdgeIndex = true;
+            newIndex = 0;
+            result = SelectionResult.previous;
+            break;
+          }
+          if (forward == null) {
+            forward = false;
+            step = -1;
+          } else if (forward) {
+            hasFoundEdgeIndex = true;
+            result = SelectionResult.end;
+          } else {
+            newIndex = index;
+          }
+        case SelectionResult.pending:
+          newIndex = index;
+          result = SelectionResult.pending;
+          hasFoundEdgeIndex = true;
+      }
+    }
+
+    if (newIndex == -1) {
+      assert(selectables.isEmpty);
+      return SelectionResult.none;
+    }
+    if (isEnd) {
+      currentSelectionEndIndex = newIndex;
+    } else {
+      currentSelectionStartIndex = newIndex;
+    }
+    _flushInactiveSelections();
+    // The result can only be null if the loop went through the entire list
+    // without any of the selection returned end or previous. In this case, the
+    // caller of this method needs to find the next selectable in their list.
+    return result ?? SelectionResult.next;
+  }
+
   SelectionResult _initSelection(SelectionEdgeUpdateEvent event, {required bool isEnd}) {
     assert(
       (isEnd && currentSelectionEndIndex == -1) || (!isEnd && currentSelectionStartIndex == -1),

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -3254,30 +3254,57 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
       (isEnd && currentSelectionEndIndex == -1) || (!isEnd && currentSelectionStartIndex == -1),
     );
     var newIndex = -1;
-    var hasFoundEdgeIndex = false;
     SelectionResult? result;
-    for (var index = 0; index < selectables.length && !hasFoundEdgeIndex; index += 1) {
+
+    // If we already have an opposite edge initialized, start our sweep from there
+    // to ensure all items between the two edges are properly visited.
+    final int oppositeEdgeIndex = isEnd ? currentSelectionStartIndex : currentSelectionEndIndex;
+    final startIndex = oppositeEdgeIndex != -1 ? oppositeEdgeIndex : 0;
+
+    int? step;
+    var hasFoundEdgeIndex = false;
+
+    for (var index = startIndex; index >= 0 && index < selectables.length; index += step ?? 1) {
       final Selectable child = selectables[index];
       final SelectionResult childResult = dispatchSelectionEventToChild(child, event);
+
       switch (childResult) {
-        case SelectionResult.next:
-        case SelectionResult.none:
-          newIndex = index;
         case SelectionResult.end:
-          newIndex = index;
-          result = SelectionResult.end;
-          hasFoundEdgeIndex = true;
-        case SelectionResult.previous:
-          hasFoundEdgeIndex = true;
-          if (index == 0) {
-            newIndex = 0;
-            result = SelectionResult.previous;
-          }
-          result ??= SelectionResult.end;
         case SelectionResult.pending:
-          newIndex = index;
-          result = SelectionResult.pending;
+        case SelectionResult.none:
           hasFoundEdgeIndex = true;
+          newIndex = index;
+          result = childResult;
+        case SelectionResult.next:
+          if (step == -1) {
+            hasFoundEdgeIndex = true;
+            newIndex = index + 1;
+            result = SelectionResult.end;
+          } else {
+            step = 1;
+            if (index == selectables.length - 1) {
+              hasFoundEdgeIndex = true;
+              newIndex = index;
+              result = childResult;
+            }
+          }
+        case SelectionResult.previous:
+          if (step == 1) {
+            hasFoundEdgeIndex = true;
+            newIndex = index - 1;
+            result = SelectionResult.end;
+          } else {
+            step = -1;
+            if (index == 0) {
+              hasFoundEdgeIndex = true;
+              newIndex = 0;
+              result = childResult;
+            }
+          }
+      }
+
+      if (hasFoundEdgeIndex) {
+        break;
       }
     }
 
@@ -3356,6 +3383,23 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
     // 2. the selectable returns previous when looking forward.
     // 2. the selectable returns next when looking backward.
     while (newIndex < selectables.length && newIndex >= 0 && finalResult == null) {
+      // if (forward == false && selectables[newIndex].boundingBoxes.isNotEmpty) {
+      //   final Rect lastRect = MatrixUtils.transformRect(
+      //     selectables[newIndex].getTransformTo(null),
+      //     selectables[newIndex].boundingBoxes.last,
+      //   );
+      //   if (isEnd) {
+      //     final SelectionEdgeUpdateEvent synthesizedEvent = SelectionEdgeUpdateEvent.forEnd(
+      //       globalPosition: lastRect.centerRight,
+      //     );
+      //     dispatchSelectionEventToChild(selectables[newIndex], synthesizedEvent);
+      //   } else {
+      //     final SelectionEdgeUpdateEvent synthesizedEvent = SelectionEdgeUpdateEvent.forStart(
+      //       globalPosition: lastRect.centerLeft,
+      //     );
+      //     dispatchSelectionEventToChild(selectables[newIndex], synthesizedEvent);
+      //   }
+      // } looks like removing this is the right thing to do!!
       currentSelectableResult = dispatchSelectionEventToChild(selectables[newIndex], event);
       switch (currentSelectableResult) {
         case SelectionResult.end:

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -3260,7 +3260,7 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
     // If we already have an opposite edge initialized, start our sweep from there
     // to ensure all items between the two edges are properly visited.
     final int oppositeEdgeIndex = isEnd ? currentSelectionStartIndex : currentSelectionEndIndex;
-    var index = math.max(oppositeEdgeIndex, 0);
+    int index = max(oppositeEdgeIndex, 0);
 
     while (index >= 0 && index < selectables.length) {
       final Selectable child = selectables[index];

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -3249,7 +3249,7 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
   /// Ideally, this method should only be called twice at the beginning of the
   /// drag selection, once for start edge update event, once for end edge update
   /// event.
-  SelectionResult _initSelectionA(SelectionEdgeUpdateEvent event, {required bool isEnd}) {
+  SelectionResult _initSelection(SelectionEdgeUpdateEvent event, {required bool isEnd}) {
     assert(
       (isEnd && currentSelectionEndIndex == -1) || (!isEnd && currentSelectionStartIndex == -1),
     );
@@ -3308,81 +3308,6 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
           newIndex = index;
           result = SelectionResult.pending;
           hasFoundEdgeIndex = true;
-      }
-    }
-
-    if (newIndex == -1) {
-      assert(selectables.isEmpty);
-      return SelectionResult.none;
-    }
-    if (isEnd) {
-      currentSelectionEndIndex = newIndex;
-    } else {
-      currentSelectionStartIndex = newIndex;
-    }
-    _flushInactiveSelections();
-    // The result can only be null if the loop went through the entire list
-    // without any of the selection returned end or previous. In this case, the
-    // caller of this method needs to find the next selectable in their list.
-    return result ?? SelectionResult.next;
-  }
-
-  SelectionResult _initSelection(SelectionEdgeUpdateEvent event, {required bool isEnd}) {
-    assert(
-      (isEnd && currentSelectionEndIndex == -1) || (!isEnd && currentSelectionStartIndex == -1),
-    );
-    var newIndex = -1;
-    SelectionResult? result;
-
-    // If we already have an opposite edge initialized, start our sweep from there
-    // to ensure all items between the two edges are properly visited.
-    final int oppositeEdgeIndex = isEnd ? currentSelectionStartIndex : currentSelectionEndIndex;
-    final startIndex = oppositeEdgeIndex != -1 ? oppositeEdgeIndex : 0;
-
-    int? step;
-    var hasFoundEdgeIndex = false;
-
-    for (var index = startIndex; index >= 0 && index < selectables.length; index += step ?? 1) {
-      final Selectable child = selectables[index];
-      final SelectionResult childResult = dispatchSelectionEventToChild(child, event);
-
-      switch (childResult) {
-        case SelectionResult.end:
-        case SelectionResult.pending:
-        case SelectionResult.none:
-          hasFoundEdgeIndex = true;
-          newIndex = index;
-          result = childResult;
-        case SelectionResult.next:
-          if (step == -1) {
-            hasFoundEdgeIndex = true;
-            newIndex = index + 1;
-            result = SelectionResult.end;
-          } else {
-            step = 1;
-            if (index == selectables.length - 1) {
-              hasFoundEdgeIndex = true;
-              newIndex = index;
-              result = childResult;
-            }
-          }
-        case SelectionResult.previous:
-          if (step == 1) {
-            hasFoundEdgeIndex = true;
-            newIndex = index - 1;
-            result = SelectionResult.end;
-          } else {
-            step = -1;
-            if (index == 0) {
-              hasFoundEdgeIndex = true;
-              newIndex = 0;
-              result = childResult;
-            }
-          }
-      }
-
-      if (hasFoundEdgeIndex) {
-        break;
       }
     }
 

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -3260,7 +3260,7 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
     // If we already have an opposite edge initialized, start our sweep from there
     // to ensure all items between the two edges are properly visited.
     final int oppositeEdgeIndex = isEnd ? currentSelectionStartIndex : currentSelectionEndIndex;
-    var index = oppositeEdgeIndex != -1 ? oppositeEdgeIndex : 0;
+    var index = math.max(oppositeEdgeIndex, 0);
 
     while (index >= 0 && index < selectables.length) {
       final Selectable child = selectables[index];

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -3383,23 +3383,6 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
     // 2. the selectable returns previous when looking forward.
     // 2. the selectable returns next when looking backward.
     while (newIndex < selectables.length && newIndex >= 0 && finalResult == null) {
-      // if (forward == false && selectables[newIndex].boundingBoxes.isNotEmpty) {
-      //   final Rect lastRect = MatrixUtils.transformRect(
-      //     selectables[newIndex].getTransformTo(null),
-      //     selectables[newIndex].boundingBoxes.last,
-      //   );
-      //   if (isEnd) {
-      //     final SelectionEdgeUpdateEvent synthesizedEvent = SelectionEdgeUpdateEvent.forEnd(
-      //       globalPosition: lastRect.centerRight,
-      //     );
-      //     dispatchSelectionEventToChild(selectables[newIndex], synthesizedEvent);
-      //   } else {
-      //     final SelectionEdgeUpdateEvent synthesizedEvent = SelectionEdgeUpdateEvent.forStart(
-      //       globalPosition: lastRect.centerLeft,
-      //     );
-      //     dispatchSelectionEventToChild(selectables[newIndex], synthesizedEvent);
-      //   }
-      // } looks like removing this is the right thing to do!!
       currentSelectableResult = dispatchSelectionEventToChild(selectables[newIndex], event);
       switch (currentSelectableResult) {
         case SelectionResult.end:

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -3263,7 +3263,6 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
     final startIndex = oppositeEdgeIndex != -1 ? oppositeEdgeIndex : 0;
     int? step;
 
-    // for (var index = 0; index < selectables.length && !hasFoundEdgeIndex; index += 1) {
     for (
       var index = startIndex;
       index >= 0 && index < selectables.length && !hasFoundEdgeIndex;

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -1114,84 +1114,6 @@ class _SelectableTextContainerDelegate extends StaticSelectionContainerDelegate 
     return SelectionResult.end;
   }
 
-  /// Initializes the selection of the selectable children.
-  ///
-  /// The goal is to find the selectable child that contains the selection edge.
-  /// Returns [SelectionResult.end] if the selection edge ends on any of the
-  /// children. Otherwise, it returns [SelectionResult.previous] if the selection
-  /// does not reach any of its children. Returns [SelectionResult.next]
-  /// if the selection reaches the end of its children.
-  ///
-  /// Ideally, this method should only be called twice at the beginning of the
-  /// drag selection, once for start edge update event, once for end edge update
-  /// event.
-  SelectionResult _initSelection(SelectionEdgeUpdateEvent event, {required bool isEnd}) {
-    assert(
-      (isEnd && currentSelectionEndIndex == -1) || (!isEnd && currentSelectionStartIndex == -1),
-    );
-    SelectionResult? finalResult;
-    // Begin the search for the selection edge at the opposite edge if it exists.
-    final hasOppositeEdge = isEnd
-        ? currentSelectionStartIndex != -1
-        : currentSelectionEndIndex != -1;
-    int newIndex = switch ((isEnd, hasOppositeEdge)) {
-      (true, true) => currentSelectionStartIndex,
-      (true, false) => 0,
-      (false, true) => currentSelectionEndIndex,
-      (false, false) => 0,
-    };
-    bool? forward;
-    late SelectionResult currentSelectableResult;
-    // This loop sends the selection event to one of the following to determine
-    // the direction of the search.
-    //  - The opposite edge index if it exists.
-    //  - Index 0 if the opposite edge index does not exist.
-    //
-    // If the result is `SelectionResult.next`, this loop look backward.
-    // Otherwise, it looks forward.
-    //
-    // The terminate condition are:
-    // 1. the selectable returns end, pending, none.
-    // 2. the selectable returns previous when looking forward.
-    // 2. the selectable returns next when looking backward.
-    while (newIndex < selectables.length && newIndex >= 0 && finalResult == null) {
-      currentSelectableResult = dispatchSelectionEventToChild(selectables[newIndex], event);
-      switch (currentSelectableResult) {
-        case SelectionResult.end:
-        case SelectionResult.pending:
-        case SelectionResult.none:
-          finalResult = currentSelectableResult;
-        case SelectionResult.next:
-          if (forward == false) {
-            newIndex += 1;
-            finalResult = SelectionResult.end;
-          } else if (newIndex == selectables.length - 1) {
-            finalResult = currentSelectableResult;
-          } else {
-            forward = true;
-            newIndex += 1;
-          }
-        case SelectionResult.previous:
-          if (forward ?? false) {
-            newIndex -= 1;
-            finalResult = SelectionResult.end;
-          } else if (newIndex == 0) {
-            finalResult = currentSelectableResult;
-          } else {
-            forward = false;
-            newIndex -= 1;
-          }
-      }
-    }
-    if (isEnd) {
-      currentSelectionEndIndex = newIndex;
-    } else {
-      currentSelectionStartIndex = newIndex;
-    }
-    _flushInactiveSelections();
-    return finalResult!;
-  }
-
   SelectionResult _adjustSelection(SelectionEdgeUpdateEvent event, {required bool isEnd}) {
     assert(() {
       if (isEnd) {
@@ -1485,11 +1407,11 @@ class _SelectableTextContainerDelegate extends StaticSelectionContainerDelegate 
     );
     if (event.type == SelectionEventType.endEdgeUpdate) {
       return currentSelectionEndIndex == -1
-          ? _initSelection(event, isEnd: true)
+          ? super.handleSelectionEdgeUpdate(event)
           : _adjustSelection(event, isEnd: true);
     }
     return currentSelectionStartIndex == -1
-        ? _initSelection(event, isEnd: false)
+        ? super.handleSelectionEdgeUpdate(event)
         : _adjustSelection(event, isEnd: false);
   }
 }

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -6731,6 +6731,79 @@ void main() {
     expect(paragraph.selections, isNotEmpty);
     expect(paragraph.selections.first, const TextSelection(baseOffset: 0, extentOffset: 12));
   });
+
+  testWidgets(
+    'selects backwards across multiple Text widgets and WidgetSpans via mouse drag',
+    (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/166462.
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: SelectableRegion(
+            selectionControls: emptyTextSelectionControls,
+            child: Column(
+              children: List<Widget>.generate(5, (int index) {
+                return Text.rich(
+                  TextSpan(
+                    children: <InlineSpan>[
+                      WidgetSpan(child: Text('${index + 1}. ')),
+                      TextSpan(text: 'Item ${index + 1}'),
+                    ],
+                  ),
+                  key: ValueKey<int>(index),
+                );
+              }),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Start at the bottom right of the last item.
+      final Offset dragStart = tester.getBottomRight(find.byKey(const ValueKey<int>(4)));
+      // End at the top left of the first item.
+      final Offset dragEnd = tester.getTopLeft(find.byKey(const ValueKey<int>(0)));
+
+      final TestGesture gesture = await tester.startGesture(
+        dragStart,
+        kind: PointerDeviceKind.mouse,
+      );
+      addTearDown(gesture.removePointer);
+      await tester.pump();
+
+      // Drag backwards up to the top left.
+      await gesture.moveTo(dragEnd);
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      for (var i = 0; i < 5; i += 1) {
+        final Iterable<RenderParagraph> paragraphs = tester.renderObjectList<RenderParagraph>(
+          find.descendant(of: find.byKey(ValueKey<int>(i)), matching: find.byType(RichText)),
+        );
+
+        // The inner widget (WidgetSpan) contains the index text.
+        final RenderParagraph innerParagraph = paragraphs.firstWhere(
+          (RenderParagraph p) => p.text.toPlainText().contains('${i + 1}. '),
+        );
+
+        // The outer widget contains the placeholder character and the item text.
+        final RenderParagraph outerParagraph = paragraphs.firstWhere(
+          (RenderParagraph p) => p.text.toPlainText().contains('Item ${i + 1}'),
+        );
+
+        // Check the WidgetSpan's inner text first.
+        expect(innerParagraph.selections, isNotEmpty);
+        expect(innerParagraph.selections.first.start, 0);
+        expect(innerParagraph.selections.first.end, innerParagraph.text.toPlainText().length);
+
+        // Then check the outer text.
+        expect(outerParagraph.selections, isNotEmpty);
+        expect(outerParagraph.selections.first.start, 1);
+        expect(outerParagraph.selections.first.end, outerParagraph.text.toPlainText().length);
+      }
+    },
+    variant: TargetPlatformVariant.all(),
+  );
 }
 
 class ColumnSelectionContainerDelegate extends StaticSelectionContainerDelegate {

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -6889,17 +6889,23 @@ void main() {
     final RenderParagraph outerParagraph2 = tester.renderObject<RenderParagraph>(
       find.descendant(of: find.byKey(const Key('rich2')), matching: find.byType(RichText)).first,
     );
+    await gesture.up();
+    await tester.pumpAndSettle();
 
     // When dragging backward from Text E to Text B, all paragraphs between
     // B and E should be fully selected in reverse.
+    expect(paragraphB.selections, isNotEmpty);
+    expect(paragraphC.selections, isNotEmpty);
+    expect(paragraphD.selections, isNotEmpty);
+    expect(paragraphE.selections, isNotEmpty);
+    expect(outerParagraph1.selections, isNotEmpty);
+    expect(outerParagraph2.selections, isNotEmpty);
     expect(paragraphB.selections[0], const TextSelection(baseOffset: 7, extentOffset: 0));
     expect(paragraphC.selections[0], const TextSelection(baseOffset: 7, extentOffset: 0));
     expect(paragraphD.selections[0], const TextSelection(baseOffset: 7, extentOffset: 0));
     expect(paragraphE.selections[0], const TextSelection(baseOffset: 7, extentOffset: 0));
-    expect(outerParagraph1.selections, isNotEmpty);
-    expect(outerParagraph2.selections, isNotEmpty);
-
-    await gesture.up();
+    expect(outerParagraph1.selections[0], const TextSelection(baseOffset: 4, extentOffset: 3));
+    expect(outerParagraph2.selections[0], const TextSelection(baseOffset: 2, extentOffset: 1));
   });
 }
 

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -6804,6 +6804,103 @@ void main() {
     },
     variant: TargetPlatformVariant.all(),
   );
+
+  testWidgets('triple-click-drag backwards involving WidgetSpans', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: SelectableRegion(
+          selectionControls: testTextSelectionHandleControls,
+          child: ListView(
+            children: const <Widget>[
+              Text.rich(
+                TextSpan(
+                  children: <InlineSpan>[
+                    WidgetSpan(child: Text('Text A.')),
+                    TextSpan(text: '\n'),
+                    WidgetSpan(child: Text('Text B.')),
+                    TextSpan(text: '\n'),
+                    WidgetSpan(child: Text('Text C.')),
+                  ],
+                ),
+                key: Key('rich1'),
+              ),
+              Text.rich(
+                TextSpan(
+                  children: <InlineSpan>[
+                    WidgetSpan(child: Text('Text D.')),
+                    TextSpan(text: '\n'),
+                    WidgetSpan(child: Text('Text E.')),
+                    TextSpan(text: '\n'),
+                    WidgetSpan(child: Text('Text F.')),
+                  ],
+                ),
+                key: Key('rich2'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final RenderParagraph paragraphE = tester.renderObject<RenderParagraph>(
+      find.descendant(of: find.text('Text E.'), matching: find.byType(RichText)),
+    );
+    final RenderParagraph paragraphB = tester.renderObject<RenderParagraph>(
+      find.descendant(of: find.text('Text B.'), matching: find.byType(RichText)),
+    );
+
+    // Triple-click on Text E.
+    final TestGesture gesture = await tester.startGesture(
+      textOffsetToPosition(paragraphE, 2),
+      kind: PointerDeviceKind.mouse,
+    );
+    addTearDown(gesture.removePointer);
+    await tester.pump();
+    await gesture.up();
+    await tester.pump();
+
+    await gesture.down(textOffsetToPosition(paragraphE, 2));
+    await tester.pump();
+    await gesture.up();
+    await tester.pump();
+
+    await gesture.down(textOffsetToPosition(paragraphE, 2));
+    await tester.pumpAndSettle();
+
+    // Text E should be selected after triple-click.
+    expect(paragraphE.selections.isNotEmpty, isTrue);
+    expect(paragraphE.selections[0], const TextSelection(baseOffset: 0, extentOffset: 7));
+
+    // Drag backward to Text B.
+    await gesture.moveTo(textOffsetToPosition(paragraphB, 3));
+    await tester.pumpAndSettle();
+
+    final RenderParagraph paragraphC = tester.renderObject<RenderParagraph>(
+      find.descendant(of: find.text('Text C.'), matching: find.byType(RichText)),
+    );
+    final RenderParagraph paragraphD = tester.renderObject<RenderParagraph>(
+      find.descendant(of: find.text('Text D.'), matching: find.byType(RichText)),
+    );
+
+    final RenderParagraph outerParagraph1 = tester.renderObject<RenderParagraph>(
+      find.descendant(of: find.byKey(const Key('rich1')), matching: find.byType(RichText)).first,
+    );
+    final RenderParagraph outerParagraph2 = tester.renderObject<RenderParagraph>(
+      find.descendant(of: find.byKey(const Key('rich2')), matching: find.byType(RichText)).first,
+    );
+
+    // When dragging backward from Text E to Text B, all paragraphs between
+    // B and E should be fully selected in reverse.
+    expect(paragraphB.selections[0], const TextSelection(baseOffset: 7, extentOffset: 0));
+    expect(paragraphC.selections[0], const TextSelection(baseOffset: 7, extentOffset: 0));
+    expect(paragraphD.selections[0], const TextSelection(baseOffset: 7, extentOffset: 0));
+    expect(paragraphE.selections[0], const TextSelection(baseOffset: 7, extentOffset: 0));
+    expect(outerParagraph1.selections, isNotEmpty);
+    expect(outerParagraph2.selections, isNotEmpty);
+
+    await gesture.up();
+  });
 }
 
 class ColumnSelectionContainerDelegate extends StaticSelectionContainerDelegate {


### PR DESCRIPTION
Original discussion: https://github.com/flutter/flutter/pull/184031

Fixes #166462

Before this change `_initSelection` would always begin its selection search at index 0, this caused issues when selecting backwards and the children of the selection delegate also contained children. This happens because when we select backwards and always start our selection search at index 0, if our pointer moves backwards from point b to point a and point a is already on index 0 (of a selection container with N selectables), the selection logic will short-circuit early thinking we found the selection, skipping any selectables in between point b and point a.

After this change `_initSelection` will begin its selection search at the opposite edge if it exists. This fixes the issue because when entering a new selectable, while dragging backwards and updating the end edge, first the selectable will call `ensureChildUpdated` and synthesize a start edge. Then it processes the end edge event and begins to search for that selection edge, we now start this search at the opposite edge which allows us ensure all items between both edges are visited so we can create a continuous selection.

Since starting `_initSelection` at the opposite edge is what `_SelectableTextContainerDelegate` does with its `_initSelection` we can remove it. I added a test to verify we aren't breaking anything here.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.