### PR TITLE
Support soft hyphen (U+00AD) rendering with a Hyphens API

### DIFF
--- a/engine/src/flutter/lib/ui/text.dart
+++ b/engine/src/flutter/lib/ui/text.dart
@@ -1327,6 +1327,20 @@ enum TextAlign {
   end,
 }
 
+/// The behavior of soft hyphens (U+00AD) at a line break.
+///
+/// This affects rendering only; it does not change where lines break, since
+/// Flutter always treats U+00AD as a line-break opportunity.
+enum Hyphens {
+  /// A hyphen glyph is rendered at the end of a line that breaks on a soft
+  /// hyphen (U+00AD). Soft hyphens elsewhere remain invisible.
+  manual,
+
+  /// No hyphen glyph is rendered for soft hyphens. The line still breaks at
+  /// U+00AD; only the glyph is suppressed.
+  hidden,
+}
+
 /// A horizontal line used for aligning text.
 enum TextBaseline {
   /// The horizontal line used to align the bottom of glyphs for alphabetic characters.
@@ -1950,8 +1964,9 @@ Int32List _encodeParagraphStyle(
   StrutStyle? strutStyle,
   String? ellipsis,
   Locale? locale,
+  Hyphens? hyphens,
 ) {
-  final result = Int32List(7); // also update paragraph_builder.cc
+  final result = Int32List(8); // also update paragraph_builder.cc
   if (textAlign != null) {
     result[0] |= 1 << 1;
     result[1] = textAlign.index;
@@ -2001,6 +2016,10 @@ Int32List _encodeParagraphStyle(
   if (locale != null) {
     result[0] |= 1 << 12;
     // Passed separately to native.
+  }
+  if (hyphens != null) {
+    result[0] |= 1 << 13;
+    result[7] = hyphens.index;
   }
   return result;
 }
@@ -2068,6 +2087,9 @@ class ParagraphStyle {
   ///   considered equivalent and turn off this behavior.
   ///
   /// * `locale`: The locale used to select region-specific glyphs.
+  ///
+  /// * `hyphens`: Whether to render a hyphen glyph for soft hyphens (U+00AD)
+  ///   that fall at a line break. Defaults to [Hyphens.manual].
   ParagraphStyle({
     TextAlign? textAlign,
     TextDirection? textDirection,
@@ -2081,6 +2103,7 @@ class ParagraphStyle {
     StrutStyle? strutStyle,
     String? ellipsis,
     Locale? locale,
+    Hyphens? hyphens,
   }) : _encoded = _encodeParagraphStyle(
          textAlign,
          textDirection,
@@ -2094,6 +2117,7 @@ class ParagraphStyle {
          strutStyle,
          ellipsis,
          locale,
+         hyphens,
        ),
        _fontFamily = fontFamily,
        _fontSize = fontSize,
@@ -2157,7 +2181,8 @@ class ParagraphStyle {
         'height: ${_encoded[0] & 0x200 == 0x200 ? "${_height}x" : "unspecified"}, '
         'strutStyle: ${_encoded[0] & 0x400 == 0x400 ? _strutStyle : "unspecified"}, '
         'ellipsis: ${_encoded[0] & 0x800 == 0x800 ? '"$_ellipsis"' : "unspecified"}, '
-        'locale: ${_encoded[0] & 0x1000 == 0x1000 ? _locale : "unspecified"}'
+        'locale: ${_encoded[0] & 0x1000 == 0x1000 ? _locale : "unspecified"}, '
+        'hyphens: ${_encoded[0] & 0x2000 == 0x2000 ? Hyphens.values[_encoded[7]] : "unspecified"}'
         ')';
   }
 }

--- a/engine/src/flutter/lib/ui/text.dart
+++ b/engine/src/flutter/lib/ui/text.dart
@@ -1329,8 +1329,8 @@ enum TextAlign {
 
 /// The behavior of soft hyphens (U+00AD) at a line break.
 ///
-/// This affects rendering only; it does not change where lines break, since
-/// Flutter always treats U+00AD as a line-break opportunity.
+/// This does not change where lines break, since Flutter always treats U+00AD
+/// as a line-break opportunity.
 enum Hyphens {
   /// A hyphen glyph is rendered at the end of a line that breaks on a soft
   /// hyphen (U+00AD). Soft hyphens elsewhere remain invisible.
@@ -1951,6 +1951,8 @@ class TextStyle {
 //
 //  - Element 6: The encoded value of |textHeightBehavior|, except its leading
 //    distribution.
+//
+//  - Element 7: The enum index of the |hyphens|.
 Int32List _encodeParagraphStyle(
   TextAlign? textAlign,
   TextDirection? textDirection,

--- a/engine/src/flutter/lib/ui/text/paragraph_builder.cc
+++ b/engine/src/flutter/lib/ui/text/paragraph_builder.cc
@@ -90,6 +90,11 @@ const int kPSHeightIndex = 9;
 const int kPSStrutStyleIndex = 10;
 const int kPSEllipsisIndex = 11;
 const int kPSLocaleIndex = 12;
+// render_soft_hyphens is the first field whose mask bit and encode slot differ:
+// it claims the next free mask bit (13), but stores its value in the next free
+// encode slot (7), since slots 7-12 are reused only as mask-bit positions.
+const int kPSRenderSoftHyphensIndex = 13;
+const int kPSRenderSoftHyphensEncodeIndex = 7;
 
 const int kPSTextAlignMask = 1 << kPSTextAlignIndex;
 const int kPSTextDirectionMask = 1 << kPSTextDirectionIndex;
@@ -103,6 +108,7 @@ const int kPSTextHeightBehaviorMask = 1 << kPSTextHeightBehaviorIndex;
 const int kPSStrutStyleMask = 1 << kPSStrutStyleIndex;
 const int kPSEllipsisMask = 1 << kPSEllipsisIndex;
 const int kPSLocaleMask = 1 << kPSLocaleIndex;
+const int kPSRenderSoftHyphensMask = 1 << kPSRenderSoftHyphensIndex;
 
 // TextShadows decoding
 
@@ -272,6 +278,12 @@ ParagraphBuilder::ParagraphBuilder(
 
     if (mask & kPSMaxLinesMask) {
       style.max_lines = encoded[kPSMaxLinesIndex];
+    }
+
+    if (mask & kPSRenderSoftHyphensMask) {
+      // Hyphens.manual (0) renders the soft hyphen glyph; Hyphens.hidden (1)
+      // suppresses it.
+      style.render_soft_hyphens = encoded[kPSRenderSoftHyphensEncodeIndex] == 0;
     }
   }
 

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
@@ -401,6 +401,7 @@ class CanvasKitRenderer extends Renderer {
     ui.StrutStyle? strutStyle,
     String? ellipsis,
     ui.Locale? locale,
+    ui.Hyphens? hyphens,
   }) => isWebParagraphEnabled
       ? WebParagraphStyle(
           textAlign: textAlign,
@@ -415,6 +416,7 @@ class CanvasKitRenderer extends Renderer {
           strutStyle: strutStyle as WebStrutStyle?,
           ellipsis: ellipsis,
           locale: locale,
+          hyphens: hyphens,
         )
       : CkParagraphStyle(
           textAlign: textAlign,
@@ -429,6 +431,7 @@ class CanvasKitRenderer extends Renderer {
           strutStyle: strutStyle,
           ellipsis: ellipsis,
           locale: locale,
+          hyphens: hyphens,
         );
 
   @override

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/text.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/text.dart
@@ -33,6 +33,7 @@ class CkParagraphStyle implements ui.ParagraphStyle {
     ui.StrutStyle? strutStyle,
     String? ellipsis,
     ui.Locale? locale,
+    ui.Hyphens? hyphens,
   }) : skParagraphStyle = toSkParagraphStyle(
          textAlign,
          textDirection,
@@ -59,7 +60,8 @@ class CkParagraphStyle implements ui.ParagraphStyle {
        _textHeightBehavior = textHeightBehavior,
        _strutStyle = strutStyle,
        _ellipsis = ellipsis,
-       _locale = locale;
+       _locale = locale,
+       _hyphens = hyphens;
 
   final SkParagraphStyle skParagraphStyle;
 
@@ -76,6 +78,11 @@ class CkParagraphStyle implements ui.ParagraphStyle {
   final ui.StrutStyle? _strutStyle;
   final String? _ellipsis;
   final ui.Locale? _locale;
+  // TODO(dbebawy): honor hyphens once the configurable-soft-hyphen-string Skia
+  // change (https://skia-review.googlesource.com/c/skia/+/1205922) lands and its
+  // binding is exposed on SkParagraphStyleProperties. Accepted and stored for now.
+  // https://github.com/flutter/flutter/issues/18443
+  final ui.Hyphens? _hyphens;
 
   static SkTextStyleProperties toSkTextStyleProperties(
     String? fontFamily,
@@ -263,7 +270,8 @@ class CkParagraphStyle implements ui.ParagraphStyle {
         other._textHeightBehavior == _textHeightBehavior &&
         other._strutStyle == _strutStyle &&
         other._ellipsis == _ellipsis &&
-        other._locale == _locale;
+        other._locale == _locale &&
+        other._hyphens == _hyphens;
   }
 
   @override
@@ -282,6 +290,7 @@ class CkParagraphStyle implements ui.ParagraphStyle {
       _strutStyle,
       _ellipsis,
       _locale,
+      _hyphens,
     );
   }
 
@@ -304,6 +313,7 @@ class CkParagraphStyle implements ui.ParagraphStyle {
           'height: ${height != null ? "${height.toStringAsFixed(1)}x" : "unspecified"}, '
           'strutStyle: ${_strutStyle ?? "unspecified"}, '
           'ellipsis: ${_ellipsis != null ? '"$_ellipsis"' : "unspecified"}, '
+          'hyphens: ${_hyphens ?? "unspecified"}, '
           'locale: ${_locale ?? "unspecified"}'
           ')';
       return true;

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/text.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/text.dart
@@ -78,10 +78,13 @@ class CkParagraphStyle implements ui.ParagraphStyle {
   final ui.StrutStyle? _strutStyle;
   final String? _ellipsis;
   final ui.Locale? _locale;
-  // TODO(dbebawy): honor hyphens once the configurable-soft-hyphen-string Skia
-  // change (https://skia-review.googlesource.com/c/skia/+/1205922) lands and its
-  // binding is exposed on SkParagraphStyleProperties. Accepted and stored for now.
+  // TODO(dbebawy): hyphens is accepted and stored but not honored here yet.
+  // Neither Hyphens.manual nor Hyphens.hidden takes effect on CanvasKit until a
+  // renderSoftHyphens setter is exposed on the CanvasKit ParagraphStyle binding
+  // (the native engine wires this via SkParagraph::setRenderSoftHyphens).
   // https://github.com/flutter/flutter/issues/18443
+  // Customizing the hyphen string is separate future work:
+  // https://github.com/flutter/flutter/issues/189617
   final ui.Hyphens? _hyphens;
 
   static SkTextStyleProperties toSkTextStyleProperties(

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/renderer.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/renderer.dart
@@ -266,6 +266,7 @@ abstract class Renderer {
     ui.StrutStyle? strutStyle,
     String? ellipsis,
     ui.Locale? locale,
+    ui.Hyphens? hyphens,
   });
 
   ui.StrutStyle createStrutStyle({

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
@@ -837,10 +837,13 @@ class SkwasmParagraphStyle implements ui.ParagraphStyle {
   final ui.StrutStyle? _strutStyle;
   final String? _ellipsis;
   final ui.Locale? _locale;
-  // TODO(dbebawy): honor hyphens once the configurable-soft-hyphen-string Skia
-  // change (https://skia-review.googlesource.com/c/skia/+/1205922) lands and a
-  // skwasm binding is exposed. Accepted and stored for now.
+  // TODO(dbebawy): hyphens is accepted and stored but not honored here yet.
+  // Neither Hyphens.manual nor Hyphens.hidden takes effect on Skwasm until a
+  // renderSoftHyphens setter is exposed on the Skwasm ParagraphStyle binding
+  // (the native engine wires this via SkParagraph::setRenderSoftHyphens).
   // https://github.com/flutter/flutter/issues/18443
+  // Customizing the hyphen string is separate future work:
+  // https://github.com/flutter/flutter/issues/189617
   final ui.Hyphens? _hyphens;
 
   @override

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
@@ -726,6 +726,7 @@ class SkwasmParagraphStyle implements ui.ParagraphStyle {
     ui.StrutStyle? strutStyle,
     String? ellipsis,
     ui.Locale? locale,
+    ui.Hyphens? hyphens,
   }) : _textAlign = textAlign,
        _textDirection = textDirection,
        _maxLines = maxLines,
@@ -737,7 +738,8 @@ class SkwasmParagraphStyle implements ui.ParagraphStyle {
        _fontStyle = fontStyle,
        _strutStyle = strutStyle,
        _ellipsis = ellipsis,
-       _locale = locale;
+       _locale = locale,
+       _hyphens = hyphens;
 
   (ParagraphStyleHandle, SkwasmNativeTextStyle) createNative() {
     final ParagraphStyleHandle handle = paragraphStyleCreate();
@@ -835,6 +837,11 @@ class SkwasmParagraphStyle implements ui.ParagraphStyle {
   final ui.StrutStyle? _strutStyle;
   final String? _ellipsis;
   final ui.Locale? _locale;
+  // TODO(dbebawy): honor hyphens once the configurable-soft-hyphen-string Skia
+  // change (https://skia-review.googlesource.com/c/skia/+/1205922) lands and a
+  // skwasm binding is exposed. Accepted and stored for now.
+  // https://github.com/flutter/flutter/issues/18443
+  final ui.Hyphens? _hyphens;
 
   @override
   bool operator ==(Object other) {
@@ -856,7 +863,8 @@ class SkwasmParagraphStyle implements ui.ParagraphStyle {
         other._textHeightBehavior == _textHeightBehavior &&
         other._strutStyle == _strutStyle &&
         other._ellipsis == _ellipsis &&
-        other._locale == _locale;
+        other._locale == _locale &&
+        other._hyphens == _hyphens;
   }
 
   @override
@@ -874,6 +882,7 @@ class SkwasmParagraphStyle implements ui.ParagraphStyle {
       _strutStyle,
       _ellipsis,
       _locale,
+      _hyphens,
     );
   }
 
@@ -896,6 +905,7 @@ class SkwasmParagraphStyle implements ui.ParagraphStyle {
           'height: ${height != null ? "${height.toStringAsFixed(1)}x" : "unspecified"}, '
           'strutStyle: ${_strutStyle ?? "unspecified"}, '
           'ellipsis: ${_ellipsis != null ? '"$_ellipsis"' : "unspecified"}, '
+          'hyphens: ${_hyphens ?? "unspecified"}, '
           'locale: ${_locale ?? "unspecified"}'
           ')';
       return true;

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
@@ -137,6 +137,7 @@ class SkwasmRenderer extends Renderer {
     ui.StrutStyle? strutStyle,
     String? ellipsis,
     ui.Locale? locale,
+    ui.Hyphens? hyphens,
   }) => SkwasmParagraphStyle(
     textAlign: textAlign,
     textDirection: textDirection,
@@ -150,6 +151,7 @@ class SkwasmRenderer extends Renderer {
     strutStyle: strutStyle,
     ellipsis: ellipsis,
     locale: locale,
+    hyphens: hyphens,
   );
 
   @override

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_stub/renderer.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_stub/renderer.dart
@@ -127,6 +127,7 @@ class SkwasmRenderer extends Renderer {
     ui.StrutStyle? strutStyle,
     String? ellipsis,
     ui.Locale? locale,
+    ui.Hyphens? hyphens,
   }) {
     throw UnimplementedError('Skwasm not implemented on this platform.');
   }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/paragraph.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/paragraph.dart
@@ -36,6 +36,7 @@ class WebParagraphStyle implements ui.ParagraphStyle {
     ui.Color? color,
     ui.StrutStyle? strutStyle,
     this.textHeightBehavior,
+    this.hyphens,
   }) : _strutStyle = strutStyle as WebStrutStyle?,
        _textStyle = WebTextStyle(
          fontFamily: fontFamily,
@@ -60,6 +61,11 @@ class WebParagraphStyle implements ui.ParagraphStyle {
 
   final ui.TextHeightBehavior? textHeightBehavior;
 
+  // TODO(dbebawy): honor hyphens in the pure-Dart line-breaker/painter (no
+  // soft-hyphen glyph emitted at a break yet). Accepted and stored for now.
+  // https://github.com/flutter/flutter/issues/18443
+  final ui.Hyphens? hyphens;
+
   WebStrutStyle? get strutStyle => _strutStyle;
   final WebStrutStyle? _strutStyle;
 
@@ -78,7 +84,8 @@ class WebParagraphStyle implements ui.ParagraphStyle {
         ellipsis == other.ellipsis &&
         textHeightBehavior == other.textHeightBehavior &&
         _strutStyle == other._strutStyle &&
-        _textStyle == other._textStyle;
+        _textStyle == other._textStyle &&
+        hyphens == other.hyphens;
   }
 
   @override
@@ -91,6 +98,7 @@ class WebParagraphStyle implements ui.ParagraphStyle {
       textHeightBehavior,
       _strutStyle,
       _textStyle,
+      hyphens,
     );
   }
 
@@ -105,6 +113,7 @@ class WebParagraphStyle implements ui.ParagraphStyle {
           'maxLines: $maxLines, '
           'ellipsis: $ellipsis, '
           'textHeightBehavior: $textHeightBehavior, '
+          'hyphens: $hyphens, '
           'strutStyle: $_strutStyle, '
           'textAlign: $textAlign'
           'textStyle: $_textStyle'

--- a/engine/src/flutter/lib/web_ui/lib/text.dart
+++ b/engine/src/flutter/lib/web_ui/lib/text.dart
@@ -381,6 +381,7 @@ abstract class ParagraphStyle {
     StrutStyle? strutStyle,
     String? ellipsis,
     Locale? locale,
+    Hyphens? hyphens,
   }) => engine.renderer.createParagraphStyle(
     textAlign: textAlign,
     textDirection: textDirection,
@@ -394,6 +395,7 @@ abstract class ParagraphStyle {
     strutStyle: strutStyle,
     ellipsis: ellipsis,
     locale: locale,
+    hyphens: hyphens,
   );
 }
 
@@ -458,6 +460,9 @@ abstract class StrutStyle {
 
 // The order of this enum must match the order of the values in TextDirection.h's TextDirection.
 enum TextDirection { rtl, ltr }
+
+/// The behavior of soft hyphens (U+00AD) at a line break.
+enum Hyphens { manual, hidden }
 
 class TextBox {
   const TextBox.fromLTRBD(this.left, this.top, this.right, this.bottom, this.direction);

--- a/engine/src/flutter/lib/web_ui/test/ui/paragraph_style_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/ui/paragraph_style_test.dart
@@ -134,6 +134,9 @@ final Map<String, _ParagraphStylePropertyPopulator> _populatorsA =
       'locale': (_TestParagraphStyleBuilder builder) {
         builder.locale = const ui.Locale('en', 'US');
       },
+      'hyphens': (_TestParagraphStyleBuilder builder) {
+        builder.hyphens = ui.Hyphens.manual;
+      },
     };
 
 final Map<String, _ParagraphStylePropertyPopulator> _populatorsB =
@@ -174,6 +177,9 @@ final Map<String, _ParagraphStylePropertyPopulator> _populatorsB =
       'locale': (_TestParagraphStyleBuilder builder) {
         builder.locale = const ui.Locale('fr', 'CA');
       },
+      'hyphens': (_TestParagraphStyleBuilder builder) {
+        builder.hyphens = ui.Hyphens.hidden;
+      },
     };
 
 class _TestParagraphStyleBuilder {
@@ -189,6 +195,7 @@ class _TestParagraphStyleBuilder {
   ui.StrutStyle? strutStyle;
   String? ellipsis;
   ui.Locale? locale;
+  ui.Hyphens? hyphens;
 
   ui.ParagraphStyle build() {
     return ui.ParagraphStyle(
@@ -204,6 +211,7 @@ class _TestParagraphStyleBuilder {
       strutStyle: strutStyle,
       ellipsis: ellipsis,
       locale: locale,
+      hyphens: hyphens,
     );
   }
 }

--- a/engine/src/flutter/testing/dart/text_test.dart
+++ b/engine/src/flutter/testing/dart/text_test.dart
@@ -61,36 +61,43 @@ void testParagraphStyle() {
   );
   final ps3 = ParagraphStyle(fontWeight: FontWeight.w700, fontSize: 12.0, height: 123.0);
   final ps4 = ParagraphStyle(fontWeight: FontWeight.w700, fontSize: 12.0, height: kTextHeightNone);
+  final ps5 = ParagraphStyle(hyphens: Hyphens.hidden);
 
   test('ParagraphStyle toString works', () {
     expect(
       ps0.toString(),
       equals(
-        'ParagraphStyle(textAlign: unspecified, textDirection: TextDirection.ltr, fontWeight: unspecified, fontStyle: unspecified, maxLines: unspecified, textHeightBehavior: unspecified, fontFamily: unspecified, fontSize: 14.0, height: unspecified, strutStyle: unspecified, ellipsis: unspecified, locale: unspecified)',
+        'ParagraphStyle(textAlign: unspecified, textDirection: TextDirection.ltr, fontWeight: unspecified, fontStyle: unspecified, maxLines: unspecified, textHeightBehavior: unspecified, fontFamily: unspecified, fontSize: 14.0, height: unspecified, strutStyle: unspecified, ellipsis: unspecified, locale: unspecified, hyphens: unspecified)',
       ),
     );
     expect(
       ps1.toString(),
       equals(
-        'ParagraphStyle(textAlign: unspecified, textDirection: TextDirection.rtl, fontWeight: unspecified, fontStyle: unspecified, maxLines: unspecified, textHeightBehavior: unspecified, fontFamily: unspecified, fontSize: 14.0, height: unspecified, strutStyle: unspecified, ellipsis: unspecified, locale: unspecified)',
+        'ParagraphStyle(textAlign: unspecified, textDirection: TextDirection.rtl, fontWeight: unspecified, fontStyle: unspecified, maxLines: unspecified, textHeightBehavior: unspecified, fontFamily: unspecified, fontSize: 14.0, height: unspecified, strutStyle: unspecified, ellipsis: unspecified, locale: unspecified, hyphens: unspecified)',
       ),
     );
     expect(
       ps2.toString(),
       equals(
-        'ParagraphStyle(textAlign: TextAlign.center, textDirection: unspecified, fontWeight: FontWeight.w800, fontStyle: unspecified, maxLines: unspecified, textHeightBehavior: unspecified, fontFamily: unspecified, fontSize: 10.0, height: 100.0x, strutStyle: unspecified, ellipsis: unspecified, locale: unspecified)',
+        'ParagraphStyle(textAlign: TextAlign.center, textDirection: unspecified, fontWeight: FontWeight.w800, fontStyle: unspecified, maxLines: unspecified, textHeightBehavior: unspecified, fontFamily: unspecified, fontSize: 10.0, height: 100.0x, strutStyle: unspecified, ellipsis: unspecified, locale: unspecified, hyphens: unspecified)',
       ),
     );
     expect(
       ps3.toString(),
       equals(
-        'ParagraphStyle(textAlign: unspecified, textDirection: unspecified, fontWeight: FontWeight.w700, fontStyle: unspecified, maxLines: unspecified, textHeightBehavior: unspecified, fontFamily: unspecified, fontSize: 12.0, height: 123.0x, strutStyle: unspecified, ellipsis: unspecified, locale: unspecified)',
+        'ParagraphStyle(textAlign: unspecified, textDirection: unspecified, fontWeight: FontWeight.w700, fontStyle: unspecified, maxLines: unspecified, textHeightBehavior: unspecified, fontFamily: unspecified, fontSize: 12.0, height: 123.0x, strutStyle: unspecified, ellipsis: unspecified, locale: unspecified, hyphens: unspecified)',
       ),
     );
     expect(
       ps4.toString(),
       equals(
-        'ParagraphStyle(textAlign: unspecified, textDirection: unspecified, fontWeight: FontWeight.w700, fontStyle: unspecified, maxLines: unspecified, textHeightBehavior: unspecified, fontFamily: unspecified, fontSize: 12.0, height: unspecified, strutStyle: unspecified, ellipsis: unspecified, locale: unspecified)',
+        'ParagraphStyle(textAlign: unspecified, textDirection: unspecified, fontWeight: FontWeight.w700, fontStyle: unspecified, maxLines: unspecified, textHeightBehavior: unspecified, fontFamily: unspecified, fontSize: 12.0, height: unspecified, strutStyle: unspecified, ellipsis: unspecified, locale: unspecified, hyphens: unspecified)',
+      ),
+    );
+    expect(
+      ps5.toString(),
+      equals(
+        'ParagraphStyle(textAlign: unspecified, textDirection: unspecified, fontWeight: unspecified, fontStyle: unspecified, maxLines: unspecified, textHeightBehavior: unspecified, fontFamily: unspecified, fontSize: unspecified, height: unspecified, strutStyle: unspecified, ellipsis: unspecified, locale: unspecified, hyphens: Hyphens.hidden)',
       ),
     );
   });

--- a/engine/src/flutter/txt/src/skia/paragraph_builder_skia.cc
+++ b/engine/src/flutter/txt/src/skia/paragraph_builder_skia.cc
@@ -139,6 +139,7 @@ skt::ParagraphStyle ParagraphBuilderSkia::TxtToSkia(const ParagraphStyle& txt) {
   skia.turnHintingOff();
   skia.setReplaceTabCharacters(true);
   skia.setApplyRoundingHack(false);
+  skia.setRenderSoftHyphens(txt.render_soft_hyphens);
 
   return skia;
 }

--- a/engine/src/flutter/txt/src/skia/paragraph_builder_skia.h
+++ b/engine/src/flutter/txt/src/skia/paragraph_builder_skia.h
@@ -35,6 +35,7 @@ class ParagraphBuilderSkia : public ParagraphBuilder {
 
  private:
   friend class SkiaParagraphBuilderTests_ParagraphStrutStyle_Test;
+  friend class SkiaParagraphBuilderTests_RenderSoftHyphensEnabled_Test;
 
   skia::textlayout::ParagraphPainter::PaintID CreatePaintID(
       const flutter::DlPaint& dl_paint);

--- a/engine/src/flutter/txt/src/txt/paragraph_style.h
+++ b/engine/src/flutter/txt/src/txt/paragraph_style.h
@@ -53,6 +53,10 @@ enum TextHeightBehavior {
   kDisableAll = 0x1 | 0x2,
 };
 
+// ParagraphStyle is instantiated rarely (roughly once per paragraph) and is not
+// performance-sensitive, so its fields are ordered for readability rather than
+// for minimal struct padding.
+// NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
 class ParagraphStyle {
  public:
   // Default TextStyle. Used in GetTextStyle() to obtain the base TextStyle to

--- a/engine/src/flutter/txt/src/txt/paragraph_style.h
+++ b/engine/src/flutter/txt/src/txt/paragraph_style.h
@@ -87,6 +87,11 @@ class ParagraphStyle {
   std::u16string ellipsis;
   std::string locale;
 
+  // Whether to render the soft hyphen (U+00AD) glyph at a line-break
+  // opportunity. Defaults to true, which renders the hyphen (Hyphens.manual);
+  // false suppresses it (Hyphens.hidden).
+  bool render_soft_hyphens = true;
+
   TextStyle GetTextStyle() const;
 
   bool unlimited_lines() const;

--- a/engine/src/flutter/txt/tests/paragraph_builder_skia_tests.cc
+++ b/engine/src/flutter/txt/tests/paragraph_builder_skia_tests.cc
@@ -30,4 +30,17 @@ TEST_F(SkiaParagraphBuilderTests, ParagraphStrutStyle) {
   strut_style = builder.TxtToSkia(style).getStrutStyle();
   ASSERT_TRUE(strut_style.getHalfLeading());
 }
+
+TEST_F(SkiaParagraphBuilderTests, RenderSoftHyphensEnabled) {
+  ParagraphStyle style = ParagraphStyle();
+  auto collection = std::make_shared<FontCollection>();
+  auto builder = ParagraphBuilderSkia(style, collection, false);
+
+  // Defaults to rendering the soft hyphen glyph (Hyphens.manual).
+  ASSERT_TRUE(builder.TxtToSkia(style).getRenderSoftHyphens());
+
+  // Hyphens.hidden suppresses the soft hyphen glyph.
+  style.render_soft_hyphens = false;
+  ASSERT_FALSE(builder.TxtToSkia(style).getRenderSoftHyphens());
+}
 }  // namespace txt

--- a/packages/flutter/lib/src/painting/basic_types.dart
+++ b/packages/flutter/lib/src/painting/basic_types.dart
@@ -25,6 +25,7 @@ export 'dart:ui'
         FontVariation,
         FontWeight,
         GlyphInfo,
+        Hyphens,
         ImageShader,
         Locale,
         MaskFilter,

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -31,7 +31,7 @@ import 'text_scaler.dart';
 import 'text_span.dart';
 import 'text_style.dart';
 
-export 'dart:ui' show LineMetrics;
+export 'dart:ui' show Hyphens, LineMetrics;
 export 'package:flutter/services.dart' show TextRange, TextSelection;
 
 /// The default font size if none is specified.
@@ -610,6 +610,7 @@ class TextPainter {
     StrutStyle? strutStyle,
     TextWidthBasis textWidthBasis = TextWidthBasis.parent,
     TextHeightBehavior? textHeightBehavior,
+    Hyphens hyphens = Hyphens.manual,
   }) : assert(text == null || text.debugAssertIsValid()),
        assert(maxLines == null || maxLines > 0),
        assert(
@@ -627,7 +628,8 @@ class TextPainter {
        _locale = locale,
        _strutStyle = strutStyle,
        _textWidthBasis = textWidthBasis,
-       _textHeightBehavior = textHeightBehavior {
+       _textHeightBehavior = textHeightBehavior,
+       _hyphens = hyphens {
     assert(debugMaybeDispatchCreated('painting', 'TextPainter', this));
   }
 
@@ -656,6 +658,7 @@ class TextPainter {
     StrutStyle? strutStyle,
     TextWidthBasis textWidthBasis = TextWidthBasis.parent,
     TextHeightBehavior? textHeightBehavior,
+    Hyphens hyphens = Hyphens.manual,
     double minWidth = 0.0,
     double maxWidth = double.infinity,
   }) {
@@ -676,6 +679,7 @@ class TextPainter {
       strutStyle: strutStyle,
       textWidthBasis: textWidthBasis,
       textHeightBehavior: textHeightBehavior,
+      hyphens: hyphens,
     )..layout(minWidth: minWidth, maxWidth: maxWidth);
 
     try {
@@ -710,6 +714,7 @@ class TextPainter {
     StrutStyle? strutStyle,
     TextWidthBasis textWidthBasis = TextWidthBasis.parent,
     TextHeightBehavior? textHeightBehavior,
+    Hyphens hyphens = Hyphens.manual,
     double minWidth = 0.0,
     double maxWidth = double.infinity,
   }) {
@@ -730,6 +735,7 @@ class TextPainter {
       strutStyle: strutStyle,
       textWidthBasis: textWidthBasis,
       textHeightBehavior: textHeightBehavior,
+      hyphens: hyphens,
     )..layout(minWidth: minWidth, maxWidth: maxWidth);
 
     try {
@@ -1031,6 +1037,23 @@ class TextPainter {
     markNeedsLayout();
   }
 
+  /// {@template flutter.painting.textPainter.hyphens}
+  /// The behavior of soft hyphens (U+00AD) at a line break.
+  ///
+  /// Defaults to [Hyphens.manual], which renders a hyphen glyph at a line break
+  /// that falls on a soft hyphen. [Hyphens.hidden] suppresses the glyph; the line
+  /// still breaks at U+00AD regardless.
+  /// {@endtemplate}
+  Hyphens get hyphens => _hyphens;
+  Hyphens _hyphens;
+  set hyphens(Hyphens value) {
+    if (_hyphens == value) {
+      return;
+    }
+    _hyphens = value;
+    markNeedsLayout();
+  }
+
   /// An ordered list of [TextBox]es that bound the positions of the placeholders
   /// in the paragraph.
   ///
@@ -1093,6 +1116,7 @@ class TextPainter {
       textScaler: textScaler,
       maxLines: _maxLines,
       textHeightBehavior: _textHeightBehavior,
+      hyphens: _hyphens,
       ellipsis: _ellipsis,
       locale: _locale,
       strutStyle: _strutStyle,

--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -1396,6 +1396,7 @@ class TextStyle with Diagnosticable {
     String? ellipsis,
     int? maxLines,
     TextHeightBehavior? textHeightBehavior,
+    Hyphens? hyphens,
     Locale? locale,
     String? fontFamily,
     double? fontSize,
@@ -1424,6 +1425,7 @@ class TextStyle with Diagnosticable {
       fontSize: textScaler.scale(fontSize ?? this.fontSize ?? kDefaultFontSize),
       height: height ?? this.height,
       textHeightBehavior: effectiveTextHeightBehavior,
+      hyphens: hyphens,
       strutStyle: strutStyle == null
           ? null
           : ui.StrutStyle(

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -14,6 +14,7 @@ import 'dart:ui'
         BoxHeightStyle,
         BoxWidthStyle,
         Gradient,
+        Hyphens,
         LineMetrics,
         PlaceholderAlignment,
         Shader,
@@ -41,10 +42,8 @@ typedef _TextBoundaryAtPosition = _TextBoundaryRecord Function(TextPosition posi
 
 /// Signature for a function that determines the [_TextBoundaryRecord] at the given
 /// [TextPosition], for the given [String].
-typedef _TextBoundaryAtPositionInText = _TextBoundaryRecord Function(
-  TextPosition position,
-  String text,
-);
+typedef _TextBoundaryAtPositionInText =
+    _TextBoundaryRecord Function(TextPosition position, String text);
 
 const String _kEllipsis = '\u2026';
 
@@ -352,6 +351,7 @@ class RenderParagraph extends RenderBox
     StrutStyle? strutStyle,
     TextWidthBasis textWidthBasis = TextWidthBasis.parent,
     ui.TextHeightBehavior? textHeightBehavior,
+    ui.Hyphens hyphens = ui.Hyphens.manual,
     List<RenderBox>? children,
     Color? selectionColor,
     SelectionRegistrar? registrar,
@@ -379,6 +379,7 @@ class RenderParagraph extends RenderBox
          strutStyle: strutStyle,
          textWidthBasis: textWidthBasis,
          textHeightBehavior: textHeightBehavior,
+         hyphens: hyphens,
        ) {
     addAll(children);
     this.registrar = registrar;
@@ -409,7 +410,8 @@ class RenderParagraph extends RenderBox
       ..locale = _textPainter.locale
       ..strutStyle = _textPainter.strutStyle
       ..textWidthBasis = _textPainter.textWidthBasis
-      ..textHeightBehavior = _textPainter.textHeightBehavior;
+      ..textHeightBehavior = _textPainter.textHeightBehavior
+      ..hyphens = _textPainter.hyphens;
   }
 
   List<AttributedString>? _cachedAttributedLabels;
@@ -757,6 +759,18 @@ class RenderParagraph extends RenderBox
       return;
     }
     _textPainter.textHeightBehavior = value;
+    _overflowShader = null;
+    markNeedsLayout();
+  }
+
+  /// {@macro flutter.painting.textPainter.hyphens}
+  ui.Hyphens get hyphens => _textPainter.hyphens;
+
+  set hyphens(ui.Hyphens value) {
+    if (_textPainter.hyphens == value) {
+      return;
+    }
+    _textPainter.hyphens = value;
     _overflowShader = null;
     markNeedsLayout();
   }

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -772,6 +772,9 @@ class RenderParagraph extends RenderBox
     }
     _textPainter.hyphens = value;
     _overflowShader = null;
+    // Although Hyphens is described as a rendering choice, rendering the hyphen
+    // glyph makes the line wider and can change where the paragraph wraps, so it
+    // affects layout — hence markNeedsLayout rather than markNeedsPaint.
     markNeedsLayout();
   }
 

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -11,7 +11,13 @@ library;
 import 'dart:math' as math;
 import 'dart:ui'
     as ui
-    show Image, ImageFilter, SemanticsHitTestBehavior, SemanticsInputType, TextHeightBehavior;
+    show
+        Hyphens,
+        Image,
+        ImageFilter,
+        SemanticsHitTestBehavior,
+        SemanticsInputType,
+        TextHeightBehavior;
 
 import 'package:flutter/animation.dart';
 import 'package:flutter/foundation.dart';
@@ -6520,6 +6526,7 @@ class RichText extends MultiChildRenderObjectWidget {
     this.strutStyle,
     this.textWidthBasis = TextWidthBasis.parent,
     this.textHeightBehavior,
+    this.hyphens = ui.Hyphens.manual,
     this.selectionRegistrar,
     this.selectionColor,
   }) : assert(maxLines == null || maxLines > 0),
@@ -6617,6 +6624,11 @@ class RichText extends MultiChildRenderObjectWidget {
   /// {@macro dart.ui.textHeightBehavior}
   final ui.TextHeightBehavior? textHeightBehavior;
 
+  /// Whether to render a hyphen glyph for soft hyphens (U+00AD) at line breaks.
+  ///
+  /// Defaults to [Hyphens.manual].
+  final ui.Hyphens hyphens;
+
   /// The [SelectionRegistrar] this rich text is subscribed to.
   ///
   /// If this is set, [selectionColor] must be non-null.
@@ -6648,6 +6660,7 @@ class RichText extends MultiChildRenderObjectWidget {
       strutStyle: strutStyle,
       textWidthBasis: textWidthBasis,
       textHeightBehavior: textHeightBehavior,
+      hyphens: hyphens,
       locale: locale ?? Localizations.maybeLocaleOf(context),
       registrar: selectionRegistrar,
       selectionColor: selectionColor,
@@ -6669,6 +6682,7 @@ class RichText extends MultiChildRenderObjectWidget {
       ..strutStyle = strutStyle
       ..textWidthBasis = textWidthBasis
       ..textHeightBehavior = textHeightBehavior
+      ..hyphens = hyphens
       ..locale = locale ?? Localizations.maybeLocaleOf(context)
       ..registrar = selectionRegistrar
       ..selectionColor = selectionColor
@@ -6713,6 +6727,7 @@ class RichText extends MultiChildRenderObjectWidget {
         defaultValue: null,
       ),
     );
+    properties.add(EnumProperty<Hyphens>('hyphens', hyphens, defaultValue: Hyphens.manual));
   }
 }
 

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -526,7 +526,7 @@ class Text extends StatelessWidget {
     this.semanticsIdentifier,
     this.textWidthBasis,
     this.textHeightBehavior,
-    this.hyphens = ui.Hyphens.manual,
+    this.hyphens,
     this.selectionColor,
   }) : textSpan = null,
        assert(
@@ -564,7 +564,7 @@ class Text extends StatelessWidget {
     this.semanticsIdentifier,
     this.textWidthBasis,
     this.textHeightBehavior,
-    this.hyphens = ui.Hyphens.manual,
+    this.hyphens,
     this.selectionColor,
   }) : data = null,
        assert(
@@ -705,7 +705,11 @@ class Text extends StatelessWidget {
   final ui.TextHeightBehavior? textHeightBehavior;
 
   /// {@macro flutter.painting.textPainter.hyphens}
-  final ui.Hyphens hyphens;
+  ///
+  /// If null, resolves to [Hyphens.manual] (via [DefaultTextStyle] once that
+  /// gains a `hyphens` field), matching the other paragraph-level properties
+  /// on this widget.
+  final ui.Hyphens? hyphens;
 
   /// The color to use when painting the selection.
   ///
@@ -774,7 +778,7 @@ class Text extends StatelessWidget {
               textHeightBehavior ??
               defaultTextStyle.textHeightBehavior ??
               DefaultTextHeightBehavior.maybeOf(context),
-          hyphens: hyphens,
+          hyphens: hyphens ?? ui.Hyphens.manual,
           selectionColor:
               selectionColor ??
               DefaultSelectionStyle.of(context).selectionColor ??
@@ -798,7 +802,7 @@ class Text extends StatelessWidget {
             textHeightBehavior ??
             defaultTextStyle.textHeightBehavior ??
             DefaultTextHeightBehavior.maybeOf(context),
-        hyphens: hyphens,
+        hyphens: hyphens ?? ui.Hyphens.manual,
         selectionColor:
             selectionColor ??
             DefaultSelectionStyle.of(context).selectionColor ??
@@ -852,7 +856,7 @@ class Text extends StatelessWidget {
         defaultValue: null,
       ),
     );
-    properties.add(EnumProperty<ui.Hyphens>('hyphens', hyphens, defaultValue: ui.Hyphens.manual));
+    properties.add(EnumProperty<ui.Hyphens>('hyphens', hyphens, defaultValue: null));
     if (semanticsLabel != null) {
       properties.add(StringProperty('semanticsLabel', semanticsLabel));
     }

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -13,7 +13,7 @@
 library;
 
 import 'dart:math';
-import 'dart:ui' as ui show TextHeightBehavior;
+import 'dart:ui' as ui show Hyphens, TextHeightBehavior;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
@@ -526,6 +526,7 @@ class Text extends StatelessWidget {
     this.semanticsIdentifier,
     this.textWidthBasis,
     this.textHeightBehavior,
+    this.hyphens = ui.Hyphens.manual,
     this.selectionColor,
   }) : textSpan = null,
        assert(
@@ -563,6 +564,7 @@ class Text extends StatelessWidget {
     this.semanticsIdentifier,
     this.textWidthBasis,
     this.textHeightBehavior,
+    this.hyphens = ui.Hyphens.manual,
     this.selectionColor,
   }) : data = null,
        assert(
@@ -702,6 +704,9 @@ class Text extends StatelessWidget {
   /// {@macro dart.ui.textHeightBehavior}
   final ui.TextHeightBehavior? textHeightBehavior;
 
+  /// {@macro flutter.painting.textPainter.hyphens}
+  final ui.Hyphens hyphens;
+
   /// The color to use when painting the selection.
   ///
   /// This is ignored if [SelectionContainer.maybeOf] returns null
@@ -769,6 +774,7 @@ class Text extends StatelessWidget {
               textHeightBehavior ??
               defaultTextStyle.textHeightBehavior ??
               DefaultTextHeightBehavior.maybeOf(context),
+          hyphens: hyphens,
           selectionColor:
               selectionColor ??
               DefaultSelectionStyle.of(context).selectionColor ??
@@ -792,6 +798,7 @@ class Text extends StatelessWidget {
             textHeightBehavior ??
             defaultTextStyle.textHeightBehavior ??
             DefaultTextHeightBehavior.maybeOf(context),
+        hyphens: hyphens,
         selectionColor:
             selectionColor ??
             DefaultSelectionStyle.of(context).selectionColor ??
@@ -845,6 +852,7 @@ class Text extends StatelessWidget {
         defaultValue: null,
       ),
     );
+    properties.add(EnumProperty<ui.Hyphens>('hyphens', hyphens, defaultValue: ui.Hyphens.manual));
     if (semanticsLabel != null) {
       properties.add(StringProperty('semanticsLabel', semanticsLabel));
     }
@@ -867,6 +875,7 @@ class _SelectableTextContainer extends StatefulWidget {
     this.strutStyle,
     required this.textWidthBasis,
     this.textHeightBehavior,
+    required this.hyphens,
     required this.selectionColor,
   });
 
@@ -881,6 +890,7 @@ class _SelectableTextContainer extends StatefulWidget {
   final StrutStyle? strutStyle;
   final TextWidthBasis textWidthBasis;
   final ui.TextHeightBehavior? textHeightBehavior;
+  final ui.Hyphens hyphens;
   final Color selectionColor;
 
   @override
@@ -921,6 +931,7 @@ class _SelectableTextContainerState extends State<_SelectableTextContainer> {
         strutStyle: widget.strutStyle,
         textWidthBasis: widget.textWidthBasis,
         textHeightBehavior: widget.textHeightBehavior,
+        hyphens: widget.hyphens,
         selectionColor: widget.selectionColor,
         text: widget.text,
       ),
@@ -942,6 +953,7 @@ class _RichText extends StatelessWidget {
     this.strutStyle,
     required this.textWidthBasis,
     this.textHeightBehavior,
+    required this.hyphens,
     required this.selectionColor,
   });
 
@@ -957,6 +969,7 @@ class _RichText extends StatelessWidget {
   final StrutStyle? strutStyle;
   final TextWidthBasis textWidthBasis;
   final ui.TextHeightBehavior? textHeightBehavior;
+  final ui.Hyphens hyphens;
   final Color selectionColor;
 
   @override
@@ -974,6 +987,7 @@ class _RichText extends StatelessWidget {
       strutStyle: strutStyle,
       textWidthBasis: textWidthBasis,
       textHeightBehavior: textHeightBehavior,
+      hyphens: hyphens,
       selectionRegistrar: registrar,
       selectionColor: selectionColor,
       text: text,

--- a/packages/flutter/test/material/theme_test.dart
+++ b/packages/flutter/test/material/theme_test.dart
@@ -1334,6 +1334,7 @@ class _TextStyleProxy implements TextStyle {
     String? ellipsis,
     int? maxLines,
     ui.TextHeightBehavior? textHeightBehavior,
+    Hyphens? hyphens,
     Locale? locale,
     String? fontFamily,
     double? fontSize,

--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -1266,6 +1266,15 @@ void main() {
     painter.dispose();
   });
 
+  test('TextPainter set hyphens test', () {
+    final painter = TextPainter()..textDirection = TextDirection.ltr;
+
+    expect(painter.hyphens, Hyphens.manual);
+    painter.hyphens = Hyphens.hidden;
+    expect(painter.hyphens, Hyphens.hidden);
+    painter.dispose();
+  });
+
   test('TextPainter line metrics', () {
     final painter = TextPainter()..textDirection = TextDirection.ltr;
 

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -399,6 +399,26 @@ void main() {
     expect(getRectForA(), const Rect.fromLTWH(90, 0, 10, 10));
   });
 
+  test('RenderParagraph hyphens control test', () {
+    final paragraph = RenderParagraph(
+      const TextSpan(text: 'Hello'),
+      textDirection: TextDirection.ltr,
+    );
+    expect(paragraph.hyphens, Hyphens.manual);
+    layout(paragraph);
+    pumpFrame(phase: EnginePhase.paint);
+    expect(paragraph.debugNeedsLayout, isFalse);
+
+    // Setting the same value is a no-op.
+    paragraph.hyphens = Hyphens.manual;
+    expect(paragraph.debugNeedsLayout, isFalse);
+
+    // A new value triggers relayout.
+    paragraph.hyphens = Hyphens.hidden;
+    expect(paragraph.hyphens, Hyphens.hidden);
+    expect(paragraph.debugNeedsLayout, isTrue);
+  });
+
   test('RenderParagraph devicePixelRatio control test', () {
     final paragraph = RenderParagraph(
       const TextSpan(text: 'Hello'),

--- a/packages/flutter/test/widgets/rich_text_test.dart
+++ b/packages/flutter/test/widgets/rich_text_test.dart
@@ -206,6 +206,7 @@ void main() {
       strutStyle: const StrutStyle(fontSize: 16),
       textWidthBasis: TextWidthBasis.longestLine,
       textHeightBehavior: const TextHeightBehavior(applyHeightToFirstAscent: false),
+      hyphens: Hyphens.hidden,
     ).debugFillProperties(builder);
 
     final List<String> description = builder.properties
@@ -231,6 +232,7 @@ void main() {
           contains('applyHeightToFirstAscent: false'),
           contains('applyHeightToLastDescent: true'),
         ),
+        contains('hyphens: hidden'),
       ]),
     );
   });
@@ -288,7 +290,9 @@ void main() {
     expect(paragraph.devicePixelRatio, 4.0);
   });
 
-  testWidgets('RichText defaults to 1.0 devicePixelRatio when no View or MediaQuery is present', (WidgetTester tester) async {
+  testWidgets('RichText defaults to 1.0 devicePixelRatio when no View or MediaQuery is present', (
+    WidgetTester tester,
+  ) async {
     await tester.pumpWidget(
       RawView(
         view: tester.view,

--- a/packages/flutter/test/widgets/text_test.dart
+++ b/packages/flutter/test/widgets/text_test.dart
@@ -1801,6 +1801,41 @@ void main() {
     );
   });
 
+  testWidgets('Text forwards hyphens to RenderParagraph', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Text('hy\u00ADphenation', hyphens: Hyphens.hidden),
+      ),
+    );
+    final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.byType(RichText));
+    expect(paragraph.hyphens, Hyphens.hidden);
+  });
+
+  testWidgets('Text defaults hyphens to Hyphens.manual', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Directionality(textDirection: TextDirection.ltr, child: Text('hy\u00ADphenation')),
+    );
+    final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.byType(RichText));
+    expect(paragraph.hyphens, Hyphens.manual);
+  });
+
+  testWidgets('Selectable Text forwards hyphens to RenderParagraph', (WidgetTester tester) async {
+    final focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: SelectableRegion(
+          selectionControls: EmptyTextSelectionControls(),
+          focusNode: focusNode,
+          child: const Text('hy\u00ADphenation', hyphens: Hyphens.hidden),
+        ),
+      ),
+    );
+    final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.byType(RichText));
+    expect(paragraph.hyphens, Hyphens.hidden);
+  });
+
   testWidgets('Mouse hovering over selectable Text uses default selection style mouse cursor', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION
## Summary

Adds visible soft hyphen (U+00AD) rendering at line breaks, exposed through a new `Hyphens` API. Fixes flutter/flutter#18443.

A line break that falls on a soft hyphen now renders a visible `-` by default. A new `Hyphens { manual, none }` enum lets callers opt out:

- `Hyphens.manual` (default) — render the hyphen glyph at the break (the corrected behavior).
- `Hyphens.none` — suppress the hyphen glyph (the soft hyphen still marks a break opportunity).

The enum is a direct parameter on `Text` / `RichText` and on `dart:ui`'s `ParagraphStyle` — **not** on `TextStyle`, matching the precedent of `textAlign` / `maxLines` / `softWrap` (paragraph-level paint parameters). `hyphenCharacter` customization is intentionally deferred (Skia's ellipsis shaping hardcodes LTR bidi, which would break RTL).

Design doc: [flutter.dev/go/soft-hyphens](https://flutter.dev/go/soft-hyphens) (tracking issue #185154). This bundles what was previously framed as Stage 1 (engine opt-in) + Stage 2 (Dart API) into one change, so the rendering ships with an opt-out from day one.

## Background

Soft hyphens (U+00AD) are invisible line-break opportunities that should render as a visible `-` when a line break falls on them. Flutter already breaks lines at U+00AD but never renders the hyphen glyph — the character behaves as a zero-width space. **This change affects rendering only; it does not introduce any new line breaks.**

The Skia-side fix landed at [`98daf58d`](https://github.com/google/skia/commit/98daf58d4c) (Skia CL [1208837](https://skia-review.googlesource.com/c/skia/+/1208837)), gated behind `ParagraphStyle::setRenderSoftHyphens(bool)` (defaults to `false` for non-Flutter consumers).

## Changes

**Engine**
- `txt::ParagraphStyle` gains a `render_soft_hyphens` flag (default `true`); `ParagraphBuilderSkia::TxtToSkia` forwards it to `setRenderSoftHyphens`.
- `paragraph_builder.cc` decodes the new `ParagraphStyle.hyphens` field from the FFI buffer (mask bit 13 / slot 7).
- `dart:ui` adds the public `Hyphens` enum and `ParagraphStyle.hyphens`.

**Framework**
- `Hyphens` is re-exported from `dart:ui` via `painting/basic_types.dart`.
- `hyphens` is threaded through `TextStyle.getParagraphStyle` → `TextPainter` → `RenderParagraph` → `RichText` → `Text` / `Text.rich`, including the selectable-text path.

## Known limitations

- The hyphen glyph is appended after line layout, so a rendered line can exceed `maxWidth` by the hyphen's advance (~5–8 px). Documented in the design doc; a Skia follow-up to reserve hyphen width during line breaking is proposed.
- `hyphenCharacter` (custom hyphen strings) is deferred pending an upstream Skia bidi fix.

## Test plan

- [ ] `paragraph_builder_skia_tests.cc::RenderSoftHyphensEnabled` — `render_soft_hyphens` maps onto Skia in both states
- [ ] `testing/dart/text_test.dart` — `ParagraphStyle.hyphens` encodes and round-trips in `toString`
- [ ] `test/widgets/rich_text_test.dart` — `RichText` exposes `hyphens` via `debugFillProperties`
- [ ] `test/widgets/text_test.dart` — `Text` forwards `hyphens` to `RenderParagraph` (incl. selectable path); default resolves to `Hyphens.manual`
- [ ] `test/rendering/paragraph_test.dart` — `RenderParagraph.hyphens` setter triggers relayout
- [ ] `test/painting/text_painter_test.dart` — `TextPainter.hyphens` setter
- [ ] Google internal testing (cc @LongCatIsLooong)
- [ ] Manual smoke: `Text('inter­national')` in a narrow container shows `inter-` / `national`

## Design status

New public API (`Hyphens`, `ParagraphStyle.hyphens`, `Text.hyphens`, `RichText.hyphens`) follows the [design doc](https://flutter.dev/go/soft-hyphens). Sign-off in progress — cc @LongCatIsLooong @chunhtai @justinmc.
