### PR TITLE
Fixed freeze flow

### DIFF
--- a/.github/workflows/freeze.yml
+++ b/.github/workflows/freeze.yml
@@ -5,7 +5,7 @@
 name: Material and Cupertino Code Freeze
 
 on:
-  pull_request: # Change back to pull_request_target, testing in PR using pull_request
+  pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
     branches:
       - master

--- a/.github/workflows/freeze.yml
+++ b/.github/workflows/freeze.yml
@@ -5,11 +5,8 @@
 name: Material and Cupertino Code Freeze
 
 on:
-  pull_request_target:
+  pull_request: # Change back to pull_request_target, testing in PR using pull_request
     types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
-    branches:
-      - master
-  merge_group:
     branches:
       - master
 
@@ -20,16 +17,13 @@ jobs:
     name: Check Code Freeze
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'flutter/flutter' }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
+    steps:
       - name: Check for changes in frozen folders
         uses: dorny/paths-filter@v3
         id: filter
         with:
+          token: ${{ github.token }}
           filters: |
             frozen:
               - 'packages/flutter/lib/src/material/**'
@@ -46,27 +40,9 @@ jobs:
               - 'packages/flutter/test_fixes/cupertino/**'
 
       - name: Fail on frozen changes
-        # This step only runs if the 'frozen' filter matched AND the override label is NOT present
-        if: |
-          steps.filter.outputs.frozen == 'true' &&
-          !contains(github.event.pull_request.labels.*.name, 'override: code freeze')
+        if: steps.filter.outputs.frozen == 'true' && !contains(github.event.pull_request.labels.*.name, 'override code freeze')
         run: |
           echo "Error: Code changes detected during the current code freeze."
-          echo "The following paths are currently frozen:"
-          echo "  - packages/flutter/lib/src/material/"
-          echo "  - packages/flutter/lib/src/cupertino/"
-          echo "  - (and associated tests/examples)"
-          echo ""
-          echo "If this is a critical fix that must land during the freeze, please file an issue for team-design."
-          echo "Information on this code freeze: https://github.com/flutter/flutter/issues/184093"
+          echo "If this is a critical fix that must land, please file an issue for team-design."
+          echo "Info: https://github.com/flutter/flutter/issues/184093"
           exit 1
-
-      - name: Pass if overridden
-        if: |
-          steps.filter.outputs.frozen == 'true' &&
-          contains(github.event.pull_request.labels.*.name, 'override: code freeze')
-        run: echo "Code freeze overridden by override: code freeze label."
-
-      - name: Pass if no frozen changes
-        if: steps.filter.outputs.frozen == 'false'
-        run: echo "No changes to frozen code."

--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -39,8 +39,6 @@ import 'theme.dart';
 // Examples can assume:
 // BuildContext context;
 
-// Test Freeze
-
 /// A [ListTile] that shows an about box.
 ///
 /// This widget is often added to an app's [Drawer]. When tapped it shows

--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -39,6 +39,8 @@ import 'theme.dart';
 // Examples can assume:
 // BuildContext context;
 
+// Test freeze
+
 /// A [ListTile] that shows an about box.
 ///
 /// This widget is often added to an app's [Drawer]. When tapped it shows

--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -39,7 +39,7 @@ import 'theme.dart';
 // Examples can assume:
 // BuildContext context;
 
-// Test freeze
+// Test Freeze
 
 /// A [ListTile] that shows an about box.
 ///


### PR DESCRIPTION
Simplifies the freeze workflow, reduces complexity.
I confirmed it works (phew), which also clarified the difference between `pull_request` and `pull_request_target`.

If this were to use `pull_request`, authors could change the workflow in a PR and CI would run off the version in the PR, potentially overriding the freeze.
`pull_request_target` protects against that by only running the workflow based on the current version on master. Much safer.

I tested this out myself, by setting it to `pull_request` and running directly from this PR:

<img width="500" alt="Screenshot 2026-04-08 at 7 19 31 PM" src="https://github.com/user-attachments/assets/a5557332-caae-417e-97be-403d51bea92d" />

This confirms it works, and that we need to use `pull_request_target` so PRs run the source of truth from the main branch.

On a separate note: I wish we had analysis over yml files. Would have saved a lot of time here.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
