### PR TITLE
Remove unnecessary Material import from editable_text_scribe_test

### DIFF
--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -113,7 +113,6 @@ class TestsCrossImportChecker {
     'packages/flutter/test/widgets/editable_text_scribble_test.dart',
     'packages/flutter/test/widgets/range_maintaining_scroll_physics_test.dart',
     'packages/flutter/test/widgets/selectable_region_test.dart',
-    'packages/flutter/test/widgets/editable_text_scribe_test.dart',
     'packages/flutter/test/widgets/semantics_debugger_test.dart',
     'packages/flutter/test/widgets/page_route_builder_test.dart',
     'packages/flutter/test/widgets/two_dimensional_scroll_view_test.dart',

--- a/packages/flutter/test/widgets/editable_text_scribe_test.dart
+++ b/packages/flutter/test/widgets/editable_text_scribe_test.dart
@@ -5,9 +5,11 @@
 import 'dart:ui' show PointerDeviceKind;
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'widgets_app_tester.dart';
 
 void main() {
   final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized();
@@ -58,17 +60,17 @@ void main() {
     final provider = TextSelectionGestureDetectorBuilder(delegate: delegate);
 
     await tester.pumpWidget(
-      MaterialApp(
+      TestWidgetsApp(
         home: provider.buildGestureDetector(
           behavior: HitTestBehavior.translucent,
           child: EditableText(
             key: editableTextKey,
             controller: controller,
-            backgroundCursorColor: Colors.grey,
+            backgroundCursorColor: const Color(0xFF9E9E9E),
             focusNode: focusNode,
             style: textStyle,
             cursorColor: cursorColor,
-            selectionControls: materialTextSelectionControls,
+            selectionControls: emptyTextSelectionControls,
             showSelectionHandles: true,
           ),
         ),


### PR DESCRIPTION
`packages/flutter/test/widgets/editable_text_scribe_test.dart` lives in the Widgets layer of the test tree but was importing `package:flutter/material.dart`. The import was only needed for a `MaterialApp` wrapper, `Colors.grey`, and
`materialTextSelectionControls` — none of which are required for what this test actually exercises (the `Scribe` system channel + `EditableText`).

Changes:
- Replace `MaterialApp` with `TestWidgetsApp` (already available next door in `widgets_app_tester.dart`).
- Replace `Colors.grey` with `const Color(0xFF9E9E9E)` (same value).
- Replace `materialTextSelectionControls` with `emptyTextSelectionControls`.
- Drop the `package:flutter/material.dart` import.

## Related Issues

Part of https://github.com/flutter/flutter/issues/177028
Related: https://github.com/flutter/flutter/issues/177412

## Tests

- No behavior change; existing tests in the file continue to exercise the
  same assertions. Verified locally with
  `flutter test packages/flutter/test/widgets/editable_text_scribe_test.dart`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.