### PR TITLE
exclude widget_preview_scaffold from pubspec updates

### DIFF
--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -214,16 +214,8 @@ class UpdatePackagesCommand extends FlutterCommand {
         final List<_ProjectDeps> toolDeps = await _upgrade(
           forceUpgrade: forceUpgrade,
           cherryPicks: cherryPicks,
-          // Since the widget_preview_scaffold depends on the Flutter SDK and flutter_tools, we
-          // need to make sure that flutter_tools uses the same versions for packages that are also
-          // used by the Flutter SDK.
           pinned: deps.toVersions(),
-          projects: [
-            // The widget_preview_scaffold project has a path dependency on flutter_tools, so we must
-            // upgrade the projects together.
-            toolProject,
-            widgetPreviewScaffoldProject,
-          ],
+          projects: <FlutterProject>[toolProject],
           relaxToAny: relaxToAny,
         );
         for (final (:project, :deps) in toolDeps) {
@@ -298,6 +290,7 @@ class UpdatePackagesCommand extends FlutterCommand {
       if (yamlEditor.parseAt(workspacePath, orElse: () => wrapAsYamlNode(null)).value != null) {
         yamlEditor.remove(workspacePath);
       }
+
       final RelaxMode relaxMode = switch (cherryPicks.isNotEmpty) {
         true => RelaxMode.strict,
         false => relaxToAny ? RelaxMode.any : RelaxMode.caret,

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -206,6 +206,8 @@ class UpdatePackagesCommand extends FlutterCommand {
         final List<_ProjectDeps> toolDeps = await _upgrade(
           forceUpgrade: forceUpgrade,
           cherryPicks: cherryPicks,
+          // Ensure that flutter_tools uses the same versions for packages that are also
+          // used by the Flutter SDK.
           pinned: deps.toVersions(),
           projects: <FlutterProject>[toolProject],
           relaxToAny: relaxToAny,

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -172,14 +172,6 @@ class UpdatePackagesCommand extends FlutterCommand {
       rootDirectory.childDirectory('packages').childDirectory('flutter_tools'),
     );
 
-    // This package is intentionally not part of the workspace as it's a rehydrated template.
-    final FlutterProject widgetPreviewScaffoldProject = FlutterProject.fromDirectory(
-      rootProject.directory
-          .childDirectory('dev')
-          .childDirectory('integration_tests')
-          .childDirectory('widget_preview_scaffold'),
-    );
-
     // This package is intentionally not part of the workspace to test
     // user-defines in its local pubspec.
     final Directory hooksUserDefineIntegrationTestDirectory = rootDirectory
@@ -237,7 +229,6 @@ class UpdatePackagesCommand extends FlutterCommand {
     // Manually do a pub get for packages not part of the workspace.
     // See https://github.com/flutter/flutter/pull/170364.
     await _pubGet(toolProject, false);
-    await _pubGet(widgetPreviewScaffoldProject, false);
     await _pubGet(FlutterProject.fromDirectory(hooksUserDefineIntegrationTestDirectory), false);
 
     await _downloadCoverageData();


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/185161

https://github.com/flutter/flutter/pull/182627 moved that project into the workspace.  I think this update was residual from when it wasn't in the workspace.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
