### PR TITLE
Skip flutter widget-preview test that times out frequently

### DIFF
--- a/packages/flutter_tools/test/integration.shard/widget_preview_smoke_test.dart
+++ b/packages/flutter_tools/test/integration.shard/widget_preview_smoke_test.dart
@@ -159,52 +159,56 @@ void main() {
       );
     });
 
-    testUsingContext("doesn't crash on flutter clean", () async {
-      // Regression test for https://github.com/flutter/flutter/issues/175058.\
-      dtdLauncher = DtdLauncher(
-        logger: logger!,
-        artifacts: globals.artifacts!,
-        processManager: globals.processManager,
-      );
+    testUsingContext(
+      "doesn't crash on flutter clean",
+      () async {
+        // Regression test for https://github.com/flutter/flutter/issues/175058.\
+        dtdLauncher = DtdLauncher(
+          logger: logger!,
+          artifacts: globals.artifacts!,
+          processManager: globals.processManager,
+        );
 
-      // Start a DTD instance.
-      final Uri dtdUri = await dtdLauncher!.launch();
+        // Start a DTD instance.
+        final Uri dtdUri = await dtdLauncher!.launch();
 
-      // Connect to it and listen to the WidgetPreviewScaffold stream.
-      //
-      // The preview scaffold will send a 'Connected' event on this stream once it has initialized
-      // and is ready.
-      final DartToolingDaemon dtdConnection = await DartToolingDaemon.connect(dtdUri);
-      final completer = Completer<void>();
-      var firstConnection = true;
-      dtdConnection.onEvent(WidgetPreviewDtdServices.kWidgetPreviewScaffoldStreamRoot).listen((
-        DTDEvent event,
-      ) {
-        expect(event.stream, WidgetPreviewDtdServices.kWidgetPreviewScaffoldStreamRoot);
-        expect(event.kind, 'Connected');
-        if (firstConnection) {
-          firstConnection = false;
-          runFlutterClean(tempDir);
-          dtdConnection.call(
-            WidgetPreviewDtdServices.kWidgetPreviewServiceRoot,
-            WidgetPreviewDtdServices.kHotRestartPreviewer,
-          );
-          return;
-        }
-        // The second `Connected` event should come after the previewer is hot restarted after
-        // we perform the `flutter clean`. This event won't be sent again if the previewer has
-        // crashed.
-        completer.complete();
-      });
-      await dtdConnection.streamListen(WidgetPreviewDtdServices.kWidgetPreviewScaffoldStreamRoot);
+        // Connect to it and listen to the WidgetPreviewScaffold stream.
+        //
+        // The preview scaffold will send a 'Connected' event on this stream once it has initialized
+        // and is ready.
+        final DartToolingDaemon dtdConnection = await DartToolingDaemon.connect(dtdUri);
+        final completer = Completer<void>();
+        var firstConnection = true;
+        dtdConnection.onEvent(WidgetPreviewDtdServices.kWidgetPreviewScaffoldStreamRoot).listen((
+          DTDEvent event,
+        ) {
+          expect(event.stream, WidgetPreviewDtdServices.kWidgetPreviewScaffoldStreamRoot);
+          expect(event.kind, 'Connected');
+          if (firstConnection) {
+            firstConnection = false;
+            runFlutterClean(tempDir);
+            dtdConnection.call(
+              WidgetPreviewDtdServices.kWidgetPreviewServiceRoot,
+              WidgetPreviewDtdServices.kHotRestartPreviewer,
+            );
+            return;
+          }
+          // The second `Connected` event should come after the previewer is hot restarted after
+          // we perform the `flutter clean`. This event won't be sent again if the previewer has
+          // crashed.
+          completer.complete();
+        });
+        await dtdConnection.streamListen(WidgetPreviewDtdServices.kWidgetPreviewScaffoldStreamRoot);
 
-      // Start the widget preview and wait for the 'Connected' event.
-      await runWidgetPreview(
-        tempDir: tempDir,
-        expectedMessages: firstLaunchMessagesWeb,
-        dtdUri: dtdUri,
-      );
-      await completer.future;
-    });
+        // Start the widget preview and wait for the 'Connected' event.
+        await runWidgetPreview(
+          tempDir: tempDir,
+          expectedMessages: firstLaunchMessagesWeb,
+          dtdUri: dtdUri,
+        );
+        await completer.future;
+      },
+      skip: true, // https://github.com/flutter/flutter/issues/184985
+    );
   });
 }


### PR DESCRIPTION
Temporarily skip this test. It is currently timing out often, causing the tree to be closed.

I'd consider reviewing this change with whitespace changes hidden: https://github.com/flutter/flutter/pull/184988/changes?w=1

Part of: https://github.com/flutter/flutter/issues/184985