### PR TITLE
[CP-stable] Fix changelog merging workflow.

### DIFF
--- a/.github/workflows/merge-changelog.yml
+++ b/.github/workflows/merge-changelog.yml
@@ -31,18 +31,10 @@ jobs:
 
       # avoid downloading hundreds of other branches/history
       # utilizing `fetch-depth:0` in actions/checkout would clone everything.
-      - name: Fetch Stable Branch Only
-        run: git fetch upstream stable:stable --depth=1
-
-      - name: Read CHANGELOG.md from the stable branch
-        id: read_stable_changelog
+      - name: Fetch upstream branches
         run: |
-          # upstream/stable is locally mapped to stable
-          # use the local stable ref from above
-          CHANGELOG_CONTENT=$(git show stable:CHANGELOG.md)
-          echo "CHANGELOG_CONTENT<<EOF" >> $GITHUB_ENV
-          echo "$CHANGELOG_CONTENT" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
+          git fetch upstream stable:stable --depth=1
+          git fetch upstream master --depth=1
 
       - name: Prepare PR branch and commit changes
         id: prepare_pr_branch
@@ -51,13 +43,27 @@ jobs:
         run: |
           PR_BRANCH="sync-changelog-stable-to-master-$(date +%s)"
           echo "pr_branch_name=$PR_BRANCH" >> "$GITHUB_OUTPUT"
-          git checkout -b "$PR_BRANCH" master
-          echo "${{ env.CHANGELOG_CONTENT }}" > CHANGELOG.md
+
+          # Base the branch on upstream's master to avoid issues if the fork's master is out of date
+          git checkout -b "$PR_BRANCH" upstream/master
+
+          # Retrieve the file from stable directly into the working directory
+          git show stable:CHANGELOG.md > CHANGELOG.md
+
+          # Stop if no changes are detected
+          if git diff --quiet CHANGELOG.md; then
+            echo "No changes detected. Skipping PR creation."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
           git add CHANGELOG.md
           git commit -m "Sync CHANGELOG.md from stable"
           git push origin "$PR_BRANCH"
 
       - name: Create Pull Request
+        if: steps.prepare_pr_branch.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ secrets.FLUTTERACTIONSBOT_CP_TOKEN }}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,34 @@ docs/releases/Hotfix-Documentation-Best-Practices.md
 
 Learn about what's new in this release in [the blog post](https://blog.flutter.dev/whats-new-in-flutter-3-41-302ec140e632), and check out the [CHANGELOG](https://docs.flutter.dev/release/release-notes/release-notes-3.41.0) for a detailed list of all the new changes.
 
+
 ## Flutter 3.38 Changes
+
+### [3.38.10](https://github.com/flutter/flutter/releases/tag/3.38.10)
+
+- [flutter/181607](https://github.com/flutter/flutter/pull/181607) When using an ffi plugin on macOS, generated frameworks have the wrong structure.
+
+### [3.38.9](https://github.com/flutter/flutter/releases/tag/3.38.9)
+
+- [flutter/181568](https://github.com/flutter/flutter/pull/181568) Update Dart to 3.10.8.
+
+### [3.38.8](https://github.com/flutter/flutter/releases/tag/3.38.8)
+
+- [flutter/178151](https://github.com/flutter/flutter/issues/178151) - `flutter run -d chrome` may crash with a `DartDevelopmentServiceException` when the application shuts down during the startup sequence.
+
+### [3.38.7](https://github.com/flutter/flutter/releases/tag/3.38.7)
+
+- [flutter/179857](https://github.com/flutter/flutter/issues/179857) - `flutter run -d all` crashes if multiple devices are available.
+
+### [3.38.6](https://github.com/flutter/flutter/releases/tag/3.38.6)
+
+- [flutter/179139](https://github.com/flutter/flutter/issues/179139) - `flutter widget-preview start` creates new cached build artifacts on each run, resulting in increasing disk usage after each run.
+- [flutter/178896](https://github.com/flutter/flutter/issues/178896) - Apps crash during launch on Windows when run from paths containing non-ASCII characters.
+- [flutter/176943](https://github.com/flutter/flutter/issues/176943) - Configuration changes to run tests on macOS 15 or 15.7.2 for Flutter's CI.
+- [flutter/179914](https://github.com/flutter/flutter/issues/179914) - Flutter Android apps that upgrade to AGP 9.0.0 require migration steps.
+- [flutter/175099](https://github.com/flutter/flutter/issues/175099) - When WebViews are scrolled on iOS 26, they become unclickable.
+- [flutter/175074](https://github.com/flutter/flutter/issues/175074) - When the virtual keyboard is closed on Android web, the area behind it remains blank and the app only draws in the area that used to be above the keyboard.
+- [flutter/180381](https://github.com/flutter/flutter/issues/180381) - Apps crash on Android when enabling accessibility, hiding a platform view, and pulling out the top curtain.
 
 ### [3.38.5](https://github.com/flutter/flutter/releases/tag/3.38.5)
 


### PR DESCRIPTION
This change also pulls some changelogs from 3.38 which happened after 3.41's original branch cut.

The changes to the workflow are from this PR: https://github.com/flutter/flutter/pull/184145