### PR TITLE
Improvements and refactoring of UberSDF and Circle SDF classes

### DIFF
--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -50,19 +50,19 @@
 #include "impeller/entity/geometry/line_geometry.h"
 #include "impeller/entity/geometry/point_field_geometry.h"
 #include "impeller/entity/geometry/rect_geometry.h"
+#include "impeller/entity/geometry/sdf_compatible_geometry.h"
 #include "impeller/entity/geometry/shadow_path_geometry.h"
 #include "impeller/entity/geometry/stroke_path_geometry.h"
 #include "impeller/entity/save_layer_utils.h"
 #include "impeller/geometry/color.h"
 #include "impeller/geometry/constants.h"
 #include "impeller/geometry/rstransform.h"
+#include "impeller/geometry/stroke_parameters.h"
 #include "impeller/renderer/command_buffer.h"
 
 namespace impeller {
 
 namespace {
-
-constexpr Scalar kAntialiasPadding = 1.0f;
 
 bool IsPipelineBlendOrMatrixFilter(const flutter::DlColorFilter* filter) {
   return filter->type() == flutter::DlColorFilterType::kMatrix ||
@@ -522,35 +522,6 @@ bool Canvas::AttemptColorFilterOptimization(
   return true;
 }
 
-bool Canvas::AttemptDrawAntialiasedCircle(const Point& center,
-                                          Scalar radius,
-                                          const Paint& paint) {
-  if (paint.HasColorFilter() || paint.image_filter || paint.invert_colors ||
-      paint.color_source || paint.mask_blur_descriptor.has_value()) {
-    return false;
-  }
-
-  Entity entity;
-  entity.SetTransform(GetCurrentTransform());
-  entity.SetBlendMode(paint.blend_mode);
-
-  const bool is_stroked = paint.style == Paint::Style::kStroke;
-  std::unique_ptr<CircleGeometry> geom;
-  if (is_stroked) {
-    geom = std::make_unique<CircleGeometry>(center, radius, paint.stroke.width);
-  } else {
-    geom = std::make_unique<CircleGeometry>(center, radius);
-  }
-  geom->SetAntialiasPadding(kAntialiasPadding);
-
-  auto contents =
-      CircleContents::Make(std::move(geom), paint.color, is_stroked);
-  entity.SetContents(std::move(contents));
-  AddRenderEntityToCurrentPass(entity);
-
-  return true;
-}
-
 bool Canvas::IsShadowBlurDrawOperation(const Paint& paint) {
   if (paint.style != Paint::Style::kFill) {
     return false;
@@ -825,34 +796,22 @@ void Canvas::DrawRect(const Rect& rect, const Paint& paint) {
   entity.SetTransform(GetCurrentTransform());
   entity.SetBlendMode(paint.blend_mode);
 
-  if (renderer_.GetContext()->GetFlags().use_sdfs &&
-      !paint.mask_blur_descriptor.has_value()) {
-    Scalar expand_size = kAntialiasPadding;
-    if (paint.style == Paint::Style::kStroke) {
-      expand_size += LineGeometry::ComputePixelHalfWidth(GetCurrentTransform(),
-                                                         paint.stroke.width);
-    }
-
-    FillRectGeometry geometry(rect);
-    geometry.SetAntialiasPadding(expand_size);
-
-    auto contents = UberSDFContents::MakeRect(
-        /*color=*/paint.color, /*stroke_width=*/paint.stroke.width,
-        /*stroke_join=*/paint.stroke.join,
-        /*stroked=*/paint.style == Paint::Style::kStroke, &geometry);
-
-    const Geometry* geom = contents->GetGeometry();
-
-    AddRenderSDFEntityToCurrentPass(entity, geom, paint, std::move(contents));
-    return;
+  std::unique_ptr<SDFCompatibleGeometry> geom;
+  if (paint.style == Paint::Style::kStroke) {
+    geom = std::make_unique<StrokeRectGeometry>(rect, paint.stroke);
+  } else {
+    geom = std::make_unique<FillRectGeometry>(rect);
   }
 
-  if (paint.style == Paint::Style::kStroke) {
-    StrokeRectGeometry geom(rect, paint.stroke);
-    AddRenderEntityWithFiltersToCurrentPass(entity, &geom, paint);
+  if (renderer_.GetContext()->GetFlags().use_sdfs &&
+      !paint.mask_blur_descriptor.has_value()) {
+    // Draw SDF rect.
+    auto contents = UberSDFContents::Make(UberSDFContents::Type::kRect,
+                                          paint.color, geom.get());
+    AddRenderSDFEntityToCurrentPass(entity, paint, std::move(contents));
   } else {
-    FillRectGeometry geom(rect);
-    AddRenderEntityWithFiltersToCurrentPass(entity, &geom, paint);
+    // Draw non-SDF rect.
+    AddRenderEntityWithFiltersToCurrentPass(entity, geom.get(), paint);
   }
 }
 
@@ -1031,45 +990,32 @@ void Canvas::DrawCircle(const Point& center,
     }
   }
 
-  if (renderer_.GetContext()->GetFlags().use_sdfs &&
-      !paint.mask_blur_descriptor.has_value()) {
-    const bool is_stroked = paint.style == Paint::Style::kStroke;
-
-    std::optional<CircleGeometry> geometry;
-    if (is_stroked) {
-      geometry.emplace(center, radius, paint.stroke.width);
-    } else {
-      geometry.emplace(center, radius);
-    }
-    geometry->SetAntialiasPadding(1.0f);
-
-    auto contents = UberSDFContents::MakeCircle(
-        /*color=*/paint.color, /*stroked=*/is_stroked, &geometry.value());
-
-    Entity entity;
-    entity.SetTransform(GetCurrentTransform());
-    entity.SetBlendMode(paint.blend_mode);
-
-    const Geometry* geom = contents->GetGeometry();
-
-    AddRenderSDFEntityToCurrentPass(entity, geom, paint, std::move(contents));
-    return;
-  }
-
-  if (AttemptDrawAntialiasedCircle(center, radius, paint)) {
-    return;
-  }
-
   Entity entity;
   entity.SetTransform(GetCurrentTransform());
   entity.SetBlendMode(paint.blend_mode);
 
-  if (paint.style == Paint::Style::kStroke) {
-    CircleGeometry geom(center, radius, paint.stroke.width);
-    AddRenderEntityWithFiltersToCurrentPass(entity, &geom, paint);
+  std::optional<Scalar> stroke_width =
+      paint.style == Paint::Style::kStroke
+          ? std::make_optional(paint.stroke.width)
+          : std::nullopt;
+  auto geom = std::make_unique<CircleGeometry>(center, radius, stroke_width);
+
+  if (renderer_.GetContext()->GetFlags().use_sdfs &&
+      !paint.mask_blur_descriptor.has_value()) {
+    // Draw SDF circle using UberSDFContents.
+    auto contents = UberSDFContents::Make(UberSDFContents::Type::kCircle,
+                                          paint.color, geom.get());
+    AddRenderSDFEntityToCurrentPass(entity, paint, std::move(contents));
+  } else if (!(paint.HasColorFilter() || paint.image_filter ||
+               paint.invert_colors || paint.color_source ||
+               paint.mask_blur_descriptor.has_value())) {
+    // Draw SDF circle using CircleContents.
+    auto contents = CircleContents::Make(std::move(geom), paint.color);
+    entity.SetContents(std::move(contents));
+    AddRenderEntityToCurrentPass(entity);
   } else {
-    CircleGeometry geom(center, radius);
-    AddRenderEntityWithFiltersToCurrentPass(entity, &geom, paint);
+    // Draw non-SDF circle.
+    AddRenderEntityWithFiltersToCurrentPass(entity, geom.get(), paint);
   }
 }
 
@@ -1960,9 +1906,9 @@ void Canvas::DrawTextFrame(const std::shared_ptr<TextFrame>& text_frame,
 
 void Canvas::AddRenderSDFEntityToCurrentPass(
     Entity& entity,
-    const Geometry* geom,
     const Paint& paint,
     std::shared_ptr<ColorSourceContents> contents) {
+  const Geometry* geom = contents->GetGeometry();
   if (paint.color_source) {
     // UberSDF doesn't perform things like gradients so we blend the SDF
     // with the color source.

--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -807,7 +807,7 @@ void Canvas::DrawRect(const Rect& rect, const Paint& paint) {
       !paint.mask_blur_descriptor.has_value()) {
     // Draw SDF rect.
     auto contents = UberSDFContents::Make(UberSDFContents::Type::kRect,
-                                          paint.color, geom.get());
+                                          paint.color, std::move(geom));
     AddRenderSDFEntityToCurrentPass(entity, paint, std::move(contents));
   } else {
     // Draw non-SDF rect.
@@ -1004,7 +1004,7 @@ void Canvas::DrawCircle(const Point& center,
       !paint.mask_blur_descriptor.has_value()) {
     // Draw SDF circle using UberSDFContents.
     auto contents = UberSDFContents::Make(UberSDFContents::Type::kCircle,
-                                          paint.color, geom.get());
+                                          paint.color, std::move(geom));
     AddRenderSDFEntityToCurrentPass(entity, paint, std::move(contents));
   } else if (!(paint.HasColorFilter() || paint.image_filter ||
                paint.invert_colors || paint.color_source ||

--- a/engine/src/flutter/impeller/display_list/canvas.h
+++ b/engine/src/flutter/impeller/display_list/canvas.h
@@ -383,7 +383,6 @@ class Canvas {
 
   void AddRenderSDFEntityToCurrentPass(
       Entity& entity,
-      const Geometry* geom,
       const Paint& paint,
       std::shared_ptr<ColorSourceContents> contents);
 

--- a/engine/src/flutter/impeller/entity/contents/circle_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/circle_contents.cc
@@ -41,7 +41,7 @@ bool CircleContents::Render(const ContentContext& renderer,
   auto& data_host_buffer = renderer.GetTransientsDataBuffer();
 
   VS::FrameInfo frame_info;
-  FS::FragInfo frag_info;
+  FS::FragInfo frag_info = {};
   frag_info.color = color_.WithAlpha(color_.alpha * GetOpacityFactor());
 
   Rect bounds = geometry_->GetBaseShapeBounds();

--- a/engine/src/flutter/impeller/entity/contents/circle_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/circle_contents.cc
@@ -11,6 +11,9 @@
 namespace impeller {
 
 namespace {
+
+static constexpr Scalar kDefaultAntialiasPadding = 1.0f;
+
 using PipelineBuilderCallback =
     std::function<PipelineRef(ContentContextOptions)>;
 
@@ -21,21 +24,16 @@ using FS = CirclePipeline::FragmentShader;
 
 std::unique_ptr<CircleContents> CircleContents::Make(
     std::unique_ptr<CircleGeometry> geometry,
-    Color color,
-    bool stroked) {
-  Scalar aa_padding = geometry->GetAntialiasPadding();
+    Color color) {
   return std::unique_ptr<CircleContents>(
-      new CircleContents(std::move(geometry), color, stroked, aa_padding));
+      new CircleContents(std::move(geometry), color));
 }
 
 CircleContents::CircleContents(std::unique_ptr<CircleGeometry> geometry,
-                               Color color,
-                               bool stroked,
-                               Scalar aa_padding)
-    : geometry_(std::move(geometry)),
-      color_(color),
-      stroked_(stroked),
-      aa_padding_(aa_padding) {}
+                               Color color)
+    : geometry_(std::move(geometry)), color_(color) {
+  geometry_->SetAntialiasPadding(kDefaultAntialiasPadding);
+}
 
 bool CircleContents::Render(const ContentContext& renderer,
                             const Entity& entity,
@@ -45,11 +43,16 @@ bool CircleContents::Render(const ContentContext& renderer,
   VS::FrameInfo frame_info;
   FS::FragInfo frag_info;
   frag_info.color = color_.WithAlpha(color_.alpha * GetOpacityFactor());
-  frag_info.center = geometry_->GetCenter();
-  frag_info.radius = geometry_->GetRadius();
-  frag_info.stroke_width = geometry_->GetStrokeWidth();
-  frag_info.aa_pixels = aa_padding_;
-  frag_info.stroked = stroked_ ? 1.0f : 0.0f;
+
+  Rect bounds = geometry_->GetBaseShapeBounds();
+  frag_info.center = bounds.GetCenter();
+  frag_info.radius = bounds.GetWidth() * 0.5f;
+
+  auto stroke = geometry_->GetStrokeParameters();
+  frag_info.stroked = stroke ? 1.0f : 0.0f;
+  frag_info.stroke_width = stroke ? stroke->width : 0.0f;
+
+  frag_info.aa_pixels = geometry_->GetAntialiasPadding();
 
   auto geometry_result = geometry_->GetPositionBuffer(renderer, entity, pass);
 

--- a/engine/src/flutter/impeller/entity/contents/circle_contents.h
+++ b/engine/src/flutter/impeller/entity/contents/circle_contents.h
@@ -14,8 +14,9 @@
 namespace impeller {
 class CircleContents : public ColorSourceContents {
  public:
-  static std::unique_ptr<CircleContents>
-  Make(std::unique_ptr<CircleGeometry> geometry, Color color, bool stroked);
+  static std::unique_ptr<CircleContents> Make(
+      std::unique_ptr<CircleGeometry> geometry,
+      Color color);
 
   bool Render(const ContentContext& renderer,
               const Entity& entity,
@@ -27,14 +28,10 @@ class CircleContents : public ColorSourceContents {
 
  private:
   explicit CircleContents(std::unique_ptr<CircleGeometry> geometry,
-                          Color color,
-                          bool stroked,
-                          Scalar aa_padding);
+                          Color color);
 
   std::unique_ptr<CircleGeometry> geometry_;
   Color color_;
-  bool stroked_;
-  Scalar aa_padding_;
 };
 }  // namespace impeller
 

--- a/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.cc
@@ -7,8 +7,6 @@
 #include "impeller/entity/contents/color_source_contents.h"
 #include "impeller/entity/contents/content_context.h"
 #include "impeller/entity/contents/pipelines.h"
-#include "impeller/entity/geometry/circle_geometry.h"
-#include "impeller/entity/geometry/rect_geometry.h"
 
 namespace impeller {
 
@@ -24,16 +22,19 @@ using FS = UberSDFPipeline::FragmentShader;
 
 }  // namespace
 
-std::unique_ptr<UberSDFContents>
-UberSDFContents::Make(Type type, Color color, SDFCompatibleGeometry* geometry) {
+std::unique_ptr<UberSDFContents> UberSDFContents::Make(
+    Type type,
+    Color color,
+    std::unique_ptr<SDFCompatibleGeometry> geometry) {
   return std::unique_ptr<UberSDFContents>(
-      new UberSDFContents(type, color, geometry));
+      new UberSDFContents(type, color, std::move(geometry)));
 }
 
-UberSDFContents::UberSDFContents(Type type,
-                                 Color color,
-                                 SDFCompatibleGeometry* geometry)
-    : type_(type), color_(color), geometry_(geometry) {
+UberSDFContents::UberSDFContents(
+    Type type,
+    Color color,
+    std::unique_ptr<SDFCompatibleGeometry> geometry)
+    : type_(type), color_(color), geometry_(std::move(geometry)) {
   geometry_->SetAntialiasPadding(kDefaultAntialiasPadding);
 }
 
@@ -45,7 +46,7 @@ bool UberSDFContents::Render(const ContentContext& renderer,
   auto& data_host_buffer = renderer.GetTransientsDataBuffer();
 
   VS::FrameInfo frame_info;
-  FS::FragInfo frag_info;
+  FS::FragInfo frag_info = {};
   frag_info.type = type_ == Type::kCircle ? 0.0f : 1.0f;
   frag_info.color = color_.WithAlpha(color_.alpha * GetOpacityFactor());
 
@@ -102,7 +103,7 @@ std::optional<Rect> UberSDFContents::GetCoverage(const Entity& entity) const {
 }
 
 const Geometry* UberSDFContents::GetGeometry() const {
-  return geometry_;
+  return geometry_.get();
 }
 
 Color UberSDFContents::GetColor() const {

--- a/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.cc
@@ -13,6 +13,9 @@
 namespace impeller {
 
 namespace {
+
+static constexpr Scalar kDefaultAntialiasPadding = 1.0f;
+
 using PipelineBuilderCallback =
     std::function<PipelineRef(ContentContextOptions)>;
 
@@ -21,49 +24,18 @@ using FS = UberSDFPipeline::FragmentShader;
 
 }  // namespace
 
-std::unique_ptr<UberSDFContents> UberSDFContents::MakeRect(
-    Color color,
-    Scalar stroke_width,
-    Join stroke_join,
-    bool stroked,
-    const FillRectGeometry* geometry) {
-  Rect bounding_box = geometry->GetRect();
-  Scalar aa_padding = 1.0f;
-  return std::make_unique<UberSDFContents>(Type::kRect, bounding_box, color,
-                                           stroke_width, stroke_join, stroked,
-                                           geometry, aa_padding);
-}
-
-std::unique_ptr<UberSDFContents> UberSDFContents::MakeCircle(
-    Color color,
-    bool stroked,
-    const CircleGeometry* geometry) {
-  Point center = geometry->GetCenter();
-  Scalar radius = geometry->GetRadius();
-  Rect bounding_box = Rect::MakeXYWH(center.x - radius, center.y - radius,
-                                     radius * 2, radius * 2);
-  Scalar aa_padding = geometry->GetAntialiasPadding();
-  return std::unique_ptr<UberSDFContents>(new UberSDFContents(
-      Type::kCircle, bounding_box, color, geometry->GetStrokeWidth(),
-      Join::kMiter, stroked, geometry, aa_padding));
+std::unique_ptr<UberSDFContents>
+UberSDFContents::Make(Type type, Color color, SDFCompatibleGeometry* geometry) {
+  return std::unique_ptr<UberSDFContents>(
+      new UberSDFContents(type, color, geometry));
 }
 
 UberSDFContents::UberSDFContents(Type type,
-                                 Rect bounding_box,
                                  Color color,
-                                 Scalar stroke_width,
-                                 Join stroke_join,
-                                 bool stroked,
-                                 const Geometry* geometry,
-                                 Scalar aa_padding)
-    : type_(type),
-      bounding_box_(bounding_box),
-      color_(color),
-      stroke_width_(stroke_width),
-      stroke_join_(stroke_join),
-      stroked_(stroked),
-      geometry_(geometry),
-      aa_padding_(aa_padding) {}
+                                 SDFCompatibleGeometry* geometry)
+    : type_(type), color_(color), geometry_(geometry) {
+  geometry_->SetAntialiasPadding(kDefaultAntialiasPadding);
+}
 
 UberSDFContents::~UberSDFContents() = default;
 
@@ -74,25 +46,31 @@ bool UberSDFContents::Render(const ContentContext& renderer,
 
   VS::FrameInfo frame_info;
   FS::FragInfo frag_info;
-  frag_info.color = color_.WithAlpha(color_.alpha * GetOpacityFactor());
-  frag_info.center = bounding_box_.GetCenter();
-  frag_info.size =
-      Point(bounding_box_.GetWidth() / 2.0f, bounding_box_.GetHeight() / 2.0f);
-  frag_info.stroke_width = stroke_width_;
-  switch (stroke_join_) {
-    case Join::kMiter:
-      frag_info.stroke_join = 0.0f;
-      break;
-    case Join::kBevel:
-      frag_info.stroke_join = 1.0f;
-      break;
-    case Join::kRound:
-      frag_info.stroke_join = 2.0f;
-      break;
-  }
-  frag_info.aa_pixels = aa_padding_;
-  frag_info.stroked = stroked_ ? 1.0f : 0.0f;
   frag_info.type = type_ == Type::kCircle ? 0.0f : 1.0f;
+  frag_info.color = color_.WithAlpha(color_.alpha * GetOpacityFactor());
+
+  Rect bounds = geometry_->GetBaseShapeBounds();
+  frag_info.center = bounds.GetCenter();
+  frag_info.size = Point(bounds.GetWidth() / 2.0f, bounds.GetHeight() / 2.0f);
+
+  auto stroke = geometry_->GetStrokeParameters();
+  frag_info.stroked = stroke ? 1.0f : 0.0f;
+  if (stroke) {
+    frag_info.stroke_width = stroke->width;
+    switch (stroke->join) {
+      case Join::kMiter:
+        frag_info.stroke_join = 0.0f;
+        break;
+      case Join::kBevel:
+        frag_info.stroke_join = 1.0f;
+        break;
+      case Join::kRound:
+        frag_info.stroke_join = 2.0f;
+        break;
+    }
+  }
+
+  frag_info.aa_pixels = geometry_->GetAntialiasPadding();
 
   auto geometry_result =
       GetGeometry()->GetPositionBuffer(renderer, entity, pass);

--- a/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.h
+++ b/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.h
@@ -25,11 +25,12 @@ class UberSDFContents : public ColorSourceContents {
     kRect,
   };
 
-  static std::unique_ptr<UberSDFContents> Make(Type type,
-                                               Color color,
-                                               SDFCompatibleGeometry* geometry);
+  static std::unique_ptr<UberSDFContents>
+  Make(Type type, Color color, std::unique_ptr<SDFCompatibleGeometry> geometry);
 
-  UberSDFContents(Type type, Color color, SDFCompatibleGeometry* geometry);
+  explicit UberSDFContents(Type type,
+                           Color color,
+                           std::unique_ptr<SDFCompatibleGeometry> geometry);
 
   ~UberSDFContents() override;
 
@@ -51,7 +52,7 @@ class UberSDFContents : public ColorSourceContents {
   /// The color of the geometry.
   Color color_;
   /// The geometry.
-  SDFCompatibleGeometry* geometry_;
+  std::unique_ptr<SDFCompatibleGeometry> geometry_;
 
   UberSDFContents(const UberSDFContents&) = delete;
 

--- a/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.h
+++ b/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.h
@@ -6,14 +6,15 @@
 #define FLUTTER_IMPELLER_ENTITY_CONTENTS_UBER_SDF_CONTENTS_H_
 
 #include <memory>
+#include <optional>
 
 #include "flutter/impeller/entity/contents/color_source_contents.h"
 #include "flutter/impeller/entity/contents/contents.h"
-#include "impeller/entity/geometry/circle_geometry.h"
 #include "impeller/entity/geometry/geometry.h"
-#include "impeller/entity/geometry/rect_geometry.h"
+#include "impeller/entity/geometry/sdf_compatible_geometry.h"
 #include "impeller/geometry/color.h"
 #include "impeller/geometry/rect.h"
+#include "impeller/geometry/stroke_parameters.h"
 
 namespace impeller {
 
@@ -24,24 +25,11 @@ class UberSDFContents : public ColorSourceContents {
     kRect,
   };
 
-  static std::unique_ptr<UberSDFContents> MakeRect(
-      Color color,
-      Scalar stroke_width,
-      Join stroke_join,
-      bool stroked,
-      const FillRectGeometry* geometry);
+  static std::unique_ptr<UberSDFContents> Make(Type type,
+                                               Color color,
+                                               SDFCompatibleGeometry* geometry);
 
-  static std::unique_ptr<UberSDFContents>
-  MakeCircle(Color color, bool stroked, const CircleGeometry* geometry);
-
-  UberSDFContents(Type type,
-                  Rect rect,
-                  Color color,
-                  Scalar stroke_width,
-                  Join stroke_join,
-                  bool stroked,
-                  const Geometry* geometry,
-                  Scalar aa_padding);
+  UberSDFContents(Type type, Color color, SDFCompatibleGeometry* geometry);
 
   ~UberSDFContents() override;
 
@@ -60,20 +48,10 @@ class UberSDFContents : public ColorSourceContents {
  private:
   /// The type of geometry (e.g. circle, rect).
   const Type type_;
-  /// The bounding box of the geometry.
-  Rect bounding_box_;
   /// The color of the geometry.
   Color color_;
-  /// The width of the stroke.
-  Scalar stroke_width_ = 0.0f;
-  /// The join of the stroke.
-  Join stroke_join_ = Join::kMiter;
-  /// Whether the geometry is stroked.
-  bool stroked_ = false;
   /// The geometry.
-  const Geometry* geometry_;
-  /// The antialias padding.
-  Scalar aa_padding_;
+  SDFCompatibleGeometry* geometry_;
 
   UberSDFContents(const UberSDFContents&) = delete;
 

--- a/engine/src/flutter/impeller/entity/contents/uber_sdf_contents_unittests.cc
+++ b/engine/src/flutter/impeller/entity/contents/uber_sdf_contents_unittests.cc
@@ -13,8 +13,8 @@ namespace testing {
 TEST(UberSDFContentsTest, ApplyColorFilter) {
   auto rect = Rect::MakeXYWH(100, 100, 200, 200);
   FillRectGeometry geometry(rect);
-  auto contents = UberSDFContents::MakeRect(Color::Red(), 0.0f, Join::kMiter,
-                                            false, &geometry);
+  auto contents = UberSDFContents::Make(UberSDFContents::Type::kRect,
+                                        Color::Red(), &geometry);
 
   ASSERT_EQ(contents->GetColor(), Color::Red());
 

--- a/engine/src/flutter/impeller/entity/contents/uber_sdf_contents_unittests.cc
+++ b/engine/src/flutter/impeller/entity/contents/uber_sdf_contents_unittests.cc
@@ -12,9 +12,9 @@ namespace testing {
 
 TEST(UberSDFContentsTest, ApplyColorFilter) {
   auto rect = Rect::MakeXYWH(100, 100, 200, 200);
-  FillRectGeometry geometry(rect);
+  auto geometry = std::make_unique<FillRectGeometry>(rect);
   auto contents = UberSDFContents::Make(UberSDFContents::Type::kRect,
-                                        Color::Red(), &geometry);
+                                        Color::Red(), std::move(geometry));
 
   ASSERT_EQ(contents->GetColor(), Color::Red());
 

--- a/engine/src/flutter/impeller/entity/entity_unittests.cc
+++ b/engine/src/flutter/impeller/entity/entity_unittests.cc
@@ -1235,8 +1235,8 @@ TEST_P(EntityTest, ContentsGetBoundsForEmptyPathReturnsNullopt) {
 TEST(EntityTest, UberSDFContentsCoverage) {
   auto rect = Rect::MakeXYWH(100, 100, 200, 200);
   FillRectGeometry geometry(rect.Expand(1.0f));
-  auto contents = UberSDFContents::MakeRect(Color::Red(), 0.0f, Join::kMiter,
-                                            false, &geometry);
+  auto contents = UberSDFContents::Make(UberSDFContents::Type::kRect,
+                                        Color::Red(), &geometry);
 
   Entity entity;
   auto coverage = contents->GetCoverage(entity);

--- a/engine/src/flutter/impeller/entity/entity_unittests.cc
+++ b/engine/src/flutter/impeller/entity/entity_unittests.cc
@@ -1234,9 +1234,9 @@ TEST_P(EntityTest, ContentsGetBoundsForEmptyPathReturnsNullopt) {
 
 TEST(EntityTest, UberSDFContentsCoverage) {
   auto rect = Rect::MakeXYWH(100, 100, 200, 200);
-  FillRectGeometry geometry(rect.Expand(1.0f));
+  auto geometry = std::make_unique<FillRectGeometry>(rect);
   auto contents = UberSDFContents::Make(UberSDFContents::Type::kRect,
-                                        Color::Red(), &geometry);
+                                        Color::Red(), std::move(geometry));
 
   Entity entity;
   auto coverage = contents->GetCoverage(entity);

--- a/engine/src/flutter/impeller/entity/geometry/circle_geometry.cc
+++ b/engine/src/flutter/impeller/entity/geometry/circle_geometry.cc
@@ -13,53 +13,36 @@
 
 namespace impeller {
 
-CircleGeometry::CircleGeometry(const Point& center, Scalar radius)
-    : center_(center),
-      radius_(radius),
-      stroke_width_(-1.0f),
-      padding_pixels_(0.0f) {
+CircleGeometry::CircleGeometry(const Point& center,
+                               Scalar radius,
+                               std::optional<Scalar> stroke_width)
+    : center_(center), radius_(radius), stroke_width_(stroke_width) {
   FML_DCHECK(radius >= 0);
+  if (stroke_width_) {
+    FML_DCHECK(stroke_width_.value() >= 0);
+  }
 }
 
 CircleGeometry::~CircleGeometry() = default;
 
-CircleGeometry::CircleGeometry(const Point& center,
-                               Scalar radius,
-                               Scalar stroke_width)
-    : center_(center),
-      radius_(radius),
-      stroke_width_(std::max(stroke_width, 0.0f)),
-      padding_pixels_(0.0) {
-  FML_DCHECK(radius >= 0);
-  FML_DCHECK(stroke_width >= 0);
+Rect CircleGeometry::GetBaseShapeBounds() const {
+  return Rect::MakeXYWH(center_.x - radius_, center_.y - radius_, radius_ * 2,
+                        radius_ * 2);
+}
+
+std::optional<StrokeParameters> CircleGeometry::GetStrokeParameters() const {
+  if (stroke_width_) {
+    return StrokeParameters{.width = *stroke_width_};
+  }
+  return std::nullopt;
 }
 
 // |Geometry|
 Scalar CircleGeometry::ComputeAlphaCoverage(const Matrix& transform) const {
-  if (stroke_width_ < 0) {
+  if (!stroke_width_) {
     return 1;
   }
-  return Geometry::ComputeStrokeAlphaCoverage(transform, stroke_width_);
-}
-
-Point CircleGeometry::GetCenter() const {
-  return center_;
-}
-
-Scalar CircleGeometry::GetRadius() const {
-  return radius_;
-}
-
-Scalar CircleGeometry::GetStrokeWidth() const {
-  return stroke_width_;
-}
-
-void CircleGeometry::SetAntialiasPadding(Scalar extra_padding) {
-  padding_pixels_ = extra_padding;
-}
-
-Scalar CircleGeometry::GetAntialiasPadding() const {
-  return padding_pixels_;
+  return Geometry::ComputeStrokeAlphaCoverage(transform, stroke_width_.value());
 }
 
 GeometryResult CircleGeometry::GetPositionBuffer(const ContentContext& renderer,
@@ -68,16 +51,16 @@ GeometryResult CircleGeometry::GetPositionBuffer(const ContentContext& renderer,
   auto& transform = entity.GetTransform();
 
   Scalar max_basis = transform.GetMaxBasisLengthXY();
-  Scalar expansion = max_basis == 0 ? 0.0 : padding_pixels_ / max_basis;
+  Scalar expansion = max_basis == 0 ? 0.0 : GetAntialiasPadding() / max_basis;
 
-  if (stroke_width_ < 0) {
+  if (!stroke_width_) {
     auto generator = renderer.GetTessellator().FilledCircle(
         transform, center_, radius_ + expansion);
     return ComputePositionGeometry(renderer, generator, entity, pass);
   }
 
   Scalar half_width =
-      LineGeometry::ComputePixelHalfWidth(transform, stroke_width_);
+      LineGeometry::ComputePixelHalfWidth(transform, stroke_width_.value());
 
   auto generator = renderer.GetTessellator().StrokedCircle(
       transform, center_, radius_, half_width + expansion);
@@ -87,9 +70,9 @@ GeometryResult CircleGeometry::GetPositionBuffer(const ContentContext& renderer,
 
 std::optional<Rect> CircleGeometry::GetCoverage(const Matrix& transform) const {
   Scalar max_basis = transform.GetMaxBasisLengthXY();
-  Scalar expansion = max_basis == 0 ? 0.0 : padding_pixels_ / max_basis;
+  Scalar expansion = max_basis == 0 ? 0.0 : GetAntialiasPadding() / max_basis;
 
-  Scalar half_width = stroke_width_ < 0 ? 0.0 : stroke_width_ * 0.5f;
+  Scalar half_width = stroke_width_.value_or(0.0) * 0.5f;
   Scalar outer_radius = radius_ + half_width + expansion;
   return Rect::MakeLTRB(-outer_radius, -outer_radius,  //
                         +outer_radius, +outer_radius)

--- a/engine/src/flutter/impeller/entity/geometry/circle_geometry.h
+++ b/engine/src/flutter/impeller/entity/geometry/circle_geometry.h
@@ -6,20 +6,25 @@
 #define FLUTTER_IMPELLER_ENTITY_GEOMETRY_CIRCLE_GEOMETRY_H_
 
 #include "impeller/entity/geometry/geometry.h"
+#include "impeller/entity/geometry/sdf_compatible_geometry.h"
 
 namespace impeller {
 
 // Geometry class that can generate vertices (with or without texture
 // coordinates) for either filled or stroked circles
-class CircleGeometry final : public Geometry {
+class CircleGeometry final : public SDFCompatibleGeometry {
  public:
-  explicit CircleGeometry(const Point& center, Scalar radius);
-
   explicit CircleGeometry(const Point& center,
                           Scalar radius,
-                          Scalar stroke_width);
+                          std::optional<Scalar> stroke_width);
 
   ~CircleGeometry() override;
+
+  // |SDFCompatibleGeometry|
+  Rect GetBaseShapeBounds() const override;
+
+  // |SDFCompatibleGeometry|
+  std::optional<StrokeParameters> GetStrokeParameters() const override;
 
   // |Geometry|
   bool CoversArea(const Matrix& transform, const Rect& rect) const override;
@@ -30,10 +35,6 @@ class CircleGeometry final : public Geometry {
   // |Geometry|
   Scalar ComputeAlphaCoverage(const Matrix& transform) const override;
 
-  Scalar GetRadius() const;
-  Scalar GetStrokeWidth() const;
-  Point GetCenter() const;
-
   // |Geometry|
   std::optional<Rect> GetCoverage(const Matrix& transform) const override;
 
@@ -42,17 +43,10 @@ class CircleGeometry final : public Geometry {
                                    const Entity& entity,
                                    RenderPass& pass) const override;
 
-  // Set the number of pixels to add to the edge(s) of the circle for
-  // SDF-based antialiasing
-  void SetAntialiasPadding(Scalar extra_pixels);
-
-  Scalar GetAntialiasPadding() const;
-
  private:
   Point center_;
   Scalar radius_;
-  Scalar stroke_width_;
-  Scalar padding_pixels_;
+  std::optional<Scalar> stroke_width_;
 
   CircleGeometry(const CircleGeometry&) = delete;
 

--- a/engine/src/flutter/impeller/entity/geometry/geometry.cc
+++ b/engine/src/flutter/impeller/entity/geometry/geometry.cc
@@ -76,6 +76,10 @@ std::unique_ptr<Geometry> Geometry::MakeStrokePath(
   return std::make_unique<StrokePathGeometry>(path, parameters);
 }
 
+// TODO(bensonluk): I don't think any of these Make* functions are used outside
+// of unit tests. Insted, all callers just call named constructors of the
+// concrete geometry type. Verify this and delete these functions.
+
 std::unique_ptr<Geometry> Geometry::MakeCover() {
   return std::make_unique<CoverGeometry>();
 }
@@ -96,13 +100,14 @@ std::unique_ptr<Geometry> Geometry::MakeLine(const Point& p0,
 
 std::unique_ptr<Geometry> Geometry::MakeCircle(const Point& center,
                                                Scalar radius) {
-  return std::make_unique<CircleGeometry>(center, radius);
+  return std::make_unique<CircleGeometry>(center, radius, std::nullopt);
 }
 
 std::unique_ptr<Geometry> Geometry::MakeStrokedCircle(const Point& center,
                                                       Scalar radius,
                                                       Scalar stroke_width) {
-  return std::make_unique<CircleGeometry>(center, radius, stroke_width);
+  return std::make_unique<CircleGeometry>(center, radius,
+                                          std::make_optional(stroke_width));
 }
 
 std::unique_ptr<Geometry> Geometry::MakeFilledArc(const Rect& oval_bounds,

--- a/engine/src/flutter/impeller/entity/geometry/geometry_unittests.cc
+++ b/engine/src/flutter/impeller/entity/geometry/geometry_unittests.cc
@@ -117,6 +117,44 @@ TEST(EntityGeometryTest, FillRectGeometryPaddingIsAdjustedByInverseMaxBasis) {
   }
 }
 
+TEST(EntityGeometryTest, StrokeRectGeometryPadding) {
+  Rect rect = Rect::MakeLTRB(0, 0, 100, 100);
+  StrokeParameters stroke = {.width = 10.0f};
+  StrokeRectGeometry geometry(rect, stroke);
+  geometry.SetAntialiasPadding(1.0);  // 1 pixel of padding
+
+  // At scale 1, padding should be 1 + 5.0f (half stroke) = 6.0f local.
+  {
+    auto coverage = geometry.GetCoverage(Matrix());
+    EXPECT_TRUE(coverage.has_value());
+    if (coverage.has_value()) {
+      EXPECT_EQ(coverage.value(), Rect::MakeLTRB(-6.0, -6.0, 106.0, 106.0));
+    }
+  }
+
+  // At scale 2, padding should be 0.5 + 5.0f (half stroke) = 5.5f local.
+  {
+    auto matrix = Matrix::MakeScale({2.0, 2.0, 1.0});
+    auto coverage = geometry.GetCoverage(matrix);
+    EXPECT_TRUE(coverage.has_value());
+    if (coverage.has_value()) {
+      EXPECT_EQ(coverage.value(), Rect::MakeLTRB(-5.5, -5.5, 105.5, 105.5)
+                                      .TransformAndClipBounds(matrix));
+    }
+  }
+
+  // At scale 0.5, padding should be 2.0 + 5.0f (half stroke) = 7.0f local.
+  {
+    auto matrix = Matrix::MakeScale({0.5, 0.5, 1.0});
+    auto coverage = geometry.GetCoverage(matrix);
+    EXPECT_TRUE(coverage.has_value());
+    if (coverage.has_value()) {
+      EXPECT_EQ(coverage.value(), Rect::MakeLTRB(-7.0, -7.0, 107.0, 107.0)
+                                      .TransformAndClipBounds(matrix));
+    }
+  }
+}
+
 TEST(EntityGeometryTest, FillPathGeometryCoversArea) {
   auto path = flutter::DlPathBuilder{}
                   .AddRect(Rect::MakeLTRB(0, 0, 100, 100))

--- a/engine/src/flutter/impeller/entity/geometry/rect_geometry.cc
+++ b/engine/src/flutter/impeller/entity/geometry/rect_geometry.cc
@@ -10,16 +10,8 @@ FillRectGeometry::FillRectGeometry(Rect rect) : rect_(rect) {}
 
 FillRectGeometry::~FillRectGeometry() = default;
 
-const Rect& FillRectGeometry::GetRect() const {
+Rect FillRectGeometry::GetBaseShapeBounds() const {
   return rect_;
-}
-
-void FillRectGeometry::SetAntialiasPadding(Scalar padding) {
-  padding_pixels_ = padding;
-}
-
-Scalar FillRectGeometry::GetAntialiasPadding() const {
-  return padding_pixels_;
 }
 
 GeometryResult FillRectGeometry::GetPositionBuffer(
@@ -28,7 +20,7 @@ GeometryResult FillRectGeometry::GetPositionBuffer(
     RenderPass& pass) const {
   auto& data_host_buffer = renderer.GetTransientsDataBuffer();
   Scalar max_basis = entity.GetTransform().GetMaxBasisLengthXY();
-  Scalar padding = max_basis == 0 ? 0 : padding_pixels_ / max_basis;
+  Scalar padding = max_basis == 0 ? 0 : GetAntialiasPadding() / max_basis;
   Rect expanded_rect = rect_.Expand(padding);
   return GeometryResult{
       .type = PrimitiveType::kTriangleStrip,
@@ -48,7 +40,7 @@ GeometryResult FillRectGeometry::GetPositionBuffer(
 std::optional<Rect> FillRectGeometry::GetCoverage(
     const Matrix& transform) const {
   Scalar max_basis = transform.GetMaxBasisLengthXY();
-  Scalar padding = max_basis == 0 ? 0 : padding_pixels_ / max_basis;
+  Scalar padding = max_basis == 0 ? 0 : GetAntialiasPadding() / max_basis;
   return rect_.Expand(padding).TransformAndClipBounds(transform);
 }
 
@@ -67,17 +59,24 @@ bool FillRectGeometry::IsAxisAlignedRect() const {
 
 StrokeRectGeometry::StrokeRectGeometry(const Rect& rect,
                                        const StrokeParameters& stroke)
-    : rect_(rect),
-      stroke_width_(stroke.width),
-      stroke_join_(AdjustStrokeJoin(stroke)) {}
+    : rect_(rect), stroke_parameters_(AdjustStrokeJoin(stroke)) {}
 
 StrokeRectGeometry::~StrokeRectGeometry() = default;
+
+Rect StrokeRectGeometry::GetBaseShapeBounds() const {
+  return rect_;
+}
+
+std::optional<StrokeParameters> StrokeRectGeometry::GetStrokeParameters()
+    const {
+  return stroke_parameters_;
+}
 
 GeometryResult StrokeRectGeometry::GetPositionBuffer(
     const ContentContext& renderer,
     const Entity& entity,
     RenderPass& pass) const {
-  if (stroke_width_ < 0.0) {
+  if (stroke_parameters_.width < 0.0) {
     return {};
   }
   Scalar max_basis = entity.GetTransform().GetMaxBasisLengthXY();
@@ -86,14 +85,18 @@ GeometryResult StrokeRectGeometry::GetPositionBuffer(
   }
 
   Scalar min_size = kMinStrokeSize / max_basis;
-  Scalar stroke_width = std::max(stroke_width_, min_size);
+  Scalar stroke_width = std::max(stroke_parameters_.width, min_size);
   Scalar half_stroke_width = stroke_width * 0.5f;
+
+  Scalar expansion = GetAntialiasPadding() / max_basis;
+  half_stroke_width += expansion;
 
   auto& data_host_buffer = renderer.GetTransientsDataBuffer();
   const Rect& rect = rect_;
-  bool interior_filled = (stroke_width >= rect.GetSize().MinDimension());
+  bool interior_filled =
+      (half_stroke_width >= rect.GetSize().MinDimension() * 0.5f);
 
-  switch (stroke_join_) {
+  switch (stroke_parameters_.join) {
     case Join::kRound: {
       Tessellator::Trigs trigs =
           renderer.GetTessellator().GetTrigsForDeviceRadius(half_stroke_width *
@@ -354,13 +357,20 @@ GeometryResult StrokeRectGeometry::GetPositionBuffer(
 
 std::optional<Rect> StrokeRectGeometry::GetCoverage(
     const Matrix& transform) const {
-  return rect_.TransformBounds(transform);
+  Scalar max_basis = transform.GetMaxBasisLengthXY();
+  Scalar aa_padding = max_basis == 0 ? 0.0 : GetAntialiasPadding() / max_basis;
+  Scalar stroke_padding = stroke_parameters_.width * 0.5f;
+  Scalar padding = stroke_padding + aa_padding;
+  return rect_.Expand(padding).TransformAndClipBounds(transform);
 }
 
-Join StrokeRectGeometry::AdjustStrokeJoin(const StrokeParameters& stroke) {
-  return (stroke.join == Join::kMiter && stroke.miter_limit < kSqrt2)
-             ? Join::kBevel
-             : stroke.join;
+StrokeParameters StrokeRectGeometry::AdjustStrokeJoin(
+    const StrokeParameters& stroke) {
+  StrokeParameters adjusted = stroke;
+  adjusted.join = (stroke.join == Join::kMiter && stroke.miter_limit < kSqrt2)
+                      ? Join::kBevel
+                      : stroke.join;
+  return adjusted;
 }
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/entity/geometry/rect_geometry.h
+++ b/engine/src/flutter/impeller/entity/geometry/rect_geometry.h
@@ -6,21 +6,19 @@
 #define FLUTTER_IMPELLER_ENTITY_GEOMETRY_RECT_GEOMETRY_H_
 
 #include "impeller/entity/geometry/geometry.h"
+#include "impeller/entity/geometry/sdf_compatible_geometry.h"
 #include "impeller/geometry/stroke_parameters.h"
 
 namespace impeller {
 
-class FillRectGeometry final : public Geometry {
+class FillRectGeometry final : public SDFCompatibleGeometry {
  public:
   explicit FillRectGeometry(Rect rect);
 
   ~FillRectGeometry() override;
 
-  const Rect& GetRect() const;
-
-  void SetAntialiasPadding(Scalar padding);
-
-  Scalar GetAntialiasPadding() const;
+  // |SDFCompatibleGeometry|
+  Rect GetBaseShapeBounds() const override;
 
   // |Geometry|
   bool CoversArea(const Matrix& transform, const Rect& rect) const override;
@@ -38,14 +36,19 @@ class FillRectGeometry final : public Geometry {
 
  private:
   Rect rect_;
-  Scalar padding_pixels_ = 0.0f;
 };
 
-class StrokeRectGeometry final : public Geometry {
+class StrokeRectGeometry final : public SDFCompatibleGeometry {
  public:
   explicit StrokeRectGeometry(const Rect& rect, const StrokeParameters& stroke);
 
   ~StrokeRectGeometry() override;
+
+  // |SDFCompatibleGeometry|
+  Rect GetBaseShapeBounds() const override;
+
+  // |SDFCompatibleGeometry|
+  std::optional<StrokeParameters> GetStrokeParameters() const override;
 
   // |Geometry|
   GeometryResult GetPositionBuffer(const ContentContext& renderer,
@@ -57,10 +60,9 @@ class StrokeRectGeometry final : public Geometry {
 
  private:
   const Rect rect_;
-  const Scalar stroke_width_;
-  const Join stroke_join_;
+  const StrokeParameters stroke_parameters_;
 
-  static Join AdjustStrokeJoin(const StrokeParameters& stroke);
+  static StrokeParameters AdjustStrokeJoin(const StrokeParameters& stroke);
 };
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/entity/geometry/sdf_compatible_geometry.h
+++ b/engine/src/flutter/impeller/entity/geometry/sdf_compatible_geometry.h
@@ -1,0 +1,44 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_IMPELLER_ENTITY_GEOMETRY_SDF_COMPATIBLE_GEOMETRY_H_
+#define FLUTTER_IMPELLER_ENTITY_GEOMETRY_SDF_COMPATIBLE_GEOMETRY_H_
+
+#include "impeller/entity/geometry/geometry.h"
+#include "impeller/geometry/rect.h"
+#include "impeller/geometry/stroke_parameters.h"
+
+namespace impeller {
+
+// Interface for geometries that can be rendered with an SDF shader.
+class SDFCompatibleGeometry : public Geometry {
+ public:
+  // Returns the bounds rectangle of the base shape. This is used by the
+  // shader to determine the size of drawn shape.
+  //
+  // This base shape bounds does not include padding for stroke width and
+  // antialiasing. The drawn shape's size is based on this bounds, but will be
+  // larger than this bounds to account for stroke and AA padding.
+  virtual Rect GetBaseShapeBounds() const = 0;
+
+  // If the geometry is stroked, returns the stroke parameters.
+  virtual std::optional<StrokeParameters> GetStrokeParameters() const {
+    return std::nullopt;
+  }
+
+  // Set the padding pixels used for antialiasing.
+  void SetAntialiasPadding(Scalar antialias_padding) {
+    antialias_padding_ = antialias_padding;
+  }
+
+  // Get the padding pixels used for antialiasing.
+  Scalar GetAntialiasPadding() const { return antialias_padding_; }
+
+ private:
+  Scalar antialias_padding_ = 0.0f;
+};
+
+}  // namespace impeller
+
+#endif  // FLUTTER_IMPELLER_ENTITY_GEOMETRY_SDF_COMPATIBLE_GEOMETRY_H_


### PR DESCRIPTION
This contains a bunch of mostly-noop refactoring I did to try to clean up ugly interfaces and redundant/unclear ownership of state across different classes related to our SDF rendering.

This is mostly a no-op, with two exceptions:
1. Stroked rects are now drawn using `StrokeRectGeometry`, instead of using a `FillRectGeometry` that is expanded to add padding for the stroke width. `StrokeRectGeometry` more tightly matches the render area of stroked rectangles (omitting the hole in the middle and accounting for bevel/round corners), so now the SDF shader for this will run on less pixels. And `StrokeRectGeometry` properly handles adjusting miter joins into bevel joins depending on miter_limit.

2. Fixes an existing issue with `StrokeRectGeometry::GetCoverage()`, where it does not account for stroke width. It now accounts for stroke width and for the AA padding.

Fixes #184402
Fixes #184404
Part of #184352

Here's a gemini-generated summary:

#### Unified SDF Geometry Ownership & Interface Refactoring
This change modernizes the Impeller rendering pipeline by unifying geometry ownership and interface usage for Signed Distance Field (SDF) rendering. It shifts state-management responsibilities (bounding boxes, stroke parameters, and anti-aliasing padding) from individual `Contents` classes directly into concrete `Geometry` classes utilizing a new **`SDFCompatibleGeometry`** interface.
##### Architectural Pillars
*   **Single Source of Truth:** High-level state measurements like bounding boxes were deleted from `UberSDFContents` and `CircleContents`. Containers now query dynamic shape dimensions directly from the geometry object, eliminating state-synchronization hazards.
*   **Polymorphic Expansion (Strategy Pattern):** By programming to an interface, `UberSDFContents` is decoupled from concrete shape types. Adding a `TriangleGeometry` or `CapsuleGeometry` in the future requires *zero* modification to the drawing container.
*   **Type-Safe Semantics (Eliminate Primitive Sentinels):** Unloaded overloads and magic sentinel numbers (such as `-1.0f` to signal a "Fill") are replaced with clean `std::optional<Scalar>` type-states and group-meaning aggregation structs (like standard `StrokeParameters`).
*   **Least Knowledge delegation (Separation of Concerns):** High-level client systems (the `Canvas` Display-List layer) were cleaned up to remove **Least Knowledge breakage**. Deep, mathematical dilation specifics (such as context expansion padding) were moved from general user interface containers and delegated into specialized drawing contexts that "know" the measurements best.

---

And here's my hand-written writeup of what I changed:

### New `SDFCompatibleGeometry` abstract class
- This is intended to be the base of all `Geometry`s that can be rendered with SDFs
- Consolidates getting/setting the AA padding into one base class
- Has virtual methods for subclasses to implement for getting the base shape bounds and stroke parameters which are used by our SDF shaders.
  - "base shape bounds" is a direct replacement for the "bounding_box" used in `UberSDFContents`. I intentionally renamed it because I thought "bounding_box" was misleading. It does not bound the drawn shape, because it doesn't include padding for stroke width and AA. "base shape bounds" might still be a little unclear, so if anyone has a better name suggestion I'm open to it.
  - `GetBaseShapeBounds()` and `GetStrokeParameters()` means the Geometry is now the source of truth for the shape's size and stroke information. SDF-based Contents classes are updated to not separately store this state.
- `CircleGeometry` and `FillRectGeometry` are migrated to inherit from this
  - Eliminates the need for shape-specific `GetRadius`/`GetCenter`/`GetStrokeWidth`/`GetRect` methods in `CircleGeometry` and `FillRectGeometry`
  - The `Set/Get AntialiasPadding` methods are consolidated to be in the base class.
- `StrokeRectGeometry` is updated to use this as well. This is now used to render stroked rects with UberSDF, instead of using a hackily padded FillRect to render stroked rects.

### `CircleContents`
- Delete `stroked_` and `aa_padding_` properties. The `Geometry` now tells us all of this.

### `UberSDfContents`
- Delete `bounding_box_`, `stroke_width_`, `stroke_join_`, `stroked_`, and `aa_padding_` properties. The `Geometry` now tells us all of this.
- Replace the `MakeRect` and `MakeCircle` constructors with a single `Make` constructor that takes any `SDFCompatibleGeometry` subclass. `UberSDfContents` no longer needs to do any shape-specific logic, which is moved to the `Geometry` classes. So `UberSDfContents` can be a generic handler for `SDFCompatibleGeometry`.

### `CircleGeometry`
- Delete its circle-specific methods and AA padding methods. Inheritance from `SDFCompatibleGeometry` replaces this.
- Clean up how stroked vs filled rects are handled.
  - Make stroke_width_ property be an optional value that is null for filled circles, instead of using a -1.0 sentinel value to indicate a filled circle.
  - Consolidate the two filled vs stroked constructors into one constructor that takes an optional stroke_width.

### `RectGeometry`
- Delete `FilledRectGeometry` `GetRect()` method and AA padding methods. Inheritance from `SDFCompatibleGeometry` replaces this.
- `StrokeRectGeometry` now implements `SDFCompatibleGeometry`.
  - `StrokeRectGeometry::GetPositionBuffer` is updated to account for AA padding. This is done by simply increasing half_stroke_width by the AA amount.
  - stroke_width_ and stroke_join_ properties are replaced with stroke_parameters_.
  - Fix existing issue with `StrokeRectGeometry::GetCoverage()`, where it does not account for stroke width. It now accounts for stroke width and for the AA padding

### `Canvas` cleanup
- Canvas doesn't need to know about SDF antialiasing. That is handled by the shader `Contents` classes instead. Canvas no longer sets AA values on Geometries.
- Clean up the branching of `DrawRect`
  - Share one Geometry object that is used for both the SDF and non-SDF branches.
  - Use the newly-SDF-compatible `StrokeRectGeometry` to draw stroked SDF rects instead of using `FillRectGeometry`.
    - Previously, `Canvas` draws stroked rects by hackily adding stroke-width padding to a `FillRectGeometry`'s "antialias" padding. This was temporarily worked around by having `UberSDFContents` ignore `FillRectGeometry`'s AA padding value and hard-code 1.0 instead. All this hackiness is eliminated.
- Clean up the branching of `DrawCircle`
  - Share a common set of `entity.SetTransform` and `entity.SetBlendMode` calls across branches, instead of having 3 separate but identical calls across the uber SDF branch, the circle SDF branch (inside `AttemptDrawAntialiasedCircle`), and the non-SDF branch.
  - Share one Geometry object across the 3 branches.
  - Almost everything in the `AttemptDrawAntialiasedCircle` function is now shared logic in `DrawCircle`. So delete `AttemptDrawAntialiasedCircle` entirely.
- Remove redundant `geometry` parameter for `AddRenderSDFEntityToCurrentPass()`. This can be retrieved from the `contents` parameter.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
