### PR TITLE
Add alignment to SliverContrainedCrossAxis

### DIFF
--- a/examples/api/lib/widgets/sliver/sliver_constrained_cross_axis.0.dart
+++ b/examples/api/lib/widgets/sliver/sliver_constrained_cross_axis.0.dart
@@ -29,6 +29,7 @@ class SliverConstrainedCrossAxisExample extends StatelessWidget {
       slivers: <Widget>[
         SliverConstrainedCrossAxis(
           maxExtent: 200,
+          alignment: Alignment.center,
           sliver: SliverList.builder(
             itemBuilder: (BuildContext context, int index) {
               return Container(

--- a/examples/api/test/widgets/sliver/sliver_constrained_cross_axis.0_test.dart
+++ b/examples/api/test/widgets/sliver/sliver_constrained_cross_axis.0_test.dart
@@ -20,5 +20,7 @@ void main() {
       find.byType(SliverList),
     );
     expect(renderSliverList.constraints.crossAxisExtent, equals(200));
+    final SliverPhysicalParentData parentData = renderSliverList.parentData! as SliverPhysicalParentData;
+    expect(parentData.paintOffset.dx, equals(300.0));
   });
 }

--- a/packages/flutter/lib/src/rendering/proxy_sliver.dart
+++ b/packages/flutter/lib/src/rendering/proxy_sliver.dart
@@ -12,6 +12,7 @@ import 'package:flutter/semantics.dart';
 import 'layer.dart';
 import 'object.dart';
 import 'proxy_box.dart';
+import 'package:flutter/painting.dart';
 import 'sliver.dart';
 
 /// A base class for sliver render objects that resemble their children.
@@ -450,9 +451,14 @@ class RenderSliverConstrainedCrossAxis extends RenderProxySliver {
   /// Creates a render object that constrains the cross axis extent of its sliver child.
   ///
   /// The [maxExtent] parameter must be nonnegative.
-  RenderSliverConstrainedCrossAxis({required double maxExtent})
-    : _maxExtent = maxExtent,
-      assert(maxExtent >= 0.0);
+  RenderSliverConstrainedCrossAxis({
+    required double maxExtent,
+    AlignmentGeometry alignment = Alignment.centerLeft,
+    TextDirection? textDirection,
+  }) : _maxExtent = maxExtent,
+       _alignment = alignment,
+       _textDirection = textDirection,
+       assert(maxExtent >= 0.0);
 
   /// The cross axis extent to apply to the sliver child.
   ///
@@ -467,22 +473,119 @@ class RenderSliverConstrainedCrossAxis extends RenderProxySliver {
     markNeedsLayout();
   }
 
+  /// The alignment of the sliver child in the cross axis.
+  ///
+  /// If [alignment] is [Alignment.centerLeft], the child will be aligned to the
+  /// start of the cross axis.
+  AlignmentGeometry get alignment => _alignment;
+  AlignmentGeometry _alignment;
+  set alignment(AlignmentGeometry value) {
+    if (_alignment == value) {
+      return;
+    }
+    _alignment = value;
+    markNeedsLayout();
+  }
+
+  /// The text direction with which to resolve [alignment].
+  ///
+  /// This may be null if the [alignment] is not direction-sensitive.
+  TextDirection? get textDirection => _textDirection;
+  TextDirection? _textDirection;
+  set textDirection(TextDirection? value) {
+    if (_textDirection == value) {
+      return;
+    }
+    _textDirection = value;
+    markNeedsLayout();
+  }
+
   @override
   void performLayout() {
+    final RenderSliver? child = this.child;
     assert(child != null);
     assert(maxExtent >= 0.0);
+    final double crossAxisExtent = min(_maxExtent, constraints.crossAxisExtent);
     child!.layout(
-      constraints.copyWith(crossAxisExtent: min(_maxExtent, constraints.crossAxisExtent)),
+      constraints.copyWith(crossAxisExtent: crossAxisExtent),
       parentUsesSize: true,
     );
-    final SliverGeometry childLayoutGeometry = child!.geometry!;
+    final SliverGeometry childLayoutGeometry = child.geometry!;
     geometry = childLayoutGeometry.copyWith(
-      crossAxisExtent: min(_maxExtent, constraints.crossAxisExtent),
+      crossAxisExtent: crossAxisExtent,
     );
+
+    final double freeSpace = constraints.crossAxisExtent - crossAxisExtent;
+    final double crossAxisOffset = alignment.resolve(textDirection).alongOffset(Offset(freeSpace, 0.0)).dx;
+    final SliverPhysicalParentData childParentData = child.parentData! as SliverPhysicalParentData;
+    childParentData.paintOffset = switch (constraints.axis) {
+      Axis.horizontal => Offset(0.0, crossAxisOffset),
+      Axis.vertical => Offset(crossAxisOffset, 0.0),
+    };
+  }
+
+  @override
+  void paint(PaintingContext context, Offset offset) {
+    final RenderSliver? child = this.child;
+    if (child != null && child.geometry!.visible) {
+      final SliverPhysicalParentData childParentData = child.parentData! as SliverPhysicalParentData;
+      context.paintChild(child, offset + childParentData.paintOffset);
+    }
+  }
+
+  @override
+  bool hitTestChildren(
+    SliverHitTestResult result, {
+    required double mainAxisPosition,
+    required double crossAxisPosition,
+  }) {
+    final RenderSliver? child = this.child;
+    if (child != null && child.geometry!.hitTestExtent > 0.0) {
+      final SliverPhysicalParentData childParentData = child.parentData! as SliverPhysicalParentData;
+      return result.addWithAxisOffset(
+        mainAxisPosition: mainAxisPosition,
+        crossAxisPosition: crossAxisPosition,
+        mainAxisOffset: childMainAxisPosition(child),
+        crossAxisOffset: childCrossAxisPosition(child),
+        paintOffset: childParentData.paintOffset,
+        hitTest: child.hitTest,
+      );
+    }
+    return false;
+  }
+
+  @override
+  double childMainAxisPosition(RenderSliver child) {
+    assert(child == this.child);
+    return 0.0;
+  }
+
+  @override
+  double childCrossAxisPosition(RenderSliver child) {
+    assert(child == this.child);
+    final SliverPhysicalParentData childParentData = child.parentData! as SliverPhysicalParentData;
+    return switch (constraints.axis) {
+      Axis.horizontal => childParentData.paintOffset.dy,
+      Axis.vertical => childParentData.paintOffset.dx,
+    };
+  }
+
+  @override
+  void applyPaintTransform(RenderObject child, Matrix4 transform) {
+    assert(child == this.child);
+    final SliverPhysicalParentData childParentData = child.parentData! as SliverPhysicalParentData;
+    childParentData.applyPaintTransform(transform);
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DoubleProperty('maxExtent', maxExtent));
+    properties.add(DiagnosticsProperty<AlignmentGeometry>('alignment', alignment));
+    properties.add(EnumProperty<TextDirection>('textDirection', textDirection, defaultValue: null));
   }
 }
 
-/// Add annotations to the [SemanticsNode] for this subtree.
 class RenderSliverSemanticsAnnotations extends RenderProxySliver with SemanticsAnnotationsMixin {
   /// Creates a render object that attaches a semantic annotation.
   ///

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -1647,12 +1647,23 @@ class SliverConstrainedCrossAxis extends StatelessWidget {
   /// Creates a sliver that constrains the cross axis extent of its sliver child.
   ///
   /// The [maxExtent] parameter is required and must be nonnegative.
-  const SliverConstrainedCrossAxis({super.key, required this.maxExtent, required this.sliver});
+  const SliverConstrainedCrossAxis({
+    super.key,
+    required this.maxExtent,
+    this.alignment = Alignment.centerLeft,
+    required this.sliver,
+  });
 
   /// The cross axis extent to apply to the sliver child.
   ///
   /// This value must be nonnegative.
   final double maxExtent;
+
+  /// The alignment of the sliver child in the cross axis.
+  ///
+  /// If [alignment] is [Alignment.centerLeft], the child will be aligned to the
+  /// start of the cross axis.
+  final AlignmentGeometry alignment;
 
   /// The widget below this widget in the tree.
   ///
@@ -1662,10 +1673,22 @@ class SliverConstrainedCrossAxis extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return _SliverZeroFlexParentDataWidget(
-      sliver: _SliverConstrainedCrossAxis(maxExtent: maxExtent, sliver: sliver),
+      sliver: _SliverConstrainedCrossAxis(
+        maxExtent: maxExtent,
+        alignment: alignment,
+        sliver: sliver,
+      ),
     );
   }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DoubleProperty('maxExtent', maxExtent));
+    properties.add(DiagnosticsProperty<AlignmentGeometry>('alignment', alignment));
+  }
 }
+
 
 class _SliverZeroFlexParentDataWidget extends ParentDataWidget<SliverPhysicalParentData> {
   const _SliverZeroFlexParentDataWidget({required Widget sliver}) : super(child: sliver);
@@ -1690,25 +1713,39 @@ class _SliverZeroFlexParentDataWidget extends ParentDataWidget<SliverPhysicalPar
 }
 
 class _SliverConstrainedCrossAxis extends SingleChildRenderObjectWidget {
-  const _SliverConstrainedCrossAxis({required this.maxExtent, required Widget sliver})
-    : assert(maxExtent >= 0.0),
-      super(child: sliver);
+  const _SliverConstrainedCrossAxis({
+    required this.maxExtent,
+    required this.alignment,
+    required Widget sliver,
+  }) : assert(maxExtent >= 0.0),
+       super(child: sliver);
 
   /// The cross axis extent to apply to the sliver child.
   ///
   /// This value must be nonnegative.
   final double maxExtent;
 
+  /// The alignment of the sliver child in the cross axis.
+  final AlignmentGeometry alignment;
+
   @override
   RenderSliverConstrainedCrossAxis createRenderObject(BuildContext context) {
-    return RenderSliverConstrainedCrossAxis(maxExtent: maxExtent);
+    return RenderSliverConstrainedCrossAxis(
+      maxExtent: maxExtent,
+      alignment: alignment,
+      textDirection: Directionality.maybeOf(context),
+    );
   }
 
   @override
   void updateRenderObject(BuildContext context, RenderSliverConstrainedCrossAxis renderObject) {
-    renderObject.maxExtent = maxExtent;
+    renderObject
+      ..maxExtent = maxExtent
+      ..alignment = alignment
+      ..textDirection = Directionality.maybeOf(context);
   }
 }
+
 
 /// Set a flex factor for allocating space in the cross axis direction.
 ///

--- a/packages/flutter/test/widgets/sliver_constrained_cross_axis_test.dart
+++ b/packages/flutter/test/widgets/sliver_constrained_cross_axis_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -62,11 +63,83 @@ void main() {
     final RenderSliver sliver = tester.renderObject(find.byType(SliverConstrainedCrossAxis));
     expect((sliver.parentData! as SliverPhysicalParentData).crossAxisFlex, equals(0));
   });
+
+  testWidgets('SliverConstrainedCrossAxis aligns child correctly', (WidgetTester tester) async {
+    final Key sliverKey = UniqueKey();
+    await tester.pumpWidget(
+      _buildSliverConstrainedCrossAxis(
+        maxExtent: 200,
+        alignment: Alignment.center,
+        sliver: SliverToBoxAdapter(
+          child: Container(key: sliverKey, color: Colors.red, height: 60),
+        ),
+      ),
+    );
+
+    // The viewport width is 300.
+    // maxExtent is 200.
+    // Child should be centered, so local offset.dx should be (300 - 200) / 2 = 50.
+    final double scrollViewDx = tester.getTopLeft(find.byType(CustomScrollView)).dx;
+    expect(tester.getTopLeft(find.byKey(sliverKey)).dx, scrollViewDx + 50.0);
+  });
+
+  testWidgets('SliverConstrainedCrossAxis aligns child center right', (WidgetTester tester) async {
+    final Key sliverKey = UniqueKey();
+    await tester.pumpWidget(
+      _buildSliverConstrainedCrossAxis(
+        maxExtent: 200,
+        alignment: Alignment.centerRight,
+        sliver: SliverToBoxAdapter(
+          child: Container(key: sliverKey, color: Colors.red, height: 60),
+        ),
+      ),
+    );
+
+    // The viewport width is 300.
+    // maxExtent is 200.
+    // Child should be right aligned, so local offset.dx should be 300 - 200 = 100.
+    final double scrollViewDx = tester.getTopLeft(find.byType(CustomScrollView)).dx;
+    expect(tester.getTopLeft(find.byKey(sliverKey)).dx, scrollViewDx + 100.0);
+  });
+
+  testWidgets('SliverConstrainedCrossAxis aligns child in RTL correctly', (WidgetTester tester) async {
+    final Key sliverKey = UniqueKey();
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.rtl,
+        child: Center(
+          child: SizedBox(
+            width: VIEWPORT_WIDTH,
+            height: VIEWPORT_HEIGHT,
+            child: CustomScrollView(
+              slivers: <Widget>[
+                SliverConstrainedCrossAxis(
+                  maxExtent: 200,
+                  alignment: AlignmentDirectional.centerEnd,
+                  sliver: SliverToBoxAdapter(
+                    child: Container(key: sliverKey, color: Colors.red, height: 60),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // The viewport width is 300.
+    // maxExtent is 200.
+    // RTL + AlignmentDirectional.centerEnd = Alignment.centerLeft = local offset.dx = 0.
+    final double scrollViewDx = tester.getTopLeft(find.byType(CustomScrollView)).dx;
+    expect(tester.getTopLeft(find.byKey(sliverKey)).dx, scrollViewDx + 0.0);
+  });
 }
 
 Widget _buildSliverConstrainedCrossAxis({
   required double maxExtent,
   Axis scrollDirection = Axis.vertical,
+  AlignmentGeometry alignment = Alignment.centerLeft,
+  Widget? sliver,
 }) {
   return Directionality(
     textDirection: TextDirection.ltr,
@@ -79,7 +152,8 @@ Widget _buildSliverConstrainedCrossAxis({
           slivers: <Widget>[
             SliverConstrainedCrossAxis(
               maxExtent: maxExtent,
-              sliver: SliverToBoxAdapter(
+              alignment: alignment,
+              sliver: sliver ?? SliverToBoxAdapter(
                 child: scrollDirection == Axis.vertical
                     ? Container(height: 100)
                     : Container(width: 100),


### PR DESCRIPTION
_TODO: me - tidying_

Fixes https://github.com/flutter/flutter/issues/184472

This PR adds an alignment property to SliverConstrainedCrossAxis and its corresponding render object, RenderSliverConstrainedCrossAxis. This allows developers to control how a sliver is positioned within the cross axis when its extent is smaller than the available space.

Previously, SliverConstrainedCrossAxis would simply constrain the child to a maxExtent, but it lacked the logic to position that constrained child if it didn't fill the entire cross-axis width (or height, depending on scroll direction).


   - RenderSliverConstrainedCrossAxis:
       - Added alignment and textDirection properties.
       - Updated performLayout to calculate the paintOffset based on the resolved alignment and
         any remaining free space in the cross axis.
       - Implemented paint, hitTestChildren, childMainAxisPosition, childCrossAxisPosition, and
         applyPaintTransform to correctly account for the new child offset.
   - SliverConstrainedCrossAxis Widget:
       - Added an alignment parameter (defaults to Alignment.centerLeft).
       - Passes the alignment and resolved TextDirection down to the render object.
   - Tests:
       - Added new test cases in sliver_constrained_cross_axis_test.dart to verify correct
         alignment in LTR and RTL layouts, as well as specific alignments like Alignment.center
         and Alignment.centerRight.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
