### PR TITLE
In the dev/bots/analyze.dart script, obtain the relevant set of paths from Git instead of crawling the filesystem

### DIFF
--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -2189,49 +2189,49 @@ Stream<File> _allFiles(
   String? extension, {
   required int minimumMatches,
 }) async* {
-  final gitFileNamesSet = <String>{};
-  gitFileNamesSet.addAll(
-    (await _gitFiles(workingDirectory)).map((File f) => path.canonicalize(f.absolute.path)),
-  );
-
   assert(
     extension == null || !extension.startsWith('.'),
     'Extension argument should not start with a period.',
   );
-  final pending = <FileSystemEntity>{Directory(workingDirectory)};
+
+  final List<File> gitFiles = await _gitFiles(workingDirectory);
+
+  final Set<String> dartIgnoreDirectories = gitFiles
+      .where((File f) => path.basename(f.path) == '.dartignore')
+      .map((File f) => path.dirname(f.path))
+      .toSet();
+
+  const skipDirectories = {'.git', '.idea', '.gradle', '.dart_tool', 'build'};
+
   var matches = 0;
-  while (pending.isNotEmpty) {
-    final FileSystemEntity entity = pending.first;
-    pending.remove(entity);
-    if (path.extension(entity.path) == '.tmpl') {
+  for (final file in gitFiles) {
+    final FileStat stat = file.statSync();
+    if (stat.type != FileSystemEntityType.file) {
       continue;
     }
-    if (entity is File) {
-      if (!gitFileNamesSet.contains(path.canonicalize(entity.absolute.path))) {
+    if (dartIgnoreDirectories.any((String d) => path.isWithin(d, file.path))) {
+      continue;
+    }
+    final List<String> components = path.split(path.relative(file.path, from: workingDirectory));
+    if (components.any((String c) => skipDirectories.contains(c))) {
+      continue;
+    }
+    if (components.any((String c) => c.endsWith('.tmpl'))) {
+      continue;
+    }
+    if (_isGeneratedPluginRegistrant(file)) {
+      continue;
+    }
+    switch (path.basename(file.path)) {
+      case 'flutter_export_environment.sh' || 'gradlew.bat' || '.DS_Store':
         continue;
-      }
-      if (_isGeneratedPluginRegistrant(entity)) {
-        continue;
-      }
-      switch (path.basename(entity.path)) {
-        case 'flutter_export_environment.sh' || 'gradlew.bat' || '.DS_Store':
-          continue;
-      }
-      if (extension == null || path.extension(entity.path) == '.$extension') {
-        matches += 1;
-        yield entity;
-      }
-    } else if (entity is Directory) {
-      if (File(path.join(entity.path, '.dartignore')).existsSync()) {
-        continue;
-      }
-      switch (path.basename(entity.path)) {
-        case '.git' || '.idea' || '.gradle' || '.dart_tool' || 'build':
-          continue;
-      }
-      pending.addAll(entity.listSync());
+    }
+    if (extension == null || path.extension(file.path) == '.$extension') {
+      matches += 1;
+      yield file;
     }
   }
+
   assert(
     matches >= minimumMatches,
     'Expected to find at least $minimumMatches files with extension ".$extension" in "$workingDirectory", but only found $matches.',

--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -2194,9 +2194,9 @@ Stream<File> _allFiles(
     'Extension argument should not start with a period.',
   );
 
-  final List<File> gitFiles = (await _gitFiles(workingDirectory))
-      .map((File f) => File(path.canonicalize(f.path)))
-      .toList();
+  final List<File> gitFiles = [
+    for (final File f in await _gitFiles(workingDirectory)) File(path.normalize(f.path)),
+  ];
 
   final Set<String> dartIgnoreDirectories = gitFiles
       .where((File f) => path.basename(f.path) == '.dartignore')

--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -2194,7 +2194,9 @@ Stream<File> _allFiles(
     'Extension argument should not start with a period.',
   );
 
-  final List<File> gitFiles = await _gitFiles(workingDirectory);
+  final List<File> gitFiles = (await _gitFiles(workingDirectory))
+      .map((File f) => File(path.canonicalize(f.path)))
+      .toList();
 
   final Set<String> dartIgnoreDirectories = gitFiles
       .where((File f) => path.basename(f.path) == '.dartignore')

--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -2207,18 +2207,15 @@ Stream<File> _allFiles(
 
   var matches = 0;
   for (final file in gitFiles) {
-    final FileStat stat = file.statSync();
-    if (stat.type != FileSystemEntityType.file) {
+    if (extension != null && path.extension(file.path) != '.$extension') {
       continue;
     }
     if (dartIgnoreDirectories.any((String d) => path.isWithin(d, file.path))) {
       continue;
     }
-    final List<String> components = path.split(path.relative(file.path, from: workingDirectory));
-    if (components.any((String c) => skipDirectories.contains(c))) {
-      continue;
-    }
-    if (components.any((String c) => c.endsWith('.tmpl'))) {
+    final String relativePath = path.relative(file.path, from: workingDirectory);
+    final List<String> components = path.split(relativePath);
+    if (components.any((String c) => skipDirectories.contains(c) || c.endsWith('.tmpl'))) {
       continue;
     }
     if (_isGeneratedPluginRegistrant(file)) {
@@ -2228,10 +2225,12 @@ Stream<File> _allFiles(
       case 'flutter_export_environment.sh' || 'gradlew.bat' || '.DS_Store':
         continue;
     }
-    if (extension == null || path.extension(file.path) == '.$extension') {
-      matches += 1;
-      yield file;
+    final FileStat stat = file.statSync();
+    if (stat.type != FileSystemEntityType.file) {
+      continue;
     }
+    matches += 1;
+    yield file;
   }
 
   assert(


### PR DESCRIPTION
The filesystem crawl can add several minutes to the script's run time if the local tree contains the third-party components downloaded by "gclient sync".