### PR TITLE
[fuchsia] Give AOT runners the ability to copy FFI callback thunks.

### DIFF
--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/meta/dart_aot_product_runner.cml
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/meta/dart_aot_product_runner.cml
@@ -8,6 +8,8 @@
         binary: "bin/app",
         forward_stdout_to: "log",
         forward_stderr_to: "log",
+        // Needed for AOT FFI callback thunks.
+        job_policy_ambient_mark_vmo_exec: "true",
     },
     capabilities: [
         {

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/meta/dart_aot_runner.cml
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/meta/dart_aot_runner.cml
@@ -8,6 +8,8 @@
         binary: "bin/app",
         forward_stdout_to: "log",
         forward_stderr_to: "log",
+        // Needed for AOT FFI callback thunks.
+        job_policy_ambient_mark_vmo_exec: "true",
     },
     capabilities: [
         {

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/meta/flutter_aot_product_runner.cml
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/meta/flutter_aot_product_runner.cml
@@ -8,6 +8,8 @@
         binary: "bin/app",
         forward_stdout_to: "log",
         forward_stderr_to: "log",
+        // Needed for AOT FFI callback thunks.
+        job_policy_ambient_mark_vmo_exec: "true",
     },
     capabilities: [
         {

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/meta/flutter_aot_runner.cml
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/meta/flutter_aot_runner.cml
@@ -8,6 +8,8 @@
         binary: "bin/app",
         forward_stdout_to: "log",
         forward_stderr_to: "log",
+        // Needed for AOT FFI callback thunks.
+        job_policy_ambient_mark_vmo_exec: "true",
     },
     capabilities: [
         {


### PR DESCRIPTION
Bug: https://dartbug.com/52579
