### PR TITLE
Remove tab scaffold test cross-import

### DIFF
--- a/packages/flutter/test/cupertino/tab_scaffold_test.dart
+++ b/packages/flutter/test/cupertino/tab_scaffold_test.dart
@@ -24,7 +24,7 @@ class _TestCallbackPainter extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(_TestCallbackPainter oldPainter) => true;
+  bool shouldRepaint(_TestCallbackPainter _) => true;
 }
 
 late List<int> selectedTabs;

--- a/packages/flutter/test/cupertino/tab_scaffold_test.dart
+++ b/packages/flutter/test/cupertino/tab_scaffold_test.dart
@@ -15,6 +15,7 @@ import 'navigator_utils.dart';
 /// Used in tests to track paint events without importing cross-file test utilities.
 class _TestCallbackPainter extends CustomPainter {
   const _TestCallbackPainter({required this.onPaint});
+  /// Called whenever the [paint] method is invoked.
   final VoidCallback onPaint;
 
   @override

--- a/packages/flutter/test/cupertino/tab_scaffold_test.dart
+++ b/packages/flutter/test/cupertino/tab_scaffold_test.dart
@@ -19,7 +19,7 @@ class _TestCallbackPainter extends CustomPainter {
   final VoidCallback onPaint;
 
   @override
-  void paint(Canvas canvas, Size size) {
+  void paint(Canvas _, Size __) {
     onPaint();
   }
 

--- a/packages/flutter/test/cupertino/tab_scaffold_test.dart
+++ b/packages/flutter/test/cupertino/tab_scaffold_test.dart
@@ -7,9 +7,24 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../rendering/rendering_tester.dart' show TestCallbackPainter;
 import '../widgets/widget_inspector_test_utils.dart';
 import 'navigator_utils.dart';
+
+/// A [CustomPainter] that invokes a callback whenever it paints.
+///
+/// Used in tests to track paint events without importing cross-file test utilities.
+class _TestCallbackPainter extends CustomPainter {
+  const _TestCallbackPainter({required this.onPaint});
+  final VoidCallback onPaint;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    onPaint();
+  }
+
+  @override
+  bool shouldRepaint(_TestCallbackPainter oldPainter) => true;
+}
 
 late List<int> selectedTabs;
 
@@ -60,7 +75,7 @@ void main() {
           tabBar: _buildTabBar(),
           tabBuilder: (BuildContext context, int index) {
             return CustomPaint(
-              painter: TestCallbackPainter(
+              painter: _TestCallbackPainter(
                 onPaint: () {
                   tabsPainted.add(index);
                 },
@@ -235,7 +250,7 @@ void main() {
           controller: controller,
           tabBuilder: (BuildContext context, int index) {
             return CustomPaint(
-              painter: TestCallbackPainter(
+              painter: _TestCallbackPainter(
                 onPaint: () {
                   tabsPainted.add(index);
                 },
@@ -275,7 +290,7 @@ void main() {
           tabBar: _buildTabBar(),
           tabBuilder: (BuildContext context, int index) {
             return CustomPaint(
-              painter: TestCallbackPainter(
+              painter: _TestCallbackPainter(
                 onPaint: () {
                   tabsPainted.add(index);
                 },
@@ -298,7 +313,7 @@ void main() {
           controller: controller, // Programmatically change the tab now.
           tabBuilder: (BuildContext context, int index) {
             return CustomPaint(
-              painter: TestCallbackPainter(
+              painter: _TestCallbackPainter(
                 onPaint: () {
                   tabsPainted.add(index);
                 },
@@ -635,7 +650,7 @@ void main() {
           controller: controller,
           tabBuilder: (BuildContext context, int index) {
             return CustomPaint(
-              painter: TestCallbackPainter(
+              painter: _TestCallbackPainter(
                 onPaint: () {
                   tabsPainted.add(index);
                 },
@@ -657,7 +672,7 @@ void main() {
           controller: controller,
           tabBuilder: (BuildContext context, int index) {
             return CustomPaint(
-              painter: TestCallbackPainter(
+              painter: _TestCallbackPainter(
                 onPaint: () {
                   tabsPainted.add(index);
                 },
@@ -692,7 +707,7 @@ void main() {
           controller: oldController,
           tabBuilder: (BuildContext context, int index) {
             return CustomPaint(
-              painter: TestCallbackPainter(
+              painter: _TestCallbackPainter(
                 onPaint: () {
                   tabsPainted.add(index);
                 },
@@ -712,7 +727,7 @@ void main() {
           tabBar: CupertinoTabBar(items: List<BottomNavigationBarItem>.generate(10, tabGenerator)),
           tabBuilder: (BuildContext context, int index) {
             return CustomPaint(
-              painter: TestCallbackPainter(
+              painter: _TestCallbackPainter(
                 onPaint: () {
                   tabsPainted.add(index);
                 },
@@ -823,7 +838,7 @@ void main() {
                 controller: controller,
                 tabBuilder: (BuildContext context, int index) {
                   return CustomPaint(
-                    painter: TestCallbackPainter(onPaint: () => tabsPainted0.add(index)),
+                    painter: _TestCallbackPainter(onPaint: () => tabsPainted0.add(index)),
                   );
                 },
               ),
@@ -834,7 +849,7 @@ void main() {
                 controller: controller,
                 tabBuilder: (BuildContext context, int index) {
                   return CustomPaint(
-                    painter: TestCallbackPainter(onPaint: () => tabsPainted1.add(index)),
+                    painter: _TestCallbackPainter(onPaint: () => tabsPainted1.add(index)),
                   );
                 },
               ),
@@ -866,7 +881,7 @@ void main() {
                 controller: controller,
                 tabBuilder: (BuildContext context, int index) {
                   return CustomPaint(
-                    painter: TestCallbackPainter(onPaint: () => tabsPainted0.add(index)),
+                    painter: _TestCallbackPainter(onPaint: () => tabsPainted0.add(index)),
                   );
                 },
               ),
@@ -896,7 +911,7 @@ void main() {
                 controller: controller,
                 tabBuilder: (BuildContext context, int index) {
                   return CustomPaint(
-                    painter: TestCallbackPainter(onPaint: () => tabsPainted0.add(index)),
+                    painter: _TestCallbackPainter(onPaint: () => tabsPainted0.add(index)),
                   );
                 },
               ),


### PR DESCRIPTION
This PR removes the cross-import of TestCallbackPainter from packages/flutter/test/cupertino/tab_scaffold_test.dart by inlining a small private _TestCallbackPainter helper directly into the file.

This follows the guidance in #182636 to avoid cross-importing test utilities between test libraries and to duplicate trivial helpers locally when the implementation is small and file-specific.

Part of #182636

Pre-launch Checklist
 I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
 I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
 I read the [Tree Hygiene] wiki page, which explains my responsibilities.
 I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
 I signed the [CLA].
 I listed at least one issue that this PR fixes in the description above.
 I updated/added relevant documentation (doc comments with ///).
 I added new tests to check the change I am making, or this PR is [test-exempt].
 All existing and new tests are passing.
 I followed the [breaking change policy] and added [Data Driven Fixes] where supported.