### PR TITLE
[ Widget Preview ] Handle collections and records in custom preview annotations

### DIFF
--- a/packages/flutter_tools/lib/src/widget_preview/preview_code_generator.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/preview_code_generator.dart
@@ -184,8 +184,10 @@ class PreviewCodeGenerator {
     final File generatedPreviewFile = fs.file(
       widgetPreviewScaffoldProject.directory.uri.resolve(getGeneratedPreviewFilePath(fs)),
     );
+    final code = lib.accept(emitter).toString();
     generatedPreviewFile.writeAsStringSync(
-      DartFormatter(languageVersion: Version.none).format(lib.accept(emitter).toString()),
+      // Format the generated file for readability, particularly during feature development.
+      DartFormatter(languageVersion: Version(3, 7, 0)).format(code),
     );
   }
 
@@ -344,6 +346,27 @@ extension on DartObject {
       DartType(isDartCoreInt: true) => cb.literalNum(toIntValue()!),
       DartType(isDartCoreString: true) => cb.literalString(toStringValue()!),
       DartType(isDartCoreNull: true) => cb.literalNull,
+      DartType(isDartCoreList: true) => cb.literalList([
+        for (final item in toListValue()!) item.toExpression(),
+      ]),
+      DartType(isDartCoreMap: true) => cb.literalMap(
+        toMapValue()!.map(
+          (key, value) => MapEntry(
+            key?.toExpression() ?? cb.literalNull,
+            value?.toExpression() ?? cb.literalNull,
+          ),
+        ),
+      ),
+      DartType(isDartCoreSet: true) => cb.literalSet([
+        for (final item in toSetValue()!) item.toExpression(),
+      ]),
+      RecordType() => () {
+        final (:Map<String, DartObject> named, :List<DartObject> positional) = toRecordValue()!;
+        return cb.literalRecord(
+          positional.map((field) => field.toExpression()).toList(),
+          named.map((key, value) => MapEntry(key, value.toExpression())),
+        );
+      }(),
       InterfaceType(element: EnumElement()) => _createEnumInstance(this),
       InterfaceType() => _createInstance(type, this),
       FunctionType() => _createTearoff(toFunctionValue()!),

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_code_generator_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_code_generator_test.dart
@@ -195,13 +195,13 @@ base class CollectionsPreview extends Preview {
     this.list = const [1, 2],
     this.map = const {'a': 1},
     this.set = const {1},
-    this.record = (1, 'a'),
+    this.record = (1, 'a', named: 'b', nested: (2, 'c')),
   });
 
   final List<int> list;
   final Map<String, int> map;
   final Set<int> set;
-  final (int, String) record;
+  final (int, String, {String named, (int, String) nested}) record;
 
   @override
   Preview transform() => this;
@@ -216,7 +216,7 @@ Widget preview() => Text('Brightness Preview');
   list: [1, 2],
   map: {'a': 1},
   set: {1},
-  record: (1, 'a'),
+  record: (1, 'a', named: 'b', nested: (2, 'c')),
 )
 Widget collectionPreview() => Text('Collections Preview');
 ''';
@@ -398,7 +398,7 @@ List<_i1.WidgetPreview> previews() => [
           list: [1, 2],
           map: {'a': 1},
           set: {1},
-          record: (1, 'a'),
+          record: (1, 'a', named: 'b', nested: (2, 'c')),
         ).transform(),
   ),
   _i2.buildWidgetPreviewError(

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_code_generator_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_code_generator_test.dart
@@ -189,9 +189,36 @@ base class FixedSizePreview extends Preview {
   }
 }
 
+base class CollectionsPreview extends Preview {
+  const CollectionsPreview({
+    required super.name,
+    this.list = const [1, 2],
+    this.map = const {'a': 1},
+    this.set = const {1},
+    this.record = (1, 'a'),
+  });
+
+  final List<int> list;
+  final Map<String, int> map;
+  final Set<int> set;
+  final (int, String) record;
+
+  @override
+  Preview transform() => this;
+}
+
 @BrightnessPreview(name: 'Foo')
 @FixedSizePreview(name: 'Bar')
 Widget preview() => Text('Brightness Preview');
+
+@CollectionsPreview(
+  name: 'Collections',
+  list: [1, 2],
+  map: {'a': 1},
+  set: {1},
+  record: (1, 'a'),
+)
+Widget collectionPreview() => Text('Collections Preview');
 ''';
 
 // Note: this test isn't under the general.shard since tests under that directory
@@ -266,6 +293,7 @@ void main() {
       // There shouldn't be any state to clean up, but this doesn't hurt.
       await previewDetector.dispose();
       project.directory.deleteSync(recursive: true);
+      await fs.dispose();
     });
 
     testUsingContext(
@@ -299,87 +327,99 @@ import 'package:foo_project/src/localizations.dart' as _i10;
 import 'package:foo_project/src/custom_previews.dart' as _i11;
 
 List<_i1.WidgetPreview> previews() => [
-      _i2.buildWidgetPreview(
-        packageName: 'foo_project',
-        scriptUri: 'STRIPPED',
-        line: 4,
-        column: 1,
-        previewFunction: () => _i3.preview(),
-        transformedPreview: const _i4.Preview().transform(),
-      ),
-      _i2.buildWidgetPreview(
-        packageName: 'foo_project',
-        scriptUri: 'STRIPPED',
-        line: 10,
-        column: 1,
-        previewFunction: () => _i5.barPreview1(),
-        transformedPreview: const _i4.Preview(group: 'group').transform(),
-      ),
-      _i2.buildWidgetPreview(
-        packageName: 'foo_project',
-        scriptUri: 'STRIPPED',
-        line: 13,
-        column: 1,
-        previewFunction: () => _i5.barPreview2(),
-        transformedPreview:
-            const _i4.Preview(brightness: _i6.brightnessConstant).transform(),
-      ),
-      _i2.buildWidgetPreview(
-        packageName: 'foo_project',
-        scriptUri: 'STRIPPED',
-        line: 16,
-        column: 1,
-        previewFunction: () => _i5.barPreview3(),
-        transformedPreview: const _i4.Preview(
+  _i2.buildWidgetPreview(
+    packageName: 'foo_project',
+    scriptUri: 'STRIPPED',
+    line: 4,
+    column: 1,
+    previewFunction: () => _i3.preview(),
+    transformedPreview: const _i4.Preview().transform(),
+  ),
+  _i2.buildWidgetPreview(
+    packageName: 'foo_project',
+    scriptUri: 'STRIPPED',
+    line: 10,
+    column: 1,
+    previewFunction: () => _i5.barPreview1(),
+    transformedPreview: const _i4.Preview(group: 'group').transform(),
+  ),
+  _i2.buildWidgetPreview(
+    packageName: 'foo_project',
+    scriptUri: 'STRIPPED',
+    line: 13,
+    column: 1,
+    previewFunction: () => _i5.barPreview2(),
+    transformedPreview:
+        const _i4.Preview(brightness: _i6.brightnessConstant).transform(),
+  ),
+  _i2.buildWidgetPreview(
+    packageName: 'foo_project',
+    scriptUri: 'STRIPPED',
+    line: 16,
+    column: 1,
+    previewFunction: () => _i5.barPreview3(),
+    transformedPreview:
+        const _i4.Preview(
           group: 'group',
           name: 'Foo',
-          size: _i7.Size(
-            123.0,
-            456.0,
-          ),
+          size: _i7.Size(123.0, 456.0),
           textScaleFactor: 50.0,
           wrapper: _i8.wrapper,
           brightness: _i7.Brightness.dark,
           theme: _i9.myThemeData,
           localizations: _i10.myLocalizations,
         ).transform(),
-      ),
-      ..._i2.buildMultiWidgetPreview(
-        packageName: 'foo_project',
-        scriptUri: 'STRIPPED',
-        line: 51,
-        column: 1,
-        previewFunction: () => _i11.preview(),
-        preview: const _i11.BrightnessPreview(name: 'Foo'),
-      ),
-      _i2.buildWidgetPreview(
-        packageName: 'foo_project',
-        scriptUri: 'STRIPPED',
-        line: 52,
-        column: 1,
-        previewFunction: () => _i11.preview(),
-        transformedPreview:
-            const _i11.FixedSizePreview(name: 'Bar').transform(),
-      ),
-      _i2.buildWidgetPreviewError(
-        packageName: 'foo_project',
-        scriptUri: 'STRIPPED',
-        line: 6,
-        column: 1,
-        packageUri: 'package:foo_project/src/error.dart',
-        functionName: 'preview',
-        dependencyHasErrors: false,
-      ),
-      _i2.buildWidgetPreviewError(
-        packageName: 'foo_project',
-        scriptUri: 'STRIPPED',
-        line: 6,
-        column: 1,
-        packageUri: 'package:foo_project/src/transitive_error.dart',
-        functionName: 'preview',
-        dependencyHasErrors: true,
-      ),
-    ];
+  ),
+  ..._i2.buildMultiWidgetPreview(
+    packageName: 'foo_project',
+    scriptUri: 'STRIPPED',
+    line: 69,
+    column: 1,
+    previewFunction: () => _i11.preview(),
+    preview: const _i11.BrightnessPreview(name: 'Foo'),
+  ),
+  _i2.buildWidgetPreview(
+    packageName: 'foo_project',
+    scriptUri: 'STRIPPED',
+    line: 70,
+    column: 1,
+    previewFunction: () => _i11.preview(),
+    transformedPreview: const _i11.FixedSizePreview(name: 'Bar').transform(),
+  ),
+  _i2.buildWidgetPreview(
+    packageName: 'foo_project',
+    scriptUri: 'STRIPPED',
+    line: 73,
+    column: 1,
+    previewFunction: () => _i11.collectionPreview(),
+    transformedPreview:
+        const _i11.CollectionsPreview(
+          name: 'Collections',
+          list: [1, 2],
+          map: {'a': 1},
+          set: {1},
+          record: (1, 'a'),
+        ).transform(),
+  ),
+  _i2.buildWidgetPreviewError(
+    packageName: 'foo_project',
+    scriptUri: 'STRIPPED',
+    line: 6,
+    column: 1,
+    packageUri: 'package:foo_project/src/error.dart',
+    functionName: 'preview',
+    dependencyHasErrors: false,
+  ),
+  _i2.buildWidgetPreviewError(
+    packageName: 'foo_project',
+    scriptUri: 'STRIPPED',
+    line: 6,
+    column: 1,
+    packageUri: 'package:foo_project/src/transitive_error.dart',
+    functionName: 'preview',
+    dependencyHasErrors: true,
+  ),
+];
 ''';
         expect(
           generatedPreviewFile.readAsStringSync().stripScriptUris,

--- a/packages/flutter_tools/test/commands.shard/permeable/widget_preview/widget_preview_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/widget_preview/widget_preview_test.dart
@@ -438,15 +438,15 @@ import 'package:flutter_project/foo.dart' as _i3;
 import 'package:flutter/src/widget_previews/widget_previews.dart' as _i4;
 
 List<_i1.WidgetPreview> previews() => [
-      _i2.buildWidgetPreview(
-        packageName: 'flutter_project',
-        scriptUri: 'STRIPPED',
-        line: 4,
-        column: 1,
-        previewFunction: () => _i3.preview(),
-        transformedPreview: const _i4.Preview(name: 'preview').transform(),
-      )
-    ];
+  _i2.buildWidgetPreview(
+    packageName: 'flutter_project',
+    scriptUri: 'STRIPPED',
+    line: 4,
+    column: 1,
+    previewFunction: () => _i3.preview(),
+    transformedPreview: const _i4.Preview(name: 'preview').transform(),
+  ),
+];
 ''';
 
     group('LSP-based preview detection', () {


### PR DESCRIPTION
The code generator wasn't configured to handle collections and records as preview arguments as these types weren't originally accepted by the `Preview(...)` constructor. This caused these types to be treated as regular instances, resulting in the previewer crashing.

This change adds support for collections and records as preview annotation arguments.

Fixes https://github.com/flutter/flutter/issues/181754