### PR TITLE
Validate itemExtent with geometry in RenderSliverFixedExtentBoxAdaptor

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
+++ b/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
@@ -305,9 +305,15 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
         final double diff = remainder > itemExtent / 2 ? itemExtent - remainder : remainder;
         if (diff > precisionErrorTolerance) {
           throw FlutterError.fromParts(<DiagnosticsNode>[
-            ErrorSummary('RenderSliverFixedExtentBoxAdaptor.computeMaxScrollOffset() returned a value that is not an even multiple of its itemExtent.'),
-            ErrorDescription('The itemExtent was $itemExtent, but the scrollExtent was $scrollExtent.'),
-            ErrorDescription('The difference was $diff, which is greater than precisionErrorTolerance ($precisionErrorTolerance).'),
+            ErrorSummary(
+              'RenderSliverFixedExtentBoxAdaptor.computeMaxScrollOffset() returned a value that is not an even multiple of its itemExtent.',
+            ),
+            ErrorDescription(
+              'The itemExtent was $itemExtent, but the scrollExtent was $scrollExtent.',
+            ),
+            ErrorDescription(
+              'The difference was $diff, which is greater than precisionErrorTolerance ($precisionErrorTolerance).',
+            ),
             describeForError('The render object in question was'),
           ]);
         }

--- a/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
+++ b/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
@@ -301,9 +301,9 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
       if (itemExtentBuilder == null && geometry!.scrollExtent.isFinite) {
         final double itemExtent = this.itemExtent!;
         final double scrollExtent = geometry!.scrollExtent;
-        final double remainder = scrollExtent % itemExtent;
-        final double diff = remainder > itemExtent / 2 ? itemExtent - remainder : remainder;
-        if (diff > precisionErrorTolerance) {
+        final double count = scrollExtent / itemExtent;
+        final double diff = (count.roundToDouble() - count).abs();
+        if (diff * itemExtent > precisionErrorTolerance && diff > precisionErrorTolerance) {
           throw FlutterError.fromParts(<DiagnosticsNode>[
             ErrorSummary(
               'RenderSliverFixedExtentBoxAdaptor.computeMaxScrollOffset() returned a value that is not an even multiple of its itemExtent.',

--- a/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
+++ b/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
@@ -295,6 +295,28 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
   SliverLayoutDimensions? _currentLayoutDimensions;
 
   @override
+  void debugAssertDoesMeetConstraints() {
+    super.debugAssertDoesMeetConstraints();
+    assert(() {
+      if (itemExtentBuilder == null && geometry!.scrollExtent.isFinite) {
+        final double itemExtent = this.itemExtent!;
+        final double scrollExtent = geometry!.scrollExtent;
+        final double remainder = scrollExtent % itemExtent;
+        final double diff = remainder > itemExtent / 2 ? itemExtent - remainder : remainder;
+        if (diff > precisionErrorTolerance) {
+          throw FlutterError.fromParts(<DiagnosticsNode>[
+            ErrorSummary('RenderSliverFixedExtentBoxAdaptor.computeMaxScrollOffset() returned a value that is not an even multiple of its itemExtent.'),
+            ErrorDescription('The itemExtent was $itemExtent, but the scrollExtent was $scrollExtent.'),
+            ErrorDescription('The difference was $diff, which is greater than precisionErrorTolerance ($precisionErrorTolerance).'),
+            describeForError('The render object in question was'),
+          ]);
+        }
+      }
+      return true;
+    }());
+  }
+
+  @override
   void performLayout() {
     assert(
       (itemExtent != null && itemExtentBuilder == null) ||

--- a/packages/flutter/test/rendering/sliver_fixed_extent_layout_test.dart
+++ b/packages/flutter/test/rendering/sliver_fixed_extent_layout_test.dart
@@ -366,12 +366,19 @@ void main() {
     );
 
     late FlutterError error;
-    layout(root, onErrors: () {
-      final FlutterErrorDetails? details = TestRenderingFlutterBinding.instance.takeFlutterErrorDetails();
-      error = details!.exception as FlutterError;
-    });
+    layout(
+      root,
+      onErrors: () {
+        final FlutterErrorDetails? details = TestRenderingFlutterBinding.instance
+            .takeFlutterErrorDetails();
+        error = details!.exception as FlutterError;
+      },
+    );
 
-    expect(error.message, contains('returned a value that is not an even multiple of its itemExtent'));
+    expect(
+      error.message,
+      contains('returned a value that is not an even multiple of its itemExtent'),
+    );
   });
 
   test('RenderSliverFixedExtentBoxAdaptor rounding tolerance test', () {
@@ -390,9 +397,12 @@ void main() {
       children: <RenderSliver>[sliver],
     );
 
-    layout(root, onErrors: () {
-      fail('Should not have errors');
-    });
+    layout(
+      root,
+      onErrors: () {
+        fail('Should not have errors');
+      },
+    );
     expect(TestRenderingFlutterBinding.instance.takeFlutterErrorDetails(), isNull);
   });
 }
@@ -496,17 +506,14 @@ class NonMultipleFixedExtentList extends RenderSliverFixedExtentList {
   @override
   void performLayout() {
     super.performLayout();
-    geometry = geometry!.copyWith(
-      scrollExtent: totalExtent,
-      maxPaintExtent: totalExtent,
-    );
+    geometry = geometry!.copyWith(scrollExtent: totalExtent, maxPaintExtent: totalExtent);
   }
 }
 
 class TestChildManagerSimple extends RenderSliverBoxChildManager {
   TestChildManagerSimple();
 
-  RenderSliverMultiBoxAdaptor? _renderObject;
+  late RenderSliverMultiBoxAdaptor? _renderObject;
   RenderBox? child;
 
   void setup(RenderSliverMultiBoxAdaptor renderObject, RenderBox child) {
@@ -515,7 +522,7 @@ class TestChildManagerSimple extends RenderSliverBoxChildManager {
   }
 
   @override
-  void createChild(int index, { required RenderBox? after }) {
+  void createChild(int index, {required RenderBox? after}) {
     if (index == 0 && child != null) {
       _renderObject!.insert(child!, after: after);
     }
@@ -523,24 +530,25 @@ class TestChildManagerSimple extends RenderSliverBoxChildManager {
 
   @override
   void removeChild(RenderBox child) {}
-  
+
   @override
-  double estimateMaxScrollOffset(SliverConstraints constraints, {
+  double estimateMaxScrollOffset(
+    SliverConstraints constraints, {
     int? firstIndex,
     int? lastIndex,
     double? leadingScrollOffset,
     double? trailingScrollOffset,
   }) => 0.0;
-  
+
   @override
   int get childCount => 1;
-  
+
   @override
   void didAdoptChild(RenderBox child) {
     final childParentData = child.parentData! as SliverMultiBoxAdaptorParentData;
     childParentData.index = 0;
   }
-  
+
   @override
   void setDidUnderflow(bool value) {}
 }

--- a/packages/flutter/test/rendering/sliver_fixed_extent_layout_test.dart
+++ b/packages/flutter/test/rendering/sliver_fixed_extent_layout_test.dart
@@ -348,6 +348,53 @@ void main() {
     expect(sliver.calculateLeadingGarbage(firstIndex: 1), 1);
     expect(sliver.calculateTrailingGarbage(lastIndex: 1), 1);
   });
+
+  test('RenderSliverFixedExtentBoxAdaptor assertion test', () {
+    final childManager = TestChildManagerSimple();
+    final sliver = NonMultipleFixedExtentList(
+      childManager: childManager,
+      itemExtent: 100.0,
+      totalExtent: 250.0, // Not a multiple of 100.0
+    );
+    final child = RenderSizedBox(const Size(400.0, 100.0));
+    childManager.setup(sliver, child);
+
+    final root = RenderViewport(
+      crossAxisDirection: AxisDirection.right,
+      offset: ViewportOffset.zero(),
+      children: <RenderSliver>[sliver],
+    );
+
+    late FlutterError error;
+    layout(root, onErrors: () {
+      final FlutterErrorDetails? details = TestRenderingFlutterBinding.instance.takeFlutterErrorDetails();
+      error = details!.exception as FlutterError;
+    });
+
+    expect(error.message, contains('returned a value that is not an even multiple of its itemExtent'));
+  });
+
+  test('RenderSliverFixedExtentBoxAdaptor rounding tolerance test', () {
+    final childManager = TestChildManagerSimple();
+    final sliver = NonMultipleFixedExtentList(
+      childManager: childManager,
+      itemExtent: 100.0,
+      totalExtent: 200.0000000000001,
+    );
+    final child = RenderSizedBox(const Size(400.0, 100.0));
+    childManager.setup(sliver, child);
+
+    final root = RenderViewport(
+      crossAxisDirection: AxisDirection.right,
+      offset: ViewportOffset.zero(),
+      children: <RenderSliver>[sliver],
+    );
+
+    layout(root, onErrors: () {
+      fail('Should not have errors');
+    });
+    expect(TestRenderingFlutterBinding.instance.takeFlutterErrorDetails(), isNull);
+  });
 }
 
 int testGetMaxChildIndexForScrollOffset(double scrollOffset, double itemExtent) {
@@ -435,4 +482,65 @@ class TestRenderSliverFixedExtentBoxAdaptor extends RenderSliverFixedExtentBoxAd
 
   @override
   double get itemExtent => _itemExtent;
+}
+
+class NonMultipleFixedExtentList extends RenderSliverFixedExtentList {
+  NonMultipleFixedExtentList({
+    required super.childManager,
+    required super.itemExtent,
+    required this.totalExtent,
+  }) : super();
+
+  final double totalExtent;
+
+  @override
+  void performLayout() {
+    super.performLayout();
+    geometry = geometry!.copyWith(
+      scrollExtent: totalExtent,
+      maxPaintExtent: totalExtent,
+    );
+  }
+}
+
+class TestChildManagerSimple extends RenderSliverBoxChildManager {
+  TestChildManagerSimple();
+
+  RenderSliverMultiBoxAdaptor? _renderObject;
+  RenderBox? child;
+
+  void setup(RenderSliverMultiBoxAdaptor renderObject, RenderBox child) {
+    _renderObject = renderObject;
+    this.child = child;
+  }
+
+  @override
+  void createChild(int index, { required RenderBox? after }) {
+    if (index == 0 && child != null) {
+      _renderObject!.insert(child!, after: after);
+    }
+  }
+
+  @override
+  void removeChild(RenderBox child) {}
+  
+  @override
+  double estimateMaxScrollOffset(SliverConstraints constraints, {
+    int? firstIndex,
+    int? lastIndex,
+    double? leadingScrollOffset,
+    double? trailingScrollOffset,
+  }) => 0.0;
+  
+  @override
+  int get childCount => 1;
+  
+  @override
+  void didAdoptChild(RenderBox child) {
+    final childParentData = child.parentData! as SliverMultiBoxAdaptorParentData;
+    childParentData.index = 0;
+  }
+  
+  @override
+  void setDidUnderflow(bool value) {}
 }


### PR DESCRIPTION
This PR implements a validation assertion for RenderSliverFixedExtentBoxAdaptor (the modern successor to the RenderBlockViewport mentioned in the original issue) to ensure that the total scroll extent is consistent with the fixed item extent.

When a sliver has a fixed itemExtent, the total scrollExtent should always be an even multiple of that extent. If a custom implementation of computeMaxScrollOffset (or manual geometry manipulation in a subclass) returns a value that isn't a multiple, it can lead to unexpected layout behavior or rounding issues in scroll offsets.

This change adds a debugAssertDoesMeetConstraints override to RenderSliverFixedExtentBoxAdaptor that verifies:
   1. itemExtentBuilder is null (meaning a single fixed itemExtent is being used).
   2. The resulting geometry.scrollExtent is a multiple of the itemExtent, within
      precisionErrorTolerance.

Fixes #2121

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
