### PR TITLE
[engine] Fix missing default return in 9 operator<< switch statements (display_list_testing.cc)

### DIFF
--- a/engine/src/flutter/testing/display_list_testing.cc
+++ b/engine/src/flutter/testing/display_list_testing.cc
@@ -145,6 +145,8 @@ extern std::ostream& operator<<(
   switch (type) {
     DLT_OSTREAM_CASE(DlPathFillType, Odd);
     DLT_OSTREAM_CASE(DlPathFillType, NonZero);
+
+    default: return os << "DlPathFillType::????";
   }
 }
 
@@ -188,6 +190,8 @@ std::ostream& operator<<(std::ostream& os, const flutter::DlClipOp& op) {
   switch (op) {
     case flutter::DlClipOp::kDifference: return os << "DlClipOp::kDifference";
     case flutter::DlClipOp::kIntersect:  return os << "DlClipOp::kIntersect";
+
+    default: return os << "DlClipOp::????";
   }
 }
 
@@ -197,6 +201,8 @@ std::ostream& operator<<(std::ostream& os, const flutter::DlSrcRectConstraint& c
       return os << "SrcRectConstraint::kFast";
     case flutter::DlSrcRectConstraint::kStrict:
       return os << "SrcRectConstraint::kStrict";
+
+    default: return os << "SrcRectConstraint::????";
   }
 }
 
@@ -205,6 +211,8 @@ std::ostream& operator<<(std::ostream& os, const DlStrokeCap& cap) {
     case DlStrokeCap::kButt:   return os << "Cap::kButt";
     case DlStrokeCap::kRound:  return os << "Cap::kRound";
     case DlStrokeCap::kSquare: return os << "Cap::kSquare";
+
+    default: return os << "Cap::????";
   }
 }
 
@@ -213,6 +221,8 @@ std::ostream& operator<<(std::ostream& os, const DlStrokeJoin& join) {
     case DlStrokeJoin::kMiter: return os << "Join::kMiter";
     case DlStrokeJoin::kRound: return os << "Join::kRound";
     case DlStrokeJoin::kBevel: return os << "Join::kBevel";
+
+    default: return os << "Join::????";
   }
 }
 
@@ -221,6 +231,8 @@ std::ostream& operator<<(std::ostream& os, const DlDrawStyle& style) {
     case DlDrawStyle::kFill:          return os << "Style::kFill";
     case DlDrawStyle::kStroke:        return os << "Style::kStroke";
     case DlDrawStyle::kStrokeAndFill: return os << "Style::kStrokeAnFill";
+
+    default: return os << "Style::????";
   }
 }
 
@@ -230,6 +242,8 @@ std::ostream& operator<<(std::ostream& os, const DlBlurStyle& style) {
     case DlBlurStyle::kSolid:  return os << "BlurStyle::kSolid";
     case DlBlurStyle::kOuter:  return os << "BlurStyle::kOuter";
     case DlBlurStyle::kInner:  return os << "BlurStyle::kInner";
+
+    default: return os << "BlurStyle::????";
   }
 }
 
@@ -238,6 +252,8 @@ std::ostream& operator<<(std::ostream& os, const flutter::DlPointMode& mode) {
     case flutter::DlPointMode::kPoints:  return os << "PointMode::kPoints";
     case flutter::DlPointMode::kLines:   return os << "PointMode::kLines";
     case flutter::DlPointMode::kPolygon: return os << "PointMode::kPolygon";
+
+    default: return os << "PointMode::????";
   }
 }
 
@@ -285,6 +301,8 @@ std::ostream& operator<<(std::ostream& os, DlImageSampling sampling) {
     case DlImageSampling::kCubic: {
       return os << "CubicSampling";
     }
+
+    default: return os << "DlImageSampling::????";
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #184486

Nine `operator<<` overloads in `engine/src/flutter/testing/display_list_testing.cc` have `switch` statements that cover all current enum values but lack a `default` case or post-switch return. This is undefined behavior per the C++ standard ([dcl.fct/6.6.3]) if an unhandled value reaches the switch.

### Problem

- **CI/CD breakage**: `-Wreturn-type` (enabled by `-Wall`) warns on all 9 functions. Under `-Werror` (common in CI), these become build failures.
- **Future-proofing**: If any enum is extended with a new value, the function silently falls through without returning — UB at runtime.
- **Static analysis**: cppcheck flags all 9 as `missingReturn` errors.

### Fix

Added `default: return os << "Type::????";` to each of the 9 affected `operator<<` functions, following the exact pattern already used by `DlFilterMode`, `DlVertexMode`, and `DlTileMode` in the same file.

**Affected functions:**
| Enum type | Default added |
|-----------|---------------|
| `DlPathFillType` | `default: return os << "DlPathFillType::????";` |
| `DlClipOp` | `default: return os << "DlClipOp::????";` |
| `DlSrcRectConstraint` | `default: return os << "SrcRectConstraint::????";` |
| `DlStrokeCap` | `default: return os << "Cap::????";` |
| `DlStrokeJoin` | `default: return os << "Join::????";` |
| `DlDrawStyle` | `default: return os << "Style::????";` |
| `DlBlurStyle` | `default: return os << "BlurStyle::????";` |
| `DlPointMode` | `default: return os << "PointMode::????";` |
| `DlImageSampling` | `default: return os << "DlImageSampling::????";` |

### References

- [Abseil Tip #147](https://abseil.io/tips/147) — Guidance on exhaustive switch statements over enums
- cppcheck `missingReturn` static analysis

## Test Plan

- [x] Code change is mechanical — adds `default` cases to existing switch statements
- [x] Pattern matches 3 existing correct examples in the same file
- [x] No functional behavior change for valid enum values
- [ ] Build with `-Wreturn-type -Werror` to confirm warnings are resolved
- [ ] Run existing display list tests to confirm no regressions