### PR TITLE
Refactor: Views should share shaders

### DIFF
--- a/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.cc
@@ -12,32 +12,6 @@
 #include "flutter/shell/platform/linux/fl_engine_private.h"
 #include "flutter/shell/platform/linux/fl_framebuffer.h"
 
-// Vertex shader to draw Flutter window contents.
-static const char* vertex_shader_src =
-    "attribute vec2 position;\n"
-    "attribute vec2 in_texcoord;\n"
-    "uniform vec2 offset;\n"
-    "uniform vec2 scale;\n"
-    "varying vec2 texcoord;\n"
-    "\n"
-    "void main() {\n"
-    "  gl_Position = vec4(offset + position * scale, 0, 1);\n"
-    "  texcoord = in_texcoord;\n"
-    "}\n";
-
-// Fragment shader to draw Flutter window contents.
-static const char* fragment_shader_src =
-    "#ifdef GL_ES\n"
-    "precision mediump float;\n"
-    "#endif\n"
-    "\n"
-    "uniform sampler2D texture;\n"
-    "varying vec2 texcoord;\n"
-    "\n"
-    "void main() {\n"
-    "  gl_FragColor = texture2D(texture, texcoord);\n"
-    "}\n";
-
 struct _FlCompositorOpenGL {
   FlCompositor parent_instance;
 
@@ -63,18 +37,6 @@ struct _FlCompositorOpenGL {
   // was rendered
   bool had_first_frame;
 
-  // Shader program.
-  GLuint program;
-
-  // Location of layer offset in [program].
-  GLuint offset_location;
-
-  // Location of layer scale in [program].
-  GLuint scale_location;
-
-  // Verticies for the uniform square.
-  GLuint vertex_buffer;
-
   // Ensure Flutter and GTK can access the frame data (framebuffer or pixels).
   GMutex frame_mutex;
 };
@@ -82,107 +44,6 @@ struct _FlCompositorOpenGL {
 G_DEFINE_TYPE(FlCompositorOpenGL,
               fl_compositor_opengl,
               fl_compositor_get_type())
-
-// Returns the log for the given OpenGL shader. Must be freed by the caller.
-static gchar* get_shader_log(GLuint shader) {
-  GLint log_length;
-  gchar* log;
-
-  glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &log_length);
-
-  log = static_cast<gchar*>(g_malloc(log_length + 1));
-  glGetShaderInfoLog(shader, log_length, nullptr, log);
-
-  return log;
-}
-
-// Returns the log for the given OpenGL program. Must be freed by the caller.
-static gchar* get_program_log(GLuint program) {
-  GLint log_length;
-  gchar* log;
-
-  glGetProgramiv(program, GL_INFO_LOG_LENGTH, &log_length);
-
-  log = static_cast<gchar*>(g_malloc(log_length + 1));
-  glGetProgramInfoLog(program, log_length, nullptr, log);
-
-  return log;
-}
-
-static void setup_shader(FlCompositorOpenGL* self) {
-  if (!fl_opengl_manager_make_platform_current(self->opengl_manager)) {
-    g_warning(
-        "Failed to setup compositor shaders, unable to make OpenGL context "
-        "current");
-    return;
-  }
-
-  GLuint vertex_shader = glCreateShader(GL_VERTEX_SHADER);
-  glShaderSource(vertex_shader, 1, &vertex_shader_src, nullptr);
-  glCompileShader(vertex_shader);
-  GLint vertex_compile_status;
-  glGetShaderiv(vertex_shader, GL_COMPILE_STATUS, &vertex_compile_status);
-  if (vertex_compile_status == GL_FALSE) {
-    g_autofree gchar* shader_log = get_shader_log(vertex_shader);
-    g_warning("Failed to compile vertex shader: %s", shader_log);
-  }
-
-  GLuint fragment_shader = glCreateShader(GL_FRAGMENT_SHADER);
-  glShaderSource(fragment_shader, 1, &fragment_shader_src, nullptr);
-  glCompileShader(fragment_shader);
-  GLint fragment_compile_status;
-  glGetShaderiv(fragment_shader, GL_COMPILE_STATUS, &fragment_compile_status);
-  if (fragment_compile_status == GL_FALSE) {
-    g_autofree gchar* shader_log = get_shader_log(fragment_shader);
-    g_warning("Failed to compile fragment shader: %s", shader_log);
-  }
-
-  self->program = glCreateProgram();
-  glAttachShader(self->program, vertex_shader);
-  glAttachShader(self->program, fragment_shader);
-  glLinkProgram(self->program);
-
-  GLint link_status;
-  glGetProgramiv(self->program, GL_LINK_STATUS, &link_status);
-  if (link_status == GL_FALSE) {
-    g_autofree gchar* program_log = get_program_log(self->program);
-    g_warning("Failed to link program: %s", program_log);
-  }
-
-  self->offset_location = glGetUniformLocation(self->program, "offset");
-  self->scale_location = glGetUniformLocation(self->program, "scale");
-
-  glDeleteShader(vertex_shader);
-  glDeleteShader(fragment_shader);
-
-  // The uniform square abcd in two triangles cba + cdb
-  // a--b
-  // |  |
-  // c--d
-  GLfloat vertex_data[] = {-1, -1, 0, 0, 1, 1,  1, 1, -1, 1, 0, 1,
-                           -1, -1, 0, 0, 1, -1, 1, 0, 1,  1, 1, 1};
-
-  glGenBuffers(1, &self->vertex_buffer);
-  glBindBuffer(GL_ARRAY_BUFFER, self->vertex_buffer);
-  glBufferData(GL_ARRAY_BUFFER, sizeof(vertex_data), vertex_data,
-               GL_STATIC_DRAW);
-}
-
-static void cleanup_shader(FlCompositorOpenGL* self) {
-  if (!fl_opengl_manager_make_platform_current(self->opengl_manager)) {
-    g_warning(
-        "Failed to cleanup compositor shaders, unable to make OpenGL context "
-        "current");
-    return;
-  }
-
-  if (self->program != 0) {
-    glDeleteProgram(self->program);
-  }
-  if (self->vertex_buffer != 0) {
-    glDeleteBuffers(1, &self->vertex_buffer);
-  }
-}
 
 static void composite_layer(FlCompositorOpenGL* self,
                             FlFramebuffer* framebuffer,
@@ -192,10 +53,12 @@ static void composite_layer(FlCompositorOpenGL* self,
                             int height) {
   size_t texture_width = fl_framebuffer_get_width(framebuffer);
   size_t texture_height = fl_framebuffer_get_height(framebuffer);
-  glUniform2f(self->offset_location, (2 * x / width) - 1.0,
-              (2 * y / width) - 1.0);
-  glUniform2f(self->scale_location, texture_width / width,
-              texture_height / height);
+  GLuint offset_location =
+      fl_opengl_manager_get_offset_location(self->opengl_manager);
+  GLuint scale_location =
+      fl_opengl_manager_get_scale_location(self->opengl_manager);
+  glUniform2f(offset_location, (2 * x / width) - 1.0, (2 * y / width) - 1.0);
+  glUniform2f(scale_location, texture_width / width, texture_height / height);
 
   GLuint texture_id = fl_framebuffer_get_texture_id(framebuffer);
   glBindTexture(GL_TEXTURE_2D, texture_id);
@@ -269,12 +132,14 @@ static gboolean fl_compositor_opengl_present_layers(FlCompositor* compositor,
   GLuint vao;
   glGenVertexArrays(1, &vao);
   glBindVertexArray(vao);
-  glBindBuffer(GL_ARRAY_BUFFER, self->vertex_buffer);
-  GLint position_location = glGetAttribLocation(self->program, "position");
+  glBindBuffer(GL_ARRAY_BUFFER,
+               fl_opengl_manager_get_vertex_buffer(self->opengl_manager));
+  GLuint program = fl_opengl_manager_get_program(self->opengl_manager);
+  GLint position_location = glGetAttribLocation(program, "position");
   glEnableVertexAttribArray(position_location);
   glVertexAttribPointer(position_location, 2, GL_FLOAT, GL_FALSE,
                         sizeof(GLfloat) * 4, 0);
-  GLint texcoord_location = glGetAttribLocation(self->program, "in_texcoord");
+  GLint texcoord_location = glGetAttribLocation(program, "in_texcoord");
   glEnableVertexAttribArray(texcoord_location);
   glVertexAttribPointer(texcoord_location, 2, GL_FLOAT, GL_FALSE,
                         sizeof(GLfloat) * 4,
@@ -283,7 +148,7 @@ static gboolean fl_compositor_opengl_present_layers(FlCompositor* compositor,
   glEnable(GL_BLEND);
   glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
-  glUseProgram(self->program);
+  glUseProgram(program);
 
   // Disable the scissor test as it can affect blit operations.
   // Prevents regressions like: https://github.com/flutter/flutter/issues/140828
@@ -455,8 +320,6 @@ static gboolean fl_compositor_opengl_render(FlCompositor* compositor,
 static void fl_compositor_opengl_dispose(GObject* object) {
   FlCompositorOpenGL* self = FL_COMPOSITOR_OPENGL(object);
 
-  cleanup_shader(self);
-
   g_clear_object(&self->task_runner);
   g_clear_object(&self->opengl_manager);
   g_clear_object(&self->framebuffer);
@@ -489,8 +352,6 @@ FlCompositorOpenGL* fl_compositor_opengl_new(FlTaskRunner* task_runner,
   self->task_runner = FL_TASK_RUNNER(g_object_ref(task_runner));
   self->shareable = shareable;
   self->opengl_manager = FL_OPENGL_MANAGER(g_object_ref(opengl_manager));
-
-  setup_shader(self);
 
   return self;
 }

--- a/engine/src/flutter/shell/platform/linux/fl_compositor_opengl_test.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_compositor_opengl_test.cc
@@ -340,6 +340,73 @@ TEST(FlCompositorOpenGLTest, NoBlitFramebuffer) {
   cairo_destroy(cr);
 }
 
+TEST(FlCompositorOpenGLTest, SharedShaders) {
+  ::testing::NiceMock<flutter::testing::MockEpoxy> epoxy;
+
+  // Shaders must be compiled exactly once regardless of how many compositors
+  // share the same FlOpenGLManager.
+  EXPECT_CALL(epoxy, glCreateProgram).Times(1);
+  EXPECT_CALL(epoxy, glCreateShader(GL_VERTEX_SHADER)).Times(1);
+  EXPECT_CALL(epoxy, glCreateShader(GL_FRAGMENT_SHADER)).Times(1);
+
+  g_autoptr(FlDartProject) project = fl_dart_project_new();
+  g_autoptr(FlEngine) engine = fl_engine_new(project);
+  g_autoptr(FlTaskRunner) task_runner = fl_task_runner_new(engine);
+  FlOpenGLManager* opengl_manager = fl_engine_get_opengl_manager(engine);
+
+  constexpr size_t width = 100;
+  constexpr size_t height = 100;
+
+  g_autoptr(FlMockRenderable) renderable = fl_mock_renderable_new();
+  fl_engine_set_implicit_view(engine, FL_RENDERABLE(renderable));
+
+  // Two compositors sharing the same OpenGL manager.
+  g_autoptr(FlCompositorOpenGL) compositor1 =
+      fl_compositor_opengl_new(task_runner, opengl_manager, FALSE);
+  g_autoptr(FlCompositorOpenGL) compositor2 =
+      fl_compositor_opengl_new(task_runner, opengl_manager, FALSE);
+
+  g_autoptr(FlFramebuffer) framebuffer1 =
+      fl_framebuffer_new(GL_RGB, width, height, FALSE);
+  FlutterBackingStore backing_store1 = {
+      .type = kFlutterBackingStoreTypeOpenGL,
+      .open_gl = {.framebuffer = {.user_data = framebuffer1}}};
+  FlutterLayer layer1 = {.type = kFlutterLayerContentTypeBackingStore,
+                         .backing_store = &backing_store1,
+                         .offset = {0, 0},
+                         .size = {width, height}};
+  const FlutterLayer* layers1[1] = {&layer1};
+  std::thread([&]() {
+    fl_compositor_present_layers(FL_COMPOSITOR(compositor1), layers1, 1);
+  }).join();
+
+  g_autoptr(FlFramebuffer) framebuffer2 =
+      fl_framebuffer_new(GL_RGB, width, height, FALSE);
+  FlutterBackingStore backing_store2 = {
+      .type = kFlutterBackingStoreTypeOpenGL,
+      .open_gl = {.framebuffer = {.user_data = framebuffer2}}};
+  FlutterLayer layer2 = {.type = kFlutterLayerContentTypeBackingStore,
+                         .backing_store = &backing_store2,
+                         .offset = {0, 0},
+                         .size = {width, height}};
+  const FlutterLayer* layers2[1] = {&layer2};
+  std::thread([&]() {
+    fl_compositor_present_layers(FL_COMPOSITOR(compositor2), layers2, 1);
+  }).join();
+
+  size_t frame_width1, frame_height1;
+  fl_compositor_get_frame_size(FL_COMPOSITOR(compositor1), &frame_width1,
+                               &frame_height1);
+  EXPECT_EQ(frame_width1, width);
+  EXPECT_EQ(frame_height1, height);
+
+  size_t frame_width2, frame_height2;
+  fl_compositor_get_frame_size(FL_COMPOSITOR(compositor2), &frame_width2,
+                               &frame_height2);
+  EXPECT_EQ(frame_width2, width);
+  EXPECT_EQ(frame_height2, height);
+}
+
 TEST(FlCompositorOpenGLTest, BlitFramebufferNvidia) {
   ::testing::NiceMock<flutter::testing::MockEpoxy> epoxy;
   g_autoptr(FlDartProject) project = fl_dart_project_new();

--- a/engine/src/flutter/shell/platform/linux/fl_opengl_manager.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_opengl_manager.cc
@@ -10,6 +10,32 @@
 
 #include "flutter/shell/platform/linux/fl_opengl_manager.h"
 
+// Vertex shader to draw Flutter window contents.
+static const char* vertex_shader_src =
+    "attribute vec2 position;\n"
+    "attribute vec2 in_texcoord;\n"
+    "uniform vec2 offset;\n"
+    "uniform vec2 scale;\n"
+    "varying vec2 texcoord;\n"
+    "\n"
+    "void main() {\n"
+    "  gl_Position = vec4(offset + position * scale, 0, 1);\n"
+    "  texcoord = in_texcoord;\n"
+    "}\n";
+
+// Fragment shader to draw Flutter window contents.
+static const char* fragment_shader_src =
+    "#ifdef GL_ES\n"
+    "precision mediump float;\n"
+    "#endif\n"
+    "\n"
+    "uniform sampler2D texture;\n"
+    "varying vec2 texcoord;\n"
+    "\n"
+    "void main() {\n"
+    "  gl_FragColor = texture2D(texture, texcoord);\n"
+    "}\n";
+
 struct _FlOpenGLManager {
   GObject parent_instance;
 
@@ -24,12 +50,143 @@ struct _FlOpenGLManager {
 
   // Context used by platform thread.
   EGLContext platform_context;
+
+  // Shader program.
+  GLuint program;
+
+  // Location of layer offset in [program].
+  GLuint offset_location;
+
+  // Location of layer scale in [program].
+  GLuint scale_location;
+
+  // Vertices for the uniform square.
+  GLuint vertex_buffer;
 };
 
 G_DEFINE_TYPE(FlOpenGLManager, fl_opengl_manager, G_TYPE_OBJECT)
 
+// Returns the log for the given OpenGL shader. Must be freed by the caller.
+static gchar* get_shader_log(GLuint shader) {
+  GLint log_length;
+  gchar* log;
+
+  glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &log_length);
+
+  log = static_cast<gchar*>(g_malloc(log_length + 1));
+  glGetShaderInfoLog(shader, log_length, nullptr, log);
+
+  return log;
+}
+
+// Returns the log for the given OpenGL program. Must be freed by the caller.
+static gchar* get_program_log(GLuint program) {
+  GLint log_length;
+  gchar* log;
+
+  glGetProgramiv(program, GL_INFO_LOG_LENGTH, &log_length);
+
+  log = static_cast<gchar*>(g_malloc(log_length + 1));
+  glGetProgramInfoLog(program, log_length, nullptr, log);
+
+  return log;
+}
+
+static void setup_shader(FlOpenGLManager* self) {
+  if (!fl_opengl_manager_make_platform_current(self)) {
+    g_warning(
+        "Failed to setup shaders, unable to make OpenGL context "
+        "current");
+    return;
+  }
+
+  GLuint vertex_shader = glCreateShader(GL_VERTEX_SHADER);
+  glShaderSource(vertex_shader, 1, &vertex_shader_src, nullptr);
+  glCompileShader(vertex_shader);
+  GLint vertex_compile_status;
+  glGetShaderiv(vertex_shader, GL_COMPILE_STATUS, &vertex_compile_status);
+  if (vertex_compile_status == GL_FALSE) {
+    g_autofree gchar* shader_log = get_shader_log(vertex_shader);
+    g_warning("Failed to compile vertex shader: %s", shader_log);
+  }
+
+  GLuint fragment_shader = glCreateShader(GL_FRAGMENT_SHADER);
+  glShaderSource(fragment_shader, 1, &fragment_shader_src, nullptr);
+  glCompileShader(fragment_shader);
+  GLint fragment_compile_status;
+  glGetShaderiv(fragment_shader, GL_COMPILE_STATUS, &fragment_compile_status);
+  if (fragment_compile_status == GL_FALSE) {
+    g_autofree gchar* shader_log = get_shader_log(fragment_shader);
+    g_warning("Failed to compile fragment shader: %s", shader_log);
+  }
+
+  self->program = glCreateProgram();
+  glAttachShader(self->program, vertex_shader);
+  glAttachShader(self->program, fragment_shader);
+  glLinkProgram(self->program);
+
+  GLint link_status;
+  glGetProgramiv(self->program, GL_LINK_STATUS, &link_status);
+  if (link_status == GL_FALSE) {
+    g_autofree gchar* program_log = get_program_log(self->program);
+    g_warning("Failed to link program: %s", program_log);
+  }
+
+  self->offset_location = glGetUniformLocation(self->program, "offset");
+  self->scale_location = glGetUniformLocation(self->program, "scale");
+
+  glDeleteShader(vertex_shader);
+  glDeleteShader(fragment_shader);
+
+  // The uniform square abcd in two triangles cba + cdb
+  // a--b
+  // |  |
+  // c--d
+  GLfloat vertex_data[] = {-1, -1, 0, 0, 1, 1,  1, 1, -1, 1, 0, 1,
+                           -1, -1, 0, 0, 1, -1, 1, 0, 1,  1, 1, 1};
+
+  glGenBuffers(1, &self->vertex_buffer);
+  glBindBuffer(GL_ARRAY_BUFFER, self->vertex_buffer);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(vertex_data), vertex_data,
+               GL_STATIC_DRAW);
+}
+
+static void cleanup_shader(FlOpenGLManager* self) {
+  if (!fl_opengl_manager_make_platform_current(self)) {
+    g_warning(
+        "Failed to cleanup shaders, unable to make OpenGL context "
+        "current");
+    return;
+  }
+
+  if (self->program != 0) {
+    glDeleteProgram(self->program);
+  }
+  if (self->vertex_buffer != 0) {
+    glDeleteBuffers(1, &self->vertex_buffer);
+  }
+}
+
+GLuint fl_opengl_manager_get_program(FlOpenGLManager* self) {
+  return self->program;
+}
+
+GLuint fl_opengl_manager_get_vertex_buffer(FlOpenGLManager* self) {
+  return self->vertex_buffer;
+}
+
+GLuint fl_opengl_manager_get_offset_location(FlOpenGLManager* self) {
+  return self->offset_location;
+}
+
+GLuint fl_opengl_manager_get_scale_location(FlOpenGLManager* self) {
+  return self->scale_location;
+}
+
 static void fl_opengl_manager_dispose(GObject* object) {
   FlOpenGLManager* self = FL_OPENGL_MANAGER(object);
+
+  cleanup_shader(self);
 
   eglDestroyContext(self->display, self->render_context);
   eglDestroyContext(self->display, self->resource_context);
@@ -87,6 +244,8 @@ static void fl_opengl_manager_init(FlOpenGLManager* self) {
   if (self->platform_context == EGL_NO_CONTEXT) {
     g_warning("Failed to create EGL context for platform thread");
   }
+
+  setup_shader(self);
 }
 
 FlOpenGLManager* fl_opengl_manager_new() {

--- a/engine/src/flutter/shell/platform/linux/fl_opengl_manager.h
+++ b/engine/src/flutter/shell/platform/linux/fl_opengl_manager.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_LINUX_FL_OPENGL_MANAGER_H_
 #define FLUTTER_SHELL_PLATFORM_LINUX_FL_OPENGL_MANAGER_H_
 
+#include <epoxy/gl.h>
 #include <glib-object.h>
 
 G_BEGIN_DECLS
@@ -63,6 +64,46 @@ gboolean fl_opengl_manager_make_platform_current(FlOpenGLManager* manager);
  * Returns: %TRUE if the context cleared.
  */
 gboolean fl_opengl_manager_clear_current(FlOpenGLManager* manager);
+
+/**
+ * fl_opengl_manager_get_program:
+ * @manager: an #FlOpenGLManager.
+ *
+ * Gets the shader program used for rendering Flutter content.
+ *
+ * Returns: the shader program.
+ */
+GLuint fl_opengl_manager_get_program(FlOpenGLManager* manager);
+
+/**
+ * fl_opengl_manager_get_vertex_buffer:
+ * @manager: an #FlOpenGLManager.
+ *
+ * Gets the vertex buffer object containing vertices for a uniform square.
+ *
+ * Returns: the vertex buffer object.
+ */
+GLuint fl_opengl_manager_get_vertex_buffer(FlOpenGLManager* manager);
+
+/**
+ * fl_opengl_manager_get_offset_location:
+ * @manager: an #FlOpenGLManager.
+ *
+ * Gets the location of the offset uniform in the shader program.
+ *
+ * Returns: the location of the offset uniform.
+ */
+GLuint fl_opengl_manager_get_offset_location(FlOpenGLManager* manager);
+
+/**
+ * fl_opengl_manager_get_scale_location:
+ * @manager: an #FlOpenGLManager.
+ *
+ * Gets the location of the scale uniform in the shader program.
+ *
+ * Returns: the location of the scale uniform.
+ */
+GLuint fl_opengl_manager_get_scale_location(FlOpenGLManager* manager);
 
 G_END_DECLS
 

--- a/engine/src/flutter/shell/platform/linux/testing/mock_epoxy.cc
+++ b/engine/src/flutter/shell/platform/linux/testing/mock_epoxy.cc
@@ -430,6 +430,9 @@ static void _glBlitFramebuffer(GLint srcX0,
 }
 
 GLuint _glCreateProgram() {
+  if (mock) {
+    return mock->glCreateProgram();
+  }
   return 0;
 }
 
@@ -440,6 +443,9 @@ void _glClearColor(GLfloat r, GLfloat g, GLfloat b, GLfloat a) {
 }
 
 GLuint _glCreateShader(GLenum shaderType) {
+  if (mock) {
+    return mock->glCreateShader(shaderType);
+  }
   return 0;
 }
 

--- a/engine/src/flutter/shell/platform/linux/testing/mock_epoxy.h
+++ b/engine/src/flutter/shell/platform/linux/testing/mock_epoxy.h
@@ -30,6 +30,8 @@ class MockEpoxy {
                const EGLint* attrib_list));
   MOCK_METHOD(EGLBoolean, eglDestroyImageKHR, (EGLDisplay dpy, EGLImage image));
   MOCK_METHOD(void, glClearColor, (GLfloat r, GLfloat g, GLfloat b, GLfloat a));
+  MOCK_METHOD(GLuint, glCreateProgram, ());
+  MOCK_METHOD(GLuint, glCreateShader, (GLenum shaderType));
   MOCK_METHOD(void,
               glBlitFramebuffer,
               (GLint srcX0,


### PR DESCRIPTION
This change moves shader creation and management from individual compositors to opengl_manager to enable sharing across views.

Previously, each view’s compositor created and managed its own shaders, resulting in redundant instantiation. This change centralizes shader ownership in opengl_manager, allowing compositors to reuse a single shared shader and access its properties.

Fixes #183911 

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
