### PR TITLE
Only use LLDB breakpoint in debug mode

### DIFF
--- a/packages/flutter_tools/lib/src/ios/core_devices.dart
+++ b/packages/flutter_tools/lib/src/ios/core_devices.dart
@@ -14,6 +14,7 @@ import '../base/logger.dart';
 import '../base/process.dart';
 import '../base/template.dart';
 import '../base/utils.dart';
+import '../build_info.dart';
 import '../convert.dart';
 import '../device.dart';
 import '../macos/xcode.dart';
@@ -96,6 +97,7 @@ class IOSCoreDeviceLauncher {
     required String bundleId,
     required List<String> launchArguments,
     required ShutdownHooks shutdownHooks,
+    required BuildMode mode,
   }) async {
     // Install app to device
     final (bool installStatus, IOSCoreDeviceInstallResult? installResult) = await _coreDeviceControl
@@ -145,6 +147,7 @@ class IOSCoreDeviceLauncher {
       deviceId: deviceId,
       appProcessId: processId,
       lldbLogForwarder: lldbLogForwarder,
+      mode: mode,
     );
 
     // If it fails to attach with lldb, kill the launched process so it doesn't stay hanging.
@@ -785,7 +788,6 @@ class IOSCoreDeviceControl {
       final StreamSubscription<String> stdoutSubscription = launchProcess.stdout
           .transform(utf8LineDecoder)
           .listen((String line) {
-            _logger.printTrace('[devicectl]: $line');
             if (line.trim().isEmpty) {
               return;
             }
@@ -803,7 +805,6 @@ class IOSCoreDeviceControl {
       final StreamSubscription<String> stderrSubscription = launchProcess.stderr
           .transform(utf8LineDecoder)
           .listen((String line) {
-            _logger.printTrace('[devicectl]: $line');
             if (line.trim().isEmpty) {
               return;
             }

--- a/packages/flutter_tools/lib/src/ios/core_devices.dart
+++ b/packages/flutter_tools/lib/src/ios/core_devices.dart
@@ -785,6 +785,7 @@ class IOSCoreDeviceControl {
       final StreamSubscription<String> stdoutSubscription = launchProcess.stdout
           .transform(utf8LineDecoder)
           .listen((String line) {
+            _logger.printTrace('[devicectl]: $line');
             if (line.trim().isEmpty) {
               return;
             }
@@ -802,6 +803,7 @@ class IOSCoreDeviceControl {
       final StreamSubscription<String> stderrSubscription = launchProcess.stderr
           .transform(utf8LineDecoder)
           .listen((String line) {
+            _logger.printTrace('[devicectl]: $line');
             if (line.trim().isEmpty) {
               return;
             }

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -1077,6 +1077,7 @@ class IOSDevice extends Device {
         bundleId: package.id,
         launchArguments: launchArguments,
         shutdownHooks: globals.shutdownHooks,
+        mode: debuggingOptions.buildInfo.mode,
       );
 
       // If it succeeds to launch with LLDB, return, otherwise continue on to

--- a/packages/flutter_tools/lib/src/ios/lldb.dart
+++ b/packages/flutter_tools/lib/src/ios/lldb.dart
@@ -172,7 +172,6 @@ return False
       final StreamSubscription<String> stderrSubscription = _lldbProcess!.stderr
           .transform(utf8LineDecoder)
           .listen((String line) {
-            _logger.printTrace('[lldb]: $line');
             _monitorError(line);
             if (_isAttached && !_ignoreLog(line)) {
               // Only forwards logs after LLDB is attached. All logs before then are part of the

--- a/packages/flutter_tools/lib/src/ios/lldb.dart
+++ b/packages/flutter_tools/lib/src/ios/lldb.dart
@@ -246,7 +246,7 @@ return False
     // Disable asynchronous mode to workaround issues with rearming of breakpoints.
     // See https://github.com/flutter/flutter/issues/184254 and upstream issue
     // https://github.com/llvm/llvm-project/issues/190956.
-    await _lldbProcess?.stdinWriteln('script lldb.debugger.SetAsync(False)');
+    // await _lldbProcess?.stdinWriteln('script lldb.debugger.SetAsync(False)');
   }
 
   /// Resume the stopped process.

--- a/packages/flutter_tools/lib/src/ios/lldb.dart
+++ b/packages/flutter_tools/lib/src/ios/lldb.dart
@@ -11,6 +11,7 @@ import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/process.dart';
 import '../base/utils.dart';
+import '../build_info.dart';
 
 /// LLDB is the default debugger in Xcode on macOS. Once the application has
 /// launched on a physical iOS device, you can attach to it using LLDB.
@@ -42,12 +43,15 @@ class LLDB {
   /// Example: (lldb) Process 6152 stopped
   static final _lldbProcessStopped = RegExp(r'Process \d* stopped');
 
-  /// Pattern of lldb log when the process is resuming and the breakpoint is added.
+  /// Pattern of lldb log when the process is resuming.
   ///
   /// Example: (lldb) Process 6152 resuming
   static final _lldbProcessResuming = RegExp(r'Process \d+ resuming');
 
-  // static final _lldbProcessResuming = RegExp(r'location added to breakpoint');
+  /// Pattern of lldb log when the process has started and the breakpoint is added.
+  ///
+  /// Example: (lldb) 1 location added to breakpoint 1
+  static final _lldbBreakpointAdded = RegExp(r'\d+ location added to breakpoint \d+');
 
   /// Pattern of lldb log when the breakpoint is added.
   ///
@@ -90,6 +94,7 @@ return False
     required String deviceId,
     required int appProcessId,
     required LLDBLogForwarder lldbLogForwarder,
+    required BuildMode mode,
   }) async {
     Timer? timer;
     try {
@@ -113,9 +118,11 @@ return False
         return false;
       }
       await _selectDevice(deviceId);
-      await _setBreakpoint();
+      if (mode == BuildMode.debug) {
+        await _setBreakpoint();
+      }
       await _attachToAppProcess(appProcessId);
-      await _resumeProcess();
+      await _resumeProcess(mode);
       _isAttached = true;
     } on _LLDBError catch (e) {
       _logger.printTrace('lldb failed with error: ${e.message}');
@@ -148,11 +155,9 @@ return False
         appProcessId: appProcessId,
         logger: _logger,
       );
-      print("VICTORIA DEBUG 2");
       final StreamSubscription<String> stdoutSubscription = _lldbProcess!.stdout
           .transform(utf8LineDecoder)
           .listen((String line) {
-            _logger.printTrace('[lldb]: $line');
             if (_isAttached && !_ignoreLog(line)) {
               // Only forwards logs after LLDB is attached. All logs before then are part of the
               // attach process.
@@ -248,13 +253,16 @@ return False
     // Disable asynchronous mode to workaround issues with rearming of breakpoints.
     // See https://github.com/flutter/flutter/issues/184254 and upstream issue
     // https://github.com/llvm/llvm-project/issues/190956.
-    // await _lldbProcess?.stdinWriteln('script lldb.debugger.SetAsync(False)');
+    await _lldbProcess?.stdinWriteln('script lldb.debugger.SetAsync(False)');
   }
 
   /// Resume the stopped process.
-  Future<void> _resumeProcess() async {
+  Future<void> _resumeProcess(BuildMode mode) async {
     final Future<String> futureLog = _startWaitingForLog(
-      _lldbProcessResuming,
+      // When using debug mode, a breakpoint is added once the process resumes and no resume log
+      // is shown. Instead we match on the breakpoint added log. In profile mode, a resume log is
+      // shown once the process resumes and no breakpoint log is shown.
+      mode == BuildMode.debug ? _lldbBreakpointAdded : _lldbProcessResuming,
     ).then((value) => value, onError: _handleAsyncError);
 
     await _lldbProcess?.stdinWriteln('process continue');

--- a/packages/flutter_tools/lib/src/ios/lldb.dart
+++ b/packages/flutter_tools/lib/src/ios/lldb.dart
@@ -131,6 +131,7 @@ if not error.Success():
     required int appProcessId,
     required LLDBLogForwarder lldbLogForwarder,
   }) async {
+    print("VICTORIA DEBUG 1");
     if (_lldbProcess != null) {
       _logger.printTrace(
         'An LLDB process is already running. It must be stopped before starting a new one.',

--- a/packages/flutter_tools/lib/src/ios/lldb.dart
+++ b/packages/flutter_tools/lib/src/ios/lldb.dart
@@ -42,10 +42,12 @@ class LLDB {
   /// Example: (lldb) Process 6152 stopped
   static final _lldbProcessStopped = RegExp(r'Process \d* stopped');
 
-  /// Pattern of lldb log when the process is resuming.
+  /// Pattern of lldb log when the process is resuming and the breakpoint is added.
   ///
   /// Example: (lldb) Process 6152 resuming
   static final _lldbProcessResuming = RegExp(r'Process \d+ resuming');
+
+  // static final _lldbProcessResuming = RegExp(r'location added to breakpoint');
 
   /// Pattern of lldb log when the breakpoint is added.
   ///
@@ -74,6 +76,9 @@ frame.GetThread().GetProcess().WriteMemory(base, data, error)
 if not error.Success():
     print(f'Failed to write into {base}[+{page_len}]', error)
     return
+
+# If the returned value is False, that tells LLDB not to stop at the breakpoint
+return False
 ''';
 
   /// Starts an LLDB process and inputs commands to start debugging the [appProcessId].
@@ -131,7 +136,6 @@ if not error.Success():
     required int appProcessId,
     required LLDBLogForwarder lldbLogForwarder,
   }) async {
-    print("VICTORIA DEBUG 1");
     if (_lldbProcess != null) {
       _logger.printTrace(
         'An LLDB process is already running. It must be stopped before starting a new one.',
@@ -145,63 +149,30 @@ if not error.Success():
         logger: _logger,
       );
 
-      void printLine(String line) {
-        if (_isAttached && !_ignoreLog(line)) {
-          // Only forwards logs after LLDB is attached. All logs before then are part of the
-          // attach process.
+      final StreamSubscription<String> stdoutSubscription = _lldbProcess!.stdout
+          .transform(utf8LineDecoder)
+          .listen((String line) {
+            if (_isAttached && !_ignoreLog(line)) {
+              // Only forwards logs after LLDB is attached. All logs before then are part of the
+              // attach process.
 
-          lldbLogForwarder.addLog(line);
-        } else {
-          // _logger.printTrace('[lldb]: $line');
-          _logCompleter?.checkForMatch(line);
-        }
-      }
-
-      String? processStopLine;
-      var suppressLogs = false;
-
-      final StreamSubscription<String>
-      stdoutSubscription = _lldbProcess!.stdout.transform(utf8LineDecoder).listen((String line) {
-        _logger.printTrace('[lldb]: $line');
-        // Skip all logs between process stop and process resume if the stop was caused by a breakpoint
-        if (line.contains(_lldbProcessStopped)) {
-          processStopLine = line;
-          return;
-        }
-        // If the last log was a proces stop log, check if it was caused by a breakpoint.
-        if (processStopLine != null) {
-          if (line.contains('stop reason = breakpoint')) {
-            // When we stop due to a breakpoint, supress all logs until we resume.
-            _lldbProcess?.stdinWriteln('process continue');
-            suppressLogs = true;
-          } else {
-            // Otherwise, print the process stop log.
-            printLine(processStopLine!);
-          }
-          processStopLine = null;
-        }
-        if (suppressLogs) {
-          if (line.contains(_lldbProcessResuming)) {
-            // After resuming, stop supressing logs.
-            suppressLogs = false;
-          }
-          return;
-        }
-
-        printLine(line);
-      });
+              lldbLogForwarder.addLog(line);
+            } else {
+              _logger.printTrace('[lldb]: $line');
+              _logCompleter?.checkForMatch(line);
+            }
+          });
 
       final StreamSubscription<String> stderrSubscription = _lldbProcess!.stderr
           .transform(utf8LineDecoder)
           .listen((String line) {
-            _logger.printTrace('[lldb]: $line');
             _monitorError(line);
             if (_isAttached && !_ignoreLog(line)) {
               // Only forwards logs after LLDB is attached. All logs before then are part of the
               // attach process.
               lldbLogForwarder.addLog(line);
             } else {
-              // _logger.printTrace('[lldb]: $line');
+              _logger.printTrace('[lldb]: $line');
             }
           });
 
@@ -256,13 +227,9 @@ if not error.Success():
       _breakpointPattern,
     ).then((value) => value, onError: _handleAsyncError);
 
-    // final Version? xcodeVersion = _xcode.currentVersion;
-    // final bool useManualContinue = xcodeVersion != null && (xcodeVersion >= Version(26, 4, 0));
-    final bool useManualContinue = true;
-    final breakpointSetCommand = useManualContinue
-        ? r"breakpoint set --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'"
-        : r"breakpoint set --auto-continue true --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'";
-    await _lldbProcess?.stdinWriteln(breakpointSetCommand);
+    await _lldbProcess?.stdinWriteln(
+      r"breakpoint set --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'",
+    );
     final String log = await futureLog;
     final Match? match = _breakpointPattern.firstMatch(log);
     final String? breakpointId = match?.group(1);
@@ -275,6 +242,11 @@ if not error.Success():
     await _lldbProcess?.stdinWriteln('breakpoint command add --script-type python $breakpointId');
     await _lldbProcess?.stdinWriteln(_pythonScript);
     await _lldbProcess?.stdinWriteln('DONE');
+
+    // Disable asynchronous mode to workaround issues with rearming of breakpoints.
+    // See https://github.com/flutter/flutter/issues/184254 and upstream issue
+    // https://github.com/llvm/llvm-project/issues/190956.
+    // await _lldbProcess?.stdinWriteln('script lldb.debugger.SetAsync(False)');
   }
 
   /// Resume the stopped process.

--- a/packages/flutter_tools/lib/src/ios/lldb.dart
+++ b/packages/flutter_tools/lib/src/ios/lldb.dart
@@ -148,10 +148,11 @@ return False
         appProcessId: appProcessId,
         logger: _logger,
       );
-
+      print("VICTORIA DEBUG 2");
       final StreamSubscription<String> stdoutSubscription = _lldbProcess!.stdout
           .transform(utf8LineDecoder)
           .listen((String line) {
+            _logger.printTrace('[lldb]: $line');
             if (_isAttached && !_ignoreLog(line)) {
               // Only forwards logs after LLDB is attached. All logs before then are part of the
               // attach process.
@@ -166,6 +167,7 @@ return False
       final StreamSubscription<String> stderrSubscription = _lldbProcess!.stderr
           .transform(utf8LineDecoder)
           .listen((String line) {
+            _logger.printTrace('[lldb]: $line');
             _monitorError(line);
             if (_isAttached && !_ignoreLog(line)) {
               // Only forwards logs after LLDB is attached. All logs before then are part of the

--- a/packages/flutter_tools/lib/src/ios/lldb.dart
+++ b/packages/flutter_tools/lib/src/ios/lldb.dart
@@ -42,10 +42,10 @@ class LLDB {
   /// Example: (lldb) Process 6152 stopped
   static final _lldbProcessStopped = RegExp(r'Process \d* stopped');
 
-  /// Pattern of lldb log when the process is resuming and the breakpoint is added.
+  /// Pattern of lldb log when the process is resuming.
   ///
-  /// Example: (lldb) 1 location added to breakpoint 1
-  static final _lldbProcessResuming = RegExp(r'location added to breakpoint');
+  /// Example: (lldb) Process 6152 resuming
+  static final _lldbProcessResuming = RegExp(r'Process \d+ resuming');
 
   /// Pattern of lldb log when the breakpoint is added.
   ///
@@ -74,9 +74,6 @@ frame.GetThread().GetProcess().WriteMemory(base, data, error)
 if not error.Success():
     print(f'Failed to write into {base}[+{page_len}]', error)
     return
-
-# If the returned value is False, that tells LLDB not to stop at the breakpoint
-return False
 ''';
 
   /// Starts an LLDB process and inputs commands to start debugging the [appProcessId].
@@ -147,26 +144,57 @@ return False
         logger: _logger,
       );
 
-      final StreamSubscription<String> stdoutSubscription = _lldbProcess!.stdout
-          .transform(utf8LineDecoder)
-          .listen((String line) {
-            _logger.printTrace('[lldb]: $line');
-            if (_isAttached && !_ignoreLog(line)) {
-              // Only forwards logs after LLDB is attached. All logs before then are part of the
-              // attach process.
+      void printLine(String line) {
+        if (_isAttached && !_ignoreLog(line)) {
+          // Only forwards logs after LLDB is attached. All logs before then are part of the
+          // attach process.
 
-              lldbLogForwarder.addLog(line);
-            } else {
-              // _logger.printTrace('[lldb]: $line');
-              _logCompleter?.checkForMatch(line);
-            }
-          });
+          lldbLogForwarder.addLog(line);
+        } else {
+          // _logger.printTrace('[lldb]: $line');
+          _logCompleter?.checkForMatch(line);
+        }
+      }
+
+      String? processStopLine;
+      var suppressLogs = false;
+
+      final StreamSubscription<String>
+      stdoutSubscription = _lldbProcess!.stdout.transform(utf8LineDecoder).listen((String line) {
+        _logger.printTrace('[lldb]: $line');
+        // Skip all logs between process stop and process resume if the stop was caused by a breakpoint
+        if (line.contains(_lldbProcessStopped)) {
+          processStopLine = line;
+          return;
+        }
+        // If the last log was a proces stop log, check if it was caused by a breakpoint.
+        if (processStopLine != null) {
+          if (line.contains('stop reason = breakpoint')) {
+            // When we stop due to a breakpoint, supress all logs until we resume.
+            _lldbProcess?.stdinWriteln('process continue');
+            suppressLogs = true;
+          } else {
+            // Otherwise, print the process stop log.
+            printLine(processStopLine!);
+          }
+          processStopLine = null;
+        }
+        if (suppressLogs) {
+          if (line.contains(_lldbProcessResuming)) {
+            // After resuming, stop supressing logs.
+            suppressLogs = false;
+          }
+          return;
+        }
+
+        printLine(line);
+      });
 
       final StreamSubscription<String> stderrSubscription = _lldbProcess!.stderr
           .transform(utf8LineDecoder)
           .listen((String line) {
-            _monitorError(line);
             _logger.printTrace('[lldb]: $line');
+            _monitorError(line);
             if (_isAttached && !_ignoreLog(line)) {
               // Only forwards logs after LLDB is attached. All logs before then are part of the
               // attach process.
@@ -227,9 +255,13 @@ return False
       _breakpointPattern,
     ).then((value) => value, onError: _handleAsyncError);
 
-    await _lldbProcess?.stdinWriteln(
-      r"breakpoint set --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'",
-    );
+    // final Version? xcodeVersion = _xcode.currentVersion;
+    // final bool useManualContinue = xcodeVersion != null && (xcodeVersion >= Version(26, 4, 0));
+    final bool useManualContinue = true;
+    final breakpointSetCommand = useManualContinue
+        ? r"breakpoint set --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'"
+        : r"breakpoint set --auto-continue true --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'";
+    await _lldbProcess?.stdinWriteln(breakpointSetCommand);
     final String log = await futureLog;
     final Match? match = _breakpointPattern.firstMatch(log);
     final String? breakpointId = match?.group(1);
@@ -242,21 +274,16 @@ return False
     await _lldbProcess?.stdinWriteln('breakpoint command add --script-type python $breakpointId');
     await _lldbProcess?.stdinWriteln(_pythonScript);
     await _lldbProcess?.stdinWriteln('DONE');
-
-    // Disable asynchronous mode to workaround issues with rearming of breakpoints.
-    // See https://github.com/flutter/flutter/issues/184254 and upstream issue
-    // https://github.com/llvm/llvm-project/issues/190956.
-    // await _lldbProcess?.stdinWriteln('script lldb.debugger.SetAsync(False)');
   }
 
   /// Resume the stopped process.
   Future<void> _resumeProcess() async {
-    // final Future<String> futureLog = _startWaitingForLog(
-    //   _lldbProcessResuming,
-    // ).then((value) => value, onError: _handleAsyncError);
+    final Future<String> futureLog = _startWaitingForLog(
+      _lldbProcessResuming,
+    ).then((value) => value, onError: _handleAsyncError);
 
     await _lldbProcess?.stdinWriteln('process continue');
-    // await futureLog;
+    await futureLog;
   }
 
   /// Creates a completer and returns its future. Methods that utilize this should

--- a/packages/flutter_tools/lib/src/ios/lldb.dart
+++ b/packages/flutter_tools/lib/src/ios/lldb.dart
@@ -51,7 +51,7 @@ class LLDB {
   /// Pattern of lldb log when the process has started and the breakpoint is added.
   ///
   /// Example: (lldb) 1 location added to breakpoint 1
-  static final _lldbBreakpointAdded = RegExp(r'\d+ location added to breakpoint \d+');
+  static final _lldbBreakpointAdded = RegExp(r'location added to breakpoint');
 
   /// Pattern of lldb log when the breakpoint is added.
   ///

--- a/packages/flutter_tools/lib/src/ios/lldb.dart
+++ b/packages/flutter_tools/lib/src/ios/lldb.dart
@@ -150,13 +150,14 @@ return False
       final StreamSubscription<String> stdoutSubscription = _lldbProcess!.stdout
           .transform(utf8LineDecoder)
           .listen((String line) {
+            _logger.printTrace('[lldb]: $line');
             if (_isAttached && !_ignoreLog(line)) {
               // Only forwards logs after LLDB is attached. All logs before then are part of the
               // attach process.
 
               lldbLogForwarder.addLog(line);
             } else {
-              _logger.printTrace('[lldb]: $line');
+              // _logger.printTrace('[lldb]: $line');
               _logCompleter?.checkForMatch(line);
             }
           });
@@ -165,12 +166,13 @@ return False
           .transform(utf8LineDecoder)
           .listen((String line) {
             _monitorError(line);
+            _logger.printTrace('[lldb]: $line');
             if (_isAttached && !_ignoreLog(line)) {
               // Only forwards logs after LLDB is attached. All logs before then are part of the
               // attach process.
               lldbLogForwarder.addLog(line);
             } else {
-              _logger.printTrace('[lldb]: $line');
+              // _logger.printTrace('[lldb]: $line');
             }
           });
 
@@ -249,12 +251,12 @@ return False
 
   /// Resume the stopped process.
   Future<void> _resumeProcess() async {
-    final Future<String> futureLog = _startWaitingForLog(
-      _lldbProcessResuming,
-    ).then((value) => value, onError: _handleAsyncError);
+    // final Future<String> futureLog = _startWaitingForLog(
+    //   _lldbProcessResuming,
+    // ).then((value) => value, onError: _handleAsyncError);
 
     await _lldbProcess?.stdinWriteln('process continue');
-    await futureLog;
+    // await futureLog;
   }
 
   /// Creates a completer and returns its future. Methods that utilize this should

--- a/packages/flutter_tools/test/general.shard/ios/core_devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/core_devices_test.dart
@@ -217,6 +217,7 @@ void main() {
           bundleId: 'bundle-id',
           launchArguments: <String>[],
           shutdownHooks: FakeShutdownHooks(),
+          mode: BuildMode.debug,
         );
 
         expect(result, isTrue);
@@ -275,6 +276,7 @@ void main() {
           bundleId: 'bundle-id',
           launchArguments: <String>[],
           shutdownHooks: FakeShutdownHooks(),
+          mode: BuildMode.debug,
         );
 
         expect(result, isTrue);
@@ -326,6 +328,7 @@ void main() {
           bundleId: 'bundle-id',
           launchArguments: <String>[],
           shutdownHooks: FakeShutdownHooks(),
+          mode: BuildMode.debug,
         );
 
         expect(result, isFalse);
@@ -370,6 +373,7 @@ void main() {
           bundleId: 'bundle-id',
           launchArguments: <String>[],
           shutdownHooks: FakeShutdownHooks(),
+          mode: BuildMode.debug,
         );
 
         expect(result, isFalse);
@@ -420,6 +424,7 @@ void main() {
           bundleId: 'bundle-id',
           launchArguments: <String>[],
           shutdownHooks: FakeShutdownHooks(),
+          mode: BuildMode.debug,
         );
 
         expect(result, isFalse);
@@ -464,6 +469,7 @@ void main() {
           bundleId: 'bundle-id',
           launchArguments: <String>[],
           shutdownHooks: FakeShutdownHooks(),
+          mode: BuildMode.debug,
         );
 
         expect(result, isFalse);
@@ -510,6 +516,7 @@ void main() {
           bundleId: 'bundle-id',
           launchArguments: <String>[],
           shutdownHooks: FakeShutdownHooks(),
+          mode: BuildMode.debug,
         );
 
         expect(result, isFalse);
@@ -558,6 +565,7 @@ void main() {
           bundleId: 'bundle-id',
           launchArguments: <String>[],
           shutdownHooks: FakeShutdownHooks(),
+          mode: BuildMode.debug,
         );
 
         expect(result, isFalse);
@@ -4020,6 +4028,7 @@ class FakeLLDB extends Fake implements LLDB {
     required String deviceId,
     required int appProcessId,
     required LLDBLogForwarder lldbLogForwarder,
+    required BuildMode mode,
   }) async {
     attemptedToAttach = true;
     attachedProcessId = appProcessId;

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
@@ -1747,6 +1747,7 @@ class FakeIOSCoreDeviceLauncher extends Fake implements IOSCoreDeviceLauncher {
     required String bundlePath,
     required String bundleId,
     required List<String> launchArguments,
+    required BuildMode mode,
     required ShutdownHooks shutdownHooks,
   }) async {
     return true;

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -1871,6 +1871,7 @@ class FakeIOSCoreDeviceLauncher extends Fake implements IOSCoreDeviceLauncher {
     required String bundlePath,
     required String bundleId,
     required List<String> launchArguments,
+    required BuildMode mode,
     required ShutdownHooks shutdownHooks,
   }) async {
     launchedWithLLDB = true;

--- a/packages/flutter_tools/test/general.shard/ios/lldb_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/lldb_test.dart
@@ -10,6 +10,7 @@ import 'package:fake_async/fake_async.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/process.dart';
+import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/ios/lldb.dart';
 import 'package:test/fake.dart';
 
@@ -42,6 +43,7 @@ void main() {
       deviceId: deviceId,
       appProcessId: appProcessId,
       lldbLogForwarder: FakeLLDBLogForwarder(),
+      mode: BuildMode.debug,
     );
     expect(success, isFalse);
     expect(lldb.isRunning, isFalse);
@@ -127,6 +129,78 @@ Target 0: (Runner) stopped.
       deviceId: deviceId,
       appProcessId: appProcessId,
       lldbLogForwarder: FakeLLDBLogForwarder(),
+      mode: BuildMode.debug,
+    );
+    expect(success, isTrue);
+    expect(lldb.isRunning, isTrue);
+    expect(lldb.appProcessId, appProcessId);
+    expect(expectedInputs, isEmpty);
+    expect(processManager.hasRemainingExpectations, isFalse);
+    expect(logger.errorText, isEmpty);
+  });
+
+  testWithoutContext('attachAndStart returns true on success for profile mode', () async {
+    const deviceId = '123';
+    const appProcessId = 5678;
+
+    final processAttachCompleter = Completer<List<int>>();
+    final processResumedCompleted = Completer<List<int>>();
+
+    final stdoutStream = Stream<List<int>>.fromFutures([
+      processAttachCompleter.future,
+      processResumedCompleted.future,
+    ]);
+
+    final stdinController = StreamController<List<int>>();
+
+    final processCompleter = Completer<void>();
+    final lldbCommand = FakeLLDBCommand(
+      command: const <String>['lldb'],
+      completer: processCompleter,
+      stdin: io.IOSink(stdinController.sink),
+      stdout: stdoutStream,
+      stderr: const Stream.empty(),
+    );
+
+    final logger = BufferLogger.test();
+
+    final processManager = FakeLLDBProcessManager([lldbCommand]);
+    final processUtils = ProcessUtils(processManager: processManager, logger: logger);
+    final lldb = LLDB(logger: logger, processUtils: processUtils);
+
+    const processAttachMatcher = 'device process attach --pid $appProcessId';
+    const processResumedMatcher = 'process continue';
+    final expectedInputs = ['device select $deviceId', processAttachMatcher, processResumedMatcher];
+
+    stdinController.stream.transform<String>(utf8.decoder).transform(const LineSplitter()).listen((
+      String line,
+    ) {
+      expectedInputs.remove(line);
+      if (line == processAttachMatcher) {
+        processAttachCompleter.complete(
+          utf8.encode('''
+Process 568 stopped
+* thread #1, stop reason = signal SIGSTOP
+    frame #0: 0x0000000102c7b240 dyld`_dyld_start
+dyld`_dyld_start:
+->  0x102c7b240 <+0>:  mov    x0, sp
+    0x102c7b244 <+4>:  and    sp, x0, #0xfffffffffffffff0
+    0x102c7b248 <+8>:  mov    x29, #0x0 ; =0
+    0x102c7b24c <+12>: mov    x30, #0x0 ; =0
+Target 0: (Runner) stopped.
+'''),
+        );
+      }
+      if (line == processResumedMatcher) {
+        processResumedCompleted.complete(utf8.encode('Process 568 resuming\n'));
+      }
+    });
+
+    final bool success = await lldb.attachAndStart(
+      deviceId: deviceId,
+      appProcessId: appProcessId,
+      lldbLogForwarder: FakeLLDBLogForwarder(),
+      mode: BuildMode.profile,
     );
     expect(success, isTrue);
     expect(lldb.isRunning, isTrue);
@@ -181,6 +255,7 @@ Target 0: (Runner) stopped.
       deviceId: deviceId,
       appProcessId: appProcessId,
       lldbLogForwarder: FakeLLDBLogForwarder(),
+      mode: BuildMode.debug,
     );
     expect(success, isFalse);
     expect(lldb.isRunning, isFalse);
@@ -231,6 +306,7 @@ Target 0: (Runner) stopped.
       deviceId: deviceId,
       appProcessId: appProcessId,
       lldbLogForwarder: FakeLLDBLogForwarder(),
+      mode: BuildMode.debug,
     );
     expect(success, isFalse);
     expect(lldb.isRunning, isFalse);
@@ -276,6 +352,7 @@ Target 0: (Runner) stopped.
         deviceId: deviceId,
         appProcessId: appProcessId,
         lldbLogForwarder: FakeLLDBLogForwarder(),
+        mode: BuildMode.debug,
       );
       time.elapse(const Duration(minutes: 2));
       time.flushMicrotasks();
@@ -371,6 +448,7 @@ Target 0: (Runner) stopped.
       deviceId: deviceId,
       appProcessId: appProcessId,
       lldbLogForwarder: lldbLogForwarder,
+      mode: BuildMode.debug,
     );
 
     logAfterAttachCompleter.complete(utf8.encode('$ignoreLog\n$expectedForwardedLog\n'));
@@ -422,6 +500,7 @@ Target 0: (Runner) stopped.
         deviceId: deviceId,
         appProcessId: appProcessId,
         lldbLogForwarder: FakeLLDBLogForwarder(),
+        mode: BuildMode.debug,
       ),
     );
 


### PR DESCRIPTION
The JIT breakpoint workaround is only needed and only enabled on the Dart side in debug mode. When running `--profile` mode, the breakpoint is never set and therefore causes the process to hang.

This PR skips the JIT breakpoint workaround for profile mode.

Fixes https://github.com/flutter/flutter/issues/185150.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
