### PR TITLE
[ios][pv] Reland platform view hitTest approach (again)

### DIFF
--- a/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
+++ b/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
@@ -123,6 +123,38 @@ static const CGFloat kStandardTimeOut = 60.0;
   XCTAssertTrue([successText waitForExistenceWithTimeout:60]);
 }
 
+
+- (void)testPlatformViewDrawingWebViewCannotBeDrawnWhenContextMenuIsShown {
+  XCUIElement *entranceButton = self.app.buttons[@"drawing web view behind context menu test"];
+  XCTAssertTrue([entranceButton waitForExistenceWithTimeout:kStandardTimeOut]);
+  [entranceButton tap];
+
+  XCUIElement *platformView = self.app.webViews[@"platform_view[0]"];
+  XCTAssertTrue([platformView waitForExistenceWithTimeout:kStandardTimeOut]);
+
+  // expand the context menu.
+  XCUIElement *showMenuButton = self.app.buttons[@"Show menu"];
+  XCTAssertTrue([showMenuButton waitForExistenceWithTimeout:kStandardTimeOut]);
+  [showMenuButton tap];
+  XCUIElement *menuItem = self.app.buttons[@"menu button 1"];
+  XCTAssertTrue([menuItem waitForExistenceWithTimeout:kStandardTimeOut]);
+
+  // draw on the canvas
+  XCUICoordinate *center = [self.app coordinateWithNormalizedOffset:CGVectorMake(0.5, 0.5)];
+  XCUICoordinate *end = [center coordinateWithOffset:CGVectorMake(0.0, 100.0)];
+  [center pressForDuration:0.1 thenDragToCoordinate:end];
+
+  // Dismiss the context menu (so that we can find web view under the accessibility tree).
+  // Since context menu is on top right, we tap on the bottom left corner to avoid tapping within the menu area.
+  XCUICoordinate *bottomLeft = [self.app coordinateWithNormalizedOffset:CGVectorMake(0.05, 0.95)];
+  [bottomLeft tap];
+  XCTAssertTrue([menuItem waitForNonExistenceWithTimeout:kStandardTimeOut]);
+
+  // Verify that the web view does not have any pixels drawn
+  XCUIElement *pixelCountLabel = self.app.staticTexts[@"pixel count: 0"];
+  XCTAssertTrue([pixelCountLabel waitForExistenceWithTimeout:kStandardTimeOut]);
+}
+
 - (void)testPlatformViewFakeAdMobBannerTappableForScrollableListScenario {
   XCUIElement *entranceButton = self.app.buttons[@"admob banner in scrollable list test"];
   XCTAssertTrue([entranceButton waitForExistenceWithTimeout:kStandardTimeOut]);

--- a/dev/integration_tests/ios_platform_view_tests/ios/Runner.xcodeproj/project.pbxproj
+++ b/dev/integration_tests/ios_platform_view_tests/ios/Runner.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		E09898DE2853DBE800064317 /* ViewFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = E09898DD2853DBE800064317 /* ViewFactory.m */; };
 		E09898E12853DC3C00064317 /* TextFieldFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = E09898E02853DC3C00064317 /* TextFieldFactory.m */; };
 		E09898E92853E9F000064317 /* PlatformViewUITests.m in Sources */ = {isa = PBXBuildFile; fileRef = E09898E82853E9F000064317 /* PlatformViewUITests.m */; };
+		E0DC4BCE2F69D8FA00CBE9CF /* drawing_website.html in Resources */ = {isa = PBXBuildFile; fileRef = E0DC4BCD2F69D8FA00CBE9CF /* drawing_website.html */; };
+		E0DC4BD12F69D91800CBE9CF /* DrawingWebViewFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = E0DC4BD02F69D91800CBE9CF /* DrawingWebViewFactory.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -75,6 +77,9 @@
 		E09898E02853DC3C00064317 /* TextFieldFactory.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TextFieldFactory.m; sourceTree = "<group>"; };
 		E09898E62853E9F000064317 /* PlatformViewUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PlatformViewUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E09898E82853E9F000064317 /* PlatformViewUITests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PlatformViewUITests.m; sourceTree = "<group>"; };
+		E0DC4BCD2F69D8FA00CBE9CF /* drawing_website.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = drawing_website.html; sourceTree = "<group>"; };
+		E0DC4BCF2F69D90D00CBE9CF /* DrawingWebViewFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DrawingWebViewFactory.h; sourceTree = "<group>"; };
+		E0DC4BD02F69D91800CBE9CF /* DrawingWebViewFactory.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DrawingWebViewFactory.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -138,10 +143,13 @@
 				E09898DD2853DBE800064317 /* ViewFactory.m */,
 				E090076F2F3A6FE400B349AE /* WebViewFactory.h */,
 				E09007702F3A6FE400B349AE /* WebViewFactory.m */,
+				E0DC4BCF2F69D90D00CBE9CF /* DrawingWebViewFactory.h */,
+				E0DC4BD02F69D91800CBE9CF /* DrawingWebViewFactory.m */,
 				E090082E2F47BE8500B349AE /* LinkNavigationWebView.h */,
 				E090082F2F47BE8500B349AE /* LinkNavigationWebView.m */,
 				E09008282F47BAFB00B349AE /* FakeAdMobBannerFactory.h */,
 				E09008292F47BAFB00B349AE /* FakeAdMobBannerFactory.m */,
+				E0DC4BCD2F69D8FA00CBE9CF /* drawing_website.html */,
 				97C146FA1CF9000F007C117D /* Main.storyboard */,
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
@@ -252,6 +260,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E0DC4BCE2F69D8FA00CBE9CF /* drawing_website.html in Resources */,
 				97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */,
 				3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */,
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
@@ -314,6 +323,7 @@
 				E090082A2F47BAFB00B349AE /* FakeAdMobBannerFactory.m in Sources */,
 				E0440002299C782300D02513 /* ButtonFactory.m in Sources */,
 				E09898E12853DC3C00064317 /* TextFieldFactory.m in Sources */,
+				E0DC4BD12F69D91800CBE9CF /* DrawingWebViewFactory.m in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 				E09898DE2853DBE800064317 /* ViewFactory.m in Sources */,
 			);

--- a/dev/integration_tests/ios_platform_view_tests/ios/Runner/AppDelegate.m
+++ b/dev/integration_tests/ios_platform_view_tests/ios/Runner/AppDelegate.m
@@ -8,6 +8,7 @@
 #import "TextFieldFactory.h"
 #import "ButtonFactory.h"
 #import "WebViewFactory.h"
+#import "DrawingWebViewFactory.h"
 #import "FakeAdMobBannerFactory.h"
 
 @implementation AppDelegate
@@ -21,6 +22,7 @@
   [registrar registerViewFactory:[[TextFieldFactory alloc] init] withId:@"platform_text_field"];
   [registrar registerViewFactory:[[ButtonFactory alloc] init] withId:@"platform_button"];
   [registrar registerViewFactory:[[WebViewFactory alloc] init] withId:@"platform_web_view"];
+  [registrar registerViewFactory:[[DrawingWebViewFactory alloc] init] withId:@"platform_drawing_web_view"];
   [registrar registerViewFactory:[[FakeAdMobBannerFactory alloc] init] withId:@"platform_fake_admob_banner"];
   return [super application:application didFinishLaunchingWithOptions:launchOptions];
 }

--- a/dev/integration_tests/ios_platform_view_tests/ios/Runner/DrawingWebViewFactory.h
+++ b/dev/integration_tests/ios_platform_view_tests/ios/Runner/DrawingWebViewFactory.h
@@ -1,0 +1,14 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Flutter/Flutter.h>
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface DrawingWebViewFactory: NSObject<FlutterPlatformViewFactory>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/dev/integration_tests/ios_platform_view_tests/ios/Runner/DrawingWebViewFactory.m
+++ b/dev/integration_tests/ios_platform_view_tests/ios/Runner/DrawingWebViewFactory.m
@@ -1,0 +1,38 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "DrawingWebViewFactory.h"
+#import <WebKit/WebKit.h>
+
+@interface DrawingWebViewPlatformView: NSObject<FlutterPlatformView>
+@property (strong, nonatomic) WKWebView *platformView;
+@end
+
+@implementation DrawingWebViewPlatformView
+
+- (instancetype)init
+{
+  self = [super init];
+  if (self) {
+    _platformView = [[WKWebView alloc] init];
+    NSString *htmlPath = [[NSBundle mainBundle] pathForResource:@"drawing_website" ofType:@"html"];
+    NSURL *htmlURL = [NSURL fileURLWithPath:htmlPath];
+    [self.platformView loadFileURL:htmlURL allowingReadAccessToURL:[htmlURL URLByDeletingLastPathComponent]];
+  }
+  return self;
+}
+
+- (UIView *)view {
+  return self.platformView;
+}
+
+@end
+
+@implementation DrawingWebViewFactory
+
+- (NSObject<FlutterPlatformView> *)createWithFrame:(CGRect)frame viewIdentifier:(int64_t)viewId arguments:(id)args {
+  return [[DrawingWebViewPlatformView alloc] init];
+}
+
+@end

--- a/dev/integration_tests/ios_platform_view_tests/ios/Runner/drawing_website.html
+++ b/dev/integration_tests/ios_platform_view_tests/ios/Runner/drawing_website.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no'>
+  <style>
+    body { margin: 0; overflow: hidden; background-color: white; touch-action: none; }
+    canvas { display: block; width: 100vw; height: 100vh; }
+    #label { position: absolute; top: 10px; left: 10px; font-size: 20px; font-family: sans-serif; pointer-events: none; }
+  </style>
+</head>
+<body>
+  <div id='label'>pixel count: 0</div>
+  <canvas id='canvas'></canvas>
+  <script>
+    const canvas = document.getElementById('canvas');
+    const ctx = canvas.getContext('2d');
+    const label = document.getElementById('label');
+    let pixelCount = 0;
+    function resize() {
+      canvas.width = window.innerWidth;
+      canvas.height = window.innerHeight;
+    }
+    window.addEventListener('resize', resize);
+    resize();
+    function drawPixel(x, y) {
+      ctx.fillStyle = 'black';
+      ctx.fillRect(x, y, 2, 2);
+      pixelCount++;
+      label.innerText = 'pixel count: ' + pixelCount;
+    }
+    function handleTouch(e) {
+      e.preventDefault();
+      for (let i = 0; i < e.changedTouches.length; i++) {
+        const touch = e.changedTouches[i];
+        drawPixel(touch.clientX, touch.clientY);
+      }
+    }
+    canvas.addEventListener('touchstart', handleTouch, {passive: false});
+    canvas.addEventListener('touchmove', handleTouch, {passive: false});
+  </script>
+</body>
+</html>

--- a/dev/integration_tests/ios_platform_view_tests/ios/Runner/drawing_website.html
+++ b/dev/integration_tests/ios_platform_view_tests/ios/Runner/drawing_website.html
@@ -1,4 +1,7 @@
-<!DOCTYPE html>
+<!DOCTYPE HTML>
+<!-- Copyright 2014 The Flutter Authors. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file. -->
 <html>
 <head>
   <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no'>

--- a/dev/integration_tests/ios_platform_view_tests/lib/main.dart
+++ b/dev/integration_tests/ios_platform_view_tests/lib/main.dart
@@ -103,6 +103,18 @@ class _MyHomePageState extends State<MyHomePage> {
             },
           ),
           TextButton(
+            key: const ValueKey<String>('drawing_web_view_behind_context_menu_test'),
+            child: const Text('drawing web view behind context menu test'),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute<DrawingWebViewBehindContextMenuTestPage>(
+                  builder: (BuildContext context) => const DrawingWebViewBehindContextMenuTestPage(),
+                ),
+              );
+            },
+          ),
+          TextButton(
             key: const ValueKey<String>('admob_banner_in_scrollable_list_test'),
             child: const Text('admob banner in scrollable list test'),
             onPressed: () {
@@ -274,6 +286,50 @@ class _WebViewBehindContextMenuTestPageState extends State<WebViewBehindContextM
           dimension: 500.0,
           child: UiKitView(
             viewType: 'platform_web_view',
+            creationParamsCodec: StandardMessageCodec(),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// A page to test a web view with drawing website cannot be drawn when a context menu is shown.
+/// See [this issue](https://github.com/flutter/flutter/issues/179916).
+class DrawingWebViewBehindContextMenuTestPage extends StatefulWidget {
+  const DrawingWebViewBehindContextMenuTestPage({super.key});
+
+  @override
+  State<DrawingWebViewBehindContextMenuTestPage> createState() => _DrawingWebViewBehindContextMenuTestPageState();
+}
+
+class _DrawingWebViewBehindContextMenuTestPageState extends State<DrawingWebViewBehindContextMenuTestPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Drawing web view behind context menu test'),
+        actions: <Widget>[
+          PopupMenuButton<String>(
+            icon: const Icon(Icons.more_vert),
+            onSelected: (String value) {},
+            itemBuilder: (BuildContext context) {
+              return <PopupMenuEntry<String>>[
+                const PopupMenuItem<String>(value: 'button 1', child: Text('menu button 1')),
+                const PopupMenuItem<String>(value: 'button 2', child: Text('menu button 2')),
+                const PopupMenuItem<String>(value: 'button 3', child: Text('menu button 3')),
+                const PopupMenuItem<String>(value: 'button 4', child: Text('menu button 4')),
+                const PopupMenuItem<String>(value: 'button 5', child: Text('menu button 5')),
+              ];
+            },
+          ),
+        ],
+      ),
+      body: const Center(
+        child: SizedBox.square(
+          dimension: 500.0,
+          child: UiKitView(
+            viewType: 'platform_drawing_web_view',
             creationParamsCodec: StandardMessageCodec(),
           ),
         ),

--- a/dev/integration_tests/ios_platform_view_tests/lib/main.dart
+++ b/dev/integration_tests/ios_platform_view_tests/lib/main.dart
@@ -109,7 +109,8 @@ class _MyHomePageState extends State<MyHomePage> {
               Navigator.push(
                 context,
                 MaterialPageRoute<DrawingWebViewBehindContextMenuTestPage>(
-                  builder: (BuildContext context) => const DrawingWebViewBehindContextMenuTestPage(),
+                  builder: (BuildContext context) =>
+                      const DrawingWebViewBehindContextMenuTestPage(),
                 ),
               );
             },
@@ -300,10 +301,12 @@ class DrawingWebViewBehindContextMenuTestPage extends StatefulWidget {
   const DrawingWebViewBehindContextMenuTestPage({super.key});
 
   @override
-  State<DrawingWebViewBehindContextMenuTestPage> createState() => _DrawingWebViewBehindContextMenuTestPageState();
+  State<DrawingWebViewBehindContextMenuTestPage> createState() =>
+      _DrawingWebViewBehindContextMenuTestPageState();
 }
 
-class _DrawingWebViewBehindContextMenuTestPageState extends State<DrawingWebViewBehindContextMenuTestPage> {
+class _DrawingWebViewBehindContextMenuTestPageState
+    extends State<DrawingWebViewBehindContextMenuTestPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(

--- a/engine/src/flutter/lib/ui/BUILD.gn
+++ b/engine/src/flutter/lib/ui/BUILD.gn
@@ -151,6 +151,7 @@ source_set("ui") {
     "window/platform_message_response_dart.h",
     "window/platform_message_response_dart_port.cc",
     "window/platform_message_response_dart_port.h",
+    "window/point_data.h",
     "window/pointer_data.cc",
     "window/pointer_data.h",
     "window/pointer_data_packet.cc",

--- a/engine/src/flutter/lib/ui/BUILD.gn
+++ b/engine/src/flutter/lib/ui/BUILD.gn
@@ -135,6 +135,7 @@ source_set("ui") {
     "text/paragraph_builder.h",
     "ui_dart_state.cc",
     "ui_dart_state.h",
+    "window/hit_test_response.h",
     "window/key_data.cc",
     "window/key_data.h",
     "window/key_data_packet.cc",

--- a/engine/src/flutter/lib/ui/hooks.dart
+++ b/engine/src/flutter/lib/ui/hooks.dart
@@ -374,6 +374,18 @@ void _dispatchPointerDataPacket(ByteData packet) {
   PlatformDispatcher.instance._dispatchPointerDataPacket(packet);
 }
 
+// TODO(hellohuanlin): rename function to _onHitTest.
+// See: https://github.com/flutter/flutter/issues/179762.
+@pragma('vm:entry-point')
+bool _platformViewShouldAcceptTouch(int viewId, double x, double y) {
+  assert(PlatformDispatcher.instance._views.containsKey(viewId), 'View $viewId does not exist.');
+  final FlutterView view = PlatformDispatcher.instance._views[viewId]!;
+  final offset = Offset(x, y);
+  final request = HitTestRequest(view: view, offset: offset);
+  final HitTestResponse response = PlatformDispatcher.instance._hitTest(request);
+  return response.isPlatformView;
+}
+
 @pragma('vm:entry-point')
 void _dispatchSemanticsAction(int viewId, int nodeId, int action, ByteData? args) {
   PlatformDispatcher.instance._dispatchSemanticsAction(viewId, nodeId, action, args);
@@ -481,6 +493,30 @@ void _invoke3<A1, A2, A3>(
     zone.runGuarded(() {
       callback(arg1, arg2, arg3);
     });
+  }
+}
+
+/// Invokes [callback] inside the given [zone] passing it [arg1],
+/// and returns a nullable result of the specified type.
+///
+/// The 1 in the name refers to the number of arguments expected by
+/// the callback (and thus passed to this function, in addition to the
+/// callback itself and the zone in which the callback is executed).
+R? _invoke1WithReturn<A1, R>(R Function(A1 a1)? callback, Zone zone, A1 arg1) {
+  if (callback == null) {
+    return null;
+  }
+  if (identical(zone, Zone.current)) {
+    return callback(arg1);
+  } else {
+    return runZonedGuarded(
+      () {
+        return callback(arg1);
+      },
+      (e, s) {
+        zone.handleUncaughtError(e, s);
+      },
+    );
   }
 }
 

--- a/engine/src/flutter/lib/ui/hooks.dart
+++ b/engine/src/flutter/lib/ui/hooks.dart
@@ -374,16 +374,22 @@ void _dispatchPointerDataPacket(ByteData packet) {
   PlatformDispatcher.instance._dispatchPointerDataPacket(packet);
 }
 
-// TODO(hellohuanlin): rename function to _onHitTest.
-// See: https://github.com/flutter/flutter/issues/179762.
+@pragma("vm:entry-point")
+class _HitTestResponse {
+  _HitTestResponse({required this.isPlatformView});
+
+  @pragma("vm:entry-point")
+  final bool isPlatformView;
+}
+
 @pragma('vm:entry-point')
-bool _platformViewShouldAcceptTouch(int viewId, double x, double y) {
+_HitTestResponse _hitTest(int viewId, double x, double y) {
   assert(PlatformDispatcher.instance._views.containsKey(viewId), 'View $viewId does not exist.');
   final FlutterView view = PlatformDispatcher.instance._views[viewId]!;
   final offset = Offset(x, y);
   final request = HitTestRequest(view: view, offset: offset);
   final HitTestResponse response = PlatformDispatcher.instance._hitTest(request);
-  return response.isPlatformView;
+  return _HitTestResponse(isPlatformView: response.isPlatformView);
 }
 
 @pragma('vm:entry-point')

--- a/engine/src/flutter/lib/ui/hooks.dart
+++ b/engine/src/flutter/lib/ui/hooks.dart
@@ -374,11 +374,11 @@ void _dispatchPointerDataPacket(ByteData packet) {
   PlatformDispatcher.instance._dispatchPointerDataPacket(packet);
 }
 
-@pragma("vm:entry-point")
+@pragma('vm:entry-point')
 class _HitTestResponse {
   _HitTestResponse({required this.isPlatformView});
 
-  @pragma("vm:entry-point")
+  @pragma('vm:entry-point')
   final bool isPlatformView;
 }
 

--- a/engine/src/flutter/lib/ui/hooks.dart
+++ b/engine/src/flutter/lib/ui/hooks.dart
@@ -376,10 +376,10 @@ void _dispatchPointerDataPacket(ByteData packet) {
 
 @pragma('vm:entry-point')
 class _HitTestResponse {
-  _HitTestResponse({required this.isPlatformView});
+  _HitTestResponse({required this.hasPlatformView});
 
   @pragma('vm:entry-point')
-  final bool isPlatformView;
+  final bool hasPlatformView;
 }
 
 @pragma('vm:entry-point')
@@ -389,7 +389,7 @@ _HitTestResponse _hitTest(int viewId, double x, double y) {
   final offset = Offset(x, y);
   final request = HitTestRequest(view: view, offset: offset);
   final HitTestResponse response = PlatformDispatcher.instance._hitTest(request);
-  return _HitTestResponse(isPlatformView: response.isPlatformView);
+  return _HitTestResponse(hasPlatformView: response.hasPlatformView);
 }
 
 @pragma('vm:entry-point')

--- a/engine/src/flutter/lib/ui/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/ui/platform_dispatcher.dart
@@ -43,6 +43,9 @@ typedef KeyDataCallback = bool Function(KeyData data);
 /// Signature for [PlatformDispatcher.onSemanticsActionEvent].
 typedef SemanticsActionEventCallback = void Function(SemanticsActionEvent action);
 
+/// Signature for [PlatformDispatcher.onHitTest].
+typedef HitTestCallback = HitTestResponse Function(HitTestRequest request);
+
 /// Signature for responses to platform messages.
 ///
 /// Used as a parameter to [PlatformDispatcher.sendPlatformMessage] and
@@ -1391,6 +1394,18 @@ class PlatformDispatcher {
     _onSemanticsActionEventZone = Zone.current;
   }
 
+  /// A callback invoked when the platform wants to hit test a [FlutterView].
+  ///
+  /// For example, this is used by iOS to determine if a gesture hits a
+  /// [UIKitView].
+  HitTestCallback? get onHitTest => _onHitTest;
+  HitTestCallback? _onHitTest;
+  Zone _onHitTestZone = Zone.root;
+  set onHitTest(HitTestCallback? callback) {
+    _onHitTest = callback;
+    _onHitTestZone = Zone.current;
+  }
+
   // Called from the engine via hooks.dart.
   void _updateFrameData(int frameNumber) {
     final FrameData previous = _frameData;
@@ -1426,6 +1441,15 @@ class PlatformDispatcher {
         arguments: args,
       ),
     );
+  }
+
+  HitTestResponse _hitTest(HitTestRequest request) {
+    return _invoke1WithReturn<HitTestRequest, HitTestResponse>(
+          onHitTest,
+          _onHitTestZone,
+          request,
+        ) ??
+        HitTestResponse.empty;
   }
 
   ErrorCallback? _onError;
@@ -3255,4 +3279,43 @@ enum ViewFocusDirection {
   ///
   /// This is typically result of the user pressing shift + tab.
   backward,
+}
+
+/// A request to evaluate the content of a view at a specific position.
+///
+/// See also:
+///
+/// * [PlatformDispatcher.onHitTest], the callback that the platform
+///   invokes to hit test a view at a specific position.
+/// * [HitTestResponse], the result of a hit test request.
+class HitTestRequest {
+  /// Creates a hit test request.
+  const HitTestRequest({required this.view, required this.offset});
+
+  /// The view that should be hit tested.
+  final FlutterView view;
+
+  /// The position in the [view] that should be hit tested.
+  final Offset offset;
+}
+
+/// The results of hit testing a view at a specific position.
+///
+/// See also:
+///
+/// * [PlatformDispatcher.onHitTest], the callback that the platform
+///   invokes to hit test a view at a specific position.
+/// * [HitTestRequest], the request to hit test a view at a specific position.
+class HitTestResponse {
+  /// Creates a hit test response.
+  const HitTestResponse({required this.isPlatformView});
+
+  /// A response with no hit entries.
+  static const HitTestResponse empty = HitTestResponse(isPlatformView: false);
+
+  /// Whether the first hit test entry is a platform view.
+  ///
+  /// The first hit test entry is typically the child that is
+  /// visually "on top" (i.e., paints later).
+  final bool isPlatformView;
 }

--- a/engine/src/flutter/lib/ui/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/ui/platform_dispatcher.dart
@@ -3317,5 +3317,10 @@ class HitTestResponse {
   ///
   /// The first hit test entry is typically the child that is
   /// visually "on top" (i.e., paints later).
+  ///
+  /// See also:
+  ///
+  /// * [NativeHitTestTarget], the Flutter framework mixin that represents a hit test target
+  ///   backed by a platform view.
   final bool isPlatformView;
 }

--- a/engine/src/flutter/lib/ui/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/ui/platform_dispatcher.dart
@@ -3308,19 +3308,16 @@ class HitTestRequest {
 /// * [HitTestRequest], the request to hit test a view at a specific position.
 class HitTestResponse {
   /// Creates a hit test response.
-  const HitTestResponse({required this.isPlatformView});
+  const HitTestResponse({required this.hasPlatformView});
 
   /// A response with no hit entries.
-  static const HitTestResponse empty = HitTestResponse(isPlatformView: false);
+  static const HitTestResponse empty = HitTestResponse(hasPlatformView: false);
 
-  /// Whether the first hit test entry is a platform view.
-  ///
-  /// The first hit test entry is typically the child that is
-  /// visually "on top" (i.e., paints later).
+  /// Whether the hit test result contains a platform view.
   ///
   /// See also:
   ///
   /// * [NativeHitTestTarget], the Flutter framework mixin that represents a hit test target
   ///   backed by a platform view.
-  final bool isPlatformView;
+  final bool hasPlatformView;
 }

--- a/engine/src/flutter/lib/ui/window/hit_test_response.h
+++ b/engine/src/flutter/lib/ui/window/hit_test_response.h
@@ -1,0 +1,21 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_LIB_UI_WINDOW_HIT_TEST_RESPONSE_H_
+#define FLUTTER_LIB_UI_WINDOW_HIT_TEST_RESPONSE_H_
+
+namespace flutter {
+
+// Represents a hit test response.
+struct HitTestResponse {
+  // Whether the first hit test entry is a platform view.
+  //
+  // The first hit test entry is typically the child that is
+  // visually "on top" (i.e., paints later).
+  bool is_platform_view;
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_LIB_UI_WINDOW_HIT_TEST_RESPONSE_H_

--- a/engine/src/flutter/lib/ui/window/hit_test_response.h
+++ b/engine/src/flutter/lib/ui/window/hit_test_response.h
@@ -9,11 +9,8 @@ namespace flutter {
 
 // Represents a hit test response.
 struct HitTestResponse {
-  // Whether the first hit test entry is a platform view.
-  //
-  // The first hit test entry is typically the child that is
-  // visually "on top" (i.e., paints later).
-  bool is_platform_view;
+  // Whether the hit test result contains a platform view.
+  bool has_platform_view;
 };
 
 }  // namespace flutter

--- a/engine/src/flutter/lib/ui/window/platform_configuration.cc
+++ b/engine/src/flutter/lib/ui/window/platform_configuration.cc
@@ -77,6 +77,12 @@ void PlatformConfiguration::DidCreateIsolate() {
   dispatch_pointer_data_packet_.Set(
       tonic::DartState::Current(),
       Dart_GetField(library, tonic::ToDart("_dispatchPointerDataPacket")));
+  // The embedded native view (e.g. UIView on iOS) is called "platform view"
+  // on framework side, but "embedded native view" on engine side. On the other
+  // hand, "platform view" refers to the whole flutter view on engine side.
+  embedded_native_view_should_accept_touch_.Set(
+      tonic::DartState::Current(),
+      Dart_GetField(library, tonic::ToDart("_platformViewShouldAcceptTouch")));
   dispatch_semantics_action_.Set(
       tonic::DartState::Current(),
       Dart_GetField(library, tonic::ToDart("_dispatchSemanticsAction")));
@@ -398,6 +404,26 @@ void PlatformConfiguration::DispatchPointerDataPacket(
 
   tonic::CheckAndHandleError(
       tonic::DartInvoke(dispatch_pointer_data_packet_.Get(), {data_handle}));
+}
+
+bool PlatformConfiguration::EmbeddedNativeViewShouldAcceptTouch(
+    int64_t view_id,
+    const flutter::PointData touch_began_location) {
+  std::shared_ptr<tonic::DartState> dart_state =
+      embedded_native_view_should_accept_touch_.dart_state().lock();
+  if (!dart_state) {
+    return false;
+  }
+  tonic::DartState::Scope scope(dart_state);
+
+  Dart_Handle dart_result = tonic::DartInvoke(
+      embedded_native_view_should_accept_touch_.Get(),
+      {tonic::ToDart(view_id), tonic::ToDart(touch_began_location.x),
+       tonic::ToDart(touch_began_location.y)});
+  if (tonic::CheckAndHandleError(dart_result)) {
+    return false;
+  }
+  return tonic::DartConverter<bool>::FromDart(dart_result);
 }
 
 void PlatformConfiguration::DispatchSemanticsAction(int64_t view_id,

--- a/engine/src/flutter/lib/ui/window/platform_configuration.cc
+++ b/engine/src/flutter/lib/ui/window/platform_configuration.cc
@@ -407,7 +407,7 @@ HitTestResponse PlatformConfiguration::HitTest(
     const flutter::PointData offset) {
   std::shared_ptr<tonic::DartState> dart_state = hit_test_.dart_state().lock();
   if (!dart_state) {
-    return {.is_platform_view = false};
+    return {.has_platform_view = false};
   }
   tonic::DartState::Scope scope(dart_state);
 
@@ -415,16 +415,16 @@ HitTestResponse PlatformConfiguration::HitTest(
       hit_test_.Get(), {tonic::ToDart(view_id), tonic::ToDart(offset.x),
                         tonic::ToDart(offset.y)});
   if (tonic::CheckAndHandleError(dart_result)) {
-    return {.is_platform_view = false};
+    return {.has_platform_view = false};
   }
 
-  Dart_Handle is_platform_view_handle =
-      Dart_GetField(dart_result, tonic::ToDart("isPlatformView"));
-  if (tonic::CheckAndHandleError(is_platform_view_handle)) {
-    return {.is_platform_view = false};
+  Dart_Handle has_platform_view_handle =
+      Dart_GetField(dart_result, tonic::ToDart("hasPlatformView"));
+  if (tonic::CheckAndHandleError(has_platform_view_handle)) {
+    return {.has_platform_view = false};
   }
-  return {.is_platform_view =
-              tonic::DartConverter<bool>::FromDart(is_platform_view_handle)};
+  return {.has_platform_view =
+              tonic::DartConverter<bool>::FromDart(has_platform_view_handle)};
 }
 
 void PlatformConfiguration::DispatchSemanticsAction(int64_t view_id,

--- a/engine/src/flutter/lib/ui/window/platform_configuration.cc
+++ b/engine/src/flutter/lib/ui/window/platform_configuration.cc
@@ -77,12 +77,8 @@ void PlatformConfiguration::DidCreateIsolate() {
   dispatch_pointer_data_packet_.Set(
       tonic::DartState::Current(),
       Dart_GetField(library, tonic::ToDart("_dispatchPointerDataPacket")));
-  // The embedded native view (e.g. UIView on iOS) is called "platform view"
-  // on framework side, but "embedded native view" on engine side. On the other
-  // hand, "platform view" refers to the whole flutter view on engine side.
-  embedded_native_view_should_accept_touch_.Set(
-      tonic::DartState::Current(),
-      Dart_GetField(library, tonic::ToDart("_platformViewShouldAcceptTouch")));
+  hit_test_.Set(tonic::DartState::Current(),
+                Dart_GetField(library, tonic::ToDart("_hitTest")));
   dispatch_semantics_action_.Set(
       tonic::DartState::Current(),
       Dart_GetField(library, tonic::ToDart("_dispatchSemanticsAction")));
@@ -406,24 +402,29 @@ void PlatformConfiguration::DispatchPointerDataPacket(
       tonic::DartInvoke(dispatch_pointer_data_packet_.Get(), {data_handle}));
 }
 
-bool PlatformConfiguration::EmbeddedNativeViewShouldAcceptTouch(
+HitTestResponse PlatformConfiguration::HitTest(
     int64_t view_id,
-    const flutter::PointData touch_began_location) {
-  std::shared_ptr<tonic::DartState> dart_state =
-      embedded_native_view_should_accept_touch_.dart_state().lock();
+    const flutter::PointData offset) {
+  std::shared_ptr<tonic::DartState> dart_state = hit_test_.dart_state().lock();
   if (!dart_state) {
-    return false;
+    return {.is_platform_view = false};
   }
   tonic::DartState::Scope scope(dart_state);
 
   Dart_Handle dart_result = tonic::DartInvoke(
-      embedded_native_view_should_accept_touch_.Get(),
-      {tonic::ToDart(view_id), tonic::ToDart(touch_began_location.x),
-       tonic::ToDart(touch_began_location.y)});
+      hit_test_.Get(), {tonic::ToDart(view_id), tonic::ToDart(offset.x),
+                        tonic::ToDart(offset.y)});
   if (tonic::CheckAndHandleError(dart_result)) {
-    return false;
+    return {.is_platform_view = false};
   }
-  return tonic::DartConverter<bool>::FromDart(dart_result);
+
+  Dart_Handle is_platform_view_handle =
+      Dart_GetField(dart_result, tonic::ToDart("isPlatformView"));
+  if (tonic::CheckAndHandleError(is_platform_view_handle)) {
+    return {.is_platform_view = false};
+  }
+  return {.is_platform_view =
+              tonic::DartConverter<bool>::FromDart(is_platform_view_handle)};
 }
 
 void PlatformConfiguration::DispatchSemanticsAction(int64_t view_id,

--- a/engine/src/flutter/lib/ui/window/platform_configuration.h
+++ b/engine/src/flutter/lib/ui/window/platform_configuration.h
@@ -15,6 +15,7 @@
 #include "flutter/fml/time/time_point.h"
 #include "flutter/lib/ui/semantics/semantics_update.h"
 #include "flutter/lib/ui/window/platform_message_response.h"
+#include "flutter/lib/ui/window/point_data.h"
 #include "flutter/lib/ui/window/pointer_data_packet.h"
 #include "flutter/lib/ui/window/view_focus.h"
 #include "flutter/lib/ui/window/viewport_metrics.h"
@@ -465,6 +466,22 @@ class PlatformConfiguration final {
   void DispatchPointerDataPacket(const PointerDataPacket& packet);
 
   //----------------------------------------------------------------------------
+  /// @brief      Requests from the engine if an embedded native view should
+  ///             accept touch at a given touch location.
+  ///
+  ///
+  /// @param[in]  view_id               The identifier of the flutter view that
+  ///                                   hosts the embedded view.
+  /// @param[in]  touch_began_location  The touch began location.
+  ///
+  /// @return     true if the embedded view should accept touch; false
+  /// otherwise.
+  ///
+  bool EmbeddedNativeViewShouldAcceptTouch(
+      int64_t view_id,
+      const flutter::PointData touch_began_location);
+
+  //----------------------------------------------------------------------------
   /// @brief      Notifies the framework that the embedder encountered an
   ///             accessibility related action on the specified node. This call
   ///             originates on the platform view and has been forwarded to the
@@ -587,6 +604,7 @@ class PlatformConfiguration final {
   tonic::DartPersistentValue update_accessibility_features_;
   tonic::DartPersistentValue dispatch_platform_message_;
   tonic::DartPersistentValue dispatch_pointer_data_packet_;
+  tonic::DartPersistentValue embedded_native_view_should_accept_touch_;
   tonic::DartPersistentValue dispatch_semantics_action_;
   tonic::DartPersistentValue begin_frame_;
   tonic::DartPersistentValue draw_frame_;

--- a/engine/src/flutter/lib/ui/window/platform_configuration.h
+++ b/engine/src/flutter/lib/ui/window/platform_configuration.h
@@ -14,6 +14,7 @@
 #include "flutter/assets/asset_manager.h"
 #include "flutter/fml/time/time_point.h"
 #include "flutter/lib/ui/semantics/semantics_update.h"
+#include "flutter/lib/ui/window/hit_test_response.h"
 #include "flutter/lib/ui/window/platform_message_response.h"
 #include "flutter/lib/ui/window/point_data.h"
 #include "flutter/lib/ui/window/pointer_data_packet.h"
@@ -466,20 +467,15 @@ class PlatformConfiguration final {
   void DispatchPointerDataPacket(const PointerDataPacket& packet);
 
   //----------------------------------------------------------------------------
-  /// @brief      Requests from the engine if an embedded native view should
-  ///             accept touch at a given touch location.
+  /// @brief      Requests to perform framework hit test from the engine.
   ///
+  /// @param[in]  view_id The identifier of the flutter view that
+  ///                     should be hit tested.
+  /// @param[in]  offset  The position in the view that should be hit tested.
   ///
-  /// @param[in]  view_id               The identifier of the flutter view that
-  ///                                   hosts the embedded view.
-  /// @param[in]  touch_began_location  The touch began location.
+  /// @return     The hit test response.
   ///
-  /// @return     true if the embedded view should accept touch; false
-  /// otherwise.
-  ///
-  bool EmbeddedNativeViewShouldAcceptTouch(
-      int64_t view_id,
-      const flutter::PointData touch_began_location);
+  HitTestResponse HitTest(int64_t view_id, const flutter::PointData offset);
 
   //----------------------------------------------------------------------------
   /// @brief      Notifies the framework that the embedder encountered an
@@ -604,7 +600,7 @@ class PlatformConfiguration final {
   tonic::DartPersistentValue update_accessibility_features_;
   tonic::DartPersistentValue dispatch_platform_message_;
   tonic::DartPersistentValue dispatch_pointer_data_packet_;
-  tonic::DartPersistentValue embedded_native_view_should_accept_touch_;
+  tonic::DartPersistentValue hit_test_;
   tonic::DartPersistentValue dispatch_semantics_action_;
   tonic::DartPersistentValue begin_frame_;
   tonic::DartPersistentValue draw_frame_;

--- a/engine/src/flutter/lib/ui/window/point_data.h
+++ b/engine/src/flutter/lib/ui/window/point_data.h
@@ -1,0 +1,17 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_LIB_UI_WINDOW_POINT_DATA_H_
+#define FLUTTER_LIB_UI_WINDOW_POINT_DATA_H_
+
+namespace flutter {
+
+// Represents a point on screen.
+struct PointData {
+  double x;
+  double y;
+};
+}  // namespace flutter
+
+#endif  // FLUTTER_LIB_UI_WINDOW_POINT_DATA_H_

--- a/engine/src/flutter/lib/ui/window/point_data.h
+++ b/engine/src/flutter/lib/ui/window/point_data.h
@@ -12,6 +12,7 @@ struct PointData {
   double x;
   double y;
 };
+
 }  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_WINDOW_POINT_DATA_H_

--- a/engine/src/flutter/lib/web_ui/lib/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/web_ui/lib/platform_dispatcher.dart
@@ -11,6 +11,7 @@ typedef TimingsCallback = void Function(List<FrameTiming> timings);
 typedef PointerDataPacketCallback = void Function(PointerDataPacket packet);
 typedef KeyDataCallback = bool Function(KeyData data);
 typedef SemanticsActionEventCallback = void Function(SemanticsActionEvent action);
+typedef HitTestCallback = HitTestResponse Function(HitTestRequest request);
 typedef PlatformMessageResponseCallback = void Function(ByteData? data);
 typedef PlatformMessageCallback =
     void Function(String name, ByteData? data, PlatformMessageResponseCallback? callback);
@@ -153,6 +154,9 @@ abstract class PlatformDispatcher {
 
   SemanticsActionEventCallback? get onSemanticsActionEvent;
   set onSemanticsActionEvent(SemanticsActionEventCallback? callback);
+
+  HitTestCallback? get onHitTest;
+  set onHitTest(HitTestCallback? callback);
 
   ErrorCallback? get onError;
   set onError(ErrorCallback? callback);
@@ -645,3 +649,15 @@ final class ViewFocusEvent {
 enum ViewFocusState { unfocused, focused }
 
 enum ViewFocusDirection { undefined, forward, backward }
+
+class HitTestRequest {
+  const HitTestRequest({required this.view, required this.offset});
+  final FlutterView view;
+  final Offset offset;
+}
+
+class HitTestResponse {
+  const HitTestResponse({required this.isPlatformView});
+  static const HitTestResponse empty = HitTestResponse(isPlatformView: false);
+  final bool isPlatformView;
+}

--- a/engine/src/flutter/lib/web_ui/lib/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/web_ui/lib/platform_dispatcher.dart
@@ -657,7 +657,7 @@ class HitTestRequest {
 }
 
 class HitTestResponse {
-  const HitTestResponse({required this.isPlatformView});
-  static const HitTestResponse empty = HitTestResponse(isPlatformView: false);
-  final bool isPlatformView;
+  const HitTestResponse({required this.hasPlatformView});
+  static const HitTestResponse empty = HitTestResponse(hasPlatformView: false);
+  final bool hasPlatformView;
 }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -1379,6 +1379,13 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
     _onSemanticsActionEventZone = Zone.current;
   }
 
+  /// A callback invoked when the platform wants to hit test a [FlutterView].
+  ///
+  /// For example, this is used by iOS to determine if a gesture hits a
+  /// [UIKitView].
+  @override
+  ui.HitTestCallback? onHitTest;
+
   /// Engine code should use this method instead of the callback directly.
   /// Otherwise zones won't work properly.
   void invokeOnSemanticsAction(int viewId, int nodeId, ui.SemanticsAction action, ByteData? args) {

--- a/engine/src/flutter/runtime/runtime_controller.cc
+++ b/engine/src/flutter/runtime/runtime_controller.cc
@@ -374,6 +374,18 @@ bool RuntimeController::DispatchPointerDataPacket(
   return false;
 }
 
+bool RuntimeController::EmbeddedNativeViewShouldAcceptTouch(
+    int64_t view_id,
+    const flutter::PointData touch_began_location) {
+  if (auto* platform_configuration = GetPlatformConfigurationIfAvailable()) {
+    TRACE_EVENT0("flutter",
+                 "RuntimeController::EmbeddedNativeViewShouldAcceptTouch");
+    return platform_configuration->EmbeddedNativeViewShouldAcceptTouch(
+        view_id, touch_began_location);
+  }
+  return false;
+}
+
 bool RuntimeController::DispatchSemanticsAction(int64_t view_id,
                                                 int32_t node_id,
                                                 SemanticsAction action,

--- a/engine/src/flutter/runtime/runtime_controller.cc
+++ b/engine/src/flutter/runtime/runtime_controller.cc
@@ -380,7 +380,7 @@ HitTestResponse RuntimeController::HitTest(int64_t view_id,
     TRACE_EVENT0("flutter", "RuntimeController::HitTest");
     return platform_configuration->HitTest(view_id, offset);
   }
-  return {.is_platform_view = false};
+  return {.has_platform_view = false};
 }
 
 bool RuntimeController::DispatchSemanticsAction(int64_t view_id,

--- a/engine/src/flutter/runtime/runtime_controller.cc
+++ b/engine/src/flutter/runtime/runtime_controller.cc
@@ -374,16 +374,13 @@ bool RuntimeController::DispatchPointerDataPacket(
   return false;
 }
 
-bool RuntimeController::EmbeddedNativeViewShouldAcceptTouch(
-    int64_t view_id,
-    const flutter::PointData touch_began_location) {
+HitTestResponse RuntimeController::HitTest(int64_t view_id,
+                                           const flutter::PointData offset) {
   if (auto* platform_configuration = GetPlatformConfigurationIfAvailable()) {
-    TRACE_EVENT0("flutter",
-                 "RuntimeController::EmbeddedNativeViewShouldAcceptTouch");
-    return platform_configuration->EmbeddedNativeViewShouldAcceptTouch(
-        view_id, touch_began_location);
+    TRACE_EVENT0("flutter", "RuntimeController::HitTest");
+    return platform_configuration->HitTest(view_id, offset);
   }
-  return false;
+  return {.is_platform_view = false};
 }
 
 bool RuntimeController::DispatchSemanticsAction(int64_t view_id,

--- a/engine/src/flutter/runtime/runtime_controller.h
+++ b/engine/src/flutter/runtime/runtime_controller.h
@@ -18,6 +18,7 @@
 #include "flutter/lib/ui/text/font_collection.h"
 #include "flutter/lib/ui/ui_dart_state.h"
 #include "flutter/lib/ui/window/platform_configuration.h"
+#include "flutter/lib/ui/window/point_data.h"
 #include "flutter/lib/ui/window/pointer_data_packet.h"
 #include "flutter/lib/ui/window/pointer_data_packet_converter.h"
 #include "flutter/lib/ui/window/view_focus.h"
@@ -475,6 +476,24 @@ class RuntimeController : public PlatformConfigurationClient,
   ///             an isolate is not running.
   ///
   bool DispatchPointerDataPacket(const PointerDataPacket& packet);
+
+  // TODO(hellohuanlin): we should make make this a generic HitTest API.
+  // See: https://github.com/flutter/flutter/issues/179762.
+  //----------------------------------------------------------------------------
+  /// @brief      Requests from the engine if an embedded native view should
+  ///             accept touch at a given touch location.
+  ///
+  ///
+  /// @param[in]  view_id               The identifier of the flutter view that
+  ///                                   hosts the embedded view.
+  /// @param[in]  touch_began_location  The touch began location.
+  ///
+  /// @return     true if the embedded view should accept touch; false
+  /// otherwise.
+  ///
+  bool EmbeddedNativeViewShouldAcceptTouch(
+      int64_t view_id,
+      const flutter::PointData touch_began_location);
 
   //----------------------------------------------------------------------------
   /// @brief      Dispatch the semantics action to the specified accessibility

--- a/engine/src/flutter/runtime/runtime_controller.h
+++ b/engine/src/flutter/runtime/runtime_controller.h
@@ -17,6 +17,7 @@
 #include "flutter/lib/ui/painting/image_generator_registry.h"
 #include "flutter/lib/ui/text/font_collection.h"
 #include "flutter/lib/ui/ui_dart_state.h"
+#include "flutter/lib/ui/window/hit_test_response.h"
 #include "flutter/lib/ui/window/platform_configuration.h"
 #include "flutter/lib/ui/window/point_data.h"
 #include "flutter/lib/ui/window/pointer_data_packet.h"
@@ -477,23 +478,16 @@ class RuntimeController : public PlatformConfigurationClient,
   ///
   bool DispatchPointerDataPacket(const PointerDataPacket& packet);
 
-  // TODO(hellohuanlin): we should make make this a generic HitTest API.
-  // See: https://github.com/flutter/flutter/issues/179762.
   //----------------------------------------------------------------------------
-  /// @brief      Requests from the engine if an embedded native view should
-  ///             accept touch at a given touch location.
+  /// @brief      Requests to perform framework hit test from the engine.
   ///
+  /// @param[in]  view_id The identifier of the flutter view that
+  ///                     should be hit tested.
+  /// @param[in]  offset  The position in the view that should be hit tested.
   ///
-  /// @param[in]  view_id               The identifier of the flutter view that
-  ///                                   hosts the embedded view.
-  /// @param[in]  touch_began_location  The touch began location.
+  /// @return     The hit test response.
   ///
-  /// @return     true if the embedded view should accept touch; false
-  /// otherwise.
-  ///
-  bool EmbeddedNativeViewShouldAcceptTouch(
-      int64_t view_id,
-      const flutter::PointData touch_began_location);
+  HitTestResponse HitTest(int64_t view_id, const flutter::PointData offset);
 
   //----------------------------------------------------------------------------
   /// @brief      Dispatch the semantics action to the specified accessibility

--- a/engine/src/flutter/shell/common/engine.cc
+++ b/engine/src/flutter/shell/common/engine.cc
@@ -476,6 +476,16 @@ void Engine::DispatchPointerDataPacket(
   pointer_data_dispatcher_->DispatchPacket(std::move(packet), trace_flow_id);
 }
 
+bool Engine::EmbeddedNativeViewShouldAcceptTouch(
+    int64_t view_id,
+    const flutter::PointData touch_began_location) {
+  if (runtime_controller_) {
+    return runtime_controller_->EmbeddedNativeViewShouldAcceptTouch(
+        view_id, touch_began_location);
+  }
+  return false;
+}
+
 void Engine::DispatchSemanticsAction(int64_t view_id,
                                      int node_id,
                                      SemanticsAction action,

--- a/engine/src/flutter/shell/common/engine.cc
+++ b/engine/src/flutter/shell/common/engine.cc
@@ -476,14 +476,12 @@ void Engine::DispatchPointerDataPacket(
   pointer_data_dispatcher_->DispatchPacket(std::move(packet), trace_flow_id);
 }
 
-bool Engine::EmbeddedNativeViewShouldAcceptTouch(
-    int64_t view_id,
-    const flutter::PointData touch_began_location) {
+HitTestResponse Engine::HitTest(int64_t view_id,
+                                const flutter::PointData offset) {
   if (runtime_controller_) {
-    return runtime_controller_->EmbeddedNativeViewShouldAcceptTouch(
-        view_id, touch_began_location);
+    return runtime_controller_->HitTest(view_id, offset);
   }
-  return false;
+  return {.is_platform_view = false};
 }
 
 void Engine::DispatchSemanticsAction(int64_t view_id,

--- a/engine/src/flutter/shell/common/engine.cc
+++ b/engine/src/flutter/shell/common/engine.cc
@@ -481,7 +481,7 @@ HitTestResponse Engine::HitTest(int64_t view_id,
   if (runtime_controller_) {
     return runtime_controller_->HitTest(view_id, offset);
   }
-  return {.is_platform_view = false};
+  return {.has_platform_view = false};
 }
 
 void Engine::DispatchSemanticsAction(int64_t view_id,

--- a/engine/src/flutter/shell/common/engine.h
+++ b/engine/src/flutter/shell/common/engine.h
@@ -830,6 +830,22 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
                                  uint64_t trace_flow_id);
 
   //----------------------------------------------------------------------------
+  /// @brief      Requests from the engine if an embedded native view should
+  ///             accept touch at a given touch location.
+  ///
+  ///
+  /// @param[in]  view_id               The identifier of the flutter view that
+  ///                                   hosts the embedded view.
+  /// @param[in]  touch_began_location  The touch began location.
+  ///
+  /// @return     true if the embedded view should accept touch; false
+  /// otherwise.
+  ///
+  bool EmbeddedNativeViewShouldAcceptTouch(
+      int64_t view_id,
+      const flutter::PointData touch_began_location);
+
+  //----------------------------------------------------------------------------
   /// @brief      Notifies the engine that the embedder encountered an
   ///             accessibility related action on the specified node. This call
   ///             originates on the platform view and has been forwarded to the

--- a/engine/src/flutter/shell/common/engine.h
+++ b/engine/src/flutter/shell/common/engine.h
@@ -830,20 +830,15 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
                                  uint64_t trace_flow_id);
 
   //----------------------------------------------------------------------------
-  /// @brief      Requests from the engine if an embedded native view should
-  ///             accept touch at a given touch location.
+  /// @brief      Requests to perform framework hit test from the engine.
   ///
+  /// @param[in]  view_id The identifier of the flutter view that
+  ///                     should be hit tested.
+  /// @param[in]  offset  The position in the view that should be hit tested.
   ///
-  /// @param[in]  view_id               The identifier of the flutter view that
-  ///                                   hosts the embedded view.
-  /// @param[in]  touch_began_location  The touch began location.
+  /// @return     The hit test response.
   ///
-  /// @return     true if the embedded view should accept touch; false
-  /// otherwise.
-  ///
-  bool EmbeddedNativeViewShouldAcceptTouch(
-      int64_t view_id,
-      const flutter::PointData touch_began_location);
+  HitTestResponse HitTest(int64_t view_id, const flutter::PointData offset);
 
   //----------------------------------------------------------------------------
   /// @brief      Notifies the engine that the embedder encountered an

--- a/engine/src/flutter/shell/common/fixtures/shell_test.dart
+++ b/engine/src/flutter/shell/common/fixtures/shell_test.dart
@@ -652,6 +652,6 @@ void hitTestInsidePlatformViewMain() {
 @pragma('vm:entry-point')
 void hitTestOutsidePlatformViewMain() {
   PlatformDispatcher.instance.onHitTest = (HitTestRequest request) {
-    return const HitTestResponse(isPlatformView: false);
+    return HitTestResponse.empty;
   };
 }

--- a/engine/src/flutter/shell/common/fixtures/shell_test.dart
+++ b/engine/src/flutter/shell/common/fixtures/shell_test.dart
@@ -645,7 +645,7 @@ void providesEngineId() {
 @pragma('vm:entry-point')
 void hitTestInsidePlatformViewMain() {
   PlatformDispatcher.instance.onHitTest = (HitTestRequest request) {
-    return const HitTestResponse(isPlatformView: true);
+    return const HitTestResponse(hasPlatformView: true);
   };
 }
 

--- a/engine/src/flutter/shell/common/fixtures/shell_test.dart
+++ b/engine/src/flutter/shell/common/fixtures/shell_test.dart
@@ -641,3 +641,17 @@ external void _reportEngineId(int? identifier);
 void providesEngineId() {
   _reportEngineId(PlatformDispatcher.instance.engineId);
 }
+
+@pragma('vm:entry-point')
+void hitTestInsidePlatformViewMain() {
+  PlatformDispatcher.instance.onHitTest = (HitTestRequest request) {
+    return const HitTestResponse(isPlatformView: true);
+  };
+}
+
+@pragma('vm:entry-point')
+void hitTestOutsidePlatformViewMain() {
+  PlatformDispatcher.instance.onHitTest = (HitTestRequest request) {
+    return const HitTestResponse(isPlatformView: false);
+  };
+}

--- a/engine/src/flutter/shell/common/platform_view.cc
+++ b/engine/src/flutter/shell/common/platform_view.cc
@@ -35,6 +35,13 @@ void PlatformView::DispatchPointerDataPacket(
   delegate_.OnPlatformViewDispatchPointerDataPacket(std::move(packet));
 }
 
+bool PlatformView::EmbeddedNativeViewShouldAcceptTouch(
+    int64_t view_id,
+    const flutter::PointData touch_began_location) {
+  return delegate_.OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
+      view_id, touch_began_location);
+}
+
 void PlatformView::DispatchSemanticsAction(int64_t view_id,
                                            int32_t node_id,
                                            SemanticsAction action,

--- a/engine/src/flutter/shell/common/platform_view.cc
+++ b/engine/src/flutter/shell/common/platform_view.cc
@@ -35,11 +35,9 @@ void PlatformView::DispatchPointerDataPacket(
   delegate_.OnPlatformViewDispatchPointerDataPacket(std::move(packet));
 }
 
-bool PlatformView::EmbeddedNativeViewShouldAcceptTouch(
-    int64_t view_id,
-    const flutter::PointData touch_began_location) {
-  return delegate_.OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
-      view_id, touch_began_location);
+HitTestResponse PlatformView::HitTest(int64_t view_id,
+                                      const flutter::PointData offset) {
+  return delegate_.OnPlatformViewHitTest(view_id, offset);
 }
 
 void PlatformView::DispatchSemanticsAction(int64_t view_id,

--- a/engine/src/flutter/shell/common/platform_view.h
+++ b/engine/src/flutter/shell/common/platform_view.h
@@ -183,6 +183,24 @@ class PlatformView {
         std::unique_ptr<PointerDataPacket> packet) = 0;
 
     //--------------------------------------------------------------------------
+    /// @brief      Requests the delegate if an embedded native view should
+    ///             accept touch at a given touch location.
+    ///             This API must be called from the UI thread.
+    ///             Calling this from the platform thread causes
+    ///             undefined behavior if the UI and platform threads
+    ///             are not merged.
+    /// @param[in]  view_id               The identifier of the flutter view
+    ///                                   that hosts the embedded view.
+    /// @param[in]  touch_began_location  The touch began location.
+    ///
+    /// @return     true if the embedded view should accept touch; false
+    /// otherwise.
+    ///
+    virtual bool OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
+        int64_t view_id,
+        const flutter::PointData touch_began_location) = 0;
+
+    //--------------------------------------------------------------------------
     /// @brief      Notifies the delegate that the platform view has encountered
     ///             an accessibility related action on the specified node. This
     ///             event must be forwarded to the running root isolate hosted
@@ -736,6 +754,22 @@ class PlatformView {
   /// @param[in]  packet  The pointer data packet to dispatch to the framework.
   ///
   void DispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet);
+
+  //----------------------------------------------------------------------------
+  /// @brief      Requests from the engine if an embedded view should accept
+  ///             touch at a given touch location.
+  ///
+  ///
+  /// @param[in]  view_id               The identifier of the flutter view that
+  ///                                   hosts the embedded view.
+  /// @param[in]  touch_began_location  The touch began location.
+  ///
+  /// @return     true if the embedded view should accept touch; false
+  /// otherwise.
+  ///
+  bool EmbeddedNativeViewShouldAcceptTouch(
+      int64_t view_id,
+      const flutter::PointData touch_began_location);
 
   //--------------------------------------------------------------------------
   /// @brief      Used by the embedder to specify a texture that it wants the

--- a/engine/src/flutter/shell/common/platform_view.h
+++ b/engine/src/flutter/shell/common/platform_view.h
@@ -183,22 +183,21 @@ class PlatformView {
         std::unique_ptr<PointerDataPacket> packet) = 0;
 
     //--------------------------------------------------------------------------
-    /// @brief      Requests the delegate if an embedded native view should
-    ///             accept touch at a given touch location.
+    /// @brief      Requests the delegate to perform framework hit test from the
+    ///             engine.
     ///             This API must be called from the UI thread.
     ///             Calling this from the platform thread causes
     ///             undefined behavior if the UI and platform threads
     ///             are not merged.
-    /// @param[in]  view_id               The identifier of the flutter view
-    ///                                   that hosts the embedded view.
-    /// @param[in]  touch_began_location  The touch began location.
+    /// @param[in]  view_id The identifier of the flutter view that
+    ///                     should be hit tested.
+    /// @param[in]  offset  The position in the view that should be hit tested.
     ///
-    /// @return     true if the embedded view should accept touch; false
-    /// otherwise.
+    /// @return     The hit test response.
     ///
-    virtual bool OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
+    virtual HitTestResponse OnPlatformViewHitTest(
         int64_t view_id,
-        const flutter::PointData touch_began_location) = 0;
+        const flutter::PointData offset) = 0;
 
     //--------------------------------------------------------------------------
     /// @brief      Notifies the delegate that the platform view has encountered
@@ -756,20 +755,15 @@ class PlatformView {
   void DispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet);
 
   //----------------------------------------------------------------------------
-  /// @brief      Requests from the engine if an embedded view should accept
-  ///             touch at a given touch location.
+  /// @brief      Requests to perform framework hit test from the engine.
   ///
+  /// @param[in]  view_id The identifier of the flutter view that
+  ///                     should be hit tested.
+  /// @param[in]  offset  The position in the view that should be hit tested.
   ///
-  /// @param[in]  view_id               The identifier of the flutter view that
-  ///                                   hosts the embedded view.
-  /// @param[in]  touch_began_location  The touch began location.
+  /// @return     The hit test response.
   ///
-  /// @return     true if the embedded view should accept touch; false
-  /// otherwise.
-  ///
-  bool EmbeddedNativeViewShouldAcceptTouch(
-      int64_t view_id,
-      const flutter::PointData touch_began_location);
+  HitTestResponse HitTest(int64_t view_id, const flutter::PointData offset);
 
   //--------------------------------------------------------------------------
   /// @brief      Used by the embedder to specify a texture that it wants the

--- a/engine/src/flutter/shell/common/shell.cc
+++ b/engine/src/flutter/shell/common/shell.cc
@@ -1226,6 +1226,17 @@ void Shell::OnPlatformViewDispatchPointerDataPacket(
   next_pointer_flow_id_++;
 }
 
+bool Shell::OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
+    int64_t view_id,
+    const flutter::PointData touch_began_location) {
+  FML_DCHECK(task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread());
+  if (engine_) {
+    return engine_->EmbeddedNativeViewShouldAcceptTouch(view_id,
+                                                        touch_began_location);
+  }
+  return false;
+}
+
 // |PlatformView::Delegate|
 void Shell::OnPlatformViewDispatchSemanticsAction(int64_t view_id,
                                                   int32_t node_id,

--- a/engine/src/flutter/shell/common/shell.cc
+++ b/engine/src/flutter/shell/common/shell.cc
@@ -1234,7 +1234,7 @@ HitTestResponse Shell::OnPlatformViewHitTest(int64_t view_id,
   if (engine_) {
     return engine_->HitTest(view_id, offset);
   }
-  return {.is_platform_view = false};
+  return {.has_platform_view = false};
 }
 
 // |PlatformView::Delegate|

--- a/engine/src/flutter/shell/common/shell.cc
+++ b/engine/src/flutter/shell/common/shell.cc
@@ -1226,15 +1226,15 @@ void Shell::OnPlatformViewDispatchPointerDataPacket(
   next_pointer_flow_id_++;
 }
 
-bool Shell::OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
-    int64_t view_id,
-    const flutter::PointData touch_began_location) {
+HitTestResponse Shell::OnPlatformViewHitTest(int64_t view_id,
+                                             const flutter::PointData offset) {
+  // hit test should be performed only when UI & platform threads are merged.
   FML_DCHECK(task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread());
+  FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
   if (engine_) {
-    return engine_->EmbeddedNativeViewShouldAcceptTouch(view_id,
-                                                        touch_began_location);
+    return engine_->HitTest(view_id, offset);
   }
-  return false;
+  return {.is_platform_view = false};
 }
 
 // |PlatformView::Delegate|

--- a/engine/src/flutter/shell/common/shell.h
+++ b/engine/src/flutter/shell/common/shell.h
@@ -608,6 +608,10 @@ class Shell final : public PlatformView::Delegate,
   void OnPlatformViewDispatchPointerDataPacket(
       std::unique_ptr<PointerDataPacket> packet) override;
 
+  bool OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
+      int64_t view_id,
+      const flutter::PointData touch_began_location) override;
+
   // |PlatformView::Delegate|
   void OnPlatformViewDispatchSemanticsAction(int64_t view_id,
                                              int32_t node_id,

--- a/engine/src/flutter/shell/common/shell.h
+++ b/engine/src/flutter/shell/common/shell.h
@@ -608,9 +608,9 @@ class Shell final : public PlatformView::Delegate,
   void OnPlatformViewDispatchPointerDataPacket(
       std::unique_ptr<PointerDataPacket> packet) override;
 
-  bool OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
+  HitTestResponse OnPlatformViewHitTest(
       int64_t view_id,
-      const flutter::PointData touch_began_location) override;
+      const flutter::PointData offset) override;
 
   // |PlatformView::Delegate|
   void OnPlatformViewDispatchSemanticsAction(int64_t view_id,

--- a/engine/src/flutter/shell/common/shell_unittests.cc
+++ b/engine/src/flutter/shell/common/shell_unittests.cc
@@ -143,6 +143,11 @@ class MockPlatformViewDelegate : public PlatformView::Delegate {
               (std::unique_ptr<PointerDataPacket> packet),
               (override));
 
+  MOCK_METHOD(bool,
+              OnPlatformViewEmbeddedNativeViewShouldAcceptTouch,
+              (int64_t view_id, const flutter::PointData touch_began_location),
+              (override));
+
   MOCK_METHOD(void,
               OnPlatformViewDispatchSemanticsAction,
               (int64_t view_id,

--- a/engine/src/flutter/shell/common/shell_unittests.cc
+++ b/engine/src/flutter/shell/common/shell_unittests.cc
@@ -143,9 +143,9 @@ class MockPlatformViewDelegate : public PlatformView::Delegate {
               (std::unique_ptr<PointerDataPacket> packet),
               (override));
 
-  MOCK_METHOD(bool,
-              OnPlatformViewEmbeddedNativeViewShouldAcceptTouch,
-              (int64_t view_id, const flutter::PointData touch_began_location),
+  MOCK_METHOD(HitTestResponse,
+              OnPlatformViewHitTest,
+              (int64_t view_id, const flutter::PointData offset),
               (override));
 
   MOCK_METHOD(void,
@@ -596,6 +596,74 @@ TEST_F(ShellTest, FixturesAreFunctional) {
   ASSERT_TRUE(DartVMRef::IsInstanceRunning());
   DestroyShell(std::move(shell));
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+}
+
+TEST_F(ShellTest, HitTestInsidePlatformViewIsFunctional) {
+  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+  auto settings = CreateSettingsForFixture();
+  auto task_runner = CreateNewThread();
+  TaskRunners task_runners("test", task_runner, task_runner, task_runner,
+                           task_runner);
+
+  auto shell = CreateShell(settings, task_runners);
+  ASSERT_TRUE(ValidateShell(shell.get()));
+
+  auto configuration = RunConfiguration::InferFromSettings(settings);
+  ASSERT_TRUE(configuration.IsValid());
+
+  configuration.SetEntrypoint("hitTestInsidePlatformViewMain");
+  RunEngine(shell.get(), std::move(configuration));
+
+  fml::AutoResetWaitableEvent latch;
+
+  task_runner->PostTask([&shell, &latch]() {
+    flutter::ViewportMetrics metrics;
+    metrics.physical_width = 100;
+    metrics.physical_height = 100;
+    metrics.device_pixel_ratio = 1.0;
+    shell->GetEngine()->SetViewportMetrics(0, metrics);
+
+    HitTestResponse response = shell->GetPlatformView()->HitTest(0, {0.0, 0.0});
+    EXPECT_TRUE(response.is_platform_view);
+    latch.Signal();
+  });
+
+  latch.Wait();
+  DestroyShell(std::move(shell), task_runners);
+}
+
+TEST_F(ShellTest, HitTestOutsidePlatformViewIsFunctional) {
+  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+  auto settings = CreateSettingsForFixture();
+  auto task_runner = CreateNewThread();
+  TaskRunners task_runners("test", task_runner, task_runner, task_runner,
+                           task_runner);
+
+  auto shell = CreateShell(settings, task_runners);
+  ASSERT_TRUE(ValidateShell(shell.get()));
+
+  auto configuration = RunConfiguration::InferFromSettings(settings);
+  ASSERT_TRUE(configuration.IsValid());
+
+  configuration.SetEntrypoint("hitTestOutsidePlatformViewMain");
+  RunEngine(shell.get(), std::move(configuration));
+
+  fml::AutoResetWaitableEvent latch;
+
+  task_runner->PostTask([&shell, &latch]() {
+    flutter::ViewportMetrics metrics;
+    metrics.physical_width = 100;
+    metrics.physical_height = 100;
+    metrics.device_pixel_ratio = 1.0;
+    shell->GetEngine()->SetViewportMetrics(0, metrics);
+
+    HitTestResponse response = shell->GetPlatformView()->HitTest(0, {0.0, 0.0});
+    EXPECT_FALSE(response.is_platform_view);
+    latch.Signal();
+  });
+
+  latch.Wait();
+  DestroyShell(std::move(shell), task_runners);
 }
 
 TEST_F(ShellTest, SecondaryIsolateBindingsAreSetupViaShellSettings) {

--- a/engine/src/flutter/shell/common/shell_unittests.cc
+++ b/engine/src/flutter/shell/common/shell_unittests.cc
@@ -624,7 +624,7 @@ TEST_F(ShellTest, HitTestInsidePlatformViewIsFunctional) {
     shell->GetEngine()->SetViewportMetrics(0, metrics);
 
     HitTestResponse response = shell->GetPlatformView()->HitTest(0, {0.0, 0.0});
-    EXPECT_TRUE(response.is_platform_view);
+    EXPECT_TRUE(response.has_platform_view);
     latch.Signal();
   });
 
@@ -658,7 +658,7 @@ TEST_F(ShellTest, HitTestOutsidePlatformViewIsFunctional) {
     shell->GetEngine()->SetViewportMetrics(0, metrics);
 
     HitTestResponse response = shell->GetPlatformView()->HitTest(0, {0.0, 0.0});
-    EXPECT_FALSE(response.is_platform_view);
+    EXPECT_FALSE(response.has_platform_view);
     latch.Signal();
   });
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
@@ -268,6 +268,17 @@ typedef enum {
    * but never recognizing the gesture (and never invoking actions).
    */
   FlutterPlatformViewGestureRecognizersBlockingPolicyWaitUntilTouchesEnded,
+
+  /**
+   * Flutter blocks all the touch event callbacks and UIGestureRecognizers on the platform view as
+   * soon as it decides they should be blocked.
+   *
+   * This is similar to FlutterPlatformViewGestureRecognizersBlockingPolicyEager. However,
+   * internally it performs hit test rather than a blocking gesture recognizer. This addresses
+   * a few bugs related to WKWebView being untappable. See
+   * https://github.com/flutter/flutter/issues/175099.
+   */
+  FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly,
   // NOLINTEND(readability-identifier-naming)
 } FlutterPlatformViewGestureRecognizersBlockingPolicy;
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
@@ -256,29 +256,28 @@ typedef enum {
    * Flutter blocks all the UIGestureRecognizers on the platform view as soon as it
    * decides they should be blocked.
    *
-   * With this policy, only the `touchesBegan` method for all the UIGestureRecognizers is guaranteed
-   * to be called.
+   * This policy employs a dual blocking strategy: synchronous blocking via hitTest results and
+   * asynchronous blocking managed through the framework’s gesture arena. With this policy, only the
+   * `touchesBegan` method for all the UIGestureRecognizers is guaranteed to be called.
    */
   FlutterPlatformViewGestureRecognizersBlockingPolicyEager,
   /**
-   * Flutter blocks the platform view's UIGestureRecognizers from recognizing only after
-   * touchesEnded was invoked.
+   * Flutter blocks all the UIGestureRecognizers on the platform view only after touchesEnded was
+   * invoked.
    *
    * This results in the platform view's UIGestureRecognizers seeing the entire touch sequence,
    * but never recognizing the gesture (and never invoking actions).
    */
   FlutterPlatformViewGestureRecognizersBlockingPolicyWaitUntilTouchesEnded,
-
   /**
-   * Flutter blocks all the touch event callbacks and UIGestureRecognizers on the platform view as
-   * soon as it decides they should be blocked.
+   * Flutter blocks all the UIGestureRecognizers on the platform view based on results from hitTest.
    *
-   * This is similar to FlutterPlatformViewGestureRecognizersBlockingPolicyEager. However,
-   * internally it performs hit test rather than a blocking gesture recognizer. This addresses
-   * a few bugs related to WKWebView being untappable. See
+   * Unlike FlutterPlatformViewGestureRecognizersBlockingPolicyEager, this policy does not rely on
+   * Flutter's gesture arena. This is a workaround to address a few bugs related to platform view's
+   * gesture recognizers being stuck in a stale state. See:
    * https://github.com/flutter/flutter/issues/175099.
    */
-  FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly,
+  FlutterPlatformViewGestureRecognizersBlockingPolicyDoNotBlockGesture,
   // NOLINTEND(readability-identifier-naming)
 } FlutterPlatformViewGestureRecognizersBlockingPolicy;
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -389,6 +389,14 @@ NSString* const kFlutterApplicationRegistrarKey = @"io.flutter.flutter.applicati
   self.platformView->DispatchPointerDataPacket(std::move(packet));
 }
 
+- (BOOL)platformViewShouldAcceptTouchAtTouchBeganLocation:(flutter::PointData)location
+                                                   viewId:(uint64_t)viewId {
+  if (!self.platformView) {
+    return NO;
+  }
+  return self.platformView->EmbeddedNativeViewShouldAcceptTouch(viewId, location);
+}
+
 - (void)installFirstFrameCallback:(void (^)(void))block {
   if (!self.platformView) {
     return;

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -394,7 +394,7 @@ NSString* const kFlutterApplicationRegistrarKey = @"io.flutter.flutter.applicati
   if (!self.platformView) {
     return NO;
   }
-  return self.platformView->HitTest(viewId, location).is_platform_view;
+  return self.platformView->HitTest(viewId, location).has_platform_view;
 }
 
 - (void)installFirstFrameCallback:(void (^)(void))block {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -394,7 +394,7 @@ NSString* const kFlutterApplicationRegistrarKey = @"io.flutter.flutter.applicati
   if (!self.platformView) {
     return NO;
   }
-  return self.platformView->EmbeddedNativeViewShouldAcceptTouch(viewId, location);
+  return self.platformView->HitTest(viewId, location).is_platform_view;
 }
 
 - (void)installFirstFrameCallback:(void (^)(void))block {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
@@ -35,6 +35,11 @@ class FakeDelegate : public PlatformView::Delegate {
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
+  bool OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
+      int64_t view_id,
+      const flutter::PointData touch_began_location) override {
+    return false;
+  }
   void OnPlatformViewDispatchSemanticsAction(int64_t view_id,
                                              int32_t node_id,
                                              SemanticsAction action,

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
@@ -36,7 +36,7 @@ class FakeDelegate : public PlatformView::Delegate {
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
   HitTestResponse OnPlatformViewHitTest(int64_t view_id, const flutter::PointData offset) override {
-    return {.is_platform_view = false};
+    return {.has_platform_view = false};
   }
   void OnPlatformViewDispatchSemanticsAction(int64_t view_id,
                                              int32_t node_id,

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
@@ -35,10 +35,8 @@ class FakeDelegate : public PlatformView::Delegate {
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
-  bool OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
-      int64_t view_id,
-      const flutter::PointData touch_began_location) override {
-    return false;
+  HitTestResponse OnPlatformViewHitTest(int64_t view_id, const flutter::PointData offset) override {
+    return {.is_platform_view = false};
   }
   void OnPlatformViewDispatchSemanticsAction(int64_t view_id,
                                              int32_t node_id,

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
@@ -37,6 +37,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)updateViewportMetrics:(flutter::ViewportMetrics)viewportMetrics;
 - (void)dispatchPointerDataPacket:(std::unique_ptr<flutter::PointerDataPacket>)packet;
+- (BOOL)platformViewShouldAcceptTouchAtTouchBeganLocation:(flutter::PointData)location
+                                                   viewId:(uint64_t)viewId;
 
 - (fml::RefPtr<fml::TaskRunner>)platformTaskRunner;
 - (fml::RefPtr<fml::TaskRunner>)uiTaskRunner;

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -517,8 +517,9 @@ static BOOL _preparedOnce = NO;
 
 @interface FlutterTouchInterceptingView ()
 @property(nonatomic, weak, readonly) UIView* embeddedView;
+@property(nonatomic, weak, readonly) UIViewController<FlutterViewResponder>* flutterViewController;
+@property(nonatomic, weak, readonly) FlutterPlatformViewsController* platformViewsController;
 @property(nonatomic, readonly) FlutterDelayingGestureRecognizer* delayingRecognizer;
-@property(nonatomic, readonly) FlutterPlatformViewGestureRecognizersBlockingPolicy blockingPolicy;
 @end
 
 @implementation FlutterTouchInterceptingView
@@ -530,6 +531,8 @@ static BOOL _preparedOnce = NO;
   if (self) {
     self.multipleTouchEnabled = YES;
     _embeddedView = embeddedView;
+    _platformViewsController = platformViewsController;
+    _flutterViewController = platformViewsController.flutterViewController;
     embeddedView.autoresizingMask =
         (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
 
@@ -545,7 +548,12 @@ static BOOL _preparedOnce = NO;
                                             forwardingRecognizer:forwardingRecognizer];
     _blockingPolicy = blockingPolicy;
 
-    [self addGestureRecognizer:_delayingRecognizer];
+    // For hit test, don't block gestures using delaying recognizer. However, we still
+    // forward touches so Flutter can process it in its gesture arena (e.g. dismiss a
+    // drop-down menu when tapping outside of the menu but inside the platform view).
+    if (blockingPolicy != FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly) {
+      [self addGestureRecognizer:_delayingRecognizer];
+    }
     [self addGestureRecognizer:forwardingRecognizer];
   }
   return self;
@@ -614,8 +622,33 @@ static BOOL _preparedOnce = NO;
   }
 }
 
+- (UIView*)hitTest:(CGPoint)point withEvent:(UIEvent*)event {
+  if (_blockingPolicy == FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly) {
+    // In release mode, FlutterTouchInterceptingView's init is called before flutterViewController
+    // is set on platformViewsController.
+    if (self.flutterViewController == nil) {
+      _flutterViewController = self.platformViewsController.flutterViewController;
+    }
+    CGPoint pointInFlutterView = [self convertPoint:point toView:self.flutterViewController.view];
+    // Consult the framework on if the touch should be handled by the platform view.
+    // If NO, the touch is handled by a Flutter widget and should be blocked (by returning self).
+    // If YES, the touch should continue to the standard hit-testing (through super), allowing the
+    // touch to be delivered to the underlying native platform view or one of its subviews.
+    if (![self.flutterViewController
+            platformViewShouldAcceptTouchAtTouchBeganLocation:pointInFlutterView]) {
+      return self;
+    }
+  }
+
+  return [super hitTest:point withEvent:event];
+}
+
 - (void)blockGesture {
   switch (_blockingPolicy) {
+    case FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly:
+      // No-op. Handled by hit test.
+      break;
+
     case FlutterPlatformViewGestureRecognizersBlockingPolicyEager:
       // We block all other gesture recognizers immediately in this policy.
       self.delayingRecognizer.state = UIGestureRecognizerStateEnded;
@@ -775,6 +808,12 @@ static BOOL _preparedOnce = NO;
 - (void)touchesBegan:(NSSet*)touches withEvent:(UIEvent*)event {
   FML_DCHECK(_currentTouchPointersCount >= 0);
   if (_currentTouchPointersCount == 0) {
+    // TODO(hellohuanlin): the following comment is likely incorrect and very misleading.
+    // The actual reason is a race condition when platform view is created before
+    // flutterViewController is set in platformViewsController in debug mode. We should clean up the
+    // code, either fix the race condition, or make flutterViewController a computed property rather
+    // than a stored property.
+    //
     // At the start of each gesture sequence, we reset the `_flutterViewController`,
     // so that all the touch events in the same sequence are forwarded to the same
     // `_flutterViewController`.

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -551,7 +551,7 @@ static BOOL _preparedOnce = NO;
     // For hit test, don't block gestures using delaying recognizer. However, we still
     // forward touches so Flutter can process it in its gesture arena (e.g. dismiss a
     // drop-down menu when tapping outside of the menu but inside the platform view).
-    if (blockingPolicy != FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly) {
+    if (blockingPolicy != FlutterPlatformViewGestureRecognizersBlockingPolicyDoNotBlockGesture) {
       [self addGestureRecognizer:_delayingRecognizer];
     }
     [self addGestureRecognizer:forwardingRecognizer];
@@ -623,21 +623,19 @@ static BOOL _preparedOnce = NO;
 }
 
 - (UIView*)hitTest:(CGPoint)point withEvent:(UIEvent*)event {
-  if (_blockingPolicy == FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly) {
-    // In release mode, FlutterTouchInterceptingView's init is called before flutterViewController
-    // is set on platformViewsController.
-    if (self.flutterViewController == nil) {
-      _flutterViewController = self.platformViewsController.flutterViewController;
-    }
-    CGPoint pointInFlutterView = [self convertPoint:point toView:self.flutterViewController.view];
-    // Consult the framework on if the touch should be handled by the platform view.
-    // If NO, the touch is handled by a Flutter widget and should be blocked (by returning self).
-    // If YES, the touch should continue to the standard hit-testing (through super), allowing the
-    // touch to be delivered to the underlying native platform view or one of its subviews.
-    if (![self.flutterViewController
-            platformViewShouldAcceptTouchAtTouchBeganLocation:pointInFlutterView]) {
-      return self;
-    }
+  // In release mode, FlutterTouchInterceptingView's init is called before flutterViewController
+  // is set on platformViewsController.
+  if (self.flutterViewController == nil) {
+    _flutterViewController = self.platformViewsController.flutterViewController;
+  }
+  CGPoint pointInFlutterView = [self convertPoint:point toView:self.flutterViewController.view];
+  // Consult the framework on if the touch should be handled by the platform view.
+  // If NO, the touch is handled by a Flutter widget and should be blocked (by returning self).
+  // If YES, the touch should continue to the standard hit-testing (through super), allowing the
+  // touch to be delivered to the underlying native platform view or one of its subviews.
+  if (![self.flutterViewController
+          platformViewShouldAcceptTouchAtTouchBeganLocation:pointInFlutterView]) {
+    return self;
   }
 
   return [super hitTest:point withEvent:event];
@@ -645,10 +643,9 @@ static BOOL _preparedOnce = NO;
 
 - (void)blockGesture {
   switch (_blockingPolicy) {
-    case FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly:
+    case FlutterPlatformViewGestureRecognizersBlockingPolicyDoNotBlockGesture:
       // No-op. Handled by hit test.
       break;
-
     case FlutterPlatformViewGestureRecognizersBlockingPolicyEager:
       // We block all other gesture recognizers immediately in this policy.
       self.delayingRecognizer.state = UIGestureRecognizerStateEnded;
@@ -813,6 +810,7 @@ static BOOL _preparedOnce = NO;
     // flutterViewController is set in platformViewsController in debug mode. We should clean up the
     // code, either fix the race condition, or make flutterViewController a computed property rather
     // than a stored property.
+    // See: https://github.com/flutter/flutter/issues/184354.
     //
     // At the start of each gesture sequence, we reset the `_flutterViewController`,
     // so that all the touch events in the same sequence are forwarded to the same

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
@@ -28,8 +28,8 @@ static constexpr NSUInteger kFlutterClippingMaskViewPoolCapacity = 5;
 
 static NSString* const kGestureBlockingPolicyEagerValue = @"eager";
 static NSString* const kGestureBlockingPolicyWaitUntilTouchesEndedValue = @"waitUntilTouchesEnded";
+static NSString* const kGestureBlockingPolicyDoNotBlockGesture = @"doNotBlockGesture";
 static NSString* const kGestureBlockingPolicyFallbackToPluginDefault = @"fallbackToPluginDefault";
-static NSString* const kGestureBlockingPolicyTouchBlockingOnly = @"touchBlockingOnly";
 
 struct LayerData {
   DlRect rect;
@@ -333,8 +333,8 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
 
   NSString* gestureBlockingPolicyValue = args[@"gestureBlockingPolicy"];
   FlutterPlatformViewGestureRecognizersBlockingPolicy gestureBlockingPolicy;
-  if ([gestureBlockingPolicyValue isEqualToString:kGestureBlockingPolicyTouchBlockingOnly]) {
-    gestureBlockingPolicy = FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly;
+  if ([gestureBlockingPolicyValue isEqualToString:kGestureBlockingPolicyDoNotBlockGesture]) {
+    gestureBlockingPolicy = FlutterPlatformViewGestureRecognizersBlockingPolicyDoNotBlockGesture;
   } else if ([gestureBlockingPolicyValue isEqualToString:kGestureBlockingPolicyEagerValue]) {
     gestureBlockingPolicy = FlutterPlatformViewGestureRecognizersBlockingPolicyEager;
   } else if ([gestureBlockingPolicyValue
@@ -345,12 +345,11 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
                  isEqualToString:kGestureBlockingPolicyFallbackToPluginDefault]) {
     gestureBlockingPolicy = self.gestureRecognizersBlockingPoliciesByType[viewType];
   } else {
-    NSString* errorMessage =
-        [NSString stringWithFormat:@"Unsupported gesture blocking policy: %@, so we fallback to "
-                                   @"use the policy set via engine API.",
-                                   gestureBlockingPolicyValue];
-    [FlutterLogger logError:errorMessage];
-    gestureBlockingPolicy = self.gestureRecognizersBlockingPoliciesByType[viewType];
+    result([FlutterError
+        errorWithCode:@"unknown_gesture_blocking_policy"
+              message:@"Trying to create a platform view with an unknown gesture blocking policy"
+              details:[NSString stringWithFormat:@"view id: '%lld'", viewId]]);
+    return;
   }
 
   FlutterTouchInterceptingView* touchInterceptor =

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
@@ -10,8 +10,10 @@
 #include "flutter/display_list/utils/dl_matrix_clip_tracker.h"
 #include "flutter/flow/surface_frame.h"
 #include "flutter/flow/view_slicer.h"
+#include "flutter/fml/logging.h"
 #include "flutter/fml/make_copyable.h"
 #include "flutter/fml/synchronization/count_down_latch.h"
+#import "flutter/shell/platform/darwin/common/InternalFlutterSwiftCommon/InternalFlutterSwiftCommon.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterView.h"
 #include "flutter/shell/platform/darwin/ios/framework/Source/overlay_layer_pool.h"
@@ -23,6 +25,11 @@ using flutter::DlRect;
 using flutter::DlRoundRect;
 
 static constexpr NSUInteger kFlutterClippingMaskViewPoolCapacity = 5;
+
+static NSString* const kGestureBlockingPolicyEagerValue = @"eager";
+static NSString* const kGestureBlockingPolicyWaitUntilTouchesEndedValue = @"waitUntilTouchesEnded";
+static NSString* const kGestureBlockingPolicyFallbackToPluginDefault = @"fallbackToPluginDefault";
+static NSString* const kGestureBlockingPolicyTouchBlockingOnly = @"touchBlockingOnly";
 
 struct LayerData {
   DlRect rect;
@@ -103,7 +110,7 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
 // The FlutterPlatformViewGestureRecognizersBlockingPolicy for each type of platform view.
 @property(nonatomic, readonly)
     std::unordered_map<std::string, FlutterPlatformViewGestureRecognizersBlockingPolicy>&
-        gestureRecognizersBlockingPolicies;
+        gestureRecognizersBlockingPoliciesByType;
 
 /// The size of the current onscreen surface in physical pixels.
 @property(nonatomic, assign) DlISize frameSize;
@@ -233,7 +240,7 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
   std::unordered_map<int64_t, std::unique_ptr<flutter::EmbedderViewSlice>> _slices;
   std::unordered_map<std::string, NSObject<FlutterPlatformViewFactory>*> _factories;
   std::unordered_map<std::string, FlutterPlatformViewGestureRecognizersBlockingPolicy>
-      _gestureRecognizersBlockingPolicies;
+      _gestureRecognizersBlockingPoliciesByType;
   fml::RefPtr<fml::TaskRunner> _platformTaskRunner;
   std::unordered_map<int64_t, PlatformViewData> _platformViews;
   std::unordered_map<int64_t, flutter::EmbeddedViewParams> _currentCompositionParams;
@@ -324,10 +331,32 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
   // Set a unique view identifier, so the platform view can be identified in unit tests.
   platformView.accessibilityIdentifier = [NSString stringWithFormat:@"platform_view[%lld]", viewId];
 
-  FlutterTouchInterceptingView* touchInterceptor = [[FlutterTouchInterceptingView alloc]
-                  initWithEmbeddedView:platformView
-               platformViewsController:self
-      gestureRecognizersBlockingPolicy:self.gestureRecognizersBlockingPolicies[viewType]];
+  NSString* gestureBlockingPolicyValue = args[@"gestureBlockingPolicy"];
+  FlutterPlatformViewGestureRecognizersBlockingPolicy gestureBlockingPolicy;
+  if ([gestureBlockingPolicyValue isEqualToString:kGestureBlockingPolicyTouchBlockingOnly]) {
+    gestureBlockingPolicy = FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly;
+  } else if ([gestureBlockingPolicyValue isEqualToString:kGestureBlockingPolicyEagerValue]) {
+    gestureBlockingPolicy = FlutterPlatformViewGestureRecognizersBlockingPolicyEager;
+  } else if ([gestureBlockingPolicyValue
+                 isEqualToString:kGestureBlockingPolicyWaitUntilTouchesEndedValue]) {
+    gestureBlockingPolicy =
+        FlutterPlatformViewGestureRecognizersBlockingPolicyWaitUntilTouchesEnded;
+  } else if ([gestureBlockingPolicyValue
+                 isEqualToString:kGestureBlockingPolicyFallbackToPluginDefault]) {
+    gestureBlockingPolicy = self.gestureRecognizersBlockingPoliciesByType[viewType];
+  } else {
+    NSString* errorMessage =
+        [NSString stringWithFormat:@"Unsupported gesture blocking policy: %@, so we fallback to "
+                                   @"use the policy set via engine API.",
+                                   gestureBlockingPolicyValue];
+    [FlutterLogger logError:errorMessage];
+    gestureBlockingPolicy = self.gestureRecognizersBlockingPoliciesByType[viewType];
+  }
+
+  FlutterTouchInterceptingView* touchInterceptor =
+      [[FlutterTouchInterceptingView alloc] initWithEmbeddedView:platformView
+                                         platformViewsController:self
+                                gestureRecognizersBlockingPolicy:gestureBlockingPolicy];
 
   ChildClippingView* clippingView = [[ChildClippingView alloc] initWithFrame:CGRectZero];
   [clippingView addSubview:touchInterceptor];
@@ -397,7 +426,7 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
   std::string idString([factoryId UTF8String]);
   FML_CHECK(self.factories.count(idString) == 0);
   self.factories[idString] = factory;
-  self.gestureRecognizersBlockingPolicies[idString] = gestureRecognizerBlockingPolicy;
+  self.gestureRecognizersBlockingPoliciesByType[idString] = gestureRecognizerBlockingPolicy;
 }
 
 - (void)beginFrameWithSize:(DlISize)frameSize {
@@ -1076,9 +1105,10 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
 - (std::unordered_map<std::string, NSObject<FlutterPlatformViewFactory>*>&)factories {
   return _factories;
 }
+
 - (std::unordered_map<std::string, FlutterPlatformViewGestureRecognizersBlockingPolicy>&)
-    gestureRecognizersBlockingPolicies {
-  return _gestureRecognizersBlockingPolicies;
+    gestureRecognizersBlockingPoliciesByType {
+  return _gestureRecognizersBlockingPoliciesByType;
 }
 
 - (std::unordered_map<int64_t, PlatformViewData>&)platformViews {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -2957,11 +2957,11 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
 
   XCTAssertNotNil(gMockPlatformView);
 
-  FlutterTouchInterceptingView* touchInteceptorView = FindTouchInterceptingView(gMockPlatformView);
-  XCTAssertNotNil(touchInteceptorView);
+  FlutterTouchInterceptingView* touchInterceptorView = FindTouchInterceptingView(gMockPlatformView);
+  XCTAssertNotNil(touchInterceptorView);
 
   UIGestureRecognizer* forwardGectureRecognizer =
-      FindForwardingGestureRecognizer(touchInteceptorView);
+      FindForwardingGestureRecognizer(touchInterceptorView);
 
   // Before setting flutter view controller, events are not dispatched.
   NSSet* touches1 = [[NSSet alloc] init];
@@ -3016,11 +3016,11 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
 
   XCTAssertNotNil(gMockPlatformView);
 
-  FlutterTouchInterceptingView* touchInteceptorView = FindTouchInterceptingView(gMockPlatformView);
-  XCTAssertNotNil(touchInteceptorView);
+  FlutterTouchInterceptingView* touchInterceptorView = FindTouchInterceptingView(gMockPlatformView);
+  XCTAssertNotNil(touchInterceptorView);
 
   UIGestureRecognizer* forwardGectureRecognizer =
-      FindForwardingGestureRecognizer(touchInteceptorView);
+      FindForwardingGestureRecognizer(touchInterceptorView);
   id flutterViewController = OCMClassMock([FlutterViewController class]);
   {
     // ***** Sequence 1, finishing touch event with touchEnded ***** //
@@ -3132,11 +3132,11 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
 
   XCTAssertNotNil(gMockPlatformView);
 
-  FlutterTouchInterceptingView* touchInteceptorView = FindTouchInterceptingView(gMockPlatformView);
-  XCTAssertNotNil(touchInteceptorView);
+  FlutterTouchInterceptingView* touchInterceptorView = FindTouchInterceptingView(gMockPlatformView);
+  XCTAssertNotNil(touchInterceptorView);
 
   UIGestureRecognizer* forwardGectureRecognizer =
-      FindForwardingGestureRecognizer(touchInteceptorView);
+      FindForwardingGestureRecognizer(touchInterceptorView);
   id flutterViewController = OCMClassMock([FlutterViewController class]);
   flutterPlatformViewsController.flutterViewController = flutterViewController;
 
@@ -3237,11 +3237,11 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
 
   XCTAssertNotNil(gMockPlatformView);
 
-  FlutterTouchInterceptingView* touchInteceptorView = FindTouchInterceptingView(gMockPlatformView);
-  XCTAssertNotNil(touchInteceptorView);
+  FlutterTouchInterceptingView* touchInterceptorView = FindTouchInterceptingView(gMockPlatformView);
+  XCTAssertNotNil(touchInterceptorView);
 
   UIGestureRecognizer* forwardGectureRecognizer =
-      FindForwardingGestureRecognizer(touchInteceptorView);
+      FindForwardingGestureRecognizer(touchInterceptorView);
   id flutterViewController = OCMClassMock([FlutterViewController class]);
   flutterPlatformViewsController.flutterViewController = flutterViewController;
 
@@ -3301,11 +3301,11 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
 
   XCTAssertNotNil(gMockPlatformView);
 
-  FlutterTouchInterceptingView* touchInteceptorView = FindTouchInterceptingView(gMockPlatformView);
-  XCTAssertNotNil(touchInteceptorView);
+  FlutterTouchInterceptingView* touchInterceptorView = FindTouchInterceptingView(gMockPlatformView);
+  XCTAssertNotNil(touchInterceptorView);
 
   __block UIGestureRecognizer* forwardGestureRecognizer =
-      FindForwardingGestureRecognizer(touchInteceptorView);
+      FindForwardingGestureRecognizer(touchInterceptorView);
   id flutterViewController = OCMClassMock([FlutterViewController class]);
   flutterPlatformViewsController.flutterViewController = flutterViewController;
 
@@ -3322,7 +3322,7 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       [self expectationWithDescription:@"Wait for gesture recognizer's state change."];
   dispatch_async(dispatch_get_main_queue(), ^{
     // Re-query forward gesture recognizer since it's recreated.
-    forwardGestureRecognizer = FindForwardingGestureRecognizer(touchInteceptorView);
+    forwardGestureRecognizer = FindForwardingGestureRecognizer(touchInterceptorView);
     XCTAssert(forwardGestureRecognizer.state == UIGestureRecognizerStatePossible,
               @"Forwarding gesture recognizer must be reset to possible state.");
     [touchEndedExpectation fulfill];
@@ -3339,7 +3339,7 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       [self expectationWithDescription:@"Wait for gesture recognizer's state change."];
   dispatch_async(dispatch_get_main_queue(), ^{
     // Re-query forward gesture recognizer since it's recreated.
-    forwardGestureRecognizer = FindForwardingGestureRecognizer(touchInteceptorView);
+    forwardGestureRecognizer = FindForwardingGestureRecognizer(touchInterceptorView);
     XCTAssert(forwardGestureRecognizer.state == UIGestureRecognizerStatePossible,
               @"Forwarding gesture recognizer must be reset to possible state.");
     [touchCancelledExpectation fulfill];
@@ -3388,17 +3388,17 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
 
   XCTAssertNotNil(gMockPlatformView);
 
-  FlutterTouchInterceptingView* touchInteceptorView = FindTouchInterceptingView(gMockPlatformView);
-  XCTAssertNotNil(touchInteceptorView);
+  FlutterTouchInterceptingView* touchInterceptorView = FindTouchInterceptingView(gMockPlatformView);
+  XCTAssertNotNil(touchInterceptorView);
 
-  XCTAssert(touchInteceptorView.gestureRecognizers.count == 2);
-  UIGestureRecognizer* delayingRecognizer = touchInteceptorView.gestureRecognizers[0];
-  UIGestureRecognizer* forwardingRecognizer = touchInteceptorView.gestureRecognizers[1];
+  XCTAssert(touchInterceptorView.gestureRecognizers.count == 2);
+  UIGestureRecognizer* delayingRecognizer = touchInterceptorView.gestureRecognizers[0];
+  UIGestureRecognizer* forwardingRecognizer = touchInterceptorView.gestureRecognizers[1];
 
   XCTAssert([delayingRecognizer isKindOfClass:[FlutterDelayingGestureRecognizer class]]);
   XCTAssert([forwardingRecognizer isKindOfClass:[ForwardingGestureRecognizer class]]);
 
-  [touchInteceptorView blockGesture];
+  [touchInterceptorView blockGesture];
 
   BOOL shouldReAddDelayingRecognizer = NO;
   if (@available(iOS 26.0, *)) {
@@ -3409,11 +3409,11 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
   }
   if (shouldReAddDelayingRecognizer) {
     // Since we remove and add back delayingRecognizer, it would be reordered to the last.
-    XCTAssertEqual(touchInteceptorView.gestureRecognizers[0], forwardingRecognizer);
-    XCTAssertEqual(touchInteceptorView.gestureRecognizers[1], delayingRecognizer);
+    XCTAssertEqual(touchInterceptorView.gestureRecognizers[0], forwardingRecognizer);
+    XCTAssertEqual(touchInterceptorView.gestureRecognizers[1], delayingRecognizer);
   } else {
-    XCTAssertEqual(touchInteceptorView.gestureRecognizers[0], delayingRecognizer);
-    XCTAssertEqual(touchInteceptorView.gestureRecognizers[1], forwardingRecognizer);
+    XCTAssertEqual(touchInterceptorView.gestureRecognizers[0], delayingRecognizer);
+    XCTAssertEqual(touchInterceptorView.gestureRecognizers[1], forwardingRecognizer);
   }
 }
 
@@ -3457,17 +3457,17 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
 
   XCTAssertNotNil(gMockPlatformView);
 
-  FlutterTouchInterceptingView* touchInteceptorView = FindTouchInterceptingView(gMockPlatformView);
-  XCTAssertNotNil(touchInteceptorView);
+  FlutterTouchInterceptingView* touchInterceptorView = FindTouchInterceptingView(gMockPlatformView);
+  XCTAssertNotNil(touchInterceptorView);
 
-  XCTAssert(touchInteceptorView.gestureRecognizers.count == 2);
-  UIGestureRecognizer* delayingRecognizer = touchInteceptorView.gestureRecognizers[0];
-  UIGestureRecognizer* forwardingRecognizer = touchInteceptorView.gestureRecognizers[1];
+  XCTAssert(touchInterceptorView.gestureRecognizers.count == 2);
+  UIGestureRecognizer* delayingRecognizer = touchInterceptorView.gestureRecognizers[0];
+  UIGestureRecognizer* forwardingRecognizer = touchInterceptorView.gestureRecognizers[1];
 
   XCTAssert([delayingRecognizer isKindOfClass:[FlutterDelayingGestureRecognizer class]]);
   XCTAssert([forwardingRecognizer isKindOfClass:[ForwardingGestureRecognizer class]]);
 
-  [touchInteceptorView blockGesture];
+  [touchInterceptorView blockGesture];
 
   BOOL shouldReAddDelayingRecognizer = NO;
   if (@available(iOS 26.0, *)) {
@@ -3479,11 +3479,11 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
   }
   if (shouldReAddDelayingRecognizer) {
     // Since we remove and add back delayingRecognizer, it would be reordered to the last.
-    XCTAssertEqual(touchInteceptorView.gestureRecognizers[0], forwardingRecognizer);
-    XCTAssertEqual(touchInteceptorView.gestureRecognizers[1], delayingRecognizer);
+    XCTAssertEqual(touchInterceptorView.gestureRecognizers[0], forwardingRecognizer);
+    XCTAssertEqual(touchInterceptorView.gestureRecognizers[1], delayingRecognizer);
   } else {
-    XCTAssertEqual(touchInteceptorView.gestureRecognizers[0], delayingRecognizer);
-    XCTAssertEqual(touchInteceptorView.gestureRecognizers[1], forwardingRecognizer);
+    XCTAssertEqual(touchInterceptorView.gestureRecognizers[0], delayingRecognizer);
+    XCTAssertEqual(touchInterceptorView.gestureRecognizers[1], forwardingRecognizer);
   }
 }
 
@@ -3526,17 +3526,17 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
 
   XCTAssertNotNil(gMockPlatformView);
 
-  FlutterTouchInterceptingView* touchInteceptorView = FindTouchInterceptingView(gMockPlatformView);
-  XCTAssertNotNil(touchInteceptorView);
+  FlutterTouchInterceptingView* touchInterceptorView = FindTouchInterceptingView(gMockPlatformView);
+  XCTAssertNotNil(touchInterceptorView);
 
-  XCTAssert(touchInteceptorView.gestureRecognizers.count == 2);
-  UIGestureRecognizer* delayingRecognizer = touchInteceptorView.gestureRecognizers[0];
-  UIGestureRecognizer* forwardingRecognizer = touchInteceptorView.gestureRecognizers[1];
+  XCTAssert(touchInterceptorView.gestureRecognizers.count == 2);
+  UIGestureRecognizer* delayingRecognizer = touchInterceptorView.gestureRecognizers[0];
+  UIGestureRecognizer* forwardingRecognizer = touchInterceptorView.gestureRecognizers[1];
 
   XCTAssert([delayingRecognizer isKindOfClass:[FlutterDelayingGestureRecognizer class]]);
   XCTAssert([forwardingRecognizer isKindOfClass:[ForwardingGestureRecognizer class]]);
 
-  [touchInteceptorView blockGesture];
+  [touchInterceptorView blockGesture];
 
   BOOL shouldReAddDelayingRecognizer = NO;
   if (@available(iOS 26.0, *)) {
@@ -3548,11 +3548,11 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
   }
   if (shouldReAddDelayingRecognizer) {
     // Since we remove and add back delayingRecognizer, it would be reordered to the last.
-    XCTAssertEqual(touchInteceptorView.gestureRecognizers[0], forwardingRecognizer);
-    XCTAssertEqual(touchInteceptorView.gestureRecognizers[1], delayingRecognizer);
+    XCTAssertEqual(touchInterceptorView.gestureRecognizers[0], forwardingRecognizer);
+    XCTAssertEqual(touchInterceptorView.gestureRecognizers[1], delayingRecognizer);
   } else {
-    XCTAssertEqual(touchInteceptorView.gestureRecognizers[0], delayingRecognizer);
-    XCTAssertEqual(touchInteceptorView.gestureRecognizers[1], forwardingRecognizer);
+    XCTAssertEqual(touchInterceptorView.gestureRecognizers[0], delayingRecognizer);
+    XCTAssertEqual(touchInterceptorView.gestureRecognizers[1], forwardingRecognizer);
   }
 }
 
@@ -3595,20 +3595,20 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
 
   XCTAssertNotNil(gMockPlatformView);
 
-  FlutterTouchInterceptingView* touchInteceptorView = FindTouchInterceptingView(gMockPlatformView);
-  XCTAssertNotNil(touchInteceptorView);
+  FlutterTouchInterceptingView* touchInterceptorView = FindTouchInterceptingView(gMockPlatformView);
+  XCTAssertNotNil(touchInterceptorView);
 
-  XCTAssert(touchInteceptorView.gestureRecognizers.count == 2);
-  UIGestureRecognizer* delayingRecognizer = touchInteceptorView.gestureRecognizers[0];
-  UIGestureRecognizer* forwardingRecognizer = touchInteceptorView.gestureRecognizers[1];
+  XCTAssert(touchInterceptorView.gestureRecognizers.count == 2);
+  UIGestureRecognizer* delayingRecognizer = touchInterceptorView.gestureRecognizers[0];
+  UIGestureRecognizer* forwardingRecognizer = touchInterceptorView.gestureRecognizers[1];
 
   XCTAssert([delayingRecognizer isKindOfClass:[FlutterDelayingGestureRecognizer class]]);
   XCTAssert([forwardingRecognizer isKindOfClass:[ForwardingGestureRecognizer class]]);
 
-  [touchInteceptorView blockGesture];
+  [touchInterceptorView blockGesture];
 
-  XCTAssertEqual(touchInteceptorView.gestureRecognizers[0], delayingRecognizer);
-  XCTAssertEqual(touchInteceptorView.gestureRecognizers[1], forwardingRecognizer);
+  XCTAssertEqual(touchInterceptorView.gestureRecognizers[0], delayingRecognizer);
+  XCTAssertEqual(touchInterceptorView.gestureRecognizers[1], forwardingRecognizer);
 }
 
 - (void)
@@ -3652,9 +3652,9 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
 
     XCTAssertNotNil(gMockPlatformView);
 
-    FlutterTouchInterceptingView* touchInteceptorView =
+    FlutterTouchInterceptingView* touchInterceptorView =
         FindTouchInterceptingView(gMockPlatformView);
-    XCTAssertNotNil(touchInteceptorView);
+    XCTAssertNotNil(touchInterceptorView);
 
     /*
       Simple Web View at root, with [*] indicating views containing
@@ -3705,7 +3705,7 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
         [[MockTouchEventsGestureRecognizer alloc] init];
     [child2_2 addGestureRecognizer:targetRecognizer2_2];
 
-    [touchInteceptorView blockGesture];
+    [touchInterceptorView blockGesture];
 
     NSArray* normalRecognizers = @[
       normalRecognizer0, normalRecognizer1, normalRecognizer2, normalRecognizer2_1,
@@ -3767,9 +3767,9 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
 
     XCTAssertNotNil(gMockPlatformView);
 
-    FlutterTouchInterceptingView* touchInteceptorView =
+    FlutterTouchInterceptingView* touchInterceptorView =
         FindTouchInterceptingView(gMockPlatformView);
-    XCTAssertNotNil(touchInteceptorView);
+    XCTAssertNotNil(touchInterceptorView);
 
     /*
       Platform View with Multiple Web Views in different branches, with [*] indicating views
@@ -3852,7 +3852,7 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
         [[MockTouchEventsGestureRecognizer alloc] init];
     [child3_1_2 addGestureRecognizer:targetRecognizer3_1_2];
 
-    [touchInteceptorView blockGesture];
+    [touchInterceptorView blockGesture];
 
     NSArray* normalRecognizers = @[
       normalRecognizer0, normalRecognizer1, normalRecognizer2, normalRecognizer2_1,
@@ -3915,9 +3915,9 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
 
     XCTAssertNotNil(gMockPlatformView);
 
-    FlutterTouchInterceptingView* touchInteceptorView =
+    FlutterTouchInterceptingView* touchInterceptorView =
         FindTouchInterceptingView(gMockPlatformView);
-    XCTAssertNotNil(touchInteceptorView);
+    XCTAssertNotNil(touchInterceptorView);
 
     /*
       Platform View with nested web views, with [*] indicating views containing
@@ -4009,7 +4009,7 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
         [[MockTouchEventsGestureRecognizer alloc] init];
     [child3_1_2_2 addGestureRecognizer:targetRecognizer3_1_2_2];
 
-    [touchInteceptorView blockGesture];
+    [touchInterceptorView blockGesture];
 
     NSArray* normalRecognizers = @[
       normalRecognizer0, normalRecognizer1, normalRecognizer2, normalRecognizer2_1,
@@ -4072,12 +4072,7 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
 
   XCTAssertNotNil(gMockPlatformView);
 
-  // Find touch inteceptor view
-  UIView* touchInterceptorView = gMockPlatformView;
-  while (touchInterceptorView != nil &&
-         ![touchInterceptorView isKindOfClass:[FlutterTouchInterceptingView class]]) {
-    touchInterceptorView = touchInterceptorView.superview;
-  }
+  FlutterTouchInterceptingView* touchInterceptorView = FindTouchInterceptingView(gMockPlatformView);
   XCTAssertNotNil(touchInterceptorView);
 
   XCTAssert(touchInterceptorView.gestureRecognizers.count == 1);
@@ -4123,12 +4118,7 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
 
   XCTAssertNotNil(gMockPlatformView);
 
-  // Find touch inteceptor view
-  UIView* touchInterceptorView = gMockPlatformView;
-  while (touchInterceptorView != nil &&
-         ![touchInterceptorView isKindOfClass:[FlutterTouchInterceptingView class]]) {
-    touchInterceptorView = touchInterceptorView.superview;
-  }
+  FlutterTouchInterceptingView* touchInterceptorView = FindTouchInterceptingView(gMockPlatformView);
   XCTAssertNotNil(touchInterceptorView);
 
   XCTAssert(touchInterceptorView.gestureRecognizers.count == 2);
@@ -4181,12 +4171,7 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
 
   XCTAssertNotNil(gMockPlatformView);
 
-  // Find touch inteceptor view
-  UIView* touchInterceptorView = gMockPlatformView;
-  while (touchInterceptorView != nil &&
-         ![touchInterceptorView isKindOfClass:[FlutterTouchInterceptingView class]]) {
-    touchInterceptorView = touchInterceptorView.superview;
-  }
+  FlutterTouchInterceptingView* touchInterceptorView = FindTouchInterceptingView(gMockPlatformView);
   XCTAssertNotNil(touchInterceptorView);
 
   touchInterceptorView.frame = CGRectMake(0, 0, 100, 100);
@@ -4247,12 +4232,7 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
 
   XCTAssertNotNil(gMockPlatformView);
 
-  // Find touch inteceptor view
-  UIView* touchInterceptorView = gMockPlatformView;
-  while (touchInterceptorView != nil &&
-         ![touchInterceptorView isKindOfClass:[FlutterTouchInterceptingView class]]) {
-    touchInterceptorView = touchInterceptorView.superview;
-  }
+  FlutterTouchInterceptingView* touchInterceptorView = FindTouchInterceptingView(gMockPlatformView);
   XCTAssertNotNil(touchInterceptorView);
 
   touchInterceptorView.frame = CGRectMake(0, 0, 100, 100);
@@ -4315,12 +4295,9 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
                                                        @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
-  UIView* touchInterceptorView = gMockPlatformView;
-  while (touchInterceptorView != nil &&
-         ![touchInterceptorView isKindOfClass:[FlutterTouchInterceptingView class]]) {
-    touchInterceptorView = touchInterceptorView.superview;
-  }
-  XCTAssertEqual(((FlutterTouchInterceptingView*)touchInterceptorView).blockingPolicy,
+
+  FlutterTouchInterceptingView* touchInterceptorView = FindTouchInterceptingView(gMockPlatformView);
+  XCTAssertEqual(touchInterceptorView.blockingPolicy,
                  FlutterPlatformViewGestureRecognizersBlockingPolicyEager);
 
   // waitUntilTouchesEnded
@@ -4333,12 +4310,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
                                         @"gestureBlockingPolicy" : @"waitUntilTouchesEnded"
                                       }]
             result:result];
-  touchInterceptorView = gMockPlatformView;
-  while (touchInterceptorView != nil &&
-         ![touchInterceptorView isKindOfClass:[FlutterTouchInterceptingView class]]) {
-    touchInterceptorView = touchInterceptorView.superview;
-  }
-  XCTAssertEqual(((FlutterTouchInterceptingView*)touchInterceptorView).blockingPolicy,
+  touchInterceptorView = FindTouchInterceptingView(gMockPlatformView);
+  XCTAssertEqual(touchInterceptorView.blockingPolicy,
                  FlutterPlatformViewGestureRecognizersBlockingPolicyWaitUntilTouchesEnded);
 
   [flutterPlatformViewsController
@@ -4350,12 +4323,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
                                         @"gestureBlockingPolicy" : @"doNotBlockGesture"
                                       }]
             result:result];
-  touchInterceptorView = gMockPlatformView;
-  while (touchInterceptorView != nil &&
-         ![touchInterceptorView isKindOfClass:[FlutterTouchInterceptingView class]]) {
-    touchInterceptorView = touchInterceptorView.superview;
-  }
-  XCTAssertEqual(((FlutterTouchInterceptingView*)touchInterceptorView).blockingPolicy,
+  touchInterceptorView = FindTouchInterceptingView(gMockPlatformView);
+  XCTAssertEqual(touchInterceptorView.blockingPolicy,
                  FlutterPlatformViewGestureRecognizersBlockingPolicyDoNotBlockGesture);
   XCTAssertNil(methodResult);
 
@@ -4369,12 +4338,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
                                         @"gestureBlockingPolicy" : @"fallbackToPluginDefault"
                                       }]
             result:result];
-  touchInterceptorView = gMockPlatformView;
-  while (touchInterceptorView != nil &&
-         ![touchInterceptorView isKindOfClass:[FlutterTouchInterceptingView class]]) {
-    touchInterceptorView = touchInterceptorView.superview;
-  }
-  XCTAssertEqual(((FlutterTouchInterceptingView*)touchInterceptorView).blockingPolicy,
+  touchInterceptorView = FindTouchInterceptingView(gMockPlatformView);
+  XCTAssertEqual(touchInterceptorView.blockingPolicy,
                  FlutterPlatformViewGestureRecognizersBlockingPolicyWaitUntilTouchesEnded);
   XCTAssertNil(methodResult);
 
@@ -5532,10 +5497,10 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
 }
 
 - (void)testFlutterTouchInterceptingViewLinksToAccessibilityContainer {
-  FlutterTouchInterceptingView* touchInteceptorView = [[FlutterTouchInterceptingView alloc] init];
+  FlutterTouchInterceptingView* touchInterceptorView = [[FlutterTouchInterceptingView alloc] init];
   NSObject* container = [[NSObject alloc] init];
-  [touchInteceptorView setFlutterAccessibilityContainer:container];
-  XCTAssertEqualObjects([touchInteceptorView accessibilityContainer], container);
+  [touchInterceptorView setFlutterAccessibilityContainer:container];
+  XCTAssertEqualObjects([touchInterceptorView accessibilityContainer], container);
 }
 
 - (void)testLayerPool {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -283,10 +283,8 @@ class FlutterPlatformViewsTestMockPlatformViewDelegate : public PlatformView::De
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
-  bool OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
-      int64_t view_id,
-      const flutter::PointData touch_began_location) override {
-    return false;
+  HitTestResponse OnPlatformViewHitTest(int64_t view_id, const flutter::PointData offset) override {
+    return {.is_platform_view = false};
   }
   void OnPlatformViewDispatchSemanticsAction(int64_t view_id,
                                              int32_t node_id,
@@ -1697,11 +1695,13 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
   FlutterResult result = ^(id result) {
   };
   [flutterPlatformViewsController
-      onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
-                                                     arguments:@{
-                                                       @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
-                                                     }]
+      onMethodCall:[FlutterMethodCall
+                       methodCallWithMethodName:@"create"
+                                      arguments:@{
+                                        @"id" : @2,
+                                        @"viewType" : @"MockFlutterPlatformView",
+                                        @"gestureBlockingPolicy" : @"fallbackToPluginDefault"
+                                      }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -1779,11 +1779,13 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
   FlutterResult result = ^(id result) {
   };
   [flutterPlatformViewsController
-      onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
-                                                     arguments:@{
-                                                       @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
-                                                     }]
+      onMethodCall:[FlutterMethodCall
+                       methodCallWithMethodName:@"create"
+                                      arguments:@{
+                                        @"id" : @2,
+                                        @"viewType" : @"MockFlutterPlatformView",
+                                        @"gestureBlockingPolicy" : @"fallbackToPluginDefault"
+                                      }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -3446,7 +3448,11 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
   [flutterPlatformViewsController
       onMethodCall:[FlutterMethodCall
                        methodCallWithMethodName:@"create"
-                                      arguments:@{@"id" : @2, @"viewType" : @"MockWrapperWebView"}]
+                                      arguments:@{
+                                        @"id" : @2,
+                                        @"viewType" : @"MockWrapperWebView",
+                                        @"gestureBlockingPolicy" : @"fallbackToPluginDefault"
+                                      }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -3637,7 +3643,11 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
     [flutterPlatformViewsController
         onMethodCall:[FlutterMethodCall
                          methodCallWithMethodName:@"create"
-                                        arguments:@{@"id" : @2, @"viewType" : @"MockWebView"}]
+                                        arguments:@{
+                                          @"id" : @2,
+                                          @"viewType" : @"MockWebView",
+                                          @"gestureBlockingPolicy" : @"fallbackToPluginDefault"
+                                        }]
               result:result];
 
     XCTAssertNotNil(gMockPlatformView);
@@ -3746,11 +3756,13 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
     FlutterResult result = ^(id result) {
     };
     [flutterPlatformViewsController
-        onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
-                                                       arguments:@{
-                                                         @"id" : @2,
-                                                         @"viewType" : @"MockWrapperWebView"
-                                                       }]
+        onMethodCall:[FlutterMethodCall
+                         methodCallWithMethodName:@"create"
+                                        arguments:@{
+                                          @"id" : @2,
+                                          @"viewType" : @"MockWrapperWebView",
+                                          @"gestureBlockingPolicy" : @"fallbackToPluginDefault"
+                                        }]
               result:result];
 
     XCTAssertNotNil(gMockPlatformView);
@@ -3894,7 +3906,11 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
     [flutterPlatformViewsController
         onMethodCall:[FlutterMethodCall
                          methodCallWithMethodName:@"create"
-                                        arguments:@{@"id" : @2, @"viewType" : @"MockWebView"}]
+                                        arguments:@{
+                                          @"id" : @2,
+                                          @"viewType" : @"MockWebView",
+                                          @"gestureBlockingPolicy" : @"fallbackToPluginDefault"
+                                        }]
               result:result];
 
     XCTAssertNotNil(gMockPlatformView);
@@ -4016,7 +4032,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
   }
 }
 
-- (void)testFlutterPlatformViewBlockGestureHitTestPolicyShouldNotAddDelayingRecognizer {
+- (void)
+    testFlutterPlatformViewGestureBlockingPolicy_ShouldNotAddDelayingRecognizerUnderDoNotBlockGesturePolicy {
   flutter::FlutterPlatformViewsTestMockPlatformViewDelegate mock_delegate;
 
   flutter::TaskRunners runners(/*label=*/self.name.UTF8String,
@@ -4040,7 +4057,7 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
   [flutterPlatformViewsController registerViewFactory:factory
                                                withId:@"MockFlutterPlatformView"
                      gestureRecognizersBlockingPolicy:
-                         FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly];
+                         FlutterPlatformViewGestureRecognizersBlockingPolicyDoNotBlockGesture];
   FlutterResult result = ^(id result) {
   };
   [flutterPlatformViewsController
@@ -4049,7 +4066,7 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
                                       arguments:@{
                                         @"id" : @2,
                                         @"viewType" : @"MockFlutterPlatformView",
-                                        @"gestureBlockingPolicy" : @"touchBlockingOnly"
+                                        @"gestureBlockingPolicy" : @"doNotBlockGesture"
                                       }]
             result:result];
 
@@ -4068,7 +4085,7 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
   XCTAssert([forwardingRecognizer isKindOfClass:[ForwardingGestureRecognizer class]]);
 }
 
-- (void)testFlutterPlatformViewBlockGestureUnderNonHitTestPolicyShouldAddDelayingRecognizer {
+- (void)testFlutterPlatformViewGestureBlockingPolicy_ShouldAddDelayingRecognizerUnderEagerPolicy {
   flutter::FlutterPlatformViewsTestMockPlatformViewDelegate mock_delegate;
 
   flutter::TaskRunners runners(/*label=*/self.name.UTF8String,
@@ -4121,7 +4138,7 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
   XCTAssert([forwardingRecognizer isKindOfClass:[ForwardingGestureRecognizer class]]);
 }
 
-- (void)testFlutterPlatformViewBlockGestureHitTestPolicyAcceptGesture {
+- (void)testFlutterPlatformViewHitTest_AcceptTouchIfInstructedByFramework {
   flutter::FlutterPlatformViewsTestMockPlatformViewDelegate mock_delegate;
 
   flutter::TaskRunners runners(/*label=*/self.name.UTF8String,
@@ -4149,70 +4166,7 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
   [flutterPlatformViewsController registerViewFactory:factory
                                                withId:@"MockFlutterPlatformView"
                      gestureRecognizersBlockingPolicy:
-                         FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly];
-  FlutterResult result = ^(id result) {
-  };
-  [flutterPlatformViewsController
-      onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
-                                                     arguments:@{
-                                                       @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy" : @"eager"
-                                                     }]
-            result:result];
-
-  XCTAssertNotNil(gMockPlatformView);
-
-  // Find touch inteceptor view
-  UIView* touchInterceptorView = gMockPlatformView;
-  while (touchInterceptorView != nil &&
-         ![touchInterceptorView isKindOfClass:[FlutterTouchInterceptingView class]]) {
-    touchInterceptorView = touchInterceptorView.superview;
-  }
-  XCTAssertNotNil(touchInterceptorView);
-
-  touchInterceptorView.frame = CGRectMake(0, 0, 100, 100);
-  CGPoint touchBeganLocation = CGPointMake(1, 1);
-
-  UIEvent* mockEvent = OCMClassMock([UIEvent class]);
-  OCMStub([mockEvent type]).andReturn(UIEventTypeTouches);
-
-  OCMStub([mockFlutterViewController
-              platformViewShouldAcceptTouchAtTouchBeganLocation:touchBeganLocation])
-      .andReturn(YES);
-  UIView* hitTestResult = [touchInterceptorView hitTest:touchBeganLocation withEvent:mockEvent];
-  XCTAssert(hitTestResult == gMockPlatformView);
-}
-
-- (void)testFlutterPlatformViewBlockGestureHitTestPolicyRejectGesture {
-  flutter::FlutterPlatformViewsTestMockPlatformViewDelegate mock_delegate;
-
-  flutter::TaskRunners runners(/*label=*/self.name.UTF8String,
-                               /*platform=*/GetDefaultTaskRunner(),
-                               /*raster=*/GetDefaultTaskRunner(),
-                               /*ui=*/GetDefaultTaskRunner(),
-                               /*io=*/GetDefaultTaskRunner());
-  FlutterPlatformViewsController* flutterPlatformViewsController =
-      [[FlutterPlatformViewsController alloc] init];
-
-  FlutterViewController* mockFlutterViewController = OCMClassMock([FlutterViewController class]);
-  flutterPlatformViewsController.flutterViewController = mockFlutterViewController;
-
-  flutterPlatformViewsController.taskRunner = GetDefaultTaskRunner();
-  auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
-      /*delegate=*/mock_delegate,
-      /*rendering_api=*/flutter::IOSRenderingAPI::kMetal,
-      /*platform_views_controller=*/flutterPlatformViewsController,
-      /*task_runners=*/runners,
-      /*worker_task_runner=*/nil,
-      /*is_gpu_disabled_jsync_switch=*/std::make_shared<fml::SyncSwitch>());
-
-  FlutterPlatformViewsTestMockFlutterPlatformFactory* factory =
-      [[FlutterPlatformViewsTestMockFlutterPlatformFactory alloc] init];
-  [flutterPlatformViewsController registerViewFactory:factory
-                                               withId:@"MockFlutterPlatformView"
-                     gestureRecognizersBlockingPolicy:
-                         FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly];
+                         FlutterPlatformViewGestureRecognizersBlockingPolicyDoNotBlockGesture];
   FlutterResult result = ^(id result) {
   };
   [flutterPlatformViewsController
@@ -4221,7 +4175,7 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
                                       arguments:@{
                                         @"id" : @2,
                                         @"viewType" : @"MockFlutterPlatformView",
-                                        @"gestureBlockingPolicy" : @"touchBlockingOnly"
+                                        @"gestureBlockingPolicy" : @"doNotBlockGesture"
                                       }]
             result:result];
 
@@ -4241,14 +4195,16 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
   UIEvent* mockEvent = OCMClassMock([UIEvent class]);
   OCMStub([mockEvent type]).andReturn(UIEventTypeTouches);
 
+  // Framework instructs "accept touch".
   OCMStub([mockFlutterViewController
               platformViewShouldAcceptTouchAtTouchBeganLocation:touchBeganLocation])
-      .andReturn(NO);
+      .andReturn(YES);
   UIView* hitTestResult = [touchInterceptorView hitTest:touchBeganLocation withEvent:mockEvent];
-  XCTAssert(hitTestResult == touchInterceptorView);
+  // HitTest returning the platform view means platform view will receive touch events.
+  XCTAssert(hitTestResult == gMockPlatformView);
 }
 
-- (void)testFlutterPlatformViewGestureBlockingPolicyMapping {
+- (void)testFlutterPlatformViewHitTest_RejectTouchIfInstructedByFramework {
   flutter::FlutterPlatformViewsTestMockPlatformViewDelegate mock_delegate;
 
   flutter::TaskRunners runners(/*label=*/self.name.UTF8String,
@@ -4276,8 +4232,78 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
   [flutterPlatformViewsController registerViewFactory:factory
                                                withId:@"MockFlutterPlatformView"
                      gestureRecognizersBlockingPolicy:
-                         FlutterPlatformViewGestureRecognizersBlockingPolicyWaitUntilTouchesEnded];
+                         FlutterPlatformViewGestureRecognizersBlockingPolicyDoNotBlockGesture];
   FlutterResult result = ^(id result) {
+  };
+  [flutterPlatformViewsController
+      onMethodCall:[FlutterMethodCall
+                       methodCallWithMethodName:@"create"
+                                      arguments:@{
+                                        @"id" : @2,
+                                        @"viewType" : @"MockFlutterPlatformView",
+                                        @"gestureBlockingPolicy" : @"doNotBlockGesture"
+                                      }]
+            result:result];
+
+  XCTAssertNotNil(gMockPlatformView);
+
+  // Find touch inteceptor view
+  UIView* touchInterceptorView = gMockPlatformView;
+  while (touchInterceptorView != nil &&
+         ![touchInterceptorView isKindOfClass:[FlutterTouchInterceptingView class]]) {
+    touchInterceptorView = touchInterceptorView.superview;
+  }
+  XCTAssertNotNil(touchInterceptorView);
+
+  touchInterceptorView.frame = CGRectMake(0, 0, 100, 100);
+  CGPoint touchBeganLocation = CGPointMake(1, 1);
+
+  UIEvent* mockEvent = OCMClassMock([UIEvent class]);
+  OCMStub([mockEvent type]).andReturn(UIEventTypeTouches);
+
+  // Framework instructs "reject touch".
+  OCMStub([mockFlutterViewController
+              platformViewShouldAcceptTouchAtTouchBeganLocation:touchBeganLocation])
+      .andReturn(NO);
+  UIView* hitTestResult = [touchInterceptorView hitTest:touchBeganLocation withEvent:mockEvent];
+  // HitTest returning the touch interceptor view means platform view will not receive touch events.
+  XCTAssert(hitTestResult == touchInterceptorView);
+}
+
+- (void)testFlutterPlatformViewGestureBlockingPolicy_PolicyMappingIsCorrect {
+  flutter::FlutterPlatformViewsTestMockPlatformViewDelegate mock_delegate;
+
+  flutter::TaskRunners runners(/*label=*/self.name.UTF8String,
+                               /*platform=*/GetDefaultTaskRunner(),
+                               /*raster=*/GetDefaultTaskRunner(),
+                               /*ui=*/GetDefaultTaskRunner(),
+                               /*io=*/GetDefaultTaskRunner());
+  FlutterPlatformViewsController* flutterPlatformViewsController =
+      [[FlutterPlatformViewsController alloc] init];
+
+  FlutterViewController* mockFlutterViewController = OCMClassMock([FlutterViewController class]);
+  flutterPlatformViewsController.flutterViewController = mockFlutterViewController;
+
+  flutterPlatformViewsController.taskRunner = GetDefaultTaskRunner();
+  auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
+      /*delegate=*/mock_delegate,
+      /*rendering_api=*/flutter::IOSRenderingAPI::kMetal,
+      /*platform_views_controller=*/flutterPlatformViewsController,
+      /*task_runners=*/runners,
+      /*worker_task_runner=*/nil,
+      /*is_gpu_disabled_jsync_switch=*/std::make_shared<fml::SyncSwitch>());
+
+  FlutterPlatformViewsTestMockFlutterPlatformFactory* factory =
+      [[FlutterPlatformViewsTestMockFlutterPlatformFactory alloc] init];
+  [flutterPlatformViewsController registerViewFactory:factory
+                                               withId:@"MockFlutterPlatformView"
+                     // the policy set by engine API will be overwritten by the dart API, unless
+                     // `fallbackToPluginDefault` is used in dart API.
+                     gestureRecognizersBlockingPolicy:
+                         FlutterPlatformViewGestureRecognizersBlockingPolicyWaitUntilTouchesEnded];
+  __block id methodResult;
+  FlutterResult result = ^(id result) {
+    methodResult = result;
   };
 
   // eager
@@ -4315,14 +4341,13 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
   XCTAssertEqual(((FlutterTouchInterceptingView*)touchInterceptorView).blockingPolicy,
                  FlutterPlatformViewGestureRecognizersBlockingPolicyWaitUntilTouchesEnded);
 
-  // touchBlockingOnly
   [flutterPlatformViewsController
       onMethodCall:[FlutterMethodCall
                        methodCallWithMethodName:@"create"
                                       arguments:@{
                                         @"id" : @4,
                                         @"viewType" : @"MockFlutterPlatformView",
-                                        @"gestureBlockingPolicy" : @"touchBlockingOnly"
+                                        @"gestureBlockingPolicy" : @"doNotBlockGesture"
                                       }]
             result:result];
   touchInterceptorView = gMockPlatformView;
@@ -4331,7 +4356,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
     touchInterceptorView = touchInterceptorView.superview;
   }
   XCTAssertEqual(((FlutterTouchInterceptingView*)touchInterceptorView).blockingPolicy,
-                 FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly);
+                 FlutterPlatformViewGestureRecognizersBlockingPolicyDoNotBlockGesture);
+  XCTAssertNil(methodResult);
 
   // fallbackToPluginDefault (which is waitUntilTouchesEnded)
   [flutterPlatformViewsController
@@ -4350,6 +4376,24 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
   }
   XCTAssertEqual(((FlutterTouchInterceptingView*)touchInterceptorView).blockingPolicy,
                  FlutterPlatformViewGestureRecognizersBlockingPolicyWaitUntilTouchesEnded);
+  XCTAssertNil(methodResult);
+
+  // Unkonwn gesture blocking policy should fail
+  [flutterPlatformViewsController
+      onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
+                                                     arguments:@{
+                                                       @"id" : @6,
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"unknownPolicy"
+                                                     }]
+            result:result];
+  XCTAssertTrue([methodResult isKindOfClass:[FlutterError class]]);
+  FlutterError* resultError = (FlutterError*)methodResult;
+  XCTAssertEqualObjects(resultError.code, @"unknown_gesture_blocking_policy");
+  XCTAssertEqualObjects(
+      resultError.message,
+      @"Trying to create a platform view with an unknown gesture blocking policy");
+  XCTAssertEqualObjects(resultError.details, @"view id: '6'");
 }
 
 - (void)testFlutterPlatformViewControllerSubmitFrameWithoutFlutterViewNotCrashing {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -284,7 +284,7 @@ class FlutterPlatformViewsTestMockPlatformViewDelegate : public PlatformView::De
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
   HitTestResponse OnPlatformViewHitTest(int64_t view_id, const flutter::PointData offset) override {
-    return {.is_platform_view = false};
+    return {.has_platform_view = false};
   }
   void OnPlatformViewDispatchSemanticsAction(int64_t view_id,
                                              int32_t node_id,

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -283,6 +283,11 @@ class FlutterPlatformViewsTestMockPlatformViewDelegate : public PlatformView::De
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
+  bool OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
+      int64_t view_id,
+      const flutter::PointData touch_began_location) override {
+    return false;
+  }
   void OnPlatformViewDispatchSemanticsAction(int64_t view_id,
                                              int32_t node_id,
                                              SemanticsAction action,
@@ -377,7 +382,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
   UIView* flutterView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 500, 500)];
@@ -435,7 +441,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -534,7 +541,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -616,7 +624,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -698,7 +707,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -781,7 +791,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -910,7 +921,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -1066,7 +1078,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -1370,7 +1383,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -1875,7 +1889,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -1939,7 +1954,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -2048,7 +2064,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -2126,7 +2143,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -2202,7 +2220,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -2277,7 +2296,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -2357,7 +2377,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -2457,7 +2478,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -2565,7 +2587,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -2690,7 +2713,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -2798,7 +2822,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -2923,7 +2948,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -2981,7 +3007,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -3096,7 +3123,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -3200,7 +3228,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -3263,7 +3292,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -3346,9 +3376,12 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
   FlutterResult result = ^(id result) {
   };
   [flutterPlatformViewsController
-      onMethodCall:[FlutterMethodCall
-                       methodCallWithMethodName:@"create"
-                                      arguments:@{@"id" : @2, @"viewType" : @"MockWebView"}]
+      onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
+                                                     arguments:@{
+                                                       @"id" : @2,
+                                                       @"viewType" : @"MockWebView",
+                                                       @"gestureBlockingPolicy" : @"eager"
+                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -3480,7 +3513,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockNestedWrapperWebView"
+                                                       @"viewType" : @"MockNestedWrapperWebView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -3548,7 +3582,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -3981,6 +4016,342 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
   }
 }
 
+- (void)testFlutterPlatformViewBlockGestureHitTestPolicyShouldNotAddDelayingRecognizer {
+  flutter::FlutterPlatformViewsTestMockPlatformViewDelegate mock_delegate;
+
+  flutter::TaskRunners runners(/*label=*/self.name.UTF8String,
+                               /*platform=*/GetDefaultTaskRunner(),
+                               /*raster=*/GetDefaultTaskRunner(),
+                               /*ui=*/GetDefaultTaskRunner(),
+                               /*io=*/GetDefaultTaskRunner());
+  FlutterPlatformViewsController* flutterPlatformViewsController =
+      [[FlutterPlatformViewsController alloc] init];
+  flutterPlatformViewsController.taskRunner = GetDefaultTaskRunner();
+  auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
+      /*delegate=*/mock_delegate,
+      /*rendering_api=*/flutter::IOSRenderingAPI::kMetal,
+      /*platform_views_controller=*/flutterPlatformViewsController,
+      /*task_runners=*/runners,
+      /*worker_task_runner=*/nil,
+      /*is_gpu_disabled_jsync_switch=*/std::make_shared<fml::SyncSwitch>());
+
+  FlutterPlatformViewsTestMockFlutterPlatformFactory* factory =
+      [[FlutterPlatformViewsTestMockFlutterPlatformFactory alloc] init];
+  [flutterPlatformViewsController registerViewFactory:factory
+                                               withId:@"MockFlutterPlatformView"
+                     gestureRecognizersBlockingPolicy:
+                         FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly];
+  FlutterResult result = ^(id result) {
+  };
+  [flutterPlatformViewsController
+      onMethodCall:[FlutterMethodCall
+                       methodCallWithMethodName:@"create"
+                                      arguments:@{
+                                        @"id" : @2,
+                                        @"viewType" : @"MockFlutterPlatformView",
+                                        @"gestureBlockingPolicy" : @"touchBlockingOnly"
+                                      }]
+            result:result];
+
+  XCTAssertNotNil(gMockPlatformView);
+
+  // Find touch inteceptor view
+  UIView* touchInterceptorView = gMockPlatformView;
+  while (touchInterceptorView != nil &&
+         ![touchInterceptorView isKindOfClass:[FlutterTouchInterceptingView class]]) {
+    touchInterceptorView = touchInterceptorView.superview;
+  }
+  XCTAssertNotNil(touchInterceptorView);
+
+  XCTAssert(touchInterceptorView.gestureRecognizers.count == 1);
+  UIGestureRecognizer* forwardingRecognizer = touchInterceptorView.gestureRecognizers[0];
+  XCTAssert([forwardingRecognizer isKindOfClass:[ForwardingGestureRecognizer class]]);
+}
+
+- (void)testFlutterPlatformViewBlockGestureUnderNonHitTestPolicyShouldAddDelayingRecognizer {
+  flutter::FlutterPlatformViewsTestMockPlatformViewDelegate mock_delegate;
+
+  flutter::TaskRunners runners(/*label=*/self.name.UTF8String,
+                               /*platform=*/GetDefaultTaskRunner(),
+                               /*raster=*/GetDefaultTaskRunner(),
+                               /*ui=*/GetDefaultTaskRunner(),
+                               /*io=*/GetDefaultTaskRunner());
+  FlutterPlatformViewsController* flutterPlatformViewsController =
+      [[FlutterPlatformViewsController alloc] init];
+  flutterPlatformViewsController.taskRunner = GetDefaultTaskRunner();
+  auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
+      /*delegate=*/mock_delegate,
+      /*rendering_api=*/flutter::IOSRenderingAPI::kMetal,
+      /*platform_views_controller=*/flutterPlatformViewsController,
+      /*task_runners=*/runners,
+      /*worker_task_runner=*/nil,
+      /*is_gpu_disabled_jsync_switch=*/std::make_shared<fml::SyncSwitch>());
+
+  FlutterPlatformViewsTestMockFlutterPlatformFactory* factory =
+      [[FlutterPlatformViewsTestMockFlutterPlatformFactory alloc] init];
+  [flutterPlatformViewsController
+                   registerViewFactory:factory
+                                withId:@"MockFlutterPlatformView"
+      gestureRecognizersBlockingPolicy:FlutterPlatformViewGestureRecognizersBlockingPolicyEager];
+  FlutterResult result = ^(id result) {
+  };
+  [flutterPlatformViewsController
+      onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
+                                                     arguments:@{
+                                                       @"id" : @2,
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
+                                                     }]
+            result:result];
+
+  XCTAssertNotNil(gMockPlatformView);
+
+  // Find touch inteceptor view
+  UIView* touchInterceptorView = gMockPlatformView;
+  while (touchInterceptorView != nil &&
+         ![touchInterceptorView isKindOfClass:[FlutterTouchInterceptingView class]]) {
+    touchInterceptorView = touchInterceptorView.superview;
+  }
+  XCTAssertNotNil(touchInterceptorView);
+
+  XCTAssert(touchInterceptorView.gestureRecognizers.count == 2);
+  UIGestureRecognizer* delayingRecognizer = touchInterceptorView.gestureRecognizers[0];
+  UIGestureRecognizer* forwardingRecognizer = touchInterceptorView.gestureRecognizers[1];
+  XCTAssert([delayingRecognizer isKindOfClass:[FlutterDelayingGestureRecognizer class]]);
+  XCTAssert([forwardingRecognizer isKindOfClass:[ForwardingGestureRecognizer class]]);
+}
+
+- (void)testFlutterPlatformViewBlockGestureHitTestPolicyAcceptGesture {
+  flutter::FlutterPlatformViewsTestMockPlatformViewDelegate mock_delegate;
+
+  flutter::TaskRunners runners(/*label=*/self.name.UTF8String,
+                               /*platform=*/GetDefaultTaskRunner(),
+                               /*raster=*/GetDefaultTaskRunner(),
+                               /*ui=*/GetDefaultTaskRunner(),
+                               /*io=*/GetDefaultTaskRunner());
+  FlutterPlatformViewsController* flutterPlatformViewsController =
+      [[FlutterPlatformViewsController alloc] init];
+
+  FlutterViewController* mockFlutterViewController = OCMClassMock([FlutterViewController class]);
+  flutterPlatformViewsController.flutterViewController = mockFlutterViewController;
+
+  flutterPlatformViewsController.taskRunner = GetDefaultTaskRunner();
+  auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
+      /*delegate=*/mock_delegate,
+      /*rendering_api=*/flutter::IOSRenderingAPI::kMetal,
+      /*platform_views_controller=*/flutterPlatformViewsController,
+      /*task_runners=*/runners,
+      /*worker_task_runner=*/nil,
+      /*is_gpu_disabled_jsync_switch=*/std::make_shared<fml::SyncSwitch>());
+
+  FlutterPlatformViewsTestMockFlutterPlatformFactory* factory =
+      [[FlutterPlatformViewsTestMockFlutterPlatformFactory alloc] init];
+  [flutterPlatformViewsController registerViewFactory:factory
+                                               withId:@"MockFlutterPlatformView"
+                     gestureRecognizersBlockingPolicy:
+                         FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly];
+  FlutterResult result = ^(id result) {
+  };
+  [flutterPlatformViewsController
+      onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
+                                                     arguments:@{
+                                                       @"id" : @2,
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
+                                                     }]
+            result:result];
+
+  XCTAssertNotNil(gMockPlatformView);
+
+  // Find touch inteceptor view
+  UIView* touchInterceptorView = gMockPlatformView;
+  while (touchInterceptorView != nil &&
+         ![touchInterceptorView isKindOfClass:[FlutterTouchInterceptingView class]]) {
+    touchInterceptorView = touchInterceptorView.superview;
+  }
+  XCTAssertNotNil(touchInterceptorView);
+
+  touchInterceptorView.frame = CGRectMake(0, 0, 100, 100);
+  CGPoint touchBeganLocation = CGPointMake(1, 1);
+
+  UIEvent* mockEvent = OCMClassMock([UIEvent class]);
+  OCMStub([mockEvent type]).andReturn(UIEventTypeTouches);
+
+  OCMStub([mockFlutterViewController
+              platformViewShouldAcceptTouchAtTouchBeganLocation:touchBeganLocation])
+      .andReturn(YES);
+  UIView* hitTestResult = [touchInterceptorView hitTest:touchBeganLocation withEvent:mockEvent];
+  XCTAssert(hitTestResult == gMockPlatformView);
+}
+
+- (void)testFlutterPlatformViewBlockGestureHitTestPolicyRejectGesture {
+  flutter::FlutterPlatformViewsTestMockPlatformViewDelegate mock_delegate;
+
+  flutter::TaskRunners runners(/*label=*/self.name.UTF8String,
+                               /*platform=*/GetDefaultTaskRunner(),
+                               /*raster=*/GetDefaultTaskRunner(),
+                               /*ui=*/GetDefaultTaskRunner(),
+                               /*io=*/GetDefaultTaskRunner());
+  FlutterPlatformViewsController* flutterPlatformViewsController =
+      [[FlutterPlatformViewsController alloc] init];
+
+  FlutterViewController* mockFlutterViewController = OCMClassMock([FlutterViewController class]);
+  flutterPlatformViewsController.flutterViewController = mockFlutterViewController;
+
+  flutterPlatformViewsController.taskRunner = GetDefaultTaskRunner();
+  auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
+      /*delegate=*/mock_delegate,
+      /*rendering_api=*/flutter::IOSRenderingAPI::kMetal,
+      /*platform_views_controller=*/flutterPlatformViewsController,
+      /*task_runners=*/runners,
+      /*worker_task_runner=*/nil,
+      /*is_gpu_disabled_jsync_switch=*/std::make_shared<fml::SyncSwitch>());
+
+  FlutterPlatformViewsTestMockFlutterPlatformFactory* factory =
+      [[FlutterPlatformViewsTestMockFlutterPlatformFactory alloc] init];
+  [flutterPlatformViewsController registerViewFactory:factory
+                                               withId:@"MockFlutterPlatformView"
+                     gestureRecognizersBlockingPolicy:
+                         FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly];
+  FlutterResult result = ^(id result) {
+  };
+  [flutterPlatformViewsController
+      onMethodCall:[FlutterMethodCall
+                       methodCallWithMethodName:@"create"
+                                      arguments:@{
+                                        @"id" : @2,
+                                        @"viewType" : @"MockFlutterPlatformView",
+                                        @"gestureBlockingPolicy" : @"touchBlockingOnly"
+                                      }]
+            result:result];
+
+  XCTAssertNotNil(gMockPlatformView);
+
+  // Find touch inteceptor view
+  UIView* touchInterceptorView = gMockPlatformView;
+  while (touchInterceptorView != nil &&
+         ![touchInterceptorView isKindOfClass:[FlutterTouchInterceptingView class]]) {
+    touchInterceptorView = touchInterceptorView.superview;
+  }
+  XCTAssertNotNil(touchInterceptorView);
+
+  touchInterceptorView.frame = CGRectMake(0, 0, 100, 100);
+  CGPoint touchBeganLocation = CGPointMake(1, 1);
+
+  UIEvent* mockEvent = OCMClassMock([UIEvent class]);
+  OCMStub([mockEvent type]).andReturn(UIEventTypeTouches);
+
+  OCMStub([mockFlutterViewController
+              platformViewShouldAcceptTouchAtTouchBeganLocation:touchBeganLocation])
+      .andReturn(NO);
+  UIView* hitTestResult = [touchInterceptorView hitTest:touchBeganLocation withEvent:mockEvent];
+  XCTAssert(hitTestResult == touchInterceptorView);
+}
+
+- (void)testFlutterPlatformViewGestureBlockingPolicyMapping {
+  flutter::FlutterPlatformViewsTestMockPlatformViewDelegate mock_delegate;
+
+  flutter::TaskRunners runners(/*label=*/self.name.UTF8String,
+                               /*platform=*/GetDefaultTaskRunner(),
+                               /*raster=*/GetDefaultTaskRunner(),
+                               /*ui=*/GetDefaultTaskRunner(),
+                               /*io=*/GetDefaultTaskRunner());
+  FlutterPlatformViewsController* flutterPlatformViewsController =
+      [[FlutterPlatformViewsController alloc] init];
+
+  FlutterViewController* mockFlutterViewController = OCMClassMock([FlutterViewController class]);
+  flutterPlatformViewsController.flutterViewController = mockFlutterViewController;
+
+  flutterPlatformViewsController.taskRunner = GetDefaultTaskRunner();
+  auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
+      /*delegate=*/mock_delegate,
+      /*rendering_api=*/flutter::IOSRenderingAPI::kMetal,
+      /*platform_views_controller=*/flutterPlatformViewsController,
+      /*task_runners=*/runners,
+      /*worker_task_runner=*/nil,
+      /*is_gpu_disabled_jsync_switch=*/std::make_shared<fml::SyncSwitch>());
+
+  FlutterPlatformViewsTestMockFlutterPlatformFactory* factory =
+      [[FlutterPlatformViewsTestMockFlutterPlatformFactory alloc] init];
+  [flutterPlatformViewsController registerViewFactory:factory
+                                               withId:@"MockFlutterPlatformView"
+                     gestureRecognizersBlockingPolicy:
+                         FlutterPlatformViewGestureRecognizersBlockingPolicyWaitUntilTouchesEnded];
+  FlutterResult result = ^(id result) {
+  };
+
+  // eager
+  [flutterPlatformViewsController
+      onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
+                                                     arguments:@{
+                                                       @"id" : @2,
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
+                                                     }]
+            result:result];
+  UIView* touchInterceptorView = gMockPlatformView;
+  while (touchInterceptorView != nil &&
+         ![touchInterceptorView isKindOfClass:[FlutterTouchInterceptingView class]]) {
+    touchInterceptorView = touchInterceptorView.superview;
+  }
+  XCTAssertEqual(((FlutterTouchInterceptingView*)touchInterceptorView).blockingPolicy,
+                 FlutterPlatformViewGestureRecognizersBlockingPolicyEager);
+
+  // waitUntilTouchesEnded
+  [flutterPlatformViewsController
+      onMethodCall:[FlutterMethodCall
+                       methodCallWithMethodName:@"create"
+                                      arguments:@{
+                                        @"id" : @3,
+                                        @"viewType" : @"MockFlutterPlatformView",
+                                        @"gestureBlockingPolicy" : @"waitUntilTouchesEnded"
+                                      }]
+            result:result];
+  touchInterceptorView = gMockPlatformView;
+  while (touchInterceptorView != nil &&
+         ![touchInterceptorView isKindOfClass:[FlutterTouchInterceptingView class]]) {
+    touchInterceptorView = touchInterceptorView.superview;
+  }
+  XCTAssertEqual(((FlutterTouchInterceptingView*)touchInterceptorView).blockingPolicy,
+                 FlutterPlatformViewGestureRecognizersBlockingPolicyWaitUntilTouchesEnded);
+
+  // touchBlockingOnly
+  [flutterPlatformViewsController
+      onMethodCall:[FlutterMethodCall
+                       methodCallWithMethodName:@"create"
+                                      arguments:@{
+                                        @"id" : @4,
+                                        @"viewType" : @"MockFlutterPlatformView",
+                                        @"gestureBlockingPolicy" : @"touchBlockingOnly"
+                                      }]
+            result:result];
+  touchInterceptorView = gMockPlatformView;
+  while (touchInterceptorView != nil &&
+         ![touchInterceptorView isKindOfClass:[FlutterTouchInterceptingView class]]) {
+    touchInterceptorView = touchInterceptorView.superview;
+  }
+  XCTAssertEqual(((FlutterTouchInterceptingView*)touchInterceptorView).blockingPolicy,
+                 FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly);
+
+  // fallbackToPluginDefault (which is waitUntilTouchesEnded)
+  [flutterPlatformViewsController
+      onMethodCall:[FlutterMethodCall
+                       methodCallWithMethodName:@"create"
+                                      arguments:@{
+                                        @"id" : @5,
+                                        @"viewType" : @"MockFlutterPlatformView",
+                                        @"gestureBlockingPolicy" : @"fallbackToPluginDefault"
+                                      }]
+            result:result];
+  touchInterceptorView = gMockPlatformView;
+  while (touchInterceptorView != nil &&
+         ![touchInterceptorView isKindOfClass:[FlutterTouchInterceptingView class]]) {
+    touchInterceptorView = touchInterceptorView.superview;
+  }
+  XCTAssertEqual(((FlutterTouchInterceptingView*)touchInterceptorView).blockingPolicy,
+                 FlutterPlatformViewGestureRecognizersBlockingPolicyWaitUntilTouchesEnded);
+}
+
 - (void)testFlutterPlatformViewControllerSubmitFrameWithoutFlutterViewNotCrashing {
   flutter::FlutterPlatformViewsTestMockPlatformViewDelegate mock_delegate;
 
@@ -4012,7 +4383,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -4096,7 +4468,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
         onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                        arguments:@{
                                                          @"id" : @2,
-                                                         @"viewType" : @"MockFlutterPlatformView"
+                                                         @"viewType" : @"MockFlutterPlatformView",
+                                                         @"gestureBlockingPolicy" : @"eager"
                                                        }]
               result:result];
 
@@ -4151,7 +4524,9 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @0,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
+
                                                      }]
             result:result];
 
@@ -4219,7 +4594,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @0,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
   UIView* view1 = gMockPlatformView;
@@ -4229,7 +4605,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @1,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
   UIView* view2 = gMockPlatformView;
@@ -4326,7 +4703,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @0,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
   UIView* view1 = gMockPlatformView;
@@ -4336,7 +4714,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @1,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
   UIView* view2 = gMockPlatformView;
@@ -4517,7 +4896,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @1,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -4567,7 +4947,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -4619,7 +5000,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @1,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
   UIView* view1 = gMockPlatformView;
@@ -4629,7 +5011,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
   UIView* view2 = gMockPlatformView;
@@ -4707,7 +5090,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @1,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -4807,14 +5191,16 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @0,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
   [flutterPlatformViewsController
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @1,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -4921,7 +5307,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
   UIView* flutterView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 500, 500)];
@@ -4991,7 +5378,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
   UIView* flutterView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 500, 500)];
@@ -5063,7 +5451,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
   UIView* flutterView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 500, 500)];
@@ -5164,7 +5553,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @0,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -5173,7 +5563,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @1,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -5245,7 +5636,8 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -156,6 +156,7 @@
 
 // Sets flutterAccessibilityContainer as this view's accessibilityContainer.
 @property(nonatomic, retain) id flutterAccessibilityContainer;
+@property(nonatomic, readonly) FlutterPlatformViewGestureRecognizersBlockingPolicy blockingPolicy;
 @end
 
 @interface UIView (FirstResponder)

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -103,6 +103,11 @@ class MockPlatformViewDelegate : public PlatformView::Delegate {
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
+  bool OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
+      int64_t view_id,
+      const flutter::PointData touch_began_location) override {
+    return false;
+  }
   void OnPlatformViewDispatchSemanticsAction(int64_t view_id,
                                              int32_t node_id,
                                              SemanticsAction action,

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -103,10 +103,8 @@ class MockPlatformViewDelegate : public PlatformView::Delegate {
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
-  bool OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
-      int64_t view_id,
-      const flutter::PointData touch_began_location) override {
-    return false;
+  HitTestResponse OnPlatformViewHitTest(int64_t view_id, const flutter::PointData offset) override {
+    return {.is_platform_view = false};
   }
   void OnPlatformViewDispatchSemanticsAction(int64_t view_id,
                                              int32_t node_id,

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -104,7 +104,7 @@ class MockPlatformViewDelegate : public PlatformView::Delegate {
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
   HitTestResponse OnPlatformViewHitTest(int64_t view_id, const flutter::PointData offset) override {
-    return {.is_platform_view = false};
+    return {.has_platform_view = false};
   }
   void OnPlatformViewDispatchSemanticsAction(int64_t view_id,
                                              int32_t node_id,

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1336,6 +1336,12 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   [self dispatchTouches:touches pointerDataChangeOverride:&cancel event:nullptr];
 }
 
+- (BOOL)platformViewShouldAcceptTouchAtTouchBeganLocation:(CGPoint)location {
+  flutter::PointData point{location.x, location.y};
+  return [self.engine platformViewShouldAcceptTouchAtTouchBeganLocation:point
+                                                                 viewId:self.viewIdentifier];
+}
+
 #pragma mark - Touch events rate correction
 
 - (void)createTouchRateCorrectionVSyncClientIfNeeded {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewResponder.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewResponder.h
@@ -47,6 +47,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)forceTouchesCancelled:(NSSet*)touches;
 
+/**
+ * Returns YES if a platform view should accept the gesture started at specified location.
+ * Returns NO otherwise. The touch location is with respect to flutter view's coordinate space.
+ */
+- (BOOL)platformViewShouldAcceptTouchAtTouchBeganLocation:(CGPoint)location;
+
 @end
 NS_ASSUME_NONNULL_END
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -82,6 +82,11 @@ class MockDelegate : public PlatformView::Delegate {
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
+  bool OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
+      int64_t view_id,
+      const flutter::PointData touch_began_location) override {
+    return false;
+  }
   void OnPlatformViewDispatchSemanticsAction(int64_t view_id,
                                              int32_t node_id,
                                              SemanticsAction action,

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -82,10 +82,8 @@ class MockDelegate : public PlatformView::Delegate {
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
-  bool OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
-      int64_t view_id,
-      const flutter::PointData touch_began_location) override {
-    return false;
+  HitTestResponse OnPlatformViewHitTest(int64_t view_id, const flutter::PointData offset) override {
+    return {.is_platform_view = false};
   }
   void OnPlatformViewDispatchSemanticsAction(int64_t view_id,
                                              int32_t node_id,

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -83,7 +83,7 @@ class MockDelegate : public PlatformView::Delegate {
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
   HitTestResponse OnPlatformViewHitTest(int64_t view_id, const flutter::PointData offset) override {
-    return {.is_platform_view = false};
+    return {.has_platform_view = false};
   }
   void OnPlatformViewDispatchSemanticsAction(int64_t view_id,
                                              int32_t node_id,

--- a/engine/src/flutter/shell/platform/darwin/ios/platform_view_ios_test.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/platform_view_ios_test.mm
@@ -30,6 +30,11 @@ class MockDelegate : public PlatformView::Delegate {
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
+  bool OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
+      int64_t view_id,
+      const flutter::PointData touch_began_location) override {
+    return false;
+  }
   void OnPlatformViewSendViewFocusEvent(const ViewFocusEvent& event) override {}
   void OnPlatformViewDispatchSemanticsAction(int64_t view_id,
                                              int32_t node_id,

--- a/engine/src/flutter/shell/platform/darwin/ios/platform_view_ios_test.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/platform_view_ios_test.mm
@@ -30,10 +30,8 @@ class MockDelegate : public PlatformView::Delegate {
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
-  bool OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
-      int64_t view_id,
-      const flutter::PointData touch_began_location) override {
-    return false;
+  HitTestResponse OnPlatformViewHitTest(int64_t view_id, const flutter::PointData offset) override {
+    return {.is_platform_view = false};
   }
   void OnPlatformViewSendViewFocusEvent(const ViewFocusEvent& event) override {}
   void OnPlatformViewDispatchSemanticsAction(int64_t view_id,

--- a/engine/src/flutter/shell/platform/darwin/ios/platform_view_ios_test.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/platform_view_ios_test.mm
@@ -31,7 +31,7 @@ class MockDelegate : public PlatformView::Delegate {
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
   HitTestResponse OnPlatformViewHitTest(int64_t view_id, const flutter::PointData offset) override {
-    return {.is_platform_view = false};
+    return {.has_platform_view = false};
   }
   void OnPlatformViewSendViewFocusEvent(const ViewFocusEvent& event) override {}
   void OnPlatformViewDispatchSemanticsAction(int64_t view_id,

--- a/engine/src/flutter/shell/platform/embedder/platform_view_embedder_unittests.cc
+++ b/engine/src/flutter/shell/platform/embedder/platform_view_embedder_unittests.cc
@@ -52,6 +52,10 @@ class MockDelegate : public PlatformView::Delegate {
               OnPlatformViewDispatchPointerDataPacket,
               (std::unique_ptr<PointerDataPacket> packet),
               (override));
+  MOCK_METHOD(bool,
+              OnPlatformViewEmbeddedNativeViewShouldAcceptTouch,
+              (int64_t view_id, const flutter::PointData touch_began_location),
+              (override));
   MOCK_METHOD(void,
               OnPlatformViewDispatchSemanticsAction,
               (int64_t view_id,

--- a/engine/src/flutter/shell/platform/embedder/platform_view_embedder_unittests.cc
+++ b/engine/src/flutter/shell/platform/embedder/platform_view_embedder_unittests.cc
@@ -52,9 +52,9 @@ class MockDelegate : public PlatformView::Delegate {
               OnPlatformViewDispatchPointerDataPacket,
               (std::unique_ptr<PointerDataPacket> packet),
               (override));
-  MOCK_METHOD(bool,
-              OnPlatformViewEmbeddedNativeViewShouldAcceptTouch,
-              (int64_t view_id, const flutter::PointData touch_began_location),
+  MOCK_METHOD(HitTestResponse,
+              OnPlatformViewHitTest,
+              (int64_t view_id, const flutter::PointData offset),
               (override));
   MOCK_METHOD(void,
               OnPlatformViewDispatchSemanticsAction,

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/platform_view.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/platform_view.cc
@@ -16,6 +16,7 @@
 
 #include "flutter/fml/logging.h"
 #include "flutter/fml/make_copyable.h"
+#include "flutter/lib/ui/window/point_data.h"
 #include "flutter/lib/ui/window/pointer_data.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/encodable_value.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/standard_message_codec.h"

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/platform_view.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/platform_view.cc
@@ -16,7 +16,6 @@
 
 #include "flutter/fml/logging.h"
 #include "flutter/fml/make_copyable.h"
-#include "flutter/lib/ui/window/point_data.h"
 #include "flutter/lib/ui/window/pointer_data.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/encodable_value.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/standard_message_codec.h"

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/platform_view_unittest.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/platform_view_unittest.cc
@@ -117,6 +117,12 @@ class MockPlatformViewDelegate : public flutter::PlatformView::Delegate {
     pointer_packets_.push_back(std::move(packet));
   }
   // |flutter::PlatformView::Delegate|
+  bool OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
+      int64_t view_id,
+      const flutter::PointData touch_began_location) {
+    return false;
+  }
+  // |flutter::PlatformView::Delegate|
   void OnPlatformViewDispatchKeyDataPacket(
       std::unique_ptr<flutter::KeyDataPacket> packet,
       std::function<void(bool)> callback) {}

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/platform_view_unittest.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/platform_view_unittest.cc
@@ -117,8 +117,9 @@ class MockPlatformViewDelegate : public flutter::PlatformView::Delegate {
     pointer_packets_.push_back(std::move(packet));
   }
   // |flutter::PlatformView::Delegate|
-  HitTestResponse OnPlatformViewHitTest(int64_t view_id,
-                                        const flutter::PointData offset) {
+  flutter::HitTestResponse OnPlatformViewHitTest(
+      int64_t view_id,
+      const flutter::PointData offset) {
     return {.is_platform_view = false};
   }
   // |flutter::PlatformView::Delegate|

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/platform_view_unittest.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/platform_view_unittest.cc
@@ -117,10 +117,9 @@ class MockPlatformViewDelegate : public flutter::PlatformView::Delegate {
     pointer_packets_.push_back(std::move(packet));
   }
   // |flutter::PlatformView::Delegate|
-  bool OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
-      int64_t view_id,
-      const flutter::PointData touch_began_location) {
-    return false;
+  HitTestResponse OnPlatformViewHitTest(int64_t view_id,
+                                        const flutter::PointData offset) {
+    return {.is_platform_view = false};
   }
   // |flutter::PlatformView::Delegate|
   void OnPlatformViewDispatchKeyDataPacket(

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/platform_view_unittest.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/platform_view_unittest.cc
@@ -120,7 +120,7 @@ class MockPlatformViewDelegate : public flutter::PlatformView::Delegate {
   flutter::HitTestResponse OnPlatformViewHitTest(
       int64_t view_id,
       const flutter::PointData offset) {
-    return {.is_platform_view = false};
+    return {.has_platform_view = false};
   }
   // |flutter::PlatformView::Delegate|
   void OnPlatformViewDispatchKeyDataPacket(

--- a/engine/src/flutter/testing/ios_scenario_app/lib/main.dart
+++ b/engine/src/flutter/testing/ios_scenario_app/lib/main.dart
@@ -73,5 +73,5 @@ void _onPointerDataPacket(PointerDataPacket packet) {
 }
 
 HitTestResponse _onHitTest(HitTestRequest request) {
-  return currentScenario?.onHitTest(request) ?? HitTestResponse(isPlatformView: false);
+  return currentScenario?.onHitTest(request) ?? HitTestResponse.empty;
 }

--- a/engine/src/flutter/testing/ios_scenario_app/lib/main.dart
+++ b/engine/src/flutter/testing/ios_scenario_app/lib/main.dart
@@ -18,6 +18,7 @@ void main() {
     ..onDrawFrame = _onDrawFrame
     ..onMetricsChanged = _onMetricsChanged
     ..onPointerDataPacket = _onPointerDataPacket
+    ..onHitTest = _onHitTest
     ..scheduleFrame();
   channelBuffers.setListener('driver', _handleDriverMessage);
 
@@ -69,4 +70,8 @@ void _onMetricsChanged() {
 
 void _onPointerDataPacket(PointerDataPacket packet) {
   currentScenario?.onPointerDataPacket(packet);
+}
+
+HitTestResponse _onHitTest(HitTestRequest request) {
+  return currentScenario?.onHitTest(request) ?? HitTestResponse(isPlatformView: false);
 }

--- a/engine/src/flutter/testing/ios_scenario_app/lib/src/platform_view.dart
+++ b/engine/src/flutter/testing/ios_scenario_app/lib/src/platform_view.dart
@@ -1586,10 +1586,10 @@ class PlatformViewForTouchIOSScenario extends Scenario with _BasePlatformViewSce
 
   @override
   HitTestResponse onHitTest(HitTestRequest request) {
-    final Rect rect1 = const Rect.fromLTWH(0, 0, 500, 500);
-    final Rect rect2 = const Rect.fromLTWH(5, 5, 500, 500);
-    bool hit = rect1.contains(request.offset) || rect2.contains(request.offset);
-    return HitTestResponse(isPlatformView: hit);
+    const Rect rect1 = .fromLTWH(0, 0, 500, 500);
+    const Rect rect2 = .fromLTWH(5, 5, 500, 500);
+    final bool isPlatformView = rect1.contains(request.offset) || rect2.contains(request.offset);
+    return HitTestResponse(isPlatformView: isPlatformView);
   }
 }
 
@@ -1719,9 +1719,9 @@ class PlatformViewForOverlappingPlatformViewsScenario extends Scenario
   @override
   HitTestResponse onHitTest(HitTestRequest request) {
     // rect1 and rect2 will overlap, but explicitly check them in case we introduce more platform views.
-    final Rect rect1 = const Rect.fromLTWH(100, 100, 100, 100);
-    final Rect rect2 = const Rect.fromLTWH(0, 0, 300, 300);
-    bool isPlatformView = rect1.contains(request.offset) || rect2.contains(request.offset);
+    const Rect rect1 = .fromLTWH(100, 100, 100, 100);
+    const Rect rect2 = .fromLTWH(0, 0, 300, 300);
+    final bool isPlatformView = rect1.contains(request.offset) || rect2.contains(request.offset);
     return HitTestResponse(isPlatformView: isPlatformView);
   }
 }

--- a/engine/src/flutter/testing/ios_scenario_app/lib/src/platform_view.dart
+++ b/engine/src/flutter/testing/ios_scenario_app/lib/src/platform_view.dart
@@ -2205,7 +2205,7 @@ void addPlatformView(
     valueString,
     ..._encodeString('create'),
     valueMap,
-    if (Platform.isIOS) 3, // 3 entries in map for iOS.
+    if (Platform.isIOS) 4, // 4 entries in map for iOS.
     if (Platform.isAndroid && !usesAndroidHybridComposition)
       7, // 7 entries in map for texture on Android.
     if (Platform.isAndroid && usesAndroidHybridComposition)
@@ -2218,10 +2218,12 @@ void addPlatformView(
     ..._encodeString('viewType'),
     valueString,
     ..._encodeString(viewType),
-    valueString,
-    ..._encodeString('gestureBlockingPolicy'),
-    valueString,
-    ..._encodeString(gestureBlockingPolicy),
+    if (Platform.isIOS) ...<int>[
+      valueString,
+      ..._encodeString('gestureBlockingPolicy'),
+      valueString,
+      ..._encodeString(gestureBlockingPolicy),
+    ],
     if (Platform.isAndroid && !usesAndroidHybridComposition) ...<int>[
       valueString,
       ..._encodeString('width'),

--- a/engine/src/flutter/testing/ios_scenario_app/lib/src/platform_view.dart
+++ b/engine/src/flutter/testing/ios_scenario_app/lib/src/platform_view.dart
@@ -1588,8 +1588,8 @@ class PlatformViewForTouchIOSScenario extends Scenario with _BasePlatformViewSce
   HitTestResponse onHitTest(HitTestRequest request) {
     const Rect rect1 = .fromLTWH(0, 0, 500, 500);
     const Rect rect2 = .fromLTWH(5, 5, 500, 500);
-    final bool isPlatformView = rect1.contains(request.offset) || rect2.contains(request.offset);
-    return HitTestResponse(isPlatformView: isPlatformView);
+    final bool hasPlatformView = rect1.contains(request.offset) || rect2.contains(request.offset);
+    return HitTestResponse(hasPlatformView: hasPlatformView);
   }
 }
 
@@ -1721,8 +1721,8 @@ class PlatformViewForOverlappingPlatformViewsScenario extends Scenario
     // rect1 and rect2 will overlap, but explicitly check them in case we introduce more platform views.
     const Rect rect1 = .fromLTWH(100, 100, 100, 100);
     const Rect rect2 = .fromLTWH(0, 0, 300, 300);
-    final bool isPlatformView = rect1.contains(request.offset) || rect2.contains(request.offset);
-    return HitTestResponse(isPlatformView: isPlatformView);
+    final bool hasPlatformView = rect1.contains(request.offset) || rect2.contains(request.offset);
+    return HitTestResponse(hasPlatformView: hasPlatformView);
   }
 }
 

--- a/engine/src/flutter/testing/ios_scenario_app/lib/src/platform_view.dart
+++ b/engine/src/flutter/testing/ios_scenario_app/lib/src/platform_view.dart
@@ -2168,6 +2168,7 @@ void addPlatformView(
   double width = 500,
   double height = 500,
   String viewType = 'scenarios/textPlatformView',
+  String gestureBlockingPolicy = 'fallbackToPluginDefault',
 }) {
   if (scenarioParams['view_type'] is String) {
     viewType = scenarioParams['view_type'] as String;
@@ -2217,6 +2218,10 @@ void addPlatformView(
     ..._encodeString('viewType'),
     valueString,
     ..._encodeString(viewType),
+    valueString,
+    ..._encodeString('gestureBlockingPolicy'),
+    valueString,
+    ..._encodeString(gestureBlockingPolicy),
     if (Platform.isAndroid && !usesAndroidHybridComposition) ...<int>[
       valueString,
       ..._encodeString('width'),

--- a/engine/src/flutter/testing/ios_scenario_app/lib/src/platform_view.dart
+++ b/engine/src/flutter/testing/ios_scenario_app/lib/src/platform_view.dart
@@ -1583,6 +1583,14 @@ class PlatformViewForTouchIOSScenario extends Scenario with _BasePlatformViewSce
     }
     finishBuilder(builder);
   }
+
+  @override
+  HitTestResponse onHitTest(HitTestRequest request) {
+    final Rect rect1 = const Rect.fromLTWH(0, 0, 500, 500);
+    final Rect rect2 = const Rect.fromLTWH(5, 5, 500, 500);
+    bool hit = rect1.contains(request.offset) || rect2.contains(request.offset);
+    return HitTestResponse(isPlatformView: hit);
+  }
 }
 
 /// Scenario for verifying overlapping platform views can accept touch gesture.
@@ -1706,6 +1714,15 @@ class PlatformViewForOverlappingPlatformViewsScenario extends Scenario
         (ByteData? response) {},
       );
     }
+  }
+
+  @override
+  HitTestResponse onHitTest(HitTestRequest request) {
+    // rect1 and rect2 will overlap, but explicitly check them in case we introduce more platform views.
+    final Rect rect1 = const Rect.fromLTWH(100, 100, 100, 100);
+    final Rect rect2 = const Rect.fromLTWH(0, 0, 300, 300);
+    bool isPlatformView = rect1.contains(request.offset) || rect2.contains(request.offset);
+    return HitTestResponse(isPlatformView: isPlatformView);
   }
 }
 

--- a/engine/src/flutter/testing/ios_scenario_app/lib/src/scenario.dart
+++ b/engine/src/flutter/testing/ios_scenario_app/lib/src/scenario.dart
@@ -50,4 +50,11 @@ abstract class Scenario {
   ///
   /// See [PlatformDispatcher.onPointerDataPacket].
   void onPointerDataPacket(PointerDataPacket packet) {}
+
+  /// Called by the program when a hit test is requested.
+  ///
+  /// See [PlatformDispatcher.onHitTest].
+  HitTestResponse onHitTest(HitTestRequest request) {
+    return const HitTestResponse(isPlatformView: false);
+  }
 }

--- a/engine/src/flutter/testing/ios_scenario_app/lib/src/scenario.dart
+++ b/engine/src/flutter/testing/ios_scenario_app/lib/src/scenario.dart
@@ -55,6 +55,6 @@ abstract class Scenario {
   ///
   /// See [PlatformDispatcher.onHitTest].
   HitTestResponse onHitTest(HitTestRequest request) {
-    return const HitTestResponse(isPlatformView: false);
+    return HitTestResponse.empty;
   }
 }

--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -325,8 +325,8 @@ mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, H
     final result = HitTestResult();
     hitTestInView(result, request.offset, request.view.viewId);
     // All targets in the path should receive hitTest.
-    final bool isPlatformView = result.path.any((entry) => entry.target is NativeHitTestTarget);
-    return ui.HitTestResponse(isPlatformView: isPlatformView);
+    final bool hasPlatformView = result.path.any((entry) => entry.target is NativeHitTestTarget);
+    return ui.HitTestResponse(hasPlatformView: hasPlatformView);
   }
 
   double? _devicePixelRatioForView(int viewId) {

--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -324,12 +324,9 @@ mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, H
   ui.HitTestResponse _handleHitTest(ui.HitTestRequest request) {
     final result = HitTestResult();
     hitTestInView(result, request.offset, request.view.viewId);
-
-    if (result.path.isEmpty) {
-      return ui.HitTestResponse.empty;
-    }
-    final HitTestTarget firstHit = result.path.first.target;
-    return ui.HitTestResponse(isPlatformView: firstHit is NativeHitTestTarget);
+    // All targets in the path should receive hitTest.
+    final bool isPlatformView = result.path.any((entry) => entry.target is NativeHitTestTarget);
+    return ui.HitTestResponse(isPlatformView: isPlatformView);
   }
 
   double? _devicePixelRatioForView(int viewId) {

--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -37,9 +37,6 @@ export 'pointer_signal_resolver.dart' show PointerSignalResolver;
 
 typedef _HandleSampleTimeChangedCallback = void Function();
 
-/// Abstract class that represents a hit test target backed by a embedded native view.
-abstract class NativeHitTestTarget {}
-
 /// Class that implements clock used for sampling.
 class SamplingClock {
   /// Returns current time.

--- a/packages/flutter/lib/src/gestures/hit_test.dart
+++ b/packages/flutter/lib/src/gestures/hit_test.dart
@@ -37,10 +37,23 @@ abstract interface class HitTestDispatcher {
 }
 
 /// An object that can handle events.
+///
+/// The type must implement [NativeHitTestTarget] if it represents a platform view.
+// TODO(hellohuanlin): Make RenderAndroidView and RenderAppKitView to extend NativeHitTestTarget.
+// See: https://github.com/flutter/flutter/issues/184440.
 abstract interface class HitTestTarget {
   /// Override this method to receive events.
   void handleEvent(PointerEvent event, HitTestEntry<HitTestTarget> entry);
 }
+
+/// A mixin that represents a hit test target backed by a platform view.
+///
+/// See also:
+///
+///   * [HitTestTarget].
+// TODO(hellohuanlin): Make RenderAndroidView and RenderAppKitView to extend NativeHitTestTarget.
+// See: https://github.com/flutter/flutter/issues/184440.
+mixin NativeHitTestTarget {}
 
 /// Data collected during a hit test about a specific [HitTestTarget].
 ///

--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -424,7 +424,8 @@ abstract class RenderDarwinPlatformView<T extends DarwinPlatformViewController> 
 ///
 ///  * [UiKitView], which is a widget that is used to show a UIView.
 ///  * [PlatformViewsService], which is a service for controlling platform views.
-class RenderUiKitView extends RenderDarwinPlatformView<UiKitViewController> {
+class RenderUiKitView extends RenderDarwinPlatformView<UiKitViewController>
+    implements NativeHitTestTarget {
   /// Creates a render object for an iOS UIView.
   RenderUiKitView({
     required super.viewController,

--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -425,7 +425,7 @@ abstract class RenderDarwinPlatformView<T extends DarwinPlatformViewController> 
 ///  * [UiKitView], which is a widget that is used to show a UIView.
 ///  * [PlatformViewsService], which is a service for controlling platform views.
 class RenderUiKitView extends RenderDarwinPlatformView<UiKitViewController>
-    implements NativeHitTestTarget {
+    with NativeHitTestTarget {
   /// Creates a render object for an iOS UIView.
   RenderUiKitView({
     required super.viewController,

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -257,8 +257,7 @@ class PlatformViewsService {
   static Future<UiKitViewController> initUiKitView({
     required int id,
     required String viewType,
-    UiKitViewGestureBlockingPolicy gestureBlockingPolicy =
-        UiKitViewGestureBlockingPolicy.fallbackToPluginDefault,
+    UiKitViewGestureBlockingPolicy gestureBlockingPolicy = .fallbackToPluginDefault,
     required TextDirection layoutDirection,
     dynamic creationParams,
     MessageCodec<dynamic>? creationParamsCodec,
@@ -266,17 +265,12 @@ class PlatformViewsService {
   }) async {
     assert(creationParams == null || creationParamsCodec != null);
 
-    final String gestureBlockingPolicyValue;
-    switch (gestureBlockingPolicy) {
-      case UiKitViewGestureBlockingPolicy.eager:
-        gestureBlockingPolicyValue = 'eager';
-      case UiKitViewGestureBlockingPolicy.waitUntilTouchesEnded:
-        gestureBlockingPolicyValue = 'waitUntilTouchesEnded';
-      case UiKitViewGestureBlockingPolicy.fallbackToPluginDefault:
-        gestureBlockingPolicyValue = 'fallbackToPluginDefault';
-      case UiKitViewGestureBlockingPolicy.touchBlockingOnly:
-        gestureBlockingPolicyValue = 'touchBlockingOnly';
-    }
+    final String gestureBlockingPolicyValue = switch (gestureBlockingPolicy) {
+      UiKitViewGestureBlockingPolicy.eager => 'eager',
+      UiKitViewGestureBlockingPolicy.waitUntilTouchesEnded => 'waitUntilTouchesEnded',
+      UiKitViewGestureBlockingPolicy.fallbackToPluginDefault => 'fallbackToPluginDefault',
+      UiKitViewGestureBlockingPolicy.doNotBlockGesture => 'doNotBlockGesture',
+    };
 
     // TODO(amirh): pass layoutDirection once the system channel supports it.
     // https://github.com/flutter/flutter/issues/133682
@@ -1604,24 +1598,62 @@ abstract class DarwinPlatformViewController {
 }
 
 /// How touch event callbacks and gesture recognizers of a platform view are blocked.
-/// This replaces engine's FlutterPlatformViewGestureRecognizersBlockingPolicy enum in FlutterPlugin.h.
+///
+/// This replaces the engine's `FlutterPlatformViewGestureRecognizersBlockingPolicy` enum in `FlutterPlugin.h`.
+///
+/// In iOS, a gesture recognizer (`UIGestureRecognizer`) is an object that decouples the logic for
+/// recognizing a sequence of touches (like a tap, pinch, or swipe) and acting on that recognition.
+///
+/// When a Flutter app embeds an iOS platform view (like a `WKWebView`), both the Flutter framework
+/// and the native iOS view receive touch events. To prevent both systems from simultaneously reacting
+/// to the same touch (e.g., a scroll gesture scrolling both a Flutter `ListView` and a native
+/// `UIScrollView`), Flutter needs a mechanism to "block" the native view's gesture recognizers when
+/// it determines that the Flutter framework should handle the gesture.
+///
+/// Flutter uses two mechanisms to achieve this:
+/// 1. **Synchronous Blocking (Hit Testing):** During the initial touch (`UIResponder.touchesBegan`),
+///    Flutter performs a synchronous hit test. If the touch lands on a Flutter widget that is
+///    visually on top of the platform view, Flutter immediately blocks the native view from
+///    receiving the touch.
+/// 2. **Asynchronous Blocking (Gesture Arena):** If the touch lands directly on the platform view,
+///    both Flutter and the native view begin tracking the gesture. Flutter's gesture arena resolves
+///    which system wins. If Flutter wins (e.g., the user is scrolling a Flutter `ListView` that
+///    contains the platform view), Flutter asynchronously cancels the native view's gesture recognizers.
+///
+/// The default policy ([fallbackToPluginDefault], which typically resolves to [eager]) works for most
+/// use cases. However, some native views (either from Apple or 3rd party) may have bugs where
+/// their internal gesture recognizers get stuck in a stale state if they are aggressively canceled by
+/// Flutter's asynchronous blocking. In these specific cases, you might need to change the policy to
+/// [doNotBlockGesture] or [waitUntilTouchesEnded] to work around the native view's bugs.
+///
+/// For more details, see: https://flutter.dev/go/ios-platform-view-touch-gesture-blocking.
 enum UiKitViewGestureBlockingPolicy {
   /// Flutter blocks all the UIGestureRecognizers on the platform view as soon as it
   /// decides they should be blocked.
+  ///
+  /// This policy employs a dual blocking strategy: synchronous blocking via hitTest results and
+  /// asynchronous blocking managed through the framework’s gesture arena.
+  /// With this policy, only the `touchesBegan` method for all the UIGestureRecognizers is guaranteed
+  /// to be called.
   eager,
 
-  /// Flutter blocks the platform view's UIGestureRecognizers from recognizing only after
-  /// touchesEnded was invoked.
+  /// Flutter blocks all the UIGestureRecognizers on the platform view only after touchesEnded was invoked.
+  ///
+  /// This results in the platform view's UIGestureRecognizers seeing the entire touch sequence,
+  /// but never recognizing the gesture (and never invoking actions).
+  /// Using this policy may cause the platform view to incorrectly receive touch events
+  /// that should have been blocked.
   waitUntilTouchesEnded,
 
-  /// Flutter blocks all the UIGestureRecognizers on the platform view as soon as it
-  /// decides they should be blocked.
+  /// Causes iOS engine to block all the UIGestureRecognizers on the platform view if it deems
+  /// the hittest shouldn't be handled by the Flutter framework.
   ///
-  /// This is similar to FlutterPlatformViewGestureRecognizersBlockingPolicyEager. However,
-  /// internally it performs hit test rather than a blocking gesture recognizer. This addresses
-  /// a few bugs related to WKWebView being untappable. See
-  /// https://github.com/flutter/flutter/issues/175099.
-  touchBlockingOnly,
+  /// Unlike [eager], this policy does not rely on Flutter's gesture arena. This is a workaround
+  /// to address a few bugs related to platform view's gesture recognizers being stuck in a stale state.
+  /// See: https://github.com/flutter/flutter/issues/175099.
+  /// Using this policy may cause the platform view to incorrectly recognize a gesture that should
+  /// have been blocked.
+  doNotBlockGesture,
 
   /// Fallback to use the policy set by the `registerViewFactory` engine API in FlutterPlugin.h.
   fallbackToPluginDefault,

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -257,6 +257,8 @@ class PlatformViewsService {
   static Future<UiKitViewController> initUiKitView({
     required int id,
     required String viewType,
+    UiKitViewGestureBlockingPolicy gestureBlockingPolicy =
+        UiKitViewGestureBlockingPolicy.fallbackToPluginDefault,
     required TextDirection layoutDirection,
     dynamic creationParams,
     MessageCodec<dynamic>? creationParamsCodec,
@@ -264,9 +266,25 @@ class PlatformViewsService {
   }) async {
     assert(creationParams == null || creationParamsCodec != null);
 
+    final String gestureBlockingPolicyValue;
+    switch (gestureBlockingPolicy) {
+      case UiKitViewGestureBlockingPolicy.eager:
+        gestureBlockingPolicyValue = 'eager';
+      case UiKitViewGestureBlockingPolicy.waitUntilTouchesEnded:
+        gestureBlockingPolicyValue = 'waitUntilTouchesEnded';
+      case UiKitViewGestureBlockingPolicy.fallbackToPluginDefault:
+        gestureBlockingPolicyValue = 'fallbackToPluginDefault';
+      case UiKitViewGestureBlockingPolicy.touchBlockingOnly:
+        gestureBlockingPolicyValue = 'touchBlockingOnly';
+    }
+
     // TODO(amirh): pass layoutDirection once the system channel supports it.
     // https://github.com/flutter/flutter/issues/133682
-    final args = <String, dynamic>{'id': id, 'viewType': viewType};
+    final args = <String, dynamic>{
+      'id': id,
+      'viewType': viewType,
+      'gestureBlockingPolicy': gestureBlockingPolicyValue,
+    };
     if (creationParams != null) {
       final ByteData paramsByteData = creationParamsCodec!.encodeMessage(creationParams)!;
       args['params'] = Uint8List.view(paramsByteData.buffer, 0, paramsByteData.lengthInBytes);
@@ -1583,6 +1601,30 @@ abstract class DarwinPlatformViewController {
     await SystemChannels.platform_views.invokeMethod<void>('dispose', id);
     PlatformViewsService._instance._focusCallbacks.remove(id);
   }
+}
+
+/// How touch event callbacks and gesture recognizers of a platform view are blocked.
+/// This replaces engine's FlutterPlatformViewGestureRecognizersBlockingPolicy enum in FlutterPlugin.h.
+enum UiKitViewGestureBlockingPolicy {
+  /// Flutter blocks all the UIGestureRecognizers on the platform view as soon as it
+  /// decides they should be blocked.
+  eager,
+
+  /// Flutter blocks the platform view's UIGestureRecognizers from recognizing only after
+  /// touchesEnded was invoked.
+  waitUntilTouchesEnded,
+
+  /// Flutter blocks all the UIGestureRecognizers on the platform view as soon as it
+  /// decides they should be blocked.
+  ///
+  /// This is similar to FlutterPlatformViewGestureRecognizersBlockingPolicyEager. However,
+  /// internally it performs hit test rather than a blocking gesture recognizer. This addresses
+  /// a few bugs related to WKWebView being untappable. See
+  /// https://github.com/flutter/flutter/issues/175099.
+  touchBlockingOnly,
+
+  /// Fallback to use the policy set by the `registerViewFactory` engine API in FlutterPlugin.h.
+  fallbackToPluginDefault,
 }
 
 /// Controller for an iOS platform view.

--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -317,6 +317,7 @@ class UiKitView extends _DarwinView {
   const UiKitView({
     super.key,
     required super.viewType,
+    this.gestureBlockingPolicy = UiKitViewGestureBlockingPolicy.fallbackToPluginDefault,
     super.onPlatformViewCreated,
     super.hitTestBehavior = PlatformViewHitTestBehavior.opaque,
     super.layoutDirection,
@@ -324,6 +325,9 @@ class UiKitView extends _DarwinView {
     super.creationParamsCodec,
     super.gestureRecognizers,
   }) : assert(creationParams == null || creationParamsCodec != null);
+
+  /// The gesture blocking policy that controls touch and gesture blocking behaviors.
+  final UiKitViewGestureBlockingPolicy gestureBlockingPolicy;
 
   @override
   State<UiKitView> createState() => _UiKitViewState();
@@ -1007,6 +1011,7 @@ class _UiKitViewState
     return PlatformViewsService.initUiKitView(
       id: id,
       viewType: widget.viewType,
+      gestureBlockingPolicy: widget.gestureBlockingPolicy,
       layoutDirection: _layoutDirection!,
       creationParams: widget.creationParams,
       creationParamsCodec: widget.creationParamsCodec,

--- a/packages/flutter/test/gestures/gesture_binding_test.dart
+++ b/packages/flutter/test/gestures/gesture_binding_test.dart
@@ -105,10 +105,10 @@ void main() {
         (HitTestResult result, Offset position, int viewId) {};
 
     final request = ui.HitTestRequest(view: _FakeFlutterView(), offset: const Offset(1, 1));
-    final ui.HitTestResponse repsonse =
+    final ui.HitTestResponse response =
         GestureBinding.instance.platformDispatcher.onHitTest?.call(request) ??
         ui.HitTestResponse.empty;
-    expect(repsonse.isPlatformView, isFalse);
+    expect(response.isPlatformView, isFalse);
   });
 
   test('Platform view hit test should not accept gesture if no platform view', () {
@@ -118,10 +118,10 @@ void main() {
         };
 
     final request = ui.HitTestRequest(view: _FakeFlutterView(), offset: const Offset(1, 1));
-    final ui.HitTestResponse repsonse =
+    final ui.HitTestResponse response =
         GestureBinding.instance.platformDispatcher.onHitTest?.call(request) ??
         ui.HitTestResponse.empty;
-    expect(repsonse.isPlatformView, isFalse);
+    expect(response.isPlatformView, isFalse);
   });
 
   test('Platform view hit test should not accept gesture if first hit is not a platform view', () {
@@ -133,11 +133,11 @@ void main() {
 
     final request = ui.HitTestRequest(view: _FakeFlutterView(), offset: const Offset(1, 1));
 
-    final ui.HitTestResponse repsonse =
+    final ui.HitTestResponse response =
         GestureBinding.instance.platformDispatcher.onHitTest?.call(request) ??
         ui.HitTestResponse.empty;
 
-    expect(repsonse.isPlatformView, isFalse);
+    expect(response.isPlatformView, isFalse);
   });
 
   test('Platform view hit test should accept gesture if first hit is a platform view', () {
@@ -149,11 +149,11 @@ void main() {
 
     final request = ui.HitTestRequest(view: _FakeFlutterView(), offset: const Offset(1, 1));
 
-    final ui.HitTestResponse repsonse =
+    final ui.HitTestResponse response =
         GestureBinding.instance.platformDispatcher.onHitTest?.call(request) ??
         ui.HitTestResponse.empty;
 
-    expect(repsonse.isPlatformView, isTrue);
+    expect(response.isPlatformView, isTrue);
   });
 
   test('Pointer tap events', () {

--- a/packages/flutter/test/gestures/gesture_binding_test.dart
+++ b/packages/flutter/test/gestures/gesture_binding_test.dart
@@ -124,37 +124,43 @@ void main() {
     expect(response.isPlatformView, isFalse);
   });
 
-  test('Platform view hit test should not accept gesture if first hit is not a platform view', () {
-    TestGestureFlutterBinding.instance.onHitTestInView =
-        (HitTestResult result, Offset position, int viewId) {
-          result.add(HitTestEntry(_DummyHitTestTarget()));
-          result.add(HitTestEntry(_DummyNativeHitTestTarget()));
-        };
+  test(
+    'Platform view hit test should accept gesture if a platform view is not the first hit in hitTest result path',
+    () {
+      TestGestureFlutterBinding.instance.onHitTestInView =
+          (HitTestResult result, Offset position, int viewId) {
+            result.add(HitTestEntry(_DummyHitTestTarget()));
+            result.add(HitTestEntry(_DummyNativeHitTestTarget()));
+          };
 
-    final request = ui.HitTestRequest(view: _FakeFlutterView(), offset: const Offset(1, 1));
+      final request = ui.HitTestRequest(view: _FakeFlutterView(), offset: const Offset(1, 1));
 
-    final ui.HitTestResponse response =
-        GestureBinding.instance.platformDispatcher.onHitTest?.call(request) ??
-        ui.HitTestResponse.empty;
+      final ui.HitTestResponse response =
+          GestureBinding.instance.platformDispatcher.onHitTest?.call(request) ??
+          ui.HitTestResponse.empty;
 
-    expect(response.isPlatformView, isFalse);
-  });
+      expect(response.isPlatformView, isTrue);
+    },
+  );
 
-  test('Platform view hit test should accept gesture if first hit is a platform view', () {
-    TestGestureFlutterBinding.instance.onHitTestInView =
-        (HitTestResult result, Offset position, int viewId) {
-          result.add(HitTestEntry(_DummyNativeHitTestTarget()));
-          result.add(HitTestEntry(_DummyHitTestTarget()));
-        };
+  test(
+    'Platform view hit test should accept gesture if a platform view is the first hit in hitTest result path',
+    () {
+      TestGestureFlutterBinding.instance.onHitTestInView =
+          (HitTestResult result, Offset position, int viewId) {
+            result.add(HitTestEntry(_DummyNativeHitTestTarget()));
+            result.add(HitTestEntry(_DummyHitTestTarget()));
+          };
 
-    final request = ui.HitTestRequest(view: _FakeFlutterView(), offset: const Offset(1, 1));
+      final request = ui.HitTestRequest(view: _FakeFlutterView(), offset: const Offset(1, 1));
 
-    final ui.HitTestResponse response =
-        GestureBinding.instance.platformDispatcher.onHitTest?.call(request) ??
-        ui.HitTestResponse.empty;
+      final ui.HitTestResponse response =
+          GestureBinding.instance.platformDispatcher.onHitTest?.call(request) ??
+          ui.HitTestResponse.empty;
 
-    expect(response.isPlatformView, isTrue);
-  });
+      expect(response.isPlatformView, isTrue);
+    },
+  );
 
   test('Pointer tap events', () {
     const packet = ui.PointerDataPacket(

--- a/packages/flutter/test/gestures/gesture_binding_test.dart
+++ b/packages/flutter/test/gestures/gesture_binding_test.dart
@@ -108,7 +108,7 @@ void main() {
     final ui.HitTestResponse response =
         GestureBinding.instance.platformDispatcher.onHitTest?.call(request) ??
         ui.HitTestResponse.empty;
-    expect(response.isPlatformView, isFalse);
+    expect(response.hasPlatformView, isFalse);
   });
 
   test('Platform view hit test should not accept gesture if no platform view', () {
@@ -121,7 +121,7 @@ void main() {
     final ui.HitTestResponse response =
         GestureBinding.instance.platformDispatcher.onHitTest?.call(request) ??
         ui.HitTestResponse.empty;
-    expect(response.isPlatformView, isFalse);
+    expect(response.hasPlatformView, isFalse);
   });
 
   test(
@@ -139,7 +139,7 @@ void main() {
           GestureBinding.instance.platformDispatcher.onHitTest?.call(request) ??
           ui.HitTestResponse.empty;
 
-      expect(response.isPlatformView, isTrue);
+      expect(response.hasPlatformView, isTrue);
     },
   );
 
@@ -158,7 +158,7 @@ void main() {
           GestureBinding.instance.platformDispatcher.onHitTest?.call(request) ??
           ui.HitTestResponse.empty;
 
-      expect(response.isPlatformView, isTrue);
+      expect(response.hasPlatformView, isTrue);
     },
   );
 


### PR DESCRIPTION
This PR tries to reland the previous PR: https://github.com/flutter/flutter/pull/183484. Refer to it for more details. 

# What happened to the previous PR? 

2 tests from `ios_platform_view_ui_test` failed due to edge swipe gesture (https://www.youtube.com/watch?v=MVO5b0eEdw8). Cupertino puts a gesture listener on left edge of screen. When tapping there, the hitTest logic returns the gesture listener as the first hit (instead of our platform view), hence blocking the platform view. 

# Why we didn't find this issue before?  

Because it only happen to iPhone, but I use iPad for testing. 

# What's the fix? 

In flutter, hitTest returns *a list of all targets that should be hit tested*. So instead of checking if the first hit is the platform view, we check if the result contains any platform view. 

I have also created a UIKit app, and verified that the expected behavior is that platform view should still receive touch even if swipe edge back gesture is recognized. 

A key info is that during Flutter's hitTest operation, the result list will not contain a target if it is blocked by another target in front (e.g. context menu covering a platform view). 

If there are multiple platform views, that's fine too, because UIKit itself will perform hitTest which finds the correct touch intercepting view, which sends the request to framework. 

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

Fixes https://github.com/flutter/flutter/issues/179916
Fixes https://github.com/flutter/flutter/issues/175099

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
