### PR TITLE
Remove editable_text_utils cross-imports from material and cupertino …

### DIFF
--- a/packages/flutter/test/cupertino/editable_text_utils.dart
+++ b/packages/flutter/test/cupertino/editable_text_utils.dart
@@ -1,0 +1,147 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// On web, the context menu (aka toolbar) is provided by the browser.
+const bool isContextMenuProvidedByPlatform = isBrowser;
+
+/// Returns the [RenderEditable] at the given [index], or the first if not
+/// given.
+RenderEditable findRenderEditable(WidgetTester tester, {int index = 0}) {
+  final RenderObject root = tester.renderObject(find.byType(EditableText).at(index));
+  expect(root, isNotNull);
+
+  late RenderEditable renderEditable;
+  void recursiveFinder(RenderObject child) {
+    if (child is RenderEditable) {
+      renderEditable = child;
+      return;
+    }
+    child.visitChildren(recursiveFinder);
+  }
+
+  root.visitChildren(recursiveFinder);
+  expect(renderEditable, isNotNull);
+  return renderEditable;
+}
+
+/// Converts a list of local [TextSelectionPoint]s to global coordinates.
+List<TextSelectionPoint> globalize(Iterable<TextSelectionPoint> points, RenderBox box) {
+  return points.map<TextSelectionPoint>((TextSelectionPoint point) {
+    return TextSelectionPoint(box.localToGlobal(point.point), point.direction);
+  }).toList();
+}
+
+/// Returns the global position of the character at the given [offset] in the
+/// [EditableText] found at the given [index].
+Offset textOffsetToPosition(WidgetTester tester, int offset, {int index = 0}) {
+  final RenderEditable renderEditable = findRenderEditable(tester, index: index);
+  final List<TextSelectionPoint> endpoints = globalize(
+    renderEditable.getEndpointsForSelection(TextSelection.collapsed(offset: offset)),
+    renderEditable,
+  );
+  expect(endpoints.length, 1);
+  return endpoints[0].point + const Offset(kIsWeb ? 1.0 : 0.0, -2.0);
+}
+
+/// Mimic key press events by sending key down and key up events via the [tester].
+Future<void> sendKeys(
+  WidgetTester tester,
+  List<LogicalKeyboardKey> keys, {
+  bool shift = false,
+  bool wordModifier = false,
+  bool lineModifier = false,
+  bool shortcutModifier = false,
+  required TargetPlatform targetPlatform,
+}) async {
+  final targetPlatformString = targetPlatform.toString();
+  final String platform = targetPlatformString
+      .substring(targetPlatformString.indexOf('.') + 1)
+      .toLowerCase();
+  if (shift) {
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft, platform: platform);
+  }
+  if (shortcutModifier) {
+    await tester.sendKeyDownEvent(
+      platform == 'macos' || platform == 'ios'
+          ? LogicalKeyboardKey.metaLeft
+          : LogicalKeyboardKey.controlLeft,
+      platform: platform,
+    );
+  }
+  if (wordModifier) {
+    await tester.sendKeyDownEvent(
+      platform == 'macos' || platform == 'ios'
+          ? LogicalKeyboardKey.altLeft
+          : LogicalKeyboardKey.controlLeft,
+      platform: platform,
+    );
+  }
+  if (lineModifier) {
+    await tester.sendKeyDownEvent(
+      platform == 'macos' || platform == 'ios'
+          ? LogicalKeyboardKey.metaLeft
+          : LogicalKeyboardKey.altLeft,
+      platform: platform,
+    );
+  }
+  for (final key in keys) {
+    await tester.sendKeyEvent(key, platform: platform);
+    await tester.pump();
+  }
+  if (lineModifier) {
+    await tester.sendKeyUpEvent(
+      platform == 'macos' || platform == 'ios'
+          ? LogicalKeyboardKey.metaLeft
+          : LogicalKeyboardKey.altLeft,
+      platform: platform,
+    );
+  }
+  if (wordModifier) {
+    await tester.sendKeyUpEvent(
+      platform == 'macos' || platform == 'ios'
+          ? LogicalKeyboardKey.altLeft
+          : LogicalKeyboardKey.controlLeft,
+      platform: platform,
+    );
+  }
+  if (shortcutModifier) {
+    await tester.sendKeyUpEvent(
+      platform == 'macos' || platform == 'ios'
+          ? LogicalKeyboardKey.metaLeft
+          : LogicalKeyboardKey.controlLeft,
+      platform: platform,
+    );
+  }
+  if (shift) {
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft, platform: platform);
+  }
+  if (shift || wordModifier || lineModifier) {
+    await tester.pump();
+  }
+}
+
+/// A [TextEditingController] that builds a [WidgetSpan] with 100 height for
+/// testing overflow behavior.
+class OverflowWidgetTextEditingController extends TextEditingController {
+  @override
+  TextSpan buildTextSpan({
+    required BuildContext context,
+    TextStyle? style,
+    required bool withComposing,
+  }) {
+    return TextSpan(
+      style: style,
+      children: <InlineSpan>[
+        const TextSpan(text: 'Hi'),
+        WidgetSpan(child: Container(color: const Color(0xffff0000), height: 100.0)),
+      ],
+    );
+  }
+}

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -24,9 +24,9 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../widgets/clipboard_utils.dart';
-import '../widgets/editable_text_utils.dart';
 import '../widgets/semantics_tester.dart';
 import '../widgets/text_selection_toolbar_utils.dart';
+import 'editable_text_utils.dart';
 import 'live_text_utils.dart';
 
 class MockTextSelectionControls extends TextSelectionControls {

--- a/packages/flutter/test/cupertino/text_form_field_row_test.dart
+++ b/packages/flutter/test/cupertino/text_form_field_row_test.dart
@@ -9,7 +9,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/src/services/spell_check.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/editable_text_utils.dart';
+import 'editable_text_utils.dart';
 
 void main() {
   testWidgets('Passes textAlign to underlying CupertinoTextField', (WidgetTester tester) async {

--- a/packages/flutter/test/cupertino/text_selection_test.dart
+++ b/packages/flutter/test/cupertino/text_selection_test.dart
@@ -17,7 +17,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../widgets/clipboard_utils.dart';
-import '../widgets/editable_text_utils.dart' show findRenderEditable, textOffsetToPosition;
+import 'editable_text_utils.dart' show findRenderEditable, textOffsetToPosition;
 
 class _LongCupertinoLocalizationsDelegate extends LocalizationsDelegate<CupertinoLocalizations> {
   const _LongCupertinoLocalizationsDelegate();

--- a/packages/flutter/test/cupertino/text_selection_toolbar_test.dart
+++ b/packages/flutter/test/cupertino/text_selection_toolbar_test.dart
@@ -11,7 +11,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/editable_text_utils.dart' show textOffsetToPosition;
+import 'editable_text_utils.dart' show textOffsetToPosition;
 
 // These constants are copied from cupertino/text_selection_toolbar.dart.
 const double _kArrowScreenPadding = 26.0;

--- a/packages/flutter/test/material/adaptive_text_selection_toolbar_test.dart
+++ b/packages/flutter/test/material/adaptive_text_selection_toolbar_test.dart
@@ -8,8 +8,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import '../widgets/clipboard_utils.dart';
-import '../widgets/editable_text_utils.dart';
 import '../widgets/text_selection_toolbar_utils.dart';
+import 'editable_text_utils.dart';
 import 'live_text_utils.dart';
 
 void main() {

--- a/packages/flutter/test/material/editable_text_utils.dart
+++ b/packages/flutter/test/material/editable_text_utils.dart
@@ -1,0 +1,147 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// On web, the context menu (aka toolbar) is provided by the browser.
+const bool isContextMenuProvidedByPlatform = isBrowser;
+
+/// Returns the [RenderEditable] at the given [index], or the first if not
+/// given.
+RenderEditable findRenderEditable(WidgetTester tester, {int index = 0}) {
+  final RenderObject root = tester.renderObject(find.byType(EditableText).at(index));
+  expect(root, isNotNull);
+
+  late RenderEditable renderEditable;
+  void recursiveFinder(RenderObject child) {
+    if (child is RenderEditable) {
+      renderEditable = child;
+      return;
+    }
+    child.visitChildren(recursiveFinder);
+  }
+
+  root.visitChildren(recursiveFinder);
+  expect(renderEditable, isNotNull);
+  return renderEditable;
+}
+
+/// Converts a list of local [TextSelectionPoint]s to global coordinates.
+List<TextSelectionPoint> globalize(Iterable<TextSelectionPoint> points, RenderBox box) {
+  return points.map<TextSelectionPoint>((TextSelectionPoint point) {
+    return TextSelectionPoint(box.localToGlobal(point.point), point.direction);
+  }).toList();
+}
+
+/// Returns the global position of the character at the given [offset] in the
+/// [EditableText] found at the given [index].
+Offset textOffsetToPosition(WidgetTester tester, int offset, {int index = 0}) {
+  final RenderEditable renderEditable = findRenderEditable(tester, index: index);
+  final List<TextSelectionPoint> endpoints = globalize(
+    renderEditable.getEndpointsForSelection(TextSelection.collapsed(offset: offset)),
+    renderEditable,
+  );
+  expect(endpoints.length, 1);
+  return endpoints[0].point + const Offset(kIsWeb ? 1.0 : 0.0, -2.0);
+}
+
+/// Mimic key press events by sending key down and key up events via the [tester].
+Future<void> sendKeys(
+  WidgetTester tester,
+  List<LogicalKeyboardKey> keys, {
+  bool shift = false,
+  bool wordModifier = false,
+  bool lineModifier = false,
+  bool shortcutModifier = false,
+  required TargetPlatform targetPlatform,
+}) async {
+  final targetPlatformString = targetPlatform.toString();
+  final String platform = targetPlatformString
+      .substring(targetPlatformString.indexOf('.') + 1)
+      .toLowerCase();
+  if (shift) {
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft, platform: platform);
+  }
+  if (shortcutModifier) {
+    await tester.sendKeyDownEvent(
+      platform == 'macos' || platform == 'ios'
+          ? LogicalKeyboardKey.metaLeft
+          : LogicalKeyboardKey.controlLeft,
+      platform: platform,
+    );
+  }
+  if (wordModifier) {
+    await tester.sendKeyDownEvent(
+      platform == 'macos' || platform == 'ios'
+          ? LogicalKeyboardKey.altLeft
+          : LogicalKeyboardKey.controlLeft,
+      platform: platform,
+    );
+  }
+  if (lineModifier) {
+    await tester.sendKeyDownEvent(
+      platform == 'macos' || platform == 'ios'
+          ? LogicalKeyboardKey.metaLeft
+          : LogicalKeyboardKey.altLeft,
+      platform: platform,
+    );
+  }
+  for (final key in keys) {
+    await tester.sendKeyEvent(key, platform: platform);
+    await tester.pump();
+  }
+  if (lineModifier) {
+    await tester.sendKeyUpEvent(
+      platform == 'macos' || platform == 'ios'
+          ? LogicalKeyboardKey.metaLeft
+          : LogicalKeyboardKey.altLeft,
+      platform: platform,
+    );
+  }
+  if (wordModifier) {
+    await tester.sendKeyUpEvent(
+      platform == 'macos' || platform == 'ios'
+          ? LogicalKeyboardKey.altLeft
+          : LogicalKeyboardKey.controlLeft,
+      platform: platform,
+    );
+  }
+  if (shortcutModifier) {
+    await tester.sendKeyUpEvent(
+      platform == 'macos' || platform == 'ios'
+          ? LogicalKeyboardKey.metaLeft
+          : LogicalKeyboardKey.controlLeft,
+      platform: platform,
+    );
+  }
+  if (shift) {
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft, platform: platform);
+  }
+  if (shift || wordModifier || lineModifier) {
+    await tester.pump();
+  }
+}
+
+/// A [TextEditingController] that builds a [WidgetSpan] with 100 height for
+/// testing overflow behavior.
+class OverflowWidgetTextEditingController extends TextEditingController {
+  @override
+  TextSpan buildTextSpan({
+    required BuildContext context,
+    TextStyle? style,
+    required bool withComposing,
+  }) {
+    return TextSpan(
+      style: style,
+      children: <InlineSpan>[
+        const TextSpan(text: 'Hi'),
+        WidgetSpan(child: Container(color: const Color(0xffff0000), height: 100.0)),
+      ],
+    );
+  }
+}

--- a/packages/flutter/test/material/selectable_text_test.dart
+++ b/packages/flutter/test/material/selectable_text_test.dart
@@ -21,7 +21,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import '../widgets/clipboard_utils.dart';
-import '../widgets/editable_text_utils.dart' show textOffsetToPosition;
+import 'editable_text_utils.dart' show textOffsetToPosition;
 import '../widgets/semantics_tester.dart';
 
 class MaterialLocalizationsDelegate extends LocalizationsDelegate<MaterialLocalizations> {

--- a/packages/flutter/test/material/selectable_text_test.dart
+++ b/packages/flutter/test/material/selectable_text_test.dart
@@ -21,8 +21,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import '../widgets/clipboard_utils.dart';
-import 'editable_text_utils.dart' show textOffsetToPosition;
 import '../widgets/semantics_tester.dart';
+import 'editable_text_utils.dart' show textOffsetToPosition;
 
 class MaterialLocalizationsDelegate extends LocalizationsDelegate<MaterialLocalizations> {
   @override

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -25,7 +25,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../widgets/clipboard_utils.dart';
-import '../widgets/editable_text_utils.dart';
+import 'editable_text_utils.dart';
 import '../widgets/feedback_tester.dart';
 import '../widgets/process_text_utils.dart';
 import '../widgets/semantics_tester.dart';

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -25,11 +25,11 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../widgets/clipboard_utils.dart';
-import 'editable_text_utils.dart';
 import '../widgets/feedback_tester.dart';
 import '../widgets/process_text_utils.dart';
 import '../widgets/semantics_tester.dart';
 import '../widgets/text_selection_toolbar_utils.dart';
+import 'editable_text_utils.dart';
 import 'live_text_utils.dart';
 
 void main() {

--- a/packages/flutter/test/material/text_form_field_test.dart
+++ b/packages/flutter/test/material/text_form_field_test.dart
@@ -13,7 +13,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../widgets/clipboard_utils.dart';
-import '../widgets/editable_text_utils.dart';
+import 'editable_text_utils.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/packages/flutter/test/material/text_selection_test.dart
+++ b/packages/flutter/test/material/text_selection_test.dart
@@ -13,7 +13,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../widgets/clipboard_utils.dart';
-import '../widgets/editable_text_utils.dart'
+import 'editable_text_utils.dart'
     show findRenderEditable, globalize, textOffsetToPosition;
 
 void main() {

--- a/packages/flutter/test/material/text_selection_test.dart
+++ b/packages/flutter/test/material/text_selection_test.dart
@@ -13,8 +13,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../widgets/clipboard_utils.dart';
-import 'editable_text_utils.dart'
-    show findRenderEditable, globalize, textOffsetToPosition;
+import 'editable_text_utils.dart' show findRenderEditable, globalize, textOffsetToPosition;
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/packages/flutter/test/material/text_selection_toolbar_test.dart
+++ b/packages/flutter/test/material/text_selection_toolbar_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/editable_text_utils.dart' show textOffsetToPosition;
+import 'editable_text_utils.dart' show textOffsetToPosition;
 
 const double _kToolbarContentDistance = 8.0;
 


### PR DESCRIPTION
Remove cross-directory test imports of `editable_text_utils.dart` from material and cupertino tests.

Part of #182636.

`editable_text_utils.dart` is a 143-line test utility containing `textOffsetToPosition`, `findRenderEditable`, `globalize`, `sendKeys`, `isContextMenuProvidedByPlatform`, and
`OverflowWidgetTextEditingController`. Duplication is the appropriate strategy per the issue guidelines. The file is copied into `test/material/` and `test/cupertino/`, and all 10 imports are updated to
reference the local copies.

This also unblocks a future PR to remove `text_selection_toolbar_utils` cross-imports, which depends on `editable_text_utils`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
