### PR TITLE
[Impeller] Provide std::optional getter for stroke property

### DIFF
--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -831,7 +831,7 @@ void Canvas::DrawRect(const Rect& rect, const Paint& paint) {
       !paint.mask_blur_descriptor.has_value()) {
     auto params = UberSDFParameters::MakeRect(
         /*color=*/paint.color, /*rect=*/rect,
-        /*stroke=*/paint.GetOptionalStroke());
+        /*stroke=*/paint.GetStroke());
     auto geometry = std::make_unique<UberSDFGeometry>(params);
     auto contents = UberSDFContents::Make(params, std::move(geometry));
 
@@ -1029,7 +1029,7 @@ void Canvas::DrawCircle(const Point& center,
       !paint.mask_blur_descriptor.has_value()) {
     auto params = UberSDFParameters::MakeCircle(
         /*color=*/paint.color, /*center=*/center, /*radius=*/radius,
-        /*stroke=*/paint.GetOptionalStroke());
+        /*stroke=*/paint.GetStroke());
     auto geometry = std::make_unique<UberSDFGeometry>(params);
     auto contents = UberSDFContents::Make(params, std::move(geometry));
 
@@ -1929,7 +1929,7 @@ void Canvas::DrawTextFrame(const std::shared_ptr<TextFrame>& text_frame,
   text_contents->SetScreenTransform(GetCurrentTransform());
   text_contents->SetForceTextColor(paint.mask_blur_descriptor.has_value());
   text_contents->SetColor(paint.color);
-  text_contents->SetTextProperties(paint.color, paint.GetOptionalStroke());
+  text_contents->SetTextProperties(paint.color, paint.GetStroke());
 
   entity.SetTransform(GetCurrentTransform());
 

--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -831,9 +831,7 @@ void Canvas::DrawRect(const Rect& rect, const Paint& paint) {
       !paint.mask_blur_descriptor.has_value()) {
     auto params = UberSDFParameters::MakeRect(
         /*color=*/paint.color, /*rect=*/rect,
-        /*stroke=*/paint.style == Paint::Style::kStroke
-            ? std::make_optional(paint.stroke)
-            : std::nullopt);
+        /*stroke=*/paint.GetOptionalStroke());
     auto geometry = std::make_unique<UberSDFGeometry>(params);
     auto contents = UberSDFContents::Make(params, std::move(geometry));
 
@@ -1031,9 +1029,7 @@ void Canvas::DrawCircle(const Point& center,
       !paint.mask_blur_descriptor.has_value()) {
     auto params = UberSDFParameters::MakeCircle(
         /*color=*/paint.color, /*center=*/center, /*radius=*/radius,
-        /*stroke=*/paint.style == Paint::Style::kStroke
-            ? std::make_optional(paint.stroke)
-            : std::nullopt);
+        /*stroke=*/paint.GetOptionalStroke());
     auto geometry = std::make_unique<UberSDFGeometry>(params);
     auto contents = UberSDFContents::Make(params, std::move(geometry));
 
@@ -1933,10 +1929,7 @@ void Canvas::DrawTextFrame(const std::shared_ptr<TextFrame>& text_frame,
   text_contents->SetScreenTransform(GetCurrentTransform());
   text_contents->SetForceTextColor(paint.mask_blur_descriptor.has_value());
   text_contents->SetColor(paint.color);
-  text_contents->SetTextProperties(paint.color,
-                                   paint.style == Paint::Style::kStroke
-                                       ? std::optional(paint.stroke)
-                                       : std::nullopt);
+  text_contents->SetTextProperties(paint.color, paint.GetOptionalStroke());
 
   entity.SetTransform(GetCurrentTransform());
 

--- a/engine/src/flutter/impeller/display_list/dl_dispatcher.cc
+++ b/engine/src/flutter/impeller/display_list/dl_dispatcher.cc
@@ -1085,9 +1085,7 @@ void FirstPassDispatcher::drawText(const std::shared_ptr<flutter::DlText>& text,
     return;
   }
 
-  if (paint_.style == Paint::Style::kStroke) {
-    properties.stroke = paint_.stroke;
-  }
+  properties.stroke = paint_.GetOptionalStroke();
 
   if (text_frame->HasColor()) {
     // Alpha is always applied when rendering, remove it here so

--- a/engine/src/flutter/impeller/display_list/dl_dispatcher.cc
+++ b/engine/src/flutter/impeller/display_list/dl_dispatcher.cc
@@ -1085,7 +1085,7 @@ void FirstPassDispatcher::drawText(const std::shared_ptr<flutter::DlText>& text,
     return;
   }
 
-  properties.stroke = paint_.GetOptionalStroke();
+  properties.stroke = paint_.GetStroke();
 
   if (text_frame->HasColor()) {
     // Alpha is always applied when rendering, remove it here so

--- a/engine/src/flutter/impeller/display_list/paint.h
+++ b/engine/src/flutter/impeller/display_list/paint.h
@@ -85,6 +85,18 @@ struct Paint {
 
   std::optional<MaskBlurDescriptor> mask_blur_descriptor;
 
+  /// @brief   Return an optional StrokeParameters if this Paint is a stroked
+  ///          Paint, otherwise return a nullopt.
+  /// @return  An optional set of StrokeParameters
+  std::optional<StrokeParameters> GetOptionalStroke() const {
+    switch (style) {
+      case Style::kFill:
+        return std::nullopt;
+      case Style::kStroke:
+        return stroke;
+    }
+  };
+
   /// @brief      Wrap this paint's configured filters to the given contents.
   /// @param[in]  input           The contents to wrap with paint's filters.
   /// @return     The filter-wrapped contents. If there are no filters that need

--- a/engine/src/flutter/impeller/display_list/paint.h
+++ b/engine/src/flutter/impeller/display_list/paint.h
@@ -88,14 +88,9 @@ struct Paint {
   /// @brief   Return an optional StrokeParameters if this Paint is a stroked
   ///          Paint, otherwise return a nullopt.
   /// @return  An optional set of StrokeParameters
-  std::optional<StrokeParameters> GetOptionalStroke() const {
-    switch (style) {
-      case Style::kFill:
-        return std::nullopt;
-      case Style::kStroke:
-        return stroke;
-    }
-  };
+  std::optional<StrokeParameters> GetStroke() const {
+    return (style == Style::kStroke) ? std::optional(stroke) : std::nullopt;
+  }
 
   /// @brief      Wrap this paint's configured filters to the given contents.
   /// @param[in]  input           The contents to wrap with paint's filters.

--- a/engine/src/flutter/impeller/display_list/paint_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/paint_unittests.cc
@@ -14,6 +14,41 @@
 namespace impeller {
 namespace testing {
 
+TEST(PaintTest, OptionalStrokeWithFill) {
+  Paint paint;
+  paint.style = Paint::Style::kFill;
+  paint.stroke.cap = Cap::kRound;
+  paint.stroke.join = Join::kRound;
+  paint.stroke.width = 20.0f;
+  paint.stroke.miter_limit = 100.0f;
+
+  EXPECT_FALSE(paint.GetOptionalStroke().has_value());
+  // Even though optional stroke wasn't returned, the underlying values
+  // are still in the Paint.
+  EXPECT_EQ(paint.stroke.cap, Cap::kRound);
+  EXPECT_EQ(paint.stroke.join, Join::kRound);
+  EXPECT_EQ(paint.stroke.width, 20.0f);
+  EXPECT_EQ(paint.stroke.miter_limit, 100.0f);
+}
+
+TEST(PaintTest, OptionalStrokeWithStroke) {
+  Paint paint;
+  paint.style = Paint::Style::kStroke;
+  paint.stroke.cap = Cap::kRound;
+  paint.stroke.join = Join::kRound;
+  paint.stroke.width = 20.0f;
+  paint.stroke.miter_limit = 100.0f;
+
+  std::optional<StrokeParameters> optional_stroke = paint.GetOptionalStroke();
+  EXPECT_TRUE(optional_stroke.has_value());
+  if (optional_stroke.has_value()) {  // Test to keep clang-tidy happy.
+    EXPECT_EQ(optional_stroke->cap, Cap::kRound);
+    EXPECT_EQ(optional_stroke->join, Join::kRound);
+    EXPECT_EQ(optional_stroke->width, 20.0f);
+    EXPECT_EQ(optional_stroke->miter_limit, 100.0f);
+  }
+}
+
 TEST(PaintTest, GradientStopConversion) {
   // Typical gradient.
   std::vector<flutter::DlColor> colors = {flutter::DlColor::kBlue(),

--- a/engine/src/flutter/impeller/display_list/paint_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/paint_unittests.cc
@@ -22,7 +22,7 @@ TEST(PaintTest, OptionalStrokeWithFill) {
   paint.stroke.width = 20.0f;
   paint.stroke.miter_limit = 100.0f;
 
-  EXPECT_FALSE(paint.GetOptionalStroke().has_value());
+  EXPECT_FALSE(paint.GetStroke().has_value());
   // Even though optional stroke wasn't returned, the underlying values
   // are still in the Paint.
   EXPECT_EQ(paint.stroke.cap, Cap::kRound);
@@ -39,7 +39,7 @@ TEST(PaintTest, OptionalStrokeWithStroke) {
   paint.stroke.width = 20.0f;
   paint.stroke.miter_limit = 100.0f;
 
-  std::optional<StrokeParameters> optional_stroke = paint.GetOptionalStroke();
+  std::optional<StrokeParameters> optional_stroke = paint.GetStroke();
   EXPECT_TRUE(optional_stroke.has_value());
   if (optional_stroke.has_value()) {  // Test to keep clang-tidy happy.
     EXPECT_EQ(optional_stroke->cap, Cap::kRound);


### PR DESCRIPTION
There are a few places where a set of stroke parameters are provided as an `std::optional<StrokeParameters>` object, but the construction of that optional value requires conditional evaluation of the properties of the Paint object. This PR adds a new getter on Paint that optional provides the StrokeParameters only if the paint is a stroking paint.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.