### PR TITLE
[ci] mac build_test bringup false

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3675,7 +3675,6 @@ targets:
 
   - name: Mac_x64 build_tests_1_5
     recipe: flutter/flutter_drone
-    bringup: true
     presubmit: false # Rely on Mac_arm build_tests in presubmit.
     timeout: 60
     properties:
@@ -3694,7 +3693,6 @@ targets:
 
   - name: Mac_x64 build_tests_2_5
     recipe: flutter/flutter_drone
-    bringup: true
     presubmit: false # Rely on Mac_arm build_tests in presubmit.
     timeout: 60
     properties:
@@ -3713,7 +3711,6 @@ targets:
 
   - name: Mac_x64 build_tests_3_5
     recipe: flutter/flutter_drone
-    bringup: true
     presubmit: false # Rely on Mac_arm build_tests in presubmit.
     timeout: 60
     properties:
@@ -3732,7 +3729,6 @@ targets:
 
   - name: Mac_x64 build_tests_4_5
     recipe: flutter/flutter_drone
-    bringup: true
     presubmit: false # Rely on Mac_arm build_tests in presubmit.
     timeout: 60
     properties:
@@ -3751,7 +3747,6 @@ targets:
 
   - name: Mac_x64 build_tests_5_5
     recipe: flutter/flutter_drone
-    bringup: true
     presubmit: false # Rely on Mac_arm build_tests in presubmit.
     timeout: 60
     properties:
@@ -3770,7 +3765,6 @@ targets:
 
   - name: Mac_arm64 build_tests_1_5
     recipe: flutter/flutter_drone
-    bringup: true
     timeout: 60
     # Flake rate of >2.5% in presubmit
     presubmit: false # https://github.com/flutter/flutter/issues/150642
@@ -3790,7 +3784,6 @@ targets:
 
   - name: Mac_arm64 build_tests_2_5
     recipe: flutter/flutter_drone
-    bringup: true
     timeout: 60
     properties:
       add_recipes_cq: "true"
@@ -3808,7 +3801,6 @@ targets:
 
   - name: Mac_arm64 build_tests_3_5
     recipe: flutter/flutter_drone
-    bringup: true
     timeout: 60
     properties:
       add_recipes_cq: "true"
@@ -3826,7 +3818,6 @@ targets:
 
   - name: Mac_arm64 build_tests_4_5
     recipe: flutter/flutter_drone
-    bringup: true
     timeout: 60
     properties:
       add_recipes_cq: "true"
@@ -3844,7 +3835,6 @@ targets:
 
   - name: Mac_arm64 build_tests_5_5
     recipe: flutter/flutter_drone
-    bringup: true
     timeout: 60
     properties:
       add_recipes_cq: "true"


### PR DESCRIPTION
We resharded the mac build-tests in https://github.com/flutter/flutter/pull/184719.

That required `bringup: true`, the bots are green for the last 3 commits, move them out of bringup.

<img width="362" height="148" alt="image" src="https://github.com/user-attachments/assets/5f9b437c-3d93-42a4-960c-0f584fbd1adf" />

The timeouts seem better this time. The slowest shard runs in 31 minutes.