### PR TITLE
[Impeller] Fix morphology filter asymmetric dilation/erosion

### DIFF
--- a/engine/src/flutter/impeller/display_list/dl_golden_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/dl_golden_unittests.cc
@@ -111,6 +111,30 @@ TEST_P(DlGoldenTest, Bug147807) {
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
+TEST_P(DlGoldenTest, FractionalDilation) {
+  auto draw = [](DlCanvas* canvas) {
+    const DlRect rect = DlRect::MakeLTRB(32, 32, 382, 382);
+    DlPaint layer_paint;
+    layer_paint.setImageFilter(DlImageFilter::MakeDilate(3.95f, 3.95f));
+    canvas->SaveLayer(rect.Expand(8.0f), &layer_paint);
+    canvas->DrawRect(rect, DlPaint().setColor(DlColor::kRed()));
+    canvas->Restore();
+    canvas->DrawRect(rect, DlPaint().setColor(DlColor::kBlack()));
+  };
+
+  DisplayListBuilder builder;
+  builder.Scale(GetContentScale().x, GetContentScale().y);
+  builder.DrawColor(DlColor::kWhite(), DlBlendMode::kSrc);
+
+  draw(&builder);
+
+  builder.Translate(440, 0);
+  builder.Scale(1.3f, 1.3f);
+  draw(&builder);
+
+  ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
+}
+
 namespace {
 void DrawBlurGrid(DlCanvas* canvas) {
   DlPaint paint;

--- a/engine/src/flutter/impeller/entity/BUILD.gn
+++ b/engine/src/flutter/impeller/entity/BUILD.gn
@@ -289,6 +289,7 @@ impeller_component("entity_unittests") {
     "contents/filters/gaussian_blur_filter_contents_unittests.cc",
     "contents/filters/inputs/filter_input_unittests.cc",
     "contents/filters/matrix_filter_contents_unittests.cc",
+    "contents/filters/morphology_filter_contents_unittests.cc",
     "contents/host_buffer_unittests.cc",
     "contents/line_contents_unittests.cc",
     "contents/text_contents_unittests.cc",

--- a/engine/src/flutter/impeller/entity/contents/filters/morphology_filter_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/filters/morphology_filter_contents.cc
@@ -140,7 +140,7 @@ std::optional<Entity> DirectionalMorphologyFilterContents::RenderFilter(
 
   fml::StatusOr<RenderTarget> render_target =
       renderer.MakeSubpass("Directional Morphology Filter",  //
-                           ISize(coverage.GetSize()),        //
+                           ISize::Ceil(coverage.GetSize()),  //
                            command_buffer,                   //
                            callback,                         //
                            /*msaa_enabled=*/false,           //

--- a/engine/src/flutter/impeller/entity/contents/filters/morphology_filter_contents_unittests.cc
+++ b/engine/src/flutter/impeller/entity/contents/filters/morphology_filter_contents_unittests.cc
@@ -1,0 +1,139 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/testing/testing.h"
+#include "impeller/entity/contents/content_context.h"
+#include "impeller/entity/contents/filters/filter_contents.h"
+#include "impeller/entity/entity_playground.h"
+#include "impeller/geometry/geometry_asserts.h"
+
+namespace impeller {
+namespace testing {
+
+class MorphologyFilterContentsTest : public EntityPlayground {
+ public:
+  std::shared_ptr<Texture> MakeTexture(ISize size) {
+    std::shared_ptr<CommandBuffer> command_buffer =
+        GetContentContext()->GetContext()->CreateCommandBuffer();
+    if (!command_buffer) {
+      return nullptr;
+    }
+
+    auto render_target = GetContentContext()->MakeSubpass(
+        "Clear Subpass", size, command_buffer,
+        [](const ContentContext&, RenderPass&) { return true; });
+
+    if (!GetContentContext()
+             ->GetContext()
+             ->GetCommandQueue()
+             ->Submit(/*buffers=*/{command_buffer})
+             .ok()) {
+      return nullptr;
+    }
+
+    if (render_target.ok()) {
+      return render_target.value().GetRenderTargetTexture();
+    }
+    return nullptr;
+  }
+};
+
+INSTANTIATE_PLAYGROUND_SUITE(MorphologyFilterContentsTest);
+
+TEST_P(MorphologyFilterContentsTest, RenderCoverageMatchesGetCoverage) {
+  std::shared_ptr<Texture> texture = MakeTexture(ISize(100, 100));
+  ASSERT_NE(texture, nullptr);
+  auto contents = FilterContents::MakeDirectionalMorphology(
+      FilterInput::Make(texture), Radius{2.0}, Vector2(1, 0),
+      FilterContents::MorphType::kDilate);
+
+  Entity entity;
+  std::shared_ptr<ContentContext> renderer = GetContentContext();
+  std::optional<Entity> result =
+      contents->GetEntity(*renderer, entity, /*coverage_hint=*/{});
+
+  ASSERT_TRUE(result.has_value());
+  if (result.has_value()) {
+    std::optional<Rect> result_coverage = result.value().GetCoverage();
+    std::optional<Rect> contents_coverage = contents->GetCoverage(entity);
+    Rect expected = Rect::MakeLTRB(-2, 0, 102, 100);
+    ASSERT_TRUE(result_coverage.has_value());
+    ASSERT_TRUE(contents_coverage.has_value());
+    if (result_coverage.has_value() && contents_coverage.has_value()) {
+      EXPECT_TRUE(RectNear(result_coverage.value(), expected));
+      EXPECT_TRUE(RectNear(contents_coverage.value(), expected));
+    }
+  }
+}
+
+TEST_P(MorphologyFilterContentsTest,
+       RenderDilateWithFractionalCoverageIsSymmetric) {
+  // Non-integer scale and radius produce a fractional pixel expansion
+  // 1.5 * 2.625 = 3.9375, exercising the render target ceiling logic.
+  Scalar radius = 1.5;
+  Scalar scale = 2.625;
+
+  std::shared_ptr<Texture> texture = MakeTexture(ISize(100, 100));
+  ASSERT_NE(texture, nullptr);
+  auto contents = FilterContents::MakeDirectionalMorphology(
+      FilterInput::Make(texture), Radius{radius}, Vector2(1, 0),
+      FilterContents::MorphType::kDilate);
+  contents->SetEffectTransform(Matrix::MakeScale(Vector2(scale, scale)));
+
+  Entity entity;
+  std::shared_ptr<ContentContext> renderer = GetContentContext();
+  std::optional<Entity> result =
+      contents->GetEntity(*renderer, entity, /*coverage_hint=*/{});
+
+  ASSERT_TRUE(result.has_value());
+  if (result.has_value()) {
+    std::optional<Rect> result_coverage = result->GetCoverage();
+    ASSERT_TRUE(result_coverage.has_value());
+    if (result_coverage.has_value()) {
+      Scalar expected_expansion = radius * scale;
+      EXPECT_TRUE(result_coverage->Contains(Rect::MakeLTRB(
+          -expected_expansion, 0, 100 + expected_expansion, 100)));
+      Scalar left_expansion = 0 - result_coverage->GetLeft();
+      Scalar right_expansion = result_coverage->GetRight() - 100;
+      EXPECT_NEAR(left_expansion, right_expansion, 0.5);
+    }
+  }
+}
+
+TEST_P(MorphologyFilterContentsTest,
+       RenderDilateYWithFractionalCoverageIsSymmetric) {
+  // Non-integer scale and radius produce a fractional pixel expansion
+  // 1.5 * 2.625 = 3.9375, exercising the render target ceiling logic.
+  Scalar radius = 1.5;
+  Scalar scale = 2.625;
+
+  std::shared_ptr<Texture> texture = MakeTexture(ISize(100, 100));
+  ASSERT_NE(texture, nullptr);
+  auto contents = FilterContents::MakeDirectionalMorphology(
+      FilterInput::Make(texture), Radius{radius}, Vector2(0, 1),
+      FilterContents::MorphType::kDilate);
+  contents->SetEffectTransform(Matrix::MakeScale(Vector2(scale, scale)));
+
+  Entity entity;
+  std::shared_ptr<ContentContext> renderer = GetContentContext();
+  std::optional<Entity> result =
+      contents->GetEntity(*renderer, entity, /*coverage_hint=*/{});
+
+  ASSERT_TRUE(result.has_value());
+  if (result.has_value()) {
+    std::optional<Rect> result_coverage = result->GetCoverage();
+    ASSERT_TRUE(result_coverage.has_value());
+    if (result_coverage.has_value()) {
+      Scalar expected_expansion = radius * scale;
+      EXPECT_TRUE(result_coverage->Contains(Rect::MakeLTRB(
+          0, -expected_expansion, 100, 100 + expected_expansion)));
+      Scalar top_expansion = 0 - result_coverage->GetTop();
+      Scalar bottom_expansion = result_coverage->GetBottom() - 100;
+      EXPECT_NEAR(top_expansion, bottom_expansion, 0.5);
+    }
+  }
+}
+
+}  // namespace testing
+}  // namespace impeller


### PR DESCRIPTION
This is the recreation of https://github.com/flutter/flutter/pull/184073, see the reasoning for this in https://github.com/flutter/flutter/pull/184073#pullrequestreview-4092929525

The render target size was truncated via ISize(coverage.GetSize()),
which drops fractional pixels on the right/bottom edges. Fixed by
using std::ceil(), preventing asymmetric dilation coverage.

before:
<img width="208" height="210" alt="image" src="https://github.com/user-attachments/assets/25dc26b1-6c05-46a3-a0e9-ce9be06e5ae1" />
after:
<img width="208" height="206" alt="image" src="https://github.com/user-attachments/assets/6500d0fd-3f64-4970-9974-ef1a2a6b4468" />

Golden test generated image:
<img width="1024" height="768" alt="image" src="https://github.com/user-attachments/assets/eeaa5037-682a-452d-b0a5-8f7f287b63a3" />

Fixes: https://github.com/flutter/flutter/issues/184072

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
