### PR TITLE
Fix web autofill not picking up values after Windows Hello authentication

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -439,21 +439,27 @@ class EngineAutofillForm {
 
     void addSubscriptionForKey(String key) {
       final DomHTMLElement element = elements[key]!;
-      subscriptions.add(
-        DomSubscription(
-          element,
-          'input',
-          createDomEventListener((DomEvent e) {
-            if (items[key] == null) {
-              throw StateError('AutofillInfo must have a valid uniqueIdentifier.');
-            } else if (key != focusedElementId) {
-              // `input` events on the focused element are handled elsewhere.
-              final AutofillInfo autofillInfo = items[key]!.autofillInfo;
-              _handleChange(element, autofillInfo);
-            }
-          }),
-        ),
-      );
+
+      void onAutofillEvent(DomEvent e) {
+        if (items[key] == null) {
+          throw StateError('AutofillInfo must have a valid uniqueIdentifier.');
+        } else if (e.type == 'change' || key != focusedElementId) {
+          // `input` events on the focused element are handled elsewhere,
+          // but `change` events are also handled here to catch async
+          // credential fills (e.g., after Windows Hello authentication)
+          // that may not fire `input`.
+          // See https://github.com/flutter/flutter/issues/162066
+          final AutofillInfo autofillInfo = items[key]!.autofillInfo;
+          _handleChange(element, autofillInfo);
+        }
+      }
+
+      final DomEventListener listener = createDomEventListener(onAutofillEvent);
+      subscriptions.add(DomSubscription(element, 'input', listener));
+      // The 'change' event is more reliably fired after async credential
+      // fills (e.g., after Windows Hello authentication in Chrome).
+      // See https://github.com/flutter/flutter/issues/162066
+      subscriptions.add(DomSubscription(element, 'change', listener));
     }
 
     keys.forEach(addSubscriptionForKey);

--- a/engine/src/flutter/lib/web_ui/test/engine/text_editing_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/text_editing_test.dart
@@ -2597,6 +2597,74 @@ Future<void> testMain() async {
       hideKeyboard();
     });
 
+    test('multiTextField Autofill responds to change event', () async {
+      // Regression test for https://github.com/flutter/flutter/issues/162066
+      // When Chrome fills credentials after a Windows Hello prompt, it may
+      // fire a 'change' event instead of (or in addition to) an 'input' event.
+      const hintForFirstElement = 'familyName';
+      final Map<String, dynamic> flutterMultiAutofillElementConfig = createFlutterConfig(
+        'text',
+        autofillHint: 'email',
+        autofillHintsForFields: <String>[
+          hintForFirstElement,
+          'email',
+          'givenName',
+          'telephoneNumber',
+        ],
+      );
+      final setClient = MethodCall('TextInput.setClient', <dynamic>[
+        123,
+        flutterMultiAutofillElementConfig,
+      ]);
+      sendFrameworkMessage(codec.encodeMethodCall(setClient));
+
+      const setEditingState1 = MethodCall('TextInput.setEditingState', <String, dynamic>{
+        'text': 'abcd',
+        'selectionBase': 2,
+        'selectionExtent': 3,
+        'composingBase': -1,
+        'composingExtent': -1,
+      });
+      sendFrameworkMessage(codec.encodeMethodCall(setEditingState1));
+
+      final MethodCall setSizeAndTransform = configureSetSizeAndTransformMethodCall(
+        150,
+        50,
+        Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList(),
+      );
+      sendFrameworkMessage(codec.encodeMethodCall(setSizeAndTransform));
+
+      const show = MethodCall('TextInput.show');
+      sendFrameworkMessage(codec.encodeMethodCall(show));
+
+      final formElement = defaultTextEditingRoot.querySelector('form')! as DomHTMLFormElement;
+      expect(formElement.childNodes, hasLength(5));
+
+      // Simulate a credential manager fill that fires 'change' instead of 'input'.
+      final element = formElement.childNodes.toList()[0] as DomHTMLInputElement;
+      element.value = 'filled_by_credential_manager';
+      element.dispatchEvent(createDomEvent('Event', 'change'));
+
+      expect(spy.messages, hasLength(1));
+      expect(spy.messages[0].channel, 'flutter/textinput');
+      expect(spy.messages[0].methodName, 'TextInputClient.updateEditingStateWithTag');
+      expect(spy.messages[0].methodArguments, <dynamic>[
+        0,
+        <String, dynamic>{
+          hintForFirstElement: <String, dynamic>{
+            'text': 'filled_by_credential_manager',
+            'selectionBase': 28,
+            'selectionExtent': 28,
+            'composingBase': -1,
+            'composingExtent': -1,
+          },
+        },
+      ]);
+
+      spy.messages.clear();
+      hideKeyboard();
+    });
+
     test('Multi-line mode also works', () async {
       final setClient = MethodCall('TextInput.setClient', <dynamic>[123, flutterMultilineConfig]);
       sendFrameworkMessage(codec.encodeMethodCall(setClient));


### PR DESCRIPTION
## Summary
- Listen for the change DOM event in addition to input on autofill form elements in EngineAutofillForm.addInputEventListeners()
- When Chrome's password manager is protected by Windows Hello, the async biometric prompt causes credential fills that fire change rather than input, so Flutter never received the updated values
- Added regression test verifying autofill works via the change event

Fixes https://github.com/flutter/flutter/issues/162066

## Test plan
- [x] Added multiTextField Autofill responds to change event test in text_editing_test.dart
- [ ] Manual test: Flutter web app with AutofillGroup + Chrome Windows Hello password protection

## Pre-launch Checklist

- [x] I read the [Contributor Guide](https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview) and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines](https://docs.flutter.dev/resources/ai-overview) and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene](https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md) wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide](https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md), including [Features we expect every widget to implement](https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement).
- [x] I signed the [CLA](https://cla.developers.google.com/).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.

Generated with [Claude Code](https://claude.com/claude-code)