### PR TITLE
refactor: Remove material imports from Widget tests 

### DIFF
--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -145,7 +145,6 @@ class TestsCrossImportChecker {
     'packages/flutter/test/widgets/draggable_test.dart',
     'packages/flutter/test/widgets/page_transitions_builder_test.dart',
     'packages/flutter/test/widgets/selectable_region_context_menu_test.dart',
-    'packages/flutter/test/widgets/sliversemantics_test.dart',
     'packages/flutter/test/widgets/tap_region_test.dart',
     'packages/flutter/test/widgets/navigator_test.dart',
     'packages/flutter/test/widgets/navigator_restoration_test.dart',

--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -127,7 +127,6 @@ class TestsCrossImportChecker {
     'packages/flutter/test/widgets/sliver_main_axis_group_test.dart',
     'packages/flutter/test/widgets/sliver_semantics_test.dart',
     'packages/flutter/test/widgets/routes_transition_test.dart',
-    'packages/flutter/test/widgets/editable_text_shortcuts_test.dart',
     'packages/flutter/test/widgets/editable_text_test.dart',
     'packages/flutter/test/widgets/scrollbar_test.dart',
     'packages/flutter/test/widgets/obscured_animated_image_test.dart',

--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -148,7 +148,6 @@ class TestsCrossImportChecker {
     'packages/flutter/test/widgets/tap_region_test.dart',
     'packages/flutter/test/widgets/navigator_test.dart',
     'packages/flutter/test/widgets/navigator_restoration_test.dart',
-    'packages/flutter/test/widgets/navigator_on_did_remove_page_test.dart',
     'packages/flutter/test/widgets/scrollable_semantics_test.dart',
     'packages/flutter/test/widgets/form_test.dart',
   };

--- a/packages/flutter/test/widgets/editable_text_shortcuts_test.dart
+++ b/packages/flutter/test/widgets/editable_text_shortcuts_test.dart
@@ -3,12 +3,13 @@
 // found in the LICENSE file.
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'clipboard_utils.dart';
 import 'keyboard_utils.dart';
+import 'widgets_app_tester.dart';
 
 Iterable<SingleActivator> allModifierVariants(LogicalKeyboardKey trigger) {
   const Iterable<bool> trueFalse = <bool>[false, true];
@@ -78,7 +79,7 @@ void main() {
     TextStyle style = const TextStyle(fontSize: 10.0),
     bool enableInteractiveSelection = true,
   }) {
-    return MaterialApp(
+    return TestWidgetsApp(
       home: Align(
         alignment: Alignment.topLeft,
         child: SizedBox(
@@ -94,9 +95,9 @@ void main() {
             textScaleFactor: 1,
             // Avoid the cursor from taking up width.
             cursorWidth: 0,
-            cursorColor: Colors.blue,
-            backgroundCursorColor: Colors.grey,
-            selectionControls: materialTextSelectionControls,
+            cursorColor: const Color(0xFF2196F3),
+            backgroundCursorColor: const Color(0xFF9E9E9E),
+            selectionControls: emptyTextSelectionControls,
             keyboardType: TextInputType.text,
             maxLines: obscured ? 1 : null,
             readOnly: readOnly,

--- a/packages/flutter/test/widgets/navigator_on_did_remove_page_test.dart
+++ b/packages/flutter/test/widgets/navigator_on_did_remove_page_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -26,13 +26,13 @@ void main() {
   testWidgets('Page API will not call onDidRemovePage', (WidgetTester tester) async {
     final removedPages = <Page<void>>[];
 
-    const page = MaterialPage<void>(key: ValueKey<String>('page'), child: Text('page'));
-    const page1 = MaterialPage<void>(key: ValueKey<String>('page1'), child: Text('page1'));
-    const page2 = MaterialPage<void>(key: ValueKey<String>('page2'), child: Text('page2'));
-    const page3 = MaterialPage<void>(key: ValueKey<String>('page3'), child: Text('page3'));
-    const page4 = MaterialPage<void>(key: ValueKey<String>('page4'), child: Text('page4'));
-    const page5 = MaterialPage<void>(key: ValueKey<String>('page5'), child: Text('page5'));
-    const page6 = MaterialPage<void>(key: ValueKey<String>('page6'), child: Text('page6'));
+    const page = _TestPage<void>(key: ValueKey<String>('page'), child: Text('page'));
+    const page1 = _TestPage<void>(key: ValueKey<String>('page1'), child: Text('page1'));
+    const page2 = _TestPage<void>(key: ValueKey<String>('page2'), child: Text('page2'));
+    const page3 = _TestPage<void>(key: ValueKey<String>('page3'), child: Text('page3'));
+    const page4 = _TestPage<void>(key: ValueKey<String>('page4'), child: Text('page4'));
+    const page5 = _TestPage<void>(key: ValueKey<String>('page5'), child: Text('page5'));
+    const page6 = _TestPage<void>(key: ValueKey<String>('page6'), child: Text('page6'));
     await buildPages(<Page<void>>[page], tester, removedPage: removedPages);
 
     expect(find.text('page'), findsOneWidget);
@@ -58,8 +58,8 @@ void main() {
     final key = GlobalKey<NavigatorState>();
     final removedPage = <Page<void>>[];
 
-    const page = MaterialPage<void>(key: ValueKey<String>('page'), child: Text('page'));
-    const page1 = MaterialPage<void>(key: ValueKey<String>('page1'), child: Text('page1'));
+    const page = _TestPage<void>(key: ValueKey<String>('page'), child: Text('page'));
+    const page1 = _TestPage<void>(key: ValueKey<String>('page1'), child: Text('page1'));
     await buildPages(<Page<void>>[page, page1], tester, removedPage: removedPage, navKey: key);
 
     expect(find.text('page1'), findsOneWidget);
@@ -81,17 +81,16 @@ void main() {
     final key = GlobalKey<NavigatorState>();
     final removedPage = <Page<void>>[];
 
-    const page = MaterialPage<void>(key: ValueKey<String>('page'), child: Text('page'));
-    const page1 = MaterialPage<void>(key: ValueKey<String>('page1'), child: Text('page1'));
+    const page = _TestPage<void>(key: ValueKey<String>('page'), child: Text('page'));
+    const page1 = _TestPage<void>(key: ValueKey<String>('page1'), child: Text('page1'));
     await buildPages(<Page<void>>[page, page1], tester, removedPage: removedPage, navKey: key);
 
     expect(find.text('page1'), findsOneWidget);
 
     key.currentState!.pushReplacement(
-      MaterialPageRoute<void>(
-        builder: (_) {
-          return const Text('new page');
-        },
+      PageRouteBuilder<void>(
+        pageBuilder: (_, _, _) => const Text('new page'),
+        transitionsBuilder: (_, _, _, child) => child,
       ),
     );
 
@@ -105,4 +104,20 @@ void main() {
     expect(find.text('new page'), findsOneWidget);
     expect(removedPage, <Page<void>>[page1]);
   });
+}
+
+/// A minimal [Page] widget for use in navigator tests without
+/// depending on the Material library.
+class _TestPage<T> extends Page<T> {
+  const _TestPage({super.key, required this.child});
+  final Widget child;
+
+  @override
+  Route<T> createRoute(BuildContext context) {
+    return PageRouteBuilder<T>(
+      settings: this,
+      pageBuilder: (_, _, _) => child,
+      transitionsBuilder: (_, _, _, child) => child,
+    );
+  }
 }

--- a/packages/flutter/test/widgets/navigator_on_did_remove_page_test.dart
+++ b/packages/flutter/test/widgets/navigator_on_did_remove_page_test.dart
@@ -5,6 +5,8 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'test_page_tester.dart';
+
 void main() {
   Future<void> buildPages(
     List<Page<void>> pages,
@@ -26,13 +28,13 @@ void main() {
   testWidgets('Page API will not call onDidRemovePage', (WidgetTester tester) async {
     final removedPages = <Page<void>>[];
 
-    const page = _TestPage<void>(key: ValueKey<String>('page'), child: Text('page'));
-    const page1 = _TestPage<void>(key: ValueKey<String>('page1'), child: Text('page1'));
-    const page2 = _TestPage<void>(key: ValueKey<String>('page2'), child: Text('page2'));
-    const page3 = _TestPage<void>(key: ValueKey<String>('page3'), child: Text('page3'));
-    const page4 = _TestPage<void>(key: ValueKey<String>('page4'), child: Text('page4'));
-    const page5 = _TestPage<void>(key: ValueKey<String>('page5'), child: Text('page5'));
-    const page6 = _TestPage<void>(key: ValueKey<String>('page6'), child: Text('page6'));
+    const page = TestPage<void>(key: ValueKey<String>('page'), child: Text('page'));
+    const page1 = TestPage<void>(key: ValueKey<String>('page1'), child: Text('page1'));
+    const page2 = TestPage<void>(key: ValueKey<String>('page2'), child: Text('page2'));
+    const page3 = TestPage<void>(key: ValueKey<String>('page3'), child: Text('page3'));
+    const page4 = TestPage<void>(key: ValueKey<String>('page4'), child: Text('page4'));
+    const page5 = TestPage<void>(key: ValueKey<String>('page5'), child: Text('page5'));
+    const page6 = TestPage<void>(key: ValueKey<String>('page6'), child: Text('page6'));
     await buildPages(<Page<void>>[page], tester, removedPage: removedPages);
 
     expect(find.text('page'), findsOneWidget);
@@ -58,8 +60,8 @@ void main() {
     final key = GlobalKey<NavigatorState>();
     final removedPage = <Page<void>>[];
 
-    const page = _TestPage<void>(key: ValueKey<String>('page'), child: Text('page'));
-    const page1 = _TestPage<void>(key: ValueKey<String>('page1'), child: Text('page1'));
+    const page = TestPage<void>(key: ValueKey<String>('page'), child: Text('page'));
+    const page1 = TestPage<void>(key: ValueKey<String>('page1'), child: Text('page1'));
     await buildPages(<Page<void>>[page, page1], tester, removedPage: removedPage, navKey: key);
 
     expect(find.text('page1'), findsOneWidget);
@@ -81,8 +83,8 @@ void main() {
     final key = GlobalKey<NavigatorState>();
     final removedPage = <Page<void>>[];
 
-    const page = _TestPage<void>(key: ValueKey<String>('page'), child: Text('page'));
-    const page1 = _TestPage<void>(key: ValueKey<String>('page1'), child: Text('page1'));
+    const page = TestPage<void>(key: ValueKey<String>('page'), child: Text('page'));
+    const page1 = TestPage<void>(key: ValueKey<String>('page1'), child: Text('page1'));
     await buildPages(<Page<void>>[page, page1], tester, removedPage: removedPage, navKey: key);
 
     expect(find.text('page1'), findsOneWidget);
@@ -104,20 +106,4 @@ void main() {
     expect(find.text('new page'), findsOneWidget);
     expect(removedPage, <Page<void>>[page1]);
   });
-}
-
-/// A minimal [Page] widget for use in navigator tests without
-/// depending on the Material library.
-class _TestPage<T> extends Page<T> {
-  const _TestPage({super.key, required this.child});
-  final Widget child;
-
-  @override
-  Route<T> createRoute(BuildContext context) {
-    return PageRouteBuilder<T>(
-      settings: this,
-      pageBuilder: (_, _, _) => child,
-      transitionsBuilder: (_, _, _, child) => child,
-    );
-  }
 }

--- a/packages/flutter/test/widgets/sliversemantics_test.dart
+++ b/packages/flutter/test/widgets/sliversemantics_test.dart
@@ -4,8 +4,8 @@
 
 import 'dart:math';
 
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'semantics_tester.dart';
@@ -829,11 +829,9 @@ void _tests() {
             onCollapse: () => performedActions.add(SemanticsAction.collapse),
             sliver: SliverList(
               delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
-                return Card(
-                  child: Padding(
-                    padding: const EdgeInsets.all(8.0),
-                    child: Text('Lorem Ipsum $index'),
-                  ),
+                return Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Text('Lorem Ipsum $index'),
                 );
               }, childCount: 1),
             ),
@@ -883,9 +881,8 @@ void _tests() {
                     SemanticsAction.expand,
                     SemanticsAction.collapse,
                   ],
-                  children: <TestSemantics>[
-                    TestSemantics(label: 'Lorem Ipsum 0', textDirection: TextDirection.ltr),
-                  ],
+                  label: 'Lorem Ipsum 0',
+                  textDirection: TextDirection.ltr,
                 ),
               ],
             ),
@@ -980,11 +977,9 @@ void _tests() {
             isRequired: true,
             sliver: SliverList(
               delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
-                return Card(
-                  child: Padding(
-                    padding: const EdgeInsets.all(8.0),
-                    child: Text('Lorem Ipsum $index'),
-                  ),
+                return Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Text('Lorem Ipsum $index'),
                 );
               }, childCount: 1),
             ),
@@ -1010,11 +1005,7 @@ void _tests() {
                   tags: <SemanticsTag>[const SemanticsTag('RenderViewport.twoPane')],
                   flags: flags,
                   children: <TestSemantics>[
-                    TestSemantics(
-                      children: <TestSemantics>[
-                        TestSemantics(label: 'Lorem Ipsum 0', textDirection: TextDirection.ltr),
-                      ],
-                    ),
+                    TestSemantics(label: 'Lorem Ipsum 0', textDirection: TextDirection.ltr),
                   ],
                 ),
               ],
@@ -1037,11 +1028,9 @@ void _tests() {
             scopesRoute: false,
             sliver: SliverList(
               delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
-                return Card(
-                  child: Padding(
-                    padding: const EdgeInsets.all(8.0),
-                    child: Text('Lorem Ipsum $index'),
-                  ),
+                return Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Text('Lorem Ipsum $index'),
                 );
               }, childCount: 1),
             ),
@@ -1059,9 +1048,8 @@ void _tests() {
                 TestSemantics(
                   tags: <SemanticsTag>[const SemanticsTag('RenderViewport.twoPane')],
                   flags: <SemanticsFlag>[],
-                  children: <TestSemantics>[
-                    TestSemantics(label: 'Lorem Ipsum 0', textDirection: TextDirection.ltr),
-                  ],
+                  label: 'Lorem Ipsum 0',
+                  textDirection: TextDirection.ltr,
                 ),
               ],
             ),
@@ -1082,11 +1070,9 @@ void _tests() {
             toggled: true,
             sliver: SliverList(
               delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
-                return Card(
-                  child: Padding(
-                    padding: const EdgeInsets.all(8.0),
-                    child: Text('Lorem Ipsum $index'),
-                  ),
+                return Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Text('Lorem Ipsum $index'),
                 );
               }, childCount: 1),
             ),
@@ -1105,9 +1091,8 @@ void _tests() {
                 TestSemantics(
                   tags: <SemanticsTag>[const SemanticsTag('RenderViewport.twoPane')],
                   flags: <SemanticsFlag>[SemanticsFlag.hasToggledState, SemanticsFlag.isToggled],
-                  children: <TestSemantics>[
-                    TestSemantics(label: 'Lorem Ipsum 0', textDirection: TextDirection.ltr),
-                  ],
+                  label: 'Lorem Ipsum 0',
+                  textDirection: TextDirection.ltr,
                 ),
               ],
             ),
@@ -1153,11 +1138,9 @@ void _tests() {
             isRequired: true,
             sliver: SliverList(
               delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
-                return Card(
-                  child: Padding(
-                    padding: const EdgeInsets.all(8.0),
-                    child: Text('Lorem Ipsum $index'),
-                  ),
+                return Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Text('Lorem Ipsum $index'),
                 );
               }, childCount: 1),
             ),
@@ -1180,11 +1163,7 @@ void _tests() {
                   tags: <SemanticsTag>[const SemanticsTag('RenderViewport.twoPane')],
                   flags: flags,
                   children: <TestSemantics>[
-                    TestSemantics(
-                      children: <TestSemantics>[
-                        TestSemantics(label: 'Lorem Ipsum 0', textDirection: TextDirection.ltr),
-                      ],
-                    ),
+                    TestSemantics(label: 'Lorem Ipsum 0', textDirection: TextDirection.ltr),
                   ],
                 ),
               ],


### PR DESCRIPTION
This PR removes Material imports from:

- sliversemantics_test.dart
- navigator_on_did_remove_page_test.dart
- editable_text_shortcuts_test.dart

part of: #177415 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

