### PR TITLE
Revert "[AGP 9] Bumping KGP error minimum to 2.0.0 (#184385)"

### DIFF
--- a/dev/devicelab/bin/tasks/android_java17_dependency_smoke_tests.dart
+++ b/dev/devicelab/bin/tasks/android_java17_dependency_smoke_tests.dart
@@ -17,14 +17,16 @@ import 'package:flutter_devicelab/framework/framework.dart';
 // (*) - support range defined in packages/flutter_tools/gradle/src/main/kotlin/dependency_version_checker.gradle.kts.
 List<VersionTuple> versionTuples = <VersionTuple>[
   // Minimum supported
-  VersionTuple(agpVersion: '8.6.0', gradleVersion: '8.7', kotlinVersion: '2.0.0'),
+  VersionTuple(agpVersion: '8.1.1', gradleVersion: '8.3', kotlinVersion: '1.8.10'),
   // Template
-  VersionTuple(agpVersion: '8.11.1', gradleVersion: '8.14', kotlinVersion: '2.2.20'),
+  VersionTuple(agpVersion: '8.9.1', gradleVersion: '8.12', kotlinVersion: '2.1.0'),
   // Max known
-  VersionTuple(agpVersion: '8.13.0', gradleVersion: '9.1.0', kotlinVersion: '2.2.20'),
+  VersionTuple(agpVersion: '8.13.0', gradleVersion: '9.1.0', kotlinVersion: '2.2.0'),
   /* Others */
+  VersionTuple(agpVersion: '8.4.0', gradleVersion: '8.6', kotlinVersion: '1.8.22'),
+  VersionTuple(agpVersion: '8.6.0', gradleVersion: '8.7', kotlinVersion: '1.8.22'),
   VersionTuple(agpVersion: '8.7.0', gradleVersion: '8.9', kotlinVersion: '2.1.0'),
-  VersionTuple(agpVersion: '8.9.0', gradleVersion: '8.11.1', kotlinVersion: '2.2.0'),
+  VersionTuple(agpVersion: '8.11.1', gradleVersion: '8.14', kotlinVersion: '2.2.20'),
 ]; // Max length is 7 entries until this test is split See https://github.com/flutter/flutter/issues/167495.
 
 Future<void> main() async {

--- a/packages/flutter_tools/gradle/build.gradle.kts
+++ b/packages/flutter_tools/gradle/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
     `java-gradle-plugin`
     groovy
     `kotlin-dsl`
-    kotlin("jvm") version "2.2.20"
+    kotlin("jvm") version "1.9.20"
 }
 
 group = "dev.flutter.plugin"
@@ -52,9 +52,7 @@ dependencies {
     // Versions available https://mvnrepository.com/artifact/androidx.annotation/annotation-jvm.
     // Version release notes https://developer.android.com/jetpack/androidx/releases/annotation
     compileOnly("androidx.annotation:annotation-jvm:1.9.1")
-    // When bumping, also update:
-    //  * KGP error version in packages/flutter_tools/gradle/src/main/kotlin/DependencyVersionChecker.kt
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.0")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.0")
     // Update to 1.8.0 when min kotlin is 2.1
     // https://github.com/Kotlin/kotlinx.serialization/releases for kotlin version compatibility.
     // All kotlinx implementation dependencies must work with the oldest kotlin supported versions.

--- a/packages/flutter_tools/gradle/src/main/kotlin/DependencyVersionChecker.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/DependencyVersionChecker.kt
@@ -90,23 +90,22 @@ object DependencyVersionChecker {
     // flutter.dev/go/android-dependency-versions for more.
     // Advice for maintainers for other areas of code that are impacted are documented
     // in packages/flutter_tools/lib/src/android/README.md.
+    @VisibleForTesting internal val warnGradleVersion: Version = Version(8, 7, 0)
 
-    @VisibleForTesting internal val warnGradleVersion: Version = Version(8, 14, 0)
-
-    @VisibleForTesting internal val errorGradleVersion: Version = Version(8, 7, 0)
+    @VisibleForTesting internal val errorGradleVersion: Version = Version(8, 3, 0)
 
     // Java error and warn should align with packages/flutter_tools/lib/src/android/gradle_utils.dart.
     @VisibleForTesting internal val warnJavaVersion: JavaVersion = JavaVersion.VERSION_17
 
     @VisibleForTesting internal val errorJavaVersion: JavaVersion = JavaVersion.VERSION_17
 
-    @VisibleForTesting internal val warnAGPVersion: AndroidPluginVersion = AndroidPluginVersion(8, 11, 1)
+    @VisibleForTesting internal val warnAGPVersion: AndroidPluginVersion = AndroidPluginVersion(8, 6, 0)
 
-    @VisibleForTesting internal val errorAGPVersion: AndroidPluginVersion = AndroidPluginVersion(8, 6, 0)
+    @VisibleForTesting internal val errorAGPVersion: AndroidPluginVersion = AndroidPluginVersion(8, 1, 1)
 
-    @VisibleForTesting internal val warnKGPVersion: Version = Version(2, 2, 20)
+    @VisibleForTesting internal val warnKGPVersion: Version = Version(2, 1, 0)
 
-    @VisibleForTesting internal val errorKGPVersion: Version = Version(2, 0, 0)
+    @VisibleForTesting internal val errorKGPVersion: Version = Version(1, 8, 10)
 
     // If this value is changed, then make sure to change the documentation on https://docs.flutter.dev/reference/supported-platforms
     // Non inclusive.

--- a/packages/flutter_tools/gradle/src/test/kotlin/DependencyVersionCheckerTest.kt
+++ b/packages/flutter_tools/gradle/src/test/kotlin/DependencyVersionCheckerTest.kt
@@ -51,18 +51,18 @@ private const val FAKE_PROJECT_ROOT_DIR = "/fake/root/dir"
 
 // The following values will need to be modified when the corresponding "warn$DepName" versions
 // are updated in DependencyVersionChecker.kt
-// These values should also match the flutter create template values.
+// These values should match the flutter create template values.
 // In //packages/flutter_tools/lib/src/android/gradle_utils.dart
-private const val SUPPORTED_GRADLE_VERSION: String = "8.14"
+private const val SUPPORTED_GRADLE_VERSION: String = "8.12"
 private val SUPPORTED_JAVA_VERSION: JavaVersion = JavaVersion.VERSION_17
-private val SUPPORTED_AGP_VERSION: AndroidPluginVersion = AndroidPluginVersion(8, 11, 1)
-private const val SUPPORTED_KGP_VERSION: String = "2.2.20"
+private val SUPPORTED_AGP_VERSION: AndroidPluginVersion = AndroidPluginVersion(8, 9, 1)
+private const val SUPPORTED_KGP_VERSION: String = "2.1.0"
 private val SUPPORTED_SDK_VERSION: MinSdkVersion = MinSdkVersion("release", 30)
 
 class DependencyVersionCheckerTest {
     @Test
     fun `AGP version in error range results in DependencyValidationException`() {
-        val exampleErrorAgpVersion = AndroidPluginVersion(8, 5, 0)
+        val exampleErrorAgpVersion = AndroidPluginVersion(8, 1, 0)
         val mockProject = MockProjectFactory.createMockProjectWithSpecifiedDependencyVersions(agpVersion = exampleErrorAgpVersion)
 
         val mockExtraPropertiesExtension = mockProject.extra
@@ -84,7 +84,7 @@ class DependencyVersionCheckerTest {
 
     @Test
     fun `AGP version in warn range results in warning logs`() {
-        val exampleWarnAgpVersion = AndroidPluginVersion(8, 10, 0)
+        val exampleWarnAgpVersion = AndroidPluginVersion(8, 2, 0)
         val mockProject = MockProjectFactory.createMockProjectWithSpecifiedDependencyVersions(agpVersion = exampleWarnAgpVersion)
 
         val mockExtraPropertiesExtension = mockProject.extra
@@ -108,7 +108,7 @@ class DependencyVersionCheckerTest {
 
     @Test
     fun `KGP version in error range results in DependencyValidationException`() {
-        val exampleErrorKgpVersion = "1.9.20"
+        val exampleErrorKgpVersion = "1.6.0"
         val mockProject = MockProjectFactory.createMockProjectWithSpecifiedDependencyVersions(kgpVersion = exampleErrorKgpVersion)
 
         val mockExtraPropertiesExtension = mockProject.extra
@@ -132,7 +132,7 @@ class DependencyVersionCheckerTest {
 
     @Test
     fun `KGP version in warn range results in warning logs`() {
-        val exampleWarnKgpVersion = "2.2.0"
+        val exampleWarnKgpVersion = "1.8.20"
         val mockProject = MockProjectFactory.createMockProjectWithSpecifiedDependencyVersions(kgpVersion = exampleWarnKgpVersion)
 
         val mockExtraPropertiesExtension = mockProject.extra
@@ -183,7 +183,7 @@ class DependencyVersionCheckerTest {
 
     @Test
     fun `Gradle version in error range results in DependencyValidationException`() {
-        val exampleErrorGradleVersion = "8.6.0"
+        val exampleErrorGradleVersion = "7.0.0"
         val mockProject = MockProjectFactory.createMockProjectWithSpecifiedDependencyVersions(gradleVersion = exampleErrorGradleVersion)
 
         val mockExtraPropertiesExtension = mockProject.extra
@@ -206,7 +206,7 @@ class DependencyVersionCheckerTest {
 
     @Test
     fun `Gradle version in warn range results in warning logs`() {
-        val exampleWarnGradleVersion = "8.12.0"
+        val exampleWarnGradleVersion = "8.5.0"
         val mockProject = MockProjectFactory.createMockProjectWithSpecifiedDependencyVersions(gradleVersion = exampleWarnGradleVersion)
 
         val mockExtraPropertiesExtension = mockProject.extra

--- a/packages/flutter_tools/lib/src/android/gradle_utils.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_utils.dart
@@ -29,24 +29,16 @@ import 'android_sdk.dart';
 //
 // Please see the README before changing any of these values.
 
-// When bumping, also update:
-//  * Gradle warn version in packages/flutter_tools/gradle/src/main/kotlin/DependencyVersionChecker.kt
-//  * Gradle test constants in packages/flutter_tools/gradle/src/test/kotlin/DependencyVersionCheckerTest.kt
 // See https://gradle.org/releases
 const templateDefaultGradleVersion = '8.14';
 
 // When bumping, also update:
 //  * AGP version constants in packages/flutter_tools/gradle/build.gradle.kts
-//  * AGP warn version in packages/flutter_tools/gradle/src/main/kotlin/DependencyVersionChecker.kt
 //  * AGP test constants in packages/flutter_tools/gradle/src/test/kotlin/DependencyVersionCheckerTest.kt
 // See https://mvnrepository.com/artifact/com.android.tools.build/gradle
 const templateAndroidGradlePluginVersion = '8.11.1';
 const templateAndroidGradlePluginVersionForModule = '8.11.1';
 
-// When bumping, also update:
-//  * KGP version constants in packages/flutter_tools/gradle/build.gradle.kts
-//  * KGP warn version in packages/flutter_tools/gradle/src/main/kotlin/DependencyVersionChecker.kt
-//  * KGP jvm constant in packages/flutter_tools/gradle/src/test/kotlin/DependencyVersionCheckerTest.kt
 // See https://kotlinlang.org/docs/releases.html#release-details
 const templateKotlinGradlePluginVersion = '2.2.20';
 

--- a/packages/flutter_tools/test/android_java17_integration.shard/android_dependency_version_checking_test.dart
+++ b/packages/flutter_tools/test/android_java17_integration.shard/android_dependency_version_checking_test.dart
@@ -25,9 +25,9 @@ void main() {
   testUsingContext('AGP version out of "warn" support band but in "error" band builds '
       'successfully and prints warning', () async {
     final versionTuple = VersionTuple(
-      agpVersion: '8.7.0',
-      gradleVersion: '8.14',
-      kotlinVersion: '2.2.20',
+      agpVersion: '8.3.0',
+      gradleVersion: '8.12',
+      kotlinVersion: '2.1.0',
     );
     final ProcessResult result = await buildFlutterApkWithSpecifiedDependencyVersions(
       versions: versionTuple,
@@ -41,9 +41,9 @@ void main() {
       'successfully and prints warning', () async {
     // Create a new flutter project.
     final versionTuple = VersionTuple(
-      agpVersion: '8.11.1',
-      gradleVersion: '8.13',
-      kotlinVersion: '2.2.20',
+      agpVersion: '8.3.0',
+      gradleVersion: '8.4',
+      kotlinVersion: '2.1.0',
     );
     final ProcessResult result = await buildFlutterApkWithSpecifiedDependencyVersions(
       versions: versionTuple,
@@ -56,9 +56,9 @@ void main() {
   testUsingContext('Kotlin version out of "warn" support band but in "error" band builds '
       'successfully and prints warning', () async {
     final versionTuple = VersionTuple(
-      agpVersion: '8.7.0',
-      gradleVersion: '8.14',
-      kotlinVersion: '2.1.20',
+      agpVersion: '8.9.1',
+      gradleVersion: '8.12',
+      kotlinVersion: '1.9.25',
     );
     final ProcessResult result = await buildFlutterApkWithSpecifiedDependencyVersions(
       versions: versionTuple,
@@ -71,9 +71,9 @@ void main() {
 
   testUsingContext('No logs are printed when suppression flag is passed', () async {
     final versionTuple = VersionTuple(
-      agpVersion: '8.6.0',
-      gradleVersion: '8.7',
-      kotlinVersion: '2.0.0',
+      agpVersion: '8.3.0',
+      gradleVersion: '8.12',
+      kotlinVersion: '2.1.0',
     );
     final ProcessResult result = await buildFlutterApkWithSpecifiedDependencyVersions(
       versions: versionTuple,


### PR DESCRIPTION
<!-- start_original_pr_link -->
Reverts: flutter/flutter#184385
<!-- end_original_pr_link -->
<!-- start_initiating_author -->
Initiated by: jason-simmons
<!-- end_initiating_author -->
<!-- start_revert_reason -->
Reason for reverting: This is causing errors in the `build_android_host_app_with_module_source` integration test.

Example: https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20build_android_host_app_with_module_source/7845/overview

https://github.com/flutter/flutter/blob/master/dev/integration_tests/pure_android_host_apps/host_app_kotlin_gradle_dsl/gradle/libs.versions.toml needs to be updated.

<!-- end_revert_reason -->
<!-- start_original_pr_author -->
Original PR Author: jesswrd
<!-- end_original_pr_author -->

<!-- start_reviewers -->
Reviewed By: {gmackall}
<!-- end_reviewers -->

<!-- start_revert_body -->
This change reverts the following previous change:
Bumped KGP error and warn versions to support Built-in Kotlin migration. AGP and Gradle error and warn versions had to be bumped as a result of bumping KGP error and warn versions.

This will be CP'ed to beta and stable.

Fixes https://github.com/flutter/flutter/issues/184384
Addresses https://github.com/flutter/flutter/issues/181557
