### PR TITLE
Roll hooks_runner from 1.1.1 to 1.2.1

### DIFF
--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -58,7 +58,7 @@ dependencies:
   pubspec_parse: 1.5.0
 
   graphs: 2.3.2
-  hooks_runner: 1.1.1
+  hooks_runner: 1.2.1
   hooks: 1.0.2
   code_assets: 1.0.0
   data_assets: 0.19.6
@@ -128,4 +128,4 @@ dartdoc:
   # Exclude this package from the hosted API docs.
   nodoc: true
 
-# PUBSPEC CHECKSUM: 3f506k
+# PUBSPEC CHECKSUM: tpog13


### PR DESCRIPTION
Roll in:

* https://github.com/dart-lang/native/pull/3305

Tests covering hooks_runner:

* packages/flutter_tools/test/integration.shard/isolated/*_test.dart