### PR TITLE
Remove Material import from toggleable_test

### DIFF
--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -144,7 +144,6 @@ class TestsCrossImportChecker {
     'packages/flutter/test/widgets/scrollable_in_overlay_test.dart',
     'packages/flutter/test/widgets/nested_scroll_view_test.dart',
     'packages/flutter/test/widgets/scrollable_selection_test.dart',
-    'packages/flutter/test/widgets/toggleable_test.dart',
     'packages/flutter/test/widgets/draggable_test.dart',
     'packages/flutter/test/widgets/page_transitions_builder_test.dart',
     'packages/flutter/test/widgets/selectable_region_context_menu_test.dart',

--- a/packages/flutter/test/widgets/toggleable_test.dart
+++ b/packages/flutter/test/widgets/toggleable_test.dart
@@ -2,8 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'widgets_app_tester.dart';
 
 void main() {
   testWidgets('Toggleable exists in widget layer', (WidgetTester tester) async {
@@ -13,7 +15,7 @@ void main() {
   });
 
   testWidgets('Toggleable exists in widget layer', (WidgetTester tester) async {
-    await tester.pumpWidget(const MaterialApp(home: TestToggleable()));
+    await tester.pumpWidget(const TestWidgetsApp(home: TestToggleable()));
     final TestToggleableState state = tester.state<TestToggleableState>(
       find.byType(TestToggleable),
     );


### PR DESCRIPTION
Part of #177412.

Replaces `MaterialApp` with `TestWidgetsApp`, removing the unnecessary dependency on `package:flutter/material.dart`. `ToggleablePainter` and `ToggleableStateMixin` are both in the widgets layer, so only a widgets-layer app wrapper is needed.

Also removes the file from the `knownWidgetsCrossImports` allowlist in `dev/bots/check_tests_cross_imports.dart`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/master/docs/contributing/AI-content-in-contributions.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md