### PR TITLE
[Android] Fix for gboard stuck text selection

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/KeyEmbedderResponder.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/KeyEmbedderResponder.java
@@ -194,6 +194,16 @@ public class KeyEmbedderResponder implements KeyboardManager.Responder {
       }
     }
 
+    boolean isVirtualUpForThisGoal = false;
+    if (event.getScanCode() == 0 && getEventType(event) == KeyData.Type.kUp) {
+      for (final KeyboardMap.KeyPair key : goal.keys) {
+        if (key.logicalKey == eventLogicalKey) {
+          isVirtualUpForThisGoal = true;
+          break;
+        }
+      }
+    }
+
     // Fill the rest of the pre-event states to match the true state.
     if (truePressed) {
       // It is required that at least one key is pressed.
@@ -201,14 +211,17 @@ public class KeyEmbedderResponder implements KeyboardManager.Responder {
         if (preEventStates[keyIdx] != null) {
           continue;
         }
-        if (postEventAnyPressed) {
+        if (isVirtualUpForThisGoal) {
+          // Force release other keys in the goal for virtual UP events with persistent meta bit.
+          preEventStates[keyIdx] = false;
+        } else if (postEventAnyPressed) {
           preEventStates[keyIdx] = nowStates[keyIdx];
         } else {
           preEventStates[keyIdx] = true;
           postEventAnyPressed = true;
         }
       }
-      if (!postEventAnyPressed) {
+      if (!postEventAnyPressed && !isVirtualUpForThisGoal) {
         preEventStates[0] = true;
       }
     } else {

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/KeyEmbedderResponder.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/KeyEmbedderResponder.java
@@ -194,13 +194,11 @@ public class KeyEmbedderResponder implements KeyboardManager.Responder {
       }
     }
 
-    boolean isVirtualUpForThisGoal = false;
-    if (event.getScanCode() == 0 && getEventType(event) == KeyData.Type.kUp) {
-      for (final KeyboardMap.KeyPair key : goal.keys) {
-        if (key.logicalKey == eventLogicalKey) {
-          isVirtualUpForThisGoal = true;
-          break;
-        }
+    boolean isGoalKey = false;
+    for (int keyIdx = 0; keyIdx < goal.keys.length; keyIdx += 1) {
+      if (goal.keys[keyIdx].logicalKey == eventLogicalKey) {
+        isGoalKey = true;
+        break;
       }
     }
 
@@ -211,17 +209,16 @@ public class KeyEmbedderResponder implements KeyboardManager.Responder {
         if (preEventStates[keyIdx] != null) {
           continue;
         }
-        if (isVirtualUpForThisGoal) {
-          // Force release other keys in the goal for virtual UP events with persistent meta bit.
-          preEventStates[keyIdx] = false;
-        } else if (postEventAnyPressed) {
+        if (postEventAnyPressed) {
+          preEventStates[keyIdx] = nowStates[keyIdx];
+        } else if (isGoalKey) {
           preEventStates[keyIdx] = nowStates[keyIdx];
         } else {
           preEventStates[keyIdx] = true;
           postEventAnyPressed = true;
         }
       }
-      if (!postEventAnyPressed && !isVirtualUpForThisGoal) {
+      if (!postEventAnyPressed && !isGoalKey) {
         preEventStates[0] = true;
       }
     } else {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/KeyboardManagerTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/KeyboardManagerTest.java
@@ -800,6 +800,55 @@ public class KeyboardManagerTest {
   }
 
   @Test
+  public void virtualKeyboardShiftUpClearsState() {
+    final KeyboardTester tester = new KeyboardTester();
+    final ArrayList<CallRecord> calls = new ArrayList<>();
+
+    tester.recordEmbedderCallsTo(calls);
+    tester.respondToTextInputWith(true); // Suppress redispatching
+
+    final long virtualShiftLeftPhysicalKey = KEYCODE_SHIFT_LEFT | KeyboardMap.kAndroidPlane;
+
+    // 1. Simulate ShiftLeft DOWN from virtual keyboard (scancode = 0)
+    assertTrue(
+        tester.keyboardManager.handleEvent(
+            new FakeKeyEvent(ACTION_DOWN, 0, KEYCODE_SHIFT_LEFT, 0, '\0', META_SHIFT_ON)));
+
+    verifyEmbedderEvents(
+        calls,
+        new KeyData[] {
+          buildKeyData(
+              Type.kDown,
+              virtualShiftLeftPhysicalKey,
+              LOGICAL_SHIFT_LEFT,
+              null,
+              false,
+              DeviceType.kKeyboard),
+        });
+    calls.clear();
+
+    // 2. Simulate ShiftLeft UP from virtual keyboard (scancode = 0) with meta bit still active
+    assertTrue(
+        tester.keyboardManager.handleEvent(
+            new FakeKeyEvent(ACTION_UP, 0, KEYCODE_SHIFT_LEFT, 0, '\0', META_SHIFT_ON)));
+
+    // Verify that it does NOT synthesize SHIFT_RIGHT DOWN.
+    // It should only send SHIFT_LEFT UP.
+    verifyEmbedderEvents(
+        calls,
+        new KeyData[] {
+          buildKeyData(
+              Type.kUp,
+              virtualShiftLeftPhysicalKey,
+              LOGICAL_SHIFT_LEFT,
+              null,
+              false,
+              DeviceType.kKeyboard),
+        });
+    calls.clear();
+  }
+
+  @Test
   public void tapUpperA() {
     final KeyboardTester tester = new KeyboardTester();
     final ArrayList<CallRecord> calls = new ArrayList<>();


### PR DESCRIPTION
Ensures the UP event releases text selections.

Fixes: #184744

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.