### PR TITLE
Remove last material dependency from cupertino tests

### DIFF
--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -167,8 +167,7 @@ class TestsCrossImportChecker {
   ///    Widgets tests importing Material or Cupertino.
   // TODO(justinmc): Fix all of these tests so there are no cross imports.
   // See https://github.com/flutter/flutter/issues/177028.
-  static final Set<String> knownCupertinoCrossImports = <String>{
-  };
+  static final Set<String> knownCupertinoCrossImports = <String>{};
 
   static final Set<String> _knownCrossImports = knownWidgetsCrossImports.union(
     knownCupertinoCrossImports,

--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -168,8 +168,6 @@ class TestsCrossImportChecker {
   // TODO(justinmc): Fix all of these tests so there are no cross imports.
   // See https://github.com/flutter/flutter/issues/177028.
   static final Set<String> knownCupertinoCrossImports = <String>{
-    // TODO(justinmc): This one uses SelectableText. See https://github.com/flutter/flutter/issues/181682
-    'packages/flutter/test/cupertino/text_selection_test.dart',
   };
 
   static final Set<String> _knownCrossImports = knownWidgetsCrossImports.union(

--- a/dev/bots/test/check_tests_cross_imports_test.dart
+++ b/dev/bots/test/check_tests_cross_imports_test.dart
@@ -127,6 +127,9 @@ void main() {
   });
 
   test('when not all cupertino knowns have cross imports', () async {
+    if (TestsCrossImportChecker.knownCupertinoCrossImports.isEmpty) {
+      return;
+    }
     final String excluded = TestsCrossImportChecker.knownCupertinoCrossImports.first;
     buildTestFiles(excludes: <String>{excluded});
     bool? success;

--- a/packages/flutter/test/cupertino/text_selection_test.dart
+++ b/packages/flutter/test/cupertino/text_selection_test.dart
@@ -11,7 +11,6 @@ import 'dart:ui' as ui show BoxHeightStyle;
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -57,6 +56,21 @@ class _LongCupertinoLocalizations extends DefaultCupertinoLocalizations {
 }
 
 const _LongCupertinoLocalizations _longLocalizations = _LongCupertinoLocalizations();
+
+class _RichTextController extends TextEditingController {
+  _RichTextController({required this.textSpan}) : super(text: textSpan.toPlainText());
+
+  final TextSpan textSpan;
+
+  @override
+  TextSpan buildTextSpan({
+    required BuildContext context,
+    TextStyle? style,
+    required bool withComposing,
+  }) {
+    return textSpan;
+  }
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -728,26 +742,39 @@ void main() {
   testWidgets(
     'iOS selection handles scale with rich text (selection height style tight)',
     (WidgetTester tester) async {
+      final focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+      final controller = _RichTextController(
+        textSpan: const TextSpan(
+          children: <InlineSpan>[
+            TextSpan(text: 'abc ', style: TextStyle(fontSize: 100.0)),
+            TextSpan(text: 'def ', style: TextStyle(fontSize: 50.0)),
+            TextSpan(text: 'hij', style: TextStyle(fontSize: 25.0)),
+          ],
+        ),
+      );
+      addTearDown(controller.dispose);
+
       await tester.pumpWidget(
-        const CupertinoApp(
+        CupertinoApp(
           home: Center(
-            child: SelectableText.rich(
-              TextSpan(
-                children: <InlineSpan>[
-                  TextSpan(text: 'abc ', style: TextStyle(fontSize: 100.0)),
-                  TextSpan(text: 'def ', style: TextStyle(fontSize: 50.0)),
-                  TextSpan(text: 'hij', style: TextStyle(fontSize: 25.0)),
-                ],
-              ),
+            child: CupertinoTextField(
+              controller: controller,
+              focusNode: focusNode,
+              style: const TextStyle(fontSize: 100.0),
+              cursorColor: const Color.fromARGB(0, 0, 0, 0),
+
               selectionHeightStyle: ui.BoxHeightStyle.tight,
+              selectionControls: cupertinoTextSelectionControls,
+              readOnly: true,
+              decoration: null,
+              padding: EdgeInsets.zero,
             ),
           ),
         ),
       );
 
-      final EditableText editableTextWidget = tester.widget(find.byType(EditableText));
       final EditableTextState editableTextState = tester.state(find.byType(EditableText));
-      final TextEditingController controller = editableTextWidget.controller;
 
       // Double tap to select the second word.
       const index = 4;
@@ -810,25 +837,38 @@ void main() {
   testWidgets(
     'iOS selection handles scale with rich text (selection height style includeLineSpacingMiddle) (default)',
     (WidgetTester tester) async {
+      final focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+      final controller = _RichTextController(
+        textSpan: const TextSpan(
+          children: <InlineSpan>[
+            TextSpan(text: 'abc ', style: TextStyle(fontSize: 100.0)),
+            TextSpan(text: 'def ', style: TextStyle(fontSize: 50.0)),
+            TextSpan(text: 'hij', style: TextStyle(fontSize: 25.0)),
+          ],
+        ),
+      );
+      addTearDown(controller.dispose);
+
       await tester.pumpWidget(
-        const CupertinoApp(
+        CupertinoApp(
           home: Center(
-            child: SelectableText.rich(
-              TextSpan(
-                children: <InlineSpan>[
-                  TextSpan(text: 'abc ', style: TextStyle(fontSize: 100.0)),
-                  TextSpan(text: 'def ', style: TextStyle(fontSize: 50.0)),
-                  TextSpan(text: 'hij', style: TextStyle(fontSize: 25.0)),
-                ],
-              ),
+            child: CupertinoTextField(
+              controller: controller,
+              focusNode: focusNode,
+              style: const TextStyle(fontSize: 100.0),
+              cursorColor: const Color.fromARGB(0, 0, 0, 0),
+
+              selectionControls: cupertinoTextSelectionControls,
+              readOnly: true,
+              decoration: null,
+              padding: EdgeInsets.zero,
             ),
           ),
         ),
       );
 
-      final EditableText editableTextWidget = tester.widget(find.byType(EditableText));
       final EditableTextState editableTextState = tester.state(find.byType(EditableText));
-      final TextEditingController controller = editableTextWidget.controller;
 
       // Double tap to select the second word.
       const index = 4;
@@ -894,27 +934,40 @@ void main() {
   testWidgets(
     'iOS selection handles scale with rich text (grapheme clusters) (selection height style tight)',
     (WidgetTester tester) async {
+      final focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+      final controller = _RichTextController(
+        textSpan: const TextSpan(
+          children: <InlineSpan>[
+            TextSpan(text: 'abc ', style: TextStyle(fontSize: 100.0)),
+            TextSpan(text: 'def ', style: TextStyle(fontSize: 50.0)),
+            TextSpan(text: '👨‍👩‍👦 ', style: TextStyle(fontSize: 35.0)),
+            TextSpan(text: 'hij', style: TextStyle(fontSize: 25.0)),
+          ],
+        ),
+      );
+      addTearDown(controller.dispose);
+
       await tester.pumpWidget(
-        const CupertinoApp(
+        CupertinoApp(
           home: Center(
-            child: SelectableText.rich(
-              TextSpan(
-                children: <InlineSpan>[
-                  TextSpan(text: 'abc ', style: TextStyle(fontSize: 100.0)),
-                  TextSpan(text: 'def ', style: TextStyle(fontSize: 50.0)),
-                  TextSpan(text: '👨‍👩‍👦 ', style: TextStyle(fontSize: 35.0)),
-                  TextSpan(text: 'hij', style: TextStyle(fontSize: 25.0)),
-                ],
-              ),
+            child: CupertinoTextField(
+              controller: controller,
+              focusNode: focusNode,
+              style: const TextStyle(fontSize: 100.0),
+              cursorColor: const Color.fromARGB(0, 0, 0, 0),
+
               selectionHeightStyle: ui.BoxHeightStyle.tight,
+              selectionControls: cupertinoTextSelectionControls,
+              readOnly: true,
+              decoration: null,
+              padding: EdgeInsets.zero,
             ),
           ),
         ),
       );
 
-      final EditableText editableTextWidget = tester.widget(find.byType(EditableText));
       final EditableTextState editableTextState = tester.state(find.byType(EditableText));
-      final TextEditingController controller = editableTextWidget.controller;
 
       // Double tap to select the second word.
       const index = 4;
@@ -977,26 +1030,39 @@ void main() {
   testWidgets(
     'iOS selection handles scale with rich text (grapheme clusters) (selection height style includeLineSpacingMiddle) (default)',
     (WidgetTester tester) async {
+      final focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+      final controller = _RichTextController(
+        textSpan: const TextSpan(
+          children: <InlineSpan>[
+            TextSpan(text: 'abc ', style: TextStyle(fontSize: 100.0)),
+            TextSpan(text: 'def ', style: TextStyle(fontSize: 50.0)),
+            TextSpan(text: '👨‍👩‍👦 ', style: TextStyle(fontSize: 35.0)),
+            TextSpan(text: 'hij', style: TextStyle(fontSize: 25.0)),
+          ],
+        ),
+      );
+      addTearDown(controller.dispose);
+
       await tester.pumpWidget(
-        const CupertinoApp(
+        CupertinoApp(
           home: Center(
-            child: SelectableText.rich(
-              TextSpan(
-                children: <InlineSpan>[
-                  TextSpan(text: 'abc ', style: TextStyle(fontSize: 100.0)),
-                  TextSpan(text: 'def ', style: TextStyle(fontSize: 50.0)),
-                  TextSpan(text: '👨‍👩‍👦 ', style: TextStyle(fontSize: 35.0)),
-                  TextSpan(text: 'hij', style: TextStyle(fontSize: 25.0)),
-                ],
-              ),
+            child: CupertinoTextField(
+              controller: controller,
+              focusNode: focusNode,
+              style: const TextStyle(fontSize: 100.0),
+              cursorColor: const Color.fromARGB(0, 0, 0, 0),
+
+              selectionControls: cupertinoTextSelectionControls,
+              readOnly: true,
+              decoration: null,
+              padding: EdgeInsets.zero,
             ),
           ),
         ),
       );
 
-      final EditableText editableTextWidget = tester.widget(find.byType(EditableText));
       final EditableTextState editableTextState = tester.state(find.byType(EditableText));
-      final TextEditingController controller = editableTextWidget.controller;
 
       // Double tap to select the second word.
       const index = 4;
@@ -1059,25 +1125,38 @@ void main() {
   testWidgets(
     'iOS selection handles scaling falls back to preferredLineHeight when the current frame does not match the previous with a tight selection height style',
     (WidgetTester tester) async {
+      final focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+      final controller = _RichTextController(
+        textSpan: const TextSpan(
+          children: <InlineSpan>[
+            TextSpan(text: 'abc', style: TextStyle(fontSize: 40.0)),
+            TextSpan(text: 'def', style: TextStyle(fontSize: 50.0)),
+          ],
+        ),
+      );
+      addTearDown(controller.dispose);
+
       await tester.pumpWidget(
-        const CupertinoApp(
+        CupertinoApp(
           home: Center(
-            child: SelectableText.rich(
-              TextSpan(
-                children: <InlineSpan>[
-                  TextSpan(text: 'abc', style: TextStyle(fontSize: 40.0)),
-                  TextSpan(text: 'def', style: TextStyle(fontSize: 50.0)),
-                ],
-              ),
+            child: CupertinoTextField(
+              controller: controller,
+              focusNode: focusNode,
+              style: const TextStyle(fontSize: 50.0),
+              cursorColor: const Color.fromARGB(0, 0, 0, 0),
+
               selectionHeightStyle: ui.BoxHeightStyle.tight,
+              selectionControls: cupertinoTextSelectionControls,
+              readOnly: true,
+              decoration: null,
+              padding: EdgeInsets.zero,
             ),
           ),
         ),
       );
 
-      final EditableText editableTextWidget = tester.widget(find.byType(EditableText));
       final EditableTextState editableTextState = tester.state(find.byType(EditableText));
-      final TextEditingController controller = editableTextWidget.controller;
 
       // Double tap to select the second word.
       const index = 4;

--- a/packages/flutter/test/cupertino/text_selection_test.dart
+++ b/packages/flutter/test/cupertino/text_selection_test.dart
@@ -763,7 +763,6 @@ void main() {
               focusNode: focusNode,
               style: const TextStyle(fontSize: 100.0),
               cursorColor: const Color.fromARGB(0, 0, 0, 0),
-
               selectionHeightStyle: ui.BoxHeightStyle.tight,
               selectionControls: cupertinoTextSelectionControls,
               readOnly: true,
@@ -858,7 +857,6 @@ void main() {
               focusNode: focusNode,
               style: const TextStyle(fontSize: 100.0),
               cursorColor: const Color.fromARGB(0, 0, 0, 0),
-
               selectionControls: cupertinoTextSelectionControls,
               readOnly: true,
               decoration: null,
@@ -956,7 +954,6 @@ void main() {
               focusNode: focusNode,
               style: const TextStyle(fontSize: 100.0),
               cursorColor: const Color.fromARGB(0, 0, 0, 0),
-
               selectionHeightStyle: ui.BoxHeightStyle.tight,
               selectionControls: cupertinoTextSelectionControls,
               readOnly: true,
@@ -1052,7 +1049,6 @@ void main() {
               focusNode: focusNode,
               style: const TextStyle(fontSize: 100.0),
               cursorColor: const Color.fromARGB(0, 0, 0, 0),
-
               selectionControls: cupertinoTextSelectionControls,
               readOnly: true,
               decoration: null,
@@ -1145,7 +1141,6 @@ void main() {
               focusNode: focusNode,
               style: const TextStyle(fontSize: 50.0),
               cursorColor: const Color.fromARGB(0, 0, 0, 0),
-
               selectionHeightStyle: ui.BoxHeightStyle.tight,
               selectionControls: cupertinoTextSelectionControls,
               readOnly: true,


### PR DESCRIPTION
This removes the last material dependency from the cupertino test library. It refactors tests that were relying on SelectableText.

**Code freeze override: this is necessary to complete decoupling, and will not cause cupertino_ui to be incompatible with the upcoming stable release.**

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
