### PR TITLE
Remove unnecessary Material imports from non-Material tests in flutter package

### DIFF
--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -113,7 +113,6 @@ class TestsCrossImportChecker {
     'packages/flutter/test/widgets/app_test.dart',
     'packages/flutter/test/widgets/navigator_replacement_test.dart',
     'packages/flutter/test/widgets/implicit_animations_test.dart',
-    'packages/flutter/test/widgets/default_text_editing_shortcuts_test.dart',
     'packages/flutter/test/widgets/routes_transition_test.dart',
     'packages/flutter/test/widgets/editable_text_test.dart',
     'packages/flutter/test/widgets/scrollbar_test.dart',
@@ -143,9 +142,7 @@ class TestsCrossImportChecker {
   /// and `knownSchedulerCrossImports` corresponds to `flutter/test/scheduler`.
   // TODO(justinmc): Fix all of these tests so there are no cross imports.
   // See https://github.com/flutter/flutter/issues/177028.
-  static final Set<String> knownAnimationCrossImports = <String>{
-    'packages/flutter/test/animation/animation_sheet_test.dart',
-  };
+  static final Set<String> knownAnimationCrossImports = <String>{};
   static final Set<String> knownCupertinoCrossImports = <String>{};
   static final Set<String> knownDartCrossImports = <String>{};
   static final Set<String> knownExamplesCrossImports = <String>{};

--- a/packages/flutter/test/animation/animation_sheet_test.dart
+++ b/packages/flutter/test/animation/animation_sheet_test.dart
@@ -7,7 +7,7 @@
 @Tags(<String>['reduced-test-set'])
 library;
 
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -152,8 +152,8 @@ class _PaintDecuplePixels extends CustomPainter {
       begin: const Rect.fromLTWH(1, 1, 1, 1),
       end: const Rect.fromLTWH(11, 1, 1, 1),
     ).transform(value)!;
-    canvas.drawRect(rect, Paint()..color = Colors.yellow);
-    final black = Paint()..color = Colors.black;
+    canvas.drawRect(rect, Paint()..color = const Color(0xFFFFEB3B));
+    final black = Paint()..color = const Color(0xFF000000);
     canvas
       // Top border
       ..drawRect(const Rect.fromLTRB(0, 0, 12, 1), black)

--- a/packages/flutter/test/widgets/default_text_editing_shortcuts_test.dart
+++ b/packages/flutter/test/widgets/default_text_editing_shortcuts_test.dart
@@ -10,6 +10,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'keyboard_utils.dart';
 import 'widgets_app_tester.dart';
 
+const _cursorColor = Color(0xFF0000FF);
+const _backgroundCursorColor = Color(0xFF9E9E9E);
+
 void main() {
   Widget buildSpyAboveEditableText({
     required FocusNode editableFocusNode,
@@ -36,8 +39,8 @@ void main() {
               textScaleFactor: 1,
               // Avoid the cursor from taking up width.
               cursorWidth: 0,
-              cursorColor: const Color(0xFF2196F3),
-              backgroundCursorColor: const Color(0xFF9E9E9E),
+              cursorColor: _cursorColor,
+              backgroundCursorColor: _backgroundCursorColor,
               selectionControls: emptyTextSelectionControls,
               keyboardType: TextInputType.text,
               maxLines: null,
@@ -526,307 +529,296 @@ void main() {
   }, skip: kIsWeb); // [intended] specific tests target non-web.
 
   group('Linux numpad shortcuts', () {
-    testWidgets(
-      'are triggered when numlock is locked',
-      (WidgetTester tester) async {
-        final editable = FocusNode();
-        addTearDown(editable.dispose);
-        final spy = FocusNode();
-        addTearDown(spy.dispose);
+    testWidgets('are triggered when numlock is locked', (WidgetTester tester) async {
+      final editable = FocusNode();
+      addTearDown(editable.dispose);
+      final spy = FocusNode();
+      addTearDown(spy.dispose);
 
-        await tester.pumpWidget(
-          buildSpyAboveEditableText(editableFocusNode: editable, spyFocusNode: spy),
-        );
-        spy.requestFocus();
-        await tester.pump();
-        final ActionSpyState state = tester.state<ActionSpyState>(find.byType(ActionSpy));
+      await tester.pumpWidget(
+        buildSpyAboveEditableText(editableFocusNode: editable, spyFocusNode: spy),
+      );
+      spy.requestFocus();
+      await tester.pump();
+      final ActionSpyState state = tester.state<ActionSpyState>(find.byType(ActionSpy));
 
-        // Lock NumLock.
-        await tester.sendKeyEvent(LogicalKeyboardKey.numLock);
-        expect(
-          HardwareKeyboard.instance.lockModesEnabled.contains(KeyboardLockMode.numLock),
-          isTrue,
-        );
+      // Lock NumLock.
+      await tester.sendKeyEvent(LogicalKeyboardKey.numLock);
+      expect(HardwareKeyboard.instance.lockModesEnabled.contains(KeyboardLockMode.numLock), isTrue);
 
-        await sendKeyCombination(
-          tester,
-          const SingleActivator(LogicalKeyboardKey.numpad6, shift: true),
-        );
-        expect(state.lastIntent, isA<ExtendSelectionByCharacterIntent>());
-        expect((state.lastIntent! as ExtendSelectionByCharacterIntent).forward, true);
-        expect((state.lastIntent! as ExtendSelectionByCharacterIntent).collapseSelection, false);
+      await sendKeyCombination(
+        tester,
+        const SingleActivator(LogicalKeyboardKey.numpad6, shift: true),
+      );
+      expect(state.lastIntent, isA<ExtendSelectionByCharacterIntent>());
+      expect((state.lastIntent! as ExtendSelectionByCharacterIntent).forward, true);
+      expect((state.lastIntent! as ExtendSelectionByCharacterIntent).collapseSelection, false);
 
-        await sendKeyCombination(
-          tester,
-          const SingleActivator(LogicalKeyboardKey.numpad4, shift: true),
-        );
-        expect(state.lastIntent, isA<ExtendSelectionByCharacterIntent>());
-        expect((state.lastIntent! as ExtendSelectionByCharacterIntent).forward, false);
-        expect((state.lastIntent! as ExtendSelectionByCharacterIntent).collapseSelection, false);
+      await sendKeyCombination(
+        tester,
+        const SingleActivator(LogicalKeyboardKey.numpad4, shift: true),
+      );
+      expect(state.lastIntent, isA<ExtendSelectionByCharacterIntent>());
+      expect((state.lastIntent! as ExtendSelectionByCharacterIntent).forward, false);
+      expect((state.lastIntent! as ExtendSelectionByCharacterIntent).collapseSelection, false);
 
-        await sendKeyCombination(
-          tester,
-          const SingleActivator(LogicalKeyboardKey.numpad8, shift: true),
-        );
-        expect(state.lastIntent, isA<ExtendSelectionVerticallyToAdjacentLineIntent>());
-        expect((state.lastIntent! as ExtendSelectionVerticallyToAdjacentLineIntent).forward, false);
-        expect(
-          (state.lastIntent! as ExtendSelectionVerticallyToAdjacentLineIntent).collapseSelection,
-          false,
-        );
+      await sendKeyCombination(
+        tester,
+        const SingleActivator(LogicalKeyboardKey.numpad8, shift: true),
+      );
+      expect(state.lastIntent, isA<ExtendSelectionVerticallyToAdjacentLineIntent>());
+      expect((state.lastIntent! as ExtendSelectionVerticallyToAdjacentLineIntent).forward, false);
+      expect(
+        (state.lastIntent! as ExtendSelectionVerticallyToAdjacentLineIntent).collapseSelection,
+        false,
+      );
 
-        await sendKeyCombination(
-          tester,
-          const SingleActivator(LogicalKeyboardKey.numpad2, shift: true),
-        );
-        expect(state.lastIntent, isA<ExtendSelectionVerticallyToAdjacentLineIntent>());
-        expect((state.lastIntent! as ExtendSelectionVerticallyToAdjacentLineIntent).forward, true);
-        expect(
-          (state.lastIntent! as ExtendSelectionVerticallyToAdjacentLineIntent).collapseSelection,
-          false,
-        );
+      await sendKeyCombination(
+        tester,
+        const SingleActivator(LogicalKeyboardKey.numpad2, shift: true),
+      );
+      expect(state.lastIntent, isA<ExtendSelectionVerticallyToAdjacentLineIntent>());
+      expect((state.lastIntent! as ExtendSelectionVerticallyToAdjacentLineIntent).forward, true);
+      expect(
+        (state.lastIntent! as ExtendSelectionVerticallyToAdjacentLineIntent).collapseSelection,
+        false,
+      );
 
-        await sendKeyCombination(
-          tester,
-          const SingleActivator(LogicalKeyboardKey.numpad9, shift: true),
-        );
-        expect(state.lastIntent, isA<ExtendSelectionVerticallyToAdjacentPageIntent>());
-        expect((state.lastIntent! as ExtendSelectionVerticallyToAdjacentPageIntent).forward, false);
-        expect(
-          (state.lastIntent! as ExtendSelectionVerticallyToAdjacentPageIntent).collapseSelection,
-          false,
-        );
+      await sendKeyCombination(
+        tester,
+        const SingleActivator(LogicalKeyboardKey.numpad9, shift: true),
+      );
+      expect(state.lastIntent, isA<ExtendSelectionVerticallyToAdjacentPageIntent>());
+      expect((state.lastIntent! as ExtendSelectionVerticallyToAdjacentPageIntent).forward, false);
+      expect(
+        (state.lastIntent! as ExtendSelectionVerticallyToAdjacentPageIntent).collapseSelection,
+        false,
+      );
 
-        await sendKeyCombination(
-          tester,
-          const SingleActivator(LogicalKeyboardKey.numpad3, shift: true),
-        );
-        expect(state.lastIntent, isA<ExtendSelectionVerticallyToAdjacentPageIntent>());
-        expect((state.lastIntent! as ExtendSelectionVerticallyToAdjacentPageIntent).forward, true);
-        expect(
-          (state.lastIntent! as ExtendSelectionVerticallyToAdjacentPageIntent).collapseSelection,
-          false,
-        );
+      await sendKeyCombination(
+        tester,
+        const SingleActivator(LogicalKeyboardKey.numpad3, shift: true),
+      );
+      expect(state.lastIntent, isA<ExtendSelectionVerticallyToAdjacentPageIntent>());
+      expect((state.lastIntent! as ExtendSelectionVerticallyToAdjacentPageIntent).forward, true);
+      expect(
+        (state.lastIntent! as ExtendSelectionVerticallyToAdjacentPageIntent).collapseSelection,
+        false,
+      );
 
-        await sendKeyCombination(
-          tester,
-          const SingleActivator(LogicalKeyboardKey.numpad7, shift: true),
-        );
-        expect(state.lastIntent, isA<ExtendSelectionVerticallyToAdjacentLineIntent>());
-        expect((state.lastIntent! as ExtendSelectionVerticallyToAdjacentLineIntent).forward, false);
-        expect(
-          (state.lastIntent! as ExtendSelectionVerticallyToAdjacentLineIntent).collapseSelection,
-          false,
-        );
+      await sendKeyCombination(
+        tester,
+        const SingleActivator(LogicalKeyboardKey.numpad7, shift: true),
+      );
+      expect(state.lastIntent, isA<ExtendSelectionVerticallyToAdjacentLineIntent>());
+      expect((state.lastIntent! as ExtendSelectionVerticallyToAdjacentLineIntent).forward, false);
+      expect(
+        (state.lastIntent! as ExtendSelectionVerticallyToAdjacentLineIntent).collapseSelection,
+        false,
+      );
 
-        await sendKeyCombination(
-          tester,
-          const SingleActivator(LogicalKeyboardKey.numpad1, shift: true),
-        );
-        expect(state.lastIntent, isA<ExtendSelectionVerticallyToAdjacentLineIntent>());
-        expect((state.lastIntent! as ExtendSelectionVerticallyToAdjacentLineIntent).forward, true);
-        expect(
-          (state.lastIntent! as ExtendSelectionVerticallyToAdjacentLineIntent).collapseSelection,
-          false,
-        );
+      await sendKeyCombination(
+        tester,
+        const SingleActivator(LogicalKeyboardKey.numpad1, shift: true),
+      );
+      expect(state.lastIntent, isA<ExtendSelectionVerticallyToAdjacentLineIntent>());
+      expect((state.lastIntent! as ExtendSelectionVerticallyToAdjacentLineIntent).forward, true);
+      expect(
+        (state.lastIntent! as ExtendSelectionVerticallyToAdjacentLineIntent).collapseSelection,
+        false,
+      );
 
-        await sendKeyCombination(
-          tester,
-          const SingleActivator(LogicalKeyboardKey.numpadDecimal, shift: true),
-        );
-        expect(state.lastIntent, isA<DeleteCharacterIntent>());
-        expect((state.lastIntent! as DeleteCharacterIntent).forward, true);
+      await sendKeyCombination(
+        tester,
+        const SingleActivator(LogicalKeyboardKey.numpadDecimal, shift: true),
+      );
+      expect(state.lastIntent, isA<DeleteCharacterIntent>());
+      expect((state.lastIntent! as DeleteCharacterIntent).forward, true);
 
-        await sendKeyCombination(
-          tester,
-          const SingleActivator(LogicalKeyboardKey.numpad6, shift: true, control: true),
-        );
-        expect(state.lastIntent, isA<ExtendSelectionToNextWordBoundaryIntent>());
-        expect((state.lastIntent! as ExtendSelectionToNextWordBoundaryIntent).forward, true);
-        expect(
-          (state.lastIntent! as ExtendSelectionToNextWordBoundaryIntent).collapseSelection,
-          false,
-        );
+      await sendKeyCombination(
+        tester,
+        const SingleActivator(LogicalKeyboardKey.numpad6, shift: true, control: true),
+      );
+      expect(state.lastIntent, isA<ExtendSelectionToNextWordBoundaryIntent>());
+      expect((state.lastIntent! as ExtendSelectionToNextWordBoundaryIntent).forward, true);
+      expect(
+        (state.lastIntent! as ExtendSelectionToNextWordBoundaryIntent).collapseSelection,
+        false,
+      );
 
-        await sendKeyCombination(
-          tester,
-          const SingleActivator(LogicalKeyboardKey.numpad4, shift: true, control: true),
-        );
-        expect(state.lastIntent, isA<ExtendSelectionToNextWordBoundaryIntent>());
-        expect((state.lastIntent! as ExtendSelectionToNextWordBoundaryIntent).forward, false);
-        expect(
-          (state.lastIntent! as ExtendSelectionToNextWordBoundaryIntent).collapseSelection,
-          false,
-        );
+      await sendKeyCombination(
+        tester,
+        const SingleActivator(LogicalKeyboardKey.numpad4, shift: true, control: true),
+      );
+      expect(state.lastIntent, isA<ExtendSelectionToNextWordBoundaryIntent>());
+      expect((state.lastIntent! as ExtendSelectionToNextWordBoundaryIntent).forward, false);
+      expect(
+        (state.lastIntent! as ExtendSelectionToNextWordBoundaryIntent).collapseSelection,
+        false,
+      );
 
-        await sendKeyCombination(
-          tester,
-          const SingleActivator(LogicalKeyboardKey.numpad8, shift: true, control: true),
-        );
-        expect(state.lastIntent, isA<ExtendSelectionToNextParagraphBoundaryIntent>());
-        expect((state.lastIntent! as ExtendSelectionToNextParagraphBoundaryIntent).forward, false);
-        expect(
-          (state.lastIntent! as ExtendSelectionToNextParagraphBoundaryIntent).collapseSelection,
-          false,
-        );
+      await sendKeyCombination(
+        tester,
+        const SingleActivator(LogicalKeyboardKey.numpad8, shift: true, control: true),
+      );
+      expect(state.lastIntent, isA<ExtendSelectionToNextParagraphBoundaryIntent>());
+      expect((state.lastIntent! as ExtendSelectionToNextParagraphBoundaryIntent).forward, false);
+      expect(
+        (state.lastIntent! as ExtendSelectionToNextParagraphBoundaryIntent).collapseSelection,
+        false,
+      );
 
-        await sendKeyCombination(
-          tester,
-          const SingleActivator(LogicalKeyboardKey.numpad2, shift: true, control: true),
-        );
-        expect(state.lastIntent, isA<ExtendSelectionToNextParagraphBoundaryIntent>());
-        expect((state.lastIntent! as ExtendSelectionToNextParagraphBoundaryIntent).forward, true);
-        expect(
-          (state.lastIntent! as ExtendSelectionToNextParagraphBoundaryIntent).collapseSelection,
-          false,
-        );
+      await sendKeyCombination(
+        tester,
+        const SingleActivator(LogicalKeyboardKey.numpad2, shift: true, control: true),
+      );
+      expect(state.lastIntent, isA<ExtendSelectionToNextParagraphBoundaryIntent>());
+      expect((state.lastIntent! as ExtendSelectionToNextParagraphBoundaryIntent).forward, true);
+      expect(
+        (state.lastIntent! as ExtendSelectionToNextParagraphBoundaryIntent).collapseSelection,
+        false,
+      );
 
-        await sendKeyCombination(
-          tester,
-          const SingleActivator(LogicalKeyboardKey.numpadDecimal, shift: true, control: true),
-        );
-        expect(state.lastIntent, isA<DeleteToNextWordBoundaryIntent>());
-        expect((state.lastIntent! as DeleteToNextWordBoundaryIntent).forward, true);
-      },
-      variant: TargetPlatformVariant.only(TargetPlatform.linux),
-    );
+      await sendKeyCombination(
+        tester,
+        const SingleActivator(LogicalKeyboardKey.numpadDecimal, shift: true, control: true),
+      );
+      expect(state.lastIntent, isA<DeleteToNextWordBoundaryIntent>());
+      expect((state.lastIntent! as DeleteToNextWordBoundaryIntent).forward, true);
+    }, variant: TargetPlatformVariant.only(TargetPlatform.linux));
 
-    testWidgets(
-      'are triggered when numlock is unlocked',
-      (WidgetTester tester) async {
-        final editable = FocusNode();
-        addTearDown(editable.dispose);
-        final spy = FocusNode();
-        addTearDown(spy.dispose);
+    testWidgets('are triggered when numlock is unlocked', (WidgetTester tester) async {
+      final editable = FocusNode();
+      addTearDown(editable.dispose);
+      final spy = FocusNode();
+      addTearDown(spy.dispose);
 
-        await tester.pumpWidget(
-          buildSpyAboveEditableText(editableFocusNode: editable, spyFocusNode: spy),
-        );
-        spy.requestFocus();
-        await tester.pump();
-        final ActionSpyState state = tester.state<ActionSpyState>(find.byType(ActionSpy));
+      await tester.pumpWidget(
+        buildSpyAboveEditableText(editableFocusNode: editable, spyFocusNode: spy),
+      );
+      spy.requestFocus();
+      await tester.pump();
+      final ActionSpyState state = tester.state<ActionSpyState>(find.byType(ActionSpy));
 
-        // Verify that NumLock is unlocked.
-        expect(
-          HardwareKeyboard.instance.lockModesEnabled.contains(KeyboardLockMode.numLock),
-          isFalse,
-        );
+      // Verify that NumLock is unlocked.
+      expect(
+        HardwareKeyboard.instance.lockModesEnabled.contains(KeyboardLockMode.numLock),
+        isFalse,
+      );
 
-        await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.numpad6));
-        expect(state.lastIntent, isA<ExtendSelectionByCharacterIntent>());
-        expect((state.lastIntent! as ExtendSelectionByCharacterIntent).forward, true);
-        expect((state.lastIntent! as ExtendSelectionByCharacterIntent).collapseSelection, true);
+      await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.numpad6));
+      expect(state.lastIntent, isA<ExtendSelectionByCharacterIntent>());
+      expect((state.lastIntent! as ExtendSelectionByCharacterIntent).forward, true);
+      expect((state.lastIntent! as ExtendSelectionByCharacterIntent).collapseSelection, true);
 
-        await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.numpad4));
-        expect(state.lastIntent, isA<ExtendSelectionByCharacterIntent>());
-        expect((state.lastIntent! as ExtendSelectionByCharacterIntent).forward, false);
-        expect((state.lastIntent! as ExtendSelectionByCharacterIntent).collapseSelection, true);
+      await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.numpad4));
+      expect(state.lastIntent, isA<ExtendSelectionByCharacterIntent>());
+      expect((state.lastIntent! as ExtendSelectionByCharacterIntent).forward, false);
+      expect((state.lastIntent! as ExtendSelectionByCharacterIntent).collapseSelection, true);
 
-        await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.numpad8));
-        expect(state.lastIntent, isA<ExtendSelectionVerticallyToAdjacentLineIntent>());
-        expect((state.lastIntent! as ExtendSelectionVerticallyToAdjacentLineIntent).forward, false);
-        expect(
-          (state.lastIntent! as ExtendSelectionVerticallyToAdjacentLineIntent).collapseSelection,
-          true,
-        );
+      await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.numpad8));
+      expect(state.lastIntent, isA<ExtendSelectionVerticallyToAdjacentLineIntent>());
+      expect((state.lastIntent! as ExtendSelectionVerticallyToAdjacentLineIntent).forward, false);
+      expect(
+        (state.lastIntent! as ExtendSelectionVerticallyToAdjacentLineIntent).collapseSelection,
+        true,
+      );
 
-        await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.numpad2));
-        expect(state.lastIntent, isA<ExtendSelectionVerticallyToAdjacentLineIntent>());
-        expect((state.lastIntent! as ExtendSelectionVerticallyToAdjacentLineIntent).forward, true);
-        expect(
-          (state.lastIntent! as ExtendSelectionVerticallyToAdjacentLineIntent).collapseSelection,
-          true,
-        );
+      await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.numpad2));
+      expect(state.lastIntent, isA<ExtendSelectionVerticallyToAdjacentLineIntent>());
+      expect((state.lastIntent! as ExtendSelectionVerticallyToAdjacentLineIntent).forward, true);
+      expect(
+        (state.lastIntent! as ExtendSelectionVerticallyToAdjacentLineIntent).collapseSelection,
+        true,
+      );
 
-        await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.numpad9));
-        expect(state.lastIntent, isA<ExtendSelectionVerticallyToAdjacentPageIntent>());
-        expect((state.lastIntent! as ExtendSelectionVerticallyToAdjacentPageIntent).forward, false);
-        expect(
-          (state.lastIntent! as ExtendSelectionVerticallyToAdjacentPageIntent).collapseSelection,
-          true,
-        );
+      await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.numpad9));
+      expect(state.lastIntent, isA<ExtendSelectionVerticallyToAdjacentPageIntent>());
+      expect((state.lastIntent! as ExtendSelectionVerticallyToAdjacentPageIntent).forward, false);
+      expect(
+        (state.lastIntent! as ExtendSelectionVerticallyToAdjacentPageIntent).collapseSelection,
+        true,
+      );
 
-        await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.numpad3));
-        expect(state.lastIntent, isA<ExtendSelectionVerticallyToAdjacentPageIntent>());
-        expect((state.lastIntent! as ExtendSelectionVerticallyToAdjacentPageIntent).forward, true);
-        expect(
-          (state.lastIntent! as ExtendSelectionVerticallyToAdjacentPageIntent).collapseSelection,
-          true,
-        );
+      await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.numpad3));
+      expect(state.lastIntent, isA<ExtendSelectionVerticallyToAdjacentPageIntent>());
+      expect((state.lastIntent! as ExtendSelectionVerticallyToAdjacentPageIntent).forward, true);
+      expect(
+        (state.lastIntent! as ExtendSelectionVerticallyToAdjacentPageIntent).collapseSelection,
+        true,
+      );
 
-        await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.numpad7));
-        expect(state.lastIntent, isA<ExtendSelectionVerticallyToAdjacentLineIntent>());
-        expect((state.lastIntent! as ExtendSelectionVerticallyToAdjacentLineIntent).forward, false);
-        expect(
-          (state.lastIntent! as ExtendSelectionVerticallyToAdjacentLineIntent).collapseSelection,
-          true,
-        );
+      await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.numpad7));
+      expect(state.lastIntent, isA<ExtendSelectionVerticallyToAdjacentLineIntent>());
+      expect((state.lastIntent! as ExtendSelectionVerticallyToAdjacentLineIntent).forward, false);
+      expect(
+        (state.lastIntent! as ExtendSelectionVerticallyToAdjacentLineIntent).collapseSelection,
+        true,
+      );
 
-        await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.numpad1));
-        expect(state.lastIntent, isA<ExtendSelectionVerticallyToAdjacentLineIntent>());
-        expect((state.lastIntent! as ExtendSelectionVerticallyToAdjacentLineIntent).forward, true);
-        expect(
-          (state.lastIntent! as ExtendSelectionVerticallyToAdjacentLineIntent).collapseSelection,
-          true,
-        );
+      await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.numpad1));
+      expect(state.lastIntent, isA<ExtendSelectionVerticallyToAdjacentLineIntent>());
+      expect((state.lastIntent! as ExtendSelectionVerticallyToAdjacentLineIntent).forward, true);
+      expect(
+        (state.lastIntent! as ExtendSelectionVerticallyToAdjacentLineIntent).collapseSelection,
+        true,
+      );
 
-        await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.numpadDecimal));
-        expect(state.lastIntent, isA<DeleteCharacterIntent>());
-        expect((state.lastIntent! as DeleteCharacterIntent).forward, true);
+      await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.numpadDecimal));
+      expect(state.lastIntent, isA<DeleteCharacterIntent>());
+      expect((state.lastIntent! as DeleteCharacterIntent).forward, true);
 
-        await sendKeyCombination(
-          tester,
-          const SingleActivator(LogicalKeyboardKey.numpad6, control: true),
-        );
-        expect(state.lastIntent, isA<ExtendSelectionToNextWordBoundaryIntent>());
-        expect((state.lastIntent! as ExtendSelectionToNextWordBoundaryIntent).forward, true);
-        expect(
-          (state.lastIntent! as ExtendSelectionToNextWordBoundaryIntent).collapseSelection,
-          true,
-        );
+      await sendKeyCombination(
+        tester,
+        const SingleActivator(LogicalKeyboardKey.numpad6, control: true),
+      );
+      expect(state.lastIntent, isA<ExtendSelectionToNextWordBoundaryIntent>());
+      expect((state.lastIntent! as ExtendSelectionToNextWordBoundaryIntent).forward, true);
+      expect(
+        (state.lastIntent! as ExtendSelectionToNextWordBoundaryIntent).collapseSelection,
+        true,
+      );
 
-        await sendKeyCombination(
-          tester,
-          const SingleActivator(LogicalKeyboardKey.numpad4, control: true),
-        );
-        expect(state.lastIntent, isA<ExtendSelectionToNextWordBoundaryIntent>());
-        expect((state.lastIntent! as ExtendSelectionToNextWordBoundaryIntent).forward, false);
-        expect(
-          (state.lastIntent! as ExtendSelectionToNextWordBoundaryIntent).collapseSelection,
-          true,
-        );
+      await sendKeyCombination(
+        tester,
+        const SingleActivator(LogicalKeyboardKey.numpad4, control: true),
+      );
+      expect(state.lastIntent, isA<ExtendSelectionToNextWordBoundaryIntent>());
+      expect((state.lastIntent! as ExtendSelectionToNextWordBoundaryIntent).forward, false);
+      expect(
+        (state.lastIntent! as ExtendSelectionToNextWordBoundaryIntent).collapseSelection,
+        true,
+      );
 
-        await sendKeyCombination(
-          tester,
-          const SingleActivator(LogicalKeyboardKey.numpad8, control: true),
-        );
-        expect(state.lastIntent, isA<ExtendSelectionToNextParagraphBoundaryIntent>());
-        expect((state.lastIntent! as ExtendSelectionToNextParagraphBoundaryIntent).forward, false);
-        expect(
-          (state.lastIntent! as ExtendSelectionToNextParagraphBoundaryIntent).collapseSelection,
-          true,
-        );
+      await sendKeyCombination(
+        tester,
+        const SingleActivator(LogicalKeyboardKey.numpad8, control: true),
+      );
+      expect(state.lastIntent, isA<ExtendSelectionToNextParagraphBoundaryIntent>());
+      expect((state.lastIntent! as ExtendSelectionToNextParagraphBoundaryIntent).forward, false);
+      expect(
+        (state.lastIntent! as ExtendSelectionToNextParagraphBoundaryIntent).collapseSelection,
+        true,
+      );
 
-        await sendKeyCombination(
-          tester,
-          const SingleActivator(LogicalKeyboardKey.numpad2, control: true),
-        );
-        expect(state.lastIntent, isA<ExtendSelectionToNextParagraphBoundaryIntent>());
-        expect((state.lastIntent! as ExtendSelectionToNextParagraphBoundaryIntent).forward, true);
-        expect(
-          (state.lastIntent! as ExtendSelectionToNextParagraphBoundaryIntent).collapseSelection,
-          true,
-        );
+      await sendKeyCombination(
+        tester,
+        const SingleActivator(LogicalKeyboardKey.numpad2, control: true),
+      );
+      expect(state.lastIntent, isA<ExtendSelectionToNextParagraphBoundaryIntent>());
+      expect((state.lastIntent! as ExtendSelectionToNextParagraphBoundaryIntent).forward, true);
+      expect(
+        (state.lastIntent! as ExtendSelectionToNextParagraphBoundaryIntent).collapseSelection,
+        true,
+      );
 
-        await sendKeyCombination(
-          tester,
-          const SingleActivator(LogicalKeyboardKey.numpadDecimal, control: true),
-        );
-        expect(state.lastIntent, isA<DeleteToNextWordBoundaryIntent>());
-        expect((state.lastIntent! as DeleteToNextWordBoundaryIntent).forward, true);
-      },
-      variant: TargetPlatformVariant.only(TargetPlatform.linux),
-    );
+      await sendKeyCombination(
+        tester,
+        const SingleActivator(LogicalKeyboardKey.numpadDecimal, control: true),
+      );
+      expect(state.lastIntent, isA<DeleteToNextWordBoundaryIntent>());
+      expect((state.lastIntent! as DeleteToNextWordBoundaryIntent).forward, true);
+    }, variant: TargetPlatformVariant.only(TargetPlatform.linux));
 
     testWidgets(
       'update the editable text content when triggered on non-web',
@@ -845,8 +837,8 @@ void main() {
                 autofocus: true,
                 focusNode: focusNode,
                 style: const TextStyle(fontSize: 10.0),
-                cursorColor: const Color(0xFF2196F3),
-                backgroundCursorColor: const Color(0xFF9E9E9E),
+                cursorColor: _cursorColor,
+                backgroundCursorColor: _backgroundCursorColor,
               ),
             ),
           ),
@@ -886,8 +878,8 @@ void main() {
                 autofocus: true,
                 focusNode: focusNode,
                 style: const TextStyle(fontSize: 10.0),
-                cursorColor: const Color(0xFF2196F3),
-                backgroundCursorColor: const Color(0xFF9E9E9E),
+                cursorColor: _cursorColor,
+                backgroundCursorColor: _backgroundCursorColor,
               ),
             ),
           ),

--- a/packages/flutter/test/widgets/default_text_editing_shortcuts_test.dart
+++ b/packages/flutter/test/widgets/default_text_editing_shortcuts_test.dart
@@ -3,11 +3,12 @@
 // found in the LICENSE file.
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'keyboard_utils.dart';
+import 'widgets_app_tester.dart';
 
 void main() {
   Widget buildSpyAboveEditableText({
@@ -17,7 +18,7 @@ void main() {
     final controller = TextEditingController(text: 'dummy text');
     addTearDown(controller.dispose);
 
-    return MaterialApp(
+    return TestWidgetsApp(
       home: Align(
         alignment: Alignment.topLeft,
         child: SizedBox(
@@ -35,9 +36,9 @@ void main() {
               textScaleFactor: 1,
               // Avoid the cursor from taking up width.
               cursorWidth: 0,
-              cursorColor: Colors.blue,
-              backgroundCursorColor: Colors.grey,
-              selectionControls: materialTextSelectionControls,
+              cursorColor: const Color(0xFF2196F3),
+              backgroundCursorColor: const Color(0xFF9E9E9E),
+              selectionControls: emptyTextSelectionControls,
               keyboardType: TextInputType.text,
               maxLines: null,
               textAlign: TextAlign.left,
@@ -836,7 +837,7 @@ void main() {
         addTearDown(controller.dispose);
 
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: Align(
               alignment: Alignment.topLeft,
               child: EditableText(
@@ -844,8 +845,8 @@ void main() {
                 autofocus: true,
                 focusNode: focusNode,
                 style: const TextStyle(fontSize: 10.0),
-                cursorColor: Colors.blue,
-                backgroundCursorColor: Colors.grey,
+                cursorColor: const Color(0xFF2196F3),
+                backgroundCursorColor: const Color(0xFF9E9E9E),
               ),
             ),
           ),
@@ -877,7 +878,7 @@ void main() {
         addTearDown(controller.dispose);
 
         await tester.pumpWidget(
-          MaterialApp(
+          TestWidgetsApp(
             home: Align(
               alignment: Alignment.topLeft,
               child: EditableText(
@@ -885,8 +886,8 @@ void main() {
                 autofocus: true,
                 focusNode: focusNode,
                 style: const TextStyle(fontSize: 10.0),
-                cursorColor: Colors.blue,
-                backgroundCursorColor: Colors.grey,
+                cursorColor: const Color(0xFF2196F3),
+                backgroundCursorColor: const Color(0xFF9E9E9E),
               ),
             ),
           ),


### PR DESCRIPTION
Several tests under `packages/flutter/test/` were importing `package:flutter/material.dart` even though they only exercise APIs from `package:flutter/widgets.dart` (or lower layers like `painting`, `animation`, `gestures`). Pulling in Material unnecessarily increases cross-package coupling between these tests and the Material library and works against the cross-import hygiene enforced by `dev/bots/check_tests_cross_imports.dart`.

This PR:

- Switches the import from `package:flutter/material.dart` to `package:flutter/widgets.dart` in tests that do not reference any Material symbols.
- Where tests referenced `Colors.*` only, replaces those with the equivalent raw `const Color(0x…)` values.
- Where tests wrapped widgets in `MaterialApp` purely as a `Directionality`/`MediaQuery`/localization host, swaps `MaterialApp` for `TestWidgetsApp` from `widgets_app_tester.dart`, and replaces `materialTextSelectionControls` with `emptyTextSelectionControls`.
- Removes the corresponding entry from the `check_tests_cross_imports.dart` allowlist where applicable.

No production code is modified and no test semantics change — the tests exercise the same widget/painting/gesture/animation behavior, just without dragging in Material.

## Files changed

Tests updated:

- `packages/flutter/test/gestures/force_press_test.dart`
- `packages/flutter/test/gestures/transformed_scale_test.dart`
- `packages/flutter/test/widgets/default_text_editing_shortcuts_test.dart`
- `packages/flutter/test/widgets/semantics_owner_test.dart`
- `packages/flutter/test/animation/animation_sheet_test.dart`
- `packages/flutter/test/painting/star_border_test.dart`
- `packages/flutter/test/painting/paint_image_test.dart`

Allowlist updated:

- `dev/bots/check_tests_cross_imports.dart`

## Scope note — two files intentionally left out

Two test files originally staged in this cleanup were dropped after local test runs showed they aren't a clean Material → widgets swap. Details and a request for guidance are in a separate PR comment below:

- `packages/flutter/test/widgets/editable_text_scribe_test.dart` — the handle-tap tests rely on `CustomPaint` widgets painted by `materialTextSelectionControls`; `emptyTextSelectionControls` paints nothing, so the handle finders return 0 widgets.
- `packages/flutter/test/widgets/editable_text_test.dart` (Live Text test only) — swapping `MaterialApp` → `TestWidgetsApp` triggers `A FocusManager was used after being disposed` in the shared `tearDown`, cascading into five downstream a11y/semantics tests.

Both files remain on the `check_tests_cross_imports.dart` allowlist and can be picked up in follow-up PRs once we agree on the approach.

## Related issues

- Part of umbrella issue flutter/flutter#177028 (Framework unit tests shouldn't cross-import libraries).
- Also addresses flutter/flutter#177412 (No legacy Material imports in tests).

## Context — why one PR

Per reviewer guidance from @navaronbracke on flutter/flutter#185238 ([comment](https://github.com/flutter/flutter/pull/185238#issuecomment-4278676074)), similar Material-import cleanups are being consolidated into a single PR that lands closer to the ~300–500-line "sweet spot" rather than as many tiny per-file PRs.

## Superseded PRs (please close once this lands)

The following open PRs are subsumed by this one and can be closed if this PR is approved (see [this comment](https://github.com/flutter/flutter/pull/185238#issuecomment-4278738146)):

- flutter/flutter#185236 — Remove unused material.dart import from force_press_test.dart
- flutter/flutter#185241 — Remove unnecessary Material import from default_text_editing_shortcuts_test

Not superseded (corresponding files were dropped from this PR — see the scope note above):

- flutter/flutter#185238 — editable_text_scribe_test
- flutter/flutter#185242 — editable_text_test Live Text

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt]. <!-- test-only cleanup: no production code or test-behavior changes; existing coverage is preserved. -->
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md