### PR TITLE
Improve the error if the tool cannot find the locally built engine

### DIFF
--- a/dev/devicelab/bin/tasks/module_test_ios.dart
+++ b/dev/devicelab/bin/tasks/module_test_ios.dart
@@ -604,7 +604,7 @@ dependencies:
             RegExp('flutter.*--local-engine-src-path=bogus assemble'),
           ) || // Verbose output
           !xcodebuildOutput.contains(
-            'Unable to detect a Flutter engine build directory in bogus',
+            'No Flutter engine build directory found at: bogus',
           )) {
         return TaskResult.failure(
           'Host Objective-C app build succeeded though flutter script failed',

--- a/dev/devicelab/bin/tasks/module_test_ios.dart
+++ b/dev/devicelab/bin/tasks/module_test_ios.dart
@@ -603,9 +603,7 @@ dependencies:
       if (!xcodebuildOutput.contains(
             RegExp('flutter.*--local-engine-src-path=bogus assemble'),
           ) || // Verbose output
-          !xcodebuildOutput.contains(
-            'No Flutter engine build directory found at: bogus',
-          )) {
+          !xcodebuildOutput.contains('No Flutter engine build directory found at: bogus')) {
         return TaskResult.failure(
           'Host Objective-C app build succeeded though flutter script failed',
         );

--- a/packages/flutter_tools/lib/src/runner/local_engine.dart
+++ b/packages/flutter_tools/lib/src/runner/local_engine.dart
@@ -56,9 +56,14 @@ class LocalEngineLocator {
       'See https://github.com/flutter/flutter/issues/132245 for details.';
 
   String _runnerNoEngineBuildDirInPath(String engineSourcePath) =>
-      'Unable to detect a Flutter engine build directory in $engineSourcePath.\n'
-      "Please ensure that $engineSourcePath is a Flutter engine 'src' directory and that "
-      "you have compiled the engine in that directory, which should produce an 'out' directory";
+      'No Flutter engine build directory found at: $engineSourcePath.\n'
+      '\n'
+      'To fix this:\n'
+      "1. Ensure '$engineSourcePath' is a valid Flutter engine 'src' directory.\n"
+      "2. Verify the engine is compiled in that directory, which should produce an 'out' directory.\n"
+      '\n'
+      'Alternatively, specify a different engine source path using the '
+      '--local-engine-src-path flag or the FLUTTER_ENGINE environment variable.';
 
   String get _runnerLocalEngineOrWebSdkRequired =>
       'You must specify --local-engine or --local-web-sdk if you are using a locally built engine or web sdk.';

--- a/packages/flutter_tools/test/general.shard/runner/local_engine_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/local_engine_test.dart
@@ -478,7 +478,7 @@ void main() {
 
       await expectToolExitLater(
         localWebEngineLocator.findEnginePath(),
-        contains('Unable to detect a Flutter engine build directory in blah'),
+        contains('No Flutter engine build directory found at: blah'),
       );
     },
   );


### PR DESCRIPTION
Updates the error message to bubble up that you can use the --local-engine-src-path flag or the FLUTTER_ENGINE environment variable to manually specify the engine source path. This can be useful in advanced scenarios.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
