### PR TITLE
Make `windowing_test` follow repo analyzer rules

### DIFF
--- a/dev/integration_tests/windowing_test/analysis_options.yaml
+++ b/dev/integration_tests/windowing_test/analysis_options.yaml
@@ -1,4 +1,0 @@
-include: package:flutter_lints/flutter.yaml
-
-linter:
-  rules:

--- a/dev/integration_tests/windowing_test/lib/main.dart
+++ b/dev/integration_tests/windowing_test/lib/main.dart
@@ -14,9 +14,7 @@ import 'package:flutter/src/widgets/_window.dart';
 import 'package:flutter_driver/driver_extension.dart';
 
 late final RegularWindowController controller;
-final ValueNotifier<DialogWindowController?> dialogController = ValueNotifier(
-  null,
-);
+final ValueNotifier<DialogWindowController?> dialogController = ValueNotifier(null);
 
 void main() {
   final Completer<void> windowCreated = Completer();
@@ -28,18 +26,15 @@ void main() {
           return '';
         }
 
-        final jsonMap = jsonDecode(message);
+        final jsonMap = jsonDecode(message) as Map<String, Object?>;
         if (!jsonMap.containsKey('type')) {
           throw ArgumentError('Message must contain a "type" field.');
         }
 
         /// This helper method registers a listener on the controller,
         /// calls [act] to perform some action on the controller, waits for
-        /// the [predicate] to be satisified, and finally cleans up the listener.
-        Future<void> awaitNotification(
-          VoidCallback act,
-          bool Function() predicate,
-        ) async {
+        /// the [predicate] to be satisfied, and finally cleans up the listener.
+        Future<void> awaitNotification(VoidCallback act, bool Function() predicate) async {
           final StreamController<bool> streamController = StreamController();
           void notificationHandler() {
             streamController.add(true);
@@ -54,12 +49,12 @@ void main() {
             // the animation is in progress and next request for state change
             // will be ignored. Easiest way to handle this is to just wait.
             if (defaultTargetPlatform == TargetPlatform.macOS) {
-              await Future.delayed(Duration(seconds: 1));
+              await Future<void>.delayed(const Duration(seconds: 1));
             }
 
             // Add a timeout to avoid hanging indefinitely
-            await for (final _ in streamController.stream.timeout(
-              Duration(seconds: 10),
+            await for (final bool _ in streamController.stream.timeout(
+              const Duration(seconds: 10),
             )) {
               if (predicate()) {
                 break;
@@ -79,22 +74,22 @@ void main() {
             'height': controller.contentSize.height,
           });
         } else if (jsonMap['type'] == 'set_size') {
-          final Size size = Size(
-            jsonMap['width'].toDouble(),
-            jsonMap['height'].toDouble(),
+          final size = Size(
+            (jsonMap['width']! as int).toDouble(),
+            (jsonMap['height']! as int).toDouble(),
           );
           await awaitNotification(() {
             controller.setSize(size);
           }, () => controller.contentSize == size);
         } else if (jsonMap['type'] == 'set_constraints') {
-          final BoxConstraints constraints = BoxConstraints(
-            minWidth: jsonMap['min_width'].toDouble(),
-            minHeight: jsonMap['min_height'].toDouble(),
-            maxWidth: jsonMap['max_width'].toDouble(),
-            maxHeight: jsonMap['max_height'].toDouble(),
+          final constraints = BoxConstraints(
+            minWidth: (jsonMap['min_width']! as int).toDouble(),
+            minHeight: (jsonMap['min_height']! as int).toDouble(),
+            maxWidth: (jsonMap['max_width']! as int).toDouble(),
+            maxHeight: (jsonMap['max_height']! as int).toDouble(),
           );
           // We assume that this will cause a resize, which the current tests do.
-          final initialSize = controller.contentSize;
+          final Size initialSize = controller.contentSize;
           await awaitNotification(() {
             controller.setConstraints(constraints);
           }, () => controller.contentSize != initialSize);
@@ -129,7 +124,7 @@ void main() {
         } else if (jsonMap['type'] == 'get_minimized') {
           return jsonEncode({'isMinimized': controller.isMinimized});
         } else if (jsonMap['type'] == 'set_title') {
-          final String title = jsonMap['title'];
+          final title = jsonMap['title']! as String;
           await awaitNotification(() {
             controller.setTitle(title);
           }, () => controller.title == title);
@@ -168,12 +163,12 @@ void main() {
     },
   );
   controller = RegularWindowController(
-    preferredSize: Size(640, 480),
+    preferredSize: const Size(640, 480),
     title: 'Integration Test',
     delegate: RegularWindowControllerDelegate(),
   );
 
-  runWidget(RegularWindow(controller: controller, child: MyApp()));
+  runWidget(RegularWindow(controller: controller, child: const MyApp()));
   windowCreated.complete();
 }
 
@@ -184,9 +179,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter Demo',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-      ),
+      theme: ThemeData(colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple)),
       home: const MyHomePage(title: 'Flutter Demo Home Page'),
     );
   }
@@ -218,33 +211,28 @@ class _MyHomePageState extends State<MyHomePage> {
   Widget build(BuildContext context) {
     return ValueListenableBuilder(
       valueListenable: dialogController,
-      builder:
-          (
-            BuildContext context,
-            DialogWindowController? dialogController,
-            Widget? child,
-          ) {
-            return ViewAnchor(
-              view: dialogController != null
-                  ? DialogWindow(
-                      controller: dialogController,
-                      child: MyDialogPage(controller: dialogController),
-                    )
-                  : null,
-              child: Scaffold(
-                appBar: AppBar(
-                  backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-                  title: Text(widget.title),
-                ),
-                body: Center(
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: <Widget>[const Text('This is the main window.')],
-                  ),
-                ),
+      builder: (BuildContext context, DialogWindowController? dialogController, Widget? child) {
+        return ViewAnchor(
+          view: dialogController != null
+              ? DialogWindow(
+                  controller: dialogController,
+                  child: MyDialogPage(controller: dialogController),
+                )
+              : null,
+          child: Scaffold(
+            appBar: AppBar(
+              backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+              title: Text(widget.title),
+            ),
+            body: const Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: <Widget>[Text('This is the main window.')],
               ),
-            );
-          },
+            ),
+          ),
+        );
+      },
     );
   }
 }
@@ -260,7 +248,7 @@ class MyDialogPage extends StatelessWidget {
       home: Scaffold(
         appBar: AppBar(
           backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-          title: Text('Dialog'),
+          title: const Text('Dialog'),
         ),
         body: Center(
           child: Column(
@@ -272,7 +260,7 @@ class MyDialogPage extends StatelessWidget {
                 onPressed: () {
                   controller.destroy();
                 },
-                child: Text('Close Dialog'),
+                child: const Text('Close Dialog'),
               ),
             ],
           ),

--- a/dev/integration_tests/windowing_test/lib/main.dart
+++ b/dev/integration_tests/windowing_test/lib/main.dart
@@ -75,18 +75,18 @@ void main() {
           });
         } else if (jsonMap['type'] == 'set_size') {
           final size = Size(
-            (jsonMap['width']! as int).toDouble(),
-            (jsonMap['height']! as int).toDouble(),
+            (jsonMap['width']! as num).toDouble(),
+            (jsonMap['height']! as num).toDouble(),
           );
           await awaitNotification(() {
             controller.setSize(size);
           }, () => controller.contentSize == size);
         } else if (jsonMap['type'] == 'set_constraints') {
           final constraints = BoxConstraints(
-            minWidth: (jsonMap['min_width']! as int).toDouble(),
-            minHeight: (jsonMap['min_height']! as int).toDouble(),
-            maxWidth: (jsonMap['max_width']! as int).toDouble(),
-            maxHeight: (jsonMap['max_height']! as int).toDouble(),
+            minWidth: (jsonMap['min_width']! as num).toDouble(),
+            minHeight: (jsonMap['min_height']! as num).toDouble(),
+            maxWidth: (jsonMap['max_width']! as num).toDouble(),
+            maxHeight: (jsonMap['max_height']! as num).toDouble(),
           );
           // We assume that this will cause a resize, which the current tests do.
           final Size initialSize = controller.contentSize;

--- a/dev/integration_tests/windowing_test/test_driver/main_test.dart
+++ b/dev/integration_tests/windowing_test/test_driver/main_test.dart
@@ -18,7 +18,7 @@ Future<String> _requestDataWithRetry(
       if (response.isNotEmpty) {
         // Check for an error returned from the driver extension handler.
         try {
-          final data = jsonDecode(response) as Map<String, dynamic>;
+          final data = jsonDecode(response) as Map<String, Object?>;
           if (data.containsKey('error')) {
             throw Exception('Driver extension handler reported an error: ${data['error']}');
           }

--- a/dev/integration_tests/windowing_test/test_driver/main_test.dart
+++ b/dev/integration_tests/windowing_test/test_driver/main_test.dart
@@ -12,18 +12,15 @@ Future<String> _requestDataWithRetry(
   String message, {
   int maxRetries = 3,
 }) async {
-  for (int attempt = 1; attempt <= maxRetries; attempt++) {
+  for (var attempt = 1; attempt <= maxRetries; attempt++) {
     try {
       final String response = await driver.requestData(message);
       if (response.isNotEmpty) {
         // Check for an error returned from the driver extension handler.
         try {
-          final Map<String, dynamic> data =
-              jsonDecode(response) as Map<String, dynamic>;
+          final data = jsonDecode(response) as Map<String, dynamic>;
           if (data.containsKey('error')) {
-            throw Exception(
-              'Driver extension handler reported an error: ${data['error']}',
-            );
+            throw Exception('Driver extension handler reported an error: ${data['error']}');
           }
         } on FormatException {
           // Not a JSON map, which is fine for some responses.
@@ -35,7 +32,7 @@ Future<String> _requestDataWithRetry(
         rethrow;
       }
 
-      await Future.delayed(Duration(milliseconds: 100 * attempt));
+      await Future<void>.delayed(Duration(milliseconds: 100 * attempt));
     }
   }
   throw StateError('Should not reach here');
@@ -59,22 +56,19 @@ void main() {
         driver,
         jsonEncode({'type': 'set_title', 'title': 'Hello World'}),
       );
-      final response = await _requestDataWithRetry(
+      final String response = await _requestDataWithRetry(
         driver,
         jsonEncode({'type': 'get_title'}),
       );
-      final data = jsonDecode(response);
+      final data = jsonDecode(response) as Map<String, Object?>;
       expect(data['title'], 'Hello World');
     }, timeout: Timeout.none);
 
     test('Initial controller size is correct', () async {
-      final response = await _requestDataWithRetry(
-        driver,
-        jsonEncode({'type': 'get_size'}),
-      );
-      final data = jsonDecode(response);
-      expect(data["width"], 640);
-      expect(data["height"], 480);
+      final String response = await _requestDataWithRetry(driver, jsonEncode({'type': 'get_size'}));
+      final data = jsonDecode(response) as Map<String, Object?>;
+      expect(data['width'], 640);
+      expect(data['height'], 480);
     }, timeout: Timeout.none);
 
     test('Can set and get size', () async {
@@ -82,90 +76,54 @@ void main() {
         driver,
         jsonEncode({'type': 'set_size', 'width': 800, 'height': 600}),
       );
-      final response = await _requestDataWithRetry(
-        driver,
-        jsonEncode({'type': 'get_size'}),
-      );
-      final data = jsonDecode(response);
-      expect(data["width"], 800);
-      expect(data["height"], 600);
+      final String response = await _requestDataWithRetry(driver, jsonEncode({'type': 'get_size'}));
+      final data = jsonDecode(response) as Map<String, Object?>;
+      expect(data['width'], 800);
+      expect(data['height'], 600);
     }, timeout: Timeout.none);
 
     test('Can set and get fullscreen', () async {
-      await _requestDataWithRetry(
-        driver,
-        jsonEncode({'type': 'set_fullscreen'}),
-      );
-      var response = await _requestDataWithRetry(
-        driver,
-        jsonEncode({'type': 'get_fullscreen'}),
-      );
-      var data = jsonDecode(response);
+      await _requestDataWithRetry(driver, jsonEncode({'type': 'set_fullscreen'}));
+      String response = await _requestDataWithRetry(driver, jsonEncode({'type': 'get_fullscreen'}));
+      var data = jsonDecode(response) as Map<String, Object?>;
       expect(data['isFullscreen'], true);
 
-      await _requestDataWithRetry(
-        driver,
-        jsonEncode({'type': 'unset_fullscreen'}),
-      );
-      response = await _requestDataWithRetry(
-        driver,
-        jsonEncode({'type': 'get_fullscreen'}),
-      );
-      data = jsonDecode(response);
+      await _requestDataWithRetry(driver, jsonEncode({'type': 'unset_fullscreen'}));
+      response = await _requestDataWithRetry(driver, jsonEncode({'type': 'get_fullscreen'}));
+      data = jsonDecode(response) as Map<String, Object?>;
       expect(data['isFullscreen'], false);
     }, timeout: Timeout.none);
 
     test('Can set and get maximized', () async {
-      await _requestDataWithRetry(
-        driver,
-        jsonEncode({'type': 'set_maximized'}),
-      );
-      var response = await _requestDataWithRetry(
-        driver,
-        jsonEncode({'type': 'get_maximized'}),
-      );
-      var data = jsonDecode(response);
+      await _requestDataWithRetry(driver, jsonEncode({'type': 'set_maximized'}));
+      String response = await _requestDataWithRetry(driver, jsonEncode({'type': 'get_maximized'}));
+      var data = jsonDecode(response) as Map<String, Object?>;
       expect(data['isMaximized'], true);
 
-      await _requestDataWithRetry(
-        driver,
-        jsonEncode({'type': 'unset_maximized'}),
-      );
-      response = await _requestDataWithRetry(
-        driver,
-        jsonEncode({'type': 'get_maximized'}),
-      );
-      data = jsonDecode(response);
+      await _requestDataWithRetry(driver, jsonEncode({'type': 'unset_maximized'}));
+      response = await _requestDataWithRetry(driver, jsonEncode({'type': 'get_maximized'}));
+      data = jsonDecode(response) as Map<String, Object?>;
       expect(data['isMaximized'], false);
     }, timeout: Timeout.none);
 
     test(
       'Can set and get minimized',
       () async {
-        await _requestDataWithRetry(
-          driver,
-          jsonEncode({'type': 'set_minimized'}),
-        );
-        var response = await _requestDataWithRetry(
+        await _requestDataWithRetry(driver, jsonEncode({'type': 'set_minimized'}));
+        String response = await _requestDataWithRetry(
           driver,
           jsonEncode({'type': 'get_minimized'}),
         );
-        var data = jsonDecode(response);
+        var data = jsonDecode(response) as Map<String, Object?>;
         expect(data['isMinimized'], true);
 
-        await _requestDataWithRetry(
-          driver,
-          jsonEncode({'type': 'unset_minimized'}),
-        );
-        response = await _requestDataWithRetry(
-          driver,
-          jsonEncode({'type': 'get_minimized'}),
-        );
-        data = jsonDecode(response);
+        await _requestDataWithRetry(driver, jsonEncode({'type': 'unset_minimized'}));
+        response = await _requestDataWithRetry(driver, jsonEncode({'type': 'get_minimized'}));
+        data = jsonDecode(response) as Map<String, Object?>;
         expect(data['isMinimized'], false);
       },
       timeout: Timeout.none,
-      onPlatform: {'linux': Skip('isMinimized is not supported on Wayland')},
+      onPlatform: {'linux': const Skip('isMinimized is not supported on Wayland')},
     );
 
     test(
@@ -175,27 +133,21 @@ void main() {
           driver,
           jsonEncode({'type': 'set_minimized'}),
         ); // Minimize first so that the window is not active
-        await _requestDataWithRetry(
-          driver,
-          jsonEncode({'type': 'set_activated'}),
-        );
-        final response = await _requestDataWithRetry(
+        await _requestDataWithRetry(driver, jsonEncode({'type': 'set_activated'}));
+        final String response = await _requestDataWithRetry(
           driver,
           jsonEncode({'type': 'get_activated'}),
         );
-        final data = jsonDecode(response);
+        final data = jsonDecode(response) as Map<String, Object?>;
         expect(data['isActivated'], true);
       },
       timeout: Timeout.none,
-      onPlatform: {'linux': Skip('isMinimized is not supported on Wayland')},
+      onPlatform: {'linux': const Skip('isMinimized is not supported on Wayland')},
     );
 
     test('Can open dialog', () async {
       await _requestDataWithRetry(driver, jsonEncode({'type': 'open_dialog'}));
-      await driver.waitFor(
-        find.byValueKey('close_dialog'),
-        timeout: Duration(seconds: 10),
-      );
+      await driver.waitFor(find.byValueKey('close_dialog'), timeout: const Duration(seconds: 10));
       await _requestDataWithRetry(driver, jsonEncode({'type': 'close_dialog'}));
     }, timeout: Timeout.none);
 
@@ -212,16 +164,16 @@ void main() {
             'max_height': 501,
           }),
         );
-        final response = await _requestDataWithRetry(
+        final String response = await _requestDataWithRetry(
           driver,
           jsonEncode({'type': 'get_size'}),
         );
-        final data = jsonDecode(response);
-        expect(data["width"], 500);
-        expect(data["height"], 501);
+        final data = jsonDecode(response) as Map<String, Object?>;
+        expect(data['width'], 500);
+        expect(data['height'], 501);
       },
       timeout: Timeout.none,
-      onPlatform: {'linux': Skip('Unable to exactly set dimensions on Linux')},
+      onPlatform: {'linux': const Skip('Unable to exactly set dimensions on Linux')},
     );
 
     test(
@@ -237,18 +189,18 @@ void main() {
             'max_height': 501,
           }),
         );
-        final response = await _requestDataWithRetry(
+        final String response = await _requestDataWithRetry(
           driver,
           jsonEncode({'type': 'get_size'}),
         );
-        final data = jsonDecode(response);
+        final data = jsonDecode(response) as Map<String, Object?>;
         // On Linux setting the constraints limits the window including the decorations,
         // but the returned size is the usable area and always smaller.
-        expect(data["width"], lessThanOrEqualTo(500));
-        expect(data["height"], lessThanOrEqualTo(501));
+        expect(data['width'], lessThanOrEqualTo(500));
+        expect(data['height'], lessThanOrEqualTo(501));
       },
       timeout: Timeout.none,
-      testOn: "linux",
+      testOn: 'linux',
     );
   });
 }


### PR DESCRIPTION
The `windowing_test` had an empty `analysis_options.yaml` file checked in that disabled the top-level analysis_options.yaml file and with it the repo-wide rule set. As far as I can tell, there isn't a good reason why the repo rules shouldn't apply here. This PR deletes the custom `analysis_options.yaml` file and makes the code adhere to the top-level rule set. Any violations were fixed by Gemini.