### PR TITLE
[iOS] Improve LaunchEngine implementation/API/docs

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -254,7 +254,7 @@ static NSString* const kBackgroundFetchCapatibility = @"fetch";
   if (flutterRootViewController) {
     return [[flutterRootViewController pluginRegistry] registrarForPlugin:pluginKey];
   }
-  return [self.launchEngine.engine registrarForPlugin:pluginKey];
+  return [[self.launchEngine acquireEngine] registrarForPlugin:pluginKey];
 }
 
 - (BOOL)hasPlugin:(NSString*)pluginKey {
@@ -262,7 +262,7 @@ static NSString* const kBackgroundFetchCapatibility = @"fetch";
   if (flutterRootViewController) {
     return [[flutterRootViewController pluginRegistry] hasPlugin:pluginKey];
   }
-  return [self.launchEngine.engine hasPlugin:pluginKey];
+  return [[self.launchEngine acquireEngine] hasPlugin:pluginKey];
 }
 
 - (NSObject*)valuePublishedByPlugin:(NSString*)pluginKey {
@@ -270,7 +270,7 @@ static NSString* const kBackgroundFetchCapatibility = @"fetch";
   if (flutterRootViewController) {
     return [[flutterRootViewController pluginRegistry] valuePublishedByPlugin:pluginKey];
   }
-  return [self.launchEngine.engine valuePublishedByPlugin:pluginKey];
+  return [[self.launchEngine acquireEngine] valuePublishedByPlugin:pluginKey];
 }
 
 #pragma mark - Selectors handling

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/LaunchEngine.swift
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/LaunchEngine.swift
@@ -4,42 +4,84 @@
 
 import Foundation
 
-/// A lazy container for an engine that will only dispense one engine.
+/// A lazy container for a FlutterEngine instance used during application startup.
 ///
-/// This is used to hold an engine for plugin registration when the GeneratedPluginRegistrant is
-/// called on a FlutterAppDelegate before the first FlutterViewController is set up. This is the
-/// typical flow after the UISceneDelegate migration.
+/// This class manages the lifecycle of a single FlutterEngine used primarily for plugin
+/// registration before a FlutterViewController is presented.
 ///
-/// The launch engine is intended to work only with first FlutterViewController instantiated with a
-/// NIB since that is the only FlutterEngine that registers plugins through the FlutterAppDelegate.
+/// Calling the `acquireEngine` method lazily creates and starts the engine. Ownership of the
+/// engine can be transferred to a consumer by calling `takeEngine()`. Once the engine has been
+/// taken, the container remains empty; subsequent calls to `acquireEngine` or `takeEngine` will
+/// return nil.
+///
+/// This class is an internal compatibility measure for applications using `FlutterAppDelegate`
+/// while migrating to `UISceneDelegate`. Apple introduced `UISceneDelegate` in iOS 13, moving UI
+/// setup (and thus `FlutterViewController` creation) out of
+/// `application:didFinishLaunching:withOptions:` and into the scene connection lifecycle.
+///
+/// Historically, Flutter plugins registered in
+/// `[UIApplicationDelegate application:didFinishLaunching:withOptions:]`. In a scene-based app, no
+/// FlutterViewController has yet been presented at that point and thus no engine would be available
+/// for registration. `LaunchEngine` bridges this gap by providing a lazy engine early, which the
+/// `FlutterViewController` adopts later.
+///
+/// For new application code, application developers should consider conforming to
+/// `FlutterImplicitEngineDelegate` and implementing `didInitializeImplicitFlutterEngine` instead of
+/// relying on `FlutterAppDelegate`'s automatic registration.
 @objc(FlutterLaunchEngine)
 public final class LaunchEngine: NSObject {
-  private var didTakeEngine = false
-  private var _engine: FlutterEngine?
 
-  /// Accessor for the launch engine.
+  /// The lifecycle state of the contained engine.
+  private enum State {
+    /// The initial state where the engine has not been instantiated yet.
+    case uninitialized
+
+    /// The engine has been instantiated by calling `acquireEngine` and is cached.
+    case created(FlutterEngine)
+
+    /// The engine has been transferred to a consumer via `takeEngine`, leaving the container empty.
+    case taken
+  }
+
+  private var state = State.uninitialized
+
+  /// Acquires the cached engine.
   ///
-  /// Getting this may allocate an engine.
-  @objc public var engine: FlutterEngine? {
-    guard !didTakeEngine, _engine == nil else { return _engine }
+  /// In cases where `takeEngine` has not yet been called, this will lazily allocate and return an
+  /// engine.
+  @objc public func acquireEngine() -> FlutterEngine? {
+    switch state {
+    case .uninitialized:
+      let newEngine = FlutterEngine(
+        name: "io.flutter",
+        project: FlutterDartProject(),
+        allowHeadlessExecution: true,
+        restorationEnabled: true
+      )
+      newEngine.run()
+      state = .created(newEngine)
+      return newEngine
 
-    _engine = FlutterEngine(
-      name: "io.flutter",
-      project: FlutterDartProject(),
-      allowHeadlessExecution: true,
-      restorationEnabled: true
-    )
-    _engine?.run()
-    return _engine
+    case .created(let existingEngine):
+      return existingEngine
+
+    case .taken:
+      return nil
+    }
   }
 
   /// Take ownership of the launch engine.
   ///
-  /// After this is called `self.engine` and `takeEngine` will always return nil.
+  /// After this is called `acquireEngine` and `takeEngine` will always return nil.
   @objc public func takeEngine() -> FlutterEngine? {
-    let result = _engine
-    _engine = nil
-    didTakeEngine = true
+    let result: FlutterEngine?
+    switch state {
+    case .created(let engine):
+      result = engine
+    case .uninitialized, .taken:
+      result = nil
+    }
+    state = .taken
     return result
   }
 }

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/LaunchEngine.swift
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/LaunchEngine.swift
@@ -4,10 +4,10 @@
 
 import Foundation
 
-/// A lazy container for a FlutterEngine instance used during application startup.
+/// A lazy container for a `FlutterEngine` instance used during application startup.
 ///
 /// This class manages the lifecycle of a single FlutterEngine used primarily for plugin
-/// registration before a FlutterViewController is presented.
+/// registration before a `FlutterViewController` is presented.
 ///
 /// Calling the `acquireEngine` method lazily creates and starts the engine. Ownership of the
 /// engine can be transferred to a consumer by calling `takeEngine()`. Once the engine has been

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/LaunchEngineTest.swift
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/LaunchEngineTest.swift
@@ -13,19 +13,19 @@ class LaunchEngineTest: XCTestCase {
     let launchEngine = LaunchEngine()
 
     // The engine should be created on first access.
-    let firstAccessEngine = launchEngine.engine
+    let firstAccessEngine = launchEngine.acquireEngine()
     XCTAssertNotNil(firstAccessEngine)
 
     // Subsequent accesses should return the same cached instance.
     XCTAssertTrue(
-      launchEngine.engine === firstAccessEngine, "Should return the cached engine instance.")
+      launchEngine.acquireEngine() === firstAccessEngine, "Should return the cached engine instance.")
 
     // The taken engine should be the same instance that was created.
     let takenEngine = launchEngine.takeEngine()
     XCTAssertTrue(takenEngine === firstAccessEngine, "Should return the original engine instance.")
 
     // The container should be empty after the engine is taken.
-    XCTAssertNil(launchEngine.engine, "Engine should be nil after being taken.")
+    XCTAssertNil(launchEngine.acquireEngine(), "Engine should be nil after being taken.")
     XCTAssertNil(launchEngine.takeEngine(), "Subsequent takes should return nil.")
   }
 
@@ -39,6 +39,6 @@ class LaunchEngineTest: XCTestCase {
     XCTAssertNil(takenEngine, "Taking before access should return nil.")
 
     // Accessing the engine after it was taken should return nil without allocating a new one.
-    XCTAssertNil(launchEngine.engine, "Accessing engine after take should return nil.")
+    XCTAssertNil(launchEngine.acquireEngine(), "Accessing engine after take should return nil.")
   }
 }


### PR DESCRIPTION
Refactors the internal state management of `LaunchEngine` to more idiomatic Swift, makes the possible states clear, and makes invalid states impossible: e.g. `didTakeEngine == true` but `_engine != nil`.

LaunchEngine has three valid states:
1. `.uninitialized`: Initial state. The engine has not yet been created.
2. `.created`: The engine has been created and is cached for future access.
3. `.taken`: The engine has been transferred to a consumer, and the container is now empty.

This also refactors the `engine` computed property into an `acquireEngine()` method. In Swift and Objective-C, properties should generally be idempotent and avoid side effects. Since the engine property triggers the lazy instantiation and execution of a `FlutterEngine` (a pretty heavy operation), exposing it as a method better communicates the potential cost / side effects.

Also adds a bit more context to the docs that this class is an internal compatibility measure introduced as part of `UISceneDelegate` migration to avoid breaking the old AppDelegate-based plugin registration API.

I'll send a followup that tags this `@MainActor` but that should probably be its own patch.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I did not list at least one issue that this PR fixes in the description above, cause mostly it just improves the existing code, or at least in my mind it does.
- [X] I added at least one checkbox that wasn't supposed to be here.
- [X] Ceci n'est pas un checklist item.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
