### PR TITLE
Detect incompatible git in content_aware_hash to prevent SDK corruption

### DIFF
--- a/bin/internal/content_aware_hash.ps1
+++ b/bin/internal/content_aware_hash.ps1
@@ -72,7 +72,7 @@ if (($currentBranch -ne "main") -and
 
 # Capture git ls-tree output separately so we can detect failures.
 # See https://github.com/flutter/flutter/issues/184523.
-$treeOutput = (git -C "$flutterRoot" ls-tree "$baseRef" -- $trackedFiles 2>&1 | Out-String)
+$treeOutput = (git -C "$flutterRoot" ls-tree "$baseRef" -- $trackedFiles 2>$null | Out-String)
 if ($LASTEXITCODE -ne 0) {
     $gitBinary = (Get-Command git -ErrorAction SilentlyContinue).Source
     $gitVersion = (git --version 2>$null)

--- a/bin/internal/content_aware_hash.ps1
+++ b/bin/internal/content_aware_hash.ps1
@@ -70,15 +70,36 @@ if (($currentBranch -ne "main") -and
     }
 }
 
-# Removing the "cmd" requirement enables powershell usage on other hosts
-# 1. git ls-tree | Out-String - combines output of pipeline into a single string
-#    rather than an array for each line.
-#    "-NoNewline" not available on PS5.1 and also removes all newlines.
-# 2. -replace "`r`n", "`n"  - removes line endings
+# Capture git ls-tree output separately so we can detect failures.
+# See https://github.com/flutter/flutter/issues/184523.
+$treeOutput = (git -C "$flutterRoot" ls-tree "$baseRef" -- $trackedFiles 2>&1 | Out-String)
+if ($LASTEXITCODE -ne 0) {
+    $gitBinary = (Get-Command git -ErrorAction SilentlyContinue).Source
+    $gitVersion = (git --version 2>$null)
+    Write-Host @"
+
+Error: Unable to compute the content hash of the Flutter SDK.
+'git ls-tree' failed for ref '$baseRef'.
+
+This is most commonly caused by an incompatible version of git.
+  git binary : $gitBinary
+  git version: $gitVersion
+
+If this Flutter SDK was cloned or last used with a different version of
+git, ensure that version is available in your PATH, or re-clone the SDK
+with the current version of git.
+
+git ls-tree output:
+$treeOutput
+"@ -ForegroundColor Red
+    exit 1
+}
+
+# 1. -replace "`r`n", "`n"  - normalizes line endings
 #    NOTE: Out-String adds a new line; so Out-File -NoNewline strips that.
-# 3. Out-File -NoNewline -Encoding ascii outputs 8bit ascii
-# 4. git hash-object with stdin from a pipeline consumes UTF-16, so consume
-#.   the contents of hash.txt
-(git -C "$flutterRoot" ls-tree "$baseRef" -- $trackedFiles | Out-String) -replace "`r`n", "`n"  | Out-File -NoNewline -Encoding ascii hash.txt
+# 2. Out-File -NoNewline -Encoding ascii outputs 8bit ascii
+# 3. git hash-object with stdin from a pipeline consumes UTF-16, so consume
+#    the contents of hash.txt
+$treeOutput -replace "`r`n", "`n" | Out-File -NoNewline -Encoding ascii hash.txt
 git hash-object hash.txt
 Remove-Item hash.txt

--- a/bin/internal/content_aware_hash.sh
+++ b/bin/internal/content_aware_hash.sh
@@ -84,4 +84,9 @@ TREE_OUTPUT="$(git -C "$FLUTTER_ROOT" ls-tree "$BASEREF" -- "${TRACKEDFILES[@]}"
   exit 1
 }
 
-echo "$TREE_OUTPUT" | git hash-object --stdin
+if [ -n "$TREE_OUTPUT" ]; then
+  printf '%s\n' "$TREE_OUTPUT" | git hash-object --stdin
+else
+  >&2 echo "Error: 'git ls-tree' produced empty output for ref '$BASEREF'."
+  exit 1
+fi

--- a/bin/internal/content_aware_hash.sh
+++ b/bin/internal/content_aware_hash.sh
@@ -65,4 +65,23 @@ if [[ "$CURRENT_BRANCH" != "main" && \
   fi
 fi
 
-git -C "$FLUTTER_ROOT" ls-tree "$BASEREF" -- "${TRACKEDFILES[@]}" | git hash-object --stdin
+# Capture git ls-tree output separately so we can detect failures.
+# A pipeline would mask a non-zero exit from ls-tree (set -e only
+# checks the last command in a pipeline when pipefail is not set).
+# See https://github.com/flutter/flutter/issues/184523.
+TREE_OUTPUT="$(git -C "$FLUTTER_ROOT" ls-tree "$BASEREF" -- "${TRACKEDFILES[@]}")" || {
+  >&2 echo ""
+  >&2 echo "Error: Unable to compute the content hash of the Flutter SDK."
+  >&2 echo "'git ls-tree' failed for ref '$BASEREF'."
+  >&2 echo ""
+  >&2 echo "This is most commonly caused by an incompatible version of git."
+  >&2 echo "  git binary : $(command -v git)"
+  >&2 echo "  git version: $(git --version 2>/dev/null || echo 'unknown')"
+  >&2 echo ""
+  >&2 echo "If this Flutter SDK was cloned or last used with a different version of"
+  >&2 echo "git, ensure that version is available in your PATH, or re-clone the SDK"
+  >&2 echo "with the current version of git."
+  exit 1
+}
+
+echo "$TREE_OUTPUT" | git hash-object --stdin

--- a/bin/internal/update_engine_version.ps1
+++ b/bin/internal/update_engine_version.ps1
@@ -62,6 +62,14 @@ if (![string]::IsNullOrEmpty($env:FLUTTER_PREBUILT_ENGINE_VERSION)) {
   $engineVersion = Invoke-Expression "& '$flutterRoot/bin/internal/content_aware_hash.ps1'"
 }
 
+# Validate that a non-empty engine version was determined.
+# See https://github.com/flutter/flutter/issues/184523.
+if ([string]::IsNullOrWhiteSpace($engineVersion)) {
+    Write-Host "Error: Failed to determine the Flutter engine version." -ForegroundColor Red
+    Write-Host "The content-aware hash script returned an empty result." -ForegroundColor Red
+    exit 1
+}
+
 # Write the engine version out so downstream tools know what to look for.
 # Use a temporary file and a retry logic to minimize chances of a race condition during
 # parallel flutter executions.

--- a/bin/internal/update_engine_version.sh
+++ b/bin/internal/update_engine_version.sh
@@ -63,6 +63,14 @@ else
   ENGINE_VERSION=$("$FLUTTER_ROOT/bin/internal/content_aware_hash.sh")
 fi
 
+# Validate that a non-empty engine version was determined.
+# See https://github.com/flutter/flutter/issues/184523.
+if [[ -z "$ENGINE_VERSION" ]]; then
+  >&2 echo "Error: Failed to determine the Flutter engine version."
+  >&2 echo "The content-aware hash script returned an empty result."
+  exit 1
+fi
+
 # Write the engine version out so downstream tools know what to look for.
 # Use a temporary file and atomic mv to prevent race conditions during parallel flutter executions.
 pid=$$

--- a/dev/tools/test/update_engine_version_test.dart
+++ b/dev/tools/test/update_engine_version_test.dart
@@ -382,6 +382,110 @@ void main() {
     });
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/184523.
+  //
+  // When an incompatible git binary is on PATH (e.g. from an AI agent or
+  // Xcode build action), `git ls-tree` can fail. Before the fix, the failure
+  // was masked by bash pipeline semantics and the empty-blob hash
+  // (e69de29bb2d1d6434b8b29ae775ad8c2e48c5391) was written to engine.stamp.
+  group('incompatible git (issue #184523)', () {
+    late Directory fakeGitDir;
+
+    setUp(() {
+      initGitRepoWithBlankInitialCommit();
+      setupRemote(remote: 'upstream');
+
+      // Find the real git binary path before we shadow it.
+      final String realGitPath = io.Process.runSync('which', <String>['git']).stdout.toString().trim();
+
+      // Create a fake git wrapper that fails on `ls-tree` (simulating a git
+      // binary that cannot read the repo's pack index format).
+      fakeGitDir = localFs.systemTempDirectory.createTempSync('fake_git.');
+      final File fakeGit = fakeGitDir.childFile('git');
+      fakeGit.writeAsStringSync(
+        '#!/bin/bash\n'
+        'for arg in "\$@"; do\n'
+        '  if [[ "\$arg" == "ls-tree" ]]; then\n'
+        '    echo "fatal: multi-pack-index version 2 not recognized" >&2\n'
+        '    exit 128\n'
+        '  fi\n'
+        'done\n'
+        'exec "$realGitPath" "\$@"\n',
+      );
+      io.Process.runSync('chmod', <String>['+x', fakeGit.path]);
+
+      // Prepend fake git to PATH so it shadows the real one.
+      final String currentPath = io.Platform.environment['PATH'] ?? '/usr/bin:/bin';
+      environment['PATH'] = '${fakeGitDir.path}:$currentPath';
+    });
+
+    test(
+      'fails with non-zero exit instead of writing empty-blob hash to engine.stamp',
+      () {
+        // Run directly (not via the run() helper) because we expect failure.
+        final String executable;
+        final List<String> args;
+        if (const LocalPlatform().isWindows) {
+          executable = 'powershell';
+          args = <String>[testRoot.binInternalUpdateEngineVersion.path];
+        } else if (usePowershellOnPosix) {
+          executable = 'pwsh';
+          args = <String>[testRoot.binInternalUpdateEngineVersion.path];
+        } else {
+          executable = testRoot.binInternalUpdateEngineVersion.path;
+          args = <String>[];
+        }
+
+        final io.ProcessResult result = io.Process.runSync(
+          executable,
+          args,
+          environment: environment,
+          workingDirectory: testRoot.root.absolute.path,
+          includeParentEnvironment: false,
+        );
+
+        // The script must fail rather than silently write a garbage hash.
+        expect(
+          result.exitCode,
+          isNot(0),
+          reason:
+              'Expected non-zero exit when git ls-tree fails, but got exit 0.\n'
+              'STDOUT:\n${result.stdout}\n'
+              'STDERR:\n${result.stderr}',
+        );
+
+        // If engine.stamp was written despite the failure, it must NOT contain
+        // the empty-blob hash that results from hashing empty input.
+        const String emptyBlobHash = 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391';
+        if (testRoot.binCacheEngineStamp.existsSync()) {
+          expect(
+            testRoot.binCacheEngineStamp.readAsStringSync().trim(),
+            isNot(equals(emptyBlobHash)),
+            reason:
+                'engine.stamp contains the empty-blob hash, indicating that '
+                'the git ls-tree failure was silently swallowed.',
+          );
+        }
+
+        // Verify the error message mentions the incompatible git issue.
+        final String stderr = result.stderr as String;
+        expect(
+          stderr,
+          contains('git'),
+          reason: 'Error output should mention git to help users diagnose the issue.',
+        );
+      },
+      // This test creates a POSIX shell script wrapper; skip on Windows.
+      skip: const LocalPlatform().isWindows
+          ? 'Test uses a bash wrapper script, not applicable on Windows'
+          : null,
+    );
+
+    tearDown(() {
+      fakeGitDir.deleteSync(recursive: true);
+    });
+  });
+
   group('concurrent execution', () {
     setUp(() {
       initGitRepoWithBlankInitialCommit();


### PR DESCRIPTION
## Summary

Fixes https://github.com/flutter/flutter/issues/184523
Related: https://github.com/flutter/flutter/issues/184376

- `content_aware_hash.sh` used a pipeline (`git ls-tree ... | git hash-object --stdin`) where bash's `set -e` only checks the exit code of the **last** command. When `git ls-tree` fails (e.g., an incompatible git version that cannot read the repo's multi-pack-index v2), `git hash-object` receives empty input and silently produces the empty-blob hash (`e69de29bb2d1d6434b8b29ae775ad8c2e48c5391`), which gets written to `engine.stamp` — corrupting the Flutter SDK cache.
- This happens when AI agents or Xcode build actions modify `PATH` to resolve a different (older) `git` binary than the one used to clone the SDK (e.g., Apple Git 2.50.1 vs Git 2.53).
- Split the pipeline to validate `git ls-tree` exit code and fail with a clear, actionable error message showing the git binary path and version.
- Applied the same fix to the PowerShell equivalents (`content_aware_hash.ps1`, `update_engine_version.ps1`).
- Added belt-and-suspenders empty-result validation in `update_engine_version.sh/.ps1`.
- Added a regression test that simulates an incompatible git binary.

## Files changed

| File | Change |
|------|--------|
| `bin/internal/content_aware_hash.sh` | Split pipeline, validate `git ls-tree` exit code, fail with error message |
| `bin/internal/content_aware_hash.ps1` | Check `$LASTEXITCODE` after `git ls-tree`, same error pattern |
| `bin/internal/update_engine_version.sh` | Validate engine version is not empty after content hash |
| `bin/internal/update_engine_version.ps1` | Same validation for PowerShell |
| `dev/tools/test/update_engine_version_test.dart` | Regression test with fake git that fails on `ls-tree` |

## Error message example

When an incompatible git is on PATH, users now see:
```
Error: Unable to compute the content hash of the Flutter SDK.
'git ls-tree' failed for ref 'HEAD'.

This is most commonly caused by an incompatible version of git.
  git binary : /usr/bin/git
  git version: git version 2.50.1 (Apple Git-155)

If this Flutter SDK was cloned or last used with a different version of
git, ensure that version is available in your PATH, or re-clone the SDK
with the current version of git.
```

## Test plan

- [x] All 11 existing + new tests pass: `cd dev/tools && dart test test/update_engine_version_test.dart`
- [x] Manual smoke test: created a fake git wrapper that fails on `ls-tree` → script now exits 1 with clear error instead of writing empty-blob hash
- [x] Normal operation verified: `content_aware_hash.sh` still produces correct hash with compatible git