### PR TITLE
[ci] mac_arm64 build_test re-enable shard 1 presubmit

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3766,8 +3766,6 @@ targets:
   - name: Mac_arm64 build_tests_1_5
     recipe: flutter/flutter_drone
     timeout: 60
-    # Flake rate of >2.5% in presubmit
-    presubmit: false # https://github.com/flutter/flutter/issues/150642
     properties:
       add_recipes_cq: "true"
       dependencies: >-


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/150642 has been closed saying that it's fixed.

And also I resharded these bots (https://github.com/flutter/flutter/pull/184719 & https://github.com/flutter/flutter/pull/184738), which likely means shard 1 now runs different tests than before.

FYI @vashworth @gmackall 