### PR TITLE
`WindowsPlugin` should not crash when ffiPlugin enabled

### DIFF
--- a/packages/flutter_tools/lib/src/platform_plugins.dart
+++ b/packages/flutter_tools/lib/src/platform_plugins.dart
@@ -441,7 +441,12 @@ class WindowsPlugin extends PluginPlatform implements NativeOrDartPlugin, Varian
     this.defaultPackage,
     this.variants = const <PluginPlatformVariant>{},
   }) : ffiPlugin = ffiPlugin ?? false,
-       assert(pluginClass != null || dartPluginClass != null || defaultPackage != null);
+       assert(
+         pluginClass != null ||
+             dartPluginClass != null ||
+             defaultPackage != null ||
+             (ffiPlugin ?? false),
+       );
 
   factory WindowsPlugin.fromYaml(String name, YamlMap yaml) {
     assert(validate(yaml));


### PR DESCRIPTION
This change updates an assert in the `WindowsPlugin` constructor that previously crashed because it did not consider `ffiPlugin` unlike `LinuxPlugin` which does.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.