### PR TITLE
Make exceptions thrown by JNI calls to Image.getHardwareBuffer non-fatal

### DIFF
--- a/engine/src/flutter/shell/platform/android/BUILD.gn
+++ b/engine/src/flutter/shell/platform/android/BUILD.gn
@@ -48,6 +48,7 @@ executable("flutter_shell_native_unittests") {
     "apk_asset_provider_unittests.cc",
     "flutter_shell_native_unittests.cc",
     "image_lru_unittests.cc",
+    "platform_view_android_jni_impl_unittests.cc",
     "platform_view_android_unittests.cc",
   ]
   if (!slimpeller) {
@@ -58,6 +59,7 @@ executable("flutter_shell_native_unittests") {
     ":flutter_shell_native_src",
     "//flutter/fml",
     "//flutter/shell/platform/android/jni:jni_mock",
+    "//flutter/shell/platform/android/jni:mock_jni_env",
     "//flutter/third_party/googletest:gmock",
     "//flutter/third_party/googletest:gtest",
   ]

--- a/engine/src/flutter/shell/platform/android/image_external_texture_gl.cc
+++ b/engine/src/flutter/shell/platform/android/image_external_texture_gl.cc
@@ -72,6 +72,9 @@ void ImageExternalTextureGL::ProcessFrame(PaintContext& context,
     return;
   }
   JavaLocalRef hardware_buffer = HardwareBufferFor(image);
+  if (hardware_buffer.is_null()) {
+    return;
+  }
   UpdateImage(hardware_buffer, bounds, context);
   CloseHardwareBuffer(hardware_buffer);
 }

--- a/engine/src/flutter/shell/platform/android/image_external_texture_vk_impeller.cc
+++ b/engine/src/flutter/shell/platform/android/image_external_texture_vk_impeller.cc
@@ -43,6 +43,9 @@ void ImageExternalTextureVKImpeller::ProcessFrame(PaintContext& context,
     return;
   }
   JavaLocalRef hardware_buffer = HardwareBufferFor(image);
+  if (hardware_buffer.is_null()) {
+    return;
+  }
   AHardwareBuffer* latest_hardware_buffer = AHardwareBufferFor(hardware_buffer);
 
   auto hb_desc =

--- a/engine/src/flutter/shell/platform/android/jni/BUILD.gn
+++ b/engine/src/flutter/shell/platform/android/jni/BUILD.gn
@@ -32,6 +32,14 @@ source_set("jni_mock") {
   deps = [ ":jni" ]
 }
 
+source_set("mock_jni_env") {
+  testonly = true
+
+  sources = [ "mock_jni_env.h" ]
+
+  public_configs = [ "//flutter:config" ]
+}
+
 test_fixtures("jni_fixtures") {
   fixtures = []
 }

--- a/engine/src/flutter/shell/platform/android/jni/mock_jni_env.h
+++ b/engine/src/flutter/shell/platform/android/jni/mock_jni_env.h
@@ -51,6 +51,7 @@ class MockableJNIEnv : public JNIEnv {
     // Replace the JNIEnv's function table with wrappers that invoke the
     // mockable virtual methods in this class.
     functions = &jni_;
+    jni_.CallObjectMethod = WrapCallObjectMethod;
     jni_.CallObjectMethodV = WrapCallObjectMethodV;
     jni_.DeleteGlobalRef = WrapDeleteGlobalRef;
     jni_.DeleteLocalRef = WrapDeleteLocalRef;

--- a/engine/src/flutter/shell/platform/android/jni/mock_jni_env.h
+++ b/engine/src/flutter/shell/platform/android/jni/mock_jni_env.h
@@ -1,0 +1,214 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_ANDROID_JNI_MOCK_JNI_ENV_H_
+#define FLUTTER_SHELL_PLATFORM_ANDROID_JNI_MOCK_JNI_ENV_H_
+
+#include <jni.h>
+
+namespace flutter {
+
+class MockJavaVM : public JavaVM {
+ public:
+  MockJavaVM() {
+    functions = &jni_invoke_;
+
+    jni_invoke_.DestroyJavaVM = DoDestroyJavaVM;
+    jni_invoke_.AttachCurrentThread = DoAttachCurrentThread;
+    jni_invoke_.DetachCurrentThread = DoDetachCurrentThread;
+    jni_invoke_.GetEnv = DoGetEnv;
+    jni_invoke_.AttachCurrentThreadAsDaemon = DoAttachCurrentThreadAsDaemon;
+  }
+
+  void SetJNIEnv(JNIEnv* env) { env_ = env; }
+
+ private:
+  static jint DoDestroyJavaVM(JavaVM* vm) { return JNI_OK; }
+  static jint DoAttachCurrentThread(JavaVM* vm,
+                                    JNIEnv** p_env,
+                                    void* thr_args) {
+    return JNI_OK;
+  }
+  static jint DoDetachCurrentThread(JavaVM* vm) { return JNI_OK; }
+  static jint DoGetEnv(JavaVM* vm, void** env, jint version) {
+    *env = static_cast<MockJavaVM*>(vm)->env_;
+    return JNI_OK;
+  }
+  static jint DoAttachCurrentThreadAsDaemon(JavaVM* vm,
+                                            JNIEnv** p_env,
+                                            void* thr_args) {
+    return JNI_OK;
+  }
+
+  JNIEnv* env_ = nullptr;
+  JNIInvokeInterface jni_invoke_;
+};
+
+class MockableJNIEnv : public JNIEnv {
+ public:
+  MockableJNIEnv() {
+    // Replace the JNIEnv's function table with wrappers that invoke the
+    // mockable virtual methods in this class.
+    functions = &jni_;
+    jni_.CallObjectMethodV = WrapCallObjectMethodV;
+    jni_.DeleteGlobalRef = WrapDeleteGlobalRef;
+    jni_.DeleteLocalRef = WrapDeleteLocalRef;
+    jni_.ExceptionCheck = WrapExceptionCheck;
+    jni_.ExceptionClear = WrapExceptionClear;
+    jni_.ExceptionDescribe = WrapExceptionDescribe;
+    jni_.ExceptionOccurred = WrapExceptionOccurred;
+    jni_.FindClass = WrapFindClass;
+    jni_.GetFieldID = WrapGetFieldID;
+    jni_.GetMethodID = WrapGetMethodID;
+    jni_.GetObjectRefType = WrapGetObjectRefType;
+    jni_.GetStaticFieldID = WrapGetStaticFieldID;
+    jni_.GetStaticMethodID = WrapGetStaticMethodID;
+    jni_.NewGlobalRef = WrapNewGlobalRef;
+    jni_.NewLocalRef = WrapNewLocalRef;
+    jni_.RegisterNatives = WrapRegisterNatives;
+  }
+
+  virtual jobject CallObjectMethodV(jobject, jmethodID, va_list) = 0;
+  virtual void DeleteGlobalRef(jobject) = 0;
+  virtual void DeleteLocalRef(jobject) = 0;
+  virtual jboolean ExceptionCheck() = 0;
+  virtual void ExceptionClear() = 0;
+  virtual void ExceptionDescribe() = 0;
+  virtual jthrowable ExceptionOccurred() = 0;
+  virtual jclass FindClass(const char*) = 0;
+  virtual jfieldID GetFieldID(jclass, const char*, const char*) = 0;
+  virtual jmethodID GetMethodID(jclass, const char*, const char*) = 0;
+  virtual jobjectRefType GetObjectRefType(jobject) = 0;
+  virtual jfieldID GetStaticFieldID(jclass, const char*, const char*) = 0;
+  virtual jmethodID GetStaticMethodID(jclass, const char*, const char*) = 0;
+  virtual jobject NewGlobalRef(jobject) = 0;
+  virtual jobject NewLocalRef(jobject) = 0;
+  virtual jint RegisterNatives(jclass, const JNINativeMethod*, jint) = 0;
+
+ private:
+  static jobject WrapCallObjectMethod(JNIEnv* env,
+                                      jobject obj,
+                                      jmethodID methodID,
+                                      ...) {
+    va_list args;
+    va_start(args, methodID);
+    jobject result = WrapCallObjectMethodV(env, obj, methodID, args);
+    va_end(args);
+    return result;
+  }
+  static jobject WrapCallObjectMethodV(JNIEnv* env,
+                                       jobject obj,
+                                       jmethodID methodID,
+                                       va_list args) {
+    return static_cast<MockableJNIEnv*>(env)->CallObjectMethodV(obj, methodID,
+                                                                args);
+  }
+  static void WrapDeleteGlobalRef(JNIEnv* env, jobject globalRef) {
+    static_cast<MockableJNIEnv*>(env)->DeleteGlobalRef(globalRef);
+  }
+  static void WrapDeleteLocalRef(JNIEnv* env, jobject localRef) {
+    static_cast<MockableJNIEnv*>(env)->DeleteLocalRef(localRef);
+  }
+  static jboolean WrapExceptionCheck(JNIEnv* env) {
+    return static_cast<MockableJNIEnv*>(env)->ExceptionCheck();
+  }
+  static void WrapExceptionClear(JNIEnv* env) {
+    static_cast<MockableJNIEnv*>(env)->ExceptionClear();
+  }
+  static void WrapExceptionDescribe(JNIEnv* env) {
+    static_cast<MockableJNIEnv*>(env)->ExceptionDescribe();
+  }
+  static jthrowable WrapExceptionOccurred(JNIEnv* env) {
+    return static_cast<MockableJNIEnv*>(env)->ExceptionOccurred();
+  }
+  static jclass WrapFindClass(JNIEnv* env, const char* name) {
+    return static_cast<MockableJNIEnv*>(env)->FindClass(name);
+  }
+  static jfieldID WrapGetFieldID(JNIEnv* env,
+                                 jclass clazz,
+                                 const char* name,
+                                 const char* sig) {
+    return static_cast<MockableJNIEnv*>(env)->GetFieldID(clazz, name, sig);
+  }
+  static jmethodID WrapGetMethodID(JNIEnv* env,
+                                   jclass clazz,
+                                   const char* name,
+                                   const char* sig) {
+    return static_cast<MockableJNIEnv*>(env)->GetMethodID(clazz, name, sig);
+  }
+  static jobjectRefType WrapGetObjectRefType(JNIEnv* env, jobject obj) {
+    return static_cast<MockableJNIEnv*>(env)->GetObjectRefType(obj);
+  }
+  static jfieldID WrapGetStaticFieldID(JNIEnv* env,
+                                       jclass clazz,
+                                       const char* name,
+                                       const char* sig) {
+    return static_cast<MockableJNIEnv*>(env)->GetStaticFieldID(clazz, name,
+                                                               sig);
+  }
+  static jmethodID WrapGetStaticMethodID(JNIEnv* env,
+                                         jclass clazz,
+                                         const char* name,
+                                         const char* sig) {
+    return static_cast<MockableJNIEnv*>(env)->GetStaticMethodID(clazz, name,
+                                                                sig);
+  }
+  static jobject WrapNewGlobalRef(JNIEnv* env, jobject ref) {
+    return static_cast<MockableJNIEnv*>(env)->NewGlobalRef(ref);
+  }
+  static jobject WrapNewLocalRef(JNIEnv* env, jobject ref) {
+    return static_cast<MockableJNIEnv*>(env)->NewLocalRef(ref);
+  }
+  static jint WrapRegisterNatives(JNIEnv* env,
+                                  jclass clazz,
+                                  const JNINativeMethod* methods,
+                                  jint nMethods) {
+    return static_cast<MockableJNIEnv*>(env)->RegisterNatives(clazz, methods,
+                                                              nMethods);
+  }
+
+  JNINativeInterface jni_ = {};
+};
+
+class MockJNIEnv : public MockableJNIEnv {
+ public:
+  MOCK_METHOD(jobject,
+              CallObjectMethodV,
+              (jobject, jmethodID, va_list),
+              (override));
+  MOCK_METHOD(void, DeleteGlobalRef, (jobject), (override));
+  MOCK_METHOD(void, DeleteLocalRef, (jobject), (override));
+  MOCK_METHOD(jboolean, ExceptionCheck, (), (override));
+  MOCK_METHOD(void, ExceptionClear, (), (override));
+  MOCK_METHOD(void, ExceptionDescribe, (), (override));
+  MOCK_METHOD(jthrowable, ExceptionOccurred, (), (override));
+  MOCK_METHOD(jclass, FindClass, (const char*), (override));
+  MOCK_METHOD(jfieldID,
+              GetFieldID,
+              (jclass, const char*, const char*),
+              (override));
+  MOCK_METHOD(jmethodID,
+              GetMethodID,
+              (jclass, const char*, const char*),
+              (override));
+  MOCK_METHOD(jobjectRefType, GetObjectRefType, (jobject), (override));
+  MOCK_METHOD(jfieldID,
+              GetStaticFieldID,
+              (jclass, const char*, const char*),
+              (override));
+  MOCK_METHOD(jmethodID,
+              GetStaticMethodID,
+              (jclass, const char*, const char*),
+              (override));
+  MOCK_METHOD(jobject, NewGlobalRef, (jobject), (override));
+  MOCK_METHOD(jobject, NewLocalRef, (jobject), (override));
+  MOCK_METHOD(jint,
+              RegisterNatives,
+              (jclass, const JNINativeMethod*, jint),
+              (override));
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_ANDROID_JNI_MOCK_JNI_ENV_H_

--- a/engine/src/flutter/shell/platform/android/platform_view_android_jni_impl.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android_jni_impl.cc
@@ -1697,7 +1697,9 @@ JavaLocalRef PlatformViewAndroidJNIImpl::ImageGetHardwareBuffer(
   JavaLocalRef r = JavaLocalRef(
       env,
       env->CallObjectMethod(image.obj(), g_image_get_hardware_buffer_method));
-  FML_CHECK(fml::jni::CheckException(env));
+  if (fml::jni::ClearException(env, false)) {
+    return JavaLocalRef();
+  }
   return r;
 }
 

--- a/engine/src/flutter/shell/platform/android/platform_view_android_jni_impl_unittests.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android_jni_impl_unittests.cc
@@ -1,0 +1,95 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "flutter/fml/platform/android/jni_util.h"
+#include "flutter/fml/platform/android/jni_weak_ref.h"
+#include "flutter/fml/platform/android/scoped_java_ref.h"
+#include "flutter/shell/platform/android/jni/mock_jni_env.h"
+#include "flutter/shell/platform/android/platform_view_android.h"
+#include "flutter/shell/platform/android/platform_view_android_jni_impl.h"
+
+namespace flutter {
+namespace testing {
+
+using ::testing::_;
+using ::testing::Return;
+using ::testing::ReturnArg;
+
+class PlatformViewAndroidJNIImplTest : public ::testing::Test {
+ public:
+  static void SetUpTestSuite() {
+    static std::once_flag jvm_init_flag;
+    std::call_once(jvm_init_flag, SetUpJVM);
+  }
+
+ protected:
+  static void SetJNIEnv(JNIEnv* env) { jvm_.SetJNIEnv(env); }
+
+ private:
+  static MockJavaVM jvm_;
+  static void SetUpJVM();
+};
+
+MockJavaVM PlatformViewAndroidJNIImplTest::jvm_;
+
+void PlatformViewAndroidJNIImplTest::SetUpJVM() {
+  fml::jni::InitJavaVM(&jvm_);
+
+  MockJNIEnv mock_env;
+  SetJNIEnv(&mock_env);
+
+  const jclass kPlaceholderClass = reinterpret_cast<jclass>(100);
+  const jfieldID kPlaceholderFieldID = reinterpret_cast<jfieldID>(200);
+  const jmethodID kPlaceholderMethodID = reinterpret_cast<jmethodID>(300);
+
+  EXPECT_CALL(mock_env, GetObjectRefType(_))
+      .WillRepeatedly(Return(JNILocalRefType));
+  EXPECT_CALL(mock_env, NewLocalRef(_)).WillRepeatedly(ReturnArg<0>());
+  EXPECT_CALL(mock_env, DeleteLocalRef(_)).WillRepeatedly(Return());
+  EXPECT_CALL(mock_env, NewGlobalRef(_)).WillRepeatedly(ReturnArg<0>());
+  EXPECT_CALL(mock_env, DeleteGlobalRef(_)).WillRepeatedly(Return());
+  EXPECT_CALL(mock_env, FindClass(_)).WillRepeatedly(Return(kPlaceholderClass));
+  EXPECT_CALL(mock_env, GetFieldID(_, _, _))
+      .WillRepeatedly(Return(kPlaceholderFieldID));
+  EXPECT_CALL(mock_env, GetMethodID(_, _, _))
+      .WillRepeatedly(Return(kPlaceholderMethodID));
+  EXPECT_CALL(mock_env, GetStaticFieldID(_, _, _))
+      .WillRepeatedly(Return(kPlaceholderFieldID));
+  EXPECT_CALL(mock_env, GetStaticMethodID(_, _, _))
+      .WillRepeatedly(Return(kPlaceholderMethodID));
+  EXPECT_CALL(mock_env, ExceptionCheck()).WillRepeatedly(Return(JNI_FALSE));
+  EXPECT_CALL(mock_env, RegisterNatives(_, _, _)).WillRepeatedly(Return(0));
+
+  PlatformViewAndroid::Register(&mock_env);
+}
+
+TEST_F(PlatformViewAndroidJNIImplTest, ImageGetHardwareBufferException) {
+  MockJNIEnv mock_env;
+  SetJNIEnv(&mock_env);
+
+  // Call ImageGetHardwareBuffer and simulate throwing an exception.
+  // Verify that it clears the exception and does not abort the process.
+  EXPECT_CALL(mock_env, GetObjectRefType(_))
+      .WillRepeatedly(Return(JNILocalRefType));
+  EXPECT_CALL(mock_env, NewLocalRef(_)).WillRepeatedly(ReturnArg<0>());
+  EXPECT_CALL(mock_env, DeleteLocalRef(_)).WillRepeatedly(Return());
+  EXPECT_CALL(mock_env, CallObjectMethodV(_, _, _))
+      .WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(mock_env, ExceptionCheck()).WillOnce(Return(JNI_TRUE));
+  EXPECT_CALL(mock_env, ExceptionDescribe()).WillOnce(Return());
+  EXPECT_CALL(mock_env, ExceptionClear()).Times(1).WillOnce(Return());
+
+  fml::jni::JavaObjectWeakGlobalRef flutter_jni_object;
+  PlatformViewAndroidJNIImpl android_jni(flutter_jni_object);
+
+  fml::jni::ScopedJavaLocalRef<jobject> image(&mock_env,
+                                              reinterpret_cast<jobject>(123));
+  android_jni.ImageGetHardwareBuffer(image);
+}
+
+}  // namespace testing
+}  // namespace flutter

--- a/engine/src/flutter/shell/platform/android/platform_view_android_jni_impl_unittests.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android_jni_impl_unittests.cc
@@ -26,21 +26,33 @@ class PlatformViewAndroidJNIImplTest : public ::testing::Test {
     std::call_once(jvm_init_flag, SetUpJVM);
   }
 
- protected:
-  static void SetJNIEnv(JNIEnv* env) { jvm_.SetJNIEnv(env); }
-
  private:
+  friend class MockJNIEnvProvider;
   static MockJavaVM jvm_;
   static void SetUpJVM();
 };
 
 MockJavaVM PlatformViewAndroidJNIImplTest::jvm_;
 
+class MockJNIEnvProvider {
+ public:
+  MockJNIEnvProvider() {
+    PlatformViewAndroidJNIImplTest::jvm_.SetJNIEnv(&env_);
+  }
+  ~MockJNIEnvProvider() {
+    PlatformViewAndroidJNIImplTest::jvm_.SetJNIEnv(nullptr);
+  }
+  MockJNIEnv& env() { return env_; }
+
+ private:
+  MockJNIEnv env_;
+};
+
 void PlatformViewAndroidJNIImplTest::SetUpJVM() {
   fml::jni::InitJavaVM(&jvm_);
 
-  MockJNIEnv mock_env;
-  SetJNIEnv(&mock_env);
+  MockJNIEnvProvider env_provider;
+  MockJNIEnv& mock_env = env_provider.env();
 
   const jclass kPlaceholderClass = reinterpret_cast<jclass>(100);
   const jfieldID kPlaceholderFieldID = reinterpret_cast<jfieldID>(200);
@@ -68,8 +80,8 @@ void PlatformViewAndroidJNIImplTest::SetUpJVM() {
 }
 
 TEST_F(PlatformViewAndroidJNIImplTest, ImageGetHardwareBufferException) {
-  MockJNIEnv mock_env;
-  SetJNIEnv(&mock_env);
+  MockJNIEnvProvider env_provider;
+  MockJNIEnv& mock_env = env_provider.env();
 
   // Call ImageGetHardwareBuffer and simulate throwing an exception.
   // Verify that it clears the exception and does not abort the process.


### PR DESCRIPTION
If a call to Android's Image.getHardwareBuffer API made by PlatformViewAndroidJNIImpl::ImageGetHardwareBuffer throws an exception, then the ImageExternalTexture can skip rendering of this frame.  It is excessive to make this a fatal exception that terminates the process.

Fixes https://github.com/flutter/flutter/issues/175267
Fixes https://github.com/flutter/flutter/issues/180804