### PR TITLE
Fix: --no-hot flag should trigger hot restart instead of being ignored

### DIFF
--- a/engine/src/flutter/runtime/platform_isolate_manager.cc
+++ b/engine/src/flutter/runtime/platform_isolate_manager.cc
@@ -22,7 +22,7 @@ bool PlatformIsolateManager::HasShutdownMaybeFalseNegative() {
 bool PlatformIsolateManager::RegisterPlatformIsolate(Dart_Isolate isolate) {
   std::scoped_lock lock(lock_);
   if (is_shutdown_) {
-    // It's possible shutdown occured while we were trying to aquire the lock.
+    // It's possible shutdown occurred while we were trying to acquire the lock.
     return false;
   }
   FML_DCHECK(platform_isolates_.find(isolate) == platform_isolates_.end());

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -704,6 +704,7 @@ class AppDomain extends Domain {
         target: target,
         debuggingOptions: options,
         stayResident: true,
+        hotMode: enableHotReload,
         urlTunneller: options.webEnableExposeUrl! ? daemon.daemonDomain.exposeUrl : null,
         machine: machine,
         analytics: globals.analytics,

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -788,6 +788,7 @@ class RunCommand extends RunCommandBase {
         flutterProject: flutterProject,
         debuggingOptions: debuggingOptions,
         stayResident: stayResident,
+        hotMode: hotMode,
         fileSystem: globals.fs,
         analytics: globals.analytics,
         logger: globals.logger,

--- a/packages/flutter_tools/lib/src/drive/web_driver_service.dart
+++ b/packages/flutter_tools/lib/src/drive/web_driver_service.dart
@@ -97,6 +97,7 @@ class WebDriverService extends DriverService {
               webUseWasm: debuggingOptions.webUseWasm,
             ),
       stayResident: true,
+      hotMode: !buildInfo.isRelease,
       flutterProject: FlutterProject.current(),
       fileSystem: globals.fs,
       analytics: globals.analytics,

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -53,6 +53,7 @@ class DwdsWebRunnerFactory extends WebRunnerFactory {
     FlutterDevice device, {
     String? target,
     required bool stayResident,
+    required bool hotMode,
     required FlutterProject flutterProject,
     required DebuggingOptions debuggingOptions,
     UrlTunneller? urlTunneller,
@@ -72,6 +73,7 @@ class DwdsWebRunnerFactory extends WebRunnerFactory {
       flutterProject: flutterProject,
       debuggingOptions: debuggingOptions,
       stayResident: stayResident,
+      hotMode: hotMode,
       urlTunneller: urlTunneller,
       machine: machine,
       analytics: analytics,
@@ -100,6 +102,7 @@ class ResidentWebRunner extends ResidentRunner {
     super.stayResident = true,
     super.machine = false,
     super.projectRootPath,
+    super.hotMode = true,
     required this.flutterProject,
     required super.debuggingOptions,
     required FileSystem fileSystem,
@@ -121,6 +124,7 @@ class ResidentWebRunner extends ResidentRunner {
        super(
          <FlutterDevice>[device],
          target: target ?? fileSystem.path.join('lib', 'main.dart'),
+         hotMode: hotMode,
          commandHelp: CommandHelp(
            logger: logger,
            terminal: terminal,

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1730,7 +1730,19 @@ class TerminalHandler {
         return true;
       case 'r':
         if (!residentRunner.canHotReload) {
-          return false;
+          // If hot reload is disabled (e.g., --no-hot flag), still allow
+          // hot restart via 'r' key since that's the expected behavior.
+          if (!residentRunner.supportsRestart) {
+            return false;
+          }
+          final OperationResult result = await residentRunner.restart(fullRestart: true);
+          if (result.fatal) {
+            throwToolExit(result.message);
+          }
+          if (!result.isOk) {
+            _logger.printStatus('Try again after fixing the above error(s).', emphasis: true);
+          }
+          return true;
         }
         final OperationResult result = await residentRunner.restart();
         if (result.fatal) {

--- a/packages/flutter_tools/lib/src/web/web_runner.dart
+++ b/packages/flutter_tools/lib/src/web/web_runner.dart
@@ -26,6 +26,7 @@ abstract class WebRunnerFactory {
     FlutterDevice device, {
     String? target,
     required bool stayResident,
+    required bool hotMode,
     required FlutterProject flutterProject,
     required DebuggingOptions debuggingOptions,
     UrlTunneller? urlTunneller,


### PR DESCRIPTION
Good day,

This PR fixes issue #179448 - the `--no-hot` flag on web-server is not working as expected.

When `--no-hot` is passed, pressing 'r' should perform a hot restart (full reload), not attempt a hot reload which doesn\'t work in that mode.

**Changes:**
- Pass hotMode through WebRunnerFactory to ResidentWebRunner
- Terminal handler allows restart via 'r' when canHotReload=false but supportsRestart=true
- Update all createWebRunner call sites to pass hotMode

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof