### PR TITLE
[CP-stable]Only use LLDB breakpoint in debug mode

### DIFF
--- a/packages/flutter_tools/lib/src/ios/core_devices.dart
+++ b/packages/flutter_tools/lib/src/ios/core_devices.dart
@@ -14,6 +14,7 @@ import '../base/logger.dart';
 import '../base/process.dart';
 import '../base/template.dart';
 import '../base/utils.dart';
+import '../build_info.dart';
 import '../convert.dart';
 import '../device.dart';
 import '../macos/xcode.dart';
@@ -96,6 +97,7 @@ class IOSCoreDeviceLauncher {
     required String bundleId,
     required List<String> launchArguments,
     required ShutdownHooks shutdownHooks,
+    required BuildMode mode,
   }) async {
     // Install app to device
     final (bool installStatus, IOSCoreDeviceInstallResult? installResult) = await _coreDeviceControl
@@ -139,6 +141,7 @@ class IOSCoreDeviceLauncher {
       deviceId: deviceId,
       appProcessId: processId,
       lldbLogForwarder: lldbLogForwarder,
+      mode: mode,
     );
 
     // If it fails to attach with lldb, kill the launched process so it doesn't stay hanging.

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -1057,6 +1057,7 @@ class IOSDevice extends Device {
         bundleId: package.id,
         launchArguments: launchArguments,
         shutdownHooks: globals.shutdownHooks,
+        mode: debuggingOptions.buildInfo.mode,
       );
 
       // If it succeeds to launch with LLDB, return, otherwise continue on to

--- a/packages/flutter_tools/lib/src/ios/lldb.dart
+++ b/packages/flutter_tools/lib/src/ios/lldb.dart
@@ -11,6 +11,7 @@ import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/process.dart';
 import '../base/utils.dart';
+import '../build_info.dart';
 
 /// LLDB is the default debugger in Xcode on macOS. Once the application has
 /// launched on a physical iOS device, you can attach to it using LLDB.
@@ -42,10 +43,15 @@ class LLDB {
   /// Example: (lldb) Process 6152 stopped
   static final _lldbProcessStopped = RegExp(r'Process \d* stopped');
 
-  /// Pattern of lldb log when the process is resuming and the breakpoint is added.
+  /// Pattern of lldb log when the process is resuming.
+  ///
+  /// Example: (lldb) Process 6152 resuming
+  static final _lldbProcessResuming = RegExp(r'Process \d+ resuming');
+
+  /// Pattern of lldb log when the process has started and the breakpoint is added.
   ///
   /// Example: (lldb) 1 location added to breakpoint 1
-  static final _lldbProcessResuming = RegExp(r'location added to breakpoint');
+  static final _lldbBreakpointAdded = RegExp(r'location added to breakpoint');
 
   /// Pattern of lldb log when the breakpoint is added.
   ///
@@ -88,6 +94,7 @@ return False
     required String deviceId,
     required int appProcessId,
     required LLDBLogForwarder lldbLogForwarder,
+    required BuildMode mode,
   }) async {
     Timer? timer;
     try {
@@ -111,9 +118,11 @@ return False
         return false;
       }
       await _selectDevice(deviceId);
-      await _setBreakpoint();
+      if (mode == BuildMode.debug) {
+        await _setBreakpoint();
+      }
       await _attachToAppProcess(appProcessId);
-      await _resumeProcess();
+      await _resumeProcess(mode);
       _isAttached = true;
     } on _LLDBError catch (e) {
       _logger.printTrace('lldb failed with error: ${e.message}');
@@ -146,7 +155,6 @@ return False
         appProcessId: appProcessId,
         logger: _logger,
       );
-
       final StreamSubscription<String> stdoutSubscription = _lldbProcess!.stdout
           .transform(utf8LineDecoder)
           .listen((String line) {
@@ -248,9 +256,12 @@ return False
   }
 
   /// Resume the stopped process.
-  Future<void> _resumeProcess() async {
+  Future<void> _resumeProcess(BuildMode mode) async {
     final Future<String> futureLog = _startWaitingForLog(
-      _lldbProcessResuming,
+      // When using debug mode, a breakpoint is added once the process resumes and no resume log
+      // is shown. Instead we match on the breakpoint added log. In profile mode, a resume log is
+      // shown once the process resumes and no breakpoint log is shown.
+      mode == BuildMode.debug ? _lldbBreakpointAdded : _lldbProcessResuming,
     ).then((value) => value, onError: _handleAsyncError);
 
     await _lldbProcess?.stdinWriteln('process continue');

--- a/packages/flutter_tools/test/general.shard/ios/core_devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/core_devices_test.dart
@@ -217,6 +217,7 @@ void main() {
           bundleId: 'bundle-id',
           launchArguments: <String>[],
           shutdownHooks: FakeShutdownHooks(),
+          mode: BuildMode.debug,
         );
 
         expect(result, isTrue);
@@ -267,6 +268,7 @@ void main() {
           bundleId: 'bundle-id',
           launchArguments: <String>[],
           shutdownHooks: FakeShutdownHooks(),
+          mode: BuildMode.debug,
         );
 
         expect(result, isFalse);
@@ -311,6 +313,7 @@ void main() {
           bundleId: 'bundle-id',
           launchArguments: <String>[],
           shutdownHooks: FakeShutdownHooks(),
+          mode: BuildMode.debug,
         );
 
         expect(result, isFalse);
@@ -361,6 +364,7 @@ void main() {
           bundleId: 'bundle-id',
           launchArguments: <String>[],
           shutdownHooks: FakeShutdownHooks(),
+          mode: BuildMode.debug,
         );
 
         expect(result, isFalse);
@@ -405,6 +409,7 @@ void main() {
           bundleId: 'bundle-id',
           launchArguments: <String>[],
           shutdownHooks: FakeShutdownHooks(),
+          mode: BuildMode.debug,
         );
 
         expect(result, isFalse);
@@ -451,6 +456,7 @@ void main() {
           bundleId: 'bundle-id',
           launchArguments: <String>[],
           shutdownHooks: FakeShutdownHooks(),
+          mode: BuildMode.debug,
         );
 
         expect(result, isFalse);
@@ -499,6 +505,7 @@ void main() {
           bundleId: 'bundle-id',
           launchArguments: <String>[],
           shutdownHooks: FakeShutdownHooks(),
+          mode: BuildMode.debug,
         );
 
         expect(result, isFalse);
@@ -3958,6 +3965,7 @@ class FakeLLDB extends Fake implements LLDB {
     required String deviceId,
     required int appProcessId,
     required LLDBLogForwarder lldbLogForwarder,
+    required BuildMode mode,
   }) async {
     attemptedToAttach = true;
     return attachSuccess;

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
@@ -1716,6 +1716,7 @@ class FakeIOSCoreDeviceLauncher extends Fake implements IOSCoreDeviceLauncher {
     required String bundlePath,
     required String bundleId,
     required List<String> launchArguments,
+    required BuildMode mode,
     required ShutdownHooks shutdownHooks,
   }) async {
     return true;

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -1803,6 +1803,7 @@ class FakeIOSCoreDeviceLauncher extends Fake implements IOSCoreDeviceLauncher {
     required String bundlePath,
     required String bundleId,
     required List<String> launchArguments,
+    required BuildMode mode,
     required ShutdownHooks shutdownHooks,
   }) async {
     launchedWithLLDB = true;

--- a/packages/flutter_tools/test/general.shard/ios/lldb_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/lldb_test.dart
@@ -10,6 +10,7 @@ import 'package:fake_async/fake_async.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/process.dart';
+import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/ios/lldb.dart';
 import 'package:test/fake.dart';
 
@@ -42,6 +43,7 @@ void main() {
       deviceId: deviceId,
       appProcessId: appProcessId,
       lldbLogForwarder: FakeLLDBLogForwarder(),
+      mode: BuildMode.debug,
     );
     expect(success, isFalse);
     expect(lldb.isRunning, isFalse);
@@ -127,6 +129,78 @@ Target 0: (Runner) stopped.
       deviceId: deviceId,
       appProcessId: appProcessId,
       lldbLogForwarder: FakeLLDBLogForwarder(),
+      mode: BuildMode.debug,
+    );
+    expect(success, isTrue);
+    expect(lldb.isRunning, isTrue);
+    expect(lldb.appProcessId, appProcessId);
+    expect(expectedInputs, isEmpty);
+    expect(processManager.hasRemainingExpectations, isFalse);
+    expect(logger.errorText, isEmpty);
+  });
+
+  testWithoutContext('attachAndStart returns true on success for profile mode', () async {
+    const deviceId = '123';
+    const appProcessId = 5678;
+
+    final processAttachCompleter = Completer<List<int>>();
+    final processResumedCompleted = Completer<List<int>>();
+
+    final stdoutStream = Stream<List<int>>.fromFutures([
+      processAttachCompleter.future,
+      processResumedCompleted.future,
+    ]);
+
+    final stdinController = StreamController<List<int>>();
+
+    final processCompleter = Completer<void>();
+    final lldbCommand = FakeLLDBCommand(
+      command: const <String>['lldb'],
+      completer: processCompleter,
+      stdin: io.IOSink(stdinController.sink),
+      stdout: stdoutStream,
+      stderr: const Stream.empty(),
+    );
+
+    final logger = BufferLogger.test();
+
+    final processManager = FakeLLDBProcessManager([lldbCommand]);
+    final processUtils = ProcessUtils(processManager: processManager, logger: logger);
+    final lldb = LLDB(logger: logger, processUtils: processUtils);
+
+    const processAttachMatcher = 'device process attach --pid $appProcessId';
+    const processResumedMatcher = 'process continue';
+    final expectedInputs = ['device select $deviceId', processAttachMatcher, processResumedMatcher];
+
+    stdinController.stream.transform<String>(utf8.decoder).transform(const LineSplitter()).listen((
+      String line,
+    ) {
+      expectedInputs.remove(line);
+      if (line == processAttachMatcher) {
+        processAttachCompleter.complete(
+          utf8.encode('''
+Process 568 stopped
+* thread #1, stop reason = signal SIGSTOP
+    frame #0: 0x0000000102c7b240 dyld`_dyld_start
+dyld`_dyld_start:
+->  0x102c7b240 <+0>:  mov    x0, sp
+    0x102c7b244 <+4>:  and    sp, x0, #0xfffffffffffffff0
+    0x102c7b248 <+8>:  mov    x29, #0x0 ; =0
+    0x102c7b24c <+12>: mov    x30, #0x0 ; =0
+Target 0: (Runner) stopped.
+'''),
+        );
+      }
+      if (line == processResumedMatcher) {
+        processResumedCompleted.complete(utf8.encode('Process 568 resuming\n'));
+      }
+    });
+
+    final bool success = await lldb.attachAndStart(
+      deviceId: deviceId,
+      appProcessId: appProcessId,
+      lldbLogForwarder: FakeLLDBLogForwarder(),
+      mode: BuildMode.profile,
     );
     expect(success, isTrue);
     expect(lldb.isRunning, isTrue);
@@ -181,6 +255,7 @@ Target 0: (Runner) stopped.
       deviceId: deviceId,
       appProcessId: appProcessId,
       lldbLogForwarder: FakeLLDBLogForwarder(),
+      mode: BuildMode.debug,
     );
     expect(success, isFalse);
     expect(lldb.isRunning, isFalse);
@@ -231,6 +306,7 @@ Target 0: (Runner) stopped.
       deviceId: deviceId,
       appProcessId: appProcessId,
       lldbLogForwarder: FakeLLDBLogForwarder(),
+      mode: BuildMode.debug,
     );
     expect(success, isFalse);
     expect(lldb.isRunning, isFalse);
@@ -276,6 +352,7 @@ Target 0: (Runner) stopped.
         deviceId: deviceId,
         appProcessId: appProcessId,
         lldbLogForwarder: FakeLLDBLogForwarder(),
+        mode: BuildMode.debug,
       );
       time.elapse(const Duration(minutes: 2));
       time.flushMicrotasks();
@@ -371,6 +448,7 @@ Target 0: (Runner) stopped.
       deviceId: deviceId,
       appProcessId: appProcessId,
       lldbLogForwarder: lldbLogForwarder,
+      mode: BuildMode.debug,
     );
 
     logAfterAttachCompleter.complete(utf8.encode('$ignoreLog\n$expectedForwardedLog\n'));
@@ -422,6 +500,7 @@ Target 0: (Runner) stopped.
         deviceId: deviceId,
         appProcessId: appProcessId,
         lldbLogForwarder: FakeLLDBLogForwarder(),
+        mode: BuildMode.debug,
       ),
     );
 


### PR DESCRIPTION
Please fill in the form below, and a flutter domain expert will evaluate this cherry pick request.

### Issue Link:
What is the link to the issue this cherry-pick is addressing?

https://github.com/flutter/flutter/issues/185150

### Impact Description:
What is the impact (ex. visual jank on Samsung phones, app crash, cannot ship an iOS app)?
Does it impact development (ex. flutter doctor crashes when Android Studio is installed),
or the shipping of production apps (the app crashes on launch).
This information is for domain experts and release engineers to understand the consequences of saying yes or no to the cherry pick.

Deploying to a physical iOS device in profile mode with Xcode 26 will hang.

### Changelog Description:
Explain this cherry pick:
* In one line that is accessible to most Flutter developers.
* That describes the state prior to the fix.
* That includes which platforms are impacted.
See [best practices](https://github.com/flutter/flutter/blob/main/docs/releases/Hotfix-Documentation-Best-Practices.md) for examples.

< Replace with changelog description here >
[flutter/185150] When using profile mode on a physical iOS device, the app may fail to connect to the Dart VM.

### Workaround:
Is there a workaround for this issue?

Disable LLDB debuggin (`flutter config --no-enable-lldb-debugging`) or run through Xcode

### Risk:
What is the risk level of this cherry-pick?

  - [x] Low
  - [ ] Medium
  - [ ] High

### Test Coverage:
Are you confident that your fix is well-tested by automated tests?

  - [x] Yes
  - [ ] No

### Validation Steps:
What are the steps to validate that this fix works?

Run one of these tests: https://github.com/flutter/flutter/issues/185150#issuecomment-4261481269
