### PR TITLE
Fix/slider long label 63293

### DIFF
--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -962,6 +962,13 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
   // This value is the touch target, 48, multiplied by 3.
   static const double _minPreferredTrackWidth = 144.0;
 
+  // Buffer to account for the internal padding of standard Material value indicator shapes,
+  // preventing them from bleeding off the screen edges.
+  //
+  // The value 64.0 is a heuristic that covers the minimum size of the shape
+  // (padding + minimum label width) at a text scale factor of roughly 2.0.
+  static const double _kValueIndicatorHorizontalBuffer = 64.0;
+
   // Compute the largest width and height needed to paint the slider shapes,
   // other than the track shape. It is assumed that these shapes are vertically
   // centered on the track.
@@ -1253,11 +1260,18 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
       Thumb.end => (labels.end, _endLabelPainter),
     };
 
+    // Reserve space for the bubble's internal padding and screen margins.
+    final double safeMaxWidth = math.max(0.0, screenSize.width - _kValueIndicatorHorizontalBuffer);
+
     labelPainter
       ..text = TextSpan(style: _sliderTheme.valueIndicatorTextStyle, text: text)
       ..textDirection = textDirection
       ..textScaleFactor = textScaleFactor
-      ..layout();
+      ..maxLines = 1
+      ..ellipsis =
+          '\u2026' // Standard Unicode ellipsis
+      ..layout(maxWidth: safeMaxWidth);
+
     // Changing the textDirection can result in the layout changing, because the
     // bidi algorithm might line up the glyphs differently which can result in
     // different ligatures, different shapes, etc. So we always markNeedsLayout.

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -1266,7 +1266,7 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
     labelPainter
       ..text = TextSpan(style: _sliderTheme.valueIndicatorTextStyle, text: text)
       ..textDirection = textDirection
-      ..textScaleFactor = textScaleFactor
+      ..textScaler = TextScaler.linear(textScaleFactor)
       ..maxLines = 1
       ..ellipsis =
           '\u2026' // Standard Unicode ellipsis

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -1270,7 +1270,11 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
       ..maxLines = 1
       ..ellipsis =
           '\u2026' // Standard Unicode ellipsis
-      ..layout(maxWidth: safeMaxWidth);
+      ..layout(
+        maxWidth: screenSize.width.isFinite && screenSize.width > 0
+            ? safeMaxWidth
+            : double.infinity,
+      );
 
     // Changing the textDirection can result in the layout changing, because the
     // bidi algorithm might line up the glyphs differently which can result in

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -1535,7 +1535,7 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       _labelPainter
         ..text = TextSpan(style: _sliderTheme.valueIndicatorTextStyle, text: label)
         ..textDirection = textDirection
-        ..textScaleFactor = textScaleFactor
+        ..textScaler = TextScaler.linear(textScaleFactor)
         ..maxLines = 1
         ..ellipsis =
             '\u2026' // Standard Unicode ellipsis

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -1539,7 +1539,11 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
         ..maxLines = 1
         ..ellipsis =
             '\u2026' // Standard Unicode ellipsis
-        ..layout(maxWidth: safeMaxWidth);
+        ..layout(
+          maxWidth: screenSize.width.isFinite && screenSize.width > 0
+              ? safeMaxWidth
+              : double.infinity,
+        );
     } else {
       _labelPainter.text = null;
     }

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -1228,6 +1228,13 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   // This value is the touch target, 48, multiplied by 3.
   static const double _minPreferredTrackWidth = 144.0;
 
+  // Buffer to account for the internal padding of standard Material value indicator shapes,
+  // preventing them from bleeding off the screen edges.
+  //
+  // The value 64.0 is a heuristic that covers the minimum size of the shape
+  // (padding + minimum label width) at a text scale factor of roughly 2.0.
+  static const double _kValueIndicatorHorizontalBuffer = 64.0;
+
   // Compute the largest width and height needed to paint the slider shapes,
   // other than the track shape. It is assumed that these shapes are vertically
   // centered on the track.
@@ -1519,11 +1526,20 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
   void _updateLabelPainter() {
     if (label != null) {
+      // Reserve space for the bubble's internal padding and screen margins.
+      final double safeMaxWidth = math.max(
+        0.0,
+        screenSize.width - _kValueIndicatorHorizontalBuffer,
+      );
+
       _labelPainter
         ..text = TextSpan(style: _sliderTheme.valueIndicatorTextStyle, text: label)
         ..textDirection = textDirection
         ..textScaleFactor = textScaleFactor
-        ..layout();
+        ..maxLines = 1
+        ..ellipsis =
+            '\u2026' // Standard Unicode ellipsis
+        ..layout(maxWidth: safeMaxWidth);
     } else {
       _labelPainter.text = null;
     }

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -4073,6 +4073,7 @@ void main() {
     expect(endFocusNode.hasFocus, isTrue, reason: 'End thumb should have focus after tab');
     expect(FocusManager.instance.primaryFocus, equals(endFocusNode));
   });
+
   testWidgets('RangeSlider labels respect horizontal buffer and avoid screen overflow', (
     WidgetTester tester,
   ) async {

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -4080,9 +4080,8 @@ void main() {
     final logPainters = <TextPainter>[];
     final shape = LoggingRangeSliderValueIndicatorShape(<InlineSpan>[], logPainters);
 
-    const String longLabelStart =
-        'A very long start label string that exceeds standard screen widths';
-    const String longLabelEnd = 'A very long end label string that exceeds standard screen widths';
+    const longLabelStart = 'A very long start label string that exceeds standard screen widths';
+    const longLabelEnd = 'A very long end label string that exceeds standard screen widths';
 
     await tester.pumpWidget(
       MaterialApp(

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -4073,13 +4073,56 @@ void main() {
     expect(endFocusNode.hasFocus, isTrue, reason: 'End thumb should have focus after tab');
     expect(FocusManager.instance.primaryFocus, equals(endFocusNode));
   });
+  testWidgets('RangeSlider labels respect horizontal buffer and avoid screen overflow', (
+    WidgetTester tester,
+  ) async {
+    final logPainters = <TextPainter>[];
+    final shape = LoggingRangeSliderValueIndicatorShape(<InlineSpan>[], logPainters);
+
+    const String longLabelStart =
+        'A very long start label string that exceeds standard screen widths';
+    const String longLabelEnd = 'A very long end label string that exceeds standard screen widths';
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SliderTheme(
+            data: SliderThemeData(
+              showValueIndicator: ShowValueIndicator.always,
+              rangeValueIndicatorShape: shape,
+            ),
+            child: RangeSlider(
+              values: const RangeValues(0.2, 0.8),
+              divisions: 10,
+              labels: const RangeLabels(longLabelStart, longLabelEnd),
+              onChanged: (RangeValues values) {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Press the range slider to trigger the value indicators
+    final TestGesture gesture = await tester.startGesture(
+      tester.getCenter(find.byType(RangeSlider)),
+    );
+    await tester.pumpAndSettle();
+
+    final double screenWidth = tester.view.physicalSize.width / tester.view.devicePixelRatio;
+
+    expect(logPainters, isNotEmpty);
+    expect(logPainters.last.width, lessThanOrEqualTo(screenWidth - 64.0));
+
+    await gesture.up();
+  });
 }
 
 // A value indicator shape to log labelPainter text.
 class LoggingRangeSliderValueIndicatorShape extends RangeSliderValueIndicatorShape {
-  LoggingRangeSliderValueIndicatorShape(this.logLabel);
+  LoggingRangeSliderValueIndicatorShape(this.logLabel, [this.logPainter]);
 
   final List<InlineSpan> logLabel;
+  final List<TextPainter>? logPainter;
 
   @override
   Size getPreferredSize(
@@ -4109,5 +4152,6 @@ class LoggingRangeSliderValueIndicatorShape extends RangeSliderValueIndicatorSha
     Thumb? thumb,
   }) {
     logLabel.add(labelPainter.text!);
+    logPainter?.add(labelPainter);
   }
 }

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -965,20 +965,10 @@ void main() {
       TestGesture gesture = await tester.startGesture(center);
       await tester.pumpAndSettle();
 
-      late Rect pathBoundsDiscrete1;
       expect(
         tester.renderObject(find.byType(Overlay)),
         paints
-          ..something((Symbol method, List<dynamic> arguments) {
-            if (method == #drawPath) {
-              final Paint paint = arguments[1] as Paint;
-              if (paint.color == const Color(0xf55f5f5f)) {
-                pathBoundsDiscrete1 = (arguments[0] as Path).getBounds();
-                return true;
-              }
-            }
-            return false;
-          })
+          ..path(color: const Color(0xf55f5f5f))
           ..paragraph(),
       );
 
@@ -990,25 +980,12 @@ void main() {
       gesture = await tester.startGesture(center);
       await tester.pumpAndSettle();
 
-      late Rect pathBoundsDiscrete2;
       expect(
         tester.renderObject(find.byType(Overlay)),
         paints
-          ..something((Symbol method, List<dynamic> arguments) {
-            if (method == #drawPath) {
-              final paint = arguments[1] as Paint;
-              if (paint.color == const Color(0xf55f5f5f)) {
-                pathBoundsDiscrete2 = (arguments[0] as Path).getBounds();
-                return true;
-              }
-            }
-            return false;
-          })
+          ..path(color: const Color(0xf55f5f5f))
           ..paragraph(),
       );
-
-      expect(pathBoundsDiscrete2.width, greaterThan(pathBoundsDiscrete1.width));
-      expect(pathBoundsDiscrete2.height, greaterThan(pathBoundsDiscrete1.height));
 
       await gesture.up();
       await tester.pumpAndSettle();
@@ -1024,20 +1001,10 @@ void main() {
       gesture = await tester.startGesture(center);
       await tester.pumpAndSettle();
 
-      late Rect pathBoundsContinuous1;
       expect(
         tester.renderObject(find.byType(Overlay)),
         paints
-          ..something((Symbol method, List<dynamic> arguments) {
-            if (method == #drawPath) {
-              final paint = arguments[1] as Paint;
-              if (paint.color == const Color(0xf55f5f5f)) {
-                pathBoundsContinuous1 = (arguments[0] as Path).getBounds();
-                return true;
-              }
-            }
-            return false;
-          })
+          ..path(color: const Color(0xf55f5f5f))
           ..paragraph(),
       );
 
@@ -1055,25 +1022,12 @@ void main() {
       gesture = await tester.startGesture(center);
       await tester.pumpAndSettle();
 
-      late Rect pathBoundsContinuous2;
       expect(
         tester.renderObject(find.byType(Overlay)),
         paints
-          ..something((Symbol method, List<dynamic> arguments) {
-            if (method == #drawPath) {
-              final paint = arguments[1] as Paint;
-              if (paint.color == const Color(0xf55f5f5f)) {
-                pathBoundsContinuous2 = (arguments[0] as Path).getBounds();
-                return true;
-              }
-            }
-            return false;
-          })
+          ..path(color: const Color(0xf55f5f5f))
           ..paragraph(),
       );
-
-      expect(pathBoundsContinuous2.width, greaterThan(pathBoundsContinuous1.width));
-      expect(pathBoundsContinuous2.height, greaterThan(pathBoundsContinuous1.height));
 
       await gesture.up();
       await tester.pumpAndSettle();

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -923,9 +923,7 @@ void main() {
             child: StatefulBuilder(
               builder: (BuildContext context, StateSetter setState) {
                 return MediaQuery(
-                  data: MediaQuery.of(
-                    context,
-                  ).copyWith(textScaler: TextScaler.linear(textScaleFactor)),
+                  data: MediaQueryData(textScaler: TextScaler.linear(textScaleFactor)),
                   child: Material(
                     child: Theme(
                       data: Theme.of(context).copyWith(
@@ -968,7 +966,15 @@ void main() {
       expect(
         tester.renderObject(find.byType(Overlay)),
         paints
-          ..path(color: const Color(0xf55f5f5f))
+          ..path(
+            includes: const <Offset>[
+              Offset.zero,
+              Offset(0.0, -8.0),
+              Offset(-276.0, -16.0),
+              Offset(-216.0, -16.0),
+            ],
+            color: const Color(0xf55f5f5f),
+          )
           ..paragraph(),
       );
 
@@ -983,13 +989,22 @@ void main() {
       expect(
         tester.renderObject(find.byType(Overlay)),
         paints
-          ..path(color: const Color(0xf55f5f5f))
+          ..path(
+            includes: const <Offset>[
+              Offset.zero,
+              Offset(0.0, -8.0),
+              Offset(-304.0, -16.0),
+              Offset(-216.0, -16.0),
+            ],
+            color: const Color(0xf55f5f5f),
+          )
           ..paragraph(),
       );
 
       await gesture.up();
       await tester.pumpAndSettle();
 
+      // Check continuous
       await tester.pumpWidget(
         buildSlider(
           textScaleFactor: 1.0,
@@ -1004,7 +1019,15 @@ void main() {
       expect(
         tester.renderObject(find.byType(Overlay)),
         paints
-          ..path(color: const Color(0xf55f5f5f))
+          ..path(
+            includes: const <Offset>[
+              Offset.zero,
+              Offset(0.0, -8.0),
+              Offset(-276.0, -16.0),
+              Offset(-216.0, -16.0),
+            ],
+            color: const Color(0xf55f5f5f),
+          )
           ..paragraph(),
       );
 
@@ -1025,7 +1048,15 @@ void main() {
       expect(
         tester.renderObject(find.byType(Overlay)),
         paints
-          ..path(color: const Color(0xf55f5f5f))
+          ..path(
+            includes: const <Offset>[
+              Offset.zero,
+              Offset(0.0, -8.0),
+              Offset(-276.0, -16.0),
+              Offset(-216.0, -16.0),
+            ],
+            color: const Color(0xf55f5f5f),
+          )
           ..paragraph(),
       );
 
@@ -1049,7 +1080,7 @@ void main() {
           child: StatefulBuilder(
             builder: (BuildContext context, StateSetter setState) {
               return MediaQuery(
-                data: MediaQuery.of(context).copyWith(boldText: boldText),
+                data: MediaQueryData(boldText: boldText),
                 child: Material(
                   child: Theme(
                     data: Theme.of(context).copyWith(
@@ -2720,9 +2751,7 @@ void main() {
               child: StatefulBuilder(
                 builder: (BuildContext context, StateSetter setState) {
                   return MediaQuery(
-                    data: MediaQuery.of(
-                      context,
-                    ).copyWith(navigationMode: NavigationMode.directional),
+                    data: const MediaQueryData(navigationMode: NavigationMode.directional),
                     child: Column(
                       children: <Widget>[
                         Slider(

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -965,10 +965,20 @@ void main() {
       TestGesture gesture = await tester.startGesture(center);
       await tester.pumpAndSettle();
 
+      late Rect pathBoundsDiscrete1;
       expect(
         tester.renderObject(find.byType(Overlay)),
         paints
-          ..path(color: const Color(0xf55f5f5f))
+          ..something((Symbol method, List<dynamic> arguments) {
+            if (method == #drawPath) {
+              final Paint paint = arguments[1] as Paint;
+              if (paint.color == const Color(0xf55f5f5f)) {
+                pathBoundsDiscrete1 = (arguments[0] as Path).getBounds();
+                return true;
+              }
+            }
+            return false;
+          })
           ..paragraph(),
       );
 
@@ -980,17 +990,29 @@ void main() {
       gesture = await tester.startGesture(center);
       await tester.pumpAndSettle();
 
+      late Rect pathBoundsDiscrete2;
       expect(
         tester.renderObject(find.byType(Overlay)),
         paints
-          ..path(color: const Color(0xf55f5f5f))
+          ..something((Symbol method, List<dynamic> arguments) {
+            if (method == #drawPath) {
+              final paint = arguments[1] as Paint;
+              if (paint.color == const Color(0xf55f5f5f)) {
+                pathBoundsDiscrete2 = (arguments[0] as Path).getBounds();
+                return true;
+              }
+            }
+            return false;
+          })
           ..paragraph(),
       );
+
+      expect(pathBoundsDiscrete2.width, greaterThan(pathBoundsDiscrete1.width));
+      expect(pathBoundsDiscrete2.height, greaterThan(pathBoundsDiscrete1.height));
 
       await gesture.up();
       await tester.pumpAndSettle();
 
-      // Check continuous
       await tester.pumpWidget(
         buildSlider(
           textScaleFactor: 1.0,
@@ -1002,10 +1024,20 @@ void main() {
       gesture = await tester.startGesture(center);
       await tester.pumpAndSettle();
 
+      late Rect pathBoundsContinuous1;
       expect(
         tester.renderObject(find.byType(Overlay)),
         paints
-          ..path(color: const Color(0xf55f5f5f))
+          ..something((Symbol method, List<dynamic> arguments) {
+            if (method == #drawPath) {
+              final paint = arguments[1] as Paint;
+              if (paint.color == const Color(0xf55f5f5f)) {
+                pathBoundsContinuous1 = (arguments[0] as Path).getBounds();
+                return true;
+              }
+            }
+            return false;
+          })
           ..paragraph(),
       );
 
@@ -1023,12 +1055,25 @@ void main() {
       gesture = await tester.startGesture(center);
       await tester.pumpAndSettle();
 
+      late Rect pathBoundsContinuous2;
       expect(
         tester.renderObject(find.byType(Overlay)),
         paints
-          ..path(color: const Color(0xf55f5f5f))
+          ..something((Symbol method, List<dynamic> arguments) {
+            if (method == #drawPath) {
+              final paint = arguments[1] as Paint;
+              if (paint.color == const Color(0xf55f5f5f)) {
+                pathBoundsContinuous2 = (arguments[0] as Path).getBounds();
+                return true;
+              }
+            }
+            return false;
+          })
           ..paragraph(),
       );
+
+      expect(pathBoundsContinuous2.width, greaterThan(pathBoundsContinuous1.width));
+      expect(pathBoundsContinuous2.height, greaterThan(pathBoundsContinuous1.height));
 
       await gesture.up();
       await tester.pumpAndSettle();
@@ -5653,6 +5698,7 @@ void main() {
     );
     expect(tester.getSize(find.byType(Slider)), Size.zero);
   });
+
   testWidgets('Slider label respects horizontal buffer and avoids screen overflow', (
     WidgetTester tester,
   ) async {

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -103,9 +103,10 @@ class LoggingThumbShape extends SliderComponentShape {
 
 // A value indicator shape to log labelPainter text.
 class LoggingValueIndicatorShape extends SliderComponentShape {
-  LoggingValueIndicatorShape(this.logLabel);
+  LoggingValueIndicatorShape(this.logLabel, [this.logPainter]);
 
   final List<InlineSpan> logLabel;
+  final List<TextPainter>? logPainter;
 
   @override
   Size getPreferredSize(bool isEnabled, bool isDiscrete) {
@@ -128,6 +129,7 @@ class LoggingValueIndicatorShape extends SliderComponentShape {
     required Size sizeWithOverflow,
   }) {
     logLabel.add(labelPainter.text!);
+    logPainter?.add(labelPainter);
   }
 }
 
@@ -921,7 +923,9 @@ void main() {
             child: StatefulBuilder(
               builder: (BuildContext context, StateSetter setState) {
                 return MediaQuery(
-                  data: MediaQueryData(textScaler: TextScaler.linear(textScaleFactor)),
+                  data: MediaQuery.of(
+                    context,
+                  ).copyWith(textScaler: TextScaler.linear(textScaleFactor)),
                   child: Material(
                     child: Theme(
                       data: Theme.of(context).copyWith(
@@ -964,15 +968,7 @@ void main() {
       expect(
         tester.renderObject(find.byType(Overlay)),
         paints
-          ..path(
-            includes: const <Offset>[
-              Offset.zero,
-              Offset(0.0, -8.0),
-              Offset(-276.0, -16.0),
-              Offset(-216.0, -16.0),
-            ],
-            color: const Color(0xf55f5f5f),
-          )
+          ..path(color: const Color(0xf55f5f5f))
           ..paragraph(),
       );
 
@@ -987,15 +983,7 @@ void main() {
       expect(
         tester.renderObject(find.byType(Overlay)),
         paints
-          ..path(
-            includes: const <Offset>[
-              Offset.zero,
-              Offset(0.0, -8.0),
-              Offset(-304.0, -16.0),
-              Offset(-216.0, -16.0),
-            ],
-            color: const Color(0xf55f5f5f),
-          )
+          ..path(color: const Color(0xf55f5f5f))
           ..paragraph(),
       );
 
@@ -1017,15 +1005,7 @@ void main() {
       expect(
         tester.renderObject(find.byType(Overlay)),
         paints
-          ..path(
-            includes: const <Offset>[
-              Offset.zero,
-              Offset(0.0, -8.0),
-              Offset(-276.0, -16.0),
-              Offset(-216.0, -16.0),
-            ],
-            color: const Color(0xf55f5f5f),
-          )
+          ..path(color: const Color(0xf55f5f5f))
           ..paragraph(),
       );
 
@@ -1046,15 +1026,7 @@ void main() {
       expect(
         tester.renderObject(find.byType(Overlay)),
         paints
-          ..path(
-            includes: const <Offset>[
-              Offset.zero,
-              Offset(0.0, -8.0),
-              Offset(-276.0, -16.0),
-              Offset(-216.0, -16.0),
-            ],
-            color: const Color(0xf55f5f5f),
-          )
+          ..path(color: const Color(0xf55f5f5f))
           ..paragraph(),
       );
 
@@ -1078,7 +1050,7 @@ void main() {
           child: StatefulBuilder(
             builder: (BuildContext context, StateSetter setState) {
               return MediaQuery(
-                data: MediaQueryData(boldText: boldText),
+                data: MediaQuery.of(context).copyWith(boldText: boldText),
                 child: Material(
                   child: Theme(
                     data: Theme.of(context).copyWith(
@@ -2749,7 +2721,9 @@ void main() {
               child: StatefulBuilder(
                 builder: (BuildContext context, StateSetter setState) {
                   return MediaQuery(
-                    data: const MediaQueryData(navigationMode: NavigationMode.directional),
+                    data: MediaQuery.of(
+                      context,
+                    ).copyWith(navigationMode: NavigationMode.directional),
                     child: Column(
                       children: <Widget>[
                         Slider(
@@ -5678,6 +5652,42 @@ void main() {
       ),
     );
     expect(tester.getSize(find.byType(Slider)), Size.zero);
+  });
+  testWidgets('Slider label respects horizontal buffer and avoids screen overflow', (
+    WidgetTester tester,
+  ) async {
+    final logPainters = <TextPainter>[];
+    final shape = LoggingValueIndicatorShape(<InlineSpan>[], logPainters);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SliderTheme(
+            data: SliderThemeData(
+              showValueIndicator: ShowValueIndicator.always,
+              valueIndicatorShape: shape,
+            ),
+            child: Slider(
+              value: 0.5,
+              divisions: 10,
+              label:
+                  'A very long label string that exceeds standard screen widths to test clipping behavior',
+              onChanged: (double value) {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final TestGesture gesture = await tester.startGesture(tester.getCenter(find.byType(Slider)));
+    await tester.pumpAndSettle();
+
+    final double screenWidth = tester.view.physicalSize.width / tester.view.devicePixelRatio;
+
+    expect(logPainters, isNotEmpty);
+    expect(logPainters.last.width, lessThanOrEqualTo(screenWidth - 64.0));
+
+    await gesture.up();
   });
 }
 


### PR DESCRIPTION
*Replaces #184208 to clean up a messy git history after a bad local merge.*

This PR addresses the issue where long text in a `Slider` or `RangeSlider` label clips off the edges of the screen.

Following the discussion in the original issue and previous PR, this limits the label's `maxWidth` to `screenSize.width` minus a calculated horizontal buffer (`_kValueIndicatorHorizontalBuffer`). It also forces `maxLines = 1` and applies the Unicode ellipsis (`\u2026`). This prevents the text from expanding beyond the screen boundaries and prevents the bubble shape from breaking vertically.

All previous feedback from @QuncCccccc has been addressed, including:
* Adding documentation for the 64.0 heuristic buffer.
* Adding new unit tests to verify the layout constraints for both `Slider` and `RangeSlider` using custom value indicator shapes to capture the `TextPainter` width.

*Fixes #63293*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Code Freeze Note:** As discussed with @QuncCccccc in #184208, this PR is being opened to finalize the review process. We can mark it as a draft until the Material library migration to `flutter/packages` is complete, and then port it over.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md