### PR TITLE
[tools]find the most recent merge base (either main or master)

### DIFF
--- a/bin/internal/content_aware_hash.sh
+++ b/bin/internal/content_aware_hash.sh
@@ -54,10 +54,22 @@ if [[ "$CURRENT_BRANCH" != "main" && \
     REMOTE="upstream"
   fi
 
-  # Try to find the merge-base with master, then main.
-  MERGEBASE=$(git -C "$FLUTTER_ROOT" merge-base HEAD "$REMOTE/master" 2>/dev/null || true)
-  if [[ -z "$MERGEBASE" ]]; then
-    MERGEBASE=$(git -C "$FLUTTER_ROOT" merge-base HEAD "$REMOTE/main" 2>/dev/null || true)
+  # Find the most recent merge base.
+  MB_MASTER=$(git -C "$FLUTTER_ROOT" merge-base HEAD "$REMOTE/master" 2>/dev/null || true)
+  MB_MAIN=$(git -C "$FLUTTER_ROOT" merge-base HEAD "$REMOTE/main" 2>/dev/null || true)
+
+  if [[ -n "$MB_MASTER" && -n "$MB_MAIN" ]]; then
+    if git -C "$FLUTTER_ROOT" merge-base --is-ancestor "$MB_MASTER" "$MB_MAIN" 2>/dev/null; then
+      # MB_MAIN is newer than MB_MASTER
+      MERGEBASE="$MB_MAIN"
+    else
+      # MB_MASTER is newer or they are the same
+      MERGEBASE="$MB_MASTER"
+    fi
+  elif [[ -n "$MB_MASTER" ]]; then
+    MERGEBASE="$MB_MASTER"
+  else
+    MERGEBASE="$MB_MAIN"
   fi
 
   if [[ -n "$MERGEBASE" ]]; then

--- a/dev/tools/test/content_aware_hash_test.dart
+++ b/dev/tools/test/content_aware_hash_test.dart
@@ -211,6 +211,56 @@ void main() {
     expect(runContentAwareHash(), processStdout('fa69812cddffc076be3aa477a93942cb8d233ccc'));
   });
 
+  test('prefers newer merge-base when main is newer than master', () {
+    initGitRepoWithBlankInitialCommit(remote: 'upstream', branch: 'master');
+    writeFileAndCommit(testRoot.deps, 'deps on master');
+    // Branch main from master (so it includes master's history).
+    run('git', <String>['checkout', '-b', 'main']);
+    writeFileAndCommit(testRoot.deps, 'deps on main');
+    run('git', <String>['fetch', 'upstream']);
+
+    // Checkout feature branch from main.
+    run('git', <String>['checkout', '-b', 'feature']);
+    writeFileAndCommit(testRoot.deps, 'deps on feature');
+
+    run('git', <String>['checkout', 'main']);
+    final String hashMain = (runContentAwareHash().stdout as String).trim();
+    run('git', <String>['checkout', 'master']);
+    final String hashMaster = (runContentAwareHash().stdout as String).trim();
+    expect(hashMain, isNot(equals(hashMaster)));
+
+    run('git', <String>['checkout', 'feature']);
+    final String hashFeature = (runContentAwareHash().stdout as String).trim();
+
+    // It should pick main.
+    expect(hashFeature, equals(hashMain));
+  });
+
+  test('prefers newer merge-base when master is newer than main', () {
+    initGitRepoWithBlankInitialCommit(remote: 'upstream', branch: 'main');
+    writeFileAndCommit(testRoot.deps, 'deps on main');
+    // Branch master from main (so it includes main's history).
+    run('git', <String>['checkout', '-b', 'master']);
+    writeFileAndCommit(testRoot.deps, 'deps on master');
+    run('git', <String>['fetch', 'upstream']);
+
+    // Checkout feature branch from master.
+    run('git', <String>['checkout', '-b', 'feature']);
+    writeFileAndCommit(testRoot.deps, 'deps on feature');
+
+    run('git', <String>['checkout', 'main']);
+    final String hashMain = (runContentAwareHash().stdout as String).trim();
+    run('git', <String>['checkout', 'master']);
+    final String hashMaster = (runContentAwareHash().stdout as String).trim();
+    expect(hashMain, isNot(equals(hashMaster)));
+
+    run('git', <String>['checkout', 'feature']);
+    final String hashFeature = (runContentAwareHash().stdout as String).trim();
+
+    // It should pick master.
+    expect(hashFeature, equals(hashMaster));
+  });
+
   test('generates a hash for upstream/main', () {
     initGitRepoWithBlankInitialCommit(branch: 'main');
     expect(runContentAwareHash(), processStdout('fa69812cddffc076be3aa477a93942cb8d233ccc'));


### PR DESCRIPTION
In my local machine the `upstream/master` tracking branch was out of date (since I usually fetch `main`). This caused the script to find an old merge-base, because the current behavior prefers `master` over `main`.

Since local references can easily get out of sync for anyone, it makes sense to compare the merge bases with both branches, and picking the most recent one.

This replaces my previous attempts which simply swaps the main/master preferences: https://github.com/flutter/flutter/pull/184943



*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

Fixes https://github.com/flutter/flutter/issues/184891

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
