### PR TITLE
[Android] Allow sensitive content to gracefully fail when unregistering host before registering

### DIFF
--- a/packages/flutter/lib/src/widgets/sensitive_content.dart
+++ b/packages/flutter/lib/src/widgets/sensitive_content.dart
@@ -229,12 +229,7 @@ class SensitiveContentHost {
   }
 
   Future<void> _unregister(ContentSensitivity widgetSensitivity) async {
-    assert(
-      _contentSensitivityIsSupported != null,
-      'SensitiveContentHost.register must be called before SensitiveContentHost.unregister',
-    );
-
-    if (!_contentSensitivityIsSupported!) {
+    if (!(_contentSensitivityIsSupported ?? false)) {
       // Setting content sensitivity is not supported on this device.
       return;
     }

--- a/packages/flutter/lib/src/widgets/sensitive_content.dart
+++ b/packages/flutter/lib/src/widgets/sensitive_content.dart
@@ -229,8 +229,9 @@ class SensitiveContentHost {
   }
 
   Future<void> _unregister(ContentSensitivity widgetSensitivity) async {
-    if (!(_contentSensitivityIsSupported ?? false)) {
-      // Setting content sensitivity is not supported on this device.
+    if (_contentSensitivityIsSupported != true) {
+      // Setting content sensitivity is not supported on this device or register
+      // was not called before unregister.
       return;
     }
 

--- a/packages/flutter/test/widgets/sensitive_content_test.dart
+++ b/packages/flutter/test/widgets/sensitive_content_test.dart
@@ -19,6 +19,17 @@ void main() {
       null,
     );
   });
+
+  testWidgets('SensitiveContent widget can be tested without mocking method channels', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      SensitiveContent(sensitivity: ContentSensitivity.sensitive, child: Container()),
+    );
+
+    expect(find.byType(SensitiveContent), findsOneWidget);
+  });
+
   testWidgets(
     'while SensitiveContent widget is being registered, SizedBox.shrink is built initially, then child widget is built upon completion',
     (WidgetTester tester) async {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/184187 by replacing an assert intended to catch internal implementation details with a graceful fail so that unit tests aren't impacted.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
