### PR TITLE
Fix discrete Slider tap position mismatch with rounded track shapes

### DIFF
--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -1577,8 +1577,21 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   }
 
   double _getValueFromGlobalPosition(Offset globalPosition) {
-    final double visualPosition =
-        (globalToLocal(globalPosition).dx - _trackRect.left) / _trackRect.width;
+    final Rect trackRect = _trackRect;
+    final double localDx = globalToLocal(globalPosition).dx;
+    final double visualPosition;
+    if (isDiscrete && _sliderTheme.trackShape!.isRounded) {
+      // For discrete sliders with rounded track shapes, the thumb and tick marks
+      // are inset by half the track height on each side. The position calculation
+      // must account for this padding to match the painted tick mark positions.
+      final double padding = trackRect.height;
+      final double adjustedTrackWidth = trackRect.width - padding;
+      visualPosition = adjustedTrackWidth > 0
+          ? (localDx - trackRect.left - padding / 2) / adjustedTrackWidth
+          : 0.0;
+    } else {
+      visualPosition = (localDx - trackRect.left) / trackRect.width;
+    }
     return _getValueFromVisualPosition(visualPosition);
   }
 
@@ -1661,7 +1674,10 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       case SliderInteraction.slideOnly:
       case SliderInteraction.slideThumb:
         if (_active && isInteractive) {
-          final double valueDelta = details.primaryDelta! / _trackRect.width;
+          final double effectiveTrackWidth = isDiscrete && _sliderTheme.trackShape!.isRounded
+              ? _trackRect.width - _trackRect.height
+              : _trackRect.width;
+          final double valueDelta = details.primaryDelta! / effectiveTrackWidth;
           _currentDragValue += switch (textDirection) {
             TextDirection.rtl => -valueDelta,
             TextDirection.ltr => valueDelta,

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -1576,22 +1576,26 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     };
   }
 
-  double _getValueFromGlobalPosition(Offset globalPosition) {
+  // For discrete sliders with rounded track shapes, the thumb and tick marks
+  // are inset by half the track height on each side. This getter returns the
+  // effective track width and left-edge offset used for position calculations,
+  // matching the layout used by tick mark painting and thumb positioning.
+  (double width, double left) get _effectiveTrackMetrics {
     final Rect trackRect = _trackRect;
-    final double localDx = globalToLocal(globalPosition).dx;
-    final double visualPosition;
     if (isDiscrete && _sliderTheme.trackShape!.isRounded) {
-      // For discrete sliders with rounded track shapes, the thumb and tick marks
-      // are inset by half the track height on each side. The position calculation
-      // must account for this padding to match the painted tick mark positions.
       final double padding = trackRect.height;
-      final double adjustedTrackWidth = trackRect.width - padding;
-      visualPosition = adjustedTrackWidth > 0
-          ? (localDx - trackRect.left - padding / 2) / adjustedTrackWidth
-          : 0.0;
-    } else {
-      visualPosition = (localDx - trackRect.left) / trackRect.width;
+      final double adjustedWidth = trackRect.width - padding;
+      return (adjustedWidth > 0 ? adjustedWidth : 0.0, trackRect.left + padding / 2);
     }
+    return (trackRect.width, trackRect.left);
+  }
+
+  double _getValueFromGlobalPosition(Offset globalPosition) {
+    final double localDx = globalToLocal(globalPosition).dx;
+    final (double effectiveWidth, double effectiveLeft) = _effectiveTrackMetrics;
+    final double visualPosition = effectiveWidth > 0
+        ? (localDx - effectiveLeft) / effectiveWidth
+        : 0.0;
     return _getValueFromVisualPosition(visualPosition);
   }
 
@@ -1674,10 +1678,10 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       case SliderInteraction.slideOnly:
       case SliderInteraction.slideThumb:
         if (_active && isInteractive) {
-          final double effectiveTrackWidth = isDiscrete && _sliderTheme.trackShape!.isRounded
-              ? _trackRect.width - _trackRect.height
-              : _trackRect.width;
-          final double valueDelta = details.primaryDelta! / effectiveTrackWidth;
+          final (double effectiveWidth, _) = _effectiveTrackMetrics;
+          final double valueDelta = effectiveWidth > 0
+              ? details.primaryDelta! / effectiveWidth
+              : 0.0;
           _currentDragValue += switch (textDirection) {
             TextDirection.rtl => -valueDelta,
             TextDirection.ltr => valueDelta,

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -680,6 +680,69 @@ void main() {
     expect(SchedulerBinding.instance.transientCallbackCount, equals(0));
   });
 
+  testWidgets('Discrete Slider tap position matches tick mark position for rounded tracks', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/184391
+    // For discrete sliders with rounded track shapes, the tap-to-value
+    // calculation must account for the same track padding used when painting
+    // tick marks and positioning the thumb.
+    final Key sliderKey = UniqueKey();
+    var value = 0.0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Directionality(
+          textDirection: TextDirection.ltr,
+          child: StatefulBuilder(
+            builder: (BuildContext context, StateSetter setState) {
+              return Material(
+                child: Center(
+                  child: SliderTheme(
+                    data: const SliderThemeData(
+                      trackHeight: 16.0,
+                      trackShape: RoundedRectSliderTrackShape(),
+                      thumbShape: RoundSliderThumbShape(enabledThumbRadius: 10.0),
+                      overlayShape: RoundSliderOverlayShape(overlayRadius: 12.0),
+                    ),
+                    child: SizedBox(
+                      width: 200.0,
+                      child: Slider(
+                        key: sliderKey,
+                        max: 100.0,
+                        divisions: 20,
+                        value: value,
+                        onChanged: (double newValue) {
+                          setState(() {
+                            value = newValue;
+                          });
+                        },
+                      ),
+                    ),
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    // Tap at the center, which should always give the correct value.
+    await tester.tap(find.byKey(sliderKey));
+    expect(value, equals(50.0));
+
+    // Tap at the left quarter - verify it snaps to the correct division.
+    final Offset topLeft = tester.getTopLeft(find.byKey(sliderKey));
+    final Offset bottomRight = tester.getBottomRight(find.byKey(sliderKey));
+    final Offset target25 = topLeft + (bottomRight - topLeft).scale(0.25, 0.5);
+    await tester.tapAt(target25);
+    // Without the fix, the value could incorrectly snap to an adjacent division
+    // due to the mismatch between tap position calculation and tick mark positions.
+    // The value should be close to 25.0 (division 5 out of 20).
+    expect(value, moreOrLessEquals(25.0, epsilon: 5.0));
+  });
+
   testWidgets('Slider can be given zero values', (WidgetTester tester) async {
     final log = <double>[];
     await tester.pumpWidget(

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -739,8 +739,10 @@ void main() {
     await tester.tapAt(target25);
     // Without the fix, the value could incorrectly snap to an adjacent division
     // due to the mismatch between tap position calculation and tick mark positions.
-    // The value should be close to 25.0 (division 5 out of 20).
-    expect(value, moreOrLessEquals(25.0, epsilon: 5.0));
+    // With divisions=20 and max=100, each division is 5.0.
+    // The value should be a multiple of 5.0 close to 25.0.
+    expect(value % 5.0, equals(0.0));
+    expect(value, moreOrLessEquals(25.0, epsilon: 2.5));
   });
 
   testWidgets('Slider can be given zero values', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

Fixes the tap-to-value calculation for discrete sliders with rounded track shapes (`RoundedRectSliderTrackShape`, `GappedSliderTrackShape`).

For discrete sliders, the thumb and tick marks are painted using an adjusted track width (`trackWidth - trackHeight`) to keep them within the rounded track bounds. However, `_getValueFromGlobalPosition` used the full `trackRect.width`, causing a systematic offset between where tick marks are painted and where taps register.

This offset is proportional to `trackHeight / trackWidth` and is most noticeable with:
- The new M3 slider style (`trackHeight: 16.0`)
- Narrower sliders
- More divisions (smaller division spacing)

The fix ensures `_getValueFromGlobalPosition` and `_handleDragUpdate` use the same adjusted track width as the tick mark painting and thumb positioning code in `_calcThumbCenter`.

## Changes

- **`_getValueFromGlobalPosition`**: For discrete + rounded track, calculate visual position using `(localDx - trackRect.left - padding/2) / adjustedTrackWidth` to match tick mark positions.
- **`_handleDragUpdate`**: Use `adjustedTrackWidth` for drag delta calculation.
- Added regression test.

Fixes https://github.com/flutter/flutter/issues/184391

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)