### PR TITLE
[AGP 9] Update AGP Error

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -664,12 +664,13 @@ final missingNdkSourcePropertiesFile = GradleHandledError(
   eventLabel: 'ndk-missing-source-properties-file',
 );
 
-// TODO(jesswon): Remove this constant and its usages once AGP 9 is supported in the ecosystem: https://github.com/flutter/flutter/issues/181383
-const String _kAgp9WarningAndMigrationPrompt = '''
-Please do not upgrade your Flutter app on Android to AGP 9 as migrating plugins to AGP 9
-and Flutter apps on AGP 9 using plugins is not yet supported. For more details, see https://github.com/flutter/flutter/issues/181383.
-\nTo proceed with the AGP 9 migration despite this warning:
-    ''';
+/// The URL for documentation on migrating to built-in Kotlin.
+const String kMigrateToBuiltInKotlinDocsUrl =
+    'https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin';
+
+/// The URL for documentation on opting out of the new AGP DSL.
+const String kOptOutOfNewDslDocsUrl =
+    'https://developer.android.com/build/releases/agp-9-0-0-release-notes';
 
 /// Handler when applying the kotlin-android plugin results in a build failure. This failure occurs when
 /// using AGP 9+ because built-in Kotlin has become the default behavior.
@@ -682,14 +683,11 @@ final applyingKotlinAndroidPluginErrorHandler = GradleHandledError(
   },
   handler:
       ({required String line, required FlutterProject project, required bool usesAndroidX}) async {
-        final File appGradleFile = project.android.appGradleFile;
-        globals.printBox(
-          '''
-${globals.logger.terminal.warningMark} $_kAgp9WarningAndMigrationPrompt
-Starting AGP 9+, the default has become built-in Kotlin. This results in a build failure when applying the kotlin-android plugin at ${appGradleFile.path}.
-\nTo resolve this, migrate to built-in Kotlin. For instructions on how to migrate, see: https://docs.flutter.dev/release/breaking-changes/migrate-to-agp-9''',
-          title: _boxTitle,
-        );
+        globals.printBox('''
+${globals.logger.terminal.warningMark} Starting AGP 9+, the default has become built-in Kotlin.
+This results in a build failure when applying the kotlin-android plugin.
+To resolve this, migrate to built-in Kotlin.
+\nFor instructions on how to migrate, see: $kMigrateToBuiltInKotlinDocsUrl''', title: _boxTitle);
 
         return GradleBuildStatus.exit;
       },
@@ -710,9 +708,10 @@ final useNewAgpDslErrorHandler = GradleHandledError(
         final File appGradleFile = project.android.appGradleFile;
         globals.printBox(
           '''
-${globals.logger.terminal.warningMark} $_kAgp9WarningAndMigrationPrompt
-Starting AGP 9+, only the new DSL interface will be read. This results in a build failure when applying the Flutter Gradle plugin at ${appGradleFile.path}.
-\nTo resolve this update flutter or opt out of `android.newDsl`. For instructions on how to opt out, see: https://docs.flutter.dev/release/breaking-changes/migrate-to-agp-9
+${globals.logger.terminal.warningMark} Starting AGP 9+, only the new DSL interface will be read.
+This results in a build failure when applying the Flutter Gradle plugin at ${appGradleFile.path}.
+\nTo resolve this update flutter or opt out of `android.newDsl`.
+For instructions on how to opt out, see: $kOptOutOfNewDslDocsUrl
 \nIf you are not upgrading to AGP 9+, run `flutter analyze --suggestions` to check for incompatible dependencies.''',
           title: _boxTitle,
         );

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -1652,19 +1652,15 @@ An exception occurred applying plugin request [id: 'kotlin-android']
 
       expect(
         testLogger.statusText,
-        contains('Please do not upgrade your Flutter app on Android to AGP 9'),
+        contains('Starting AGP 9+, the default has become built-in Kotlin.'),
       );
       expect(
         testLogger.statusText,
-        contains('To proceed with the AGP 9 migration despite this warning:'),
-      );
-      expect(
-        testLogger.statusText,
-        contains(
-          'Starting AGP 9+, the default has become built-in Kotlin. This results in a build failure when',
-        ),
+        contains(' This results in a build failure when applying the kotlin-android plugin'),
       );
       expect(testLogger.statusText, contains('applying the kotlin-android plugin'));
+      expect(testLogger.statusText, contains('For instructions on how to migrate, see:'));
+      expect(testLogger.statusText, contains(kMigrateToBuiltInKotlinDocsUrl));
     },
     overrides: <Type, Generator>{
       GradleUtils: () => FakeGradleUtils(),
@@ -1698,18 +1694,14 @@ An exception occurred applying plugin request [id: 'dev.flutter.flutter-gradle-p
 
       expect(
         testLogger.statusText,
-        contains('Please do not upgrade your Flutter app on Android to AGP 9'),
-      );
-      expect(
-        testLogger.statusText,
-        contains('To proceed with the AGP 9 migration despite this warning:'),
-      );
-      expect(
-        testLogger.statusText,
         contains('Starting AGP 9+, only the new DSL interface will be read.'),
       );
-      expect(testLogger.statusText, contains('This results in a build failure when'));
-      expect(testLogger.statusText, contains('applying the Flutter Gradle plugin'));
+      expect(
+        testLogger.statusText,
+        contains('This results in a build failure when applying the Flutter Gradle plugin'),
+      );
+      expect(testLogger.statusText, contains('For instructions on how to opt out, see:'));
+      expect(testLogger.statusText, contains(kOptOutOfNewDslDocsUrl));
       expect(
         testLogger.statusText,
         contains('If you are not upgrading to AGP 9+, run `flutter analyze --suggestions`'),


### PR DESCRIPTION
AGP is ready to use. Developers should not be running into this error at all due to support that has been added for Built-in Kotlin https://github.com/flutter/flutter/issues/184836. But in the event that they do run into this error, they will be guided to the right docs.

Fixes https://github.com/flutter/flutter/issues/186097

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
