### PR TITLE
Remove live_text_utils cross-imports from material and cupertino tests

### DIFF
--- a/packages/flutter/test/cupertino/adaptive_text_selection_toolbar_test.dart
+++ b/packages/flutter/test/cupertino/adaptive_text_selection_toolbar_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../widgets/clipboard_utils.dart';
-import '../widgets/live_text_utils.dart';
+import 'live_text_utils.dart';
 import '../widgets/text_selection_toolbar_utils.dart';
 
 void main() {

--- a/packages/flutter/test/cupertino/adaptive_text_selection_toolbar_test.dart
+++ b/packages/flutter/test/cupertino/adaptive_text_selection_toolbar_test.dart
@@ -8,8 +8,8 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../widgets/clipboard_utils.dart';
-import 'live_text_utils.dart';
 import '../widgets/text_selection_toolbar_utils.dart';
+import 'live_text_utils.dart';
 
 void main() {
   final mockClipboard = MockClipboard();

--- a/packages/flutter/test/cupertino/live_text_utils.dart
+++ b/packages/flutter/test/cupertino/live_text_utils.dart
@@ -1,0 +1,78 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// A mock class to control the return result of Live Text input functions.
+class LiveTextInputTester {
+  /// Creates a [LiveTextInputTester] and installs a mock handler on
+  /// [SystemChannels.platform].
+  LiveTextInputTester() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      _handler,
+    );
+  }
+
+  /// Whether the mock Live Text input is enabled.
+  bool mockLiveTextInputEnabled = false;
+
+  Future<Object?> _handler(MethodCall methodCall) async {
+    // Need to set Clipboard.hasStrings method handler because when showing the tool bar,
+    // the Clipboard.hasStrings will also be invoked. If this isn't handled,
+    // an exception will be thrown.
+    if (methodCall.method == 'Clipboard.hasStrings') {
+      return <String, bool>{'value': true};
+    }
+    if (methodCall.method == 'LiveText.isLiveTextInputAvailable') {
+      return mockLiveTextInputEnabled;
+    }
+    return false;
+  }
+
+  /// Removes the mock handler from [SystemChannels.platform].
+  void dispose() {
+    assert(
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.checkMockMessageHandler(
+        SystemChannels.platform.name,
+        _handler,
+      ),
+    );
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      null,
+    );
+  }
+}
+
+/// A function to find the live text button.
+///
+/// LiveText button is displayed either using a custom painter,
+/// a Text with an empty label, or a Text with the 'Scan text' label.
+Finder findLiveTextButton() {
+  final bool isMobile =
+      defaultTargetPlatform == TargetPlatform.android ||
+      defaultTargetPlatform == TargetPlatform.fuchsia ||
+      defaultTargetPlatform == TargetPlatform.iOS;
+  if (isMobile) {
+    return find.byWidgetPredicate((Widget widget) {
+      return (widget is CustomPaint &&
+              '${widget.painter?.runtimeType}' == '_LiveTextIconPainter') ||
+          (widget is Text &&
+              widget.data == 'Scan text'); // Android and Fuchsia when inside a MaterialApp.
+    });
+  }
+  if (defaultTargetPlatform == TargetPlatform.macOS) {
+    return find.ancestor(
+      of: find.text(''),
+      matching: find.byType(CupertinoDesktopTextSelectionToolbarButton),
+    );
+  }
+  return find.byWidgetPredicate((Widget widget) {
+    return widget is Text && (widget.data == '' || widget.data == 'Scan text');
+  });
+}

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -25,7 +25,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../widgets/clipboard_utils.dart';
 import '../widgets/editable_text_utils.dart';
-import '../widgets/live_text_utils.dart';
+import 'live_text_utils.dart';
 import '../widgets/semantics_tester.dart';
 import '../widgets/text_selection_toolbar_utils.dart';
 

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -25,9 +25,9 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../widgets/clipboard_utils.dart';
 import '../widgets/editable_text_utils.dart';
-import 'live_text_utils.dart';
 import '../widgets/semantics_tester.dart';
 import '../widgets/text_selection_toolbar_utils.dart';
+import 'live_text_utils.dart';
 
 class MockTextSelectionControls extends TextSelectionControls {
   @override

--- a/packages/flutter/test/material/adaptive_text_selection_toolbar_test.dart
+++ b/packages/flutter/test/material/adaptive_text_selection_toolbar_test.dart
@@ -9,7 +9,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import '../widgets/clipboard_utils.dart';
 import '../widgets/editable_text_utils.dart';
-import '../widgets/live_text_utils.dart';
+import 'live_text_utils.dart';
 import '../widgets/text_selection_toolbar_utils.dart';
 
 void main() {

--- a/packages/flutter/test/material/adaptive_text_selection_toolbar_test.dart
+++ b/packages/flutter/test/material/adaptive_text_selection_toolbar_test.dart
@@ -9,8 +9,8 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import '../widgets/clipboard_utils.dart';
 import '../widgets/editable_text_utils.dart';
-import 'live_text_utils.dart';
 import '../widgets/text_selection_toolbar_utils.dart';
+import 'live_text_utils.dart';
 
 void main() {
   final mockClipboard = MockClipboard();

--- a/packages/flutter/test/material/live_text_utils.dart
+++ b/packages/flutter/test/material/live_text_utils.dart
@@ -1,0 +1,78 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// A mock class to control the return result of Live Text input functions.
+class LiveTextInputTester {
+  /// Creates a [LiveTextInputTester] and installs a mock handler on
+  /// [SystemChannels.platform].
+  LiveTextInputTester() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      _handler,
+    );
+  }
+
+  /// Whether the mock Live Text input is enabled.
+  bool mockLiveTextInputEnabled = false;
+
+  Future<Object?> _handler(MethodCall methodCall) async {
+    // Need to set Clipboard.hasStrings method handler because when showing the tool bar,
+    // the Clipboard.hasStrings will also be invoked. If this isn't handled,
+    // an exception will be thrown.
+    if (methodCall.method == 'Clipboard.hasStrings') {
+      return <String, bool>{'value': true};
+    }
+    if (methodCall.method == 'LiveText.isLiveTextInputAvailable') {
+      return mockLiveTextInputEnabled;
+    }
+    return false;
+  }
+
+  /// Removes the mock handler from [SystemChannels.platform].
+  void dispose() {
+    assert(
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.checkMockMessageHandler(
+        SystemChannels.platform.name,
+        _handler,
+      ),
+    );
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      null,
+    );
+  }
+}
+
+/// A function to find the live text button.
+///
+/// LiveText button is displayed either using a custom painter,
+/// a Text with an empty label, or a Text with the 'Scan text' label.
+Finder findLiveTextButton() {
+  final bool isMobile =
+      defaultTargetPlatform == TargetPlatform.android ||
+      defaultTargetPlatform == TargetPlatform.fuchsia ||
+      defaultTargetPlatform == TargetPlatform.iOS;
+  if (isMobile) {
+    return find.byWidgetPredicate((Widget widget) {
+      return (widget is CustomPaint &&
+              '${widget.painter?.runtimeType}' == '_LiveTextIconPainter') ||
+          (widget is Text &&
+              widget.data == 'Scan text'); // Android and Fuchsia when inside a MaterialApp.
+    });
+  }
+  if (defaultTargetPlatform == TargetPlatform.macOS) {
+    return find.ancestor(
+      of: find.text(''),
+      matching: find.byType(CupertinoDesktopTextSelectionToolbarButton),
+    );
+  }
+  return find.byWidgetPredicate((Widget widget) {
+    return widget is Text && (widget.data == '' || widget.data == 'Scan text');
+  });
+}

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -27,7 +27,7 @@ import 'package:flutter_test/flutter_test.dart';
 import '../widgets/clipboard_utils.dart';
 import '../widgets/editable_text_utils.dart';
 import '../widgets/feedback_tester.dart';
-import '../widgets/live_text_utils.dart';
+import 'live_text_utils.dart';
 import '../widgets/process_text_utils.dart';
 import '../widgets/semantics_tester.dart';
 import '../widgets/text_selection_toolbar_utils.dart';

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -27,10 +27,10 @@ import 'package:flutter_test/flutter_test.dart';
 import '../widgets/clipboard_utils.dart';
 import '../widgets/editable_text_utils.dart';
 import '../widgets/feedback_tester.dart';
-import 'live_text_utils.dart';
 import '../widgets/process_text_utils.dart';
 import '../widgets/semantics_tester.dart';
 import '../widgets/text_selection_toolbar_utils.dart';
+import 'live_text_utils.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();


### PR DESCRIPTION
Remove cross-directory test imports of `live_text_utils.dart` from material and cupertino tests.

Part of #182636.

`LiveTextInputTester` is a small (75-line) test utility with a trivial implementation, so duplication is the appropriate strategy per the issue guidelines. The file is copied into `test/material/` and
`test/cupertino/`, and all 4 imports are updated to reference the local copies.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
