### PR TITLE
Add tests for debugPrint-ing exciting Unicode codepoints

### DIFF
--- a/packages/flutter/test/foundation/print_test.dart
+++ b/packages/flutter/test/foundation/print_test.dart
@@ -46,6 +46,13 @@ void main() {
       }),
       equals(<String>['Hello,', 'world']),
     );
+
+    expect(
+      captureOutput(() {
+        debugPrintSynchronously('Hello, \u{FFFD}\u{1F525}\u{FEFF}\u{10FFFE} world');
+      }),
+      equals(<String>['Hello, \u{FFFD}\u{1F525}\u{FEFF}\u{10FFFE} world']),
+    );
   });
 
   test('debugPrint throttling', () {


### PR DESCRIPTION
This adds a test that *ought* to reproduce #184646 if run on the web platform (unless the output capture gets in the way). 

This will fix #184648 by adding the missing test.

This touches the tests, but isn't a breaking change; I'm not changing tests to fix them failing on changed code.

I looked through a lot of the testing documentation, and I saw that there's a "device lab" and something called `felt` exists for testing the "engine", but I think I've added this test to the "framework". I was not able to find any documentation about how to run a particular test *on the web version of Flutter*; https://github.com/flutter/flutter/blob/master/docs/contributing/testing/Running-and-writing-tests.md#running-unit-tests explains that the tests, when I run them, will run "inside a headless flutter shell on your workstation", which is not where this test needs to run if it is to trigger the bug it is looking for.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing. (I have not been able to figure out how to run this test in the environment it is meant to test, and if it worked as intended, it would be failing there anyway.)

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
