### PR TITLE
[web] Async rendering for benchmarks

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/src/web/recorder.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/recorder.dart
@@ -273,13 +273,14 @@ abstract class SceneBuilderRecorder extends Recorder {
     };
     PlatformDispatcher.instance.onDrawFrame = () {
       try {
-        _profile!.record('drawFrameDuration', () {
+        _profile!.recordAsync('drawFrameDuration', () async {
           final sceneBuilder = SceneBuilder();
           onDrawFrame(sceneBuilder);
-          _profile!.record('sceneBuildDuration', () {
+          _profile!.recordAsync('sceneBuildDuration', () async {
             final Scene scene = sceneBuilder.build();
-            _profile!.record('windowRenderDuration', () {
-              view.render(scene);
+            _profile!.recordAsync('windowRenderDuration', () async {
+              // On the web, render is asynchronous.
+              await (PlatformDispatcher.instance as dynamic).render(scene);
             }, reported: false);
           }, reported: false);
         }, reported: true);


### PR DESCRIPTION
In the recent past, there've been a few changes to the rendering pipeline in the web engine. These changes have caused unexpected jumps in our benchmarks, even though there's no extra work being done during rendering.

Most recent example:
- PR: https://github.com/flutter/flutter/pull/183791
- Regression reported in: https://github.com/flutter/flutter/issues/184022
- Benchmark: [link](https://flutter-flutter-perf.luci.app/e/?begin=1773409816&enable_chart_tooltip=true&end=1774285808&keys=Xafc90b7a58b5e744fd23c4adf9bd5958&plotSummary=true&requestType=0&use_titles=true&xbaroffset=2806999)

Previous example:
- PR: https://github.com/flutter/flutter/pull/180610
- Benchmark: [link](https://flutter-flutter-perf.luci.app/e/?begin=1767712957&enable_chart_tooltip=true&end=1768320686&keys=Xafc90b7a58b5e744fd23c4adf9bd5958&plotSummary=true&requestType=0&use_titles=true&xbaroffset=2806999)

This PR fixes the issue by making our benchmarks handle asynchronous rendering correctly.