### PR TITLE
Expose platform specific handles for multi-window API

### DIFF
--- a/packages/flutter/lib/src/widgets/_window_linux.dart
+++ b/packages/flutter/lib/src/widgets/_window_linux.dart
@@ -191,13 +191,20 @@ abstract interface class WindowControllerLinux {
   ///
   /// Using this pointer implies the user is aware of any side effects changes may have to Flutter behavior.
   ///
+  /// The handle is only valid for the lifetime of the window. Once the window
+  /// is destroyed, this handle becomes invalid and must not be used.
+  ///
   /// {@macro flutter.widgets.windowing.experimental}
   @internal
   ffi.Pointer<ffi.Void> getWindowHandle();
 
   /// Returns pointer to the [FlView](https://github.com/flutter/flutter/blob/main/engine/src/flutter/shell/platform/linux/public/flutter_linux/fl_view.h)
   /// that renders the Flutter content in this window.
+  ///
   /// Using this pointer implies the user is aware of any side effects changes may have to Flutter behavior.
+  ///
+  /// The handle is only valid for the lifetime of the window. Once the window
+  /// is destroyed, this handle becomes invalid and must not be used.
   ///
   /// {@macro flutter.widgets.windowing.experimental}
   @internal

--- a/packages/flutter/lib/src/widgets/_window_linux.dart
+++ b/packages/flutter/lib/src/widgets/_window_linux.dart
@@ -196,7 +196,7 @@ abstract interface class WindowControllerLinux {
   ///
   /// {@macro flutter.widgets.windowing.experimental}
   @internal
-  ffi.Pointer<ffi.Void> getWindowHandle();
+  ffi.Pointer<ffi.Void> get windowHandle;
 
   /// Returns pointer to the [FlView](https://github.com/flutter/flutter/blob/main/engine/src/flutter/shell/platform/linux/public/flutter_linux/fl_view.h)
   /// that renders the Flutter content in this window.
@@ -208,7 +208,7 @@ abstract interface class WindowControllerLinux {
   ///
   /// {@macro flutter.widgets.windowing.experimental}
   @internal
-  ffi.Pointer<ffi.Void> getFlutterViewHandle();
+  ffi.Pointer<ffi.Void> get flutterViewHandle;
 }
 
 /// Implementation of [RegularWindowController] for the Linux platform.
@@ -396,7 +396,7 @@ class RegularWindowControllerLinux extends RegularWindowController
   }
 
   @override
-  ffi.Pointer<ffi.Void> getWindowHandle() {
+  ffi.Pointer<ffi.Void> get windowHandle {
     if (_destroyed) {
       throw StateError('Window has been destroyed.');
     }
@@ -404,7 +404,7 @@ class RegularWindowControllerLinux extends RegularWindowController
   }
 
   @override
-  ffi.Pointer<ffi.Void> getFlutterViewHandle() {
+  ffi.Pointer<ffi.Void> get flutterViewHandle {
     if (_destroyed) {
       throw StateError('Window has been destroyed.');
     }
@@ -580,7 +580,7 @@ class DialogWindowControllerLinux extends DialogWindowController implements Wind
   }
 
   @override
-  ffi.Pointer<ffi.Void> getWindowHandle() {
+  ffi.Pointer<ffi.Void> get windowHandle {
     if (_destroyed) {
       throw StateError('Window has been destroyed.');
     }
@@ -588,7 +588,7 @@ class DialogWindowControllerLinux extends DialogWindowController implements Wind
   }
 
   @override
-  ffi.Pointer<ffi.Void> getFlutterViewHandle() {
+  ffi.Pointer<ffi.Void> get flutterViewHandle {
     if (_destroyed) {
       throw StateError('Window has been destroyed.');
     }
@@ -771,7 +771,7 @@ class TooltipWindowControllerLinux extends TooltipWindowController
   }
 
   @override
-  ffi.Pointer<ffi.Void> getWindowHandle() {
+  ffi.Pointer<ffi.Void> get windowHandle {
     if (_destroyed) {
       throw StateError('Window has been destroyed.');
     }
@@ -779,7 +779,7 @@ class TooltipWindowControllerLinux extends TooltipWindowController
   }
 
   @override
-  ffi.Pointer<ffi.Void> getFlutterViewHandle() {
+  ffi.Pointer<ffi.Void> get flutterViewHandle {
     if (_destroyed) {
       throw StateError('Window has been destroyed.');
     }

--- a/packages/flutter/lib/src/widgets/_window_linux.dart
+++ b/packages/flutter/lib/src/widgets/_window_linux.dart
@@ -182,6 +182,26 @@ class WindowingOwnerLinux extends WindowingOwner {
   }
 }
 
+/// Platform specific functionality for all window controllers on Linux.
+///
+/// {@macro flutter.widgets.windowing.experimental}
+@internal
+abstract interface class WindowControllerLinux {
+  /// Returns pointer to the underlying [GtkWindow](https://docs.gtk.org/gtk3/class.Window.html).
+  /// Using this pointer implies the user is aware of any side effects changes may have to Flutter behavior.
+  ///
+  /// {@macro flutter.widgets.windowing.experimental}
+  @internal
+  ffi.Pointer<ffi.Void> getWindowHandle();
+
+  /// Returns pointer to the [FlView](https://github.com/flutter/flutter/blob/master/engine/src/flutter/shell/platform/linux/public/flutter_linux/fl_view.h) that renders the Flutter content in this window.
+  /// Using this pointer implies the user is aware of any side effects changes may have to Flutter behavior.
+  ///
+  /// {@macro flutter.widgets.windowing.experimental}
+  @internal
+  ffi.Pointer<ffi.Void> getFlutterViewHandle();
+}
+
 /// Implementation of [RegularWindowController] for the Linux platform.
 ///
 /// {@macro flutter.widgets.windowing.experimental}
@@ -189,7 +209,8 @@ class WindowingOwnerLinux extends WindowingOwner {
 /// See also:
 ///
 ///  * [RegularWindowController], the base class for regular windows.
-class RegularWindowControllerLinux extends RegularWindowController {
+class RegularWindowControllerLinux extends RegularWindowController
+    implements WindowControllerLinux {
   /// Creates a new regular window controller for Linux.
   ///
   /// When this constructor completes the native window has been created and
@@ -364,6 +385,16 @@ class RegularWindowControllerLinux extends RegularWindowController {
       _window.unfullscreen();
     }
   }
+
+  @override
+  ffi.Pointer<ffi.Void> getWindowHandle() {
+    return _window.instance.cast();
+  }
+
+  @override
+  ffi.Pointer<ffi.Void> getFlutterViewHandle() {
+    return _view.instance.cast();
+  }
 }
 
 /// Implementation of [DialogWindowController] for the Linux platform.
@@ -373,7 +404,7 @@ class RegularWindowControllerLinux extends RegularWindowController {
 /// See also:
 ///
 ///  * [DialogWindowController], the base class for dialog windows.
-class DialogWindowControllerLinux extends DialogWindowController {
+class DialogWindowControllerLinux extends DialogWindowController implements WindowControllerLinux {
   /// Creates a new dialog window controller for Linux.
   ///
   /// When this constructor completes the native window has been created and
@@ -532,6 +563,16 @@ class DialogWindowControllerLinux extends DialogWindowController {
       _window.deiconify();
     }
   }
+
+  @override
+  ffi.Pointer<ffi.Void> getWindowHandle() {
+    return _window.instance.cast();
+  }
+
+  @override
+  ffi.Pointer<ffi.Void> getFlutterViewHandle() {
+    return _view.instance.cast();
+  }
 }
 
 /// Implementation of [TooltipWindowController] for the Linux platform.
@@ -541,7 +582,8 @@ class DialogWindowControllerLinux extends DialogWindowController {
 /// See also:
 ///
 ///  * [TooltipWindowController], the base class for tooltip windows.
-class TooltipWindowControllerLinux extends TooltipWindowController {
+class TooltipWindowControllerLinux extends TooltipWindowController
+    implements WindowControllerLinux {
   /// Creates a new tooltip window controller for Linux.
   ///
   /// When this constructor completes the native window has been created and
@@ -705,6 +747,16 @@ class TooltipWindowControllerLinux extends TooltipWindowController {
       maxWidth: constraints.maxWidth.isInfinite ? 0x7fffffff : constraints.maxWidth.toInt(),
       maxHeight: constraints.maxHeight.isInfinite ? 0x7fffffff : constraints.maxHeight.toInt(),
     );
+  }
+
+  @override
+  ffi.Pointer<ffi.Void> getWindowHandle() {
+    return _window.instance.cast();
+  }
+
+  @override
+  ffi.Pointer<ffi.Void> getFlutterViewHandle() {
+    return _view.instance.cast();
   }
 }
 

--- a/packages/flutter/lib/src/widgets/_window_linux.dart
+++ b/packages/flutter/lib/src/widgets/_window_linux.dart
@@ -397,11 +397,17 @@ class RegularWindowControllerLinux extends RegularWindowController
 
   @override
   ffi.Pointer<ffi.Void> getWindowHandle() {
+    if (_destroyed) {
+      throw StateError('Window has been destroyed.');
+    }
     return _window.instance.cast();
   }
 
   @override
   ffi.Pointer<ffi.Void> getFlutterViewHandle() {
+    if (_destroyed) {
+      throw StateError('Window has been destroyed.');
+    }
     return _view.instance.cast();
   }
 }
@@ -575,11 +581,17 @@ class DialogWindowControllerLinux extends DialogWindowController implements Wind
 
   @override
   ffi.Pointer<ffi.Void> getWindowHandle() {
+    if (_destroyed) {
+      throw StateError('Window has been destroyed.');
+    }
     return _window.instance.cast();
   }
 
   @override
   ffi.Pointer<ffi.Void> getFlutterViewHandle() {
+    if (_destroyed) {
+      throw StateError('Window has been destroyed.');
+    }
     return _view.instance.cast();
   }
 }
@@ -760,11 +772,17 @@ class TooltipWindowControllerLinux extends TooltipWindowController
 
   @override
   ffi.Pointer<ffi.Void> getWindowHandle() {
+    if (_destroyed) {
+      throw StateError('Window has been destroyed.');
+    }
     return _window.instance.cast();
   }
 
   @override
   ffi.Pointer<ffi.Void> getFlutterViewHandle() {
+    if (_destroyed) {
+      throw StateError('Window has been destroyed.');
+    }
     return _view.instance.cast();
   }
 }

--- a/packages/flutter/lib/src/widgets/_window_linux.dart
+++ b/packages/flutter/lib/src/widgets/_window_linux.dart
@@ -194,7 +194,8 @@ abstract interface class WindowControllerLinux {
   @internal
   ffi.Pointer<ffi.Void> getWindowHandle();
 
-  /// Returns pointer to the [FlView](https://github.com/flutter/flutter/blob/master/engine/src/flutter/shell/platform/linux/public/flutter_linux/fl_view.h) that renders the Flutter content in this window.
+  /// Returns pointer to the [FlView](https://github.com/flutter/flutter/blob/main/engine/src/flutter/shell/platform/linux/public/flutter_linux/fl_view.h)
+  /// that renders the Flutter content in this window.
   /// Using this pointer implies the user is aware of any side effects changes may have to Flutter behavior.
   ///
   /// {@macro flutter.widgets.windowing.experimental}

--- a/packages/flutter/lib/src/widgets/_window_linux.dart
+++ b/packages/flutter/lib/src/widgets/_window_linux.dart
@@ -188,6 +188,7 @@ class WindowingOwnerLinux extends WindowingOwner {
 @internal
 abstract interface class WindowControllerLinux {
   /// Returns pointer to the underlying [GtkWindow](https://docs.gtk.org/gtk3/class.Window.html).
+  ///
   /// Using this pointer implies the user is aware of any side effects changes may have to Flutter behavior.
   ///
   /// {@macro flutter.widgets.windowing.experimental}

--- a/packages/flutter/lib/src/widgets/_window_macos.dart
+++ b/packages/flutter/lib/src/widgets/_window_macos.dart
@@ -184,7 +184,6 @@ class WindowingOwnerMacOS extends WindowingOwner {
   }
 }
 
-
 /// Platform specific functionality for all window controllers on macOS.
 ///
 /// {@macro flutter.widgets.windowing.experimental}

--- a/packages/flutter/lib/src/widgets/_window_macos.dart
+++ b/packages/flutter/lib/src/widgets/_window_macos.dart
@@ -184,7 +184,21 @@ class WindowingOwnerMacOS extends WindowingOwner {
   }
 }
 
-mixin _WindowControllerMixin {
+
+/// Platform specific functionality for all window controllers on macOS.
+///
+/// {@macro flutter.widgets.windowing.experimental}
+@internal
+abstract interface class WindowControllerMacOS {
+  /// Returns pointer to the underlying NSWindow.
+  /// Using this pointer implies the user is aware of any side effects changes may have to Flutter behavior.
+  ///
+  /// {@macro flutter.widgets.windowing.experimental}
+  @internal
+  Pointer<Void> getWindowHandle();
+}
+
+mixin _WindowControllerMixin implements WindowControllerMacOS {
   void _initController(WindowingOwnerMacOS owner) {
     if (!isWindowingEnabled) {
       throw UnsupportedError(_kWindowingDisabledErrorMessage);
@@ -238,6 +252,7 @@ mixin _WindowControllerMixin {
 
   /// Returns window handle for the current window.
   /// The handle is a pointer to NSWindow instance.
+  @override
   Pointer<Void> getWindowHandle() {
     _ensureNotDestroyed();
     return WindowingOwnerMacOS.getWindowHandle(rootView);

--- a/packages/flutter/lib/src/widgets/_window_macos.dart
+++ b/packages/flutter/lib/src/widgets/_window_macos.dart
@@ -198,7 +198,7 @@ abstract interface class WindowControllerMacOS {
   ///
   /// {@macro flutter.widgets.windowing.experimental}
   @internal
-  Pointer<Void> getWindowHandle();
+  Pointer<Void> get windowHandle;
 }
 
 mixin _WindowControllerMixin implements WindowControllerMacOS {
@@ -256,21 +256,21 @@ mixin _WindowControllerMixin implements WindowControllerMacOS {
   /// Returns window handle for the current window.
   /// The handle is a pointer to NSWindow instance.
   @override
-  Pointer<Void> getWindowHandle() {
+  Pointer<Void> get windowHandle {
     _ensureNotDestroyed();
     return WindowingOwnerMacOS.getWindowHandle(rootView);
   }
 
   Size get contentSize {
     _ensureNotDestroyed();
-    return _MacOSPlatformInterface.getWindowContentSize(getWindowHandle());
+    return _MacOSPlatformInterface.getWindowContentSize(windowHandle);
   }
 
   void destroy() {
     if (_destroyed) {
       return;
     }
-    final Pointer<Void> handle = getWindowHandle();
+    final Pointer<Void> handle = windowHandle;
     _MacOSPlatformInterface.destroyWindow(handle);
   }
 
@@ -335,7 +335,7 @@ class TooltipWindowControllerMacOS extends TooltipWindowController with _WindowC
     if (positioner != null) {
       _positioner = positioner;
     }
-    _MacOSPlatformInterface.updateWindowPosition(getWindowHandle());
+    _MacOSPlatformInterface.updateWindowPosition(windowHandle);
   }
 
   @override
@@ -381,7 +381,7 @@ class TooltipWindowControllerMacOS extends TooltipWindowController with _WindowC
   @override
   void setConstraints(BoxConstraints constraints) {
     _ensureNotDestroyed();
-    _MacOSPlatformInterface.setWindowConstraints(getWindowHandle(), constraints);
+    _MacOSPlatformInterface.setWindowConstraints(windowHandle, constraints);
   }
 
   final TooltipWindowControllerDelegate _delegate;
@@ -432,12 +432,12 @@ class PopupWindowControllerMacOS extends PopupWindowController with _WindowContr
     if (positioner != null) {
       _positioner = positioner;
     }
-    _MacOSPlatformInterface.updateWindowPosition(getWindowHandle());
+    _MacOSPlatformInterface.updateWindowPosition(windowHandle);
   }
 
   @override
   Offset get offsetFromParent {
-    return _MacOSPlatformInterface.getOffsetInParent(getWindowHandle()).toOffset();
+    return _MacOSPlatformInterface.getOffsetInParent(windowHandle).toOffset();
   }
 
   @override
@@ -483,7 +483,7 @@ class PopupWindowControllerMacOS extends PopupWindowController with _WindowContr
   @override
   void setConstraints(BoxConstraints constraints) {
     _ensureNotDestroyed();
-    _MacOSPlatformInterface.setWindowConstraints(getWindowHandle(), constraints);
+    _MacOSPlatformInterface.setWindowConstraints(windowHandle, constraints);
   }
 
   final PopupWindowControllerDelegate _delegate;
@@ -555,82 +555,82 @@ class RegularWindowControllerMacOS extends RegularWindowController with _WindowC
   @internal
   void setSize(Size size) {
     _ensureNotDestroyed();
-    _MacOSPlatformInterface.setWindowContentSize(getWindowHandle(), size);
+    _MacOSPlatformInterface.setWindowContentSize(windowHandle, size);
   }
 
   @override
   @internal
   void setConstraints(BoxConstraints constraints) {
     _ensureNotDestroyed();
-    _MacOSPlatformInterface.setWindowConstraints(getWindowHandle(), constraints);
+    _MacOSPlatformInterface.setWindowConstraints(windowHandle, constraints);
   }
 
   @override
   void setTitle(String title) {
     _ensureNotDestroyed();
-    _MacOSPlatformInterface.setWindowTitle(getWindowHandle(), title);
+    _MacOSPlatformInterface.setWindowTitle(windowHandle, title);
     notifyListeners();
   }
 
   @override
   Size get contentSize {
     _ensureNotDestroyed();
-    return _MacOSPlatformInterface.getWindowContentSize(getWindowHandle());
+    return _MacOSPlatformInterface.getWindowContentSize(windowHandle);
   }
 
   @override
   void activate() {
     _ensureNotDestroyed();
-    _MacOSPlatformInterface.activate(getWindowHandle());
+    _MacOSPlatformInterface.activate(windowHandle);
   }
 
   @override
   void setMaximized(bool maximized) {
     _ensureNotDestroyed();
-    _MacOSPlatformInterface.setMaximized(getWindowHandle(), maximized);
+    _MacOSPlatformInterface.setMaximized(windowHandle, maximized);
   }
 
   @override
   bool get isMaximized {
     _ensureNotDestroyed();
-    return _MacOSPlatformInterface.isMaximized(getWindowHandle());
+    return _MacOSPlatformInterface.isMaximized(windowHandle);
   }
 
   @override
   void setMinimized(bool minimized) {
     _ensureNotDestroyed();
     if (minimized) {
-      _MacOSPlatformInterface.minimize(getWindowHandle());
+      _MacOSPlatformInterface.minimize(windowHandle);
     } else {
-      _MacOSPlatformInterface.unminimize(getWindowHandle());
+      _MacOSPlatformInterface.unminimize(windowHandle);
     }
   }
 
   @override
   bool get isMinimized {
     _ensureNotDestroyed();
-    return _MacOSPlatformInterface.isMinimized(getWindowHandle());
+    return _MacOSPlatformInterface.isMinimized(windowHandle);
   }
 
   @override
   void setFullscreen(bool fullscreen, {Display? display}) {
     _ensureNotDestroyed();
-    _MacOSPlatformInterface.setFullscreen(getWindowHandle(), fullscreen);
+    _MacOSPlatformInterface.setFullscreen(windowHandle, fullscreen);
   }
 
   @override
   bool get isFullscreen {
     _ensureNotDestroyed();
-    return _MacOSPlatformInterface.isFullscreen(getWindowHandle());
+    return _MacOSPlatformInterface.isFullscreen(windowHandle);
   }
 
   final RegularWindowControllerDelegate _delegate;
 
   @override
-  bool get isActivated => _MacOSPlatformInterface.isActivated(getWindowHandle());
+  bool get isActivated => _MacOSPlatformInterface.isActivated(windowHandle);
 
   @override
-  String get title => _MacOSPlatformInterface.getTitle(getWindowHandle());
+  String get title => _MacOSPlatformInterface.getTitle(windowHandle);
 }
 
 /// Implementation of [DialogWindowController] for the macOS platform.
@@ -698,20 +698,20 @@ class DialogWindowControllerMacOS extends DialogWindowController with _WindowCon
   @internal
   void setSize(Size size) {
     _ensureNotDestroyed();
-    _MacOSPlatformInterface.setWindowContentSize(getWindowHandle(), size);
+    _MacOSPlatformInterface.setWindowContentSize(windowHandle, size);
   }
 
   @override
   @internal
   void setConstraints(BoxConstraints constraints) {
     _ensureNotDestroyed();
-    _MacOSPlatformInterface.setWindowConstraints(getWindowHandle(), constraints);
+    _MacOSPlatformInterface.setWindowConstraints(windowHandle, constraints);
   }
 
   @override
   void setTitle(String title) {
     _ensureNotDestroyed();
-    _MacOSPlatformInterface.setWindowTitle(getWindowHandle(), title);
+    _MacOSPlatformInterface.setWindowTitle(windowHandle, title);
     notifyListeners();
   }
 
@@ -720,36 +720,36 @@ class DialogWindowControllerMacOS extends DialogWindowController with _WindowCon
   @override
   Size get contentSize {
     _ensureNotDestroyed();
-    return _MacOSPlatformInterface.getWindowContentSize(getWindowHandle());
+    return _MacOSPlatformInterface.getWindowContentSize(windowHandle);
   }
 
   @override
   void activate() {
     _ensureNotDestroyed();
-    _MacOSPlatformInterface.activate(getWindowHandle());
+    _MacOSPlatformInterface.activate(windowHandle);
   }
 
   @override
   void setMinimized(bool minimized) {
     _ensureNotDestroyed();
     if (minimized) {
-      _MacOSPlatformInterface.minimize(getWindowHandle());
+      _MacOSPlatformInterface.minimize(windowHandle);
     } else {
-      _MacOSPlatformInterface.unminimize(getWindowHandle());
+      _MacOSPlatformInterface.unminimize(windowHandle);
     }
   }
 
   @override
   bool get isMinimized {
     _ensureNotDestroyed();
-    return _MacOSPlatformInterface.isMinimized(getWindowHandle());
+    return _MacOSPlatformInterface.isMinimized(windowHandle);
   }
 
   @override
-  bool get isActivated => _MacOSPlatformInterface.isActivated(getWindowHandle());
+  bool get isActivated => _MacOSPlatformInterface.isActivated(windowHandle);
 
   @override
-  String get title => _MacOSPlatformInterface.getTitle(getWindowHandle());
+  String get title => _MacOSPlatformInterface.getTitle(windowHandle);
 
   @override
   final BaseWindowController? parent;

--- a/packages/flutter/lib/src/widgets/_window_macos.dart
+++ b/packages/flutter/lib/src/widgets/_window_macos.dart
@@ -190,7 +190,11 @@ class WindowingOwnerMacOS extends WindowingOwner {
 @internal
 abstract interface class WindowControllerMacOS {
   /// Returns pointer to the underlying NSWindow.
+  ///
   /// Using this pointer implies the user is aware of any side effects changes may have to Flutter behavior.
+  ///
+  /// The handle is only valid for the lifetime of the window. Once the window
+  /// is destroyed, this handle becomes invalid and must not be used.
   ///
   /// {@macro flutter.widgets.windowing.experimental}
   @internal

--- a/packages/flutter/lib/src/widgets/_window_win32.dart
+++ b/packages/flutter/lib/src/widgets/_window_win32.dart
@@ -222,7 +222,7 @@ class WindowingOwnerWin32 extends WindowingOwner {
     throw UnimplementedError('Satellite windows are not yet implemented on Windows.');
   }
 
-  /// Register a new [WindowsMessageHandler].
+  /// Register a new [_WindowsMessageHandler].
   ///
   /// The handler will be triggered for unhandled messages for all top level
   /// windows.
@@ -241,7 +241,7 @@ class WindowingOwnerWin32 extends WindowingOwner {
     _messageHandlers.add(handler);
   }
 
-  /// Unregister a [WindowsMessageHandler].
+  /// Unregister a [_WindowsMessageHandler].
   ///
   /// If the handler has not been registered, this method has no effect.
   void _removeMessageHandler(_WindowsMessageHandler handler) {
@@ -292,6 +292,65 @@ class _RegularWindowMesageHandler implements _WindowsMessageHandler {
   }
 }
 
+/// A message handler that can respond to windows message sent to window
+/// of a specific window controller.
+///
+/// {@macro flutter.widgets.windowing.experimental}
+@internal
+abstract interface class WindowsMessageHandler {
+  /// Handles a window message.
+  ///
+  /// Returned value, if not null will be returned to the system as LRESULT
+  /// and will stop all registered other handlers from being called. See
+  /// https://learn.microsoft.com/en-us/windows/win32/api/winuser/nc-winuser-wndproc
+  /// for more information.
+  ///
+  /// {@macro flutter.widgets.windowing.experimental}
+  @internal
+  int? handleWindowsMessage(HWND windowHandle, int message, int wParam, int lParam);
+}
+
+/// Platform specific functionality for all window controllers on Windows.
+///
+/// {@macro flutter.widgets.windowing.experimental}
+@internal
+abstract mixin class WindowControllerWin32 {
+  /// Returns the underlying HWND for this window.
+  /// Using this handle implies the user is aware of any side effects changes may have to Flutter behavior.
+  ///
+  /// {@macro flutter.widgets.windowing.experimental}
+  @internal
+  HWND getWindowHandle();
+
+  /// Registers a [WindowsMessageHandler] to receive Windows messages for this window.
+  ///
+  /// {@macro flutter.widgets.windowing.experimental}
+  @internal
+  void addWindowsMessageHandler(WindowsMessageHandler handler) {
+    _messageHandlers.add(handler);
+  }
+
+  /// Unregisters a [WindowsMessageHandler] from receiving Windows messages for this window.
+  ///
+  /// {@macro flutter.widgets.windowing.experimental}
+  @internal
+  void removeWindowsMessageHandler(WindowsMessageHandler handler) {
+    _messageHandlers.remove(handler);
+  }
+
+  final _messageHandlers = <WindowsMessageHandler>{};
+
+  int? _dispatchWindowsMessage(HWND windowHandle, int message, int wParam, int lParam) {
+    for (final WindowsMessageHandler handler in _messageHandlers) {
+      final int? result = handler.handleWindowsMessage(windowHandle, message, wParam, lParam);
+      if (result != null) {
+        return result;
+      }
+    }
+    return null;
+  }
+}
+
 /// Implementation of [RegularWindowController] for the Windows platform.
 ///
 /// {@macro flutter.widgets.windowing.experimental}
@@ -299,7 +358,7 @@ class _RegularWindowMesageHandler implements _WindowsMessageHandler {
 /// See also:
 ///
 ///  * [RegularWindowController], the base class for regular windows.
-class RegularWindowControllerWin32 extends RegularWindowController {
+class RegularWindowControllerWin32 extends RegularWindowController with WindowControllerWin32 {
   /// Creates a new regular window controller for Win32.
   ///
   /// When this constructor completes the native window has been created and
@@ -462,7 +521,7 @@ class RegularWindowControllerWin32 extends RegularWindowController {
   }
 
   /// Returns HWND pointer to the top level window.
-  @internal
+  @override
   HWND getWindowHandle() {
     _ensureNotDestroyed();
     return _Win32PlatformInterface.getWindowHandle(
@@ -497,6 +556,9 @@ class RegularWindowControllerWin32 extends RegularWindowController {
       return null;
     }
 
+    final int? result = _dispatchWindowsMessage(windowHandle, message, wParam, lParam);
+
+    // User handler can not prevent controller from processing windows message.
     if (message == _WM_CLOSE) {
       _delegate.onWindowCloseRequested(this);
       return 0;
@@ -508,7 +570,7 @@ class RegularWindowControllerWin32 extends RegularWindowController {
     } else if (message == _WM_SIZE || message == _WM_ACTIVATE) {
       notifyListeners();
     }
-    return null;
+    return result;
   }
 }
 
@@ -536,7 +598,7 @@ class _DialogWindowMesageHandler implements _WindowsMessageHandler {
 /// See also:
 ///
 ///  * [DialogWindowController], the base class for dialog windows.
-class DialogWindowControllerWin32 extends DialogWindowController {
+class DialogWindowControllerWin32 extends DialogWindowController with WindowControllerWin32 {
   /// Creates a new dialog window controller for Win32.
   ///
   /// When this constructor completes the native window has been created and
@@ -683,7 +745,7 @@ class DialogWindowControllerWin32 extends DialogWindowController {
   BaseWindowController? get parent => _parent;
 
   /// Returns HWND pointer to the top level window.
-  @internal
+  @override
   HWND getWindowHandle() {
     _ensureNotDestroyed();
     return _Win32PlatformInterface.getWindowHandle(
@@ -717,6 +779,9 @@ class DialogWindowControllerWin32 extends DialogWindowController {
       return null;
     }
 
+    final int? result = _dispatchWindowsMessage(windowHandle, message, wParam, lParam);
+
+    // User handler can not prevent controller from processing windows message.
     if (message == _WM_CLOSE) {
       _delegate.onWindowCloseRequested(this);
       return 0;
@@ -728,7 +793,7 @@ class DialogWindowControllerWin32 extends DialogWindowController {
     } else if (message == _WM_SIZE || message == _WM_ACTIVATE) {
       notifyListeners();
     }
-    return null;
+    return result;
   }
 }
 
@@ -747,6 +812,7 @@ typedef _GetWindowPositionNative =
 ///
 ///  * [TooltipWindowController], the base class for tooltip windows.
 class TooltipWindowControllerWin32 extends TooltipWindowController
+    with WindowControllerWin32
     implements _WindowsMessageHandler {
   /// Creates a new tooltip window controller for Win32.
   ///
@@ -836,7 +902,7 @@ class TooltipWindowControllerWin32 extends TooltipWindowController
   }
 
   /// Returns HWND pointer to the top level window.
-  @internal
+  @override
   HWND getWindowHandle() {
     _ensureNotDestroyed();
     return _Win32PlatformInterface.getWindowHandle(
@@ -907,6 +973,8 @@ class TooltipWindowControllerWin32 extends TooltipWindowController
       return null;
     }
 
+    final int? result = _dispatchWindowsMessage(windowHandle, message, wParam, lParam);
+
     if (message == _WM_DESTROY) {
       _destroyed = true;
       _onGetWindowPosition.close();
@@ -914,7 +982,7 @@ class TooltipWindowControllerWin32 extends TooltipWindowController
       _delegate.onWindowDestroyed();
       return 0;
     }
-    return null;
+    return result;
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/_window_win32.dart
+++ b/packages/flutter/lib/src/widgets/_window_win32.dart
@@ -295,20 +295,19 @@ class _RegularWindowMesageHandler implements _WindowsMessageHandler {
 /// A message handler that can respond to windows message sent to window
 /// of a specific window controller.
 ///
+/// Returned value, if not null will be returned to the system as LRESULT
+/// and will stop all registered other handlers from being called. See
+/// https://learn.microsoft.com/en-us/windows/win32/api/winuser/nc-winuser-wndproc
+/// for more information.
+///
 /// {@macro flutter.widgets.windowing.experimental}
 @internal
-abstract interface class WindowsMessageHandler {
-  /// Handles a window message.
-  ///
-  /// Returned value, if not null will be returned to the system as LRESULT
-  /// and will stop all registered other handlers from being called. See
-  /// https://learn.microsoft.com/en-us/windows/win32/api/winuser/nc-winuser-wndproc
-  /// for more information.
-  ///
-  /// {@macro flutter.widgets.windowing.experimental}
-  @internal
-  int? handleWindowsMessage(HWND windowHandle, int message, int wParam, int lParam);
-}
+typedef WindowsMessageHandler = int? Function(
+  HWND windowHandle,
+  int message,
+  int wParam,
+  int lParam,
+);
 
 /// Platform specific functionality for all window controllers on Windows.
 ///
@@ -346,7 +345,7 @@ abstract mixin class WindowControllerWin32 {
 
   int? _dispatchWindowsMessage(HWND windowHandle, int message, int wParam, int lParam) {
     for (final WindowsMessageHandler handler in _messageHandlers) {
-      final int? result = handler.handleWindowsMessage(windowHandle, message, wParam, lParam);
+      final int? result = handler(windowHandle, message, wParam, lParam);
       if (result != null) {
         return result;
       }

--- a/packages/flutter/lib/src/widgets/_window_win32.dart
+++ b/packages/flutter/lib/src/widgets/_window_win32.dart
@@ -324,7 +324,7 @@ abstract mixin class WindowControllerWin32 {
   ///
   /// {@macro flutter.widgets.windowing.experimental}
   @internal
-  HWND getWindowHandle();
+  HWND get windowHandle;
 
   /// Registers a [WindowsMessageHandler] to receive Windows messages for this window.
   ///
@@ -421,7 +421,7 @@ class RegularWindowControllerWin32 extends RegularWindowController with WindowCo
   @internal
   Size get contentSize {
     _ensureNotDestroyed();
-    final _ActualContentSize size = _Win32PlatformInterface.getWindowContentSize(getWindowHandle());
+    final _ActualContentSize size = _Win32PlatformInterface.getWindowContentSize(windowHandle);
     final result = Size(size.width, size.height);
     return result;
   }
@@ -430,49 +430,49 @@ class RegularWindowControllerWin32 extends RegularWindowController with WindowCo
   @internal
   String get title {
     _ensureNotDestroyed();
-    return _Win32PlatformInterface.getWindowTitle(_owner.allocator, getWindowHandle());
+    return _Win32PlatformInterface.getWindowTitle(_owner.allocator, windowHandle);
   }
 
   @override
   @internal
   bool get isActivated {
     _ensureNotDestroyed();
-    return _Win32PlatformInterface.getForegroundWindow() == getWindowHandle();
+    return _Win32PlatformInterface.getForegroundWindow() == windowHandle;
   }
 
   @override
   @internal
   bool get isMaximized {
     _ensureNotDestroyed();
-    return _Win32PlatformInterface.isZoomed(getWindowHandle()) != 0;
+    return _Win32PlatformInterface.isZoomed(windowHandle) != 0;
   }
 
   @override
   @internal
   bool get isMinimized {
     _ensureNotDestroyed();
-    return _Win32PlatformInterface.isIconic(getWindowHandle()) != 0;
+    return _Win32PlatformInterface.isIconic(windowHandle) != 0;
   }
 
   @override
   @internal
   bool get isFullscreen {
     _ensureNotDestroyed();
-    return _Win32PlatformInterface.getFullscreen(getWindowHandle());
+    return _Win32PlatformInterface.getFullscreen(windowHandle);
   }
 
   @override
   @internal
   void setSize(Size? size) {
     _ensureNotDestroyed();
-    _Win32PlatformInterface.setWindowContentSize(_owner.allocator, getWindowHandle(), size);
+    _Win32PlatformInterface.setWindowContentSize(_owner.allocator, windowHandle, size);
   }
 
   @override
   @internal
   void setConstraints(BoxConstraints constraints) {
     _ensureNotDestroyed();
-    _Win32PlatformInterface.setWindowConstraints(_owner.allocator, getWindowHandle(), constraints);
+    _Win32PlatformInterface.setWindowConstraints(_owner.allocator, windowHandle, constraints);
     notifyListeners();
   }
 
@@ -480,7 +480,7 @@ class RegularWindowControllerWin32 extends RegularWindowController with WindowCo
   @internal
   void setTitle(String title) {
     _ensureNotDestroyed();
-    _Win32PlatformInterface.setWindowTitle(_owner.allocator, getWindowHandle(), title);
+    _Win32PlatformInterface.setWindowTitle(_owner.allocator, windowHandle, title);
     notifyListeners();
   }
 
@@ -488,7 +488,7 @@ class RegularWindowControllerWin32 extends RegularWindowController with WindowCo
   @internal
   void activate() {
     _ensureNotDestroyed();
-    _Win32PlatformInterface.showWindow(getWindowHandle(), _SW_RESTORE);
+    _Win32PlatformInterface.showWindow(windowHandle, _SW_RESTORE);
   }
 
   @override
@@ -496,9 +496,9 @@ class RegularWindowControllerWin32 extends RegularWindowController with WindowCo
   void setMaximized(bool maximized) {
     _ensureNotDestroyed();
     if (maximized) {
-      _Win32PlatformInterface.showWindow(getWindowHandle(), _SW_MAXIMIZE);
+      _Win32PlatformInterface.showWindow(windowHandle, _SW_MAXIMIZE);
     } else {
-      _Win32PlatformInterface.showWindow(getWindowHandle(), _SW_RESTORE);
+      _Win32PlatformInterface.showWindow(windowHandle, _SW_RESTORE);
     }
   }
 
@@ -507,9 +507,9 @@ class RegularWindowControllerWin32 extends RegularWindowController with WindowCo
   void setMinimized(bool minimized) {
     _ensureNotDestroyed();
     if (minimized) {
-      _Win32PlatformInterface.showWindow(getWindowHandle(), _SW_MINIMIZE);
+      _Win32PlatformInterface.showWindow(windowHandle, _SW_MINIMIZE);
     } else {
-      _Win32PlatformInterface.showWindow(getWindowHandle(), _SW_RESTORE);
+      _Win32PlatformInterface.showWindow(windowHandle, _SW_RESTORE);
     }
   }
 
@@ -518,7 +518,7 @@ class RegularWindowControllerWin32 extends RegularWindowController with WindowCo
   void setFullscreen(bool fullscreen, {Display? display}) {
     _Win32PlatformInterface.setFullscreen(
       _owner.allocator,
-      getWindowHandle(),
+      windowHandle,
       fullscreen,
       display: display,
     );
@@ -526,7 +526,7 @@ class RegularWindowControllerWin32 extends RegularWindowController with WindowCo
 
   /// Returns HWND pointer to the top level window.
   @override
-  HWND getWindowHandle() {
+  HWND get windowHandle {
     _ensureNotDestroyed();
     return _Win32PlatformInterface.getWindowHandle(
       WidgetsBinding.instance.platformDispatcher.engineId!,
@@ -545,7 +545,7 @@ class RegularWindowControllerWin32 extends RegularWindowController with WindowCo
     if (_destroyed) {
       return;
     }
-    _Win32PlatformInterface.destroyWindow(getWindowHandle());
+    _Win32PlatformInterface.destroyWindow(windowHandle);
     _destroyed = true;
   }
 
@@ -670,7 +670,7 @@ class DialogWindowControllerWin32 extends DialogWindowController with WindowCont
   @internal
   Size get contentSize {
     _ensureNotDestroyed();
-    final _ActualContentSize size = _Win32PlatformInterface.getWindowContentSize(getWindowHandle());
+    final _ActualContentSize size = _Win32PlatformInterface.getWindowContentSize(windowHandle);
     final result = Size(size.width, size.height);
     return result;
   }
@@ -679,28 +679,28 @@ class DialogWindowControllerWin32 extends DialogWindowController with WindowCont
   @internal
   String get title {
     _ensureNotDestroyed();
-    return _Win32PlatformInterface.getWindowTitle(_owner.allocator, getWindowHandle());
+    return _Win32PlatformInterface.getWindowTitle(_owner.allocator, windowHandle);
   }
 
   @override
   @internal
   bool get isActivated {
     _ensureNotDestroyed();
-    return _Win32PlatformInterface.getForegroundWindow() == getWindowHandle();
+    return _Win32PlatformInterface.getForegroundWindow() == windowHandle;
   }
 
   @override
   @internal
   bool get isMinimized {
     _ensureNotDestroyed();
-    return _Win32PlatformInterface.isIconic(getWindowHandle()) != 0;
+    return _Win32PlatformInterface.isIconic(windowHandle) != 0;
   }
 
   @override
   @internal
   void setSize(Size? size) {
     _ensureNotDestroyed();
-    _Win32PlatformInterface.setWindowContentSize(_owner.allocator, getWindowHandle(), size);
+    _Win32PlatformInterface.setWindowContentSize(_owner.allocator, windowHandle, size);
     // Note that we do not notify the listener when setting the size,
     // as that will happen when the WM_SIZE message is received in
     // _handleWindowsMessage.
@@ -710,7 +710,7 @@ class DialogWindowControllerWin32 extends DialogWindowController with WindowCont
   @internal
   void setConstraints(BoxConstraints constraints) {
     _ensureNotDestroyed();
-    _Win32PlatformInterface.setWindowConstraints(_owner.allocator, getWindowHandle(), constraints);
+    _Win32PlatformInterface.setWindowConstraints(_owner.allocator, windowHandle, constraints);
     notifyListeners();
   }
 
@@ -718,7 +718,7 @@ class DialogWindowControllerWin32 extends DialogWindowController with WindowCont
   @internal
   void setTitle(String title) {
     _ensureNotDestroyed();
-    _Win32PlatformInterface.setWindowTitle(_owner.allocator, getWindowHandle(), title);
+    _Win32PlatformInterface.setWindowTitle(_owner.allocator, windowHandle, title);
     notifyListeners();
   }
 
@@ -726,7 +726,7 @@ class DialogWindowControllerWin32 extends DialogWindowController with WindowCont
   @internal
   void activate() {
     _ensureNotDestroyed();
-    _Win32PlatformInterface.showWindow(getWindowHandle(), _SW_RESTORE);
+    _Win32PlatformInterface.showWindow(windowHandle, _SW_RESTORE);
   }
 
   @override
@@ -738,9 +738,9 @@ class DialogWindowControllerWin32 extends DialogWindowController with WindowCont
 
     _ensureNotDestroyed();
     if (minimized) {
-      _Win32PlatformInterface.showWindow(getWindowHandle(), _SW_MINIMIZE);
+      _Win32PlatformInterface.showWindow(windowHandle, _SW_MINIMIZE);
     } else {
-      _Win32PlatformInterface.showWindow(getWindowHandle(), _SW_RESTORE);
+      _Win32PlatformInterface.showWindow(windowHandle, _SW_RESTORE);
     }
   }
 
@@ -750,7 +750,7 @@ class DialogWindowControllerWin32 extends DialogWindowController with WindowCont
 
   /// Returns HWND pointer to the top level window.
   @override
-  HWND getWindowHandle() {
+  HWND get windowHandle {
     _ensureNotDestroyed();
     return _Win32PlatformInterface.getWindowHandle(
       WidgetsBinding.instance.platformDispatcher.engineId!,
@@ -769,7 +769,7 @@ class DialogWindowControllerWin32 extends DialogWindowController with WindowCont
     if (_destroyed) {
       return;
     }
-    _Win32PlatformInterface.destroyWindow(getWindowHandle());
+    _Win32PlatformInterface.destroyWindow(windowHandle);
   }
 
   int? _handleWindowsMessage(
@@ -907,7 +907,7 @@ class TooltipWindowControllerWin32 extends TooltipWindowController
 
   /// Returns HWND pointer to the top level window.
   @override
-  HWND getWindowHandle() {
+  HWND get windowHandle {
     _ensureNotDestroyed();
     return _Win32PlatformInterface.getWindowHandle(
       PlatformDispatcher.instance.engineId!,
@@ -918,7 +918,7 @@ class TooltipWindowControllerWin32 extends TooltipWindowController
   @override
   Size get contentSize {
     _ensureNotDestroyed();
-    final _ActualContentSize size = _Win32PlatformInterface.getWindowContentSize(getWindowHandle());
+    final _ActualContentSize size = _Win32PlatformInterface.getWindowContentSize(windowHandle);
     return Size(size.width, size.height);
   }
 
@@ -933,7 +933,7 @@ class TooltipWindowControllerWin32 extends TooltipWindowController
     if (_destroyed) {
       return;
     }
-    _Win32PlatformInterface.destroyWindow(getWindowHandle());
+    _Win32PlatformInterface.destroyWindow(windowHandle);
     _destroyed = true;
   }
 
@@ -945,7 +945,7 @@ class TooltipWindowControllerWin32 extends TooltipWindowController
     if (positioner != null) {
       _positioner = positioner;
     }
-    _Win32PlatformInterface.updateTooltipWindowPosition(getWindowHandle());
+    _Win32PlatformInterface.updateTooltipWindowPosition(windowHandle);
   }
 
   late final ffi.NativeCallable<_GetWindowPositionNative> _onGetWindowPosition;

--- a/packages/flutter/lib/src/widgets/_window_win32.dart
+++ b/packages/flutter/lib/src/widgets/_window_win32.dart
@@ -316,7 +316,11 @@ abstract interface class WindowsMessageHandler {
 @internal
 abstract mixin class WindowControllerWin32 {
   /// Returns the underlying HWND for this window.
+  ///
   /// Using this handle implies the user is aware of any side effects changes may have to Flutter behavior.
+  ///
+  /// The handle is only valid for the lifetime of the window. Once the window
+  /// is destroyed, this handle becomes invalid and must not be used.
   ///
   /// {@macro flutter.widgets.windowing.experimental}
   @internal

--- a/packages/flutter/lib/src/widgets/_window_win32.dart
+++ b/packages/flutter/lib/src/widgets/_window_win32.dart
@@ -292,23 +292,6 @@ class _RegularWindowMesageHandler implements _WindowsMessageHandler {
   }
 }
 
-/// A message handler that can respond to windows message sent to window
-/// of a specific window controller.
-///
-/// Returned value, if not null will be returned to the system as LRESULT
-/// and will stop all registered other handlers from being called. See
-/// https://learn.microsoft.com/en-us/windows/win32/api/winuser/nc-winuser-wndproc
-/// for more information.
-///
-/// {@macro flutter.widgets.windowing.experimental}
-@internal
-typedef WindowsMessageHandler = int? Function(
-  HWND windowHandle,
-  int message,
-  int wParam,
-  int lParam,
-);
-
 /// Platform specific functionality for all window controllers on Windows.
 ///
 /// {@macro flutter.widgets.windowing.experimental}
@@ -324,34 +307,6 @@ abstract mixin class WindowControllerWin32 {
   /// {@macro flutter.widgets.windowing.experimental}
   @internal
   HWND get windowHandle;
-
-  /// Registers a [WindowsMessageHandler] to receive Windows messages for this window.
-  ///
-  /// {@macro flutter.widgets.windowing.experimental}
-  @internal
-  void addWindowsMessageHandler(WindowsMessageHandler handler) {
-    _messageHandlers.add(handler);
-  }
-
-  /// Unregisters a [WindowsMessageHandler] from receiving Windows messages for this window.
-  ///
-  /// {@macro flutter.widgets.windowing.experimental}
-  @internal
-  void removeWindowsMessageHandler(WindowsMessageHandler handler) {
-    _messageHandlers.remove(handler);
-  }
-
-  final _messageHandlers = <WindowsMessageHandler>{};
-
-  int? _dispatchWindowsMessage(HWND windowHandle, int message, int wParam, int lParam) {
-    for (final WindowsMessageHandler handler in _messageHandlers) {
-      final int? result = handler(windowHandle, message, wParam, lParam);
-      if (result != null) {
-        return result;
-      }
-    }
-    return null;
-  }
 }
 
 /// Implementation of [RegularWindowController] for the Windows platform.
@@ -559,8 +514,6 @@ class RegularWindowControllerWin32 extends RegularWindowController with WindowCo
       return null;
     }
 
-    final int? result = _dispatchWindowsMessage(windowHandle, message, wParam, lParam);
-
     // User handler can not prevent controller from processing windows message.
     if (message == _WM_CLOSE) {
       _delegate.onWindowCloseRequested(this);
@@ -573,7 +526,7 @@ class RegularWindowControllerWin32 extends RegularWindowController with WindowCo
     } else if (message == _WM_SIZE || message == _WM_ACTIVATE) {
       notifyListeners();
     }
-    return result;
+    return null;
   }
 }
 
@@ -782,8 +735,6 @@ class DialogWindowControllerWin32 extends DialogWindowController with WindowCont
       return null;
     }
 
-    final int? result = _dispatchWindowsMessage(windowHandle, message, wParam, lParam);
-
     // User handler can not prevent controller from processing windows message.
     if (message == _WM_CLOSE) {
       _delegate.onWindowCloseRequested(this);
@@ -796,7 +747,7 @@ class DialogWindowControllerWin32 extends DialogWindowController with WindowCont
     } else if (message == _WM_SIZE || message == _WM_ACTIVATE) {
       notifyListeners();
     }
-    return result;
+    return null;
   }
 }
 
@@ -976,8 +927,6 @@ class TooltipWindowControllerWin32 extends TooltipWindowController
       return null;
     }
 
-    final int? result = _dispatchWindowsMessage(windowHandle, message, wParam, lParam);
-
     if (message == _WM_DESTROY) {
       _destroyed = true;
       _onGetWindowPosition.close();
@@ -985,7 +934,7 @@ class TooltipWindowControllerWin32 extends TooltipWindowController
       _delegate.onWindowDestroyed();
       return 0;
     }
-    return result;
+    return null;
   }
 
   @override


### PR DESCRIPTION
Native windowing API has a very large surface with many platform specific areas (i.e. window collection behavior on macOS) and we can't possibly cover it all.

This PR will provide the functionality for users and package authors to access the underlying platform handles. 

For every platform window controller (WindowControllerMacOS, WindowControllerWin32, WindowControllerLinux) a new getter is added:
```dart
ffi.Pointer<ffi.Void> get windowHandle;
```

The interpretation of returned handle depends on platform:
| Platform | Handle Type |
| ---- |----|
| macOS | Pointer to `NSWindow` |
| Windows | `HWND` |
| Linux | Pointer to `GtkWindow` |

Because the handles are platform specific, it is necessary to cast the window controller to a platform specific controller first to obtain the handle:

```dart
final RegularWindowController controller = ....
if (controller is WindowControllerWin32) {
   final controllerWin32 = controller as WindowControllerWin32;
   SetWindowDisplayAffinity(controllerWin32.windowHandle, WDA_EXCLUDEFROMCAPTURE);
}
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
