### PR TITLE
Add more 0x0 size tests part 7

### DIFF
--- a/packages/flutter/test/material/button_bar_test.dart
+++ b/packages/flutter/test/material/button_bar_test.dart
@@ -632,4 +632,19 @@ void main() {
     expect(renderButtonBar.debugNeedsLayout, isTrue);
     expect(() => renderButtonBar.constraints, throwsStateError);
   });
+
+  testWidgets('ButtonBar does not crash at zero area', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: SizedBox.shrink(
+            child: ButtonBar(
+              children: <Widget>[TextButton(onPressed: () {}, child: const Text('X'))],
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(tester.getSize(find.byType(ButtonBar)), Size.zero);
+  });
 }

--- a/packages/flutter/test/material/material_button_test.dart
+++ b/packages/flutter/test/material/material_button_test.dart
@@ -971,4 +971,17 @@ void main() {
     final RawMaterialButton rawMaterialButton = tester.widget(rawMaterialButtonFinder);
     expect(rawMaterialButton.disabledElevation, equals(0.0));
   });
+
+  testWidgets('MaterialButton does not crash at zero area', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: SizedBox.shrink(
+            child: MaterialButton(onPressed: () {}, child: const Text('X')),
+          ),
+        ),
+      ),
+    );
+    expect(tester.getSize(find.byType(MaterialButton)), Size.zero);
+  });
 }

--- a/packages/flutter/test/material/raw_material_button_test.dart
+++ b/packages/flutter/test/material/raw_material_button_test.dart
@@ -663,4 +663,15 @@ void main() {
       SystemMouseCursors.basic,
     );
   });
+
+  testWidgets('RawMaterialButton does not crash at zero area', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: SizedBox.shrink(child: RawMaterialButton(onPressed: () {})),
+        ),
+      ),
+    );
+    expect(tester.getSize(find.byType(RawMaterialButton)), Size.zero);
+  });
 }

--- a/packages/flutter/test/widgets/snapshot_widget_test.dart
+++ b/packages/flutter/test/widgets/snapshot_widget_test.dart
@@ -340,6 +340,21 @@ void main() {
       areCreateAndDispose,
     );
   });
+
+  testWidgets('SnapshotWidget does not crash at zero area', (WidgetTester tester) async {
+    final controller = SnapshotController();
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: Center(
+          child: SizedBox.shrink(
+            child: SnapshotWidget(controller: controller, child: const Placeholder()),
+          ),
+        ),
+      ),
+    );
+    expect(tester.getSize(find.byType(SnapshotWidget)), Size.zero);
+  });
 }
 
 class TestPlatformView extends SingleChildRenderObjectWidget {

--- a/packages/flutter/test/widgets/spacer_test.dart
+++ b/packages/flutter/test/widgets/spacer_test.dart
@@ -76,4 +76,16 @@ void main() {
     expect(spacerRect.topLeft, const Offset(400.0, 10.0));
     expect(flexRect, const Rect.fromLTWH(390.0, 0.0, 20.0, 600.0));
   });
+
+  testWidgets('Spacer does not crash at zero area', (WidgetTester tester) async {
+    tester.view.physicalSize = Size.zero;
+    addTearDown(tester.view.reset);
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Column(children: [Spacer()]),
+      ),
+    );
+    expect(tester.getSize(find.byType(Spacer)), Size.zero);
+  });
 }

--- a/packages/flutter/test/widgets/stretch_effect_test.dart
+++ b/packages/flutter/test/widgets/stretch_effect_test.dart
@@ -53,4 +53,18 @@ void main() {
     // Skips this test when fragment shaders are not used.
     skip: !shaderSupported,
   );
+
+  testWidgets('StretchEffect does not crash at zero area', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: SizedBox.shrink(
+            child: StretchEffect(axis: Axis.vertical, child: Placeholder()),
+          ),
+        ),
+      ),
+    );
+    expect(tester.getSize(find.byType(StretchEffect)), Size.zero);
+  });
 }

--- a/packages/flutter/test/widgets/table_test.dart
+++ b/packages/flutter/test/widgets/table_test.dart
@@ -1054,4 +1054,21 @@ void main() {
     final int? cellWrapperIdAfterUIchanges = textFieldSemanticsNodeNew.parent?.id;
     expect(cellWrapperIdAfterUIchanges, cellWrapperId);
   });
+
+  testWidgets('Table does not crash at zero area', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: Center(
+          child: SizedBox.shrink(
+            child: Table(
+              children: const <TableRow>[
+                TableRow(children: <Widget>[Placeholder()]),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(tester.getSize(find.byType(Table)), Size.zero);
+  });
 }

--- a/packages/flutter/test/widgets/tap_region_test.dart
+++ b/packages/flutter/test/widgets/tap_region_test.dart
@@ -1253,4 +1253,16 @@ void main() {
     );
     expect(tester.getSize(find.byType(TapRegionSurface)), Size.zero);
   });
+
+  testWidgets('TapRegion does not crash at zero area', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: SizedBox.shrink(child: TapRegion(child: Placeholder())),
+        ),
+      ),
+    );
+    expect(tester.getSize(find.byType(TapRegion)), Size.zero);
+  });
 }

--- a/packages/flutter/test/widgets/tap_region_test.dart
+++ b/packages/flutter/test/widgets/tap_region_test.dart
@@ -1241,4 +1241,16 @@ void main() {
       reason: 'Button tap was not consumed by a TapRegion on a non-current route',
     );
   });
+
+  testWidgets('TapRegionSurface does not crash at zero area', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: SizedBox.shrink(child: TapRegionSurface(child: Placeholder())),
+        ),
+      ),
+    );
+    expect(tester.getSize(find.byType(TapRegionSurface)), Size.zero);
+  });
 }

--- a/packages/flutter/test/widgets/tap_region_test.dart
+++ b/packages/flutter/test/widgets/tap_region_test.dart
@@ -1265,4 +1265,16 @@ void main() {
     );
     expect(tester.getSize(find.byType(TapRegion)), Size.zero);
   });
+
+  testWidgets('TextFieldTapRegion does not crash at zero area', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: SizedBox.shrink(child: TextFieldTapRegion(child: Placeholder())),
+        ),
+      ),
+    );
+    expect(tester.getSize(find.byType(TextFieldTapRegion)), Size.zero);
+  });
 }


### PR DESCRIPTION
This is my attempt to handle https://github.com/flutter/flutter/issues/6537 for the following widgets:
TapRegionSurface
TapRegion
TextFieldTapRegion
Table
StretchEffect
Spacer
SnapshotWidget
ButtonBar
RawMaterialButton
MaterialButton