### PR TITLE
[flutter_tools] Set GIT_TERMINAL_PROMPT to 0 by default to prevent silent hangs

### DIFF
--- a/packages/flutter_tools/lib/src/git.dart
+++ b/packages/flutter_tools/lib/src/git.dart
@@ -131,7 +131,7 @@ interface class Git {
   Map<String, String> _buildGitEnvironment(Map<String, String>? environment) {
     return <String, String>{
       if (_platform.isWindows) ..._useNoGlobCygwinGit,
-      if (!_platform.environment.containsKey(_kGitTerminalPrompt)) _kGitTerminalPrompt: '0',
+      _kGitTerminalPrompt: _platform.environment[_kGitTerminalPrompt] ?? '0',
       ...?environment,
     };
   }

--- a/packages/flutter_tools/lib/src/git.dart
+++ b/packages/flutter_tools/lib/src/git.dart
@@ -37,6 +37,7 @@ interface class Git {
   }
 
   static const _ignoreLogShowSignature = ['-c', 'log.showSignature=false'];
+  static const String _kGitTerminalPrompt = 'GIT_TERMINAL_PROMPT';
 
   /// Spawns a child process to run `git`.
   ///
@@ -60,7 +61,7 @@ interface class Git {
       allowedFailures: allowedFailures,
       workingDirectory: workingDirectory,
       allowReentrantFlutter: allowReentrantFlutter,
-      environment: {if (_platform.isWindows) ..._useNoGlobCygwinGit, ...?environment},
+      environment: _buildGitEnvironment(environment),
       timeout: timeout,
       timeoutRetries: timeoutRetries,
     );
@@ -90,7 +91,7 @@ interface class Git {
       allowedFailures: allowedFailures,
       hideStdout: hideStdout,
       workingDirectory: workingDirectory,
-      environment: {if (_platform.isWindows) ..._useNoGlobCygwinGit, ...?environment},
+      environment: _buildGitEnvironment(environment),
       allowReentrantFlutter: allowReentrantFlutter,
       encoding: encoding,
     );
@@ -123,8 +124,16 @@ interface class Git {
       filter: filter,
       stdoutErrorMatcher: stdoutErrorMatcher,
       mapFunction: mapFunction,
-      environment: {if (_platform.isWindows) ..._useNoGlobCygwinGit, ...?environment},
+      environment: _buildGitEnvironment(environment),
     );
+  }
+
+  Map<String, String> _buildGitEnvironment(Map<String, String>? environment) {
+    return <String, String>{
+      if (_platform.isWindows) ..._useNoGlobCygwinGit,
+      if (!_platform.environment.containsKey(_kGitTerminalPrompt)) _kGitTerminalPrompt: '0',
+      ...?environment,
+    };
   }
 
   static const _useNoGlobCygwinGit = {'MSYS': 'noglob', 'CYGWIN': 'noglob'};

--- a/packages/flutter_tools/test/general.shard/git_test.dart
+++ b/packages/flutter_tools/test/general.shard/git_test.dart
@@ -26,17 +26,17 @@ void main() {
 
     setUp(() {
       git = Git(
-        currentPlatform: FakePlatform(
-          operatingSystem: 'windows',
-          environment: {'GIT_TERMINAL_PROMPT': '0'},
-        ),
+        currentPlatform: FakePlatform(operatingSystem: 'windows'),
         runProcessWith: ProcessUtils(processManager: processManager, logger: logger),
       );
     });
 
     test('git.runSync passes ENV=noglob if environment is omitted', () {
       processManager.addCommand(
-        const FakeCommand(command: ['git', 'foo', 'bar'], environment: expectedCygwinEnvVars),
+        const FakeCommand(
+          command: ['git', 'foo', 'bar'],
+          environment: {...expectedCygwinEnvVars, 'GIT_TERMINAL_PROMPT': '0'},
+        ),
       );
       git.runSync(['foo', 'bar']);
     });
@@ -45,7 +45,7 @@ void main() {
       processManager.addCommand(
         const FakeCommand(
           command: ['git', 'foo', 'bar'],
-          environment: {...expectedCygwinEnvVars, 'baz': 'BAZ'},
+          environment: {...expectedCygwinEnvVars, 'GIT_TERMINAL_PROMPT': '0', 'baz': 'BAZ'},
         ),
       );
       git.runSync(['foo', 'bar'], environment: {'baz': 'BAZ'});
@@ -53,7 +53,10 @@ void main() {
 
     test('git.run passes ENV=noglob if environment is omitted', () async {
       processManager.addCommand(
-        const FakeCommand(command: ['git', 'foo', 'bar'], environment: expectedCygwinEnvVars),
+        const FakeCommand(
+          command: ['git', 'foo', 'bar'],
+          environment: {...expectedCygwinEnvVars, 'GIT_TERMINAL_PROMPT': '0'},
+        ),
       );
       await git.run(['foo', 'bar']);
     });
@@ -62,7 +65,7 @@ void main() {
       processManager.addCommand(
         const FakeCommand(
           command: ['git', 'foo', 'bar'],
-          environment: {...expectedCygwinEnvVars, 'baz': 'BAZ'},
+          environment: {...expectedCygwinEnvVars, 'GIT_TERMINAL_PROMPT': '0', 'baz': 'BAZ'},
         ),
       );
       await git.run(['foo', 'bar'], environment: {'baz': 'BAZ'});
@@ -70,7 +73,10 @@ void main() {
 
     test('git.stream passes ENV=noglob if environment is omitted', () async {
       processManager.addCommand(
-        const FakeCommand(command: ['git', 'foo', 'bar'], environment: expectedCygwinEnvVars),
+        const FakeCommand(
+          command: ['git', 'foo', 'bar'],
+          environment: {...expectedCygwinEnvVars, 'GIT_TERMINAL_PROMPT': '0'},
+        ),
       );
       await git.stream(['foo', 'bar']);
     });
@@ -79,7 +85,7 @@ void main() {
       processManager.addCommand(
         const FakeCommand(
           command: ['git', 'foo', 'bar'],
-          environment: {...expectedCygwinEnvVars, 'baz': 'BAZ'},
+          environment: {...expectedCygwinEnvVars, 'GIT_TERMINAL_PROMPT': '0', 'baz': 'BAZ'},
         ),
       );
       await git.stream(['foo', 'bar'], environment: {'baz': 'BAZ'});
@@ -116,7 +122,7 @@ void main() {
         ),
         runProcessWith: ProcessUtils(processManager: processManager, logger: logger),
       );
-      processManager.addCommand(const FakeCommand(command: ['git', 'foo'], environment: {}));
+      processManager.addCommand(const FakeCommand(command: ['git', 'foo'], environment: {'GIT_TERMINAL_PROMPT': '1'}));
       git.runSync(['foo']);
     });
 

--- a/packages/flutter_tools/test/general.shard/git_test.dart
+++ b/packages/flutter_tools/test/general.shard/git_test.dart
@@ -26,7 +26,10 @@ void main() {
 
     setUp(() {
       git = Git(
-        currentPlatform: FakePlatform(operatingSystem: 'windows'),
+        currentPlatform: FakePlatform(
+          operatingSystem: 'windows',
+          environment: {'GIT_TERMINAL_PROMPT': '0'},
+        ),
         runProcessWith: ProcessUtils(processManager: processManager, logger: logger),
       );
     });
@@ -80,6 +83,55 @@ void main() {
         ),
       );
       await git.stream(['foo', 'bar'], environment: {'baz': 'BAZ'});
+    });
+  });
+
+  group('GIT_TERMINAL_PROMPT', () {
+    setUp(() {
+      git = Git(
+        currentPlatform: FakePlatform(operatingSystem: 'macos'),
+        runProcessWith: ProcessUtils(processManager: processManager, logger: logger),
+      );
+    });
+
+    test('git.runSync sets GIT_TERMINAL_PROMPT to 0 by default', () {
+      processManager.addCommand(
+        const FakeCommand(command: ['git', 'foo'], environment: {'GIT_TERMINAL_PROMPT': '0'}),
+      );
+      git.runSync(['foo']);
+    });
+
+    test('git.runSync respects caller environment for GIT_TERMINAL_PROMPT', () {
+      processManager.addCommand(
+        const FakeCommand(command: ['git', 'foo'], environment: {'GIT_TERMINAL_PROMPT': '1'}),
+      );
+      git.runSync(['foo'], environment: {'GIT_TERMINAL_PROMPT': '1'});
+    });
+
+    test('git.runSync respects platform environment for GIT_TERMINAL_PROMPT', () {
+      git = Git(
+        currentPlatform: FakePlatform(
+          operatingSystem: 'macos',
+          environment: {'GIT_TERMINAL_PROMPT': '1'},
+        ),
+        runProcessWith: ProcessUtils(processManager: processManager, logger: logger),
+      );
+      processManager.addCommand(const FakeCommand(command: ['git', 'foo'], environment: {}));
+      git.runSync(['foo']);
+    });
+
+    test('git.run sets GIT_TERMINAL_PROMPT to 0 by default', () async {
+      processManager.addCommand(
+        const FakeCommand(command: ['git', 'foo'], environment: {'GIT_TERMINAL_PROMPT': '0'}),
+      );
+      await git.run(['foo']);
+    });
+
+    test('git.stream sets GIT_TERMINAL_PROMPT to 0 by default', () async {
+      processManager.addCommand(
+        const FakeCommand(command: ['git', 'foo'], environment: {'GIT_TERMINAL_PROMPT': '0'}),
+      );
+      await git.stream(['foo']);
     });
   });
 }


### PR DESCRIPTION
The flutter_tool can hang silently when executing git commands (like `git fetch --tags` during version determination or snapshot generation) if git prompts for a passphrase or credentials (e.g., when ssh-agent is not running).

This commit modifies the Git wrapper class to inject `GIT_TERMINAL_PROMPT: '0'` into the environment of spawned git processes if it is not already present in the parent environment. This causes git to fail immediately with an error if it requires user interaction instead of prompting and hanging.

Callers can still override this by passing it in the environment argument, or by setting it in their shell environment.

Fixes https://github.com/flutter/flutter/issues/184309
