### PR TITLE
Use an if-element in a collection literal instead of a conditional expression

### DIFF
--- a/packages/flutter_test/lib/src/mock_canvas.dart
+++ b/packages/flutter_test/lib/src/mock_canvas.dart
@@ -2127,7 +2127,7 @@ class _FunctionPaintPredicate extends _PaintPredicate {
   String toString() {
     final adjectives = <String>[
       for (int index = 0; index < arguments.length; index += 1)
-        arguments[index] != null ? _valueName(arguments[index]) : '...',
+        if (arguments[index] != null) _valueName(arguments[index]) else '...',
     ];
     return '${_symbolName(symbol)}(${adjectives.join(", ")})';
   }


### PR DESCRIPTION
This is necessary to land an improvement to the lint rule: https://dart-review.googlesource.com/c/sdk/+/493961