### PR TITLE
Improve RenderBox debugCheckingIntrinsics error messages

### DIFF
--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -2076,8 +2076,8 @@ abstract class RenderBox extends RenderObject {
             'The ${objectRuntimeType(this, 'RenderBox')} class does not implement "computeDryLayout".',
           ),
           ErrorHint(
-            'If you are not writing your own RenderBox subclass, then this is an\n'
-            'issue in the framework.',
+            'If you are not writing your own RenderBox subclass, then this is not\n'
+            'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
           ),
         ]),
       ),
@@ -2187,8 +2187,8 @@ abstract class RenderBox extends RenderObject {
             'The ${objectRuntimeType(this, 'RenderBox')} class does not implement "computeDryBaseline".',
           ),
           ErrorHint(
-            'If you are not writing your own RenderBox subclass, then this is an\n'
-            'issue in the framework.',
+            'If you are not writing your own RenderBox subclass, then this is not\n'
+            'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
           ),
         ]),
       ),
@@ -2644,7 +2644,8 @@ abstract class RenderBox extends RenderObject {
           ),
           DiagnosticsProperty<Size>('Size', _size, style: DiagnosticsTreeStyle.errorProperty),
           ErrorHint(
-            'If you are not writing your own RenderBox subclass, then this is an issue in the framework.',
+            'If you are not writing your own RenderBox subclass, then this is not '
+            'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
           ),
         ]);
       }
@@ -2745,8 +2746,8 @@ abstract class RenderBox extends RenderObject {
             ), // should this be tagged as an error or not?
             ...failures,
             ErrorHint(
-              'If you are not writing your own RenderBox subclass, then this is an\n'
-              'issue in the framework.',
+              'If you are not writing your own RenderBox subclass, then this is not\n'
+              'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
             ),
           ]);
         }
@@ -2778,8 +2779,8 @@ abstract class RenderBox extends RenderObject {
             ),
             ErrorDescription('The constraints used were $constraints.'),
             ErrorHint(
-              'If you are not writing your own RenderBox subclass, then this is an\n'
-              'issue in the framework.',
+              'If you are not writing your own RenderBox subclass, then this is not\n'
+              'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
             ),
           ]);
         }
@@ -2793,8 +2794,8 @@ abstract class RenderBox extends RenderObject {
       final messages = <DiagnosticsNode>[
         ErrorDescription('The constraints used were $constraints.'),
         ErrorHint(
-          'If you are not writing your own RenderBox subclass, then this is an\n'
-          'issue in the framework.',
+          'If you are not writing your own RenderBox subclass, then this is not\n'
+          'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
         ),
       ];
 
@@ -2874,7 +2875,7 @@ abstract class RenderBox extends RenderObject {
       ErrorDescription('This happened while RenderObject.debugCheckingIntrinsics was true.'),
       ErrorDescription(explanation),
       ErrorHint(
-        'If you are not writing your own RenderBox subclass, then this is an issue in the framework.',
+        'If you are not writing your own RenderBox subclass, then this is not your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
       ),
       DiagnosticsStackTrace('Stack trace', stack),
     ]);

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -2660,7 +2660,28 @@ abstract class RenderBox extends RenderObject {
           String name,
           double constraint,
         ) {
-          final double result = function(constraint);
+          final double result;
+          try {
+            result = function(constraint);
+          } catch (e, stack) {
+            throw FlutterError.fromParts(<DiagnosticsNode>[
+              ErrorSummary(
+                'The $name method of the $runtimeType class threw an exception during verification.',
+              ),
+              ErrorDescription('The following exception was raised:'),
+              ErrorDescription('$e'),
+              ErrorDescription(
+                'This happened while RenderObject.debugCheckingIntrinsics was true.',
+              ),
+              ErrorDescription(
+                'These methods are called in debug mode to ensure they are consistent.',
+              ),
+              ErrorHint(
+                'If you are not writing your own RenderBox subclass, then this is not your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+              ),
+              DiagnosticsStackTrace('Stack trace', stack),
+            ]);
+          }
           if (result < 0) {
             failures.add(
               ErrorDescription(' * $name($constraint) returned a negative value: $result'),
@@ -2748,6 +2769,22 @@ abstract class RenderBox extends RenderObject {
         final Size dryLayoutSize;
         try {
           dryLayoutSize = getDryLayout(constraints);
+        } catch (e, stack) {
+          throw FlutterError.fromParts(<DiagnosticsNode>[
+            ErrorSummary(
+              'The getDryLayout method of the $runtimeType class threw an exception during verification.',
+            ),
+            ErrorDescription('The following exception was raised:'),
+            ErrorDescription('$e'),
+            ErrorDescription('This happened while RenderObject.debugCheckingIntrinsics was true.'),
+            ErrorDescription(
+              'The getDryLayout method is called in debug mode to ensure it is consistent with the performLayout method.',
+            ),
+            ErrorHint(
+              'If you are not writing your own RenderBox subclass, then this is not your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+            ),
+            DiagnosticsStackTrace('Stack trace', stack),
+          ]);
         } finally {
           RenderObject.debugCheckingIntrinsics = false;
         }
@@ -2791,6 +2828,22 @@ abstract class RenderBox extends RenderObject {
         try {
           dryBaseline = getDryBaseline(constraints, baseline);
           realBaseline = getDistanceToBaseline(baseline, onlyReal: true);
+        } catch (e, stack) {
+          throw FlutterError.fromParts(<DiagnosticsNode>[
+            ErrorSummary(
+              'The getDryBaseline or getDistanceToBaseline method of the $runtimeType class threw an exception during verification.',
+            ),
+            ErrorDescription('The following exception was raised:'),
+            ErrorDescription('$e'),
+            ErrorDescription('This happened while RenderObject.debugCheckingIntrinsics was true.'),
+            ErrorDescription(
+              'The getDryBaseline method is called in debug mode to ensure it is consistent with the getDistanceToBaseline method.',
+            ),
+            ErrorHint(
+              'If you are not writing your own RenderBox subclass, then this is not your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+            ),
+            DiagnosticsStackTrace('Stack trace', stack),
+          ]);
         } finally {
           RenderObject.debugCheckingIntrinsics = false;
         }

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -2875,7 +2875,8 @@ abstract class RenderBox extends RenderObject {
       ErrorDescription('This happened while RenderObject.debugCheckingIntrinsics was true.'),
       ErrorDescription(explanation),
       ErrorHint(
-        'If you are not writing your own RenderBox subclass, then this is not your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+        'If you are not writing your own RenderBox subclass, then this is an issue in the framework. '
+        'Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
       ),
       DiagnosticsStackTrace('Stack trace', stack),
     ]);

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -2076,8 +2076,8 @@ abstract class RenderBox extends RenderObject {
             'The ${objectRuntimeType(this, 'RenderBox')} class does not implement "computeDryLayout".',
           ),
           ErrorHint(
-            'If you are not writing your own RenderBox subclass, then this is not\n'
-            'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+            'If you are not writing your own RenderBox subclass, then this is an\n'
+            'issue in the framework.',
           ),
         ]),
       ),
@@ -2187,8 +2187,8 @@ abstract class RenderBox extends RenderObject {
             'The ${objectRuntimeType(this, 'RenderBox')} class does not implement "computeDryBaseline".',
           ),
           ErrorHint(
-            'If you are not writing your own RenderBox subclass, then this is not\n'
-            'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+            'If you are not writing your own RenderBox subclass, then this is an\n'
+            'issue in the framework.',
           ),
         ]),
       ),
@@ -2644,8 +2644,7 @@ abstract class RenderBox extends RenderObject {
           ),
           DiagnosticsProperty<Size>('Size', _size, style: DiagnosticsTreeStyle.errorProperty),
           ErrorHint(
-            'If you are not writing your own RenderBox subclass, then this is not '
-            'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+            'If you are not writing your own RenderBox subclass, then this is an issue in the framework.',
           ),
         ]);
       }
@@ -2677,7 +2676,7 @@ abstract class RenderBox extends RenderObject {
                 'These methods are called in debug mode to ensure they are consistent.',
               ),
               ErrorHint(
-                'If you are not writing your own RenderBox subclass, then this is not your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+                'If you are not writing your own RenderBox subclass, then this is an issue in the framework.',
               ),
               DiagnosticsStackTrace('Stack trace', stack),
             ]);
@@ -2757,8 +2756,8 @@ abstract class RenderBox extends RenderObject {
             ), // should this be tagged as an error or not?
             ...failures,
             ErrorHint(
-              'If you are not writing your own RenderBox subclass, then this is not\n'
-              'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+              'If you are not writing your own RenderBox subclass, then this is an\n'
+              'issue in the framework.',
             ),
           ]);
         }
@@ -2781,7 +2780,7 @@ abstract class RenderBox extends RenderObject {
               'The getDryLayout method is called in debug mode to ensure it is consistent with the performLayout method.',
             ),
             ErrorHint(
-              'If you are not writing your own RenderBox subclass, then this is not your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+              'If you are not writing your own RenderBox subclass, then this is an issue in the framework.',
             ),
             DiagnosticsStackTrace('Stack trace', stack),
           ]);
@@ -2799,8 +2798,8 @@ abstract class RenderBox extends RenderObject {
             ),
             ErrorDescription('The constraints used were $constraints.'),
             ErrorHint(
-              'If you are not writing your own RenderBox subclass, then this is not\n'
-              'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+              'If you are not writing your own RenderBox subclass, then this is an\n'
+              'issue in the framework.',
             ),
           ]);
         }
@@ -2814,8 +2813,8 @@ abstract class RenderBox extends RenderObject {
       final messages = <DiagnosticsNode>[
         ErrorDescription('The constraints used were $constraints.'),
         ErrorHint(
-          'If you are not writing your own RenderBox subclass, then this is not\n'
-          'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+          'If you are not writing your own RenderBox subclass, then this is an\n'
+          'issue in the framework.',
         ),
       ];
 
@@ -2840,7 +2839,7 @@ abstract class RenderBox extends RenderObject {
               'The getDryBaseline method is called in debug mode to ensure it is consistent with the getDistanceToBaseline method.',
             ),
             ErrorHint(
-              'If you are not writing your own RenderBox subclass, then this is not your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+              'If you are not writing your own RenderBox subclass, then this is an issue in the framework.',
             ),
             DiagnosticsStackTrace('Stack trace', stack),
           ]);

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -2663,23 +2663,12 @@ abstract class RenderBox extends RenderObject {
           try {
             result = function(constraint);
           } catch (e, stack) {
-            throw FlutterError.fromParts(<DiagnosticsNode>[
-              ErrorSummary(
-                'The $name method of the $runtimeType class threw an exception during verification.',
-              ),
-              ErrorDescription('The following exception was raised:'),
-              ErrorDescription('$e'),
-              ErrorDescription(
-                'This happened while RenderObject.debugCheckingIntrinsics was true.',
-              ),
-              ErrorDescription(
-                'These methods are called in debug mode to ensure they are consistent.',
-              ),
-              ErrorHint(
-                'If you are not writing your own RenderBox subclass, then this is an issue in the framework.',
-              ),
-              DiagnosticsStackTrace('Stack trace', stack),
-            ]);
+            _debugReportExceptionDuringIntrinsicsCheck(
+              name,
+              'These methods are called in debug mode to ensure they are consistent.',
+              e,
+              stack,
+            );
           }
           if (result < 0) {
             failures.add(
@@ -2769,21 +2758,12 @@ abstract class RenderBox extends RenderObject {
         try {
           dryLayoutSize = getDryLayout(constraints);
         } catch (e, stack) {
-          throw FlutterError.fromParts(<DiagnosticsNode>[
-            ErrorSummary(
-              'The getDryLayout method of the $runtimeType class threw an exception during verification.',
-            ),
-            ErrorDescription('The following exception was raised:'),
-            ErrorDescription('$e'),
-            ErrorDescription('This happened while RenderObject.debugCheckingIntrinsics was true.'),
-            ErrorDescription(
-              'The getDryLayout method is called in debug mode to ensure it is consistent with the performLayout method.',
-            ),
-            ErrorHint(
-              'If you are not writing your own RenderBox subclass, then this is an issue in the framework.',
-            ),
-            DiagnosticsStackTrace('Stack trace', stack),
-          ]);
+          _debugReportExceptionDuringIntrinsicsCheck(
+            'getDryLayout',
+            'The getDryLayout method is called in debug mode to ensure it is consistent with the performLayout method.',
+            e,
+            stack,
+          );
         } finally {
           RenderObject.debugCheckingIntrinsics = false;
         }
@@ -2828,21 +2808,12 @@ abstract class RenderBox extends RenderObject {
           dryBaseline = getDryBaseline(constraints, baseline);
           realBaseline = getDistanceToBaseline(baseline, onlyReal: true);
         } catch (e, stack) {
-          throw FlutterError.fromParts(<DiagnosticsNode>[
-            ErrorSummary(
-              'The getDryBaseline or getDistanceToBaseline method of the $runtimeType class threw an exception during verification.',
-            ),
-            ErrorDescription('The following exception was raised:'),
-            ErrorDescription('$e'),
-            ErrorDescription('This happened while RenderObject.debugCheckingIntrinsics was true.'),
-            ErrorDescription(
-              'The getDryBaseline method is called in debug mode to ensure it is consistent with the getDistanceToBaseline method.',
-            ),
-            ErrorHint(
-              'If you are not writing your own RenderBox subclass, then this is an issue in the framework.',
-            ),
-            DiagnosticsStackTrace('Stack trace', stack),
-          ]);
+          _debugReportExceptionDuringIntrinsicsCheck(
+            'getDryBaseline or getDistanceToBaseline',
+            'The getDryBaseline method is called in debug mode to ensure it is consistent with the getDistanceToBaseline method.',
+            e,
+            stack,
+          );
         } finally {
           RenderObject.debugCheckingIntrinsics = false;
         }
@@ -2886,6 +2857,27 @@ abstract class RenderBox extends RenderObject {
       }
       return true;
     }());
+  }
+
+  Never _debugReportExceptionDuringIntrinsicsCheck(
+    String methodName,
+    String explanation,
+    Object exception,
+    StackTrace stack,
+  ) {
+    throw FlutterError.fromParts(<DiagnosticsNode>[
+      ErrorSummary(
+        'The $methodName method of the $runtimeType class threw an exception during verification.',
+      ),
+      ErrorDescription('The following exception was raised:'),
+      ErrorDescription('$exception'),
+      ErrorDescription('This happened while RenderObject.debugCheckingIntrinsics was true.'),
+      ErrorDescription(explanation),
+      ErrorHint(
+        'If you are not writing your own RenderBox subclass, then this is an issue in the framework.',
+      ),
+      DiagnosticsStackTrace('Stack trace', stack),
+    ]);
   }
 
   @override

--- a/packages/flutter/test/rendering/box_test.dart
+++ b/packages/flutter/test/rendering/box_test.dart
@@ -721,6 +721,34 @@ void main() {
     }
   });
 
+  test('RenderBox.debugCheckingIntrinsics error messages', () {
+    final testBox = _ThrowingRenderBox();
+    const viewport = BoxConstraints(maxHeight: 100.0, maxWidth: 100.0);
+
+    late FlutterError error;
+    final FlutterExceptionHandler? oldHandler = FlutterError.onError;
+    FlutterError.onError = (FlutterErrorDetails details) {
+      error = details.exception as FlutterError;
+    };
+    try {
+      layout(testBox, constraints: viewport);
+    } finally {
+      FlutterError.onError = oldHandler;
+    }
+
+    expect(error, isNotNull);
+    final String errorMessage = error.toStringDeep();
+    expect(errorMessage, contains('getMinIntrinsicWidth'));
+    expect(errorMessage, contains('RenderPositionedBox'));
+    expect(errorMessage, contains('threw an exception during verification.'));
+    expect(errorMessage, contains('following exception was raised:'));
+    expect(errorMessage, contains('Exception: In computeMinIntrinsicWidth'));
+    expect(errorMessage, contains('RenderObject.debugCheckingIntrinsics'));
+    expect(errorMessage, contains('true.'));
+    expect(errorMessage, contains('consistent'));
+    expect(errorMessage, contains('fault'));
+  });
+
   test('UnconstrainedBox.toStringDeep returns useful information', () {
     final unconstrained = RenderConstraintsTransformBox(
       constraintsTransform: ConstraintsTransformBox.unconstrained,
@@ -1373,4 +1401,16 @@ class _DummyHitTestTarget implements HitTestTarget {
 
 class MyHitTestResult extends HitTestResult {
   void publicPushTransform(Matrix4 transform) => pushTransform(transform);
+}
+
+class _ThrowingRenderBox extends RenderBox {
+  @override
+  double computeMinIntrinsicWidth(double height) {
+    throw Exception('In computeMinIntrinsicWidth');
+  }
+
+  @override
+  void performLayout() {
+    size = constraints.biggest;
+  }
 }

--- a/packages/flutter/test/rendering/box_test.dart
+++ b/packages/flutter/test/rendering/box_test.dart
@@ -746,7 +746,7 @@ void main() {
     expect(errorMessage, contains('RenderObject.debugCheckingIntrinsics'));
     expect(errorMessage, contains('true.'));
     expect(errorMessage, contains('consistent'));
-    expect(errorMessage, contains('fault'));
+    expect(errorMessage, contains('framework'));
   });
 
   test('UnconstrainedBox.toStringDeep returns useful information', () {

--- a/packages/flutter/test/rendering/box_test.dart
+++ b/packages/flutter/test/rendering/box_test.dart
@@ -746,7 +746,7 @@ void main() {
     expect(errorMessage, contains('RenderObject.debugCheckingIntrinsics'));
     expect(errorMessage, contains('true.'));
     expect(errorMessage, contains('consistent'));
-    expect(errorMessage, contains('framework'));
+    expect(errorMessage, contains('fault'));
   });
 
   test('UnconstrainedBox.toStringDeep returns useful information', () {


### PR DESCRIPTION
This PR improves the developer experience when debugging intrinsic dimension and dry layout issues by providing more descriptive error messages when an exception is thrown during RenderObject.debugCheckingIntrinsics mode.

Previously, if a RenderBox subclass threw an exception in its intrinsic dimension methods (computeMinIntrinsicWidth, etc.), computeDryLayout, or computeDryBaseline while the framework was performing debug-only consistency checks, the resulting error message was often confusing. It didn't explicitly state that the exception occurred during a background verification process, making it difficult for developers to understand why their code was being called in that specific context.

This change wraps these debug-time calls in try-catch blocks and throws a structured FlutterError that explains:
   1. Which specific method failed (e.g., getMinIntrinsicWidth).
   2. That the failure happened during RenderObject.debugCheckingIntrinsics verification.
   3. The original exception and its stack trace.
   4. Guidance for the developer, including a hint that if they aren't writing a custom RenderBox, it might be a framework bug.

  Fixes #3304

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
