### PR TITLE
[Windows] Propagate the enabled accessibility state

### DIFF
--- a/engine/src/flutter/shell/platform/common/accessibility_bridge.cc
+++ b/engine/src/flutter/shell/platform/common/accessibility_bridge.cc
@@ -373,6 +373,11 @@ void AccessibilityBridge::SetStateFromFlutterUpdate(ui::AXNodeData& node_data,
   if (flags->is_text_field && !flags->is_read_only) {
     node_data.AddState(ax::mojom::State::kEditable);
   }
+  if (flags->is_enabled == FlutterTristate::kFlutterTristateFalse) {
+    node_data.SetRestriction(ax::mojom::Restriction::kDisabled);
+  } else if (flags->is_read_only) {
+    node_data.SetRestriction(ax::mojom::Restriction::kReadOnly);
+  }
   if (node_data.role == ax::mojom::Role::kStaticText &&
       (actions & kHasScrollingAction) == 0 && node.value.empty() &&
       node.label.empty() && node.hint.empty()) {

--- a/engine/src/flutter/shell/platform/common/accessibility_bridge.cc
+++ b/engine/src/flutter/shell/platform/common/accessibility_bridge.cc
@@ -318,7 +318,7 @@ void AccessibilityBridge::SetRoleFromFlutterUpdate(ui::AXNodeData& node_data,
     node_data.role = ax::mojom::Role::kButton;
     return;
   }
-  if (flags->is_text_field && !flags->is_read_only) {
+  if (flags->is_text_field) {
     node_data.role = ax::mojom::Role::kTextField;
     return;
   }

--- a/engine/src/flutter/shell/platform/common/accessibility_bridge_unittests.cc
+++ b/engine/src/flutter/shell/platform/common/accessibility_bridge_unittests.cc
@@ -689,5 +689,57 @@ TEST(AccessibilityBridgeTest, ReadOnlyTextFieldHasReadOnlyRestriction) {
             ax::mojom::Restriction::kReadOnly);
 }
 
+TEST(AccessibilityBridgeTest, ReadOnlyTextFieldHasTextFieldRole) {
+  std::shared_ptr<TestAccessibilityBridge> bridge =
+      std::make_shared<TestAccessibilityBridge>();
+  FlutterSemanticsNode2 root = CreateSemanticsNode(0, "root");
+  auto flags = FlutterSemanticsFlags{
+      .is_enabled = FlutterTristate::kFlutterTristateTrue,
+      .is_text_field = true,
+      .is_read_only = true,
+  };
+  root.flags2 = &flags;
+  bridge->AddFlutterSemanticsNodeUpdate(root);
+  bridge->CommitUpdates();
+
+  auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
+  EXPECT_EQ(root_node->GetData().role, ax::mojom::Role::kTextField);
+}
+
+TEST(AccessibilityBridgeTest, EditableTextFieldHasTextFieldRole) {
+  std::shared_ptr<TestAccessibilityBridge> bridge =
+      std::make_shared<TestAccessibilityBridge>();
+  FlutterSemanticsNode2 root = CreateSemanticsNode(0, "root");
+  auto flags = FlutterSemanticsFlags{
+      .is_enabled = FlutterTristate::kFlutterTristateTrue,
+      .is_text_field = true,
+      .is_read_only = false,
+  };
+  root.flags2 = &flags;
+  bridge->AddFlutterSemanticsNodeUpdate(root);
+  bridge->CommitUpdates();
+
+  auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
+  EXPECT_EQ(root_node->GetData().role, ax::mojom::Role::kTextField);
+  EXPECT_TRUE(root_node->GetData().HasState(ax::mojom::State::kEditable));
+}
+
+TEST(AccessibilityBridgeTest, ReadOnlyTextFieldIsNotEditable) {
+  std::shared_ptr<TestAccessibilityBridge> bridge =
+      std::make_shared<TestAccessibilityBridge>();
+  FlutterSemanticsNode2 root = CreateSemanticsNode(0, "root");
+  auto flags = FlutterSemanticsFlags{
+      .is_enabled = FlutterTristate::kFlutterTristateTrue,
+      .is_text_field = true,
+      .is_read_only = true,
+  };
+  root.flags2 = &flags;
+  bridge->AddFlutterSemanticsNodeUpdate(root);
+  bridge->CommitUpdates();
+
+  auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
+  EXPECT_FALSE(root_node->GetData().HasState(ax::mojom::State::kEditable));
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/engine/src/flutter/shell/platform/common/accessibility_bridge_unittests.cc
+++ b/engine/src/flutter/shell/platform/common/accessibility_bridge_unittests.cc
@@ -635,5 +635,59 @@ TEST(AccessibilityBridgeTest, IsSelectedAttribute) {
       ax::mojom::BoolAttribute::kSelected));
 }
 
+TEST(AccessibilityBridgeTest, DisabledButtonHasDisabledRestriction) {
+  std::shared_ptr<TestAccessibilityBridge> bridge =
+      std::make_shared<TestAccessibilityBridge>();
+  FlutterSemanticsNode2 root = CreateSemanticsNode(0, "root");
+  auto flags = FlutterSemanticsFlags{
+      .is_enabled = FlutterTristate::kFlutterTristateFalse,
+      .is_button = true,
+  };
+  root.flags2 = &flags;
+  bridge->AddFlutterSemanticsNodeUpdate(root);
+  bridge->CommitUpdates();
+
+  auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
+  EXPECT_EQ(root_node->GetData().role, ax::mojom::Role::kButton);
+  EXPECT_EQ(root_node->GetData().GetRestriction(),
+            ax::mojom::Restriction::kDisabled);
+}
+
+TEST(AccessibilityBridgeTest, EnabledButtonHasNoRestriction) {
+  std::shared_ptr<TestAccessibilityBridge> bridge =
+      std::make_shared<TestAccessibilityBridge>();
+  FlutterSemanticsNode2 root = CreateSemanticsNode(0, "root");
+  auto flags = FlutterSemanticsFlags{
+      .is_enabled = FlutterTristate::kFlutterTristateTrue,
+      .is_button = true,
+  };
+  root.flags2 = &flags;
+  bridge->AddFlutterSemanticsNodeUpdate(root);
+  bridge->CommitUpdates();
+
+  auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
+  EXPECT_EQ(root_node->GetData().role, ax::mojom::Role::kButton);
+  EXPECT_EQ(root_node->GetData().GetRestriction(),
+            ax::mojom::Restriction::kNone);
+}
+
+TEST(AccessibilityBridgeTest, ReadOnlyTextFieldHasReadOnlyRestriction) {
+  std::shared_ptr<TestAccessibilityBridge> bridge =
+      std::make_shared<TestAccessibilityBridge>();
+  FlutterSemanticsNode2 root = CreateSemanticsNode(0, "root");
+  auto flags = FlutterSemanticsFlags{
+      .is_enabled = FlutterTristate::kFlutterTristateTrue,
+      .is_text_field = true,
+      .is_read_only = true,
+  };
+  root.flags2 = &flags;
+  bridge->AddFlutterSemanticsNodeUpdate(root);
+  bridge->CommitUpdates();
+
+  auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
+  EXPECT_EQ(root_node->GetData().GetRestriction(),
+            ax::mojom::Restriction::kReadOnly);
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/engine/src/flutter/shell/platform/windows/accessibility_bridge_windows.cc
+++ b/engine/src/flutter/shell/platform/windows/accessibility_bridge_windows.cc
@@ -104,6 +104,7 @@ void AccessibilityBridgeWindows::OnAccessibilityEvent(
                                     ax::mojom::Event::kStateChanged);
       break;
     case ui::AXEventGenerator::Event::ENABLED_CHANGED:
+    case ui::AXEventGenerator::Event::READONLY_CHANGED:
       DispatchWinAccessibilityEvent(win_delegate,
                                     ax::mojom::Event::kStateChanged);
       break;
@@ -145,7 +146,6 @@ void AccessibilityBridgeWindows::OnAccessibilityEvent(
     case ui::AXEventGenerator::Event::PLACEHOLDER_CHANGED:
     case ui::AXEventGenerator::Event::PORTAL_ACTIVATED:
     case ui::AXEventGenerator::Event::POSITION_IN_SET_CHANGED:
-    case ui::AXEventGenerator::Event::READONLY_CHANGED:
     case ui::AXEventGenerator::Event::RELATED_NODE_CHANGED:
     case ui::AXEventGenerator::Event::REQUIRED_STATE_CHANGED:
     case ui::AXEventGenerator::Event::ROLE_CHANGED:

--- a/engine/src/flutter/shell/platform/windows/accessibility_bridge_windows.cc
+++ b/engine/src/flutter/shell/platform/windows/accessibility_bridge_windows.cc
@@ -103,6 +103,10 @@ void AccessibilityBridgeWindows::OnAccessibilityEvent(
       DispatchWinAccessibilityEvent(win_delegate,
                                     ax::mojom::Event::kStateChanged);
       break;
+    case ui::AXEventGenerator::Event::ENABLED_CHANGED:
+      DispatchWinAccessibilityEvent(win_delegate,
+                                    ax::mojom::Event::kStateChanged);
+      break;
     case ui::AXEventGenerator::Event::ACCESS_KEY_CHANGED:
     case ui::AXEventGenerator::Event::ACTIVE_DESCENDANT_CHANGED:
     case ui::AXEventGenerator::Event::ATK_TEXT_OBJECT_ATTRIBUTE_CHANGED:
@@ -116,7 +120,6 @@ void AccessibilityBridgeWindows::OnAccessibilityEvent(
     case ui::AXEventGenerator::Event::DESCRIPTION_CHANGED:
     case ui::AXEventGenerator::Event::DOCUMENT_TITLE_CHANGED:
     case ui::AXEventGenerator::Event::DROPEFFECT_CHANGED:
-    case ui::AXEventGenerator::Event::ENABLED_CHANGED:
     case ui::AXEventGenerator::Event::EXPANDED:
     case ui::AXEventGenerator::Event::FLOW_FROM_CHANGED:
     case ui::AXEventGenerator::Event::FLOW_TO_CHANGED:

--- a/engine/src/flutter/shell/platform/windows/accessibility_bridge_windows_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/accessibility_bridge_windows_unittests.cc
@@ -427,5 +427,10 @@ TEST(AccessibilityBridgeWindows, OnAccessibilityEnabledChanged) {
             ax::mojom::Event::kStateChanged);
 }
 
+TEST(AccessibilityBridgeWindows, OnAccessibilityReadOnlyChanged) {
+  ExpectWinEventFromAXEvent(1, ui::AXEventGenerator::Event::READONLY_CHANGED,
+                            ax::mojom::Event::kStateChanged);
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/engine/src/flutter/shell/platform/windows/accessibility_bridge_windows_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/accessibility_bridge_windows_unittests.cc
@@ -402,5 +402,30 @@ TEST(AccessibilityBridgeWindows, OnDocumentSelectionChanged) {
       ax::mojom::Event::kDocumentSelectionChanged, 2);
 }
 
+TEST(AccessibilityBridgeWindows, OnAccessibilityEnabledChanged) {
+  auto engine = GetTestEngine();
+  FlutterWindowsViewSpy view{
+      engine.get(), std::make_unique<NiceMock<MockWindowBindingHandler>>()};
+  EngineModifier modifier{engine.get()};
+  modifier.SetImplicitView(&view);
+  view.OnUpdateSemanticsEnabled(true);
+
+  auto bridge = GetAccessibilityBridgeSpy(view);
+  PopulateAXTree(bridge);
+
+  bridge->ResetRecords();
+  bridge->OnAccessibilityEvent({AXNodeFromID(bridge, 1),
+                                {ui::AXEventGenerator::Event::ENABLED_CHANGED,
+                                 ax::mojom::EventFrom::kNone,
+                                 {}}});
+
+  // Should dispatch an MSAA state change event. The UIA property change for
+  // UIA_IsEnabledPropertyId is now raised internally by AXPlatformNodeWin
+  // when it processes the kStateChanged event.
+  ASSERT_EQ(bridge->dispatched_events().size(), 1u);
+  EXPECT_EQ(bridge->dispatched_events()[0].event_type,
+            ax::mojom::Event::kStateChanged);
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/engine/src/flutter/third_party/accessibility/ax/platform/ax_platform_node_win.cc
+++ b/engine/src/flutter/third_party/accessibility/ax/platform/ax_platform_node_win.cc
@@ -5313,6 +5313,8 @@ std::optional<PROPERTYID> AXPlatformNodeWin::MojoEventToUIAProperty(
         return UIA_ToggleToggleStatePropertyId;
       }
       return std::nullopt;
+    case ax::mojom::Event::kStateChanged:
+      return UIA_IsEnabledPropertyId;
     default:
       return std::nullopt;
   }


### PR DESCRIPTION
This PR propagates the enabled/diabled/read-only state of Flutter widgets to the Windows Accessiblity tree.

see #184559 

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.
