### PR TITLE
Fix an ordering dependency in the services/system_chrome_test.dart test suite

### DIFF
--- a/packages/flutter/test/services/system_chrome_test.dart
+++ b/packages/flutter/test/services/system_chrome_test.dart
@@ -22,6 +22,11 @@ void main() {
       },
     );
 
+    // Start with the overlay style set to dark mode.
+    SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle.dark);
+    await tester.idle();
+    log.clear();
+
     // The first call is a cache miss and will queue a microtask
     SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle.light);
     expect(tester.binding.microtaskCount, equals(1));


### PR DESCRIPTION
The "SystemChrome overlay style test" assumed that the overlay style was not set to SystemUiOverlayStyle.light at the start of the test.  That may not be the case if other tests previously modified that state.

Fixes https://github.com/flutter/flutter/issues/185085