### PR TITLE
refactor: Remove material imports from editable_text_scribble_test, editable_text_scribe_test, page_route_builder_test, radio_group_test, semantics_debugger_test, range_maintaining_scroll_physics_test, two_dimensional_scroll_view_test, routes_test, text_selection_test, selectable_region_test and text_golden_test

### DIFF
--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -107,20 +107,10 @@ class TestsCrossImportChecker {
   // TODO(justinmc): Fix all of these tests so there are no cross imports.
   // See https://github.com/flutter/flutter/issues/177028.
   static final Set<String> knownWidgetsCrossImports = <String>{
-    'packages/flutter/test/widgets/text_golden_test.dart',
     'packages/flutter/test/widgets/restoration_scopes_moving_test.dart',
     'packages/flutter/test/widgets/page_transitions_test.dart',
-    'packages/flutter/test/widgets/editable_text_scribble_test.dart',
-    'packages/flutter/test/widgets/range_maintaining_scroll_physics_test.dart',
-    'packages/flutter/test/widgets/selectable_region_test.dart',
-    'packages/flutter/test/widgets/editable_text_scribe_test.dart',
-    'packages/flutter/test/widgets/semantics_debugger_test.dart',
-    'packages/flutter/test/widgets/page_route_builder_test.dart',
-    'packages/flutter/test/widgets/two_dimensional_scroll_view_test.dart',
     'packages/flutter/test/widgets/routes_test.dart',
-    'packages/flutter/test/widgets/text_selection_test.dart',
     'packages/flutter/test/widgets/app_test.dart',
-    'packages/flutter/test/widgets/radio_group_test.dart',
     'packages/flutter/test/widgets/navigator_replacement_test.dart',
     'packages/flutter/test/widgets/implicit_animations_test.dart',
     'packages/flutter/test/widgets/default_text_editing_shortcuts_test.dart',

--- a/packages/flutter/test/widgets/checkbox_tester.dart
+++ b/packages/flutter/test/widgets/checkbox_tester.dart
@@ -55,6 +55,13 @@ class TestCheckbox extends StatelessWidget {
     }
   }
 
+  // Matches the reported size of Material's Checkbox with the default
+  // MaterialTapTargetSize.padded (kMinInteractiveDimension = 48.0). The 18×18
+  // visible box is centered in the 48×48 tap target, which is what pre-
+  // migration goldens and inline WidgetSpan layouts were calibrated against.
+  static const double _tapTargetSize = 48.0;
+  static const double _boxSize = 18.0;
+
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
@@ -65,12 +72,18 @@ class TestCheckbox extends StatelessWidget {
         mixed: tristate && value == null,
         enabled: _enabled,
         child: SizedBox(
-          width: 18.0,
-          height: 18.0,
-          child: DecoratedBox(
-            decoration: BoxDecoration(
-              border: Border.all(),
-              color: value ?? false ? const Color(0xFF000000) : const Color(0xFFFFFFFF),
+          width: _tapTargetSize,
+          height: _tapTargetSize,
+          child: Center(
+            child: SizedBox(
+              width: _boxSize,
+              height: _boxSize,
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  border: Border.all(),
+                  color: value ?? false ? const Color(0xFF000000) : const Color(0xFFFFFFFF),
+                ),
+              ),
             ),
           ),
         ),

--- a/packages/flutter/test/widgets/checkbox_tester.dart
+++ b/packages/flutter/test/widgets/checkbox_tester.dart
@@ -1,0 +1,80 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+
+/// A minimal checkbox widget for testing purposes to avoid relying on
+/// widgets from material.dart.
+///
+/// This provides semantics (checked/unchecked state, enabled/disabled) and
+/// tap interaction, matching the behavior tests expect from a checkbox.
+///
+/// See https://github.com/flutter/flutter/issues/177415.
+class TestCheckbox extends StatelessWidget {
+  /// Creates a test checkbox.
+  ///
+  /// The [value] parameter is required and determines whether the checkbox
+  /// is checked.
+  const TestCheckbox({
+    super.key,
+    required this.value,
+    required this.onChanged,
+    this.tristate = false,
+  }) : assert(tristate || value != null);
+
+  /// Whether this checkbox is checked.
+  ///
+  /// When [tristate] is true, a value of null corresponds to the mixed state.
+  /// When [tristate] is false, this value must not be null.
+  final bool? value;
+
+  /// Called when the value of the checkbox should change.
+  ///
+  /// When null, the checkbox is disabled.
+  final ValueChanged<bool?>? onChanged;
+
+  /// If true, the checkbox's [value] can be true, false, or null.
+  ///
+  /// When false, the checkbox's [value] must be true or false.
+  final bool tristate;
+
+  bool get _enabled => onChanged != null;
+
+  void _handleTap() {
+    if (!_enabled) {
+      return;
+    }
+    switch (value) {
+      case false:
+        onChanged!(true);
+      case true:
+        onChanged!(tristate ? null : false);
+      case null:
+        onChanged!(false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: _enabled ? _handleTap : null,
+      child: Semantics(
+        checked: value ?? false,
+        mixed: tristate && value == null,
+        enabled: _enabled,
+        child: SizedBox(
+          width: 18.0,
+          height: 18.0,
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              border: Border.all(),
+              color: value ?? false ? const Color(0xFF000000) : const Color(0xFFFFFFFF),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/flutter/test/widgets/checkbox_tester.dart
+++ b/packages/flutter/test/widgets/checkbox_tester.dart
@@ -8,7 +8,7 @@ import 'package:flutter/widgets.dart';
 /// widgets from material.dart.
 ///
 /// This provides semantics (checked/unchecked state, enabled/disabled) and
-/// tap interaction, matching the behavior tests expect from a checkbox.
+/// tap interaction, matching the behavior that tests expect from a checkbox.
 ///
 /// See https://github.com/flutter/flutter/issues/177415.
 class TestCheckbox extends StatelessWidget {

--- a/packages/flutter/test/widgets/checkbox_tester_test.dart
+++ b/packages/flutter/test/widgets/checkbox_tester_test.dart
@@ -1,0 +1,120 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'checkbox_tester.dart';
+
+void main() {
+  testWidgets('TestCheckbox renders and can be tapped', (WidgetTester tester) async {
+    bool? value = false;
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: StatefulBuilder(
+            builder: (BuildContext context, StateSetter setState) {
+              return TestCheckbox(
+                value: value,
+                onChanged: (bool? newValue) {
+                  setState(() {
+                    value = newValue;
+                  });
+                },
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(value, isFalse);
+    await tester.tap(find.byType(TestCheckbox));
+    await tester.pump();
+    expect(value, isTrue);
+    await tester.tap(find.byType(TestCheckbox));
+    await tester.pump();
+    expect(value, isFalse);
+  });
+
+  testWidgets('TestCheckbox disabled does not respond to taps', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(child: TestCheckbox(value: false, onChanged: null)),
+      ),
+    );
+
+    expect(
+      tester.getSemantics(find.byType(Semantics).last),
+      isSemantics(isChecked: false, isEnabled: false),
+    );
+  });
+
+  testWidgets('TestCheckbox provides correct semantics', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(child: TestCheckbox(value: true, onChanged: (bool? _) {})),
+      ),
+    );
+
+    expect(
+      tester.getSemantics(find.byType(Semantics).last),
+      isSemantics(isChecked: true, isEnabled: true),
+    );
+  });
+
+  testWidgets('TestCheckbox tristate cycles through true, null, false', (
+    WidgetTester tester,
+  ) async {
+    bool? value = false;
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: StatefulBuilder(
+            builder: (BuildContext context, StateSetter setState) {
+              return TestCheckbox(
+                value: value,
+                tristate: true,
+                onChanged: (bool? newValue) {
+                  setState(() {
+                    value = newValue;
+                  });
+                },
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(value, isFalse);
+    await tester.tap(find.byType(TestCheckbox));
+    await tester.pump();
+    expect(value, isTrue);
+    await tester.tap(find.byType(TestCheckbox));
+    await tester.pump();
+    expect(value, isNull);
+    await tester.tap(find.byType(TestCheckbox));
+    await tester.pump();
+    expect(value, isFalse);
+  });
+
+  testWidgets('TestCheckbox has correct size', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(child: TestCheckbox(value: false, onChanged: null)),
+      ),
+    );
+
+    final Size size = tester.getSize(find.byType(SizedBox).last);
+    expect(size, const Size(18.0, 18.0));
+  });
+}

--- a/packages/flutter/test/widgets/editable_text_scribble_test.dart
+++ b/packages/flutter/test/widgets/editable_text_scribble_test.dart
@@ -3,12 +3,18 @@
 // found in the LICENSE file.
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'editable_text_tester.dart';
 import 'editable_text_utils.dart';
+import 'widgets_app_tester.dart';
+
+const Color _blue = Color(0xFF0000FF);
+const Color _grey = Color(0xFF888888);
+const Color _black = Color(0xFF000000);
 
 void main() {
   const textStyle = TextStyle();
@@ -79,9 +85,9 @@ void main() {
                     maxLines: null,
                     focusNode: focusNode,
                     cursorWidth: 0,
-                    style: Typography.material2018().black.titleMedium!,
-                    cursorColor: Colors.blue,
-                    backgroundCursorColor: Colors.grey,
+                    style: const TextStyle(),
+                    cursorColor: _blue,
+                    backgroundCursorColor: _grey,
                   ),
                 ),
               ),
@@ -133,14 +139,14 @@ void main() {
       late SelectionChangedCause selectionCause;
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: EditableText(
             controller: controller,
-            backgroundCursorColor: Colors.grey,
+            backgroundCursorColor: _grey,
             focusNode: focusNode,
             style: textStyle,
             cursorColor: cursorColor,
-            selectionControls: materialTextSelectionControls,
+            selectionControls: testTextSelectionHandleControls,
             onSelectionChanged: (TextSelection selection, SelectionChangedCause? cause) {
               if (cause != null) {
                 selectionCause = cause;
@@ -187,14 +193,14 @@ void main() {
       late SelectionChangedCause selectionCause;
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: EditableText(
             controller: controller,
-            backgroundCursorColor: Colors.grey,
+            backgroundCursorColor: _grey,
             focusNode: focusNode,
             style: textStyle,
             cursorColor: cursorColor,
-            selectionControls: materialTextSelectionControls,
+            selectionControls: testTextSelectionHandleControls,
             onSelectionChanged: (TextSelection selection, SelectionChangedCause? cause) {
               if (cause != null) {
                 selectionCause = cause;
@@ -225,14 +231,14 @@ void main() {
       controller.text = 'Lorem ipsum dolor sit amet';
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: EditableText(
             controller: controller,
-            backgroundCursorColor: Colors.grey,
+            backgroundCursorColor: _grey,
             focusNode: focusNode,
             style: textStyle,
             cursorColor: cursorColor,
-            selectionControls: materialTextSelectionControls,
+            selectionControls: testTextSelectionHandleControls,
           ),
         ),
       );
@@ -252,15 +258,15 @@ void main() {
 
       // Widget is read only.
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: EditableText(
             readOnly: true,
             controller: controller,
-            backgroundCursorColor: Colors.grey,
+            backgroundCursorColor: _grey,
             focusNode: focusNode,
             style: textStyle,
             cursorColor: cursorColor,
-            selectionControls: materialTextSelectionControls,
+            selectionControls: testTextSelectionHandleControls,
           ),
         ),
       );
@@ -272,24 +278,18 @@ void main() {
 
       // Widget is not touchable.
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: Stack(
             children: <Widget>[
               EditableText(
                 controller: controller,
-                backgroundCursorColor: Colors.grey,
+                backgroundCursorColor: _grey,
                 focusNode: focusNode,
                 style: textStyle,
                 cursorColor: cursorColor,
-                selectionControls: materialTextSelectionControls,
+                selectionControls: testTextSelectionHandleControls,
               ),
-              Positioned(
-                left: 0,
-                top: 0,
-                right: 0,
-                bottom: 0,
-                child: Container(color: Colors.black),
-              ),
+              Positioned(left: 0, top: 0, right: 0, bottom: 0, child: Container(color: _black)),
             ],
           ),
         ),
@@ -302,14 +302,14 @@ void main() {
 
       // Widget has scribble disabled.
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: EditableText(
             controller: controller,
-            backgroundCursorColor: Colors.grey,
+            backgroundCursorColor: _grey,
             focusNode: focusNode,
             style: textStyle,
             cursorColor: cursorColor,
-            selectionControls: materialTextSelectionControls,
+            selectionControls: testTextSelectionHandleControls,
             stylusHandwritingEnabled: false,
           ),
         ),
@@ -333,14 +333,14 @@ void main() {
       controller.text = 'Lorem ipsum dolor sit amet';
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: EditableText(
             controller: controller,
-            backgroundCursorColor: Colors.grey,
+            backgroundCursorColor: _grey,
             focusNode: focusNode,
             style: textStyle,
             cursorColor: cursorColor,
-            selectionControls: materialTextSelectionControls,
+            selectionControls: testTextSelectionHandleControls,
           ),
         ),
       );
@@ -373,14 +373,14 @@ void main() {
 
       // Widget has scribble disabled.
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: EditableText(
             controller: controller,
-            backgroundCursorColor: Colors.grey,
+            backgroundCursorColor: _grey,
             focusNode: focusNode,
             style: textStyle,
             cursorColor: cursorColor,
-            selectionControls: materialTextSelectionControls,
+            selectionControls: testTextSelectionHandleControls,
             stylusHandwritingEnabled: false,
           ),
         ),
@@ -416,14 +416,14 @@ void main() {
       controller.text = 'Lorem ipsum dolor sit amet';
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: EditableText(
             controller: controller,
-            backgroundCursorColor: Colors.grey,
+            backgroundCursorColor: _grey,
             focusNode: focusNode,
             style: textStyle,
             cursorColor: cursorColor,
-            selectionControls: materialTextSelectionControls,
+            selectionControls: testTextSelectionHandleControls,
             maxLines: 2,
           ),
         ),
@@ -458,14 +458,14 @@ void main() {
 
       // Widget has scribble disabled.
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: EditableText(
             controller: controller,
-            backgroundCursorColor: Colors.grey,
+            backgroundCursorColor: _grey,
             focusNode: focusNode,
             style: textStyle,
             cursorColor: cursorColor,
-            selectionControls: materialTextSelectionControls,
+            selectionControls: testTextSelectionHandleControls,
             maxLines: 2,
             stylusHandwritingEnabled: false,
           ),
@@ -553,9 +553,9 @@ void main() {
                     maxLines: null,
                     focusNode: focusNode,
                     cursorWidth: 0,
-                    style: Typography.material2018().black.titleMedium!,
-                    cursorColor: Colors.blue,
-                    backgroundCursorColor: Colors.grey,
+                    style: const TextStyle(),
+                    cursorColor: _blue,
+                    backgroundCursorColor: _grey,
                   ),
                 ),
               ),
@@ -679,9 +679,9 @@ void main() {
                   key: ValueKey<String>(controller.text),
                   controller: controller,
                   focusNode: focusNode,
-                  style: Typography.material2018().black.titleMedium!,
-                  cursorColor: Colors.blue,
-                  backgroundCursorColor: Colors.grey,
+                  style: const TextStyle(),
+                  cursorColor: _blue,
+                  backgroundCursorColor: _grey,
                   stylusHandwritingEnabled: false,
                 ),
               ],
@@ -756,9 +756,9 @@ void main() {
                     focusNode: focusNode,
                     cursorWidth: 0,
                     key: editableTextKey,
-                    style: Typography.material2018().black.titleMedium!,
-                    cursorColor: Colors.blue,
-                    backgroundCursorColor: Colors.grey,
+                    style: const TextStyle(),
+                    cursorColor: _blue,
+                    backgroundCursorColor: _grey,
                   ),
                 ),
               ),
@@ -802,25 +802,23 @@ void main() {
       final GlobalKey<EditableTextState> editableTextKey = GlobalKey();
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: EditableText(
             key: editableTextKey,
             controller: controller,
-            backgroundCursorColor: Colors.grey,
+            backgroundCursorColor: _grey,
             focusNode: focusNode,
             style: textStyle,
             cursorColor: cursorColor,
-            selectionControls: materialTextSelectionHandleControls,
+            selectionControls: testTextSelectionHandleControls,
             contextMenuBuilder: (BuildContext context, EditableTextState editableTextState) {
-              return AdaptiveTextSelectionToolbar.editableText(
-                editableTextState: editableTextState,
-              );
+              return const SizedBox(key: Key('test-toolbar'));
             },
           ),
         ),
       );
 
-      expect(find.byType(AdaptiveTextSelectionToolbar), findsNothing);
+      expect(find.byKey(const Key('test-toolbar')), findsNothing);
 
       await tester.showKeyboard(find.byType(EditableText));
 
@@ -833,21 +831,21 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(find.byType(AdaptiveTextSelectionToolbar), findsNothing);
+      expect(find.byKey(const Key('test-toolbar')), findsNothing);
 
       expect(editableTextKey.currentState!.showToolbar(), isTrue);
       await tester.pumpAndSettle();
 
-      expect(find.byType(AdaptiveTextSelectionToolbar), findsOneWidget);
+      expect(find.byKey(const Key('test-toolbar')), findsOneWidget);
 
       expect(editableTextKey.currentState!.showToolbar(), isFalse);
       await tester.pump();
 
-      expect(find.byType(AdaptiveTextSelectionToolbar), findsOneWidget);
+      expect(find.byKey(const Key('test-toolbar')), findsOneWidget);
 
       await tester.pumpAndSettle();
 
-      expect(find.byType(AdaptiveTextSelectionToolbar), findsOneWidget);
+      expect(find.byKey(const Key('test-toolbar')), findsOneWidget);
 
       await tester.testTextInput.finishScribbleInteraction();
     },

--- a/packages/flutter/test/widgets/editable_text_scribe_test.dart
+++ b/packages/flutter/test/widgets/editable_text_scribe_test.dart
@@ -5,9 +5,13 @@
 import 'dart:ui' show PointerDeviceKind;
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'widgets_app_tester.dart';
+
+const Color _grey = Color(0xFF888888);
 
 void main() {
   final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized();
@@ -58,17 +62,17 @@ void main() {
     final provider = TextSelectionGestureDetectorBuilder(delegate: delegate);
 
     await tester.pumpWidget(
-      MaterialApp(
+      TestWidgetsApp(
         home: provider.buildGestureDetector(
           behavior: HitTestBehavior.translucent,
           child: EditableText(
             key: editableTextKey,
             controller: controller,
-            backgroundCursorColor: Colors.grey,
+            backgroundCursorColor: _grey,
             focusNode: focusNode,
             style: textStyle,
             cursorColor: cursorColor,
-            selectionControls: materialTextSelectionControls,
+            selectionControls: _visibleHandleControls,
             showSelectionHandles: true,
           ),
         ),
@@ -248,6 +252,39 @@ void main() {
     variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.android}),
   );
 }
+
+/// Selection controls that render visible handles using [CustomPaint],
+/// needed for tests that interact with handles by finding [CustomPaint]
+/// descendants of [CompositedTransformFollower].
+class _VisibleHandleControls extends TextSelectionControls with TextSelectionHandleControls {
+  @override
+  Widget buildHandle(
+    BuildContext context,
+    TextSelectionHandleType type,
+    double textLineHeight, [
+    VoidCallback? onTap,
+  ]) {
+    return SizedBox(width: 20, height: 20, child: CustomPaint(painter: _HandlePainter()));
+  }
+
+  @override
+  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) => Offset.zero;
+
+  @override
+  Size getHandleSize(double textLineHeight) => const Size(20, 20);
+}
+
+class _HandlePainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    canvas.drawRect(Offset.zero & size, Paint()..color = const Color(0xFF000000));
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+}
+
+final TextSelectionControls _visibleHandleControls = _VisibleHandleControls();
 
 class FakeTextSelectionGestureDetectorBuilderDelegate
     implements TextSelectionGestureDetectorBuilderDelegate {

--- a/packages/flutter/test/widgets/editable_text_tester.dart
+++ b/packages/flutter/test/widgets/editable_text_tester.dart
@@ -99,27 +99,31 @@ class _TestTextFieldState extends State<TestTextField>
 
   @override
   Widget build(BuildContext context) {
-    return _selectionGestureDetectorBuilder.buildGestureDetector(
-      behavior: HitTestBehavior.translucent,
-      child: EditableText(
-        key: editableTextKey,
-        autofillHints: widget.autofillHints,
-        autofocus: widget.autofocus,
-        backgroundCursorColor: _red, // required by editable text.
-        contextMenuBuilder: widget.contextMenuBuilder,
-        cursorColor: widget.cursorColor ?? _red, // required by editable text.
-        cursorOpacityAnimates: widget.cursorOpacityAnimates,
-        focusNode: _effectiveFocusNode, // required by editable text.
-        groupId: widget.groupId,
-        maxLines: widget.maxLines,
-        onChanged: widget.onChanged,
-        onSubmitted: widget.onSubmitted,
-        readOnly: widget.readOnly,
-        rendererIgnoresPointer: true, // gestures are provided by text selection gesture detector.
-        selectionControls: widget.selectionControls ?? testTextSelectionHandleControls,
-        showCursor: widget.showCursor,
-        style: widget.style ?? const TextStyle(), // required by editable text.
-        controller: _effectiveController, // required by editable text.
+    return Semantics(
+      enabled: true,
+      onTap: widget.readOnly ? null : () => _effectiveFocusNode.requestFocus(),
+      child: _selectionGestureDetectorBuilder.buildGestureDetector(
+        behavior: HitTestBehavior.translucent,
+        child: EditableText(
+          key: editableTextKey,
+          autofillHints: widget.autofillHints,
+          autofocus: widget.autofocus,
+          backgroundCursorColor: _red, // required by editable text.
+          contextMenuBuilder: widget.contextMenuBuilder,
+          cursorColor: widget.cursorColor ?? _red, // required by editable text.
+          cursorOpacityAnimates: widget.cursorOpacityAnimates,
+          focusNode: _effectiveFocusNode, // required by editable text.
+          groupId: widget.groupId,
+          maxLines: widget.maxLines,
+          onChanged: widget.onChanged,
+          onSubmitted: widget.onSubmitted,
+          readOnly: widget.readOnly,
+          rendererIgnoresPointer: true, // gestures are provided by text selection gesture detector.
+          selectionControls: widget.selectionControls ?? testTextSelectionHandleControls,
+          showCursor: widget.showCursor,
+          style: widget.style ?? const TextStyle(), // required by editable text.
+          controller: _effectiveController, // required by editable text.
+        ),
       ),
     );
   }

--- a/packages/flutter/test/widgets/page_route_builder_test.dart
+++ b/packages/flutter/test/widgets/page_route_builder_test.dart
@@ -7,22 +7,21 @@
 @Tags(<String>['reduced-test-set'])
 library;
 
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-class TestPage extends StatelessWidget {
-  const TestPage({super.key, this.useMaterial3});
+import 'button_tester.dart';
+import 'widgets_app_tester.dart';
 
-  final bool? useMaterial3;
+const Color _debugBlack54 = Color(0x8A000000);
+const Color _debugTeal = Color(0xFF009688);
+
+class TestPage extends StatelessWidget {
+  const TestPage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Test',
-      debugShowCheckedModeBanner: false, // https://github.com/flutter/flutter/issues/143616
-      theme: ThemeData(useMaterial3: useMaterial3, primarySwatch: Colors.blue),
-      home: const HomePage(),
-    );
+    return const TestWidgetsApp(home: HomePage());
   }
 }
 
@@ -37,7 +36,7 @@ class _HomePageState extends State<HomePage> {
   void _presentModalPage() {
     Navigator.of(context).push(
       PageRouteBuilder<void>(
-        barrierColor: Colors.black54,
+        barrierColor: _debugBlack54,
         opaque: false,
         pageBuilder: (BuildContext context, _, _) {
           return const ModalPage();
@@ -48,12 +47,14 @@ class _HomePageState extends State<HomePage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: const Center(child: Text('Test Home')),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _presentModalPage,
-        child: const Icon(Icons.add),
-      ),
+    return Column(
+      children: <Widget>[
+        const Expanded(child: Center(child: Text('Test Home'))),
+        Align(
+          alignment: Alignment.bottomRight,
+          child: TestButton(onPressed: _presentModalPage, child: const Text('+')),
+        ),
+      ],
     );
   }
 }
@@ -63,48 +64,30 @@ class ModalPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Material(
-      type: MaterialType.transparency,
-      child: SafeArea(
-        child: Stack(
-          children: <Widget>[
-            InkWell(
-              highlightColor: Colors.transparent,
-              splashColor: Colors.transparent,
-              onTap: () {
-                Navigator.of(context).pop();
-              },
-              child: const SizedBox.expand(),
-            ),
-            Align(
-              alignment: Alignment.bottomCenter,
-              child: Container(height: 150, color: Colors.teal),
-            ),
-          ],
-        ),
+    return SafeArea(
+      child: Stack(
+        children: <Widget>[
+          GestureDetector(
+            onTap: () {
+              Navigator.of(context).pop();
+            },
+            child: const SizedBox.expand(),
+          ),
+          Align(
+            alignment: Alignment.bottomCenter,
+            child: Container(height: 150, color: _debugTeal),
+          ),
+        ],
       ),
     );
   }
 }
 
 void main() {
-  testWidgets('Material2 - Barriers show when using PageRouteBuilder', (WidgetTester tester) async {
-    await tester.pumpWidget(const TestPage(useMaterial3: false));
-    await tester.tap(find.byType(FloatingActionButton));
-    await tester.pumpAndSettle();
-    await expectLater(
-      find.byType(TestPage),
-      matchesGoldenFile('m2_page_route_builder.barrier.png'),
-    );
-  });
-
-  testWidgets('Material3 - Barriers show when using PageRouteBuilder', (WidgetTester tester) async {
+  testWidgets('Barriers show when using PageRouteBuilder', (WidgetTester tester) async {
     await tester.pumpWidget(const TestPage());
-    await tester.tap(find.byType(FloatingActionButton));
+    await tester.tap(find.byType(TestButton));
     await tester.pumpAndSettle();
-    await expectLater(
-      find.byType(TestPage),
-      matchesGoldenFile('m3_page_route_builder.barrier.png'),
-    );
+    await expectLater(find.byType(TestPage), matchesGoldenFile('page_route_builder.barrier.png'));
   });
 }

--- a/packages/flutter/test/widgets/radio_group_test.dart
+++ b/packages/flutter/test/widgets/radio_group_test.dart
@@ -2,11 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'checkbox_tester.dart';
 import 'editable_text_tester.dart';
 import 'widgets_app_tester.dart';
 
@@ -16,12 +17,13 @@ void main() {
     final key1 = UniqueKey();
 
     await tester.pumpWidget(
-      Material(
+      Directionality(
+        textDirection: TextDirection.ltr,
         child: TestRadioGroup<int>(
           child: Column(
             children: <Widget>[
-              Radio<int>(key: key0, value: 0),
-              Radio<int>(key: key1, value: 1),
+              _TestRadio<int>(key: key0, value: 0),
+              _TestRadio<int>(key: key1, value: 1),
             ],
           ),
         ),
@@ -64,12 +66,13 @@ void main() {
     final key1 = UniqueKey();
 
     await tester.pumpWidget(
-      Material(
+      Directionality(
+        textDirection: TextDirection.ltr,
         child: TestRadioGroup<int>(
           child: Column(
             children: <Widget>[
-              Radio<int>(key: key0, value: 0, enabled: false),
-              Radio<int>(key: key1, value: 1),
+              _TestRadio<int>(key: key0, value: 0, enabled: false),
+              _TestRadio<int>(key: key1, value: 1),
             ],
           ),
         ),
@@ -99,16 +102,19 @@ void main() {
 
   testWidgets('Radio group will not merge up', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Material(
+      Directionality(
+        textDirection: TextDirection.ltr,
         child: Semantics(
           container: true,
           child: Column(
             children: <Widget>[
-              Checkbox(value: true, onChanged: (bool? value) {}),
+              TestCheckbox(value: true, onChanged: (bool? value) {}),
               const TestRadioGroup<int>(
-                child: Column(children: <Widget>[Radio<int>(value: 0), Radio<int>(value: 1)]),
+                child: Column(
+                  children: <Widget>[_TestRadio<int>(value: 0), _TestRadio<int>(value: 1)],
+                ),
               ),
-              Checkbox(value: true, onChanged: (bool? value) {}),
+              TestCheckbox(value: true, onChanged: (bool? value) {}),
             ],
           ),
         ),
@@ -125,16 +131,14 @@ void main() {
     final focusNode = FocusNode();
     addTearDown(focusNode.dispose);
     await tester.pumpWidget(
-      MaterialApp(
-        home: Material(
-          child: TestRadioGroup<int>(
-            child: Column(
-              children: <Widget>[
-                Radio<int>(key: key0, focusNode: focusNode, value: 0),
-                Radio<int>(key: key1, value: 1),
-                Radio<int>(key: key2, value: 2),
-              ],
-            ),
+      TestWidgetsApp(
+        home: TestRadioGroup<int>(
+          child: Column(
+            children: <Widget>[
+              _TestRadio<int>(key: key0, focusNode: focusNode, value: 0),
+              _TestRadio<int>(key: key1, value: 1),
+              _TestRadio<int>(key: key2, value: 2),
+            ],
           ),
         ),
       ),
@@ -181,16 +185,14 @@ void main() {
     final focusNode = FocusNode();
     addTearDown(focusNode.dispose);
     await tester.pumpWidget(
-      MaterialApp(
-        home: Material(
-          child: TestRadioGroup<int>(
-            child: Column(
-              children: <Widget>[
-                Radio<int>(key: key0, focusNode: focusNode, value: 0),
-                Radio<int>(key: key1, enabled: false, value: 1),
-                Radio<int>(key: key2, value: 2),
-              ],
-            ),
+      TestWidgetsApp(
+        home: TestRadioGroup<int>(
+          child: Column(
+            children: <Widget>[
+              _TestRadio<int>(key: key0, focusNode: focusNode, value: 0),
+              _TestRadio<int>(key: key1, enabled: false, value: 1),
+              _TestRadio<int>(key: key2, value: 2),
+            ],
           ),
         ),
       ),
@@ -242,23 +244,21 @@ void main() {
     final textFieldAfter = FocusNode();
     addTearDown(textFieldAfter.dispose);
     await tester.pumpWidget(
-      MaterialApp(
-        home: Material(
-          child: Column(
-            children: <Widget>[
-              TestTextField(focusNode: textFieldBefore),
-              TestRadioGroup<int>(
-                child: Column(
-                  children: <Widget>[
-                    Radio<int>(key: key0, focusNode: radio0, value: 0),
-                    Radio<int>(key: key1, focusNode: radio1, value: 1),
-                    Radio<int>(key: key2, value: 2),
-                  ],
-                ),
+      TestWidgetsApp(
+        home: Column(
+          children: <Widget>[
+            TestTextField(focusNode: textFieldBefore),
+            TestRadioGroup<int>(
+              child: Column(
+                children: <Widget>[
+                  _TestRadio<int>(key: key0, focusNode: radio0, value: 0),
+                  _TestRadio<int>(key: key1, focusNode: radio1, value: 1),
+                  _TestRadio<int>(key: key2, value: 2),
+                ],
               ),
-              TestTextField(focusNode: textFieldAfter),
-            ],
-          ),
+            ),
+            TestTextField(focusNode: textFieldAfter),
+          ],
         ),
       ),
     );
@@ -307,17 +307,15 @@ void main() {
   testWidgets('Radio group throws on multiple selection', (WidgetTester tester) async {
     final key1 = UniqueKey();
     await tester.pumpWidget(
-      MaterialApp(
-        home: Material(
-          child: TestRadioGroup<int>(
-            child: Column(
-              children: <Widget>[
-                const Radio<int>(value: 0),
-                Radio<int>(key: key1, value: 1),
-                const Radio<int>(value: 1),
-                const Radio<int>(value: 2),
-              ],
-            ),
+      TestWidgetsApp(
+        home: TestRadioGroup<int>(
+          child: Column(
+            children: <Widget>[
+              const _TestRadio<int>(value: 0),
+              _TestRadio<int>(key: key1, value: 1),
+              const _TestRadio<int>(value: 1),
+              const _TestRadio<int>(value: 2),
+            ],
           ),
         ),
       ),
@@ -343,20 +341,18 @@ void main() {
     WidgetTester tester,
   ) async {
     await tester.pumpWidget(
-      MaterialApp(
-        home: Material(
-          child: RadioGroup<int>(
-            onChanged: (_) {},
-            groupValue: 4,
-            child: const Column(
-              children: <Widget>[
-                Radio<int>(value: 0),
-                Radio<int>(value: 1),
-                Radio<int>(value: 2),
-                Radio<int>(value: 3),
-                Radio<int>(value: 4),
-              ],
-            ),
+      TestWidgetsApp(
+        home: RadioGroup<int>(
+          onChanged: (_) {},
+          groupValue: 4,
+          child: const Column(
+            children: <Widget>[
+              _TestRadio<int>(value: 0),
+              _TestRadio<int>(value: 1),
+              _TestRadio<int>(value: 2),
+              _TestRadio<int>(value: 3),
+              _TestRadio<int>(value: 4),
+            ],
           ),
         ),
       ),
@@ -365,19 +361,17 @@ void main() {
     expect(tester.takeException(), isNull);
 
     await tester.pumpWidget(
-      MaterialApp(
-        home: Material(
-          child: RadioGroup<int>(
-            onChanged: (_) {},
-            groupValue: 4,
-            child: const Column(
-              children: <Widget>[
-                Radio<int>(value: 1),
-                Radio<int>(value: 2),
-                Radio<int>(value: 3),
-                Radio<int>(value: 4),
-              ],
-            ),
+      TestWidgetsApp(
+        home: RadioGroup<int>(
+          onChanged: (_) {},
+          groupValue: 4,
+          child: const Column(
+            children: <Widget>[
+              _TestRadio<int>(value: 1),
+              _TestRadio<int>(value: 2),
+              _TestRadio<int>(value: 3),
+              _TestRadio<int>(value: 4),
+            ],
           ),
         ),
       ),
@@ -405,19 +399,17 @@ void main() {
     addTearDown(textFieldFocusNode.dispose);
 
     await tester.pumpWidget(
-      MaterialApp(
-        home: Material(
-          child: Shortcuts(
-            shortcuts: shortcuts,
-            child: TestRadioGroup<int>(
-              child: Column(
-                children: <Widget>[
-                  Radio<int>(focusNode: firstRadioFocusNode, value: 0),
-                  const RadioListTile<int>(value: 1),
-                  const Radio<int>(value: 2),
-                  TestTextField(focusNode: textFieldFocusNode),
-                ],
-              ),
+      TestWidgetsApp(
+        home: Shortcuts(
+          shortcuts: shortcuts,
+          child: TestRadioGroup<int>(
+            child: Column(
+              children: <Widget>[
+                _TestRadio<int>(focusNode: firstRadioFocusNode, value: 0),
+                const _TestRadio<int>(value: 1),
+                const _TestRadio<int>(value: 2),
+                TestTextField(focusNode: textFieldFocusNode),
+              ],
             ),
           ),
         ),
@@ -569,6 +561,60 @@ class TestRadioGroupState<T> extends State<TestRadioGroup<T>> {
       },
       groupValue: groupValue,
       child: widget.child,
+    );
+  }
+}
+
+/// A minimal radio button for widget tests that registers with a [RadioGroup]
+/// ancestor, avoiding a dependency on the Material library.
+class _TestRadio<T> extends StatefulWidget {
+  const _TestRadio({super.key, required this.value, this.focusNode, this.enabled});
+
+  final T value;
+  final FocusNode? focusNode;
+  final bool? enabled;
+
+  @override
+  State<_TestRadio<T>> createState() => _TestRadioState<T>();
+}
+
+class _TestRadioState<T> extends State<_TestRadio<T>> {
+  FocusNode? _internalFocusNode;
+  FocusNode get _effectiveFocusNode => widget.focusNode ?? (_internalFocusNode ??= FocusNode());
+
+  @override
+  void dispose() {
+    _internalFocusNode?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bool enabled = widget.enabled ?? true;
+    return RawRadio<T>(
+      value: widget.value,
+      mouseCursor: WidgetStateProperty.all<MouseCursor>(SystemMouseCursors.click),
+      toggleable: false,
+      focusNode: _effectiveFocusNode,
+      autofocus: false,
+      groupRegistry: enabled ? RadioGroup.maybeOf<T>(context) : null,
+      enabled: enabled,
+      builder: (BuildContext context, ToggleableStateMixin state) {
+        return SizedBox(
+          width: 18,
+          height: 18,
+          child: Center(
+            child: Container(
+              width: 10,
+              height: 10,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: state.value ?? false ? const Color(0xFF000000) : const Color(0x00000000),
+              ),
+            ),
+          ),
+        );
+      },
     );
   }
 }

--- a/packages/flutter/test/widgets/range_maintaining_scroll_physics_test.dart
+++ b/packages/flutter/test/widgets/range_maintaining_scroll_physics_test.dart
@@ -4,8 +4,14 @@
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'button_tester.dart';
+import 'widgets_app_tester.dart';
+
+const Color _green = Color(0xFF00FF00);
+const Color _red = Color(0xFFFF0000);
 
 class ExpandingBox extends StatefulWidget {
   const ExpandingBox({super.key, required this.collapsedSize, required this.expandedSize});
@@ -38,10 +44,10 @@ class _ExpandingBoxState extends State<ExpandingBox>
     super.build(context);
     return Container(
       height: _height,
-      color: Colors.green,
+      color: _green,
       child: Align(
         alignment: Alignment.bottomCenter,
-        child: TextButton(onPressed: toggleSize, child: const Text('Collapse')),
+        child: TestButton(onPressed: toggleSize, child: const Text('Collapse')),
       ),
     );
   }
@@ -53,11 +59,11 @@ class _ExpandingBoxState extends State<ExpandingBox>
 void main() {
   testWidgets('shrink listview', (WidgetTester tester) async {
     await tester.pumpWidget(
-      MaterialApp(
+      TestWidgetsApp(
         home: ListView.builder(
           itemBuilder: (BuildContext context, int index) => index == 0
               ? const ExpandingBox(collapsedSize: 400, expandedSize: 1200)
-              : Container(height: 300, color: Colors.red),
+              : Container(height: 300, color: _red),
           itemCount: 2,
         ),
       ),
@@ -68,7 +74,7 @@ void main() {
     expect(position.minScrollExtent, 0.0);
     expect(position.maxScrollExtent, 100.0);
     expect(position.pixels, 0.0);
-    await tester.tap(find.byType(TextButton));
+    await tester.tap(find.byType(TestButton));
     await tester.pump();
 
     final TestGesture drag1 = await tester.startGesture(const Offset(10.0, 500.0));
@@ -91,7 +97,7 @@ void main() {
     expect(position.pixels, moreOrLessEquals(900.0));
 
     await tester.pump();
-    await tester.tap(find.byType(TextButton));
+    await tester.tap(find.byType(TestButton));
     await tester.pump();
     expect(position.minScrollExtent, 0.0);
     expect(position.maxScrollExtent, 100.0);
@@ -100,11 +106,11 @@ void main() {
 
   testWidgets('shrink listview while dragging', (WidgetTester tester) async {
     await tester.pumpWidget(
-      MaterialApp(
+      TestWidgetsApp(
         home: ListView.builder(
           itemBuilder: (BuildContext context, int index) => index == 0
               ? const ExpandingBox(collapsedSize: 400, expandedSize: 1200)
-              : Container(height: 300, color: Colors.red),
+              : Container(height: 300, color: _red),
           itemCount: 2,
         ),
       ),
@@ -115,7 +121,7 @@ void main() {
     expect(position.minScrollExtent, 0.0);
     expect(position.maxScrollExtent, 100.0);
     expect(position.pixels, 0.0);
-    await tester.tap(find.byType(TextButton));
+    await tester.tap(find.byType(TestButton));
     await tester.pump(); // start button animation
     await tester.pump(const Duration(seconds: 1)); // finish button animation
     expect(position.minScrollExtent, 0.0);
@@ -163,7 +169,7 @@ void main() {
 
   testWidgets('shrink listview while ballistic', (WidgetTester tester) async {
     await tester.pumpWidget(
-      MaterialApp(
+      TestWidgetsApp(
         home: GestureDetector(
           onTap: () {
             assert(false);
@@ -172,7 +178,7 @@ void main() {
             physics: const RangeMaintainingScrollPhysics(parent: BouncingScrollPhysics()),
             itemBuilder: (BuildContext context, int index) => index == 0
                 ? const ExpandingBox(collapsedSize: 400, expandedSize: 1200)
-                : Container(height: 300, color: Colors.red),
+                : Container(height: 300, color: _red),
             itemCount: 2,
           ),
         ),
@@ -232,14 +238,14 @@ void main() {
 
   testWidgets('expanding page views', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const Padding(padding: EdgeInsets.only(right: 200.0), child: TabBarDemo()),
+      const Padding(padding: EdgeInsets.only(right: 200.0), child: _PageViewDemo()),
     );
     await tester.tap(find.text('bike'));
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
-    final Rect bike1 = tester.getRect(find.byIcon(Icons.directions_bike));
-    await tester.pumpWidget(const Padding(padding: EdgeInsets.zero, child: TabBarDemo()));
-    final Rect bike2 = tester.getRect(find.byIcon(Icons.directions_bike));
+    final Rect bike1 = tester.getRect(find.text('bike-icon'));
+    await tester.pumpWidget(const Padding(padding: EdgeInsets.zero, child: _PageViewDemo()));
+    final Rect bike2 = tester.getRect(find.text('bike-icon'));
     expect(bike2.center, bike1.shift(const Offset(100.0, 0.0)).center);
   });
 
@@ -361,33 +367,54 @@ void main() {
   });
 }
 
-class TabBarDemo extends StatelessWidget {
-  const TabBarDemo({super.key});
+class _PageViewDemo extends StatefulWidget {
+  const _PageViewDemo();
+
+  @override
+  State<_PageViewDemo> createState() => _PageViewDemoState();
+}
+
+class _PageViewDemoState extends State<_PageViewDemo> {
+  final PageController _controller = PageController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _goToPage(int page) {
+    _controller.animateToPage(
+      page,
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.ease,
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      home: DefaultTabController(
-        length: 3,
-        child: Scaffold(
-          appBar: AppBar(
-            bottom: const TabBar(
-              tabs: <Widget>[
-                Tab(text: 'car'),
-                Tab(text: 'transit'),
-                Tab(text: 'bike'),
-              ],
-            ),
-            title: const Text('Tabs Demo'),
-          ),
-          body: const TabBarView(
+    return Directionality(
+      textDirection: TextDirection.ltr,
+      child: Column(
+        children: <Widget>[
+          Row(
             children: <Widget>[
-              Icon(Icons.directions_car),
-              Icon(Icons.directions_transit),
-              Icon(Icons.directions_bike),
+              GestureDetector(onTap: () => _goToPage(0), child: const Text('car')),
+              GestureDetector(onTap: () => _goToPage(1), child: const Text('transit')),
+              GestureDetector(onTap: () => _goToPage(2), child: const Text('bike')),
             ],
           ),
-        ),
+          Expanded(
+            child: PageView(
+              controller: _controller,
+              children: const <Widget>[
+                Center(child: Text('car-icon')),
+                Center(child: Text('transit-icon')),
+                Center(child: Text('bike-icon')),
+              ],
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -6,13 +6,19 @@ import 'dart:collection';
 import 'dart:ui';
 
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/physics.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'button_tester.dart';
 import 'editable_text_tester.dart';
 import 'semantics_tester.dart';
+import 'widgets_app_tester.dart';
+
+const Color _transparent = Color(0x00000000);
+const Color _green = Color(0xFF00FF00);
+const Color _black = Color(0xFF000000);
+const Color _white = Color(0xFFFFFFFF);
 
 final List<String> results = <String>[];
 
@@ -519,23 +525,17 @@ void main() {
     addTearDown(focusNode.dispose);
 
     await tester.pumpWidget(
-      Material(
-        child: MaterialApp(
-          onGenerateRoute: (RouteSettings settings) {
-            return PageRouteBuilder<void>(
-              settings: settings,
-              pageBuilder: (BuildContext context, Animation<double> input, Animation<double> out) {
-                return Focus(
-                  child: TestTextField(
-                    autofocus: true,
-                    focusNode: focusNode,
-                    controller: controller,
-                  ),
-                );
-              },
-            );
-          },
-        ),
+      TestWidgetsApp(
+        onGenerateRoute: (RouteSettings settings) {
+          return PageRouteBuilder<void>(
+            settings: settings,
+            pageBuilder: (BuildContext context, Animation<double> input, Animation<double> out) {
+              return Focus(
+                child: TestTextField(autofocus: true, focusNode: focusNode, controller: controller),
+              );
+            },
+          );
+        },
       ),
     );
     await tester.pump();
@@ -547,11 +547,12 @@ void main() {
     testWidgets('reverseTransitionDuration defaults to 300ms', (WidgetTester tester) async {
       // Default PageRouteBuilder reverse transition duration should be 300ms.
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           onGenerateRoute: (RouteSettings settings) {
-            return MaterialPageRoute<dynamic>(
-              builder: (BuildContext context) {
-                return ElevatedButton(
+            return PageRouteBuilder<dynamic>(
+              settings: settings,
+              pageBuilder: (BuildContext context, Animation<double> _, Animation<double> _) {
+                return TestButton(
                   onPressed: () {
                     Navigator.of(context).push<void>(
                       PageRouteBuilder<void>(
@@ -572,7 +573,7 @@ void main() {
       );
 
       // Open the new route.
-      await tester.tap(find.byType(ElevatedButton));
+      await tester.tap(find.byType(TestButton));
       await tester.pumpAndSettle();
       expect(find.text('Open page'), findsNothing);
       expect(find.text('Page Two'), findsOneWidget);
@@ -598,11 +599,12 @@ void main() {
 
     testWidgets('reverseTransitionDuration can be customized', (WidgetTester tester) async {
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           onGenerateRoute: (RouteSettings settings) {
-            return MaterialPageRoute<dynamic>(
-              builder: (BuildContext context) {
-                return ElevatedButton(
+            return PageRouteBuilder<dynamic>(
+              settings: settings,
+              pageBuilder: (BuildContext context, Animation<double> _, Animation<double> _) {
+                return TestButton(
                   onPressed: () {
                     Navigator.of(context).push<void>(
                       PageRouteBuilder<void>(
@@ -625,7 +627,7 @@ void main() {
       );
 
       // Open the new route.
-      await tester.tap(find.byType(ElevatedButton));
+      await tester.tap(find.byType(TestButton));
       await tester.pumpAndSettle();
       expect(find.text('Open page'), findsNothing);
       expect(find.text('Page Two'), findsOneWidget);
@@ -655,7 +657,7 @@ void main() {
       WidgetTester tester,
     ) async {
       final navigator = GlobalKey<NavigatorState>();
-      await tester.pumpWidget(MaterialApp(navigatorKey: navigator, home: const Text('home')));
+      await tester.pumpWidget(TestWidgetsApp(navigatorKey: navigator, home: const Text('home')));
 
       // Push page one, its secondary animation is kAlwaysDismissedAnimation.
       late ProxyAnimation secondaryAnimationProxyPageOne;
@@ -710,7 +712,7 @@ void main() {
       WidgetTester tester,
     ) async {
       final navigator = GlobalKey<NavigatorState>();
-      await tester.pumpWidget(MaterialApp(navigatorKey: navigator, home: const Text('home')));
+      await tester.pumpWidget(TestWidgetsApp(navigatorKey: navigator, home: const Text('home')));
 
       // Push page one, its secondary animation is kAlwaysDismissedAnimation.
       late ProxyAnimation secondaryAnimationProxyPageOne;
@@ -758,26 +760,11 @@ void main() {
       expect(secondaryAnimationPageOne.parent, kAlwaysDismissedAnimation);
     });
 
-    // TODO(justinmc): Widgets tests should not import Material/Cupertino. This
-    // test can probably go into Cupertino with a CupertinoApp.
-    // https://github.com/flutter/flutter/issues/177028
     testWidgets(
       'delegated transitions are removed when secondary animation is dismissed and next route is removed',
       (WidgetTester tester) async {
         final navigator = GlobalKey<NavigatorState>();
-        await tester.pumpWidget(
-          MaterialApp(
-            navigatorKey: navigator,
-            theme: ThemeData(
-              pageTransitionsTheme: const PageTransitionsTheme(
-                builders: <TargetPlatform, PageTransitionsBuilder>{
-                  TargetPlatform.android: CupertinoPageTransitionsBuilder(),
-                },
-              ),
-            ),
-            home: const Text('home'),
-          ),
-        );
+        await tester.pumpWidget(TestWidgetsApp(navigatorKey: navigator, home: const Text('home')));
 
         // Push first page with custom transition builder.
         final Route<void> firstRoute = CupertinoSheetRoute<void>(
@@ -814,7 +801,7 @@ void main() {
       WidgetTester tester,
     ) async {
       final navigator = GlobalKey<NavigatorState>();
-      await tester.pumpWidget(MaterialApp(navigatorKey: navigator, home: const Text('home')));
+      await tester.pumpWidget(TestWidgetsApp(navigatorKey: navigator, home: const Text('home')));
 
       // Push page one, its secondary animation is kAlwaysDismissedAnimation.
       late ProxyAnimation secondaryAnimationProxyPageOne;
@@ -883,7 +870,7 @@ void main() {
       WidgetTester tester,
     ) async {
       final navigator = GlobalKey<NavigatorState>();
-      await tester.pumpWidget(MaterialApp(navigatorKey: navigator, home: const Text('home')));
+      await tester.pumpWidget(TestWidgetsApp(navigatorKey: navigator, home: const Text('home')));
 
       // Push page one, its secondary animation is kAlwaysDismissedAnimation.
       late ProxyAnimation secondaryAnimationProxyPageOne;
@@ -952,7 +939,7 @@ void main() {
       late Animation<double> secondaryAnimationOfRouteOne;
       late Animation<double> primaryAnimationOfRouteTwo;
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           navigatorKey: navigator,
           onGenerateRoute: (RouteSettings settings) {
             return PageRouteBuilder<void>(
@@ -987,16 +974,16 @@ void main() {
 
     testWidgets('showGeneralDialog handles transparent barrier color', (WidgetTester tester) async {
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: Builder(
             builder: (BuildContext context) {
-              return ElevatedButton(
+              return TestButton(
                 onPressed: () {
                   showGeneralDialog<void>(
                     context: context,
                     barrierDismissible: true,
                     barrierLabel: 'barrier_label',
-                    barrierColor: const Color(0x00000000),
+                    barrierColor: _transparent,
                     transitionDuration: Duration.zero,
                     pageBuilder: (BuildContext innerContext, _, _) {
                       return const SizedBox();
@@ -1011,7 +998,7 @@ void main() {
       );
 
       // Open the dialog.
-      await tester.tap(find.byType(ElevatedButton));
+      await tester.tap(find.byType(TestButton));
       await tester.pump();
       expect(find.byType(ModalBarrier), findsNWidgets(2));
 
@@ -1025,10 +1012,10 @@ void main() {
       WidgetTester tester,
     ) async {
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: Builder(
             builder: (BuildContext context) {
-              return ElevatedButton(
+              return TestButton(
                 onPressed: () {
                   showGeneralDialog<void>(
                     context: context,
@@ -1046,7 +1033,7 @@ void main() {
       );
 
       // Open the dialog.
-      await tester.tap(find.byType(ElevatedButton));
+      await tester.tap(find.byType(TestButton));
       await tester.pump();
       expect(find.byType(ModalBarrier), findsNWidgets(2));
       final barrier = find.byType(ModalBarrier).evaluate().last.widget as ModalBarrier;
@@ -1064,10 +1051,10 @@ void main() {
       WidgetTester tester,
     ) async {
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: Builder(
             builder: (BuildContext context) {
-              return ElevatedButton(
+              return TestButton(
                 onPressed: () {
                   showGeneralDialog<void>(
                     context: context,
@@ -1085,7 +1072,7 @@ void main() {
       );
 
       // Open the dialog.
-      await tester.tap(find.byType(ElevatedButton));
+      await tester.tap(find.byType(TestButton));
       await tester.pump();
       expect(find.byType(ModalBarrier), findsNWidgets(2));
       final barrier = find.byType(ModalBarrier).evaluate().last.widget as ModalBarrier;
@@ -1104,14 +1091,15 @@ void main() {
       final nestedObserver = DialogObserver();
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           navigatorObservers: <NavigatorObserver>[rootObserver],
           home: Navigator(
             observers: <NavigatorObserver>[nestedObserver],
             onGenerateRoute: (RouteSettings settings) {
-              return MaterialPageRoute<dynamic>(
-                builder: (BuildContext context) {
-                  return ElevatedButton(
+              return PageRouteBuilder<dynamic>(
+                settings: settings,
+                pageBuilder: (BuildContext context, Animation<double> _, Animation<double> _) {
+                  return TestButton(
                     onPressed: () {
                       showGeneralDialog<void>(
                         context: context,
@@ -1131,7 +1119,7 @@ void main() {
       );
 
       // Open the dialog.
-      await tester.tap(find.byType(ElevatedButton));
+      await tester.tap(find.byType(TestButton));
 
       expect(rootObserver.dialogCount, 1);
       expect(nestedObserver.dialogCount, 0);
@@ -1144,14 +1132,15 @@ void main() {
       final nestedObserver = DialogObserver();
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           navigatorObservers: <NavigatorObserver>[rootObserver],
           home: Navigator(
             observers: <NavigatorObserver>[nestedObserver],
             onGenerateRoute: (RouteSettings settings) {
-              return MaterialPageRoute<dynamic>(
-                builder: (BuildContext context) {
-                  return ElevatedButton(
+              return PageRouteBuilder<dynamic>(
+                settings: settings,
+                pageBuilder: (BuildContext context, Animation<double> _, Animation<double> _) {
+                  return TestButton(
                     onPressed: () {
                       showGeneralDialog<void>(
                         useRootNavigator: false,
@@ -1172,7 +1161,7 @@ void main() {
       );
 
       // Open the dialog.
-      await tester.tap(find.byType(ElevatedButton));
+      await tester.tap(find.byType(TestButton));
 
       expect(rootObserver.dialogCount, 0);
       expect(nestedObserver.dialogCount, 1);
@@ -1182,13 +1171,14 @@ void main() {
       final rootObserver = DialogObserver();
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           navigatorObservers: <NavigatorObserver>[rootObserver],
           home: Navigator(
             onGenerateRoute: (RouteSettings settings) {
-              return MaterialPageRoute<dynamic>(
-                builder: (BuildContext context) {
-                  return ElevatedButton(
+              return PageRouteBuilder<dynamic>(
+                settings: settings,
+                pageBuilder: (BuildContext context, Animation<double> _, Animation<double> _) {
+                  return TestButton(
                     onPressed: () {
                       showGeneralDialog<void>(
                         context: context,
@@ -1207,7 +1197,7 @@ void main() {
       );
 
       // Open the dialog.
-      await tester.tap(find.byType(ElevatedButton));
+      await tester.tap(find.byType(TestButton));
       expect(rootObserver.dialogRoutes.length, equals(1));
       final ModalRoute<dynamic> route = rootObserver.dialogRoutes.last;
       expect(route.barrierDismissible, isNotNull);
@@ -1218,7 +1208,7 @@ void main() {
     group('showGeneralDialog avoids overlapping display features', () {
       testWidgets('positioning with anchorPoint', (WidgetTester tester) async {
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             builder: (BuildContext context, Widget? child) {
               return MediaQuery(
                 // Display has a vertical hinge down the middle
@@ -1256,7 +1246,7 @@ void main() {
 
       testWidgets('positioning with Directionality', (WidgetTester tester) async {
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             builder: (BuildContext context, Widget? child) {
               return MediaQuery(
                 // Display has a vertical hinge down the middle
@@ -1293,7 +1283,7 @@ void main() {
 
       testWidgets('positioning by default', (WidgetTester tester) async {
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             builder: (BuildContext context, Widget? child) {
               return MediaQuery(
                 // Display has a vertical hinge down the middle
@@ -1335,20 +1325,22 @@ void main() {
       final GlobalKey containerKey = GlobalKey();
       final observer = TransitionDurationObserver();
 
-      // Default MaterialPageRoute transition duration should be 300ms.
+      // Default PageRouteBuilder transition duration should be 300ms.
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           navigatorObservers: <NavigatorObserver>[observer],
           onGenerateRoute: (RouteSettings settings) {
-            return MaterialPageRoute<dynamic>(
-              builder: (BuildContext context) {
-                return ElevatedButton(
+            return PageRouteBuilder<dynamic>(
+              settings: settings,
+              pageBuilder: (BuildContext context, Animation<double> _, Animation<double> _) {
+                return TestButton(
                   onPressed: () {
                     Navigator.of(context).push<void>(
-                      MaterialPageRoute<void>(
-                        builder: (BuildContext innerContext) {
-                          return Container(key: containerKey, color: Colors.green);
-                        },
+                      PageRouteBuilder<void>(
+                        pageBuilder:
+                            (BuildContext innerContext, Animation<double> _, Animation<double> _) {
+                              return Container(key: containerKey, color: _green);
+                            },
                       ),
                     );
                   },
@@ -1361,7 +1353,7 @@ void main() {
       );
 
       // Open the new route.
-      await tester.tap(find.byType(ElevatedButton));
+      await tester.tap(find.byType(TestButton));
       await tester.pumpAndSettle();
       expect(find.text('Open page'), findsNothing);
       expect(find.byKey(containerKey), findsOneWidget);
@@ -1387,18 +1379,20 @@ void main() {
     testWidgets('reverseTransitionDuration can be customized', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           onGenerateRoute: (RouteSettings settings) {
-            return MaterialPageRoute<dynamic>(
-              builder: (BuildContext context) {
-                return ElevatedButton(
+            return PageRouteBuilder<dynamic>(
+              settings: settings,
+              pageBuilder: (BuildContext context, Animation<double> _, Animation<double> _) {
+                return TestButton(
                   onPressed: () {
                     Navigator.of(context).push<void>(
-                      ModifiedReverseTransitionDurationRoute<void>(
-                        builder: (BuildContext innerContext) {
-                          return Container(key: containerKey, color: Colors.green);
-                        },
-                        // modified value, default MaterialPageRoute transition duration should be 300ms.
+                      PageRouteBuilder<void>(
+                        pageBuilder:
+                            (BuildContext innerContext, Animation<double> _, Animation<double> _) {
+                              return Container(key: containerKey, color: _green);
+                            },
+                        // modified value, default PageRouteBuilder transition duration should be 300ms.
                         reverseTransitionDuration: const Duration(milliseconds: 150),
                       ),
                     );
@@ -1412,7 +1406,7 @@ void main() {
       );
 
       // Open the new route.
-      await tester.tap(find.byType(ElevatedButton));
+      await tester.tap(find.byType(TestButton));
       await tester.pumpAndSettle();
       expect(find.text('Open page'), findsNothing);
       expect(find.byKey(containerKey), findsOneWidget);
@@ -1440,26 +1434,20 @@ void main() {
     ) async {
       final GlobalKey containerKey = GlobalKey();
       await tester.pumpWidget(
-        MaterialApp(
-          theme: ThemeData(
-            pageTransitionsTheme: const PageTransitionsTheme(
-              builders: <TargetPlatform, PageTransitionsBuilder>{
-                TargetPlatform.android:
-                    FadeUpwardsPageTransitionsBuilder(), // use a fade transition
-              },
-            ),
-          ),
+        TestWidgetsApp(
           onGenerateRoute: (RouteSettings settings) {
-            return MaterialPageRoute<dynamic>(
-              builder: (BuildContext context) {
-                return ElevatedButton(
+            return PageRouteBuilder<dynamic>(
+              settings: settings,
+              pageBuilder: (BuildContext context, Animation<double> _, Animation<double> _) {
+                return TestButton(
                   onPressed: () {
                     Navigator.of(context).push<void>(
-                      ModifiedReverseTransitionDurationRoute<void>(
-                        builder: (BuildContext innerContext) {
-                          return Container(key: containerKey, color: Colors.green);
-                        },
-                        // modified value, default MaterialPageRoute transition duration should be 300ms.
+                      PageRouteBuilder<void>(
+                        pageBuilder:
+                            (BuildContext innerContext, Animation<double> _, Animation<double> _) {
+                              return Container(key: containerKey, color: _green);
+                            },
+                        // modified value, default PageRouteBuilder transition duration should be 300ms.
                         reverseTransitionDuration: const Duration(milliseconds: 150),
                       ),
                     );
@@ -1473,7 +1461,7 @@ void main() {
       );
 
       // Open the new route.
-      await tester.tap(find.byType(ElevatedButton));
+      await tester.tap(find.byType(TestButton));
       await tester.pump();
       await tester.pump(
         const Duration(milliseconds: 200),
@@ -1509,11 +1497,12 @@ void main() {
       final GlobalKey containerKey = GlobalKey();
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           onGenerateRoute: (RouteSettings settings) {
-            return MaterialPageRoute<dynamic>(
-              builder: (BuildContext context) {
-                return ElevatedButton(
+            return PageRouteBuilder<dynamic>(
+              settings: settings,
+              pageBuilder: (BuildContext context, Animation<double> _, Animation<double> _) {
+                return TestButton(
                   onPressed: () {
                     Navigator.of(context).push<void>(
                       _SimulationRoute(
@@ -1532,7 +1521,7 @@ void main() {
                         reverseTransitionDuration: const Duration(days: 1),
                         pageBuilder:
                             (_, Animation<double> animation, Animation<double> secondaryAnimation) {
-                              return Container(key: containerKey, color: Colors.green);
+                              return Container(key: containerKey, color: _green);
                             },
                         transitionBuilder:
                             (BuildContext context, Animation<double> animation, Widget child) {
@@ -1550,7 +1539,7 @@ void main() {
       );
 
       // Open the new route.
-      await tester.tap(find.byType(ElevatedButton));
+      await tester.tap(find.byType(TestButton));
       await tester.pumpAndSettle();
       expect(find.text('Open page'), findsNothing);
       expect(find.byKey(containerKey), findsOneWidget);
@@ -1585,11 +1574,12 @@ void main() {
       final GlobalKey containerKey = GlobalKey();
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           onGenerateRoute: (RouteSettings settings) {
-            return MaterialPageRoute<dynamic>(
-              builder: (BuildContext context) {
-                return ElevatedButton(
+            return PageRouteBuilder<dynamic>(
+              settings: settings,
+              pageBuilder: (BuildContext context, Animation<double> _, Animation<double> _) {
+                return TestButton(
                   onPressed: () {
                     Navigator.of(context).push<void>(
                       _SimulationRoute(
@@ -1603,7 +1593,7 @@ void main() {
                         reverseTransitionDuration: const Duration(days: 1),
                         pageBuilder:
                             (_, Animation<double> animation, Animation<double> secondaryAnimation) {
-                              return Container(key: containerKey, color: Colors.green);
+                              return Container(key: containerKey, color: _green);
                             },
                         transitionBuilder:
                             (BuildContext context, Animation<double> animation, Widget child) {
@@ -1627,7 +1617,7 @@ void main() {
       );
 
       // Open the new route.
-      await tester.tap(find.byType(ElevatedButton));
+      await tester.tap(find.byType(TestButton));
       // Must pump two frames for the animation to take effect. The first pump
       // starts the animation, the 2nd pump makes the wiget appear.
       await tester.pump();
@@ -1671,24 +1661,22 @@ void main() {
   group('ModalRoute', () {
     testWidgets('default barrierCurve', (WidgetTester tester) async {
       await tester.pumpWidget(
-        MaterialApp(
-          home: Material(
-            child: Builder(
-              builder: (BuildContext context) {
-                return Center(
-                  child: ElevatedButton(
-                    child: const Text('X'),
-                    onPressed: () {
-                      Navigator.of(context).push<void>(
-                        _TestDialogRouteWithCustomBarrierCurve<void>(
-                          child: const Text('Hello World'),
-                        ),
-                      );
-                    },
-                  ),
-                );
-              },
-            ),
+        TestWidgetsApp(
+          home: Builder(
+            builder: (BuildContext context) {
+              return Center(
+                child: TestButton(
+                  child: const Text('X'),
+                  onPressed: () {
+                    Navigator.of(context).push<void>(
+                      _TestDialogRouteWithCustomBarrierCurve<void>(
+                        child: const Text('Hello World'),
+                      ),
+                    );
+                  },
+                ),
+              );
+            },
           ),
         ),
       );
@@ -1705,7 +1693,7 @@ void main() {
 
       Animation<Color?> modalBarrierAnimation;
       modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
-      expect(modalBarrierAnimation.value, Colors.transparent);
+      expect(modalBarrierAnimation.value, _transparent);
 
       await tester.pump(const Duration(milliseconds: 25));
       modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
@@ -1730,30 +1718,28 @@ void main() {
 
       await tester.pumpAndSettle();
       modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
-      expect(modalBarrierAnimation.value, Colors.black);
+      expect(modalBarrierAnimation.value, _black);
     });
 
     testWidgets('custom barrierCurve', (WidgetTester tester) async {
       await tester.pumpWidget(
-        MaterialApp(
-          home: Material(
-            child: Builder(
-              builder: (BuildContext context) {
-                return Center(
-                  child: ElevatedButton(
-                    child: const Text('X'),
-                    onPressed: () {
-                      Navigator.of(context).push<void>(
-                        _TestDialogRouteWithCustomBarrierCurve<void>(
-                          child: const Text('Hello World'),
-                          barrierCurve: Curves.linear,
-                        ),
-                      );
-                    },
-                  ),
-                );
-              },
-            ),
+        TestWidgetsApp(
+          home: Builder(
+            builder: (BuildContext context) {
+              return Center(
+                child: TestButton(
+                  child: const Text('X'),
+                  onPressed: () {
+                    Navigator.of(context).push<void>(
+                      _TestDialogRouteWithCustomBarrierCurve<void>(
+                        child: const Text('Hello World'),
+                        barrierCurve: Curves.linear,
+                      ),
+                    );
+                  },
+                ),
+              );
+            },
           ),
         ),
       );
@@ -1770,7 +1756,7 @@ void main() {
 
       Animation<Color?> modalBarrierAnimation;
       modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
-      expect(modalBarrierAnimation.value, Colors.transparent);
+      expect(modalBarrierAnimation.value, _transparent);
 
       await tester.pump(const Duration(milliseconds: 25));
       modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
@@ -1795,30 +1781,28 @@ void main() {
 
       await tester.pumpAndSettle();
       modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
-      expect(modalBarrierAnimation.value, Colors.black);
+      expect(modalBarrierAnimation.value, _black);
     });
 
     testWidgets('white barrierColor', (WidgetTester tester) async {
       await tester.pumpWidget(
-        MaterialApp(
-          home: Material(
-            child: Builder(
-              builder: (BuildContext context) {
-                return Center(
-                  child: ElevatedButton(
-                    child: const Text('X'),
-                    onPressed: () {
-                      Navigator.of(context).push<void>(
-                        _TestDialogRouteWithCustomBarrierCurve<void>(
-                          child: const Text('Hello World'),
-                          barrierColor: Colors.white,
-                        ),
-                      );
-                    },
-                  ),
-                );
-              },
-            ),
+        TestWidgetsApp(
+          home: Builder(
+            builder: (BuildContext context) {
+              return Center(
+                child: TestButton(
+                  child: const Text('X'),
+                  onPressed: () {
+                    Navigator.of(context).push<void>(
+                      _TestDialogRouteWithCustomBarrierCurve<void>(
+                        child: const Text('Hello World'),
+                        barrierColor: _white,
+                      ),
+                    );
+                  },
+                ),
+              );
+            },
           ),
         ),
       );
@@ -1835,7 +1819,7 @@ void main() {
 
       Animation<Color?> modalBarrierAnimation;
       modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
-      expect(modalBarrierAnimation.value, Colors.white.withOpacity(0));
+      expect(modalBarrierAnimation.value, _white.withOpacity(0));
 
       await tester.pump(const Duration(milliseconds: 25));
       modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
@@ -1860,7 +1844,7 @@ void main() {
 
       await tester.pumpAndSettle();
       modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
-      expect(modalBarrierAnimation.value, Colors.white);
+      expect(modalBarrierAnimation.value, _white);
     });
 
     testWidgets(
@@ -1869,26 +1853,24 @@ void main() {
         // Regression test for https://github.com/flutter/flutter/issues/46625.
         final semantics = SemanticsTester(tester);
         await tester.pumpWidget(
-          MaterialApp(
-            home: Material(
-              child: Builder(
-                builder: (BuildContext context) {
-                  return Center(
-                    child: ElevatedButton(
-                      child: const Text('X'),
-                      onPressed: () {
-                        Navigator.of(context).push<void>(
-                          _TestDialogRouteWithCustomBarrierCurve<void>(
-                            child: const Text('Hello World'),
-                            barrierLabel: 'test label',
-                            barrierCurve: Curves.linear,
-                          ),
-                        );
-                      },
-                    ),
-                  );
-                },
-              ),
+          TestWidgetsApp(
+            home: Builder(
+              builder: (BuildContext context) {
+                return Center(
+                  child: TestButton(
+                    child: const Text('X'),
+                    onPressed: () {
+                      Navigator.of(context).push<void>(
+                        _TestDialogRouteWithCustomBarrierCurve<void>(
+                          child: const Text('Hello World'),
+                          barrierLabel: 'test label',
+                          barrierCurve: Curves.linear,
+                        ),
+                      );
+                    },
+                  ),
+                );
+              },
             ),
           ),
         );
@@ -1946,14 +1928,16 @@ void main() {
     ) async {
       // Regression test: https://github.com/flutter/flutter/issues/48903
       final navigatorKey = GlobalKey<NavigatorState>();
-      await tester.pumpWidget(MaterialApp(navigatorKey: navigatorKey, home: const Text('dummy1')));
+      await tester.pumpWidget(
+        TestWidgetsApp(navigatorKey: navigatorKey, home: const Text('dummy1')),
+      );
       final Element textOnPageOne = tester.element(find.text('dummy1'));
       final FocusScopeNode focusNodeOnPageOne = FocusScope.of(textOnPageOne);
       expect(focusNodeOnPageOne.hasFocus, isTrue);
 
       // Pushes one page.
       navigatorKey.currentState!.push<void>(
-        MaterialPageRoute<void>(builder: (BuildContext context) => const Text('dummy2')),
+        PageRouteBuilder<void>(pageBuilder: (BuildContext context, _, _) => const Text('dummy2')),
       );
       await tester.pumpAndSettle();
 
@@ -1965,7 +1949,7 @@ void main() {
 
       // Pushes another page.
       navigatorKey.currentState!.push<void>(
-        MaterialPageRoute<void>(builder: (BuildContext context) => const Text('dummy3')),
+        PageRouteBuilder<void>(pageBuilder: (BuildContext context, _, _) => const Text('dummy3')),
       );
       await tester.pumpAndSettle();
       final Element textOnPageThree = tester.element(find.text('dummy3'));
@@ -1988,7 +1972,7 @@ void main() {
         // Regression test: https://github.com/flutter/flutter/issues/48903
         final navigatorKey = GlobalKey<NavigatorState>();
         await tester.pumpWidget(
-          MaterialApp(navigatorKey: navigatorKey, home: const Text('dummy1')),
+          TestWidgetsApp(navigatorKey: navigatorKey, home: const Text('dummy1')),
         );
         final Element textOnPageOne = tester.element(find.text('dummy1'));
         final FocusScopeNode focusNodeOnPageOne = FocusScope.of(textOnPageOne);
@@ -1996,8 +1980,9 @@ void main() {
 
         // Pushes one page.
         navigatorKey.currentState!.push<void>(
-          MaterialPageRoute<void>(
-            builder: (BuildContext context) => const Material(child: TestTextField()),
+          PageRouteBuilder<void>(
+            pageBuilder: (BuildContext context, Animation<double> _, Animation<double> _) =>
+                const TestTextField(),
           ),
         );
         await tester.pumpAndSettle();
@@ -2016,7 +2001,7 @@ void main() {
 
         // Pushes another page.
         navigatorKey.currentState!.push<void>(
-          MaterialPageRoute<void>(builder: (BuildContext context) => const Text('dummy3')),
+          PageRouteBuilder<void>(pageBuilder: (BuildContext context, _, _) => const Text('dummy3')),
         );
         await tester.pumpAndSettle();
         final Element textOnPageThree = tester.element(find.text('dummy3'));
@@ -2036,7 +2021,7 @@ void main() {
 
     testWidgets('child with local history can be disposed', (WidgetTester tester) async {
       // Regression test: https://github.com/flutter/flutter/issues/52478
-      await tester.pumpWidget(const MaterialApp(home: WidgetWithLocalHistory()));
+      await tester.pumpWidget(const TestWidgetsApp(home: WidgetWithLocalHistory()));
 
       final WidgetWithLocalHistoryState state = tester.state(find.byType(WidgetWithLocalHistory));
       state.addLocalHistory();
@@ -2045,14 +2030,14 @@ void main() {
       // Pumps a new widget to dispose WidgetWithLocalHistory. This should cause
       // it to remove the local history entry from modal route during
       // finalizeTree.
-      await tester.pumpWidget(const MaterialApp(home: Text('dummy')));
+      await tester.pumpWidget(const TestWidgetsApp(home: Text('dummy')));
       // Waits for modal route to update its internal state;
       await tester.pump();
       expect(tester.takeException(), null);
     });
 
     testWidgets('child with no local history can be disposed', (WidgetTester tester) async {
-      await tester.pumpWidget(const MaterialApp(home: WidgetWithNoLocalHistory()));
+      await tester.pumpWidget(const TestWidgetsApp(home: WidgetWithNoLocalHistory()));
 
       final WidgetWithNoLocalHistoryState state = tester.state(
         find.byType(WidgetWithNoLocalHistory),
@@ -2063,20 +2048,20 @@ void main() {
       // Pumps a new widget to dispose WidgetWithNoLocalHistory. This should cause
       // it to remove the local history entry from modal route during
       // finalizeTree.
-      await tester.pumpWidget(const MaterialApp(home: Text('dummy')));
+      await tester.pumpWidget(const TestWidgetsApp(home: Text('dummy')));
       await tester.pump();
       expect(tester.takeException(), null);
     });
 
     testWidgets('requestFocus can be updated', (WidgetTester tester) async {
       final navigatorKey = GlobalKey<NavigatorState>();
-      await tester.pumpWidget(MaterialApp(navigatorKey: navigatorKey, home: const Text('home')));
+      await tester.pumpWidget(TestWidgetsApp(navigatorKey: navigatorKey, home: const Text('home')));
       expect(find.text('page2'), findsNothing);
 
       // Navigate to page 2.
       navigatorKey.currentState!.push<void>(
-        MaterialPageRoute<void>(
-          builder: (BuildContext context) {
+        PageRouteBuilder<void>(
+          pageBuilder: (BuildContext context, _, _) {
             return const Text('page2');
           },
         ),
@@ -2097,9 +2082,9 @@ void main() {
 
       // Navigate to page 2 again with requestFocus set to false.
       navigatorKey.currentState!.push<void>(
-        MaterialPageRoute<void>(
+        PageRouteBuilder<void>(
           requestFocus: false,
-          builder: (BuildContext context) {
+          pageBuilder: (BuildContext context, _, _) {
             return const Text('page2');
           },
         ),
@@ -2119,63 +2104,51 @@ void main() {
     ) async {
       final navigatorKey = GlobalKey<NavigatorState>();
 
-      final materialPageRoute = MaterialPageRoute<void>(
-        builder: (BuildContext context) {
-          return Scaffold(
-            body: TextButton(
-              onPressed: () {
-                final route = CupertinoPageRoute<void>(
-                  builder: (BuildContext context) {
-                    return const Text('Cupertino Transition');
-                  },
-                );
-                Navigator.of(context).push(route);
-              },
-              child: const Text('Cupertino Transition'),
-            ),
+      final pageRoute = PageRouteBuilder<void>(
+        pageBuilder: (BuildContext context, Animation<double> _, Animation<double> _) {
+          return TestButton(
+            onPressed: () {
+              final route = CupertinoPageRoute<void>(
+                builder: (BuildContext context) {
+                  return const Text('Cupertino Transition');
+                },
+              );
+              Navigator.of(context).push(route);
+            },
+            child: const Text('Cupertino Transition'),
           );
         },
       );
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           navigatorKey: navigatorKey,
-          theme: ThemeData(
-            pageTransitionsTheme: const PageTransitionsTheme(
-              builders: <TargetPlatform, PageTransitionsBuilder>{
-                TargetPlatform.iOS: ZoomPageTransitionsBuilder(),
-                TargetPlatform.android: ZoomPageTransitionsBuilder(),
-              },
-            ),
-          ),
-          home: Scaffold(
-            body: TextButton(
-              onPressed: () {
-                navigatorKey.currentState!.push<void>(materialPageRoute);
-              },
-              child: const Text('Material Route Transition'),
-            ),
+          home: TestButton(
+            onPressed: () {
+              navigatorKey.currentState!.push<void>(pageRoute);
+            },
+            child: const Text('Page Route Transition'),
           ),
         ),
       );
 
-      expect(materialPageRoute.receivedTransition, null);
+      expect(pageRoute.receivedTransition, null);
 
-      await tester.tap(find.text('Material Route Transition'));
+      await tester.tap(find.text('Page Route Transition'));
 
       await tester.pumpAndSettle();
 
       expect(find.text('Cupertino Transition'), findsOneWidget);
-      expect(find.text('Material Route Transition'), findsNothing);
+      expect(find.text('Page Route Transition'), findsNothing);
 
-      expect(materialPageRoute.receivedTransition, null);
+      expect(pageRoute.receivedTransition, null);
 
       await tester.tap(find.text('Cupertino Transition'));
 
       await tester.pumpAndSettle();
 
-      expect(materialPageRoute.receivedTransition, isNotNull);
-      expect(materialPageRoute.receivedTransition, CupertinoPageTransition.delegatedTransition);
+      expect(pageRoute.receivedTransition, isNotNull);
+      expect(pageRoute.receivedTransition, CupertinoPageTransition.delegatedTransition);
     });
 
     testWidgets(
@@ -2183,59 +2156,47 @@ void main() {
       (WidgetTester tester) async {
         final navigatorKey = GlobalKey<NavigatorState>();
 
-        final materialPageRoute = MaterialPageRoute<void>(
-          builder: (BuildContext context) {
-            return Scaffold(
-              body: TextButton(
-                onPressed: () {
-                  final route = MaterialPageRoute<void>(
-                    builder: (BuildContext context) {
-                      return const Text('Page 3');
-                    },
-                  );
-                  Navigator.of(context).push(route);
-                },
-                child: const Text('Second Material Transition'),
-              ),
+        final firstPageRoute = PageRouteBuilder<void>(
+          pageBuilder: (BuildContext context, Animation<double> _, Animation<double> _) {
+            return TestButton(
+              onPressed: () {
+                final route = PageRouteBuilder<void>(
+                  pageBuilder: (BuildContext context, Animation<double> _, Animation<double> _) {
+                    return const Text('Page 3');
+                  },
+                );
+                Navigator.of(context).push(route);
+              },
+              child: const Text('Second Page Transition'),
             );
           },
         );
 
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             navigatorKey: navigatorKey,
-            theme: ThemeData(
-              pageTransitionsTheme: const PageTransitionsTheme(
-                builders: <TargetPlatform, PageTransitionsBuilder>{
-                  TargetPlatform.iOS: ZoomPageTransitionsBuilder(),
-                  TargetPlatform.android: ZoomPageTransitionsBuilder(),
-                },
-              ),
-            ),
-            home: Scaffold(
-              body: TextButton(
-                onPressed: () {
-                  navigatorKey.currentState!.push<void>(materialPageRoute);
-                },
-                child: const Text('Material Route Transition'),
-              ),
+            home: TestButton(
+              onPressed: () {
+                navigatorKey.currentState!.push<void>(firstPageRoute);
+              },
+              child: const Text('Page Route Transition'),
             ),
           ),
         );
 
-        expect(materialPageRoute.receivedTransition, null);
+        expect(firstPageRoute.receivedTransition, null);
 
-        await tester.tap(find.text('Material Route Transition'));
-
-        await tester.pumpAndSettle();
-
-        expect(materialPageRoute.receivedTransition, null);
-
-        await tester.tap(find.text('Second Material Transition'));
+        await tester.tap(find.text('Page Route Transition'));
 
         await tester.pumpAndSettle();
 
-        expect(materialPageRoute.receivedTransition, null);
+        expect(firstPageRoute.receivedTransition, null);
+
+        await tester.tap(find.text('Second Page Transition'));
+
+        await tester.pumpAndSettle();
+
+        expect(firstPageRoute.receivedTransition, null);
       },
     );
 
@@ -2244,66 +2205,54 @@ void main() {
       (WidgetTester tester) async {
         final navigatorKey = GlobalKey<NavigatorState>();
 
-        final materialPageRoute = MaterialPageRoute<void>(
+        final firstPageRoute = PageRouteBuilder<void>(
           allowSnapshotting: false,
-          builder: (BuildContext context) {
-            return Scaffold(
-              body: TextButton(
-                onPressed: () {
-                  final route = MaterialPageRoute<void>(
-                    allowSnapshotting: false,
-                    builder: (BuildContext context) {
-                      return const Text('Page 3');
-                    },
-                  );
-                  Navigator.of(context).push(route);
-                },
-                child: const Text('Second Material Transition'),
-              ),
+          pageBuilder: (BuildContext context, Animation<double> _, Animation<double> _) {
+            return TestButton(
+              onPressed: () {
+                final route = PageRouteBuilder<void>(
+                  allowSnapshotting: false,
+                  pageBuilder: (BuildContext context, Animation<double> _, Animation<double> _) {
+                    return const Text('Page 3');
+                  },
+                );
+                Navigator.of(context).push(route);
+              },
+              child: const Text('Second Page Transition'),
             );
           },
         );
 
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             navigatorKey: navigatorKey,
-            theme: ThemeData(
-              pageTransitionsTheme: const PageTransitionsTheme(
-                builders: <TargetPlatform, PageTransitionsBuilder>{
-                  TargetPlatform.iOS: ZoomPageTransitionsBuilder(),
-                  TargetPlatform.android: ZoomPageTransitionsBuilder(),
-                },
-              ),
-            ),
-            home: Scaffold(
-              body: TextButton(
-                onPressed: () {
-                  navigatorKey.currentState!.push<void>(materialPageRoute);
-                },
-                child: const Text('Material Route Transition'),
-              ),
+            home: TestButton(
+              onPressed: () {
+                navigatorKey.currentState!.push<void>(firstPageRoute);
+              },
+              child: const Text('Page Route Transition'),
             ),
           ),
         );
 
-        expect(materialPageRoute.receivedTransition, null);
+        expect(firstPageRoute.receivedTransition, null);
 
-        await tester.tap(find.text('Material Route Transition'));
-
-        await tester.pumpAndSettle();
-
-        expect(materialPageRoute.receivedTransition, null);
-
-        await tester.tap(find.text('Second Material Transition'));
+        await tester.tap(find.text('Page Route Transition'));
 
         await tester.pumpAndSettle();
 
-        expect(materialPageRoute.receivedTransition, null);
+        expect(firstPageRoute.receivedTransition, null);
+
+        await tester.tap(find.text('Second Page Transition'));
+
+        await tester.pumpAndSettle();
+
+        expect(firstPageRoute.receivedTransition, null);
 
         navigatorKey.currentState!.pop();
         await tester.pumpAndSettle();
 
-        expect(materialPageRoute.receivedTransition, null);
+        expect(firstPageRoute.receivedTransition, null);
       },
     );
 
@@ -2320,13 +2269,13 @@ void main() {
           return Column(
             children: <Widget>[
               const Placeholder(key: secondPlaceholderKey),
-              TextButton(
+              TestButton(
                 onPressed: () {
                   final route = CupertinoPageRoute<void>(
                     builder: (BuildContext context) {
                       return Column(
                         children: <Widget>[
-                          TextButton(onPressed: () {}, child: const Text('Page 3')),
+                          TestButton(onPressed: () {}, child: const Text('Page 3')),
                         ],
                       );
                     },
@@ -2341,20 +2290,12 @@ void main() {
       );
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           navigatorKey: navigatorKey,
-          theme: ThemeData(
-            pageTransitionsTheme: const PageTransitionsTheme(
-              builders: <TargetPlatform, PageTransitionsBuilder>{
-                TargetPlatform.iOS: ZoomPageTransitionsBuilder(),
-                TargetPlatform.android: ZoomPageTransitionsBuilder(),
-              },
-            ),
-          ),
           home: Column(
             children: <Widget>[
               const Placeholder(key: firstPlaceholderKey),
-              TextButton(
+              TestButton(
                 onPressed: () {
                   navigatorKey.currentState!.push<void>(cupertinoPageRoute);
                 },
@@ -2504,7 +2445,7 @@ void main() {
       }
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           navigatorKey: navigator,
           home: Builder(builder: buildCounter),
         ),
@@ -2515,7 +2456,9 @@ void main() {
 
       // Push a new route - first route should remain first
       navigator.currentState!.push<void>(
-        MaterialPageRoute<void>(builder: (BuildContext context) => const Text('New Route')),
+        PageRouteBuilder<void>(
+          pageBuilder: (BuildContext context, _, _) => const Text('New Route'),
+        ),
       );
       await tester.pumpAndSettle();
 
@@ -2536,7 +2479,7 @@ void main() {
       }
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           navigatorKey: navigator,
           home: Builder(builder: buildCounter),
         ),
@@ -2547,7 +2490,9 @@ void main() {
 
       // Push a new route - first route should remain active
       navigator.currentState!.push<void>(
-        MaterialPageRoute<void>(builder: (BuildContext context) => const Text('New Route')),
+        PageRouteBuilder<void>(
+          pageBuilder: (BuildContext context, _, _) => const Text('New Route'),
+        ),
       );
       await tester.pumpAndSettle();
 
@@ -2568,7 +2513,7 @@ void main() {
       }
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           navigatorKey: navigator,
           home: Builder(builder: buildCounter),
         ),
@@ -2579,7 +2524,9 @@ void main() {
 
       // Push a new route - first route should remain opaque
       navigator.currentState!.push<void>(
-        MaterialPageRoute<void>(builder: (BuildContext context) => const Text('New Route')),
+        PageRouteBuilder<void>(
+          pageBuilder: (BuildContext context, _, _) => const Text('New Route'),
+        ),
       );
       await tester.pumpAndSettle();
 
@@ -2600,7 +2547,7 @@ void main() {
       }
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           navigatorKey: navigator,
           home: Builder(builder: buildCounter),
         ),
@@ -2611,7 +2558,7 @@ void main() {
 
       // Change PopScope's canPop to false
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           navigatorKey: navigator,
           home: PopScope(canPop: false, child: Builder(builder: buildCounter)),
         ),
@@ -2624,7 +2571,9 @@ void main() {
 
       // Push a new route - should change from bubble to pop
       navigator.currentState!.push<void>(
-        MaterialPageRoute<void>(builder: (BuildContext context) => const Text('New Route')),
+        PageRouteBuilder<void>(
+          pageBuilder: (BuildContext context, _, _) => const Text('New Route'),
+        ),
       );
       await tester.pumpAndSettle();
 
@@ -2635,13 +2584,16 @@ void main() {
 
   testWidgets('can be dismissed with escape keyboard shortcut', (WidgetTester tester) async {
     final navigatorKey = GlobalKey<NavigatorState>();
-    await tester.pumpWidget(MaterialApp(navigatorKey: navigatorKey, home: const Text('dummy1')));
+    await tester.pumpWidget(TestWidgetsApp(navigatorKey: navigatorKey, home: const Text('dummy1')));
     final Element textOnPageOne = tester.element(find.text('dummy1'));
 
     // Show a simple dialog
-    showDialog<void>(
+    showGeneralDialog<void>(
       context: textOnPageOne,
-      builder: (BuildContext context) => const Text('dialog1'),
+      barrierDismissible: true,
+      barrierLabel: 'Dismiss',
+      pageBuilder: (BuildContext context, Animation<double> _, Animation<double> _) =>
+          const Text('dialog1'),
     );
     await tester.pumpAndSettle();
     expect(find.text('dialog1'), findsOneWidget);
@@ -2656,14 +2608,15 @@ void main() {
     WidgetTester tester,
   ) async {
     final navigatorKey = GlobalKey<NavigatorState>();
-    await tester.pumpWidget(MaterialApp(navigatorKey: navigatorKey, home: const Text('dummy1')));
+    await tester.pumpWidget(TestWidgetsApp(navigatorKey: navigatorKey, home: const Text('dummy1')));
     final Element textOnPageOne = tester.element(find.text('dummy1'));
 
     // Show a simple dialog
-    showDialog<void>(
+    showGeneralDialog<void>(
       context: textOnPageOne,
-      barrierDismissible: false,
-      builder: (BuildContext context) => const Text('dialog1'),
+      barrierLabel: 'Dismiss',
+      pageBuilder: (BuildContext context, Animation<double> _, Animation<double> _) =>
+          const Text('dialog1'),
     );
     await tester.pumpAndSettle();
     expect(find.text('dialog1'), findsOneWidget);
@@ -2676,12 +2629,12 @@ void main() {
 
   testWidgets('ModalRoute.of works for void routes', (WidgetTester tester) async {
     final navigatorKey = GlobalKey<NavigatorState>();
-    await tester.pumpWidget(MaterialApp(navigatorKey: navigatorKey, home: const Text('home')));
+    await tester.pumpWidget(TestWidgetsApp(navigatorKey: navigatorKey, home: const Text('home')));
     expect(find.text('page2'), findsNothing);
 
     navigatorKey.currentState!.push<void>(
-      MaterialPageRoute<void>(
-        builder: (BuildContext context) {
+      PageRouteBuilder<void>(
+        pageBuilder: (BuildContext context, Animation<double> _, Animation<double> _) {
           return const Text('page2');
         },
       ),
@@ -2692,34 +2645,34 @@ void main() {
 
     final ModalRoute<void>? parentRoute = ModalRoute.of<void>(tester.element(find.text('page2')));
     expect(parentRoute, isNotNull);
-    expect(parentRoute, isA<MaterialPageRoute<void>>());
+    expect(parentRoute, isA<PageRouteBuilder<void>>());
   });
 
   testWidgets('RawDialogRoute is state restorable', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(restorationScopeId: 'app', home: _RestorableDialogTestWidget()),
+      const TestWidgetsApp(restorationScopeId: 'app', home: _RestorableDialogTestWidget()),
     );
 
-    expect(find.byType(AlertDialog), findsNothing);
+    expect(find.byType(_TestDialog), findsNothing);
 
     await tester.tap(find.text('X'));
     await tester.pumpAndSettle();
 
-    expect(find.byType(AlertDialog), findsOneWidget);
+    expect(find.byType(_TestDialog), findsOneWidget);
     final TestRestorationData restorationData = await tester.getRestorationData();
 
     await tester.restartAndRestore();
 
-    expect(find.byType(AlertDialog), findsOneWidget);
+    expect(find.byType(_TestDialog), findsOneWidget);
 
     // Tap on the barrier.
     await tester.tapAt(const Offset(10.0, 10.0));
     await tester.pumpAndSettle();
 
-    expect(find.byType(AlertDialog), findsNothing);
+    expect(find.byType(_TestDialog), findsNothing);
 
     await tester.restoreFrom(restorationData);
-    expect(find.byType(AlertDialog), findsOneWidget);
+    expect(find.byType(_TestDialog), findsOneWidget);
   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/33615
 
   group('NavigationNotifications', () {
@@ -2736,8 +2689,8 @@ void main() {
             child: Navigator(
               initialRoute: '/',
               onGenerateRoute: (RouteSettings settings) {
-                return MaterialPageRoute<void>(
-                  builder: (BuildContext context) {
+                return PageRouteBuilder<void>(
+                  pageBuilder: (BuildContext context, _, _) {
                     return const SizedBox.shrink();
                   },
                   settings: settings,
@@ -2767,8 +2720,8 @@ void main() {
             child: Navigator(
               initialRoute: '/',
               onGenerateRoute: (RouteSettings settings) {
-                return MaterialPageRoute<void>(
-                  builder: (BuildContext context) {
+                return PageRouteBuilder<void>(
+                  pageBuilder: (BuildContext context, _, _) {
                     return WillPopScope(
                       onWillPop: () {
                         return Future<bool>.value(false);
@@ -2805,8 +2758,8 @@ void main() {
             key: UniqueKey(),
             routeDirectionalTraversalEdgeBehavior: behavior,
             onGenerateRoute: (RouteSettings settings) {
-              return MaterialPageRoute<void>(
-                builder: (BuildContext context) {
+              return PageRouteBuilder<void>(
+                pageBuilder: (BuildContext context, _, _) {
                   return const Center(child: Text('page'));
                 },
                 settings: settings,
@@ -2830,9 +2783,9 @@ void main() {
     final focusNode = FocusNode();
     addTearDown(focusNode.dispose);
     await tester.pumpWidget(
-      MaterialApp(
+      TestWidgetsApp(
         navigatorKey: navigatorKey,
-        home: Scaffold(body: TestTextField(focusNode: focusNode)),
+        home: TestTextField(focusNode: focusNode),
       ),
     );
     focusNode.requestFocus();
@@ -2879,18 +2832,6 @@ double _getOpacity(GlobalKey key, WidgetTester tester) {
     final transition = widget as FadeTransition;
     return a * transition.opacity.value;
   });
-}
-
-class ModifiedReverseTransitionDurationRoute<T> extends MaterialPageRoute<T> {
-  ModifiedReverseTransitionDurationRoute({
-    required super.builder,
-    super.settings,
-    required this.reverseTransitionDuration,
-    super.fullscreenDialog,
-  });
-
-  @override
-  final Duration reverseTransitionDuration;
 }
 
 class MockPageRoute extends Fake implements PageRoute<dynamic> {}
@@ -2960,7 +2901,7 @@ class _TestDialogRouteWithCustomBarrierCurve<T> extends PopupRoute<T> {
   _TestDialogRouteWithCustomBarrierCurve({
     required Widget child,
     this.barrierLabel,
-    this.barrierColor = Colors.black,
+    this.barrierColor = _black,
     Curve? barrierCurve,
   }) : _barrierCurve = barrierCurve,
        _child = child;
@@ -3049,6 +2990,17 @@ class WidgetWithNoLocalHistoryState extends State<WidgetWithNoLocalHistory> {
   }
 }
 
+class _TestDialog extends StatelessWidget {
+  const _TestDialog({required this.title});
+
+  final Widget title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(child: title);
+  }
+}
+
 @pragma('vm:entry-point')
 class _RestorableDialogTestWidget extends StatelessWidget {
   const _RestorableDialogTestWidget();
@@ -3062,21 +3014,19 @@ class _RestorableDialogTestWidget extends StatelessWidget {
             Animation<double> animation,
             Animation<double> secondaryAnimation,
           ) {
-            return const AlertDialog(title: Text('Alert!'));
+            return const _TestDialog(title: Text('Alert!'));
           },
     );
   }
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: Center(
-        child: OutlinedButton(
-          onPressed: () {
-            Navigator.of(context).restorablePush(_dialogBuilder);
-          },
-          child: const Text('X'),
-        ),
+    return Center(
+      child: TestButton(
+        onPressed: () {
+          Navigator.of(context).restorablePush(_dialogBuilder);
+        },
+        child: const Text('X'),
       ),
     );
   }

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -2,18 +2,22 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:math' as math;
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'button_tester.dart';
 import 'clipboard_utils.dart';
 import 'editable_text_tester.dart';
 import 'keyboard_utils.dart';
 import 'process_text_utils.dart';
 import 'semantics_tester.dart';
+import 'test_page_tester.dart';
 import 'widgets_app_tester.dart';
 
 Offset textOffsetToPosition(RenderParagraph paragraph, int offset) {
@@ -27,6 +31,134 @@ Offset textOffsetToPosition(RenderParagraph paragraph, int offset) {
 Offset globalize(Offset point, RenderBox box) {
   return box.localToGlobal(point);
 }
+
+/// Text style matching MaterialApp's default [DefaultTextStyle].
+///
+/// This is needed for tests that depend on character widths for drag-based
+/// selection, because the drag distance must exceed the gesture recognizer's
+/// slop threshold.
+const TextStyle _materialDefaultTextStyle = TextStyle(
+  fontSize: 48.0,
+  fontFamily: 'monospace',
+  fontWeight: FontWeight.w900,
+);
+
+const double _kTestHandleSize = 22.0;
+
+/// Selection controls with non-zero handle size for tests that need handle
+/// dragging. Does NOT mix in [TextSelectionHandleControls], so the toolbar
+/// goes through the deprecated [buildToolbar] path (matching how
+/// [materialTextSelectionControls] worked).
+class _TestDraggableSelectionControls extends TextSelectionControls {
+  @override
+  Widget buildHandle(
+    BuildContext context,
+    TextSelectionHandleType type,
+    double textLineHeight, [
+    VoidCallback? onTap,
+  ]) {
+    final Widget handle = SizedBox.square(
+      dimension: _kTestHandleSize,
+      child: CustomPaint(
+        painter: _TestHandlePainter(),
+        child: GestureDetector(onTap: onTap, behavior: HitTestBehavior.translucent),
+      ),
+    );
+    return switch (type) {
+      TextSelectionHandleType.left => Transform.rotate(angle: math.pi / 2.0, child: handle),
+      TextSelectionHandleType.right => handle,
+      TextSelectionHandleType.collapsed => Transform.rotate(angle: math.pi / 4.0, child: handle),
+    };
+  }
+
+  @override
+  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
+    return switch (type) {
+      TextSelectionHandleType.collapsed => const Offset(_kTestHandleSize / 2, -4),
+      TextSelectionHandleType.left => const Offset(_kTestHandleSize, 0),
+      TextSelectionHandleType.right => Offset.zero,
+    };
+  }
+
+  @override
+  Size getHandleSize(double textLineHeight) {
+    return const Size(_kTestHandleSize, _kTestHandleSize);
+  }
+
+  @Deprecated(
+    'Use contextMenuBuilder instead. '
+    'This feature was deprecated after v3.43.0-0.3.pre.',
+  )
+  @override
+  bool canSelectAll(TextSelectionDelegate delegate) {
+    final TextEditingValue value = delegate.textEditingValue;
+    return delegate.selectAllEnabled &&
+        value.text.isNotEmpty &&
+        !(value.selection.start == 0 && value.selection.end == value.text.length);
+  }
+
+  @Deprecated(
+    'Use contextMenuBuilder instead. '
+    'This feature was deprecated after v3.43.0-0.3.pre.',
+  )
+  @override
+  Widget buildToolbar(
+    BuildContext context,
+    Rect globalEditableRegion,
+    double textLineHeight,
+    Offset selectionMidpoint,
+    List<TextSelectionPoint> endpoints,
+    TextSelectionDelegate delegate,
+    ValueListenable<ClipboardStatus>? clipboardStatus,
+    Offset? lastSecondaryTapDownPosition,
+  ) => const SizedBox.shrink();
+}
+
+class _TestHandlePainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    canvas.drawRect(Offset.zero & size, Paint()..color = const Color(0xFF000000));
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+}
+
+final TextSelectionControls _testDraggableSelectionControls = _TestDraggableSelectionControls();
+
+/// Like [_TestDraggableSelectionControls] but builds a toolbar with
+/// "Copy" and "Select all" buttons so tests can interact with them.
+class _TestDraggableSelectionControlsWithToolbar extends _TestDraggableSelectionControls {
+  @Deprecated(
+    'Use contextMenuBuilder instead. '
+    'This feature was deprecated after v3.43.0-0.3.pre.',
+  )
+  @override
+  Widget buildToolbar(
+    BuildContext context,
+    Rect globalEditableRegion,
+    double textLineHeight,
+    Offset selectionMidpoint,
+    List<TextSelectionPoint> endpoints,
+    TextSelectionDelegate delegate,
+    ValueListenable<ClipboardStatus>? clipboardStatus,
+    Offset? lastSecondaryTapDownPosition,
+  ) {
+    final items = <Widget>[];
+    if (canCopy(delegate)) {
+      items.add(GestureDetector(onTap: () => handleCopy(delegate), child: const Text('Copy')));
+    }
+    if (canSelectAll(delegate)) {
+      items.add(
+        GestureDetector(onTap: () => handleSelectAll(delegate), child: const Text('Select all')),
+      );
+    }
+    return Column(mainAxisSize: MainAxisSize.min, children: items);
+  }
+}
+
+final TextSelectionControls _testDraggableSelectionControlsWithToolbar =
+    _TestDraggableSelectionControlsWithToolbar();
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -60,9 +192,13 @@ void main() {
     testWidgets('mouse selection single click sends correct events', (WidgetTester tester) async {
       final spy = UniqueKey();
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
+            contextMenuBuilder:
+                (BuildContext context, SelectableRegionState selectableRegionState) {
+                  return const SizedBox.shrink();
+                },
+            selectionControls: testTextSelectionHandleControls,
             child: SelectionSpy(key: spy),
           ),
         ),
@@ -103,9 +239,13 @@ void main() {
       final spy = UniqueKey();
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
+            contextMenuBuilder:
+                (BuildContext context, SelectableRegionState selectableRegionState) {
+                  return const SizedBox.shrink();
+                },
+            selectionControls: testTextSelectionHandleControls,
             child: SelectionSpy(key: spy),
           ),
         ),
@@ -136,9 +276,13 @@ void main() {
       final spy = UniqueKey();
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
+            contextMenuBuilder:
+                (BuildContext context, SelectableRegionState selectableRegionState) {
+                  return const SizedBox.shrink();
+                },
+            selectionControls: testTextSelectionHandleControls,
             child: SelectionSpy(key: spy),
           ),
         ),
@@ -165,22 +309,26 @@ void main() {
     testWidgets('Does not crash when using Navigator pages', (WidgetTester tester) async {
       // Regression test for https://github.com/flutter/flutter/issues/119776
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: Navigator(
             pages: <Page<void>>[
-              MaterialPage<void>(
+              TestPage<void>(
                 child: Column(
                   children: <Widget>[
                     const Text('How are you?'),
                     SelectableRegion(
-                      selectionControls: materialTextSelectionControls,
+                      contextMenuBuilder:
+                          (BuildContext context, SelectableRegionState selectableRegionState) {
+                            return const SizedBox.shrink();
+                          },
+                      selectionControls: testTextSelectionHandleControls,
                       child: const SelectAllWidget(child: SizedBox(width: 100, height: 100)),
                     ),
                     const Text('Fine, thank you.'),
                   ],
                 ),
               ),
-              const MaterialPage<void>(child: Scaffold(body: Text('Foreground Page'))),
+              const TestPage<void>(child: Text('Foreground Page')),
             ],
             onPopPage: (_, _) => false,
           ),
@@ -194,12 +342,16 @@ void main() {
       final spy = UniqueKey();
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: Column(
             children: <Widget>[
               const Text('How are you?'),
               SelectableRegion(
-                selectionControls: materialTextSelectionControls,
+                contextMenuBuilder:
+                    (BuildContext context, SelectableRegionState selectableRegionState) {
+                      return const SizedBox.shrink();
+                    },
+                selectionControls: testTextSelectionHandleControls,
                 child: SelectAllWidget(key: spy, child: const SizedBox(width: 100, height: 100)),
               ),
               const Text('Fine, thank you.'),
@@ -224,9 +376,13 @@ void main() {
       final spy = UniqueKey();
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
+            contextMenuBuilder:
+                (BuildContext context, SelectableRegionState selectableRegionState) {
+                  return const SizedBox.shrink();
+                },
+            selectionControls: testTextSelectionHandleControls,
             child: SelectionSpy(key: spy),
           ),
         ),
@@ -250,13 +406,15 @@ void main() {
       (WidgetTester tester) async {
         const text = 'Hello world';
         await tester.pumpWidget(
-          MaterialApp(
-            home: Scaffold(
-              body: Center(
-                child: SelectableRegion(
-                  selectionControls: materialTextSelectionControls,
-                  child: const Text(text),
-                ),
+          TestWidgetsApp(
+            home: Center(
+              child: SelectableRegion(
+                contextMenuBuilder:
+                    (BuildContext context, SelectableRegionState selectableRegionState) {
+                      return const SizedBox.shrink();
+                    },
+                selectionControls: testTextSelectionHandleControls,
+                child: const Text(text),
               ),
             ),
           ),
@@ -299,19 +457,21 @@ void main() {
       final semantics = SemanticsTester(tester);
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
-            child: Scaffold(
-              body: Center(
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: <Widget>[
-                    const Text('Line one'),
-                    const Text('Line two'),
-                    ElevatedButton(onPressed: () {}, child: const Text('Button')),
-                  ],
-                ),
+            contextMenuBuilder:
+                (BuildContext context, SelectableRegionState selectableRegionState) {
+                  return const SizedBox.shrink();
+                },
+            selectionControls: testTextSelectionHandleControls,
+            child: Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  const Text('Line one'),
+                  const Text('Line two'),
+                  TestButton(onPressed: () {}, child: const Text('Button')),
+                ],
               ),
             ),
           ),
@@ -328,18 +488,21 @@ void main() {
                 children: <TestSemantics>[
                   TestSemantics(
                     children: <TestSemantics>[
+                      TestSemantics(label: 'Line one', textDirection: TextDirection.ltr),
+                      TestSemantics(label: 'Line two', textDirection: TextDirection.ltr),
                       TestSemantics(
-                        flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
+                        flags: <SemanticsFlag>[
+                          SemanticsFlag.isButton,
+                          SemanticsFlag.hasEnabledState,
+                          SemanticsFlag.isEnabled,
+                          SemanticsFlag.isFocusable,
+                        ],
+                        actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.focus],
+                        label: 'button',
+                        textDirection: TextDirection.ltr,
                         children: <TestSemantics>[
-                          TestSemantics(label: 'Line one', textDirection: TextDirection.ltr),
-                          TestSemantics(label: 'Line two', textDirection: TextDirection.ltr),
                           TestSemantics(
-                            flags: <SemanticsFlag>[
-                              SemanticsFlag.isButton,
-                              SemanticsFlag.hasEnabledState,
-                              SemanticsFlag.isEnabled,
-                              SemanticsFlag.isFocusable,
-                            ],
+                            flags: <SemanticsFlag>[SemanticsFlag.isFocusable],
                             actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.focus],
                             label: 'Button',
                             textDirection: TextDirection.ltr,
@@ -369,13 +532,17 @@ void main() {
         addTearDown(pageController.dispose);
 
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: PageView(
               controller: pageController,
               children: <Widget>[
                 Center(
                   child: SelectableRegion(
-                    selectionControls: materialTextSelectionControls,
+                    contextMenuBuilder:
+                        (BuildContext context, SelectableRegionState selectableRegionState) {
+                          return const SizedBox.shrink();
+                        },
+                    selectionControls: testTextSelectionHandleControls,
                     child: const Text(testValue),
                   ),
                 ),
@@ -437,14 +604,18 @@ void main() {
         addTearDown(pageController.dispose);
 
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: PageView(
               scrollDirection: Axis.vertical,
               controller: pageController,
               children: <Widget>[
                 Center(
                   child: SelectableRegion(
-                    selectionControls: materialTextSelectionControls,
+                    contextMenuBuilder:
+                        (BuildContext context, SelectableRegionState selectableRegionState) {
+                          return const SizedBox.shrink();
+                        },
+                    selectionControls: testTextSelectionHandleControls,
                     child: const Text(testValue),
                   ),
                 ),
@@ -518,14 +689,18 @@ void main() {
         addTearDown(pageController.dispose);
 
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: PageView(
               scrollDirection: Axis.vertical,
               controller: pageController,
               children: <Widget>[
                 Center(
                   child: SelectableRegion(
-                    selectionControls: materialTextSelectionControls,
+                    contextMenuBuilder:
+                        (BuildContext context, SelectableRegionState selectableRegionState) {
+                          return const SizedBox.shrink();
+                        },
+                    selectionControls: testTextSelectionHandleControls,
                     child: const Text(testValue),
                   ),
                 ),
@@ -591,9 +766,13 @@ void main() {
       final spy = UniqueKey();
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
+            contextMenuBuilder:
+                (BuildContext context, SelectableRegionState selectableRegionState) {
+                  return const SizedBox.shrink();
+                },
+            selectionControls: testTextSelectionHandleControls,
             child: SelectionSpy(key: spy),
           ),
         ),
@@ -628,9 +807,13 @@ void main() {
       final spy = UniqueKey();
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
+            contextMenuBuilder:
+                (BuildContext context, SelectableRegionState selectableRegionState) {
+                  return const SizedBox.shrink();
+                },
+            selectionControls: testTextSelectionHandleControls,
             child: SelectionSpy(key: spy),
           ),
         ),
@@ -657,9 +840,9 @@ void main() {
         const text = 'Hello world, how are you today?';
         final toolbarKey = UniqueKey();
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
-              selectionControls: materialTextSelectionControls,
+              selectionControls: testTextSelectionHandleControls,
               contextMenuBuilder:
                   (BuildContext context, SelectableRegionState selectableRegionState) {
                     return SizedBox(key: toolbarKey);
@@ -735,9 +918,13 @@ void main() {
       final spy = UniqueKey();
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
+            contextMenuBuilder:
+                (BuildContext context, SelectableRegionState selectableRegionState) {
+                  return const SizedBox.shrink();
+                },
+            selectionControls: testTextSelectionHandleControls,
             child: SelectionSpy(key: spy),
           ),
         ),
@@ -772,9 +959,13 @@ void main() {
       final spy = UniqueKey();
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
+            contextMenuBuilder:
+                (BuildContext context, SelectableRegionState selectableRegionState) {
+                  return const SizedBox.shrink();
+                },
+            selectionControls: testTextSelectionHandleControls,
             child: SelectionSpy(key: spy),
           ),
         ),
@@ -804,14 +995,18 @@ void main() {
       final spy = UniqueKey();
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: SizedBox(
             height: 750,
             child: SingleChildScrollView(
               child: SizedBox(
                 height: 2000,
                 child: SelectableRegion(
-                  selectionControls: materialTextSelectionControls,
+                  contextMenuBuilder:
+                      (BuildContext context, SelectableRegionState selectableRegionState) {
+                        return const SizedBox.shrink();
+                      },
+                  selectionControls: testTextSelectionHandleControls,
                   child: SelectionSpy(key: spy),
                 ),
               ),
@@ -845,9 +1040,13 @@ void main() {
       final spy = UniqueKey();
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
+            contextMenuBuilder:
+                (BuildContext context, SelectableRegionState selectableRegionState) {
+                  return const SizedBox.shrink();
+                },
+            selectionControls: testTextSelectionHandleControls,
             child: SelectionSpy(key: spy),
           ),
         ),
@@ -883,10 +1082,13 @@ void main() {
     addTearDown(selectionDelegate.dispose);
 
     await tester.pumpWidget(
-      MaterialApp(
+      TestWidgetsApp(
         home: SelectableRegion(
+          contextMenuBuilder: (BuildContext context, SelectableRegionState selectableRegionState) {
+            return const SizedBox.shrink();
+          },
           onSelectionChanged: (SelectedContent? selectedContent) => content = selectedContent,
-          selectionControls: materialTextSelectionControls,
+          selectionControls: testTextSelectionHandleControls,
           child: SelectionContainer(
             delegate: selectionDelegate,
             child: const Center(
@@ -939,9 +1141,10 @@ void main() {
       });
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
+          textStyle: _materialDefaultTextStyle,
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
+            selectionControls: _testDraggableSelectionControls,
             child: const Text('How are you?'),
           ),
         ),
@@ -1001,11 +1204,15 @@ void main() {
         final GlobalKey selectableKey = GlobalKey();
         addTearDown(focusNode.dispose);
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
+              contextMenuBuilder:
+                  (BuildContext context, SelectableRegionState selectableRegionState) {
+                    return const SizedBox.shrink();
+                  },
               key: selectableKey,
               focusNode: focusNode,
-              selectionControls: materialTextSelectionControls,
+              selectionControls: testTextSelectionHandleControls,
               child: const Center(child: Text('How are you')),
             ),
           ),
@@ -1048,9 +1255,10 @@ void main() {
       'touch can select word-by-word on double tap drag on mobile platforms',
       (WidgetTester tester) async {
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
+            textStyle: _materialDefaultTextStyle,
             home: SelectableRegion(
-              selectionControls: materialTextSelectionControls,
+              selectionControls: _testDraggableSelectionControls,
               child: const Center(child: Text('How are you')),
             ),
           ),
@@ -1123,9 +1331,13 @@ void main() {
       'touch can select multiple widgets on double tap drag on mobile platforms',
       (WidgetTester tester) async {
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
-              selectionControls: materialTextSelectionControls,
+              contextMenuBuilder:
+                  (BuildContext context, SelectableRegionState selectableRegionState) {
+                    return const SizedBox.shrink();
+                  },
+              selectionControls: testTextSelectionHandleControls,
               child: const Column(
                 children: <Widget>[
                   Text('How are you?'),
@@ -1180,9 +1392,13 @@ void main() {
       'touch can select multiple widgets on double tap drag and return to origin word on mobile platforms',
       (WidgetTester tester) async {
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
-              selectionControls: materialTextSelectionControls,
+              contextMenuBuilder:
+                  (BuildContext context, SelectableRegionState selectableRegionState) {
+                    return const SizedBox.shrink();
+                  },
+              selectionControls: testTextSelectionHandleControls,
               child: const Column(
                 children: <Widget>[
                   Text('How are you?'),
@@ -1249,9 +1465,13 @@ void main() {
       'touch can reverse selection across multiple widgets on double tap drag on mobile platforms',
       (WidgetTester tester) async {
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
-              selectionControls: materialTextSelectionControls,
+              contextMenuBuilder:
+                  (BuildContext context, SelectableRegionState selectableRegionState) {
+                    return const SizedBox.shrink();
+                  },
+              selectionControls: testTextSelectionHandleControls,
               child: const Column(
                 children: <Widget>[
                   Text('How are you?'),
@@ -1312,9 +1532,13 @@ void main() {
             'of text all of it should be selected.';
 
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
-              selectionControls: materialTextSelectionControls,
+              contextMenuBuilder:
+                  (BuildContext context, SelectableRegionState selectableRegionState) {
+                    return const SizedBox.shrink();
+                  },
+              selectionControls: testTextSelectionHandleControls,
               child: const Center(child: Text(longText)),
             ),
           ),
@@ -1427,9 +1651,13 @@ void main() {
       'touch cannot select word-by-word on double tap drag when on Android web',
       (WidgetTester tester) async {
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
-              selectionControls: materialTextSelectionControls,
+              contextMenuBuilder:
+                  (BuildContext context, SelectableRegionState selectableRegionState) {
+                    return const SizedBox.shrink();
+                  },
+              selectionControls: testTextSelectionHandleControls,
               child: const Center(child: Text('How are you')),
             ),
           ),
@@ -1478,9 +1706,13 @@ void main() {
       'touch can double tap + drag on iOS web',
       (WidgetTester tester) async {
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
-              selectionControls: materialTextSelectionControls,
+              contextMenuBuilder:
+                  (BuildContext context, SelectableRegionState selectableRegionState) {
+                    return const SizedBox.shrink();
+                  },
+              selectionControls: testTextSelectionHandleControls,
               child: const Center(child: Text('How are you')),
             ),
           ),
@@ -1532,9 +1764,13 @@ void main() {
       'touch cannot double tap on iOS web',
       (WidgetTester tester) async {
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
-              selectionControls: materialTextSelectionControls,
+              contextMenuBuilder:
+                  (BuildContext context, SelectableRegionState selectableRegionState) {
+                    return const SizedBox.shrink();
+                  },
+              selectionControls: testTextSelectionHandleControls,
               child: const Center(child: Text('How are you')),
             ),
           ),
@@ -1569,9 +1805,13 @@ void main() {
         const testString = 'How are you doing today? Good, and you?';
 
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
-              selectionControls: materialTextSelectionControls,
+              contextMenuBuilder:
+                  (BuildContext context, SelectableRegionState selectableRegionState) {
+                    return const SizedBox.shrink();
+                  },
+              selectionControls: testTextSelectionHandleControls,
               child: const Center(child: Text(testString)),
             ),
           ),
@@ -1631,12 +1871,14 @@ void main() {
       addTearDown(tester.view.reset);
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
-            child: Scaffold(
-              body: Center(child: Text('How are you doing today? Good, and you?', key: outerText)),
-            ),
+            contextMenuBuilder:
+                (BuildContext context, SelectableRegionState selectableRegionState) {
+                  return const SizedBox.shrink();
+                },
+            selectionControls: testTextSelectionHandleControls,
+            child: Center(child: Text('How are you doing today? Good, and you?', key: outerText)),
           ),
         ),
       );
@@ -1688,9 +1930,13 @@ void main() {
 
     testWidgets('mouse can select single text on desktop platforms', (WidgetTester tester) async {
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
+            contextMenuBuilder:
+                (BuildContext context, SelectableRegionState selectableRegionState) {
+                  return const SizedBox.shrink();
+                },
+            selectionControls: testTextSelectionHandleControls,
             child: const Center(child: Text('How are you')),
           ),
         ),
@@ -1738,9 +1984,13 @@ void main() {
 
     testWidgets('mouse can select single text on mobile platforms', (WidgetTester tester) async {
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
+            contextMenuBuilder:
+                (BuildContext context, SelectableRegionState selectableRegionState) {
+                  return const SizedBox.shrink();
+                },
+            selectionControls: testTextSelectionHandleControls,
             child: const Center(child: Text('How are you')),
           ),
         ),
@@ -1792,9 +2042,13 @@ void main() {
       SelectableRegionSelectionStatus? selectionStatus;
       final GlobalKey textKey = GlobalKey();
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
+            contextMenuBuilder:
+                (BuildContext context, SelectableRegionState selectableRegionState) {
+                  return const SizedBox.shrink();
+                },
+            selectionControls: testTextSelectionHandleControls,
             child: Center(child: Text(key: textKey, 'How are you')),
           ),
         ),
@@ -1837,9 +2091,13 @@ void main() {
         SelectableRegionSelectionStatus? selectionStatus;
         final GlobalKey textKey = GlobalKey();
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
-              selectionControls: materialTextSelectionControls,
+              contextMenuBuilder:
+                  (BuildContext context, SelectableRegionState selectableRegionState) {
+                    return const SizedBox.shrink();
+                  },
+              selectionControls: testTextSelectionHandleControls,
               child: Center(child: Text(key: textKey, 'How are you')),
             ),
           ),
@@ -1876,9 +2134,13 @@ void main() {
 
     testWidgets('mouse can select word-by-word on double click drag', (WidgetTester tester) async {
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
+            contextMenuBuilder:
+                (BuildContext context, SelectableRegionState selectableRegionState) {
+                  return const SizedBox.shrink();
+                },
+            selectionControls: testTextSelectionHandleControls,
             child: const Center(child: Text('How are you')),
           ),
         ),
@@ -1950,9 +2212,13 @@ void main() {
       WidgetTester tester,
     ) async {
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
+            contextMenuBuilder:
+                (BuildContext context, SelectableRegionState selectableRegionState) {
+                  return const SizedBox.shrink();
+                },
+            selectionControls: testTextSelectionHandleControls,
             child: const Column(
               children: <Widget>[
                 Text('How are you?'),
@@ -2006,9 +2272,13 @@ void main() {
       'mouse can select multiple widgets on double click drag and return to origin word',
       (WidgetTester tester) async {
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
-              selectionControls: materialTextSelectionControls,
+              contextMenuBuilder:
+                  (BuildContext context, SelectableRegionState selectableRegionState) {
+                    return const SizedBox.shrink();
+                  },
+              selectionControls: testTextSelectionHandleControls,
               child: const Column(
                 children: <Widget>[
                   Text('How are you?'),
@@ -2075,9 +2345,13 @@ void main() {
       WidgetTester tester,
     ) async {
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
+            contextMenuBuilder:
+                (BuildContext context, SelectableRegionState selectableRegionState) {
+                  return const SizedBox.shrink();
+                },
+            selectionControls: testTextSelectionHandleControls,
             child: const Column(
               children: <Widget>[
                 Text('How are you?'),
@@ -2137,9 +2411,13 @@ void main() {
           'of text all of it should be selected.';
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
+            contextMenuBuilder:
+                (BuildContext context, SelectableRegionState selectableRegionState) {
+                  return const SizedBox.shrink();
+                },
+            selectionControls: testTextSelectionHandleControls,
             child: const Center(child: Text(longText)),
           ),
         ),
@@ -2213,9 +2491,13 @@ void main() {
       'mouse can select multiple widgets on triple click drag when selecting inside a WidgetSpan',
       (WidgetTester tester) async {
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
-              selectionControls: materialTextSelectionControls,
+              contextMenuBuilder:
+                  (BuildContext context, SelectableRegionState selectableRegionState) {
+                    return const SizedBox.shrink();
+                  },
+              selectionControls: testTextSelectionHandleControls,
               child: const Text.rich(
                 WidgetSpan(
                   child: Column(
@@ -2286,9 +2568,13 @@ void main() {
       WidgetTester tester,
     ) async {
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
+            contextMenuBuilder:
+                (BuildContext context, SelectableRegionState selectableRegionState) {
+                  return const SizedBox.shrink();
+                },
+            selectionControls: testTextSelectionHandleControls,
             child: const Column(
               children: <Widget>[
                 Text('How are you?\nThis is the first text widget.'),
@@ -2368,9 +2654,13 @@ void main() {
       'mouse can select multiple widgets on triple click drag and return to origin paragraph',
       (WidgetTester tester) async {
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
-              selectionControls: materialTextSelectionControls,
+              contextMenuBuilder:
+                  (BuildContext context, SelectableRegionState selectableRegionState) {
+                    return const SizedBox.shrink();
+                  },
+              selectionControls: testTextSelectionHandleControls,
               child: const Column(
                 children: <Widget>[
                   Text('How are you?\nThis is the first text widget.'),
@@ -2461,9 +2751,13 @@ void main() {
       WidgetTester tester,
     ) async {
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
+            contextMenuBuilder:
+                (BuildContext context, SelectableRegionState selectableRegionState) {
+                  return const SizedBox.shrink();
+                },
+            selectionControls: testTextSelectionHandleControls,
             child: const Column(
               children: <Widget>[
                 Text('How are you?\nThis is the first text widget.'),
@@ -2522,9 +2816,13 @@ void main() {
 
     testWidgets('mouse can select multiple widgets', (WidgetTester tester) async {
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
+            contextMenuBuilder:
+                (BuildContext context, SelectableRegionState selectableRegionState) {
+                  return const SizedBox.shrink();
+                },
+            selectionControls: testTextSelectionHandleControls,
             child: const Column(
               children: <Widget>[
                 Text('How are you?'),
@@ -2572,9 +2870,10 @@ void main() {
       'mouse shift + click holds the selection start in place and moves the end',
       (WidgetTester tester) async {
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
+            textStyle: _materialDefaultTextStyle,
             home: SelectableRegion(
-              selectionControls: materialTextSelectionControls,
+              selectionControls: _testDraggableSelectionControls,
               child: const Column(
                 children: <Widget>[
                   Text('How are you?'),
@@ -2644,9 +2943,13 @@ void main() {
       'mouse shift + click collapses the selection when it has not been initialized',
       (WidgetTester tester) async {
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
-              selectionControls: materialTextSelectionControls,
+              contextMenuBuilder:
+                  (BuildContext context, SelectableRegionState selectableRegionState) {
+                    return const SizedBox.shrink();
+                  },
+              selectionControls: testTextSelectionHandleControls,
               child: const Column(
                 children: <Widget>[
                   Text('How are you?'),
@@ -2687,9 +2990,10 @@ void main() {
       WidgetTester tester,
     ) async {
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
+          textStyle: _materialDefaultTextStyle,
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
+            selectionControls: _testDraggableSelectionControls,
             child: const Column(
               children: <Widget>[
                 Text('How are you?'),
@@ -2738,9 +3042,13 @@ void main() {
 
     testWidgets('mouse can work with disabled container', (WidgetTester tester) async {
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
+            contextMenuBuilder:
+                (BuildContext context, SelectableRegionState selectableRegionState) {
+                  return const SizedBox.shrink();
+                },
+            selectionControls: testTextSelectionHandleControls,
             child: const Column(
               children: <Widget>[
                 Text('How are you?'),
@@ -2787,9 +3095,13 @@ void main() {
 
     testWidgets('mouse can reverse selection', (WidgetTester tester) async {
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
+            contextMenuBuilder:
+                (BuildContext context, SelectableRegionState selectableRegionState) {
+                  return const SizedBox.shrink();
+                },
+            selectionControls: testTextSelectionHandleControls,
             child: const Column(
               children: <Widget>[
                 Text('How are you?'),
@@ -2842,9 +3154,9 @@ void main() {
         var buttonTypes = <ContextMenuButtonType>{};
         final toolbarKey = UniqueKey();
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
-              selectionControls: materialTextSelectionHandleControls,
+              selectionControls: testTextSelectionHandleControls,
               contextMenuBuilder:
                   (BuildContext context, SelectableRegionState selectableRegionState) {
                     buttonTypes = selectableRegionState.contextMenuButtonItems
@@ -2956,9 +3268,9 @@ void main() {
         final toolbarKey = UniqueKey();
 
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
-              selectionControls: materialTextSelectionHandleControls,
+              selectionControls: testTextSelectionHandleControls,
               contextMenuBuilder:
                   (BuildContext context, SelectableRegionState selectableRegionState) {
                     buttonTypes = selectableRegionState.contextMenuButtonItems
@@ -3029,9 +3341,9 @@ void main() {
         final toolbarKey = UniqueKey();
 
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
-              selectionControls: materialTextSelectionHandleControls,
+              selectionControls: testTextSelectionHandleControls,
               contextMenuBuilder:
                   (BuildContext context, SelectableRegionState selectableRegionState) {
                     buttonTypes = selectableRegionState.contextMenuButtonItems
@@ -3117,9 +3429,9 @@ void main() {
         final toolbarKey = UniqueKey();
 
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
-              selectionControls: materialTextSelectionHandleControls,
+              selectionControls: testTextSelectionHandleControls,
               contextMenuBuilder:
                   (BuildContext context, SelectableRegionState selectableRegionState) {
                     buttonTypes = selectableRegionState.contextMenuButtonItems
@@ -3202,9 +3514,9 @@ void main() {
         final toolbarKey = UniqueKey();
 
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
-              selectionControls: materialTextSelectionHandleControls,
+              selectionControls: testTextSelectionHandleControls,
               contextMenuBuilder:
                   (BuildContext context, SelectableRegionState selectableRegionState) {
                     buttonTypes = selectableRegionState.contextMenuButtonItems
@@ -3310,9 +3622,9 @@ void main() {
         final toolbarKey = UniqueKey();
 
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
-              selectionControls: materialTextSelectionHandleControls,
+              selectionControls: testTextSelectionHandleControls,
               contextMenuBuilder:
                   (BuildContext context, SelectableRegionState selectableRegionState) {
                     buttonTypes = selectableRegionState.contextMenuButtonItems
@@ -3438,9 +3750,9 @@ void main() {
         final toolbarKey = UniqueKey();
 
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
-              selectionControls: materialTextSelectionHandleControls,
+              selectionControls: testTextSelectionHandleControls,
               contextMenuBuilder:
                   (BuildContext context, SelectableRegionState selectableRegionState) {
                     buttonTypes = selectableRegionState.contextMenuButtonItems
@@ -3567,9 +3879,13 @@ void main() {
       'can copy a selection made with the mouse',
       (WidgetTester tester) async {
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
-              selectionControls: materialTextSelectionControls,
+              contextMenuBuilder:
+                  (BuildContext context, SelectableRegionState selectableRegionState) {
+                    return const SizedBox.shrink();
+                  },
+              selectionControls: testTextSelectionHandleControls,
               child: const Column(
                 children: <Widget>[
                   Text('How are you?'),
@@ -3625,18 +3941,20 @@ void main() {
         addTearDown(textFieldFocus.dispose);
 
         await tester.pumpWidget(
-          MaterialApp(
-            home: Material(
-              child: SelectableRegion(
-                focusNode: selectableRegionFocus,
-                selectionControls: materialTextSelectionControls,
-                child: Column(
-                  children: <Widget>[
-                    const Text('How are you?'),
-                    const Text('Good, and you?'),
-                    TestTextField(controller: controller, focusNode: textFieldFocus),
-                  ],
-                ),
+          TestWidgetsApp(
+            home: SelectableRegion(
+              contextMenuBuilder:
+                  (BuildContext context, SelectableRegionState selectableRegionState) {
+                    return const SizedBox.shrink();
+                  },
+              focusNode: selectableRegionFocus,
+              selectionControls: testTextSelectionHandleControls,
+              child: Column(
+                children: <Widget>[
+                  const Text('How are you?'),
+                  const Text('Good, and you?'),
+                  TestTextField(controller: controller, focusNode: textFieldFocus),
+                ],
               ),
             ),
           ),
@@ -3697,18 +4015,20 @@ void main() {
         addTearDown(textFieldFocus.dispose);
 
         await tester.pumpWidget(
-          MaterialApp(
-            home: Material(
-              child: SelectableRegion(
-                focusNode: selectableRegionFocus,
-                selectionControls: materialTextSelectionControls,
-                child: Column(
-                  children: <Widget>[
-                    const Text('How are you?'),
-                    const Text('Good, and you?'),
-                    TestTextField(controller: controller, focusNode: textFieldFocus),
-                  ],
-                ),
+          TestWidgetsApp(
+            home: SelectableRegion(
+              contextMenuBuilder:
+                  (BuildContext context, SelectableRegionState selectableRegionState) {
+                    return const SizedBox.shrink();
+                  },
+              focusNode: selectableRegionFocus,
+              selectionControls: testTextSelectionHandleControls,
+              child: Column(
+                children: <Widget>[
+                  const Text('How are you?'),
+                  const Text('Good, and you?'),
+                  TestTextField(controller: controller, focusNode: textFieldFocus),
+                ],
               ),
             ),
           ),
@@ -3763,10 +4083,14 @@ void main() {
         addTearDown(focusNode.dispose);
 
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
+              contextMenuBuilder:
+                  (BuildContext context, SelectableRegionState selectableRegionState) {
+                    return const SizedBox.shrink();
+                  },
               focusNode: focusNode,
-              selectionControls: materialTextSelectionControls,
+              selectionControls: testTextSelectionHandleControls,
               child: const Column(
                 children: <Widget>[
                   Text('How are you?'),
@@ -3813,9 +4137,13 @@ void main() {
         final outerText = UniqueKey();
 
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
-              selectionControls: materialTextSelectionControls,
+              contextMenuBuilder:
+                  (BuildContext context, SelectableRegionState selectableRegionState) {
+                    return const SizedBox.shrink();
+                  },
+              selectionControls: testTextSelectionHandleControls,
               child: Center(
                 child: Text.rich(
                   const TextSpan(
@@ -3865,9 +4193,13 @@ void main() {
         final outerText = UniqueKey();
 
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
-              selectionControls: materialTextSelectionControls,
+              contextMenuBuilder:
+                  (BuildContext context, SelectableRegionState selectableRegionState) {
+                    return const SizedBox.shrink();
+                  },
+              selectionControls: testTextSelectionHandleControls,
               child: Center(
                 child: Text.rich(
                   const TextSpan(
@@ -3923,9 +4255,13 @@ void main() {
         final innerText = UniqueKey();
 
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
-              selectionControls: materialTextSelectionControls,
+              contextMenuBuilder:
+                  (BuildContext context, SelectableRegionState selectableRegionState) {
+                    return const SizedBox.shrink();
+                  },
+              selectionControls: testTextSelectionHandleControls,
               child: Center(
                 child: Text.rich(
                   TextSpan(
@@ -3978,9 +4314,13 @@ void main() {
         final innerText = UniqueKey();
 
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
-              selectionControls: materialTextSelectionControls,
+              contextMenuBuilder:
+                  (BuildContext context, SelectableRegionState selectableRegionState) {
+                    return const SizedBox.shrink();
+                  },
+              selectionControls: testTextSelectionHandleControls,
               child: Center(
                 child: Text.rich(
                   TextSpan(
@@ -4027,22 +4367,24 @@ void main() {
         addTearDown(focusNode.dispose);
 
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
-              selectionControls: materialTextSelectionControls,
-              child: Scaffold(
-                body: Center(
-                  child: Text.rich(
-                    TextSpan(
-                      children: <InlineSpan>[
-                        const TextSpan(
-                          text:
-                              'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
-                        ),
-                        WidgetSpan(child: FlutterLogo(key: flutterLogo)),
-                        const TextSpan(text: 'Hello, world.'),
-                      ],
-                    ),
+              contextMenuBuilder:
+                  (BuildContext context, SelectableRegionState selectableRegionState) {
+                    return const SizedBox.shrink();
+                  },
+              selectionControls: testTextSelectionHandleControls,
+              child: Center(
+                child: Text.rich(
+                  TextSpan(
+                    children: <InlineSpan>[
+                      const TextSpan(
+                        text:
+                            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+                      ),
+                      WidgetSpan(child: FlutterLogo(key: flutterLogo)),
+                      const TextSpan(text: 'Hello, world.'),
+                    ],
                   ),
                 ),
               ),
@@ -4075,24 +4417,26 @@ void main() {
         final outerText = UniqueKey();
 
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
-              selectionControls: materialTextSelectionControls,
-              child: Scaffold(
-                body: Center(
-                  child: Text.rich(
-                    const TextSpan(
-                      children: <InlineSpan>[
-                        TextSpan(
-                          text:
-                              'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
-                        ),
-                        WidgetSpan(child: Text('Some text in a WidgetSpan. ')),
-                        TextSpan(text: 'Hello, world.'),
-                      ],
-                    ),
-                    key: outerText,
+              contextMenuBuilder:
+                  (BuildContext context, SelectableRegionState selectableRegionState) {
+                    return const SizedBox.shrink();
+                  },
+              selectionControls: testTextSelectionHandleControls,
+              child: Center(
+                child: Text.rich(
+                  const TextSpan(
+                    children: <InlineSpan>[
+                      TextSpan(
+                        text:
+                            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+                      ),
+                      WidgetSpan(child: Text('Some text in a WidgetSpan. ')),
+                      TextSpan(text: 'Hello, world.'),
+                    ],
                   ),
+                  key: outerText,
                 ),
               ),
             ),
@@ -4124,24 +4468,26 @@ void main() {
         final outerText = UniqueKey();
 
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
-              selectionControls: materialTextSelectionControls,
-              child: Scaffold(
-                body: Center(
-                  child: Text.rich(
-                    const TextSpan(
-                      children: <InlineSpan>[
-                        TextSpan(
-                          text:
-                              'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
-                        ),
-                        WidgetSpan(child: SizedBox.shrink()),
-                        TextSpan(text: 'Hello, world.'),
-                      ],
-                    ),
-                    key: outerText,
+              contextMenuBuilder:
+                  (BuildContext context, SelectableRegionState selectableRegionState) {
+                    return const SizedBox.shrink();
+                  },
+              selectionControls: testTextSelectionHandleControls,
+              child: Center(
+                child: Text.rich(
+                  const TextSpan(
+                    children: <InlineSpan>[
+                      TextSpan(
+                        text:
+                            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+                      ),
+                      WidgetSpan(child: SizedBox.shrink()),
+                      TextSpan(text: 'Hello, world.'),
+                    ],
                   ),
+                  key: outerText,
                 ),
               ),
             ),
@@ -4173,9 +4519,13 @@ void main() {
         final outerText = UniqueKey();
 
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
-              selectionControls: materialTextSelectionControls,
+              contextMenuBuilder:
+                  (BuildContext context, SelectableRegionState selectableRegionState) {
+                    return const SizedBox.shrink();
+                  },
+              selectionControls: testTextSelectionHandleControls,
               child: Center(
                 child: Text.rich(
                   const TextSpan(
@@ -4225,9 +4575,13 @@ void main() {
         final outerText = UniqueKey();
 
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
-              selectionControls: materialTextSelectionControls,
+              contextMenuBuilder:
+                  (BuildContext context, SelectableRegionState selectableRegionState) {
+                    return const SizedBox.shrink();
+                  },
+              selectionControls: testTextSelectionHandleControls,
               child: Center(
                 child: Text.rich(
                   const TextSpan(
@@ -4271,9 +4625,13 @@ void main() {
 
     testWidgets('mouse can select across bidi text', (WidgetTester tester) async {
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
+            contextMenuBuilder:
+                (BuildContext context, SelectableRegionState selectableRegionState) {
+                  return const SizedBox.shrink();
+                },
+            selectionControls: testTextSelectionHandleControls,
             child: const Column(
               children: <Widget>[
                 Text('How are you?'),
@@ -4322,9 +4680,13 @@ void main() {
       WidgetTester tester,
     ) async {
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
+            contextMenuBuilder:
+                (BuildContext context, SelectableRegionState selectableRegionState) {
+                  return const SizedBox.shrink();
+                },
+            selectionControls: testTextSelectionHandleControls,
             child: const Column(
               children: <Widget>[
                 Text('How are you?'),
@@ -4360,12 +4722,13 @@ void main() {
       // Regression test for https://github.com/flutter/flutter/issues/104620.
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
+          textStyle: _materialDefaultTextStyle,
           home: Column(
             children: <Widget>[
               const Text('How are you?'),
               SelectableRegion(
-                selectionControls: materialTextSelectionControls,
+                selectionControls: _testDraggableSelectionControls,
                 child: const Text('Good, and you?'),
               ),
               const Text('Fine, thank you.'),
@@ -4405,12 +4768,13 @@ void main() {
       // Regression test for https://github.com/flutter/flutter/issues/104620.
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
+          textStyle: _materialDefaultTextStyle,
           home: Column(
             children: <Widget>[
               const Text('How are you?'),
               SelectableRegion(
-                selectionControls: materialTextSelectionControls,
+                selectionControls: _testDraggableSelectionControls,
                 child: const Text('Good, and you?'),
               ),
               const Text('Fine, thank you.'),
@@ -4445,9 +4809,10 @@ void main() {
 
     testWidgets('can drag start selection handle', (WidgetTester tester) async {
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
+          textStyle: _materialDefaultTextStyle,
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
+            selectionControls: _testDraggableSelectionControls,
             child: const Column(
               children: <Widget>[
                 Text('How are you?'),
@@ -4500,9 +4865,10 @@ void main() {
       WidgetTester tester,
     ) async {
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
+          textStyle: _materialDefaultTextStyle,
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
+            selectionControls: _testDraggableSelectionControls,
             child: const Column(
               children: <Widget>[
                 Text('How are you?'),
@@ -4546,9 +4912,10 @@ void main() {
       WidgetTester tester,
     ) async {
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
+          textStyle: _materialDefaultTextStyle,
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
+            selectionControls: _testDraggableSelectionControls,
             child: const Column(
               children: <Widget>[
                 Text('How are you?'),
@@ -4590,9 +4957,10 @@ void main() {
 
     testWidgets('can select all from toolbar', (WidgetTester tester) async {
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
+          textStyle: _materialDefaultTextStyle,
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
+            selectionControls: _testDraggableSelectionControlsWithToolbar,
             child: const Column(
               children: <Widget>[
                 Text('How are you?'),
@@ -4633,9 +5001,10 @@ void main() {
 
     testWidgets('can copy from toolbar', (WidgetTester tester) async {
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
+          textStyle: _materialDefaultTextStyle,
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
+            selectionControls: _testDraggableSelectionControlsWithToolbar,
             child: const Column(
               children: <Widget>[
                 Text('How are you?'),
@@ -4682,9 +5051,13 @@ void main() {
       'can use keyboard to granularly extend selection - character',
       (WidgetTester tester) async {
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
-              selectionControls: materialTextSelectionControls,
+              contextMenuBuilder:
+                  (BuildContext context, SelectableRegionState selectableRegionState) {
+                    return const SizedBox.shrink();
+                  },
+              selectionControls: testTextSelectionHandleControls,
               child: const Column(
                 children: <Widget>[
                   Text('How are you?'),
@@ -4757,9 +5130,13 @@ void main() {
       WidgetTester tester,
     ) async {
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
+            contextMenuBuilder:
+                (BuildContext context, SelectableRegionState selectableRegionState) {
+                  return const SizedBox.shrink();
+                },
+            selectionControls: testTextSelectionHandleControls,
             child: const Column(
               children: <Widget>[
                 Text('How are you?'),
@@ -4895,9 +5272,13 @@ void main() {
       WidgetTester tester,
     ) async {
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
+            contextMenuBuilder:
+                (BuildContext context, SelectableRegionState selectableRegionState) {
+                  return const SizedBox.shrink();
+                },
+            selectionControls: testTextSelectionHandleControls,
             child: const Column(
               children: <Widget>[
                 Text('How are you?'),
@@ -5006,9 +5387,13 @@ void main() {
       'should not throw range error when selecting previous paragraph',
       (WidgetTester tester) async {
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
-              selectionControls: materialTextSelectionControls,
+              contextMenuBuilder:
+                  (BuildContext context, SelectableRegionState selectableRegionState) {
+                    return const SizedBox.shrink();
+                  },
+              selectionControls: testTextSelectionHandleControls,
               child: const Column(
                 children: <Widget>[
                   Text('How are you?'),
@@ -5092,9 +5477,13 @@ void main() {
       'can use keyboard to granularly extend selection - document',
       (WidgetTester tester) async {
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
-              selectionControls: materialTextSelectionControls,
+              contextMenuBuilder:
+                  (BuildContext context, SelectableRegionState selectableRegionState) {
+                    return const SizedBox.shrink();
+                  },
+              selectionControls: testTextSelectionHandleControls,
               child: const Column(
                 children: <Widget>[
                   Text('How are you?'),
@@ -5188,9 +5577,13 @@ void main() {
 
     testWidgets('can use keyboard to directionally extend selection', (WidgetTester tester) async {
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
+            contextMenuBuilder:
+                (BuildContext context, SelectableRegionState selectableRegionState) {
+                  return const SizedBox.shrink();
+                },
+            selectionControls: testTextSelectionHandleControls,
             child: const Column(
               children: <Widget>[
                 Text('How are you?'),
@@ -5314,7 +5707,8 @@ void main() {
         const text = 'Monkeys and rabbits in my soup';
 
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
+            textStyle: _materialDefaultTextStyle,
             home: SelectableRegion(
               magnifierConfiguration: TextMagnifierConfiguration(
                 magnifierBuilder:
@@ -5327,7 +5721,7 @@ void main() {
                       return fakeMagnifier;
                     },
               ),
-              selectionControls: materialTextSelectionControls,
+              selectionControls: _testDraggableSelectionControls,
               child: const Text(text),
             ),
           ),
@@ -5381,9 +5775,10 @@ void main() {
       addTearDown(tester.view.reset);
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
+          textStyle: _materialDefaultTextStyle,
           home: SelectableRegion(
-            selectionControls: materialTextSelectionControls,
+            selectionControls: _testDraggableSelectionControlsWithToolbar,
             child: const Text('How are you?'),
           ),
         ),
@@ -5481,6 +5876,10 @@ void main() {
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: <Widget>[
               SelectableRegion(
+                contextMenuBuilder:
+                    (BuildContext context, SelectableRegionState selectableRegionState) {
+                      return const SizedBox.shrink();
+                    },
                 selectionControls: emptyTextSelectionControls,
                 child: const Text('row 1'),
               ),
@@ -5510,6 +5909,10 @@ void main() {
             child: ConstrainedBox(
               constraints: const BoxConstraints(minWidth: 300.0, minHeight: 400.0),
               child: SelectableRegion(
+                contextMenuBuilder:
+                    (BuildContext context, SelectableRegionState selectableRegionState) {
+                      return const SizedBox.shrink();
+                    },
                 selectionControls: emptyTextSelectionControls,
                 child: Container(
                   key: const Key('container'),
@@ -5540,9 +5943,9 @@ void main() {
       var buttonItems = <ContextMenuButtonItem>[];
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: SelectableRegion(
-            selectionControls: materialTextSelectionHandleControls,
+            selectionControls: testTextSelectionHandleControls,
             contextMenuBuilder:
                 (BuildContext context, SelectableRegionState selectableRegionState) {
                   buttonItems = selectableRegionState.contextMenuButtonItems;
@@ -5598,9 +6001,9 @@ void main() {
       var buttonItems = <ContextMenuButtonItem>[];
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: SelectableRegion(
-            selectionControls: materialTextSelectionHandleControls,
+            selectionControls: testTextSelectionHandleControls,
             contextMenuBuilder:
                 (BuildContext context, SelectableRegionState selectableRegionState) {
                   buttonItems = selectableRegionState.contextMenuButtonItems;
@@ -5666,9 +6069,9 @@ void main() {
       var buttonItems = <ContextMenuButtonItem>[];
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: SelectableRegion(
-            selectionControls: materialTextSelectionHandleControls,
+            selectionControls: testTextSelectionHandleControls,
             contextMenuBuilder:
                 (BuildContext context, SelectableRegionState selectableRegionState) {
                   buttonItems = selectableRegionState.contextMenuButtonItems;
@@ -5729,9 +6132,9 @@ void main() {
       var buttonItems = <ContextMenuButtonItem>[];
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: SelectableRegion(
-            selectionControls: materialTextSelectionHandleControls,
+            selectionControls: testTextSelectionHandleControls,
             contextMenuBuilder:
                 (BuildContext context, SelectableRegionState selectableRegionState) {
                   buttonItems = selectableRegionState.contextMenuButtonItems;
@@ -5742,8 +6145,6 @@ void main() {
         ),
       );
       await tester.pumpAndSettle();
-
-      expect(find.byType(AdaptiveTextSelectionToolbar), findsNothing);
 
       final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(
         find.descendant(of: find.text('How are you?'), matching: find.byType(RichText)),
@@ -5782,9 +6183,12 @@ void main() {
 
   testWidgets('can clear selection through SelectableRegionState', (WidgetTester tester) async {
     await tester.pumpWidget(
-      MaterialApp(
+      TestWidgetsApp(
         home: SelectableRegion(
-          selectionControls: materialTextSelectionControls,
+          contextMenuBuilder: (BuildContext context, SelectableRegionState selectableRegionState) {
+            return const SizedBox.shrink();
+          },
+          selectionControls: testTextSelectionHandleControls,
           child: const Column(
             children: <Widget>[
               Text('How are you?'),
@@ -5862,9 +6266,9 @@ void main() {
       var buttonLabels = <String?>{};
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: SelectableRegion(
-            selectionControls: materialTextSelectionHandleControls,
+            selectionControls: testTextSelectionHandleControls,
             contextMenuBuilder:
                 (BuildContext context, SelectableRegionState selectableRegionState) {
                   buttonLabels = selectableRegionState.contextMenuButtonItems
@@ -5909,9 +6313,12 @@ void main() {
     addTearDown(selectionNotifier.dispose);
 
     await tester.pumpWidget(
-      MaterialApp(
+      TestWidgetsApp(
         home: SelectableRegion(
-          selectionControls: materialTextSelectionControls,
+          contextMenuBuilder: (BuildContext context, SelectableRegionState selectableRegionState) {
+            return const SizedBox.shrink();
+          },
+          selectionControls: testTextSelectionHandleControls,
           child: SelectionListener(
             selectionNotifier: selectionNotifier,
             child: Column(
@@ -6030,9 +6437,12 @@ void main() {
     addTearDown(selectionNotifier.dispose);
 
     await tester.pumpWidget(
-      MaterialApp(
+      TestWidgetsApp(
         home: SelectableRegion(
-          selectionControls: materialTextSelectionControls,
+          contextMenuBuilder: (BuildContext context, SelectableRegionState selectableRegionState) {
+            return const SizedBox.shrink();
+          },
+          selectionControls: testTextSelectionHandleControls,
           child: SelectionListener(
             selectionNotifier: selectionNotifier,
             child: Column(
@@ -6150,10 +6560,11 @@ void main() {
     SelectedContent? content;
 
     await tester.pumpWidget(
-      MaterialApp(
+      TestWidgetsApp(
+        textStyle: _materialDefaultTextStyle,
         home: SelectableRegion(
           onSelectionChanged: (SelectedContent? selectedContent) => content = selectedContent,
-          selectionControls: materialTextSelectionControls,
+          selectionControls: _testDraggableSelectionControls,
           child: const Center(child: Text('How are you')),
         ),
       ),
@@ -6293,10 +6704,13 @@ void main() {
     SelectedContent? content;
 
     await tester.pumpWidget(
-      MaterialApp(
+      TestWidgetsApp(
         home: SelectableRegion(
+          contextMenuBuilder: (BuildContext context, SelectableRegionState selectableRegionState) {
+            return const SizedBox.shrink();
+          },
           onSelectionChanged: (SelectedContent? selectedContent) => content = selectedContent,
-          selectionControls: materialTextSelectionControls,
+          selectionControls: testTextSelectionHandleControls,
           child: const Column(
             children: <Widget>[
               Text('How are you?'),
@@ -6490,10 +6904,14 @@ void main() {
       'web can show flutter context menu when the browser context menu is disabled',
       (WidgetTester tester) async {
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
+              contextMenuBuilder:
+                  (BuildContext context, SelectableRegionState selectableRegionState) {
+                    return const SizedBox.shrink();
+                  },
               onSelectionChanged: (SelectedContent? selectedContent) {},
-              selectionControls: materialTextSelectionControls,
+              selectionControls: testTextSelectionHandleControls,
               child: const Center(child: Text('How are you')),
             ),
           ),
@@ -6522,9 +6940,9 @@ void main() {
         final contextMenu = UniqueKey();
 
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SelectableRegion(
-              selectionControls: materialTextSelectionHandleControls,
+              selectionControls: testTextSelectionHandleControls,
               contextMenuBuilder:
                   (BuildContext context, SelectableRegionState selectableRegionState) {
                     return SizedBox.shrink(key: contextMenu);
@@ -6575,24 +6993,25 @@ void main() {
     const textStyle = TextStyle(fontSize: 10);
 
     await tester.pumpWidget(
-      MaterialApp(
+      TestWidgetsApp(
         home: SelectableRegion(
-          selectionControls: materialTextSelectionControls,
-          child: Scaffold(
-            body: Center(
-              child: Text.rich(
-                const TextSpan(
-                  children: <InlineSpan>[
-                    TextSpan(text: 'Hello my name is ', style: textStyle),
-                    WidgetSpan(
-                      child: Text('Dash', style: textStyle),
-                      alignment: PlaceholderAlignment.middle,
-                    ),
-                    TextSpan(text: '.', style: textStyle),
-                  ],
-                ),
-                key: outerText,
+          contextMenuBuilder: (BuildContext context, SelectableRegionState selectableRegionState) {
+            return const SizedBox.shrink();
+          },
+          selectionControls: testTextSelectionHandleControls,
+          child: Center(
+            child: Text.rich(
+              const TextSpan(
+                children: <InlineSpan>[
+                  TextSpan(text: 'Hello my name is ', style: textStyle),
+                  WidgetSpan(
+                    child: Text('Dash', style: textStyle),
+                    alignment: PlaceholderAlignment.middle,
+                  ),
+                  TextSpan(text: '.', style: textStyle),
+                ],
               ),
+              key: outerText,
             ),
           ),
         ),
@@ -6634,6 +7053,10 @@ void main() {
               decoration: BoxDecoration(border: Border.all()),
               // Region 2 (SelectableRegion)
               child: SelectableRegion(
+                contextMenuBuilder:
+                    (BuildContext context, SelectableRegionState selectableRegionState) {
+                      return const SizedBox.shrink();
+                    },
                 selectionControls: emptyTextSelectionControls,
                 child: Padding(
                   padding: const EdgeInsets.all(40),
@@ -6702,6 +7125,9 @@ void main() {
     await tester.pumpWidget(
       TestWidgetsApp(
         home: SelectableRegion(
+          contextMenuBuilder: (BuildContext context, SelectableRegionState selectableRegionState) {
+            return const SizedBox.shrink();
+          },
           selectionControls: emptyTextSelectionControls,
           child: const Text(
             text,

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -46,8 +46,10 @@ const TextStyle _materialDefaultTextStyle = TextStyle(
 const double _kTestHandleSize = 22.0;
 
 /// Selection controls with non-zero handle size for tests that need handle
-/// dragging. Does NOT mix in [TextSelectionHandleControls], so the toolbar
-/// goes through the deprecated [buildToolbar] path (matching how
+/// dragging.
+///
+/// Does NOT mix in [TextSelectionHandleControls], so the toolbar goes through
+/// the deprecated [buildToolbar] path (matching how
 /// [materialTextSelectionControls] worked).
 class _TestDraggableSelectionControls extends TextSelectionControls {
   @override
@@ -6143,6 +6145,7 @@ void main() {
     'builds the correct button items',
     (WidgetTester tester) async {
       var buttonItems = <ContextMenuButtonItem>[];
+      final toolbarKey = UniqueKey();
 
       await tester.pumpWidget(
         TestWidgetsApp(
@@ -6151,13 +6154,15 @@ void main() {
             contextMenuBuilder:
                 (BuildContext context, SelectableRegionState selectableRegionState) {
                   buttonItems = selectableRegionState.contextMenuButtonItems;
-                  return const SizedBox.shrink();
+                  return SizedBox.shrink(key: toolbarKey);
                 },
             child: const Text('How are you?'),
           ),
         ),
       );
       await tester.pumpAndSettle();
+
+      expect(find.byKey(toolbarKey), findsNothing);
 
       final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(
         find.descendant(of: find.text('How are you?'), matching: find.byType(RichText)),

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -170,6 +170,35 @@ class _TestDraggableSelectionHandleControls extends _TestDraggableSelectionContr
 final TextSelectionControls _testDraggableSelectionHandleControls =
     _TestDraggableSelectionHandleControls();
 
+/// Collapsed [SelectableRegionContextMenuBuilder] used by tests that don't
+/// care about toolbar content — suppresses the default context menu.
+Widget _emptyContextMenu(BuildContext context, SelectableRegionState state) =>
+    const SizedBox.shrink();
+
+/// [SelectableRegion] with the defaults most tests in this file use:
+/// [_emptyContextMenu] and [testTextSelectionHandleControls]. Other params
+/// are exposed as overrides. Pass `contextMenuBuilder: null` to explicitly
+/// opt out of a context menu (matches raw [SelectableRegion] default).
+SelectableRegion _selectableRegion({
+  Key? key,
+  required Widget child,
+  FocusNode? focusNode,
+  ValueChanged<SelectedContent?>? onSelectionChanged,
+  SelectableRegionContextMenuBuilder? contextMenuBuilder = _emptyContextMenu,
+  TextSelectionControls? selectionControls,
+  TextMagnifierConfiguration magnifierConfiguration = TextMagnifierConfiguration.disabled,
+}) {
+  return SelectableRegion(
+    key: key,
+    contextMenuBuilder: contextMenuBuilder,
+    selectionControls: selectionControls ?? testTextSelectionHandleControls,
+    focusNode: focusNode,
+    onSelectionChanged: onSelectionChanged,
+    magnifierConfiguration: magnifierConfiguration,
+    child: child,
+  );
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   final mockClipboard = MockClipboard();
@@ -203,14 +232,7 @@ void main() {
       final spy = UniqueKey();
       await tester.pumpWidget(
         TestWidgetsApp(
-          home: SelectableRegion(
-            contextMenuBuilder:
-                (BuildContext context, SelectableRegionState selectableRegionState) {
-                  return const SizedBox.shrink();
-                },
-            selectionControls: testTextSelectionHandleControls,
-            child: SelectionSpy(key: spy),
-          ),
+          home: _selectableRegion(child: SelectionSpy(key: spy)),
         ),
       );
       await tester.pumpAndSettle();
@@ -250,14 +272,7 @@ void main() {
 
       await tester.pumpWidget(
         TestWidgetsApp(
-          home: SelectableRegion(
-            contextMenuBuilder:
-                (BuildContext context, SelectableRegionState selectableRegionState) {
-                  return const SizedBox.shrink();
-                },
-            selectionControls: testTextSelectionHandleControls,
-            child: SelectionSpy(key: spy),
-          ),
+          home: _selectableRegion(child: SelectionSpy(key: spy)),
         ),
       );
 
@@ -287,14 +302,7 @@ void main() {
 
       await tester.pumpWidget(
         TestWidgetsApp(
-          home: SelectableRegion(
-            contextMenuBuilder:
-                (BuildContext context, SelectableRegionState selectableRegionState) {
-                  return const SizedBox.shrink();
-                },
-            selectionControls: testTextSelectionHandleControls,
-            child: SelectionSpy(key: spy),
-          ),
+          home: _selectableRegion(child: SelectionSpy(key: spy)),
         ),
       );
 
@@ -326,12 +334,7 @@ void main() {
                 child: Column(
                   children: <Widget>[
                     const Text('How are you?'),
-                    SelectableRegion(
-                      contextMenuBuilder:
-                          (BuildContext context, SelectableRegionState selectableRegionState) {
-                            return const SizedBox.shrink();
-                          },
-                      selectionControls: testTextSelectionHandleControls,
+                    _selectableRegion(
                       child: const SelectAllWidget(child: SizedBox(width: 100, height: 100)),
                     ),
                     const Text('Fine, thank you.'),
@@ -356,12 +359,7 @@ void main() {
           home: Column(
             children: <Widget>[
               const Text('How are you?'),
-              SelectableRegion(
-                contextMenuBuilder:
-                    (BuildContext context, SelectableRegionState selectableRegionState) {
-                      return const SizedBox.shrink();
-                    },
-                selectionControls: testTextSelectionHandleControls,
+              _selectableRegion(
                 child: SelectAllWidget(key: spy, child: const SizedBox(width: 100, height: 100)),
               ),
               const Text('Fine, thank you.'),
@@ -387,14 +385,7 @@ void main() {
 
       await tester.pumpWidget(
         TestWidgetsApp(
-          home: SelectableRegion(
-            contextMenuBuilder:
-                (BuildContext context, SelectableRegionState selectableRegionState) {
-                  return const SizedBox.shrink();
-                },
-            selectionControls: testTextSelectionHandleControls,
-            child: SelectionSpy(key: spy),
-          ),
+          home: _selectableRegion(child: SelectionSpy(key: spy)),
         ),
       );
 
@@ -417,16 +408,7 @@ void main() {
         const text = 'Hello world';
         await tester.pumpWidget(
           TestWidgetsApp(
-            home: Center(
-              child: SelectableRegion(
-                contextMenuBuilder:
-                    (BuildContext context, SelectableRegionState selectableRegionState) {
-                      return const SizedBox.shrink();
-                    },
-                selectionControls: testTextSelectionHandleControls,
-                child: const Text(text),
-              ),
-            ),
+            home: Center(child: _selectableRegion(child: const Text(text))),
           ),
         );
         // The selection only dismisses when unfocused if the app
@@ -468,12 +450,7 @@ void main() {
 
       await tester.pumpWidget(
         TestWidgetsApp(
-          home: SelectableRegion(
-            contextMenuBuilder:
-                (BuildContext context, SelectableRegionState selectableRegionState) {
-                  return const SizedBox.shrink();
-                },
-            selectionControls: testTextSelectionHandleControls,
+          home: _selectableRegion(
             child: Center(
               child: Column(
                 mainAxisSize: MainAxisSize.min,
@@ -546,16 +523,7 @@ void main() {
             home: PageView(
               controller: pageController,
               children: <Widget>[
-                Center(
-                  child: SelectableRegion(
-                    contextMenuBuilder:
-                        (BuildContext context, SelectableRegionState selectableRegionState) {
-                          return const SizedBox.shrink();
-                        },
-                    selectionControls: testTextSelectionHandleControls,
-                    child: const Text(testValue),
-                  ),
-                ),
+                Center(child: _selectableRegion(child: const Text(testValue))),
                 const SizedBox(height: 200.0, child: Center(child: Text('Page 2'))),
               ],
             ),
@@ -619,16 +587,7 @@ void main() {
               scrollDirection: Axis.vertical,
               controller: pageController,
               children: <Widget>[
-                Center(
-                  child: SelectableRegion(
-                    contextMenuBuilder:
-                        (BuildContext context, SelectableRegionState selectableRegionState) {
-                          return const SizedBox.shrink();
-                        },
-                    selectionControls: testTextSelectionHandleControls,
-                    child: const Text(testValue),
-                  ),
-                ),
+                Center(child: _selectableRegion(child: const Text(testValue))),
                 const SizedBox(height: 200.0, child: Center(child: Text('Page 2'))),
               ],
             ),
@@ -704,16 +663,7 @@ void main() {
               scrollDirection: Axis.vertical,
               controller: pageController,
               children: <Widget>[
-                Center(
-                  child: SelectableRegion(
-                    contextMenuBuilder:
-                        (BuildContext context, SelectableRegionState selectableRegionState) {
-                          return const SizedBox.shrink();
-                        },
-                    selectionControls: testTextSelectionHandleControls,
-                    child: const Text(testValue),
-                  ),
-                ),
+                Center(child: _selectableRegion(child: const Text(testValue))),
                 const SizedBox(height: 200.0, child: Center(child: Text('Page 2'))),
               ],
             ),
@@ -777,14 +727,7 @@ void main() {
 
       await tester.pumpWidget(
         TestWidgetsApp(
-          home: SelectableRegion(
-            contextMenuBuilder:
-                (BuildContext context, SelectableRegionState selectableRegionState) {
-                  return const SizedBox.shrink();
-                },
-            selectionControls: testTextSelectionHandleControls,
-            child: SelectionSpy(key: spy),
-          ),
+          home: _selectableRegion(child: SelectionSpy(key: spy)),
         ),
       );
       await tester.pumpAndSettle();
@@ -818,14 +761,7 @@ void main() {
 
       await tester.pumpWidget(
         TestWidgetsApp(
-          home: SelectableRegion(
-            contextMenuBuilder:
-                (BuildContext context, SelectableRegionState selectableRegionState) {
-                  return const SizedBox.shrink();
-                },
-            selectionControls: testTextSelectionHandleControls,
-            child: SelectionSpy(key: spy),
-          ),
+          home: _selectableRegion(child: SelectionSpy(key: spy)),
         ),
       );
       await tester.pumpAndSettle();
@@ -933,14 +869,7 @@ void main() {
 
       await tester.pumpWidget(
         TestWidgetsApp(
-          home: SelectableRegion(
-            contextMenuBuilder:
-                (BuildContext context, SelectableRegionState selectableRegionState) {
-                  return const SizedBox.shrink();
-                },
-            selectionControls: testTextSelectionHandleControls,
-            child: SelectionSpy(key: spy),
-          ),
+          home: _selectableRegion(child: SelectionSpy(key: spy)),
         ),
       );
       await tester.pumpAndSettle();
@@ -974,14 +903,7 @@ void main() {
 
       await tester.pumpWidget(
         TestWidgetsApp(
-          home: SelectableRegion(
-            contextMenuBuilder:
-                (BuildContext context, SelectableRegionState selectableRegionState) {
-                  return const SizedBox.shrink();
-                },
-            selectionControls: testTextSelectionHandleControls,
-            child: SelectionSpy(key: spy),
-          ),
+          home: _selectableRegion(child: SelectionSpy(key: spy)),
         ),
       );
       await tester.pumpAndSettle();
@@ -1015,14 +937,7 @@ void main() {
             child: SingleChildScrollView(
               child: SizedBox(
                 height: 2000,
-                child: SelectableRegion(
-                  contextMenuBuilder:
-                      (BuildContext context, SelectableRegionState selectableRegionState) {
-                        return const SizedBox.shrink();
-                      },
-                  selectionControls: testTextSelectionHandleControls,
-                  child: SelectionSpy(key: spy),
-                ),
+                child: _selectableRegion(child: SelectionSpy(key: spy)),
               ),
             ),
           ),
@@ -1055,14 +970,7 @@ void main() {
 
       await tester.pumpWidget(
         TestWidgetsApp(
-          home: SelectableRegion(
-            contextMenuBuilder:
-                (BuildContext context, SelectableRegionState selectableRegionState) {
-                  return const SizedBox.shrink();
-                },
-            selectionControls: testTextSelectionHandleControls,
-            child: SelectionSpy(key: spy),
-          ),
+          home: _selectableRegion(child: SelectionSpy(key: spy)),
         ),
       );
       await tester.pumpAndSettle();
@@ -1097,12 +1005,8 @@ void main() {
 
     await tester.pumpWidget(
       TestWidgetsApp(
-        home: SelectableRegion(
-          contextMenuBuilder: (BuildContext context, SelectableRegionState selectableRegionState) {
-            return const SizedBox.shrink();
-          },
+        home: _selectableRegion(
           onSelectionChanged: (SelectedContent? selectedContent) => content = selectedContent,
-          selectionControls: testTextSelectionHandleControls,
           child: SelectionContainer(
             delegate: selectionDelegate,
             child: const Center(
@@ -1219,14 +1123,9 @@ void main() {
         addTearDown(focusNode.dispose);
         await tester.pumpWidget(
           TestWidgetsApp(
-            home: SelectableRegion(
-              contextMenuBuilder:
-                  (BuildContext context, SelectableRegionState selectableRegionState) {
-                    return const SizedBox.shrink();
-                  },
+            home: _selectableRegion(
               key: selectableKey,
               focusNode: focusNode,
-              selectionControls: testTextSelectionHandleControls,
               child: const Center(child: Text('How are you')),
             ),
           ),
@@ -1346,12 +1245,7 @@ void main() {
       (WidgetTester tester) async {
         await tester.pumpWidget(
           TestWidgetsApp(
-            home: SelectableRegion(
-              contextMenuBuilder:
-                  (BuildContext context, SelectableRegionState selectableRegionState) {
-                    return const SizedBox.shrink();
-                  },
-              selectionControls: testTextSelectionHandleControls,
+            home: _selectableRegion(
               child: const Column(
                 children: <Widget>[
                   Text('How are you?'),
@@ -1407,12 +1301,7 @@ void main() {
       (WidgetTester tester) async {
         await tester.pumpWidget(
           TestWidgetsApp(
-            home: SelectableRegion(
-              contextMenuBuilder:
-                  (BuildContext context, SelectableRegionState selectableRegionState) {
-                    return const SizedBox.shrink();
-                  },
-              selectionControls: testTextSelectionHandleControls,
+            home: _selectableRegion(
               child: const Column(
                 children: <Widget>[
                   Text('How are you?'),
@@ -1480,12 +1369,7 @@ void main() {
       (WidgetTester tester) async {
         await tester.pumpWidget(
           TestWidgetsApp(
-            home: SelectableRegion(
-              contextMenuBuilder:
-                  (BuildContext context, SelectableRegionState selectableRegionState) {
-                    return const SizedBox.shrink();
-                  },
-              selectionControls: testTextSelectionHandleControls,
+            home: _selectableRegion(
               child: const Column(
                 children: <Widget>[
                   Text('How are you?'),
@@ -1547,14 +1431,7 @@ void main() {
 
         await tester.pumpWidget(
           TestWidgetsApp(
-            home: SelectableRegion(
-              contextMenuBuilder:
-                  (BuildContext context, SelectableRegionState selectableRegionState) {
-                    return const SizedBox.shrink();
-                  },
-              selectionControls: testTextSelectionHandleControls,
-              child: const Center(child: Text(longText)),
-            ),
+            home: _selectableRegion(child: const Center(child: Text(longText))),
           ),
         );
         final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(
@@ -1666,14 +1543,7 @@ void main() {
       (WidgetTester tester) async {
         await tester.pumpWidget(
           TestWidgetsApp(
-            home: SelectableRegion(
-              contextMenuBuilder:
-                  (BuildContext context, SelectableRegionState selectableRegionState) {
-                    return const SizedBox.shrink();
-                  },
-              selectionControls: testTextSelectionHandleControls,
-              child: const Center(child: Text('How are you')),
-            ),
+            home: _selectableRegion(child: const Center(child: Text('How are you'))),
           ),
         );
         final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(
@@ -1722,14 +1592,7 @@ void main() {
         await tester.pumpWidget(
           TestWidgetsApp(
             textStyle: _materialDefaultTextStyle,
-            home: SelectableRegion(
-              contextMenuBuilder:
-                  (BuildContext context, SelectableRegionState selectableRegionState) {
-                    return const SizedBox.shrink();
-                  },
-              selectionControls: testTextSelectionHandleControls,
-              child: const Center(child: Text('How are you')),
-            ),
+            home: _selectableRegion(child: const Center(child: Text('How are you'))),
           ),
         );
         final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(
@@ -1780,14 +1643,7 @@ void main() {
       (WidgetTester tester) async {
         await tester.pumpWidget(
           TestWidgetsApp(
-            home: SelectableRegion(
-              contextMenuBuilder:
-                  (BuildContext context, SelectableRegionState selectableRegionState) {
-                    return const SizedBox.shrink();
-                  },
-              selectionControls: testTextSelectionHandleControls,
-              child: const Center(child: Text('How are you')),
-            ),
+            home: _selectableRegion(child: const Center(child: Text('How are you'))),
           ),
         );
         final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(
@@ -1821,14 +1677,7 @@ void main() {
 
         await tester.pumpWidget(
           TestWidgetsApp(
-            home: SelectableRegion(
-              contextMenuBuilder:
-                  (BuildContext context, SelectableRegionState selectableRegionState) {
-                    return const SizedBox.shrink();
-                  },
-              selectionControls: testTextSelectionHandleControls,
-              child: const Center(child: Text(testString)),
-            ),
+            home: _selectableRegion(child: const Center(child: Text(testString))),
           ),
         );
         final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(
@@ -1887,12 +1736,7 @@ void main() {
 
       await tester.pumpWidget(
         TestWidgetsApp(
-          home: SelectableRegion(
-            contextMenuBuilder:
-                (BuildContext context, SelectableRegionState selectableRegionState) {
-                  return const SizedBox.shrink();
-                },
-            selectionControls: testTextSelectionHandleControls,
+          home: _selectableRegion(
             child: Center(child: Text('How are you doing today? Good, and you?', key: outerText)),
           ),
         ),
@@ -1946,14 +1790,7 @@ void main() {
     testWidgets('mouse can select single text on desktop platforms', (WidgetTester tester) async {
       await tester.pumpWidget(
         TestWidgetsApp(
-          home: SelectableRegion(
-            contextMenuBuilder:
-                (BuildContext context, SelectableRegionState selectableRegionState) {
-                  return const SizedBox.shrink();
-                },
-            selectionControls: testTextSelectionHandleControls,
-            child: const Center(child: Text('How are you')),
-          ),
+          home: _selectableRegion(child: const Center(child: Text('How are you'))),
         ),
       );
       final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(
@@ -2000,14 +1837,7 @@ void main() {
     testWidgets('mouse can select single text on mobile platforms', (WidgetTester tester) async {
       await tester.pumpWidget(
         TestWidgetsApp(
-          home: SelectableRegion(
-            contextMenuBuilder:
-                (BuildContext context, SelectableRegionState selectableRegionState) {
-                  return const SizedBox.shrink();
-                },
-            selectionControls: testTextSelectionHandleControls,
-            child: const Center(child: Text('How are you')),
-          ),
+          home: _selectableRegion(child: const Center(child: Text('How are you'))),
         ),
       );
       final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(
@@ -2058,12 +1888,7 @@ void main() {
       final GlobalKey textKey = GlobalKey();
       await tester.pumpWidget(
         TestWidgetsApp(
-          home: SelectableRegion(
-            contextMenuBuilder:
-                (BuildContext context, SelectableRegionState selectableRegionState) {
-                  return const SizedBox.shrink();
-                },
-            selectionControls: testTextSelectionHandleControls,
+          home: _selectableRegion(
             child: Center(child: Text(key: textKey, 'How are you')),
           ),
         ),
@@ -2107,12 +1932,7 @@ void main() {
         final GlobalKey textKey = GlobalKey();
         await tester.pumpWidget(
           TestWidgetsApp(
-            home: SelectableRegion(
-              contextMenuBuilder:
-                  (BuildContext context, SelectableRegionState selectableRegionState) {
-                    return const SizedBox.shrink();
-                  },
-              selectionControls: testTextSelectionHandleControls,
+            home: _selectableRegion(
               child: Center(child: Text(key: textKey, 'How are you')),
             ),
           ),
@@ -2150,14 +1970,7 @@ void main() {
     testWidgets('mouse can select word-by-word on double click drag', (WidgetTester tester) async {
       await tester.pumpWidget(
         TestWidgetsApp(
-          home: SelectableRegion(
-            contextMenuBuilder:
-                (BuildContext context, SelectableRegionState selectableRegionState) {
-                  return const SizedBox.shrink();
-                },
-            selectionControls: testTextSelectionHandleControls,
-            child: const Center(child: Text('How are you')),
-          ),
+          home: _selectableRegion(child: const Center(child: Text('How are you'))),
         ),
       );
       final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(
@@ -2228,12 +2041,7 @@ void main() {
     ) async {
       await tester.pumpWidget(
         TestWidgetsApp(
-          home: SelectableRegion(
-            contextMenuBuilder:
-                (BuildContext context, SelectableRegionState selectableRegionState) {
-                  return const SizedBox.shrink();
-                },
-            selectionControls: testTextSelectionHandleControls,
+          home: _selectableRegion(
             child: const Column(
               children: <Widget>[
                 Text('How are you?'),
@@ -2288,12 +2096,7 @@ void main() {
       (WidgetTester tester) async {
         await tester.pumpWidget(
           TestWidgetsApp(
-            home: SelectableRegion(
-              contextMenuBuilder:
-                  (BuildContext context, SelectableRegionState selectableRegionState) {
-                    return const SizedBox.shrink();
-                  },
-              selectionControls: testTextSelectionHandleControls,
+            home: _selectableRegion(
               child: const Column(
                 children: <Widget>[
                   Text('How are you?'),
@@ -2361,12 +2164,7 @@ void main() {
     ) async {
       await tester.pumpWidget(
         TestWidgetsApp(
-          home: SelectableRegion(
-            contextMenuBuilder:
-                (BuildContext context, SelectableRegionState selectableRegionState) {
-                  return const SizedBox.shrink();
-                },
-            selectionControls: testTextSelectionHandleControls,
+          home: _selectableRegion(
             child: const Column(
               children: <Widget>[
                 Text('How are you?'),
@@ -2427,14 +2225,7 @@ void main() {
 
       await tester.pumpWidget(
         TestWidgetsApp(
-          home: SelectableRegion(
-            contextMenuBuilder:
-                (BuildContext context, SelectableRegionState selectableRegionState) {
-                  return const SizedBox.shrink();
-                },
-            selectionControls: testTextSelectionHandleControls,
-            child: const Center(child: Text(longText)),
-          ),
+          home: _selectableRegion(child: const Center(child: Text(longText))),
         ),
       );
       final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(
@@ -2507,12 +2298,7 @@ void main() {
       (WidgetTester tester) async {
         await tester.pumpWidget(
           TestWidgetsApp(
-            home: SelectableRegion(
-              contextMenuBuilder:
-                  (BuildContext context, SelectableRegionState selectableRegionState) {
-                    return const SizedBox.shrink();
-                  },
-              selectionControls: testTextSelectionHandleControls,
+            home: _selectableRegion(
               child: const Text.rich(
                 WidgetSpan(
                   child: Column(
@@ -2584,12 +2370,7 @@ void main() {
     ) async {
       await tester.pumpWidget(
         TestWidgetsApp(
-          home: SelectableRegion(
-            contextMenuBuilder:
-                (BuildContext context, SelectableRegionState selectableRegionState) {
-                  return const SizedBox.shrink();
-                },
-            selectionControls: testTextSelectionHandleControls,
+          home: _selectableRegion(
             child: const Column(
               children: <Widget>[
                 Text('How are you?\nThis is the first text widget.'),
@@ -2670,12 +2451,7 @@ void main() {
       (WidgetTester tester) async {
         await tester.pumpWidget(
           TestWidgetsApp(
-            home: SelectableRegion(
-              contextMenuBuilder:
-                  (BuildContext context, SelectableRegionState selectableRegionState) {
-                    return const SizedBox.shrink();
-                  },
-              selectionControls: testTextSelectionHandleControls,
+            home: _selectableRegion(
               child: const Column(
                 children: <Widget>[
                   Text('How are you?\nThis is the first text widget.'),
@@ -2767,12 +2543,7 @@ void main() {
     ) async {
       await tester.pumpWidget(
         TestWidgetsApp(
-          home: SelectableRegion(
-            contextMenuBuilder:
-                (BuildContext context, SelectableRegionState selectableRegionState) {
-                  return const SizedBox.shrink();
-                },
-            selectionControls: testTextSelectionHandleControls,
+          home: _selectableRegion(
             child: const Column(
               children: <Widget>[
                 Text('How are you?\nThis is the first text widget.'),
@@ -2832,12 +2603,7 @@ void main() {
     testWidgets('mouse can select multiple widgets', (WidgetTester tester) async {
       await tester.pumpWidget(
         TestWidgetsApp(
-          home: SelectableRegion(
-            contextMenuBuilder:
-                (BuildContext context, SelectableRegionState selectableRegionState) {
-                  return const SizedBox.shrink();
-                },
-            selectionControls: testTextSelectionHandleControls,
+          home: _selectableRegion(
             child: const Column(
               children: <Widget>[
                 Text('How are you?'),
@@ -2959,12 +2725,7 @@ void main() {
       (WidgetTester tester) async {
         await tester.pumpWidget(
           TestWidgetsApp(
-            home: SelectableRegion(
-              contextMenuBuilder:
-                  (BuildContext context, SelectableRegionState selectableRegionState) {
-                    return const SizedBox.shrink();
-                  },
-              selectionControls: testTextSelectionHandleControls,
+            home: _selectableRegion(
               child: const Column(
                 children: <Widget>[
                   Text('How are you?'),
@@ -3058,12 +2819,7 @@ void main() {
     testWidgets('mouse can work with disabled container', (WidgetTester tester) async {
       await tester.pumpWidget(
         TestWidgetsApp(
-          home: SelectableRegion(
-            contextMenuBuilder:
-                (BuildContext context, SelectableRegionState selectableRegionState) {
-                  return const SizedBox.shrink();
-                },
-            selectionControls: testTextSelectionHandleControls,
+          home: _selectableRegion(
             child: const Column(
               children: <Widget>[
                 Text('How are you?'),
@@ -3111,12 +2867,7 @@ void main() {
     testWidgets('mouse can reverse selection', (WidgetTester tester) async {
       await tester.pumpWidget(
         TestWidgetsApp(
-          home: SelectableRegion(
-            contextMenuBuilder:
-                (BuildContext context, SelectableRegionState selectableRegionState) {
-                  return const SizedBox.shrink();
-                },
-            selectionControls: testTextSelectionHandleControls,
+          home: _selectableRegion(
             child: const Column(
               children: <Widget>[
                 Text('How are you?'),
@@ -3895,12 +3646,7 @@ void main() {
       (WidgetTester tester) async {
         await tester.pumpWidget(
           TestWidgetsApp(
-            home: SelectableRegion(
-              contextMenuBuilder:
-                  (BuildContext context, SelectableRegionState selectableRegionState) {
-                    return const SizedBox.shrink();
-                  },
-              selectionControls: testTextSelectionHandleControls,
+            home: _selectableRegion(
               child: const Column(
                 children: <Widget>[
                   Text('How are you?'),
@@ -3957,13 +3703,8 @@ void main() {
 
         await tester.pumpWidget(
           TestWidgetsApp(
-            home: SelectableRegion(
-              contextMenuBuilder:
-                  (BuildContext context, SelectableRegionState selectableRegionState) {
-                    return const SizedBox.shrink();
-                  },
+            home: _selectableRegion(
               focusNode: selectableRegionFocus,
-              selectionControls: testTextSelectionHandleControls,
               child: Column(
                 children: <Widget>[
                   const Text('How are you?'),
@@ -4031,13 +3772,8 @@ void main() {
 
         await tester.pumpWidget(
           TestWidgetsApp(
-            home: SelectableRegion(
-              contextMenuBuilder:
-                  (BuildContext context, SelectableRegionState selectableRegionState) {
-                    return const SizedBox.shrink();
-                  },
+            home: _selectableRegion(
               focusNode: selectableRegionFocus,
-              selectionControls: testTextSelectionHandleControls,
               child: Column(
                 children: <Widget>[
                   const Text('How are you?'),
@@ -4099,13 +3835,8 @@ void main() {
 
         await tester.pumpWidget(
           TestWidgetsApp(
-            home: SelectableRegion(
-              contextMenuBuilder:
-                  (BuildContext context, SelectableRegionState selectableRegionState) {
-                    return const SizedBox.shrink();
-                  },
+            home: _selectableRegion(
               focusNode: focusNode,
-              selectionControls: testTextSelectionHandleControls,
               child: const Column(
                 children: <Widget>[
                   Text('How are you?'),
@@ -4153,12 +3884,7 @@ void main() {
 
         await tester.pumpWidget(
           TestWidgetsApp(
-            home: SelectableRegion(
-              contextMenuBuilder:
-                  (BuildContext context, SelectableRegionState selectableRegionState) {
-                    return const SizedBox.shrink();
-                  },
-              selectionControls: testTextSelectionHandleControls,
+            home: _selectableRegion(
               child: Center(
                 child: Text.rich(
                   const TextSpan(
@@ -4209,12 +3935,7 @@ void main() {
 
         await tester.pumpWidget(
           TestWidgetsApp(
-            home: SelectableRegion(
-              contextMenuBuilder:
-                  (BuildContext context, SelectableRegionState selectableRegionState) {
-                    return const SizedBox.shrink();
-                  },
-              selectionControls: testTextSelectionHandleControls,
+            home: _selectableRegion(
               child: Center(
                 child: Text.rich(
                   const TextSpan(
@@ -4271,12 +3992,7 @@ void main() {
 
         await tester.pumpWidget(
           TestWidgetsApp(
-            home: SelectableRegion(
-              contextMenuBuilder:
-                  (BuildContext context, SelectableRegionState selectableRegionState) {
-                    return const SizedBox.shrink();
-                  },
-              selectionControls: testTextSelectionHandleControls,
+            home: _selectableRegion(
               child: Center(
                 child: Text.rich(
                   TextSpan(
@@ -4330,12 +4046,7 @@ void main() {
 
         await tester.pumpWidget(
           TestWidgetsApp(
-            home: SelectableRegion(
-              contextMenuBuilder:
-                  (BuildContext context, SelectableRegionState selectableRegionState) {
-                    return const SizedBox.shrink();
-                  },
-              selectionControls: testTextSelectionHandleControls,
+            home: _selectableRegion(
               child: Center(
                 child: Text.rich(
                   TextSpan(
@@ -4383,12 +4094,7 @@ void main() {
 
         await tester.pumpWidget(
           TestWidgetsApp(
-            home: SelectableRegion(
-              contextMenuBuilder:
-                  (BuildContext context, SelectableRegionState selectableRegionState) {
-                    return const SizedBox.shrink();
-                  },
-              selectionControls: testTextSelectionHandleControls,
+            home: _selectableRegion(
               child: Center(
                 child: Text.rich(
                   TextSpan(
@@ -4433,12 +4139,7 @@ void main() {
 
         await tester.pumpWidget(
           TestWidgetsApp(
-            home: SelectableRegion(
-              contextMenuBuilder:
-                  (BuildContext context, SelectableRegionState selectableRegionState) {
-                    return const SizedBox.shrink();
-                  },
-              selectionControls: testTextSelectionHandleControls,
+            home: _selectableRegion(
               child: Center(
                 child: Text.rich(
                   const TextSpan(
@@ -4484,12 +4185,7 @@ void main() {
 
         await tester.pumpWidget(
           TestWidgetsApp(
-            home: SelectableRegion(
-              contextMenuBuilder:
-                  (BuildContext context, SelectableRegionState selectableRegionState) {
-                    return const SizedBox.shrink();
-                  },
-              selectionControls: testTextSelectionHandleControls,
+            home: _selectableRegion(
               child: Center(
                 child: Text.rich(
                   const TextSpan(
@@ -4535,12 +4231,7 @@ void main() {
 
         await tester.pumpWidget(
           TestWidgetsApp(
-            home: SelectableRegion(
-              contextMenuBuilder:
-                  (BuildContext context, SelectableRegionState selectableRegionState) {
-                    return const SizedBox.shrink();
-                  },
-              selectionControls: testTextSelectionHandleControls,
+            home: _selectableRegion(
               child: Center(
                 child: Text.rich(
                   const TextSpan(
@@ -4591,12 +4282,7 @@ void main() {
 
         await tester.pumpWidget(
           TestWidgetsApp(
-            home: SelectableRegion(
-              contextMenuBuilder:
-                  (BuildContext context, SelectableRegionState selectableRegionState) {
-                    return const SizedBox.shrink();
-                  },
-              selectionControls: testTextSelectionHandleControls,
+            home: _selectableRegion(
               child: Center(
                 child: Text.rich(
                   const TextSpan(
@@ -4641,12 +4327,7 @@ void main() {
     testWidgets('mouse can select across bidi text', (WidgetTester tester) async {
       await tester.pumpWidget(
         TestWidgetsApp(
-          home: SelectableRegion(
-            contextMenuBuilder:
-                (BuildContext context, SelectableRegionState selectableRegionState) {
-                  return const SizedBox.shrink();
-                },
-            selectionControls: testTextSelectionHandleControls,
+          home: _selectableRegion(
             child: const Column(
               children: <Widget>[
                 Text('How are you?'),
@@ -4696,12 +4377,7 @@ void main() {
     ) async {
       await tester.pumpWidget(
         TestWidgetsApp(
-          home: SelectableRegion(
-            contextMenuBuilder:
-                (BuildContext context, SelectableRegionState selectableRegionState) {
-                  return const SizedBox.shrink();
-                },
-            selectionControls: testTextSelectionHandleControls,
+          home: _selectableRegion(
             child: const Column(
               children: <Widget>[
                 Text('How are you?'),
@@ -5067,12 +4743,7 @@ void main() {
       (WidgetTester tester) async {
         await tester.pumpWidget(
           TestWidgetsApp(
-            home: SelectableRegion(
-              contextMenuBuilder:
-                  (BuildContext context, SelectableRegionState selectableRegionState) {
-                    return const SizedBox.shrink();
-                  },
-              selectionControls: testTextSelectionHandleControls,
+            home: _selectableRegion(
               child: const Column(
                 children: <Widget>[
                   Text('How are you?'),
@@ -5146,12 +4817,7 @@ void main() {
     ) async {
       await tester.pumpWidget(
         TestWidgetsApp(
-          home: SelectableRegion(
-            contextMenuBuilder:
-                (BuildContext context, SelectableRegionState selectableRegionState) {
-                  return const SizedBox.shrink();
-                },
-            selectionControls: testTextSelectionHandleControls,
+          home: _selectableRegion(
             child: const Column(
               children: <Widget>[
                 Text('How are you?'),
@@ -5288,12 +4954,7 @@ void main() {
     ) async {
       await tester.pumpWidget(
         TestWidgetsApp(
-          home: SelectableRegion(
-            contextMenuBuilder:
-                (BuildContext context, SelectableRegionState selectableRegionState) {
-                  return const SizedBox.shrink();
-                },
-            selectionControls: testTextSelectionHandleControls,
+          home: _selectableRegion(
             child: const Column(
               children: <Widget>[
                 Text('How are you?'),
@@ -5403,12 +5064,7 @@ void main() {
       (WidgetTester tester) async {
         await tester.pumpWidget(
           TestWidgetsApp(
-            home: SelectableRegion(
-              contextMenuBuilder:
-                  (BuildContext context, SelectableRegionState selectableRegionState) {
-                    return const SizedBox.shrink();
-                  },
-              selectionControls: testTextSelectionHandleControls,
+            home: _selectableRegion(
               child: const Column(
                 children: <Widget>[
                   Text('How are you?'),
@@ -5493,12 +5149,7 @@ void main() {
       (WidgetTester tester) async {
         await tester.pumpWidget(
           TestWidgetsApp(
-            home: SelectableRegion(
-              contextMenuBuilder:
-                  (BuildContext context, SelectableRegionState selectableRegionState) {
-                    return const SizedBox.shrink();
-                  },
-              selectionControls: testTextSelectionHandleControls,
+            home: _selectableRegion(
               child: const Column(
                 children: <Widget>[
                   Text('How are you?'),
@@ -5593,12 +5244,7 @@ void main() {
     testWidgets('can use keyboard to directionally extend selection', (WidgetTester tester) async {
       await tester.pumpWidget(
         TestWidgetsApp(
-          home: SelectableRegion(
-            contextMenuBuilder:
-                (BuildContext context, SelectableRegionState selectableRegionState) {
-                  return const SizedBox.shrink();
-                },
-            selectionControls: testTextSelectionHandleControls,
+          home: _selectableRegion(
             child: const Column(
               children: <Widget>[
                 Text('How are you?'),
@@ -5891,10 +5537,7 @@ void main() {
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: <Widget>[
               SelectableRegion(
-                contextMenuBuilder:
-                    (BuildContext context, SelectableRegionState selectableRegionState) {
-                      return const SizedBox.shrink();
-                    },
+                contextMenuBuilder: _emptyContextMenu,
                 selectionControls: emptyTextSelectionControls,
                 child: const Text('row 1'),
               ),
@@ -5924,10 +5567,7 @@ void main() {
             child: ConstrainedBox(
               constraints: const BoxConstraints(minWidth: 300.0, minHeight: 400.0),
               child: SelectableRegion(
-                contextMenuBuilder:
-                    (BuildContext context, SelectableRegionState selectableRegionState) {
-                      return const SizedBox.shrink();
-                    },
+                contextMenuBuilder: _emptyContextMenu,
                 selectionControls: emptyTextSelectionControls,
                 child: Container(
                   key: const Key('container'),
@@ -6202,11 +5842,7 @@ void main() {
   testWidgets('can clear selection through SelectableRegionState', (WidgetTester tester) async {
     await tester.pumpWidget(
       TestWidgetsApp(
-        home: SelectableRegion(
-          contextMenuBuilder: (BuildContext context, SelectableRegionState selectableRegionState) {
-            return const SizedBox.shrink();
-          },
-          selectionControls: testTextSelectionHandleControls,
+        home: _selectableRegion(
           child: const Column(
             children: <Widget>[
               Text('How are you?'),
@@ -6332,11 +5968,7 @@ void main() {
 
     await tester.pumpWidget(
       TestWidgetsApp(
-        home: SelectableRegion(
-          contextMenuBuilder: (BuildContext context, SelectableRegionState selectableRegionState) {
-            return const SizedBox.shrink();
-          },
-          selectionControls: testTextSelectionHandleControls,
+        home: _selectableRegion(
           child: SelectionListener(
             selectionNotifier: selectionNotifier,
             child: Column(
@@ -6456,11 +6088,7 @@ void main() {
 
     await tester.pumpWidget(
       TestWidgetsApp(
-        home: SelectableRegion(
-          contextMenuBuilder: (BuildContext context, SelectableRegionState selectableRegionState) {
-            return const SizedBox.shrink();
-          },
-          selectionControls: testTextSelectionHandleControls,
+        home: _selectableRegion(
           child: SelectionListener(
             selectionNotifier: selectionNotifier,
             child: Column(
@@ -6723,12 +6351,8 @@ void main() {
 
     await tester.pumpWidget(
       TestWidgetsApp(
-        home: SelectableRegion(
-          contextMenuBuilder: (BuildContext context, SelectableRegionState selectableRegionState) {
-            return const SizedBox.shrink();
-          },
+        home: _selectableRegion(
           onSelectionChanged: (SelectedContent? selectedContent) => content = selectedContent,
-          selectionControls: testTextSelectionHandleControls,
           child: const Column(
             children: <Widget>[
               Text('How are you?'),
@@ -7008,11 +6632,7 @@ void main() {
 
     await tester.pumpWidget(
       TestWidgetsApp(
-        home: SelectableRegion(
-          contextMenuBuilder: (BuildContext context, SelectableRegionState selectableRegionState) {
-            return const SizedBox.shrink();
-          },
-          selectionControls: testTextSelectionHandleControls,
+        home: _selectableRegion(
           child: Center(
             child: Text.rich(
               const TextSpan(
@@ -7067,10 +6687,7 @@ void main() {
               decoration: BoxDecoration(border: Border.all()),
               // Region 2 (SelectableRegion)
               child: SelectableRegion(
-                contextMenuBuilder:
-                    (BuildContext context, SelectableRegionState selectableRegionState) {
-                      return const SizedBox.shrink();
-                    },
+                contextMenuBuilder: _emptyContextMenu,
                 selectionControls: emptyTextSelectionControls,
                 child: Padding(
                   padding: const EdgeInsets.all(40),
@@ -7139,9 +6756,7 @@ void main() {
     await tester.pumpWidget(
       TestWidgetsApp(
         home: SelectableRegion(
-          contextMenuBuilder: (BuildContext context, SelectableRegionState selectableRegionState) {
-            return const SizedBox.shrink();
-          },
+          contextMenuBuilder: _emptyContextMenu,
           selectionControls: emptyTextSelectionControls,
           child: const Text(
             text,

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -160,6 +160,14 @@ class _TestDraggableSelectionControlsWithToolbar extends _TestDraggableSelection
 final TextSelectionControls _testDraggableSelectionControlsWithToolbar =
     _TestDraggableSelectionControlsWithToolbar();
 
+/// Like [_TestDraggableSelectionControls] but mixes in [TextSelectionHandleControls]
+/// so the toolbar goes through the [SelectableRegion.contextMenuBuilder] path.
+class _TestDraggableSelectionHandleControls extends _TestDraggableSelectionControls
+    with TextSelectionHandleControls {}
+
+final TextSelectionControls _testDraggableSelectionHandleControls =
+    _TestDraggableSelectionHandleControls();
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   final mockClipboard = MockClipboard();
@@ -841,8 +849,9 @@ void main() {
         final toolbarKey = UniqueKey();
         await tester.pumpWidget(
           TestWidgetsApp(
+            textStyle: _materialDefaultTextStyle,
             home: SelectableRegion(
-              selectionControls: testTextSelectionHandleControls,
+              selectionControls: _testDraggableSelectionHandleControls,
               contextMenuBuilder:
                   (BuildContext context, SelectableRegionState selectableRegionState) {
                     return SizedBox(key: toolbarKey);
@@ -910,7 +919,10 @@ void main() {
         expect(paragraph.selections.length, 1);
         expect(paragraph.selections.first, const TextSelection(baseOffset: 1, extentOffset: 20));
       },
-      variant: TargetPlatformVariant.mobile(),
+      // Fuchsia is the only mobile platform where the browser context menu is
+      // enabled by default on web, so it is the only mobile platform where this
+      // scenario applies. See: https://github.com/flutter/flutter/pull/177122.
+      variant: TargetPlatformVariant.only(TargetPlatform.fuchsia),
       skip: !kIsWeb, // [intended] This test verifies mobile web behavior.
     );
 
@@ -1707,6 +1719,7 @@ void main() {
       (WidgetTester tester) async {
         await tester.pumpWidget(
           TestWidgetsApp(
+            textStyle: _materialDefaultTextStyle,
             home: SelectableRegion(
               contextMenuBuilder:
                   (BuildContext context, SelectableRegionState selectableRegionState) {
@@ -6906,12 +6919,8 @@ void main() {
         await tester.pumpWidget(
           TestWidgetsApp(
             home: SelectableRegion(
-              contextMenuBuilder:
-                  (BuildContext context, SelectableRegionState selectableRegionState) {
-                    return const SizedBox.shrink();
-                  },
               onSelectionChanged: (SelectedContent? selectedContent) {},
-              selectionControls: testTextSelectionHandleControls,
+              selectionControls: _testDraggableSelectionControlsWithToolbar,
               child: const Center(child: Text('How are you')),
             ),
           ),

--- a/packages/flutter/test/widgets/semantics_debugger_test.dart
+++ b/packages/flutter/test/widgets/semantics_debugger_test.dart
@@ -499,12 +499,7 @@ void main() {
       TestWidgetsApp(
         home: SemanticsDebugger(
           key: debugger,
-          child: Semantics(
-            key: textField,
-            textField: true,
-            enabled: true,
-            child: const TestTextField(),
-          ),
+          child: TestTextField(key: textField),
         ),
       ),
     );

--- a/packages/flutter/test/widgets/semantics_debugger_test.dart
+++ b/packages/flutter/test/widgets/semantics_debugger_test.dart
@@ -3,8 +3,16 @@
 // found in the LICENSE file.
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'button_tester.dart';
+import 'checkbox_tester.dart';
+import 'editable_text_tester.dart';
+import 'widgets_app_tester.dart';
+
+const Color _green = Color(0xFF4CAF50);
+const Color _amber = Color(0xFFFFC107);
 
 void main() {
   testWidgets('SemanticsDebugger will schedule a frame', (WidgetTester tester) async {
@@ -161,23 +169,21 @@ void main() {
       Directionality(
         textDirection: TextDirection.ltr,
         child: SemanticsDebugger(
-          child: Material(
-            child: ListView(
-              children: <Widget>[
-                ElevatedButton(
-                  onPressed: () {
-                    log.add('top');
-                  },
-                  child: const Text('TOP'),
-                ),
-                ElevatedButton(
-                  onPressed: () {
-                    log.add('bottom');
-                  },
-                  child: const Text('BOTTOM'),
-                ),
-              ],
-            ),
+          child: ListView(
+            children: <Widget>[
+              TestButton(
+                onPressed: () {
+                  log.add('top');
+                },
+                child: const Text('TOP'),
+              ),
+              TestButton(
+                onPressed: () {
+                  log.add('bottom');
+                },
+                child: const Text('BOTTOM'),
+              ),
+            ],
           ),
         ),
       ),
@@ -199,25 +205,23 @@ void main() {
       Directionality(
         textDirection: TextDirection.ltr,
         child: SemanticsDebugger(
-          child: Material(
-            child: ListView(
-              children: <Widget>[
-                ElevatedButton(
+          child: ListView(
+            children: <Widget>[
+              TestButton(
+                onPressed: () {
+                  log.add('top');
+                },
+                child: const Text('TOP', textDirection: TextDirection.ltr),
+              ),
+              ExcludeSemantics(
+                child: TestButton(
                   onPressed: () {
-                    log.add('top');
+                    log.add('bottom');
                   },
-                  child: const Text('TOP', textDirection: TextDirection.ltr),
+                  child: const Text('BOTTOM', textDirection: TextDirection.ltr),
                 ),
-                ExcludeSemantics(
-                  child: ElevatedButton(
-                    onPressed: () {
-                      log.add('bottom');
-                    },
-                    child: const Text('BOTTOM', textDirection: TextDirection.ltr),
-                  ),
-                ),
-              ],
-            ),
+              ),
+            ],
           ),
         ),
       ),
@@ -240,7 +244,7 @@ void main() {
         textDirection: TextDirection.ltr,
         child: SemanticsDebugger(
           child: ListView(
-            children: <Widget>[Container(key: childKey, height: 5000.0, color: Colors.green[500])],
+            children: <Widget>[Container(key: childKey, height: 5000.0, color: _green)],
           ),
         ),
       ),
@@ -315,23 +319,19 @@ void main() {
     var value = 0.5;
 
     await tester.pumpWidget(
-      MaterialApp(
-        home: Directionality(
-          textDirection: TextDirection.ltr,
-          child: SemanticsDebugger(
-            child: Directionality(
-              textDirection: TextDirection.ltr,
-              child: MediaQuery(
-                data: MediaQueryData.fromView(tester.view),
-                child: Material(
-                  child: Center(
-                    child: Slider(
-                      value: value,
-                      onChanged: (double newValue) {
-                        value = newValue;
-                      },
-                    ),
-                  ),
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: SemanticsDebugger(
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: MediaQuery(
+              data: MediaQueryData.fromView(tester.view),
+              child: Center(
+                child: _TestSlider(
+                  value: value,
+                  onChanged: (double newValue) {
+                    value = newValue;
+                  },
                 ),
               ),
             ),
@@ -346,22 +346,13 @@ void main() {
     // interpreted as a gesture by the semantics debugger and sent to the widget
     // as a semantic action that always moves by 10% of the complete track.
     await tester.fling(
-      find.byType(Slider),
+      find.byType(_TestSlider),
       const Offset(-100.0, 0.0),
       2000.0,
       warnIfMissed: false,
     ); // hitting the debugger
-    switch (defaultTargetPlatform) {
-      case TargetPlatform.iOS:
-      case TargetPlatform.macOS:
-        expect(value, equals(0.4));
-      case TargetPlatform.linux:
-      case TargetPlatform.windows:
-      case TargetPlatform.android:
-      case TargetPlatform.fuchsia:
-        expect(value, equals(0.45));
-    }
-  }, variant: TargetPlatformVariant.all());
+    expect(value, equals(0.4));
+  });
 
   testWidgets('SemanticsDebugger checkbox', (WidgetTester tester) async {
     final Key keyTop = UniqueKey();
@@ -373,19 +364,17 @@ void main() {
       Directionality(
         textDirection: TextDirection.ltr,
         child: SemanticsDebugger(
-          child: Material(
-            child: ListView(
-              children: <Widget>[
-                Checkbox(
-                  key: keyTop,
-                  value: valueTop,
-                  onChanged: (bool? newValue) {
-                    valueTop = newValue;
-                  },
-                ),
-                Checkbox(key: keyBottom, value: false, onChanged: null),
-              ],
-            ),
+          child: ListView(
+            children: <Widget>[
+              TestCheckbox(
+                key: keyTop,
+                value: valueTop,
+                onChanged: (bool? newValue) {
+                  valueTop = newValue;
+                },
+              ),
+              TestCheckbox(key: keyBottom, value: false, onChanged: null),
+            ],
           ),
         ),
       ),
@@ -412,31 +401,29 @@ void main() {
         textDirection: TextDirection.ltr,
         child: SemanticsDebugger(
           key: debugger,
-          child: Material(
-            child: ListView(
-              children: <Widget>[
-                Semantics(
-                  container: true,
-                  key: checkbox,
-                  child: Checkbox(value: true, onChanged: (bool? _) {}),
-                ),
-                Semantics(
-                  container: true,
-                  key: checkboxUnchecked,
-                  child: Checkbox(value: false, onChanged: (bool? _) {}),
-                ),
-                Semantics(
-                  container: true,
-                  key: checkboxDisabled,
-                  child: const Checkbox(value: true, onChanged: null),
-                ),
-                Semantics(
-                  container: true,
-                  key: checkboxDisabledUnchecked,
-                  child: const Checkbox(value: false, onChanged: null),
-                ),
-              ],
-            ),
+          child: ListView(
+            children: <Widget>[
+              Semantics(
+                container: true,
+                key: checkbox,
+                child: TestCheckbox(value: true, onChanged: (bool? _) {}),
+              ),
+              Semantics(
+                container: true,
+                key: checkboxUnchecked,
+                child: TestCheckbox(value: false, onChanged: (bool? _) {}),
+              ),
+              Semantics(
+                container: true,
+                key: checkboxDisabled,
+                child: const TestCheckbox(value: true, onChanged: null),
+              ),
+              Semantics(
+                container: true,
+                key: checkboxDisabledUnchecked,
+                child: const TestCheckbox(value: false, onChanged: null),
+              ),
+            ],
           ),
         ),
       ),
@@ -487,9 +474,7 @@ void main() {
           textDirection: TextDirection.ltr,
           child: SemanticsDebugger(
             key: debugger,
-            child: Material(
-              child: Semantics(container: true, key: child, label: 'text', tooltip: 'text'),
-            ),
+            child: Semantics(container: true, key: child, label: 'text', tooltip: 'text'),
           ),
         ),
       );
@@ -511,10 +496,15 @@ void main() {
     final debugger = UniqueKey();
 
     await tester.pumpWidget(
-      MaterialApp(
+      TestWidgetsApp(
         home: SemanticsDebugger(
           key: debugger,
-          child: Material(child: TextField(key: textField)),
+          child: Semantics(
+            key: textField,
+            textField: true,
+            enabled: true,
+            child: const TestTextField(),
+          ),
         ),
       ),
     );
@@ -523,20 +513,17 @@ void main() {
       debuggerKey: debugger,
       tester: tester,
     );
-    final RenderObject renderTextfield = tester.renderObject(
-      find.descendant(of: find.byKey(textField), matching: find.byType(Semantics)).first,
-    );
+    final RenderObject renderTextfield = tester.renderObject(find.byKey(textField));
 
-    expect(
-      // ignore: avoid_dynamic_calls
-      semanticsDebuggerPainter.getMessage(renderTextfield.debugSemantics),
-      'textfield',
-    );
+    final message =
+        // ignore: avoid_dynamic_calls
+        semanticsDebuggerPainter.getMessage(renderTextfield.debugSemantics) as String;
+    expect(message, contains('textfield'));
   });
 
   testWidgets('SemanticsDebugger label style is used in the painter.', (WidgetTester tester) async {
     final debugger = UniqueKey();
-    const labelStyle = TextStyle(color: Colors.amber);
+    const labelStyle = TextStyle(color: _amber);
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
@@ -602,6 +589,27 @@ String _getMessageShownInSemanticsDebugger({
         tester.renderObject(find.byKey(widgetKey)).debugSemantics,
       )
       as String;
+}
+
+/// A minimal slider widget for testing SemanticsDebugger interactions without
+/// depending on the Material library.
+class _TestSlider extends StatelessWidget {
+  const _TestSlider({required this.value, required this.onChanged});
+
+  final double value;
+  final ValueChanged<double> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      value: '${(value * 100).round()}%',
+      increasedValue: '${((value + 0.1).clamp(0.0, 1.0) * 100).round()}%',
+      decreasedValue: '${((value - 0.1).clamp(0.0, 1.0) * 100).round()}%',
+      onIncrease: () => onChanged((value + 0.1).clamp(0.0, 1.0)),
+      onDecrease: () => onChanged((value - 0.1).clamp(0.0, 1.0)),
+      child: const SizedBox(width: 200, height: 36),
+    );
+  }
 }
 
 dynamic _getSemanticsDebuggerPainter({required Key debuggerKey, required WidgetTester tester}) {

--- a/packages/flutter/test/widgets/text_golden_test.dart
+++ b/packages/flutter/test/widgets/text_golden_test.dart
@@ -8,8 +8,18 @@
 @TestOn('!chrome')
 library;
 
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'checkbox_tester.dart';
+import 'editable_text_tester.dart';
+import 'widgets_app_tester.dart';
+
+const Color _debugRed = Color(0xFFFF0000);
+const Color _debugBlue = Color(0xFF0000FF);
+const Color _debugGreen = Color(0xFF00FF00);
+const Color _debugBlack = Color(0xFF000000);
+const Color _debugWhite = Color(0xFFFFFFFF);
 
 void main() {
   testWidgets('Centered text', (WidgetTester tester) async {
@@ -136,8 +146,8 @@ void main() {
   // drawing from the beginning of the line bug is fixed. The current
   // tested version is not completely correct.
   testWidgets('Text Background', (WidgetTester tester) async {
-    const Color red = Colors.red;
-    const Color blue = Colors.blue;
+    const Color red = _debugRed;
+    const Color blue = _debugBlue;
     const translucentGreen = Color(0x5000F000);
     const translucentDarkRed = Color(0x500F0000);
     await tester.pumpWidget(
@@ -147,7 +157,7 @@ void main() {
           child: Container(
             width: 200.0,
             height: 100.0,
-            decoration: const BoxDecoration(color: Colors.green),
+            decoration: const BoxDecoration(color: _debugGreen),
             child: Text.rich(
               TextSpan(
                 text: 'text1 ',
@@ -180,26 +190,22 @@ void main() {
 
   testWidgets('Text Fade', (WidgetTester tester) async {
     await tester.pumpWidget(
-      MaterialApp(
-        theme: ThemeData(useMaterial3: false),
-        home: Scaffold(
-          backgroundColor: Colors.transparent,
-          body: RepaintBoundary(
-            child: Center(
-              child: Container(
-                width: 200.0,
-                height: 200.0,
-                color: Colors.green,
-                child: Center(
-                  child: Container(
-                    width: 100.0,
-                    color: Colors.blue,
-                    child: const Text(
-                      'Pp PPp PPPp PPPPp PPPPpp PPPPppp PPPPppppp ',
-                      style: TextStyle(color: Colors.black),
-                      maxLines: 3,
-                      overflow: TextOverflow.fade,
-                    ),
+      TestWidgetsApp(
+        home: RepaintBoundary(
+          child: Center(
+            child: Container(
+              width: 200.0,
+              height: 200.0,
+              color: _debugGreen,
+              child: Center(
+                child: Container(
+                  width: 100.0,
+                  color: _debugBlue,
+                  child: const Text(
+                    'Pp PPp PPPp PPPPp PPPPpp PPPPppp PPPPppppp ',
+                    style: TextStyle(color: _debugBlack),
+                    maxLines: 3,
+                    overflow: TextOverflow.fade,
                   ),
                 ),
               ),
@@ -289,15 +295,15 @@ void main() {
             child: const Text.rich(
               TextSpan(
                 text: 'Hello\n',
-                style: TextStyle(color: Colors.red, fontSize: 30),
+                style: TextStyle(color: _debugRed, fontSize: 30),
                 children: <InlineSpan>[
                   TextSpan(
                     text: 'Second line!\n',
-                    style: TextStyle(fontSize: 5, color: Colors.blue),
+                    style: TextStyle(fontSize: 5, color: _debugBlue),
                   ),
                   TextSpan(
                     text: 'Third line!\n',
-                    style: TextStyle(fontSize: 25, color: Colors.white),
+                    style: TextStyle(fontSize: 25, color: _debugWhite),
                   ),
                 ],
               ),
@@ -348,15 +354,15 @@ void main() {
             child: const Text.rich(
               TextSpan(
                 text: 'Hello\n',
-                style: TextStyle(color: Colors.red, fontSize: 30),
+                style: TextStyle(color: _debugRed, fontSize: 30),
                 children: <InlineSpan>[
                   TextSpan(
                     text: 'Second line!\n',
-                    style: TextStyle(fontSize: 9, color: Colors.blue),
+                    style: TextStyle(fontSize: 9, color: _debugBlue),
                   ),
                   TextSpan(
                     text: 'Third line!\n',
-                    style: TextStyle(fontSize: 27, color: Colors.white),
+                    style: TextStyle(fontSize: 27, color: _debugWhite),
                   ),
                 ],
               ),
@@ -389,7 +395,7 @@ void main() {
               style: TextStyle(
                 fontSize: 25,
                 decoration: allDecorations,
-                decorationColor: Colors.blue,
+                decorationColor: _debugBlue,
                 decorationStyle: TextDecorationStyle.dashed,
               ),
               textDirection: TextDirection.rtl,
@@ -420,7 +426,7 @@ void main() {
               style: TextStyle(
                 fontSize: 25,
                 decoration: allDecorations,
-                decorationColor: Colors.blue,
+                decorationColor: _debugBlue,
                 decorationStyle: TextDecorationStyle.wavy,
                 decorationThickness: 4,
               ),
@@ -438,70 +444,125 @@ void main() {
 
   testWidgets('Text Inline widget', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Theme(
-        data: ThemeData(useMaterial3: false),
-        child: Center(
-          child: RepaintBoundary(
-            child: Material(
-              child: Directionality(
-                textDirection: TextDirection.ltr,
-                child: Container(
-                  width: 400.0,
-                  height: 200.0,
-                  decoration: const BoxDecoration(color: Color(0xff00ff00)),
-                  child: ConstrainedBox(
-                    constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
-                    child: const Text.rich(
-                      TextSpan(
-                        text: 'C ',
-                        style: TextStyle(fontSize: 16),
-                        children: <InlineSpan>[
-                          WidgetSpan(child: Checkbox(value: true, onChanged: null)),
-                          WidgetSpan(child: Checkbox(value: false, onChanged: null)),
-                          TextSpan(text: 'He ', style: TextStyle(fontSize: 20)),
-                          WidgetSpan(
-                            child: SizedBox(
-                              width: 50.0,
-                              height: 55.0,
-                              child: DecoratedBox(
-                                decoration: BoxDecoration(color: Color(0xffffff00)),
-                                child: Center(
-                                  child: SizedBox(
-                                    width: 10.0,
-                                    height: 15.0,
-                                    child: DecoratedBox(
-                                      decoration: BoxDecoration(color: Color(0xffff0000)),
-                                    ),
-                                  ),
+      Center(
+        child: RepaintBoundary(
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Container(
+              width: 400.0,
+              height: 200.0,
+              decoration: const BoxDecoration(color: Color(0xff00ff00)),
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
+                child: const Text.rich(
+                  TextSpan(
+                    text: 'C ',
+                    style: TextStyle(fontSize: 16),
+                    children: <InlineSpan>[
+                      WidgetSpan(
+                        child: SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: DecoratedBox(
+                            decoration: BoxDecoration(
+                              border: Border.fromBorderSide(BorderSide()),
+                              color: _debugBlack,
+                            ),
+                          ),
+                        ),
+                      ),
+                      WidgetSpan(
+                        child: SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: DecoratedBox(
+                            decoration: BoxDecoration(
+                              border: Border.fromBorderSide(BorderSide()),
+                              color: _debugWhite,
+                            ),
+                          ),
+                        ),
+                      ),
+                      TextSpan(text: 'He ', style: TextStyle(fontSize: 20)),
+                      WidgetSpan(
+                        child: SizedBox(
+                          width: 50.0,
+                          height: 55.0,
+                          child: DecoratedBox(
+                            decoration: BoxDecoration(color: Color(0xffffff00)),
+                            child: Center(
+                              child: SizedBox(
+                                width: 10.0,
+                                height: 15.0,
+                                child: DecoratedBox(
+                                  decoration: BoxDecoration(color: Color(0xffff0000)),
                                 ),
                               ),
                             ),
                           ),
-                          TextSpan(text: 'hello world! seize the day!'),
-                          WidgetSpan(child: Checkbox(value: false, onChanged: null)),
-                          WidgetSpan(
-                            child: SizedBox.square(
-                              dimension: 20.0,
-                              child: Checkbox(value: true, onChanged: null),
-                            ),
-                          ),
-                          WidgetSpan(
-                            child: Checkbox(value: false, onChanged: null),
-                            alignment: PlaceholderAlignment.baseline,
-                            baseline: TextBaseline.alphabetic,
-                          ),
-                          WidgetSpan(
-                            child: SizedBox.square(
-                              dimension: 20.0,
-                              child: Checkbox(value: true, onChanged: null),
-                            ),
-                          ),
-                          WidgetSpan(child: Text('embedded')),
-                        ],
+                        ),
                       ),
-                      textDirection: TextDirection.ltr,
-                    ),
+                      TextSpan(text: 'hello world! seize the day!'),
+                      WidgetSpan(
+                        child: SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: DecoratedBox(
+                            decoration: BoxDecoration(
+                              border: Border.fromBorderSide(BorderSide()),
+                              color: _debugWhite,
+                            ),
+                          ),
+                        ),
+                      ),
+                      WidgetSpan(
+                        child: SizedBox.square(
+                          dimension: 20.0,
+                          child: SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: DecoratedBox(
+                              decoration: BoxDecoration(
+                                border: Border.fromBorderSide(BorderSide()),
+                                color: _debugBlack,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                      WidgetSpan(
+                        child: SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: DecoratedBox(
+                            decoration: BoxDecoration(
+                              border: Border.fromBorderSide(BorderSide()),
+                              color: _debugWhite,
+                            ),
+                          ),
+                        ),
+                        alignment: PlaceholderAlignment.baseline,
+                        baseline: TextBaseline.alphabetic,
+                      ),
+                      WidgetSpan(
+                        child: SizedBox.square(
+                          dimension: 20.0,
+                          child: SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: DecoratedBox(
+                              decoration: BoxDecoration(
+                                border: Border.fromBorderSide(BorderSide()),
+                                color: _debugBlack,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                      WidgetSpan(child: Text('embedded')),
+                    ],
                   ),
+                  textDirection: TextDirection.ltr,
                 ),
               ),
             ),
@@ -518,31 +579,25 @@ void main() {
   testWidgets('Text Inline widget textfield', (WidgetTester tester) async {
     await tester.pumpWidget(
       Center(
-        child: MaterialApp(
-          theme: ThemeData(useMaterial3: false),
+        child: TestWidgetsApp(
           home: RepaintBoundary(
-            child: Material(
-              child: Container(
-                width: 400.0,
-                height: 200.0,
-                decoration: const BoxDecoration(color: Color(0xff00ff00)),
-                child: ConstrainedBox(
-                  constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
-                  child: const Text.rich(
-                    TextSpan(
-                      text: 'My name is: ',
-                      style: TextStyle(fontSize: 20),
-                      children: <InlineSpan>[
-                        WidgetSpan(child: SizedBox(width: 70, height: 25, child: TextField())),
-                        TextSpan(
-                          text: ', and my favorite city is: ',
-                          style: TextStyle(fontSize: 20),
-                        ),
-                        WidgetSpan(child: SizedBox(width: 70, height: 25, child: TextField())),
-                      ],
-                    ),
-                    textDirection: TextDirection.ltr,
+            child: Container(
+              width: 400.0,
+              height: 200.0,
+              decoration: const BoxDecoration(color: Color(0xff00ff00)),
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
+                child: const Text.rich(
+                  TextSpan(
+                    text: 'My name is: ',
+                    style: TextStyle(fontSize: 20),
+                    children: <InlineSpan>[
+                      WidgetSpan(child: SizedBox(width: 70, height: 25, child: TestTextField())),
+                      TextSpan(text: ', and my favorite city is: ', style: TextStyle(fontSize: 20)),
+                      WidgetSpan(child: SizedBox(width: 70, height: 25, child: TestTextField())),
+                    ],
                   ),
+                  textDirection: TextDirection.ltr,
                 ),
               ),
             ),
@@ -560,103 +615,100 @@ void main() {
   testWidgets('Text Inline widget nesting', (WidgetTester tester) async {
     await tester.pumpWidget(
       Center(
-        child: MaterialApp(
-          theme: ThemeData(useMaterial3: false),
+        child: TestWidgetsApp(
           home: RepaintBoundary(
-            child: Material(
-              child: Container(
-                width: 400.0,
-                height: 200.0,
-                decoration: const BoxDecoration(color: Color(0xff00ff00)),
-                child: ConstrainedBox(
-                  constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
-                  child: const Text.rich(
-                    TextSpan(
-                      text: 'outer',
-                      style: TextStyle(fontSize: 20),
-                      children: <InlineSpan>[
-                        WidgetSpan(
-                          child: Text.rich(
-                            TextSpan(
-                              text: 'inner',
-                              style: TextStyle(color: Color(0xf402f4ff)),
-                              children: <InlineSpan>[
-                                WidgetSpan(
-                                  child: Text.rich(
-                                    TextSpan(
-                                      text: 'inner2',
-                                      style: TextStyle(color: Color(0xf003ffff)),
-                                      children: <InlineSpan>[
-                                        WidgetSpan(
-                                          child: SizedBox(
-                                            width: 50.0,
-                                            height: 55.0,
-                                            child: DecoratedBox(
-                                              decoration: BoxDecoration(color: Color(0xffffff30)),
-                                              child: Center(
-                                                child: SizedBox(
-                                                  width: 10.0,
-                                                  height: 15.0,
-                                                  child: DecoratedBox(
-                                                    decoration: BoxDecoration(
-                                                      color: Color(0xff5f00f0),
-                                                    ),
+            child: Container(
+              width: 400.0,
+              height: 200.0,
+              decoration: const BoxDecoration(color: Color(0xff00ff00)),
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
+                child: const Text.rich(
+                  TextSpan(
+                    text: 'outer',
+                    style: TextStyle(fontSize: 20),
+                    children: <InlineSpan>[
+                      WidgetSpan(
+                        child: Text.rich(
+                          TextSpan(
+                            text: 'inner',
+                            style: TextStyle(color: Color(0xf402f4ff)),
+                            children: <InlineSpan>[
+                              WidgetSpan(
+                                child: Text.rich(
+                                  TextSpan(
+                                    text: 'inner2',
+                                    style: TextStyle(color: Color(0xf003ffff)),
+                                    children: <InlineSpan>[
+                                      WidgetSpan(
+                                        child: SizedBox(
+                                          width: 50.0,
+                                          height: 55.0,
+                                          child: DecoratedBox(
+                                            decoration: BoxDecoration(color: Color(0xffffff30)),
+                                            child: Center(
+                                              child: SizedBox(
+                                                width: 10.0,
+                                                height: 15.0,
+                                                child: DecoratedBox(
+                                                  decoration: BoxDecoration(
+                                                    color: Color(0xff5f00f0),
                                                   ),
                                                 ),
                                               ),
                                             ),
                                           ),
                                         ),
-                                      ],
-                                    ),
+                                      ),
+                                    ],
                                   ),
                                 ),
-                                WidgetSpan(
-                                  child: SizedBox(
-                                    width: 50.0,
-                                    height: 55.0,
-                                    child: DecoratedBox(
-                                      decoration: BoxDecoration(color: Color(0xff5fff00)),
-                                      child: Center(
-                                        child: SizedBox(
-                                          width: 10.0,
-                                          height: 15.0,
-                                          child: DecoratedBox(
-                                            decoration: BoxDecoration(color: Color(0xff5f0000)),
-                                          ),
+                              ),
+                              WidgetSpan(
+                                child: SizedBox(
+                                  width: 50.0,
+                                  height: 55.0,
+                                  child: DecoratedBox(
+                                    decoration: BoxDecoration(color: Color(0xff5fff00)),
+                                    child: Center(
+                                      child: SizedBox(
+                                        width: 10.0,
+                                        height: 15.0,
+                                        child: DecoratedBox(
+                                          decoration: BoxDecoration(color: Color(0xff5f0000)),
                                         ),
                                       ),
                                     ),
                                   ),
                                 ),
-                              ],
-                            ),
+                              ),
+                            ],
                           ),
                         ),
-                        TextSpan(text: 'outer', style: TextStyle(fontSize: 20)),
-                        WidgetSpan(child: SizedBox(width: 70, height: 25, child: TextField())),
-                        WidgetSpan(
-                          child: SizedBox(
-                            width: 50.0,
-                            height: 55.0,
-                            child: DecoratedBox(
-                              decoration: BoxDecoration(color: Color(0xffff00ff)),
-                              child: Center(
-                                child: SizedBox(
-                                  width: 10.0,
-                                  height: 15.0,
-                                  child: DecoratedBox(
-                                    decoration: BoxDecoration(color: Color(0xff0000ff)),
-                                  ),
+                      ),
+                      TextSpan(text: 'outer', style: TextStyle(fontSize: 20)),
+                      WidgetSpan(child: SizedBox(width: 70, height: 25, child: TestTextField())),
+                      WidgetSpan(
+                        child: SizedBox(
+                          width: 50.0,
+                          height: 55.0,
+                          child: DecoratedBox(
+                            decoration: BoxDecoration(color: Color(0xffff00ff)),
+                            child: Center(
+                              child: SizedBox(
+                                width: 10.0,
+                                height: 15.0,
+                                child: DecoratedBox(
+                                  decoration: BoxDecoration(color: Color(0xff0000ff)),
                                 ),
                               ),
                             ),
                           ),
                         ),
-                      ],
-                    ),
-                    textDirection: TextDirection.ltr,
+                      ),
+                    ],
                   ),
+                  textDirection: TextDirection.ltr,
                 ),
               ),
             ),
@@ -672,89 +724,140 @@ void main() {
 
   testWidgets('Text Inline widget baseline', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Theme(
-        data: ThemeData(useMaterial3: false),
-        child: Center(
-          child: RepaintBoundary(
-            child: Material(
-              child: Directionality(
-                textDirection: TextDirection.ltr,
-                child: Container(
-                  width: 400.0,
-                  height: 200.0,
-                  decoration: const BoxDecoration(color: Color(0xff00ff00)),
-                  child: ConstrainedBox(
-                    constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
-                    child: const Text.rich(
-                      TextSpan(
-                        text: 'C ',
-                        style: TextStyle(fontSize: 16),
-                        children: <InlineSpan>[
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.baseline,
-                            baseline: TextBaseline.alphabetic,
-                            child: Checkbox(value: true, onChanged: null),
+      Center(
+        child: RepaintBoundary(
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Container(
+              width: 400.0,
+              height: 200.0,
+              decoration: const BoxDecoration(color: Color(0xff00ff00)),
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
+                child: const Text.rich(
+                  TextSpan(
+                    text: 'C ',
+                    style: TextStyle(fontSize: 16),
+                    children: <InlineSpan>[
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.baseline,
+                        baseline: TextBaseline.alphabetic,
+                        child: SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: DecoratedBox(
+                            decoration: BoxDecoration(
+                              border: Border.fromBorderSide(BorderSide()),
+                              color: _debugBlack,
+                            ),
                           ),
-                          WidgetSpan(child: Checkbox(value: false, onChanged: null)),
-                          TextSpan(text: 'He ', style: TextStyle(fontSize: 20)),
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.baseline,
-                            baseline: TextBaseline.alphabetic,
-                            child: SizedBox(
-                              width: 50.0,
-                              height: 55.0,
-                              child: DecoratedBox(
-                                decoration: BoxDecoration(color: Color(0xffffff00)),
-                                child: Center(
-                                  child: SizedBox(
-                                    width: 10.0,
-                                    height: 15.0,
-                                    child: DecoratedBox(
-                                      decoration: BoxDecoration(color: Color(0xffff0000)),
-                                    ),
-                                  ),
+                        ),
+                      ),
+                      WidgetSpan(
+                        child: SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: DecoratedBox(
+                            decoration: BoxDecoration(
+                              border: Border.fromBorderSide(BorderSide()),
+                              color: _debugWhite,
+                            ),
+                          ),
+                        ),
+                      ),
+                      TextSpan(text: 'He ', style: TextStyle(fontSize: 20)),
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.baseline,
+                        baseline: TextBaseline.alphabetic,
+                        child: SizedBox(
+                          width: 50.0,
+                          height: 55.0,
+                          child: DecoratedBox(
+                            decoration: BoxDecoration(color: Color(0xffffff00)),
+                            child: Center(
+                              child: SizedBox(
+                                width: 10.0,
+                                height: 15.0,
+                                child: DecoratedBox(
+                                  decoration: BoxDecoration(color: Color(0xffff0000)),
                                 ),
                               ),
                             ),
                           ),
-                          TextSpan(text: 'hello world! seize the day!'),
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.baseline,
-                            baseline: TextBaseline.alphabetic,
-                            child: Checkbox(value: false, onChanged: null),
-                          ),
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.baseline,
-                            baseline: TextBaseline.alphabetic,
-                            child: SizedBox.square(
-                              dimension: 20,
-                              child: Checkbox(value: true, onChanged: null),
-                            ),
-                          ),
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.baseline,
-                            baseline: TextBaseline.alphabetic,
-                            child: Checkbox(value: false, onChanged: null),
-                          ),
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.baseline,
-                            baseline: TextBaseline.alphabetic,
-                            child: SizedBox.square(
-                              dimension: 20,
-                              child: Checkbox(value: true, onChanged: null),
-                            ),
-                          ),
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.baseline,
-                            baseline: TextBaseline.alphabetic,
-                            child: Text('embedded'),
-                          ),
-                          TextSpan(text: 'ref'),
-                        ],
+                        ),
                       ),
-                      textDirection: TextDirection.ltr,
-                    ),
+                      TextSpan(text: 'hello world! seize the day!'),
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.baseline,
+                        baseline: TextBaseline.alphabetic,
+                        child: SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: DecoratedBox(
+                            decoration: BoxDecoration(
+                              border: Border.fromBorderSide(BorderSide()),
+                              color: _debugWhite,
+                            ),
+                          ),
+                        ),
+                      ),
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.baseline,
+                        baseline: TextBaseline.alphabetic,
+                        child: SizedBox.square(
+                          dimension: 20,
+                          child: SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: DecoratedBox(
+                              decoration: BoxDecoration(
+                                border: Border.fromBorderSide(BorderSide()),
+                                color: _debugBlack,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.baseline,
+                        baseline: TextBaseline.alphabetic,
+                        child: SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: DecoratedBox(
+                            decoration: BoxDecoration(
+                              border: Border.fromBorderSide(BorderSide()),
+                              color: _debugWhite,
+                            ),
+                          ),
+                        ),
+                      ),
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.baseline,
+                        baseline: TextBaseline.alphabetic,
+                        child: SizedBox.square(
+                          dimension: 20,
+                          child: SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: DecoratedBox(
+                              decoration: BoxDecoration(
+                                border: Border.fromBorderSide(BorderSide()),
+                                color: _debugBlack,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.baseline,
+                        baseline: TextBaseline.alphabetic,
+                        child: Text('embedded'),
+                      ),
+                      TextSpan(text: 'ref'),
+                    ],
                   ),
+                  textDirection: TextDirection.ltr,
                 ),
               ),
             ),
@@ -770,89 +873,84 @@ void main() {
 
   testWidgets('Text Inline widget aboveBaseline', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Theme(
-        data: ThemeData(useMaterial3: false),
-        child: Center(
-          child: RepaintBoundary(
-            child: Material(
-              child: Directionality(
-                textDirection: TextDirection.ltr,
-                child: Container(
-                  width: 400.0,
-                  height: 200.0,
-                  decoration: const BoxDecoration(color: Color(0xff00ff00)),
-                  child: ConstrainedBox(
-                    constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
-                    child: const Text.rich(
-                      TextSpan(
-                        text: 'C ',
-                        style: TextStyle(fontSize: 16),
-                        children: <InlineSpan>[
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.aboveBaseline,
-                            baseline: TextBaseline.alphabetic,
-                            child: Checkbox(value: true, onChanged: null),
-                          ),
-                          WidgetSpan(child: Checkbox(value: false, onChanged: null)),
-                          TextSpan(text: 'He ', style: TextStyle(fontSize: 20)),
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.aboveBaseline,
-                            baseline: TextBaseline.alphabetic,
-                            child: SizedBox(
-                              width: 50.0,
-                              height: 55.0,
-                              child: DecoratedBox(
-                                decoration: BoxDecoration(color: Color(0xffffff00)),
-                                child: Center(
-                                  child: SizedBox(
-                                    width: 10.0,
-                                    height: 15.0,
-                                    child: DecoratedBox(
-                                      decoration: BoxDecoration(color: Color(0xffff0000)),
-                                    ),
-                                  ),
+      Center(
+        child: RepaintBoundary(
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Container(
+              width: 400.0,
+              height: 200.0,
+              decoration: const BoxDecoration(color: Color(0xff00ff00)),
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
+                child: const Text.rich(
+                  TextSpan(
+                    text: 'C ',
+                    style: TextStyle(fontSize: 16),
+                    children: <InlineSpan>[
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.aboveBaseline,
+                        baseline: TextBaseline.alphabetic,
+                        child: TestCheckbox(value: true, onChanged: null),
+                      ),
+                      WidgetSpan(child: TestCheckbox(value: false, onChanged: null)),
+                      TextSpan(text: 'He ', style: TextStyle(fontSize: 20)),
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.aboveBaseline,
+                        baseline: TextBaseline.alphabetic,
+                        child: SizedBox(
+                          width: 50.0,
+                          height: 55.0,
+                          child: DecoratedBox(
+                            decoration: BoxDecoration(color: Color(0xffffff00)),
+                            child: Center(
+                              child: SizedBox(
+                                width: 10.0,
+                                height: 15.0,
+                                child: DecoratedBox(
+                                  decoration: BoxDecoration(color: Color(0xffff0000)),
                                 ),
                               ),
                             ),
                           ),
-                          TextSpan(text: 'hello world! seize the day!'),
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.aboveBaseline,
-                            baseline: TextBaseline.alphabetic,
-                            child: Checkbox(value: false, onChanged: null),
-                          ),
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.aboveBaseline,
-                            baseline: TextBaseline.alphabetic,
-                            child: SizedBox.square(
-                              dimension: 20,
-                              child: Checkbox(value: true, onChanged: null),
-                            ),
-                          ),
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.aboveBaseline,
-                            baseline: TextBaseline.alphabetic,
-                            child: Checkbox(value: false, onChanged: null),
-                          ),
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.aboveBaseline,
-                            baseline: TextBaseline.alphabetic,
-                            child: SizedBox.square(
-                              dimension: 20,
-                              child: Checkbox(value: true, onChanged: null),
-                            ),
-                          ),
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.aboveBaseline,
-                            baseline: TextBaseline.alphabetic,
-                            child: Text('embedded'),
-                          ),
-                          TextSpan(text: 'ref'),
-                        ],
+                        ),
                       ),
-                      textDirection: TextDirection.ltr,
-                    ),
+                      TextSpan(text: 'hello world! seize the day!'),
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.aboveBaseline,
+                        baseline: TextBaseline.alphabetic,
+                        child: TestCheckbox(value: false, onChanged: null),
+                      ),
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.aboveBaseline,
+                        baseline: TextBaseline.alphabetic,
+                        child: SizedBox.square(
+                          dimension: 20,
+                          child: TestCheckbox(value: true, onChanged: null),
+                        ),
+                      ),
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.aboveBaseline,
+                        baseline: TextBaseline.alphabetic,
+                        child: TestCheckbox(value: false, onChanged: null),
+                      ),
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.aboveBaseline,
+                        baseline: TextBaseline.alphabetic,
+                        child: SizedBox.square(
+                          dimension: 20,
+                          child: TestCheckbox(value: true, onChanged: null),
+                        ),
+                      ),
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.aboveBaseline,
+                        baseline: TextBaseline.alphabetic,
+                        child: Text('embedded'),
+                      ),
+                      TextSpan(text: 'ref'),
+                    ],
                   ),
+                  textDirection: TextDirection.ltr,
                 ),
               ),
             ),
@@ -868,89 +966,84 @@ void main() {
 
   testWidgets('Text Inline widget belowBaseline', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Theme(
-        data: ThemeData(useMaterial3: false),
-        child: Center(
-          child: RepaintBoundary(
-            child: Material(
-              child: Directionality(
-                textDirection: TextDirection.ltr,
-                child: Container(
-                  width: 400.0,
-                  height: 200.0,
-                  decoration: const BoxDecoration(color: Color(0xff00ff00)),
-                  child: ConstrainedBox(
-                    constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
-                    child: const Text.rich(
-                      TextSpan(
-                        text: 'C ',
-                        style: TextStyle(fontSize: 16),
-                        children: <InlineSpan>[
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.belowBaseline,
-                            baseline: TextBaseline.alphabetic,
-                            child: Checkbox(value: true, onChanged: null),
-                          ),
-                          WidgetSpan(child: Checkbox(value: false, onChanged: null)),
-                          TextSpan(text: 'He ', style: TextStyle(fontSize: 20)),
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.belowBaseline,
-                            baseline: TextBaseline.alphabetic,
-                            child: SizedBox(
-                              width: 50.0,
-                              height: 55.0,
-                              child: DecoratedBox(
-                                decoration: BoxDecoration(color: Color(0xffffff00)),
-                                child: Center(
-                                  child: SizedBox(
-                                    width: 10.0,
-                                    height: 15.0,
-                                    child: DecoratedBox(
-                                      decoration: BoxDecoration(color: Color(0xffff0000)),
-                                    ),
-                                  ),
+      Center(
+        child: RepaintBoundary(
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Container(
+              width: 400.0,
+              height: 200.0,
+              decoration: const BoxDecoration(color: Color(0xff00ff00)),
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
+                child: const Text.rich(
+                  TextSpan(
+                    text: 'C ',
+                    style: TextStyle(fontSize: 16),
+                    children: <InlineSpan>[
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.belowBaseline,
+                        baseline: TextBaseline.alphabetic,
+                        child: TestCheckbox(value: true, onChanged: null),
+                      ),
+                      WidgetSpan(child: TestCheckbox(value: false, onChanged: null)),
+                      TextSpan(text: 'He ', style: TextStyle(fontSize: 20)),
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.belowBaseline,
+                        baseline: TextBaseline.alphabetic,
+                        child: SizedBox(
+                          width: 50.0,
+                          height: 55.0,
+                          child: DecoratedBox(
+                            decoration: BoxDecoration(color: Color(0xffffff00)),
+                            child: Center(
+                              child: SizedBox(
+                                width: 10.0,
+                                height: 15.0,
+                                child: DecoratedBox(
+                                  decoration: BoxDecoration(color: Color(0xffff0000)),
                                 ),
                               ),
                             ),
                           ),
-                          TextSpan(text: 'hello world! seize the day!'),
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.belowBaseline,
-                            baseline: TextBaseline.alphabetic,
-                            child: Checkbox(value: false, onChanged: null),
-                          ),
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.belowBaseline,
-                            baseline: TextBaseline.alphabetic,
-                            child: SizedBox.square(
-                              dimension: 20,
-                              child: Checkbox(value: true, onChanged: null),
-                            ),
-                          ),
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.belowBaseline,
-                            baseline: TextBaseline.alphabetic,
-                            child: Checkbox(value: false, onChanged: null),
-                          ),
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.belowBaseline,
-                            baseline: TextBaseline.alphabetic,
-                            child: SizedBox.square(
-                              dimension: 20,
-                              child: Checkbox(value: true, onChanged: null),
-                            ),
-                          ),
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.belowBaseline,
-                            baseline: TextBaseline.alphabetic,
-                            child: Text('embedded'),
-                          ),
-                          TextSpan(text: 'ref'),
-                        ],
+                        ),
                       ),
-                      textDirection: TextDirection.ltr,
-                    ),
+                      TextSpan(text: 'hello world! seize the day!'),
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.belowBaseline,
+                        baseline: TextBaseline.alphabetic,
+                        child: TestCheckbox(value: false, onChanged: null),
+                      ),
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.belowBaseline,
+                        baseline: TextBaseline.alphabetic,
+                        child: SizedBox.square(
+                          dimension: 20,
+                          child: TestCheckbox(value: true, onChanged: null),
+                        ),
+                      ),
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.belowBaseline,
+                        baseline: TextBaseline.alphabetic,
+                        child: TestCheckbox(value: false, onChanged: null),
+                      ),
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.belowBaseline,
+                        baseline: TextBaseline.alphabetic,
+                        child: SizedBox.square(
+                          dimension: 20,
+                          child: TestCheckbox(value: true, onChanged: null),
+                        ),
+                      ),
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.belowBaseline,
+                        baseline: TextBaseline.alphabetic,
+                        child: Text('embedded'),
+                      ),
+                      TextSpan(text: 'ref'),
+                    ],
                   ),
+                  textDirection: TextDirection.ltr,
                 ),
               ),
             ),
@@ -966,89 +1059,84 @@ void main() {
 
   testWidgets('Text Inline widget top', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Theme(
-        data: ThemeData(useMaterial3: false),
-        child: Center(
-          child: RepaintBoundary(
-            child: Material(
-              child: Directionality(
-                textDirection: TextDirection.ltr,
-                child: Container(
-                  width: 400.0,
-                  height: 200.0,
-                  decoration: const BoxDecoration(color: Color(0xff00ff00)),
-                  child: ConstrainedBox(
-                    constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
-                    child: const Text.rich(
-                      TextSpan(
-                        text: 'C ',
-                        style: TextStyle(fontSize: 16),
-                        children: <InlineSpan>[
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.top,
-                            baseline: TextBaseline.alphabetic,
-                            child: Checkbox(value: true, onChanged: null),
-                          ),
-                          WidgetSpan(child: Checkbox(value: false, onChanged: null)),
-                          TextSpan(text: 'He ', style: TextStyle(fontSize: 20)),
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.top,
-                            baseline: TextBaseline.alphabetic,
-                            child: SizedBox(
-                              width: 50.0,
-                              height: 55.0,
-                              child: DecoratedBox(
-                                decoration: BoxDecoration(color: Color(0xffffff00)),
-                                child: Center(
-                                  child: SizedBox(
-                                    width: 10.0,
-                                    height: 15.0,
-                                    child: DecoratedBox(
-                                      decoration: BoxDecoration(color: Color(0xffff0000)),
-                                    ),
-                                  ),
+      Center(
+        child: RepaintBoundary(
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Container(
+              width: 400.0,
+              height: 200.0,
+              decoration: const BoxDecoration(color: Color(0xff00ff00)),
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
+                child: const Text.rich(
+                  TextSpan(
+                    text: 'C ',
+                    style: TextStyle(fontSize: 16),
+                    children: <InlineSpan>[
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.top,
+                        baseline: TextBaseline.alphabetic,
+                        child: TestCheckbox(value: true, onChanged: null),
+                      ),
+                      WidgetSpan(child: TestCheckbox(value: false, onChanged: null)),
+                      TextSpan(text: 'He ', style: TextStyle(fontSize: 20)),
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.top,
+                        baseline: TextBaseline.alphabetic,
+                        child: SizedBox(
+                          width: 50.0,
+                          height: 55.0,
+                          child: DecoratedBox(
+                            decoration: BoxDecoration(color: Color(0xffffff00)),
+                            child: Center(
+                              child: SizedBox(
+                                width: 10.0,
+                                height: 15.0,
+                                child: DecoratedBox(
+                                  decoration: BoxDecoration(color: Color(0xffff0000)),
                                 ),
                               ),
                             ),
                           ),
-                          TextSpan(text: 'hello world! seize the day!'),
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.top,
-                            baseline: TextBaseline.alphabetic,
-                            child: Checkbox(value: false, onChanged: null),
-                          ),
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.top,
-                            baseline: TextBaseline.alphabetic,
-                            child: SizedBox.square(
-                              dimension: 20,
-                              child: Checkbox(value: true, onChanged: null),
-                            ),
-                          ),
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.top,
-                            baseline: TextBaseline.alphabetic,
-                            child: Checkbox(value: false, onChanged: null),
-                          ),
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.top,
-                            baseline: TextBaseline.alphabetic,
-                            child: SizedBox.square(
-                              dimension: 20,
-                              child: Checkbox(value: true, onChanged: null),
-                            ),
-                          ),
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.top,
-                            baseline: TextBaseline.alphabetic,
-                            child: Text('embedded'),
-                          ),
-                          TextSpan(text: 'ref'),
-                        ],
+                        ),
                       ),
-                      textDirection: TextDirection.ltr,
-                    ),
+                      TextSpan(text: 'hello world! seize the day!'),
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.top,
+                        baseline: TextBaseline.alphabetic,
+                        child: TestCheckbox(value: false, onChanged: null),
+                      ),
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.top,
+                        baseline: TextBaseline.alphabetic,
+                        child: SizedBox.square(
+                          dimension: 20,
+                          child: TestCheckbox(value: true, onChanged: null),
+                        ),
+                      ),
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.top,
+                        baseline: TextBaseline.alphabetic,
+                        child: TestCheckbox(value: false, onChanged: null),
+                      ),
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.top,
+                        baseline: TextBaseline.alphabetic,
+                        child: SizedBox.square(
+                          dimension: 20,
+                          child: TestCheckbox(value: true, onChanged: null),
+                        ),
+                      ),
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.top,
+                        baseline: TextBaseline.alphabetic,
+                        child: Text('embedded'),
+                      ),
+                      TextSpan(text: 'ref'),
+                    ],
                   ),
+                  textDirection: TextDirection.ltr,
                 ),
               ),
             ),
@@ -1064,89 +1152,84 @@ void main() {
 
   testWidgets('Text Inline widget middle', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Theme(
-        data: ThemeData(useMaterial3: false),
-        child: Center(
-          child: RepaintBoundary(
-            child: Material(
-              child: Directionality(
-                textDirection: TextDirection.ltr,
-                child: Container(
-                  width: 400.0,
-                  height: 200.0,
-                  decoration: const BoxDecoration(color: Color(0xff00ff00)),
-                  child: ConstrainedBox(
-                    constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
-                    child: const Text.rich(
-                      TextSpan(
-                        text: 'C ',
-                        style: TextStyle(fontSize: 16),
-                        children: <InlineSpan>[
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.middle,
-                            baseline: TextBaseline.alphabetic,
-                            child: Checkbox(value: true, onChanged: null),
-                          ),
-                          WidgetSpan(child: Checkbox(value: false, onChanged: null)),
-                          TextSpan(text: 'He ', style: TextStyle(fontSize: 20)),
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.middle,
-                            baseline: TextBaseline.alphabetic,
-                            child: SizedBox(
-                              width: 50.0,
-                              height: 55.0,
-                              child: DecoratedBox(
-                                decoration: BoxDecoration(color: Color(0xffffff00)),
-                                child: Center(
-                                  child: SizedBox(
-                                    width: 10.0,
-                                    height: 15.0,
-                                    child: DecoratedBox(
-                                      decoration: BoxDecoration(color: Color(0xffff0000)),
-                                    ),
-                                  ),
+      Center(
+        child: RepaintBoundary(
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Container(
+              width: 400.0,
+              height: 200.0,
+              decoration: const BoxDecoration(color: Color(0xff00ff00)),
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
+                child: const Text.rich(
+                  TextSpan(
+                    text: 'C ',
+                    style: TextStyle(fontSize: 16),
+                    children: <InlineSpan>[
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.middle,
+                        baseline: TextBaseline.alphabetic,
+                        child: TestCheckbox(value: true, onChanged: null),
+                      ),
+                      WidgetSpan(child: TestCheckbox(value: false, onChanged: null)),
+                      TextSpan(text: 'He ', style: TextStyle(fontSize: 20)),
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.middle,
+                        baseline: TextBaseline.alphabetic,
+                        child: SizedBox(
+                          width: 50.0,
+                          height: 55.0,
+                          child: DecoratedBox(
+                            decoration: BoxDecoration(color: Color(0xffffff00)),
+                            child: Center(
+                              child: SizedBox(
+                                width: 10.0,
+                                height: 15.0,
+                                child: DecoratedBox(
+                                  decoration: BoxDecoration(color: Color(0xffff0000)),
                                 ),
                               ),
                             ),
                           ),
-                          TextSpan(text: 'hello world! seize the day!'),
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.middle,
-                            baseline: TextBaseline.alphabetic,
-                            child: Checkbox(value: false, onChanged: null),
-                          ),
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.middle,
-                            baseline: TextBaseline.alphabetic,
-                            child: SizedBox.square(
-                              dimension: 20,
-                              child: Checkbox(value: true, onChanged: null),
-                            ),
-                          ),
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.middle,
-                            baseline: TextBaseline.alphabetic,
-                            child: Checkbox(value: false, onChanged: null),
-                          ),
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.middle,
-                            baseline: TextBaseline.alphabetic,
-                            child: SizedBox.square(
-                              dimension: 20,
-                              child: Checkbox(value: true, onChanged: null),
-                            ),
-                          ),
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.middle,
-                            baseline: TextBaseline.alphabetic,
-                            child: Text('embedded'),
-                          ),
-                          TextSpan(text: 'ref'),
-                        ],
+                        ),
                       ),
-                      textDirection: TextDirection.ltr,
-                    ),
+                      TextSpan(text: 'hello world! seize the day!'),
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.middle,
+                        baseline: TextBaseline.alphabetic,
+                        child: TestCheckbox(value: false, onChanged: null),
+                      ),
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.middle,
+                        baseline: TextBaseline.alphabetic,
+                        child: SizedBox.square(
+                          dimension: 20,
+                          child: TestCheckbox(value: true, onChanged: null),
+                        ),
+                      ),
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.middle,
+                        baseline: TextBaseline.alphabetic,
+                        child: TestCheckbox(value: false, onChanged: null),
+                      ),
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.middle,
+                        baseline: TextBaseline.alphabetic,
+                        child: SizedBox.square(
+                          dimension: 20,
+                          child: TestCheckbox(value: true, onChanged: null),
+                        ),
+                      ),
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.middle,
+                        baseline: TextBaseline.alphabetic,
+                        child: Text('embedded'),
+                      ),
+                      TextSpan(text: 'ref'),
+                    ],
                   ),
+                  textDirection: TextDirection.ltr,
                 ),
               ),
             ),

--- a/packages/flutter/test/widgets/text_golden_test.dart
+++ b/packages/flutter/test/widgets/text_golden_test.dart
@@ -21,6 +21,13 @@ const Color _debugGreen = Color(0xFF00FF00);
 const Color _debugBlack = Color(0xFF000000);
 const Color _debugWhite = Color(0xFFFFFFFF);
 
+const TextStyle _bodyMediumTextStyle = TextStyle(
+  color: Color(0xdd000000),
+  fontSize: 14.0,
+  fontWeight: FontWeight.w400,
+  textBaseline: TextBaseline.alphabetic,
+);
+
 void main() {
   testWidgets('Centered text', (WidgetTester tester) async {
     await tester.pumpWidget(
@@ -191,6 +198,7 @@ void main() {
   testWidgets('Text Fade', (WidgetTester tester) async {
     await tester.pumpWidget(
       TestWidgetsApp(
+        textStyle: _bodyMediumTextStyle,
         home: RepaintBoundary(
           child: Center(
             child: Container(
@@ -448,121 +456,64 @@ void main() {
         child: RepaintBoundary(
           child: Directionality(
             textDirection: TextDirection.ltr,
-            child: Container(
-              width: 400.0,
-              height: 200.0,
-              decoration: const BoxDecoration(color: Color(0xff00ff00)),
-              child: ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
-                child: const Text.rich(
-                  TextSpan(
-                    text: 'C ',
-                    style: TextStyle(fontSize: 16),
-                    children: <InlineSpan>[
-                      WidgetSpan(
-                        child: SizedBox(
-                          width: 18,
-                          height: 18,
-                          child: DecoratedBox(
-                            decoration: BoxDecoration(
-                              border: Border.fromBorderSide(BorderSide()),
-                              color: _debugBlack,
-                            ),
-                          ),
-                        ),
-                      ),
-                      WidgetSpan(
-                        child: SizedBox(
-                          width: 18,
-                          height: 18,
-                          child: DecoratedBox(
-                            decoration: BoxDecoration(
-                              border: Border.fromBorderSide(BorderSide()),
-                              color: _debugWhite,
-                            ),
-                          ),
-                        ),
-                      ),
-                      TextSpan(text: 'He ', style: TextStyle(fontSize: 20)),
-                      WidgetSpan(
-                        child: SizedBox(
-                          width: 50.0,
-                          height: 55.0,
-                          child: DecoratedBox(
-                            decoration: BoxDecoration(color: Color(0xffffff00)),
-                            child: Center(
-                              child: SizedBox(
-                                width: 10.0,
-                                height: 15.0,
-                                child: DecoratedBox(
-                                  decoration: BoxDecoration(color: Color(0xffff0000)),
+            child: DefaultTextStyle(
+              style: _bodyMediumTextStyle,
+              child: Container(
+                width: 400.0,
+                height: 200.0,
+                decoration: const BoxDecoration(color: Color(0xff00ff00)),
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
+                  child: const Text.rich(
+                    TextSpan(
+                      text: 'C ',
+                      style: TextStyle(fontSize: 16),
+                      children: <InlineSpan>[
+                        WidgetSpan(child: TestCheckbox(value: true, onChanged: null)),
+                        WidgetSpan(child: TestCheckbox(value: false, onChanged: null)),
+                        TextSpan(text: 'He ', style: TextStyle(fontSize: 20)),
+                        WidgetSpan(
+                          child: SizedBox(
+                            width: 50.0,
+                            height: 55.0,
+                            child: DecoratedBox(
+                              decoration: BoxDecoration(color: Color(0xffffff00)),
+                              child: Center(
+                                child: SizedBox(
+                                  width: 10.0,
+                                  height: 15.0,
+                                  child: DecoratedBox(
+                                    decoration: BoxDecoration(color: Color(0xffff0000)),
+                                  ),
                                 ),
                               ),
                             ),
                           ),
                         ),
-                      ),
-                      TextSpan(text: 'hello world! seize the day!'),
-                      WidgetSpan(
-                        child: SizedBox(
-                          width: 18,
-                          height: 18,
-                          child: DecoratedBox(
-                            decoration: BoxDecoration(
-                              border: Border.fromBorderSide(BorderSide()),
-                              color: _debugWhite,
-                            ),
+                        TextSpan(text: 'hello world! seize the day!'),
+                        WidgetSpan(child: TestCheckbox(value: false, onChanged: null)),
+                        WidgetSpan(
+                          child: SizedBox.square(
+                            dimension: 20.0,
+                            child: TestCheckbox(value: true, onChanged: null),
                           ),
                         ),
-                      ),
-                      WidgetSpan(
-                        child: SizedBox.square(
-                          dimension: 20.0,
-                          child: SizedBox(
-                            width: 18,
-                            height: 18,
-                            child: DecoratedBox(
-                              decoration: BoxDecoration(
-                                border: Border.fromBorderSide(BorderSide()),
-                                color: _debugBlack,
-                              ),
-                            ),
+                        WidgetSpan(
+                          child: TestCheckbox(value: false, onChanged: null),
+                          alignment: PlaceholderAlignment.baseline,
+                          baseline: TextBaseline.alphabetic,
+                        ),
+                        WidgetSpan(
+                          child: SizedBox.square(
+                            dimension: 20.0,
+                            child: TestCheckbox(value: true, onChanged: null),
                           ),
                         ),
-                      ),
-                      WidgetSpan(
-                        child: SizedBox(
-                          width: 18,
-                          height: 18,
-                          child: DecoratedBox(
-                            decoration: BoxDecoration(
-                              border: Border.fromBorderSide(BorderSide()),
-                              color: _debugWhite,
-                            ),
-                          ),
-                        ),
-                        alignment: PlaceholderAlignment.baseline,
-                        baseline: TextBaseline.alphabetic,
-                      ),
-                      WidgetSpan(
-                        child: SizedBox.square(
-                          dimension: 20.0,
-                          child: SizedBox(
-                            width: 18,
-                            height: 18,
-                            child: DecoratedBox(
-                              decoration: BoxDecoration(
-                                border: Border.fromBorderSide(BorderSide()),
-                                color: _debugBlack,
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
-                      WidgetSpan(child: Text('embedded')),
-                    ],
+                        WidgetSpan(child: Text('embedded')),
+                      ],
+                    ),
+                    textDirection: TextDirection.ltr,
                   ),
-                  textDirection: TextDirection.ltr,
                 ),
               ),
             ),
@@ -580,6 +531,7 @@ void main() {
     await tester.pumpWidget(
       Center(
         child: TestWidgetsApp(
+          textStyle: _bodyMediumTextStyle,
           home: RepaintBoundary(
             child: Container(
               width: 400.0,
@@ -616,6 +568,7 @@ void main() {
     await tester.pumpWidget(
       Center(
         child: TestWidgetsApp(
+          textStyle: _bodyMediumTextStyle,
           home: RepaintBoundary(
             child: Container(
               width: 400.0,
@@ -728,136 +681,83 @@ void main() {
         child: RepaintBoundary(
           child: Directionality(
             textDirection: TextDirection.ltr,
-            child: Container(
-              width: 400.0,
-              height: 200.0,
-              decoration: const BoxDecoration(color: Color(0xff00ff00)),
-              child: ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
-                child: const Text.rich(
-                  TextSpan(
-                    text: 'C ',
-                    style: TextStyle(fontSize: 16),
-                    children: <InlineSpan>[
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.baseline,
-                        baseline: TextBaseline.alphabetic,
-                        child: SizedBox(
-                          width: 18,
-                          height: 18,
-                          child: DecoratedBox(
-                            decoration: BoxDecoration(
-                              border: Border.fromBorderSide(BorderSide()),
-                              color: _debugBlack,
-                            ),
-                          ),
+            child: DefaultTextStyle(
+              style: _bodyMediumTextStyle,
+              child: Container(
+                width: 400.0,
+                height: 200.0,
+                decoration: const BoxDecoration(color: Color(0xff00ff00)),
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
+                  child: const Text.rich(
+                    TextSpan(
+                      text: 'C ',
+                      style: TextStyle(fontSize: 16),
+                      children: <InlineSpan>[
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.baseline,
+                          baseline: TextBaseline.alphabetic,
+                          child: TestCheckbox(value: true, onChanged: null),
                         ),
-                      ),
-                      WidgetSpan(
-                        child: SizedBox(
-                          width: 18,
-                          height: 18,
-                          child: DecoratedBox(
-                            decoration: BoxDecoration(
-                              border: Border.fromBorderSide(BorderSide()),
-                              color: _debugWhite,
-                            ),
-                          ),
-                        ),
-                      ),
-                      TextSpan(text: 'He ', style: TextStyle(fontSize: 20)),
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.baseline,
-                        baseline: TextBaseline.alphabetic,
-                        child: SizedBox(
-                          width: 50.0,
-                          height: 55.0,
-                          child: DecoratedBox(
-                            decoration: BoxDecoration(color: Color(0xffffff00)),
-                            child: Center(
-                              child: SizedBox(
-                                width: 10.0,
-                                height: 15.0,
-                                child: DecoratedBox(
-                                  decoration: BoxDecoration(color: Color(0xffff0000)),
+                        WidgetSpan(child: TestCheckbox(value: false, onChanged: null)),
+                        TextSpan(text: 'He ', style: TextStyle(fontSize: 20)),
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.baseline,
+                          baseline: TextBaseline.alphabetic,
+                          child: SizedBox(
+                            width: 50.0,
+                            height: 55.0,
+                            child: DecoratedBox(
+                              decoration: BoxDecoration(color: Color(0xffffff00)),
+                              child: Center(
+                                child: SizedBox(
+                                  width: 10.0,
+                                  height: 15.0,
+                                  child: DecoratedBox(
+                                    decoration: BoxDecoration(color: Color(0xffff0000)),
+                                  ),
                                 ),
                               ),
                             ),
                           ),
                         ),
-                      ),
-                      TextSpan(text: 'hello world! seize the day!'),
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.baseline,
-                        baseline: TextBaseline.alphabetic,
-                        child: SizedBox(
-                          width: 18,
-                          height: 18,
-                          child: DecoratedBox(
-                            decoration: BoxDecoration(
-                              border: Border.fromBorderSide(BorderSide()),
-                              color: _debugWhite,
-                            ),
+                        TextSpan(text: 'hello world! seize the day!'),
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.baseline,
+                          baseline: TextBaseline.alphabetic,
+                          child: TestCheckbox(value: false, onChanged: null),
+                        ),
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.baseline,
+                          baseline: TextBaseline.alphabetic,
+                          child: SizedBox.square(
+                            dimension: 20,
+                            child: TestCheckbox(value: true, onChanged: null),
                           ),
                         ),
-                      ),
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.baseline,
-                        baseline: TextBaseline.alphabetic,
-                        child: SizedBox.square(
-                          dimension: 20,
-                          child: SizedBox(
-                            width: 18,
-                            height: 18,
-                            child: DecoratedBox(
-                              decoration: BoxDecoration(
-                                border: Border.fromBorderSide(BorderSide()),
-                                color: _debugBlack,
-                              ),
-                            ),
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.baseline,
+                          baseline: TextBaseline.alphabetic,
+                          child: TestCheckbox(value: false, onChanged: null),
+                        ),
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.baseline,
+                          baseline: TextBaseline.alphabetic,
+                          child: SizedBox.square(
+                            dimension: 20,
+                            child: TestCheckbox(value: true, onChanged: null),
                           ),
                         ),
-                      ),
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.baseline,
-                        baseline: TextBaseline.alphabetic,
-                        child: SizedBox(
-                          width: 18,
-                          height: 18,
-                          child: DecoratedBox(
-                            decoration: BoxDecoration(
-                              border: Border.fromBorderSide(BorderSide()),
-                              color: _debugWhite,
-                            ),
-                          ),
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.baseline,
+                          baseline: TextBaseline.alphabetic,
+                          child: Text('embedded'),
                         ),
-                      ),
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.baseline,
-                        baseline: TextBaseline.alphabetic,
-                        child: SizedBox.square(
-                          dimension: 20,
-                          child: SizedBox(
-                            width: 18,
-                            height: 18,
-                            child: DecoratedBox(
-                              decoration: BoxDecoration(
-                                border: Border.fromBorderSide(BorderSide()),
-                                color: _debugBlack,
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.baseline,
-                        baseline: TextBaseline.alphabetic,
-                        child: Text('embedded'),
-                      ),
-                      TextSpan(text: 'ref'),
-                    ],
+                        TextSpan(text: 'ref'),
+                      ],
+                    ),
+                    textDirection: TextDirection.ltr,
                   ),
-                  textDirection: TextDirection.ltr,
                 ),
               ),
             ),
@@ -877,80 +777,83 @@ void main() {
         child: RepaintBoundary(
           child: Directionality(
             textDirection: TextDirection.ltr,
-            child: Container(
-              width: 400.0,
-              height: 200.0,
-              decoration: const BoxDecoration(color: Color(0xff00ff00)),
-              child: ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
-                child: const Text.rich(
-                  TextSpan(
-                    text: 'C ',
-                    style: TextStyle(fontSize: 16),
-                    children: <InlineSpan>[
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.aboveBaseline,
-                        baseline: TextBaseline.alphabetic,
-                        child: TestCheckbox(value: true, onChanged: null),
-                      ),
-                      WidgetSpan(child: TestCheckbox(value: false, onChanged: null)),
-                      TextSpan(text: 'He ', style: TextStyle(fontSize: 20)),
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.aboveBaseline,
-                        baseline: TextBaseline.alphabetic,
-                        child: SizedBox(
-                          width: 50.0,
-                          height: 55.0,
-                          child: DecoratedBox(
-                            decoration: BoxDecoration(color: Color(0xffffff00)),
-                            child: Center(
-                              child: SizedBox(
-                                width: 10.0,
-                                height: 15.0,
-                                child: DecoratedBox(
-                                  decoration: BoxDecoration(color: Color(0xffff0000)),
+            child: DefaultTextStyle(
+              style: _bodyMediumTextStyle,
+              child: Container(
+                width: 400.0,
+                height: 200.0,
+                decoration: const BoxDecoration(color: Color(0xff00ff00)),
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
+                  child: const Text.rich(
+                    TextSpan(
+                      text: 'C ',
+                      style: TextStyle(fontSize: 16),
+                      children: <InlineSpan>[
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.aboveBaseline,
+                          baseline: TextBaseline.alphabetic,
+                          child: TestCheckbox(value: true, onChanged: null),
+                        ),
+                        WidgetSpan(child: TestCheckbox(value: false, onChanged: null)),
+                        TextSpan(text: 'He ', style: TextStyle(fontSize: 20)),
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.aboveBaseline,
+                          baseline: TextBaseline.alphabetic,
+                          child: SizedBox(
+                            width: 50.0,
+                            height: 55.0,
+                            child: DecoratedBox(
+                              decoration: BoxDecoration(color: Color(0xffffff00)),
+                              child: Center(
+                                child: SizedBox(
+                                  width: 10.0,
+                                  height: 15.0,
+                                  child: DecoratedBox(
+                                    decoration: BoxDecoration(color: Color(0xffff0000)),
+                                  ),
                                 ),
                               ),
                             ),
                           ),
                         ),
-                      ),
-                      TextSpan(text: 'hello world! seize the day!'),
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.aboveBaseline,
-                        baseline: TextBaseline.alphabetic,
-                        child: TestCheckbox(value: false, onChanged: null),
-                      ),
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.aboveBaseline,
-                        baseline: TextBaseline.alphabetic,
-                        child: SizedBox.square(
-                          dimension: 20,
-                          child: TestCheckbox(value: true, onChanged: null),
+                        TextSpan(text: 'hello world! seize the day!'),
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.aboveBaseline,
+                          baseline: TextBaseline.alphabetic,
+                          child: TestCheckbox(value: false, onChanged: null),
                         ),
-                      ),
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.aboveBaseline,
-                        baseline: TextBaseline.alphabetic,
-                        child: TestCheckbox(value: false, onChanged: null),
-                      ),
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.aboveBaseline,
-                        baseline: TextBaseline.alphabetic,
-                        child: SizedBox.square(
-                          dimension: 20,
-                          child: TestCheckbox(value: true, onChanged: null),
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.aboveBaseline,
+                          baseline: TextBaseline.alphabetic,
+                          child: SizedBox.square(
+                            dimension: 20,
+                            child: TestCheckbox(value: true, onChanged: null),
+                          ),
                         ),
-                      ),
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.aboveBaseline,
-                        baseline: TextBaseline.alphabetic,
-                        child: Text('embedded'),
-                      ),
-                      TextSpan(text: 'ref'),
-                    ],
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.aboveBaseline,
+                          baseline: TextBaseline.alphabetic,
+                          child: TestCheckbox(value: false, onChanged: null),
+                        ),
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.aboveBaseline,
+                          baseline: TextBaseline.alphabetic,
+                          child: SizedBox.square(
+                            dimension: 20,
+                            child: TestCheckbox(value: true, onChanged: null),
+                          ),
+                        ),
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.aboveBaseline,
+                          baseline: TextBaseline.alphabetic,
+                          child: Text('embedded'),
+                        ),
+                        TextSpan(text: 'ref'),
+                      ],
+                    ),
+                    textDirection: TextDirection.ltr,
                   ),
-                  textDirection: TextDirection.ltr,
                 ),
               ),
             ),
@@ -970,80 +873,83 @@ void main() {
         child: RepaintBoundary(
           child: Directionality(
             textDirection: TextDirection.ltr,
-            child: Container(
-              width: 400.0,
-              height: 200.0,
-              decoration: const BoxDecoration(color: Color(0xff00ff00)),
-              child: ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
-                child: const Text.rich(
-                  TextSpan(
-                    text: 'C ',
-                    style: TextStyle(fontSize: 16),
-                    children: <InlineSpan>[
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.belowBaseline,
-                        baseline: TextBaseline.alphabetic,
-                        child: TestCheckbox(value: true, onChanged: null),
-                      ),
-                      WidgetSpan(child: TestCheckbox(value: false, onChanged: null)),
-                      TextSpan(text: 'He ', style: TextStyle(fontSize: 20)),
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.belowBaseline,
-                        baseline: TextBaseline.alphabetic,
-                        child: SizedBox(
-                          width: 50.0,
-                          height: 55.0,
-                          child: DecoratedBox(
-                            decoration: BoxDecoration(color: Color(0xffffff00)),
-                            child: Center(
-                              child: SizedBox(
-                                width: 10.0,
-                                height: 15.0,
-                                child: DecoratedBox(
-                                  decoration: BoxDecoration(color: Color(0xffff0000)),
+            child: DefaultTextStyle(
+              style: _bodyMediumTextStyle,
+              child: Container(
+                width: 400.0,
+                height: 200.0,
+                decoration: const BoxDecoration(color: Color(0xff00ff00)),
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
+                  child: const Text.rich(
+                    TextSpan(
+                      text: 'C ',
+                      style: TextStyle(fontSize: 16),
+                      children: <InlineSpan>[
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.belowBaseline,
+                          baseline: TextBaseline.alphabetic,
+                          child: TestCheckbox(value: true, onChanged: null),
+                        ),
+                        WidgetSpan(child: TestCheckbox(value: false, onChanged: null)),
+                        TextSpan(text: 'He ', style: TextStyle(fontSize: 20)),
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.belowBaseline,
+                          baseline: TextBaseline.alphabetic,
+                          child: SizedBox(
+                            width: 50.0,
+                            height: 55.0,
+                            child: DecoratedBox(
+                              decoration: BoxDecoration(color: Color(0xffffff00)),
+                              child: Center(
+                                child: SizedBox(
+                                  width: 10.0,
+                                  height: 15.0,
+                                  child: DecoratedBox(
+                                    decoration: BoxDecoration(color: Color(0xffff0000)),
+                                  ),
                                 ),
                               ),
                             ),
                           ),
                         ),
-                      ),
-                      TextSpan(text: 'hello world! seize the day!'),
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.belowBaseline,
-                        baseline: TextBaseline.alphabetic,
-                        child: TestCheckbox(value: false, onChanged: null),
-                      ),
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.belowBaseline,
-                        baseline: TextBaseline.alphabetic,
-                        child: SizedBox.square(
-                          dimension: 20,
-                          child: TestCheckbox(value: true, onChanged: null),
+                        TextSpan(text: 'hello world! seize the day!'),
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.belowBaseline,
+                          baseline: TextBaseline.alphabetic,
+                          child: TestCheckbox(value: false, onChanged: null),
                         ),
-                      ),
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.belowBaseline,
-                        baseline: TextBaseline.alphabetic,
-                        child: TestCheckbox(value: false, onChanged: null),
-                      ),
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.belowBaseline,
-                        baseline: TextBaseline.alphabetic,
-                        child: SizedBox.square(
-                          dimension: 20,
-                          child: TestCheckbox(value: true, onChanged: null),
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.belowBaseline,
+                          baseline: TextBaseline.alphabetic,
+                          child: SizedBox.square(
+                            dimension: 20,
+                            child: TestCheckbox(value: true, onChanged: null),
+                          ),
                         ),
-                      ),
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.belowBaseline,
-                        baseline: TextBaseline.alphabetic,
-                        child: Text('embedded'),
-                      ),
-                      TextSpan(text: 'ref'),
-                    ],
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.belowBaseline,
+                          baseline: TextBaseline.alphabetic,
+                          child: TestCheckbox(value: false, onChanged: null),
+                        ),
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.belowBaseline,
+                          baseline: TextBaseline.alphabetic,
+                          child: SizedBox.square(
+                            dimension: 20,
+                            child: TestCheckbox(value: true, onChanged: null),
+                          ),
+                        ),
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.belowBaseline,
+                          baseline: TextBaseline.alphabetic,
+                          child: Text('embedded'),
+                        ),
+                        TextSpan(text: 'ref'),
+                      ],
+                    ),
+                    textDirection: TextDirection.ltr,
                   ),
-                  textDirection: TextDirection.ltr,
                 ),
               ),
             ),
@@ -1063,80 +969,83 @@ void main() {
         child: RepaintBoundary(
           child: Directionality(
             textDirection: TextDirection.ltr,
-            child: Container(
-              width: 400.0,
-              height: 200.0,
-              decoration: const BoxDecoration(color: Color(0xff00ff00)),
-              child: ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
-                child: const Text.rich(
-                  TextSpan(
-                    text: 'C ',
-                    style: TextStyle(fontSize: 16),
-                    children: <InlineSpan>[
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.top,
-                        baseline: TextBaseline.alphabetic,
-                        child: TestCheckbox(value: true, onChanged: null),
-                      ),
-                      WidgetSpan(child: TestCheckbox(value: false, onChanged: null)),
-                      TextSpan(text: 'He ', style: TextStyle(fontSize: 20)),
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.top,
-                        baseline: TextBaseline.alphabetic,
-                        child: SizedBox(
-                          width: 50.0,
-                          height: 55.0,
-                          child: DecoratedBox(
-                            decoration: BoxDecoration(color: Color(0xffffff00)),
-                            child: Center(
-                              child: SizedBox(
-                                width: 10.0,
-                                height: 15.0,
-                                child: DecoratedBox(
-                                  decoration: BoxDecoration(color: Color(0xffff0000)),
+            child: DefaultTextStyle(
+              style: _bodyMediumTextStyle,
+              child: Container(
+                width: 400.0,
+                height: 200.0,
+                decoration: const BoxDecoration(color: Color(0xff00ff00)),
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
+                  child: const Text.rich(
+                    TextSpan(
+                      text: 'C ',
+                      style: TextStyle(fontSize: 16),
+                      children: <InlineSpan>[
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.top,
+                          baseline: TextBaseline.alphabetic,
+                          child: TestCheckbox(value: true, onChanged: null),
+                        ),
+                        WidgetSpan(child: TestCheckbox(value: false, onChanged: null)),
+                        TextSpan(text: 'He ', style: TextStyle(fontSize: 20)),
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.top,
+                          baseline: TextBaseline.alphabetic,
+                          child: SizedBox(
+                            width: 50.0,
+                            height: 55.0,
+                            child: DecoratedBox(
+                              decoration: BoxDecoration(color: Color(0xffffff00)),
+                              child: Center(
+                                child: SizedBox(
+                                  width: 10.0,
+                                  height: 15.0,
+                                  child: DecoratedBox(
+                                    decoration: BoxDecoration(color: Color(0xffff0000)),
+                                  ),
                                 ),
                               ),
                             ),
                           ),
                         ),
-                      ),
-                      TextSpan(text: 'hello world! seize the day!'),
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.top,
-                        baseline: TextBaseline.alphabetic,
-                        child: TestCheckbox(value: false, onChanged: null),
-                      ),
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.top,
-                        baseline: TextBaseline.alphabetic,
-                        child: SizedBox.square(
-                          dimension: 20,
-                          child: TestCheckbox(value: true, onChanged: null),
+                        TextSpan(text: 'hello world! seize the day!'),
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.top,
+                          baseline: TextBaseline.alphabetic,
+                          child: TestCheckbox(value: false, onChanged: null),
                         ),
-                      ),
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.top,
-                        baseline: TextBaseline.alphabetic,
-                        child: TestCheckbox(value: false, onChanged: null),
-                      ),
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.top,
-                        baseline: TextBaseline.alphabetic,
-                        child: SizedBox.square(
-                          dimension: 20,
-                          child: TestCheckbox(value: true, onChanged: null),
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.top,
+                          baseline: TextBaseline.alphabetic,
+                          child: SizedBox.square(
+                            dimension: 20,
+                            child: TestCheckbox(value: true, onChanged: null),
+                          ),
                         ),
-                      ),
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.top,
-                        baseline: TextBaseline.alphabetic,
-                        child: Text('embedded'),
-                      ),
-                      TextSpan(text: 'ref'),
-                    ],
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.top,
+                          baseline: TextBaseline.alphabetic,
+                          child: TestCheckbox(value: false, onChanged: null),
+                        ),
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.top,
+                          baseline: TextBaseline.alphabetic,
+                          child: SizedBox.square(
+                            dimension: 20,
+                            child: TestCheckbox(value: true, onChanged: null),
+                          ),
+                        ),
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.top,
+                          baseline: TextBaseline.alphabetic,
+                          child: Text('embedded'),
+                        ),
+                        TextSpan(text: 'ref'),
+                      ],
+                    ),
+                    textDirection: TextDirection.ltr,
                   ),
-                  textDirection: TextDirection.ltr,
                 ),
               ),
             ),
@@ -1156,80 +1065,83 @@ void main() {
         child: RepaintBoundary(
           child: Directionality(
             textDirection: TextDirection.ltr,
-            child: Container(
-              width: 400.0,
-              height: 200.0,
-              decoration: const BoxDecoration(color: Color(0xff00ff00)),
-              child: ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
-                child: const Text.rich(
-                  TextSpan(
-                    text: 'C ',
-                    style: TextStyle(fontSize: 16),
-                    children: <InlineSpan>[
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.middle,
-                        baseline: TextBaseline.alphabetic,
-                        child: TestCheckbox(value: true, onChanged: null),
-                      ),
-                      WidgetSpan(child: TestCheckbox(value: false, onChanged: null)),
-                      TextSpan(text: 'He ', style: TextStyle(fontSize: 20)),
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.middle,
-                        baseline: TextBaseline.alphabetic,
-                        child: SizedBox(
-                          width: 50.0,
-                          height: 55.0,
-                          child: DecoratedBox(
-                            decoration: BoxDecoration(color: Color(0xffffff00)),
-                            child: Center(
-                              child: SizedBox(
-                                width: 10.0,
-                                height: 15.0,
-                                child: DecoratedBox(
-                                  decoration: BoxDecoration(color: Color(0xffff0000)),
+            child: DefaultTextStyle(
+              style: _bodyMediumTextStyle,
+              child: Container(
+                width: 400.0,
+                height: 200.0,
+                decoration: const BoxDecoration(color: Color(0xff00ff00)),
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
+                  child: const Text.rich(
+                    TextSpan(
+                      text: 'C ',
+                      style: TextStyle(fontSize: 16),
+                      children: <InlineSpan>[
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.middle,
+                          baseline: TextBaseline.alphabetic,
+                          child: TestCheckbox(value: true, onChanged: null),
+                        ),
+                        WidgetSpan(child: TestCheckbox(value: false, onChanged: null)),
+                        TextSpan(text: 'He ', style: TextStyle(fontSize: 20)),
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.middle,
+                          baseline: TextBaseline.alphabetic,
+                          child: SizedBox(
+                            width: 50.0,
+                            height: 55.0,
+                            child: DecoratedBox(
+                              decoration: BoxDecoration(color: Color(0xffffff00)),
+                              child: Center(
+                                child: SizedBox(
+                                  width: 10.0,
+                                  height: 15.0,
+                                  child: DecoratedBox(
+                                    decoration: BoxDecoration(color: Color(0xffff0000)),
+                                  ),
                                 ),
                               ),
                             ),
                           ),
                         ),
-                      ),
-                      TextSpan(text: 'hello world! seize the day!'),
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.middle,
-                        baseline: TextBaseline.alphabetic,
-                        child: TestCheckbox(value: false, onChanged: null),
-                      ),
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.middle,
-                        baseline: TextBaseline.alphabetic,
-                        child: SizedBox.square(
-                          dimension: 20,
-                          child: TestCheckbox(value: true, onChanged: null),
+                        TextSpan(text: 'hello world! seize the day!'),
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.middle,
+                          baseline: TextBaseline.alphabetic,
+                          child: TestCheckbox(value: false, onChanged: null),
                         ),
-                      ),
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.middle,
-                        baseline: TextBaseline.alphabetic,
-                        child: TestCheckbox(value: false, onChanged: null),
-                      ),
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.middle,
-                        baseline: TextBaseline.alphabetic,
-                        child: SizedBox.square(
-                          dimension: 20,
-                          child: TestCheckbox(value: true, onChanged: null),
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.middle,
+                          baseline: TextBaseline.alphabetic,
+                          child: SizedBox.square(
+                            dimension: 20,
+                            child: TestCheckbox(value: true, onChanged: null),
+                          ),
                         ),
-                      ),
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.middle,
-                        baseline: TextBaseline.alphabetic,
-                        child: Text('embedded'),
-                      ),
-                      TextSpan(text: 'ref'),
-                    ],
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.middle,
+                          baseline: TextBaseline.alphabetic,
+                          child: TestCheckbox(value: false, onChanged: null),
+                        ),
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.middle,
+                          baseline: TextBaseline.alphabetic,
+                          child: SizedBox.square(
+                            dimension: 20,
+                            child: TestCheckbox(value: true, onChanged: null),
+                          ),
+                        ),
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.middle,
+                          baseline: TextBaseline.alphabetic,
+                          child: Text('embedded'),
+                        ),
+                        TextSpan(text: 'ref'),
+                      ],
+                    ),
+                    textDirection: TextDirection.ltr,
                   ),
-                  textDirection: TextDirection.ltr,
                 ),
               ),
             ),

--- a/packages/flutter/test/widgets/text_selection_test.dart
+++ b/packages/flutter/test/widgets/text_selection_test.dart
@@ -1015,63 +1015,76 @@ void main() {
     expect(controller.selection.baseOffset, 10);
   });
 
-  testWidgets('Stylus drag selects text', (WidgetTester tester) async {
-    // Regression test for https://github.com/flutter/flutter/issues/102928
-    final controller = TextEditingController(text: 'I love flutter!');
-    addTearDown(controller.dispose);
-    final editableTextKey = GlobalKey<EditableTextState>();
-    final delegate = FakeTextSelectionGestureDetectorBuilderDelegate(
-      editableTextKey: editableTextKey,
-      forcePressEnabled: false,
-      selectionEnabled: true,
-    );
-    final provider = TextSelectionGestureDetectorBuilder(delegate: delegate);
-    final focusNode = FocusNode();
-    addTearDown(focusNode.dispose);
+  testWidgets(
+    'Stylus drag selects text',
+    (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/102928
+      final controller = TextEditingController(text: 'I love flutter!');
+      addTearDown(controller.dispose);
+      final editableTextKey = GlobalKey<EditableTextState>();
+      final delegate = FakeTextSelectionGestureDetectorBuilderDelegate(
+        editableTextKey: editableTextKey,
+        forcePressEnabled: false,
+        selectionEnabled: true,
+      );
+      final provider = TextSelectionGestureDetectorBuilder(delegate: delegate);
+      final focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
 
-    await tester.pumpWidget(
-      TestWidgetsApp(
-        home: provider.buildGestureDetector(
-          behavior: HitTestBehavior.translucent,
-          child: EditableText(
-            key: editableTextKey,
-            controller: controller,
-            focusNode: focusNode,
-            backgroundCursorColor: _white,
-            cursorColor: _white,
-            style: const TextStyle(),
-            selectionControls: testTextSelectionHandleControls,
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: provider.buildGestureDetector(
+            behavior: HitTestBehavior.translucent,
+            child: EditableText(
+              key: editableTextKey,
+              controller: controller,
+              focusNode: focusNode,
+              backgroundCursorColor: _white,
+              cursorColor: _white,
+              style: const TextStyle(),
+              selectionControls: testTextSelectionHandleControls,
+            ),
           ),
         ),
-      ),
-    );
+      );
 
-    expect(controller.selection.isCollapsed, isTrue);
-    expect(controller.selection.baseOffset, -1);
+      expect(controller.selection.isCollapsed, isTrue);
+      expect(controller.selection.baseOffset, -1);
 
-    final Offset position = textOffsetToPosition(tester, 4);
+      final Offset position = textOffsetToPosition(tester, 4);
 
-    await tester.tapAt(position);
-    await tester.pump();
+      await tester.tapAt(position);
+      await tester.pump();
 
-    expect(controller.selection.isCollapsed, isTrue);
-    expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.isCollapsed, isTrue);
+      expect(controller.selection.baseOffset, 4);
 
-    final TestGesture gesture = await tester.startGesture(position, kind: PointerDeviceKind.stylus);
-    addTearDown(gesture.removePointer);
-    await tester.pump();
-    await gesture.moveTo(textOffsetToPosition(tester, 7));
-    await tester.pump();
-    await gesture.moveTo(textOffsetToPosition(tester, 10));
-    await tester.pump();
-    await gesture.up();
-    await tester.pumpAndSettle();
+      final TestGesture gesture = await tester.startGesture(
+        position,
+        kind: PointerDeviceKind.stylus,
+      );
+      addTearDown(gesture.removePointer);
+      await tester.pump();
+      await gesture.moveTo(textOffsetToPosition(tester, 7));
+      await tester.pump();
+      await gesture.moveTo(textOffsetToPosition(tester, 10));
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
 
-    // On Android, stylus drag selects text (like mouse), not moves cursor.
-    expect(controller.selection.isCollapsed, isFalse);
-    expect(controller.selection.baseOffset, 4);
-    expect(controller.selection.extentOffset, 10);
-  });
+      // On Android, stylus drag selects text (like mouse), not moves cursor.
+      expect(controller.selection.isCollapsed, isFalse);
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 10);
+    },
+    variant: const TargetPlatformVariant(<TargetPlatform>{
+      TargetPlatform.android,
+      TargetPlatform.fuchsia,
+      TargetPlatform.linux,
+      TargetPlatform.macOS,
+      TargetPlatform.windows,
+    }),
+  );
 
   testWidgets('Drag of unknown type moves the cursor', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/102928

--- a/packages/flutter/test/widgets/text_selection_test.dart
+++ b/packages/flutter/test/widgets/text_selection_test.dart
@@ -4,17 +4,19 @@
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import 'clipboard_utils.dart';
 import 'editable_text_tester.dart';
 import 'editable_text_utils.dart';
+import 'widgets_app_tester.dart';
 
 const int kSingleTapUpTimeout = 500;
+const Color _white = Color(0xFFFFFFFF);
 
 void main() {
   late int tapCount;
@@ -127,7 +129,7 @@ void main() {
     addTearDown(focusNode.dispose);
 
     await tester.pumpWidget(
-      MaterialApp(
+      TestWidgetsApp(
         home: provider.buildGestureDetector(
           behavior: HitTestBehavior.translucent,
           child: FakeEditableText(
@@ -562,21 +564,18 @@ void main() {
       addTearDown(scrollController.dispose);
 
       await tester.pumpWidget(
-        MaterialApp(
-          home: Material(
-            child: CustomScrollView(
-              controller: scrollController,
-              slivers: <Widget>[
-                SliverList(
-                  delegate: SliverChildBuilderDelegate(
-                    (_, int index) =>
-                        index == 0 ? const TestTextField() : const SizedBox(height: 50),
-                    childCount: 200,
-                    addAutomaticKeepAlives: false,
-                  ),
+        TestWidgetsApp(
+          home: CustomScrollView(
+            controller: scrollController,
+            slivers: <Widget>[
+              SliverList(
+                delegate: SliverChildBuilderDelegate(
+                  (_, int index) => index == 0 ? const TestTextField() : const SizedBox(height: 50),
+                  childCount: 200,
+                  addAutomaticKeepAlives: false,
                 ),
-              ],
-            ),
+              ),
+            ],
           ),
         ),
       );
@@ -874,11 +873,13 @@ void main() {
 
   testWidgets('Mouse drag does not show handles nor toolbar', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/69001
+    final controller = TextEditingController(text: 'I love Flutter!');
+    addTearDown(controller.dispose);
     await tester.pumpWidget(
-      const MaterialApp(home: Scaffold(body: SelectableText('I love Flutter!'))),
+      TestWidgetsApp(home: TestTextField(controller: controller, readOnly: true)),
     );
 
-    final Offset textFieldStart = tester.getTopLeft(find.byType(SelectableText));
+    final Offset textFieldStart = tester.getTopLeft(find.byType(TestTextField));
 
     final TestGesture gesture = await tester.startGesture(
       textFieldStart,
@@ -910,17 +911,17 @@ void main() {
     addTearDown(focusNode.dispose);
 
     await tester.pumpWidget(
-      MaterialApp(
+      TestWidgetsApp(
         home: provider.buildGestureDetector(
           behavior: HitTestBehavior.translucent,
           child: EditableText(
             key: editableTextKey,
             controller: controller,
             focusNode: focusNode,
-            backgroundCursorColor: Colors.white,
-            cursorColor: Colors.white,
+            backgroundCursorColor: _white,
+            cursorColor: _white,
             style: const TextStyle(),
-            selectionControls: materialTextSelectionControls,
+            selectionControls: testTextSelectionHandleControls,
           ),
         ),
       ),
@@ -973,17 +974,17 @@ void main() {
     addTearDown(focusNode.dispose);
 
     await tester.pumpWidget(
-      MaterialApp(
+      TestWidgetsApp(
         home: provider.buildGestureDetector(
           behavior: HitTestBehavior.translucent,
           child: EditableText(
             key: editableTextKey,
             controller: controller,
             focusNode: focusNode,
-            backgroundCursorColor: Colors.white,
-            cursorColor: Colors.white,
+            backgroundCursorColor: _white,
+            cursorColor: _white,
             style: const TextStyle(),
-            selectionControls: materialTextSelectionControls,
+            selectionControls: testTextSelectionHandleControls,
           ),
         ),
       ),
@@ -1014,7 +1015,7 @@ void main() {
     expect(controller.selection.baseOffset, 10);
   });
 
-  testWidgets('Stylus drag moves the cursor', (WidgetTester tester) async {
+  testWidgets('Stylus drag selects text', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/102928
     final controller = TextEditingController(text: 'I love flutter!');
     addTearDown(controller.dispose);
@@ -1029,17 +1030,17 @@ void main() {
     addTearDown(focusNode.dispose);
 
     await tester.pumpWidget(
-      MaterialApp(
+      TestWidgetsApp(
         home: provider.buildGestureDetector(
           behavior: HitTestBehavior.translucent,
           child: EditableText(
             key: editableTextKey,
             controller: controller,
             focusNode: focusNode,
-            backgroundCursorColor: Colors.white,
-            cursorColor: Colors.white,
+            backgroundCursorColor: _white,
+            cursorColor: _white,
             style: const TextStyle(),
-            selectionControls: materialTextSelectionControls,
+            selectionControls: testTextSelectionHandleControls,
           ),
         ),
       ),
@@ -1066,8 +1067,10 @@ void main() {
     await gesture.up();
     await tester.pumpAndSettle();
 
-    expect(controller.selection.isCollapsed, isTrue);
-    expect(controller.selection.baseOffset, 10);
+    // On Android, stylus drag selects text (like mouse), not moves cursor.
+    expect(controller.selection.isCollapsed, isFalse);
+    expect(controller.selection.baseOffset, 4);
+    expect(controller.selection.extentOffset, 10);
   });
 
   testWidgets('Drag of unknown type moves the cursor', (WidgetTester tester) async {
@@ -1085,17 +1088,17 @@ void main() {
     addTearDown(focusNode.dispose);
 
     await tester.pumpWidget(
-      MaterialApp(
+      TestWidgetsApp(
         home: provider.buildGestureDetector(
           behavior: HitTestBehavior.translucent,
           child: EditableText(
             key: editableTextKey,
             controller: controller,
             focusNode: focusNode,
-            backgroundCursorColor: Colors.white,
-            cursorColor: Colors.white,
+            backgroundCursorColor: _white,
+            cursorColor: _white,
             style: const TextStyle(),
-            selectionControls: materialTextSelectionControls,
+            selectionControls: testTextSelectionHandleControls,
           ),
         ),
       ),
@@ -1237,9 +1240,7 @@ void main() {
       addTearDown(controller.dispose);
 
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(body: TestTextField(autofocus: true, controller: controller)),
-        ),
+        TestWidgetsApp(home: TestTextField(autofocus: true, controller: controller)),
       );
 
       await tester.pumpAndSettle();
@@ -1281,16 +1282,22 @@ void main() {
       final endHandleLayerLink = LayerLink();
       final toolbarLayerLink = LayerLink();
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: Column(
             key: column,
             children: <Widget>[
               CompositedTransformTarget(
                 link: startHandleLayerLink,
-                child: const Text('start handle'),
+                child: const SizedBox(height: 100, child: Text('start handle')),
               ),
-              CompositedTransformTarget(link: endHandleLayerLink, child: const Text('end handle')),
-              CompositedTransformTarget(link: toolbarLayerLink, child: const Text('toolbar')),
+              CompositedTransformTarget(
+                link: endHandleLayerLink,
+                child: const SizedBox(height: 100, child: Text('end handle')),
+              ),
+              CompositedTransformTarget(
+                link: toolbarLayerLink,
+                child: const SizedBox(height: 100, child: Text('toolbar')),
+              ),
             ],
           ),
         ),
@@ -1670,27 +1677,25 @@ void main() {
     addTearDown(focusNode.dispose);
 
     await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: SizedBox(
-            // Only 4 lines visible of 8 given.
-            height: kLineHeight * 4,
-            child: SingleChildScrollView(
-              controller: scrollController,
-              child: provider.buildGestureDetector(
-                behavior: HitTestBehavior.translucent,
-                child: EditableText(
-                  key: editableTextKey,
-                  controller: controller,
-                  focusNode: focusNode,
-                  backgroundCursorColor: Colors.white,
-                  cursorColor: Colors.white,
-                  style: const TextStyle(),
-                  selectionControls: materialTextSelectionControls,
-                  // EditableText will expand to the full 8 line height and will
-                  // not scroll itself.
-                  maxLines: null,
-                ),
+      TestWidgetsApp(
+        home: SizedBox(
+          // Only 4 lines visible of 8 given.
+          height: kLineHeight * 4,
+          child: SingleChildScrollView(
+            controller: scrollController,
+            child: provider.buildGestureDetector(
+              behavior: HitTestBehavior.translucent,
+              child: EditableText(
+                key: editableTextKey,
+                controller: controller,
+                focusNode: focusNode,
+                backgroundCursorColor: _white,
+                cursorColor: _white,
+                style: const TextStyle(),
+                selectionControls: testTextSelectionHandleControls,
+                // EditableText will expand to the full 8 line height and will
+                // not scroll itself.
+                maxLines: null,
               ),
             ),
           ),
@@ -1748,27 +1753,25 @@ void main() {
       addTearDown(focusNode.dispose);
 
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: SizedBox(
-              // Only 4 lines visible of 8 given.
-              height: kLineHeight * 4,
-              child: SingleChildScrollView(
-                controller: scrollController,
-                child: provider.buildGestureDetector(
-                  behavior: HitTestBehavior.translucent,
-                  child: EditableText(
-                    key: editableTextKey,
-                    controller: controller,
-                    focusNode: focusNode,
-                    backgroundCursorColor: Colors.white,
-                    cursorColor: Colors.white,
-                    style: const TextStyle(),
-                    selectionControls: materialTextSelectionControls,
-                    // EditableText is taller than the SizedBox but not taller
-                    // than the text.
-                    maxLines: 6,
-                  ),
+        TestWidgetsApp(
+          home: SizedBox(
+            // Only 4 lines visible of 8 given.
+            height: kLineHeight * 4,
+            child: SingleChildScrollView(
+              controller: scrollController,
+              child: provider.buildGestureDetector(
+                behavior: HitTestBehavior.translucent,
+                child: EditableText(
+                  key: editableTextKey,
+                  controller: controller,
+                  focusNode: focusNode,
+                  backgroundCursorColor: _white,
+                  cursorColor: _white,
+                  style: const TextStyle(),
+                  selectionControls: testTextSelectionHandleControls,
+                  // EditableText is taller than the SizedBox but not taller
+                  // than the text.
+                  maxLines: 6,
                 ),
               ),
             ),
@@ -1823,7 +1826,7 @@ void main() {
       addTearDown(focusNode.dispose);
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: Column(
             key: column,
             children: <Widget>[
@@ -1877,15 +1880,15 @@ void main() {
     addTearDown(focusNode.dispose);
 
     await tester.pumpWidget(
-      MaterialApp(
+      TestWidgetsApp(
         home: provider.buildGestureDetector(
           behavior: HitTestBehavior.translucent,
           child: EditableText(
             key: editableTextKey,
             controller: controller,
             focusNode: focusNode,
-            backgroundCursorColor: Colors.white,
-            cursorColor: Colors.white,
+            backgroundCursorColor: _white,
+            cursorColor: _white,
             style: const TextStyle(),
             contextMenuBuilder: (BuildContext context, EditableTextState editableTextState) {
               return const Placeholder();
@@ -1923,11 +1926,7 @@ class FakeTextSelectionGestureDetectorBuilderDelegate
 
 class FakeEditableText extends EditableText {
   FakeEditableText({required super.controller, required super.focusNode, super.key})
-    : super(
-        backgroundCursorColor: Colors.white,
-        cursorColor: Colors.white,
-        style: const TextStyle(),
-      );
+    : super(backgroundCursorColor: _white, cursorColor: _white, style: const TextStyle());
 
   @override
   FakeEditableTextState createState() => FakeEditableTextState();
@@ -2078,8 +2077,8 @@ class TextSelectionControlsSpy extends TextSelectionControls {
     double textLineHeight, [
     VoidCallback? onTap,
   ]) {
-    return ElevatedButton(
-      onPressed: onTap,
+    return _TapCallbackWidget(
+      onTap: onTap,
       child: Text(
         key: switch (type) {
           TextSelectionHandleType.left => leftHandleKey,
@@ -2132,4 +2131,26 @@ class FakeTextSelectionDelegate extends Fake implements TextSelectionDelegate {
 
   @override
   void copySelection(SelectionChangedCause cause) {}
+}
+
+/// A widget that calls [onTap] when tapped via a [Listener] rather than a
+/// [GestureDetector], so it does not participate in the gesture arena.
+///
+/// This is used in [TextSelectionControlsSpy] to handle tap callbacks from
+/// [TextSelectionControls.buildHandle] without interfering with the
+/// [PanGestureRecognizer] used by [SelectionOverlay] for handle dragging.
+class _TapCallbackWidget extends StatelessWidget {
+  const _TapCallbackWidget({required this.onTap, required this.child});
+
+  final VoidCallback? onTap;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Listener(
+      behavior: HitTestBehavior.opaque,
+      onPointerUp: onTap != null ? (_) => onTap!() : null,
+      child: child,
+    );
+  }
 }

--- a/packages/flutter/test/widgets/two_dimensional_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_scroll_view_test.dart
@@ -3,13 +3,14 @@
 // found in the LICENSE file.
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/src/gestures/monodrag.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'editable_text_tester.dart';
 import 'two_dimensional_utils.dart';
+import 'widgets_app_tester.dart';
 
 Widget? _testChildBuilder(BuildContext context, ChildVicinity vicinity) {
   return SizedBox.square(
@@ -32,7 +33,7 @@ void main() {
         late final TwoDimensionalChildBuilderDelegate delegate1;
         addTearDown(() => delegate1.dispose());
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SimpleBuilderTableView(
               delegate: delegate1 = TwoDimensionalChildBuilderDelegate(builder: (_, _) => null),
               horizontalDetails: const ScrollableDetails.vertical(),
@@ -45,7 +46,7 @@ void main() {
         late final TwoDimensionalChildBuilderDelegate delegate2;
         addTearDown(() => delegate2.dispose());
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SimpleBuilderTableView(
               delegate: delegate2 = TwoDimensionalChildBuilderDelegate(builder: (_, _) => null),
               verticalDetails: const ScrollableDetails.horizontal(),
@@ -58,7 +59,7 @@ void main() {
         late final TwoDimensionalChildBuilderDelegate delegate3;
         addTearDown(() => delegate3.dispose());
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SimpleBuilderTableView(
               delegate: delegate3 = TwoDimensionalChildBuilderDelegate(builder: (_, _) => null),
               verticalDetails: const ScrollableDetails.horizontal(),
@@ -88,7 +89,7 @@ void main() {
         addTearDown(() => delegate.dispose());
 
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SimpleBuilderTableView(
               verticalDetails: ScrollableDetails.vertical(controller: verticalController),
               horizontalDetails: ScrollableDetails.horizontal(controller: horizontalController),
@@ -142,7 +143,7 @@ void main() {
           late final TwoDimensionalChildBuilderDelegate delegate;
           addTearDown(() => delegate.dispose());
 
-          return MaterialApp(
+          return TestWidgetsApp(
             home: PrimaryScrollController(
               controller: controller,
               child: SimpleBuilderTableView(
@@ -329,7 +330,7 @@ void main() {
         late final TwoDimensionalChildBuilderDelegate delegate1;
         addTearDown(() => delegate1.dispose());
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SimpleBuilderTableView(
               delegate: delegate1 = TwoDimensionalChildBuilderDelegate(
                 builder: (BuildContext context, ChildVicinity vicinity) {
@@ -351,7 +352,7 @@ void main() {
         late final TwoDimensionalChildBuilderDelegate delegate2;
         addTearDown(() => delegate2.dispose());
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: SimpleBuilderTableView(
               verticalDetails: const ScrollableDetails.vertical(reverse: true),
               horizontalDetails: const ScrollableDetails.horizontal(reverse: true),
@@ -379,7 +380,7 @@ void main() {
         late final TwoDimensionalChildBuilderDelegate delegate;
         addTearDown(() => delegate.dispose());
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: Stack(
               children: <Widget>[
                 Positioned.fill(
@@ -948,15 +949,14 @@ void main() {
       WidgetTester tester,
     ) async {
       late final TwoDimensionalChildBuilderDelegate delegate;
-      final scaffoldKey = GlobalKey<ScaffoldState>();
+      final overlayKey = GlobalKey<_DrawerLikeContainerState>();
       addTearDown(() => delegate.dispose());
 
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            key: scaffoldKey,
-            drawer: Container(),
-            body: Column(
+        TestWidgetsApp(
+          home: _DrawerLikeContainer(
+            key: overlayKey,
+            child: Column(
               children: <Widget>[
                 const TestTextField(),
                 Expanded(
@@ -986,7 +986,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(tester.testTextInput.isVisible, isFalse);
-      scaffoldKey.currentState!.openDrawer();
+      overlayKey.currentState!.showOverlay();
       await tester.pumpAndSettle();
 
       expect(tester.testTextInput.isVisible, isFalse);
@@ -996,7 +996,7 @@ void main() {
       late final TwoDimensionalChildBuilderDelegate delegate;
       addTearDown(() => delegate.dispose());
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: SimpleBuilderTableView(
             cacheExtent: 1.0,
             cacheExtentStyle: CacheExtentStyle.viewport,
@@ -1017,4 +1017,36 @@ void main() {
       expect(viewport.cacheExtentStyle, CacheExtentStyle.viewport);
     });
   });
+}
+
+/// A simple container that can show an overlay on top of its child,
+/// used to simulate the effect of opening a drawer without depending
+/// on [Scaffold] from the Material library.
+class _DrawerLikeContainer extends StatefulWidget {
+  const _DrawerLikeContainer({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  State<_DrawerLikeContainer> createState() => _DrawerLikeContainerState();
+}
+
+class _DrawerLikeContainerState extends State<_DrawerLikeContainer> {
+  bool _showOverlay = false;
+
+  void showOverlay() {
+    setState(() {
+      _showOverlay = true;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: <Widget>[
+        widget.child,
+        if (_showOverlay) Positioned.fill(child: Container(color: const Color(0x88000000))),
+      ],
+    );
+  }
 }

--- a/packages/flutter/test/widgets/widgets_app_tester.dart
+++ b/packages/flutter/test/widgets/widgets_app_tester.dart
@@ -75,6 +75,7 @@ class TestWidgetsApp extends StatelessWidget {
     this.home,
     this.initialRoute,
     this.onGenerateRoute,
+    this.navigatorObservers = const <NavigatorObserver>[],
     this.routes = const <String, WidgetBuilder>{},
     this.color = const Color(0xFFFFFFFF),
     this.textStyle,
@@ -136,6 +137,15 @@ class TestWidgetsApp extends StatelessWidget {
   ///
   ///  * [WidgetsApp.onGenerateRoute], the equivalent property in [WidgetsApp].
   final RouteFactory? onGenerateRoute;
+
+  /// A list of [NavigatorObserver] for the app's [Navigator].
+  ///
+  /// Defaults to an empty list.
+  ///
+  /// See also:
+  ///
+  ///  * [WidgetsApp.navigatorObservers], the equivalent property in [WidgetsApp].
+  final List<NavigatorObserver> navigatorObservers;
 
   /// The application's top-level routing table.
   ///
@@ -263,6 +273,7 @@ class TestWidgetsApp extends StatelessWidget {
       color: color,
       textStyle: textStyle,
       navigatorKey: navigatorKey,
+      navigatorObservers: navigatorObservers,
       home: home,
       initialRoute: initialRoute,
       onGenerateRoute: onGenerateRoute,


### PR DESCRIPTION
This PR removes Material imports from 
* editable_text_scribble_test
* editable_text_scribe_test
* page_route_builder_test
* radio_group_test
* semantics_debugger_test
* range_maintaining_scroll_physics_test
* two_dimensional_scroll_view_test
* routes_test
* text_selection_test
* selectable_region_test
* text_golden_test

part of: https://github.com/flutter/flutter/issues/177415

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
