### PR TITLE
Reland "Apply rect clipping to surface views"

### DIFF
--- a/dev/integration_tests/android_engine_test/lib/hcpp/platform_view_cliprect_surfaceview_main.dart
+++ b/dev/integration_tests/android_engine_test/lib/hcpp/platform_view_cliprect_surfaceview_main.dart
@@ -1,0 +1,155 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:android_driver_extensions/extension.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_driver/driver_extension.dart';
+
+import '../src/allow_list_devices.dart';
+
+void main() async {
+  ensureAndroidDevice();
+  enableFlutterDriverExtension(
+    handler: (String? command) async {
+      return json.encode(<String, Object?>{
+        'supported': await HybridAndroidViewController.checkIfSupported(),
+      });
+    },
+    commands: <CommandExtension>[nativeDriverCommands],
+  );
+
+  // Run on full screen.
+  await SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersive);
+  runApp(const SimpleClipRectApp());
+}
+
+class SimpleClipRectApp extends StatelessWidget {
+  const SimpleClipRectApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      theme: ThemeData(elevatedButtonTheme: const ElevatedButtonThemeData()),
+      home: const ClipRectHomePage(),
+    );
+  }
+}
+
+class ClipRectHomePage extends StatefulWidget {
+  const ClipRectHomePage({super.key});
+
+  @override
+  State<ClipRectHomePage> createState() => _ClipRectHomePageState();
+}
+
+class _ClipRectHomePageState extends State<ClipRectHomePage> {
+  bool _isClipped = false;
+
+  void _toggleClip() {
+    setState(() {
+      _isClipped = !_isClipped;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Content that will be clipped
+    Widget content = const Stack(
+      alignment: Alignment.center,
+      children: <Widget>[
+        // Background
+        SizedBox.square(dimension: 500, child: ColoredBox(color: Colors.green)),
+        // Platform View
+        SizedBox.square(
+          dimension: 400,
+          child: _HybridCompositionAndroidPlatformView(
+            viewType: 'blue_orange_gradient_surface_view_platform_view',
+          ),
+        ),
+      ],
+    );
+
+    // Apply the ClipRect conditionally
+    if (_isClipped) {
+      content = ClipRect(clipper: const SimpleRectClipper(dimension: 300.0), child: content);
+    }
+
+    return Scaffold(
+      body: Column(
+        children: <Widget>[
+          // Button to toggle the clip state
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: ElevatedButton(
+              key: const ValueKey<String>('toggle_cliprect_button'),
+              onPressed: _toggleClip,
+              child: Text(_isClipped ? 'Disable ClipRect' : 'Enable ClipRect'),
+            ),
+          ),
+          // Expanded takes remaining space for the clipped content
+          Expanded(child: Center(child: content)),
+        ],
+      ),
+    );
+  }
+}
+
+// A simple clipper that enforces a strict bounding box of the specified dimension
+class SimpleRectClipper extends CustomClipper<Rect> {
+  const SimpleRectClipper({required this.dimension});
+
+  final double dimension;
+
+  @override
+  Rect getClip(Size size) {
+    // Centers the clip area over the widget
+    return Rect.fromCenter(
+      center: Offset(size.width / 2, size.height / 2),
+      width: dimension,
+      height: dimension,
+    );
+  }
+
+  @override
+  bool shouldReclip(covariant SimpleRectClipper oldClipper) {
+    return oldClipper.dimension != dimension;
+  }
+}
+
+// --- Platform View Definition ---
+final class _HybridCompositionAndroidPlatformView extends StatelessWidget {
+  const _HybridCompositionAndroidPlatformView({required this.viewType});
+
+  final String viewType;
+
+  @override
+  Widget build(BuildContext context) {
+    return PlatformViewLink(
+      viewType: viewType,
+      surfaceFactory: (BuildContext context, PlatformViewController controller) {
+        return AndroidViewSurface(
+          controller: controller as AndroidViewController,
+          gestureRecognizers: const <Factory<OneSequenceGestureRecognizer>>{},
+          hitTestBehavior: PlatformViewHitTestBehavior.transparent,
+        );
+      },
+      onCreatePlatformView: (PlatformViewCreationParams params) {
+        return PlatformViewsService.initHybridAndroidView(
+            id: params.id,
+            viewType: viewType,
+            layoutDirection: TextDirection.ltr,
+            creationParamsCodec: const StandardMessageCodec(),
+          )
+          ..addOnPlatformViewCreatedListener(params.onPlatformViewCreated)
+          ..create();
+      },
+    );
+  }
+}

--- a/dev/integration_tests/android_engine_test/test_driver/hcpp/platform_view_cliprect_surfaceview_main_test.dart
+++ b/dev/integration_tests/android_engine_test/test_driver/hcpp/platform_view_cliprect_surfaceview_main_test.dart
@@ -54,7 +54,7 @@ void main() async {
   test('should screenshot a platform view with no rect clipping', () async {
     await expectLater(
       nativeDriver.screenshot(),
-      matchesGoldenFile('$goldenPrefix.no_rect_clipping_surfaceview.png'),
+      matchesGoldenFile('$goldenPrefix.no_rect_surfaceview.png'),
     );
   }, timeout: Timeout.none);
 
@@ -62,7 +62,7 @@ void main() async {
     await flutterDriver.tap(find.byValueKey('toggle_cliprect_button'));
     await expectLater(
       nativeDriver.screenshot(),
-      matchesGoldenFile('$goldenPrefix.yes_rect_clipping_surfaceview.png'),
+      matchesGoldenFile('$goldenPrefix.yes_rect_surfaceview.png'),
     );
   }, timeout: Timeout.none);
 }

--- a/dev/integration_tests/android_engine_test/test_driver/hcpp/platform_view_cliprect_surfaceview_main_test.dart
+++ b/dev/integration_tests/android_engine_test/test_driver/hcpp/platform_view_cliprect_surfaceview_main_test.dart
@@ -1,0 +1,68 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:android_driver_extensions/native_driver.dart';
+import 'package:android_driver_extensions/skia_gold.dart';
+import 'package:flutter_driver/flutter_driver.dart';
+import 'package:test/test.dart';
+
+import '../_luci_skia_gold_prelude.dart';
+
+/// For local debugging, a (local) golden-file is required as a baseline:
+///
+/// ```sh
+/// # Checkout HEAD, i.e. *before* changes you want to test.
+/// UPDATE_GOLDENS=1 flutter drive lib/hcpp/platform_view_cliprect_surfaceview_main.dart
+///
+/// # Make your changes.
+///
+/// # Run the test against baseline.
+/// flutter drive lib/hcpp/platform_view_cliprect_surfaceview_main.dart
+/// ```
+///
+/// For a convenient way to deflake a test, see `tool/deflake.dart`.
+void main() async {
+  const goldenPrefix = 'hybrid_composition_pp_platform_view';
+
+  late final FlutterDriver flutterDriver;
+  late final NativeDriver nativeDriver;
+
+  setUpAll(() async {
+    if (isLuci) {
+      await enableSkiaGoldComparator(namePrefix: 'android_engine_test$goldenVariant');
+    }
+    flutterDriver = await FlutterDriver.connect();
+    nativeDriver = await AndroidNativeDriver.connect(flutterDriver);
+    await nativeDriver.configureForScreenshotTesting();
+    await flutterDriver.waitUntilFirstFrameRasterized();
+  });
+
+  tearDownAll(() async {
+    await nativeDriver.close();
+    await flutterDriver.close();
+  });
+
+  test('verify that HCPP is supported and enabled', () async {
+    final response = json.decode(await flutterDriver.requestData('')) as Map<String, Object?>;
+
+    expect(response['supported'], true);
+  }, timeout: Timeout.none);
+
+  test('should screenshot a platform view with no rect clipping', () async {
+    await expectLater(
+      nativeDriver.screenshot(),
+      matchesGoldenFile('$goldenPrefix.no_rect_clipping_surfaceview.png'),
+    );
+  }, timeout: Timeout.none);
+
+  test('should properly clip surfaceview', () async {
+    await flutterDriver.tap(find.byValueKey('toggle_cliprect_button'));
+    await expectLater(
+      nativeDriver.screenshot(),
+      matchesGoldenFile('$goldenPrefix.yes_rect_clipping_surfaceview.png'),
+    );
+  }, timeout: Timeout.none);
+}

--- a/docs/platforms/android/Android-Platform-Views.md
+++ b/docs/platforms/android/Android-Platform-Views.md
@@ -68,7 +68,6 @@ You can enable HCPP using one of the following methods:
 
 ### Limitations and Known Issues
 The following is a list of limitations and known issues. If you encounter an issue not listed below, please file an issue!
-- **SurfaceView Compatibility**: Opting in is currently not recommended if your application contains a platform view which is or contains a native [`SurfaceView`](https://developer.android.com/reference/android/view/SurfaceView) (often used by video players or map plugins), due to clipping issues. This is tracked in https://github.com/flutter/flutter/issues/175546.
 - **Complex Overlay Stacking**: Transparent platform views will not display correctly in layout stacks structured as: Flutter canvas -> Platform View -> Overlay -> Transparent Platform View, when all four of these layers intersect.
 
 ## Virtual Display

--- a/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController2.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController2.java
@@ -7,7 +7,10 @@ package io.flutter.plugin.platform;
 import static io.flutter.Build.API_LEVELS;
 
 import android.content.Context;
+import android.graphics.Path;
 import android.graphics.PixelFormat;
+import android.graphics.Rect;
+import android.graphics.RectF;
 import android.util.SparseArray;
 import android.view.Gravity;
 import android.view.MotionEvent;
@@ -15,6 +18,8 @@ import android.view.MotionEvent.PointerCoords;
 import android.view.MotionEvent.PointerProperties;
 import android.view.Surface;
 import android.view.SurfaceControl;
+import android.view.SurfaceHolder;
+import android.view.SurfaceView;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
@@ -38,6 +43,7 @@ import io.flutter.embedding.engine.systemchannels.PlatformViewsChannel2;
 import io.flutter.plugin.editing.TextInputPlugin;
 import io.flutter.view.AccessibilityBridge;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 
 /**
@@ -72,6 +78,8 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
   private final ArrayList<SurfaceControl.Transaction> activeTransactions;
   private Surface overlayerSurface = null;
   private SurfaceControl overlaySurfaceControl = null;
+
+  private final HashSet<Integer> viewsWithPendingSurfaceCallback = new HashSet<>();
 
   public PlatformViewsController2() {
     accessibilityEventsDelegate = new AccessibilityEventsDelegate();
@@ -500,6 +508,7 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
    * @param mutatorsStack The mutator stack. This member is not intended for public use, and is only
    *     visible for testing.
    */
+  @RequiresApi(API_LEVELS.API_34)
   public void onDisplayPlatformView(
       int viewId,
       int x,
@@ -524,7 +533,127 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
     if (view != null) {
       view.setLayoutParams(layoutParams);
       view.bringToFront();
+      if (view instanceof SurfaceView) {
+        maybeApplyClipToSurfaceView((SurfaceView) view, x, y, width, height, mutatorsStack, viewId);
+      }
     }
+  }
+
+  @RequiresApi(API_LEVELS.API_34)
+  private void maybeApplyClipToSurfaceView(
+      SurfaceView surfaceView,
+      int x,
+      int y,
+      int width,
+      int height,
+      FlutterMutatorsStack mutatorsStack,
+      int viewId) {
+    // 1. CALCULATE THE FINAL RECT (RECT, RRECT, PATH, TRANSFORM)
+    // We start with the view's final on-screen bounds.
+    RectF screenRectF = new RectF(x, y, x + width, y + height);
+    Rect screenRect = new Rect();
+    screenRectF.roundOut(screenRect);
+
+    List<Path> clippingPaths = mutatorsStack.getFinalClippingPaths();
+
+    if (clippingPaths != null && !clippingPaths.isEmpty()) {
+      RectF pathBounds = new RectF();
+      for (Path path : clippingPaths) {
+        // Compute the axis-aligned bounding box of the path.
+        path.computeBounds(pathBounds, true);
+
+        // Round out to ensure we cover the pixels (ceil/floor logic).
+        Rect pathRectInt = new Rect();
+        pathBounds.roundOut(pathRectInt);
+
+        // Intersect the current visible area with this clip.
+        // If the path is a complex shape (star, rounded rect), this
+        // constrains the surface to the bounding box of that shape.
+        boolean anyIntersection = screenRect.intersect(pathRectInt);
+        if (!anyIntersection) {
+          screenRect.setEmpty();
+          break;
+        }
+      }
+    }
+
+    // 2. CONVERT TO LOCAL SURFACE COORDINATES
+    // SurfaceControl.setCrop expects coordinates relative to the Surface (0,0).
+    // We shift the calculated screen-space rect by the view's origin (-x, -y).
+    screenRect.offset(-x, -y);
+    if (screenRect.width() < 0 || screenRect.height() < 0) {
+      screenRect.setEmpty();
+    }
+
+    // 3. APPLY EITHER IN TIME, OR AS A CALLBACK
+    // If the widget tree recently changed, the SurfaceControl will likely be null.
+    // So apply via a SurfaceHolder.Callback(). Otherwise, apply via standard
+    // transaction apis.
+    float opacity = mutatorsStack.getFinalOpacity();
+    SurfaceControl sc = surfaceView.getSurfaceControl();
+    if (sc == null) {
+      if (viewsWithPendingSurfaceCallback.contains(viewId)) {
+        return;
+      }
+      viewsWithPendingSurfaceCallback.add(viewId);
+      SurfaceHolder.Callback cb =
+          createSurfaceClipCallback(surfaceView, opacity, screenRect, viewId);
+      surfaceView.getHolder().addCallback(cb);
+      return;
+    }
+    if (!sc.isValid()) {
+      Log.i(
+          TAG,
+          "Skipping applying clip to SurfaceView: "
+              + surfaceView.getId()
+              + " because it has an invalid SurfaceControl.");
+      return;
+    }
+    SurfaceControl.Transaction tx =
+        createTransaction().setAlpha(sc, opacity).setCrop(sc, screenRect);
+  }
+
+  @RequiresApi(API_LEVELS.API_34)
+  private SurfaceHolder.Callback createSurfaceClipCallback(
+      @NonNull final SurfaceView surfaceView,
+      final float opacity,
+      @NonNull final Rect screenRect,
+      final int viewId) {
+    return new SurfaceHolder.Callback() {
+      @Override
+      public void surfaceCreated(@NonNull SurfaceHolder holder) {
+        SurfaceControl surfaceControl = surfaceView.getSurfaceControl();
+        if (surfaceControl != null && surfaceControl.isValid()) {
+          SurfaceControl.Transaction tx =
+              createTransaction()
+                  .setAlpha(surfaceControl, opacity)
+                  .setCrop(surfaceControl, screenRect);
+        } else {
+          Log.i(
+              TAG,
+              "Failed to apply clipping to SurfaceView: "
+                  + surfaceView.getId()
+                  + " - the SurfaceControl was null or invalid during surfaceCreated callback.");
+        }
+        // Because this transaction is created outside of the frame timing, we can't
+        // guarantee there is another frame coming (if, say, the app has a static
+        // layout). So we schedule one to ensure the crop is rendered properly.
+        // See https://github.com/flutter/flutter/issues/175546.
+        flutterJNI.scheduleFrame();
+        viewsWithPendingSurfaceCallback.remove(viewId);
+        surfaceView.getHolder().removeCallback(this);
+      }
+
+      @Override
+      public void surfaceChanged(
+          @NonNull SurfaceHolder holder, int format, int width, int height) {}
+
+      @Override
+      public void surfaceDestroyed(@NonNull SurfaceHolder holder) {
+        viewsWithPendingSurfaceCallback.remove(viewId);
+        surfaceView.getHolder().removeCallback(this);
+      }
+    };
   }
 
   public void hidePlatformView(int viewId) {
@@ -639,6 +768,7 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
 
         @Override
         public void dispose(int viewId) {
+          viewsWithPendingSurfaceCallback.remove(viewId);
           final PlatformView platformView = platformViews.get(viewId);
           if (platformView == null) {
             Log.e(TAG, "Disposing unknown platform view with id: " + viewId);


### PR DESCRIPTION
Relands https://github.com/flutter/flutter/pull/184471 which [was reverted](https://github.com/flutter/flutter/pull/184728) because of suspected skia gold bug where the triage button was not working for the created digests.

I also changed the names of the output files just in case, to make sure the state doesn't collide with old.