### PR TITLE
Agent rule: Dart editing

### DIFF
--- a/.agents/rules/dart-editing.md
+++ b/.agents/rules/dart-editing.md
@@ -1,8 +1,5 @@
----
-trigger: always_on
----
-
 Before declaring a task done:
-1. Address all lints, warnings, and errors introduced or present in the modified files.
-2. Run `dart format` on the modified files.
-Either use the Dart/Flutter MCP server or the command line to perform these checks.
+1. Address all lints, warnings, and errors introduced or present in the modified
+   files. Run `dart analyze --fatal-infos <files>` or use the MCP server.
+2. Run `dart format` on the modified files. Run `dart format <files>` or use the
+   MCP server.

--- a/.agents/rules/dart-editing.md
+++ b/.agents/rules/dart-editing.md
@@ -1,0 +1,8 @@
+---
+trigger: always_on
+---
+
+Before declaring a task done:
+1. Address all lints, warnings, and errors introduced or present in the modified files.
+2. Run `dart format` on the modified files.
+Either use the Dart/Flutter MCP server or the command line to perform these checks.

--- a/.agents/rules/dart-editing.md
+++ b/.agents/rules/dart-editing.md
@@ -1,3 +1,7 @@
+---
+trigger: always_on
+---
+
 Before declaring a task done:
 1. Address all lints, warnings, and errors introduced or present in the modified
    files. Run `dart analyze --fatal-infos <files>` or use the MCP server.

--- a/.gitignore
+++ b/.gitignore
@@ -165,4 +165,5 @@ app.*.symbols
 .gclient_previous_sync_commits
 
 # AI related
+.agents/rules/personal-*
 .agents/skills/personal-*


### PR DESCRIPTION
Various agents read `.agents/rules/` for rules that must always be respected.

Add a rule about always addressing all lints and running the formatter.