### PR TITLE
Replace FlutterDesktopViewGetGraphicsAdapter with FlutterDesktopEngineGetGraphicsAdapter

### DIFF
--- a/engine/src/flutter/shell/platform/windows/client_wrapper/flutter_engine_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/client_wrapper/flutter_engine_unittests.cc
@@ -227,4 +227,13 @@ TEST(FlutterEngineTest, ProcessExternalWindowMessage) {
   EXPECT_EQ(test_api->last_external_message(), 1234);
 }
 
+TEST(FlutterEngineTest, GetGraphicsAdapter) {
+  testing::ScopedStubFlutterWindowsApi scoped_api_stub(
+      std::make_unique<TestFlutterWindowsApi>());
+  FlutterEngine engine(DartProject(L"fake/project/path"));
+
+  IDXGIAdapter* adapter = engine.GetGraphicsAdapter();
+  EXPECT_NE(adapter, nullptr);
+}
+
 }  // namespace flutter

--- a/engine/src/flutter/shell/platform/windows/client_wrapper/flutter_view_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/client_wrapper/flutter_view_unittests.cc
@@ -17,9 +17,6 @@ namespace {
 class TestWindowsApi : public testing::StubFlutterWindowsApi {
   HWND ViewGetHWND() override { return reinterpret_cast<HWND>(7); }
 
-  IDXGIAdapter* ViewGetGraphicsAdapter() override {
-    return reinterpret_cast<IDXGIAdapter*>(8);
-  }
 };
 
 }  // namespace
@@ -32,14 +29,5 @@ TEST(FlutterViewTest, HwndAccessPassesThrough) {
   EXPECT_EQ(view.GetNativeWindow(), reinterpret_cast<HWND>(7));
 }
 
-TEST(FlutterViewTest, GraphicsAdapterAccessPassesThrough) {
-  testing::ScopedStubFlutterWindowsApi scoped_api_stub(
-      std::make_unique<TestWindowsApi>());
-  auto test_api = static_cast<TestWindowsApi*>(scoped_api_stub.stub());
-  FlutterView view(reinterpret_cast<FlutterDesktopViewRef>(2));
-
-  IDXGIAdapter* adapter = view.GetGraphicsAdapter();
-  EXPECT_EQ(adapter, reinterpret_cast<IDXGIAdapter*>(8));
-}
 
 }  // namespace flutter

--- a/engine/src/flutter/shell/platform/windows/client_wrapper/include/flutter/flutter_engine.h
+++ b/engine/src/flutter/shell/platform/windows/client_wrapper/include/flutter/flutter_engine.h
@@ -94,6 +94,11 @@ class FlutterEngine : public PluginRegistry {
                                                       WPARAM wparam,
                                                       LPARAM lparam);
 
+  // Returns the DXGI adapter used for rendering or nullptr in case of error.
+  IDXGIAdapter* GetGraphicsAdapter() {
+    return FlutterDesktopEngineGetGraphicsAdapter(engine_);
+  }
+
  private:
   // For access to the engine handle.
   friend class FlutterViewController;

--- a/engine/src/flutter/shell/platform/windows/client_wrapper/include/flutter/flutter_view.h
+++ b/engine/src/flutter/shell/platform/windows/client_wrapper/include/flutter/flutter_view.h
@@ -27,11 +27,6 @@ class FlutterView {
   // Returns the backing HWND for the view.
   HWND GetNativeWindow() { return FlutterDesktopViewGetHWND(view_); }
 
-  // Returns the DXGI adapter used for rendering or nullptr in case of error.
-  IDXGIAdapter* GetGraphicsAdapter() {
-    return FlutterDesktopViewGetGraphicsAdapter(view_);
-  }
-
  private:
   // Handle for interacting with the C API's view.
   FlutterDesktopViewRef view_ = nullptr;

--- a/engine/src/flutter/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.cc
+++ b/engine/src/flutter/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.cc
@@ -161,9 +161,9 @@ HWND FlutterDesktopViewGetHWND(FlutterDesktopViewRef controller) {
   return reinterpret_cast<HWND>(-1);
 }
 
-IDXGIAdapter* FlutterDesktopViewGetGraphicsAdapter(FlutterDesktopViewRef view) {
+IDXGIAdapter* FlutterDesktopEngineGetGraphicsAdapter(FlutterDesktopEngineRef engine) {
   if (s_stub_implementation) {
-    return s_stub_implementation->ViewGetGraphicsAdapter();
+    return s_stub_implementation->EngineGetGraphicsAdapter();
   }
   return nullptr;
 }

--- a/engine/src/flutter/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.h
+++ b/engine/src/flutter/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.h
@@ -81,8 +81,8 @@ class StubFlutterWindowsApi {
   // Called for FlutterDesktopViewGetHWND.
   virtual HWND ViewGetHWND() { return reinterpret_cast<HWND>(1); }
 
-  // Called for FlutterDesktopViewGetGraphicsAdapter.
-  virtual IDXGIAdapter* ViewGetGraphicsAdapter() {
+  // Called for FlutterDesktopEngineGetGraphicsAdapter.
+  virtual IDXGIAdapter* EngineGetGraphicsAdapter() {
     return reinterpret_cast<IDXGIAdapter*>(2);
   }
 

--- a/engine/src/flutter/shell/platform/windows/flutter_windows.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows.cc
@@ -254,8 +254,9 @@ HWND FlutterDesktopViewGetHWND(FlutterDesktopViewRef view) {
   return ViewFromHandle(view)->GetWindowHandle();
 }
 
-IDXGIAdapter* FlutterDesktopViewGetGraphicsAdapter(FlutterDesktopViewRef view) {
-  auto egl_manager = ViewFromHandle(view)->GetEngine()->egl_manager();
+IDXGIAdapter* FlutterDesktopEngineGetGraphicsAdapter(
+    FlutterDesktopEngineRef engine) {
+  auto egl_manager = EngineFromHandle(engine)->egl_manager();
   if (egl_manager) {
     Microsoft::WRL::ComPtr<ID3D11Device> d3d_device;
     Microsoft::WRL::ComPtr<IDXGIDevice> dxgi_device;

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_unittests.cc
@@ -423,10 +423,10 @@ TEST_F(WindowsTest, GetGraphicsAdapter) {
   WindowsConfigBuilder builder(context);
   ViewControllerPtr controller{builder.Run()};
   ASSERT_NE(controller, nullptr);
-  auto view = FlutterDesktopViewControllerGetView(controller.get());
+  auto engine = FlutterDesktopViewControllerGetEngine(controller.get());
 
   Microsoft::WRL::ComPtr<IDXGIAdapter> dxgi_adapter;
-  dxgi_adapter = FlutterDesktopViewGetGraphicsAdapter(view);
+  dxgi_adapter = FlutterDesktopEngineGetGraphicsAdapter(engine);
   ASSERT_NE(dxgi_adapter, nullptr);
   DXGI_ADAPTER_DESC desc{};
   ASSERT_TRUE(SUCCEEDED(dxgi_adapter->GetDesc(&desc)));
@@ -443,10 +443,10 @@ TEST_F(WindowsTest, GetGraphicsAdapterWithLowPowerPreference) {
   builder.SetGpuPreference(FlutterDesktopGpuPreference::LowPowerPreference);
   ViewControllerPtr controller{builder.Run()};
   ASSERT_NE(controller, nullptr);
-  auto view = FlutterDesktopViewControllerGetView(controller.get());
+  auto engine = FlutterDesktopViewControllerGetEngine(controller.get());
 
   Microsoft::WRL::ComPtr<IDXGIAdapter> dxgi_adapter;
-  dxgi_adapter = FlutterDesktopViewGetGraphicsAdapter(view);
+  dxgi_adapter = FlutterDesktopEngineGetGraphicsAdapter(engine);
   ASSERT_NE(dxgi_adapter, nullptr);
   DXGI_ADAPTER_DESC desc{};
   ASSERT_TRUE(SUCCEEDED(dxgi_adapter->GetDesc(&desc)));
@@ -466,10 +466,10 @@ TEST_F(WindowsTest, GetGraphicsAdapterWithHighPerformancePreference) {
       FlutterDesktopGpuPreference::HighPerformancePreference);
   ViewControllerPtr controller{builder.Run()};
   ASSERT_NE(controller, nullptr);
-  auto view = FlutterDesktopViewControllerGetView(controller.get());
+  auto engine = FlutterDesktopViewControllerGetEngine(controller.get());
 
   Microsoft::WRL::ComPtr<IDXGIAdapter> dxgi_adapter;
-  dxgi_adapter = FlutterDesktopViewGetGraphicsAdapter(view);
+  dxgi_adapter = FlutterDesktopEngineGetGraphicsAdapter(engine);
   ASSERT_NE(dxgi_adapter, nullptr);
   DXGI_ADAPTER_DESC desc{};
   ASSERT_TRUE(SUCCEEDED(dxgi_adapter->GetDesc(&desc)));

--- a/engine/src/flutter/shell/platform/windows/public/flutter_windows.h
+++ b/engine/src/flutter/shell/platform/windows/public/flutter_windows.h
@@ -261,8 +261,8 @@ FLUTTER_EXPORT void FlutterDesktopEngineSetNextFrameCallback(
 FLUTTER_EXPORT HWND FlutterDesktopViewGetHWND(FlutterDesktopViewRef view);
 
 // Returns the DXGI adapter used for rendering or nullptr in case of error.
-FLUTTER_EXPORT IDXGIAdapter* FlutterDesktopViewGetGraphicsAdapter(
-    FlutterDesktopViewRef view);
+FLUTTER_EXPORT IDXGIAdapter* FlutterDesktopEngineGetGraphicsAdapter(
+    FlutterDesktopEngineRef engine);
 
 // Called to pass an external window message to the engine for lifecycle
 // state updates. Non-Flutter windows must call this method in their WndProc


### PR DESCRIPTION
## Summary

Fixes #184477

Replaces `FlutterDesktopViewGetGraphicsAdapter` with `FlutterDesktopEngineGetGraphicsAdapter` in the Windows embedder API.

There is only one graphics adapter per engine, so there's no need to tie this API to the view level. The previous view-level API was broken for multi-window scenarios since plugins may assume an implicit view (e.g., Rive).

## Changes

### C API (`shell/platform/windows/`)
- **`public/flutter_windows.h`**: Replaced `FlutterDesktopViewGetGraphicsAdapter(FlutterDesktopViewRef)` with `FlutterDesktopEngineGetGraphicsAdapter(FlutterDesktopEngineRef)`
- **`flutter_windows.cc`**: Updated implementation to use `EngineFromHandle(engine)->egl_manager()` directly instead of going through `ViewFromHandle(view)->GetEngine()->egl_manager()`
- **`flutter_windows_unittests.cc`**: Updated 3 integration tests to get engine from controller instead of view

### C++ Wrapper (`client_wrapper/`)
- **`include/flutter/flutter_view.h`**: Removed `GetGraphicsAdapter()` from `FlutterView` class
- **`include/flutter/flutter_engine.h`**: Added `GetGraphicsAdapter()` to `FlutterEngine` class
- **`testing/stub_flutter_windows_api.h`**: Renamed `ViewGetGraphicsAdapter()` → `EngineGetGraphicsAdapter()`
- **`testing/stub_flutter_windows_api.cc`**: Updated stub C API function signature
- **`flutter_view_unittests.cc`**: Removed `GraphicsAdapterAccessPassesThrough` test
- **`flutter_engine_unittests.cc`**: Added `GetGraphicsAdapter` test

## Test Plan

- [x] Updated all 3 integration tests in `flutter_windows_unittests.cc` to use engine-level API
- [x] Updated C++ wrapper unit tests in `flutter_engine_unittests.cc`
- [x] Removed obsolete view-level wrapper test
- [ ] CI Windows build and tests should pass