### PR TITLE
[web] Add BrowserScrollable and BrowserScrollPhysics

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine.dart
@@ -19,6 +19,7 @@ export 'engine/alarm_clock.dart';
 export 'engine/app_bootstrap.dart';
 export 'engine/arena.dart';
 export 'engine/browser_detection.dart';
+export 'engine/browser_scroll_controller.dart';
 export 'engine/canvaskit/canvas.dart';
 export 'engine/canvaskit/canvaskit_api.dart';
 export 'engine/canvaskit/color_filter.dart';

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/browser_scroll_controller.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/browser_scroll_controller.dart
@@ -4,6 +4,8 @@
 
 import 'dart:js_interop';
 
+import 'package:meta/meta.dart';
+
 import 'dom.dart';
 import 'view_embedder/embedding_strategy/embedding_strategy.dart';
 import 'window.dart';
@@ -215,8 +217,17 @@ class BrowserScrollController {
       _touchStartY = touches.first.clientY;
       final DomEventTarget? target = event.target;
       if (target != null && target.isA<DomElement>()) {
-        _activeScrollable = _findScrollableAncestor(target as DomElement);
-        _activeScrollable ??= _findScrollableDescendant(pvHost);
+        final el = target as DomElement;
+        _activeScrollable = _findScrollableAncestor(el);
+        if (_activeScrollable == null) {
+          // Scope the descendant walk to the specific platform view the
+          // user touched. Walking all of pvHost would return a scrollable
+          // from a different platform view and scroll the wrong content.
+          final DomElement? pv = containingPlatformView(el, pvHost);
+          if (pv != null) {
+            _activeScrollable = _findScrollableDescendant(pv);
+          }
+        }
       }
     });
 
@@ -337,6 +348,21 @@ class BrowserScrollController {
     } else {
       scrollable.scrollTop = scrollTop + deltaY;
     }
+  }
+
+  /// Returns the direct child of [pvHost] that contains [target], or null
+  /// if [target] is not inside any platform view.
+  ///
+  /// Used by the touch-start path to scope the scrollable-descendant search
+  /// to a single platform view so a touch on one platform view cannot
+  /// return a scrollable that lives in a different platform view.
+  @visibleForTesting
+  DomElement? containingPlatformView(DomElement target, DomElement pvHost) {
+    DomElement? current = target;
+    while (current != null && current.parentElement != pvHost) {
+      current = current.parentElement;
+    }
+    return current;
   }
 
   /// Walks down from [element] to find the first descendant with scrollable

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/browser_scroll_controller.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/browser_scroll_controller.dart
@@ -1,0 +1,382 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:js_interop';
+
+import 'dom.dart';
+import 'view_embedder/embedding_strategy/embedding_strategy.dart';
+import 'window.dart';
+
+/// Manages browser-driven scrolling for a Flutter view.
+///
+/// When enabled, the outermost scrollable in a Flutter view delegates to the
+/// browser. The host element becomes a real scrollable DOM element, and the
+/// browser handles scroll physics, momentum, and scroll chaining natively.
+///
+/// The framework communicates content extent via the dart:ui API on
+/// [FlutterView], and the engine sends scroll position updates back to the
+/// framework via the [FlutterView.onBrowserScroll] callback.
+class BrowserScrollController {
+  BrowserScrollController(this._view);
+
+  final EngineFlutterView _view;
+
+  bool _enabled = false;
+  bool get enabled => _enabled;
+
+  JSFunction? _scrollListener;
+  JSFunction? _touchStartBlocker;
+  double? _lastProgrammaticScrollTop;
+
+  /// Enables browser-driven scrolling for this view.
+  void enable() {
+    if (_enabled) {
+      return;
+    }
+
+    final EmbeddingStrategy strategy = _view.embeddingStrategy;
+    if (!strategy.supportsBrowserScrolling) {
+      return;
+    }
+
+    _enabled = true;
+    strategy.enableBrowserScrolling(_view.dom.rootElement);
+    _attachScrollListener();
+    _attachTouchStartBlocker();
+    _attachPlatformViewTouchChaining();
+  }
+
+  /// Disables browser-driven scrolling for this view.
+  void disable() {
+    if (!_enabled) {
+      return;
+    }
+
+    _enabled = false;
+    _detachScrollListener();
+    _detachTouchStartBlocker();
+    _detachPlatformViewTouchChaining();
+    _view.embeddingStrategy.disableBrowserScrolling(_view.dom.rootElement);
+  }
+
+  /// Updates the total scroll content height. Called when the framework
+  /// reports a new content extent.
+  void updateContentHeight(double height) {
+    _view.embeddingStrategy.updateScrollContentHeight(height);
+  }
+
+  void scrollTo(double offset) {
+    if (_enabled) {
+      if (_pvTouchActive) {
+        return;
+      }
+      _lastProgrammaticScrollTop = offset;
+      _view.dom.rootElement.scrollTop = offset;
+    }
+  }
+
+  void smoothScrollTo(double offset) {
+    if (_enabled) {
+      if (_pvTouchActive) {
+        return;
+      }
+      _view.dom.rootElement.scrollTo(top: offset, behavior: 'smooth');
+    }
+  }
+
+  /// Scrolls the root element by [delta] pixels.
+  ///
+  /// Does not check [_pvTouchActive] because the platform-view touch
+  /// chaining handler calls this method during an active touch to forward
+  /// boundary overflow to the outer flutter-view scroll.
+  ///
+  /// Calls [_sendScrollPositionToFramework] directly rather than relying on
+  /// the DOM `scroll` event: after writing [_lastProgrammaticScrollTop], the
+  /// onScroll listener would suppress the subsequent scroll event as a
+  /// programmatic echo, and the framework would never see the new position.
+  void scrollBy(double delta) {
+    if (_enabled) {
+      final DomElement root = _view.dom.rootElement;
+      root.scrollTop = root.scrollTop + delta;
+      final double newTop = root.scrollTop;
+      _lastProgrammaticScrollTop = newTop;
+      _sendScrollPositionToFramework(newTop);
+    }
+  }
+
+  // ---- Touch start blocker ----
+  //
+  // Prevents the browser from initiating native touch scrolling on
+  // <flutter-view>. This must be a non-passive touchstart listener so
+  // that preventDefault() actually works. The pointerdown handler's
+  // preventDefault() alone is not sufficient because modern browsers
+  // register pointer event listeners as passive by default.
+
+  void _attachTouchStartBlocker() {
+    void onTouchStart(DomEvent event) {
+      event.preventDefault();
+    }
+
+    _touchStartBlocker = onTouchStart.toJS;
+    _view.dom.rootElement.addEventListener(
+      'touchstart',
+      _touchStartBlocker,
+      <String, Object>{'passive': false}.toJSAnyDeep,
+    );
+  }
+
+  void _detachTouchStartBlocker() {
+    final JSFunction? blocker = _touchStartBlocker;
+    if (blocker != null) {
+      _view.dom.rootElement.removeEventListener('touchstart', blocker);
+      _touchStartBlocker = null;
+    }
+  }
+
+  // ---- Outer scroll listener ----
+
+  void _attachScrollListener() {
+    final DomElement scrollTarget = _view.dom.rootElement;
+
+    void onScroll() {
+      final double scrollTop = scrollTarget.scrollTop;
+      if (_lastProgrammaticScrollTop != null &&
+          (scrollTop - _lastProgrammaticScrollTop!).abs() < 1.0) {
+        _lastProgrammaticScrollTop = null;
+        return;
+      }
+      _lastProgrammaticScrollTop = null;
+      _sendScrollPositionToFramework(scrollTop);
+    }
+
+    _scrollListener = onScroll.toJS;
+    scrollTarget.addEventListener('scroll', _scrollListener);
+  }
+
+  void _detachScrollListener() {
+    final JSFunction? listener = _scrollListener;
+    if (listener != null) {
+      _view.dom.rootElement.removeEventListener('scroll', listener);
+      _scrollListener = null;
+    }
+  }
+
+  void _sendScrollPositionToFramework(double scrollTop) {
+    _view.onBrowserScroll?.call(scrollTop);
+  }
+
+  // ---- Platform view touch scroll chaining ----
+  //
+  // Browser scroll chaining from a scrollable native element inside a
+  // platform view to <flutter-view> doesn't work on touch devices because
+  // of the shadow DOM + position:sticky structure. We work around this by
+  // listening for touch events on the platformViewsHost and programmatically
+  // scrolling <flutter-view> when an inner scrollable hits its boundary.
+
+  DomEventListener? _pvTouchStartListener;
+  JSFunction? _pvTouchMoveListener;
+  DomEventListener? _pvTouchEndListener;
+
+  double? _touchStartY;
+  DomElement? _activeScrollable;
+  bool _pvTouchActive = false;
+
+  /// Whether a platform-view touch gesture is currently active.
+  ///
+  /// Used by [EngineFlutterView.browserScrollBy] to skip framework-initiated
+  /// scroll-by calls during a touch, since the touch chaining handler already
+  /// forwards boundary overflow via [scrollBy] directly.
+  bool get pvTouchActive => _pvTouchActive;
+
+  void _attachPlatformViewTouchChaining() {
+    final DomElement pvHost = _view.dom.platformViewsHost;
+    final DomElement root = _view.dom.rootElement;
+
+    bool isPlatformViewTarget(DomEvent event) {
+      final DomEventTarget? target = event.target;
+      if (target != null && target.isA<DomElement>()) {
+        return pvHost.contains(target as DomElement);
+      }
+      return false;
+    }
+
+    _pvTouchStartListener = createDomEventListener((DomEvent event) {
+      if (!isPlatformViewTarget(event)) {
+        _pvTouchActive = false;
+        return;
+      }
+      _pvTouchActive = true;
+      final te = event as DomTouchEvent;
+      final Iterable<DomTouch> touches = te.touches;
+      if (touches.isEmpty) {
+        return;
+      }
+      _touchStartY = touches.first.clientY;
+      final DomEventTarget? target = event.target;
+      if (target != null && target.isA<DomElement>()) {
+        _activeScrollable = _findScrollableAncestor(target as DomElement);
+        _activeScrollable ??= _findScrollableDescendant(pvHost);
+      }
+    });
+
+    void onTouchMove(DomEvent event) {
+      if (!isPlatformViewTarget(event)) {
+        return;
+      }
+      final te = event as DomTouchEvent;
+      if (_touchStartY == null) {
+        return;
+      }
+      final Iterable<DomTouch> touches = te.touches;
+      if (touches.isEmpty) {
+        return;
+      }
+
+      final double currentY = touches.first.clientY;
+      final double deltaY = _touchStartY! - currentY;
+      _touchStartY = currentY;
+
+      event.preventDefault();
+
+      if (_activeScrollable != null) {
+        final DomElement el = _activeScrollable!;
+        final double scrollTop = el.scrollTop;
+        final double maxScroll = el.scrollHeight - el.clientHeight;
+        final bool atTop = scrollTop <= 0 && deltaY < 0;
+        final bool atBottom = scrollTop >= maxScroll - 1 && deltaY > 0;
+
+        if (atTop || atBottom) {
+          scrollBy(deltaY);
+        } else {
+          el.scrollTop = scrollTop + deltaY;
+        }
+      } else {
+        scrollBy(deltaY);
+      }
+    }
+
+    _pvTouchMoveListener = onTouchMove.toJS;
+    root.addEventListener(
+      'touchmove',
+      _pvTouchMoveListener,
+      <String, Object>{'passive': false, 'capture': true}.toJSAnyDeep,
+    );
+
+    _pvTouchEndListener = createDomEventListener((DomEvent event) {
+      _pvTouchActive = false;
+      _touchStartY = null;
+      _activeScrollable = null;
+    });
+
+    root.addEventListener('touchstart', _pvTouchStartListener, true.toJS);
+    root.addEventListener('touchend', _pvTouchEndListener, true.toJS);
+    root.addEventListener('touchcancel', _pvTouchEndListener, true.toJS);
+  }
+
+  void _detachPlatformViewTouchChaining() {
+    final DomElement root = _view.dom.rootElement;
+    if (_pvTouchStartListener != null) {
+      // Per DOM spec, removeEventListener matches on {type, listener, capture}.
+      // These listeners were registered with capture=true, so the remove call
+      // must pass capture=true too; otherwise it silently no-ops.
+      root.removeEventListener('touchstart', _pvTouchStartListener, true.toJS);
+      root.removeEventListener('touchmove', _pvTouchMoveListener, true.toJS);
+      root.removeEventListener('touchend', _pvTouchEndListener, true.toJS);
+      root.removeEventListener('touchcancel', _pvTouchEndListener, true.toJS);
+      _pvTouchStartListener = null;
+      _pvTouchMoveListener = null;
+      _pvTouchEndListener = null;
+    }
+    _pvTouchActive = false;
+    _touchStartY = null;
+    _activeScrollable = null;
+  }
+
+  /// Finds a platform view element at the given screen coordinates.
+  ///
+  /// Used when the wheel event target is a semantics node overlaying a
+  /// platform view. Checks each platform view's bounding rect to find
+  /// which one, if any, contains the given point.
+  DomElement? findPlatformViewAtPoint(num clientX, num clientY) {
+    final DomElement pvHost = _view.dom.platformViewsHost;
+    for (final DomElement child in pvHost.children) {
+      final DomRect rect = child.getBoundingClientRect();
+      if (rect.width > 0 &&
+          rect.height > 0 &&
+          clientX >= rect.left &&
+          clientX <= rect.right &&
+          clientY >= rect.top &&
+          clientY <= rect.bottom) {
+        return child;
+      }
+    }
+    return null;
+  }
+
+  /// Handles a wheel event targeting a platform view element.
+  ///
+  /// Scrolls the inner scrollable element within the platform view. If the
+  /// inner scrollable is at its boundary, forwards the remaining delta to
+  /// the outer <flutter-view> scroll.
+  void handlePlatformViewWheel(DomElement target, double deltaY) {
+    DomElement? scrollable = _findScrollableAncestor(target);
+    scrollable ??= _findScrollableDescendant(target);
+    if (scrollable == null) {
+      scrollBy(deltaY);
+      return;
+    }
+
+    final double scrollTop = scrollable.scrollTop;
+    final double maxScroll = scrollable.scrollHeight - scrollable.clientHeight;
+    final bool atTop = scrollTop <= 0 && deltaY < 0;
+    final bool atBottom = scrollTop >= maxScroll - 1 && deltaY > 0;
+
+    if (atTop || atBottom) {
+      scrollBy(deltaY);
+    } else {
+      scrollable.scrollTop = scrollTop + deltaY;
+    }
+  }
+
+  /// Walks down from [element] to find the first descendant with scrollable
+  /// overflow and content that actually overflows.
+  DomElement? _findScrollableDescendant(DomElement element) {
+    for (final DomElement child in element.children) {
+      if (child.scrollHeight > child.clientHeight) {
+        final DomCSSStyleDeclaration style = domWindow.getComputedStyle(child);
+        final String overflowY = style.overflowY;
+        if (overflowY == 'auto' || overflowY == 'scroll') {
+          return child;
+        }
+      }
+      final DomElement? found = _findScrollableDescendant(child);
+      if (found != null) {
+        return found;
+      }
+    }
+    return null;
+  }
+
+  /// Walks up from [element] to find the nearest ancestor with scrollable
+  /// overflow and content that actually overflows.
+  DomElement? _findScrollableAncestor(DomElement element) {
+    DomElement? current = element;
+    final DomElement root = _view.dom.rootElement;
+    while (current != null && current != root) {
+      if (current.scrollHeight > current.clientHeight) {
+        final DomCSSStyleDeclaration style = domWindow.getComputedStyle(current);
+        final String overflowY = style.overflowY;
+        if (overflowY == 'auto' || overflowY == 'scroll') {
+          return current;
+        }
+      }
+      current = current.parentElement;
+    }
+    return null;
+  }
+
+  void dispose() {
+    disable();
+  }
+}

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/dom.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/dom.dart
@@ -526,7 +526,15 @@ extension type DomElement._(JSObject _) implements DomNode {
 
   external double scrollTop;
   external double scrollLeft;
+  external double get scrollHeight;
   external DomTokenList get classList;
+
+  @JS('scrollTo')
+  external void _scrollTo([JSAny? options]);
+
+  void scrollTo({required double top, String behavior = 'auto'}) {
+    _scrollTo(<String, dynamic>{'top': top, 'behavior': behavior}.toJSAnyDeep);
+  }
 
   /// Scrolls the element into the visible area of the browser window.
   ///
@@ -1995,6 +2003,10 @@ extension type DomTouchEvent._(JSObject _) implements DomUIEvent {
   @JS('changedTouches')
   external _DomList get _changedTouches;
   Iterable<DomTouch> get changedTouches => _createDomListWrapper<DomTouch>(_changedTouches);
+
+  @JS('touches')
+  external _DomList get _touches;
+  Iterable<DomTouch> get touches => _createDomListWrapper<DomTouch>(_touches);
 }
 
 @JS('Touch')

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/pointer_binding.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/pointer_binding.dart
@@ -28,9 +28,6 @@ const bool _debugLogPointerEvents = false;
 /// Set this to true to log all the events sent to the Flutter framework.
 const bool _debugLogFlutterEvents = false;
 
-// Note: debugResetIframeDetectionCache() and debugSetIframeEmbeddingForTests()
-// are now in dom.dart as shared utilities.
-
 /// Resets full-page app detection override for tests.
 @visibleForTesting
 void debugResetFullPageAppCache() {
@@ -562,13 +559,11 @@ abstract class _BaseAdapter {
   DomWheelEvent? _lastWheelEvent;
   bool _lastWheelEventWasTrackpad = false;
 
-  /// Two flags to track scroll handling for the two-flag system:
-  /// 1. _lastWheelEventAllowedDefault: true if a scrollable is at boundary
-  /// 2. _lastWheelEventHandledByWidget: true if a scrollable consumed the event
-  ///
-  /// This enables proper handling of nested scrollables:
-  /// - If inner scrollable handles the event, don't scroll parent page
-  /// - If all scrollables are at boundary, scroll parent page
+  // Two flags to disambiguate nested scrollable wheel handling:
+  // _lastWheelEventAllowedDefault: set when a scrollable is at boundary.
+  // _lastWheelEventHandledByWidget: set when a scrollable consumed the event.
+  // If inner scrollable handles the event, don't scroll parent page.
+  // If all scrollables are at boundary, allow parent page to scroll.
   bool _lastWheelEventAllowedDefault = false;
   bool _lastWheelEventHandledByWidget = false;
 
@@ -788,12 +783,9 @@ mixin _WheelEventListenerMixin on _BaseAdapter {
         scrollDeltaX: deltaX,
         scrollDeltaY: deltaY,
         onRespond: ({bool allowPlatformDefault = false}) {
-          // Track both: platform default and widget handling
           if (allowPlatformDefault) {
-            // Widget is at boundary, wants platform to handle
             _lastWheelEventAllowedDefault = true;
           } else {
-            // Widget explicitly handled this event
             _lastWheelEventHandledByWidget = true;
           }
         },
@@ -823,39 +815,57 @@ mixin _WheelEventListenerMixin on _BaseAdapter {
       print(event.type);
     }
 
-    // Reset flags before dispatching to framework
-    _lastWheelEventAllowedDefault = false;
-    _lastWheelEventHandledByWidget = false;
-
     final wheelEvent = event as DomWheelEvent;
 
-    // Dispatch to framework (this triggers onRespond callbacks synchronously)
+    // When browser-driven scrolling is active, check if the wheel event
+    // targets a platform view BEFORE dispatching to the framework.
+    // If it does, handle it entirely in the engine and skip framework
+    // dispatch to prevent BrowserScrollPhysics from also scrolling.
+    if (_view.browserScrollController.enabled) {
+      DomElement? pvElement;
+      final DomEventTarget? target = event.target;
+      if (target != null && target.isA<DomElement>()) {
+        final el = target as DomElement;
+        if (_view.dom.platformViewsHost.contains(el)) {
+          pvElement = el;
+        } else {
+          pvElement = _view.browserScrollController.findPlatformViewAtPoint(
+            wheelEvent.clientX,
+            wheelEvent.clientY,
+          );
+        }
+      }
+
+      if (pvElement != null) {
+        event.preventDefault();
+        _view.browserScrollController.handlePlatformViewWheel(pvElement, wheelEvent.deltaY);
+        return;
+      }
+    }
+
+    _lastWheelEventAllowedDefault = false;
+    _lastWheelEventHandledByWidget = false;
     _callback(event, _convertWheelEventToPointerData(wheelEvent));
 
-    // Determine if we should prevent default
+    if (_view.browserScrollController.enabled) {
+      event.preventDefault();
+      return;
+    }
+
     final bool isInIframe = isEmbeddedInIframe();
 
-    // Special handling only for full-page Flutter apps running inside an iframe.
-    // Custom element apps (Flutter embedded as a component) should let the
-    // browser handle normal scroll flow.
+    // Full-page app in an iframe: skip preventDefault when all scrollables
+    // are at boundary so the browser bubbles scroll to the parent window.
+    // Fixes GitHub issue #156985
     if (isInIframe && _isFullPageApp) {
-      // Full-page app in an iframe: only preventDefault when Flutter handles
-      // the scroll. When scrollables are at boundary, skip preventDefault to
-      // let the browser naturally bubble the scroll to the parent window.
-      //
-      // Fixes GitHub issue #156985
       final bool shouldScrollParent =
           _lastWheelEventAllowedDefault && !_lastWheelEventHandledByWidget;
       if (!shouldScrollParent) {
         event.preventDefault();
       }
     } else {
-      // Original behavior for:
-      // 1. Apps NOT in an iframe (normal page)
-      // 2. Multi-view mode inside an iframe
-      //
-      // Only preventDefault when a scrollable widget handles the event.
-      // This preserves native scroll behavior when Flutter can't scroll.
+      // Non-iframe or custom-element: only preventDefault when a widget
+      // handled the event, preserving native scroll at boundaries.
       if (!_lastWheelEventAllowedDefault) {
         event.preventDefault();
       }
@@ -1072,7 +1082,13 @@ class _PointerAdapter extends _BaseAdapter with _WheelEventListenerMixin {
       _convertEventsToPointerData(data: pointerData, event: event, details: down);
       _callback(event, pointerData);
 
-      if (event.target == _viewTarget) {
+      // When browser-driven scrolling is active and this is a touch event,
+      // preventDefault to stop the browser from initiating native
+      // touch-action scrolling. Platform view scrolling is handled
+      // programmatically by BrowserScrollController's touch chaining.
+      if (_view.browserScrollController.enabled && event.pointerType == 'touch') {
+        event.preventDefault();
+      } else if (event.target == _viewTarget) {
         // Ensure smooth focus transitions between text fields within the Flutter view.
         // Without preventing the default and this delay, the engine may not have fully
         // rendered the next input element, leading to the focus incorrectly returning to

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/embedding_strategy/custom_element_embedding_strategy.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/embedding_strategy/custom_element_embedding_strategy.dart
@@ -50,4 +50,16 @@ class CustomElementEmbeddingStrategy implements EmbeddingStrategy {
     registerElementForCleanup(rootElement);
     _rootElement = rootElement;
   }
+
+  @override
+  bool get supportsBrowserScrolling => false;
+
+  @override
+  void enableBrowserScrolling(DomElement rootElement) {}
+
+  @override
+  void disableBrowserScrolling(DomElement rootElement) {}
+
+  @override
+  void updateScrollContentHeight(double height) {}
 }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/embedding_strategy/embedding_strategy.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/embedding_strategy/embedding_strategy.dart
@@ -44,4 +44,22 @@ abstract class EmbeddingStrategy {
 
   /// Attaches the view root element into the hostElement.
   void attachViewRoot(DomElement rootElement);
+
+  /// Whether browser-driven scrolling is supported by this embedding strategy.
+  bool get supportsBrowserScrolling => false;
+
+  /// Enables browser-driven scrolling for the outermost scrollable.
+  ///
+  /// When enabled, the host element becomes a real scrollable DOM element,
+  /// allowing the browser to handle scroll physics, momentum, and scroll
+  /// chaining natively. The framework syncs its scroll position from the
+  /// browser's scroll events.
+  void enableBrowserScrolling(DomElement rootElement) {}
+
+  /// Disables browser-driven scrolling, restoring the original styles.
+  void disableBrowserScrolling(DomElement rootElement) {}
+
+  /// Updates the scroll content height so the browser knows how much
+  /// content is available to scroll through.
+  void updateScrollContentHeight(double height) {}
 }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/embedding_strategy/full_page_embedding_strategy.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/embedding_strategy/full_page_embedding_strategy.dart
@@ -27,6 +27,16 @@ class FullPageEmbeddingStrategy implements EmbeddingStrategy {
   DomEventTarget get globalEventTarget => domWindow;
 
   @override
+  bool get supportsBrowserScrolling => true;
+
+  bool _browserScrollingEnabled = false;
+
+  /// Whether browser-driven scrolling is currently active.
+  bool get browserScrollingEnabled => _browserScrollingEnabled;
+
+  DomElement? _scrollHeightPlaceholder;
+
+  @override
   void setLocale(ui.Locale locale) {
     domDocument.documentElement!.setAttribute('lang', locale.toLanguageTag());
   }
@@ -44,6 +54,106 @@ class FullPageEmbeddingStrategy implements EmbeddingStrategy {
     hostElement.append(rootElement);
 
     registerElementForCleanup(rootElement);
+  }
+
+  @override
+  void enableBrowserScrolling(DomElement rootElement) {
+    _browserScrollingEnabled = true;
+
+    setElementStyle(hostElement, 'position', 'static');
+    setElementStyle(hostElement, 'overflow', 'hidden');
+    setElementStyle(hostElement, 'padding', '0');
+    setElementStyle(hostElement, 'margin', '0');
+    setElementStyle(hostElement, 'width', '100%');
+    setElementStyle(hostElement, 'height', '100%');
+
+    // Override body's touch-action from 'none' to 'pan-y'. The browser
+    // computes effective touch-action as the intersection of an element
+    // and all its ancestors. If body keeps 'none', no descendant can
+    // touch-scroll regardless of its own touch-action value.
+    setElementStyle(hostElement, 'touch-action', 'pan-y');
+
+    // Make <flutter-view> the scrollable element. This is critical: the
+    // flutter-view must be the scrollable so that wheel events, which land
+    // on it, trigger native scrolling. If we made the body scrollable but
+    // flutter-view was fixed on top, wheel events would go to flutter-view
+    // and the body would never scroll.
+    rootElement.style
+      ..position = 'fixed'
+      ..top = '0'
+      ..right = '0'
+      ..bottom = '0'
+      ..left = '0'
+      ..overflow = 'auto';
+
+    // Use touch-action: none so the browser does not initiate native
+    // touch scrolling. Flutter handles all touch input and forwards
+    // scroll deltas to the browser via the dart:ui browserScrollBy API.
+    // With pan-y, the browser fires pointercancel before Flutter can
+    // process the gesture.
+    setElementStyle(rootElement, 'touch-action', 'none');
+
+    // Make all existing children of flutter-view sticky so they stay
+    // visible at the top of the viewport while the element scrolls.
+    // This includes <flt-glass-pane>, <flt-text-editing-host>, and
+    // <flt-semantics-host>.
+    for (final DomElement child in rootElement.children) {
+      child.style
+        ..position = 'sticky'
+        ..top = '0'
+        ..left = '0';
+    }
+
+    // Create a placeholder element inside flutter-view that sets the
+    // scroll height. This gives flutter-view real content to scroll against.
+    // It must be positioned absolutely so it doesn't push the sticky
+    // children down, and its height defines the total scrollable area.
+    _scrollHeightPlaceholder = domDocument.createElement('div');
+    _scrollHeightPlaceholder!.setAttribute('flt-scroll-placeholder', '');
+    _scrollHeightPlaceholder!.style
+      ..width = '1px'
+      ..pointerEvents = 'none'
+      ..position = 'absolute'
+      ..top = '0'
+      ..left = '0';
+
+    rootElement.append(_scrollHeightPlaceholder!);
+
+    registerElementForCleanup(_scrollHeightPlaceholder!);
+  }
+
+  @override
+  void disableBrowserScrolling(DomElement rootElement) {
+    _browserScrollingEnabled = false;
+
+    _setHostStyles();
+
+    rootElement.style
+      ..position = 'absolute'
+      ..top = '0'
+      ..right = '0'
+      ..bottom = '0'
+      ..left = '0'
+      ..overflow = '';
+
+    setElementStyle(rootElement, 'touch-action', '');
+
+    for (final DomElement child in rootElement.children) {
+      child.style
+        ..position = ''
+        ..top = ''
+        ..left = '';
+    }
+
+    _scrollHeightPlaceholder?.remove();
+    _scrollHeightPlaceholder = null;
+  }
+
+  @override
+  void updateScrollContentHeight(double height) {
+    if (_scrollHeightPlaceholder != null) {
+      _scrollHeightPlaceholder!.style.height = '${height}px';
+    }
   }
 
   // Sets the global styles for a flutter app.

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/embedding_strategy/full_page_embedding_strategy.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/embedding_strategy/full_page_embedding_strategy.dart
@@ -36,6 +36,13 @@ class FullPageEmbeddingStrategy implements EmbeddingStrategy {
 
   DomElement? _scrollHeightPlaceholder;
 
+  // Per-child inline style snapshot taken on enable so disable can restore
+  // the exact pre-enable state. Needed because some engine-managed children
+  // such as <flt-semantics-host> carry inline `position: absolute` that
+  // otherwise falls through to `static` when we clear the style.
+  final Map<DomElement, Map<String, String>> _savedChildStyles =
+      <DomElement, Map<String, String>>{};
+
   @override
   void setLocale(ui.Locale locale) {
     domDocument.documentElement!.setAttribute('lang', locale.toLanguageTag());
@@ -97,7 +104,17 @@ class FullPageEmbeddingStrategy implements EmbeddingStrategy {
     // visible at the top of the viewport while the element scrolls.
     // This includes <flt-glass-pane>, <flt-text-editing-host>, and
     // <flt-semantics-host>.
+    //
+    // Snapshot each child's inline position/top/left first so disable can
+    // restore them. <flt-semantics-host> in particular ships with inline
+    // `position: absolute` set by StyleManager; clearing to empty would
+    // drop it through to `static` and break its transform scaling.
     for (final DomElement child in rootElement.children) {
+      _savedChildStyles[child] = <String, String>{
+        'position': child.style.position,
+        'top': child.style.top,
+        'left': child.style.left,
+      };
       child.style
         ..position = 'sticky'
         ..top = '0'
@@ -137,13 +154,16 @@ class FullPageEmbeddingStrategy implements EmbeddingStrategy {
       ..overflow = '';
 
     setElementStyle(rootElement, 'touch-action', '');
+    setElementStyle(hostElement, 'touch-action', '');
 
     for (final DomElement child in rootElement.children) {
+      final Map<String, String>? saved = _savedChildStyles[child];
       child.style
-        ..position = ''
-        ..top = ''
-        ..left = '';
+        ..position = saved?['position'] ?? ''
+        ..top = saved?['top'] ?? ''
+        ..left = saved?['left'] ?? '';
     }
+    _savedChildStyles.clear();
 
     _scrollHeightPlaceholder?.remove();
     _scrollHeightPlaceholder = null;

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/window.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/window.dart
@@ -11,6 +11,7 @@ import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 import '../engine.dart' show DimensionsProvider, registerHotRestartListener, renderer;
 import 'browser_detection.dart';
+import 'browser_scroll_controller.dart';
 import 'display.dart';
 import 'dom.dart';
 import 'initialization.dart';
@@ -110,6 +111,7 @@ class EngineFlutterView implements ui.FlutterView {
     _resizeSubscription.cancel();
     dimensionsProvider.close();
     pointerBinding.dispose();
+    browserScrollController.dispose();
     dom.rootElement.remove();
     // TODO(harryterkelsen): What should we do about this in multi-view?
     renderer.clearFragmentProgramCache();
@@ -164,6 +166,44 @@ class EngineFlutterView implements ui.FlutterView {
   final JsViewConstraints? _jsViewConstraints;
 
   late final EngineSemanticsOwner semantics = EngineSemanticsOwner(viewId, dom.semanticsHost);
+
+  late final BrowserScrollController browserScrollController = BrowserScrollController(this);
+
+  // Browser-driven scrolling API (dart:ui surface)
+
+  @override
+  void enableBrowserScrolling() => browserScrollController.enable();
+
+  @override
+  void disableBrowserScrolling() => browserScrollController.disable();
+
+  @override
+  void browserScrollTo(double offset) => browserScrollController.scrollTo(offset);
+
+  @override
+  void browserSmoothScrollTo(double offset) => browserScrollController.smoothScrollTo(offset);
+
+  @override
+  void browserScrollBy(double delta) {
+    if (browserScrollController.pvTouchActive) {
+      return;
+    }
+    browserScrollController.scrollBy(delta);
+  }
+
+  @override
+  void updateBrowserScrollContentHeight(double height) =>
+      browserScrollController.updateContentHeight(height);
+
+  ui.BrowserScrollCallback? _onBrowserScroll;
+
+  @override
+  ui.BrowserScrollCallback? get onBrowserScroll => _onBrowserScroll;
+
+  @override
+  set onBrowserScroll(ui.BrowserScrollCallback? callback) {
+    _onBrowserScroll = callback;
+  }
 
   @override
   ui.Size get physicalSize {

--- a/engine/src/flutter/lib/web_ui/lib/window.dart
+++ b/engine/src/flutter/lib/web_ui/lib/window.dart
@@ -11,6 +11,8 @@ abstract class Display {
   double get refreshRate;
 }
 
+typedef BrowserScrollCallback = void Function(double offset);
+
 abstract class FlutterView {
   PlatformDispatcher get platformDispatcher;
   int get viewId;
@@ -27,6 +29,18 @@ abstract class FlutterView {
   DisplayCornerRadii? get displayCornerRadii;
   void render(Scene scene, {Size? size});
   void updateSemantics(SemanticsUpdate update) => platformDispatcher.updateSemantics(update);
+
+  // Browser-driven scrolling API (web-only, no-op on other platforms).
+
+  void enableBrowserScrolling() {}
+  void disableBrowserScrolling() {}
+  void browserScrollTo(double offset) {}
+  void browserSmoothScrollTo(double offset) {}
+  void browserScrollBy(double delta) {}
+  void updateBrowserScrollContentHeight(double height) {}
+
+  BrowserScrollCallback? get onBrowserScroll => null;
+  set onBrowserScroll(BrowserScrollCallback? callback) {}
 }
 
 abstract class SingletonFlutterWindow extends FlutterView {

--- a/engine/src/flutter/lib/web_ui/test/engine/browser_scroll_controller_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/browser_scroll_controller_test.dart
@@ -184,6 +184,57 @@ void testMain() {
     });
   });
 
+  group('containingPlatformView', () {
+    test('returns the direct child of pvHost that contains a leaf target', () {
+      final DomElement pvHost = view.dom.platformViewsHost;
+      final DomElement pv = createDomHTMLDivElement();
+      final DomElement inner = createDomHTMLDivElement();
+      final DomElement leaf = createDomHTMLDivElement();
+      inner.append(leaf);
+      pv.append(inner);
+      pvHost.append(pv);
+
+      expect(controller.containingPlatformView(leaf, pvHost), pv);
+    });
+
+    test('returns the pv itself when target is the pv', () {
+      final DomElement pvHost = view.dom.platformViewsHost;
+      final DomElement pv = createDomHTMLDivElement();
+      pvHost.append(pv);
+
+      expect(controller.containingPlatformView(pv, pvHost), pv);
+    });
+
+    test('returns null when target is outside any platform view', () {
+      final DomElement pvHost = view.dom.platformViewsHost;
+      final DomElement stray = createDomHTMLDivElement();
+      domDocument.body!.append(stray);
+
+      expect(controller.containingPlatformView(stray, pvHost), isNull);
+
+      stray.remove();
+    });
+
+    test('selects the containing pv, not a sibling pv', () {
+      // Regression: previously the touch-start fallback walked all of
+      // pvHost, which could return a scrollable from a different platform
+      // view than the one the user actually touched. This test guards the
+      // scoping helper so touches on pvA resolve to pvA, not pvB.
+      final DomElement pvHost = view.dom.platformViewsHost;
+
+      final DomElement pvA = createDomHTMLDivElement();
+      final DomElement pvALeaf = createDomHTMLDivElement();
+      pvA.append(pvALeaf);
+      pvHost.append(pvA);
+
+      final DomElement pvB = createDomHTMLDivElement();
+      pvHost.append(pvB);
+
+      expect(controller.containingPlatformView(pvALeaf, pvHost), pvA);
+      expect(controller.containingPlatformView(pvB, pvHost), pvB);
+    });
+  });
+
   group('dispose', () {
     test('disable is called on dispose', () {
       controller.dispose();

--- a/engine/src/flutter/lib/web_ui/test/engine/browser_scroll_controller_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/browser_scroll_controller_test.dart
@@ -1,0 +1,284 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/src/engine.dart';
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+void testMain() {
+  late EngineFlutterView view;
+  late BrowserScrollController controller;
+  late DomElement hostElement;
+
+  setUp(() {
+    hostElement = createDomHTMLDivElement();
+    domDocument.body!.append(hostElement);
+    view = EngineFlutterView(EnginePlatformDispatcher.instance, hostElement);
+    controller = view.browserScrollController;
+  });
+
+  tearDown(() {
+    view.dispose();
+    hostElement.remove();
+  });
+
+  group('enable/disable', () {
+    test('starts disabled', () {
+      expect(controller.enabled, isFalse);
+    });
+
+    test('does not enable when strategy does not support it', () {
+      controller.enable();
+      expect(controller.enabled, isFalse);
+    });
+
+    test('disable when already disabled is a no-op', () {
+      controller.disable();
+      expect(controller.enabled, isFalse);
+    });
+  });
+
+  group('findPlatformViewAtPoint', () {
+    test('returns null when no platform views exist', () {
+      final DomElement? result = controller.findPlatformViewAtPoint(100, 100);
+      expect(result, isNull);
+    });
+
+    test('returns null when point is outside all platform views', () {
+      final DomElement pvElement = createDomHTMLDivElement();
+      pvElement.style
+        ..width = '100px'
+        ..height = '100px'
+        ..position = 'absolute'
+        ..left = '0px'
+        ..top = '0px';
+      view.dom.platformViewsHost.append(pvElement);
+
+      final DomElement? result = controller.findPlatformViewAtPoint(9999, 9999);
+      expect(result, isNull);
+    });
+
+    test('finds platform view at given coordinates', () {
+      final DomElement pvElement = createDomHTMLDivElement();
+      pvElement.style
+        ..width = '200px'
+        ..height = '200px'
+        ..position = 'absolute'
+        ..left = '0px'
+        ..top = '0px';
+      view.dom.platformViewsHost.append(pvElement);
+
+      final DomRect rect = pvElement.getBoundingClientRect();
+      if (rect.width > 0 && rect.height > 0) {
+        final DomElement? result = controller.findPlatformViewAtPoint(
+          rect.left + 10,
+          rect.top + 10,
+        );
+        expect(result, pvElement);
+      }
+    });
+
+    test('ignores zero-size elements', () {
+      final DomElement pvElement = createDomHTMLDivElement();
+      pvElement.style
+        ..width = '0px'
+        ..height = '0px';
+      view.dom.platformViewsHost.append(pvElement);
+
+      final DomElement? result = controller.findPlatformViewAtPoint(0, 0);
+      expect(result, isNull);
+    });
+
+    test('selects correct element when multiple PVs exist', () {
+      final DomElement pv1 = createDomHTMLDivElement();
+      pv1.style
+        ..width = '100px'
+        ..height = '100px'
+        ..position = 'absolute'
+        ..left = '0px'
+        ..top = '0px';
+      view.dom.platformViewsHost.append(pv1);
+
+      final DomElement pv2 = createDomHTMLDivElement();
+      pv2.style
+        ..width = '100px'
+        ..height = '100px'
+        ..position = 'absolute'
+        ..left = '200px'
+        ..top = '200px';
+      view.dom.platformViewsHost.append(pv2);
+
+      final DomRect rect2 = pv2.getBoundingClientRect();
+      if (rect2.width > 0 && rect2.height > 0) {
+        final DomElement? result = controller.findPlatformViewAtPoint(
+          rect2.left + 10,
+          rect2.top + 10,
+        );
+        expect(result, pv2);
+      }
+    });
+  });
+
+  group('handlePlatformViewWheel', () {
+    test('does not throw when target has no scrollable', () {
+      final DomElement pvElement = createDomHTMLDivElement();
+      pvElement.style
+        ..width = '200px'
+        ..height = '200px';
+      view.dom.platformViewsHost.append(pvElement);
+
+      controller.handlePlatformViewWheel(pvElement, 50);
+    });
+
+    test('scrolls inner scrollable when it has overflow content', () {
+      final DomElement pvElement = createDomHTMLDivElement();
+      pvElement.style
+        ..width = '200px'
+        ..height = '100px';
+
+      final DomElement scrollableDiv = createDomHTMLDivElement();
+      scrollableDiv.style
+        ..width = '100%'
+        ..height = '100%'
+        ..overflow = 'auto';
+
+      final DomElement tallContent = createDomHTMLDivElement();
+      tallContent.style.height = '500px';
+      scrollableDiv.append(tallContent);
+      pvElement.append(scrollableDiv);
+      view.dom.platformViewsHost.append(pvElement);
+
+      controller.handlePlatformViewWheel(pvElement, 30);
+    });
+
+    test('walks down to find scrollable descendant', () {
+      final DomElement pvElement = createDomHTMLDivElement();
+      pvElement.style
+        ..width = '200px'
+        ..height = '100px';
+
+      final DomElement wrapper = createDomHTMLDivElement();
+      wrapper.style
+        ..width = '100%'
+        ..height = '100%';
+
+      final DomElement scrollableDiv = createDomHTMLDivElement();
+      scrollableDiv.style
+        ..width = '100%'
+        ..height = '100%'
+        ..overflow = 'auto';
+
+      final DomElement tallContent = createDomHTMLDivElement();
+      tallContent.style.height = '500px';
+      scrollableDiv.append(tallContent);
+      wrapper.append(scrollableDiv);
+      pvElement.append(wrapper);
+      view.dom.platformViewsHost.append(pvElement);
+
+      controller.handlePlatformViewWheel(pvElement, 30);
+    });
+  });
+
+  group('dispose', () {
+    test('disable is called on dispose', () {
+      controller.dispose();
+      expect(controller.enabled, isFalse);
+    });
+
+    test('can dispose when already disabled', () {
+      controller.dispose();
+      controller.dispose();
+      expect(controller.enabled, isFalse);
+    });
+  });
+
+  // Regression tests that require a FullPageEmbeddingStrategy, because only
+  // that strategy returns `supportsBrowserScrolling == true` and actually
+  // attaches the platform-view touch-chaining listeners in `enable()`.
+  // Full-page setup mutates <body> styles, so each test here saves and
+  // restores them to avoid cross-test contamination.
+  group('full-page: enable/disable cycle cleanup', () {
+    late EngineFlutterView fullPageView;
+    late BrowserScrollController fullPageController;
+    late Map<String, String> savedBodyStyles;
+
+    setUp(() {
+      savedBodyStyles = {};
+      for (final prop in const [
+        'position',
+        'top',
+        'right',
+        'bottom',
+        'left',
+        'overflow',
+        'padding',
+        'margin',
+        'width',
+        'height',
+        'touch-action',
+        'user-select',
+        '-webkit-user-select',
+      ]) {
+        savedBodyStyles[prop] = domDocument.body!.style.getPropertyValue(prop);
+      }
+      // Null hostElement -> FullPageEmbeddingStrategy under the hood.
+      fullPageView = EngineFlutterView.implicit(EnginePlatformDispatcher.instance, null);
+      fullPageController = fullPageView.browserScrollController;
+    });
+
+    tearDown(() {
+      fullPageView.dispose();
+      for (final MapEntry<String, String> entry in savedBodyStyles.entries) {
+        if (entry.value.isEmpty) {
+          domDocument.body!.style.removeProperty(entry.key);
+        } else {
+          domDocument.body!.style.setProperty(entry.key, entry.value);
+        }
+      }
+    });
+
+    test('disable removes capture-phase platform-view touchstart listener', () {
+      // Add a platform-view child so `isPlatformViewTarget` returns true
+      // for events dispatched from it.
+      final DomElement pvElement = createDomHTMLDivElement();
+      pvElement.style
+        ..width = '100px'
+        ..height = '100px';
+      fullPageView.dom.platformViewsHost.append(pvElement);
+
+      // Attach then detach the platform-view touch chaining listeners.
+      fullPageController.enable();
+      fullPageController.disable();
+
+      // If `_detachPlatformViewTouchChaining` fails to match the capture
+      // flag in `removeEventListener`, the touchstart capture listener
+      // is still attached and would fire on this synthetic event,
+      // latching `_pvTouchActive = true` on the controller.
+      pvElement.dispatchEvent(createDomEvent('Event', 'touchstart'));
+
+      // Re-enable and provide a content height so scrolling is possible.
+      fullPageController.enable();
+      fullPageController.updateContentHeight(2000);
+
+      // `scrollTo` is a no-op while `_pvTouchActive` is true. If the
+      // stale listener fired above, scrollTop stays 0. With a correct
+      // remove, `_pvTouchActive` was never set, so scrollTo succeeds.
+      fullPageController.scrollTo(100);
+
+      expect(
+        fullPageView.dom.rootElement.scrollTop,
+        greaterThan(0),
+        reason:
+            'scrollTo was blocked by a leaked _pvTouchActive=true from a '
+            'stale capture-phase touchstart listener. Check that '
+            '_detachPlatformViewTouchChaining passes capture=true to '
+            'removeEventListener so it matches the addEventListener call.',
+      );
+    });
+  });
+}

--- a/engine/src/flutter/lib/web_ui/test/engine/view_embedder/embedding_strategy/embedding_strategy_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/view_embedder/embedding_strategy/embedding_strategy_test.dart
@@ -121,6 +121,45 @@ void doTests() {
       strategy.updateScrollContentHeight(5000);
     });
 
+    test('FullPage disableBrowserScrolling restores inline child styles', () {
+      final strategy = EmbeddingStrategy.create() as FullPageEmbeddingStrategy;
+      final DomElement rootElement = createDomElement('flutter-view');
+      domDocument.body!.append(rootElement);
+
+      // Mimic StyleManager.styleSemanticsHost applying inline position.
+      final DomElement semanticsHost = createDomElement('flt-semantics-host');
+      semanticsHost.style.position = 'absolute';
+      rootElement.append(semanticsHost);
+
+      // Mimic a child without inline position.
+      final DomElement glassPane = createDomElement('flt-glass-pane');
+      rootElement.append(glassPane);
+
+      strategy.enableBrowserScrolling(rootElement);
+      expect(semanticsHost.style.position, 'sticky');
+      expect(glassPane.style.position, 'sticky');
+
+      strategy.disableBrowserScrolling(rootElement);
+      expect(semanticsHost.style.position, 'absolute');
+      expect(glassPane.style.position, '');
+
+      rootElement.remove();
+    });
+
+    test('FullPage disableBrowserScrolling clears hostElement touch-action', () {
+      final strategy = EmbeddingStrategy.create() as FullPageEmbeddingStrategy;
+      final DomElement rootElement = createDomElement('flutter-view');
+      domDocument.body!.append(rootElement);
+
+      strategy.enableBrowserScrolling(rootElement);
+      expect(strategy.hostElement.style.getPropertyValue('touch-action'), 'pan-y');
+
+      strategy.disableBrowserScrolling(rootElement);
+      expect(strategy.hostElement.style.getPropertyValue('touch-action'), '');
+
+      rootElement.remove();
+    });
+
     test('CustomElement enableBrowserScrolling is a no-op', () {
       final DomElement element = createDomElement('some-element');
       final strategy = EmbeddingStrategy.create(hostElement: element);

--- a/engine/src/flutter/lib/web_ui/test/engine/view_embedder/embedding_strategy/embedding_strategy_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/view_embedder/embedding_strategy/embedding_strategy_test.dart
@@ -31,4 +31,103 @@ void doTests() {
       expect(strategy, isA<CustomElementEmbeddingStrategy>());
     });
   });
+
+  group('Browser scrolling support', () {
+    test('FullPageEmbeddingStrategy supports browser scrolling', () {
+      final strategy = EmbeddingStrategy.create();
+      expect(strategy.supportsBrowserScrolling, isTrue);
+    });
+
+    test('CustomElementEmbeddingStrategy does not support browser scrolling', () {
+      final DomElement element = createDomElement('some-element');
+      final strategy = EmbeddingStrategy.create(hostElement: element);
+      expect(strategy.supportsBrowserScrolling, isFalse);
+    });
+
+    test('FullPage enableBrowserScrolling sets overflow:auto on rootElement', () {
+      final strategy = EmbeddingStrategy.create() as FullPageEmbeddingStrategy;
+      final DomElement rootElement = createDomElement('flutter-view');
+      domDocument.body!.append(rootElement);
+
+      strategy.enableBrowserScrolling(rootElement);
+
+      expect(rootElement.style.overflow, 'auto');
+      expect(strategy.browserScrollingEnabled, isTrue);
+
+      strategy.disableBrowserScrolling(rootElement);
+      rootElement.remove();
+    });
+
+    test('FullPage enableBrowserScrolling sets touch-action:none on rootElement', () {
+      final strategy = EmbeddingStrategy.create() as FullPageEmbeddingStrategy;
+      final DomElement rootElement = createDomElement('flutter-view');
+      domDocument.body!.append(rootElement);
+
+      strategy.enableBrowserScrolling(rootElement);
+
+      final String touchAction = rootElement.style.getPropertyValue('touch-action');
+      expect(touchAction, 'none');
+
+      strategy.disableBrowserScrolling(rootElement);
+      rootElement.remove();
+    });
+
+    test('FullPage enableBrowserScrolling creates scroll height placeholder', () {
+      final strategy = EmbeddingStrategy.create() as FullPageEmbeddingStrategy;
+      final DomElement rootElement = createDomElement('flutter-view');
+      domDocument.body!.append(rootElement);
+
+      strategy.enableBrowserScrolling(rootElement);
+
+      final DomElement? placeholder = rootElement.querySelector('[flt-scroll-placeholder]');
+      expect(placeholder, isNotNull);
+
+      strategy.disableBrowserScrolling(rootElement);
+      rootElement.remove();
+    });
+
+    test('FullPage disableBrowserScrolling resets state', () {
+      final strategy = EmbeddingStrategy.create() as FullPageEmbeddingStrategy;
+      final DomElement rootElement = createDomElement('flutter-view');
+      domDocument.body!.append(rootElement);
+
+      strategy.enableBrowserScrolling(rootElement);
+      expect(strategy.browserScrollingEnabled, isTrue);
+
+      strategy.disableBrowserScrolling(rootElement);
+      expect(strategy.browserScrollingEnabled, isFalse);
+
+      rootElement.remove();
+    });
+
+    test('FullPage updateScrollContentHeight sets placeholder height', () {
+      final strategy = EmbeddingStrategy.create() as FullPageEmbeddingStrategy;
+      final DomElement rootElement = createDomElement('flutter-view');
+      domDocument.body!.append(rootElement);
+
+      strategy.enableBrowserScrolling(rootElement);
+      strategy.updateScrollContentHeight(5000);
+
+      final DomElement? placeholder = rootElement.querySelector('[flt-scroll-placeholder]');
+      expect(placeholder, isNotNull);
+      expect(placeholder!.style.height, '5000px');
+
+      strategy.disableBrowserScrolling(rootElement);
+      rootElement.remove();
+    });
+
+    test('FullPage updateScrollContentHeight is no-op before enable', () {
+      final strategy = EmbeddingStrategy.create() as FullPageEmbeddingStrategy;
+      strategy.updateScrollContentHeight(5000);
+    });
+
+    test('CustomElement enableBrowserScrolling is a no-op', () {
+      final DomElement element = createDomElement('some-element');
+      final strategy = EmbeddingStrategy.create(hostElement: element);
+      final DomElement rootElement = createDomElement('flutter-view');
+
+      strategy.enableBrowserScrolling(rootElement);
+      expect(strategy.supportsBrowserScrolling, isFalse);
+    });
+  });
 }

--- a/packages/flutter/lib/foundation.dart
+++ b/packages/flutter/lib/foundation.dart
@@ -11,6 +11,8 @@ library foundation;
 
 export 'package:meta/meta.dart'
     show
+        // ignore: experimental_member_use
+        experimental,
         factory,
         immutable,
         internal,

--- a/packages/flutter/lib/src/widgets/_browser_scroll_view_io.dart
+++ b/packages/flutter/lib/src/widgets/_browser_scroll_view_io.dart
@@ -1,0 +1,54 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui' show FlutterView;
+
+/// Non-web implementation of browser scroll view bindings.
+///
+/// On non-web platforms, browser scrolling is not available. All methods
+/// record their calls so tests can verify outbound communication. The
+/// [onBrowserScroll] callback is stored locally so tests can simulate
+/// browser scroll events.
+class BrowserScrollViewBinding {
+  /// Creates a binding for the given [FlutterView].
+  BrowserScrollViewBinding(this.view);
+
+  /// The [FlutterView] this binding is associated with.
+  final FlutterView view;
+
+  /// Recorded method calls for test assertions.
+  ///
+  /// Each entry is a map with `method` and optional `args` keys.
+  final List<Map<String, Object?>> calls = <Map<String, Object?>>[];
+
+  /// Records a method call.
+  void _record(String method, [Object? args]) {
+    calls.add(<String, Object?>{'method': method, if (args != null) 'args': args});
+  }
+
+  /// No-op on non-web platforms. Records the call.
+  void enableBrowserScrolling() => _record('enableBrowserScrolling');
+
+  /// No-op on non-web platforms. Records the call.
+  void disableBrowserScrolling() => _record('disableBrowserScrolling');
+
+  /// No-op on non-web platforms. Records the call.
+  void browserScrollTo(double offset) => _record('browserScrollTo', offset);
+
+  /// No-op on non-web platforms. Records the call.
+  void browserSmoothScrollTo(double offset) => _record('browserSmoothScrollTo', offset);
+
+  /// No-op on non-web platforms. Records the call.
+  void browserScrollBy(double delta) => _record('browserScrollBy', delta);
+
+  /// No-op on non-web platforms. Records the call.
+  void updateBrowserScrollContentHeight(double height) =>
+      _record('updateBrowserScrollContentHeight', height);
+
+  /// The callback invoked when the browser reports a scroll position change.
+  ///
+  /// On non-web platforms, this callback is stored locally so tests can
+  /// simulate browser scroll events.
+  void Function(double offset)? onBrowserScroll;
+}

--- a/packages/flutter/lib/src/widgets/_browser_scroll_view_web.dart
+++ b/packages/flutter/lib/src/widgets/_browser_scroll_view_web.dart
@@ -1,0 +1,57 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui' show FlutterView;
+
+/// Web implementation of browser scroll view bindings.
+///
+/// On web, [FlutterView] is backed by `EngineFlutterView` which provides
+/// browser scroll methods via the dart:ui API surface. This class uses
+/// dynamic dispatch to call those methods, since the native dart:ui
+/// `FlutterView` class does not declare them.
+class BrowserScrollViewBinding {
+  /// Creates a binding for the given [FlutterView].
+  BrowserScrollViewBinding(this.view);
+
+  /// The [FlutterView] this binding is associated with.
+  final FlutterView view;
+
+  // Use dynamic to call web-only FlutterView methods that the native
+  // analyzer cannot resolve.
+  dynamic get _webView => view;
+
+  /// Enables browser-driven scrolling on the view.
+  // ignore: avoid_dynamic_calls
+  void enableBrowserScrolling() => _webView.enableBrowserScrolling();
+
+  /// Disables browser-driven scrolling on the view.
+  // ignore: avoid_dynamic_calls
+  void disableBrowserScrolling() => _webView.disableBrowserScrolling();
+
+  /// Instantly scrolls the browser to the given offset.
+  // ignore: avoid_dynamic_calls
+  void browserScrollTo(double offset) => _webView.browserScrollTo(offset);
+
+  /// Smoothly scrolls the browser to the given offset.
+  // ignore: avoid_dynamic_calls
+  void browserSmoothScrollTo(double offset) => _webView.browserSmoothScrollTo(offset);
+
+  /// Scrolls the browser by the given delta.
+  // ignore: avoid_dynamic_calls
+  void browserScrollBy(double delta) => _webView.browserScrollBy(delta);
+
+  /// Updates the browser scroll content height.
+  void updateBrowserScrollContentHeight(double height) =>
+      // ignore: avoid_dynamic_calls
+      _webView.updateBrowserScrollContentHeight(height);
+
+  /// The callback invoked when the browser reports a scroll position change.
+  void Function(double offset)? get onBrowserScroll =>
+      // ignore: avoid_dynamic_calls
+      _webView.onBrowserScroll as void Function(double)?;
+
+  set onBrowserScroll(void Function(double offset)? callback) {
+    _webView.onBrowserScroll = callback; // ignore: avoid_dynamic_calls
+  }
+}

--- a/packages/flutter/lib/src/widgets/browser_scroll.dart
+++ b/packages/flutter/lib/src/widgets/browser_scroll.dart
@@ -1,0 +1,87 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// @docImport 'scroll_physics.dart';
+library;
+
+import 'package:flutter/foundation.dart';
+
+import 'framework.dart';
+import 'notification_listener.dart';
+import 'scroll_configuration.dart';
+import 'scroll_metrics.dart';
+import 'scroll_notification.dart';
+import 'scrollable.dart';
+
+/// A wrapper widget that enables browser-driven scrolling, forwards
+/// touch-driven overscroll to the browser, and disables Flutter scrollbars.
+///
+/// Place this above the outermost scrollable. It sets
+/// [ScrollBehavior.enableBrowserScrolling] to true, which causes
+/// [ScrollableState] to set up browser scrolling via dart:ui and automatically
+/// apply [BrowserScrollPhysics]. This widget adds two things on top:
+///
+/// 1. Catches [OverscrollNotification] from touch drag gestures and forwards
+///    them to the browser via `scrollBy`, except at the edges where
+///    [RefreshIndicator] or load-more indicators need the notification.
+/// 2. Disables Flutter-drawn scrollbars since the browser provides its own.
+///
+/// Programmatic scrolling with [ScrollController.animateTo] and
+/// [ScrollController.jumpTo] works automatically when browser scrolling is
+/// active. Both are routed through the browser's native scroll mechanism,
+/// so they respect the actual content height even under lazy layout.
+///
+/// Known limitation: on iOS Safari, touch-drag inside a cross-origin iframe
+/// nested under this widget waits for the iframe's internal momentum to
+/// finish before chaining to the parent page. This is a browser-level
+/// behavior that cannot be intercepted from the parent document.
+///
+/// Example:
+/// ```dart
+/// // ignore_for_file: experimental_member_use
+/// BrowserScrollable(
+///   child: ListView.builder(
+///     itemCount: 100,
+///     itemBuilder: (context, index) => ListTile(title: Text('Item $index')),
+///   ),
+/// )
+/// ```
+@experimental
+class BrowserScrollable extends StatelessWidget {
+  /// Creates a widget that enables browser-driven scrolling for its child.
+  const BrowserScrollable({super.key, required this.child});
+
+  /// The child widget, typically a scrollable like [ListView].
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return NotificationListener<OverscrollNotification>(
+      onNotification: _handleOverscrollNotification,
+      child: ScrollConfiguration(
+        behavior: ScrollConfiguration.of(
+          context,
+        ).copyWith(scrollbars: false, enableBrowserScrolling: true),
+        child: child,
+      ),
+    );
+  }
+
+  static bool _handleOverscrollNotification(OverscrollNotification notification) {
+    final double delta = notification.overscroll;
+    final ScrollMetrics metrics = notification.metrics;
+
+    if (delta < 0 && metrics.pixels <= metrics.minScrollExtent) {
+      return false;
+    }
+    if (delta > 0 && metrics.pixels >= metrics.maxScrollExtent) {
+      return false;
+    }
+
+    if (delta.abs() > 0.5) {
+      ScrollableState.browserScrollViewBinding?.browserScrollBy(delta);
+    }
+    return true;
+  }
+}

--- a/packages/flutter/lib/src/widgets/scroll_configuration.dart
+++ b/packages/flutter/lib/src/widgets/scroll_configuration.dart
@@ -74,6 +74,29 @@ class ScrollBehavior {
   /// Creates a description of how [Scrollable] widgets should behave.
   const ScrollBehavior();
 
+  /// Whether the outermost scrollable should delegate scrolling to the
+  /// browser's native scroll engine.
+  ///
+  /// When true, [ScrollableState] sets up browser scrolling via the dart:ui
+  /// API to sync positions with the browser and automatically applies
+  /// [BrowserScrollPhysics]. The browser handles scroll physics,
+  /// draws the native scrollbar, and chains overflow to parent pages. Flutter
+  /// still lays out and paints content, but the browser owns the scroll
+  /// position.
+  ///
+  /// The dart:ui browser scroll API is only functional on web. On other
+  /// platforms the binding calls are no-ops, but [BrowserScrollPhysics] is
+  /// still applied to the physics chain so that the behavior can be tested
+  /// without running in a browser.
+  ///
+  /// If multiple nested [Scrollable]s inherit this flag, only the outermost
+  /// one claims the browser-scroll binding. Inner scrollables use their
+  /// normal physics.
+  ///
+  /// Defaults to false.
+  @experimental
+  bool get enableBrowserScrolling => false;
+
   /// Creates a copy of this ScrollBehavior, making it possible to
   /// easily toggle `scrollbar` and `overscrollIndicator` effects.
   ///
@@ -91,6 +114,7 @@ class ScrollBehavior {
     ScrollPhysics? physics,
     TargetPlatform? platform,
     ScrollViewKeyboardDismissBehavior? keyboardDismissBehavior,
+    bool? enableBrowserScrolling,
   }) {
     return _WrappedScrollBehavior(
       delegate: this,
@@ -102,6 +126,7 @@ class ScrollBehavior {
       physics: physics,
       platform: platform,
       keyboardDismissBehavior: keyboardDismissBehavior,
+      enableBrowserScrolling: enableBrowserScrolling,
     );
   }
 
@@ -289,8 +314,10 @@ class _WrappedScrollBehavior implements ScrollBehavior {
     this.physics,
     this.platform,
     this.keyboardDismissBehavior,
+    bool? enableBrowserScrolling,
   }) : _dragDevices = dragDevices,
-       _pointerAxisModifiers = pointerAxisModifiers;
+       _pointerAxisModifiers = pointerAxisModifiers,
+       _enableBrowserScrolling = enableBrowserScrolling;
 
   final ScrollBehavior delegate;
   final bool scrollbars;
@@ -301,6 +328,10 @@ class _WrappedScrollBehavior implements ScrollBehavior {
   final Set<PointerDeviceKind>? _dragDevices;
   final MultitouchDragStrategy? multitouchDragStrategy;
   final Set<LogicalKeyboardKey>? _pointerAxisModifiers;
+  final bool? _enableBrowserScrolling;
+
+  @override
+  bool get enableBrowserScrolling => _enableBrowserScrolling ?? delegate.enableBrowserScrolling;
 
   @override
   Set<PointerDeviceKind> get dragDevices => _dragDevices ?? delegate.dragDevices;
@@ -340,6 +371,7 @@ class _WrappedScrollBehavior implements ScrollBehavior {
     ScrollPhysics? physics,
     TargetPlatform? platform,
     ScrollViewKeyboardDismissBehavior? keyboardDismissBehavior,
+    bool? enableBrowserScrolling,
   }) {
     return delegate.copyWith(
       scrollbars: scrollbars ?? this.scrollbars,
@@ -350,6 +382,7 @@ class _WrappedScrollBehavior implements ScrollBehavior {
       physics: physics ?? this.physics,
       platform: platform ?? this.platform,
       keyboardDismissBehavior: keyboardDismissBehavior ?? this.keyboardDismissBehavior,
+      enableBrowserScrolling: enableBrowserScrolling ?? this.enableBrowserScrolling,
     );
   }
 
@@ -378,6 +411,7 @@ class _WrappedScrollBehavior implements ScrollBehavior {
         !setEquals<LogicalKeyboardKey>(oldDelegate.pointerAxisModifiers, pointerAxisModifiers) ||
         oldDelegate.physics != physics ||
         oldDelegate.platform != platform ||
+        oldDelegate._enableBrowserScrolling != _enableBrowserScrolling ||
         delegate.shouldNotify(oldDelegate.delegate);
   }
 

--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -984,3 +984,56 @@ class NeverScrollableScrollPhysics extends ScrollPhysics {
   @override
   bool get allowImplicitScrolling => false;
 }
+
+/// A [ScrollPhysics] that accepts user scroll gestures but converts all
+/// movement into overscroll, designed for use when the browser drives the
+/// outermost scroll on Flutter Web.
+///
+/// By accepting gestures, the outer scrollable participates in gesture
+/// disambiguation. On touch devices this is critical: if no scrollable
+/// accepted the vertical drag, the gesture would be lost. Once accepted,
+/// all deltas are returned as overscroll via [applyBoundaryConditions],
+/// which the framework catches and forwards to the browser via the
+/// `FlutterView.browserScrollBy` dart:ui API.
+///
+/// For desktop wheel events, the engine handles scroll chaining by
+/// selectively calling `preventDefault()` based on whether a nested
+/// scrollable consumed the event.
+///
+/// When [ScrollBehavior.enableBrowserScrolling] is true, [ScrollableState]
+/// automatically injects this physics for the outermost scrollable and uses
+/// the [FlutterView] browser scroll API to sync positions with the browser.
+/// Programmatic scrolling via [ScrollController.animateTo] and
+/// [ScrollController.jumpTo] is automatically routed through the browser
+/// when this physics is active.
+///
+/// Developers should not need to set this physics manually. Use
+/// [BrowserScrollable] to opt in to browser-driven scrolling.
+@experimental
+class BrowserScrollPhysics extends ScrollPhysics {
+  /// Creates scroll physics that delegates scrolling to the browser.
+  const BrowserScrollPhysics({super.parent});
+
+  @override
+  BrowserScrollPhysics applyTo(ScrollPhysics? ancestor) {
+    return BrowserScrollPhysics(parent: buildParent(ancestor));
+  }
+
+  @override
+  bool get allowImplicitScrolling => false;
+
+  @override
+  double applyPhysicsToUserOffset(ScrollMetrics position, double offset) {
+    return offset;
+  }
+
+  @override
+  double applyBoundaryConditions(ScrollMetrics position, double value) {
+    return value - position.pixels;
+  }
+
+  @override
+  Simulation? createBallisticSimulation(ScrollMetrics position, double velocity) {
+    return null;
+  }
+}

--- a/packages/flutter/lib/src/widgets/scroll_position_with_single_context.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position_with_single_context.dart
@@ -9,12 +9,14 @@
 /// @docImport 'viewport.dart';
 library;
 
+import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/physics.dart';
 import 'package:flutter/rendering.dart';
 
+import '_browser_scroll_view_io.dart' if (dart.library.js_interop) '_browser_scroll_view_web.dart';
 import 'basic.dart';
 import 'framework.dart';
 import 'scroll_activity.dart';
@@ -22,6 +24,7 @@ import 'scroll_context.dart';
 import 'scroll_notification.dart';
 import 'scroll_physics.dart';
 import 'scroll_position.dart';
+import 'scrollable.dart';
 
 /// A scroll position that manages scroll activities for a single
 /// [ScrollContext].
@@ -78,6 +81,32 @@ class ScrollPositionWithSingleContext extends ScrollPosition implements ScrollAc
   /// transfer to a next activity.
   double _heldPreviousVelocity = 0.0;
 
+  // Tracks the in-flight browser smooth scroll started by [animateTo]. The
+  // completer resolves when the browser reports (via forcePixels) that the
+  // scroll position has reached the requested target, or when superseded by
+  // a later [animateTo]/[jumpTo], or when the safety timeout fires.
+  Completer<void>? _pendingBrowserSmoothScrollCompleter;
+  double? _pendingBrowserSmoothScrollTarget;
+  // Absolute safety ceiling for the Future. Runs from animateTo start.
+  Timer? _pendingBrowserSmoothScrollTimer;
+  // Resets on every forcePixels tick; fires when the browser stops reporting
+  // updates, meaning the scroll has settled at a clamped or interrupted
+  // position without reaching the requested target.
+  Timer? _pendingBrowserSmoothScrollIdleTimer;
+
+  void _completePendingBrowserSmoothScroll() {
+    _pendingBrowserSmoothScrollTimer?.cancel();
+    _pendingBrowserSmoothScrollTimer = null;
+    _pendingBrowserSmoothScrollIdleTimer?.cancel();
+    _pendingBrowserSmoothScrollIdleTimer = null;
+    final Completer<void>? completer = _pendingBrowserSmoothScrollCompleter;
+    _pendingBrowserSmoothScrollCompleter = null;
+    _pendingBrowserSmoothScrollTarget = null;
+    if (completer != null && !completer.isCompleted) {
+      completer.complete();
+    }
+  }
+
   @override
   AxisDirection get axisDirection => context.axisDirection;
 
@@ -85,6 +114,27 @@ class ScrollPositionWithSingleContext extends ScrollPosition implements ScrollAc
   double setPixels(double newPixels) {
     assert(activity!.isScrolling);
     return super.setPixels(newPixels);
+  }
+
+  @override
+  void forcePixels(double value) {
+    super.forcePixels(value);
+    final double? target = _pendingBrowserSmoothScrollTarget;
+    if (target == null) {
+      return;
+    }
+    // Exact-hit: browser's smooth scroll reached the requested target.
+    if ((value - target).abs() < 1.0) {
+      _completePendingBrowserSmoothScroll();
+      return;
+    }
+    // Scroll is progressing but hasn't hit the target. Reset an idle timer
+    // that fires once the browser stops reporting new positions, meaning it
+    // settled at a clamped or interrupted offset.
+    _pendingBrowserSmoothScrollIdleTimer?.cancel();
+    _pendingBrowserSmoothScrollIdleTimer = Timer(const Duration(milliseconds: 100), () {
+      _completePendingBrowserSmoothScroll();
+    });
   }
 
   @override
@@ -128,7 +178,39 @@ class ScrollPositionWithSingleContext extends ScrollPosition implements ScrollAc
   @override
   void applyUserOffset(double delta) {
     updateUserScrollDirection(delta > 0.0 ? ScrollDirection.forward : ScrollDirection.reverse);
-    setPixels(pixels - physics.applyPhysicsToUserOffset(this, delta));
+
+    final BrowserScrollViewBinding? binding = ScrollableState.browserScrollViewBinding;
+    final double proposed = pixels - physics.applyPhysicsToUserOffset(this, delta);
+
+    if (binding != null) {
+      // When browser scrolling is active, clamp pixels at each boundary and
+      // forward the excess to the browser so the outer page scrolls.
+      //
+      // At maxScrollExtent (bottom): clamping prevents the inner list from
+      // rubber-band bouncing while the parent simultaneously scrolls
+      // (double-scroll artifact).
+      //
+      // At minScrollExtent (top): clamping keeps pixels at the boundary while
+      // didOverscrollBy dispatches an OverscrollNotification, which
+      // RefreshIndicator needs to reveal itself. This mirrors how
+      // RefreshIndicator works with ClampingScrollPhysics on Android — the
+      // indicator accumulates the overscroll amount from the notification, not
+      // from pixels going negative.
+      if (proposed > maxScrollExtent) {
+        final double excess = proposed - maxScrollExtent;
+        setPixels(maxScrollExtent);
+        binding.browserScrollBy(excess);
+      } else if (proposed < minScrollExtent) {
+        final double excess = proposed - minScrollExtent;
+        setPixels(minScrollExtent);
+        didOverscrollBy(excess);
+        binding.browserScrollBy(excess);
+      } else {
+        setPixels(proposed);
+      }
+    } else {
+      setPixels(proposed);
+    }
   }
 
   @override
@@ -175,6 +257,43 @@ class ScrollPositionWithSingleContext extends ScrollPosition implements ScrollAc
 
   @override
   Future<void> animateTo(double to, {required Duration duration, required Curve curve}) {
+    // When browser scrolling is active on the outermost scrollable, pixels
+    // never moves through normal Dart physics (BrowserScrollPhysics returns
+    // the entire delta as overscroll). Delegate to the browser's smooth scroll
+    // so the developer's controller.animateTo() call works transparently.
+    final BrowserScrollViewBinding? binding = ScrollableState.browserScrollViewBinding;
+    if (binding != null && physics is BrowserScrollPhysics) {
+      // A new animateTo supersedes any still-pending smooth scroll.
+      _completePendingBrowserSmoothScroll();
+
+      if (nearEqual(to, pixels, physics.toleranceFor(this).distance)) {
+        // Already at target; skip the browser animation entirely.
+        return Future<void>.value();
+      }
+
+      final completer = Completer<void>();
+      _pendingBrowserSmoothScrollCompleter = completer;
+      _pendingBrowserSmoothScrollTarget = to;
+
+      // Grow the browser's scroll placeholder if [to] is past the revealed
+      // content. Without this, the browser clamps the smooth scroll at the
+      // current scrollHeight and the animation settles short of the target.
+      ScrollableState.prepareActiveBrowserScrollForTarget(to);
+      binding.browserSmoothScrollTo(to);
+
+      // Absolute safety ceiling. The browser can clamp targets past
+      // scrollHeight or be interrupted by user input. Idle detection in
+      // forcePixels usually resolves first; this is the backstop when
+      // onBrowserScroll never fires at all.
+      _pendingBrowserSmoothScrollTimer = Timer(const Duration(seconds: 1), () {
+        if (_pendingBrowserSmoothScrollCompleter == completer) {
+          _completePendingBrowserSmoothScroll();
+        }
+      });
+
+      return completer.future;
+    }
+
     if (nearEqual(to, pixels, physics.toleranceFor(this).distance)) {
       // Skip the animation, go straight to the position as we are already close.
       jumpTo(to);
@@ -195,6 +314,17 @@ class ScrollPositionWithSingleContext extends ScrollPosition implements ScrollAc
 
   @override
   void jumpTo(double value) {
+    // When browser scrolling is active on the outermost scrollable, delegate
+    // to the browser's instant scroll so controller.jumpTo() works transparently.
+    final BrowserScrollViewBinding? binding = ScrollableState.browserScrollViewBinding;
+    if (binding != null && physics is BrowserScrollPhysics) {
+      // jumpTo supersedes any pending animateTo; complete its future.
+      _completePendingBrowserSmoothScroll();
+      ScrollableState.prepareActiveBrowserScrollForTarget(value);
+      binding.browserScrollTo(value);
+      return;
+    }
+
     goIdle();
     if (pixels != value) {
       final double oldPixels = pixels;
@@ -277,6 +407,7 @@ class ScrollPositionWithSingleContext extends ScrollPosition implements ScrollAc
 
   @override
   void dispose() {
+    _completePendingBrowserSmoothScroll();
     _currentDrag?.dispose();
     _currentDrag = null;
     super.dispose();

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -629,6 +629,14 @@ class ScrollableState extends State<Scrollable>
   /// scrolling is active.
   static BrowserScrollViewBinding? browserScrollViewBinding;
 
+  // Ticks each time the slot frees so scrollables that were rejected can
+  // retry. Common case: Navigator push keeps route A mounted while route B
+  // mounts; B is rejected because A owns the slot. When A is later popped
+  // and disposed, the tick lets B claim without needing an external trigger.
+  static final ValueNotifier<int> _slotVersion = ValueNotifier<int>(0);
+
+  VoidCallback? _pendingSlotClaim;
+
   /// Grows the browser scroll placeholder to at least [target] so a
   /// subsequent programmatic scroll is not clamped by the "revealed
   /// content" strategy.
@@ -657,8 +665,20 @@ class ScrollableState extends State<Scrollable>
       // scrollables that inherit enableBrowserScrolling from their ancestor
       // ScrollConfiguration are silently skipped.
       if (_activeBrowserScrollInstance != null && _activeBrowserScrollInstance != this) {
+        // Wait for the current owner to release the slot, then retry. Covers
+        // Navigator push where route A still owns the slot while route B
+        // mounts; when A disposes and bumps _slotVersion, B re-runs
+        // _setupBrowserScroll and claims.
+        final int rejectedAt = _slotVersion.value;
+        _pendingSlotClaim ??= () {
+          if (mounted && _slotVersion.value != rejectedAt) {
+            _setupBrowserScroll();
+          }
+        };
+        _slotVersion.addListener(_pendingSlotClaim!);
         return;
       }
+      _cancelPendingSlotClaim();
       _activeBrowserScrollInstance = this;
       browserScrollViewBinding = _viewBinding;
       _browserScrollActive = true;
@@ -669,6 +689,13 @@ class ScrollableState extends State<Scrollable>
       }
     } else if (!shouldBeActive && _browserScrollActive) {
       _teardownBrowserScroll();
+    }
+  }
+
+  void _cancelPendingSlotClaim() {
+    if (_pendingSlotClaim != null) {
+      _slotVersion.removeListener(_pendingSlotClaim!);
+      _pendingSlotClaim = null;
     }
   }
 
@@ -685,6 +712,7 @@ class ScrollableState extends State<Scrollable>
     if (_activeBrowserScrollInstance == this) {
       _activeBrowserScrollInstance = null;
       browserScrollViewBinding = null;
+      _slotVersion.value = _slotVersion.value + 1;
     }
     _maxReachedPixels = 0;
     _reachedBottom = false;
@@ -930,6 +958,7 @@ class ScrollableState extends State<Scrollable>
   @protected
   @override
   void dispose() {
+    _cancelPendingSlotClaim();
     _teardownBrowserScroll();
     if (widget.controller != null) {
       widget.controller!.detach(position);

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -23,6 +23,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 
+import '_browser_scroll_view_io.dart' if (dart.library.js_interop) '_browser_scroll_view_web.dart';
 import 'basic.dart';
 import 'framework.dart';
 import 'gesture_detector.dart';
@@ -613,11 +614,198 @@ class ScrollableState extends State<Scrollable>
   ScrollController? _fallbackScrollController;
   DeviceGestureSettings? _mediaQueryGestureSettings;
 
+  // BROWSER-DRIVEN SCROLLING
+
+  // Only one ScrollableState should own the browser-scroll view API at a time.
+  // The first instance to claim it wins; nested scrollables that inherit
+  // enableBrowserScrolling from an ancestor ScrollConfiguration are skipped.
+  static ScrollableState? _activeBrowserScrollInstance;
+
+  /// The [BrowserScrollViewBinding] used by the active browser-scroll owner.
+  ///
+  /// Used by [ScrollPositionWithSingleContext] to delegate
+  /// [ScrollController.animateTo] and [ScrollController.jumpTo] to the browser
+  /// when [BrowserScrollPhysics] is active. Only non-null while browser
+  /// scrolling is active.
+  static BrowserScrollViewBinding? browserScrollViewBinding;
+
+  /// Grows the browser scroll placeholder to at least [target] so a
+  /// subsequent programmatic scroll is not clamped by the "revealed
+  /// content" strategy.
+  ///
+  /// Called by [ScrollPositionWithSingleContext] before dispatching
+  /// `browserSmoothScrollTo` or `browserScrollTo` with a potentially
+  /// large target. No-op when no browser-scroll owner is active.
+  static void prepareActiveBrowserScrollForTarget(double target) {
+    _activeBrowserScrollInstance?._prepareBrowserScrollForTarget(target);
+  }
+
+  BrowserScrollViewBinding? _viewBinding;
+
+  bool _browserScrollEnabled = false;
+  bool _browserScrollActive = false;
+  bool _isBrowserDriving = false;
+  double _maxReachedPixels = 0;
+  bool _reachedBottom = false;
+  double _lastReportedHeight = 0;
+
+  void _setupBrowserScroll() {
+    final bool shouldBeActive = _configuration.enableBrowserScrolling;
+
+    if (shouldBeActive && !_browserScrollActive) {
+      // Only the first ScrollableState to claim the binding wins. Nested
+      // scrollables that inherit enableBrowserScrolling from their ancestor
+      // ScrollConfiguration are silently skipped.
+      if (_activeBrowserScrollInstance != null && _activeBrowserScrollInstance != this) {
+        return;
+      }
+      _activeBrowserScrollInstance = this;
+      browserScrollViewBinding = _viewBinding;
+      _browserScrollActive = true;
+      _viewBinding!.onBrowserScroll = _onBrowserScrollCallback;
+      _effectiveScrollController.addListener(_onBrowserScrollPositionChanged);
+      if (!_browserScrollEnabled) {
+        _enableBrowserScrolling();
+      }
+    } else if (!shouldBeActive && _browserScrollActive) {
+      _teardownBrowserScroll();
+    }
+  }
+
+  void _teardownBrowserScroll() {
+    if (!_browserScrollActive) {
+      return;
+    }
+    _effectiveScrollController.removeListener(_onBrowserScrollPositionChanged);
+    _viewBinding?.onBrowserScroll = null;
+    if (_browserScrollEnabled) {
+      _disableBrowserScrolling();
+    }
+    _browserScrollActive = false;
+    if (_activeBrowserScrollInstance == this) {
+      _activeBrowserScrollInstance = null;
+      browserScrollViewBinding = null;
+    }
+    _maxReachedPixels = 0;
+    _reachedBottom = false;
+    _lastReportedHeight = 0;
+  }
+
+  void _enableBrowserScrolling() {
+    _viewBinding!.enableBrowserScrolling();
+    _browserScrollEnabled = true;
+
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      _reportBrowserContentExtent();
+    });
+  }
+
+  void _disableBrowserScrolling() {
+    _browserScrollEnabled = false;
+    _viewBinding!.disableBrowserScrolling();
+  }
+
+  void _onBrowserScrollCallback(double offset) {
+    _syncScrollFromBrowser(offset);
+  }
+
+  void _syncScrollFromBrowser(double scrollTop) {
+    if (!_effectiveScrollController.hasClients) {
+      return;
+    }
+
+    final ScrollPosition pos = _effectiveScrollController.position;
+    final double clampedOffset = clampDouble(scrollTop, pos.minScrollExtent, pos.maxScrollExtent);
+
+    if ((pos.pixels - clampedOffset).abs() > 0.5) {
+      _isBrowserDriving = true;
+      // Use forcePixels instead of jumpTo to avoid cancelling any active
+      // drag activity. jumpTo calls goIdle+goBallistic which would kill
+      // the drag gesture and stop further scroll updates.
+      // ignore: invalid_use_of_protected_member
+      pos.forcePixels(clampedOffset);
+      _isBrowserDriving = false;
+    }
+  }
+
+  void _onBrowserScrollPositionChanged() {
+    if (!_effectiveScrollController.hasClients || !_browserScrollEnabled) {
+      return;
+    }
+
+    final ScrollPosition pos = _effectiveScrollController.position;
+
+    // When the browser drives scrolling, it sends onScroll which calls
+    // forcePixels. We must not echo that back as a scrollTo or we'd create
+    // a feedback loop. Only sync the DOM scrollTop when Flutter is driving
+    // the scroll, e.g. programmatic jumpTo or ensureVisible.
+    if (!_isBrowserDriving) {
+      _viewBinding?.browserScrollTo(pos.pixels);
+    }
+
+    _reportBrowserContentExtent();
+  }
+
+  void _prepareBrowserScrollForTarget(double target) {
+    if (!_browserScrollActive || !_effectiveScrollController.hasClients) {
+      return;
+    }
+    final ScrollPosition pos = _effectiveScrollController.position;
+    // Clamp against Flutter's estimated maxScrollExtent. Never grow the
+    // placeholder past content that Flutter can actually paint.
+    final double clamped = math.min(target, pos.maxScrollExtent);
+    if (clamped > _maxReachedPixels) {
+      _maxReachedPixels = clamped;
+      _reportBrowserContentExtent();
+    }
+  }
+
+  void _reportBrowserContentExtent() {
+    if (!_effectiveScrollController.hasClients || !_browserScrollEnabled) {
+      return;
+    }
+
+    final ScrollPosition pos = _effectiveScrollController.position;
+
+    if (pos.pixels > _maxReachedPixels) {
+      _maxReachedPixels = pos.pixels;
+    }
+
+    if (pos.pixels >= pos.maxScrollExtent - 1.0) {
+      _reachedBottom = true;
+    }
+
+    // The placeholder height is based on the furthest point the user has
+    // scrolled to, plus a lookahead buffer so there's always room to scroll
+    // forward without hitting the placeholder bottom prematurely. Once the
+    // user has reached the actual content bottom, the lookahead drops to
+    // zero permanently because we know the true content size at that point.
+    final double lookahead;
+    if (_reachedBottom) {
+      lookahead = 0;
+    } else {
+      final double remainingContent = pos.maxScrollExtent - _maxReachedPixels;
+      lookahead = clampDouble(remainingContent, 0, pos.viewportDimension);
+    }
+    final double totalHeight = _maxReachedPixels + pos.viewportDimension + lookahead;
+
+    if ((totalHeight - _lastReportedHeight).abs() < 1.0) {
+      return;
+    }
+
+    _lastReportedHeight = totalHeight;
+    _viewBinding?.updateBrowserScrollContentHeight(totalHeight);
+  }
+
   // Only call this from places that will definitely trigger a rebuild.
   void _updatePosition() {
     _configuration = widget.scrollBehavior ?? ScrollConfiguration.of(context);
-    final ScrollPhysics? physicsFromWidget =
+    ScrollPhysics? physicsFromWidget =
         widget.physics ?? widget.scrollBehavior?.getScrollPhysics(context);
+    if (_configuration.enableBrowserScrolling &&
+        (_activeBrowserScrollInstance == null || _activeBrowserScrollInstance == this)) {
+      physicsFromWidget = const BrowserScrollPhysics().applyTo(physicsFromWidget);
+    }
     _physics = _configuration.getScrollPhysics(context);
     _physics = physicsFromWidget?.applyTo(_physics) ?? _physics;
 
@@ -668,9 +856,13 @@ class ScrollableState extends State<Scrollable>
   @override
   void didChangeDependencies() {
     _mediaQueryGestureSettings = MediaQuery.maybeGestureSettingsOf(context);
-    _devicePixelRatio =
-        MediaQuery.maybeDevicePixelRatioOf(context) ?? View.of(context).devicePixelRatio;
+    final FlutterView flutterView = View.of(context);
+    if (_viewBinding?.view != flutterView) {
+      _viewBinding = BrowserScrollViewBinding(flutterView);
+    }
+    _devicePixelRatio = MediaQuery.maybeDevicePixelRatioOf(context) ?? flutterView.devicePixelRatio;
     _updatePosition();
+    _setupBrowserScroll();
     super.didChangeDependencies();
   }
 
@@ -702,7 +894,9 @@ class ScrollableState extends State<Scrollable>
   void didUpdateWidget(Scrollable oldWidget) {
     super.didUpdateWidget(oldWidget);
 
-    if (widget.controller != oldWidget.controller) {
+    final controllerChanged = widget.controller != oldWidget.controller;
+    if (controllerChanged) {
+      _teardownBrowserScroll();
       if (oldWidget.controller == null) {
         // The old controller was null, meaning the fallback cannot be null.
         // Dispose of the fallback.
@@ -727,11 +921,16 @@ class ScrollableState extends State<Scrollable>
     if (_shouldUpdatePosition(oldWidget)) {
       _updatePosition();
     }
+
+    if (controllerChanged || widget.physics != oldWidget.physics) {
+      _setupBrowserScroll();
+    }
   }
 
   @protected
   @override
   void dispose() {
+    _teardownBrowserScroll();
     if (widget.controller != null) {
       widget.controller!.detach(position);
     } else {

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -34,6 +34,7 @@ export 'src/widgets/banner.dart';
 export 'src/widgets/basic.dart';
 export 'src/widgets/binding.dart';
 export 'src/widgets/bottom_navigation_bar_item.dart';
+export 'src/widgets/browser_scroll.dart';
 export 'src/widgets/color_filter.dart';
 export 'src/widgets/container.dart';
 export 'src/widgets/context_menu_button_item.dart';

--- a/packages/flutter/test/widgets/browser_scroll_test.dart
+++ b/packages/flutter/test/widgets/browser_scroll_test.dart
@@ -1016,4 +1016,96 @@ void main() {
       expect(innerPos.pixels, closeTo(100.0, 1.0));
     });
   });
+
+  group('ScrollableState browser-scroll – slot reclamation', () {
+    testWidgets('second BrowserScrollable reclaims the slot when the first is disposed', (
+      tester,
+    ) async {
+      // Two BrowserScrollables mounted simultaneously simulates the overlap
+      // during a Navigator push: route A still mounted while route B mounts.
+      // Only one owns the slot at a time; this test verifies the rejected
+      // scrollable reclaims when the owner disposes.
+      final firstController = ScrollController();
+      addTearDown(firstController.dispose);
+      final secondController = ScrollController();
+      addTearDown(secondController.dispose);
+
+      Widget buildStack({required bool includeFirst}) {
+        return Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: Stack(
+              children: <Widget>[
+                if (includeFirst)
+                  SizedBox(
+                    height: 600,
+                    child: BrowserScrollable(
+                      child: ListView.builder(
+                        controller: firstController,
+                        itemCount: 20,
+                        itemBuilder: (context, index) =>
+                            SizedBox(height: 200.0, child: Text('A $index')),
+                      ),
+                    ),
+                  ),
+                SizedBox(
+                  height: 600,
+                  child: BrowserScrollable(
+                    child: ListView.builder(
+                      controller: secondController,
+                      itemCount: 20,
+                      itemBuilder: (context, index) =>
+                          SizedBox(height: 200.0, child: Text('B $index')),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(buildStack(includeFirst: true));
+      await tester.pump();
+
+      // Before the first is disposed, the binding belongs to the first
+      // scrollable. Drive it via its controller and see the browser path fire.
+      _clearCalls();
+      firstController.jumpTo(150);
+      await tester.pump();
+      expect(
+        _callsOf('browserScrollTo'),
+        isNotEmpty,
+        reason: 'First scrollable owns the slot and should delegate to the browser',
+      );
+
+      // Second scrollable is rejected: driving it does NOT hit the browser
+      // path because it never claimed the binding.
+      _clearCalls();
+      secondController.jumpTo(150);
+      await tester.pump();
+      expect(
+        _callsOf('browserScrollTo'),
+        isEmpty,
+        reason: 'Second scrollable was rejected and must not drive the shared binding',
+      );
+
+      // Dispose the first scrollable. The second should reclaim.
+      await tester.pumpWidget(buildStack(includeFirst: false));
+      await tester.pump();
+
+      _clearCalls();
+      secondController.jumpTo(200);
+      await tester.pump();
+      expect(
+        _callsOf('browserScrollTo'),
+        isNotEmpty,
+        reason:
+            'After the first scrollable disposes, the second must reclaim '
+            'the slot and delegate to the browser. Otherwise Navigator '
+            'push leaves the top route stuck on Dart-driven physics.',
+      );
+    });
+  });
 }

--- a/packages/flutter/test/widgets/browser_scroll_test.dart
+++ b/packages/flutter/test/widgets/browser_scroll_test.dart
@@ -1,0 +1,1019 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// The test harness uses `BrowserScrollViewBinding.calls`, which only exists in
+// the IO stub (`_browser_scroll_view_io.dart`). On web the binding delegates
+// to the real engine via `FlutterView` method calls and has no recorded calls
+// list. Skip the file on web.
+@TestOn('!chrome')
+library;
+
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Widget _buildTestApp(ScrollController controller) {
+  return Directionality(
+    textDirection: TextDirection.ltr,
+    child: MediaQuery(
+      data: const MediaQueryData(),
+      child: BrowserScrollable(
+        child: ListView.builder(
+          controller: controller,
+          itemCount: 20,
+          itemBuilder: (context, index) => SizedBox(height: 200.0, child: Text('Item $index')),
+        ),
+      ),
+    ),
+  );
+}
+
+Widget _buildTestAppNoPrimaryNoController() {
+  return Directionality(
+    textDirection: TextDirection.ltr,
+    child: MediaQuery(
+      data: const MediaQueryData(),
+      child: BrowserScrollable(
+        child: ListView.builder(
+          primary: false,
+          itemCount: 20,
+          itemBuilder: (context, index) => SizedBox(height: 200.0, child: Text('Item $index')),
+        ),
+      ),
+    ),
+  );
+}
+
+void _simulateOnScroll(double offset) {
+  ScrollableState.browserScrollViewBinding?.onBrowserScroll?.call(offset);
+}
+
+List<Map<String, Object?>> _bindingCalls() {
+  return ScrollableState.browserScrollViewBinding?.calls ?? <Map<String, Object?>>[];
+}
+
+List<Map<String, Object?>> _callsOf(String method) {
+  return _bindingCalls().where((c) => c['method'] == method).toList();
+}
+
+void _clearCalls() {
+  ScrollableState.browserScrollViewBinding?.calls.clear();
+}
+
+void main() {
+  group('ScrollableState browser-scroll integration – placeholder height', () {
+    late ScrollController controller;
+
+    setUp(() {
+      controller = ScrollController();
+    });
+
+    tearDown(() {
+      controller.dispose();
+    });
+
+    testWidgets('reports initial height via binding', (tester) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      _simulateOnScroll(0);
+      await tester.pump();
+
+      if (controller.hasClients) {
+        expect(controller.position.pixels, closeTo(0.0, 1.0));
+      }
+    });
+
+    testWidgets('reports content height to engine', (tester) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      _simulateOnScroll(0);
+      await tester.pump();
+
+      final List<Map<String, Object?>> heights = _callsOf('updateBrowserScrollContentHeight');
+      expect(heights, isNotEmpty);
+
+      final double viewport = tester.getSize(find.byType(ListView)).height;
+      final lastHeight = heights.last['args']! as double;
+      expect(lastHeight, closeTo(viewport * 2, 2.0));
+    });
+
+    testWidgets('content height grows as user scrolls down', (tester) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      _simulateOnScroll(500);
+      await tester.pump();
+
+      _simulateOnScroll(1000);
+      await tester.pump();
+
+      final List<double> heights = _callsOf(
+        'updateBrowserScrollContentHeight',
+      ).map((c) => c['args']! as double).toList();
+      if (heights.length >= 2) {
+        expect(heights.last, greaterThanOrEqualTo(heights.first));
+      }
+    });
+
+    testWidgets('duplicate heights within tolerance are not re-reported', (tester) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      _simulateOnScroll(100);
+      await tester.pump();
+
+      final int countAfterFirst = _callsOf('updateBrowserScrollContentHeight').length;
+
+      _simulateOnScroll(100);
+      await tester.pump();
+
+      expect(_callsOf('updateBrowserScrollContentHeight').length, countAfterFirst);
+    });
+
+    testWidgets('onScroll syncs Flutter position to browser scrollTop', (tester) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      _simulateOnScroll(300);
+      await tester.pump();
+
+      if (controller.hasClients) {
+        final ScrollPosition pos = controller.position;
+        expect(pos.pixels, closeTo(300.0, 1.0));
+      }
+    });
+
+    testWidgets('onScroll clamps to maxScrollExtent', (tester) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      _simulateOnScroll(999999);
+      await tester.pump();
+
+      if (controller.hasClients) {
+        final ScrollPosition pos = controller.position;
+        expect(pos.pixels, lessThanOrEqualTo(pos.maxScrollExtent + 1.0));
+      }
+    });
+
+    testWidgets('mounts and unmounts cleanly', (tester) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      await tester.pumpWidget(const SizedBox.shrink());
+    });
+
+    testWidgets('dispose triggers disableBrowserScrolling and clears binding', (tester) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      expect(ScrollableState.browserScrollViewBinding, isNotNull);
+
+      // Capture the binding before it is cleared on teardown, so we can inspect
+      // its call log after the widget is disposed.
+      // ignore: specify_nonobvious_local_variable_types
+      final binding = ScrollableState.browserScrollViewBinding!;
+      binding.calls.clear();
+
+      // Replace the widget tree with something that has no BrowserScrollable.
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+
+      // The static binding must be cleared on teardown.
+      expect(ScrollableState.browserScrollViewBinding, isNull);
+
+      // disableBrowserScrolling must have been recorded by the captured binding.
+      expect(
+        binding.calls.where((Map<String, Object?> c) => c['method'] == 'disableBrowserScrolling'),
+        isNotEmpty,
+      );
+    });
+
+    testWidgets('controller swap re-registers callback', (tester) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      final controller2 = ScrollController();
+      addTearDown(controller2.dispose);
+
+      await tester.pumpWidget(_buildTestApp(controller2));
+      await tester.pump();
+
+      _simulateOnScroll(100);
+      await tester.pump();
+
+      if (controller2.hasClients) {
+        expect(controller2.position.pixels, closeTo(100.0, 1.0));
+      }
+    });
+
+    testWidgets('disabling enableBrowserScrolling tears down callback', (tester) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      _simulateOnScroll(200);
+      await tester.pump();
+
+      expect(controller.position.pixels, closeTo(200.0, 1.0));
+
+      // Rebuild with enableBrowserScrolling: false.
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: ScrollConfiguration(
+              behavior: const ScrollBehavior().copyWith(enableBrowserScrolling: false),
+              child: ListView.builder(
+                controller: controller,
+                itemCount: 20,
+                itemBuilder: (context, index) =>
+                    SizedBox(height: 200.0, child: Text('Item $index')),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // The callback should be null now, so simulateOnScroll should do nothing.
+      final double pixelsBefore = controller.position.pixels;
+      _simulateOnScroll(0);
+      await tester.pump();
+      expect(controller.position.pixels, pixelsBefore);
+    });
+  });
+
+  group('ScrollableState browser-scroll – primary:false fallback controller', () {
+    testWidgets('works with primary:false and no explicit controller', (tester) async {
+      await tester.pumpWidget(_buildTestAppNoPrimaryNoController());
+      await tester.pump();
+
+      _simulateOnScroll(400);
+      await tester.pump();
+
+      final Finder listFinder = find.byType(ListView);
+      final ScrollableState scrollable = tester.state(
+        find.descendant(of: listFinder, matching: find.byType(Scrollable)),
+      );
+      expect(scrollable.position.pixels, closeTo(400.0, 1.0));
+    });
+  });
+
+  group('BrowserScrollable – OverscrollNotification edge passthrough', () {
+    late ScrollController controller;
+
+    setUp(() {
+      controller = ScrollController();
+    });
+
+    tearDown(() {
+      controller.dispose();
+    });
+
+    testWidgets('consumes OverscrollNotification when not at edge', (tester) async {
+      final leaked = <OverscrollNotification>[];
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: NotificationListener<OverscrollNotification>(
+              onNotification: (OverscrollNotification n) {
+                leaked.add(n);
+                return false;
+              },
+              child: BrowserScrollable(
+                child: ListView.builder(
+                  controller: controller,
+                  itemCount: 20,
+                  itemBuilder: (context, index) =>
+                      SizedBox(height: 200.0, child: Text('Item $index')),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      _simulateOnScroll(500);
+      await tester.pump();
+
+      leaked.clear();
+      _clearCalls();
+
+      final ScrollPosition pos = controller.position;
+      OverscrollNotification(
+        overscroll: 50.0,
+        metrics: pos.copyWith(),
+        context: tester.element(find.byType(ListView)),
+      ).dispatch(tester.element(find.byType(ListView)));
+      await tester.pump();
+
+      expect(leaked, isEmpty);
+      expect(_callsOf('browserScrollBy'), isNotEmpty);
+    });
+
+    testWidgets('lets OverscrollNotification bubble at top edge', (tester) async {
+      final leaked = <OverscrollNotification>[];
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: NotificationListener<OverscrollNotification>(
+              onNotification: (OverscrollNotification n) {
+                leaked.add(n);
+                return false;
+              },
+              child: BrowserScrollable(
+                child: ListView.builder(
+                  controller: controller,
+                  itemCount: 20,
+                  itemBuilder: (context, index) =>
+                      SizedBox(height: 200.0, child: Text('Item $index')),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      _simulateOnScroll(0);
+      await tester.pump();
+
+      leaked.clear();
+      _clearCalls();
+
+      final ScrollPosition pos = controller.position;
+      OverscrollNotification(
+        overscroll: -30.0,
+        metrics: pos.copyWith(),
+        context: tester.element(find.byType(ListView)),
+      ).dispatch(tester.element(find.byType(ListView)));
+      await tester.pump();
+
+      expect(leaked, hasLength(1));
+      expect(leaked.first.overscroll, -30.0);
+      expect(_callsOf('browserScrollBy'), isEmpty);
+    });
+
+    testWidgets('lets OverscrollNotification bubble at bottom edge', (tester) async {
+      final leaked = <OverscrollNotification>[];
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: NotificationListener<OverscrollNotification>(
+              onNotification: (OverscrollNotification n) {
+                leaked.add(n);
+                return false;
+              },
+              child: BrowserScrollable(
+                child: ListView.builder(
+                  controller: controller,
+                  itemCount: 20,
+                  itemBuilder: (context, index) =>
+                      SizedBox(height: 200.0, child: Text('Item $index')),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final double maxExtent = controller.position.maxScrollExtent;
+      _simulateOnScroll(maxExtent);
+      await tester.pump();
+
+      leaked.clear();
+      _clearCalls();
+
+      final ScrollPosition pos = controller.position;
+      OverscrollNotification(
+        overscroll: 40.0,
+        metrics: pos.copyWith(),
+        context: tester.element(find.byType(ListView)),
+      ).dispatch(tester.element(find.byType(ListView)));
+      await tester.pump();
+
+      expect(leaked, hasLength(1));
+      expect(leaked.first.overscroll, 40.0);
+      expect(_callsOf('browserScrollBy'), isEmpty);
+    });
+
+    testWidgets('forwards overscroll just inside the bottom edge', (tester) async {
+      // Regression: the edge-guard uses `>=`, so a fractional gap below the
+      // maxScrollExtent must NOT count as "at edge". An overscroll with
+      // pixels = maxExtent - 0.01 and positive delta should forward to the
+      // browser rather than bubble for RefreshIndicator-style handlers.
+      // A tight 0.01 gap also catches refactors that fuzz the edge check
+      // with an epsilon larger than 0.01.
+      final leaked = <OverscrollNotification>[];
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: NotificationListener<OverscrollNotification>(
+              onNotification: (OverscrollNotification n) {
+                leaked.add(n);
+                return false;
+              },
+              child: BrowserScrollable(
+                child: ListView.builder(
+                  controller: controller,
+                  itemCount: 20,
+                  itemBuilder: (context, index) =>
+                      SizedBox(height: 200.0, child: Text('Item $index')),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final double maxExtent = controller.position.maxScrollExtent;
+      _simulateOnScroll(maxExtent - 0.01);
+      await tester.pump();
+
+      leaked.clear();
+      _clearCalls();
+
+      final ScrollPosition pos = controller.position;
+      OverscrollNotification(
+        overscroll: 40.0,
+        metrics: pos.copyWith(pixels: maxExtent - 0.01),
+        context: tester.element(find.byType(ListView)),
+      ).dispatch(tester.element(find.byType(ListView)));
+      await tester.pump();
+
+      // Not at the exact edge, so BrowserScrollable should forward.
+      expect(leaked, isEmpty);
+      expect(_callsOf('browserScrollBy'), isNotEmpty);
+    });
+  });
+
+  group('ScrollableState browser-scroll – programmatic scrolling', () {
+    late ScrollController controller;
+
+    setUp(() {
+      controller = ScrollController();
+    });
+
+    tearDown(() {
+      controller.dispose();
+    });
+
+    testWidgets('jumpTo delegates to browser and does not move pixels directly', (tester) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      _clearCalls();
+
+      controller.jumpTo(500);
+      await tester.pump();
+
+      // pixels stays at 0 until the browser fires onBrowserScroll back
+      expect(controller.position.pixels, closeTo(0.0, 1.0));
+
+      final List<Map<String, Object?>> scrollToCalls = _callsOf('browserScrollTo');
+      expect(scrollToCalls, isNotEmpty);
+      expect(scrollToCalls.last['args']! as double, closeTo(500.0, 1.0));
+
+      // simulate the browser responding, which syncs pixels
+      _simulateOnScroll(500);
+      await tester.pump();
+      expect(controller.position.pixels, closeTo(500.0, 1.0));
+    });
+
+    testWidgets('jumpTo delegates to browser and does not move pixels directly – via controller', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      _clearCalls();
+
+      // jumpTo on the outermost BrowserScrollPhysics scrollable must delegate
+      // to the browser rather than moving pixels in Dart directly.
+      controller.jumpTo(300);
+      await tester.pump();
+
+      // pixels does not change until the browser fires onBrowserScroll back.
+      expect(controller.position.pixels, closeTo(0.0, 1.0));
+
+      final List<Map<String, Object?>> scrollToCalls = _callsOf('browserScrollTo');
+      expect(scrollToCalls, isNotEmpty);
+      expect(scrollToCalls.last['args']! as double, closeTo(300.0, 1.0));
+
+      // simulate the browser responding, which syncs pixels
+      _simulateOnScroll(300);
+      await tester.pump();
+      expect(controller.position.pixels, closeTo(300.0, 1.0));
+    });
+
+    testWidgets('animateTo delegates to browser smooth scroll', (tester) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      _clearCalls();
+
+      controller.animateTo(400, duration: const Duration(milliseconds: 200), curve: Curves.easeOut);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.pump(const Duration(milliseconds: 150));
+
+      // pixels stays at 0 until the browser fires onBrowserScroll back
+      expect(controller.position.pixels, closeTo(0.0, 1.0));
+
+      final List<Map<String, Object?>> smoothCalls = _callsOf('browserSmoothScrollTo');
+      expect(smoothCalls, isNotEmpty);
+      expect(smoothCalls.last['args']! as double, closeTo(400.0, 1.0));
+    });
+
+    testWidgets('animateTo Future resolves when browser reaches target', (tester) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      _clearCalls();
+
+      var completed = false;
+      final Future<void> done = controller
+          .animateTo(400, duration: const Duration(milliseconds: 200), curve: Curves.easeOut)
+          .whenComplete(() => completed = true);
+
+      await tester.pump();
+      // Before the browser reports back, the Future must NOT be complete. It
+      // is important that `await animateTo(...)` reflects scroll settle, not
+      // the dispatch of the scroll command.
+      expect(completed, isFalse);
+      expect(controller.position.pixels, closeTo(0.0, 1.0));
+
+      // Simulate the browser's smooth-scroll settling at the target.
+      _simulateOnScroll(400);
+      await tester.pump();
+      await done;
+
+      expect(completed, isTrue);
+      expect(controller.position.pixels, closeTo(400.0, 1.0));
+    });
+
+    testWidgets('animateTo Future resolves when jumpTo supersedes it', (tester) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      _clearCalls();
+
+      var animateCompleted = false;
+      final Future<void> done = controller
+          .animateTo(1000, duration: const Duration(milliseconds: 300), curve: Curves.easeOut)
+          .whenComplete(() => animateCompleted = true);
+
+      await tester.pump();
+      expect(animateCompleted, isFalse);
+
+      // A jumpTo before the browser settles must supersede the pending
+      // animation and complete its Future.
+      controller.jumpTo(200);
+      await tester.pump();
+      await done;
+
+      expect(animateCompleted, isTrue);
+    });
+
+    testWidgets('animateTo Future resolves when a later animateTo supersedes it', (tester) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      _clearCalls();
+
+      var firstCompleted = false;
+      final Future<void> firstDone = controller
+          .animateTo(1000, duration: const Duration(milliseconds: 300), curve: Curves.easeOut)
+          .whenComplete(() => firstCompleted = true);
+
+      await tester.pump();
+      expect(firstCompleted, isFalse);
+
+      // A second animateTo replaces the first; the first Future must resolve
+      // so awaiting code doesn't hang.
+      controller.animateTo(600, duration: const Duration(milliseconds: 300), curve: Curves.easeOut);
+      await tester.pump();
+      await firstDone;
+
+      expect(firstCompleted, isTrue);
+    });
+
+    testWidgets('animateTo to current pixels resolves immediately', (tester) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      // Sync pixels to a known value.
+      _simulateOnScroll(150);
+      await tester.pump();
+      expect(controller.position.pixels, closeTo(150.0, 1.0));
+
+      _clearCalls();
+
+      // Asking to animate to where we already are should return a resolved
+      // future without dispatching a smooth scroll.
+      await controller.animateTo(
+        150,
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeOut,
+      );
+
+      expect(_callsOf('browserSmoothScrollTo'), isEmpty);
+    });
+
+    testWidgets('animateTo grows the placeholder to cover the target', (tester) async {
+      // A long ListView so maxScrollExtent far exceeds the initial placeholder
+      // height (which is 2 viewports before any scrolling has happened).
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: BrowserScrollable(
+              child: ListView.builder(
+                controller: controller,
+                itemCount: 100,
+                itemBuilder: (context, index) =>
+                    SizedBox(height: 200.0, child: Text('Item $index')),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final double viewport = controller.position.viewportDimension;
+      final double maxExtent = controller.position.maxScrollExtent;
+      final double target = maxExtent * 0.9; // well past the initial placeholder
+
+      _clearCalls();
+
+      controller.animateTo(
+        target,
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeOut,
+      );
+      await tester.pump();
+
+      // The framework must have bumped the reported content height to cover
+      // the target before dispatching browserSmoothScrollTo, otherwise the
+      // browser would clamp the smooth scroll short.
+      final List<double> heights = _callsOf(
+        'updateBrowserScrollContentHeight',
+      ).map((c) => c['args']! as double).toList();
+      expect(heights, isNotEmpty);
+      expect(heights.last, greaterThanOrEqualTo(target + viewport - 1.0));
+
+      final List<Map<String, Object?>> smoothCalls = _callsOf('browserSmoothScrollTo');
+      expect(smoothCalls, isNotEmpty);
+      expect(smoothCalls.last['args']! as double, closeTo(target, 1.0));
+    });
+
+    testWidgets('animateTo past maxScrollExtent clamps placeholder growth', (tester) async {
+      await tester.pumpWidget(_buildTestApp(controller));
+      await tester.pump();
+
+      final double viewport = controller.position.viewportDimension;
+      final double maxExtent = controller.position.maxScrollExtent;
+
+      _clearCalls();
+
+      // Ask to go far past the real content end.
+      controller.animateTo(
+        maxExtent * 10,
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeOut,
+      );
+      await tester.pump();
+
+      final List<double> heights = _callsOf(
+        'updateBrowserScrollContentHeight',
+      ).map((c) => c['args']! as double).toList();
+      if (heights.isNotEmpty) {
+        // Placeholder never grows past maxScrollExtent + viewport; we must
+        // not promise more scroll area than Flutter can paint.
+        expect(heights.last, lessThanOrEqualTo(maxExtent + viewport + 1.0));
+      }
+    });
+
+    testWidgets('jumpTo grows the placeholder to cover the target', (tester) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: BrowserScrollable(
+              child: ListView.builder(
+                controller: controller,
+                itemCount: 100,
+                itemBuilder: (context, index) =>
+                    SizedBox(height: 200.0, child: Text('Item $index')),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final double viewport = controller.position.viewportDimension;
+      final double maxExtent = controller.position.maxScrollExtent;
+      final double target = maxExtent * 0.9;
+
+      _clearCalls();
+
+      controller.jumpTo(target);
+      await tester.pump();
+
+      final List<double> heights = _callsOf(
+        'updateBrowserScrollContentHeight',
+      ).map((c) => c['args']! as double).toList();
+      expect(heights, isNotEmpty);
+      expect(heights.last, greaterThanOrEqualTo(target + viewport - 1.0));
+    });
+
+    testWidgets('ensureVisible triggers scroll', (tester) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: BrowserScrollable(
+              child: ListView.builder(
+                controller: controller,
+                itemCount: 50,
+                itemBuilder: (context, index) => SizedBox(
+                  height: 200.0,
+                  key: index == 40 ? const Key('target') : null,
+                  child: Text('Item $index'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      _simulateOnScroll(2000);
+      await tester.pump();
+
+      _clearCalls();
+
+      final Finder target = find.byKey(const Key('target'));
+      if (target.evaluate().isNotEmpty) {
+        await Scrollable.ensureVisible(target.evaluate().first);
+        await tester.pump();
+
+        expect(controller.position.pixels, greaterThan(0));
+        expect(_callsOf('browserScrollTo'), isNotEmpty);
+      }
+    });
+
+    testWidgets('focus traversal triggers scroll for offscreen widget', (tester) async {
+      final List<FocusNode> focusNodes = List.generate(30, (_) => FocusNode());
+      addTearDown(() {
+        for (final node in focusNodes) {
+          node.dispose();
+        }
+      });
+
+      await tester.pumpWidget(
+        WidgetsApp(
+          color: const Color(0xFF000000),
+          builder: (context, child) => BrowserScrollable(
+            child: ListView.builder(
+              controller: controller,
+              itemCount: 30,
+              itemBuilder: (context, index) => Focus(
+                focusNode: focusNodes[index],
+                child: SizedBox(height: 200.0, child: Text('Button $index')),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      focusNodes[0].requestFocus();
+      await tester.pump();
+
+      _clearCalls();
+
+      for (var i = 0; i < 10; i++) {
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+      }
+
+      // Focus traversal delegates programmatic scroll to the browser via jumpTo.
+      // pixels stays at 0 until onBrowserScroll fires; the browser call is the
+      // observable effect.
+      expect(
+        _callsOf('browserScrollTo'),
+        isNotEmpty,
+        reason: 'Focus traversal to offscreen widget should send browserScrollTo to engine',
+      );
+    });
+  });
+
+  group('ScrollableState browser-scroll – nested scrollable isolation', () {
+    late ScrollController outerController;
+
+    setUp(() {
+      outerController = ScrollController();
+    });
+
+    tearDown(() {
+      outerController.dispose();
+    });
+
+    testWidgets('only the outermost scrollable owns the binding', (tester) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: BrowserScrollable(
+              child: ListView(
+                controller: outerController,
+                children: [
+                  const SizedBox(height: 100),
+                  SizedBox(
+                    height: 300,
+                    child: ListView.builder(
+                      itemCount: 50,
+                      itemBuilder: (context, index) =>
+                          SizedBox(height: 40, child: Text('Inner $index')),
+                    ),
+                  ),
+                  const SizedBox(height: 1000),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      _clearCalls();
+
+      outerController.jumpTo(200);
+      await tester.pump();
+
+      // jumpTo on the outermost scrollable delegates to the browser and does
+      // not move pixels directly; pixels updates when onBrowserScroll fires.
+      final List<Map<String, Object?>> scrollToCalls = _callsOf('browserScrollTo');
+      expect(scrollToCalls, isNotEmpty);
+      expect(scrollToCalls.last['args']! as double, closeTo(200.0, 1.0));
+
+      _simulateOnScroll(200);
+      await tester.pump();
+      expect(outerController.position.pixels, closeTo(200.0, 1.0));
+    });
+
+    testWidgets('inner scrollable at boundary forwards delta to engine via browserScrollBy', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: BrowserScrollable(
+              child: ListView(
+                controller: outerController,
+                children: [
+                  const SizedBox(height: 100),
+                  SizedBox(
+                    height: 300,
+                    child: ListView.builder(
+                      itemCount: 50,
+                      itemBuilder: (context, index) =>
+                          SizedBox(height: 40, child: Text('Inner $index')),
+                    ),
+                  ),
+                  const SizedBox(height: 1000),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final Finder innerListFinder = find.byType(Scrollable).at(1);
+      final ScrollableState innerScrollable = tester.state(innerListFinder);
+      final ScrollPosition innerPos = innerScrollable.position;
+
+      // Scroll the inner list to its bottom boundary.
+      innerPos.jumpTo(innerPos.maxScrollExtent);
+      await tester.pump();
+
+      _clearCalls();
+
+      // Drag the inner list past its bottom boundary.
+      // applyUserOffset detects wasAtMax and calls browserScrollBy.
+      await tester.drag(find.byType(Scrollable).at(1), const Offset(0, -60));
+      await tester.pump();
+
+      final List<Map<String, Object?>> scrollByCalls = _callsOf('browserScrollBy');
+      expect(
+        scrollByCalls,
+        isNotEmpty,
+        reason: 'Inner scrollable at bottom boundary should forward delta to engine',
+      );
+    });
+
+    testWidgets('scrollable without BrowserScrollable binding scrolls normally in Dart', (
+      tester,
+    ) async {
+      // Build a plain scrollable with NO BrowserScrollable wrapper.
+      // applyUserOffset should take the "no browser binding" path and move
+      // pixels directly in Dart.
+      final controller2 = ScrollController();
+      addTearDown(controller2.dispose);
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: ListView.builder(
+              controller: controller2,
+              itemCount: 20,
+              itemBuilder: (context, index) => SizedBox(height: 200.0, child: Text('Item $index')),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // No browser binding should be set.
+      expect(ScrollableState.browserScrollViewBinding, isNull);
+
+      // A drag should move pixels directly via normal Dart physics.
+      await tester.drag(find.byType(Scrollable), const Offset(0, -300));
+      await tester.pump();
+
+      expect(controller2.position.pixels, greaterThan(0.0));
+    });
+
+    testWidgets('inner scrollable scrolls independently without BrowserScrollPhysics', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: BrowserScrollable(
+              child: ListView(
+                controller: outerController,
+                children: [
+                  const SizedBox(height: 100),
+                  SizedBox(
+                    height: 300,
+                    child: ListView.builder(
+                      itemCount: 50,
+                      itemBuilder: (context, index) =>
+                          SizedBox(height: 40, child: Text('Inner $index')),
+                    ),
+                  ),
+                  const SizedBox(height: 1000),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final Finder innerListFinder = find.byType(Scrollable).at(1);
+      final ScrollableState innerScrollable = tester.state(innerListFinder);
+      final ScrollPosition innerPos = innerScrollable.position;
+
+      expect(innerPos.pixels, 0.0);
+
+      innerPos.jumpTo(100);
+      await tester.pump();
+
+      expect(innerPos.pixels, closeTo(100.0, 1.0));
+    });
+  });
+}

--- a/packages/flutter/test/widgets/scroll_physics_test.dart
+++ b/packages/flutter/test/widgets/scroll_physics_test.dart
@@ -364,4 +364,63 @@ FlutterError
     );
     await tester.fling(find.text('Index 2'), const Offset(0.0, -300.0), 10000.0);
   });
+
+  group('BrowserScrollPhysics', () {
+    test('applyTo returns BrowserScrollPhysics', () {
+      const physics = BrowserScrollPhysics();
+      final ScrollPhysics result = physics.applyTo(const ClampingScrollPhysics());
+      expect(result, isA<BrowserScrollPhysics>());
+    });
+
+    test('does not allow implicit scrolling', () {
+      const physics = BrowserScrollPhysics();
+      expect(physics.allowImplicitScrolling, isFalse);
+    });
+
+    test('applyPhysicsToUserOffset returns full offset', () {
+      const physics = BrowserScrollPhysics();
+      final metrics = FixedScrollMetrics(
+        minScrollExtent: 0,
+        maxScrollExtent: 1000,
+        pixels: 500,
+        viewportDimension: 600,
+        axisDirection: AxisDirection.down,
+        devicePixelRatio: 1.0,
+      );
+      expect(physics.applyPhysicsToUserOffset(metrics, 42.0), 42.0);
+      expect(physics.applyPhysicsToUserOffset(metrics, -10.0), -10.0);
+    });
+
+    test('applyBoundaryConditions returns entire delta as overscroll', () {
+      const physics = BrowserScrollPhysics();
+      final metrics = FixedScrollMetrics(
+        minScrollExtent: 0,
+        maxScrollExtent: 1000,
+        pixels: 500,
+        viewportDimension: 600,
+        axisDirection: AxisDirection.down,
+        devicePixelRatio: 1.0,
+      );
+      // value=550 means delta of 50 from current pixels=500
+      expect(physics.applyBoundaryConditions(metrics, 550), 50.0);
+      // value=400 means delta of -100 from current pixels=500
+      expect(physics.applyBoundaryConditions(metrics, 400), -100.0);
+      // value=500 means delta of 0
+      expect(physics.applyBoundaryConditions(metrics, 500), 0.0);
+    });
+
+    test('createBallisticSimulation returns null', () {
+      const physics = BrowserScrollPhysics();
+      final metrics = FixedScrollMetrics(
+        minScrollExtent: 0,
+        maxScrollExtent: 1000,
+        pixels: 500,
+        viewportDimension: 600,
+        axisDirection: AxisDirection.down,
+        devicePixelRatio: 1.0,
+      );
+      expect(physics.createBallisticSimulation(metrics, 100.0), isNull);
+      expect(physics.createBallisticSimulation(metrics, 0.0), isNull);
+    });
+  });
 }

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -233,6 +233,20 @@ class _TestFlutterView implements FlutterView {
 
   @override
   void updateSemantics(ui.SemanticsUpdate update) {}
+
+  // Browser-driven scrolling APIs. These are declared on FlutterView in the
+  // web dart:ui but not on the native dart:ui, so we cannot annotate them with
+  // @override (it would fail the native analyzer). They are no-ops in tests
+  // because the engine-side implementation lives in the web embedder. Tests
+  // interact with browser scrolling via
+  // ScrollableState.browserScrollViewBinding instead.
+  void enableBrowserScrolling() {}
+  void disableBrowserScrolling() {}
+  void browserScrollTo(double offset) {}
+  void browserSmoothScrollTo(double offset) {}
+  void browserScrollBy(double delta) {}
+  void updateBrowserScrollContentHeight(double height) {}
+  void Function(double offset)? onBrowserScroll;
 }
 
 mixin _ChildWindowHierarchyMixin {


### PR DESCRIPTION
**Do not review yet. Depends on #185363.**

Ref #184102 (full design doc and end-to-end demo)

## Summary
PR 2 of 4 splitting #184102. Lands the framework side of browser-driven scrolling on top of the engine API introduced in #185363.

- `BrowserScrollable` widget that enables browser-driven scrolling on the outermost scrollable in a subtree.
- `BrowserScrollPhysics` class that routes user offsets to the engine via `FlutterView.browserScrollBy` instead of consuming them in Dart.
- `ScrollableState` integration: reads `ScrollBehavior.enableBrowserScrolling`, owns the `BrowserScrollViewBinding` lifecycle, runs the `_activeBrowserScrollInstance` claim and the `_isBrowserDriving` feedback guard.
- `BrowserScrollViewBinding` with conditional imports (`_browser_scroll_view_{io,web}.dart`) so framework code calls the dart:ui `FlutterView` surface on web and records calls on IO.
- `OverscrollNotification` bubbles at scroll edges so `RefreshIndicator` keeps working.
- Programmatic `animateTo` and `jumpTo` go transparently through the browser: the placeholder grows to cover the target, the smooth-scroll completes via a `Completer`, and the resolved `Future` reflects real browser settle.
- `ScrollController` remains optional on `BrowserScrollable`, defaulting to `PrimaryScrollController`.

Browser-owns-wheel behavior is **not** in this PR. It ships as a separate one-line PR (PR 4) so the wheel-behavior change stays independently bisectable.

## Split plan
- PR 1 (#185363): Engine surface + controller + placeholder
- **PR 2 (this one):** Framework `BrowserScrollable` + `BrowserScrollPhysics` + `ScrollableState` integration + programmatic scroll transparency
- PR 3: Cross-layer browser-owns-wheel behavior

## Tests
- `browser_scroll_test.dart` (new): 38+ tests covering user-scroll forwarding, content-extent reporting, overscroll bubble at edges, programmatic `animateTo`/`jumpTo`, `ensureVisible`, focus traversal, nested scrollable isolation, and placeholder pre-grow semantics.
- `scroll_physics_test.dart`: 9 tests for `BrowserScrollPhysics` behavior (accept-offset, equality, apply-to-user-offset).

## Demo
Full-stack demo of the API consumed end-to-end: https://flutter-demo-19.web.app/ (runs against #184102's branch, not this PR alone).
