### PR TITLE
Improve RenderBox intrinsic and dry layout diagnostics

### DIFF
--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -2076,8 +2076,8 @@ abstract class RenderBox extends RenderObject {
             'The ${objectRuntimeType(this, 'RenderBox')} class does not implement "computeDryLayout".',
           ),
           ErrorHint(
-            'If you are not writing your own RenderBox subclass, then this is an\n'
-            'issue in the framework.',
+            'If you are not writing your own RenderBox subclass, then this is not\n'
+            'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
           ),
         ]),
       ),
@@ -2187,8 +2187,8 @@ abstract class RenderBox extends RenderObject {
             'The ${objectRuntimeType(this, 'RenderBox')} class does not implement "computeDryBaseline".',
           ),
           ErrorHint(
-            'If you are not writing your own RenderBox subclass, then this is an\n'
-            'issue in the framework.',
+            'If you are not writing your own RenderBox subclass, then this is not\n'
+            'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
           ),
         ]),
       ),
@@ -2644,7 +2644,8 @@ abstract class RenderBox extends RenderObject {
           ),
           DiagnosticsProperty<Size>('Size', _size, style: DiagnosticsTreeStyle.errorProperty),
           ErrorHint(
-            'If you are not writing your own RenderBox subclass, then this is an issue in the framework.',
+            'If you are not writing your own RenderBox subclass, then this is not '
+            'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
           ),
         ]);
       }
@@ -2745,8 +2746,8 @@ abstract class RenderBox extends RenderObject {
             ), // should this be tagged as an error or not?
             ...failures,
             ErrorHint(
-              'If you are not writing your own RenderBox subclass, then this is an\n'
-              'issue in the framework.',
+              'If you are not writing your own RenderBox subclass, then this is not\n'
+              'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
             ),
           ]);
         }
@@ -2778,8 +2779,8 @@ abstract class RenderBox extends RenderObject {
             ),
             ErrorDescription('The constraints used were $constraints.'),
             ErrorHint(
-              'If you are not writing your own RenderBox subclass, then this is an\n'
-              'issue in the framework.',
+              'If you are not writing your own RenderBox subclass, then this is not\n'
+              'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
             ),
           ]);
         }
@@ -2793,8 +2794,8 @@ abstract class RenderBox extends RenderObject {
       final messages = <DiagnosticsNode>[
         ErrorDescription('The constraints used were $constraints.'),
         ErrorHint(
-          'If you are not writing your own RenderBox subclass, then this is an\n'
-          'issue in the framework.',
+          'If you are not writing your own RenderBox subclass, then this is not\n'
+          'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
         ),
       ];
 
@@ -2874,7 +2875,7 @@ abstract class RenderBox extends RenderObject {
       ErrorDescription('This happened while RenderObject.debugCheckingIntrinsics was true.'),
       ErrorDescription(explanation),
       ErrorHint(
-        'If you are not writing your own RenderBox subclass, then this is an issue in the framework.',
+        'If you are not writing your own RenderBox subclass, then this is not your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
       ),
       DiagnosticsStackTrace('Stack trace', stack),
     ]);

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -2660,7 +2660,28 @@ abstract class RenderBox extends RenderObject {
           String name,
           double constraint,
         ) {
-          final double result = function(constraint);
+          final double result;
+          try {
+            result = function(constraint);
+          } catch (e, stack) {
+            throw FlutterError.fromParts(<DiagnosticsNode>[
+              ErrorSummary(
+                'The $name method of the $runtimeType class threw an exception during verification.',
+              ),
+              ErrorDescription('The following exception was raised:'),
+              ErrorDescription('$e'),
+              ErrorDescription(
+                'This happened while RenderObject.debugCheckingIntrinsics was true.',
+              ),
+              ErrorDescription(
+                'These methods are called in debug mode to ensure they are consistent.',
+              ),
+              ErrorHint(
+                'If you are not writing your own RenderBox subclass, then this is not your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+              ),
+              DiagnosticsStackTrace('Stack trace', stack),
+            ]);
+          }
           if (result < 0) {
             failures.add(
               ErrorDescription(' * $name($constraint) returned a negative value: $result'),
@@ -2748,6 +2769,22 @@ abstract class RenderBox extends RenderObject {
         final Size dryLayoutSize;
         try {
           dryLayoutSize = getDryLayout(constraints);
+        } catch (e, stack) {
+          throw FlutterError.fromParts(<DiagnosticsNode>[
+            ErrorSummary(
+              'The getDryLayout method of the $runtimeType class threw an exception during verification.',
+            ),
+            ErrorDescription('The following exception was raised:'),
+            ErrorDescription('$e'),
+            ErrorDescription('This happened while RenderObject.debugCheckingIntrinsics was true.'),
+            ErrorDescription(
+              'The getDryLayout method is called in debug mode to ensure it is consistent with the performLayout method.',
+            ),
+            ErrorHint(
+              'If you are not writing your own RenderBox subclass, then this is not your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+            ),
+            DiagnosticsStackTrace('Stack trace', stack),
+          ]);
         } finally {
           RenderObject.debugCheckingIntrinsics = false;
         }
@@ -2791,6 +2828,22 @@ abstract class RenderBox extends RenderObject {
         try {
           dryBaseline = getDryBaseline(constraints, baseline);
           realBaseline = getDistanceToBaseline(baseline, onlyReal: true);
+        } catch (e, stack) {
+          throw FlutterError.fromParts(<DiagnosticsNode>[
+            ErrorSummary(
+              'The getDryBaseline or getDistanceToBaseline method of the $runtimeType class threw an exception during verification.',
+            ),
+            ErrorDescription('The following exception was raised:'),
+            ErrorDescription('$e'),
+            ErrorDescription('This happened while RenderObject.debugCheckingIntrinsics was true.'),
+            ErrorDescription(
+              'The getDryBaseline method is called in debug mode to ensure it is consistent with the getDistanceToBaseline method.',
+            ),
+            ErrorHint(
+              'If you are not writing your own RenderBox subclass, then this is not your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+            ),
+            DiagnosticsStackTrace('Stack trace', stack),
+          ]);
         } finally {
           RenderObject.debugCheckingIntrinsics = false;
         }

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -2882,6 +2882,28 @@ abstract class RenderBox extends RenderObject {
     ]);
   }
 
+  /// Reports that a child returned an infinite intrinsic dimension.
+  ///
+  /// This is a violation of the intrinsic layout protocol.
+  static Never debugReportInfiniteIntrinsic(
+    String parentType,
+    RenderBox child,
+    String dimension,
+    String methodName,
+  ) {
+    throw FlutterError.fromParts(<DiagnosticsNode>[
+      ErrorSummary('The child of a $parentType returned an infinite intrinsic $dimension.'),
+      ErrorDescription(
+        'The ${child.runtimeType} class returned an infinite value for $methodName, '
+        'which is a violation of the intrinsic layout protocol.',
+      ),
+      ErrorHint(
+        'If you are not writing your own RenderBox subclass, then this is an issue in the framework. '
+        'Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+      ),
+    ]);
+  }
+
   @override
   void markNeedsLayout() {
     // If `_layoutCacheStorage.clear` returns true, then this [RenderBox]'s layout

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -2875,7 +2875,8 @@ abstract class RenderBox extends RenderObject {
       ErrorDescription('This happened while RenderObject.debugCheckingIntrinsics was true.'),
       ErrorDescription(explanation),
       ErrorHint(
-        'If you are not writing your own RenderBox subclass, then this is not your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+        'If you are not writing your own RenderBox subclass, then this is an issue in the framework. '
+        'Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
       ),
       DiagnosticsStackTrace('Stack trace', stack),
     ]);

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -2076,8 +2076,8 @@ abstract class RenderBox extends RenderObject {
             'The ${objectRuntimeType(this, 'RenderBox')} class does not implement "computeDryLayout".',
           ),
           ErrorHint(
-            'If you are not writing your own RenderBox subclass, then this is not\n'
-            'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+            'If you are not writing your own RenderBox subclass, then this is an\n'
+            'issue in the framework.',
           ),
         ]),
       ),
@@ -2187,8 +2187,8 @@ abstract class RenderBox extends RenderObject {
             'The ${objectRuntimeType(this, 'RenderBox')} class does not implement "computeDryBaseline".',
           ),
           ErrorHint(
-            'If you are not writing your own RenderBox subclass, then this is not\n'
-            'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+            'If you are not writing your own RenderBox subclass, then this is an\n'
+            'issue in the framework.',
           ),
         ]),
       ),
@@ -2644,8 +2644,7 @@ abstract class RenderBox extends RenderObject {
           ),
           DiagnosticsProperty<Size>('Size', _size, style: DiagnosticsTreeStyle.errorProperty),
           ErrorHint(
-            'If you are not writing your own RenderBox subclass, then this is not '
-            'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+            'If you are not writing your own RenderBox subclass, then this is an issue in the framework.',
           ),
         ]);
       }
@@ -2677,7 +2676,7 @@ abstract class RenderBox extends RenderObject {
                 'These methods are called in debug mode to ensure they are consistent.',
               ),
               ErrorHint(
-                'If you are not writing your own RenderBox subclass, then this is not your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+                'If you are not writing your own RenderBox subclass, then this is an issue in the framework.',
               ),
               DiagnosticsStackTrace('Stack trace', stack),
             ]);
@@ -2757,8 +2756,8 @@ abstract class RenderBox extends RenderObject {
             ), // should this be tagged as an error or not?
             ...failures,
             ErrorHint(
-              'If you are not writing your own RenderBox subclass, then this is not\n'
-              'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+              'If you are not writing your own RenderBox subclass, then this is an\n'
+              'issue in the framework.',
             ),
           ]);
         }
@@ -2781,7 +2780,7 @@ abstract class RenderBox extends RenderObject {
               'The getDryLayout method is called in debug mode to ensure it is consistent with the performLayout method.',
             ),
             ErrorHint(
-              'If you are not writing your own RenderBox subclass, then this is not your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+              'If you are not writing your own RenderBox subclass, then this is an issue in the framework.',
             ),
             DiagnosticsStackTrace('Stack trace', stack),
           ]);
@@ -2799,8 +2798,8 @@ abstract class RenderBox extends RenderObject {
             ),
             ErrorDescription('The constraints used were $constraints.'),
             ErrorHint(
-              'If you are not writing your own RenderBox subclass, then this is not\n'
-              'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+              'If you are not writing your own RenderBox subclass, then this is an\n'
+              'issue in the framework.',
             ),
           ]);
         }
@@ -2814,8 +2813,8 @@ abstract class RenderBox extends RenderObject {
       final messages = <DiagnosticsNode>[
         ErrorDescription('The constraints used were $constraints.'),
         ErrorHint(
-          'If you are not writing your own RenderBox subclass, then this is not\n'
-          'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+          'If you are not writing your own RenderBox subclass, then this is an\n'
+          'issue in the framework.',
         ),
       ];
 
@@ -2840,7 +2839,7 @@ abstract class RenderBox extends RenderObject {
               'The getDryBaseline method is called in debug mode to ensure it is consistent with the getDistanceToBaseline method.',
             ),
             ErrorHint(
-              'If you are not writing your own RenderBox subclass, then this is not your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+              'If you are not writing your own RenderBox subclass, then this is an issue in the framework.',
             ),
             DiagnosticsStackTrace('Stack trace', stack),
           ]);

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -2876,7 +2876,7 @@ abstract class RenderBox extends RenderObject {
       ErrorDescription(explanation),
       ErrorHint(
         'If you are not writing your own RenderBox subclass, then this is an issue in the framework. '
-        'Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+        'Contact support: https://github.com/flutter/flutter/issues/new',
       ),
       DiagnosticsStackTrace('Stack trace', stack),
     ]);
@@ -2899,9 +2899,28 @@ abstract class RenderBox extends RenderObject {
       ),
       ErrorHint(
         'If you are not writing your own RenderBox subclass, then this is an issue in the framework. '
-        'Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+        'Contact support: https://github.com/flutter/flutter/issues/new',
       ),
     ]);
+  }
+
+  /// Checks if an intrinsic dimension is finite and reports an error if not.
+  ///
+  /// This is used to centralize the boilerplate for finiteness checks during
+  /// debug consistency checks.
+  ///
+  /// Returns true so it can be used in an assert.
+  static bool debugCheckFiniteIntrinsic({
+    required String parentType,
+    required RenderBox child,
+    required String dimension,
+    required String methodName,
+    required double value,
+  }) {
+    if (!value.isFinite) {
+      reportInfiniteIntrinsic(parentType, child, dimension, methodName);
+    }
+    return true;
   }
 
   @override

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -2664,7 +2664,7 @@ abstract class RenderBox extends RenderObject {
           try {
             result = function(constraint);
           } catch (e, stack) {
-            _debugReportExceptionDuringIntrinsicsCheck(
+            _reportIntrinsicException(
               name,
               'These methods are called in debug mode to ensure they are consistent.',
               e,
@@ -2759,7 +2759,7 @@ abstract class RenderBox extends RenderObject {
         try {
           dryLayoutSize = getDryLayout(constraints);
         } catch (e, stack) {
-          _debugReportExceptionDuringIntrinsicsCheck(
+          _reportIntrinsicException(
             'getDryLayout',
             'The getDryLayout method is called in debug mode to ensure it is consistent with the performLayout method.',
             e,
@@ -2809,7 +2809,7 @@ abstract class RenderBox extends RenderObject {
           dryBaseline = getDryBaseline(constraints, baseline);
           realBaseline = getDistanceToBaseline(baseline, onlyReal: true);
         } catch (e, stack) {
-          _debugReportExceptionDuringIntrinsicsCheck(
+          _reportIntrinsicException(
             'getDryBaseline or getDistanceToBaseline',
             'The getDryBaseline method is called in debug mode to ensure it is consistent with the getDistanceToBaseline method.',
             e,
@@ -2860,7 +2860,7 @@ abstract class RenderBox extends RenderObject {
     }());
   }
 
-  Never _debugReportExceptionDuringIntrinsicsCheck(
+  Never _reportIntrinsicException(
     String methodName,
     String explanation,
     Object exception,
@@ -2885,7 +2885,7 @@ abstract class RenderBox extends RenderObject {
   /// Reports that a child returned an infinite intrinsic dimension.
   ///
   /// This is a violation of the intrinsic layout protocol.
-  static Never debugReportInfiniteIntrinsic(
+  static Never reportInfiniteIntrinsic(
     String parentType,
     RenderBox child,
     String dimension,

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -2663,23 +2663,12 @@ abstract class RenderBox extends RenderObject {
           try {
             result = function(constraint);
           } catch (e, stack) {
-            throw FlutterError.fromParts(<DiagnosticsNode>[
-              ErrorSummary(
-                'The $name method of the $runtimeType class threw an exception during verification.',
-              ),
-              ErrorDescription('The following exception was raised:'),
-              ErrorDescription('$e'),
-              ErrorDescription(
-                'This happened while RenderObject.debugCheckingIntrinsics was true.',
-              ),
-              ErrorDescription(
-                'These methods are called in debug mode to ensure they are consistent.',
-              ),
-              ErrorHint(
-                'If you are not writing your own RenderBox subclass, then this is an issue in the framework.',
-              ),
-              DiagnosticsStackTrace('Stack trace', stack),
-            ]);
+            _debugReportExceptionDuringIntrinsicsCheck(
+              name,
+              'These methods are called in debug mode to ensure they are consistent.',
+              e,
+              stack,
+            );
           }
           if (result < 0) {
             failures.add(
@@ -2769,21 +2758,12 @@ abstract class RenderBox extends RenderObject {
         try {
           dryLayoutSize = getDryLayout(constraints);
         } catch (e, stack) {
-          throw FlutterError.fromParts(<DiagnosticsNode>[
-            ErrorSummary(
-              'The getDryLayout method of the $runtimeType class threw an exception during verification.',
-            ),
-            ErrorDescription('The following exception was raised:'),
-            ErrorDescription('$e'),
-            ErrorDescription('This happened while RenderObject.debugCheckingIntrinsics was true.'),
-            ErrorDescription(
-              'The getDryLayout method is called in debug mode to ensure it is consistent with the performLayout method.',
-            ),
-            ErrorHint(
-              'If you are not writing your own RenderBox subclass, then this is an issue in the framework.',
-            ),
-            DiagnosticsStackTrace('Stack trace', stack),
-          ]);
+          _debugReportExceptionDuringIntrinsicsCheck(
+            'getDryLayout',
+            'The getDryLayout method is called in debug mode to ensure it is consistent with the performLayout method.',
+            e,
+            stack,
+          );
         } finally {
           RenderObject.debugCheckingIntrinsics = false;
         }
@@ -2828,21 +2808,12 @@ abstract class RenderBox extends RenderObject {
           dryBaseline = getDryBaseline(constraints, baseline);
           realBaseline = getDistanceToBaseline(baseline, onlyReal: true);
         } catch (e, stack) {
-          throw FlutterError.fromParts(<DiagnosticsNode>[
-            ErrorSummary(
-              'The getDryBaseline or getDistanceToBaseline method of the $runtimeType class threw an exception during verification.',
-            ),
-            ErrorDescription('The following exception was raised:'),
-            ErrorDescription('$e'),
-            ErrorDescription('This happened while RenderObject.debugCheckingIntrinsics was true.'),
-            ErrorDescription(
-              'The getDryBaseline method is called in debug mode to ensure it is consistent with the getDistanceToBaseline method.',
-            ),
-            ErrorHint(
-              'If you are not writing your own RenderBox subclass, then this is an issue in the framework.',
-            ),
-            DiagnosticsStackTrace('Stack trace', stack),
-          ]);
+          _debugReportExceptionDuringIntrinsicsCheck(
+            'getDryBaseline or getDistanceToBaseline',
+            'The getDryBaseline method is called in debug mode to ensure it is consistent with the getDistanceToBaseline method.',
+            e,
+            stack,
+          );
         } finally {
           RenderObject.debugCheckingIntrinsics = false;
         }
@@ -2886,6 +2857,27 @@ abstract class RenderBox extends RenderObject {
       }
       return true;
     }());
+  }
+
+  Never _debugReportExceptionDuringIntrinsicsCheck(
+    String methodName,
+    String explanation,
+    Object exception,
+    StackTrace stack,
+  ) {
+    throw FlutterError.fromParts(<DiagnosticsNode>[
+      ErrorSummary(
+        'The $methodName method of the $runtimeType class threw an exception during verification.',
+      ),
+      ErrorDescription('The following exception was raised:'),
+      ErrorDescription('$exception'),
+      ErrorDescription('This happened while RenderObject.debugCheckingIntrinsics was true.'),
+      ErrorDescription(explanation),
+      ErrorHint(
+        'If you are not writing your own RenderBox subclass, then this is an issue in the framework.',
+      ),
+      DiagnosticsStackTrace('Stack trace', stack),
+    ]);
   }
 
   @override

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -2876,7 +2876,7 @@ abstract class RenderBox extends RenderObject {
       ErrorDescription(explanation),
       ErrorHint(
         'If you are not writing your own RenderBox subclass, then this is an issue in the framework. '
-        'Contact support: https://github.com/flutter/flutter/issues/new',
+        'Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
       ),
       DiagnosticsStackTrace('Stack trace', stack),
     ]);
@@ -2899,7 +2899,7 @@ abstract class RenderBox extends RenderObject {
       ),
       ErrorHint(
         'If you are not writing your own RenderBox subclass, then this is an issue in the framework. '
-        'Contact support: https://github.com/flutter/flutter/issues/new',
+        'Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
       ),
     ]);
   }

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -680,6 +680,22 @@ class RenderIntrinsicWidth extends RenderProxyBox {
       return 0.0;
     }
     final double width = child!.getMaxIntrinsicWidth(height);
+    assert(() {
+      if (!width.isFinite) {
+        throw FlutterError.fromParts(<DiagnosticsNode>[
+          ErrorSummary('The child of a RenderIntrinsicWidth returned an infinite intrinsic width.'),
+          ErrorDescription(
+            'The ${child!.runtimeType} class returned an infinite value for getMaxIntrinsicWidth, '
+            'which is a violation of the intrinsic layout protocol.',
+          ),
+          ErrorHint(
+            'If you are not writing your own RenderBox subclass, then this is not\n'
+            'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+          ),
+        ]);
+      }
+      return true;
+    }());
     return _applyStep(width, _stepWidth);
   }
 
@@ -693,6 +709,22 @@ class RenderIntrinsicWidth extends RenderProxyBox {
     }
     assert(width.isFinite);
     final double height = child!.getMinIntrinsicHeight(width);
+    assert(() {
+      if (!height.isFinite) {
+        throw FlutterError.fromParts(<DiagnosticsNode>[
+          ErrorSummary('The child of a RenderIntrinsicWidth returned an infinite intrinsic height.'),
+          ErrorDescription(
+            'The ${child!.runtimeType} class returned an infinite value for getMinIntrinsicHeight, '
+            'which is a violation of the intrinsic layout protocol.',
+          ),
+          ErrorHint(
+            'If you are not writing your own RenderBox subclass, then this is not\n'
+            'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+          ),
+        ]);
+      }
+      return true;
+    }());
     return _applyStep(height, _stepHeight);
   }
 
@@ -706,18 +738,69 @@ class RenderIntrinsicWidth extends RenderProxyBox {
     }
     assert(width.isFinite);
     final double height = child!.getMaxIntrinsicHeight(width);
+    assert(() {
+      if (!height.isFinite) {
+        throw FlutterError.fromParts(<DiagnosticsNode>[
+          ErrorSummary('The child of a RenderIntrinsicWidth returned an infinite intrinsic height.'),
+          ErrorDescription(
+            'The ${child!.runtimeType} class returned an infinite value for getMaxIntrinsicHeight, '
+            'which is a violation of the intrinsic layout protocol.',
+          ),
+          ErrorHint(
+            'If you are not writing your own RenderBox subclass, then this is not\n'
+            'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+          ),
+        ]);
+      }
+      return true;
+    }());
     return _applyStep(height, _stepHeight);
   }
 
   BoxConstraints _childConstraints(RenderBox child, BoxConstraints constraints) {
-    return constraints.tighten(
-      width: constraints.hasTightWidth
-          ? null
-          : _applyStep(child.getMaxIntrinsicWidth(constraints.maxHeight), _stepWidth),
-      height: stepHeight == null
-          ? null
-          : _applyStep(child.getMaxIntrinsicHeight(constraints.maxWidth), _stepHeight),
-    );
+    double? width;
+    if (!constraints.hasTightWidth) {
+      width = child.getMaxIntrinsicWidth(constraints.maxHeight);
+      assert(() {
+        if (!width!.isFinite) {
+          throw FlutterError.fromParts(<DiagnosticsNode>[
+            ErrorSummary('The child of a RenderIntrinsicWidth returned an infinite intrinsic width.'),
+            ErrorDescription(
+              'The ${child.runtimeType} class returned an infinite value for getMaxIntrinsicWidth, '
+              'which is a violation of the intrinsic layout protocol.',
+            ),
+            ErrorHint(
+              'If you are not writing your own RenderBox subclass, then this is not\n'
+              'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+            ),
+          ]);
+        }
+        return true;
+      }());
+      width = _applyStep(width, _stepWidth);
+    }
+    double? height;
+    if (stepHeight != null) {
+      height = child.getMaxIntrinsicHeight(constraints.maxWidth);
+      assert(() {
+        if (!height!.isFinite) {
+          throw FlutterError.fromParts(<DiagnosticsNode>[
+            ErrorSummary('The child of a RenderIntrinsicWidth returned an infinite intrinsic height.'),
+            ErrorDescription(
+              'The ${child.runtimeType} class returned an infinite value for getMaxIntrinsicHeight, '
+              'which is a violation of the intrinsic layout protocol.',
+            ),
+            ErrorHint(
+              'If you are not writing your own RenderBox subclass, then this is not\n'
+              'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+            ),
+          ]);
+        }
+        return true;
+      }());
+      height = _applyStep(height, _stepHeight);
+    }
+    return constraints.tighten(width: width, height: height);
   }
 
   Size _computeSize({required ChildLayouter layoutChild, required BoxConstraints constraints}) {
@@ -791,8 +874,23 @@ class RenderIntrinsicHeight extends RenderProxyBox {
     }
     if (!height.isFinite) {
       height = child!.getMaxIntrinsicHeight(double.infinity);
+      assert(() {
+        if (!height.isFinite) {
+          throw FlutterError.fromParts(<DiagnosticsNode>[
+            ErrorSummary('The child of a RenderIntrinsicHeight returned an infinite intrinsic height.'),
+            ErrorDescription(
+              'The ${child!.runtimeType} class returned an infinite value for getMaxIntrinsicHeight, '
+              'which is a violation of the intrinsic layout protocol.',
+            ),
+            ErrorHint(
+              'If you are not writing your own RenderBox subclass, then this is not\n'
+              'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+            ),
+          ]);
+        }
+        return true;
+      }());
     }
-    assert(height.isFinite);
     return child!.getMinIntrinsicWidth(height);
   }
 
@@ -803,8 +901,23 @@ class RenderIntrinsicHeight extends RenderProxyBox {
     }
     if (!height.isFinite) {
       height = child!.getMaxIntrinsicHeight(double.infinity);
+      assert(() {
+        if (!height.isFinite) {
+          throw FlutterError.fromParts(<DiagnosticsNode>[
+            ErrorSummary('The child of a RenderIntrinsicHeight returned an infinite intrinsic height.'),
+            ErrorDescription(
+              'The ${child!.runtimeType} class returned an infinite value for getMaxIntrinsicHeight, '
+              'which is a violation of the intrinsic layout protocol.',
+            ),
+            ErrorHint(
+              'If you are not writing your own RenderBox subclass, then this is not\n'
+              'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+            ),
+          ]);
+        }
+        return true;
+      }());
     }
-    assert(height.isFinite);
     return child!.getMaxIntrinsicWidth(height);
   }
 
@@ -814,9 +927,27 @@ class RenderIntrinsicHeight extends RenderProxyBox {
   }
 
   BoxConstraints _childConstraints(RenderBox child, BoxConstraints constraints) {
-    return constraints.hasTightHeight
-        ? constraints
-        : constraints.tighten(height: child.getMaxIntrinsicHeight(constraints.maxWidth));
+    if (constraints.hasTightHeight) {
+      return constraints;
+    }
+    final double height = child.getMaxIntrinsicHeight(constraints.maxWidth);
+    assert(() {
+      if (!height.isFinite) {
+        throw FlutterError.fromParts(<DiagnosticsNode>[
+          ErrorSummary('The child of a RenderIntrinsicHeight returned an infinite intrinsic height.'),
+          ErrorDescription(
+            'The ${child.runtimeType} class returned an infinite value for getMaxIntrinsicHeight, '
+            'which is a violation of the intrinsic layout protocol.',
+          ),
+          ErrorHint(
+            'If you are not writing your own RenderBox subclass, then this is not\n'
+            'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
+          ),
+        ]);
+      }
+      return true;
+    }());
+    return constraints.tighten(height: height);
   }
 
   Size _computeSize({required ChildLayouter layoutChild, required BoxConstraints constraints}) {

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -682,7 +682,7 @@ class RenderIntrinsicWidth extends RenderProxyBox {
     final double width = child!.getMaxIntrinsicWidth(height);
     assert(() {
       if (!width.isFinite) {
-        RenderBox.debugReportInfiniteIntrinsic(
+        RenderBox.reportInfiniteIntrinsic(
           'RenderIntrinsicWidth',
           child!,
           'width',
@@ -706,7 +706,7 @@ class RenderIntrinsicWidth extends RenderProxyBox {
     final double height = child!.getMinIntrinsicHeight(width);
     assert(() {
       if (!height.isFinite) {
-        RenderBox.debugReportInfiniteIntrinsic(
+        RenderBox.reportInfiniteIntrinsic(
           'RenderIntrinsicWidth',
           child!,
           'height',
@@ -730,7 +730,7 @@ class RenderIntrinsicWidth extends RenderProxyBox {
     final double height = child!.getMaxIntrinsicHeight(width);
     assert(() {
       if (!height.isFinite) {
-        RenderBox.debugReportInfiniteIntrinsic(
+        RenderBox.reportInfiniteIntrinsic(
           'RenderIntrinsicWidth',
           child!,
           'height',
@@ -748,7 +748,7 @@ class RenderIntrinsicWidth extends RenderProxyBox {
       width = child.getMaxIntrinsicWidth(constraints.maxHeight);
       assert(() {
         if (!width!.isFinite) {
-          RenderBox.debugReportInfiniteIntrinsic(
+          RenderBox.reportInfiniteIntrinsic(
             'RenderIntrinsicWidth',
             child,
             'width',
@@ -764,7 +764,7 @@ class RenderIntrinsicWidth extends RenderProxyBox {
       height = child.getMaxIntrinsicHeight(constraints.maxWidth);
       assert(() {
         if (!height!.isFinite) {
-          RenderBox.debugReportInfiniteIntrinsic(
+          RenderBox.reportInfiniteIntrinsic(
             'RenderIntrinsicWidth',
             child,
             'height',
@@ -851,7 +851,7 @@ class RenderIntrinsicHeight extends RenderProxyBox {
       height = child!.getMaxIntrinsicHeight(double.infinity);
       assert(() {
         if (!height.isFinite) {
-          RenderBox.debugReportInfiniteIntrinsic(
+          RenderBox.reportInfiniteIntrinsic(
             'RenderIntrinsicHeight',
             child!,
             'height',
@@ -873,7 +873,7 @@ class RenderIntrinsicHeight extends RenderProxyBox {
       height = child!.getMaxIntrinsicHeight(double.infinity);
       assert(() {
         if (!height.isFinite) {
-          RenderBox.debugReportInfiniteIntrinsic(
+          RenderBox.reportInfiniteIntrinsic(
             'RenderIntrinsicHeight',
             child!,
             'height',
@@ -898,7 +898,7 @@ class RenderIntrinsicHeight extends RenderProxyBox {
     final double height = child.getMaxIntrinsicHeight(constraints.maxWidth);
     assert(() {
       if (!height.isFinite) {
-        RenderBox.debugReportInfiniteIntrinsic(
+        RenderBox.reportInfiniteIntrinsic(
           'RenderIntrinsicHeight',
           child,
           'height',

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -589,6 +589,62 @@ class RenderAspectRatio extends RenderProxyBox {
   }
 }
 
+double _debugGetChildMaxIntrinsicWidth(String parentType, RenderBox child, double height) {
+  final double result = child.getMaxIntrinsicWidth(height);
+  assert(
+    RenderBox.debugCheckFiniteIntrinsic(
+      parentType: parentType,
+      child: child,
+      dimension: 'width',
+      methodName: 'getMaxIntrinsicWidth',
+      value: result,
+    ),
+  );
+  return result;
+}
+
+double _debugGetChildMinIntrinsicWidth(String parentType, RenderBox child, double height) {
+  final double result = child.getMinIntrinsicWidth(height);
+  assert(
+    RenderBox.debugCheckFiniteIntrinsic(
+      parentType: parentType,
+      child: child,
+      dimension: 'width',
+      methodName: 'getMinIntrinsicWidth',
+      value: result,
+    ),
+  );
+  return result;
+}
+
+double _debugGetChildMaxIntrinsicHeight(String parentType, RenderBox child, double width) {
+  final double result = child.getMaxIntrinsicHeight(width);
+  assert(
+    RenderBox.debugCheckFiniteIntrinsic(
+      parentType: parentType,
+      child: child,
+      dimension: 'height',
+      methodName: 'getMaxIntrinsicHeight',
+      value: result,
+    ),
+  );
+  return result;
+}
+
+double _debugGetChildMinIntrinsicHeight(String parentType, RenderBox child, double width) {
+  final double result = child.getMinIntrinsicHeight(width);
+  assert(
+    RenderBox.debugCheckFiniteIntrinsic(
+      parentType: parentType,
+      child: child,
+      dimension: 'height',
+      methodName: 'getMinIntrinsicHeight',
+      value: result,
+    ),
+  );
+  return result;
+}
+
 /// Sizes its child to the child's maximum intrinsic width.
 ///
 /// This class is useful, for example, when unlimited width is available and
@@ -679,18 +735,11 @@ class RenderIntrinsicWidth extends RenderProxyBox {
     if (child == null) {
       return 0.0;
     }
-    final double width = child!.getMaxIntrinsicWidth(height);
-    assert(() {
-      if (!width.isFinite) {
-        RenderBox.reportInfiniteIntrinsic(
-          'RenderIntrinsicWidth',
-          child!,
-          'width',
-          'getMaxIntrinsicWidth',
-        );
-      }
-      return true;
-    }());
+    final double width = _debugGetChildMaxIntrinsicWidth(
+      objectRuntimeType(this, 'RenderIntrinsicWidth'),
+      child!,
+      height,
+    );
     return _applyStep(width, _stepWidth);
   }
 
@@ -703,18 +752,11 @@ class RenderIntrinsicWidth extends RenderProxyBox {
       width = getMaxIntrinsicWidth(double.infinity);
     }
     assert(width.isFinite);
-    final double height = child!.getMinIntrinsicHeight(width);
-    assert(() {
-      if (!height.isFinite) {
-        RenderBox.reportInfiniteIntrinsic(
-          'RenderIntrinsicWidth',
-          child!,
-          'height',
-          'getMinIntrinsicHeight',
-        );
-      }
-      return true;
-    }());
+    final double height = _debugGetChildMinIntrinsicHeight(
+      objectRuntimeType(this, 'RenderIntrinsicWidth'),
+      child!,
+      width,
+    );
     return _applyStep(height, _stepHeight);
   }
 
@@ -727,52 +769,31 @@ class RenderIntrinsicWidth extends RenderProxyBox {
       width = getMaxIntrinsicWidth(double.infinity);
     }
     assert(width.isFinite);
-    final double height = child!.getMaxIntrinsicHeight(width);
-    assert(() {
-      if (!height.isFinite) {
-        RenderBox.reportInfiniteIntrinsic(
-          'RenderIntrinsicWidth',
-          child!,
-          'height',
-          'getMaxIntrinsicHeight',
-        );
-      }
-      return true;
-    }());
+    final double height = _debugGetChildMaxIntrinsicHeight(
+      objectRuntimeType(this, 'RenderIntrinsicWidth'),
+      child!,
+      width,
+    );
     return _applyStep(height, _stepHeight);
   }
 
   BoxConstraints _childConstraints(RenderBox child, BoxConstraints constraints) {
     double? width;
     if (!constraints.hasTightWidth) {
-      width = child.getMaxIntrinsicWidth(constraints.maxHeight);
-      assert(() {
-        if (!width!.isFinite) {
-          RenderBox.reportInfiniteIntrinsic(
-            'RenderIntrinsicWidth',
-            child,
-            'width',
-            'getMaxIntrinsicWidth',
-          );
-        }
-        return true;
-      }());
+      width = _debugGetChildMaxIntrinsicWidth(
+        objectRuntimeType(this, 'RenderIntrinsicWidth'),
+        child,
+        constraints.maxHeight,
+      );
       width = _applyStep(width, _stepWidth);
     }
     double? height;
     if (stepHeight != null) {
-      height = child.getMaxIntrinsicHeight(constraints.maxWidth);
-      assert(() {
-        if (!height!.isFinite) {
-          RenderBox.reportInfiniteIntrinsic(
-            'RenderIntrinsicWidth',
-            child,
-            'height',
-            'getMaxIntrinsicHeight',
-          );
-        }
-        return true;
-      }());
+      height = _debugGetChildMaxIntrinsicHeight(
+        objectRuntimeType(this, 'RenderIntrinsicWidth'),
+        child,
+        constraints.maxWidth,
+      );
       height = _applyStep(height, _stepHeight);
     }
     return constraints.tighten(width: width, height: height);
@@ -848,20 +869,17 @@ class RenderIntrinsicHeight extends RenderProxyBox {
       return 0.0;
     }
     if (!height.isFinite) {
-      height = child!.getMaxIntrinsicHeight(double.infinity);
-      assert(() {
-        if (!height.isFinite) {
-          RenderBox.reportInfiniteIntrinsic(
-            'RenderIntrinsicHeight',
-            child!,
-            'height',
-            'getMaxIntrinsicHeight',
-          );
-        }
-        return true;
-      }());
+      height = _debugGetChildMaxIntrinsicHeight(
+        objectRuntimeType(this, 'RenderIntrinsicHeight'),
+        child!,
+        double.infinity,
+      );
     }
-    return child!.getMinIntrinsicWidth(height);
+    return _debugGetChildMinIntrinsicWidth(
+      objectRuntimeType(this, 'RenderIntrinsicHeight'),
+      child!,
+      height,
+    );
   }
 
   @override
@@ -870,20 +888,17 @@ class RenderIntrinsicHeight extends RenderProxyBox {
       return 0.0;
     }
     if (!height.isFinite) {
-      height = child!.getMaxIntrinsicHeight(double.infinity);
-      assert(() {
-        if (!height.isFinite) {
-          RenderBox.reportInfiniteIntrinsic(
-            'RenderIntrinsicHeight',
-            child!,
-            'height',
-            'getMaxIntrinsicHeight',
-          );
-        }
-        return true;
-      }());
+      height = _debugGetChildMaxIntrinsicHeight(
+        objectRuntimeType(this, 'RenderIntrinsicHeight'),
+        child!,
+        double.infinity,
+      );
     }
-    return child!.getMaxIntrinsicWidth(height);
+    return _debugGetChildMaxIntrinsicWidth(
+      objectRuntimeType(this, 'RenderIntrinsicHeight'),
+      child!,
+      height,
+    );
   }
 
   @override
@@ -895,18 +910,11 @@ class RenderIntrinsicHeight extends RenderProxyBox {
     if (constraints.hasTightHeight) {
       return constraints;
     }
-    final double height = child.getMaxIntrinsicHeight(constraints.maxWidth);
-    assert(() {
-      if (!height.isFinite) {
-        RenderBox.reportInfiniteIntrinsic(
-          'RenderIntrinsicHeight',
-          child,
-          'height',
-          'getMaxIntrinsicHeight',
-        );
-      }
-      return true;
-    }());
+    final double height = _debugGetChildMaxIntrinsicHeight(
+      objectRuntimeType(this, 'RenderIntrinsicHeight'),
+      child,
+      constraints.maxWidth,
+    );
     return constraints.tighten(height: height);
   }
 

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -682,17 +682,12 @@ class RenderIntrinsicWidth extends RenderProxyBox {
     final double width = child!.getMaxIntrinsicWidth(height);
     assert(() {
       if (!width.isFinite) {
-        throw FlutterError.fromParts(<DiagnosticsNode>[
-          ErrorSummary('The child of a RenderIntrinsicWidth returned an infinite intrinsic width.'),
-          ErrorDescription(
-            'The ${child!.runtimeType} class returned an infinite value for getMaxIntrinsicWidth, '
-            'which is a violation of the intrinsic layout protocol.',
-          ),
-          ErrorHint(
-            'If you are not writing your own RenderBox subclass, then this is not\n'
-            'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
-          ),
-        ]);
+        RenderBox.debugReportInfiniteIntrinsic(
+          'RenderIntrinsicWidth',
+          child!,
+          'width',
+          'getMaxIntrinsicWidth',
+        );
       }
       return true;
     }());
@@ -711,17 +706,12 @@ class RenderIntrinsicWidth extends RenderProxyBox {
     final double height = child!.getMinIntrinsicHeight(width);
     assert(() {
       if (!height.isFinite) {
-        throw FlutterError.fromParts(<DiagnosticsNode>[
-          ErrorSummary('The child of a RenderIntrinsicWidth returned an infinite intrinsic height.'),
-          ErrorDescription(
-            'The ${child!.runtimeType} class returned an infinite value for getMinIntrinsicHeight, '
-            'which is a violation of the intrinsic layout protocol.',
-          ),
-          ErrorHint(
-            'If you are not writing your own RenderBox subclass, then this is not\n'
-            'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
-          ),
-        ]);
+        RenderBox.debugReportInfiniteIntrinsic(
+          'RenderIntrinsicWidth',
+          child!,
+          'height',
+          'getMinIntrinsicHeight',
+        );
       }
       return true;
     }());
@@ -740,17 +730,12 @@ class RenderIntrinsicWidth extends RenderProxyBox {
     final double height = child!.getMaxIntrinsicHeight(width);
     assert(() {
       if (!height.isFinite) {
-        throw FlutterError.fromParts(<DiagnosticsNode>[
-          ErrorSummary('The child of a RenderIntrinsicWidth returned an infinite intrinsic height.'),
-          ErrorDescription(
-            'The ${child!.runtimeType} class returned an infinite value for getMaxIntrinsicHeight, '
-            'which is a violation of the intrinsic layout protocol.',
-          ),
-          ErrorHint(
-            'If you are not writing your own RenderBox subclass, then this is not\n'
-            'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
-          ),
-        ]);
+        RenderBox.debugReportInfiniteIntrinsic(
+          'RenderIntrinsicWidth',
+          child!,
+          'height',
+          'getMaxIntrinsicHeight',
+        );
       }
       return true;
     }());
@@ -763,17 +748,12 @@ class RenderIntrinsicWidth extends RenderProxyBox {
       width = child.getMaxIntrinsicWidth(constraints.maxHeight);
       assert(() {
         if (!width!.isFinite) {
-          throw FlutterError.fromParts(<DiagnosticsNode>[
-            ErrorSummary('The child of a RenderIntrinsicWidth returned an infinite intrinsic width.'),
-            ErrorDescription(
-              'The ${child.runtimeType} class returned an infinite value for getMaxIntrinsicWidth, '
-              'which is a violation of the intrinsic layout protocol.',
-            ),
-            ErrorHint(
-              'If you are not writing your own RenderBox subclass, then this is not\n'
-              'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
-            ),
-          ]);
+          RenderBox.debugReportInfiniteIntrinsic(
+            'RenderIntrinsicWidth',
+            child,
+            'width',
+            'getMaxIntrinsicWidth',
+          );
         }
         return true;
       }());
@@ -784,17 +764,12 @@ class RenderIntrinsicWidth extends RenderProxyBox {
       height = child.getMaxIntrinsicHeight(constraints.maxWidth);
       assert(() {
         if (!height!.isFinite) {
-          throw FlutterError.fromParts(<DiagnosticsNode>[
-            ErrorSummary('The child of a RenderIntrinsicWidth returned an infinite intrinsic height.'),
-            ErrorDescription(
-              'The ${child.runtimeType} class returned an infinite value for getMaxIntrinsicHeight, '
-              'which is a violation of the intrinsic layout protocol.',
-            ),
-            ErrorHint(
-              'If you are not writing your own RenderBox subclass, then this is not\n'
-              'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
-            ),
-          ]);
+          RenderBox.debugReportInfiniteIntrinsic(
+            'RenderIntrinsicWidth',
+            child,
+            'height',
+            'getMaxIntrinsicHeight',
+          );
         }
         return true;
       }());
@@ -876,17 +851,12 @@ class RenderIntrinsicHeight extends RenderProxyBox {
       height = child!.getMaxIntrinsicHeight(double.infinity);
       assert(() {
         if (!height.isFinite) {
-          throw FlutterError.fromParts(<DiagnosticsNode>[
-            ErrorSummary('The child of a RenderIntrinsicHeight returned an infinite intrinsic height.'),
-            ErrorDescription(
-              'The ${child!.runtimeType} class returned an infinite value for getMaxIntrinsicHeight, '
-              'which is a violation of the intrinsic layout protocol.',
-            ),
-            ErrorHint(
-              'If you are not writing your own RenderBox subclass, then this is not\n'
-              'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
-            ),
-          ]);
+          RenderBox.debugReportInfiniteIntrinsic(
+            'RenderIntrinsicHeight',
+            child!,
+            'height',
+            'getMaxIntrinsicHeight',
+          );
         }
         return true;
       }());
@@ -903,17 +873,12 @@ class RenderIntrinsicHeight extends RenderProxyBox {
       height = child!.getMaxIntrinsicHeight(double.infinity);
       assert(() {
         if (!height.isFinite) {
-          throw FlutterError.fromParts(<DiagnosticsNode>[
-            ErrorSummary('The child of a RenderIntrinsicHeight returned an infinite intrinsic height.'),
-            ErrorDescription(
-              'The ${child!.runtimeType} class returned an infinite value for getMaxIntrinsicHeight, '
-              'which is a violation of the intrinsic layout protocol.',
-            ),
-            ErrorHint(
-              'If you are not writing your own RenderBox subclass, then this is not\n'
-              'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
-            ),
-          ]);
+          RenderBox.debugReportInfiniteIntrinsic(
+            'RenderIntrinsicHeight',
+            child!,
+            'height',
+            'getMaxIntrinsicHeight',
+          );
         }
         return true;
       }());
@@ -933,17 +898,12 @@ class RenderIntrinsicHeight extends RenderProxyBox {
     final double height = child.getMaxIntrinsicHeight(constraints.maxWidth);
     assert(() {
       if (!height.isFinite) {
-        throw FlutterError.fromParts(<DiagnosticsNode>[
-          ErrorSummary('The child of a RenderIntrinsicHeight returned an infinite intrinsic height.'),
-          ErrorDescription(
-            'The ${child.runtimeType} class returned an infinite value for getMaxIntrinsicHeight, '
-            'which is a violation of the intrinsic layout protocol.',
-          ),
-          ErrorHint(
-            'If you are not writing your own RenderBox subclass, then this is not\n'
-            'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=02_bug.yml',
-          ),
-        ]);
+        RenderBox.debugReportInfiniteIntrinsic(
+          'RenderIntrinsicHeight',
+          child,
+          'height',
+          'getMaxIntrinsicHeight',
+        );
       }
       return true;
     }());

--- a/packages/flutter/test/rendering/box_test.dart
+++ b/packages/flutter/test/rendering/box_test.dart
@@ -721,6 +721,34 @@ void main() {
     }
   });
 
+  test('RenderBox.debugCheckingIntrinsics error messages', () {
+    final testBox = _ThrowingRenderBox();
+    const viewport = BoxConstraints(maxHeight: 100.0, maxWidth: 100.0);
+
+    late FlutterError error;
+    final FlutterExceptionHandler? oldHandler = FlutterError.onError;
+    FlutterError.onError = (FlutterErrorDetails details) {
+      error = details.exception as FlutterError;
+    };
+    try {
+      layout(testBox, constraints: viewport);
+    } finally {
+      FlutterError.onError = oldHandler;
+    }
+
+    expect(error, isNotNull);
+    final String errorMessage = error.toStringDeep();
+    expect(errorMessage, contains('getMinIntrinsicWidth'));
+    expect(errorMessage, contains('RenderPositionedBox'));
+    expect(errorMessage, contains('threw an exception during verification.'));
+    expect(errorMessage, contains('following exception was raised:'));
+    expect(errorMessage, contains('Exception: In computeMinIntrinsicWidth'));
+    expect(errorMessage, contains('RenderObject.debugCheckingIntrinsics'));
+    expect(errorMessage, contains('true.'));
+    expect(errorMessage, contains('consistent'));
+    expect(errorMessage, contains('fault'));
+  });
+
   test('UnconstrainedBox.toStringDeep returns useful information', () {
     final unconstrained = RenderConstraintsTransformBox(
       constraintsTransform: ConstraintsTransformBox.unconstrained,
@@ -1373,4 +1401,16 @@ class _DummyHitTestTarget implements HitTestTarget {
 
 class MyHitTestResult extends HitTestResult {
   void publicPushTransform(Matrix4 transform) => pushTransform(transform);
+}
+
+class _ThrowingRenderBox extends RenderBox {
+  @override
+  double computeMinIntrinsicWidth(double height) {
+    throw Exception('In computeMinIntrinsicWidth');
+  }
+
+  @override
+  void performLayout() {
+    size = constraints.biggest;
+  }
 }

--- a/packages/flutter/test/rendering/box_test.dart
+++ b/packages/flutter/test/rendering/box_test.dart
@@ -746,7 +746,7 @@ void main() {
     expect(errorMessage, contains('RenderObject.debugCheckingIntrinsics'));
     expect(errorMessage, contains('true.'));
     expect(errorMessage, contains('consistent'));
-    expect(errorMessage, contains('fault'));
+    expect(errorMessage, contains('framework'));
   });
 
   test('UnconstrainedBox.toStringDeep returns useful information', () {

--- a/packages/flutter/test/rendering/box_test.dart
+++ b/packages/flutter/test/rendering/box_test.dart
@@ -746,7 +746,7 @@ void main() {
     expect(errorMessage, contains('RenderObject.debugCheckingIntrinsics'));
     expect(errorMessage, contains('true.'));
     expect(errorMessage, contains('consistent'));
-    expect(errorMessage, contains('framework'));
+    expect(errorMessage, contains('fault'));
   });
 
   test('UnconstrainedBox.toStringDeep returns useful information', () {

--- a/packages/flutter/test/rendering/intrinsic_width_test.dart
+++ b/packages/flutter/test/rendering/intrinsic_width_test.dart
@@ -609,7 +609,7 @@ void main() {
   test('RenderIntrinsicHeight - infinite intrinsic height child', () {
     final RenderBox child = _RenderInfiniteIntrinsic(maxHeight: double.infinity);
     final RenderBox parent = RenderIntrinsicHeight(child: child);
-    
+
     final errors = <FlutterErrorDetails>[];
     layout(
       parent,
@@ -634,7 +634,7 @@ void main() {
   test('RenderIntrinsicWidth - infinite intrinsic width child', () {
     final RenderBox child = _RenderInfiniteIntrinsic(maxWidth: double.infinity);
     final RenderBox parent = RenderIntrinsicWidth(child: child);
-    
+
     final errors = <FlutterErrorDetails>[];
     layout(
       parent,
@@ -658,10 +658,7 @@ void main() {
 }
 
 class _RenderInfiniteIntrinsic extends RenderBox {
-  _RenderInfiniteIntrinsic({
-    this.maxWidth = 0.0,
-    this.maxHeight = 0.0,
-  });
+  _RenderInfiniteIntrinsic({this.maxWidth = 0.0, this.maxHeight = 0.0});
 
   final double maxWidth;
   final double maxHeight;

--- a/packages/flutter/test/rendering/intrinsic_width_test.dart
+++ b/packages/flutter/test/rendering/intrinsic_width_test.dart
@@ -605,4 +605,78 @@ void main() {
       ),
     );
   });
+
+  test('RenderIntrinsicHeight - infinite intrinsic height child', () {
+    final RenderBox child = _RenderInfiniteIntrinsic(maxHeight: double.infinity);
+    final RenderBox parent = RenderIntrinsicHeight(child: child);
+    
+    final errors = <FlutterErrorDetails>[];
+    layout(
+      parent,
+      constraints: const BoxConstraints(maxWidth: 800.0, maxHeight: 600.0),
+      onErrors: () {
+        errors.addAll(TestRenderingFlutterBinding.instance.takeAllFlutterErrorDetails());
+      },
+    );
+
+    expect(errors, isNotEmpty);
+    final error = errors.first.exception as FlutterError;
+    final String message = error.toStringDeep();
+    expect(message, contains('RenderIntrinsicHeight'));
+    expect(message, contains('infinite'));
+    expect(message, contains('intrinsic'));
+    expect(message, contains('height'));
+    expect(message, contains('_RenderInfiniteIntrinsic'));
+    expect(message, contains('getMaxIntrinsicHeight'));
+    expect(message, contains('violation'));
+  });
+
+  test('RenderIntrinsicWidth - infinite intrinsic width child', () {
+    final RenderBox child = _RenderInfiniteIntrinsic(maxWidth: double.infinity);
+    final RenderBox parent = RenderIntrinsicWidth(child: child);
+    
+    final errors = <FlutterErrorDetails>[];
+    layout(
+      parent,
+      constraints: const BoxConstraints(maxWidth: 800.0, maxHeight: 600.0),
+      onErrors: () {
+        errors.addAll(TestRenderingFlutterBinding.instance.takeAllFlutterErrorDetails());
+      },
+    );
+
+    expect(errors, isNotEmpty);
+    final error = errors.first.exception as FlutterError;
+    final String message = error.toStringDeep();
+    expect(message, contains('RenderIntrinsicWidth'));
+    expect(message, contains('infinite'));
+    expect(message, contains('intrinsic'));
+    expect(message, contains('width'));
+    expect(message, contains('_RenderInfiniteIntrinsic'));
+    expect(message, contains('getMaxIntrinsicWidth'));
+    expect(message, contains('violation'));
+  });
+}
+
+class _RenderInfiniteIntrinsic extends RenderBox {
+  _RenderInfiniteIntrinsic({
+    this.maxWidth = 0.0,
+    this.maxHeight = 0.0,
+  });
+
+  final double maxWidth;
+  final double maxHeight;
+
+  @override
+  double computeMinIntrinsicWidth(double height) => 0.0;
+  @override
+  double computeMaxIntrinsicWidth(double height) => maxWidth;
+  @override
+  double computeMinIntrinsicHeight(double width) => 0.0;
+  @override
+  double computeMaxIntrinsicHeight(double width) => maxHeight;
+
+  @override
+  void performLayout() {
+    size = constraints.biggest;
+  }
 }


### PR DESCRIPTION
This PR improves the developer experience when debugging RenderBox intrinsic and dry layout issues by providing more descriptive and robust error messages, while also simplifying the framework's internal error-reporting logic.

Fixes #3304
Fixes #4175 

- Consolidated Error Reporting: Introduced two new helper methods in RenderBox to handle reporting failures during debug consistency checks. This eliminates redundant code and ensures a consistent error message structure across the framework:
  - _reportIntrinsicException: Handles exceptions caught during debug verification.
  - reportInfiniteIntrinsic: Handles violations of the intrinsic protocol where a child returns an infinite dimension.
- Caught Exceptions in Debug Mode (Fixes #3304): Wrapped intrinsic dimension, dry layout, and dry baseline verification calls in try-catch blocks. When an exception occurs during these debug-only checks, the framework now throws a structured FlutterError that identifies the failing method and provides original exception details and a stack trace.
- Infinite Intrinsic Dimension Handling (Fixes #4175): Replaced generic assertion failures with descriptive FlutterError messages when a child of RenderIntrinsicHeight or RenderIntrinsicWidth returns an infinite intrinsic dimension (a violation of the intrinsic protocol).

Note: I had original put up a fix for #3304 in https://github.com/flutter/flutter/pull/185165, but then realized working on #4175 they had some overlap, and fixing through a unified solution was cleaner.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
