### PR TITLE
[ci] Fix freeze.yml syntax

### DIFF
--- a/.github/workflows/freeze.yml
+++ b/.github/workflows/freeze.yml
@@ -63,7 +63,7 @@ jobs:
         if: |
           steps.filter.outputs.frozen == 'true' &&
           contains(github.event.pull_request.labels.*.name, 'override: code freeze')
-        run: 'echo "Code freeze overridden by ''override: code freeze'' label."'
+        run: echo "Code freeze overridden by override: code freeze label."
 
       - name: Pass if no frozen changes
         if: steps.filter.outputs.frozen == 'false'

--- a/.github/workflows/freeze.yml
+++ b/.github/workflows/freeze.yml
@@ -63,7 +63,7 @@ jobs:
         if: |
           steps.filter.outputs.frozen == 'true' &&
           contains(github.event.pull_request.labels.*.name, 'override: code freeze')
-        run: echo "Code freeze overridden by 'override: code freeze' label."
+        run: 'echo "Code freeze overridden by ''override: code freeze'' label."'
 
       - name: Pass if no frozen changes
         if: steps.filter.outputs.frozen == 'false'


### PR DESCRIPTION
I get a syntax error on every CI run:

```
Invalid workflow file: .github/workflows/freeze.yml#L66
You have an error in your yaml syntax on line 66
```

This should fix it.