### PR TITLE
test: inline TestCallbackPainter in cupertino/picker_test.dart

### DIFF
--- a/packages/flutter/test/cupertino/picker_test.dart
+++ b/packages/flutter/test/cupertino/picker_test.dart
@@ -8,8 +8,21 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../rendering/rendering_tester.dart';
 import '../widgets/semantics_tester.dart';
+
+class TestCallbackPainter extends CustomPainter {
+  const TestCallbackPainter({required this.onPaint});
+
+  final VoidCallback onPaint;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    onPaint();
+  }
+
+  @override
+  bool shouldRepaint(TestCallbackPainter oldPainter) => true;
+}
 
 class SpyFixedExtentScrollController extends FixedExtentScrollController {
   /// Override for test visibility only.

--- a/packages/flutter/test/cupertino/picker_test.dart
+++ b/packages/flutter/test/cupertino/picker_test.dart
@@ -10,9 +10,12 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../widgets/semantics_tester.dart';
 
+/// A [CustomPainter] that calls a callback when it paints.
 class TestCallbackPainter extends CustomPainter {
+  /// Creates a [TestCallbackPainter] that calls [onPaint] when it paints.
   const TestCallbackPainter({required this.onPaint});
 
+  /// The callback called when the painter paints.
   final VoidCallback onPaint;
 
   @override
@@ -21,7 +24,7 @@ class TestCallbackPainter extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(TestCallbackPainter oldPainter) => true;
+  bool shouldRepaint(covariant TestCallbackPainter oldDelegate) => true;
 }
 
 class SpyFixedExtentScrollController extends FixedExtentScrollController {


### PR DESCRIPTION
## Description

Removes the cross-import of `TestCallbackPainter` from `test/rendering/rendering_tester.dart` in `test/cupertino/picker_test.dart`, and inlines the trivial 12-line class directly in the test file.

Per the issue guidelines: "Duplicate the util if its implementation is trivial."

## Tests

All existing tests continue to pass:
- `packages/flutter/test/cupertino/picker_test.dart` — 27 tests pass

## Related Issues

Part of #182636