### PR TITLE
[CP-stable] Disable async mode with LLDB

### DIFF
--- a/dev/devicelab/bin/tasks/ios_debug_workflow.dart
+++ b/dev/devicelab/bin/tasks/ios_debug_workflow.dart
@@ -90,7 +90,7 @@ Future<TaskResult> _validateWorkflow({
   Pattern expectedLog;
   Pattern unexpectedLog;
   const Pattern xcodeExpectedLog = 'Action result status: not yet started';
-  final Pattern lldbExpectedLog = RegExp(r'Process .* resuming');
+  final Pattern lldbExpectedLog = RegExp(r'location added to breakpoint');
   switch (workflow) {
     case IosDebugWorkflow.xcode:
       expectedLog = xcodeExpectedLog;

--- a/packages/flutter_tools/lib/src/ios/lldb.dart
+++ b/packages/flutter_tools/lib/src/ios/lldb.dart
@@ -42,10 +42,10 @@ class LLDB {
   /// Example: (lldb) Process 6152 stopped
   static final _lldbProcessStopped = RegExp(r'Process \d* stopped');
 
-  /// Pattern of lldb log when the process is resuming.
+  /// Pattern of lldb log when the process is resuming and the breakpoint is added.
   ///
-  /// Example: (lldb) Process 6152 resuming
-  static final _lldbProcessResuming = RegExp(r'Process \d+ resuming');
+  /// Example: (lldb) 1 location added to breakpoint 1
+  static final _lldbProcessResuming = RegExp(r'location added to breakpoint');
 
   /// Pattern of lldb log when the breakpoint is added.
   ///
@@ -240,6 +240,11 @@ return False
     await _lldbProcess?.stdinWriteln('breakpoint command add --script-type python $breakpointId');
     await _lldbProcess?.stdinWriteln(_pythonScript);
     await _lldbProcess?.stdinWriteln('DONE');
+
+    // Disable asynchronous mode to workaround issues with rearming of breakpoints.
+    // See https://github.com/flutter/flutter/issues/184254 and upstream issue
+    // https://github.com/llvm/llvm-project/issues/190956.
+    await _lldbProcess?.stdinWriteln('script lldb.debugger.SetAsync(False)');
   }
 
   /// Resume the stopped process.

--- a/packages/flutter_tools/test/general.shard/ios/lldb_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/lldb_test.dart
@@ -89,6 +89,7 @@ void main() {
       'device select $deviceId',
       breakPointMatcher,
       'breakpoint command add --script-type python $breakpointId',
+      'script lldb.debugger.SetAsync(False)',
       processAttachMatcher,
       processResumedMatcher,
     ];
@@ -118,7 +119,7 @@ Target 0: (Runner) stopped.
         );
       }
       if (line == processResumedMatcher) {
-        processResumedCompleted.complete(utf8.encode('Process $appProcessId resuming\n'));
+        processResumedCompleted.complete(utf8.encode('1 location added to breakpoint 1\n'));
       }
     });
 
@@ -328,6 +329,7 @@ Target 0: (Runner) stopped.
       'device select $deviceId',
       breakPointMatcher,
       'breakpoint command add --script-type python $breakpointId',
+      'script lldb.debugger.SetAsync(False)',
       processAttachMatcher,
       processResumedMatcher,
     ];
@@ -357,7 +359,7 @@ Target 0: (Runner) stopped.
         );
       }
       if (line == processResumedMatcher) {
-        processResumedCompleted.complete(utf8.encode('Process $appProcessId resuming\n'));
+        processResumedCompleted.complete(utf8.encode('1 location added to breakpoint 1\n'));
       }
     });
 


### PR DESCRIPTION
### Issue Link:
What is the link to the issue this cherry-pick is addressing?

https://github.com/flutter/flutter/issues/184254

### Impact Description:
What is the impact (ex. visual jank on Samsung phones, app crash, cannot ship an iOS app)?
Does it impact development (ex. flutter doctor crashes when Android Studio is installed),
or the shipping of production apps (the app crashes on launch).
This information is for domain experts and release engineers to understand the consequences of saying yes or no to the cherry pick.

Debugging on physical iOS devices often crashes when using Xcode 26.4.

### Changelog Description:
Explain this cherry pick:
* In one line that is accessible to most Flutter developers.
* That describes the state prior to the fix.
* That includes which platforms are impacted.
See [best practices](https://github.com/flutter/flutter/blob/main/docs/releases/Hotfix-Documentation-Best-Practices.md) for examples.

When debugging on physical iOS devices and Xcode 26.4+, app often crashes.

### Workaround:
Is there a workaround for this issue?

* Use a simulator
* Or launch from Xcode
* Or use Xcode 26.3
* Or use a wireless device

### Risk:
What is the risk level of this cherry-pick?

  - [x] Low
  - [ ] Medium
  - [ ] High

### Test Coverage:
Are you confident that your fix is well-tested by automated tests?

  - [x] Yes
  - [ ] No

### Validation Steps:
What are the steps to validate that this fix works?

Do `flutter run` in https://github.com/flutter/flutter/tree/master/dev/integration_tests/flutter_gallery using Xcode 26.4 and a physical iOS device.