### PR TITLE
WIP - Improve Scaffold accessibility by defining a logical traversal order for its slots

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -2932,24 +2932,12 @@ class ScaffoldState extends State<Scaffold>
     if (child != null) {
       Widget wrappedChild = MediaQuery(data: data, child: child);
       if (traversalOrder != null) {
-        wrappedChild = FocusTraversalOrder(
-          order: traversalOrder,
-          child: wrappedChild,
-        );
+        wrappedChild = FocusTraversalOrder(order: traversalOrder, child: wrappedChild);
       }
       if (semanticsSortKey != null) {
-        wrappedChild = Semantics(
-          container: true,
-          sortKey: semanticsSortKey,
-          child: wrappedChild,
-        );
+        wrappedChild = Semantics(container: true, sortKey: semanticsSortKey, child: wrappedChild);
       }
-      children.add(
-        LayoutId(
-          id: childId,
-          child: wrappedChild,
-        ),
-      );
+      children.add(LayoutId(id: childId, child: wrappedChild));
     }
   }
 

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -23,6 +23,7 @@ import 'dart:ui';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart' show DragStartBehavior, HitTestEntry, HitTestResult;
 import 'package:flutter/rendering.dart' show RenderMetaData;
+import 'package:flutter/semantics.dart';
 import 'package:flutter/widgets.dart';
 
 import 'app_bar.dart';
@@ -2911,6 +2912,8 @@ class ScaffoldState extends State<Scaffold>
     required bool removeBottomPadding,
     bool removeBottomInset = false,
     bool maintainBottomViewPadding = false,
+    FocusOrder? traversalOrder,
+    SemanticsSortKey? semanticsSortKey,
   }) {
     MediaQueryData data = MediaQuery.of(context).removePadding(
       removeLeft: removeLeftPadding,
@@ -2927,10 +2930,24 @@ class ScaffoldState extends State<Scaffold>
     }
 
     if (child != null) {
+      Widget wrappedChild = MediaQuery(data: data, child: child);
+      if (traversalOrder != null) {
+        wrappedChild = FocusTraversalOrder(
+          order: traversalOrder,
+          child: wrappedChild,
+        );
+      }
+      if (semanticsSortKey != null) {
+        wrappedChild = Semantics(
+          container: true,
+          sortKey: semanticsSortKey,
+          child: wrappedChild,
+        );
+      }
       children.add(
         LayoutId(
           id: childId,
-          child: MediaQuery(data: data, child: child),
+          child: wrappedChild,
         ),
       );
     }
@@ -3032,6 +3049,8 @@ class ScaffoldState extends State<Scaffold>
       removeBottomPadding:
           widget.bottomNavigationBar != null || widget.persistentFooterButtons != null,
       removeBottomInset: _resizeToAvoidBottomInset,
+      traversalOrder: const NumericFocusOrder(5.0),
+      semanticsSortKey: const OrdinalSortKey(5.0),
     );
     if (_showBodyScrim) {
       _addIfNonNull(
@@ -3064,6 +3083,8 @@ class ScaffoldState extends State<Scaffold>
         removeTopPadding: false,
         removeRightPadding: false,
         removeBottomPadding: true,
+        traversalOrder: const NumericFocusOrder(2.0),
+        semanticsSortKey: const OrdinalSortKey(2.0),
       );
     }
 
@@ -3073,7 +3094,10 @@ class ScaffoldState extends State<Scaffold>
     if (_currentBottomSheet != null || _dismissedBottomSheets.isNotEmpty) {
       final Widget stack = Stack(
         alignment: Alignment.bottomCenter,
-        children: <Widget>[..._dismissedBottomSheets, ?_currentBottomSheet?._widget],
+        children: <Widget>[
+          ..._dismissedBottomSheets,
+          if (_currentBottomSheet != null) _currentBottomSheet!._widget,
+        ],
       );
       _addIfNonNull(
         children,
@@ -3083,6 +3107,8 @@ class ScaffoldState extends State<Scaffold>
         removeTopPadding: true,
         removeRightPadding: false,
         removeBottomPadding: _resizeToAvoidBottomInset,
+        traversalOrder: const NumericFocusOrder(6.0),
+        semanticsSortKey: const OrdinalSortKey(6.0),
       );
     }
 
@@ -3104,6 +3130,8 @@ class ScaffoldState extends State<Scaffold>
         removeBottomPadding:
             widget.bottomNavigationBar != null || widget.persistentFooterButtons != null,
         maintainBottomViewPadding: !_resizeToAvoidBottomInset,
+        traversalOrder: const NumericFocusOrder(7.0),
+        semanticsSortKey: const OrdinalSortKey(7.0),
       );
     }
 
@@ -3124,6 +3152,8 @@ class ScaffoldState extends State<Scaffold>
         removeRightPadding: false,
         removeBottomPadding: true,
         maintainBottomViewPadding: !_resizeToAvoidBottomInset,
+        traversalOrder: const NumericFocusOrder(1.0),
+        semanticsSortKey: const OrdinalSortKey(1.0),
       );
     }
 
@@ -3157,6 +3187,8 @@ class ScaffoldState extends State<Scaffold>
         removeRightPadding: false,
         removeBottomPadding: widget.bottomNavigationBar != null,
         maintainBottomViewPadding: !_resizeToAvoidBottomInset,
+        traversalOrder: const NumericFocusOrder(8.0),
+        semanticsSortKey: const OrdinalSortKey(8.0),
       );
     }
 
@@ -3170,6 +3202,8 @@ class ScaffoldState extends State<Scaffold>
         removeRightPadding: false,
         removeBottomPadding: false,
         maintainBottomViewPadding: !_resizeToAvoidBottomInset,
+        traversalOrder: const NumericFocusOrder(3.0),
+        semanticsSortKey: const OrdinalSortKey(3.0),
       );
     }
 
@@ -3187,6 +3221,8 @@ class ScaffoldState extends State<Scaffold>
       removeTopPadding: true,
       removeRightPadding: true,
       removeBottomPadding: true,
+      traversalOrder: const NumericFocusOrder(4.0),
+      semanticsSortKey: const OrdinalSortKey(4.0),
     );
 
     final Widget? statusBar = switch (themeData.platform) {
@@ -3239,23 +3275,26 @@ class ScaffoldState extends State<Scaffold>
             builder: (BuildContext context) {
               return Actions(
                 actions: <Type, Action<Intent>>{DismissIntent: _DismissDrawerAction(context)},
-                child: CustomMultiChildLayout(
-                  delegate: _ScaffoldLayout(
-                    extendBody: widget.extendBody,
-                    extendBodyBehindAppBar: widget.extendBodyBehindAppBar,
-                    minInsets: minInsets,
-                    minViewPadding: minViewPadding,
-                    currentFloatingActionButtonLocation: _floatingActionButtonLocation!,
-                    floatingActionButtonMoveAnimation: _floatingActionButtonMoveController,
-                    floatingActionButtonMotionAnimator: _floatingActionButtonAnimator,
-                    geometryNotifier: _geometryNotifier,
-                    previousFloatingActionButtonLocation: _previousFloatingActionButtonLocation!,
-                    textDirection: textDirection,
-                    isSnackBarFloating: isSnackBarFloating,
-                    extendBodyBehindMaterialBanner: extendBodyBehindMaterialBanner,
-                    snackBarWidth: snackBarWidth,
+                child: FocusTraversalGroup(
+                  policy: OrderedTraversalPolicy(),
+                  child: CustomMultiChildLayout(
+                    delegate: _ScaffoldLayout(
+                      extendBody: widget.extendBody,
+                      extendBodyBehindAppBar: widget.extendBodyBehindAppBar,
+                      minInsets: minInsets,
+                      minViewPadding: minViewPadding,
+                      currentFloatingActionButtonLocation: _floatingActionButtonLocation!,
+                      floatingActionButtonMoveAnimation: _floatingActionButtonMoveController,
+                      floatingActionButtonMotionAnimator: _floatingActionButtonAnimator,
+                      geometryNotifier: _geometryNotifier,
+                      previousFloatingActionButtonLocation: _previousFloatingActionButtonLocation!,
+                      textDirection: textDirection,
+                      isSnackBarFloating: isSnackBarFloating,
+                      extendBodyBehindMaterialBanner: extendBodyBehindMaterialBanner,
+                      snackBarWidth: snackBarWidth,
+                    ),
+                    children: children,
                   ),
-                  children: children,
                 ),
               );
             },

--- a/packages/flutter/test/material/bottom_navigation_bar_test.dart
+++ b/packages/flutter/test/material/bottom_navigation_bar_test.dart
@@ -2554,7 +2554,10 @@ void main() {
                                     SemanticsFlag.hasSelectedState,
                                     SemanticsFlag.isSelected,
                                   ],
-                                  actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.focus],
+                                  actions: <SemanticsAction>[
+                                    SemanticsAction.tap,
+                                    SemanticsAction.focus,
+                                  ],
                                   label: 'A\nTab 1 of 2',
                                   textDirection: TextDirection.ltr,
                                 ),
@@ -2564,7 +2567,10 @@ void main() {
                                     SemanticsFlag.isFocusable,
                                     SemanticsFlag.hasSelectedState,
                                   ],
-                                  actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.focus],
+                                  actions: <SemanticsAction>[
+                                    SemanticsAction.tap,
+                                    SemanticsAction.focus,
+                                  ],
                                   label: 'B\nTab 2 of 2',
                                   textDirection: TextDirection.ltr,
                                 ),

--- a/packages/flutter/test/material/bottom_navigation_bar_test.dart
+++ b/packages/flutter/test/material/bottom_navigation_bar_test.dart
@@ -2544,25 +2544,33 @@ void main() {
                       flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
                       children: <TestSemantics>[
                         TestSemantics(
-                          flags: <SemanticsFlag>[
-                            SemanticsFlag.isButton,
-                            SemanticsFlag.isFocusable,
-                            SemanticsFlag.hasSelectedState,
-                            SemanticsFlag.isSelected,
+                          children: <TestSemantics>[
+                            TestSemantics(
+                              children: <TestSemantics>[
+                                TestSemantics(
+                                  flags: <SemanticsFlag>[
+                                    SemanticsFlag.isButton,
+                                    SemanticsFlag.isFocusable,
+                                    SemanticsFlag.hasSelectedState,
+                                    SemanticsFlag.isSelected,
+                                  ],
+                                  actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.focus],
+                                  label: 'A\nTab 1 of 2',
+                                  textDirection: TextDirection.ltr,
+                                ),
+                                TestSemantics(
+                                  flags: <SemanticsFlag>[
+                                    SemanticsFlag.isButton,
+                                    SemanticsFlag.isFocusable,
+                                    SemanticsFlag.hasSelectedState,
+                                  ],
+                                  actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.focus],
+                                  label: 'B\nTab 2 of 2',
+                                  textDirection: TextDirection.ltr,
+                                ),
+                              ],
+                            ),
                           ],
-                          actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.focus],
-                          label: 'A\nTab 1 of 2',
-                          textDirection: TextDirection.ltr,
-                        ),
-                        TestSemantics(
-                          flags: <SemanticsFlag>[
-                            SemanticsFlag.isButton,
-                            SemanticsFlag.isFocusable,
-                            SemanticsFlag.hasSelectedState,
-                          ],
-                          actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.focus],
-                          label: 'B\nTab 2 of 2',
-                          textDirection: TextDirection.ltr,
                         ),
                       ],
                     ),

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -4400,7 +4400,7 @@ void main() {
       hasSemantics(
         TestSemantics.root(
           children: <TestSemantics>[
-            TestSemantics(
+            TestSemantics.rootChild(
               id: 1,
               textDirection: TextDirection.ltr,
               children: <TestSemantics>[
@@ -4411,34 +4411,44 @@ void main() {
                       id: 3,
                       flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
                       children: <TestSemantics>[
-                        if (kIsWeb)
-                          TestSemantics(
-                            flags: <SemanticsFlag>[
-                              SemanticsFlag.isButton,
-                              SemanticsFlag.hasExpandedState,
-                            ],
-                            actions: <SemanticsAction>[SemanticsAction.expand],
-                          )
-                        else
-                          TestSemantics(
-                            id: 5,
-                            inputType: SemanticsInputType.text,
-                            flags: <SemanticsFlag>[
-                              SemanticsFlag.isTextField,
-                              SemanticsFlag.isFocusable,
-                              SemanticsFlag.hasEnabledState,
-                              SemanticsFlag.isEnabled,
-                              SemanticsFlag.isReadOnly,
-                              SemanticsFlag.isButton,
-                              SemanticsFlag.hasExpandedState,
-                            ],
-                            actions: <SemanticsAction>[
-                              SemanticsAction.focus,
-                              SemanticsAction.expand,
-                            ],
-                            textDirection: TextDirection.ltr,
-                            currentValueLength: 0,
-                          ),
+                        TestSemantics(
+                          id: 4,
+                          children: <TestSemantics>[
+                            TestSemantics(
+                              id: 5,
+                              children: <TestSemantics>[
+                                if (kIsWeb)
+                                  TestSemantics(
+                                    flags: <SemanticsFlag>[
+                                      SemanticsFlag.isButton,
+                                      SemanticsFlag.hasExpandedState,
+                                    ],
+                                    actions: <SemanticsAction>[SemanticsAction.expand],
+                                  )
+                                else
+                                  TestSemantics(
+                                    id: 7,
+                                    inputType: SemanticsInputType.text,
+                                    flags: <SemanticsFlag>[
+                                      SemanticsFlag.isTextField,
+                                      SemanticsFlag.isFocusable,
+                                      SemanticsFlag.hasEnabledState,
+                                      SemanticsFlag.isEnabled,
+                                      SemanticsFlag.isReadOnly,
+                                      SemanticsFlag.isButton,
+                                      SemanticsFlag.hasExpandedState,
+                                    ],
+                                    actions: <SemanticsAction>[
+                                      SemanticsAction.focus,
+                                      SemanticsAction.expand,
+                                    ],
+                                    textDirection: TextDirection.ltr,
+                                    currentValueLength: 0,
+                                  ),
+                              ],
+                            ),
+                          ],
+                        ),
                       ],
                     ),
                   ],

--- a/packages/flutter/test/material/flexible_space_bar_test.dart
+++ b/packages/flutter/test/material/flexible_space_bar_test.dart
@@ -336,7 +336,10 @@ void main() {
       ],
     );
 
-    expect(semantics, hasSemantics(expectedSemantics, ignoreTransform: true, ignoreId: true, ignoreRect: true));
+    expect(
+      semantics,
+      hasSemantics(expectedSemantics, ignoreTransform: true, ignoreId: true, ignoreRect: true),
+    );
 
     // We drag up to fully collapse the space bar.
     await tester.drag(find.text('Item 1'), const Offset(0, -600.0));
@@ -438,7 +441,10 @@ void main() {
       ],
     );
 
-    expect(semantics, hasSemantics(expectedSemantics, ignoreTransform: true, ignoreId: true, ignoreRect: true));
+    expect(
+      semantics,
+      hasSemantics(expectedSemantics, ignoreTransform: true, ignoreId: true, ignoreRect: true),
+    );
 
     semantics.dispose();
   });
@@ -553,7 +559,10 @@ void main() {
       ],
     );
 
-    expect(semantics, hasSemantics(expectedSemantics, ignoreTransform: true, ignoreId: true, ignoreRect: true));
+    expect(
+      semantics,
+      hasSemantics(expectedSemantics, ignoreTransform: true, ignoreId: true, ignoreRect: true),
+    );
 
     // We drag up to fully collapse the space bar.
     await tester.drag(find.text('Item 1'), const Offset(0, -600.0));
@@ -655,7 +664,10 @@ void main() {
       ],
     );
 
-    expect(semantics, hasSemantics(expectedSemantics, ignoreTransform: true, ignoreId: true, ignoreRect: true));
+    expect(
+      semantics,
+      hasSemantics(expectedSemantics, ignoreTransform: true, ignoreId: true, ignoreRect: true),
+    );
 
     semantics.dispose();
   });

--- a/packages/flutter/test/material/flexible_space_bar_test.dart
+++ b/packages/flutter/test/material/flexible_space_bar_test.dart
@@ -258,90 +258,70 @@ void main() {
     var expectedSemantics = TestSemantics.root(
       children: <TestSemantics>[
         TestSemantics.rootChild(
-          id: 1,
-          rect: TestSemantics.fullScreen,
           children: <TestSemantics>[
             TestSemantics(
-              id: 2,
-              rect: TestSemantics.fullScreen,
               children: <TestSemantics>[
                 TestSemantics(
-                  id: 3,
-                  rect: TestSemantics.fullScreen,
                   flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
                   children: <TestSemantics>[
                     TestSemantics(
-                      id: 4,
-                      rect: TestSemantics.fullScreen,
                       children: <TestSemantics>[
                         TestSemantics(
-                          id: 9,
-                          rect: const Rect.fromLTRB(0.0, 0.0, 800.0, expandedHeight),
                           children: <TestSemantics>[
                             TestSemantics(
-                              id: 12,
-                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
                               children: <TestSemantics>[
                                 TestSemantics(
-                                  id: 13,
-                                  rect: const Rect.fromLTRB(0.0, 0.0, 110.0, 28.0),
-                                  flags: <SemanticsFlag>[
-                                    SemanticsFlag.isHeader,
-                                    SemanticsFlag.namesRoute,
+                                  children: <TestSemantics>[
+                                    TestSemantics(
+                                      children: <TestSemantics>[
+                                        TestSemantics(
+                                          flags: <SemanticsFlag>[
+                                            SemanticsFlag.isHeader,
+                                            SemanticsFlag.namesRoute,
+                                          ],
+                                          label: 'Title',
+                                          textDirection: TextDirection.ltr,
+                                        ),
+                                      ],
+                                    ),
+                                    TestSemantics(
+                                      children: <TestSemantics>[
+                                        TestSemantics(
+                                          label: 'Expanded title',
+                                          textDirection: TextDirection.ltr,
+                                        ),
+                                      ],
+                                    ),
                                   ],
-                                  label: 'Title',
-                                  textDirection: TextDirection.ltr,
                                 ),
-                              ],
-                            ),
-                            TestSemantics(
-                              id: 10,
-                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
-                              children: <TestSemantics>[
                                 TestSemantics(
-                                  id: 11,
-                                  rect: const Rect.fromLTRB(0.0, 0.0, 800.0, expandedHeight),
-                                  label: 'Expanded title',
-                                  textDirection: TextDirection.ltr,
+                                  flags: <SemanticsFlag>[SemanticsFlag.hasImplicitScrolling],
+                                  actions: <SemanticsAction>[
+                                    SemanticsAction.scrollUp,
+                                    SemanticsAction.scrollToOffset,
+                                  ],
+                                  children: <TestSemantics>[
+                                    TestSemantics(
+                                      label: 'Item 0',
+                                      textDirection: TextDirection.ltr,
+                                    ),
+                                    TestSemantics(
+                                      label: 'Item 1',
+                                      textDirection: TextDirection.ltr,
+                                    ),
+                                    TestSemantics(
+                                      flags: <SemanticsFlag>[SemanticsFlag.isHidden],
+                                      label: 'Item 2',
+                                      textDirection: TextDirection.ltr,
+                                    ),
+                                    TestSemantics(
+                                      flags: <SemanticsFlag>[SemanticsFlag.isHidden],
+                                      label: 'Item 3',
+                                      textDirection: TextDirection.ltr,
+                                    ),
+                                  ],
                                 ),
                               ],
-                            ),
-                          ],
-                        ),
-                        TestSemantics(
-                          id: 14,
-                          flags: <SemanticsFlag>[SemanticsFlag.hasImplicitScrolling],
-                          rect: TestSemantics.fullScreen,
-                          actions: <SemanticsAction>[
-                            SemanticsAction.scrollUp,
-                            SemanticsAction.scrollToOffset,
-                          ],
-                          children: <TestSemantics>[
-                            TestSemantics(
-                              id: 5,
-                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
-                              label: 'Item 0',
-                              textDirection: TextDirection.ltr,
-                            ),
-                            TestSemantics(
-                              id: 6,
-                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
-                              label: 'Item 1',
-                              textDirection: TextDirection.ltr,
-                            ),
-                            TestSemantics(
-                              id: 7,
-                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
-                              flags: <SemanticsFlag>[SemanticsFlag.isHidden],
-                              label: 'Item 2',
-                              textDirection: TextDirection.ltr,
-                            ),
-                            TestSemantics(
-                              id: 8,
-                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 50.0),
-                              flags: <SemanticsFlag>[SemanticsFlag.isHidden],
-                              label: 'Item 3',
-                              textDirection: TextDirection.ltr,
                             ),
                           ],
                         ),
@@ -356,7 +336,7 @@ void main() {
       ],
     );
 
-    expect(semantics, hasSemantics(expectedSemantics, ignoreTransform: true));
+    expect(semantics, hasSemantics(expectedSemantics, ignoreTransform: true, ignoreId: true, ignoreRect: true));
 
     // We drag up to fully collapse the space bar.
     await tester.drag(find.text('Item 1'), const Offset(0, -600.0));
@@ -365,114 +345,85 @@ void main() {
     expectedSemantics = TestSemantics.root(
       children: <TestSemantics>[
         TestSemantics.rootChild(
-          id: 1,
-          rect: TestSemantics.fullScreen,
           children: <TestSemantics>[
             TestSemantics(
-              id: 2,
-              rect: TestSemantics.fullScreen,
               children: <TestSemantics>[
                 TestSemantics(
-                  id: 3,
-                  rect: TestSemantics.fullScreen,
                   flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
                   children: <TestSemantics>[
                     TestSemantics(
-                      id: 4,
-                      rect: TestSemantics.fullScreen,
                       children: <TestSemantics>[
                         TestSemantics(
-                          id: 9,
-                          // The app bar is collapsed.
-                          rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 56.0),
                           children: <TestSemantics>[
                             TestSemantics(
-                              id: 12,
-                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 56.0),
                               children: <TestSemantics>[
                                 TestSemantics(
-                                  id: 13,
-                                  rect: const Rect.fromLTRB(0.0, 0.0, 110.0, 28.0),
-                                  flags: <SemanticsFlag>[
-                                    SemanticsFlag.isHeader,
-                                    SemanticsFlag.namesRoute,
+                                  children: <TestSemantics>[
+                                    TestSemantics(
+                                      children: <TestSemantics>[
+                                        TestSemantics(
+                                          flags: <SemanticsFlag>[
+                                            SemanticsFlag.isHeader,
+                                            SemanticsFlag.namesRoute,
+                                          ],
+                                          label: 'Title',
+                                          textDirection: TextDirection.ltr,
+                                        ),
+                                      ],
+                                    ),
+                                    TestSemantics(
+                                      children: <TestSemantics>[
+                                        TestSemantics(
+                                          label: 'Expanded title',
+                                          textDirection: TextDirection.ltr,
+                                        ),
+                                      ],
+                                    ),
                                   ],
-                                  label: 'Title',
-                                  textDirection: TextDirection.ltr,
                                 ),
-                              ],
-                            ),
-                            // The flexible space bar still persists in the
-                            // semantic tree even if it is collapsed.
-                            TestSemantics(
-                              id: 10,
-                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 56.0),
-                              children: <TestSemantics>[
                                 TestSemantics(
-                                  id: 11,
-                                  rect: const Rect.fromLTRB(0.0, 36.0, 800.0, 92.0),
-                                  label: 'Expanded title',
-                                  textDirection: TextDirection.ltr,
+                                  flags: <SemanticsFlag>[SemanticsFlag.hasImplicitScrolling],
+                                  actions: <SemanticsAction>[
+                                    SemanticsAction.scrollUp,
+                                    SemanticsAction.scrollDown,
+                                    SemanticsAction.scrollToOffset,
+                                  ],
+                                  children: <TestSemantics>[
+                                    TestSemantics(
+                                      flags: <SemanticsFlag>[SemanticsFlag.isHidden],
+                                      label: 'Item 0',
+                                      textDirection: TextDirection.ltr,
+                                    ),
+                                    TestSemantics(
+                                      flags: <SemanticsFlag>[SemanticsFlag.isHidden],
+                                      label: 'Item 1',
+                                      textDirection: TextDirection.ltr,
+                                    ),
+                                    TestSemantics(
+                                      label: 'Item 2',
+                                      textDirection: TextDirection.ltr,
+                                    ),
+                                    TestSemantics(
+                                      label: 'Item 3',
+                                      textDirection: TextDirection.ltr,
+                                    ),
+                                    TestSemantics(
+                                      label: 'Item 4',
+                                      textDirection: TextDirection.ltr,
+                                    ),
+                                    TestSemantics(
+                                      flags: <SemanticsFlag>[SemanticsFlag.isHidden],
+                                      label: 'Item 5',
+                                      textDirection: TextDirection.ltr,
+                                    ),
+                                    TestSemantics(
+                                      flags: <SemanticsFlag>[SemanticsFlag.isHidden],
+                                      label: 'Item 6',
+                                      textDirection: TextDirection.ltr,
+                                    ),
+                                  ],
                                 ),
                               ],
-                            ),
-                          ],
-                        ),
-                        TestSemantics(
-                          id: 14,
-                          flags: <SemanticsFlag>[SemanticsFlag.hasImplicitScrolling],
-                          rect: TestSemantics.fullScreen,
-                          actions: <SemanticsAction>[
-                            SemanticsAction.scrollUp,
-                            SemanticsAction.scrollDown,
-                            SemanticsAction.scrollToOffset,
-                          ],
-                          children: <TestSemantics>[
-                            TestSemantics(
-                              id: 5,
-                              rect: const Rect.fromLTRB(0.0, 150.0, 800.0, 200.0),
-                              flags: <SemanticsFlag>[SemanticsFlag.isHidden],
-                              label: 'Item 0',
-                              textDirection: TextDirection.ltr,
-                            ),
-                            TestSemantics(
-                              id: 6,
-                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
-                              flags: <SemanticsFlag>[SemanticsFlag.isHidden],
-                              label: 'Item 1',
-                              textDirection: TextDirection.ltr,
-                            ),
-                            TestSemantics(
-                              id: 7,
-                              rect: const Rect.fromLTRB(0.0, 56.0, 800.0, 200.0),
-                              label: 'Item 2',
-                              textDirection: TextDirection.ltr,
-                            ),
-                            TestSemantics(
-                              id: 8,
-                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
-                              label: 'Item 3',
-                              textDirection: TextDirection.ltr,
-                            ),
-                            TestSemantics(
-                              id: 15,
-                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
-                              label: 'Item 4',
-                              textDirection: TextDirection.ltr,
-                            ),
-                            TestSemantics(
-                              id: 16,
-                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
-                              flags: <SemanticsFlag>[SemanticsFlag.isHidden],
-                              label: 'Item 5',
-                              textDirection: TextDirection.ltr,
-                            ),
-                            TestSemantics(
-                              id: 17,
-                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 50.0),
-                              flags: <SemanticsFlag>[SemanticsFlag.isHidden],
-                              label: 'Item 6',
-                              textDirection: TextDirection.ltr,
                             ),
                           ],
                         ),
@@ -487,7 +438,7 @@ void main() {
       ],
     );
 
-    expect(semantics, hasSemantics(expectedSemantics, ignoreTransform: true));
+    expect(semantics, hasSemantics(expectedSemantics, ignoreTransform: true, ignoreId: true, ignoreRect: true));
 
     semantics.dispose();
   });
@@ -524,90 +475,70 @@ void main() {
     var expectedSemantics = TestSemantics.root(
       children: <TestSemantics>[
         TestSemantics.rootChild(
-          id: 1,
-          rect: TestSemantics.fullScreen,
           children: <TestSemantics>[
             TestSemantics(
-              id: 2,
-              rect: TestSemantics.fullScreen,
               children: <TestSemantics>[
                 TestSemantics(
-                  id: 3,
-                  rect: TestSemantics.fullScreen,
                   flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
                   children: <TestSemantics>[
                     TestSemantics(
-                      id: 4,
-                      rect: TestSemantics.fullScreen,
                       children: <TestSemantics>[
                         TestSemantics(
-                          id: 9,
-                          rect: const Rect.fromLTRB(0.0, 0.0, 800.0, expandedHeight),
                           children: <TestSemantics>[
                             TestSemantics(
-                              id: 12,
-                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
                               children: <TestSemantics>[
                                 TestSemantics(
-                                  id: 13,
-                                  rect: const Rect.fromLTRB(0.0, 0.0, 100.0, 20.0),
-                                  flags: <SemanticsFlag>[
-                                    SemanticsFlag.isHeader,
-                                    SemanticsFlag.namesRoute,
+                                  children: <TestSemantics>[
+                                    TestSemantics(
+                                      children: <TestSemantics>[
+                                        TestSemantics(
+                                          flags: <SemanticsFlag>[
+                                            SemanticsFlag.isHeader,
+                                            SemanticsFlag.namesRoute,
+                                          ],
+                                          label: 'Title',
+                                          textDirection: TextDirection.ltr,
+                                        ),
+                                      ],
+                                    ),
+                                    TestSemantics(
+                                      children: <TestSemantics>[
+                                        TestSemantics(
+                                          label: 'Expanded title',
+                                          textDirection: TextDirection.ltr,
+                                        ),
+                                      ],
+                                    ),
                                   ],
-                                  label: 'Title',
-                                  textDirection: TextDirection.ltr,
                                 ),
-                              ],
-                            ),
-                            TestSemantics(
-                              id: 10,
-                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
-                              children: <TestSemantics>[
                                 TestSemantics(
-                                  id: 11,
-                                  rect: const Rect.fromLTRB(0.0, 0.0, 800.0, expandedHeight),
-                                  label: 'Expanded title',
-                                  textDirection: TextDirection.ltr,
+                                  flags: <SemanticsFlag>[SemanticsFlag.hasImplicitScrolling],
+                                  actions: <SemanticsAction>[
+                                    SemanticsAction.scrollUp,
+                                    SemanticsAction.scrollToOffset,
+                                  ],
+                                  children: <TestSemantics>[
+                                    TestSemantics(
+                                      label: 'Item 0',
+                                      textDirection: TextDirection.ltr,
+                                    ),
+                                    TestSemantics(
+                                      label: 'Item 1',
+                                      textDirection: TextDirection.ltr,
+                                    ),
+                                    TestSemantics(
+                                      flags: <SemanticsFlag>[SemanticsFlag.isHidden],
+                                      label: 'Item 2',
+                                      textDirection: TextDirection.ltr,
+                                    ),
+                                    TestSemantics(
+                                      flags: <SemanticsFlag>[SemanticsFlag.isHidden],
+                                      label: 'Item 3',
+                                      textDirection: TextDirection.ltr,
+                                    ),
+                                  ],
                                 ),
                               ],
-                            ),
-                          ],
-                        ),
-                        TestSemantics(
-                          id: 14,
-                          flags: <SemanticsFlag>[SemanticsFlag.hasImplicitScrolling],
-                          rect: TestSemantics.fullScreen,
-                          actions: <SemanticsAction>[
-                            SemanticsAction.scrollUp,
-                            SemanticsAction.scrollToOffset,
-                          ],
-                          children: <TestSemantics>[
-                            TestSemantics(
-                              id: 5,
-                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
-                              label: 'Item 0',
-                              textDirection: TextDirection.ltr,
-                            ),
-                            TestSemantics(
-                              id: 6,
-                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
-                              label: 'Item 1',
-                              textDirection: TextDirection.ltr,
-                            ),
-                            TestSemantics(
-                              id: 7,
-                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
-                              flags: <SemanticsFlag>[SemanticsFlag.isHidden],
-                              label: 'Item 2',
-                              textDirection: TextDirection.ltr,
-                            ),
-                            TestSemantics(
-                              id: 8,
-                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 50.0),
-                              flags: <SemanticsFlag>[SemanticsFlag.isHidden],
-                              label: 'Item 3',
-                              textDirection: TextDirection.ltr,
                             ),
                           ],
                         ),
@@ -622,7 +553,7 @@ void main() {
       ],
     );
 
-    expect(semantics, hasSemantics(expectedSemantics, ignoreTransform: true));
+    expect(semantics, hasSemantics(expectedSemantics, ignoreTransform: true, ignoreId: true, ignoreRect: true));
 
     // We drag up to fully collapse the space bar.
     await tester.drag(find.text('Item 1'), const Offset(0, -600.0));
@@ -631,114 +562,85 @@ void main() {
     expectedSemantics = TestSemantics.root(
       children: <TestSemantics>[
         TestSemantics.rootChild(
-          id: 1,
-          rect: TestSemantics.fullScreen,
           children: <TestSemantics>[
             TestSemantics(
-              id: 2,
-              rect: TestSemantics.fullScreen,
               children: <TestSemantics>[
                 TestSemantics(
-                  id: 3,
-                  rect: TestSemantics.fullScreen,
                   flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
                   children: <TestSemantics>[
                     TestSemantics(
-                      id: 4,
-                      rect: TestSemantics.fullScreen,
                       children: <TestSemantics>[
                         TestSemantics(
-                          id: 9,
-                          // The app bar is collapsed.
-                          rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 56.0),
                           children: <TestSemantics>[
                             TestSemantics(
-                              id: 12,
-                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 56.0),
                               children: <TestSemantics>[
                                 TestSemantics(
-                                  id: 13,
-                                  rect: const Rect.fromLTRB(0.0, 0.0, 100.0, 20.0),
-                                  flags: <SemanticsFlag>[
-                                    SemanticsFlag.isHeader,
-                                    SemanticsFlag.namesRoute,
+                                  children: <TestSemantics>[
+                                    TestSemantics(
+                                      children: <TestSemantics>[
+                                        TestSemantics(
+                                          flags: <SemanticsFlag>[
+                                            SemanticsFlag.isHeader,
+                                            SemanticsFlag.namesRoute,
+                                          ],
+                                          label: 'Title',
+                                          textDirection: TextDirection.ltr,
+                                        ),
+                                      ],
+                                    ),
+                                    TestSemantics(
+                                      children: <TestSemantics>[
+                                        TestSemantics(
+                                          label: 'Expanded title',
+                                          textDirection: TextDirection.ltr,
+                                        ),
+                                      ],
+                                    ),
                                   ],
-                                  label: 'Title',
-                                  textDirection: TextDirection.ltr,
                                 ),
-                              ],
-                            ),
-                            // The flexible space bar still persists in the
-                            // semantic tree even if it is collapsed.
-                            TestSemantics(
-                              id: 10,
-                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 56.0),
-                              children: <TestSemantics>[
                                 TestSemantics(
-                                  id: 11,
-                                  rect: const Rect.fromLTRB(0.0, 36.0, 800.0, 92.0),
-                                  label: 'Expanded title',
-                                  textDirection: TextDirection.ltr,
+                                  flags: <SemanticsFlag>[SemanticsFlag.hasImplicitScrolling],
+                                  actions: <SemanticsAction>[
+                                    SemanticsAction.scrollUp,
+                                    SemanticsAction.scrollDown,
+                                    SemanticsAction.scrollToOffset,
+                                  ],
+                                  children: <TestSemantics>[
+                                    TestSemantics(
+                                      flags: <SemanticsFlag>[SemanticsFlag.isHidden],
+                                      label: 'Item 0',
+                                      textDirection: TextDirection.ltr,
+                                    ),
+                                    TestSemantics(
+                                      flags: <SemanticsFlag>[SemanticsFlag.isHidden],
+                                      label: 'Item 1',
+                                      textDirection: TextDirection.ltr,
+                                    ),
+                                    TestSemantics(
+                                      label: 'Item 2',
+                                      textDirection: TextDirection.ltr,
+                                    ),
+                                    TestSemantics(
+                                      label: 'Item 3',
+                                      textDirection: TextDirection.ltr,
+                                    ),
+                                    TestSemantics(
+                                      label: 'Item 4',
+                                      textDirection: TextDirection.ltr,
+                                    ),
+                                    TestSemantics(
+                                      flags: <SemanticsFlag>[SemanticsFlag.isHidden],
+                                      label: 'Item 5',
+                                      textDirection: TextDirection.ltr,
+                                    ),
+                                    TestSemantics(
+                                      flags: <SemanticsFlag>[SemanticsFlag.isHidden],
+                                      label: 'Item 6',
+                                      textDirection: TextDirection.ltr,
+                                    ),
+                                  ],
                                 ),
                               ],
-                            ),
-                          ],
-                        ),
-                        TestSemantics(
-                          id: 14,
-                          flags: <SemanticsFlag>[SemanticsFlag.hasImplicitScrolling],
-                          rect: TestSemantics.fullScreen,
-                          actions: <SemanticsAction>[
-                            SemanticsAction.scrollUp,
-                            SemanticsAction.scrollDown,
-                            SemanticsAction.scrollToOffset,
-                          ],
-                          children: <TestSemantics>[
-                            TestSemantics(
-                              id: 5,
-                              rect: const Rect.fromLTRB(0.0, 150.0, 800.0, 200.0),
-                              flags: <SemanticsFlag>[SemanticsFlag.isHidden],
-                              label: 'Item 0',
-                              textDirection: TextDirection.ltr,
-                            ),
-                            TestSemantics(
-                              id: 6,
-                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
-                              flags: <SemanticsFlag>[SemanticsFlag.isHidden],
-                              label: 'Item 1',
-                              textDirection: TextDirection.ltr,
-                            ),
-                            TestSemantics(
-                              id: 7,
-                              rect: const Rect.fromLTRB(0.0, 56.0, 800.0, 200.0),
-                              label: 'Item 2',
-                              textDirection: TextDirection.ltr,
-                            ),
-                            TestSemantics(
-                              id: 8,
-                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
-                              label: 'Item 3',
-                              textDirection: TextDirection.ltr,
-                            ),
-                            TestSemantics(
-                              id: 15,
-                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
-                              label: 'Item 4',
-                              textDirection: TextDirection.ltr,
-                            ),
-                            TestSemantics(
-                              id: 16,
-                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
-                              flags: <SemanticsFlag>[SemanticsFlag.isHidden],
-                              label: 'Item 5',
-                              textDirection: TextDirection.ltr,
-                            ),
-                            TestSemantics(
-                              id: 17,
-                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 50.0),
-                              flags: <SemanticsFlag>[SemanticsFlag.isHidden],
-                              label: 'Item 6',
-                              textDirection: TextDirection.ltr,
                             ),
                           ],
                         ),
@@ -753,7 +655,7 @@ void main() {
       ],
     );
 
-    expect(semantics, hasSemantics(expectedSemantics, ignoreTransform: true));
+    expect(semantics, hasSemantics(expectedSemantics, ignoreTransform: true, ignoreId: true, ignoreRect: true));
 
     semantics.dispose();
   });

--- a/packages/flutter/test/material/floating_action_button_test.dart
+++ b/packages/flutter/test/material/floating_action_button_test.dart
@@ -692,7 +692,10 @@ void main() {
                               children: <TestSemantics>[
                                 TestSemantics(
                                   tooltip: 'Add Photo',
-                                  actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.focus],
+                                  actions: <SemanticsAction>[
+                                    SemanticsAction.tap,
+                                    SemanticsAction.focus,
+                                  ],
                                   flags: <SemanticsFlag>[
                                     SemanticsFlag.hasEnabledState,
                                     SemanticsFlag.isButton,

--- a/packages/flutter/test/material/floating_action_button_test.dart
+++ b/packages/flutter/test/material/floating_action_button_test.dart
@@ -687,13 +687,21 @@ void main() {
                       flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
                       children: <TestSemantics>[
                         TestSemantics(
-                          tooltip: 'Add Photo',
-                          actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.focus],
-                          flags: <SemanticsFlag>[
-                            SemanticsFlag.hasEnabledState,
-                            SemanticsFlag.isButton,
-                            SemanticsFlag.isEnabled,
-                            SemanticsFlag.isFocusable,
+                          children: <TestSemantics>[
+                            TestSemantics(
+                              children: <TestSemantics>[
+                                TestSemantics(
+                                  tooltip: 'Add Photo',
+                                  actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.focus],
+                                  flags: <SemanticsFlag>[
+                                    SemanticsFlag.hasEnabledState,
+                                    SemanticsFlag.isButton,
+                                    SemanticsFlag.isEnabled,
+                                    SemanticsFlag.isFocusable,
+                                  ],
+                                ),
+                              ],
+                            ),
                           ],
                         ),
                       ],

--- a/packages/flutter/test/material/navigation_rail_test.dart
+++ b/packages/flutter/test/material/navigation_rail_test.dart
@@ -6217,14 +6217,24 @@ TestSemantics _expectedSemantics({bool scrollable = false}) {
         textDirection: TextDirection.ltr,
         children: <TestSemantics>[
           TestSemantics(
+            textDirection: TextDirection.ltr,
             children: <TestSemantics>[
               TestSemantics(
                 children: <TestSemantics>[
                   TestSemantics(
                     flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
                     children: <TestSemantics>[
-                      TestSemantics(children: destinations),
-                      TestSemantics(label: 'body', textDirection: TextDirection.ltr),
+                      TestSemantics(
+                        children: <TestSemantics>[
+                          TestSemantics(
+                            label: 'body',
+                            textDirection: TextDirection.ltr,
+                            children: <TestSemantics>[
+                              TestSemantics(children: destinations),
+                            ],
+                          ),
+                        ],
+                      ),
                     ],
                   ),
                 ],

--- a/packages/flutter/test/material/navigation_rail_test.dart
+++ b/packages/flutter/test/material/navigation_rail_test.dart
@@ -6229,9 +6229,7 @@ TestSemantics _expectedSemantics({bool scrollable = false}) {
                           TestSemantics(
                             label: 'body',
                             textDirection: TextDirection.ltr,
-                            children: <TestSemantics>[
-                              TestSemantics(children: destinations),
-                            ],
+                            children: <TestSemantics>[TestSemantics(children: destinations)],
                           ),
                         ],
                       ),

--- a/packages/flutter/test/material/scaffold_navigation_order_test.dart
+++ b/packages/flutter/test/material/scaffold_navigation_order_test.dart
@@ -1,0 +1,184 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../widgets/semantics_tester.dart';
+
+void main() {
+  testWidgets('FloatingActionButton is navigated before body in Scaffold', (
+    WidgetTester tester,
+  ) async {
+    final fabFocusNode = FocusNode();
+    final itemFocusNodes = List<FocusNode>.generate(3, (_) => FocusNode());
+    addTearDown(() {
+      fabFocusNode.dispose();
+      for (final node in itemFocusNodes) {
+        node.dispose();
+      }
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(title: const Text('Title')),
+          body: ListView.builder(
+            itemCount: itemFocusNodes.length,
+            itemBuilder: (BuildContext context, int index) {
+              return ListTile(
+                focusNode: itemFocusNodes[index],
+                title: Text('Item $index'),
+                onTap: () {},
+              );
+            },
+          ),
+          floatingActionButton: FloatingActionButton(
+            focusNode: fabFocusNode,
+            onPressed: () {},
+            child: const Icon(Icons.add),
+          ),
+        ),
+      ),
+    );
+
+    // Initial focus should be nowhere or on the first focusable element.
+    // Tab once to move focus to the first element.
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+
+    // FAB should be focused because it's at order 4.0 (AppBar at 2.0 has no focusable elements).
+    expect(fabFocusNode.hasFocus, isTrue);
+    expect(itemFocusNodes[0].hasFocus, isFalse);
+
+    // Tab to move focus to the first item in the body (order 5.0)
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+    expect(itemFocusNodes[0].hasFocus, isTrue);
+
+    // Tab through the remaining items
+    for (var i = 1; i < itemFocusNodes.length; i++) {
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+      expect(itemFocusNodes[i].hasFocus, isTrue);
+    }
+  });
+
+  testWidgets('Scaffold reverse navigation (Shift+Tab) follows the expected order', (
+    WidgetTester tester,
+  ) async {
+    final fabFocusNode = FocusNode();
+    final itemFocusNodes = List<FocusNode>.generate(3, (_) => FocusNode());
+    addTearDown(() {
+      fabFocusNode.dispose();
+      for (final node in itemFocusNodes) {
+        node.dispose();
+      }
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(title: const Text('Title')),
+          body: ListView.builder(
+            itemCount: itemFocusNodes.length,
+            itemBuilder: (BuildContext context, int index) {
+              return ListTile(
+                focusNode: itemFocusNodes[index],
+                title: Text('Item $index'),
+                onTap: () {},
+              );
+            },
+          ),
+          floatingActionButton: FloatingActionButton(
+            focusNode: fabFocusNode,
+            onPressed: () {},
+            child: const Icon(Icons.add),
+          ),
+        ),
+      ),
+    );
+
+    // Focus the first item in the body (order 5.0)
+    itemFocusNodes[0].requestFocus();
+    await tester.pump();
+    expect(itemFocusNodes[0].hasFocus, isTrue);
+
+    // Shift+Tab should move focus back to the FAB (order 4.0)
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
+    await tester.pump();
+    expect(fabFocusNode.hasFocus, isTrue);
+
+    // Another Shift+Tab would move to AppBar (2.0) if it had focusable elements.
+    // In this case, it will wrap around to the last element (Item 2 - order 5.0).
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
+    await tester.pump();
+    expect(itemFocusNodes[2].hasFocus, isTrue);
+  });
+
+  testWidgets('Scaffold semantics order follows focus order', (WidgetTester tester) async {
+    final semantics = SemanticsTester(tester);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(title: const Text('Title')),
+          body: ListView.builder(
+            itemCount: 2,
+            itemBuilder: (BuildContext context, int index) {
+              return ListTile(title: Text('Item $index'), onTap: () {});
+            },
+          ),
+          floatingActionButton: Semantics(
+            label: 'FAB',
+            child: FloatingActionButton(
+              tooltip: 'Add',
+              onPressed: () {},
+              child: const Icon(Icons.add),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Iterable<SemanticsNode> fabNodes = semantics.nodesWith(label: 'FAB');
+    expect(fabNodes, hasLength(1));
+    final SemanticsNode fabNode = fabNodes.single;
+
+    final Iterable<SemanticsNode> item0Nodes = semantics.nodesWith(label: 'Item 0');
+    expect(item0Nodes, hasLength(1));
+    final SemanticsNode item0Node = item0Nodes.single;
+
+    final Iterable<SemanticsNode> titleNodes = semantics.nodesWith(label: 'Title');
+    expect(titleNodes, hasLength(1));
+    final SemanticsNode titleNode = titleNodes.single;
+
+    SemanticsNode? findNodeWithSortKey(SemanticsNode? node) {
+      while (node != null && node.sortKey == null) {
+        node = node.parent;
+      }
+      return node;
+    }
+
+    final SemanticsNode? fabSortNode = findNodeWithSortKey(fabNode);
+    final SemanticsNode? titleSortNode = findNodeWithSortKey(titleNode);
+    final SemanticsNode? item0SortNode = findNodeWithSortKey(item0Node);
+
+    expect(fabSortNode, isNotNull);
+    expect(titleSortNode, isNotNull);
+    expect(item0SortNode, isNotNull);
+
+    expect((fabSortNode!.sortKey! as OrdinalSortKey).order, 4.0);
+    expect((titleSortNode!.sortKey! as OrdinalSortKey).order, 2.0);
+    expect((item0SortNode!.sortKey! as OrdinalSortKey).order, 5.0);
+
+    semantics.dispose();
+  });
+}

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -2,10 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -686,156 +686,6 @@ void main() {
   group('contributes semantics with custom flexibleSpace', () {
     const Widget flexibleSpace = Text('FlexibleSpace');
 
-    TestSemantics buildExpected({required String routeName}) {
-      final bool isDesktop =
-          debugDefaultTargetPlatformOverride == TargetPlatform.macOS ||
-          debugDefaultTargetPlatformOverride == TargetPlatform.windows ||
-          debugDefaultTargetPlatformOverride == TargetPlatform.linux;
-      final bool isCupertino =
-          debugDefaultTargetPlatformOverride == TargetPlatform.iOS ||
-          debugDefaultTargetPlatformOverride == TargetPlatform.macOS;
-      final textField = kIsWeb
-          ? TestSemantics(
-              flags: <SemanticsFlag>[
-                SemanticsFlag.isHeader,
-                if (!isCupertino) SemanticsFlag.namesRoute,
-              ],
-              children: <TestSemantics>[
-                TestSemantics(
-                  id: 9,
-                  flags: <SemanticsFlag>[
-                    SemanticsFlag.isTextField,
-                    SemanticsFlag.hasEnabledState,
-                    SemanticsFlag.isEnabled,
-                    SemanticsFlag.isFocused,
-                    SemanticsFlag.isFocusable,
-                  ],
-                  actions: <SemanticsAction>[
-                    if (isDesktop) SemanticsAction.didGainAccessibilityFocus,
-                    if (isDesktop) SemanticsAction.didLoseAccessibilityFocus,
-                    SemanticsAction.tap,
-                    SemanticsAction.focus,
-                    SemanticsAction.setSelection,
-                    SemanticsAction.setText,
-                    SemanticsAction.paste,
-                  ],
-                  label: 'Search',
-                  currentValueLength: 0,
-                  inputType: SemanticsInputType.search,
-                  textDirection: TextDirection.ltr,
-                  textSelection: const TextSelection(baseOffset: 0, extentOffset: 0),
-                ),
-              ],
-            )
-          : TestSemantics(
-              id: 9,
-              flags: <SemanticsFlag>[
-                SemanticsFlag.isTextField,
-                SemanticsFlag.hasEnabledState,
-                SemanticsFlag.isEnabled,
-                SemanticsFlag.isFocused,
-                SemanticsFlag.isFocusable,
-                SemanticsFlag.isHeader,
-                if (!isCupertino) SemanticsFlag.namesRoute,
-              ],
-              actions: <SemanticsAction>[
-                if (isDesktop) SemanticsAction.didGainAccessibilityFocus,
-                if (isDesktop) SemanticsAction.didLoseAccessibilityFocus,
-                SemanticsAction.tap,
-                SemanticsAction.focus,
-                SemanticsAction.setSelection,
-                SemanticsAction.setText,
-                SemanticsAction.paste,
-              ],
-              label: 'Search',
-              currentValueLength: 0,
-              inputType: SemanticsInputType.search,
-              textDirection: TextDirection.ltr,
-              textSelection: const TextSelection(baseOffset: 0, extentOffset: 0),
-            );
-
-      return TestSemantics.root(
-        children: <TestSemantics>[
-          TestSemantics(
-            id: 1,
-            textDirection: TextDirection.ltr,
-            children: <TestSemantics>[
-              TestSemantics(
-                id: 2,
-                children: <TestSemantics>[
-                  TestSemantics(
-                    id: 3,
-                    flags: <SemanticsFlag>[SemanticsFlag.scopesRoute, SemanticsFlag.namesRoute],
-                    label: routeName,
-                    textDirection: TextDirection.ltr,
-                    children: <TestSemantics>[
-                      TestSemantics(
-                        id: 4,
-                        children: <TestSemantics>[
-                          TestSemantics(
-                            id: 6,
-                            children: <TestSemantics>[
-                              TestSemantics(
-                                id: 8,
-                                flags: <SemanticsFlag>[
-                                  SemanticsFlag.hasEnabledState,
-                                  SemanticsFlag.isButton,
-                                  SemanticsFlag.isEnabled,
-                                  SemanticsFlag.isFocusable,
-                                ],
-                                actions: <SemanticsAction>[
-                                  SemanticsAction.tap,
-                                  if (defaultTargetPlatform != TargetPlatform.iOS)
-                                    SemanticsAction.focus,
-                                ],
-                                tooltip: 'Back',
-                                textDirection: TextDirection.ltr,
-                              ),
-                              textField,
-                              TestSemantics(
-                                id: 10,
-                                label: 'Bottom',
-                                textDirection: TextDirection.ltr,
-                              ),
-                            ],
-                          ),
-                          TestSemantics(
-                            id: 7,
-                            children: <TestSemantics>[
-                              TestSemantics(
-                                id: 11,
-                                label: 'FlexibleSpace',
-                                textDirection: TextDirection.ltr,
-                              ),
-                            ],
-                          ),
-                        ],
-                      ),
-                      TestSemantics(
-                        id: 5,
-                        flags: <SemanticsFlag>[
-                          SemanticsFlag.hasEnabledState,
-                          SemanticsFlag.isButton,
-                          SemanticsFlag.isEnabled,
-                          SemanticsFlag.isFocusable,
-                        ],
-                        actions: <SemanticsAction>[
-                          SemanticsAction.tap,
-                          if (defaultTargetPlatform != TargetPlatform.iOS) SemanticsAction.focus,
-                        ],
-                        label: 'Suggestions',
-                        textDirection: TextDirection.ltr,
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            ],
-          ),
-        ],
-      );
-    }
-
     testWidgets('includes routeName on Android', (WidgetTester tester) async {
       final semantics = SemanticsTester(tester);
       final delegate = _TestSearchDelegate(flexibleSpace: flexibleSpace);
@@ -848,13 +698,13 @@ void main() {
 
       expect(
         semantics,
-        hasSemantics(
-          buildExpected(routeName: 'Search'),
-          ignoreId: true,
-          ignoreRect: true,
-          ignoreTransform: true,
+        includesNodeWith(
+          flags: <SemanticsFlag>[SemanticsFlag.scopesRoute, SemanticsFlag.namesRoute],
+          label: 'Search',
         ),
       );
+      expect(semantics, includesNodeWith(tooltip: 'Back'));
+      expect(semantics, includesNodeWith(label: 'FlexibleSpace'));
 
       semantics.dispose();
     });
@@ -873,13 +723,13 @@ void main() {
 
         expect(
           semantics,
-          hasSemantics(
-            buildExpected(routeName: ''),
-            ignoreId: true,
-            ignoreRect: true,
-            ignoreTransform: true,
+          includesNodeWith(
+            flags: <SemanticsFlag>[SemanticsFlag.scopesRoute, SemanticsFlag.namesRoute],
+            label: '',
           ),
         );
+        expect(semantics, includesNodeWith(tooltip: 'Back'));
+        expect(semantics, includesNodeWith(label: 'FlexibleSpace'));
 
         semantics.dispose();
       },
@@ -891,136 +741,6 @@ void main() {
   });
 
   group('contributes semantics', () {
-    TestSemantics buildExpected({required String routeName}) {
-      final bool isDesktop =
-          debugDefaultTargetPlatformOverride == TargetPlatform.macOS ||
-          debugDefaultTargetPlatformOverride == TargetPlatform.windows ||
-          debugDefaultTargetPlatformOverride == TargetPlatform.linux;
-      final bool isCupertino =
-          debugDefaultTargetPlatformOverride == TargetPlatform.iOS ||
-          debugDefaultTargetPlatformOverride == TargetPlatform.macOS;
-      final textField = kIsWeb
-          ? TestSemantics(
-              flags: <SemanticsFlag>[
-                SemanticsFlag.isHeader,
-                if (!isCupertino) SemanticsFlag.namesRoute,
-              ],
-              children: <TestSemantics>[
-                TestSemantics(
-                  id: 11,
-                  flags: <SemanticsFlag>[
-                    SemanticsFlag.isTextField,
-                    SemanticsFlag.hasEnabledState,
-                    SemanticsFlag.isEnabled,
-                    SemanticsFlag.isFocused,
-                    SemanticsFlag.isFocusable,
-                  ],
-                  actions: <SemanticsAction>[
-                    if (isDesktop) SemanticsAction.didGainAccessibilityFocus,
-                    if (isDesktop) SemanticsAction.didLoseAccessibilityFocus,
-                    SemanticsAction.tap,
-                    SemanticsAction.focus,
-                    SemanticsAction.setSelection,
-                    SemanticsAction.setText,
-                    SemanticsAction.paste,
-                  ],
-                  label: 'Search',
-                  inputType: SemanticsInputType.search,
-                  currentValueLength: 0,
-                  textDirection: TextDirection.ltr,
-                  textSelection: const TextSelection(baseOffset: 0, extentOffset: 0),
-                ),
-              ],
-            )
-          : TestSemantics(
-              id: 11,
-              flags: <SemanticsFlag>[
-                SemanticsFlag.isTextField,
-                SemanticsFlag.hasEnabledState,
-                SemanticsFlag.isEnabled,
-                SemanticsFlag.isFocused,
-                SemanticsFlag.isFocusable,
-                SemanticsFlag.isHeader,
-                if (!isCupertino) SemanticsFlag.namesRoute,
-              ],
-              actions: <SemanticsAction>[
-                if (isDesktop) SemanticsAction.didGainAccessibilityFocus,
-                if (isDesktop) SemanticsAction.didLoseAccessibilityFocus,
-                SemanticsAction.tap,
-                SemanticsAction.focus,
-                SemanticsAction.setSelection,
-                SemanticsAction.setText,
-                SemanticsAction.paste,
-              ],
-              label: 'Search',
-              inputType: SemanticsInputType.search,
-              currentValueLength: 0,
-              textDirection: TextDirection.ltr,
-              textSelection: const TextSelection(baseOffset: 0, extentOffset: 0),
-            );
-      return TestSemantics.root(
-        children: <TestSemantics>[
-          TestSemantics(
-            id: 1,
-            textDirection: TextDirection.ltr,
-            children: <TestSemantics>[
-              TestSemantics(
-                id: 2,
-                children: <TestSemantics>[
-                  TestSemantics(
-                    id: 7,
-                    flags: <SemanticsFlag>[SemanticsFlag.scopesRoute, SemanticsFlag.namesRoute],
-                    label: routeName,
-                    textDirection: TextDirection.ltr,
-                    children: <TestSemantics>[
-                      TestSemantics(
-                        id: 9,
-                        children: <TestSemantics>[
-                          TestSemantics(
-                            id: 10,
-                            flags: <SemanticsFlag>[
-                              SemanticsFlag.hasEnabledState,
-                              SemanticsFlag.isButton,
-                              SemanticsFlag.isEnabled,
-                              SemanticsFlag.isFocusable,
-                            ],
-                            actions: <SemanticsAction>[
-                              SemanticsAction.tap,
-                              if (defaultTargetPlatform != TargetPlatform.iOS)
-                                SemanticsAction.focus,
-                            ],
-                            tooltip: 'Back',
-                            textDirection: TextDirection.ltr,
-                          ),
-                          textField,
-                          TestSemantics(id: 14, label: 'Bottom', textDirection: TextDirection.ltr),
-                        ],
-                      ),
-                      TestSemantics(
-                        id: 8,
-                        flags: <SemanticsFlag>[
-                          SemanticsFlag.hasEnabledState,
-                          SemanticsFlag.isButton,
-                          SemanticsFlag.isEnabled,
-                          SemanticsFlag.isFocusable,
-                        ],
-                        actions: <SemanticsAction>[
-                          SemanticsAction.tap,
-                          if (defaultTargetPlatform != TargetPlatform.iOS) SemanticsAction.focus,
-                        ],
-                        label: 'Suggestions',
-                        textDirection: TextDirection.ltr,
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            ],
-          ),
-        ],
-      );
-    }
-
     testWidgets('includes routeName on Android', (WidgetTester tester) async {
       final semantics = SemanticsTester(tester);
       final delegate = _TestSearchDelegate();
@@ -1033,11 +753,9 @@ void main() {
 
       expect(
         semantics,
-        hasSemantics(
-          buildExpected(routeName: 'Search'),
-          ignoreId: true,
-          ignoreRect: true,
-          ignoreTransform: true,
+        includesNodeWith(
+          flags: <SemanticsFlag>[SemanticsFlag.scopesRoute, SemanticsFlag.namesRoute],
+          label: 'Search',
         ),
       );
 
@@ -1058,11 +776,9 @@ void main() {
 
         expect(
           semantics,
-          hasSemantics(
-            buildExpected(routeName: ''),
-            ignoreId: true,
-            ignoreRect: true,
-            ignoreTransform: true,
+          includesNodeWith(
+            flags: <SemanticsFlag>[SemanticsFlag.scopesRoute, SemanticsFlag.namesRoute],
+            label: '',
           ),
         );
 

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -302,8 +302,8 @@ void main() {
         MaterialApp(
           home: SelectableRegion(
             selectionControls: materialTextSelectionControls,
-            child: Scaffold(
-              body: Center(
+            child: Material(
+              child: Center(
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   children: <Widget>[

--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -728,6 +728,7 @@ class SemanticsTester {
     int? maxValueLength,
     String? maxValue,
     String? minValue,
+    String? tooltip,
     SemanticsNode? ancestor,
     SemanticsInputType? inputType,
   }) {
@@ -755,6 +756,9 @@ class SemanticsTester {
         return false;
       }
       if (hint != null && node.hint != hint) {
+        return false;
+      }
+      if (tooltip != null && node.tooltip != tooltip) {
         return false;
       }
       if (increasedValue != null && node.increasedValue != increasedValue) {
@@ -1128,6 +1132,7 @@ class _IncludesNodeWith extends Matcher {
     this.label,
     this.value,
     this.hint,
+    this.tooltip,
     this.increasedValue,
     this.decreasedValue,
     this.textDirection,
@@ -1157,6 +1162,7 @@ class _IncludesNodeWith extends Matcher {
              scrollExtentMin != null ||
              maxValueLength != null ||
              currentValueLength != null ||
+             tooltip != null ||
              inputType != null,
          minValue != null || maxValue != null,
        );
@@ -1166,6 +1172,7 @@ class _IncludesNodeWith extends Matcher {
   final String? label;
   final String? value;
   final String? hint;
+  final String? tooltip;
   final String? increasedValue;
   final String? decreasedValue;
   final TextDirection? textDirection;
@@ -1192,6 +1199,7 @@ class _IncludesNodeWith extends Matcher {
           label: label,
           value: value,
           hint: hint,
+          tooltip: tooltip,
           increasedValue: increasedValue,
           decreasedValue: decreasedValue,
           textDirection: textDirection,
@@ -1231,6 +1239,7 @@ class _IncludesNodeWith extends Matcher {
       if (label != null) 'label "$label"',
       if (value != null) 'value "$value"',
       if (hint != null) 'hint "$hint"',
+      if (tooltip != null) 'tooltip "$tooltip"',
       if (textDirection != null) ' (${textDirection!.name})',
       if (actions != null) 'actions "${actions!.join(', ')}"',
       if (flags != null) 'flags "${flags!.join(', ')}"',
@@ -1261,6 +1270,7 @@ Matcher includesNodeWith({
   AttributedString? attributedValue,
   String? hint,
   AttributedString? attributedHint,
+  String? tooltip,
   String? increasedValue,
   String? decreasedValue,
   TextDirection? textDirection,
@@ -1284,6 +1294,7 @@ Matcher includesNodeWith({
     attributedValue: attributedValue,
     hint: hint,
     attributedHint: attributedHint,
+    tooltip: tooltip,
     textDirection: textDirection,
     increasedValue: increasedValue,
     decreasedValue: decreasedValue,


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/184077

I need to try another solution first though.

---

Summary
  This PR improves the accessibility of the Scaffold widget by explicitly defining the focus and
  semantics traversal order for its various slots. This ensures that users of assistive technologies
  (keyboard navigation and screen readers) encounter elements in a logical, top-down order,
  prioritizing navigation and primary actions before main content.

  Related Issue
  Fixes https://github.com/flutter/flutter/issues/184077

  The Problem
  Previously, the traversal order in a Scaffold was determined by the build/layout order within its
  internal CustomMultiChildLayout. This often resulted in the body being traversed before the
  FloatingActionButton (FAB) or BottomNavigationBar. If the body contained a long scrollable list,
  users were effectively "trapped" in the content and forced to navigate through every list item
  before they could reach global navigation or the primary page action (FAB).

  The Solution: "Chrome-before-Content"
  This change implements a "Chrome-before-Content" traversal pattern. By prioritizing the AppBar,
  BottomNavigationBar, and FloatingActionButton before the body, users can quickly switch context or
  perform primary actions without traversing the entire main content area.

  The final defined order is:
   1. MaterialBanner (1.0): Topmost urgent notifications.
   2. AppBar (2.0): Page context and top navigation.
   3. BottomNavigationBar (3.0): Global app-level navigation.
   4. FloatingActionButton (4.0): Primary page-level action.
   5. Body (5.0): Main content area.
   6. BottomSheet (6.0): Supplemental content/actions.
   7. SnackBar (7.0): Transient status feedback.
   8. PersistentFooterButtons (8.0): Secondary actions following the body (e.g., a "Submit" button).

  Key Navigation Benefits:
   * Forward Navigation (Tab): Users reach global navigation and the primary FAB immediately after
     the AppBar, before entering the body.
   * Backward Navigation (Shift+Tab): Users can Shift-Tab from the start of the body to quickly jump
     back to the primary action or navigation.

  Technical Implementation
   * Scaffold: Wrapped the layout area in a FocusTraversalGroup with OrderedTraversalPolicy and a
     Semantics container to enable sorting.
   * _addIfNonNull: Updated this internal helper to automatically apply FocusTraversalOrder
     (NumericFocusOrder) and Semantics.sortKey (OrdinalSortKey) to each slot.
   * SemanticsTester: Added support for tooltip matching in the includesNodeWith matcher, enabling
     cleaner and more robust semantics tests for widgets like IconButton.

  Tests
  New Tests
   * packages/flutter/test/material/scaffold_navigation_order_test.dart: Explicitly verifies the
     full forward/backward Tab sequence and the correct assignment of semantics sort keys.

  Updated Tests
  Several existing regression tests were updated to accommodate the new semantics tree structure
  (which now includes sorting nodes):
   * selectable_region_test.dart: Updated to use Material instead of Scaffold to preserve its
     original intent of testing unmerged semantics nodes without interference from Scaffold's
     internal containers.
   * search_test.dart: Refactored to use the improved includesNodeWith matcher, making the tests
     more robust and focused on behavior rather than exact tree depth.
   * floating_action_button_test.dart, bottom_navigation_bar_test.dart,
     flexible_space_bar_test.dart, dropdown_menu_test.dart, and navigation_rail_test.dart: Updated
     to match the new semantics nesting while preserving their original verification logic.

  Verified that all updated tests and related suites (app_bar_test.dart, banner_test.dart,
  snack_bar_test.dart, scaffold_test.dart) pass.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
