### PR TITLE
Fix: text selection context menu should reappear after a non-fling scroll on Android and iOS

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -4315,7 +4315,14 @@ class EditableTextState extends State<EditableText>
         return;
       }
       _showToolbarOnScreenScheduled = true;
-      SchedulerBinding.instance.addPostFrameCallback((Duration _) {
+      // Schedule the toolbar to show at the beginning of the next frame
+      // rather than at the end of the current frame (addPostFrameCallback).
+      // ScrollEndNotification and the subsequent ScrollStartNotification
+      // (from a ballistic animation) can arrive in the same build phase.
+      // A post-frame callback would run after both, showing the toolbar
+      // mid-scroll. A frame callback runs at the start of the next frame,
+      // before the next build phase dispatches any new scroll notifications.
+      SchedulerBinding.instance.scheduleFrameCallback((Duration _) {
         _showToolbarOnScreenScheduled = false;
         if (!mounted || _dataWhenToolbarShowScheduled == null) {
           return;
@@ -4343,7 +4350,7 @@ class EditableTextState extends State<EditableText>
           showToolbar();
           _dataWhenToolbarShowScheduled = null;
         }
-      }, debugLabel: 'EditableText.scheduleToolbar');
+      });
     }
   }
 

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -4315,7 +4315,7 @@ class EditableTextState extends State<EditableText>
         return;
       }
       _showToolbarOnScreenScheduled = true;
-      SchedulerBinding.instance.scheduleFrameCallback((Duration _) {
+      void scheduleToolbar(Duration _) {
         _showToolbarOnScreenScheduled = false;
         if (!mounted || _dataWhenToolbarShowScheduled == null) {
           return;
@@ -4343,7 +4343,25 @@ class EditableTextState extends State<EditableText>
           showToolbar();
           _dataWhenToolbarShowScheduled = null;
         }
-      });
+      }
+
+      switch (SchedulerBinding.instance.schedulerPhase) {
+        case SchedulerPhase.idle:
+        case SchedulerPhase.postFrameCallbacks:
+          // During these scheduler phases we cannot guarantee
+          // there will be a frame after, so we use scheduleFrameCallback.
+          SchedulerBinding.instance.scheduleFrameCallback(scheduleToolbar);
+        case SchedulerPhase.transientCallbacks:
+        case SchedulerPhase.midFrameMicrotasks:
+        case SchedulerPhase.persistentCallbacks:
+          // During an active frame we can still schedule
+          // a post-frame callback to be run after the
+          // current frame.
+          SchedulerBinding.instance.addPostFrameCallback(
+            scheduleToolbar,
+            debugLabel: 'EditableText.scheduleToolbar',
+          );
+      }
     }
   }
 

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -4315,13 +4315,6 @@ class EditableTextState extends State<EditableText>
         return;
       }
       _showToolbarOnScreenScheduled = true;
-      // Schedule the toolbar to show at the beginning of the next frame
-      // rather than at the end of the current frame (addPostFrameCallback).
-      // ScrollEndNotification and the subsequent ScrollStartNotification
-      // (from a ballistic animation) can arrive in the same build phase.
-      // A post-frame callback would run after both, showing the toolbar
-      // mid-scroll. A frame callback runs at the start of the next frame,
-      // before the next build phase dispatches any new scroll notifications.
       SchedulerBinding.instance.scheduleFrameCallback((Duration _) {
         _showToolbarOnScreenScheduled = false;
         if (!mounted || _dataWhenToolbarShowScheduled == null) {

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -10809,65 +10809,6 @@ void main() {
   );
 
   testWidgets(
-    'Toolbar re-appears after first parent scroll when selection stays in view on Android and iOS',
-    (WidgetTester tester) async {
-      // Regression test: toolbar should re-appear on the first scroll end
-      // without requiring a second scroll when the selection stays in view.
-      final controller = TextEditingController(text: 'Atwater Peel Sherbrooke Bonaventure ' * 20);
-      addTearDown(controller.dispose);
-
-      await tester.pumpWidget(
-        CupertinoApp(
-          home: CupertinoPageScaffold(
-            child: Center(
-              child: ListView(
-                children: <Widget>[
-                  const SizedBox(height: 200),
-                  CupertinoTextField(controller: controller),
-                  const SizedBox(height: 1000),
-                ],
-              ),
-            ),
-          ),
-        ),
-      );
-
-      final EditableTextState state = tester.state<EditableTextState>(
-        find.byType(EditableText),
-      );
-
-      final Offset textfieldStart = tester.getTopLeft(find.byType(CupertinoTextField));
-
-      await tester.longPressAt(textfieldStart + const Offset(50.0, 9.0));
-      await tester.pumpAndSettle();
-
-      expect(state.selectionOverlay?.toolbarIsVisible, true);
-
-      // Perform a small scroll so the selection stays in view.
-      final TestGesture gesture = await tester.startGesture(
-        tester.getCenter(find.byType(CupertinoTextField)),
-      );
-      await tester.pump();
-      await gesture.moveBy(const Offset(0.0, -50.0));
-      await tester.pumpAndSettle();
-      expect(state.selectionOverlay?.toolbarIsVisible, false);
-
-      // Release to end scroll. Toolbar should re-appear on the first scroll end.
-      await gesture.up();
-      await tester.pumpAndSettle();
-      expect(state.selectionOverlay?.toolbarIsVisible, true);
-      expect(state.renderEditable.selectionStartInViewport.value, true);
-      expect(state.renderEditable.selectionEndInViewport.value, true);
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{
-      TargetPlatform.android,
-      TargetPlatform.iOS,
-    }),
-    // [intended] only applies to platforms where we supply the context menu.
-    skip: kIsWeb,
-  );
-
-  testWidgets(
     'Does not crash when editing value changes between consecutive scrolls',
     (WidgetTester tester) async {
       // Regression test for https://github.com/flutter/flutter/issues/179164.

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -10809,6 +10809,65 @@ void main() {
   );
 
   testWidgets(
+    'Toolbar re-appears after first parent scroll when selection stays in view on Android and iOS',
+    (WidgetTester tester) async {
+      // Regression test: toolbar should re-appear on the first scroll end
+      // without requiring a second scroll when the selection stays in view.
+      final controller = TextEditingController(text: 'Atwater Peel Sherbrooke Bonaventure ' * 20);
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: CupertinoPageScaffold(
+            child: Center(
+              child: ListView(
+                children: <Widget>[
+                  const SizedBox(height: 200),
+                  CupertinoTextField(controller: controller),
+                  const SizedBox(height: 1000),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final EditableTextState state = tester.state<EditableTextState>(
+        find.byType(EditableText),
+      );
+
+      final Offset textfieldStart = tester.getTopLeft(find.byType(CupertinoTextField));
+
+      await tester.longPressAt(textfieldStart + const Offset(50.0, 9.0));
+      await tester.pumpAndSettle();
+
+      expect(state.selectionOverlay?.toolbarIsVisible, true);
+
+      // Perform a small scroll so the selection stays in view.
+      final TestGesture gesture = await tester.startGesture(
+        tester.getCenter(find.byType(CupertinoTextField)),
+      );
+      await tester.pump();
+      await gesture.moveBy(const Offset(0.0, -50.0));
+      await tester.pumpAndSettle();
+      expect(state.selectionOverlay?.toolbarIsVisible, false);
+
+      // Release to end scroll. Toolbar should re-appear on the first scroll end.
+      await gesture.up();
+      await tester.pumpAndSettle();
+      expect(state.selectionOverlay?.toolbarIsVisible, true);
+      expect(state.renderEditable.selectionStartInViewport.value, true);
+      expect(state.renderEditable.selectionEndInViewport.value, true);
+    },
+    variant: const TargetPlatformVariant(<TargetPlatform>{
+      TargetPlatform.android,
+      TargetPlatform.iOS,
+    }),
+    // [intended] only applies to platforms where we supply the context menu.
+    skip: kIsWeb,
+  );
+
+  testWidgets(
     'Does not crash when editing value changes between consecutive scrolls',
     (WidgetTester tester) async {
       // Regression test for https://github.com/flutter/flutter/issues/179164.

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -18497,6 +18497,70 @@ void main() {
       TargetPlatform.fuchsia,
     }),
   );
+
+  testWidgets(
+    'context menu reappears after a non-fling scroll that keeps selection in view while semantics are disabled',
+    (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/185052.
+      controller.text = 'Lorem ipsum dolor sit amet ' * 200;
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: Center(
+            child: EditableText(
+              maxLines: null,
+              style: textStyle,
+              cursorColor: cursorColor,
+              backgroundCursorColor: const Color(0xFF424242),
+              focusNode: focusNode,
+              selectionControls: testTextSelectionHandleControls,
+              contextMenuBuilder: (context, editableTextState) {
+                return const SizedBox.shrink();
+              },
+              controller: controller,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final Finder editableText = find.byType(EditableText);
+      final EditableTextState editableTextState = tester.state<EditableTextState>(editableText);
+
+      // Long press at the center of the widget to select a word that is
+      // well within the viewport.
+      await tester.longPressAt(tester.getCenter(editableText));
+      await tester.pumpAndSettle();
+      expect(editableTextState.showToolbar(), true);
+      await tester.pumpAndSettle();
+      expect(editableTextState.selectionOverlay?.toolbarIsVisible, true);
+
+      // Perform a short scroll that keeps the selection in view.
+      final TestGesture gesture = await tester.startGesture(tester.getCenter(editableText));
+      await gesture.moveBy(const Offset(0.0, -20.0));
+      await tester.pump();
+
+      // The toolbar should be hidden during the scroll.
+      expect(editableTextState.selectionOverlay?.toolbarIsVisible, false);
+
+      // Release the gesture / end the scroll.
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      // The toolbar should re-appear since the selection is still in view.
+      expect(editableTextState.selectionOverlay?.toolbarIsVisible, true);
+    },
+    // semanticsEnabled is set to false to match on-device behavior. With
+    // semantics enabled (the testWidgets default), setIgnorePointer during
+    // scroll activity transitions calls markNeedsSemanticsUpdate which
+    // schedules a frame as a side effect, masking the bug.
+    semanticsEnabled: false,
+    variant: const TargetPlatformVariant(<TargetPlatform>{
+      TargetPlatform.android,
+      TargetPlatform.iOS,
+    }), // Only applies to platforms where the context menu hides on scroll.
+    // [intended] only applies to platforms where we supply the context menu.
+    skip: kIsWeb,
+  );
 }
 
 class UnsettableController extends TextEditingController {


### PR DESCRIPTION
Fixes #185052 

This change fixes an issue where the context menu would not reappear on the end of a non-fling scroll (a short scroll that does not create any ballistic simulation). This was due to no frames being scheduled after a non-fling scroll so the scheduled `addPostFrameCallback` could not run.

This issue was not caught by any of our tests because in `testWidgets` semantics is enabled by default. When semantics is enabled we hit a special case where a semantics update schedules an additional frame at the end of a scroll. The added regression test simulates this by running with semantics disabled.

`setIgnorePointer` is called at the end of a scroll

https://github.com/flutter/flutter/blob/2c50daf9203d714791a320c8c78a928253dff4ab/packages/flutter/lib/src/widgets/scrollable.dart#L845-L855

and `setIgnorePointer` trigers a semantics update

https://github.com/flutter/flutter/blob/2c50daf9203d714791a320c8c78a928253dff4ab/packages/flutter/lib/src/rendering/proxy_box.dart#L3767-L3775

and `RenderObject.markNeedsSemanticsUpdate` short-circuits if semantics/screenreader is disabled resulting in no additional frames scheduled.

https://github.com/flutter/flutter/blob/2c50daf9203d714791a320c8c78a928253dff4ab/packages/flutter/lib/src/rendering/object.dart#L3904-L3916

https://github.com/user-attachments/assets/7c00f053-4eb0-49aa-8008-db2715d3922b


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.