### PR TITLE
Delete `--no-enable-merged-platform-ui-thread`

### DIFF
--- a/engine/src/flutter/shell/common/switch_defs.h
+++ b/engine/src/flutter/shell/common/switch_defs.h
@@ -279,11 +279,6 @@ DEF_SWITCH(EnablePlatformIsolates,
 DEF_SWITCH(MergedPlatformUIThread,
            "merged-platform-ui-thread",
            "Sets whether the ui thread and platform thread should be merged.")
-// This is a legacy flag that has been superseded by merged-platform-ui-thread.
-// TODO(163064): remove this when users have been migrated.
-DEF_SWITCH(DisableMergedPlatformUIThread,
-           "no-enable-merged-platform-ui-thread",
-           "Disables merging of the UI and platform threads.")
 DEF_SWITCH(EnableAndroidHcppAndSurfaceControl,
            "enable-hcpp-and-surface-control",
            "Enable the HCPP platform view mode and SurfaceControl backed "


### PR DESCRIPTION
As per https://github.com/flutter/flutter/issues/163064.

For Android, there's a [warning](https://github.com/flutter/flutter/blob/2150dfd507718fac280bc1f0bd80d7c94a391410/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java#L325) still if [the flag](https://github.com/flutter/flutter/blob/fc48d79ecaefcdb249b58761d29bcfabbff16fc1/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/FlutterEngineFlags.java#L426-L433) gets used (not sure if we'd want something similar on other platforms). 

g3 fix: cl/902778836.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
