### PR TITLE
Fix killing wrong xcrun command

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3926,7 +3926,7 @@ targets:
       - DEPS
 
   - name: Mac flavors_test_macos
-    presubmit: false
+    presubmit: true
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3926,7 +3926,7 @@ targets:
       - DEPS
 
   - name: Mac flavors_test_macos
-    presubmit: true
+    presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -408,7 +408,12 @@ class XcodeProjectInterpreter {
         // Check if process is already running from a previous Flutter command. If it is, kill it
         // so we don't have the process running twice. When this process is run twice, it'll cause
         // one to error. The new process will pick up where the old one left off.
-        final RunResult result = await _processUtils.run(['pgrep', '-n', ...command]);
+        final RunResult result = await _processUtils.run([
+          'pgrep',
+          '-n', //Select only the newest
+          '-f', // Match against full argument lists
+          ...command,
+        ]);
         if (result.exitCode == 0) {
           final int? pid = int.tryParse(result.stdout.trim());
           if (pid != null) {

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -410,7 +410,7 @@ class XcodeProjectInterpreter {
         // one to error. The new process will pick up where the old one left off.
         final RunResult result = await _processUtils.run([
           'pgrep',
-          '-n', //Select only the newest
+          '-n', // Select only the newest
           '-f', // Match against full argument lists
           ...command,
         ]);

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -57,7 +57,7 @@ void main() {
   ];
 
   const kFindProcessResolvePackagesCommand = FakeCommand(
-    command: <String>['pgrep', '-n', ...kResolvePackagesCommandList],
+    command: <String>['pgrep', '-n', '-f', ...kResolvePackagesCommandList],
   );
 
   const kResolvePackagesCommand = FakeCommand(command: kResolvePackagesCommandList);
@@ -562,6 +562,7 @@ void main() {
           command: <String>[
             'pgrep',
             '-n',
+            '-f',
             'xcrun',
             'xcodebuild',
             '-clonedSourcePackagesDirPath',
@@ -2440,6 +2441,7 @@ flutter:
           command: <String>[
             'pgrep',
             '-n',
+            '-f',
             'xcrun',
             'xcodebuild',
             '-clonedSourcePackagesDirPath',
@@ -2519,6 +2521,7 @@ Xcode is fetching Swift Package Manager dependencies. This may take several minu
         command: <String>[
           'pgrep',
           '-n',
+          '-f',
           'xcrun',
           'xcodebuild',
           '-clonedSourcePackagesDirPath',
@@ -2576,6 +2579,7 @@ Xcode is fetching Swift Package Manager dependencies. This may take several minu
         command: <String>[
           'pgrep',
           '-n',
+          '-f',
           'xcrun',
           'xcodebuild',
           '-clonedSourcePackagesDirPath',
@@ -2648,6 +2652,7 @@ Resolved source packages:
           command: <String>[
             'pgrep',
             '-n',
+            '-f',
             'xcrun',
             'xcodebuild',
             '-clonedSourcePackagesDirPath',
@@ -2722,6 +2727,7 @@ Resolved source packages:
         command: <String>[
           'pgrep',
           '-n',
+          '-f',
           'xcrun',
           'xcodebuild',
           '-clonedSourcePackagesDirPath',


### PR DESCRIPTION
We use `pgrep` to kill any matching existing `xcrun xcodebuild -resolvePackageDependencies` command. However, we did not specify that it should match on arguments and therefore was only matching on process name, killing other xcrun` commands.

Fixes https://github.com/flutter/flutter/issues/184754.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
