### PR TITLE
Add dart_skills_lint to dev/tool with test and update readme instructions for new skills authors

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -27,6 +27,33 @@ We encourage contributors to follow these practices when authoring skills, thoug
 * **Read-Only Mode**: When appropriate, tell agents how to access real data strictly in read-only mode to prevent unintended changes.
 * **Dart Scripts**: Scripts should be written in Dart.
 
+## Validating Skills
+
+You can manually run the `dart_skills_lint` tool to validate your skills and fix common issues. Navigate to the `dev/tools` directory and run:
+
+```bash
+dart run dart_skills_lint:cli --skills-directory ../../.agents/skills --check-trailing-whitespace --check-absolute-paths --check-relative-paths
+```
+
+### Helpful Flags for Authors
+
+- `--fix`: Preview fixes for failing lints without modifying files (dry run).
+- `--fix-apply`: Automatically apply fixes for fixable rules (like trailing whitespace).
+- `--check-trailing-whitespace`: Enforce no trailing whitespace (except 2 spaces for line breaks).
+- `--check-absolute-paths`: Ensure links do not use absolute paths.
+- `--check-relative-paths`: Ensure relative links point to existing files.
+
+### Running Automated Tests
+You can also run the automated validation tests from the `dev/tools` directory:
+```bash
+dart test test/validate_skills_test.dart
+```
+
+For example, to check everything and preview fixes, you can run:
+```bash
+dart run dart_skills_lint:cli --fix --check-trailing-whitespace --check-absolute-paths --check-relative-paths --skills-directory ../../.agents/skills
+```
+
 # How to help
 If you are a regular contributor looking for areas where you can author a skill, the following are good places to start:
 

--- a/dev/tools/pubspec.yaml
+++ b/dev/tools/pubspec.yaml
@@ -22,6 +22,12 @@ dependencies:
   file: any
   platform: any
   yaml_edit: any
+  dart_skills_lint:
+    git:
+      url: https://github.com/flutter/skills
+      path: tool/dart_skills_lint
+      ref: 9eff6bbcfa27c2724ea9ad67a611c19fe77057ea
+  logging: ^1.3.0
 
 dev_dependencies:
   test: any
@@ -30,4 +36,4 @@ dev_dependencies:
 
   matcher: any
 
-# PUBSPEC CHECKSUM: k73ud7
+# PUBSPEC CHECKSUM: oojo9a

--- a/dev/tools/test/validate_skills_test.dart
+++ b/dev/tools/test/validate_skills_test.dart
@@ -1,0 +1,33 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'package:dart_skills_lint/dart_skills_lint.dart';
+import 'package:logging/logging.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Validate Flutter Skills', () async {
+    final Level oldLevel = Logger.root.level;
+    Logger.root.level = Level.ALL;
+    final StreamSubscription<LogRecord> subscription = Logger.root.onRecord.listen((record) {
+      print(record.message);
+    });
+
+    try {
+      final bool isValid = await validateSkills(
+        skillDirPaths: ['../../.agents/skills'],
+        resolvedRules: {
+          'check-relative-paths': AnalysisSeverity.error,
+          'check-absolute-paths': AnalysisSeverity.error,
+          'check-trailing-whitespace': AnalysisSeverity.error,
+        },
+      );
+      expect(isValid, isTrue, reason: 'Skills validation failed. See above for details.');
+    } finally {
+      Logger.root.level = oldLevel;
+      await subscription.cancel();
+    }
+  });
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -178,6 +178,15 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
+  dart_skills_lint:
+    dependency: transitive
+    description:
+      path: "tool/dart_skills_lint"
+      ref: "9eff6bbcfa27c2724ea9ad67a611c19fe77057ea"
+      resolved-ref: "9eff6bbcfa27c2724ea9ad67a611c19fe77057ea"
+      url: "https://github.com/flutter/skills"
+    source: git
+    version: "0.2.0"
   dart_style:
     dependency: "direct main"
     description:


### PR DESCRIPTION
Add a static analysis linter for skills authors in flutter/flutter

I want to call out that this is adding a dependency on repo we control but is not yet available in pub.dev. 

Update deps also had me fix an build error caused by updating build_runner. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
