### PR TITLE
Fix arm64e incorrectly matching arm64 in EXCLUDED_ARCHS regex

### DIFF
--- a/packages/flutter_tools/lib/src/xcode_project.dart
+++ b/packages/flutter_tools/lib/src/xcode_project.dart
@@ -572,7 +572,7 @@ def __lldb_init_module(debugger: lldb.SBDebugger, _):
       }
     }
 
-    return !buildSettings.contains(RegExp('EXCLUDED_ARCHS.*arm64'));
+    return !buildSettings.contains(RegExp(r'EXCLUDED_ARCHS.*\barm64\b'));
   }
 
   /// Returns a list of targets and their associated plugin (if found) that exclude arm64 architecture.

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -1567,6 +1567,11 @@ Build settings for action build and target good_plugin:
           final File config = fs.file('path/to/project/ios/Flutter/Generated.xcconfig');
           expect(logger.warningText, isEmpty);
           expect(config.readAsStringSync(), contains('EXCLUDED_ARCHS[sdk=iphonesimulator*]=i386'));
+          // Verify arm64 is NOT incorrectly added when only arm64e is excluded
+          expect(
+            config.readAsStringSync(),
+            isNot(contains('EXCLUDED_ARCHS[sdk=iphonesimulator*]=i386 arm64')),
+          );
           expect(config.readAsStringSync(), contains('EXCLUDED_ARCHS[sdk=iphoneos*]=armv7'));
           expect(fakeProcessManager, hasNoRemainingExpectations);
         },


### PR DESCRIPTION
## Summary
- The regex `EXCLUDED_ARCHS.*arm64` incorrectly matches `arm64e`, causing projects that only exclude `arm64e` to be treated as if they exclude `arm64` — leading to wrong build configuration
- Use word boundary anchors (`\barm64\b`) so `arm64e` is no longer a false positive

## Changes
- `packages/flutter_tools/lib/src/xcode_project.dart`: Changed regex from `EXCLUDED_ARCHS.*arm64` to `EXCLUDED_ARCHS.*\barm64\b`
- `packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart`: Added assertion verifying `arm64` is not incorrectly added when only `arm64e` is excluded

Fixes flutter/flutter#184056