### PR TITLE
Add widget accessibility skill

### DIFF
--- a/.agents/rules/generate-widget.md
+++ b/.agents/rules/generate-widget.md
@@ -1,0 +1,1 @@
+When generating code for widgets, you must refer to and follow the guidelines in the `widget-accessibility` skill located in `.agents/skills/widget-accessibility` to ensure proper implementation and testing of accessibility features.

--- a/.agents/skills/widget-accessibility/SKILL.md
+++ b/.agents/skills/widget-accessibility/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: widget-accessibility
+description: Guidelines and instructions for implementing and testing widget accessibility in Flutter.
+---
+
+# Widget Accessibility Skill
+
+This skill provides instructions and best practices for ensuring Flutter widgets comply with accessibility guidelines.
+
+## Guidelines
+
+- **Avoid redundant tooltips and labels**: Do not wrap widgets that already support a `tooltip` or `semanticLabel` property directly in a `Tooltip` or `Semantics` widget with the same message. This creates duplicate semantic nodes.
+- **Ensure minimum tap target size**: Interactive elements should have a minimum tap target size of 48x48 logical pixels to accommodate users with limited dexterity.
+- **Provide semantic labels**: Tappable widgets must have a non-empty semantic label or tooltip.
+
+## Testing
+
+- Use `meetsGuideline` with `textContrastGuideline`, `androidTapTargetGuideline`, `iOSTapTargetGuideline`, and `labeledTapTargetGuideline` to verify accessibility in tests.
+- Use `debugDumpSemanticsTree()` to inspect the semantics tree when diagnosing failures related to missing or incorrect labels.

--- a/.agents/skills/widget-accessibility/SKILL.md
+++ b/.agents/skills/widget-accessibility/SKILL.md
@@ -10,8 +10,9 @@ This skill provides instructions and best practices for ensuring Flutter widgets
 ## Guidelines
 
 - **Avoid redundant tooltips and labels**: Do not wrap widgets that already support a `tooltip` or `semanticLabel` property directly in a `Tooltip` or `Semantics` widget with the same message. This creates duplicate semantic nodes.
+- **Prefer tooltips for interactive widgets**: For widgets like `IconButton`, use the `tooltip` property instead of providing a `semanticsLabel` to the internal icon. This provides both a visual hint and accessibility information.
 - **Ensure minimum tap target size**: Interactive elements should have a minimum tap target size of 48x48 logical pixels to accommodate users with limited dexterity.
-- **Provide semantic labels**: Tappable widgets must have a non-empty semantic label or tooltip.
+- **Provide semantic labels**: Tappable widgets must have a non-empty semantic label or tooltip. Decorative elements should be hidden from semantics using `ExcludeSemantics` or by leaving labels null.
 
 ## Testing
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -57,3 +57,4 @@
 .agents/skills/find-release @reidbaker
 .agents/skills/rebuilding-flutter-tool @vashworth
 .agents/skills/upgrade-browser @mdebbar
+.agents/skills/widget-accessibility @chunhtai


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

as title, I have run into multiple situation like
```dart
Tooltip(
  message: 'string',
  child: IconButton(...)
)
```

or 
```dart
Semantics(
  label: 'string',
  child: IconButton(...)
)
```

where they should be
 ```dart
IconButton(
  tooltip: 'string',
  ...
)
```

or
```dart
IconButton(
   icon: Icon(semanticsLabel: 'string')
)
```

I wrote a skill and rule to try to avoid this
## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
