### PR TITLE
Use the default version of Git in the content_aware_hash script instead of Xcode's Git

### DIFF
--- a/bin/internal/content_aware_hash.sh
+++ b/bin/internal/content_aware_hash.sh
@@ -12,8 +12,10 @@
 # -------------------------------------------------------------------------- #
 
 set -e
+set -o pipefail
 
 FLUTTER_ROOT="$(dirname "$(dirname "$(dirname "${BASH_SOURCE[0]}")")")"
+GIT=${FLUTTER_GIT:-git}
 
 unset GIT_DIR
 unset GIT_INDEX_FILE
@@ -25,7 +27,7 @@ unset GIT_WORK_TREE
 # bin/internal/release-candidate-branch.version: release marker
 TRACKEDFILES=(DEPS engine bin/internal/release-candidate-branch.version)
 BASEREF="HEAD"
-CURRENT_BRANCH="$(git -C "$FLUTTER_ROOT" rev-parse --abbrev-ref HEAD)"
+CURRENT_BRANCH="$($GIT -C "$FLUTTER_ROOT" rev-parse --abbrev-ref HEAD)"
 
 # By default, the content hash is based on HEAD.
 # For local development branches, we want to base the hash on the merge-base
@@ -50,14 +52,14 @@ if [[ "$CURRENT_BRANCH" != "main" && \
   # This is a development branch. Find the merge-base.
   # We will fallback to origin if upstream is not detected.
   REMOTE="origin"
-  if git -C "$FLUTTER_ROOT" remote get-url upstream >/dev/null 2>&1; then
+  if $GIT -C "$FLUTTER_ROOT" remote get-url upstream >/dev/null 2>&1; then
     REMOTE="upstream"
   fi
 
   # Try to find the merge-base with master, then main.
-  MERGEBASE=$(git -C "$FLUTTER_ROOT" merge-base HEAD "$REMOTE/master" 2>/dev/null || true)
+  MERGEBASE=$($GIT -C "$FLUTTER_ROOT" merge-base HEAD "$REMOTE/master" 2>/dev/null || true)
   if [[ -z "$MERGEBASE" ]]; then
-    MERGEBASE=$(git -C "$FLUTTER_ROOT" merge-base HEAD "$REMOTE/main" 2>/dev/null || true)
+    MERGEBASE=$($GIT -C "$FLUTTER_ROOT" merge-base HEAD "$REMOTE/main" 2>/dev/null || true)
   fi
 
   if [[ -n "$MERGEBASE" ]]; then
@@ -65,4 +67,4 @@ if [[ "$CURRENT_BRANCH" != "main" && \
   fi
 fi
 
-git -C "$FLUTTER_ROOT" ls-tree "$BASEREF" -- "${TRACKEDFILES[@]}" | git hash-object --stdin
+$GIT -C "$FLUTTER_ROOT" ls-tree "$BASEREF" -- "${TRACKEDFILES[@]}" | git hash-object --stdin

--- a/bin/internal/content_aware_hash.sh
+++ b/bin/internal/content_aware_hash.sh
@@ -67,4 +67,4 @@ if [[ "$CURRENT_BRANCH" != "main" && \
   fi
 fi
 
-$GIT -C "$FLUTTER_ROOT" ls-tree "$BASEREF" -- "${TRACKEDFILES[@]}" | git hash-object --stdin
+$GIT -C "$FLUTTER_ROOT" ls-tree "$BASEREF" -- "${TRACKEDFILES[@]}" | $GIT hash-object --stdin

--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -37,9 +37,9 @@ DART="$FLUTTER_ROOT/bin/dart"
 # primary installation of Git on the host.  If another Git is found when all
 # Xcode directories are removed from the PATH, then tell Flutter's scripts to
 # use that version of Git.
-NO_XCODE_PATH=$(echo $PATH | tr ":" "\n" | grep -v /Xcode.app/ | tr "\n" ":")
-if NO_XCODE_GIT=$(env PATH=$NO_XCODE_PATH which git); then
-  export FLUTTER_GIT=$NO_XCODE_GIT
+NO_XCODE_PATH=$(echo "$PATH" | tr ":" "\n" | grep -v "/Xcode.app/" | paste -sd ":" -)
+if NO_XCODE_GIT=$(env PATH="$NO_XCODE_PATH" which git); then
+  export FLUTTER_GIT="$NO_XCODE_GIT"
 fi
 
 "$DART" "$BIN_DIR/xcode_backend.dart" "$@" "ios"

--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -33,4 +33,13 @@ BIN_DIR="$(cd "${PROG_NAME%/*}" ; pwd -P)"
 FLUTTER_ROOT="$BIN_DIR/../../.."
 DART="$FLUTTER_ROOT/bin/dart"
 
+# Xcode provides its own version of Git that may be incompatible with the
+# primary installation of Git on the host.  If another Git is found when all
+# Xcode directories are removed from the PATH, then tell Flutter's scripts to
+# use that version of Git.
+NO_XCODE_PATH=$(echo $PATH | tr ":" "\n" | grep -v /Xcode.app/ | tr "\n" ":")
+if NO_XCODE_GIT=$(env PATH=$NO_XCODE_PATH which git); then
+  export FLUTTER_GIT=$NO_XCODE_GIT
+fi
+
 "$DART" "$BIN_DIR/xcode_backend.dart" "$@" "ios"


### PR DESCRIPTION
Xcode provides a version of Git in its Xcode.app/Contents/Developer/usr/bin directory.  When Xcode runs Flutter's tools, it sets a PATH that prioritizes Xcode's Git over other installations of Git on the host.

If the local Flutter repository was created with a newer version of Git, then it may be incompatible with Xcode's Git.  This will cause Flutter's content_aware_hash script to output the wrong result and ultimately cause failures in the Flutter build launched by Xcode.

This PR searches for another version of Git in a PATH with Xcode's directories removed.  If it finds one, then it tells content_aware_hash to use that version of Git.

See https://github.com/flutter/flutter/issues/184376