### PR TITLE
[macOS] Implement size to content regular and dialog windows.

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterView.h
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterView.h
@@ -93,7 +93,7 @@
 @property(readonly, nonatomic, nonnull) FlutterSurfaceManager* surfaceManager;
 
 /**
- * Optional content delegate. If set, the view will inform the delegate about content change;
+ * Optional content delegate. If set, the view will inform the delegate about content change.
  */
 @property(readwrite, nonatomic, weak, nullable) id<FlutterViewContentDelegate> contentDelegate;
 

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterView.h
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterView.h
@@ -15,6 +15,16 @@
 
 @class FlutterView;
 
+@protocol FlutterViewContentDelegate <NSObject>
+
+/**
+ * Called when the view's size changes. The container should update its
+ * layout to accommodate the new size.
+ */
+- (void)viewDidUpdateContents:(nonnull FlutterView*)view withSize:(NSSize)newSize;
+
+@end
+
 /**
  * Interface that facilitates process of sizing the FlutterView to its
  * content. It is used to determine the content constraints and to notify
@@ -36,12 +46,6 @@
  * For views that are not sized to content, this method should return std::nullopt.
  */
 - (std::optional<NSSize>)maximumViewSize:(nonnull FlutterView*)view;
-
-/**
- * Called when the view's size changes. The container should update its
- * layout to accommodate the new size.
- */
-- (void)viewDidUpdateContents:(nonnull FlutterView*)view withSize:(NSSize)newSize;
 
 @end
 
@@ -87,6 +91,11 @@
  * providing and presenting render surfaces.
  */
 @property(readonly, nonatomic, nonnull) FlutterSurfaceManager* surfaceManager;
+
+/**
+ * Optional content delegate. If set, the view will inform the delegate about content change;
+ */
+@property(readwrite, nonatomic, weak, nullable) id<FlutterViewContentDelegate> contentDelegate;
 
 /**
  * Optional sizing delegate. If set, the view can be sized to its content.

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterView.h
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterView.h
@@ -18,8 +18,8 @@
 @protocol FlutterViewContentDelegate <NSObject>
 
 /**
- * Called when the view's size changes. The container should update its
- * layout to accommodate the new size.
+ * Called when the view's content changes. If the size changed the container
+ * should update its layout to accommodate new size.
  */
 - (void)viewDidUpdateContents:(nonnull FlutterView*)view withSize:(NSSize)newSize;
 

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterView.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterView.mm
@@ -49,7 +49,7 @@
   // update.
   auto notifyBlock = ^{
     NSSize scaledSize = [self convertSizeFromBacking:frameSize];
-    [self.sizingDelegate viewDidUpdateContents:self withSize:scaledSize];
+    [self.contentDelegate viewDidUpdateContents:self withSize:scaledSize];
     block();
   };
   [_resizeSynchronizer performCommitForSize:frameSize afterDelay:delay notify:notifyBlock];

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowController.h
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowController.h
@@ -76,6 +76,7 @@ struct FlutterWindowCreationRequest {
   struct FlutterWindowSize size;
   bool has_constraints;
   struct FlutterWindowConstraints constraints;
+  bool resizable;
   int64_t parent_view_id;
   void (*on_should_close)();
   void (*on_will_close)();

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowController.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowController.mm
@@ -201,9 +201,9 @@ static void FlipRect(NSRect& rect, const NSRect& globalScreenFrame) {
   // There is no positioner associated with this window.
   if (_creationRequest.on_get_window_position == nullptr) {
     bool firstFrame = self.onFirstFrame != nil;
-    // Either missing initiali size or always sized to content, resize the window
+    // Either missing initial size or always sized to content, resize the window
     // based on content size.
-    if ((firstFrame && _creationRequest.has_size) || !_creationRequest.resizable) {
+    if ((firstFrame && !_creationRequest.has_size) || !_creationRequest.resizable) {
       [view.window setContentSize:newSize];
     }
     if (_creationRequest.resizable) {

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowController.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowController.mm
@@ -13,7 +13,8 @@
 #include "flutter/shell/platform/common/isolate_scope.h"
 
 // A delegate for a Flutter managed window.
-@interface FlutterWindowOwner : NSObject <NSWindowDelegate, FlutterViewSizingDelegate> {
+@interface FlutterWindowOwner
+    : NSObject <NSWindowDelegate, FlutterViewContentDelegate, FlutterViewSizingDelegate> {
   // Strong reference to the window. This is the only strong reference to the
   // window.
   NSWindow* _window;
@@ -28,6 +29,7 @@
 @property(readonly, nonatomic) NSWindow* window;
 @property(readonly, nonatomic) FlutterViewController* flutterViewController;
 @property(readwrite, nonatomic) BOOL closeWhenParentResignsKey;
+@property(readwrite, nonatomic) dispatch_block_t onFirstFrame;
 
 - (instancetype)initWithWindow:(NSWindow*)window
          flutterViewController:(FlutterViewController*)viewController
@@ -196,41 +198,56 @@ static void FlipRect(NSRect& rect, const NSRect& globalScreenFrame) {
 }
 
 - (void)viewDidUpdateContents:(FlutterView*)view withSize:(NSSize)newSize {
+  // There is no positioner associated with this window.
   if (_creationRequest.on_get_window_position == nullptr) {
-    // There is no positioner associated with this window.
-    return;
-  }
-
-  NSRect globalScreenFrame = ComputeGlobalScreenFrame();
-
-  NSRect parentRect =
-      [self.window.parentWindow contentRectForFrameRect:self.window.parentWindow.frame];
-  FlipRect(parentRect, globalScreenFrame);
-
-  NSRect screenRect = [self.window.screen visibleFrame];
-  FlipRect(screenRect, globalScreenFrame);
-
-  flutter::IsolateScope isolate_scope(*_isolate);
-  auto position = _creationRequest.on_get_window_position(
-      FlutterWindowSize::fromNSSize(newSize), FlutterWindowRect::fromNSRect(parentRect),
-      FlutterWindowRect::fromNSRect(screenRect));
-
-  NSRect positionRect = position->toNSRect();
-  FlipRect(positionRect, globalScreenFrame);
-
-  [self.window setFrame:positionRect display:NO animate:NO];
-
-  free(position);
-
-  // For windows sized to contents if the positioner size doesn't match actual size
-  // the requested size needs to be passed through constraints.
-  if (view.sizedToContents &&
-      (positionRect.size.width < newSize.width || positionRect.size.height < newSize.height)) {
-    _positionerSizeConstraints = positionRect.size;
-    [view constraintsDidChange];
+    bool firstFrame = self.onFirstFrame != nil;
+    // Either missing initiali size or always sized to content, resize the window
+    // based on content size.
+    if ((firstFrame && _creationRequest.has_size) || !_creationRequest.resizable) {
+      [view.window setContentSize:newSize];
+    }
+    if (_creationRequest.resizable) {
+      view.sizingDelegate = nil;
+    }
+    if (firstFrame) {
+      self.onFirstFrame();
+      self.onFirstFrame = nil;
+    }
   } else {
-    // Only show the window initially if positioner agrees with the size.
-    self.window.alphaValue = 1.0;
+    NSRect globalScreenFrame = ComputeGlobalScreenFrame();
+
+    NSRect parentRect =
+        [self.window.parentWindow contentRectForFrameRect:self.window.parentWindow.frame];
+    FlipRect(parentRect, globalScreenFrame);
+
+    NSRect screenRect = [self.window.screen visibleFrame];
+    FlipRect(screenRect, globalScreenFrame);
+
+    flutter::IsolateScope isolate_scope(*_isolate);
+    auto position = _creationRequest.on_get_window_position(
+        FlutterWindowSize::fromNSSize(newSize), FlutterWindowRect::fromNSRect(parentRect),
+        FlutterWindowRect::fromNSRect(screenRect));
+
+    NSRect positionRect = position->toNSRect();
+    FlipRect(positionRect, globalScreenFrame);
+
+    [self.window setFrame:positionRect display:NO animate:NO];
+
+    free(position);
+
+    // For windows sized to contents if the positioner size doesn't match actual size
+    // the requested size needs to be passed through constraints.
+    if (view.sizedToContents &&
+        (positionRect.size.width < newSize.width || positionRect.size.height < newSize.height)) {
+      _positionerSizeConstraints = positionRect.size;
+      [view constraintsDidChange];
+    } else {
+      // Only show the window initially if positioner agrees with the size.
+      if (self.onFirstFrame) {
+        self.onFirstFrame();
+        self.onFirstFrame = nil;
+      }
+    }
   }
 }
 
@@ -332,13 +349,16 @@ static void FlipRect(NSRect& rect, const NSRect& globalScreenFrame) {
   [window setReleasedWhenClosed:NO];
 
   window.contentViewController = controller;
-  window.styleMask =
-      NSWindowStyleMaskResizable | NSWindowStyleMaskTitled | NSWindowStyleMaskClosable;
+  window.styleMask = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable;
+  if (request->resizable) {
+    window.styleMask |= NSWindowStyleMaskResizable;
+  }
+
   window.collectionBehavior = NSWindowCollectionBehaviorFullScreenAuxiliary;
   if (request->has_size) {
     [window flutterSetContentSize:request->size];
   }
-  if (request->has_constraints) {
+  if (request->resizable && request->has_constraints) {
     [window flutterSetConstraints:request->constraints];
   }
 
@@ -347,6 +367,12 @@ static void FlipRect(NSRect& rect, const NSRect& globalScreenFrame) {
                                                          creationRequest:*request];
   window.delegate = owner;
   [_windows addObject:owner];
+
+  if (!request->has_size) {
+    controller.flutterView.sizingDelegate = owner;
+    [controller.flutterView constraintsDidChange];
+  }
+  controller.flutterView.contentDelegate = owner;
 
   NSWindow* parent = nil;
 
@@ -362,20 +388,22 @@ static void FlipRect(NSRect& rect, const NSRect& globalScreenFrame) {
     }
   }
 
-  if (parent != nil) {
-    dispatch_async(dispatch_get_main_queue(), ^{
-      [self fixMoveRunLoopModeIfNeeded];
-      // beginCriticalSheet blocks with nested run loop until the
-      // sheet animation is finished.
-      [parent beginCriticalSheet:window
-               completionHandler:^(NSModalResponse response){
-               }];
-    });
+  owner.onFirstFrame = ^{
+    if (parent != nil) {
+      dispatch_async(dispatch_get_main_queue(), ^{
+        [self fixMoveRunLoopModeIfNeeded];
+        // beginCriticalSheet blocks with nested run loop until the
+        // sheet animation is finished.
+        [parent beginCriticalSheet:window
+                 completionHandler:^(NSModalResponse response){
+                 }];
+      });
 
-  } else {
-    [window setIsVisible:YES];
-    [window makeKeyAndOrderFront:nil];
-  }
+    } else {
+      [window setIsVisible:YES];
+      [window makeKeyAndOrderFront:nil];
+    }
+  };
 
   return controller.viewIdentifier;
 }
@@ -401,6 +429,7 @@ static void FlipRect(NSRect& rect, const NSRect& globalScreenFrame) {
                                                          creationRequest:*request];
 
   controller.flutterView.sizingDelegate = owner;
+  controller.flutterView.contentDelegate = owner;
   controller.flutterView.backgroundColor = [NSColor clearColor];
   // Resend configure event after setting the sizing delegate.
   [controller.flutterView constraintsDidChange];
@@ -425,6 +454,11 @@ static void FlipRect(NSRect& rect, const NSRect& globalScreenFrame) {
   window.collectionBehavior = NSWindowCollectionBehaviorAuxiliary;
   [parent addChildWindow:window ordered:NSWindowAbove];
   window.alphaValue = 0.0;
+
+  owner.onFirstFrame = ^{
+    window.alphaValue = 1.0;
+  };
+
   return controller.viewIdentifier;
 }
 
@@ -447,18 +481,19 @@ static void FlipRect(NSRect& rect, const NSRect& globalScreenFrame) {
   window.opaque = NO;
   window.backgroundColor = [NSColor clearColor];
 
-  FlutterWindowOwner* w = [[FlutterWindowOwner alloc] initWithWindow:window
-                                               flutterViewController:controller
-                                                     creationRequest:*request];
+  FlutterWindowOwner* owner = [[FlutterWindowOwner alloc] initWithWindow:window
+                                                   flutterViewController:controller
+                                                         creationRequest:*request];
 
-  controller.flutterView.sizingDelegate = w;
+  controller.flutterView.sizingDelegate = owner;
+  controller.flutterView.contentDelegate = owner;
   [controller.flutterView setBackgroundColor:[NSColor clearColor]];
   // Resend configure event after setting the sizing delegate.
   [controller.flutterView constraintsDidChange];
-  w.closeWhenParentResignsKey = NO;
+  owner.closeWhenParentResignsKey = NO;
 
-  window.delegate = w;
-  [_windows addObject:w];
+  window.delegate = owner;
+  [_windows addObject:owner];
 
   NSWindow* parent = nil;
 
@@ -475,6 +510,11 @@ static void FlipRect(NSRect& rect, const NSRect& globalScreenFrame) {
   window.collectionBehavior = NSWindowCollectionBehaviorAuxiliary;
   [parent addChildWindow:window ordered:NSWindowAbove];
   window.alphaValue = 0.0;
+
+  owner.onFirstFrame = ^{
+    window.alphaValue = 1.0;
+  };
+
   return controller.viewIdentifier;
 }
 
@@ -488,23 +528,39 @@ static void FlipRect(NSRect& rect, const NSRect& globalScreenFrame) {
   // using ARC.
   [window setReleasedWhenClosed:NO];
 
+  window.styleMask =
+      NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable;
+  if (request->resizable) {
+    window.styleMask |= NSWindowStyleMaskResizable;
+  }
+
   window.contentViewController = controller;
-  window.styleMask = NSWindowStyleMaskResizable | NSWindowStyleMaskTitled |
-                     NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable;
+
   if (request->has_size) {
     [window flutterSetContentSize:request->size];
   }
-  if (request->has_constraints) {
+  if (request->resizable && request->has_constraints) {
     [window flutterSetConstraints:request->constraints];
   }
-  [window setIsVisible:YES];
-  [window makeKeyAndOrderFront:nil];
 
   FlutterWindowOwner* owner = [[FlutterWindowOwner alloc] initWithWindow:window
                                                    flutterViewController:controller
                                                          creationRequest:*request];
+
+  controller.flutterView.contentDelegate = owner;
+
+  if (!request->has_size) {
+    controller.flutterView.sizingDelegate = owner;
+    [controller.flutterView constraintsDidChange];
+  }
+
   window.delegate = owner;
   [_windows addObject:owner];
+
+  owner.onFirstFrame = ^{
+    [window setIsVisible:YES];
+    [window makeKeyAndOrderFront:nil];
+  };
 
   return controller.viewIdentifier;
 }

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowController.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowController.mm
@@ -388,6 +388,7 @@ static void FlipRect(NSRect& rect, const NSRect& globalScreenFrame) {
     }
   }
 
+  FML_DCHECK(owner.onFirstFrame == nil);
   owner.onFirstFrame = ^{
     if (parent != nil) {
       dispatch_async(dispatch_get_main_queue(), ^{
@@ -455,6 +456,7 @@ static void FlipRect(NSRect& rect, const NSRect& globalScreenFrame) {
   [parent addChildWindow:window ordered:NSWindowAbove];
   window.alphaValue = 0.0;
 
+  FML_DCHECK(owner.onFirstFrame == nil);
   owner.onFirstFrame = ^{
     window.alphaValue = 1.0;
   };
@@ -511,6 +513,7 @@ static void FlipRect(NSRect& rect, const NSRect& globalScreenFrame) {
   [parent addChildWindow:window ordered:NSWindowAbove];
   window.alphaValue = 0.0;
 
+  FML_DCHECK(owner.onFirstFrame == nil);
   owner.onFirstFrame = ^{
     window.alphaValue = 1.0;
   };
@@ -557,6 +560,7 @@ static void FlipRect(NSRect& rect, const NSRect& globalScreenFrame) {
   window.delegate = owner;
   [_windows addObject:owner];
 
+  FML_DCHECK(owner.onFirstFrame == nil);
   owner.onFirstFrame = ^{
     [window setIsVisible:YES];
     [window makeKeyAndOrderFront:nil];

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowController.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowController.mm
@@ -239,14 +239,16 @@ static void FlipRect(NSRect& rect, const NSRect& globalScreenFrame) {
     // the requested size needs to be passed through constraints.
     if (view.sizedToContents &&
         (positionRect.size.width < newSize.width || positionRect.size.height < newSize.height)) {
+      // Positioner disagreed with content size, tighten the constraints and regenerate
+      // the frame.
       _positionerSizeConstraints = positionRect.size;
       [view constraintsDidChange];
-    } else {
-      // Only show the window initially if positioner agrees with the size.
-      if (self.onFirstFrame) {
-        self.onFirstFrame();
-        self.onFirstFrame = nil;
-      }
+      return;
+    }
+
+    if (self.onFirstFrame) {
+      self.onFirstFrame();
+      self.onFirstFrame = nil;
     }
   }
 }

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowController.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowController.mm
@@ -342,7 +342,7 @@ static void FlipRect(NSRect& rect, const NSRect& globalScreenFrame) {
   FlutterViewController* controller = [[FlutterViewController alloc] initWithEngine:_engine
                                                                             nibName:nil
                                                                              bundle:nil];
-  controller.mouseTrackingMode = kFlutterMouseTrackingModeAlways;
+
   NSWindow* window = [[NSWindow alloc] init];
   // If this is not set there will be double free on window close when
   // using ARC.
@@ -412,7 +412,7 @@ static void FlipRect(NSRect& rect, const NSRect& globalScreenFrame) {
   FlutterViewController* controller = [[FlutterViewController alloc] initWithEngine:_engine
                                                                             nibName:nil
                                                                              bundle:nil];
-  controller.mouseTrackingMode = kFlutterMouseTrackingModeAlways;
+
   NSWindow* window = [[NSWindow alloc] init];
   // If this is not set there will be double free on window close when
   // using ARC.
@@ -466,7 +466,9 @@ static void FlipRect(NSRect& rect, const NSRect& globalScreenFrame) {
   FlutterViewController* controller = [[FlutterViewController alloc] initWithEngine:_engine
                                                                             nibName:nil
                                                                              bundle:nil];
-  controller.mouseTrackingMode = kFlutterMouseTrackingModeAlways;
+  // By default this is kFlutterMouseTrackingModeInKeyWindow but popup window is never
+  // key window.
+  controller.mouseTrackingMode = kFlutterMouseTrackingModeInActiveApp;
 
   NSWindow* window = [[FlutterPopupWindow alloc] init];
   // If this is not set there will be double free on window close when
@@ -520,7 +522,7 @@ static void FlipRect(NSRect& rect, const NSRect& globalScreenFrame) {
   FlutterViewController* controller = [[FlutterViewController alloc] initWithEngine:_engine
                                                                             nibName:nil
                                                                              bundle:nil];
-  controller.mouseTrackingMode = kFlutterMouseTrackingModeAlways;
+
   NSWindow* window = [[NSWindow alloc] init];
   // If this is not set there will be double free on window close when
   // using ARC.

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowController.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowController.mm
@@ -342,7 +342,7 @@ static void FlipRect(NSRect& rect, const NSRect& globalScreenFrame) {
   FlutterViewController* controller = [[FlutterViewController alloc] initWithEngine:_engine
                                                                             nibName:nil
                                                                              bundle:nil];
-
+  controller.mouseTrackingMode = kFlutterMouseTrackingModeAlways;
   NSWindow* window = [[NSWindow alloc] init];
   // If this is not set there will be double free on window close when
   // using ARC.
@@ -412,7 +412,7 @@ static void FlipRect(NSRect& rect, const NSRect& globalScreenFrame) {
   FlutterViewController* controller = [[FlutterViewController alloc] initWithEngine:_engine
                                                                             nibName:nil
                                                                              bundle:nil];
-
+  controller.mouseTrackingMode = kFlutterMouseTrackingModeAlways;
   NSWindow* window = [[NSWindow alloc] init];
   // If this is not set there will be double free on window close when
   // using ARC.
@@ -466,9 +466,7 @@ static void FlipRect(NSRect& rect, const NSRect& globalScreenFrame) {
   FlutterViewController* controller = [[FlutterViewController alloc] initWithEngine:_engine
                                                                             nibName:nil
                                                                              bundle:nil];
-  // By default this is kFlutterMouseTrackingModeInKeyWindow but popup window is never
-  // key window.
-  controller.mouseTrackingMode = kFlutterMouseTrackingModeInActiveApp;
+  controller.mouseTrackingMode = kFlutterMouseTrackingModeAlways;
 
   NSWindow* window = [[FlutterPopupWindow alloc] init];
   // If this is not set there will be double free on window close when
@@ -522,7 +520,7 @@ static void FlipRect(NSRect& rect, const NSRect& globalScreenFrame) {
   FlutterViewController* controller = [[FlutterViewController alloc] initWithEngine:_engine
                                                                             nibName:nil
                                                                              bundle:nil];
-
+  controller.mouseTrackingMode = kFlutterMouseTrackingModeAlways;
   NSWindow* window = [[NSWindow alloc] init];
   // If this is not set there will be double free on window close when
   // using ARC.

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowControllerTest.mm
@@ -57,6 +57,8 @@ class FlutterWindowControllerTest : public FlutterEngineTest {
 
 class FlutterWindowControllerRetainTest : public ::testing::Test {};
 
+class FlutterWindowControllerSizeTest : public FlutterEngineTest {};
+
 TEST_F(FlutterWindowControllerTest, FixMoveRunLoopMode) {
   FlutterEngine* engine = GetFlutterEngine();
   [engine.windowController fixMoveRunLoopModeIfNeeded];
@@ -457,4 +459,58 @@ TEST_F(FlutterWindowControllerTest, GetOffsetInParent) {
   [childWindow close];
   [parentWindow close];
 }
+
+TEST_F(FlutterWindowControllerSizeTest, SizedToContent) {
+  FlutterWindowCreationRequest request{
+      .has_size = false,
+      .has_constraints = true,
+      .constraints{
+          .min_width = 0,
+          .min_height = 0,
+          .max_width = 1000,
+          .max_height = 1000,
+      },
+      .resizable = false,
+      .on_should_close = [] {},
+      .on_will_close = [] {},
+      .notify_listeners = [] {},
+  };
+
+  auto engine = GetFlutterEngine();
+  [engine runWithEntrypoint:@"testRenderSizedToContent"];
+
+  auto engineId = reinterpret_cast<int64_t>(GetFlutterEngine());
+
+  std::optional<Isolate> isolate;
+
+  bool signalled = false;
+  AddNativeCallback("SignalNativeTest", CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
+                      signalled = true;
+                      isolate = Isolate::Current();
+                    }));
+
+  while (!signalled) {
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, true);
+  }
+
+  int64_t viewId = 0;
+  {
+    IsolateScope isolate_scope(*isolate);
+    viewId = InternalFlutter_WindowController_CreateRegularWindow(engineId, &request);
+  }
+
+  auto controller = [engine viewControllerForIdentifier:viewId];
+  auto window = controller.view.window;
+  while (window.frame.size.width == 0) {
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, true);
+  }
+
+  NSRect contentRect = [window contentRectForFrameRect:window.frame];
+  EXPECT_EQ(contentRect.size.width, 150.0);
+  EXPECT_EQ(contentRect.size.height, 150.0);
+
+  [engine.windowController closeAllWindows];
+  [engine shutDownEngine];
+}
+
 }  // namespace flutter::testing

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowControllerTest.mm
@@ -75,6 +75,7 @@ TEST_F(FlutterWindowControllerTest, CreateRegularWindow) {
   FlutterWindowCreationRequest request{
       .has_size = true,
       .size = {.width = 800, .height = 600},
+      .resizable = true,
       .on_should_close = [] {},
       .on_will_close = [] {},
       .notify_listeners = [] {},
@@ -104,6 +105,7 @@ TEST_F(FlutterWindowControllerTest, CreateTooltipWindow) {
   auto request = FlutterWindowCreationRequest{
       .has_size = true,
       .size = {.width = 800, .height = 600},
+      .resizable = true,
       .on_should_close = [] {},
       .on_will_close = [] {},
       .notify_listeners = [] {},
@@ -128,6 +130,7 @@ TEST_F(FlutterWindowControllerTest, CreateTooltipWindow) {
           .max_width = 1000,
           .max_height = 1000,
       },
+      .resizable = true,
       .parent_view_id = parentViewId,
       .on_should_close = [] {},
       .on_will_close = [] {},
@@ -148,6 +151,7 @@ TEST_F(FlutterWindowControllerTest, CreatePopupWindow) {
   auto request = FlutterWindowCreationRequest{
       .has_size = true,
       .size = {.width = 800, .height = 600},
+      .resizable = true,
       .on_should_close = [] {},
       .on_will_close = [] {},
       .notify_listeners = [] {},
@@ -172,6 +176,7 @@ TEST_F(FlutterWindowControllerTest, CreatePopupWindow) {
           .max_width = 1000,
           .max_height = 1000,
       },
+      .resizable = true,
       .parent_view_id = parentViewId,
       .on_should_close = [] {},
       .on_will_close = [] {},
@@ -188,6 +193,7 @@ TEST_F(FlutterWindowControllerRetainTest, WindowControllerDoesNotRetainEngine) {
   FlutterWindowCreationRequest request{
       .has_size = true,
       .size = {.width = 800, .height = 600},
+      .resizable = true,
       .on_should_close = [] {},
       .on_will_close = [] {},
       .notify_listeners = [] {},
@@ -211,6 +217,8 @@ TEST_F(FlutterWindowControllerRetainTest, WindowControllerDoesNotRetainEngine) {
     weakEngine = engine;
     [engine runWithEntrypoint:@"testWindowControllerRetainCycle"];
 
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 1, false);
+
     int64_t engineId = reinterpret_cast<int64_t>(engine);
 
     {
@@ -220,6 +228,8 @@ TEST_F(FlutterWindowControllerRetainTest, WindowControllerDoesNotRetainEngine) {
       int64_t handle = InternalFlutter_WindowController_CreateRegularWindow(engineId, &request);
       EXPECT_EQ(handle, 1);
     }
+
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 1, false);
 
     [engine.windowController closeAllWindows];
     [engine shutDownEngine];
@@ -231,6 +241,7 @@ TEST_F(FlutterWindowControllerTest, DestroyRegularWindow) {
   FlutterWindowCreationRequest request{
       .has_size = true,
       .size = {.width = 800, .height = 600},
+      .resizable = true,
       .on_should_close = [] {},
       .on_will_close = [] {},
       .notify_listeners = [] {},
@@ -252,6 +263,7 @@ TEST_F(FlutterWindowControllerTest, InternalFlutterWindowGetHandle) {
   FlutterWindowCreationRequest request{
       .has_size = true,
       .size = {.width = 800, .height = 600},
+      .resizable = true,
       .on_should_close = [] {},
       .on_will_close = [] {},
       .notify_listeners = [] {},
@@ -272,6 +284,7 @@ TEST_F(FlutterWindowControllerTest, WindowStates) {
   FlutterWindowCreationRequest request{
       .has_size = true,
       .size = {.width = 800, .height = 600},
+      .resizable = true,
       .on_should_close = [] {},
       .on_will_close = [] {},
       .notify_listeners = [] {},
@@ -310,6 +323,7 @@ TEST_F(FlutterWindowControllerTest, ClosesAllWindowsOnEngineRestart) {
   FlutterWindowCreationRequest request{
       .has_size = true,
       .size = {.width = 800, .height = 600},
+      .resizable = true,
       .on_should_close = [] {},
       .on_will_close = [] {},
       .notify_listeners = [] {},
@@ -353,6 +367,7 @@ TEST_F(FlutterWindowControllerTest, ViewMetricsRespectPositionCallbackConstraint
   auto parentRequest = FlutterWindowCreationRequest{
       .has_size = true,
       .size = {.width = 800, .height = 600},
+      .resizable = true,
       .on_should_close = [] {},
       .on_will_close = [] {},
       .notify_listeners = [] {},
@@ -398,7 +413,7 @@ TEST_F(FlutterWindowControllerTest, ViewMetricsRespectPositionCallbackConstraint
 
   CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, false);
 
-  [flutterView.sizingDelegate viewDidUpdateContents:flutterView withSize:NSMakeSize(1000, 1000)];
+  [flutterView.contentDelegate viewDidUpdateContents:flutterView withSize:NSMakeSize(1000, 1000)];
 
   // The constraints from request are 1000x1000, but additional constraints came from the positioner
   // and must be respected.

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowControllerTest.mm
@@ -504,13 +504,15 @@ TEST_F(FlutterWindowControllerSizeTest, SizedToContentResizable) {
   auto controller = [engine viewControllerForIdentifier:viewId];
   auto window = controller.view.window;
   CFAbsoluteTime startTime = CFAbsoluteTimeGetCurrent();
-  while (window.frame.size.width != 150 && CFAbsoluteTimeGetCurrent() - startTime < kTestTimeout) {
+  double pixelRatio = [window backingScaleFactor];
+  while (window.frame.size.width != 300 / pixelRatio &&
+         CFAbsoluteTimeGetCurrent() - startTime < kTestTimeout) {
     CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, true);
   }
 
   NSRect contentRect = [window contentRectForFrameRect:window.frame];
-  EXPECT_EQ(contentRect.size.width, 150.0);
-  EXPECT_EQ(contentRect.size.height, 150.0);
+  EXPECT_EQ(contentRect.size.width, 300 / pixelRatio);
+  EXPECT_EQ(contentRect.size.height, 300 / pixelRatio);
   EXPECT_TRUE((window.styleMask & NSWindowStyleMaskResizable) != 0);
 
   [engine.windowController closeAllWindows];
@@ -560,25 +562,28 @@ TEST_F(FlutterWindowControllerSizeTest, SizedToContentNotResizable) {
   auto window = controller.view.window;
 
   CFAbsoluteTime startTime = CFAbsoluteTimeGetCurrent();
-  while (window.frame.size.width != 150 && CFAbsoluteTimeGetCurrent() - startTime < kTestTimeout) {
+  double pixelRatio = [window backingScaleFactor];
+  while (window.frame.size.width != 300 / pixelRatio &&
+         CFAbsoluteTimeGetCurrent() - startTime < kTestTimeout) {
     CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, true);
   }
 
   NSRect contentRect = [window contentRectForFrameRect:window.frame];
-  EXPECT_EQ(contentRect.size.width, 150.0);
-  EXPECT_EQ(contentRect.size.height, 150.0);
+  EXPECT_EQ(contentRect.size.width, 300 / pixelRatio);
+  EXPECT_EQ(contentRect.size.height, 300 / pixelRatio);
   EXPECT_TRUE((window.styleMask & NSWindowStyleMaskResizable) == 0);
 
   // Wait until the second frame is rendered, which should resize the window based
   // on new content.
   startTime = CFAbsoluteTimeGetCurrent();
-  while (window.frame.size.width == 150 && CFAbsoluteTimeGetCurrent() - startTime < kTestTimeout) {
+  while (window.frame.size.width == 300 / pixelRatio &&
+         CFAbsoluteTimeGetCurrent() - startTime < kTestTimeout) {
     CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, true);
   }
 
   contentRect = [window contentRectForFrameRect:window.frame];
-  EXPECT_EQ(contentRect.size.width, 100.0);
-  EXPECT_EQ(contentRect.size.height, 100.0);
+  EXPECT_EQ(contentRect.size.width, 200 / pixelRatio);
+  EXPECT_EQ(contentRect.size.height, 200 / pixelRatio);
 
   [engine.windowController closeAllWindows];
   [engine shutDownEngine];

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowControllerTest.mm
@@ -460,6 +460,60 @@ TEST_F(FlutterWindowControllerTest, GetOffsetInParent) {
   [parentWindow close];
 }
 
+TEST_F(FlutterWindowControllerSizeTest, SizedToContentResizable) {
+  FlutterWindowCreationRequest request{
+      .has_size = false,
+      .has_constraints = true,
+      .constraints{
+          .min_width = 0,
+          .min_height = 0,
+          .max_width = 1000,
+          .max_height = 1000,
+      },
+      .resizable = true,
+      .on_should_close = [] {},
+      .on_will_close = [] {},
+      .notify_listeners = [] {},
+  };
+
+  auto engine = GetFlutterEngine();
+  [engine runWithEntrypoint:@"testRenderSizedToContentResizable"];
+
+  auto engineId = reinterpret_cast<int64_t>(GetFlutterEngine());
+
+  std::optional<Isolate> isolate;
+
+  bool signalled = false;
+  AddNativeCallback("SignalNativeTest", CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
+                      signalled = true;
+                      isolate = Isolate::Current();
+                    }));
+
+  while (!signalled) {
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, true);
+  }
+
+  int64_t viewId = 0;
+  {
+    IsolateScope isolate_scope(*isolate);
+    viewId = InternalFlutter_WindowController_CreateRegularWindow(engineId, &request);
+  }
+
+  auto controller = [engine viewControllerForIdentifier:viewId];
+  auto window = controller.view.window;
+  while (window.frame.size.width != 150) {
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, true);
+  }
+
+  NSRect contentRect = [window contentRectForFrameRect:window.frame];
+  EXPECT_EQ(contentRect.size.width, 150.0);
+  EXPECT_EQ(contentRect.size.height, 150.0);
+  EXPECT_TRUE((window.styleMask & NSWindowStyleMaskResizable) != 0);
+
+  [engine.windowController closeAllWindows];
+  [engine shutDownEngine];
+}
+
 TEST_F(FlutterWindowControllerSizeTest, SizedToContent) {
   FlutterWindowCreationRequest request{
       .has_size = false,
@@ -501,13 +555,25 @@ TEST_F(FlutterWindowControllerSizeTest, SizedToContent) {
 
   auto controller = [engine viewControllerForIdentifier:viewId];
   auto window = controller.view.window;
-  while (window.frame.size.width == 0) {
+
+  while (window.frame.size.width != 150) {
     CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, true);
   }
 
   NSRect contentRect = [window contentRectForFrameRect:window.frame];
   EXPECT_EQ(contentRect.size.width, 150.0);
   EXPECT_EQ(contentRect.size.height, 150.0);
+  EXPECT_TRUE((window.styleMask & NSWindowStyleMaskResizable) == 0);
+
+  // Wait until the second frame is rendered, which should resize the window based
+  // on new content.
+  while (window.frame.size.width == 150) {
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, true);
+  }
+
+  contentRect = [window contentRectForFrameRect:window.frame];
+  EXPECT_EQ(contentRect.size.width, 100.0);
+  EXPECT_EQ(contentRect.size.height, 100.0);
 
   [engine.windowController closeAllWindows];
   [engine shutDownEngine];

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowControllerTest.mm
@@ -485,13 +485,13 @@ TEST_F(FlutterWindowControllerSizeTest, SizedToContentResizable) {
 
   std::optional<Isolate> isolate;
 
-  bool signalled = false;
+  bool signaled = false;
   AddNativeCallback("SignalNativeTest", CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
-                      signalled = true;
+                      signaled = true;
                       isolate = Isolate::Current();
                     }));
 
-  while (!signalled) {
+  while (!signaled) {
     CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, true);
   }
 
@@ -540,13 +540,13 @@ TEST_F(FlutterWindowControllerSizeTest, SizedToContentNotResizable) {
 
   std::optional<Isolate> isolate;
 
-  bool signalled = false;
+  bool signaled = false;
   AddNativeCallback("SignalNativeTest", CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
-                      signalled = true;
+                      signaled = true;
                       isolate = Isolate::Current();
                     }));
 
-  while (!signalled) {
+  while (!signaled) {
     CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, true);
   }
 

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowControllerTest.mm
@@ -515,7 +515,7 @@ TEST_F(FlutterWindowControllerSizeTest, SizedToContentResizable) {
   [engine shutDownEngine];
 }
 
-TEST_F(FlutterWindowControllerSizeTest, SizedToContent) {
+TEST_F(FlutterWindowControllerSizeTest, SizedToContentNotResizable) {
   FlutterWindowCreationRequest request{
       .has_size = false,
       .has_constraints = true,

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowControllerTest.mm
@@ -501,7 +501,8 @@ TEST_F(FlutterWindowControllerSizeTest, SizedToContentResizable) {
 
   auto controller = [engine viewControllerForIdentifier:viewId];
   auto window = controller.view.window;
-  while (window.frame.size.width != 150) {
+  CFAbsoluteTime startTime = CFAbsoluteTimeGetCurrent();
+  while (window.frame.size.width != 150 && CFAbsoluteTimeGetCurrent() - startTime < 5) {
     CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, true);
   }
 
@@ -556,7 +557,8 @@ TEST_F(FlutterWindowControllerSizeTest, SizedToContent) {
   auto controller = [engine viewControllerForIdentifier:viewId];
   auto window = controller.view.window;
 
-  while (window.frame.size.width != 150) {
+  CFAbsoluteTime startTime = CFAbsoluteTimeGetCurrent();
+  while (window.frame.size.width != 150 && CFAbsoluteTimeGetCurrent() - startTime < 5) {
     CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, true);
   }
 
@@ -567,7 +569,8 @@ TEST_F(FlutterWindowControllerSizeTest, SizedToContent) {
 
   // Wait until the second frame is rendered, which should resize the window based
   // on new content.
-  while (window.frame.size.width == 150) {
+  startTime = CFAbsoluteTimeGetCurrent();
+  while (window.frame.size.width == 150 && CFAbsoluteTimeGetCurrent() - startTime < 5) {
     CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, true);
   }
 

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowControllerTest.mm
@@ -13,6 +13,9 @@
 #import "flutter/testing/testing.h"
 #import "third_party/googletest/googletest/include/gtest/gtest.h"
 
+// CREATE_NATIVE_ENTRY is leaky.
+// NOLINTBEGIN(clang-analyzer-core.StackAddressEscape)
+
 namespace flutter::testing {
 
 class FlutterWindowControllerTest : public FlutterEngineTest {
@@ -590,3 +593,5 @@ TEST_F(FlutterWindowControllerSizeTest, SizedToContentNotResizable) {
 }
 
 }  // namespace flutter::testing
+
+// NOLINTEND(clang-analyzer-core.StackAddressEscape)

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowControllerTest.mm
@@ -460,6 +460,8 @@ TEST_F(FlutterWindowControllerTest, GetOffsetInParent) {
   [parentWindow close];
 }
 
+const CFAbsoluteTime kTestTimeout = 30.0;
+
 TEST_F(FlutterWindowControllerSizeTest, SizedToContentResizable) {
   FlutterWindowCreationRequest request{
       .has_size = false,
@@ -502,7 +504,7 @@ TEST_F(FlutterWindowControllerSizeTest, SizedToContentResizable) {
   auto controller = [engine viewControllerForIdentifier:viewId];
   auto window = controller.view.window;
   CFAbsoluteTime startTime = CFAbsoluteTimeGetCurrent();
-  while (window.frame.size.width != 150 && CFAbsoluteTimeGetCurrent() - startTime < 5) {
+  while (window.frame.size.width != 150 && CFAbsoluteTimeGetCurrent() - startTime < kTestTimeout) {
     CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, true);
   }
 
@@ -558,7 +560,7 @@ TEST_F(FlutterWindowControllerSizeTest, SizedToContentNotResizable) {
   auto window = controller.view.window;
 
   CFAbsoluteTime startTime = CFAbsoluteTimeGetCurrent();
-  while (window.frame.size.width != 150 && CFAbsoluteTimeGetCurrent() - startTime < 5) {
+  while (window.frame.size.width != 150 && CFAbsoluteTimeGetCurrent() - startTime < kTestTimeout) {
     CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, true);
   }
 
@@ -570,7 +572,7 @@ TEST_F(FlutterWindowControllerSizeTest, SizedToContentNotResizable) {
   // Wait until the second frame is rendered, which should resize the window based
   // on new content.
   startTime = CFAbsoluteTimeGetCurrent();
-  while (window.frame.size.width == 150 && CFAbsoluteTimeGetCurrent() - startTime < 5) {
+  while (window.frame.size.width == 150 && CFAbsoluteTimeGetCurrent() - startTime < kTestTimeout) {
     CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, true);
   }
 

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowControllerTest.mm
@@ -481,18 +481,18 @@ TEST_F(FlutterWindowControllerSizeTest, SizedToContentResizable) {
       .notify_listeners = [] {},
   };
 
+  std::optional<Isolate> isolate;
+
+  bool signaled = false;
+  AddFfiNativeCallback("SignalNativeTest", CREATE_FFI_LAMBDA([&](Dart_NativeArguments args) {
+                         signaled = true;
+                         isolate = Isolate::Current();
+                       }));
+
   auto engine = GetFlutterEngine();
   [engine runWithEntrypoint:@"testRenderSizedToContentResizable"];
 
   auto engineId = reinterpret_cast<int64_t>(GetFlutterEngine());
-
-  std::optional<Isolate> isolate;
-
-  bool signaled = false;
-  AddNativeCallback("SignalNativeTest", CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
-                      signaled = true;
-                      isolate = Isolate::Current();
-                    }));
 
   while (!signaled) {
     CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, true);
@@ -538,18 +538,18 @@ TEST_F(FlutterWindowControllerSizeTest, SizedToContentNotResizable) {
       .notify_listeners = [] {},
   };
 
+  std::optional<Isolate> isolate;
+
+  bool signaled = false;
+  AddFfiNativeCallback("SignalNativeTest", CREATE_FFI_LAMBDA([&](Dart_NativeArguments args) {
+                         signaled = true;
+                         isolate = Isolate::Current();
+                       }));
+
   auto engine = GetFlutterEngine();
   [engine runWithEntrypoint:@"testRenderSizedToContent"];
 
   auto engineId = reinterpret_cast<int64_t>(GetFlutterEngine());
-
-  std::optional<Isolate> isolate;
-
-  bool signaled = false;
-  AddNativeCallback("SignalNativeTest", CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
-                      signaled = true;
-                      isolate = Isolate::Current();
-                    }));
 
   while (!signaled) {
     CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, true);

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
@@ -103,6 +103,7 @@ void testWindowController() {
 void testWindowControllerRetainCycle() {}
 
 @pragma('vm:entry-point')
+// Used in FlutterWindowControllerSizeTest.SizedToContentResizable
 void testRenderSizedToContentResizable() {
   PlatformDispatcher.instance.onBeginFrame = (Duration duration) {
     final baseRecorder = PictureRecorder();
@@ -120,6 +121,7 @@ void testRenderSizedToContentResizable() {
 }
 
 @pragma('vm:entry-point')
+// Used in FlutterWindowControllerSizeTest.SizedToContent
 void testRenderSizedToContent() {
   int frameCount = 0;
   PlatformDispatcher.instance.onBeginFrame = (Duration duration) {

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
@@ -103,7 +103,7 @@ void testWindowController() {
 void testWindowControllerRetainCycle() {}
 
 @pragma('vm:entry-point')
-void testRenderSizedToContent() {
+void testRenderSizedToContentResizable() {
   PlatformDispatcher.instance.onBeginFrame = (Duration duration) {
     final baseRecorder = PictureRecorder();
     final canvas = Canvas(baseRecorder);
@@ -114,6 +114,28 @@ void testRenderSizedToContent() {
     final builder = SceneBuilder();
     builder.addPicture(const Offset(0.0, 0.0), picture);
     PlatformDispatcher.instance.views.last.render(builder.build(), size: const Size(300, 300));
+  };
+
+  signalNativeTest();
+}
+
+@pragma('vm:entry-point')
+void testRenderSizedToContent() {
+  int frameCount = 0;
+  PlatformDispatcher.instance.onBeginFrame = (Duration duration) {
+    Size size = frameCount == 0 ? const Size(300, 300) : const Size(200, 200);
+    final baseRecorder = PictureRecorder();
+    final canvas = Canvas(baseRecorder);
+    final blackPaint = Paint()..color = const Color(0xFF000000);
+    canvas.drawRect(Offset.zero & size, blackPaint);
+    final picture = baseRecorder.endRecording();
+    final builder = SceneBuilder();
+    builder.addPicture(const Offset(0.0, 0.0), picture);
+    PlatformDispatcher.instance.views.last.render(builder.build(), size: size);
+    ++frameCount;
+    if (frameCount == 1) {
+      PlatformDispatcher.instance.scheduleFrame();
+    }
   };
 
   signalNativeTest();

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
@@ -110,10 +110,10 @@ void testRenderSizedToContentResizable() {
     final canvas = Canvas(baseRecorder);
     final blackPaint = Paint()..color = const Color(0xFF000000);
     canvas.drawRect(const Rect.fromLTRB(0.0, 0.0, 300, 300.0), blackPaint);
-    final picture = baseRecorder.endRecording();
+    final Picture picture = baseRecorder.endRecording();
 
     final builder = SceneBuilder();
-    builder.addPicture(const Offset(0.0, 0.0), picture);
+    builder.addPicture(Offset.zero, picture);
     PlatformDispatcher.instance.views.last.render(builder.build(), size: const Size(300, 300));
   };
 
@@ -123,16 +123,16 @@ void testRenderSizedToContentResizable() {
 @pragma('vm:entry-point')
 // Used in FlutterWindowControllerSizeTest.SizedToContentNotResizable
 void testRenderSizedToContent() {
-  int frameCount = 0;
+  var frameCount = 0;
   PlatformDispatcher.instance.onBeginFrame = (Duration duration) {
-    Size size = frameCount == 0 ? const Size(300, 300) : const Size(200, 200);
+    final size = frameCount == 0 ? const Size(300, 300) : const Size(200, 200);
     final baseRecorder = PictureRecorder();
     final canvas = Canvas(baseRecorder);
     final blackPaint = Paint()..color = const Color(0xFF000000);
     canvas.drawRect(Offset.zero & size, blackPaint);
-    final picture = baseRecorder.endRecording();
+    final Picture picture = baseRecorder.endRecording();
     final builder = SceneBuilder();
-    builder.addPicture(const Offset(0.0, 0.0), picture);
+    builder.addPicture(Offset.zero, picture);
     PlatformDispatcher.instance.views.last.render(builder.build(), size: size);
     ++frameCount;
     if (frameCount == 1) {

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
@@ -121,7 +121,7 @@ void testRenderSizedToContentResizable() {
 }
 
 @pragma('vm:entry-point')
-// Used in FlutterWindowControllerSizeTest.SizedToContent
+// Used in FlutterWindowControllerSizeTest.SizedToContentNotResizable
 void testRenderSizedToContent() {
   int frameCount = 0;
   PlatformDispatcher.instance.onBeginFrame = (Duration duration) {

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
@@ -101,3 +101,20 @@ void testWindowController() {
 
 @pragma('vm:entry-point')
 void testWindowControllerRetainCycle() {}
+
+@pragma('vm:entry-point')
+void testRenderSizedToContent() {
+  PlatformDispatcher.instance.onBeginFrame = (Duration duration) {
+    final baseRecorder = PictureRecorder();
+    final canvas = Canvas(baseRecorder);
+    final blackPaint = Paint()..color = const Color(0xFF000000);
+    canvas.drawRect(const Rect.fromLTRB(0.0, 0.0, 300, 300.0), blackPaint);
+    final picture = baseRecorder.endRecording();
+
+    final builder = SceneBuilder();
+    builder.addPicture(const Offset(0.0, 0.0), picture);
+    PlatformDispatcher.instance.views.last.render(builder.build(), size: const Size(300, 300));
+  };
+
+  signalNativeTest();
+}

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
@@ -104,6 +104,7 @@ void testWindowController() {
 void testWindowControllerRetainCycle() {}
 
 @pragma('vm:entry-point')
+// Used in FlutterWindowControllerSizeTest.SizedToContentResizable
 void testRenderSizedToContentResizable() {
   PlatformDispatcher.instance.onBeginFrame = (Duration duration) {
     final baseRecorder = PictureRecorder();
@@ -121,6 +122,7 @@ void testRenderSizedToContentResizable() {
 }
 
 @pragma('vm:entry-point')
+// Used in FlutterWindowControllerSizeTest.SizedToContent
 void testRenderSizedToContent() {
   int frameCount = 0;
   PlatformDispatcher.instance.onBeginFrame = (Duration duration) {

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
@@ -122,7 +122,7 @@ void testRenderSizedToContentResizable() {
 }
 
 @pragma('vm:entry-point')
-// Used in FlutterWindowControllerSizeTest.SizedToContent
+// Used in FlutterWindowControllerSizeTest.SizedToContentNotResizable
 void testRenderSizedToContent() {
   int frameCount = 0;
   PlatformDispatcher.instance.onBeginFrame = (Duration duration) {

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
@@ -111,10 +111,10 @@ void testRenderSizedToContentResizable() {
     final canvas = Canvas(baseRecorder);
     final blackPaint = Paint()..color = const Color(0xFF000000);
     canvas.drawRect(const Rect.fromLTRB(0.0, 0.0, 300, 300.0), blackPaint);
-    final picture = baseRecorder.endRecording();
+    final Picture picture = baseRecorder.endRecording();
 
     final builder = SceneBuilder();
-    builder.addPicture(const Offset(0.0, 0.0), picture);
+    builder.addPicture(Offset.zero, picture);
     PlatformDispatcher.instance.views.last.render(builder.build(), size: const Size(300, 300));
   };
 
@@ -124,16 +124,16 @@ void testRenderSizedToContentResizable() {
 @pragma('vm:entry-point')
 // Used in FlutterWindowControllerSizeTest.SizedToContentNotResizable
 void testRenderSizedToContent() {
-  int frameCount = 0;
+  var frameCount = 0;
   PlatformDispatcher.instance.onBeginFrame = (Duration duration) {
-    Size size = frameCount == 0 ? const Size(300, 300) : const Size(200, 200);
+    final size = frameCount == 0 ? const Size(300, 300) : const Size(200, 200);
     final baseRecorder = PictureRecorder();
     final canvas = Canvas(baseRecorder);
     final blackPaint = Paint()..color = const Color(0xFF000000);
     canvas.drawRect(Offset.zero & size, blackPaint);
-    final picture = baseRecorder.endRecording();
+    final Picture picture = baseRecorder.endRecording();
     final builder = SceneBuilder();
-    builder.addPicture(const Offset(0.0, 0.0), picture);
+    builder.addPicture(Offset.zero, picture);
     PlatformDispatcher.instance.views.last.render(builder.build(), size: size);
     ++frameCount;
     if (frameCount == 1) {

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: avoid_print
 
-import 'dart:ffi';
+import 'dart:ffi' hide Size;
 import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui';

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
@@ -102,3 +102,20 @@ void testWindowController() {
 
 @pragma('vm:entry-point')
 void testWindowControllerRetainCycle() {}
+
+@pragma('vm:entry-point')
+void testRenderSizedToContent() {
+  PlatformDispatcher.instance.onBeginFrame = (Duration duration) {
+    final baseRecorder = PictureRecorder();
+    final canvas = Canvas(baseRecorder);
+    final blackPaint = Paint()..color = const Color(0xFF000000);
+    canvas.drawRect(const Rect.fromLTRB(0.0, 0.0, 300, 300.0), blackPaint);
+    final picture = baseRecorder.endRecording();
+
+    final builder = SceneBuilder();
+    builder.addPicture(const Offset(0.0, 0.0), picture);
+    PlatformDispatcher.instance.views.last.render(builder.build(), size: const Size(300, 300));
+  };
+
+  signalNativeTest();
+}

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
@@ -104,7 +104,7 @@ void testWindowController() {
 void testWindowControllerRetainCycle() {}
 
 @pragma('vm:entry-point')
-void testRenderSizedToContent() {
+void testRenderSizedToContentResizable() {
   PlatformDispatcher.instance.onBeginFrame = (Duration duration) {
     final baseRecorder = PictureRecorder();
     final canvas = Canvas(baseRecorder);
@@ -115,6 +115,28 @@ void testRenderSizedToContent() {
     final builder = SceneBuilder();
     builder.addPicture(const Offset(0.0, 0.0), picture);
     PlatformDispatcher.instance.views.last.render(builder.build(), size: const Size(300, 300));
+  };
+
+  signalNativeTest();
+}
+
+@pragma('vm:entry-point')
+void testRenderSizedToContent() {
+  int frameCount = 0;
+  PlatformDispatcher.instance.onBeginFrame = (Duration duration) {
+    Size size = frameCount == 0 ? const Size(300, 300) : const Size(200, 200);
+    final baseRecorder = PictureRecorder();
+    final canvas = Canvas(baseRecorder);
+    final blackPaint = Paint()..color = const Color(0xFF000000);
+    canvas.drawRect(Offset.zero & size, blackPaint);
+    final picture = baseRecorder.endRecording();
+    final builder = SceneBuilder();
+    builder.addPicture(const Offset(0.0, 0.0), picture);
+    PlatformDispatcher.instance.views.last.render(builder.build(), size: size);
+    ++frameCount;
+    if (frameCount == 1) {
+      PlatformDispatcher.instance.scheduleFrame();
+    }
   };
 
   signalNativeTest();

--- a/packages/flutter/lib/src/widgets/_window_macos.dart
+++ b/packages/flutter/lib/src/widgets/_window_macos.dart
@@ -87,6 +87,7 @@ class WindowingOwnerMacOS extends WindowingOwner {
       delegate: delegate,
       size: size,
       title: title,
+      resizable: resizable,
     );
     _activeControllers.add(controller);
     return controller;
@@ -107,6 +108,7 @@ class WindowingOwnerMacOS extends WindowingOwner {
       size: size,
       parent: parent,
       title: title,
+      resizable: resizable,
     );
     _activeControllers.add(controller);
     return controller;
@@ -515,6 +517,7 @@ class WindowControllerMacOS extends WindowController with _WindowControllerMixin
     required WindowingOwnerMacOS owner,
     required WindowControllerDelegate delegate,
     required Size? size,
+    required bool resizable,
     BoxConstraints? constraints,
     String? title,
   }) : _delegate = delegate,
@@ -527,6 +530,7 @@ class WindowControllerMacOS extends WindowController with _WindowControllerMixin
       onShouldClose: _onShouldClose.nativeFunction,
       onWillClose: _onWillClose.nativeFunction,
       onNotifyListeners: _onResize.nativeFunction,
+      resizable: resizable,
     );
     final FlutterView flutterView = WidgetsBinding.instance.platformDispatcher.views.firstWhere(
       (FlutterView view) => view.viewId == viewId,
@@ -650,6 +654,7 @@ class DialogWindowControllerMacOS extends DialogWindowController with _WindowCon
     required WindowingOwnerMacOS owner,
     required DialogWindowControllerDelegate delegate,
     required Size? size,
+    required bool resizable,
     this.parent,
     BoxConstraints? constraints,
     String? title,
@@ -664,6 +669,7 @@ class DialogWindowControllerMacOS extends DialogWindowController with _WindowCon
       onWillClose: _onWillClose.nativeFunction,
       onNotifyListeners: _onResize.nativeFunction,
       parentViewId: parent?.rootView.viewId,
+      resizable: resizable,
     );
     final FlutterView flutterView = WidgetsBinding.instance.platformDispatcher.views.firstWhere(
       (FlutterView view) => view.viewId == viewId,
@@ -760,6 +766,9 @@ final class _WindowCreationRequest extends Struct {
   @Bool()
   external bool hasConstraints;
   external _Constraints constraints;
+
+  @Bool()
+  external bool resizable;
 
   @Int64()
   external int parentViewId;
@@ -892,6 +901,7 @@ class _MacOSPlatformInterface {
     required Pointer<NativeFunction<Void Function()>> onShouldClose,
     required Pointer<NativeFunction<Void Function()>> onWillClose,
     required Pointer<NativeFunction<Void Function()>> onNotifyListeners,
+    required bool resizable,
   }) {
     final Pointer<_WindowCreationRequest> request = _allocator<_WindowCreationRequest>()
       ..ref.onShouldClose = onShouldClose
@@ -905,6 +915,10 @@ class _MacOSPlatformInterface {
         ..contentSize.height = size.height;
     }
 
+    if (preferredSize == null) {
+      preferredConstraints ??= const BoxConstraints();
+    }
+
     if (constraints != null) {
       request.ref
         ..hasConstraints = true
@@ -913,6 +927,7 @@ class _MacOSPlatformInterface {
         ..constraints.maxWidth = constraints.maxWidth
         ..constraints.maxHeight = constraints.maxHeight;
     }
+    request.ref.resizable = resizable;
     final int viewId = _createWindow(
       WidgetsBinding.instance.platformDispatcher.engineId!,
       request,
@@ -929,6 +944,7 @@ class _MacOSPlatformInterface {
   /// Creates a new window and returns the viewId of the created FlutterView.
   static int createDialogWindow({
     required Size? size,
+    required bool resizable,
     BoxConstraints? constraints,
     int? parentViewId,
     required Pointer<NativeFunction<Void Function()>> onShouldClose,
@@ -956,6 +972,12 @@ class _MacOSPlatformInterface {
         ..constraints.maxWidth = constraints.maxWidth
         ..constraints.maxHeight = constraints.maxHeight;
     }
+    request.ref.resizable = resizable;
+
+    if (preferredSize == null) {
+      preferredConstraints ??= const BoxConstraints();
+    }
+
     try {
       final int viewId = _createDialogWindow(
         WidgetsBinding.instance.platformDispatcher.engineId!,

--- a/packages/flutter/lib/src/widgets/_window_macos.dart
+++ b/packages/flutter/lib/src/widgets/_window_macos.dart
@@ -915,8 +915,8 @@ class _MacOSPlatformInterface {
         ..contentSize.height = size.height;
     }
 
-    if (preferredSize == null) {
-      preferredConstraints ??= const BoxConstraints();
+    if (size == null) {
+      constraints ??= const BoxConstraints();
     }
 
     if (constraints != null) {
@@ -974,8 +974,8 @@ class _MacOSPlatformInterface {
     }
     request.ref.resizable = resizable;
 
-    if (preferredSize == null) {
-      preferredConstraints ??= const BoxConstraints();
+    if (size == null) {
+      constraints ??= const BoxConstraints();
     }
 
     try {


### PR DESCRIPTION
Implements size to content in both resizable and non-resizable regular and dialog windows.
Delays displaying windows until first render.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
