### PR TITLE
[web] Add engine browser scroll controller and placeholder

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine.dart
@@ -19,6 +19,7 @@ export 'engine/alarm_clock.dart';
 export 'engine/app_bootstrap.dart';
 export 'engine/arena.dart';
 export 'engine/browser_detection.dart';
+export 'engine/browser_scroll_controller.dart';
 export 'engine/canvaskit/canvas.dart';
 export 'engine/canvaskit/canvaskit_api.dart';
 export 'engine/canvaskit/color_filter.dart';

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/browser_scroll_controller.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/browser_scroll_controller.dart
@@ -4,6 +4,8 @@
 
 import 'dart:js_interop';
 
+import 'package:meta/meta.dart';
+
 import 'dom.dart';
 import 'view_embedder/embedding_strategy/embedding_strategy.dart';
 import 'window.dart';
@@ -215,8 +217,17 @@ class BrowserScrollController {
       _touchStartY = touches.first.clientY;
       final DomEventTarget? target = event.target;
       if (target != null && target.isA<DomElement>()) {
-        _activeScrollable = _findScrollableAncestor(target as DomElement);
-        _activeScrollable ??= _findScrollableDescendant(pvHost);
+        final el = target as DomElement;
+        _activeScrollable = _findScrollableAncestor(el);
+        if (_activeScrollable == null) {
+          // Scope the descendant walk to the specific platform view the
+          // user touched. Walking all of pvHost would return a scrollable
+          // from a different platform view and scroll the wrong content.
+          final DomElement? pv = containingPlatformView(el, pvHost);
+          if (pv != null) {
+            _activeScrollable = _findScrollableDescendant(pv);
+          }
+        }
       }
     });
 
@@ -337,6 +348,21 @@ class BrowserScrollController {
     } else {
       scrollable.scrollTop = scrollTop + deltaY;
     }
+  }
+
+  /// Returns the direct child of [pvHost] that contains [target], or null
+  /// if [target] is not inside any platform view.
+  ///
+  /// Used by the touch-start path to scope the scrollable-descendant search
+  /// to a single platform view so a touch on one platform view cannot
+  /// return a scrollable that lives in a different platform view.
+  @visibleForTesting
+  DomElement? containingPlatformView(DomElement target, DomElement pvHost) {
+    DomElement? current = target;
+    while (current != null && current.parentElement != pvHost) {
+      current = current.parentElement;
+    }
+    return current;
   }
 
   /// Walks down from [element] to find the first descendant with scrollable

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/browser_scroll_controller.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/browser_scroll_controller.dart
@@ -1,0 +1,382 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:js_interop';
+
+import 'dom.dart';
+import 'view_embedder/embedding_strategy/embedding_strategy.dart';
+import 'window.dart';
+
+/// Manages browser-driven scrolling for a Flutter view.
+///
+/// When enabled, the outermost scrollable in a Flutter view delegates to the
+/// browser. The host element becomes a real scrollable DOM element, and the
+/// browser handles scroll physics, momentum, and scroll chaining natively.
+///
+/// The framework communicates content extent via the dart:ui API on
+/// [FlutterView], and the engine sends scroll position updates back to the
+/// framework via the [FlutterView.onBrowserScroll] callback.
+class BrowserScrollController {
+  BrowserScrollController(this._view);
+
+  final EngineFlutterView _view;
+
+  bool _enabled = false;
+  bool get enabled => _enabled;
+
+  JSFunction? _scrollListener;
+  JSFunction? _touchStartBlocker;
+  double? _lastProgrammaticScrollTop;
+
+  /// Enables browser-driven scrolling for this view.
+  void enable() {
+    if (_enabled) {
+      return;
+    }
+
+    final EmbeddingStrategy strategy = _view.embeddingStrategy;
+    if (!strategy.supportsBrowserScrolling) {
+      return;
+    }
+
+    _enabled = true;
+    strategy.enableBrowserScrolling(_view.dom.rootElement);
+    _attachScrollListener();
+    _attachTouchStartBlocker();
+    _attachPlatformViewTouchChaining();
+  }
+
+  /// Disables browser-driven scrolling for this view.
+  void disable() {
+    if (!_enabled) {
+      return;
+    }
+
+    _enabled = false;
+    _detachScrollListener();
+    _detachTouchStartBlocker();
+    _detachPlatformViewTouchChaining();
+    _view.embeddingStrategy.disableBrowserScrolling(_view.dom.rootElement);
+  }
+
+  /// Updates the total scroll content height. Called when the framework
+  /// reports a new content extent.
+  void updateContentHeight(double height) {
+    _view.embeddingStrategy.updateScrollContentHeight(height);
+  }
+
+  void scrollTo(double offset) {
+    if (_enabled) {
+      if (_pvTouchActive) {
+        return;
+      }
+      _lastProgrammaticScrollTop = offset;
+      _view.dom.rootElement.scrollTop = offset;
+    }
+  }
+
+  void smoothScrollTo(double offset) {
+    if (_enabled) {
+      if (_pvTouchActive) {
+        return;
+      }
+      _view.dom.rootElement.scrollTo(top: offset, behavior: 'smooth');
+    }
+  }
+
+  /// Scrolls the root element by [delta] pixels.
+  ///
+  /// Does not check [_pvTouchActive] because the platform-view touch
+  /// chaining handler calls this method during an active touch to forward
+  /// boundary overflow to the outer flutter-view scroll.
+  ///
+  /// Calls [_sendScrollPositionToFramework] directly rather than relying on
+  /// the DOM `scroll` event: after writing [_lastProgrammaticScrollTop], the
+  /// onScroll listener would suppress the subsequent scroll event as a
+  /// programmatic echo, and the framework would never see the new position.
+  void scrollBy(double delta) {
+    if (_enabled) {
+      final DomElement root = _view.dom.rootElement;
+      root.scrollTop = root.scrollTop + delta;
+      final double newTop = root.scrollTop;
+      _lastProgrammaticScrollTop = newTop;
+      _sendScrollPositionToFramework(newTop);
+    }
+  }
+
+  // ---- Touch start blocker ----
+  //
+  // Prevents the browser from initiating native touch scrolling on
+  // <flutter-view>. This must be a non-passive touchstart listener so
+  // that preventDefault() actually works. The pointerdown handler's
+  // preventDefault() alone is not sufficient because modern browsers
+  // register pointer event listeners as passive by default.
+
+  void _attachTouchStartBlocker() {
+    void onTouchStart(DomEvent event) {
+      event.preventDefault();
+    }
+
+    _touchStartBlocker = onTouchStart.toJS;
+    _view.dom.rootElement.addEventListener(
+      'touchstart',
+      _touchStartBlocker,
+      <String, Object>{'passive': false}.toJSAnyDeep,
+    );
+  }
+
+  void _detachTouchStartBlocker() {
+    final JSFunction? blocker = _touchStartBlocker;
+    if (blocker != null) {
+      _view.dom.rootElement.removeEventListener('touchstart', blocker);
+      _touchStartBlocker = null;
+    }
+  }
+
+  // ---- Outer scroll listener ----
+
+  void _attachScrollListener() {
+    final DomElement scrollTarget = _view.dom.rootElement;
+
+    void onScroll() {
+      final double scrollTop = scrollTarget.scrollTop;
+      if (_lastProgrammaticScrollTop != null &&
+          (scrollTop - _lastProgrammaticScrollTop!).abs() < 1.0) {
+        _lastProgrammaticScrollTop = null;
+        return;
+      }
+      _lastProgrammaticScrollTop = null;
+      _sendScrollPositionToFramework(scrollTop);
+    }
+
+    _scrollListener = onScroll.toJS;
+    scrollTarget.addEventListener('scroll', _scrollListener);
+  }
+
+  void _detachScrollListener() {
+    final JSFunction? listener = _scrollListener;
+    if (listener != null) {
+      _view.dom.rootElement.removeEventListener('scroll', listener);
+      _scrollListener = null;
+    }
+  }
+
+  void _sendScrollPositionToFramework(double scrollTop) {
+    _view.onBrowserScroll?.call(scrollTop);
+  }
+
+  // ---- Platform view touch scroll chaining ----
+  //
+  // Browser scroll chaining from a scrollable native element inside a
+  // platform view to <flutter-view> doesn't work on touch devices because
+  // of the shadow DOM + position:sticky structure. We work around this by
+  // listening for touch events on the platformViewsHost and programmatically
+  // scrolling <flutter-view> when an inner scrollable hits its boundary.
+
+  DomEventListener? _pvTouchStartListener;
+  JSFunction? _pvTouchMoveListener;
+  DomEventListener? _pvTouchEndListener;
+
+  double? _touchStartY;
+  DomElement? _activeScrollable;
+  bool _pvTouchActive = false;
+
+  /// Whether a platform-view touch gesture is currently active.
+  ///
+  /// Used by [EngineFlutterView.browserScrollBy] to skip framework-initiated
+  /// scroll-by calls during a touch, since the touch chaining handler already
+  /// forwards boundary overflow via [scrollBy] directly.
+  bool get pvTouchActive => _pvTouchActive;
+
+  void _attachPlatformViewTouchChaining() {
+    final DomElement pvHost = _view.dom.platformViewsHost;
+    final DomElement root = _view.dom.rootElement;
+
+    bool isPlatformViewTarget(DomEvent event) {
+      final DomEventTarget? target = event.target;
+      if (target != null && target.isA<DomElement>()) {
+        return pvHost.contains(target as DomElement);
+      }
+      return false;
+    }
+
+    _pvTouchStartListener = createDomEventListener((DomEvent event) {
+      if (!isPlatformViewTarget(event)) {
+        _pvTouchActive = false;
+        return;
+      }
+      _pvTouchActive = true;
+      final te = event as DomTouchEvent;
+      final Iterable<DomTouch> touches = te.touches;
+      if (touches.isEmpty) {
+        return;
+      }
+      _touchStartY = touches.first.clientY;
+      final DomEventTarget? target = event.target;
+      if (target != null && target.isA<DomElement>()) {
+        _activeScrollable = _findScrollableAncestor(target as DomElement);
+        _activeScrollable ??= _findScrollableDescendant(pvHost);
+      }
+    });
+
+    void onTouchMove(DomEvent event) {
+      if (!isPlatformViewTarget(event)) {
+        return;
+      }
+      final te = event as DomTouchEvent;
+      if (_touchStartY == null) {
+        return;
+      }
+      final Iterable<DomTouch> touches = te.touches;
+      if (touches.isEmpty) {
+        return;
+      }
+
+      final double currentY = touches.first.clientY;
+      final double deltaY = _touchStartY! - currentY;
+      _touchStartY = currentY;
+
+      event.preventDefault();
+
+      if (_activeScrollable != null) {
+        final DomElement el = _activeScrollable!;
+        final double scrollTop = el.scrollTop;
+        final double maxScroll = el.scrollHeight - el.clientHeight;
+        final bool atTop = scrollTop <= 0 && deltaY < 0;
+        final bool atBottom = scrollTop >= maxScroll - 1 && deltaY > 0;
+
+        if (atTop || atBottom) {
+          scrollBy(deltaY);
+        } else {
+          el.scrollTop = scrollTop + deltaY;
+        }
+      } else {
+        scrollBy(deltaY);
+      }
+    }
+
+    _pvTouchMoveListener = onTouchMove.toJS;
+    root.addEventListener(
+      'touchmove',
+      _pvTouchMoveListener,
+      <String, Object>{'passive': false, 'capture': true}.toJSAnyDeep,
+    );
+
+    _pvTouchEndListener = createDomEventListener((DomEvent event) {
+      _pvTouchActive = false;
+      _touchStartY = null;
+      _activeScrollable = null;
+    });
+
+    root.addEventListener('touchstart', _pvTouchStartListener, true.toJS);
+    root.addEventListener('touchend', _pvTouchEndListener, true.toJS);
+    root.addEventListener('touchcancel', _pvTouchEndListener, true.toJS);
+  }
+
+  void _detachPlatformViewTouchChaining() {
+    final DomElement root = _view.dom.rootElement;
+    if (_pvTouchStartListener != null) {
+      // Per DOM spec, removeEventListener matches on {type, listener, capture}.
+      // These listeners were registered with capture=true, so the remove call
+      // must pass capture=true too; otherwise it silently no-ops.
+      root.removeEventListener('touchstart', _pvTouchStartListener, true.toJS);
+      root.removeEventListener('touchmove', _pvTouchMoveListener, true.toJS);
+      root.removeEventListener('touchend', _pvTouchEndListener, true.toJS);
+      root.removeEventListener('touchcancel', _pvTouchEndListener, true.toJS);
+      _pvTouchStartListener = null;
+      _pvTouchMoveListener = null;
+      _pvTouchEndListener = null;
+    }
+    _pvTouchActive = false;
+    _touchStartY = null;
+    _activeScrollable = null;
+  }
+
+  /// Finds a platform view element at the given screen coordinates.
+  ///
+  /// Used when the wheel event target is a semantics node overlaying a
+  /// platform view. Checks each platform view's bounding rect to find
+  /// which one, if any, contains the given point.
+  DomElement? findPlatformViewAtPoint(num clientX, num clientY) {
+    final DomElement pvHost = _view.dom.platformViewsHost;
+    for (final DomElement child in pvHost.children) {
+      final DomRect rect = child.getBoundingClientRect();
+      if (rect.width > 0 &&
+          rect.height > 0 &&
+          clientX >= rect.left &&
+          clientX <= rect.right &&
+          clientY >= rect.top &&
+          clientY <= rect.bottom) {
+        return child;
+      }
+    }
+    return null;
+  }
+
+  /// Handles a wheel event targeting a platform view element.
+  ///
+  /// Scrolls the inner scrollable element within the platform view. If the
+  /// inner scrollable is at its boundary, forwards the remaining delta to
+  /// the outer <flutter-view> scroll.
+  void handlePlatformViewWheel(DomElement target, double deltaY) {
+    DomElement? scrollable = _findScrollableAncestor(target);
+    scrollable ??= _findScrollableDescendant(target);
+    if (scrollable == null) {
+      scrollBy(deltaY);
+      return;
+    }
+
+    final double scrollTop = scrollable.scrollTop;
+    final double maxScroll = scrollable.scrollHeight - scrollable.clientHeight;
+    final bool atTop = scrollTop <= 0 && deltaY < 0;
+    final bool atBottom = scrollTop >= maxScroll - 1 && deltaY > 0;
+
+    if (atTop || atBottom) {
+      scrollBy(deltaY);
+    } else {
+      scrollable.scrollTop = scrollTop + deltaY;
+    }
+  }
+
+  /// Walks down from [element] to find the first descendant with scrollable
+  /// overflow and content that actually overflows.
+  DomElement? _findScrollableDescendant(DomElement element) {
+    for (final DomElement child in element.children) {
+      if (child.scrollHeight > child.clientHeight) {
+        final DomCSSStyleDeclaration style = domWindow.getComputedStyle(child);
+        final String overflowY = style.overflowY;
+        if (overflowY == 'auto' || overflowY == 'scroll') {
+          return child;
+        }
+      }
+      final DomElement? found = _findScrollableDescendant(child);
+      if (found != null) {
+        return found;
+      }
+    }
+    return null;
+  }
+
+  /// Walks up from [element] to find the nearest ancestor with scrollable
+  /// overflow and content that actually overflows.
+  DomElement? _findScrollableAncestor(DomElement element) {
+    DomElement? current = element;
+    final DomElement root = _view.dom.rootElement;
+    while (current != null && current != root) {
+      if (current.scrollHeight > current.clientHeight) {
+        final DomCSSStyleDeclaration style = domWindow.getComputedStyle(current);
+        final String overflowY = style.overflowY;
+        if (overflowY == 'auto' || overflowY == 'scroll') {
+          return current;
+        }
+      }
+      current = current.parentElement;
+    }
+    return null;
+  }
+
+  void dispose() {
+    disable();
+  }
+}

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/dom.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/dom.dart
@@ -526,7 +526,15 @@ extension type DomElement._(JSObject _) implements DomNode {
 
   external double scrollTop;
   external double scrollLeft;
+  external double get scrollHeight;
   external DomTokenList get classList;
+
+  @JS('scrollTo')
+  external void _scrollTo([JSAny? options]);
+
+  void scrollTo({required double top, String behavior = 'auto'}) {
+    _scrollTo(<String, dynamic>{'top': top, 'behavior': behavior}.toJSAnyDeep);
+  }
 
   /// Scrolls the element into the visible area of the browser window.
   ///
@@ -1995,6 +2003,10 @@ extension type DomTouchEvent._(JSObject _) implements DomUIEvent {
   @JS('changedTouches')
   external _DomList get _changedTouches;
   Iterable<DomTouch> get changedTouches => _createDomListWrapper<DomTouch>(_changedTouches);
+
+  @JS('touches')
+  external _DomList get _touches;
+  Iterable<DomTouch> get touches => _createDomListWrapper<DomTouch>(_touches);
 }
 
 @JS('Touch')

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/pointer_binding.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/pointer_binding.dart
@@ -28,9 +28,6 @@ const bool _debugLogPointerEvents = false;
 /// Set this to true to log all the events sent to the Flutter framework.
 const bool _debugLogFlutterEvents = false;
 
-// Note: debugResetIframeDetectionCache() and debugSetIframeEmbeddingForTests()
-// are now in dom.dart as shared utilities.
-
 /// Resets full-page app detection override for tests.
 @visibleForTesting
 void debugResetFullPageAppCache() {
@@ -562,13 +559,11 @@ abstract class _BaseAdapter {
   DomWheelEvent? _lastWheelEvent;
   bool _lastWheelEventWasTrackpad = false;
 
-  /// Two flags to track scroll handling for the two-flag system:
-  /// 1. _lastWheelEventAllowedDefault: true if a scrollable is at boundary
-  /// 2. _lastWheelEventHandledByWidget: true if a scrollable consumed the event
-  ///
-  /// This enables proper handling of nested scrollables:
-  /// - If inner scrollable handles the event, don't scroll parent page
-  /// - If all scrollables are at boundary, scroll parent page
+  // Two flags to disambiguate nested scrollable wheel handling:
+  // _lastWheelEventAllowedDefault: set when a scrollable is at boundary.
+  // _lastWheelEventHandledByWidget: set when a scrollable consumed the event.
+  // If inner scrollable handles the event, don't scroll parent page.
+  // If all scrollables are at boundary, allow parent page to scroll.
   bool _lastWheelEventAllowedDefault = false;
   bool _lastWheelEventHandledByWidget = false;
 
@@ -788,12 +783,9 @@ mixin _WheelEventListenerMixin on _BaseAdapter {
         scrollDeltaX: deltaX,
         scrollDeltaY: deltaY,
         onRespond: ({bool allowPlatformDefault = false}) {
-          // Track both: platform default and widget handling
           if (allowPlatformDefault) {
-            // Widget is at boundary, wants platform to handle
             _lastWheelEventAllowedDefault = true;
           } else {
-            // Widget explicitly handled this event
             _lastWheelEventHandledByWidget = true;
           }
         },
@@ -823,39 +815,57 @@ mixin _WheelEventListenerMixin on _BaseAdapter {
       print(event.type);
     }
 
-    // Reset flags before dispatching to framework
-    _lastWheelEventAllowedDefault = false;
-    _lastWheelEventHandledByWidget = false;
-
     final wheelEvent = event as DomWheelEvent;
 
-    // Dispatch to framework (this triggers onRespond callbacks synchronously)
+    // When browser-driven scrolling is active, check if the wheel event
+    // targets a platform view BEFORE dispatching to the framework.
+    // If it does, handle it entirely in the engine and skip framework
+    // dispatch to prevent BrowserScrollPhysics from also scrolling.
+    if (_view.browserScrollController.enabled) {
+      DomElement? pvElement;
+      final DomEventTarget? target = event.target;
+      if (target != null && target.isA<DomElement>()) {
+        final el = target as DomElement;
+        if (_view.dom.platformViewsHost.contains(el)) {
+          pvElement = el;
+        } else {
+          pvElement = _view.browserScrollController.findPlatformViewAtPoint(
+            wheelEvent.clientX,
+            wheelEvent.clientY,
+          );
+        }
+      }
+
+      if (pvElement != null) {
+        event.preventDefault();
+        _view.browserScrollController.handlePlatformViewWheel(pvElement, wheelEvent.deltaY);
+        return;
+      }
+    }
+
+    _lastWheelEventAllowedDefault = false;
+    _lastWheelEventHandledByWidget = false;
     _callback(event, _convertWheelEventToPointerData(wheelEvent));
 
-    // Determine if we should prevent default
+    if (_view.browserScrollController.enabled) {
+      event.preventDefault();
+      return;
+    }
+
     final bool isInIframe = isEmbeddedInIframe();
 
-    // Special handling only for full-page Flutter apps running inside an iframe.
-    // Custom element apps (Flutter embedded as a component) should let the
-    // browser handle normal scroll flow.
+    // Full-page app in an iframe: skip preventDefault when all scrollables
+    // are at boundary so the browser bubbles scroll to the parent window.
+    // Fixes GitHub issue #156985
     if (isInIframe && _isFullPageApp) {
-      // Full-page app in an iframe: only preventDefault when Flutter handles
-      // the scroll. When scrollables are at boundary, skip preventDefault to
-      // let the browser naturally bubble the scroll to the parent window.
-      //
-      // Fixes GitHub issue #156985
       final bool shouldScrollParent =
           _lastWheelEventAllowedDefault && !_lastWheelEventHandledByWidget;
       if (!shouldScrollParent) {
         event.preventDefault();
       }
     } else {
-      // Original behavior for:
-      // 1. Apps NOT in an iframe (normal page)
-      // 2. Multi-view mode inside an iframe
-      //
-      // Only preventDefault when a scrollable widget handles the event.
-      // This preserves native scroll behavior when Flutter can't scroll.
+      // Non-iframe or custom-element: only preventDefault when a widget
+      // handled the event, preserving native scroll at boundaries.
       if (!_lastWheelEventAllowedDefault) {
         event.preventDefault();
       }
@@ -1072,7 +1082,13 @@ class _PointerAdapter extends _BaseAdapter with _WheelEventListenerMixin {
       _convertEventsToPointerData(data: pointerData, event: event, details: down);
       _callback(event, pointerData);
 
-      if (event.target == _viewTarget) {
+      // When browser-driven scrolling is active and this is a touch event,
+      // preventDefault to stop the browser from initiating native
+      // touch-action scrolling. Platform view scrolling is handled
+      // programmatically by BrowserScrollController's touch chaining.
+      if (_view.browserScrollController.enabled && event.pointerType == 'touch') {
+        event.preventDefault();
+      } else if (event.target == _viewTarget) {
         // Ensure smooth focus transitions between text fields within the Flutter view.
         // Without preventing the default and this delay, the engine may not have fully
         // rendered the next input element, leading to the focus incorrectly returning to

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/embedding_strategy/custom_element_embedding_strategy.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/embedding_strategy/custom_element_embedding_strategy.dart
@@ -50,4 +50,16 @@ class CustomElementEmbeddingStrategy implements EmbeddingStrategy {
     registerElementForCleanup(rootElement);
     _rootElement = rootElement;
   }
+
+  @override
+  bool get supportsBrowserScrolling => false;
+
+  @override
+  void enableBrowserScrolling(DomElement rootElement) {}
+
+  @override
+  void disableBrowserScrolling(DomElement rootElement) {}
+
+  @override
+  void updateScrollContentHeight(double height) {}
 }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/embedding_strategy/embedding_strategy.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/embedding_strategy/embedding_strategy.dart
@@ -44,4 +44,22 @@ abstract class EmbeddingStrategy {
 
   /// Attaches the view root element into the hostElement.
   void attachViewRoot(DomElement rootElement);
+
+  /// Whether browser-driven scrolling is supported by this embedding strategy.
+  bool get supportsBrowserScrolling => false;
+
+  /// Enables browser-driven scrolling for the outermost scrollable.
+  ///
+  /// When enabled, the host element becomes a real scrollable DOM element,
+  /// allowing the browser to handle scroll physics, momentum, and scroll
+  /// chaining natively. The framework syncs its scroll position from the
+  /// browser's scroll events.
+  void enableBrowserScrolling(DomElement rootElement) {}
+
+  /// Disables browser-driven scrolling, restoring the original styles.
+  void disableBrowserScrolling(DomElement rootElement) {}
+
+  /// Updates the scroll content height so the browser knows how much
+  /// content is available to scroll through.
+  void updateScrollContentHeight(double height) {}
 }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/embedding_strategy/full_page_embedding_strategy.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/embedding_strategy/full_page_embedding_strategy.dart
@@ -27,6 +27,16 @@ class FullPageEmbeddingStrategy implements EmbeddingStrategy {
   DomEventTarget get globalEventTarget => domWindow;
 
   @override
+  bool get supportsBrowserScrolling => true;
+
+  bool _browserScrollingEnabled = false;
+
+  /// Whether browser-driven scrolling is currently active.
+  bool get browserScrollingEnabled => _browserScrollingEnabled;
+
+  DomElement? _scrollHeightPlaceholder;
+
+  @override
   void setLocale(ui.Locale locale) {
     domDocument.documentElement!.setAttribute('lang', locale.toLanguageTag());
   }
@@ -44,6 +54,106 @@ class FullPageEmbeddingStrategy implements EmbeddingStrategy {
     hostElement.append(rootElement);
 
     registerElementForCleanup(rootElement);
+  }
+
+  @override
+  void enableBrowserScrolling(DomElement rootElement) {
+    _browserScrollingEnabled = true;
+
+    setElementStyle(hostElement, 'position', 'static');
+    setElementStyle(hostElement, 'overflow', 'hidden');
+    setElementStyle(hostElement, 'padding', '0');
+    setElementStyle(hostElement, 'margin', '0');
+    setElementStyle(hostElement, 'width', '100%');
+    setElementStyle(hostElement, 'height', '100%');
+
+    // Override body's touch-action from 'none' to 'pan-y'. The browser
+    // computes effective touch-action as the intersection of an element
+    // and all its ancestors. If body keeps 'none', no descendant can
+    // touch-scroll regardless of its own touch-action value.
+    setElementStyle(hostElement, 'touch-action', 'pan-y');
+
+    // Make <flutter-view> the scrollable element. This is critical: the
+    // flutter-view must be the scrollable so that wheel events, which land
+    // on it, trigger native scrolling. If we made the body scrollable but
+    // flutter-view was fixed on top, wheel events would go to flutter-view
+    // and the body would never scroll.
+    rootElement.style
+      ..position = 'fixed'
+      ..top = '0'
+      ..right = '0'
+      ..bottom = '0'
+      ..left = '0'
+      ..overflow = 'auto';
+
+    // Use touch-action: none so the browser does not initiate native
+    // touch scrolling. Flutter handles all touch input and forwards
+    // scroll deltas to the browser via the dart:ui browserScrollBy API.
+    // With pan-y, the browser fires pointercancel before Flutter can
+    // process the gesture.
+    setElementStyle(rootElement, 'touch-action', 'none');
+
+    // Make all existing children of flutter-view sticky so they stay
+    // visible at the top of the viewport while the element scrolls.
+    // This includes <flt-glass-pane>, <flt-text-editing-host>, and
+    // <flt-semantics-host>.
+    for (final DomElement child in rootElement.children) {
+      child.style
+        ..position = 'sticky'
+        ..top = '0'
+        ..left = '0';
+    }
+
+    // Create a placeholder element inside flutter-view that sets the
+    // scroll height. This gives flutter-view real content to scroll against.
+    // It must be positioned absolutely so it doesn't push the sticky
+    // children down, and its height defines the total scrollable area.
+    _scrollHeightPlaceholder = domDocument.createElement('div');
+    _scrollHeightPlaceholder!.setAttribute('flt-scroll-placeholder', '');
+    _scrollHeightPlaceholder!.style
+      ..width = '1px'
+      ..pointerEvents = 'none'
+      ..position = 'absolute'
+      ..top = '0'
+      ..left = '0';
+
+    rootElement.append(_scrollHeightPlaceholder!);
+
+    registerElementForCleanup(_scrollHeightPlaceholder!);
+  }
+
+  @override
+  void disableBrowserScrolling(DomElement rootElement) {
+    _browserScrollingEnabled = false;
+
+    _setHostStyles();
+
+    rootElement.style
+      ..position = 'absolute'
+      ..top = '0'
+      ..right = '0'
+      ..bottom = '0'
+      ..left = '0'
+      ..overflow = '';
+
+    setElementStyle(rootElement, 'touch-action', '');
+
+    for (final DomElement child in rootElement.children) {
+      child.style
+        ..position = ''
+        ..top = ''
+        ..left = '';
+    }
+
+    _scrollHeightPlaceholder?.remove();
+    _scrollHeightPlaceholder = null;
+  }
+
+  @override
+  void updateScrollContentHeight(double height) {
+    if (_scrollHeightPlaceholder != null) {
+      _scrollHeightPlaceholder!.style.height = '${height}px';
+    }
   }
 
   // Sets the global styles for a flutter app.

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/embedding_strategy/full_page_embedding_strategy.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/embedding_strategy/full_page_embedding_strategy.dart
@@ -36,6 +36,13 @@ class FullPageEmbeddingStrategy implements EmbeddingStrategy {
 
   DomElement? _scrollHeightPlaceholder;
 
+  // Per-child inline style snapshot taken on enable so disable can restore
+  // the exact pre-enable state. Needed because some engine-managed children
+  // such as <flt-semantics-host> carry inline `position: absolute` that
+  // otherwise falls through to `static` when we clear the style.
+  final Map<DomElement, Map<String, String>> _savedChildStyles =
+      <DomElement, Map<String, String>>{};
+
   @override
   void setLocale(ui.Locale locale) {
     domDocument.documentElement!.setAttribute('lang', locale.toLanguageTag());
@@ -97,7 +104,17 @@ class FullPageEmbeddingStrategy implements EmbeddingStrategy {
     // visible at the top of the viewport while the element scrolls.
     // This includes <flt-glass-pane>, <flt-text-editing-host>, and
     // <flt-semantics-host>.
+    //
+    // Snapshot each child's inline position/top/left first so disable can
+    // restore them. <flt-semantics-host> in particular ships with inline
+    // `position: absolute` set by StyleManager; clearing to empty would
+    // drop it through to `static` and break its transform scaling.
     for (final DomElement child in rootElement.children) {
+      _savedChildStyles[child] = <String, String>{
+        'position': child.style.position,
+        'top': child.style.top,
+        'left': child.style.left,
+      };
       child.style
         ..position = 'sticky'
         ..top = '0'
@@ -137,13 +154,16 @@ class FullPageEmbeddingStrategy implements EmbeddingStrategy {
       ..overflow = '';
 
     setElementStyle(rootElement, 'touch-action', '');
+    setElementStyle(hostElement, 'touch-action', '');
 
     for (final DomElement child in rootElement.children) {
+      final Map<String, String>? saved = _savedChildStyles[child];
       child.style
-        ..position = ''
-        ..top = ''
-        ..left = '';
+        ..position = saved?['position'] ?? ''
+        ..top = saved?['top'] ?? ''
+        ..left = saved?['left'] ?? '';
     }
+    _savedChildStyles.clear();
 
     _scrollHeightPlaceholder?.remove();
     _scrollHeightPlaceholder = null;

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/window.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/window.dart
@@ -11,6 +11,7 @@ import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 import '../engine.dart' show DimensionsProvider, registerHotRestartListener, renderer;
 import 'browser_detection.dart';
+import 'browser_scroll_controller.dart';
 import 'display.dart';
 import 'dom.dart';
 import 'initialization.dart';
@@ -110,6 +111,7 @@ class EngineFlutterView implements ui.FlutterView {
     _resizeSubscription.cancel();
     dimensionsProvider.close();
     pointerBinding.dispose();
+    browserScrollController.dispose();
     dom.rootElement.remove();
     // TODO(harryterkelsen): What should we do about this in multi-view?
     renderer.clearFragmentProgramCache();
@@ -164,6 +166,44 @@ class EngineFlutterView implements ui.FlutterView {
   final JsViewConstraints? _jsViewConstraints;
 
   late final EngineSemanticsOwner semantics = EngineSemanticsOwner(viewId, dom.semanticsHost);
+
+  late final BrowserScrollController browserScrollController = BrowserScrollController(this);
+
+  // Browser-driven scrolling API (dart:ui surface)
+
+  @override
+  void enableBrowserScrolling() => browserScrollController.enable();
+
+  @override
+  void disableBrowserScrolling() => browserScrollController.disable();
+
+  @override
+  void browserScrollTo(double offset) => browserScrollController.scrollTo(offset);
+
+  @override
+  void browserSmoothScrollTo(double offset) => browserScrollController.smoothScrollTo(offset);
+
+  @override
+  void browserScrollBy(double delta) {
+    if (browserScrollController.pvTouchActive) {
+      return;
+    }
+    browserScrollController.scrollBy(delta);
+  }
+
+  @override
+  void updateBrowserScrollContentHeight(double height) =>
+      browserScrollController.updateContentHeight(height);
+
+  ui.BrowserScrollCallback? _onBrowserScroll;
+
+  @override
+  ui.BrowserScrollCallback? get onBrowserScroll => _onBrowserScroll;
+
+  @override
+  set onBrowserScroll(ui.BrowserScrollCallback? callback) {
+    _onBrowserScroll = callback;
+  }
 
   @override
   ui.Size get physicalSize {

--- a/engine/src/flutter/lib/web_ui/lib/window.dart
+++ b/engine/src/flutter/lib/web_ui/lib/window.dart
@@ -11,6 +11,8 @@ abstract class Display {
   double get refreshRate;
 }
 
+typedef BrowserScrollCallback = void Function(double offset);
+
 abstract class FlutterView {
   PlatformDispatcher get platformDispatcher;
   int get viewId;
@@ -27,6 +29,18 @@ abstract class FlutterView {
   DisplayCornerRadii? get displayCornerRadii;
   void render(Scene scene, {Size? size});
   void updateSemantics(SemanticsUpdate update) => platformDispatcher.updateSemantics(update);
+
+  // Browser-driven scrolling API (web-only, no-op on other platforms).
+
+  void enableBrowserScrolling() {}
+  void disableBrowserScrolling() {}
+  void browserScrollTo(double offset) {}
+  void browserSmoothScrollTo(double offset) {}
+  void browserScrollBy(double delta) {}
+  void updateBrowserScrollContentHeight(double height) {}
+
+  BrowserScrollCallback? get onBrowserScroll => null;
+  set onBrowserScroll(BrowserScrollCallback? callback) {}
 }
 
 abstract class SingletonFlutterWindow extends FlutterView {

--- a/engine/src/flutter/lib/web_ui/test/engine/browser_scroll_controller_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/browser_scroll_controller_test.dart
@@ -184,6 +184,57 @@ void testMain() {
     });
   });
 
+  group('containingPlatformView', () {
+    test('returns the direct child of pvHost that contains a leaf target', () {
+      final DomElement pvHost = view.dom.platformViewsHost;
+      final DomElement pv = createDomHTMLDivElement();
+      final DomElement inner = createDomHTMLDivElement();
+      final DomElement leaf = createDomHTMLDivElement();
+      inner.append(leaf);
+      pv.append(inner);
+      pvHost.append(pv);
+
+      expect(controller.containingPlatformView(leaf, pvHost), pv);
+    });
+
+    test('returns the pv itself when target is the pv', () {
+      final DomElement pvHost = view.dom.platformViewsHost;
+      final DomElement pv = createDomHTMLDivElement();
+      pvHost.append(pv);
+
+      expect(controller.containingPlatformView(pv, pvHost), pv);
+    });
+
+    test('returns null when target is outside any platform view', () {
+      final DomElement pvHost = view.dom.platformViewsHost;
+      final DomElement stray = createDomHTMLDivElement();
+      domDocument.body!.append(stray);
+
+      expect(controller.containingPlatformView(stray, pvHost), isNull);
+
+      stray.remove();
+    });
+
+    test('selects the containing pv, not a sibling pv', () {
+      // Regression: previously the touch-start fallback walked all of
+      // pvHost, which could return a scrollable from a different platform
+      // view than the one the user actually touched. This test guards the
+      // scoping helper so touches on pvA resolve to pvA, not pvB.
+      final DomElement pvHost = view.dom.platformViewsHost;
+
+      final DomElement pvA = createDomHTMLDivElement();
+      final DomElement pvALeaf = createDomHTMLDivElement();
+      pvA.append(pvALeaf);
+      pvHost.append(pvA);
+
+      final DomElement pvB = createDomHTMLDivElement();
+      pvHost.append(pvB);
+
+      expect(controller.containingPlatformView(pvALeaf, pvHost), pvA);
+      expect(controller.containingPlatformView(pvB, pvHost), pvB);
+    });
+  });
+
   group('dispose', () {
     test('disable is called on dispose', () {
       controller.dispose();

--- a/engine/src/flutter/lib/web_ui/test/engine/browser_scroll_controller_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/browser_scroll_controller_test.dart
@@ -1,0 +1,284 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/src/engine.dart';
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+void testMain() {
+  late EngineFlutterView view;
+  late BrowserScrollController controller;
+  late DomElement hostElement;
+
+  setUp(() {
+    hostElement = createDomHTMLDivElement();
+    domDocument.body!.append(hostElement);
+    view = EngineFlutterView(EnginePlatformDispatcher.instance, hostElement);
+    controller = view.browserScrollController;
+  });
+
+  tearDown(() {
+    view.dispose();
+    hostElement.remove();
+  });
+
+  group('enable/disable', () {
+    test('starts disabled', () {
+      expect(controller.enabled, isFalse);
+    });
+
+    test('does not enable when strategy does not support it', () {
+      controller.enable();
+      expect(controller.enabled, isFalse);
+    });
+
+    test('disable when already disabled is a no-op', () {
+      controller.disable();
+      expect(controller.enabled, isFalse);
+    });
+  });
+
+  group('findPlatformViewAtPoint', () {
+    test('returns null when no platform views exist', () {
+      final DomElement? result = controller.findPlatformViewAtPoint(100, 100);
+      expect(result, isNull);
+    });
+
+    test('returns null when point is outside all platform views', () {
+      final DomElement pvElement = createDomHTMLDivElement();
+      pvElement.style
+        ..width = '100px'
+        ..height = '100px'
+        ..position = 'absolute'
+        ..left = '0px'
+        ..top = '0px';
+      view.dom.platformViewsHost.append(pvElement);
+
+      final DomElement? result = controller.findPlatformViewAtPoint(9999, 9999);
+      expect(result, isNull);
+    });
+
+    test('finds platform view at given coordinates', () {
+      final DomElement pvElement = createDomHTMLDivElement();
+      pvElement.style
+        ..width = '200px'
+        ..height = '200px'
+        ..position = 'absolute'
+        ..left = '0px'
+        ..top = '0px';
+      view.dom.platformViewsHost.append(pvElement);
+
+      final DomRect rect = pvElement.getBoundingClientRect();
+      if (rect.width > 0 && rect.height > 0) {
+        final DomElement? result = controller.findPlatformViewAtPoint(
+          rect.left + 10,
+          rect.top + 10,
+        );
+        expect(result, pvElement);
+      }
+    });
+
+    test('ignores zero-size elements', () {
+      final DomElement pvElement = createDomHTMLDivElement();
+      pvElement.style
+        ..width = '0px'
+        ..height = '0px';
+      view.dom.platformViewsHost.append(pvElement);
+
+      final DomElement? result = controller.findPlatformViewAtPoint(0, 0);
+      expect(result, isNull);
+    });
+
+    test('selects correct element when multiple PVs exist', () {
+      final DomElement pv1 = createDomHTMLDivElement();
+      pv1.style
+        ..width = '100px'
+        ..height = '100px'
+        ..position = 'absolute'
+        ..left = '0px'
+        ..top = '0px';
+      view.dom.platformViewsHost.append(pv1);
+
+      final DomElement pv2 = createDomHTMLDivElement();
+      pv2.style
+        ..width = '100px'
+        ..height = '100px'
+        ..position = 'absolute'
+        ..left = '200px'
+        ..top = '200px';
+      view.dom.platformViewsHost.append(pv2);
+
+      final DomRect rect2 = pv2.getBoundingClientRect();
+      if (rect2.width > 0 && rect2.height > 0) {
+        final DomElement? result = controller.findPlatformViewAtPoint(
+          rect2.left + 10,
+          rect2.top + 10,
+        );
+        expect(result, pv2);
+      }
+    });
+  });
+
+  group('handlePlatformViewWheel', () {
+    test('does not throw when target has no scrollable', () {
+      final DomElement pvElement = createDomHTMLDivElement();
+      pvElement.style
+        ..width = '200px'
+        ..height = '200px';
+      view.dom.platformViewsHost.append(pvElement);
+
+      controller.handlePlatformViewWheel(pvElement, 50);
+    });
+
+    test('scrolls inner scrollable when it has overflow content', () {
+      final DomElement pvElement = createDomHTMLDivElement();
+      pvElement.style
+        ..width = '200px'
+        ..height = '100px';
+
+      final DomElement scrollableDiv = createDomHTMLDivElement();
+      scrollableDiv.style
+        ..width = '100%'
+        ..height = '100%'
+        ..overflow = 'auto';
+
+      final DomElement tallContent = createDomHTMLDivElement();
+      tallContent.style.height = '500px';
+      scrollableDiv.append(tallContent);
+      pvElement.append(scrollableDiv);
+      view.dom.platformViewsHost.append(pvElement);
+
+      controller.handlePlatformViewWheel(pvElement, 30);
+    });
+
+    test('walks down to find scrollable descendant', () {
+      final DomElement pvElement = createDomHTMLDivElement();
+      pvElement.style
+        ..width = '200px'
+        ..height = '100px';
+
+      final DomElement wrapper = createDomHTMLDivElement();
+      wrapper.style
+        ..width = '100%'
+        ..height = '100%';
+
+      final DomElement scrollableDiv = createDomHTMLDivElement();
+      scrollableDiv.style
+        ..width = '100%'
+        ..height = '100%'
+        ..overflow = 'auto';
+
+      final DomElement tallContent = createDomHTMLDivElement();
+      tallContent.style.height = '500px';
+      scrollableDiv.append(tallContent);
+      wrapper.append(scrollableDiv);
+      pvElement.append(wrapper);
+      view.dom.platformViewsHost.append(pvElement);
+
+      controller.handlePlatformViewWheel(pvElement, 30);
+    });
+  });
+
+  group('dispose', () {
+    test('disable is called on dispose', () {
+      controller.dispose();
+      expect(controller.enabled, isFalse);
+    });
+
+    test('can dispose when already disabled', () {
+      controller.dispose();
+      controller.dispose();
+      expect(controller.enabled, isFalse);
+    });
+  });
+
+  // Regression tests that require a FullPageEmbeddingStrategy, because only
+  // that strategy returns `supportsBrowserScrolling == true` and actually
+  // attaches the platform-view touch-chaining listeners in `enable()`.
+  // Full-page setup mutates <body> styles, so each test here saves and
+  // restores them to avoid cross-test contamination.
+  group('full-page: enable/disable cycle cleanup', () {
+    late EngineFlutterView fullPageView;
+    late BrowserScrollController fullPageController;
+    late Map<String, String> savedBodyStyles;
+
+    setUp(() {
+      savedBodyStyles = {};
+      for (final prop in const [
+        'position',
+        'top',
+        'right',
+        'bottom',
+        'left',
+        'overflow',
+        'padding',
+        'margin',
+        'width',
+        'height',
+        'touch-action',
+        'user-select',
+        '-webkit-user-select',
+      ]) {
+        savedBodyStyles[prop] = domDocument.body!.style.getPropertyValue(prop);
+      }
+      // Null hostElement -> FullPageEmbeddingStrategy under the hood.
+      fullPageView = EngineFlutterView.implicit(EnginePlatformDispatcher.instance, null);
+      fullPageController = fullPageView.browserScrollController;
+    });
+
+    tearDown(() {
+      fullPageView.dispose();
+      for (final MapEntry<String, String> entry in savedBodyStyles.entries) {
+        if (entry.value.isEmpty) {
+          domDocument.body!.style.removeProperty(entry.key);
+        } else {
+          domDocument.body!.style.setProperty(entry.key, entry.value);
+        }
+      }
+    });
+
+    test('disable removes capture-phase platform-view touchstart listener', () {
+      // Add a platform-view child so `isPlatformViewTarget` returns true
+      // for events dispatched from it.
+      final DomElement pvElement = createDomHTMLDivElement();
+      pvElement.style
+        ..width = '100px'
+        ..height = '100px';
+      fullPageView.dom.platformViewsHost.append(pvElement);
+
+      // Attach then detach the platform-view touch chaining listeners.
+      fullPageController.enable();
+      fullPageController.disable();
+
+      // If `_detachPlatformViewTouchChaining` fails to match the capture
+      // flag in `removeEventListener`, the touchstart capture listener
+      // is still attached and would fire on this synthetic event,
+      // latching `_pvTouchActive = true` on the controller.
+      pvElement.dispatchEvent(createDomEvent('Event', 'touchstart'));
+
+      // Re-enable and provide a content height so scrolling is possible.
+      fullPageController.enable();
+      fullPageController.updateContentHeight(2000);
+
+      // `scrollTo` is a no-op while `_pvTouchActive` is true. If the
+      // stale listener fired above, scrollTop stays 0. With a correct
+      // remove, `_pvTouchActive` was never set, so scrollTo succeeds.
+      fullPageController.scrollTo(100);
+
+      expect(
+        fullPageView.dom.rootElement.scrollTop,
+        greaterThan(0),
+        reason:
+            'scrollTo was blocked by a leaked _pvTouchActive=true from a '
+            'stale capture-phase touchstart listener. Check that '
+            '_detachPlatformViewTouchChaining passes capture=true to '
+            'removeEventListener so it matches the addEventListener call.',
+      );
+    });
+  });
+}

--- a/engine/src/flutter/lib/web_ui/test/engine/view_embedder/embedding_strategy/embedding_strategy_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/view_embedder/embedding_strategy/embedding_strategy_test.dart
@@ -121,6 +121,45 @@ void doTests() {
       strategy.updateScrollContentHeight(5000);
     });
 
+    test('FullPage disableBrowserScrolling restores inline child styles', () {
+      final strategy = EmbeddingStrategy.create() as FullPageEmbeddingStrategy;
+      final DomElement rootElement = createDomElement('flutter-view');
+      domDocument.body!.append(rootElement);
+
+      // Mimic StyleManager.styleSemanticsHost applying inline position.
+      final DomElement semanticsHost = createDomElement('flt-semantics-host');
+      semanticsHost.style.position = 'absolute';
+      rootElement.append(semanticsHost);
+
+      // Mimic a child without inline position.
+      final DomElement glassPane = createDomElement('flt-glass-pane');
+      rootElement.append(glassPane);
+
+      strategy.enableBrowserScrolling(rootElement);
+      expect(semanticsHost.style.position, 'sticky');
+      expect(glassPane.style.position, 'sticky');
+
+      strategy.disableBrowserScrolling(rootElement);
+      expect(semanticsHost.style.position, 'absolute');
+      expect(glassPane.style.position, '');
+
+      rootElement.remove();
+    });
+
+    test('FullPage disableBrowserScrolling clears hostElement touch-action', () {
+      final strategy = EmbeddingStrategy.create() as FullPageEmbeddingStrategy;
+      final DomElement rootElement = createDomElement('flutter-view');
+      domDocument.body!.append(rootElement);
+
+      strategy.enableBrowserScrolling(rootElement);
+      expect(strategy.hostElement.style.getPropertyValue('touch-action'), 'pan-y');
+
+      strategy.disableBrowserScrolling(rootElement);
+      expect(strategy.hostElement.style.getPropertyValue('touch-action'), '');
+
+      rootElement.remove();
+    });
+
     test('CustomElement enableBrowserScrolling is a no-op', () {
       final DomElement element = createDomElement('some-element');
       final strategy = EmbeddingStrategy.create(hostElement: element);

--- a/engine/src/flutter/lib/web_ui/test/engine/view_embedder/embedding_strategy/embedding_strategy_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/view_embedder/embedding_strategy/embedding_strategy_test.dart
@@ -31,4 +31,103 @@ void doTests() {
       expect(strategy, isA<CustomElementEmbeddingStrategy>());
     });
   });
+
+  group('Browser scrolling support', () {
+    test('FullPageEmbeddingStrategy supports browser scrolling', () {
+      final strategy = EmbeddingStrategy.create();
+      expect(strategy.supportsBrowserScrolling, isTrue);
+    });
+
+    test('CustomElementEmbeddingStrategy does not support browser scrolling', () {
+      final DomElement element = createDomElement('some-element');
+      final strategy = EmbeddingStrategy.create(hostElement: element);
+      expect(strategy.supportsBrowserScrolling, isFalse);
+    });
+
+    test('FullPage enableBrowserScrolling sets overflow:auto on rootElement', () {
+      final strategy = EmbeddingStrategy.create() as FullPageEmbeddingStrategy;
+      final DomElement rootElement = createDomElement('flutter-view');
+      domDocument.body!.append(rootElement);
+
+      strategy.enableBrowserScrolling(rootElement);
+
+      expect(rootElement.style.overflow, 'auto');
+      expect(strategy.browserScrollingEnabled, isTrue);
+
+      strategy.disableBrowserScrolling(rootElement);
+      rootElement.remove();
+    });
+
+    test('FullPage enableBrowserScrolling sets touch-action:none on rootElement', () {
+      final strategy = EmbeddingStrategy.create() as FullPageEmbeddingStrategy;
+      final DomElement rootElement = createDomElement('flutter-view');
+      domDocument.body!.append(rootElement);
+
+      strategy.enableBrowserScrolling(rootElement);
+
+      final String touchAction = rootElement.style.getPropertyValue('touch-action');
+      expect(touchAction, 'none');
+
+      strategy.disableBrowserScrolling(rootElement);
+      rootElement.remove();
+    });
+
+    test('FullPage enableBrowserScrolling creates scroll height placeholder', () {
+      final strategy = EmbeddingStrategy.create() as FullPageEmbeddingStrategy;
+      final DomElement rootElement = createDomElement('flutter-view');
+      domDocument.body!.append(rootElement);
+
+      strategy.enableBrowserScrolling(rootElement);
+
+      final DomElement? placeholder = rootElement.querySelector('[flt-scroll-placeholder]');
+      expect(placeholder, isNotNull);
+
+      strategy.disableBrowserScrolling(rootElement);
+      rootElement.remove();
+    });
+
+    test('FullPage disableBrowserScrolling resets state', () {
+      final strategy = EmbeddingStrategy.create() as FullPageEmbeddingStrategy;
+      final DomElement rootElement = createDomElement('flutter-view');
+      domDocument.body!.append(rootElement);
+
+      strategy.enableBrowserScrolling(rootElement);
+      expect(strategy.browserScrollingEnabled, isTrue);
+
+      strategy.disableBrowserScrolling(rootElement);
+      expect(strategy.browserScrollingEnabled, isFalse);
+
+      rootElement.remove();
+    });
+
+    test('FullPage updateScrollContentHeight sets placeholder height', () {
+      final strategy = EmbeddingStrategy.create() as FullPageEmbeddingStrategy;
+      final DomElement rootElement = createDomElement('flutter-view');
+      domDocument.body!.append(rootElement);
+
+      strategy.enableBrowserScrolling(rootElement);
+      strategy.updateScrollContentHeight(5000);
+
+      final DomElement? placeholder = rootElement.querySelector('[flt-scroll-placeholder]');
+      expect(placeholder, isNotNull);
+      expect(placeholder!.style.height, '5000px');
+
+      strategy.disableBrowserScrolling(rootElement);
+      rootElement.remove();
+    });
+
+    test('FullPage updateScrollContentHeight is no-op before enable', () {
+      final strategy = EmbeddingStrategy.create() as FullPageEmbeddingStrategy;
+      strategy.updateScrollContentHeight(5000);
+    });
+
+    test('CustomElement enableBrowserScrolling is a no-op', () {
+      final DomElement element = createDomElement('some-element');
+      final strategy = EmbeddingStrategy.create(hostElement: element);
+      final DomElement rootElement = createDomElement('flutter-view');
+
+      strategy.enableBrowserScrolling(rootElement);
+      expect(strategy.supportsBrowserScrolling, isFalse);
+    });
+  });
 }


### PR DESCRIPTION
Ref #184102 (design reference)

## Summary
PR 1 of 4 splitting #184102. Lands the engine side of browser-driven scrolling for Flutter Web.

- `BrowserScrollController` (new) owns the `<flutter-view>` scroll listener, platform-view touch chaining, and wheel delegation from `pointer_binding.dart`.
- `FullPageEmbeddingStrategy` grows `<flt-scroll-placeholder>` by revealed-content math when the framework asks.
- `PointerBinding` delegates wheel events when `browserScrollController` is enabled.
- `FlutterView` gains 6 dart:ui methods on web: `enableBrowserScrolling`, `disableBrowserScrolling`, `browserScrollTo`, `browserSmoothScrollTo`, `browserScrollBy`, `updateBrowserScrollContentHeight`, plus `onBrowserScroll` callback.

No framework caller is landed in this PR. The `@experimental` `BrowserScrollable` widget and `BrowserScrollPhysics` class land in PR 2 along with their `ScrollableState` integration.

## Split plan
- **PR 1 (this one):** Engine surface + controller + placeholder
- PR 2: Framework `BrowserScrollable` + `BrowserScrollPhysics` + `ScrollableState` integration
- PR 3: Framework `animateTo`/`jumpTo` transparency for `BrowserScrollable`
- PR 4: Cross-layer browser-owns-wheel behavior

See #184102 for the complete design and end-to-end demo.

## Tests
- `browser_scroll_controller_test.dart` (new): 14 tests covering enable/disable lifecycle, platform-view chaining, capture-flag cleanup, `findPlatformViewAtPoint` variants.
- `embedding_strategy_test.dart`: 11 new tests covering placeholder create/grow/reset + enable/disable flow.

## Demo
Engine infrastructure with no end-user surface in this PR. The controller is inert until a framework caller enables it, so existing Flutter Web apps are unaffected.

Full-stack demo of the API consumed end-to-end (runs on #184102's branch): https://flutter-demo-19.web.app/
