### PR TITLE
widgets: Guard _compareScreenOrder against unlaid-out selectables

### DIFF
--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -2575,28 +2575,45 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
   @protected
   Comparator<Selectable> get compareOrder => _compareScreenOrder;
 
-  static int _compareScreenOrder(Selectable a, Selectable b) {
+  // Returns null instead of throwing when `selectable`'s RenderBox isn't laid
+  // out. This happens when _RenderTheater skips layout for an obscured
+  // OverlayEntry but selectables remain registered: accessing `size` throws
+  // StateError in release mode, while debug-mode asserts (hasSize /
+  // debugNeedsLayout) throw AssertionError first.
+  // See https://github.com/flutter/flutter/issues/151536
+  static Rect? _getScreenRect(Selectable selectable) {
     try {
-      final Rect rectA = MatrixUtils.transformRect(a.getTransformTo(null), _getBoundingBox(a));
-      final Rect rectB = MatrixUtils.transformRect(b.getTransformTo(null), _getBoundingBox(b));
-      final int result = _compareVertically(rectA, rectB);
-      if (result != 0) {
-        return result;
-      }
-      return _compareHorizontally(rectA, rectB);
+      return MatrixUtils.transformRect(
+        selectable.getTransformTo(null),
+        _getBoundingBox(selectable),
+      );
     } on StateError {
-      // In release mode, accessing `size` on an unlaid-out RenderBox throws
-      // StateError. This happens when _RenderTheater skips layout for an
-      // obscured OverlayEntry but selectables remain registered.
-      // Treat unlaid-out selectables as equal in sort order — they will be
-      // properly positioned on the next frame when layout completes.
-      // See https://github.com/flutter/flutter/issues/151536
-      return 0;
+      return null;
     } on AssertionError {
-      // In debug mode, hasSize/debugNeedsLayout asserts fire before
-      // StateError. Catch both to prevent crashes in all build modes.
+      return null;
+    }
+  }
+
+  static int _compareScreenOrder(Selectable a, Selectable b) {
+    final Rect? rectA = _getScreenRect(a);
+    final Rect? rectB = _getScreenRect(b);
+    if (rectA == null && rectB == null) {
       return 0;
     }
+    if (rectA == null) {
+      // Unavailable selectables sort after available ones instead of
+      // crashing; order self-corrects the next time selectables are
+      // flushed/re-sorted.
+      return 1;
+    }
+    if (rectB == null) {
+      return -1;
+    }
+    final int result = _compareVertically(rectA, rectB);
+    if (result != 0) {
+      return result;
+    }
+    return _compareHorizontally(rectA, rectB);
   }
 
   /// Compares two rectangles in the screen order solely by their vertical

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -2602,8 +2602,7 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
     }
     if (rectA == null) {
       // Unavailable selectables sort after available ones instead of
-      // crashing; order self-corrects the next time selectables are
-      // flushed/re-sorted.
+      // crashing the sort.
       return 1;
     }
     if (rectB == null) {

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -2576,13 +2576,27 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
   Comparator<Selectable> get compareOrder => _compareScreenOrder;
 
   static int _compareScreenOrder(Selectable a, Selectable b) {
-    final Rect rectA = MatrixUtils.transformRect(a.getTransformTo(null), _getBoundingBox(a));
-    final Rect rectB = MatrixUtils.transformRect(b.getTransformTo(null), _getBoundingBox(b));
-    final int result = _compareVertically(rectA, rectB);
-    if (result != 0) {
-      return result;
+    try {
+      final Rect rectA = MatrixUtils.transformRect(a.getTransformTo(null), _getBoundingBox(a));
+      final Rect rectB = MatrixUtils.transformRect(b.getTransformTo(null), _getBoundingBox(b));
+      final int result = _compareVertically(rectA, rectB);
+      if (result != 0) {
+        return result;
+      }
+      return _compareHorizontally(rectA, rectB);
+    } on StateError {
+      // In release mode, accessing `size` on an unlaid-out RenderBox throws
+      // StateError. This happens when _RenderTheater skips layout for an
+      // obscured OverlayEntry but selectables remain registered.
+      // Treat unlaid-out selectables as equal in sort order — they will be
+      // properly positioned on the next frame when layout completes.
+      // See https://github.com/flutter/flutter/issues/151536
+      return 0;
+    } on AssertionError {
+      // In debug mode, hasSize/debugNeedsLayout asserts fire before
+      // StateError. Catch both to prevent crashes in all build modes.
+      return 0;
     }
-    return _compareHorizontally(rectA, rectB);
   }
 
   /// Compares two rectangles in the screen order solely by their vertical

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -2563,13 +2563,27 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
   Comparator<Selectable> get compareOrder => _compareScreenOrder;
 
   static int _compareScreenOrder(Selectable a, Selectable b) {
-    final Rect rectA = MatrixUtils.transformRect(a.getTransformTo(null), _getBoundingBox(a));
-    final Rect rectB = MatrixUtils.transformRect(b.getTransformTo(null), _getBoundingBox(b));
-    final int result = _compareVertically(rectA, rectB);
-    if (result != 0) {
-      return result;
+    try {
+      final Rect rectA = MatrixUtils.transformRect(a.getTransformTo(null), _getBoundingBox(a));
+      final Rect rectB = MatrixUtils.transformRect(b.getTransformTo(null), _getBoundingBox(b));
+      final int result = _compareVertically(rectA, rectB);
+      if (result != 0) {
+        return result;
+      }
+      return _compareHorizontally(rectA, rectB);
+    } on StateError {
+      // In release mode, accessing `size` on an unlaid-out RenderBox throws
+      // StateError. This happens when _RenderTheater skips layout for an
+      // obscured OverlayEntry but selectables remain registered.
+      // Treat unlaid-out selectables as equal in sort order — they will be
+      // properly positioned on the next frame when layout completes.
+      // See https://github.com/flutter/flutter/issues/151536
+      return 0;
+    } on AssertionError {
+      // In debug mode, hasSize/debugNeedsLayout asserts fire before
+      // StateError. Catch both to prevent crashes in all build modes.
+      return 0;
     }
-    return _compareHorizontally(rectA, rectB);
   }
 
   /// Compares two rectangles in the screen order solely by their vertical

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -1223,30 +1223,47 @@ class _SelectableTextContainerDelegate extends StaticSelectionContainerDelegate 
   @override
   Comparator<Selectable> get compareOrder => _compareScreenOrder;
 
+  // Returns null instead of throwing when `selectable`'s RenderBox isn't laid
+  // out. This happens when _RenderTheater skips layout for an obscured
+  // OverlayEntry but selectables remain registered: accessing `size` throws
+  // StateError in release mode, while debug-mode asserts (hasSize /
+  // debugNeedsLayout) throw AssertionError first.
+  // See https://github.com/flutter/flutter/issues/151536
+  static Rect? _getScreenRect(Selectable selectable) {
+    try {
+      return MatrixUtils.transformRect(
+        selectable.getTransformTo(null),
+        selectable.boundingBoxes.first,
+      );
+    } on StateError {
+      return null;
+    } on AssertionError {
+      return null;
+    }
+  }
+
   static int _compareScreenOrder(Selectable a, Selectable b) {
     // Attempt to sort the selectables under a [_SelectableTextContainerDelegate]
     // by the top left rect.
-    try {
-      final Rect rectA = MatrixUtils.transformRect(a.getTransformTo(null), a.boundingBoxes.first);
-      final Rect rectB = MatrixUtils.transformRect(b.getTransformTo(null), b.boundingBoxes.first);
-      final int result = _compareVertically(rectA, rectB);
-      if (result != 0) {
-        return result;
-      }
-      return _compareHorizontally(rectA, rectB);
-    } on StateError {
-      // In release mode, accessing `size` on an unlaid-out RenderBox throws
-      // StateError. This happens when _RenderTheater skips layout for an
-      // obscured OverlayEntry but selectables remain registered.
-      // Treat unlaid-out selectables as equal in sort order — they will be
-      // properly positioned on the next frame when layout completes.
-      // See https://github.com/flutter/flutter/issues/151536
-      return 0;
-    } on AssertionError {
-      // In debug mode, hasSize/debugNeedsLayout asserts fire before
-      // StateError. Catch both to prevent crashes in all build modes.
+    final Rect? rectA = _getScreenRect(a);
+    final Rect? rectB = _getScreenRect(b);
+    if (rectA == null && rectB == null) {
       return 0;
     }
+    if (rectA == null) {
+      // Unavailable selectables sort after available ones instead of
+      // crashing; order self-corrects the next time selectables are
+      // flushed/re-sorted.
+      return 1;
+    }
+    if (rectB == null) {
+      return -1;
+    }
+    final int result = _compareVertically(rectA, rectB);
+    if (result != 0) {
+      return result;
+    }
+    return _compareHorizontally(rectA, rectB);
   }
 
   /// Compares two rectangles in the screen order solely by their vertical

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -1226,13 +1226,27 @@ class _SelectableTextContainerDelegate extends StaticSelectionContainerDelegate 
   static int _compareScreenOrder(Selectable a, Selectable b) {
     // Attempt to sort the selectables under a [_SelectableTextContainerDelegate]
     // by the top left rect.
-    final Rect rectA = MatrixUtils.transformRect(a.getTransformTo(null), a.boundingBoxes.first);
-    final Rect rectB = MatrixUtils.transformRect(b.getTransformTo(null), b.boundingBoxes.first);
-    final int result = _compareVertically(rectA, rectB);
-    if (result != 0) {
-      return result;
+    try {
+      final Rect rectA = MatrixUtils.transformRect(a.getTransformTo(null), a.boundingBoxes.first);
+      final Rect rectB = MatrixUtils.transformRect(b.getTransformTo(null), b.boundingBoxes.first);
+      final int result = _compareVertically(rectA, rectB);
+      if (result != 0) {
+        return result;
+      }
+      return _compareHorizontally(rectA, rectB);
+    } on StateError {
+      // In release mode, accessing `size` on an unlaid-out RenderBox throws
+      // StateError. This happens when _RenderTheater skips layout for an
+      // obscured OverlayEntry but selectables remain registered.
+      // Treat unlaid-out selectables as equal in sort order — they will be
+      // properly positioned on the next frame when layout completes.
+      // See https://github.com/flutter/flutter/issues/151536
+      return 0;
+    } on AssertionError {
+      // In debug mode, hasSize/debugNeedsLayout asserts fire before
+      // StateError. Catch both to prevent crashes in all build modes.
+      return 0;
     }
-    return _compareHorizontally(rectA, rectB);
   }
 
   /// Compares two rectangles in the screen order solely by their vertical

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -1252,8 +1252,7 @@ class _SelectableTextContainerDelegate extends StaticSelectionContainerDelegate 
     }
     if (rectA == null) {
       // Unavailable selectables sort after available ones instead of
-      // crashing; order self-corrects the next time selectables are
-      // flushed/re-sorted.
+      // crashing the sort.
       return 1;
     }
     if (rectB == null) {

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -1304,13 +1304,27 @@ class _SelectableTextContainerDelegate extends StaticSelectionContainerDelegate 
   static int _compareScreenOrder(Selectable a, Selectable b) {
     // Attempt to sort the selectables under a [_SelectableTextContainerDelegate]
     // by the top left rect.
-    final Rect rectA = MatrixUtils.transformRect(a.getTransformTo(null), a.boundingBoxes.first);
-    final Rect rectB = MatrixUtils.transformRect(b.getTransformTo(null), b.boundingBoxes.first);
-    final int result = _compareVertically(rectA, rectB);
-    if (result != 0) {
-      return result;
+    try {
+      final Rect rectA = MatrixUtils.transformRect(a.getTransformTo(null), a.boundingBoxes.first);
+      final Rect rectB = MatrixUtils.transformRect(b.getTransformTo(null), b.boundingBoxes.first);
+      final int result = _compareVertically(rectA, rectB);
+      if (result != 0) {
+        return result;
+      }
+      return _compareHorizontally(rectA, rectB);
+    } on StateError {
+      // In release mode, accessing `size` on an unlaid-out RenderBox throws
+      // StateError. This happens when _RenderTheater skips layout for an
+      // obscured OverlayEntry but selectables remain registered.
+      // Treat unlaid-out selectables as equal in sort order — they will be
+      // properly positioned on the next frame when layout completes.
+      // See https://github.com/flutter/flutter/issues/151536
+      return 0;
+    } on AssertionError {
+      // In debug mode, hasSize/debugNeedsLayout asserts fire before
+      // StateError. Catch both to prevent crashes in all build modes.
+      return 0;
     }
-    return _compareHorizontally(rectA, rectB);
   }
 
   /// Compares two rectangles in the screen order solely by their vertical

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -7017,6 +7017,58 @@ void main() {
       expect(find.text('Top page'), findsOneWidget);
     },
   );
+
+  testWidgets('MultiSelectableSelectionContainerDelegate._compareScreenOrder catches '
+      'StateError from unlaid-out selectables', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/151536
+    //
+    // Red/green test that directly exercises the `on StateError` catch
+    // branch of MultiSelectableSelectionContainerDelegate._compareScreenOrder
+    // by registering mock Selectables whose `boundingBoxes` getter throws,
+    // simulating the production scenario where _RenderTheater skipped layout
+    // for an obscured OverlayEntry. Without the guard, _flushAdditions would
+    // propagate the StateError out of its post-frame callback and
+    // tester.takeException() would report it.
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: SelectableRegion(
+          selectionControls: emptyTextSelectionControls,
+          child: const Column(
+            children: <Widget>[
+              _ThrowingSelectionSpy(throwKind: _ThrowKind.stateError),
+              _ThrowingSelectionSpy(throwKind: _ThrowKind.stateError),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('MultiSelectableSelectionContainerDelegate._compareScreenOrder catches '
+      'AssertionError from unlaid-out selectables', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/151536
+    //
+    // Red/green test for the `on AssertionError` catch, which covers
+    // debug-mode builds where `assert(hasSize)` fires before the
+    // `_size ?? throw StateError(...)` expression in RenderBox.size.
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: SelectableRegion(
+          selectionControls: emptyTextSelectionControls,
+          child: const Column(
+            children: <Widget>[
+              _ThrowingSelectionSpy(throwKind: _ThrowKind.assertionError),
+              _ThrowingSelectionSpy(throwKind: _ThrowKind.assertionError),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+  });
 }
 
 void _noopRemovePage(Page<Object?> page) {}
@@ -7235,4 +7287,85 @@ class _TextSelectionControlsSpy extends TextSelectionControls with TextSelection
   Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
     return Offset.zero;
   }
+}
+
+// Mock Selectable whose [boundingBoxes] getter throws — used by the
+// `_compareScreenOrder` regression tests for
+// https://github.com/flutter/flutter/issues/151536 to directly exercise the
+// `on StateError` / `on AssertionError` catch branches.
+enum _ThrowKind { stateError, assertionError }
+
+class _ThrowingSelectionSpy extends LeafRenderObjectWidget {
+  const _ThrowingSelectionSpy({required this.throwKind});
+
+  final _ThrowKind throwKind;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) {
+    return _RenderThrowingSelectionSpy(SelectionContainer.maybeOf(context), throwKind);
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, covariant RenderObject renderObject) {}
+}
+
+class _RenderThrowingSelectionSpy extends RenderProxyBox with Selectable, SelectionRegistrant {
+  _RenderThrowingSelectionSpy(SelectionRegistrar? registrar, this._throwKind) {
+    this.registrar = registrar;
+  }
+
+  final _ThrowKind _throwKind;
+
+  @override
+  List<Rect> get boundingBoxes {
+    switch (_throwKind) {
+      case _ThrowKind.stateError:
+        throw StateError('Bad state: RenderBox was not laid out (test)');
+      case _ThrowKind.assertionError:
+        throw AssertionError('RenderBox was not laid out (test)');
+    }
+  }
+
+  @override
+  Size computeDryLayout(BoxConstraints constraints) => constraints.smallest;
+
+  @override
+  void performLayout() => size = computeDryLayout(constraints);
+
+  @override
+  void addListener(VoidCallback listener) {}
+
+  @override
+  void removeListener(VoidCallback listener) {}
+
+  @override
+  SelectionResult dispatchSelectionEvent(SelectionEvent event) => SelectionResult.end;
+
+  @override
+  SelectedContent? getSelectedContent() => null;
+
+  @override
+  SelectedContentRange? getSelection() => null;
+
+  @override
+  int get contentLength => 0;
+
+  @override
+  final SelectionGeometry value = const SelectionGeometry(
+    hasContent: true,
+    status: SelectionStatus.uncollapsed,
+    startSelectionPoint: SelectionPoint(
+      localPosition: Offset.zero,
+      lineHeight: 0.0,
+      handleType: TextSelectionHandleType.left,
+    ),
+    endSelectionPoint: SelectionPoint(
+      localPosition: Offset.zero,
+      lineHeight: 0.0,
+      handleType: TextSelectionHandleType.left,
+    ),
+  );
+
+  @override
+  void pushHandleLayers(LayerLink? startHandle, LayerLink? endHandle) {}
 }

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -6977,7 +6977,49 @@ void main() {
     expect(outerParagraph1.selections[0], const TextSelection(baseOffset: 4, extentOffset: 3));
     expect(outerParagraph2.selections[0], const TextSelection(baseOffset: 2, extentOffset: 1));
   });
+
+  testWidgets(
+    'MultiSelectableSelectionContainerDelegate._compareScreenOrder does not crash with unlaid-out selectables',
+    (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/151536
+      //
+      // When _RenderTheater skips laying out an obscured OverlayEntry, selectables
+      // in that entry remain registered with their SelectionContainerDelegate but
+      // their RenderBoxes have no size. _flushAdditions then calls _compareScreenOrder
+      // which accesses paintBounds/getTransformTo and throws StateError in release
+      // mode / AssertionError in debug. This test drives
+      // MultiSelectableSelectionContainerDelegate._compareScreenOrder via multiple
+      // sibling Text widgets under a single SelectableRegion.
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: Navigator(
+            pages: <Page<void>>[
+              TestPage<void>(
+                child: SelectableRegion(
+                  selectionControls: emptyTextSelectionControls,
+                  child: const Column(
+                    children: <Widget>[
+                      Text('Bottom page text A'),
+                      Text('Bottom page text B'),
+                      Text('Bottom page text C'),
+                    ],
+                  ),
+                ),
+              ),
+              const TestPage<void>(child: Text('Top page')),
+            ],
+            onDidRemovePage: _noopRemovePage,
+          ),
+        ),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('Top page'), findsOneWidget);
+    },
+  );
 }
+
+void _noopRemovePage(Page<Object?> page) {}
 
 class ColumnSelectionContainerDelegate extends StaticSelectionContainerDelegate {
   /// Copies the selected contents of all [Selectable]s, separating their

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -7069,6 +7069,45 @@ void main() {
 
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets('MultiSelectableSelectionContainerDelegate._compareScreenOrder places unlaid-out '
+      'selectables last and keeps laid-out ones in a consistent, deterministic order', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/151536
+    //
+    // Mixes laid-out and unlaid-out selectables. The unlaid-out one sits
+    // between the two laid-out ones in the widget tree, but the sort must
+    // still place it after both — otherwise `List.sort`, which requires a
+    // consistent comparator, could scramble the laid-out ones' relative
+    // order too.
+    SelectedContent? content;
+
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: SelectableRegion(
+          onSelectionChanged: (SelectedContent? selectedContent) => content = selectedContent,
+          selectionControls: emptyTextSelectionControls,
+          child: const Column(
+            children: <Widget>[
+              _OrderProbeSelectionSpy(label: 'A'),
+              _OrderProbeSelectionSpy(label: 'Z', unlaidOut: true),
+              _OrderProbeSelectionSpy(label: 'B'),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final SelectableRegionState state = tester.state<SelectableRegionState>(
+      find.byType(SelectableRegion),
+    );
+    state.selectAll();
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(content?.plainText, 'ABZ');
+  });
 }
 
 void _noopRemovePage(Page<Object?> page) {}
@@ -7349,6 +7388,86 @@ class _RenderThrowingSelectionSpy extends RenderProxyBox with Selectable, Select
 
   @override
   int get contentLength => 0;
+
+  @override
+  final SelectionGeometry value = const SelectionGeometry(
+    hasContent: true,
+    status: SelectionStatus.uncollapsed,
+    startSelectionPoint: SelectionPoint(
+      localPosition: Offset.zero,
+      lineHeight: 0.0,
+      handleType: TextSelectionHandleType.left,
+    ),
+    endSelectionPoint: SelectionPoint(
+      localPosition: Offset.zero,
+      lineHeight: 0.0,
+      handleType: TextSelectionHandleType.left,
+    ),
+  );
+
+  @override
+  void pushHandleLayers(LayerLink? startHandle, LayerLink? endHandle) {}
+}
+
+// Mock Selectable with a fixed [size] and [getSelectedContent] result, and an
+// optional forced-unlaid-out `boundingBoxes` — used by the
+// `_compareScreenOrder` ordering regression test for
+// https://github.com/flutter/flutter/issues/151536 to observe the resulting
+// selectable order through the concatenated selected content.
+class _OrderProbeSelectionSpy extends LeafRenderObjectWidget {
+  const _OrderProbeSelectionSpy({required this.label, this.unlaidOut = false});
+
+  final String label;
+  final bool unlaidOut;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) {
+    return _RenderOrderProbeSelectionSpy(SelectionContainer.maybeOf(context), label, unlaidOut);
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, covariant RenderObject renderObject) {}
+}
+
+class _RenderOrderProbeSelectionSpy extends RenderProxyBox with Selectable, SelectionRegistrant {
+  _RenderOrderProbeSelectionSpy(SelectionRegistrar? registrar, this._label, this._unlaidOut) {
+    this.registrar = registrar;
+  }
+
+  final String _label;
+  final bool _unlaidOut;
+
+  @override
+  List<Rect> get boundingBoxes {
+    if (_unlaidOut) {
+      throw StateError('Bad state: RenderBox was not laid out (test)');
+    }
+    return <Rect>[Offset.zero & size];
+  }
+
+  @override
+  Size computeDryLayout(BoxConstraints constraints) => const Size(20, 20);
+
+  @override
+  void performLayout() => size = computeDryLayout(constraints);
+
+  @override
+  void addListener(VoidCallback listener) {}
+
+  @override
+  void removeListener(VoidCallback listener) {}
+
+  @override
+  SelectionResult dispatchSelectionEvent(SelectionEvent event) => SelectionResult.end;
+
+  @override
+  SelectedContent? getSelectedContent() => SelectedContent(plainText: _label);
+
+  @override
+  SelectedContentRange? getSelection() => null;
+
+  @override
+  int get contentLength => _label.length;
 
   @override
   final SelectionGeometry value = const SelectionGeometry(

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -6688,7 +6688,48 @@ void main() {
     expect(paragraph.selections, isNotEmpty);
     expect(paragraph.selections.first, const TextSelection(baseOffset: 0, extentOffset: 12));
   });
+
+  testWidgets(
+    'MultiSelectableSelectionContainerDelegate._compareScreenOrder does not crash with unlaid-out selectables',
+    (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/151536
+      //
+      // When _RenderTheater skips laying out an obscured OverlayEntry, selectables
+      // in that entry remain registered with their SelectionContainerDelegate but
+      // their RenderBoxes have no size. _flushAdditions then calls _compareScreenOrder
+      // which accesses paintBounds/getTransformTo and throws StateError in release
+      // mode / AssertionError in debug. This test drives
+      // MultiSelectableSelectionContainerDelegate._compareScreenOrder via multiple
+      // sibling Text widgets under a single SelectionArea.
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Navigator(
+            pages: <Page<void>>[
+              MaterialPage<void>(
+                child: SelectionArea(
+                  child: Column(
+                    children: <Widget>[
+                      Text('Bottom page text A'),
+                      Text('Bottom page text B'),
+                      Text('Bottom page text C'),
+                    ],
+                  ),
+                ),
+              ),
+              MaterialPage<void>(child: Scaffold(body: Text('Top page'))),
+            ],
+            onDidRemovePage: _noopRemovePage,
+          ),
+        ),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('Top page'), findsOneWidget);
+    },
+  );
 }
+
+void _noopRemovePage(Page<Object?> page) {}
 
 class ColumnSelectionContainerDelegate extends StaticSelectionContainerDelegate {
   /// Copies the selected contents of all [Selectable]s, separating their

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -6727,6 +6727,58 @@ void main() {
       expect(find.text('Top page'), findsOneWidget);
     },
   );
+
+  testWidgets('MultiSelectableSelectionContainerDelegate._compareScreenOrder catches '
+      'StateError from unlaid-out selectables', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/151536
+    //
+    // Red/green test that directly exercises the `on StateError` catch
+    // branch of MultiSelectableSelectionContainerDelegate._compareScreenOrder
+    // by registering mock Selectables whose `boundingBoxes` getter throws,
+    // simulating the production scenario where _RenderTheater skipped layout
+    // for an obscured OverlayEntry. Without the guard, _flushAdditions would
+    // propagate the StateError out of its post-frame callback and
+    // tester.takeException() would report it.
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SelectableRegion(
+          selectionControls: materialTextSelectionControls,
+          child: const Column(
+            children: <Widget>[
+              _ThrowingSelectionSpy(throwKind: _ThrowKind.stateError),
+              _ThrowingSelectionSpy(throwKind: _ThrowKind.stateError),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('MultiSelectableSelectionContainerDelegate._compareScreenOrder catches '
+      'AssertionError from unlaid-out selectables', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/151536
+    //
+    // Red/green test for the `on AssertionError` catch, which covers
+    // debug-mode builds where `assert(hasSize)` fires before the
+    // `_size ?? throw StateError(...)` expression in RenderBox.size.
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SelectableRegion(
+          selectionControls: materialTextSelectionControls,
+          child: const Column(
+            children: <Widget>[
+              _ThrowingSelectionSpy(throwKind: _ThrowKind.assertionError),
+              _ThrowingSelectionSpy(throwKind: _ThrowKind.assertionError),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+  });
 }
 
 void _noopRemovePage(Page<Object?> page) {}
@@ -6918,4 +6970,85 @@ class RenderSelectAll extends RenderProxyBox with Selectable, SelectionRegistran
     this.startHandle = startHandle;
     this.endHandle = endHandle;
   }
+}
+
+// Mock Selectable whose [boundingBoxes] getter throws — used by the
+// `_compareScreenOrder` regression tests for
+// https://github.com/flutter/flutter/issues/151536 to directly exercise the
+// `on StateError` / `on AssertionError` catch branches.
+enum _ThrowKind { stateError, assertionError }
+
+class _ThrowingSelectionSpy extends LeafRenderObjectWidget {
+  const _ThrowingSelectionSpy({required this.throwKind});
+
+  final _ThrowKind throwKind;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) {
+    return _RenderThrowingSelectionSpy(SelectionContainer.maybeOf(context), throwKind);
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, covariant RenderObject renderObject) {}
+}
+
+class _RenderThrowingSelectionSpy extends RenderProxyBox with Selectable, SelectionRegistrant {
+  _RenderThrowingSelectionSpy(SelectionRegistrar? registrar, this._throwKind) {
+    this.registrar = registrar;
+  }
+
+  final _ThrowKind _throwKind;
+
+  @override
+  List<Rect> get boundingBoxes {
+    switch (_throwKind) {
+      case _ThrowKind.stateError:
+        throw StateError('Bad state: RenderBox was not laid out (test)');
+      case _ThrowKind.assertionError:
+        throw AssertionError('RenderBox was not laid out (test)');
+    }
+  }
+
+  @override
+  Size computeDryLayout(BoxConstraints constraints) => constraints.smallest;
+
+  @override
+  void performLayout() => size = computeDryLayout(constraints);
+
+  @override
+  void addListener(VoidCallback listener) {}
+
+  @override
+  void removeListener(VoidCallback listener) {}
+
+  @override
+  SelectionResult dispatchSelectionEvent(SelectionEvent event) => SelectionResult.end;
+
+  @override
+  SelectedContent? getSelectedContent() => null;
+
+  @override
+  SelectedContentRange? getSelection() => null;
+
+  @override
+  int get contentLength => 0;
+
+  @override
+  final SelectionGeometry value = const SelectionGeometry(
+    hasContent: true,
+    status: SelectionStatus.uncollapsed,
+    startSelectionPoint: SelectionPoint(
+      localPosition: Offset.zero,
+      lineHeight: 0.0,
+      handleType: TextSelectionHandleType.left,
+    ),
+    endSelectionPoint: SelectionPoint(
+      localPosition: Offset.zero,
+      lineHeight: 0.0,
+      handleType: TextSelectionHandleType.left,
+    ),
+  );
+
+  @override
+  void pushHandleLayers(LayerLink? startHandle, LayerLink? endHandle) {}
 }

--- a/packages/flutter/test/widgets/text_test.dart
+++ b/packages/flutter/test/widgets/text_test.dart
@@ -1917,9 +1917,159 @@ void main() {
       expect(find.text('Top page'), findsOneWidget);
     },
   );
+
+  testWidgets('_SelectableTextContainerDelegate._compareScreenOrder catches StateError '
+      'from unlaid-out selectables', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/151536
+    //
+    // Red/green test that exercises the `on StateError` catch branch of
+    // _SelectableTextContainerDelegate._compareScreenOrder (text.dart).
+    // Registers mock throwing Selectables inside a Text.rich via WidgetSpan
+    // children; the enclosing _SelectableTextContainer's delegate picks them
+    // up through SelectionContainer.maybeOf(context), and the post-frame
+    // sort routes them through text.dart's comparator override.
+    final focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: SelectableRegion(
+          focusNode: focusNode,
+          selectionControls: EmptyTextSelectionControls(),
+          child: const Text.rich(
+            TextSpan(
+              children: <InlineSpan>[
+                TextSpan(text: 'before '),
+                WidgetSpan(child: _ThrowingSelectionSpy(throwKind: _ThrowKind.stateError)),
+                TextSpan(text: ' middle '),
+                WidgetSpan(child: _ThrowingSelectionSpy(throwKind: _ThrowKind.stateError)),
+                TextSpan(text: ' after'),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('_SelectableTextContainerDelegate._compareScreenOrder catches '
+      'AssertionError from unlaid-out selectables', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/151536
+    //
+    // Red/green test for the `on AssertionError` catch in text.dart, which
+    // covers debug-mode builds where `assert(hasSize)` fires before the
+    // `_size ?? throw StateError(...)` expression in RenderBox.size.
+    final focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: SelectableRegion(
+          focusNode: focusNode,
+          selectionControls: EmptyTextSelectionControls(),
+          child: const Text.rich(
+            TextSpan(
+              children: <InlineSpan>[
+                TextSpan(text: 'before '),
+                WidgetSpan(child: _ThrowingSelectionSpy(throwKind: _ThrowKind.assertionError)),
+                TextSpan(text: ' middle '),
+                WidgetSpan(child: _ThrowingSelectionSpy(throwKind: _ThrowKind.assertionError)),
+                TextSpan(text: ' after'),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+  });
 }
 
 void _noopRemovePage(Page<Object?> page) {}
+
+// Mock Selectable whose [boundingBoxes] getter throws — used by the text.dart
+// `_SelectableTextContainerDelegate._compareScreenOrder` regression tests for
+// https://github.com/flutter/flutter/issues/151536 to directly exercise the
+// `on StateError` / `on AssertionError` catch branches.
+enum _ThrowKind { stateError, assertionError }
+
+class _ThrowingSelectionSpy extends LeafRenderObjectWidget {
+  const _ThrowingSelectionSpy({required this.throwKind});
+
+  final _ThrowKind throwKind;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) {
+    return _RenderThrowingSelectionSpy(SelectionContainer.maybeOf(context), throwKind);
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, covariant RenderObject renderObject) {}
+}
+
+class _RenderThrowingSelectionSpy extends RenderProxyBox with Selectable, SelectionRegistrant {
+  _RenderThrowingSelectionSpy(SelectionRegistrar? registrar, this._throwKind) {
+    this.registrar = registrar;
+  }
+
+  final _ThrowKind _throwKind;
+
+  @override
+  List<Rect> get boundingBoxes {
+    switch (_throwKind) {
+      case _ThrowKind.stateError:
+        throw StateError('Bad state: RenderBox was not laid out (test)');
+      case _ThrowKind.assertionError:
+        throw AssertionError('RenderBox was not laid out (test)');
+    }
+  }
+
+  @override
+  Size computeDryLayout(BoxConstraints constraints) => constraints.smallest;
+
+  @override
+  void performLayout() => size = computeDryLayout(constraints);
+
+  @override
+  void addListener(VoidCallback listener) {}
+
+  @override
+  void removeListener(VoidCallback listener) {}
+
+  @override
+  SelectionResult dispatchSelectionEvent(SelectionEvent event) => SelectionResult.end;
+
+  @override
+  SelectedContent? getSelectedContent() => null;
+
+  @override
+  SelectedContentRange? getSelection() => null;
+
+  @override
+  int get contentLength => 0;
+
+  @override
+  final SelectionGeometry value = const SelectionGeometry(
+    hasContent: true,
+    status: SelectionStatus.uncollapsed,
+    startSelectionPoint: SelectionPoint(
+      localPosition: Offset.zero,
+      lineHeight: 0.0,
+      handleType: TextSelectionHandleType.left,
+    ),
+    endSelectionPoint: SelectionPoint(
+      localPosition: Offset.zero,
+      lineHeight: 0.0,
+      handleType: TextSelectionHandleType.left,
+    ),
+  );
+
+  @override
+  void pushHandleLayers(LayerLink? startHandle, LayerLink? endHandle) {}
+}
 
 Future<void> _pumpTextWidget({
   required WidgetTester tester,

--- a/packages/flutter/test/widgets/text_test.dart
+++ b/packages/flutter/test/widgets/text_test.dart
@@ -1986,6 +1986,50 @@ void main() {
 
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets('_SelectableTextContainerDelegate._compareScreenOrder places unlaid-out selectables '
+      'last and keeps laid-out ones in a consistent, deterministic order', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/151536
+    //
+    // Mixes laid-out and unlaid-out WidgetSpan selectables. The unlaid-out
+    // one sits between the two laid-out ones in the span order, but the
+    // sort must still place it after both — otherwise `List.sort`, which
+    // requires a consistent comparator, could scramble the laid-out ones'
+    // relative order too.
+    final focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+    SelectedContent? content;
+
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: SelectableRegion(
+          focusNode: focusNode,
+          onSelectionChanged: (SelectedContent? selectedContent) => content = selectedContent,
+          selectionControls: EmptyTextSelectionControls(),
+          child: const Text.rich(
+            TextSpan(
+              children: <InlineSpan>[
+                WidgetSpan(child: _OrderProbeSelectionSpy(label: 'A')),
+                WidgetSpan(child: _OrderProbeSelectionSpy(label: 'Z', unlaidOut: true)),
+                WidgetSpan(child: _OrderProbeSelectionSpy(label: 'B')),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final SelectableRegionState state = tester.state<SelectableRegionState>(
+      find.byType(SelectableRegion),
+    );
+    state.selectAll();
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(content?.plainText, 'ABZ');
+  });
 }
 
 void _noopRemovePage(Page<Object?> page) {}
@@ -2050,6 +2094,86 @@ class _RenderThrowingSelectionSpy extends RenderProxyBox with Selectable, Select
 
   @override
   int get contentLength => 0;
+
+  @override
+  final SelectionGeometry value = const SelectionGeometry(
+    hasContent: true,
+    status: SelectionStatus.uncollapsed,
+    startSelectionPoint: SelectionPoint(
+      localPosition: Offset.zero,
+      lineHeight: 0.0,
+      handleType: TextSelectionHandleType.left,
+    ),
+    endSelectionPoint: SelectionPoint(
+      localPosition: Offset.zero,
+      lineHeight: 0.0,
+      handleType: TextSelectionHandleType.left,
+    ),
+  );
+
+  @override
+  void pushHandleLayers(LayerLink? startHandle, LayerLink? endHandle) {}
+}
+
+// Mock Selectable with a fixed [size] and [getSelectedContent] result, and an
+// optional forced-unlaid-out `boundingBoxes` — used by the text.dart
+// `_SelectableTextContainerDelegate._compareScreenOrder` ordering regression
+// test for https://github.com/flutter/flutter/issues/151536 to observe the
+// resulting selectable order through the concatenated selected content.
+class _OrderProbeSelectionSpy extends LeafRenderObjectWidget {
+  const _OrderProbeSelectionSpy({required this.label, this.unlaidOut = false});
+
+  final String label;
+  final bool unlaidOut;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) {
+    return _RenderOrderProbeSelectionSpy(SelectionContainer.maybeOf(context), label, unlaidOut);
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, covariant RenderObject renderObject) {}
+}
+
+class _RenderOrderProbeSelectionSpy extends RenderProxyBox with Selectable, SelectionRegistrant {
+  _RenderOrderProbeSelectionSpy(SelectionRegistrar? registrar, this._label, this._unlaidOut) {
+    this.registrar = registrar;
+  }
+
+  final String _label;
+  final bool _unlaidOut;
+
+  @override
+  List<Rect> get boundingBoxes {
+    if (_unlaidOut) {
+      throw StateError('Bad state: RenderBox was not laid out (test)');
+    }
+    return <Rect>[Offset.zero & size];
+  }
+
+  @override
+  Size computeDryLayout(BoxConstraints constraints) => const Size(20, 20);
+
+  @override
+  void performLayout() => size = computeDryLayout(constraints);
+
+  @override
+  void addListener(VoidCallback listener) {}
+
+  @override
+  void removeListener(VoidCallback listener) {}
+
+  @override
+  SelectionResult dispatchSelectionEvent(SelectionEvent event) => SelectionResult.end;
+
+  @override
+  SelectedContent? getSelectedContent() => SelectedContent(plainText: _label);
+
+  @override
+  SelectedContentRange? getSelection() => null;
+
+  @override
+  int get contentLength => _label.length;
 
   @override
   final SelectionGeometry value = const SelectionGeometry(

--- a/packages/flutter/test/widgets/text_test.dart
+++ b/packages/flutter/test/widgets/text_test.dart
@@ -12,6 +12,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import 'semantics_tester.dart';
+import 'test_page_tester.dart';
 
 void main() {
   const kBlack = Color(0xFF000000);
@@ -1869,7 +1870,56 @@ void main() {
     );
     expect(tester.getSize(find.byType(Text)), Size.zero);
   });
+
+  testWidgets(
+    '_SelectableTextContainerDelegate._compareScreenOrder does not crash with unlaid-out fragments',
+    (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/151536
+      //
+      // Drives _SelectableTextContainerDelegate._compareScreenOrder by using
+      // Text.rich with WidgetSpan children. Each WidgetSpan placeholder splits
+      // the text into a separate _SelectableFragment, so the delegate must sort
+      // them — which invokes the comparator that accesses boundingBoxes.first
+      // on each fragment. See paragraph.dart:_getSelectableFragments — fragments
+      // are only created when placeholder characters exist in the plain text.
+      final focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: Navigator(
+            pages: <Page<void>>[
+              TestPage<void>(
+                child: SelectableRegion(
+                  focusNode: focusNode,
+                  selectionControls: EmptyTextSelectionControls(),
+                  child: const Text.rich(
+                    TextSpan(
+                      children: <InlineSpan>[
+                        TextSpan(text: 'Before '),
+                        WidgetSpan(child: SizedBox(width: 8, height: 8)),
+                        TextSpan(text: ' middle '),
+                        WidgetSpan(child: SizedBox(width: 8, height: 8)),
+                        TextSpan(text: ' after'),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+              const TestPage<void>(child: Text('Top page')),
+            ],
+            onDidRemovePage: _noopRemovePage,
+          ),
+        ),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('Top page'), findsOneWidget);
+    },
+  );
 }
+
+void _noopRemovePage(Page<Object?> page) {}
 
 Future<void> _pumpTextWidget({
   required WidgetTester tester,

--- a/packages/flutter/test/widgets/text_test.dart
+++ b/packages/flutter/test/widgets/text_test.dart
@@ -1871,9 +1871,159 @@ void main() {
       expect(find.text('Top page'), findsOneWidget);
     },
   );
+
+  testWidgets('_SelectableTextContainerDelegate._compareScreenOrder catches StateError '
+      'from unlaid-out selectables', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/151536
+    //
+    // Red/green test that exercises the `on StateError` catch branch of
+    // _SelectableTextContainerDelegate._compareScreenOrder (text.dart).
+    // Registers mock throwing Selectables inside a Text.rich via WidgetSpan
+    // children; the enclosing _SelectableTextContainer's delegate picks them
+    // up through SelectionContainer.maybeOf(context), and the post-frame
+    // sort routes them through text.dart's comparator override.
+    final focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: SelectableRegion(
+          focusNode: focusNode,
+          selectionControls: EmptyTextSelectionControls(),
+          child: const Text.rich(
+            TextSpan(
+              children: <InlineSpan>[
+                TextSpan(text: 'before '),
+                WidgetSpan(child: _ThrowingSelectionSpy(throwKind: _ThrowKind.stateError)),
+                TextSpan(text: ' middle '),
+                WidgetSpan(child: _ThrowingSelectionSpy(throwKind: _ThrowKind.stateError)),
+                TextSpan(text: ' after'),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('_SelectableTextContainerDelegate._compareScreenOrder catches '
+      'AssertionError from unlaid-out selectables', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/151536
+    //
+    // Red/green test for the `on AssertionError` catch in text.dart, which
+    // covers debug-mode builds where `assert(hasSize)` fires before the
+    // `_size ?? throw StateError(...)` expression in RenderBox.size.
+    final focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: SelectableRegion(
+          focusNode: focusNode,
+          selectionControls: EmptyTextSelectionControls(),
+          child: const Text.rich(
+            TextSpan(
+              children: <InlineSpan>[
+                TextSpan(text: 'before '),
+                WidgetSpan(child: _ThrowingSelectionSpy(throwKind: _ThrowKind.assertionError)),
+                TextSpan(text: ' middle '),
+                WidgetSpan(child: _ThrowingSelectionSpy(throwKind: _ThrowKind.assertionError)),
+                TextSpan(text: ' after'),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+  });
 }
 
 void _noopRemovePage(Page<Object?> page) {}
+
+// Mock Selectable whose [boundingBoxes] getter throws — used by the text.dart
+// `_SelectableTextContainerDelegate._compareScreenOrder` regression tests for
+// https://github.com/flutter/flutter/issues/151536 to directly exercise the
+// `on StateError` / `on AssertionError` catch branches.
+enum _ThrowKind { stateError, assertionError }
+
+class _ThrowingSelectionSpy extends LeafRenderObjectWidget {
+  const _ThrowingSelectionSpy({required this.throwKind});
+
+  final _ThrowKind throwKind;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) {
+    return _RenderThrowingSelectionSpy(SelectionContainer.maybeOf(context), throwKind);
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, covariant RenderObject renderObject) {}
+}
+
+class _RenderThrowingSelectionSpy extends RenderProxyBox with Selectable, SelectionRegistrant {
+  _RenderThrowingSelectionSpy(SelectionRegistrar? registrar, this._throwKind) {
+    this.registrar = registrar;
+  }
+
+  final _ThrowKind _throwKind;
+
+  @override
+  List<Rect> get boundingBoxes {
+    switch (_throwKind) {
+      case _ThrowKind.stateError:
+        throw StateError('Bad state: RenderBox was not laid out (test)');
+      case _ThrowKind.assertionError:
+        throw AssertionError('RenderBox was not laid out (test)');
+    }
+  }
+
+  @override
+  Size computeDryLayout(BoxConstraints constraints) => constraints.smallest;
+
+  @override
+  void performLayout() => size = computeDryLayout(constraints);
+
+  @override
+  void addListener(VoidCallback listener) {}
+
+  @override
+  void removeListener(VoidCallback listener) {}
+
+  @override
+  SelectionResult dispatchSelectionEvent(SelectionEvent event) => SelectionResult.end;
+
+  @override
+  SelectedContent? getSelectedContent() => null;
+
+  @override
+  SelectedContentRange? getSelection() => null;
+
+  @override
+  int get contentLength => 0;
+
+  @override
+  final SelectionGeometry value = const SelectionGeometry(
+    hasContent: true,
+    status: SelectionStatus.uncollapsed,
+    startSelectionPoint: SelectionPoint(
+      localPosition: Offset.zero,
+      lineHeight: 0.0,
+      handleType: TextSelectionHandleType.left,
+    ),
+    endSelectionPoint: SelectionPoint(
+      localPosition: Offset.zero,
+      lineHeight: 0.0,
+      handleType: TextSelectionHandleType.left,
+    ),
+  );
+
+  @override
+  void pushHandleLayers(LayerLink? startHandle, LayerLink? endHandle) {}
+}
 
 Future<void> _pumpTextWidget({
   required WidgetTester tester,

--- a/packages/flutter/test/widgets/text_test.dart
+++ b/packages/flutter/test/widgets/text_test.dart
@@ -12,6 +12,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import 'semantics_tester.dart';
+import 'test_page_tester.dart';
 import 'widgets_app_tester.dart';
 
 void main() {
@@ -1823,7 +1824,56 @@ void main() {
 
     semantics.dispose();
   });
+
+  testWidgets(
+    '_SelectableTextContainerDelegate._compareScreenOrder does not crash with unlaid-out fragments',
+    (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/151536
+      //
+      // Drives _SelectableTextContainerDelegate._compareScreenOrder by using
+      // Text.rich with WidgetSpan children. Each WidgetSpan placeholder splits
+      // the text into a separate _SelectableFragment, so the delegate must sort
+      // them — which invokes the comparator that accesses boundingBoxes.first
+      // on each fragment. See paragraph.dart:_getSelectableFragments — fragments
+      // are only created when placeholder characters exist in the plain text.
+      final focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: Navigator(
+            pages: <Page<void>>[
+              TestPage<void>(
+                child: SelectableRegion(
+                  focusNode: focusNode,
+                  selectionControls: EmptyTextSelectionControls(),
+                  child: const Text.rich(
+                    TextSpan(
+                      children: <InlineSpan>[
+                        TextSpan(text: 'Before '),
+                        WidgetSpan(child: SizedBox(width: 8, height: 8)),
+                        TextSpan(text: ' middle '),
+                        WidgetSpan(child: SizedBox(width: 8, height: 8)),
+                        TextSpan(text: ' after'),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+              const TestPage<void>(child: Text('Top page')),
+            ],
+            onDidRemovePage: _noopRemovePage,
+          ),
+        ),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('Top page'), findsOneWidget);
+    },
+  );
 }
+
+void _noopRemovePage(Page<Object?> page) {}
 
 Future<void> _pumpTextWidget({
   required WidgetTester tester,


### PR DESCRIPTION
Relates to https://github.com/flutter/flutter/issues/151536

## Description

When `_RenderTheater` skips layout for an obscured `OverlayEntry` (e.g., a non-current route behind an opaque route), selectables in that entry remain registered with their `SelectionContainerDelegate`. When `_flushAdditions` runs the merge-sort via `_compareScreenOrder`, it accesses `paintBounds` / `getTransformTo` / `boundingBoxes.first` on `RenderBox`es that have no size, throwing `StateError` in release mode and `AssertionError` in debug.

This change makes geometry-acquisition failure explicit instead of crashing the sort: each `_compareScreenOrder` now reads geometry through a small `Rect?` helper whose `on StateError` / `on AssertionError` catch is scoped to just that read. The comparator handles `null` explicitly — unavailable selectables tie with each other and always sort after available ones — so comparisons involving unavailable selectables are mutually consistent and laid-out selectables keep their correct relative order. (An earlier revision of this PR returned `0` whenever either side lacked geometry; that tied an unlaid-out selectable with every laid-out one — an inconsistent order that `List.sort` and the merge logic aren't guaranteed to handle.)

Two methods are guarded because `_flushAdditions` can end up calling either override:

- `MultiSelectableSelectionContainerDelegate._compareScreenOrder` in `packages/flutter/lib/src/widgets/selectable_region.dart` — used by top-level `SelectionArea` / `SelectableRegion`.
- `_SelectableTextContainerDelegate._compareScreenOrder` in `packages/flutter/lib/src/widgets/text.dart` — used when a single `Text` / `Text.rich` has multiple `_SelectableFragment`s (e.g., text with `WidgetSpan`s).

## Why catch `AssertionError` too

`RenderBox.size` evaluates `_size ?? (throw StateError(...))`. In release mode the `StateError` fires. In debug mode `assert(hasSize)` fires first and throws `AssertionError` before control ever reaches the `throw`. Catching only `StateError` would leave debug builds crashing while release silently recovers — the exact opposite of what we want. The `on AssertionError` clause keeps the guard symmetric across build modes.

Note: `avoid_catching_errors` is currently commented out in `analysis_options.yaml` (blocked on dart-lang/linter#4998), so the catch is lint-clean.

## Testing

### Red/green coverage of both catch branches, in both files

Four `testWidgets` cases directly exercise the `on StateError` and `on AssertionError` catch branches of both guarded methods by registering mock `Selectable`s whose `boundingBoxes` getter throws. All four are proper red/green tests: they **fail on `master`** (the thrown error propagates out of `_flushAdditions`' post-frame callback and `tester.takeException()` reports it) and **pass with this change** (the helper returns `null`, unavailable selectables sort after available ones, and the sort completes).

- `packages/flutter/test/widgets/selectable_region_test.dart` — mock `Selectable`s under a top-level `SelectableRegion` route through `MultiSelectableSelectionContainerDelegate._compareScreenOrder` (the override in `selectable_region.dart`). One case per error type.
- `packages/flutter/test/widgets/text_test.dart` — mock `Selectable`s wrapped in `WidgetSpan` children of a `Text.rich` inside a `SelectableRegion`. The enclosing `_SelectableTextContainer`'s delegate picks up the mocks through `SelectionContainer.maybeOf(context)`, so the post-frame sort routes them through `_SelectableTextContainerDelegate._compareScreenOrder` (the override in `text.dart`) specifically. One case per error type.

A comparator-consistency test in each file additionally mixes laid-out and unlaid-out selectables (with the unlaid-out one placed between the others in the tree) and asserts the merged order is deterministic with the unlaid-out entry last.

### Widget-level regression guards

Two additional `testWidgets` cases cover the happy path of both guarded methods so later edits don't accidentally break normal sort behavior:

- `selectable_region_test.dart` — multiple sibling `Text` widgets under a `SelectionArea` inside a `Navigator(pages:)` where the second page covers the first.
- `text_test.dart` — `Text.rich` with `WidgetSpan` children. `paragraph.dart`'s `_getSelectableFragments` only splits on placeholder characters, so plain `Text` produces a single fragment and wouldn't drive the sort — `WidgetSpan` placeholders are required to get multiple fragments per container. Kept at the `widgets/` layer (`TestWidgetsApp` + `TestPage`) to match the rest of `text_test.dart`.

Full affected suites are green locally:

| Suite | Result |
|---|---|
| `selectable_region_test.dart` + `text_test.dart` | 287 passed, 0 failed |
| `selection_container_test.dart` + `rendering/paragraph_test.dart` | 54 passed, 0 failed |

`flutter analyze --flutter-repo` is clean on the full tree.

### Additional evidence: dart2wasm runtime repro

The red/green unit tests prove the catch branches work in isolation. The dart2wasm runtime repro proves the guard prevents the actual production crash end-to-end:

**Repro:** https://github.com/davidmigloz/flutter_selection_crash — three approaches (A / B / C) that crash reliably on dart2wasm Chrome (`flutter run -d chrome --wasm`) with `StateError: Bad state: RenderBox was not laid out` thrown from `_compareScreenOrder`. Each approach hits a different frame in the same method. Approaches A and C land in `selectable_region.dart`; approach B lands in `text.dart` via `_SelectableFragment.boundingBoxes`.

**Verified locally:** Built the repro app against this branch and exercised all three approaches with `flutter run -d chrome --wasm` (dart2wasm debug). All three previously crashed, none throw the error anymore. The crash also reproduces on master in DDC debug, dart2js release, and dart2wasm release — same `_compareScreenOrder` code path in each case — so the guard is expected to cover them too, but only dart2wasm debug was verified by hand on this branch.

## Why not a route-level `SelectionContainer.disabled` wrapper?

We originally explored wrapping non-current route content in `SelectionContainer.disabled` inside `_ModalScopeState.build()`. This approach is fundamentally limited: `SelectionArea` / `SelectableRegion` create their own `SelectionContainer(registrar: this, ...)` inside the route (`selectable_region.dart:1944`), which installs a fresh registrar that shadows the disabled outer scope. The route-level wrapper cannot suppress selection inside nested `SelectionArea` instances — exactly the case this issue is about. Independent review of four separate research passes converged on the comparator-level guard as the only viable surgical framework fix.

## Known limitations

- **Dead zones ([#182573](https://github.com/flutter/flutter/issues/182573)):** Stale selectables from offstage routes remain registered and can intercept drag events (silent variant). This PR is a crash guard at sort time — it prevents `_flushAdditions` from crashing when it encounters an unlaid-out selectable, but it does not remove those selectables from the delegate or fix the dead-zone behavior itself. App-level workarounds like [flutter/packages#11062](https://github.com/flutter/packages/pull/11062) (for `go_router`) remain needed for the behavioral fix. A proper framework fix is likely structural rather than comparator-based: the underlying problem is that selectables from obscured routes can remain registered even when `_RenderTheater` skips laying them out, so they continue participating in selection before their geometry is valid. Fixing that cleanly would likely require a route/overlay-driven visibility or readiness signal in the selection system itself, so hidden selectables are suppressed or unregistered until they are laid out again.
- **Other unguarded geometry reads:** `selectable_region.dart` and `text.dart` have other `boundingBoxes` / `getTransformTo(null)` sites outside `_compareScreenOrder` (e.g., `_handleSelectWordSelectionEvent` around line 2969 in `selectable_region.dart`; `text.dart` at lines 1069, 1071, 1407). These are less frequently hit in the `_flushAdditions` post-frame path — the vast majority of production Sentry events for this issue land in `_compareScreenOrder`. Follow-up PRs can guard them if reported.

## Related

- [Upstream comment](https://github.com/flutter/flutter/issues/151536#issuecomment-4225683042) with repro + analysis + fix direction
- [flutter/packages#11062](https://github.com/flutter/packages/pull/11062) — `go_router`-level workaround, reviewed by @Renzo-Olivares
- [flutter/flutter#157996](https://github.com/flutter/flutter/pull/157996), [flutter/flutter#158918](https://github.com/flutter/flutter/pull/158918) — prior attempts (incomplete)
- [flutter/flutter#182573](https://github.com/flutter/flutter/issues/182573) — sibling dead-zone variant (not fixed here)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md

