### PR TITLE
Fix RenderParagraph.textAlign setter to call markNeedsLayout instead of markNeedsPaint

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -575,7 +575,7 @@ class RenderParagraph extends RenderBox
       return;
     }
     _textPainter.textAlign = value;
-    markNeedsPaint();
+    markNeedsLayout();
   }
 
   /// The directionality of the text.

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -374,7 +374,7 @@ void main() {
     expect(paragraph.size.height, 30.0);
   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61018
 
-  test('textAlign triggers TextPainter relayout in the paint method', () {
+  test('textAlign marks RenderParagraph as needing layout', () {
     final paragraph = RenderParagraph(
       const TextSpan(text: 'A', style: TextStyle(fontSize: 10.0)),
       textDirection: TextDirection.ltr,
@@ -391,10 +391,9 @@ void main() {
     expect(getRectForA(), const Rect.fromLTWH(0, 0, 10, 10));
 
     paragraph.textAlign = TextAlign.right;
-    expect(paragraph.debugNeedsLayout, isFalse);
-    expect(paragraph.debugNeedsPaint, isTrue);
+    expect(paragraph.debugNeedsLayout, isTrue);
 
-    paragraph.paint(MockPaintingContext(), Offset.zero);
+    pumpFrame();
     expect(getRectForA(), const Rect.fromLTWH(90, 0, 10, 10));
   });
 


### PR DESCRIPTION
## Description

`RenderParagraph.textAlign` setter was calling `markNeedsPaint()` when the alignment changed, but it should call `markNeedsLayout()`.

**Why this is wrong:** Text alignment changes affect character positions (e.g. `getBoxesForSelection` results). These positions are derived from the layout phase, not the paint phase. Ancestors such as `LayoutBuilder` observe layout invalidations — so when `textAlign` changes, they never rebuild, leading to stale layout information.

**Consistency:** All analogous setters in `RenderParagraph` already call `markNeedsLayout()`:
- `textDirection` → `markNeedsLayout()`
- `softWrap` → `markNeedsLayout()`
- `overflow` → `markNeedsLayout()`
- `textAlign` → was `markNeedsPaint()` ← **this PR fixes it**

## Changes

- `packages/flutter/lib/src/rendering/paragraph.dart`: changed `markNeedsPaint()` to `markNeedsLayout()` in the `textAlign` setter.
- `packages/flutter/test/rendering/paragraph_test.dart`: updated the existing test to assert `debugNeedsLayout: true` (not `debugNeedsPaint: true`) and drive the re-layout via `pumpFrame()` instead of calling `paint()` directly.

## Related Issue

Fixes #140756