### PR TITLE
Report an error if the git ls-tree command fails in the content_aware_hash script

### DIFF
--- a/bin/internal/content_aware_hash.sh
+++ b/bin/internal/content_aware_hash.sh
@@ -71,8 +71,8 @@ GIT_OPTS=()
 if [[ "$(git --version)" == *"Apple Git"* ]]; then
   GIT_OPTS=(-c core.multiPackIndex=false)
 fi
-if ! HASH=$(git "${GIT_OPTS[@]}" -C "$FLUTTER_ROOT" ls-tree "$BASEREF" -- "${TRACKEDFILES[@]}" | git hash-object --stdin; exit ${PIPESTATUS[0]}); then
-  >&2 echo "${0}: git ls-tree failed"
+if ! HASH=$(set -o pipefail; git "${GIT_OPTS[@]}" -C "$FLUTTER_ROOT" ls-tree "$BASEREF" -- "${TRACKEDFILES[@]}" | git hash-object --stdin); then
+  >&2 echo "${0}: git error when generating Flutter content-aware hash"
   exit 1
 fi
-echo $HASH
+echo "$HASH"

--- a/bin/internal/content_aware_hash.sh
+++ b/bin/internal/content_aware_hash.sh
@@ -71,4 +71,8 @@ GIT_OPTS=()
 if [[ "$(git --version)" == *"Apple Git"* ]]; then
   GIT_OPTS=(-c core.multiPackIndex=false)
 fi
-git "${GIT_OPTS[@]}" -C "$FLUTTER_ROOT" ls-tree "$BASEREF" -- "${TRACKEDFILES[@]}" | git hash-object --stdin
+if ! HASH=$(git "${GIT_OPTS[@]}" -C "$FLUTTER_ROOT" ls-tree "$BASEREF" -- "${TRACKEDFILES[@]}" | git hash-object --stdin; exit ${PIPESTATUS[0]}); then
+  >&2 echo "${0}: git ls-tree failed"
+  exit 1
+fi
+echo $HASH


### PR DESCRIPTION
Without this, the script will output an incorrect hash and return a successful exit code if "git ls-tree" fails.

See https://github.com/flutter/flutter/issues/184376