### PR TITLE
[flutter_tools] Bump dwds dependency to v27.1.1

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/web_asset_server.dart
+++ b/packages/flutter_tools/lib/src/isolated/web_asset_server.dart
@@ -327,20 +327,6 @@ class WebAssetServer implements AssetReader {
 
     // Ensure dwds is present and provide middleware to avoid trying to
     // load the through the isolate APIs.
-    final Directory directory = await loadDwdsDirectory(fileSystem, logger);
-    shelf.Handler middleware(FutureOr<shelf.Response> Function(shelf.Request) innerHandler) {
-      return (shelf.Request request) async {
-        if (request.url.path.endsWith('dwds/src/injected/client.js')) {
-          final Uri uri = directory.uri.resolve('src/injected/client.js');
-          final String result = await fileSystem.file(uri.toFilePath()).readAsString();
-          return shelf.Response.ok(
-            result,
-            headers: <String, String>{HttpHeaders.contentTypeHeader: 'application/javascript'},
-          );
-        }
-        return innerHandler(request);
-      };
-    }
 
     logging.Logger.root.level = logging.Level.ALL;
     logging.Logger.root.onRecord.listen((logging.LogRecord event) => log(logger, event));
@@ -398,7 +384,7 @@ class WebAssetServer implements AssetReader {
     );
     var pipeline = const shelf.Pipeline();
     if (shouldEnableMiddleware) {
-      pipeline = pipeline.addMiddleware(middleware).addMiddleware(dwds.middleware);
+      pipeline = pipeline.addMiddleware(dwds.middleware);
     }
     pipeline = pipeline.addMiddleware(proxyMiddleware(proxy, globals.logger));
     final shelf.Handler dwdsHandler = pipeline.addHandler(server.handleRequest);

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -128,12 +128,4 @@ dartdoc:
   # Exclude this package from the hosted API docs.
   nodoc: true
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-# PUBSPEC CHECKSUM: 3bm17u
-=======
-# PUBSPEC CHECKSUM: lim8o
->>>>>>> 578994cc647 (use update-packages to update the pubspec.lock)
-=======
-# PUBSPEC CHECKSUM: k2fl4e
->>>>>>> 28251fdf0d2 (update to published v27.1.1)
+# PUBSPEC CHECKSUM: 7qgq4g

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -14,7 +14,10 @@ dependencies:
   archive: 3.6.1
   args: 2.7.0
   dds: 5.3.0
-  dwds: 26.2.5
+  dwds:
+    git:
+      url: git@github.com:dart-lang/webdev.git
+      ref: e43744b235531f409ab5e2f1271178943569697a
   code_builder: 4.11.1
   collection: 1.19.1
   completion: 1.0.2

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -3,7 +3,7 @@ description: Tools for building Flutter applications
 homepage: https://flutter.dev
 
 environment:
-  sdk: ^3.12.0-307.0.dev
+  sdk: ^3.10.0-0
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   dds: 5.3.0
   dwds:
     git:
-      url: git@github.com:dart-lang/webdev.git
+      url: https://github.com/dart-lang/webdev.git
       ref: e43744b235531f409ab5e2f1271178943569697a
       path: dwds
   code_builder: 4.11.1

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -132,4 +132,8 @@ dartdoc:
   # Exclude this package from the hosted API docs.
   nodoc: true
 
+<<<<<<< HEAD
 # PUBSPEC CHECKSUM: 3bm17u
+=======
+# PUBSPEC CHECKSUM: lim8o
+>>>>>>> 578994cc647 (use update-packages to update the pubspec.lock)

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -14,11 +14,7 @@ dependencies:
   archive: 3.6.1
   args: 2.7.0
   dds: 5.3.0
-  dwds:
-    git:
-      url: https://github.com/dart-lang/webdev.git
-      ref: e43744b235531f409ab5e2f1271178943569697a
-      path: dwds
+  dwds: 27.1.1
   code_builder: 4.11.1
   collection: 1.19.1
   completion: 1.0.2
@@ -133,7 +129,11 @@ dartdoc:
   nodoc: true
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 # PUBSPEC CHECKSUM: 3bm17u
 =======
 # PUBSPEC CHECKSUM: lim8o
 >>>>>>> 578994cc647 (use update-packages to update the pubspec.lock)
+=======
+# PUBSPEC CHECKSUM: k2fl4e
+>>>>>>> 28251fdf0d2 (update to published v27.1.1)

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -3,7 +3,7 @@ description: Tools for building Flutter applications
 homepage: https://flutter.dev
 
 environment:
-  sdk: ^3.10.0-0
+  sdk: ^3.12.0-307.0.dev
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".
@@ -18,6 +18,7 @@ dependencies:
     git:
       url: git@github.com:dart-lang/webdev.git
       ref: e43744b235531f409ab5e2f1271178943569697a
+      path: dwds
   code_builder: 4.11.1
   collection: 1.19.1
   completion: 1.0.2

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1377,5 +1377,5 @@ packages:
     source: hosted
     version: "2.2.4"
 sdks:
-  dart: ">=3.12.0-307.0.dev <4.0.0"
+  dart: ">=3.11.0 <4.0.0"
   flutter: ">=3.38.4"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -310,12 +310,11 @@ packages:
   dwds:
     dependency: transitive
     description:
-      path: dwds
-      ref: e43744b235531f409ab5e2f1271178943569697a
-      resolved-ref: e43744b235531f409ab5e2f1271178943569697a
-      url: "https://github.com/dart-lang/webdev.git"
-    source: git
-    version: "27.1.1-wip"
+      name: dwds
+      sha256: d2fe0b3608330627871d7b0e070ffb4f356087a3e19fea64fa58f95a2c2871d6
+      url: "https://pub.dev"
+    source: hosted
+    version: "27.1.1"
   extension_discovery:
     dependency: transitive
     description:
@@ -1377,5 +1376,5 @@ packages:
     source: hosted
     version: "2.2.4"
 sdks:
-  dart: ">=3.11.0 <4.0.0"
+  dart: ">=3.12.0-307.0.dev <4.0.0"
   flutter: ">=3.38.4"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -310,11 +310,12 @@ packages:
   dwds:
     dependency: transitive
     description:
-      name: dwds
-      sha256: "37829d11cc9ef3fe4cd8c6263873b4e8b640a8862d4d741b8fa58dd1eeadfb48"
-      url: "https://pub.dev"
-    source: hosted
-    version: "26.2.5"
+      path: dwds
+      ref: e43744b235531f409ab5e2f1271178943569697a
+      resolved-ref: e43744b235531f409ab5e2f1271178943569697a
+      url: "https://github.com/dart-lang/webdev.git"
+    source: git
+    version: "27.1.1-wip"
   extension_discovery:
     dependency: transitive
     description:
@@ -1376,5 +1377,5 @@ packages:
     source: hosted
     version: "2.2.4"
 sdks:
-  dart: ">=3.11.0 <4.0.0"
+  dart: ">=3.12.0-307.0.dev <4.0.0"
   flutter: ">=3.38.4"


### PR DESCRIPTION
Remove custom shelf handler for injected_client.js and allow the dwds handler to provide the file contents. The file is no longer shipped as an asset that can be read from disk.