### PR TITLE
Remove list_tile_tester and rendering_tester cross-imports from cupertino tests

### DIFF
--- a/packages/flutter/test/cupertino/picker_test.dart
+++ b/packages/flutter/test/cupertino/picker_test.dart
@@ -9,23 +9,8 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../widgets/semantics_tester.dart';
+import 'rendering_test_utils.dart';
 
-/// A [CustomPainter] that calls a callback when it paints.
-class TestCallbackPainter extends CustomPainter {
-  /// Creates a [TestCallbackPainter] that calls [onPaint] when it paints.
-  const TestCallbackPainter({required this.onPaint});
-
-  /// The callback called when the painter paints.
-  final VoidCallback onPaint;
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    onPaint();
-  }
-
-  @override
-  bool shouldRepaint(covariant TestCallbackPainter oldDelegate) => true;
-}
 
 class SpyFixedExtentScrollController extends FixedExtentScrollController {
   /// Override for test visibility only.

--- a/packages/flutter/test/cupertino/picker_test.dart
+++ b/packages/flutter/test/cupertino/picker_test.dart
@@ -11,7 +11,6 @@ import 'package:flutter_test/flutter_test.dart';
 import '../widgets/semantics_tester.dart';
 import 'rendering_test_utils.dart';
 
-
 class SpyFixedExtentScrollController extends FixedExtentScrollController {
   /// Override for test visibility only.
   @override

--- a/packages/flutter/test/cupertino/picker_test.dart
+++ b/packages/flutter/test/cupertino/picker_test.dart
@@ -457,51 +457,49 @@ void main() {
       expect(selectedItems, <int>[2, 1]);
     });
 
-    testWidgets(
-      'does not trigger haptics or sounds when scrolling by tapping on the item',
-      (WidgetTester tester) async {
-        final selectedItems = <int>[];
-        final systemCalls = <MethodCall>[];
+    testWidgets('does not trigger haptics or sounds when scrolling by tapping on the item', (
+      WidgetTester tester,
+    ) async {
+      final selectedItems = <int>[];
+      final systemCalls = <MethodCall>[];
 
-        tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(SystemChannels.platform, (
-          MethodCall methodCall,
-        ) async {
-          systemCalls.add(methodCall);
-          return null;
-        });
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(SystemChannels.platform, (
+        MethodCall methodCall,
+      ) async {
+        systemCalls.add(methodCall);
+        return null;
+      });
 
-        await tester.pumpWidget(
-          Directionality(
-            textDirection: TextDirection.ltr,
-            child: CupertinoPicker(
-              itemExtent: 100.0,
-              onSelectedItemChanged: (int index) {
-                selectedItems.add(index);
-              },
-              children: List<Widget>.generate(100, (int index) {
-                return Center(
-                  child: SizedBox(width: 400.0, height: 100.0, child: Text(index.toString())),
-                );
-              }),
-            ),
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: CupertinoPicker(
+            itemExtent: 100.0,
+            onSelectedItemChanged: (int index) {
+              selectedItems.add(index);
+            },
+            children: List<Widget>.generate(100, (int index) {
+              return Center(
+                child: SizedBox(width: 400.0, height: 100.0, child: Text(index.toString())),
+              );
+            }),
           ),
-        );
+        ),
+      );
 
-        await tester.tap(find.text('2'), warnIfMissed: false); // has an IgnorePointer
-        await tester.pumpAndSettle(const Duration(milliseconds: 10));
+      await tester.tap(find.text('2'), warnIfMissed: false); // has an IgnorePointer
+      await tester.pumpAndSettle(const Duration(milliseconds: 10));
 
-        // Expect that the item changed, but haptics were not triggered.
-        expect(selectedItems, <int>[1, 2]);
-        expect(systemCalls, isEmpty);
+      // Expect that the item changed, but haptics were not triggered.
+      expect(selectedItems, <int>[1, 2]);
+      expect(systemCalls, isEmpty);
 
-        await tester.drag(find.text('2'), const Offset(0.0, -30.0), warnIfMissed: false);
-        await tester.pumpAndSettle(const Duration(milliseconds: 10));
-        // Expect that moving within the item does not trigger haptics after animating scroll.
-        expect(selectedItems, <int>[1, 2]);
-        expect(systemCalls, isEmpty);
-      },
-      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-    );
+      await tester.drag(find.text('2'), const Offset(0.0, -30.0), warnIfMissed: false);
+      await tester.pumpAndSettle(const Duration(milliseconds: 10));
+      // Expect that moving within the item does not trigger haptics after animating scroll.
+      expect(selectedItems, <int>[1, 2]);
+      expect(systemCalls, isEmpty);
+    }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
     testWidgets(
       'do not trigger haptic or sounds on non-iOS devices',

--- a/packages/flutter/test/cupertino/rendering_test_utils.dart
+++ b/packages/flutter/test/cupertino/rendering_test_utils.dart
@@ -1,0 +1,20 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+
+/// A [CustomPainter] that invokes a callback when it paints.
+class TestCallbackPainter extends CustomPainter {
+  const TestCallbackPainter({required this.onPaint});
+
+  final VoidCallback onPaint;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    onPaint();
+  }
+
+  @override
+  bool shouldRepaint(TestCallbackPainter oldPainter) => true;
+}

--- a/packages/flutter/test/cupertino/rendering_test_utils.dart
+++ b/packages/flutter/test/cupertino/rendering_test_utils.dart
@@ -8,6 +8,7 @@ import 'package:flutter/widgets.dart';
 class TestCallbackPainter extends CustomPainter {
   const TestCallbackPainter({required this.onPaint});
 
+  /// The callback to invoke during [paint].
   final VoidCallback onPaint;
 
   @override

--- a/packages/flutter/test/cupertino/rendering_test_utils.dart
+++ b/packages/flutter/test/cupertino/rendering_test_utils.dart
@@ -6,6 +6,7 @@ import 'package:flutter/widgets.dart';
 
 /// A [CustomPainter] that invokes a callback when it paints.
 class TestCallbackPainter extends CustomPainter {
+  /// Creates a [TestCallbackPainter] that calls [onPaint] when it paints.
   const TestCallbackPainter({required this.onPaint});
 
   /// The callback to invoke during [paint].

--- a/packages/flutter/test/cupertino/switch_test.dart
+++ b/packages/flutter/test/cupertino/switch_test.dart
@@ -89,143 +89,137 @@ void main() {
     expect(value, isTrue);
   });
 
-  testWidgets(
-    'Switch emits light haptic vibration on tap',
-    (WidgetTester tester) async {
-      final Key switchKey = UniqueKey();
-      var value = false;
+  testWidgets('Switch emits light haptic vibration on tap', (WidgetTester tester) async {
+    final Key switchKey = UniqueKey();
+    var value = false;
 
-      final log = <MethodCall>[];
+    final log = <MethodCall>[];
 
-      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(SystemChannels.platform, (
-        MethodCall methodCall,
-      ) async {
-        log.add(methodCall);
-        return null;
-      });
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(SystemChannels.platform, (
+      MethodCall methodCall,
+    ) async {
+      log.add(methodCall);
+      return null;
+    });
 
-      await tester.pumpWidget(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: StatefulBuilder(
-            builder: (BuildContext context, StateSetter setState) {
-              return Center(
-                child: CupertinoSwitch(
-                  key: switchKey,
-                  value: value,
-                  dragStartBehavior: DragStartBehavior.down,
-                  onChanged: (bool newValue) {
-                    setState(() {
-                      value = newValue;
-                    });
-                  },
-                ),
-              );
-            },
-          ),
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return Center(
+              child: CupertinoSwitch(
+                key: switchKey,
+                value: value,
+                dragStartBehavior: DragStartBehavior.down,
+                onChanged: (bool newValue) {
+                  setState(() {
+                    value = newValue;
+                  });
+                },
+              ),
+            );
+          },
         ),
-      );
+      ),
+    );
 
-      await tester.tap(find.byKey(switchKey));
-      await tester.pump();
+    await tester.tap(find.byKey(switchKey));
+    await tester.pump();
 
-      expect(log, hasLength(1));
-      expect(
-        log.single,
-        isMethodCall('HapticFeedback.vibrate', arguments: 'HapticFeedbackType.lightImpact'),
-      );
-    },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-  );
+    expect(log, hasLength(1));
+    expect(
+      log.single,
+      isMethodCall('HapticFeedback.vibrate', arguments: 'HapticFeedbackType.lightImpact'),
+    );
+  }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
-  testWidgets(
-    'Using other widgets that rebuild the switch will not cause vibrations',
-    (WidgetTester tester) async {
-      final Key switchKey = UniqueKey();
-      final Key switchKey2 = UniqueKey();
-      var value = false;
-      var value2 = false;
-      final log = <MethodCall>[];
+  testWidgets('Using other widgets that rebuild the switch will not cause vibrations', (
+    WidgetTester tester,
+  ) async {
+    final Key switchKey = UniqueKey();
+    final Key switchKey2 = UniqueKey();
+    var value = false;
+    var value2 = false;
+    final log = <MethodCall>[];
 
-      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(SystemChannels.platform, (
-        MethodCall methodCall,
-      ) async {
-        log.add(methodCall);
-        return null;
-      });
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(SystemChannels.platform, (
+      MethodCall methodCall,
+    ) async {
+      log.add(methodCall);
+      return null;
+    });
 
-      await tester.pumpWidget(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: StatefulBuilder(
-            builder: (BuildContext context, StateSetter setState) {
-              return Center(
-                child: Column(
-                  children: <Widget>[
-                    CupertinoSwitch(
-                      key: switchKey,
-                      value: value,
-                      onChanged: (bool newValue) {
-                        setState(() {
-                          value = newValue;
-                        });
-                      },
-                    ),
-                    CupertinoSwitch(
-                      key: switchKey2,
-                      value: value2,
-                      onChanged: (bool newValue) {
-                        setState(() {
-                          value2 = newValue;
-                        });
-                      },
-                    ),
-                  ],
-                ),
-              );
-            },
-          ),
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return Center(
+              child: Column(
+                children: <Widget>[
+                  CupertinoSwitch(
+                    key: switchKey,
+                    value: value,
+                    onChanged: (bool newValue) {
+                      setState(() {
+                        value = newValue;
+                      });
+                    },
+                  ),
+                  CupertinoSwitch(
+                    key: switchKey2,
+                    value: value2,
+                    onChanged: (bool newValue) {
+                      setState(() {
+                        value2 = newValue;
+                      });
+                    },
+                  ),
+                ],
+              ),
+            );
+          },
         ),
-      );
+      ),
+    );
 
-      await tester.tap(find.byKey(switchKey));
-      await tester.pump();
+    await tester.tap(find.byKey(switchKey));
+    await tester.pump();
 
-      expect(log, hasLength(1));
-      expect(
-        log[0],
-        isMethodCall('HapticFeedback.vibrate', arguments: 'HapticFeedbackType.lightImpact'),
-      );
+    expect(log, hasLength(1));
+    expect(
+      log[0],
+      isMethodCall('HapticFeedback.vibrate', arguments: 'HapticFeedbackType.lightImpact'),
+    );
 
-      await tester.tap(find.byKey(switchKey2));
-      await tester.pump();
+    await tester.tap(find.byKey(switchKey2));
+    await tester.pump();
 
-      expect(log, hasLength(2));
-      expect(
-        log[1],
-        isMethodCall('HapticFeedback.vibrate', arguments: 'HapticFeedbackType.lightImpact'),
-      );
+    expect(log, hasLength(2));
+    expect(
+      log[1],
+      isMethodCall('HapticFeedback.vibrate', arguments: 'HapticFeedbackType.lightImpact'),
+    );
 
-      await tester.tap(find.byKey(switchKey));
-      await tester.pump();
+    await tester.tap(find.byKey(switchKey));
+    await tester.pump();
 
-      expect(log, hasLength(3));
-      expect(
-        log[2],
-        isMethodCall('HapticFeedback.vibrate', arguments: 'HapticFeedbackType.lightImpact'),
-      );
+    expect(log, hasLength(3));
+    expect(
+      log[2],
+      isMethodCall('HapticFeedback.vibrate', arguments: 'HapticFeedbackType.lightImpact'),
+    );
 
-      await tester.tap(find.byKey(switchKey2));
-      await tester.pump();
+    await tester.tap(find.byKey(switchKey2));
+    await tester.pump();
 
-      expect(log, hasLength(4));
-      expect(
-        log[3],
-        isMethodCall('HapticFeedback.vibrate', arguments: 'HapticFeedbackType.lightImpact'),
-      );
-    },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-  );
+    expect(log, hasLength(4));
+    expect(
+      log[3],
+      isMethodCall('HapticFeedback.vibrate', arguments: 'HapticFeedbackType.lightImpact'),
+    );
+  }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
   testWidgets('Haptic vibration triggers on drag', (WidgetTester tester) async {
     var value = false;
@@ -270,63 +264,61 @@ void main() {
     );
   }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
-  testWidgets(
-    'No haptic vibration triggers from a programmatic value change',
-    (WidgetTester tester) async {
-      final Key switchKey = UniqueKey();
-      var value = false;
+  testWidgets('No haptic vibration triggers from a programmatic value change', (
+    WidgetTester tester,
+  ) async {
+    final Key switchKey = UniqueKey();
+    var value = false;
 
-      final log = <MethodCall>[];
-      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(SystemChannels.platform, (
-        MethodCall methodCall,
-      ) async {
-        log.add(methodCall);
-        return null;
-      });
+    final log = <MethodCall>[];
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(SystemChannels.platform, (
+      MethodCall methodCall,
+    ) async {
+      log.add(methodCall);
+      return null;
+    });
 
-      await tester.pumpWidget(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: StatefulBuilder(
-            builder: (BuildContext context, StateSetter setState) {
-              return Center(
-                child: Column(
-                  children: <Widget>[
-                    CupertinoButton(
-                      child: const Text('Button'),
-                      onPressed: () {
-                        setState(() {
-                          value = !value;
-                        });
-                      },
-                    ),
-                    CupertinoSwitch(
-                      key: switchKey,
-                      value: value,
-                      onChanged: (bool newValue) {
-                        setState(() {
-                          value = newValue;
-                        });
-                      },
-                    ),
-                  ],
-                ),
-              );
-            },
-          ),
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return Center(
+              child: Column(
+                children: <Widget>[
+                  CupertinoButton(
+                    child: const Text('Button'),
+                    onPressed: () {
+                      setState(() {
+                        value = !value;
+                      });
+                    },
+                  ),
+                  CupertinoSwitch(
+                    key: switchKey,
+                    value: value,
+                    onChanged: (bool newValue) {
+                      setState(() {
+                        value = newValue;
+                      });
+                    },
+                  ),
+                ],
+              ),
+            );
+          },
         ),
-      );
+      ),
+    );
 
-      expect(value, isFalse);
+    expect(value, isFalse);
 
-      await tester.tap(find.byType(CupertinoButton));
-      expect(value, isTrue);
-      await tester.pump();
+    await tester.tap(find.byType(CupertinoButton));
+    expect(value, isTrue);
+    await tester.pump();
 
-      expect(log, hasLength(0));
-    },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-  );
+    expect(log, hasLength(0));
+  }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
   testWidgets('Switch can drag (LTR)', (WidgetTester tester) async {
     var value = false;

--- a/packages/flutter/test/cupertino/tab_scaffold_test.dart
+++ b/packages/flutter/test/cupertino/tab_scaffold_test.dart
@@ -13,7 +13,6 @@ import 'rendering_test_utils.dart' show TestCallbackPainter;
 
 late List<int> selectedTabs;
 
-
 class MockCupertinoTabController extends CupertinoTabController {
   MockCupertinoTabController({required super.initialIndex});
 

--- a/packages/flutter/test/cupertino/tab_scaffold_test.dart
+++ b/packages/flutter/test/cupertino/tab_scaffold_test.dart
@@ -9,24 +9,10 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../widgets/widget_inspector_test_utils.dart';
 import 'navigator_utils.dart';
+import 'rendering_test_utils.dart' show TestCallbackPainter;
 
 late List<int> selectedTabs;
 
-/// A [CustomPainter] that invokes the [onPaint] callback when it is painted.
-class _TestCallbackPainter extends CustomPainter {
-  const _TestCallbackPainter({required this.onPaint});
-
-  /// The callback that is invoked when the painter paints.
-  final VoidCallback onPaint;
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    onPaint();
-  }
-
-  @override
-  bool shouldRepaint(covariant _TestCallbackPainter oldDelegate) => true;
-}
 
 class MockCupertinoTabController extends CupertinoTabController {
   MockCupertinoTabController({required super.initialIndex});
@@ -75,7 +61,7 @@ void main() {
           tabBar: _buildTabBar(),
           tabBuilder: (BuildContext context, int index) {
             return CustomPaint(
-              painter: _TestCallbackPainter(
+              painter: TestCallbackPainter(
                 onPaint: () {
                   tabsPainted.add(index);
                 },
@@ -250,7 +236,7 @@ void main() {
           controller: controller,
           tabBuilder: (BuildContext context, int index) {
             return CustomPaint(
-              painter: _TestCallbackPainter(
+              painter: TestCallbackPainter(
                 onPaint: () {
                   tabsPainted.add(index);
                 },
@@ -290,7 +276,7 @@ void main() {
           tabBar: _buildTabBar(),
           tabBuilder: (BuildContext context, int index) {
             return CustomPaint(
-              painter: _TestCallbackPainter(
+              painter: TestCallbackPainter(
                 onPaint: () {
                   tabsPainted.add(index);
                 },
@@ -313,7 +299,7 @@ void main() {
           controller: controller, // Programmatically change the tab now.
           tabBuilder: (BuildContext context, int index) {
             return CustomPaint(
-              painter: _TestCallbackPainter(
+              painter: TestCallbackPainter(
                 onPaint: () {
                   tabsPainted.add(index);
                 },
@@ -650,7 +636,7 @@ void main() {
           controller: controller,
           tabBuilder: (BuildContext context, int index) {
             return CustomPaint(
-              painter: _TestCallbackPainter(
+              painter: TestCallbackPainter(
                 onPaint: () {
                   tabsPainted.add(index);
                 },
@@ -672,7 +658,7 @@ void main() {
           controller: controller,
           tabBuilder: (BuildContext context, int index) {
             return CustomPaint(
-              painter: _TestCallbackPainter(
+              painter: TestCallbackPainter(
                 onPaint: () {
                   tabsPainted.add(index);
                 },
@@ -707,7 +693,7 @@ void main() {
           controller: oldController,
           tabBuilder: (BuildContext context, int index) {
             return CustomPaint(
-              painter: _TestCallbackPainter(
+              painter: TestCallbackPainter(
                 onPaint: () {
                   tabsPainted.add(index);
                 },
@@ -727,7 +713,7 @@ void main() {
           tabBar: CupertinoTabBar(items: List<BottomNavigationBarItem>.generate(10, tabGenerator)),
           tabBuilder: (BuildContext context, int index) {
             return CustomPaint(
-              painter: _TestCallbackPainter(
+              painter: TestCallbackPainter(
                 onPaint: () {
                   tabsPainted.add(index);
                 },
@@ -838,7 +824,7 @@ void main() {
                 controller: controller,
                 tabBuilder: (BuildContext context, int index) {
                   return CustomPaint(
-                    painter: _TestCallbackPainter(onPaint: () => tabsPainted0.add(index)),
+                    painter: TestCallbackPainter(onPaint: () => tabsPainted0.add(index)),
                   );
                 },
               ),
@@ -849,7 +835,7 @@ void main() {
                 controller: controller,
                 tabBuilder: (BuildContext context, int index) {
                   return CustomPaint(
-                    painter: _TestCallbackPainter(onPaint: () => tabsPainted1.add(index)),
+                    painter: TestCallbackPainter(onPaint: () => tabsPainted1.add(index)),
                   );
                 },
               ),
@@ -881,7 +867,7 @@ void main() {
                 controller: controller,
                 tabBuilder: (BuildContext context, int index) {
                   return CustomPaint(
-                    painter: _TestCallbackPainter(onPaint: () => tabsPainted0.add(index)),
+                    painter: TestCallbackPainter(onPaint: () => tabsPainted0.add(index)),
                   );
                 },
               ),
@@ -911,7 +897,7 @@ void main() {
                 controller: controller,
                 tabBuilder: (BuildContext context, int index) {
                   return CustomPaint(
-                    painter: _TestCallbackPainter(onPaint: () => tabsPainted0.add(index)),
+                    painter: TestCallbackPainter(onPaint: () => tabsPainted0.add(index)),
                   );
                 },
               ),


### PR DESCRIPTION
Remove cross-directory test imports of `list_tile_tester.dart` and `rendering_tester.dart` from cupertino tests by duplicating the relevant trivial test utilities locally:

- **`TestListTile`** (~30 lines) → duplicated into `test/cupertino/list_tile_tester.dart`, used by `cupertino/switch_test.dart`
- **`TestCallbackPainter`** (~10 lines) → duplicated into `test/cupertino/rendering_test_utils.dart`, used by `cupertino/picker_test.dart` and `cupertino/tab_scaffold_test.dart`

Both utilities are trivial and match the "duplicate the util" criteria from the issue.

Part of #182636.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md