### PR TITLE
dev: Remove unused parameters

### DIFF
--- a/dev/integration_tests/new_gallery/lib/demos/material/dialog_demo.dart
+++ b/dev/integration_tests/new_gallery/lib/demos/material/dialog_demo.dart
@@ -198,10 +198,7 @@ class _DialogDemoState extends State<DialogDemo> with RestorationMixin {
 
 /// A MaterialPageRoute without any transition animations.
 class _NoAnimationMaterialPageRoute<T> extends MaterialPageRoute<T> {
-  _NoAnimationMaterialPageRoute({
-    required super.builder,
-    super.settings,
-  });
+  _NoAnimationMaterialPageRoute({required super.builder, super.settings});
 
   @override
   Widget buildTransitions(

--- a/dev/integration_tests/new_gallery/lib/demos/material/dialog_demo.dart
+++ b/dev/integration_tests/new_gallery/lib/demos/material/dialog_demo.dart
@@ -201,8 +201,6 @@ class _NoAnimationMaterialPageRoute<T> extends MaterialPageRoute<T> {
   _NoAnimationMaterialPageRoute({
     required super.builder,
     super.settings,
-    super.maintainState,
-    super.fullscreenDialog,
   });
 
   @override


### PR DESCRIPTION
Work towards https://github.com/dart-lang/sdk/issues/47839

The lint rule will start reporting these unused parameters. These are parameters for which no arguments are ever given, so they are dead code.