### PR TITLE
[a11y] Add CONTENT_CHANGE_TYPE_EXPANDED support on android.

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -2030,6 +2030,9 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
       if (Build.VERSION.SDK_INT >= API_LEVELS.API_36 && object.didChangeCheckedState()) {
         sendWindowContentChangeEvent(object.id, AccessibilityEvent.CONTENT_CHANGE_TYPE_CHECKED);
       }
+      if (Build.VERSION.SDK_INT >= API_LEVELS.API_36 && object.didChangeExpandState()) {
+        sendWindowContentChangeEvent(object.id, AccessibilityEvent.CONTENT_CHANGE_TYPE_EXPANDED);
+      }
       if (accessibilityFocusedSemanticsNode != null
           && accessibilityFocusedSemanticsNode.id == object.id
           && !object.hadFlag(Flag.IS_SELECTED)
@@ -2746,6 +2749,14 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
       return (hasFlag(Flag.IS_CHECKED) != hadFlag(Flag.IS_CHECKED))
           || (hasFlag(Flag.IS_CHECK_STATE_MIXED) != hadFlag(Flag.IS_CHECK_STATE_MIXED))
           || (hasFlag(Flag.IS_TOGGLED) != hadFlag(Flag.IS_TOGGLED));
+    }
+
+    private boolean didChangeExpandState() {
+      if (!hadPreviousConfig) {
+        return false;
+      }
+      return (hasFlag(Flag.IS_EXPANDED) != hadFlag(Flag.IS_EXPANDED))
+          || (hasFlag(Flag.HAS_EXPANDED_STATE) != hadFlag(Flag.HAS_EXPANDED_STATE));
     }
 
     private void log(@NonNull String indent, boolean recursive) {

--- a/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -2027,11 +2027,13 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
       if (object.hasFlag(Flag.IS_LIVE_REGION) && object.didChangeLabel()) {
         sendWindowContentChangeEvent(object.id, AccessibilityEvent.CONTENT_CHANGE_TYPE_SUBTREE);
       }
-      if (Build.VERSION.SDK_INT >= API_LEVELS.API_36 && object.didChangeCheckedState()) {
-        sendWindowContentChangeEvent(object.id, AccessibilityEvent.CONTENT_CHANGE_TYPE_CHECKED);
-      }
-      if (Build.VERSION.SDK_INT >= API_LEVELS.API_36 && object.didChangeExpandState()) {
-        sendWindowContentChangeEvent(object.id, AccessibilityEvent.CONTENT_CHANGE_TYPE_EXPANDED);
+      if (Build.VERSION.SDK_INT >= API_LEVELS.API_36) {
+        if (object.didChangeCheckedState()) {
+          sendWindowContentChangeEvent(object.id, AccessibilityEvent.CONTENT_CHANGE_TYPE_CHECKED);
+        }
+        if (object.didChangeExpandState()) {
+          sendWindowContentChangeEvent(object.id, AccessibilityEvent.CONTENT_CHANGE_TYPE_EXPANDED);
+        }
       }
       if (accessibilityFocusedSemanticsNode != null
           && accessibilityFocusedSemanticsNode.id == object.id

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -2905,6 +2905,7 @@ public class AccessibilityBridgeTest {
 
     AccessibilityBridge accessibilityBridge = setUpBridge(mockRootView, mockManager, null);
 
+    // Initially expanded state: false
     TestSemanticsNode node = new TestSemanticsNode();
     node.id = 0;
     node.addFlag(AccessibilityBridge.Flag.HAS_EXPANDED_STATE);
@@ -2932,7 +2933,7 @@ public class AccessibilityBridgeTest {
     }
     assertEquals(
         "CONTENT_CHANGE_TYPE_EXPANDED event should be sent twice for expansion state changes",
-        2,
+        3,
         foundCount);
   }
 

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -2936,6 +2936,48 @@ public class AccessibilityBridgeTest {
         foundCount);
   }
 
+  @Config(sdk = API_LEVELS.API_35)
+  @TargetApi(API_LEVELS.API_35)
+  @Test
+  public void itDoesNotSendContentChangeExpandedOnAPI35() {
+    View mockRootView = mock(View.class);
+    Context mockContext = mock(Context.class);
+    when(mockRootView.getContext()).thenReturn(mockContext);
+    when(mockContext.getPackageName()).thenReturn("test");
+    ViewParent mockParent = mock(ViewParent.class);
+    when(mockRootView.getParent()).thenReturn(mockParent);
+    AccessibilityManager mockManager = mock(AccessibilityManager.class);
+    when(mockManager.isEnabled()).thenReturn(true);
+
+    AccessibilityBridge accessibilityBridge = setUpBridge(mockRootView, mockManager, null);
+
+    TestSemanticsNode node = new TestSemanticsNode();
+    node.id = 0;
+    node.addFlag(AccessibilityBridge.Flag.HAS_EXPANDED_STATE);
+    node.toUpdate().sendUpdateToBridge(accessibilityBridge);
+
+    // Change expanded state: false -> true
+    node.addFlag(AccessibilityBridge.Flag.IS_EXPANDED);
+    node.toUpdate().sendUpdateToBridge(accessibilityBridge);
+
+    ArgumentCaptor<AccessibilityEvent> eventCaptor =
+        ArgumentCaptor.forClass(AccessibilityEvent.class);
+    verify(mockParent, atLeastOnce())
+        .requestSendAccessibilityEvent(eq(mockRootView), eventCaptor.capture());
+
+    int foundCount = 0;
+    for (AccessibilityEvent event : eventCaptor.getAllValues()) {
+      if (event.getEventType() == AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED
+          && event.getContentChangeTypes() == AccessibilityEvent.CONTENT_CHANGE_TYPE_EXPANDED) {
+        foundCount++;
+      }
+    }
+    assertEquals(
+        "CONTENT_CHANGE_TYPE_EXPANDED event should not be sent on API 35",
+        0,
+        foundCount);
+  }
+
   @Config(sdk = API_LEVELS.API_28)
   @TargetApi(API_LEVELS.API_28)
   @Test

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -2890,6 +2890,52 @@ public class AccessibilityBridgeTest {
         foundCount);
   }
 
+  @Config(sdk = API_LEVELS.API_36)
+  @TargetApi(API_LEVELS.API_36)
+  @Test
+  public void itSendsContentChangeExpandedOnAPI36() {
+    View mockRootView = mock(View.class);
+    Context mockContext = mock(Context.class);
+    when(mockRootView.getContext()).thenReturn(mockContext);
+    when(mockContext.getPackageName()).thenReturn("test");
+    ViewParent mockParent = mock(ViewParent.class);
+    when(mockRootView.getParent()).thenReturn(mockParent);
+    AccessibilityManager mockManager = mock(AccessibilityManager.class);
+    when(mockManager.isEnabled()).thenReturn(true);
+
+    AccessibilityBridge accessibilityBridge = setUpBridge(mockRootView, mockManager, null);
+
+    TestSemanticsNode node = new TestSemanticsNode();
+    node.id = 0;
+    node.addFlag(AccessibilityBridge.Flag.HAS_EXPANDED_STATE);
+    node.toUpdate().sendUpdateToBridge(accessibilityBridge);
+
+    // Change expanded state: false -> true
+    node.addFlag(AccessibilityBridge.Flag.IS_EXPANDED);
+    node.toUpdate().sendUpdateToBridge(accessibilityBridge);
+
+    // Change expanded state: true -> false
+    node.flags &= ~AccessibilityBridge.Flag.IS_EXPANDED.value;
+    node.toUpdate().sendUpdateToBridge(accessibilityBridge);
+
+    ArgumentCaptor<AccessibilityEvent> eventCaptor =
+        ArgumentCaptor.forClass(AccessibilityEvent.class);
+    verify(mockParent, atLeastOnce())
+        .requestSendAccessibilityEvent(eq(mockRootView), eventCaptor.capture());
+
+    int foundCount = 0;
+    for (AccessibilityEvent event : eventCaptor.getAllValues()) {
+      if (event.getEventType() == AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED
+          && event.getContentChangeTypes() == AccessibilityEvent.CONTENT_CHANGE_TYPE_EXPANDED) {
+        foundCount++;
+      }
+    }
+    assertEquals(
+        "CONTENT_CHANGE_TYPE_EXPANDED event should be sent twice for expand transitions",
+        2,
+        foundCount);
+  }
+
   @Config(sdk = API_LEVELS.API_28)
   @TargetApi(API_LEVELS.API_28)
   @Test

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -2972,10 +2972,7 @@ public class AccessibilityBridgeTest {
         foundCount++;
       }
     }
-    assertEquals(
-        "CONTENT_CHANGE_TYPE_EXPANDED event should not be sent on API 35",
-        0,
-        foundCount);
+    assertEquals("CONTENT_CHANGE_TYPE_EXPANDED event should not be sent on API 35", 0, foundCount);
   }
 
   @Config(sdk = API_LEVELS.API_28)

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -2931,7 +2931,7 @@ public class AccessibilityBridgeTest {
       }
     }
     assertEquals(
-        "CONTENT_CHANGE_TYPE_EXPANDED event should be sent twice for expand transitions",
+        "CONTENT_CHANGE_TYPE_EXPANDED event should be sent twice for expansion state changes",
         2,
         foundCount);
   }


### PR DESCRIPTION


https://github.com/flutter/flutter/pull/174981 added expand flag support, this PR is a follow-up to add CONTENT_CHANGE_TYPE_EXPANDED (it's added in android 16 API 36)



## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
