### PR TITLE
fix: --no-hot flag should trigger hot restart instead of being ignored

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -704,6 +704,7 @@ class AppDomain extends Domain {
         target: target,
         debuggingOptions: options,
         stayResident: true,
+        hotMode: enableHotReload,
         urlTunneller: options.webEnableExposeUrl! ? daemon.daemonDomain.exposeUrl : null,
         machine: machine,
         analytics: globals.analytics,

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -788,6 +788,7 @@ class RunCommand extends RunCommandBase {
         flutterProject: flutterProject,
         debuggingOptions: debuggingOptions,
         stayResident: stayResident,
+        hotMode: hotMode,
         fileSystem: globals.fs,
         analytics: globals.analytics,
         logger: globals.logger,

--- a/packages/flutter_tools/lib/src/drive/web_driver_service.dart
+++ b/packages/flutter_tools/lib/src/drive/web_driver_service.dart
@@ -97,6 +97,7 @@ class WebDriverService extends DriverService {
               webUseWasm: debuggingOptions.webUseWasm,
             ),
       stayResident: true,
+      hotMode: !buildInfo.isRelease,
       flutterProject: FlutterProject.current(),
       fileSystem: globals.fs,
       analytics: globals.analytics,

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -53,6 +53,7 @@ class DwdsWebRunnerFactory extends WebRunnerFactory {
     FlutterDevice device, {
     String? target,
     required bool stayResident,
+    required bool hotMode,
     required FlutterProject flutterProject,
     required DebuggingOptions debuggingOptions,
     UrlTunneller? urlTunneller,
@@ -72,6 +73,7 @@ class DwdsWebRunnerFactory extends WebRunnerFactory {
       flutterProject: flutterProject,
       debuggingOptions: debuggingOptions,
       stayResident: stayResident,
+      hotMode: hotMode,
       urlTunneller: urlTunneller,
       machine: machine,
       analytics: analytics,
@@ -100,6 +102,7 @@ class ResidentWebRunner extends ResidentRunner {
     super.stayResident = true,
     super.machine = false,
     super.projectRootPath,
+    super.hotMode = true,
     required this.flutterProject,
     required super.debuggingOptions,
     required FileSystem fileSystem,
@@ -121,6 +124,7 @@ class ResidentWebRunner extends ResidentRunner {
        super(
          <FlutterDevice>[device],
          target: target ?? fileSystem.path.join('lib', 'main.dart'),
+         hotMode: hotMode,
          commandHelp: CommandHelp(
            logger: logger,
            terminal: terminal,

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1730,7 +1730,19 @@ class TerminalHandler {
         return true;
       case 'r':
         if (!residentRunner.canHotReload) {
-          return false;
+          // If hot reload is disabled (e.g., --no-hot flag), still allow
+          // hot restart via 'r' key since that's the expected behavior.
+          if (!residentRunner.supportsRestart) {
+            return false;
+          }
+          final OperationResult result = await residentRunner.restart(fullRestart: true);
+          if (result.fatal) {
+            throwToolExit(result.message);
+          }
+          if (!result.isOk) {
+            _logger.printStatus('Try again after fixing the above error(s).', emphasis: true);
+          }
+          return true;
         }
         final OperationResult result = await residentRunner.restart();
         if (result.fatal) {

--- a/packages/flutter_tools/lib/src/web/web_runner.dart
+++ b/packages/flutter_tools/lib/src/web/web_runner.dart
@@ -26,6 +26,7 @@ abstract class WebRunnerFactory {
     FlutterDevice device, {
     String? target,
     required bool stayResident,
+    required bool hotMode,
     required FlutterProject flutterProject,
     required DebuggingOptions debuggingOptions,
     UrlTunneller? urlTunneller,


### PR DESCRIPTION
## Description

When `--no-hot` flag is passed to `flutter run` for web, pressing `r` should perform a hot restart (fullReload) since hot reload is disabled. However, the `r` key handler was simply returning `false` (doing nothing) when `canHotReload` was `false`, ignoring the expected behavior.

## Root Cause

1. `ResidentWebRunner` had `hotMode` hardcoded to `true` (default in `ResidentRunner`) and was never receiving the actual hot mode setting from the run command.
2. The `WebRunnerFactory.createWebRunner` interface did not include a `hotMode` parameter, so the configuration couldn't be passed through.
3. The `TerminalHandler` for `r` key simply returned `false` when `canHotReload` was false, without checking if hot restart was available.

## Fix

1. Added `hotMode` parameter to `WebRunnerFactory.createWebRunner` interface
2. Pass `hotMode` through `DwdsWebRunnerFactory` to `ResidentWebRunner`
3. Set `hotMode` in `ResidentWebRunner` constructor and pass it to the parent `ResidentRunner`
4. Update all `createWebRunner` call sites to pass `hotMode`
5. Modified `TerminalHandler` to allow restart via `r` when `canHotReload=false` but `supportsRestart=true`, performing a full restart instead

## Testing

The fix follows the existing pattern where `R` key already performs full restart. With this change, pressing `r` in `--no-hot` mode will correctly trigger a full restart.

Fixes flutter/flutter#179448
