### PR TITLE
(Test cross-imports) Remove cross-imported test utils from Cupertino sheet/tab scaffold tests

### DIFF
--- a/packages/flutter/test/cupertino/sheet_test.dart
+++ b/packages/flutter/test/cupertino/sheet_test.dart
@@ -7,7 +7,14 @@ import 'package:flutter/services.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/navigator_utils.dart';
+/// Simulates a system back, like a back gesture on Android.
+Future<void> simulateSystemBack() {
+  return TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
+    'flutter/navigation',
+    const JSONMessageCodec().encodeMessage(<String, dynamic>{'method': 'popRoute'}),
+    (ByteData? _) {},
+  );
+}
 
 // Matches _kTopGapRatio in cupertino/sheet.dart.
 const double _kTopGapRatio = 0.08;

--- a/packages/flutter/test/cupertino/tab_scaffold_test.dart
+++ b/packages/flutter/test/cupertino/tab_scaffold_test.dart
@@ -9,6 +9,9 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../widgets/widget_inspector_test_utils.dart';
 
+/// A [CustomPainter] that invokes a callback when it paints.
+///
+/// Used in tests to verify when a repaint occurs.
 class TestCallbackPainter extends CustomPainter {
   const TestCallbackPainter({required this.onPaint});
 

--- a/packages/flutter/test/cupertino/tab_scaffold_test.dart
+++ b/packages/flutter/test/cupertino/tab_scaffold_test.dart
@@ -7,9 +7,30 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../rendering/rendering_tester.dart' show TestCallbackPainter;
-import '../widgets/navigator_utils.dart';
 import '../widgets/widget_inspector_test_utils.dart';
+
+class TestCallbackPainter extends CustomPainter {
+  const TestCallbackPainter({required this.onPaint});
+
+  final VoidCallback onPaint;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    onPaint();
+  }
+
+  @override
+  bool shouldRepaint(TestCallbackPainter oldPainter) => true;
+}
+
+/// Simulates a system back, like a back gesture on Android.
+Future<void> simulateSystemBack() {
+  return TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
+    'flutter/navigation',
+    const JSONMessageCodec().encodeMessage(<String, dynamic>{'method': 'popRoute'}),
+    (ByteData? _) {},
+  );
+}
 
 late List<int> selectedTabs;
 


### PR DESCRIPTION
Part of #182636

## Summary
Removes cross-imported test utilities from two Cupertino test files by inlining file-local equivalents:
- `packages/flutter/test/cupertino/sheet_test.dart`
  - replaces `../widgets/navigator_utils.dart` import with a local `simulateSystemBack()` helper.
- `packages/flutter/test/cupertino/tab_scaffold_test.dart`
  - replaces `../widgets/navigator_utils.dart` import with a local `simulateSystemBack()` helper.
  - replaces `../rendering/rendering_tester.dart` import with a local `TestCallbackPainter`.

This keeps tests self-contained and avoids dependencies on other test libraries, aligned with the cross-import cleanup effort.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated or added relevant documentation.
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

## Tests
- Unable to complete local targeted test execution in this environment due to a Flutter SDK and dependency floor mismatch during package resolution.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/AI-Usage-Policy.md