### PR TITLE
[iOS] Make it easier to run unit tests from CLI

### DIFF
--- a/engine/src/flutter/testing/run_tests.py
+++ b/engine/src/flutter/testing/run_tests.py
@@ -750,13 +750,9 @@ def ensure_ios_tests_are_built(ios_out_dir: str) -> None:
   message.append(f'ninja -C {ios_out_dir} ios_test_flutter')
   joined_message = '\n  '.join(message)
   final_message = (
-      f"{ios_out_dir} or {ios_test_lib} doesn't exist.\n"
-      f'\n'
-      f'Please run the following commands: \n'
-      f'\n'
-      f'  {joined_message}\n'
-      f'\n'
-      f''
+      f"{ios_out_dir} or {ios_test_lib} doesn't exist.\n\n"
+      f'Please run the following commands:\n\n'
+      f'  {joined_message}\n\n'
       f'Alternatively, use --ios-variant to specify a different build configuration.'
   )
   assert os.path.exists(tmp_out_dir) and os.path.exists(ios_test_lib), final_message
@@ -1401,9 +1397,10 @@ Flutter Wiki page on the subject: https://github.com/flutter/flutter/wiki/Testin
 
   build_dir = os.path.join(OUT_DIR, args.variant)
   if args.type not in ('java', 'android'):
-    assert os.path.exists(
-        build_dir
-    ), f'Build directory {build_dir} does not exist!\n\nYou can use --variant to specify a different build configuration if needed.'
+    assert os.path.exists(build_dir), (
+        f'Build directory {build_dir} does not exist!\n\n'
+        'You can use --variant to specify a different build configuration if needed.'
+    )
 
   if args.sanitizer_suppressions:
     assert is_linux() or is_mac(

--- a/engine/src/flutter/testing/run_tests.py
+++ b/engine/src/flutter/testing/run_tests.py
@@ -748,10 +748,16 @@ def ensure_ios_tests_are_built(ios_out_dir: str) -> None:
   message = []
   message.append('gn --ios --unoptimized --runtime-mode=debug --no-lto --simulator')
   message.append(f'ninja -C {ios_out_dir} ios_test_flutter')
-  joined_message = '\n'.join(message)
+  joined_message = '\n  '.join(message)
   final_message = (
-      f"{ios_out_dir} or {ios_test_lib} doesn't exist. "
-      f'Please run the following commands: \n{joined_message}'
+      f"{ios_out_dir} or {ios_test_lib} doesn't exist.\n"
+      f'\n'
+      f'Please run the following commands: \n'
+      f'\n'
+      f'  {joined_message}\n'
+      f'\n'
+      f''
+      f'Alternatively, use --ios-variant to specify a different build configuration.'
   )
   assert os.path.exists(tmp_out_dir) and os.path.exists(ios_test_lib), final_message
 
@@ -1395,7 +1401,9 @@ Flutter Wiki page on the subject: https://github.com/flutter/flutter/wiki/Testin
 
   build_dir = os.path.join(OUT_DIR, args.variant)
   if args.type not in ('java', 'android'):
-    assert os.path.exists(build_dir), f'Build variant directory {build_dir} does not exist!'
+    assert os.path.exists(
+        build_dir
+    ), f'Build directory {build_dir} does not exist!\n\nYou can use --variant to specify a different build configuration if needed.'
 
   if args.sanitizer_suppressions:
     assert is_linux() or is_mac(


### PR DESCRIPTION
You can use `run_tests.py` to run iOS unit tests from the command line. This script assumes you built the `ios_debug_sim_unopt` variant. This improves the error messages if you built a different variant, like `ios_debug_sim_unopt_arm64`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
