### PR TITLE
Fix DoNothingAction assertion when overriding Action.overridable

### DIFF
--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -921,13 +921,21 @@ class Actions extends StatefulWidget {
     final Action<Intent>? mappedAction = actionsMarker.actions[intent?.runtimeType ?? T];
     if (mappedAction is Action<T>?) {
       return mappedAction;
-    } else {
-      assert(
-        false,
-        '$T cannot be handled by an Action of runtime type ${mappedAction.runtimeType}.',
-      );
-      return null;
     }
+    // An Action<Intent> (e.g. DoNothingAction) can handle any Intent subtype
+    // but Dart's invariant reified generics cause `Action<Intent>` to fail the
+    // `is Action<T>` check when T is a concrete Intent subclass.  Since the
+    // action was explicitly mapped to this intent type, it is safe to return.
+    if (mappedAction.intentType == Intent) {
+      // The unchecked cast is safe: Action<Intent>.invoke accepts any Intent,
+      // so passing a T (which extends Intent) is valid.
+      return _UnsafeCastAction<T>(mappedAction);
+    }
+    assert(
+      false,
+      '$T cannot be handled by an Action of runtime type ${mappedAction.runtimeType}.',
+    );
+    return null;
   }
 
   /// Returns the [ActionDispatcher] associated with the [Actions] widget that
@@ -1484,6 +1492,49 @@ class DoNothingAction extends Action<Intent> {
 
   @override
   void invoke(Intent intent) {}
+}
+
+/// Wraps an [Action<Intent>] so it can be used where an [Action<T>] is
+/// expected.  This is needed because Dart's reified generics make
+/// `Action<Intent>` fail the `is Action<T>` check even though `T extends
+/// Intent`.
+class _UnsafeCastAction<T extends Intent> extends Action<T> {
+  _UnsafeCastAction(this._delegate);
+  final Action<Intent> _delegate;
+
+  @override
+  void addActionListener(ActionListenerCallback listener) {
+    super.addActionListener(listener);
+    _delegate.addActionListener(listener);
+  }
+
+  @override
+  void removeActionListener(ActionListenerCallback listener) {
+    super.removeActionListener(listener);
+    _delegate.removeActionListener(listener);
+  }
+
+  @override
+  bool get isActionEnabled => _delegate.isActionEnabled;
+
+  @override
+  bool isEnabled(T intent) => _delegate.isEnabled(intent);
+
+  @override
+  bool consumesKey(T intent) => _delegate.consumesKey(intent);
+
+  @override
+  KeyEventResult toKeyEventResult(T intent, Object? invokeResult) =>
+      _delegate.toKeyEventResult(intent, invokeResult);
+
+  @override
+  Object? invoke(T intent) => _delegate.invoke(intent);
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<Action<Intent>>('delegate', _delegate));
+  }
 }
 
 /// An [Intent] that activates the currently focused control.

--- a/packages/flutter/test/widgets/actions_test.dart
+++ b/packages/flutter/test/widgets/actions_test.dart
@@ -1881,6 +1881,40 @@ void main() {
       expect(LogInvocationContextAction.invokeContext, invokingContext);
     });
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/180435
+  testWidgets('DoNothingAction can override Action.overridable intents', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      WidgetsApp(
+        color: const Color(0xFFFFFFFF),
+        builder: (BuildContext context, Widget? child) {
+          return Actions(
+            actions: <Type, Action<Intent>>{SelectAllTextIntent: DoNothingAction()},
+            child: EditableText(
+              controller: TextEditingController(),
+              focusNode: FocusNode(),
+              style: TextStyle(),
+              cursorColor: Color(0xFF000000),
+              backgroundCursorColor: Color(0xFF000000),
+            ),
+          );
+        },
+      ),
+    );
+
+    await tester.tap(find.byType(EditableText));
+    await tester.pump();
+
+    // Press Ctrl+A — should not throw an assertion error.
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+    await tester.sendKeyEvent(LogicalKeyboardKey.keyA);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+  });
 }
 
 typedef PostInvokeCallback =


### PR DESCRIPTION
### Description
Fixes the assertion failure in Actions._castAction when a DoNothingAction is used to override Action.overridable intents.

### Problem
When wrapping a TextField with Actions and mapping text editing intents (e.g. SelectAllTextIntent) to DoNothingAction(), pressing keyboard shortcuts throws:

```
SelectAllTextIntent cannot be handled by an Action of runtime type DoNothingAction.
Failed assertion: line 926 pos 9: 'false'
```

DoNothingAction extends Action<Intent>. The _castAction method does mappedAction is Action<T>? where T is a concrete Intent subclass. Due to Dart's invariant reified generics, Action<Intent> is NOT Action<SelectAllTextIntent> at runtime — so the check fails and the assertion fires.

### Fix
When the is Action<T> check fails and the action's intentType is Intent (meaning it's designed to handle any intent), wrap it in _UnsafeCastAction<T> — a thin delegate that forwards all methods to the original action but has the correct generic type parameter.

This is safe because Action<Intent>.invoke accepts any Intent, so passing a T (which extends Intent) is valid.

### Test
Added regression test that maps SelectAllTextIntent to DoNothingAction() on an EditableText and triggers Ctrl+A — previously crashed, now passes.

Fixes #180435