### PR TITLE
Add javaHeapSpaceHandler to handle Gradle build failures due to Java …

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -352,19 +352,13 @@ final transformInputIssueHandler = GradleHandledError(
 final javaHeapSpaceHandler = GradleHandledError(
   test: _lineMatcher(const <String>['Java heap space']),
   handler: ({required String line, required FlutterProject project, required bool usesAndroidX}) async {
-    final File gradlePropertiesFile = project.android.hostAppGradleRoot.childFile('gradle.properties');
     final String textInBold = globals.logger.terminal.bolden(
-      'Open ${gradlePropertiesFile.path} and ensure org.gradle.jvmargs includes enough heap.\n'
-      'If org.gradle.jvmargs is already set, append these flags to the existing value '
-      '(keep your other JVM arguments, such as file encoding):\n'
-      '-Xmx4G -XX:MaxMetaspaceSize=2G\n'
-      'If org.gradle.jvmargs is not set, add a line such as:\n'
-      'org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=2G',
+      'Adjust the maximum Java heap allocation according to the documentation:\n'
+      'https://docs.gradle.org/current/userguide/config_gradle.html#sec:configuring_jvm_memory',
     );
     globals.printBox(
       '${globals.logger.terminal.warningMark} The Gradle build ran out of Java heap space.\n'
-      '$textInBold\n\n'
-      'If this error continues, increase the -Xmx and -XX:MaxMetaspaceSize values based on your machine resources.',
+      '$textInBold',
       title: _boxTitle,
     );
     return GradleBuildStatus.exit;

--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -70,6 +70,7 @@ final gradleErrors = <GradleHandledError>[
   r8DexingBugInAgp73Handler,
   minSdkVersionHandler,
   transformInputIssueHandler,
+  javaHeapSpaceHandler,
   lockFileDepMissingHandler,
   minCompileSdkVersionHandler,
   incompatibleJavaAndAgpVersionsHandler,
@@ -344,6 +345,27 @@ final transformInputIssueHandler = GradleHandledError(
         return GradleBuildStatus.exit;
       },
   eventLabel: 'transform-input-issue',
+);
+
+/// Handler when a Gradle task fails due to Java heap space exhaustion.
+@visibleForTesting
+final javaHeapSpaceHandler = GradleHandledError(
+  test: _lineMatcher(const <String>['Java heap space']),
+  handler: ({required String line, required FlutterProject project, required bool usesAndroidX}) async {
+    final File gradlePropertiesFile = project.android.hostAppGradleRoot.childFile('gradle.properties');
+    final String textInBold = globals.logger.terminal.bolden(
+      'Open ${gradlePropertiesFile.path} and update (or add) this line:\n'
+      'org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=2G',
+    );
+    globals.printBox(
+      '${globals.logger.terminal.warningMark} The Gradle build ran out of Java heap space.\n'
+      '$textInBold\n\n'
+      'If this error continues, increase these values further based on your machine resources.',
+      title: _boxTitle,
+    );
+    return GradleBuildStatus.exit;
+  },
+  eventLabel: 'java-heap-space',
 );
 
 /// Handler when a dependency is missing in the lockfile.

--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -354,13 +354,17 @@ final javaHeapSpaceHandler = GradleHandledError(
   handler: ({required String line, required FlutterProject project, required bool usesAndroidX}) async {
     final File gradlePropertiesFile = project.android.hostAppGradleRoot.childFile('gradle.properties');
     final String textInBold = globals.logger.terminal.bolden(
-      'Open ${gradlePropertiesFile.path} and update (or add) this line:\n'
+      'Open ${gradlePropertiesFile.path} and ensure org.gradle.jvmargs includes enough heap.\n'
+      'If org.gradle.jvmargs is already set, append these flags to the existing value '
+      '(keep your other JVM arguments, such as file encoding):\n'
+      '-Xmx4G -XX:MaxMetaspaceSize=2G\n'
+      'If org.gradle.jvmargs is not set, add a line such as:\n'
       'org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=2G',
     );
     globals.printBox(
       '${globals.logger.terminal.warningMark} The Gradle build ran out of Java heap space.\n'
       '$textInBold\n\n'
-      'If this error continues, increase these values further based on your machine resources.',
+      'If this error continues, increase the -Xmx and -XX:MaxMetaspaceSize values based on your machine resources.',
       title: _boxTitle,
     );
     return GradleBuildStatus.exit;

--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -351,18 +351,19 @@ final transformInputIssueHandler = GradleHandledError(
 @visibleForTesting
 final javaHeapSpaceHandler = GradleHandledError(
   test: _lineMatcher(const <String>['Java heap space']),
-  handler: ({required String line, required FlutterProject project, required bool usesAndroidX}) async {
-    final String textInBold = globals.logger.terminal.bolden(
-      'Adjust the maximum Java heap allocation according to the documentation:\n'
-      'https://docs.gradle.org/current/userguide/config_gradle.html#sec:configuring_jvm_memory',
-    );
-    globals.printBox(
-      '${globals.logger.terminal.warningMark} The Gradle build ran out of Java heap space.\n'
-      '$textInBold',
-      title: _boxTitle,
-    );
-    return GradleBuildStatus.exit;
-  },
+  handler:
+      ({required String line, required FlutterProject project, required bool usesAndroidX}) async {
+        final String textInBold = globals.logger.terminal.bolden(
+          'Adjust the maximum Java heap allocation according to the documentation:\n'
+          'https://docs.gradle.org/current/userguide/config_gradle.html#sec:configuring_jvm_memory',
+        );
+        globals.printBox(
+          '${globals.logger.terminal.warningMark} The Gradle build ran out of Java heap space.\n'
+          '$textInBold',
+          title: _boxTitle,
+        );
+        return GradleBuildStatus.exit;
+      },
   eventLabel: 'java-heap-space',
 );
 

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -42,6 +42,7 @@ void main() {
           r8DexingBugInAgp73Handler,
           minSdkVersionHandler,
           transformInputIssueHandler,
+          javaHeapSpaceHandler,
           lockFileDepMissingHandler,
           minCompileSdkVersionHandler,
           incompatibleJavaAndAgpVersionsHandler,
@@ -806,6 +807,37 @@ assembleProfile
             '└───────────────────────────────────────────────────────────────────────────────┘\n',
           ),
         );
+      },
+      overrides: <Type, Generator>{
+        GradleUtils: () => FakeGradleUtils(),
+        Platform: () => fakePlatform('android'),
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+      },
+    );
+  });
+
+  group('java heap space', () {
+    testWithoutContext('pattern', () {
+      expect(javaHeapSpaceHandler.test('> Java heap space'), isTrue);
+      expect(
+        javaHeapSpaceHandler.test('java.lang.OutOfMemoryError: Java heap space'),
+        isTrue,
+      );
+    });
+
+    testUsingContext(
+      'suggestion',
+      () async {
+        final GradleBuildStatus status = await javaHeapSpaceHandler.handler(
+          project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
+          usesAndroidX: true,
+          line: '> Java heap space',
+        );
+
+        expect(status, GradleBuildStatus.exit);
+        expect(testLogger.statusText, contains('org.gradle.jvmargs'));
+        expect(testLogger.statusText, contains('gradle.properties'));
       },
       overrides: <Type, Generator>{
         GradleUtils: () => FakeGradleUtils(),

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -836,8 +836,11 @@ assembleProfile
         );
 
         expect(status, GradleBuildStatus.exit);
-        expect(testLogger.statusText, contains('org.gradle.jvmargs'));
-        expect(testLogger.statusText, contains('gradle.properties'));
+        expect(testLogger.statusText, contains('Java heap space'));
+        expect(
+          testLogger.statusText,
+          contains('https://docs.gradle.org/current/userguide/config_gradle.html#sec:configuring_jvm_memory'),
+        );
       },
       overrides: <Type, Generator>{
         GradleUtils: () => FakeGradleUtils(),

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -820,10 +820,7 @@ assembleProfile
   group('java heap space', () {
     testWithoutContext('pattern', () {
       expect(javaHeapSpaceHandler.test('> Java heap space'), isTrue);
-      expect(
-        javaHeapSpaceHandler.test('java.lang.OutOfMemoryError: Java heap space'),
-        isTrue,
-      );
+      expect(javaHeapSpaceHandler.test('java.lang.OutOfMemoryError: Java heap space'), isTrue);
     });
 
     testUsingContext(
@@ -839,7 +836,9 @@ assembleProfile
         expect(testLogger.statusText, contains('Java heap space'));
         expect(
           testLogger.statusText,
-          contains('https://docs.gradle.org/current/userguide/config_gradle.html#sec:configuring_jvm_memory'),
+          contains(
+            'https://docs.gradle.org/current/userguide/config_gradle.html#sec:configuring_jvm_memory',
+          ),
         );
       },
       overrides: <Type, Generator>{


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

Adds a new Gradle error handler in `flutter_tools` for Java heap space failures (`java.lang.OutOfMemoryError: Java heap space`).  
When detected, Flutter now shows a clear `Flutter Fix` message with actionable guidance to increase `org.gradle.jvmargs` in `android/gradle.properties`, instead of only surfacing raw Gradle output.

Fixes [#163801](https://github.com/flutter/flutter/issues/163801).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md