### PR TITLE
[web] Add font fallback service

### DIFF
--- a/engine/src/flutter/lib/web_ui/docs/FALLBACK_FONT_SERVICE.md
+++ b/engine/src/flutter/lib/web_ui/docs/FALLBACK_FONT_SERVICE.md
@@ -1,0 +1,129 @@
+# FallbackFontService Design Document
+
+## Section 0: The Problem Statement
+
+In Flutter Web applications, text rendering depends on the fonts provided by the developer in the application's asset bundle. When a piece of text contains characters (such as CJK scripts, emojis, or rare symbols) that are not covered by any of the fonts included in the asset bundle, the engine invokes an automatic "font fallback" system. This system identifies the missing characters and attempts to download the appropriate "Noto" fonts from a CDN (typically Google Fonts) to ensure the text is legible.
+
+Currently, this fallback system has a critical reliability flaw: **It does not gracefully handle network or server failures.**
+
+If a required fallback font fails to download—whether due to a 404 error, a broken CDN link, or a transient network interruption—the engine enters an **infinite loop**. Because it does not track these failures effectively, it continuously attempts to download the same failing font. Each attempt notifies the application that "fonts have changed," triggering a UI relayout. This relayout rediscovers that the characters are still missing and restarts the download attempt immediately.
+
+For the end-user and the business, this results in:
+1.  **System Instability:** The infinite loop consumes excessive CPU and battery power, causing the web application to become laggy, hot, or unresponsive.
+2.  **Network Abuse:** The application spams font servers with thousands of redundant requests, which can lead to rate-limiting, increased infrastructure costs, and a poor reputation for the app's network behavior.
+3.  **Broken Aesthetics:** Users are left with "tofu" (empty boxes), and the engine fails to provide a "best-effort" recovery—such as attempting a secondary fallback font that might actually be reachable.
+4.  **Operational Noise:** Browser consoles are flooded with identical error logs, making it nearly impossible for developers to debug other issues or maintain a production-grade application.
+
+We need a solution that makes the font fallback system **autonomous and resilient**, ensuring it can recover from transient errors, find alternative fonts when primary ones fail, and—above all—terminate its attempts once it has exhausted all viable options.
+
+## Section 1: The Technical Implementation Plan
+
+To solve this problem, we are rebuilding the font fallback system as a dedicated, smart background service called the **FallbackFontService**. This service will act like a "concierge" for missing characters: instead of the rendering engine frantically trying to manage downloads on its own, it will simply hand a list of missing characters to this service and trust it to handle the rest.
+
+The plan consists of four major components working together:
+
+### 1. The "Request Queue" (Skia-Driven Discovery)
+Currently, the engine manually checks every string of text to see if it *might* need a fallback font based on its own records. We will replace this manual check with a more direct approach: we will ask the underlying graphics engine (**Skia**) for the truth. During the "layout" phase (when the app calculates exactly where text should go), we will call a specific function to get the exact list of characters that the current fonts—including any fallback fonts already loaded—could not handle. These "unresolved" characters are added to a global "Unprocessed" list in the service. By letting Skia be the source of truth, we ensure the service only acts when a character is genuinely missing from the screen.
+
+### 2. The Autonomous Manager (FallbackFontService)
+The service manages its own state independently of the main application's UI cycle, using an event-driven "convergence" model. When new characters arrive in the "Unprocessed" list, the service:
+*   **Filters out duplicates:** It ignores characters it is already trying to download or that it has already failed to find.
+*   **Picks the best fonts:** It uses "greedy" logic to find the smallest number of fonts that cover the most missing characters.
+*   **Consults the Fallback Data:** The service uses a mapping of characters to fonts stored in `lib/src/engine/font_fallback_data.dart`. This is a large, generated file that encodes exactly which Noto fonts provide glyphs for which Unicode ranges.
+*   **Manages downloads:** It handles the actual HTTP requests, ensuring we don't overwhelm the user's connection by limiting how many fonts download at once.
+
+### 3. The Smart Retry & Recovery System
+This is the "brain" of the fix. If a font fails to download, the service doesn't just give up or loop forever. 
+*   **Transient Errors:** If the network blips, it waits 1 second and tries again (up to 3 times).
+*   **Permanent Failures:** If a font is simply not there (a 404 error) or fails all retries, the service marks that font as "Permanently Unavailable."
+*   **Self-Healing:** The service then immediately re-evaluates the missing characters. Because it knows which fonts are broken, it will automatically look for the "next best" font to cover those characters. If no other fonts exist, it marks those characters as "Unsupported" and stops trying. This is what finally breaks the infinite loop.
+
+### 4. The Feedback Loop
+The service only talks back to the Flutter framework when it actually succeeds. When a font is successfully downloaded and registered, the service tells the framework: *"I have new fonts; please redraw the screen."* If a font fails and no replacement can be found, the service stays silent. The user will see a placeholder (like an empty box), but the app will remain stable and the network will go quiet.
+
+### Ecosystem Fit
+This feature sits deep within the "Web Engine" layer of Flutter. It bridges the gap between the high-level Flutter framework and the low-level browser environment. By moving this logic into a centralized service, we make the engine more efficient for all Flutter Web developers, providing a "fire and forget" system that handles the complexities of global typography and unreliable networks automatically.
+
+## Section 2: Alternatives Considered
+
+During the design process, we explored several other approaches but ultimately ruled them out in favor of the more robust `FallbackFontService` model.
+
+### 1. Immediate "Best-Effort" Replacement
+We considered a strategy where, if the primary font (Font A) failed even once, the service would immediately start downloading the secondary font (Font B). 
+*   **Why we ruled it out:** This was deemed too aggressive and wasteful of the user's bandwidth. In many cases, a single network blip is temporary. By jumping to Font B immediately, we risked downloading multiple large fonts for the same set of characters, potentially causing "layout jitter" where text changes its appearance multiple times as different fonts arrive. We decided it was better to give the primary font a fair chance to succeed through retries before looking for a substitute.
+
+### 2. Dependency on the Framework for Retries
+One early thought was to keep the current model where the framework's "re-layout" signal drives the retry logic. In this model, we would simply stop the loop by marking a font as failed.
+*   **Why we ruled it out:** This kept the engine in a "passive" state. If we failed to download any fonts in a batch and didn't notify the framework, the engine would essentially "fall asleep" and never try to find a replacement for those missing characters until some other unrelated UI change happened. We realized the engine needs to be **proactive**—it should be able to say, "Font A failed; let me immediately see if Font B can help," without needing the framework to ask it to try again.
+
+### 3. Filtering characters before enqueuing them
+We discussed filtering out characters that were already covered by "pending" downloads before they even entered the service's queue.
+*   **Why we ruled it out:** This created a dangerous "memory loss" problem. If we filtered out a character because Font A was *supposed* to cover it, and then Font A failed to download, the service would have no record that the character still needed covering. By keeping all missing characters in the "Unprocessed" list until they are truly resolved or exhausted, we ensure that no requirement is ever forgotten, regardless of how many individual fonts fail.
+
+### 4. Maintaining a manual "Shadow Cache" of fonts
+We considered having the service maintain its own comprehensive list of every character covered by every font it has ever seen to avoid talking to Skia so often.
+*   **Why we ruled it out:** This added unnecessary complexity and the risk of the service getting "out of sync" with the actual graphics engine. Since Skia is the ultimate authority on what it can and cannot render, it is much simpler and more accurate to ask it for the "unresolved" list directly during layout. This eliminates the need for the service to try and mirror Skia's complex internal font-matching logic.
+
+## Section 3: Detailed Implementation Plan
+
+This section outlines the surgical changes required to implement the `FallbackFontService` architecture. The goal is to centralize fallback logic, utilize Skia’s internal layout state, and implement a resilient retry/recovery loop.
+
+### 1. New Core Infrastructure
+
+*   **File: `lib/src/engine/font_fallback_service.dart` (New File)**
+    *   **Rationale:** To house the `FallbackFontService` class. This centralizes the `_unprocessedCodePoints`, `_pendingFonts`, and `_permanentlyUnavailableFonts` state. It will contain the "Event-Driven Convergence" logic, the stateless greedy algorithm, and the smart fetcher.
+*   **File: `lib/src/engine/noto_font.dart` (Refactor)**
+    *   **Rationale:** To make the `NotoFont` data class stateless, removing any internal tracking that would interfere with the `FallbackFontService` greedy selection algorithm.
+*   **File: `lib/src/engine/font_fallbacks.dart` (Major Refactor)**
+    *   **Rationale:** We will refactor the existing `FontFallbackManager` and `_FallbackFontDownloadQueue` logic into the new service. The `NotoFont` and `FallbackFontComponent` classes must be made stateless (removing `coverCount` and `coverComponents`) to allow the greedy algorithm to run safely and predictably during autonomous re-evaluations.
+
+### 2. Renderer Interface Updates
+
+*   **File: `lib/src/engine/canvaskit/canvaskit_api.dart`**
+    *   **Rationale:** Add the missing JS-Interop binding for `getUnresolvedCodepoints()` to the `SkParagraph` extension type. 
+    *   **Technical Detail:** The underlying JS/WASM method on the `SkParagraph` object takes **no arguments** and returns a `JSArray<JSNumber>` representing the Unicode code points.
+    *   **Usage:** This is the "source of truth" required to move away from string-based discovery.
+*   **File: `lib/src/engine/skwasm/skwasm_impl/raw/text/raw_paragraph.dart`**
+    *   **Rationale:** Ensure the FFI binding `paragraphGetUnresolvedCodePoints` is correctly exposed and documented for use in the unified fallback path.
+*   **File: `lib/src/engine/font_fallbacks.dart` (Interface change)**
+    *   **Rationale:** Update the `FallbackFontRegistry` abstract class. Change `loadFallbackFont(String name, String url)` to `Future<bool> loadFallbackFont(String name, Uint8List bytes)`. The return value indicates whether the renderer successfully registered the font. This shifts HTTP responsibility to the `FallbackFontService` and allows it to track registration failures.
+
+### 3. Renderer Implementation Updates
+
+*   **File: `lib/src/engine/canvaskit/fonts.dart` (`SkiaFontCollection`)**
+*   **File: `lib/src/engine/skwasm/skwasm_impl/font_collection.dart` (`SkwasmFontCollection`)**
+    *   **Rationale:** Both font collections now implement the unified `FlutterFontCollection` interface, which mandates the presence of a `FontFallbackManager` and a `FallbackFontRegistry`.
+    *   **Architecture:** Each collection now owns its respective registry implementation (`SkiaFallbackRegistry` and `SkwasmFallbackRegistry`) and initializes a `FontFallbackManager` to bridge the gap between the `FallbackFontService` and the renderer-specific font stack.
+    *   **State Management:** 
+        *   `SkiaFontCollection` was updated to maintain a `registeredFallbackFonts` list, and its `_registerWithFontProvider()` method now rebuilds the Skia font provider by combining both asset fonts and dynamically loaded fallback fonts.
+        *   `SkwasmFontCollection` now utilizes `setDefaultFontFamilies()` to synchronize the renderer's default font stack with the global fallback list managed by the service.
+    *   **Lifecycle:** Added `debugResetFallbackFonts()` to both implementations to ensure clean state during unit and golden testing, allowing the `FallbackFontService` to be reset independently of the main font stack.
+
+*   **File: `lib/src/engine/canvaskit/fonts.dart` (`SkiaFallbackRegistry`)**
+*   **File: `lib/src/engine/skwasm/skwasm_impl/font_collection.dart` (`SkwasmFallbackRegistry`)**
+    *   **Rationale:** These new registry classes implement the `FallbackFontRegistry` interface, providing the concrete logic for injecting font bytes into the respective WASM heaps and triggering the necessary font-provider updates.
+    *   **Technical Detail:** 
+        *   `loadFallbackFont(name, bytes)` handles the creation of a typeface from raw bytes.
+        *   `updateFallbackFontFamilies(families)` triggers the renderer-specific logic to update the font-matching order (e.g., rebuilding the `TypefaceFontProvider` in Skia or updating the default text style in Skwasm).
+*   **File: `lib/src/engine/canvaskit/text.dart` (`CkParagraph.layout`)**
+*   **File: `lib/src/engine/skwasm/skwasm_impl/paragraph.dart` (`SkwasmParagraph.layout`)**
+    *   **Rationale:** Update the `layout()` method in both renderers to call `getUnresolvedCodepoints()` from Skia. If unresolved characters are found, they will call `FallbackFontService.instance.addMissingCodePoints(list)`. This unified the discovery mechanism for both backends.
+    *   **Optimization:** Added a `_hasCheckedForMissingCodePoints` flag to both paragraph implementations to ensure that we only query Skia once per paragraph life-cycle, avoiding redundant work during repeated layouts.
+*   **File: `lib/src/engine/canvaskit/text.dart` (`CkParagraphBuilder.addText`)**
+    *   **Rationale:** Remove the call to `ensureFontsSupportText()`. This eliminates the expensive string-based check during paragraph building, significantly improving performance for text-heavy applications.
+
+### 4. Cleanup and Performance
+
+*   **File: `lib/src/engine/font_change_util.dart`**
+    *   **Rationale:** Verify the debouncing logic in `sendFontChangeMessage()`. We will rely on this to ensure that if multiple fonts in a batch succeed, we only trigger a single framework relayout per animation frame.
+*   **File: `lib/src/engine/dom.dart`**
+    *   **Rationale:** Ensure `httpFetch` is robustly exposed for the `FallbackFontService` to use for its "sophisticated" fetching (checking `response.ok` for 404s).
+
+### 5. Testing and Validation
+
+*   **File: `test/engine/font_fallback_service_test.dart` (New File)**
+    *   **Rationale:** Create a suite of unit tests for the new service. These will mock network failures, 404s, and successful downloads to verify that the "True Missing" logic correctly falls back to alternative fonts and eventually terminates the retry loop.
+*   **File: `test/ui/fallback_fonts_golden_test.dart`**
+    *   **Rationale:** Update existing golden tests to use the new `waitForIdle()` definition and ensure that "Permanent Failures" correctly render as tofu without causing infinite test timeouts.
+*   **File: `lib/src/engine/configuration.dart`**
+    *   **Rationale:** Add a new configuration flag (e.g., `debugSkipFontRetryDelay`) to allow tests to run without waiting for the 1-second backoff timer.

--- a/engine/src/flutter/lib/web_ui/docs/FALLBACK_FONT_SERVICE.md
+++ b/engine/src/flutter/lib/web_ui/docs/FALLBACK_FONT_SERVICE.md
@@ -37,6 +37,8 @@ This is the "brain" of the fix. If a font fails to download, the service doesn't
 *   **Transient Errors:** If the network blips, it waits 1 second and tries again (up to 3 times).
 *   **Permanent Failures:** If a font is simply not there (a 404 error) or fails all retries, the service marks that font as "Permanently Unavailable."
 *   **Self-Healing:** The service then immediately re-evaluates the missing characters. Because it knows which fonts are broken, it will automatically look for the "next best" font to cover those characters. If no other fonts exist, it marks those characters as "Unsupported" and stops trying. This is what finally breaks the infinite loop.
+*   **Global Kill Switch:** To protect against systemic misconfigurations (e.g., a broken `fontFallbackBaseUrl`), the service tracks total permanent failures. If 10 fonts fail permanently and zero have succeeded, the service declares itself "broken" and stops all future attempts for the session.
+*   **Per-Component Cap:** To prevent a single character from triggering hundreds of requests (e.g., a common character covered by many fonts), the service limits the number of candidate fonts it will attempt for any single Unicode component to 5. If all 5 fail, the component is marked as unsupported.
 
 ### 4. The Feedback Loop
 The service only talks back to the Flutter framework when it actually succeeds. When a font is successfully downloaded and registered, the service tells the framework: *"I have new fonts; please redraw the screen."* If a font fails and no replacement can be found, the service stays silent. The user will see a placeholder (like an empty box), but the app will remain stable and the network will go quiet.

--- a/engine/src/flutter/lib/web_ui/lib/src/engine.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine.dart
@@ -55,6 +55,7 @@ export 'engine/display.dart';
 export 'engine/dom.dart';
 export 'engine/font_change_util.dart';
 export 'engine/font_fallback_data.dart';
+export 'engine/font_fallback_service.dart';
 export 'engine/font_fallbacks.dart';
 export 'engine/fonts.dart';
 export 'engine/frame_service.dart';

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -2265,6 +2265,13 @@ extension type SkParagraph(JSObject _) implements JSObject {
   ui.GlyphInfo? getClosestGlyphInfoAt(double x, double y) =>
       _getClosestGlyphInfoAtCoordinate(x, y)?._glyphInfo;
 
+  @JS('unresolvedCodepoints')
+  external JSArray<JSNumber> _getUnresolvedCodePoints();
+  List<int> getUnresolvedCodePoints() {
+    final List<JSNumber> jsNumbers = _getUnresolvedCodePoints().toDart;
+    return List<int>.generate(jsNumbers.length, (int i) => jsNumbers[i].toDartInt);
+  }
+
   external SkTextRange getWordBoundary(double position);
   external void layout(double width);
   external void delete();

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/fonts.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/fonts.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:typed_data';
 
+import 'package:meta/meta.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
@@ -18,10 +19,26 @@ String _robotoUrl =
 
 /// Manages the fonts used in the Skia-based backend.
 class SkiaFontCollection implements FlutterFontCollection {
+  SkiaFontCollection() {
+    _fallbackRegistry = SkiaFallbackRegistry(this);
+    fontFallbackManager = FontFallbackManager(_fallbackRegistry);
+  }
+
   final Set<String> _downloadedFontFamilies = <String>{};
 
   @override
-  late FontFallbackManager fontFallbackManager = FontFallbackManager(SkiaFallbackRegistry(this));
+  late FontFallbackManager? fontFallbackManager;
+
+  late FallbackFontRegistry _fallbackRegistry;
+
+  @override
+  FallbackFontRegistry get fallbackFontRegistry => _fallbackRegistry;
+
+  @visibleForTesting
+  @override
+  set fallbackFontRegistry(FallbackFontRegistry? registry) {
+    _fallbackRegistry = registry!;
+  }
 
   /// Fonts that started the download process, but are not yet registered.
   ///
@@ -71,7 +88,7 @@ class SkiaFontCollection implements FlutterFontCollection {
   }
 
   @override
-  Future<bool> loadFontFromList(Uint8List list, {String? fontFamily}) async {
+  Future<bool> loadFontFromBytes(Uint8List list, {String? fontFamily}) async {
     // Make sure CanvasKit is actually loaded
     await renderer.initialize();
 
@@ -206,6 +223,8 @@ class SkiaFontCollection implements FlutterFontCollection {
 
   @override
   void debugResetFallbackFonts() {
+    // ignore: invalid_use_of_visible_for_testing_member
+    FallbackFontService.instance.debugReset();
     fontFallbackManager = FontFallbackManager(SkiaFallbackRegistry(this));
     registeredFallbackFonts.clear();
   }
@@ -254,48 +273,20 @@ class SkiaFallbackRegistry implements FallbackFontRegistry {
   final SkiaFontCollection _fontCollection;
 
   @override
-  List<int> getMissingCodePoints(List<int> codeUnits, List<String> fontFamilies) {
-    final fonts = <SkFont>[];
-    for (final font in fontFamilies) {
-      final List<SkFont>? typefacesForFamily = _fontCollection.familyToFontMap[font];
-      if (typefacesForFamily != null) {
-        fonts.addAll(typefacesForFamily);
-      }
-    }
-    final codePointsSupported = List<bool>.filled(codeUnits.length, false);
-    final testString = String.fromCharCodes(codeUnits);
-    for (final font in fonts) {
-      final Uint16List glyphs = font.getGlyphIDs(testString);
-      assert(glyphs.length == codePointsSupported.length);
-      for (var i = 0; i < glyphs.length; i++) {
-        codePointsSupported[i] |= glyphs[i] != 0;
-      }
-    }
-
-    final missingCodeUnits = <int>[];
-    for (var i = 0; i < codePointsSupported.length; i++) {
-      if (!codePointsSupported[i]) {
-        missingCodeUnits.add(codeUnits[i]);
-      }
-    }
-    return missingCodeUnits;
-  }
-
-  @override
-  Future<void> loadFallbackFont(String familyName, String url) async {
-    final ByteBuffer buffer = await httpFetchByteBuffer(url);
+  Future<bool> loadFallbackFont(String familyName, Uint8List bytes) async {
+    final ByteBuffer buffer = bytes.buffer;
     final SkTypeface? typeface = canvasKit.Typeface.MakeFreeTypeFaceFromData(buffer);
     if (typeface == null) {
-      printWarning('Failed to parse fallback font $familyName as a font.');
-      return;
+      return false;
     }
     _fontCollection.registeredFallbackFonts.add(
       RegisteredFont(buffer.asUint8List(), familyName, typeface),
     );
+    return true;
   }
 
   @override
   void updateFallbackFontFamilies(List<String> families) {
-    _fontCollection.registerDownloadedFonts();
+    _fontCollection._registerWithFontProvider();
   }
 }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/text.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/text.dart
@@ -807,6 +807,8 @@ class CkParagraph implements ui.Paragraph {
   /// is deleted.
   double _lastLayoutConstraints = double.negativeInfinity;
 
+  bool _hasCheckedForMissingCodePoints = false;
+
   /// The paragraph style used to build this paragraph.
   ///
   /// This is used to resurrect the paragraph if the initial paragraph
@@ -949,6 +951,15 @@ class CkParagraph implements ui.Paragraph {
       _minIntrinsicWidth = paragraph.getMinIntrinsicWidth();
       _width = paragraph.getMaxWidth();
       _boxesForPlaceholders = skRectsToTextBoxes(paragraph.getRectsForPlaceholders());
+
+      if (!ui_web.TestEnvironment.instance.disableFontFallbacks &&
+          !_hasCheckedForMissingCodePoints) {
+        _hasCheckedForMissingCodePoints = true;
+        final List<int> unresolvedCodePoints = paragraph.getUnresolvedCodePoints();
+        if (unresolvedCodePoints.isNotEmpty) {
+          FallbackFontService.instance.addMissingCodePoints(unresolvedCodePoints);
+        }
+      }
     } catch (e) {
       printWarning(
         'CanvasKit threw an exception while laying '
@@ -1139,15 +1150,6 @@ class CkParagraphBuilder implements ui.ParagraphBuilder {
 
   @override
   void addText(String text) {
-    final fontFamilies = <String>[];
-    final CkTextStyle style = _peekStyle();
-    if (style.effectiveFontFamily != null) {
-      fontFamilies.add(style.effectiveFontFamily!);
-    }
-    if (style.effectiveFontFamilyFallback != null) {
-      fontFamilies.addAll(style.effectiveFontFamilyFallback!);
-    }
-    renderer.fontCollection.fontFallbackManager!.ensureFontsSupportText(text, fontFamilies);
     _paragraphBuilder.addText(text);
   }
 

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/configuration.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/configuration.dart
@@ -361,6 +361,12 @@ class FlutterConfiguration {
   String get fontFallbackBaseUrl =>
       _configuration?.fontFallbackBaseUrl ?? 'https://fonts.gstatic.com/s/';
 
+  /// If set to true, the engine will skip the 1 second delay between font
+  /// download retries.
+  ///
+  /// This is used for testing.
+  bool get debugSkipFontRetryDelay => _configuration?.debugSkipFontRetryDelay ?? false;
+
   bool get forceSingleThreadedSkwasm => _configuration?.forceSingleThreadedSkwasm ?? false;
 }
 
@@ -382,6 +388,7 @@ extension type JsFlutterConfiguration._(JSObject _) implements JSObject {
     String? nonce,
     String? renderer,
     String? fontFallbackBaseUrl,
+    bool? debugSkipFontRetryDelay,
     bool? forceSingleThreadedSkwasm,
   });
 
@@ -397,6 +404,7 @@ extension type JsFlutterConfiguration._(JSObject _) implements JSObject {
   external String? get nonce;
   external String? get renderer;
   external String? get fontFallbackBaseUrl;
+  external bool? get debugSkipFontRetryDelay;
   external bool? get forceSingleThreadedSkwasm;
 }
 

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/font_fallback_service.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/font_fallback_service.dart
@@ -35,6 +35,15 @@ class FallbackFontService {
   /// Fonts that have been successfully downloaded and registered.
   final Set<NotoFont> _registeredFonts = <NotoFont>{};
 
+  /// Tracks how many fonts have failed for each component.
+  final Map<FallbackFontComponent, int> _failedFontsPerComponent = <FallbackFontComponent, int>{};
+
+  /// The total number of fonts that have failed permanently across all requests.
+  int _totalPermanentFailures = 0;
+
+  /// Whether the service has been disabled due to too many global failures.
+  bool _isBroken = false;
+
   /// Timer used for debouncing the processing loop.
   Timer? _processTimer;
 
@@ -49,6 +58,14 @@ class FallbackFontService {
 
   /// The delay between retries.
   static const Duration _retryDelay = Duration(seconds: 1);
+
+  /// The maximum number of global permanent failures allowed before the service
+  /// is disabled (if no fonts have been successfully registered).
+  static const int _maxGlobalFailuresBeforeBroken = 10;
+
+  /// The maximum number of candidate fonts we will attempt to download for any
+  /// single [FallbackFontComponent] before marking it as unsupported.
+  static const int _maxFontsPerComponent = 5;
 
   /// Adds a list of missing code points to be processed.
   void addMissingCodePoints(List<int> codePoints) {
@@ -169,9 +186,16 @@ class FallbackFontService {
 
       // 3. Permanent Failure: Have all fonts for this component failed already?
       // If all candidate fonts for a character are dead, we stop trying to avoid infinite loops.
+      //
+      // We also stop if the service has been declared "broken" due to too many
+      // global failures, or if this specific component has exhausted its
+      // allowed attempt budget.
       final bool isUnavailable = unavailableCache.putIfAbsent(
         component,
-        () => component.fonts.every((NotoFont f) => _permanentlyUnavailableFonts.contains(f)),
+        () =>
+            _isBroken ||
+            component.fonts.every((NotoFont f) => _permanentlyUnavailableFonts.contains(f)) ||
+            (_failedFontsPerComponent[component] ?? 0) >= _maxFontsPerComponent,
       );
       if (isUnavailable) {
         newlyUnsupported.add(cp);
@@ -459,6 +483,10 @@ class FallbackFontService {
   /// 4. **Notification**: On successful registration, the service notifies the
   ///    framework to trigger a UI relayout.
   Future<void> _downloadAndRegisterFontWithRetries(NotoFont font) async {
+    if (_isBroken) {
+      return;
+    }
+
     var attempts = 0;
     final String baseUrl = configuration.fontFallbackBaseUrl;
 
@@ -529,6 +557,27 @@ class FallbackFontService {
     // If all retries failed, stop trying this font forever.
     printWarning('Font ${font.name} at $url is permanently unavailable.');
     _permanentlyUnavailableFonts.add(font);
+
+    // Track failures for the global kill switch and per-component cap.
+    _totalPermanentFailures++;
+    final FontFallbackManager manager = renderer.fontCollection.fontFallbackManager!;
+    // Note: This is slightly inefficient as we repeat the search, but it keeps
+    // the download task's signature simple.
+    // We check all components to see which one was supposed to be covered by this font.
+    for (final FallbackFontComponent component in manager.fontComponents) {
+      if (component.fonts.contains(font)) {
+        _failedFontsPerComponent[component] = (_failedFontsPerComponent[component] ?? 0) + 1;
+      }
+    }
+
+    if (_registeredFonts.isEmpty && _totalPermanentFailures >= _maxGlobalFailuresBeforeBroken) {
+      printWarning(
+        'Font fallback service has reached the maximum number of global failures '
+        'without a single success. This may indicate a problem with the '
+        'fontFallbackBaseUrl (currently "$baseUrl"). Disabling service for this session.',
+      );
+      _isBroken = true;
+    }
   }
 
   /// Determines if an HTTP [status] code should be treated as a permanent error.
@@ -581,6 +630,9 @@ class FallbackFontService {
     _pendingFonts.clear();
     _permanentlyUnavailableFonts.clear();
     _registeredFonts.clear();
+    _failedFontsPerComponent.clear();
+    _totalPermanentFailures = 0;
+    _isBroken = false;
     _processTimer?.cancel();
     _processTimer = null;
     _notifyTimer?.cancel();

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/font_fallback_service.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/font_fallback_service.dart
@@ -1,0 +1,590 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:meta/meta.dart';
+
+import 'configuration.dart';
+import 'dom.dart';
+import 'font_change_util.dart';
+import 'font_fallbacks.dart';
+import 'noto_font.dart';
+import 'renderer.dart';
+import 'util.dart';
+
+class FallbackFontService {
+  FallbackFontService._();
+
+  static final FallbackFontService instance = FallbackFontService._();
+
+  /// Code points that we have discovered are missing but haven't processed yet.
+  final Set<int> _unprocessedCodePoints = <int>{};
+
+  /// Code points that we have already tried to find fonts for and failed.
+  final Set<int> _unsupportedCodePoints = <int>{};
+
+  /// Fonts that are currently being downloaded.
+  final Set<NotoFont> _pendingFonts = <NotoFont>{};
+
+  /// Fonts that have failed to download or register permanently.
+  final Set<NotoFont> _permanentlyUnavailableFonts = <NotoFont>{};
+
+  /// Fonts that have been successfully downloaded and registered.
+  final Set<NotoFont> _registeredFonts = <NotoFont>{};
+
+  /// Timer used for debouncing the processing loop.
+  Timer? _processTimer;
+
+  /// Timer used for debouncing the font change notification.
+  Timer? _notifyTimer;
+
+  /// Completer for [waitForIdle].
+  Completer<void>? _idleCompleter;
+
+  /// The number of retries per font.
+  static const int _maxRetries = 3;
+
+  /// The delay between retries.
+  static const Duration _retryDelay = Duration(seconds: 1);
+
+  /// Adds a list of missing code points to be processed.
+  void addMissingCodePoints(List<int> codePoints) {
+    var added = false;
+    final FontFallbackManager manager = renderer.fontCollection.fontFallbackManager!;
+
+    // Caches to avoid redundant binary-search lookups for consecutive
+    // characters (common in script blocks like CJK or Arabic).
+    FallbackFontComponent? lastComponent;
+    bool? lastComponentCovered;
+
+    // Filter out code points that we already know are unsupported or are
+    // already in the queue to be processed. For the remaining code points,
+    // determine which fallback font component covers them and whether that
+    // component is already satisfied by a registered font.
+    for (final codePoint in codePoints) {
+      // Skip if we already know this character can't be rendered or if it's
+      // already scheduled for processing.
+      if (!_unsupportedCodePoints.contains(codePoint) &&
+          !_unprocessedCodePoints.contains(codePoint)) {
+        final FallbackFontComponent component = manager.codePointToComponents.lookup(codePoint);
+
+        bool isCovered;
+        if (component == lastComponent) {
+          isCovered = lastComponentCovered!;
+        } else {
+          // Check if any of the fonts belonging to this component's block
+          // have already been successfully loaded.
+          isCovered = component.fonts.any((NotoFont f) => _registeredFonts.contains(f));
+          lastComponent = component;
+          lastComponentCovered = isCovered;
+        }
+
+        if (!isCovered) {
+          _unprocessedCodePoints.add(codePoint);
+          added = true;
+        }
+      }
+    }
+
+    if (added) {
+      // If we added new requirements, ensure we are tracking the "idle" state
+      // and schedule a processing run.
+      _idleCompleter ??= Completer<void>();
+      _scheduleProcess();
+    }
+  }
+
+  /// Schedules a processing run in the next microtask.
+  ///
+  /// Debouncing processing allows multiple calls to [addMissingCodePoints]
+  /// in the same turn of the event loop (e.g. from different paragraphs in the
+  /// same frame) to be processed together.
+  void _scheduleProcess() {
+    _processTimer ??= Timer(Duration.zero, _process);
+  }
+
+  /// Core processing loop of the service.
+  ///
+  /// Categorizes all unprocessed code points into:
+  /// 1. Resolved (already covered by a registered font)
+  /// 2. Pending (currently being downloaded)
+  /// 3. Unsupported (all candidate fonts failed permanently)
+  /// 4. The Gap (missing characters that need a new font download)
+  ///
+  /// Once the "Gap" is identified, it runs the greedy selection algorithm and
+  /// triggers download tasks for the chosen fonts.
+  void _process() {
+    _processTimer = null;
+
+    final FontFallbackManager manager = renderer.fontCollection.fontFallbackManager!;
+
+    // The "Gap" represents unique components that we need to find new fonts for.
+    // We map Component -> Count of missing codepoints it covers in this batch.
+    final gapComponentCounts = <FallbackFontComponent, int>{};
+
+    // Lists to track codepoints that should be removed from the active queue.
+    final resolvedCodePoints = <int>[];
+    final newlyUnsupported = <int>[];
+
+    // Caches to avoid redundant font-set iterations for codepoints that share a component.
+    final coveredCache = <FallbackFontComponent, bool>{};
+    final pendingCache = <FallbackFontComponent, bool>{};
+    final unavailableCache = <FallbackFontComponent, bool>{};
+
+    // Perform a single pass over all unprocessed codepoints to categorize them.
+    for (final int cp in _unprocessedCodePoints) {
+      if (_unsupportedCodePoints.contains(cp)) {
+        resolvedCodePoints.add(cp);
+        continue;
+      }
+
+      final FallbackFontComponent component = manager.codePointToComponents.lookup(cp);
+
+      // 1. Prune: Is it already covered by a font we successfully registered?
+      // This can happen if a font finished downloading while these characters
+      // were still in the unprocessed queue.
+      final bool isCovered = coveredCache.putIfAbsent(
+        component,
+        () => component.fonts.any((NotoFont f) => _registeredFonts.contains(f)),
+      );
+      if (isCovered) {
+        resolvedCodePoints.add(cp);
+        continue;
+      }
+
+      // 2. Pending: Are we already in the middle of downloading a font for this?
+      // We don't want to start multiple concurrent downloads for the same script block.
+      final bool isPending = pendingCache.putIfAbsent(
+        component,
+        () => component.fonts.any((NotoFont f) => _pendingFonts.contains(f)),
+      );
+      if (isPending) {
+        // Keep in _unprocessedCodePoints so we re-evaluate when the download finishes,
+        // but don't add to the "Gap" (don't start a duplicate download).
+        continue;
+      }
+
+      // 3. Permanent Failure: Have all fonts for this component failed already?
+      // If all candidate fonts for a character are dead, we stop trying to avoid infinite loops.
+      final bool isUnavailable = unavailableCache.putIfAbsent(
+        component,
+        () => !component.fonts.any((NotoFont f) => !_permanentlyUnavailableFonts.contains(f)),
+      );
+      if (isUnavailable) {
+        newlyUnsupported.add(cp);
+        resolvedCodePoints.add(cp);
+        continue;
+      }
+
+      // 4. The Gap: This component is missing and we aren't fetching it yet.
+      // We track the count of codepoints to weight the greedy algorithm later.
+      gapComponentCounts[component] = (gapComponentCounts[component] ?? 0) + 1;
+    }
+
+    // Efficiently remove resolved/failed codepoints from the processing set.
+    _unprocessedCodePoints.removeAll(resolvedCodePoints);
+
+    if (newlyUnsupported.isNotEmpty) {
+      printWarning(
+        'Could not find a set of Noto fonts to display all missing '
+        'characters. Please add a font asset for the missing characters.'
+        ' See: https://docs.flutter.dev/cookbook/design/fonts',
+      );
+      _unsupportedCodePoints.addAll(newlyUnsupported);
+    }
+
+    if (gapComponentCounts.isEmpty) {
+      _checkIdle();
+      return;
+    }
+
+    // Resolve the Gap: Run the greedy algorithm on unique components.
+    // This finds the smallest set of fonts that will resolve all current "Gaps".
+    final List<NotoFont> newFonts = _findFontsForComponents(gapComponentCounts);
+
+    if (newFonts.isEmpty) {
+      _checkIdle();
+      return;
+    }
+
+    // Fire and Forget: Start downloads for the selected fonts.
+    newFonts.forEach(_startDownloadTask);
+  }
+
+  /// Wraps the download and registration process in a managed task.
+  ///
+  /// This ensures the [_pendingFonts] set is correctly updated and triggers
+  /// a re-evaluation of the queue once the task finishes (either successfully
+  /// or with a failure that might allow secondary fonts to be selected).
+  Future<void> _startDownloadTask(NotoFont font) async {
+    _pendingFonts.add(font);
+    try {
+      await _downloadAndRegisterFontWithRetries(font);
+    } catch (e) {
+      printWarning('Unexpected error during fallback font download task for ${font.name}: $e');
+    } finally {
+      _pendingFonts.remove(font);
+      // Only re-schedule if we potentially finished the entire queue or if a failure
+      // occurred that requires us to re-evaluate alternative fonts.
+      // If a font failed, we need to run _process again to see if there's a
+      // secondary fallback font that can cover the now-unmet requirements.
+      if (!_registeredFonts.contains(font) || _pendingFonts.isEmpty) {
+        _scheduleProcess();
+      }
+    }
+  }
+
+  /// Checks if the service has finished all work and notifies [waitForIdle].
+  void _checkIdle() {
+    // We are only truly "idle" when nothing is left to process and no downloads are in flight.
+    if (_unprocessedCodePoints.isEmpty && _pendingFonts.isEmpty) {
+      if (_idleCompleter != null) {
+        final Completer<void> completer = _idleCompleter!;
+        _idleCompleter = null;
+        completer.complete();
+      }
+    }
+  }
+
+  /// Implements a greedy algorithm to find the minimal set of fonts covering
+  /// the required components, optimized by operating on component counts.
+  List<NotoFont> _findFontsForComponents(Map<FallbackFontComponent, int> componentCoverCounts) {
+    if (componentCoverCounts.isEmpty) {
+      return <NotoFont>[];
+    }
+
+    final List<FallbackFontComponent> requiredComponents = componentCoverCounts.keys.toList();
+    final FontFallbackManager manager = renderer.fontCollection.fontFallbackManager!;
+
+    // Initialize coverage state for candidate fonts. We only consider fonts
+    // that haven't been marked as permanently unavailable. For each candidate
+    // font, we track the total number of missing code points it covers across
+    // all components, and maintain a mapping of the font to the components it
+    // covers to facilitate efficient updates during the greedy selection process.
+    final fontCoverCounts = <NotoFont, int>{};
+    final fontToComponents = <NotoFont, List<FallbackFontComponent>>{};
+    final candidateFonts = <NotoFont>{};
+
+    for (final component in requiredComponents) {
+      final int count = componentCoverCounts[component]!;
+      for (final NotoFont font in component.fonts) {
+        // Skip fonts that we've already tried and failed to load permanently.
+        if (_permanentlyUnavailableFonts.contains(font)) {
+          continue;
+        }
+        if (!fontCoverCounts.containsKey(font)) {
+          fontCoverCounts[font] = 0;
+          fontToComponents[font] = <FallbackFontComponent>[];
+          candidateFonts.add(font);
+        }
+        // A font's weight is the sum of all codepoints in the blocks it covers.
+        fontCoverCounts[font] = fontCoverCounts[font]! + count;
+        fontToComponents[font]!.add(component);
+      }
+    }
+
+    final selectedFonts = <NotoFont>[];
+    while (candidateFonts.isNotEmpty) {
+      // Pick the "best" font based on coverage and language priority.
+      final NotoFont selectedFont = _selectBestFont(
+        candidateFonts.toList(),
+        fontCoverCounts,
+        manager,
+      );
+      selectedFonts.add(selectedFont);
+
+      // Once a font is selected, we consider all of its covered components
+      // "resolved" for this batch.
+      final List<FallbackFontComponent> componentsToRemove = fontToComponents[selectedFont]!;
+      for (final component in componentsToRemove) {
+        final int count = componentCoverCounts[component]!;
+        if (count == 0) {
+          continue;
+        }
+        // Update the coverage weights for all OTHER candidate fonts that
+        // also covered this now-resolved component.
+        for (final NotoFont font in component.fonts) {
+          if (candidateFonts.contains(font)) {
+            fontCoverCounts[font] = fontCoverCounts[font]! - count;
+          }
+        }
+        componentCoverCounts[component] = 0;
+      }
+
+      // Prune fonts that no longer provide unique coverage (weight <= 0).
+      candidateFonts.removeWhere((NotoFont f) => fontCoverCounts[f]! <= 0);
+    }
+
+    return selectedFonts;
+  }
+
+  /// Data-driven mapping of BCP47 language tags to Noto font family prefixes.
+  /// The order within each list represents the priority for that specific language.
+  static const Map<String, List<String>> _kLanguageFontPreferences = <String, List<String>>{
+    'zh-Hant': <String>['Noto Sans TC'],
+    'zh-TW': <String>['Noto Sans TC'],
+    'zh-MO': <String>['Noto Sans TC'],
+    'zh-HK': <String>['Noto Sans HK', 'Noto Sans TC'],
+    'ja': <String>['Noto Sans JP'],
+    'ko': <String>['Noto Sans KR'],
+    'zh': <String>['Noto Sans SC'],
+    'zh-Hans': <String>['Noto Sans SC'],
+    'zh-CN': <String>['Noto Sans SC', 'Noto Sans TC'],
+  };
+
+  /// Global priority list for tie-breaking when multiple fonts offer equal coverage.
+  static const List<String> _kGlobalTieBreakers = <String>[
+    'Noto Color Emoji',
+    'Noto Sans Symbols',
+    'Noto Sans SC',
+    'Noto Sans TC',
+    'Noto Sans HK',
+    'Noto Sans JP',
+    'Noto Sans KR',
+  ];
+
+  /// Selects the optimal font from a list of [fonts] based on a multi-stage
+  /// tie-breaking process.
+  ///
+  /// The selection criteria, in order of priority, are:
+  /// 1. **Language Preference**: Choose a font that matches the user's
+  ///    preferred language (if specified).
+  /// 2. **Maximum Coverage**: Choose the font(s) that cover the greatest number
+  ///    of currently missing code points.
+  /// 3. **Global Tie-Breakers**: If multiple fonts have equal maximum coverage,
+  ///    use a predefined global priority list (e.g., favoring Emojis).
+  /// 4. **Deterministic Fallback**: If still tied, pick the font with the
+  ///    lowest original index.
+  NotoFont _selectBestFont(
+    List<NotoFont> fonts,
+    Map<NotoFont, int> coverCounts,
+    FontFallbackManager manager,
+  ) {
+    assert(fonts.every((NotoFont f) => coverCounts.containsKey(f)));
+    final String language = manager.preferredLanguage;
+
+    // 1. Language-Specific Preference
+    final List<String> preferredPrefixes = _getPrefixesForLanguage(language);
+    for (final prefix in preferredPrefixes) {
+      final NotoFont? match = fonts.firstWhereOrNull((NotoFont f) => f.name.startsWith(prefix));
+      if (match != null && coverCounts[match]! > 0) {
+        return match;
+      }
+    }
+
+    // 2. Maximum Coverage Selection
+    final List<NotoFont> bestFonts = _findFontsWithMaxCoverage(fonts, coverCounts);
+    if (bestFonts.length == 1) {
+      return bestFonts.first;
+    }
+
+    // 3. Global Tie-Breaking
+    for (final String prefix in _kGlobalTieBreakers) {
+      final NotoFont? match = bestFonts.firstWhereOrNull((NotoFont f) => f.name.startsWith(prefix));
+      if (match != null) {
+        return match;
+      }
+    }
+
+    // 4. Deterministic fallback: pick the one with the smallest original index.
+    return bestFonts.first;
+  }
+
+  /// Returns the prioritized font prefixes for a given BCP47 [lang] tag.
+  List<String> _getPrefixesForLanguage(String lang) {
+    // 1. Exact match (e.g., 'zh-HK')
+    if (_kLanguageFontPreferences.containsKey(lang)) {
+      return _kLanguageFontPreferences[lang]!;
+    }
+
+    // 2. Base language match (e.g., 'en-US' -> 'en')
+    final int dashIndex = lang.indexOf('-');
+    if (dashIndex != -1) {
+      final String baseLang = lang.substring(0, dashIndex);
+      if (_kLanguageFontPreferences.containsKey(baseLang)) {
+        return _kLanguageFontPreferences[baseLang]!;
+      }
+    }
+
+    return const <String>[];
+  }
+
+  /// Finds the subset of [fonts] that provide the maximum possible coverage
+  /// of missing code points, as defined by [coverCounts].
+  ///
+  /// If multiple fonts provide the same maximum coverage, all are returned,
+  /// sorted by their original index to ensure deterministic behavior in
+  /// subsequent tie-breaking steps.
+  List<NotoFont> _findFontsWithMaxCoverage(List<NotoFont> fonts, Map<NotoFont, int> coverCounts) {
+    assert(fonts.every((NotoFont f) => coverCounts.containsKey(f)));
+    var maxCovered = -1;
+    final bestFonts = <NotoFont>[];
+
+    for (final font in fonts) {
+      final int count = coverCounts[font]!;
+      if (count > maxCovered) {
+        // Found a new maximum; start a new list.
+        maxCovered = count;
+        bestFonts.clear();
+        bestFonts.add(font);
+      } else if (count == maxCovered) {
+        // Another font with the same coverage; add to the tie-break set.
+        bestFonts.add(font);
+      }
+    }
+
+    // Ensure deterministic order for tie-breaking step.
+    bestFonts.sort((NotoFont a, NotoFont b) => a.index.compareTo(b.index));
+    return bestFonts;
+  }
+
+  /// Downloads and registers a single fallback [font], implementing a resilient
+  /// retry strategy for network and server errors.
+  ///
+  /// The process follows these steps:
+  /// 1. **HTTP Fetch**: Attempts to download the font file from the configured
+  ///    CDN.
+  /// 2. **Registration**: Once downloaded, the font is registered with the
+  ///    renderer. If registration fails (e.g., due to corrupt font data), it
+  ///    is treated as a permanent failure.
+  /// 3. **Retry Strategy**:
+  ///    - **Transient Failures**: Errors like network timeouts or specific HTTP
+  ///      status codes (e.g., 408, 429) trigger a retry after a 1-second delay.
+  ///      A font is retried up to 3 times.
+  ///    - **Permanent Failures**: Errors like 404 (Not Found) or illegal font
+  ///      data cause the font to be marked as "Permanently Unavailable."
+  /// 4. **Notification**: On successful registration, the service notifies the
+  ///    framework to trigger a UI relayout.
+  Future<void> _downloadAndRegisterFontWithRetries(NotoFont font) async {
+    var attempts = 0;
+    final String baseUrl = configuration.fontFallbackBaseUrl;
+
+    // Resolve the full URL from the configured CDN base.
+    final url = Uri.parse(baseUrl).resolve(font.url).toString();
+
+    // Attempt the download multiple times if transient errors occur.
+    while (attempts < _maxRetries) {
+      try {
+        final HttpFetchResponse response = await httpFetch(url);
+
+        if (response.hasPayload) {
+          // If we got data, try to register it as a typeface in the browser.
+          final Uint8List bytes = await response.asUint8List();
+          final bool success = await renderer.fontCollection.fallbackFontRegistry!.loadFallbackFont(
+            font.name,
+            bytes,
+          );
+
+          if (success) {
+            _registeredFonts.add(font);
+            renderer.fontCollection.fontFallbackManager!.registerFallbackFont(font.name);
+            _notifyFontsChanged();
+            return;
+          } else {
+            // Registration failure is usually due to corrupt or invalid font data.
+            printWarning(
+              'Failed to parse font data for ${font.name} from $url. '
+              'Treating as permanent failure.',
+            );
+            break;
+          }
+        } else if (_isPermanentStatus(response.status)) {
+          // 404s and similar are permanent; other errors might be temporary.
+          printWarning(
+            'Permanent HTTP failure (status ${response.status}) for '
+            '${font.name} at $url.',
+          );
+          break;
+        } else {
+          printWarning(
+            'Transient HTTP failure (status ${response.status}) for '
+            '${font.name} at $url. Retrying (attempt ${attempts + 1})...',
+          );
+        }
+      } catch (e) {
+        // Only retry for network-level failures or timeouts.
+        if (e is HttpFetchError || e is TimeoutException) {
+          printWarning(
+            'Transient error (attempt ${attempts + 1}) for ${font.name}: $e. '
+            'Retrying...',
+          );
+        } else {
+          printWarning('Unexpected permanent error for ${font.name}: $e');
+          break;
+        }
+      }
+
+      attempts++;
+      if (attempts < _maxRetries) {
+        // Optional delay between retries to give the network time to recover.
+        if (!configuration.debugSkipFontRetryDelay) {
+          await Future<void>.delayed(_retryDelay);
+        }
+      }
+    }
+
+    // If all retries failed, stop trying this font forever.
+    printWarning('Font ${font.name} at $url is permanently unavailable.');
+    _permanentlyUnavailableFonts.add(font);
+  }
+
+  /// Determines if an HTTP [status] code should be treated as a permanent error.
+  bool _isPermanentStatus(int status) {
+    // 4xx errors are generally permanent, except 408 (Request Timeout) and
+    // 429 (Too Many Requests).
+    return (status >= 400 && status < 500) && status != 408 && status != 429;
+  }
+
+  /// Notifies the Flutter framework that fonts have changed.
+  ///
+  /// This is debounced to avoid redundant relayouts when multiple fonts are
+  /// registered in the same turn of the event loop.
+  void _notifyFontsChanged() {
+    // Debounce the notification to the framework. Since font downloads are
+    // asynchronous and can finish in batches, we wait for the next microtask
+    // to ensure we only send a single "font change" message even if multiple
+    // fonts were registered in the same turn of the event loop.
+    _notifyTimer ??= Timer(Duration.zero, () {
+      _notifyTimer = null;
+      final FontFallbackManager manager = renderer.fontCollection.fontFallbackManager!;
+
+      // Update the font family lists used by Skia/CanvasKit.
+      manager.updateFallbackFontFamilies();
+
+      // Send the platform message to the Flutter framework to trigger a re-layout.
+      sendFontChangeMessage();
+    });
+  }
+
+  /// Returns a future that completes when the service is idle.
+  ///
+  /// The service is considered idle when there are no more missing code points
+  /// to process and no more fonts being downloaded.
+  ///
+  /// Note that this idle state is transient; if the framework triggers another
+  /// layout immediately after a font is registered, new code points may be
+  /// enqueued, making the service no longer idle.
+  Future<void> waitForIdle() {
+    if (_idleCompleter == null) {
+      return Future<void>.value();
+    }
+    return _idleCompleter!.future;
+  }
+
+  @visibleForTesting
+  void debugReset() {
+    _unprocessedCodePoints.clear();
+    _unsupportedCodePoints.clear();
+    _pendingFonts.clear();
+    _permanentlyUnavailableFonts.clear();
+    _registeredFonts.clear();
+    _processTimer?.cancel();
+    _processTimer = null;
+    _notifyTimer?.cancel();
+    _notifyTimer = null;
+    _idleCompleter = null;
+  }
+}

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/font_fallback_service.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/font_fallback_service.dart
@@ -171,7 +171,7 @@ class FallbackFontService {
       // If all candidate fonts for a character are dead, we stop trying to avoid infinite loops.
       final bool isUnavailable = unavailableCache.putIfAbsent(
         component,
-        () => !component.fonts.any((NotoFont f) => !_permanentlyUnavailableFonts.contains(f)),
+        () => component.fonts.every((NotoFont f) => _permanentlyUnavailableFonts.contains(f)),
       );
       if (isUnavailable) {
         newlyUnsupported.add(cp);

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/font_fallbacks.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/font_fallbacks.dart
@@ -3,44 +3,24 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:meta/meta.dart';
 import 'package:ui/src/engine.dart';
-import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 abstract class FallbackFontRegistry {
-  List<int> getMissingCodePoints(List<int> codePoints, List<String> fontFamilies);
-  Future<void> loadFallbackFont(String familyName, String string);
+  Future<bool> loadFallbackFont(String familyName, Uint8List bytes);
   void updateFallbackFontFamilies(List<String> families);
 }
-
-bool _isNotoSansSC(NotoFont font) => font.name.startsWith('Noto Sans SC');
-bool _isNotoSansTC(NotoFont font) => font.name.startsWith('Noto Sans TC');
-bool _isNotoSansHK(NotoFont font) => font.name.startsWith('Noto Sans HK');
-bool _isNotoSansJP(NotoFont font) => font.name.startsWith('Noto Sans JP');
-bool _isNotoSansKR(NotoFont font) => font.name.startsWith('Noto Sans KR');
 
 /// Global static font fallback data.
 class FontFallbackManager {
   factory FontFallbackManager(FallbackFontRegistry registry) =>
       FontFallbackManager._(registry, getFallbackFontList());
 
-  FontFallbackManager._(this._registry, this._fallbackFonts)
-    : _notoSymbols = _fallbackFonts.singleWhere(
-        (NotoFont font) => font.name == 'Noto Sans Symbols',
-      ) {
-    _downloadQueue = _FallbackFontDownloadQueue(this);
-  }
+  FontFallbackManager._(this._registry, this._fallbackFonts);
 
   final FallbackFontRegistry _registry;
-
-  late final _FallbackFontDownloadQueue _downloadQueue;
-
-  /// Code points that no known font has a glyph for.
-  final Set<int> _codePointsWithNoKnownFont = <int>{};
-
-  /// Code points which are known to be covered by at least one fallback font.
-  final Set<int> _knownCoveredCodePoints = <int>{};
 
   final List<NotoFont> _fallbackFonts;
 
@@ -48,8 +28,7 @@ class FontFallbackManager {
   // language. This can be overridden through [debugUserPreferredLanguage] for testing.
   String _language = domWindow.navigator.language;
 
-  @visibleForTesting
-  String get debugUserPreferredLanguage => _language;
+  String get preferredLanguage => _language;
 
   @visibleForTesting
   set debugUserPreferredLanguage(String value) {
@@ -59,98 +38,10 @@ class FontFallbackManager {
   @visibleForTesting
   void Function(String family)? debugOnLoadFontFamily;
 
-  final NotoFont _notoSymbols;
-
-  Future<void> _idleFuture = Future<void>.value();
-
   final List<String> globalFontFallbacks = <String>['Roboto'];
 
-  /// A list of code points to check against the global fallback fonts.
-  final Set<int> _codePointsToCheckAgainstFallbackFonts = <int>{};
-
-  /// This is [true] if we have scheduled a check for missing code points.
-  ///
-  /// We only do this once a frame, since checking if a font supports certain
-  /// code points is very expensive.
-  bool _scheduledCodePointCheck = false;
-
-  Future<void> debugWhenIdle() {
-    Future<void>? result;
-    assert(() {
-      result = _idleFuture;
-      return true;
-    }());
-
-    if (result != null) {
-      return result!;
-    }
-
-    throw UnimplementedError();
-  }
-
-  /// Determines if the given [text] contains any code points which are not
-  /// supported by the current set of fonts.
-  void ensureFontsSupportText(String text, List<String> fontFamilies) {
-    // TODO(hterkelsen): Make this faster for the common case where the text
-    // is supported by the given fonts.
-    if (ui_web.TestEnvironment.instance.disableFontFallbacks) {
-      return;
-    }
-
-    // We have a cache of code points which are known to be covered by at least
-    // one of our fallback fonts, and a cache of code points which are known not
-    // to be covered by any fallback font. From the given text, construct a set
-    // of code points which need to be checked.
-    final runesToCheck = <int>{};
-    for (final int rune in text.runes) {
-      // Filter out code points that don't need checking.
-      if (!(rune < 160 || // ASCII and Unicode control points.
-          _knownCoveredCodePoints.contains(rune) || // Points we've already covered
-          _codePointsWithNoKnownFont.contains(rune)) // Points that don't have a fallback font
-      ) {
-        runesToCheck.add(rune);
-      }
-    }
-    if (runesToCheck.isEmpty) {
-      return;
-    }
-
-    final List<int> codePoints = runesToCheck.toList();
-    final List<int> missingCodePoints = _registry.getMissingCodePoints(codePoints, fontFamilies);
-
-    if (missingCodePoints.isNotEmpty) {
-      addMissingCodePoints(codePoints);
-    }
-  }
-
-  void addMissingCodePoints(List<int> codePoints) {
-    _codePointsToCheckAgainstFallbackFonts.addAll(codePoints);
-    if (!_scheduledCodePointCheck) {
-      _scheduledCodePointCheck = true;
-      _idleFuture = Future<void>.delayed(Duration.zero, () async {
-        _ensureFallbackFonts();
-        _scheduledCodePointCheck = false;
-        await _downloadQueue.waitForIdle();
-      });
-    }
-  }
-
-  /// Checks the missing code points against the current set of fallback fonts
-  /// and starts downloading new fallback fonts if the current set can't cover
-  /// the code points.
-  void _ensureFallbackFonts() {
-    _scheduledCodePointCheck = false;
-    // We don't know if the remaining code points are covered by our fallback
-    // fonts. Check them and update the cache.
-    if (_codePointsToCheckAgainstFallbackFonts.isEmpty) {
-      return;
-    }
-    final List<int> codePoints = _codePointsToCheckAgainstFallbackFonts.toList();
-    _codePointsToCheckAgainstFallbackFonts.clear();
-    findFontsForMissingCodePoints(codePoints);
-  }
-
   void registerFallbackFont(String family) {
+    debugOnLoadFontFamily?.call(family);
     // Insert emoji font before all other fallback fonts so we use the emoji
     // whenever it's available.
     if (family.startsWith('Noto Color Emoji') || family == 'Noto Emoji') {
@@ -164,135 +55,8 @@ class FontFallbackManager {
     }
   }
 
-  /// Finds the minimum set of fonts which covers all of the [codePoints].
-  ///
-  /// Since set cover is NP-complete, we approximate using a greedy algorithm
-  /// which finds the font which covers the most code points. If multiple CJK
-  /// fonts match the same number of code points, we choose one based on the
-  /// user's locale.
-  ///
-  /// If a code point is not covered by any font, it is added to
-  /// [_codePointsWithNoKnownFont] so it can be omitted next time to avoid
-  /// searching for fonts unnecessarily.
-  void findFontsForMissingCodePoints(List<int> codePoints) {
-    final missingCodePoints = <int>[];
-
-    final requiredComponents = <FallbackFontComponent>[];
-    final candidateFonts = <NotoFont>[];
-
-    // Collect the components that cover the code points.
-    for (final codePoint in codePoints) {
-      final FallbackFontComponent component = codePointToComponents.lookup(codePoint);
-      if (component.fonts.isEmpty) {
-        missingCodePoints.add(codePoint);
-      } else {
-        // A zero cover count means we have not yet seen this component.
-        if (component.coverCount == 0) {
-          requiredComponents.add(component);
-        }
-        component.coverCount++;
-      }
-    }
-
-    // Aggregate the component cover counts to the fonts that use the component.
-    for (final component in requiredComponents) {
-      for (final NotoFont font in component.fonts) {
-        // A zero cover cover count means we have not yet seen this font.
-        if (font.coverCount == 0) {
-          candidateFonts.add(font);
-        }
-        font.coverCount += component.coverCount;
-        font.coverComponents.add(component);
-      }
-    }
-
-    final selectedFonts = <NotoFont>[];
-
-    while (candidateFonts.isNotEmpty) {
-      final NotoFont selectedFont = _selectFont(candidateFonts);
-      selectedFonts.add(selectedFont);
-
-      // All the code points in the selected font are now covered. Zero out each
-      // component that is used by the font and adjust the counts of other fonts
-      // that use the same components.
-      for (final component in <FallbackFontComponent>[...selectedFont.coverComponents]) {
-        for (final NotoFont font in component.fonts) {
-          font.coverCount -= component.coverCount;
-          font.coverComponents.remove(component);
-        }
-        component.coverCount = 0;
-      }
-      assert(selectedFont.coverCount == 0);
-      assert(selectedFont.coverComponents.isEmpty);
-      // The selected font will have a zero cover count, but other fonts may
-      // too. Remove these from further consideration.
-      candidateFonts.removeWhere((NotoFont font) => font.coverCount == 0);
-    }
-
-    selectedFonts.forEach(_downloadQueue.add);
-
-    // Report code points not covered by any fallback font and ensure we don't
-    // process those code points again.
-    if (missingCodePoints.isNotEmpty) {
-      if (!_downloadQueue.isPending) {
-        printWarning(
-          'Could not find a set of Noto fonts to display all missing '
-          'characters. Please add a font asset for the missing characters.'
-          ' See: https://docs.flutter.dev/cookbook/design/fonts',
-        );
-        _codePointsWithNoKnownFont.addAll(missingCodePoints);
-      }
-    }
-  }
-
-  NotoFont _selectFont(List<NotoFont> fonts) {
-    // Priority is given to fonts that match the language.
-    NotoFont? bestFont = switch (_language) {
-      'zh-Hans' || 'zh-CN' || 'zh-SG' || 'zh-MY' => fonts.firstWhereOrNull(_isNotoSansSC),
-      'zh-Hant' || 'zh-TW' || 'zh-MO' => fonts.firstWhereOrNull(_isNotoSansTC),
-      'zh-HK' => fonts.firstWhereOrNull(_isNotoSansHK),
-      'ja' => fonts.firstWhereOrNull(_isNotoSansJP),
-      'ko' => fonts.firstWhereOrNull(_isNotoSansKR),
-      _ => null,
-    };
-
-    if (bestFont != null) {
-      return bestFont;
-    }
-
-    var maxCodePointsCovered = -1;
-    final List<NotoFont> bestFonts = [];
-
-    for (final font in fonts) {
-      if (font.coverCount > maxCodePointsCovered) {
-        bestFonts.clear();
-        bestFonts.add(font);
-        bestFont = font;
-        maxCodePointsCovered = font.coverCount;
-      } else if (font.coverCount == maxCodePointsCovered) {
-        bestFonts.add(font);
-        // Tie-break with the lowest index which corresponds to a font name
-        // being earlier in the list of fonts in the font fallback data
-        // generator.
-        if (font.index < bestFont!.index) {
-          bestFont = font;
-        }
-      }
-    }
-
-    if (bestFonts.length > 1) {
-      // To be predictable, if there is a tie for best font, choose a font
-      // from this list first, then just choose the first font.
-      if (bestFonts.contains(_notoSymbols)) {
-        bestFont = _notoSymbols;
-      } else {
-        final NotoFont? notoSansSC = bestFonts.firstWhereOrNull(_isNotoSansSC);
-        if (notoSansSC != null) {
-          bestFont = notoSansSC;
-        }
-      }
-    }
-    return bestFont!;
+  void updateFallbackFontFamilies() {
+    _registry.updateFallbackFontFamilies(globalFontFallbacks);
   }
 
   late final List<FallbackFontComponent> fontComponents = _decodeFontComponents(encodedFontSets);
@@ -417,82 +181,6 @@ class _UnicodePropertyLookup<P> {
       final P value = _values[i];
       action(start, end - 1, value);
       start = end;
-    }
-  }
-}
-
-class _FallbackFontDownloadQueue {
-  _FallbackFontDownloadQueue(this.fallbackManager);
-
-  final FontFallbackManager fallbackManager;
-
-  final Set<NotoFont> downloadedFonts = <NotoFont>{};
-  final Map<String, NotoFont> pendingFonts = <String, NotoFont>{};
-
-  bool get isPending => pendingFonts.isNotEmpty;
-
-  Completer<void>? _idleCompleter;
-
-  Future<void> waitForIdle() {
-    if (_idleCompleter == null) {
-      // We're already idle
-      return Future<void>.value();
-    } else {
-      return _idleCompleter!.future;
-    }
-  }
-
-  void add(NotoFont font) {
-    if (downloadedFonts.contains(font) || pendingFonts.containsKey(font.url)) {
-      return;
-    }
-    final bool firstInBatch = pendingFonts.isEmpty;
-    pendingFonts[font.url] = font;
-    _idleCompleter ??= Completer<void>();
-    if (firstInBatch) {
-      Timer.run(startDownloads);
-    }
-  }
-
-  Future<void> startDownloads() async {
-    final downloads = <String, Future<void>>{};
-    final downloadedFontFamilies = <String>[];
-    for (final NotoFont font in pendingFonts.values) {
-      downloads[font.url] = Future<void>(() async {
-        final url = '${configuration.fontFallbackBaseUrl}${font.url}';
-        try {
-          fallbackManager.debugOnLoadFontFamily?.call(font.name);
-          await fallbackManager._registry.loadFallbackFont(font.name, url);
-          downloadedFontFamilies.add(font.url);
-        } catch (e) {
-          pendingFonts.remove(font.url);
-          printWarning('Failed to load font ${font.name} at $url');
-          printWarning(e.toString());
-          return;
-        }
-        downloadedFonts.add(font);
-      });
-    }
-
-    await Future.wait<void>(downloads.values);
-
-    // Register fallback fonts in a predictable order. Otherwise, the fonts
-    // change their precedence depending on the download order causing
-    // visual differences between app reloads.
-    downloadedFontFamilies.sort();
-    for (final url in downloadedFontFamilies) {
-      final NotoFont font = pendingFonts.remove(url)!;
-      fallbackManager.registerFallbackFont(font.name);
-    }
-
-    if (pendingFonts.isEmpty) {
-      fallbackManager._registry.updateFallbackFontFamilies(fallbackManager.globalFontFallbacks);
-      sendFontChangeMessage();
-      final Completer<void> idleCompleter = _idleCompleter!;
-      _idleCompleter = null;
-      idleCompleter.complete();
-    } else {
-      await startDownloads();
     }
   }
 }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/fonts.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/fonts.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 import 'dart:js_interop';
 import 'dart:typed_data';
 
+import 'package:meta/meta.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
@@ -124,7 +125,7 @@ class AssetFontsResult {
 
 abstract class FlutterFontCollection {
   /// Loads a font directly from font data.
-  Future<bool> loadFontFromList(Uint8List list, {String? fontFamily});
+  Future<bool> loadFontFromBytes(Uint8List list, {String? fontFamily});
 
   /// Completes when fonts from FontManifest.json have been loaded.
   Future<AssetFontsResult> loadAssetFonts(FontManifest manifest);
@@ -134,7 +135,17 @@ abstract class FlutterFontCollection {
   // properly.
   FontFallbackManager? get fontFallbackManager;
 
+  @visibleForTesting
+  set fontFallbackManager(FontFallbackManager? value);
+
+  /// The font fallback registry for this font collection.
+  FallbackFontRegistry? get fallbackFontRegistry;
+
+  @visibleForTesting
+  set fallbackFontRegistry(FallbackFontRegistry? value);
+
   // Reset the state of font fallbacks. Only to be used in testing.
+  @visibleForTesting
   void debugResetFallbackFonts();
 
   // Unregisters all fonts.

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/initialization.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/initialization.dart
@@ -214,7 +214,7 @@ Future<void> _downloadAssetFonts() async {
   if (ui_web.TestEnvironment.instance.forceTestFonts) {
     // Load the embedded test font before loading fonts from the assets so that
     // the embedded test font is the default (first) font.
-    await renderer.fontCollection.loadFontFromList(
+    await renderer.fontCollection.loadFontFromBytes(
       EmbeddedTestFont.flutterTest.data,
       fontFamily: EmbeddedTestFont.flutterTest.fontFamily,
     );

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/noto_font.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/noto_font.dart
@@ -10,16 +10,6 @@ class NotoFont {
 
   final int index = _index++;
   static int _index = 0;
-
-  /// During fallback font selection this is the number of missing code points
-  /// that are covered by (i.e. in) this font.
-  int coverCount = 0;
-
-  /// During fallback font selection this is a list of [FallbackFontComponent]s
-  /// from this font that are required to cover some of the missing code
-  /// points. The cover count for the font is the sum of the cover counts for
-  /// the components that make up the font.
-  final List<FallbackFontComponent> coverComponents = <FallbackFontComponent>[];
 }
 
 /// A component is a set of code points common to some fonts. Each code point is
@@ -31,8 +21,4 @@ class NotoFont {
 class FallbackFontComponent {
   FallbackFontComponent(this.fonts);
   final List<NotoFont> fonts;
-
-  /// During fallback font selection this is the number of missing code points
-  /// that are covered by this component.
-  int coverCount = 0;
 }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/font_collection.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/font_collection.dart
@@ -7,6 +7,7 @@ import 'dart:ffi';
 import 'dart:js_interop';
 import 'dart:typed_data';
 
+import 'package:meta/meta.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
@@ -26,6 +27,8 @@ class SkwasmTypeface extends SkwasmObjectWrapper<RawTypeface> {
 
 class SkwasmFontCollection implements FlutterFontCollection {
   SkwasmFontCollection() {
+    _fallbackRegistry = SkwasmFallbackRegistry(this);
+    fontFallbackManager = FontFallbackManager(_fallbackRegistry);
     setDefaultFontFamilies(<String>['Roboto']);
   }
 
@@ -52,8 +55,27 @@ class SkwasmFontCollection implements FlutterFontCollection {
     }
   });
 
+  @visibleForTesting
   @override
-  late FontFallbackManager fontFallbackManager = FontFallbackManager(SkwasmFallbackRegistry(this));
+  set fontFallbackManager(FontFallbackManager? value) {
+    _fontFallbackManager = value;
+  }
+
+  FontFallbackManager? _fontFallbackManager;
+
+  @override
+  FontFallbackManager? get fontFallbackManager => _fontFallbackManager;
+
+  late FallbackFontRegistry _fallbackRegistry;
+
+  @override
+  FallbackFontRegistry get fallbackFontRegistry => _fallbackRegistry;
+
+  @visibleForTesting
+  @override
+  set fallbackFontRegistry(FallbackFontRegistry? registry) {
+    _fallbackRegistry = registry!;
+  }
 
   @override
   void clear() {
@@ -104,26 +126,12 @@ class SkwasmFontCollection implements FlutterFontCollection {
     if (!response.hasPayload) {
       return FontNotFoundError(ui_web.assetManager.getAssetUrl(asset.asset));
     }
-    var length = 0;
-    final chunks = <JSUint8Array>[];
-    await response.read((JSUint8Array chunk) {
-      length += chunk.length;
-      chunks.add(chunk);
-    });
-    final SkDataHandle fontData = skDataCreate(length);
-    int dataAddress = skDataGetPointer(fontData).cast<Int8>().address;
-    final wasmMemory = JSUint8Array(skwasmInstance.wasmMemory.buffer);
-    for (final chunk in chunks) {
-      wasmMemory.set(chunk, dataAddress);
-      dataAddress += chunk.length;
-    }
-    final typeface = SkwasmTypeface(fontData);
+
+    final SkDataHandle fontData = await _loadDataFromResponse(response);
+    final bool success = _registerTypeface(family, fontData);
     skDataDispose(fontData);
-    if (typeface.handle != nullptr) {
-      final SkStringHandle familyNameHandle = skStringFromDartString(family);
-      fontCollectionRegisterTypeface(handle, typeface.handle, familyNameHandle);
-      registeredTypefaces.putIfAbsent(family, () => <SkwasmTypeface>[]).add(typeface);
-      skStringFree(familyNameHandle);
+
+    if (success) {
       return null;
     } else {
       return FontInvalidDataError(ui_web.assetManager.getAssetUrl(asset.asset));
@@ -132,6 +140,29 @@ class SkwasmFontCollection implements FlutterFontCollection {
 
   Future<bool> loadFontFromUrl(String familyName, String url) async {
     final HttpFetchResponse response = await httpFetch(url);
+    final SkDataHandle fontData = await _loadDataFromResponse(response);
+    final bool success = _registerTypeface(familyName, fontData);
+    skDataDispose(fontData);
+    return success;
+  }
+
+  @override
+  Future<bool> loadFontFromBytes(Uint8List list, {String? fontFamily}) async {
+    final SkDataHandle fontData = skDataCreate(list.length);
+    final int dataAddress = skDataGetPointer(fontData).cast<Int8>().address;
+    final wasmMemory = JSUint8Array(skwasmInstance.wasmMemory.buffer);
+    wasmMemory.set(list.toJS, dataAddress);
+
+    final bool success = _registerTypeface(fontFamily, fontData);
+    skDataDispose(fontData);
+
+    if (success) {
+      fontCollectionClearCaches(handle);
+    }
+    return success;
+  }
+
+  Future<SkDataHandle> _loadDataFromResponse(HttpFetchResponse response) async {
     var length = 0;
     final chunks = <JSUint8Array>[];
     await response.read((JSUint8Array chunk) {
@@ -145,45 +176,29 @@ class SkwasmFontCollection implements FlutterFontCollection {
       wasmMemory.set(chunk, dataAddress);
       dataAddress += chunk.length;
     }
-
-    final typeface = SkwasmTypeface(fontData);
-    skDataDispose(fontData);
-    if (typeface.handle == nullptr) {
-      return false;
-    }
-    final SkStringHandle familyNameHandle = skStringFromDartString(familyName);
-    fontCollectionRegisterTypeface(handle, typeface.handle, familyNameHandle);
-    registeredTypefaces.putIfAbsent(familyName, () => <SkwasmTypeface>[]).add(typeface);
-    skStringFree(familyNameHandle);
-    return true;
+    return fontData;
   }
 
-  @override
-  Future<bool> loadFontFromList(Uint8List list, {String? fontFamily}) async {
-    final SkDataHandle dataHandle = skDataCreate(list.length);
-    final Pointer<Int8> dataPointer = skDataGetPointer(dataHandle).cast<Int8>();
-    for (var i = 0; i < list.length; i++) {
-      dataPointer[i] = list[i];
-    }
-    final typeface = SkwasmTypeface(dataHandle);
-    skDataDispose(dataHandle);
+  bool _registerTypeface(String? familyName, SkDataHandle fontData) {
+    final typeface = SkwasmTypeface(fontData);
     if (typeface.handle == nullptr) {
       return false;
     }
-
-    if (fontFamily != null) {
-      final SkStringHandle familyHandle = skStringFromDartString(fontFamily);
-      fontCollectionRegisterTypeface(handle, typeface.handle, familyHandle);
-      skStringFree(familyHandle);
-    } else {
-      fontCollectionRegisterTypeface(handle, typeface.handle, nullptr);
+    final SkStringHandle familyNameHandle = familyName != null
+        ? skStringFromDartString(familyName)
+        : nullptr;
+    fontCollectionRegisterTypeface(handle, typeface.handle, familyNameHandle);
+    if (familyName != null) {
+      registeredTypefaces.putIfAbsent(familyName, () => <SkwasmTypeface>[]).add(typeface);
+      skStringFree(familyNameHandle);
     }
-    fontCollectionClearCaches(handle);
     return true;
   }
 
   @override
   void debugResetFallbackFonts() {
+    // ignore: invalid_use_of_visible_for_testing_member
+    FallbackFontService.instance.debugReset();
     setDefaultFontFamilies(<String>['Roboto']);
     fontFallbackManager = FontFallbackManager(SkwasmFallbackRegistry(this));
     fontCollectionClearCaches(handle);
@@ -196,38 +211,8 @@ class SkwasmFallbackRegistry implements FallbackFontRegistry {
   final SkwasmFontCollection _fontCollection;
 
   @override
-  List<int> getMissingCodePoints(List<int> codePoints, List<String> fontFamilies) =>
-      withStackScope((StackScope scope) {
-        final List<SkwasmTypeface> typefaces = fontFamilies
-            .map((String family) => _fontCollection.registeredTypefaces[family])
-            .fold(
-              const Iterable<SkwasmTypeface>.empty(),
-              (Iterable<SkwasmTypeface> accumulated, List<SkwasmTypeface>? typefaces) =>
-                  typefaces == null ? accumulated : accumulated.followedBy(typefaces),
-            )
-            .toList();
-        final Pointer<TypefaceHandle> typefaceBuffer = scope
-            .allocPointerArray(typefaces.length)
-            .cast<TypefaceHandle>();
-        for (var i = 0; i < typefaces.length; i++) {
-          typefaceBuffer[i] = typefaces[i].handle;
-        }
-        final Pointer<Int32> codePointBuffer = scope.allocInt32Array(codePoints.length);
-        for (var i = 0; i < codePoints.length; i++) {
-          codePointBuffer[i] = codePoints[i];
-        }
-        final int missingCodePointCount = typefacesFilterCoveredCodePoints(
-          typefaceBuffer,
-          typefaces.length,
-          codePointBuffer,
-          codePoints.length,
-        );
-        return List<int>.generate(missingCodePointCount, (int index) => codePointBuffer[index]);
-      });
-
-  @override
-  Future<void> loadFallbackFont(String familyName, String url) =>
-      _fontCollection.loadFontFromUrl(familyName, url);
+  Future<bool> loadFallbackFont(String familyName, Uint8List bytes) =>
+      _fontCollection.loadFontFromBytes(bytes, fontFamily: familyName);
 
   @override
   void updateFallbackFontFamilies(List<String> families) =>

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/font_collection.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/font_collection.dart
@@ -138,14 +138,6 @@ class SkwasmFontCollection implements FlutterFontCollection {
     }
   }
 
-  Future<bool> loadFontFromUrl(String familyName, String url) async {
-    final HttpFetchResponse response = await httpFetch(url);
-    final SkDataHandle fontData = await _loadDataFromResponse(response);
-    final bool success = _registerTypeface(familyName, fontData);
-    skDataDispose(fontData);
-    return success;
-  }
-
   @override
   Future<bool> loadFontFromBytes(Uint8List list, {String? fontFamily}) async {
     final SkDataHandle fontData = skDataCreate(list.length);

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
@@ -143,7 +143,7 @@ class SkwasmParagraph extends SkwasmObjectWrapper<RawParagraph> implements ui.Pa
             missingCodePointCount,
           );
           assert(missingCodePointCount == returnedCodePointCount);
-          renderer.fontCollection.fontFallbackManager!.addMissingCodePoints(
+          FallbackFontService.instance.addMissingCodePoints(
             List<int>.generate(missingCodePointCount, (int index) => codePointBuffer[index]),
           );
         });

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_fonts.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_fonts.dart
@@ -29,17 +29,6 @@ external TypefaceHandle typefaceCreate(SkDataHandle fontData);
 @Native<Void Function(TypefaceHandle)>(symbol: 'typeface_dispose', isLeaf: true)
 external void typefaceDispose(TypefaceHandle handle);
 
-@Native<Int Function(Pointer<TypefaceHandle>, Int, Pointer<Int32>, Int)>(
-  symbol: 'typefaces_filterCoveredCodePoints',
-  isLeaf: true,
-)
-external int typefacesFilterCoveredCodePoints(
-  Pointer<TypefaceHandle> typefaces,
-  int typefaceCount,
-  Pointer<Int32> codepoints,
-  int codePointCount,
-);
-
 @Native<Void Function(FontCollectionHandle, TypefaceHandle, SkStringHandle)>(
   symbol: 'fontCollection_registerTypeface',
   isLeaf: true,

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/font_collection.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/font_collection.dart
@@ -5,11 +5,8 @@
 import 'dart:async';
 import 'dart:typed_data';
 
+import 'package:ui/src/engine.dart';
 import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
-
-import '../dom.dart';
-import '../fonts.dart';
-import '../util.dart';
 
 /// This class is responsible for registering and loading fonts.
 ///
@@ -45,7 +42,7 @@ class WebFontCollection implements FlutterFontCollection {
   }
 
   @override
-  Future<bool> loadFontFromList(Uint8List list, {String? fontFamily}) async {
+  Future<bool> loadFontFromBytes(Uint8List list, {String? fontFamily}) async {
     if (fontFamily == null) {
       printWarning('Font family must be provided to WebFontCollection.');
       return false;
@@ -54,7 +51,16 @@ class WebFontCollection implements FlutterFontCollection {
   }
 
   @override
-  Null get fontFallbackManager => null;
+  FontFallbackManager? get fontFallbackManager => null;
+
+  @override
+  set fontFallbackManager(FontFallbackManager? value) {}
+
+  @override
+  FallbackFontRegistry? get fallbackFontRegistry => null;
+
+  @override
+  set fallbackFontRegistry(FallbackFontRegistry? value) {}
 
   /// Unregister all fonts that have been registered.
   @override

--- a/engine/src/flutter/lib/web_ui/lib/text.dart
+++ b/engine/src/flutter/lib/web_ui/lib/text.dart
@@ -684,6 +684,6 @@ abstract class ParagraphBuilder {
 }
 
 Future<void> loadFontFromList(Uint8List list, {String? fontFamily}) async {
-  await engine.renderer.fontCollection.loadFontFromList(list, fontFamily: fontFamily);
+  await engine.renderer.fontCollection.loadFontFromBytes(list, fontFamily: fontFamily);
   engine.sendFontChangeMessage();
 }

--- a/engine/src/flutter/lib/web_ui/test/engine/font_fallback_service_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/font_fallback_service_test.dart
@@ -240,5 +240,67 @@ void testMain() {
       expect(requestedUrls.last, startsWith('https://example.com/'));
       expect(requestedUrls.last, isNot(contains('fonts')));
     });
+
+    test('global kill switch disables service after enough failures with no success', () async {
+      var callCount = 0;
+      mockHttpFetchResponseFactory = (String url) async {
+        callCount++;
+        return MockHttpFetchResponse(url: url, status: 404);
+      };
+
+      // We need enough missing codepoints to trigger at least 10 unique font requests.
+      // 0x4E00 (CJK), 0x0627 (Arabic), 0x05D0 (Hebrew), 0x0905 (Devanagari),
+      // 0x03B1 (Greek), 0x0410 (Cyrillic), 0x0E01 (Thai), 0x1200 (Ethiopic),
+      // 0x10A0 (Georgian), 0x0531 (Armenian), 0x13A0 (Cherokee)
+      final missing = <int>[
+        0x4E00,
+        0x0627,
+        0x05D0,
+        0x0905,
+        0x03B1,
+        0x0410,
+        0x0E01,
+        0x1200,
+        0x10A0,
+        0x0531,
+        0x13A0,
+      ];
+
+      FallbackFontService.instance.addMissingCodePoints(missing);
+      await FallbackFontService.instance.waitForIdle();
+
+      // It should have stopped once it hit the threshold.
+      // Since downloads are in parallel, it might have started a few more
+      // than exactly 10, but it should definitely be in that ballpark.
+      expect(callCount, greaterThanOrEqualTo(10));
+      expect(callCount, lessThan(20));
+
+      // Subsequent requests should fail immediately.
+      callCount = 0;
+      FallbackFontService.instance.addMissingCodePoints(<int>[0x1100]); // Hangul Jamo
+      await FallbackFontService.instance.waitForIdle();
+      expect(callCount, 0);
+    });
+
+    test('per-component cap stops attempts after 5 failures for a single component', () async {
+      var callCount = 0;
+      mockHttpFetchResponseFactory = (String url) async {
+        callCount++;
+        return MockHttpFetchResponse(url: url, status: 404);
+      };
+
+      // CJK Unified Ideograph (0x4E00) is covered by many fonts (SC, TC, HK, JP, KR, etc).
+      FallbackFontService.instance.addMissingCodePoints(<int>[0x4E00]);
+      await FallbackFontService.instance.waitForIdle();
+
+      // It should have stopped after trying 5 fonts for this component.
+      expect(callCount, 5);
+
+      // The service should NOT be broken yet (global limit is 10).
+      callCount = 0;
+      FallbackFontService.instance.addMissingCodePoints(<int>[0x0627]); // Arabic
+      await FallbackFontService.instance.waitForIdle();
+      expect(callCount, greaterThan(0));
+    });
   });
 }

--- a/engine/src/flutter/lib/web_ui/test/engine/font_fallback_service_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/font_fallback_service_test.dart
@@ -1,0 +1,244 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/src/engine.dart';
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+class MockFallbackFontRegistry implements FallbackFontRegistry {
+  final Map<String, Uint8List> loadedFonts = <String, Uint8List>{};
+  final List<String> updatedFamilies = <String>[];
+  bool failNextLoad = false;
+
+  @override
+  Future<bool> loadFallbackFont(String familyName, Uint8List bytes) async {
+    if (failNextLoad) {
+      failNextLoad = false;
+      return false;
+    }
+    loadedFonts[familyName] = bytes;
+    return true;
+  }
+
+  @override
+  void updateFallbackFontFamilies(List<String> families) {
+    updatedFamilies.clear();
+    updatedFamilies.addAll(families);
+  }
+}
+
+void testMain() {
+  group('FallbackFontService', () {
+    late MockFallbackFontRegistry mockRegistry;
+    late FontFallbackManager fontFallbackManager;
+
+    setUp(() async {
+      await renderer.initialize();
+      mockRegistry = MockFallbackFontRegistry();
+      fontFallbackManager = FontFallbackManager(mockRegistry);
+
+      // Inject our mock manager and registry into the renderer.
+      renderer.fontCollection.fontFallbackManager = fontFallbackManager;
+      renderer.fontCollection.fallbackFontRegistry = mockRegistry;
+
+      FallbackFontService.instance.debugReset();
+
+      debugOverrideJsConfiguration(JsFlutterConfiguration(debugSkipFontRetryDelay: true));
+    });
+
+    tearDown(() async {
+      await FallbackFontService.instance.waitForIdle();
+      debugOverrideJsConfiguration(null);
+    });
+
+    test('successfully downloads and registers a font', () async {
+      // Code point 0x4E00 is CJK Unified Ideograph, usually covered by Noto Sans SC/TC/JP/KR.
+      FallbackFontService.instance.addMissingCodePoints(<int>[0x4E00]);
+      await FallbackFontService.instance.waitForIdle();
+
+      // Check if some font was loaded.
+      expect(mockRegistry.loadedFonts.isNotEmpty, isTrue);
+      expect(mockRegistry.updatedFamilies.isNotEmpty, isTrue);
+    });
+
+    test('retries on failure and eventually marks as permanently unavailable', () async {
+      debugOverrideJsConfiguration(
+        JsFlutterConfiguration(
+          debugSkipFontRetryDelay: true,
+          fontFallbackBaseUrl: 'http://invalid-url-that-fails.com/',
+        ),
+      );
+
+      // Arabic code point
+      FallbackFontService.instance.addMissingCodePoints(<int>[0x0627]);
+      await FallbackFontService.instance.waitForIdle();
+
+      // Since it failed, no fonts should be registered.
+      expect(mockRegistry.loadedFonts, isEmpty);
+    });
+
+    test('re-evaluates code points when a font fails', () async {
+      String? failedFontUrl;
+      mockHttpFetchResponseFactory = (String url) async {
+        // Fail the very first font that the service decides to download.
+        if (failedFontUrl == null) {
+          failedFontUrl = url;
+          return MockHttpFetchResponse(
+            url: url,
+            status: 404, // Permanent failure
+          );
+        }
+        // Return a successful response for the subsequent attempts (alternatives).
+        return MockHttpFetchResponse(
+          url: url,
+          status: 200,
+          payload: MockHttpFetchPayload(byteBuffer: Uint8List(0).buffer),
+        );
+      };
+
+      FallbackFontService.instance.addMissingCodePoints(<int>[0x4E00]);
+      await FallbackFontService.instance.waitForIdle();
+
+      expect(failedFontUrl, isNotNull);
+
+      // The service should have tried another font that covers 0x4E00.
+      final List<String> loadedFamilies = mockRegistry.loadedFonts.keys.toList();
+      expect(loadedFamilies, isNotEmpty);
+
+      // Verify that the loaded font also covers 0x4E00 (is a CJK font).
+      final bool coveredByAlternative = loadedFamilies.any(
+        (family) =>
+            family.startsWith('Noto Sans SC') ||
+            family.startsWith('Noto Sans TC') ||
+            family.startsWith('Noto Sans HK') ||
+            family.startsWith('Noto Sans JP') ||
+            family.startsWith('Noto Sans KR'),
+      );
+
+      expect(
+        coveredByAlternative,
+        isTrue,
+        reason: 'Should have loaded an alternative font for 0x4E00',
+      );
+    });
+
+    test('treats 403 as permanent failure and tries alternative', () async {
+      String? failedFontUrl;
+      mockHttpFetchResponseFactory = (String url) async {
+        if (failedFontUrl == null) {
+          failedFontUrl = url;
+          return MockHttpFetchResponse(url: url, status: 403);
+        }
+        return MockHttpFetchResponse(
+          url: url,
+          status: 200,
+          payload: MockHttpFetchPayload(byteBuffer: Uint8List(0).buffer),
+        );
+      };
+
+      FallbackFontService.instance.addMissingCodePoints(<int>[0x4E00]);
+      await FallbackFontService.instance.waitForIdle();
+
+      expect(failedFontUrl, isNotNull);
+      expect(mockRegistry.loadedFonts.isNotEmpty, isTrue);
+    });
+
+    test('treats 500 as transient and retries', () async {
+      var attemptsForFirstFont = 0;
+      String? firstFontUrl;
+
+      mockHttpFetchResponseFactory = (String url) async {
+        if (firstFontUrl == null || firstFontUrl == url) {
+          firstFontUrl = url;
+          attemptsForFirstFont++;
+          if (attemptsForFirstFont < 3) {
+            return MockHttpFetchResponse(url: url, status: 500);
+          }
+        }
+        return MockHttpFetchResponse(
+          url: url,
+          status: 200,
+          payload: MockHttpFetchPayload(byteBuffer: Uint8List(0).buffer),
+        );
+      };
+
+      FallbackFontService.instance.addMissingCodePoints(<int>[0x4E00]);
+      await FallbackFontService.instance.waitForIdle();
+
+      expect(attemptsForFirstFont, greaterThan(1));
+      expect(
+        mockRegistry.loadedFonts.keys,
+        contains(mockRegistry.loadedFonts.keys.firstWhere((k) => true)),
+      );
+    });
+
+    test('treats font registration failure as permanent', () async {
+      mockHttpFetchResponseFactory = (String url) async {
+        return MockHttpFetchResponse(
+          url: url,
+          status: 200,
+          payload: MockHttpFetchPayload(byteBuffer: Uint8List(0).buffer),
+        );
+      };
+
+      // Mock the registry to fail the first time, but succeed afterwards.
+      mockRegistry.failNextLoad = true;
+
+      FallbackFontService.instance.addMissingCodePoints(<int>[0x4E00]);
+      await FallbackFontService.instance.waitForIdle();
+
+      // The first font failed to register, so it should have tried an alternative.
+      expect(mockRegistry.loadedFonts.isNotEmpty, isTrue);
+    });
+
+    test('correctly resolves URLs with and without trailing slashes in base URL', () async {
+      final requestedUrls = <String>[];
+      mockHttpFetchResponseFactory = (String url) async {
+        requestedUrls.add(url);
+        return MockHttpFetchResponse(
+          url: url,
+          status: 200,
+          payload: MockHttpFetchPayload(byteBuffer: Uint8List(0).buffer),
+        );
+      };
+
+      // Test with trailing slash
+      debugOverrideJsConfiguration(
+        JsFlutterConfiguration(
+          debugSkipFontRetryDelay: true,
+          fontFallbackBaseUrl: 'https://example.com/fonts/',
+        ),
+      );
+      FallbackFontService.instance.addMissingCodePoints(<int>[0x0627]);
+      await FallbackFontService.instance.waitForIdle();
+      expect(requestedUrls.last, startsWith('https://example.com/fonts/'));
+
+      // Test without trailing slash.
+      // NOTE: Uri.resolve('a/b').resolve('c') results in 'a/c' if 'a/b' is not recognized as a directory.
+      // But usually base URLs for fonts are intended to be directories.
+      // If the user provides 'https://example.com/fonts', Uri.resolve will replace 'fonts' with the font path
+      // unless 'fonts' ends with a slash.
+      debugOverrideJsConfiguration(
+        JsFlutterConfiguration(
+          debugSkipFontRetryDelay: true,
+          fontFallbackBaseUrl: 'https://example.com/fonts',
+        ),
+      );
+      // Reset so it tries to download again.
+      FallbackFontService.instance.debugReset();
+      FallbackFontService.instance.addMissingCodePoints(<int>[0x0627]);
+      await FallbackFontService.instance.waitForIdle();
+      // 'https://example.com/fonts' resolved with 'noto...' becomes 'https://example.com/noto...'
+      expect(requestedUrls.last, startsWith('https://example.com/'));
+      expect(requestedUrls.last, isNot(contains('fonts')));
+    });
+  });
+}

--- a/engine/src/flutter/lib/web_ui/test/ui/fallback_fonts_golden_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/ui/fallback_fonts_golden_test.dart
@@ -33,6 +33,7 @@ void testMain() {
     final downloadedFontFamilies = <String>[];
 
     setUp(() {
+      FallbackFontService.instance.debugReset();
       renderer.fontCollection.debugResetFallbackFonts();
       debugOverrideJsConfiguration(
         <String, Object?>{'fontFallbackBaseUrl': 'assets/fallback_fonts/'}.jsify()
@@ -44,7 +45,8 @@ void testMain() {
       savedCallback = ui.PlatformDispatcher.instance.onPlatformMessage;
     });
 
-    tearDown(() {
+    tearDown(() async {
+      await FallbackFontService.instance.waitForIdle();
       downloadedFontFamilies.clear();
       ui.PlatformDispatcher.instance.onPlatformMessage = savedCallback;
     });
@@ -72,7 +74,7 @@ void testMain() {
       pb.addText('مرحبا');
       pb.build().layout(const ui.ParagraphConstraints(width: 1000));
 
-      await renderer.fontCollection.fontFallbackManager!.debugWhenIdle();
+      await FallbackFontService.instance.waitForIdle();
 
       expect(
         renderer.fontCollection.fontFallbackManager!.globalFontFallbacks,
@@ -107,7 +109,7 @@ void testMain() {
       pb.addText('表紙がゆっくりと開き始める。ページの間から淡い光が漏れ出る、');
       pb.build().layout(const ui.ParagraphConstraints(width: 1000));
 
-      await renderer.fontCollection.fontFallbackManager!.debugWhenIdle();
+      await FallbackFontService.instance.waitForIdle();
 
       expect(
         renderer.fontCollection.fontFallbackManager!.globalFontFallbacks,
@@ -140,7 +142,7 @@ void testMain() {
       pb.addText('مرحبا');
       pb.build().layout(const ui.ParagraphConstraints(width: 1000));
 
-      await renderer.fontCollection.fontFallbackManager!.debugWhenIdle();
+      await FallbackFontService.instance.waitForIdle();
 
       expect(renderer.fontCollection.fontFallbackManager!.globalFontFallbacks, <String>[
         'Roboto',
@@ -154,7 +156,7 @@ void testMain() {
       final ui.Paragraph paragraph = pb.build();
       paragraph.layout(const ui.ParagraphConstraints(width: 1000));
 
-      await renderer.fontCollection.fontFallbackManager!.debugWhenIdle();
+      await FallbackFontService.instance.waitForIdle();
 
       expect(renderer.fontCollection.fontFallbackManager!.globalFontFallbacks, <String>[
         'Roboto',
@@ -172,7 +174,7 @@ void testMain() {
       pb.addText('Hello 😊');
       pb.build().layout(const ui.ParagraphConstraints(width: 1000));
 
-      await renderer.fontCollection.fontFallbackManager!.debugWhenIdle();
+      await FallbackFontService.instance.waitForIdle();
 
       expect(
         renderer.fontCollection.fontFallbackManager!.globalFontFallbacks,
@@ -209,7 +211,7 @@ void testMain() {
       pb.addText(text);
       pb.build().layout(const ui.ParagraphConstraints(width: 1000));
 
-      await renderer.fontCollection.fontFallbackManager!.debugWhenIdle();
+      await FallbackFontService.instance.waitForIdle();
       expect(downloadedFontFamilies, expectedFamilies);
 
       // Do the same thing but this time with loaded fonts.
@@ -218,7 +220,7 @@ void testMain() {
       pb.addText(text);
       pb.build().layout(const ui.ParagraphConstraints(width: 1000));
 
-      await renderer.fontCollection.fontFallbackManager!.debugWhenIdle();
+      await FallbackFontService.instance.waitForIdle();
       expect(downloadedFontFamilies, isEmpty);
     }
 
@@ -237,7 +239,7 @@ void testMain() {
       // renderer.fontCollection.debugResetFallbackFonts();
 
       final FontFallbackManager fallbackManager = renderer.fontCollection.fontFallbackManager!;
-      final String oldLanguage = fallbackManager.debugUserPreferredLanguage;
+      final String oldLanguage = fallbackManager.preferredLanguage;
       if (userPreferredLanguage != null) {
         fallbackManager.debugUserPreferredLanguage = userPreferredLanguage;
       }
@@ -247,7 +249,7 @@ void testMain() {
       pb.addText(String.fromCharCode(charCode));
       pb.build().layout(const ui.ParagraphConstraints(width: 1000));
 
-      await renderer.fontCollection.fontFallbackManager!.debugWhenIdle();
+      await FallbackFontService.instance.waitForIdle();
       if (userPreferredLanguage != null) {
         fallbackManager.debugUserPreferredLanguage = oldLanguage;
       }
@@ -583,19 +585,6 @@ void testMain() {
           expect(fontsForPoint, isNotEmpty);
           fonts.addAll(fontsForPoint);
         }
-
-        try {
-          renderer.fontCollection.fontFallbackManager!.findFontsForMissingCodePoints(
-            codePoints.toList(),
-          );
-        } catch (e) {
-          print(
-            'findFontsForMissingCodePoints failed:\n'
-            '  Code points: ${codePoints.join(', ')}\n'
-            '  Fonts: ${fonts.map((NotoFont f) => f.name).join(', ')}',
-          );
-          rethrow;
-        }
       }
     });
 
@@ -618,7 +607,7 @@ void testMain() {
         pb.addText('Hello 😊');
         pb.build().layout(const ui.ParagraphConstraints(width: 1000));
 
-        await renderer.fontCollection.fontFallbackManager!.debugWhenIdle();
+        await FallbackFontService.instance.waitForIdle();
 
         // Make sure we didn't download the fallback font.
         expect(

--- a/engine/src/flutter/lib/web_ui/test/ui/font_collection_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/ui/font_collection_test.dart
@@ -29,20 +29,17 @@ Future<void> testMain() async {
     fakeAssetManager.popAssetScope(testScope);
   });
 
-  test(
-    'Loading valid font from data succeeds without family name (except in HTML renderer)',
-    () async {
-      final FlutterFontCollection collection = renderer.fontCollection;
-      final ByteBuffer ahemData = await httpFetchByteBuffer('/assets/fonts/ahem.ttf');
-      expect(await collection.loadFontFromList(ahemData.asUint8List()), isTrue);
-    },
-  );
+  test('Loading valid font from data succeeds without family name', () async {
+    final FlutterFontCollection collection = renderer.fontCollection;
+    final ByteBuffer ahemData = await httpFetchByteBuffer('/assets/fonts/ahem.ttf');
+    expect(await collection.loadFontFromBytes(ahemData.asUint8List()), isTrue);
+  });
 
   test('Loading valid font from data succeeds with family name', () async {
     final FlutterFontCollection collection = renderer.fontCollection;
     final ByteBuffer ahemData = await httpFetchByteBuffer('/assets/fonts/ahem.ttf');
     expect(
-      await collection.loadFontFromList(ahemData.asUint8List(), fontFamily: 'FamilyName'),
+      await collection.loadFontFromBytes(ahemData.asUint8List(), fontFamily: 'FamilyName'),
       true,
     );
   });
@@ -51,7 +48,7 @@ Future<void> testMain() async {
     final FlutterFontCollection collection = renderer.fontCollection;
     final List<int> invalidFontData = utf8.encode('This is not valid font data');
     expect(
-      await collection.loadFontFromList(
+      await collection.loadFontFromBytes(
         Uint8List.fromList(invalidFontData),
         fontFamily: 'FamilyName',
       ),

--- a/engine/src/flutter/lib/web_ui/test/ui/text_golden_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/ui/text_golden_test.dart
@@ -187,7 +187,7 @@ Future<void> testMain() async {
       '/assets/fonts/RobotoSlab-VariableFont_wght.ttf',
     );
     expect(
-      await collection.loadFontFromList(robotoSlabData.asUint8List(), fontFamily: 'Roboto Slab'),
+      await collection.loadFontFromBytes(robotoSlabData.asUint8List(), fontFamily: 'Roboto Slab'),
       true,
     );
     await testTextStyle('after font load', fontFamily: 'Roboto Slab');
@@ -764,7 +764,7 @@ Future<void> testTextStyle(
 
   // Render once to trigger font downloads.
   renderPicture();
-  await renderer.fontCollection.fontFallbackManager?.debugWhenIdle();
+  await FallbackFontService.instance.waitForIdle();
   final ui.Picture picture = renderPicture();
   await drawPictureUsingCurrentRenderer(picture);
 
@@ -792,7 +792,7 @@ Future<void> testSampleText(
 
   // Render once to trigger font downloads.
   renderPicture();
-  await renderer.fontCollection.fontFallbackManager?.debugWhenIdle();
+  await FallbackFontService.instance.waitForIdle();
   final ui.Picture picture = renderPicture();
   await drawPictureUsingCurrentRenderer(picture);
   await matchGoldenFile(

--- a/engine/src/flutter/skwasm/fonts.cc
+++ b/engine/src/flutter/skwasm/fonts.cc
@@ -46,41 +46,6 @@ SKWASM_EXPORT void typeface_dispose(SkTypeface* typeface) {
   typeface->unref();
 }
 
-// Calculates the code points that are not covered by the specified typefaces.
-// This function mutates the `code_points` buffer in place and returns the count
-// of code points that are not covered by the fonts.
-SKWASM_EXPORT int typefaces_filterCoveredCodePoints(SkTypeface** typefaces,
-                                                    int typeface_count,
-                                                    SkUnichar* code_points,
-                                                    int code_point_count) {
-  std::unique_ptr<SkGlyphID[]> glyph_buffer =
-      std::make_unique<SkGlyphID[]>(code_point_count);
-  SkGlyphID* glyph_pointer = glyph_buffer.get();
-  int remaining_code_point_count = code_point_count;
-  for (int typeface_index = 0; typeface_index < typeface_count;
-       typeface_index++) {
-    typefaces[typeface_index]->unicharsToGlyphs(
-        {code_points, remaining_code_point_count},
-        {glyph_pointer, remaining_code_point_count});
-    int output_index = 0;
-    for (int input_index = 0; input_index < remaining_code_point_count;
-         input_index++) {
-      if (glyph_pointer[input_index] == 0) {
-        if (output_index != input_index) {
-          code_points[output_index] = code_points[input_index];
-        }
-        output_index++;
-      }
-    }
-    if (output_index == 0) {
-      return 0;
-    } else {
-      remaining_code_point_count = output_index;
-    }
-  }
-  return remaining_code_point_count;
-}
-
 SKWASM_EXPORT void fontCollection_registerTypeface(
     Skwasm::FlutterFontCollection* collection,
     SkTypeface* typeface,


### PR DESCRIPTION
This change introduces a centralized `FallbackFontService` to resolve infinite download loops through resilient failure tracking while significantly boosting text rendering performance by shifting missing character discovery directly to the underlying graphics engine.

By replacing expensive string-based character scanning with a "source of truth" query to Skia for unresolved codepoints during layout, this update eliminates redundant processing and layout thrashing during paragraph building. The new service acts as a stateful coordinator that manages font downloads independently of the UI cycle, implementing a robust retry-and-recovery logic that marks failed assets as permanently unavailable to break infinite re-layout loops.

Fixes https://github.com/flutter/flutter/issues/184449

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
