### PR TITLE
Explain TextField.onChanged limitations with IME composing text

### DIFF
--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -145,7 +145,7 @@ class _CupertinoTextFieldSelectionGestureDetectorBuilder
 /// field (e.g., by pressing a button on the soft keyboard), the text field
 /// calls the [onSubmitted] callback.
 ///
-/// {@macro flutter.widgets.EditableText.onChanged}
+/// {@macro flutter.widgets.editableText.onChangedComplexCharacters}
 ///
 /// {@tool dartpad}
 /// This example shows how to set the initial value of the [CupertinoTextField] using

--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -64,7 +64,7 @@ import 'theme.dart';
 /// used to exit the search page.
 ///
 /// ## Handling emojis and other complex characters
-/// {@macro flutter.widgets.EditableText.onChanged}
+/// {@macro flutter.widgets.editableText.onChangedComplexCharacters}
 ///
 /// See also:
 ///
@@ -112,7 +112,7 @@ Future<T?> showSearch<T>({
 /// for another [showSearch] call.
 ///
 /// ## Handling emojis and other complex characters
-/// {@macro flutter.widgets.EditableText.onChanged}
+/// {@macro flutter.widgets.editableText.onChangedComplexCharacters}
 abstract class SearchDelegate<T> {
   /// Constructor to be called by subclasses which may specify
   /// [searchFieldLabel], either [searchFieldStyle] or [searchFieldDecorationTheme],

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -153,7 +153,7 @@ class _TextFieldSelectionGestureDetectorBuilder extends TextSelectionGestureDete
 /// [TextEditingController] using [TextEditingController.text].
 ///
 /// ## Handling emojis and other complex characters
-/// {@macro flutter.widgets.EditableText.onChanged}
+/// {@macro flutter.widgets.editableText.onChangedComplexCharacters}
 ///
 /// In the live Dartpad example above, try typing the emoji 👨‍👩‍👦
 /// into the field and submitting. Because the example code measures the length

--- a/packages/flutter/lib/src/services/text_formatter.dart
+++ b/packages/flutter/lib/src/services/text_formatter.dart
@@ -82,7 +82,7 @@ enum MaxLengthEnforcement {
 /// implement the [formatEditUpdate] method.
 ///
 /// ## Handling emojis and other complex characters
-/// {@macro flutter.widgets.EditableText.onChanged}
+/// {@macro flutter.widgets.editableText.onChangedComplexCharacters}
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1404,19 +1404,20 @@ class EditableText extends StatefulWidget {
   final TextInputAction? textInputAction;
 
   /// {@template flutter.widgets.editableText.onChanged}
-  /// Called when the user initiates a change to the TextField's
-  /// value: when they have inserted or deleted text.
+  /// Called when the user updates the text within the TextField.
   ///
-  /// This callback doesn't run when the TextField's text is changed
-  /// programmatically, via the TextField's [controller]. Typically it
-  /// isn't necessary to be notified of such changes, since they're
-  /// initiated by the app itself.
+  /// This callback is triggered only by changes to the text by
+  /// user-initiated interactions, such as typing, deleting, or
+  /// pasting text.
   ///
-  /// This callback doesn't run if committing a composition range doesn't change
-  /// the TextField's value.
+  /// This callback is _not_ triggered by:
   ///
-  /// To be notified of all changes to the TextField's text, cursor,
-  /// selection, and composing state, one can add a listener to its [controller]
+  /// 1. Programmatic changes to the text via the [controller].
+  /// 2. Selection or cursor changes.
+  /// 3. IME composition changes that don't alter the text string.
+  ///
+  /// To be notified of all changes to the TextField's text, cursor, selection,
+  /// and composing state, one can add a listener to its [controller]
   /// with [TextEditingController.addListener].
   ///
   /// [onChanged] is called before [onSubmitted] when user indicates completion

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1404,20 +1404,19 @@ class EditableText extends StatefulWidget {
   final TextInputAction? textInputAction;
 
   /// {@template flutter.widgets.editableText.onChanged}
-  /// Called when the user updates the text within the TextField.
+  /// Called when the user changes the text within the TextField, such as
+  /// typing, pasting, or deleting text.
   ///
-  /// This callback is triggered only by changes to the text by
-  /// user-initiated interactions, such as typing, deleting, or
-  /// pasting text.
+  /// This callback is triggered only by user-initiated changes to the text.
   ///
   /// This callback is _not_ triggered by:
   ///
-  /// 1. Programmatic changes to the text via the [controller].
+  /// 1. Programmatic changes to the text, via the TextField's [controller].
   /// 2. Selection or cursor changes.
   /// 3. IME composition changes that don't alter the text string.
   ///
   /// To be notified of all changes to the TextField's text, cursor, selection,
-  /// and composing state, one can add a listener to its [controller]
+  /// and composing state, you can add a listener to its [controller]
   /// with [TextEditingController.addListener].
   ///
   /// [onChanged] is called before [onSubmitted] when user indicates completion

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1412,9 +1412,12 @@ class EditableText extends StatefulWidget {
   /// isn't necessary to be notified of such changes, since they're
   /// initiated by the app itself.
   ///
+  /// This callback doesn't run if committing a composition range doesn't change
+  /// the TextField's value.
+  ///
   /// To be notified of all changes to the TextField's text, cursor,
-  /// and selection, one can add a listener to its [controller] with
-  /// [TextEditingController.addListener].
+  /// selection, and composing state, one can add a listener to its [controller]
+  /// with [TextEditingController.addListener].
   ///
   /// [onChanged] is called before [onSubmitted] when user indicates completion
   /// of editing, such as when pressing the "done" button on the keyboard. That
@@ -1429,7 +1432,7 @@ class EditableText extends StatefulWidget {
   /// {@endtemplate}
   ///
   /// ## Handling emojis and other complex characters
-  /// {@template flutter.widgets.EditableText.onChanged}
+  /// {@template flutter.widgets.editableText.onChangedComplexCharacters}
   /// It's important to always use
   /// [characters](https://pub.dev/packages/characters) when dealing with user
   /// input text that may contain complex characters. This will ensure that


### PR DESCRIPTION
Clarify that you should use `TextEditingController.addListener` instead of `TextField.onChanged` to be notified when an IME composition is committed.

Addresses: https://github.com/flutter/flutter/issues/174159

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
