### PR TITLE
[ios] Extract SplashScreenManager from FlutterViewController

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/BUILD.gn
+++ b/engine/src/flutter/shell/platform/darwin/ios/BUILD.gn
@@ -57,6 +57,7 @@ source_set("InternalFlutterSwift") {
     "framework/Source/AccessibilityFeatures.swift",
     "framework/Source/ConnectionCollection.swift",
     "framework/Source/LaunchEngine.swift",
+    "framework/Source/SplashScreenManager.swift",
     "framework/Source/UIPressProxy.swift",
   ]
   public = _flutter_framework_headers + framework_common_headers
@@ -222,6 +223,7 @@ if (enable_ios_unittests) {
       "framework/Source/ConnectionCollectionTest.swift",
       "framework/Source/FakeUIPressProxy.swift",
       "framework/Source/LaunchEngineTest.swift",
+      "framework/Source/SplashScreenManagerTests.swift",
     ]
     frameworks = [ "XCTest.framework" ]
     deps = [ ":flutter_framework_source" ]

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -74,6 +74,8 @@ typedef struct MouseState {
 @property(nonatomic, strong) FlutterView* flutterView;
 @property(nonatomic, strong) void (^flutterViewRenderedCallback)(void);
 
+@property(nonatomic, strong) FlutterSplashScreenManager* splashScreenManager;
+
 @property(nonatomic, assign) UIInterfaceOrientationMask orientationPreferences;
 @property(nonatomic, assign) UIStatusBarStyle statusBarStyle;
 @property(nonatomic, assign) BOOL initialized;
@@ -166,11 +168,19 @@ typedef struct MouseState {
 @implementation FlutterViewController {
   flutter::ViewportMetrics _viewportMetrics;
   MouseState _mouseState;
+  FlutterSplashScreenManager* _splashScreenManager;
 }
 
 // Synthesize properties with an overridden getter/setter.
 @synthesize viewOpaque = _viewOpaque;
 @synthesize displayingFlutterUI = _displayingFlutterUI;
+
+- (FlutterSplashScreenManager*)splashScreenManager {
+  if (!_splashScreenManager) {
+    _splashScreenManager = [[FlutterSplashScreenManager alloc] init];
+  }
+  return _splashScreenManager;
+}
 
 // TODO(dkwingsmt): https://github.com/flutter/flutter/issues/138168
 // No backing ivar is currently required; when multiple views are supported, we'll need to
@@ -332,7 +342,7 @@ typedef struct MouseState {
 
   // TODO(cbracken): https://github.com/flutter/flutter/issues/157140
   // Eliminate method calls in initializers and dealloc.
-  [self loadDefaultSplashScreenView];
+  [self.splashScreenManager loadDefaultSplashScreenView];
   [self performCommonViewControllerInitialization];
 }
 
@@ -567,21 +577,20 @@ static UIView* GetViewOrPlaceholder(UIView* existing_view) {
 #pragma mark - Managing launch views
 
 - (void)installSplashScreenViewIfNecessary {
-  // Show the launch screen view again on top of the FlutterView if available.
-  // This launch screen view will be removed once the first Flutter frame is rendered.
+  // The splash screen is automatically loaded during initialization (if configured), but should
+  // only be shown during the cold start of the application when we're the root view controller.
+  //
+  // If we are being presented modally or pushed onto a navigation controller later,
+  // remove the splash screen immediately to avoid a jarring visual transition.
   if (self.splashScreenView && (self.isBeingPresented || self.isMovingToParentViewController)) {
+    // Explicitly remove from superview to bypass the fade-out animation.
     [self.splashScreenView removeFromSuperview];
     self.splashScreenView = nil;
     return;
   }
 
-  // Use the property getter to initialize the default value.
-  UIView* splashScreenView = self.splashScreenView;
-  if (splashScreenView == nil) {
-    return;
-  }
-  splashScreenView.frame = self.view.bounds;
-  [self.view addSubview:splashScreenView];
+  // Cold start. Install the splash screen. It will removed in onFirstFrameRendered.
+  [self.splashScreenManager installSplashScreenViewAsSubviewOf:self.view];
 }
 
 + (BOOL)automaticallyNotifiesObserversOfDisplayingFlutterUI {
@@ -609,27 +618,10 @@ static UIView* GetViewOrPlaceholder(UIView* existing_view) {
   }
 }
 
-- (void)removeSplashScreenWithCompletion:(dispatch_block_t _Nullable)onComplete {
-  NSAssert(self.splashScreenView, @"The splash screen view must not be nil");
-  UIView* splashScreen = self.splashScreenView;
-  // setSplashScreenView calls this method. Assign directly to ivar to avoid an infinite loop.
-  _splashScreenView = nil;
-  [UIView animateWithDuration:0.2
-      animations:^{
-        splashScreen.alpha = 0;
-      }
-      completion:^(BOOL finished) {
-        [splashScreen removeFromSuperview];
-        if (onComplete) {
-          onComplete();
-        }
-      }];
-}
-
 - (void)onFirstFrameRendered {
   if (self.splashScreenView) {
     __weak FlutterViewController* weakSelf = self;
-    [self removeSplashScreenWithCompletion:^{
+    [self.splashScreenManager removeSplashScreenWithCompletion:^{
       [weakSelf callViewRenderedCallback];
     }];
   } else {
@@ -656,66 +648,15 @@ static UIView* GetViewOrPlaceholder(UIView* existing_view) {
 }
 
 - (BOOL)loadDefaultSplashScreenView {
-  NSString* launchscreenName =
-      [[[NSBundle mainBundle] infoDictionary] objectForKey:@"UILaunchStoryboardName"];
-  if (launchscreenName == nil) {
-    return NO;
-  }
-  UIView* splashView = [self splashScreenFromStoryboard:launchscreenName];
-  if (!splashView) {
-    splashView = [self splashScreenFromXib:launchscreenName];
-  }
-  if (!splashView) {
-    return NO;
-  }
-  self.splashScreenView = splashView;
-  return YES;
+  return [self.splashScreenManager loadDefaultSplashScreenView];
 }
 
-- (UIView*)splashScreenFromStoryboard:(NSString*)name {
-  UIStoryboard* storyboard = nil;
-  @try {
-    storyboard = [UIStoryboard storyboardWithName:name bundle:nil];
-  } @catch (NSException* exception) {
-    return nil;
-  }
-  if (storyboard) {
-    UIViewController* splashScreenViewController = [storyboard instantiateInitialViewController];
-    return splashScreenViewController.view;
-  }
-  return nil;
-}
-
-- (UIView*)splashScreenFromXib:(NSString*)name {
-  NSArray* objects = nil;
-  @try {
-    objects = [[NSBundle mainBundle] loadNibNamed:name owner:self options:nil];
-  } @catch (NSException* exception) {
-    return nil;
-  }
-  if ([objects count] != 0) {
-    UIView* view = [objects objectAtIndex:0];
-    return view;
-  }
-  return nil;
+- (UIView*)splashScreenView {
+  return self.splashScreenManager.splashScreenView;
 }
 
 - (void)setSplashScreenView:(UIView*)view {
-  if (view == _splashScreenView) {
-    return;
-  }
-
-  // Special case: user wants to remove the splash screen view.
-  if (!view) {
-    if (_splashScreenView) {
-      [self removeSplashScreenWithCompletion:nil];
-    }
-    return;
-  }
-
-  _splashScreenView = view;
-  _splashScreenView.autoresizingMask =
-      UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+  self.splashScreenManager.splashScreenView = view;
 }
 
 - (void)setFlutterViewDidRenderCallback:(void (^)(void))callback {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/SplashScreenManager.swift
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/SplashScreenManager.swift
@@ -1,0 +1,125 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import UIKit
+
+/// Manages the loading, display, and removal of the application's splash screen.
+///
+/// Handles loading from storyboards or XIBs based on the `UILaunchStoryboardName` in the app's
+/// Info.plist. Performs an animated fade-out transition when the splash screen is removed.
+@objc(FlutterSplashScreenManager)
+public class SplashScreenManager: NSObject {
+
+  /// The default duration for the splash screen fade-out animation.
+  private static let defaultAnimationDuration: TimeInterval = 0.2
+
+  private let bundle: Bundle
+
+  private var _splashScreenView: UIView?
+
+  /// The current splash screen view.
+  ///
+  /// Setting this property to a new view will update view and apply flexible width/height
+  /// autoresizing masks. Setting to `nil` will trigger the removal of the current splash screen
+  /// with a fade-out animation.
+  @objc public var splashScreenView: UIView? {
+    get { return _splashScreenView }
+    set {
+      guard newValue !== _splashScreenView else { return }
+
+      if let newView = newValue {
+        _splashScreenView = newView
+        newView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+      } else {
+        removeSplashScreen(completion: nil)
+      }
+    }
+  }
+
+  /// Initializes a new manager with the specified bundle.
+  ///
+  /// The bundle is used to look up the launch storyboard name and resources.
+  @objc public init(bundle: Bundle = .main) {
+    self.bundle = bundle
+    super.init()
+  }
+
+  /// Initializes a new manager with the main bundle.
+  @objc public override convenience init() {
+    self.init(bundle: .main)
+  }
+
+  /// Attempts to load the splash screen view specified by `UILaunchStoryboardName` in Info.plist.
+  /// - Returns: `true` if successful, `false` otherwise.
+  @discardableResult
+  @objc public func loadDefaultSplashScreenView() -> Bool {
+    guard let launchscreenName = bundle.infoDictionary?["UILaunchStoryboardName"] as? String else {
+      return false
+    }
+
+    var splashView = splashScreenFromStoryboard(name: launchscreenName)
+    if splashView == nil {
+      splashView = splashScreenFromXib(name: launchscreenName)
+    }
+
+    guard let view = splashView else { return false }
+
+    splashScreenView = view
+    return true
+  }
+
+  /// Loads a view from the initial view controller of the specified storyboard.
+  func splashScreenFromStoryboard(name: String) -> UIView? {
+    // Check if storyboard exists to prevent exceptions.
+    guard bundle.path(forResource: name, ofType: "storyboardc") != nil else { return nil }
+
+    let storyboard = UIStoryboard(name: name, bundle: bundle)
+    let splashScreenViewController = storyboard.instantiateInitialViewController()
+    return splashScreenViewController?.view
+  }
+
+  /// Loads a view from the specified XIB file.
+  func splashScreenFromXib(name: String) -> UIView? {
+    // Check if nib exists to prevent exceptions.
+    guard bundle.path(forResource: name, ofType: "nib") != nil else { return nil }
+
+    let nib = UINib(nibName: name, bundle: bundle)
+    let objects = nib.instantiate(withOwner: nil, options: nil)
+    return objects.first as? UIView
+  }
+
+  /// Removes the splash screen with a fade-out animation.
+  ///
+  /// The completion block is invoked after the animation completes and the view is removed from its
+  /// superview.
+  @objc public func removeSplashScreen(completion: (() -> Void)?) {
+    // If no splash screen, bail out immediately and invoke the completion handler.
+    guard let splashScreen = _splashScreenView else {
+      completion?()
+      return
+    }
+
+    _splashScreenView = nil
+    UIView.animate(
+      withDuration: Self.defaultAnimationDuration,
+      animations: {
+        splashScreen.alpha = 0
+      }
+    ) { _ in
+      splashScreen.removeFromSuperview()
+      completion?()
+    }
+  }
+
+  /// Installs the splash screen view into the specified parent view, if it is not already added.
+  ///
+  /// The view's frame is set to match the parent view's bounds.
+  @objc(installSplashScreenViewAsSubviewOf:)
+  public func installSplashScreenView(asSubviewOf parentView: UIView) {
+    guard let splashScreen = splashScreenView else { return }
+
+    splashScreen.frame = parentView.bounds
+    parentView.addSubview(splashScreen)
+  }
+}

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/SplashScreenManager.swift
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/SplashScreenManager.swift
@@ -9,7 +9,7 @@ import UIKit
 /// Handles loading from storyboards or XIBs based on the `UILaunchStoryboardName` in the app's
 /// Info.plist. Performs an animated fade-out transition when the splash screen is removed.
 @objc(FlutterSplashScreenManager)
-public class SplashScreenManager: NSObject {
+public final class SplashScreenManager: NSObject {
 
   /// The default duration for the splash screen fade-out animation.
   private static let defaultAnimationDuration: TimeInterval = 0.2
@@ -70,7 +70,7 @@ public class SplashScreenManager: NSObject {
   }
 
   /// Loads a view from the initial view controller of the specified storyboard.
-  func splashScreenFromStoryboard(name: String) -> UIView? {
+  private func splashScreenFromStoryboard(name: String) -> UIView? {
     // Check if storyboard exists to prevent exceptions.
     guard bundle.path(forResource: name, ofType: "storyboardc") != nil else { return nil }
 
@@ -80,7 +80,7 @@ public class SplashScreenManager: NSObject {
   }
 
   /// Loads a view from the specified XIB file.
-  func splashScreenFromXib(name: String) -> UIView? {
+  private func splashScreenFromXib(name: String) -> UIView? {
     // Check if nib exists to prevent exceptions.
     guard bundle.path(forResource: name, ofType: "nib") != nil else { return nil }
 
@@ -115,8 +115,7 @@ public class SplashScreenManager: NSObject {
   /// Installs the splash screen view into the specified parent view, if it is not already added.
   ///
   /// The view's frame is set to match the parent view's bounds.
-  @objc(installSplashScreenViewAsSubviewOf:)
-  public func installSplashScreenView(asSubviewOf parentView: UIView) {
+  @objc public func installSplashScreenView(asSubviewOf parentView: UIView) {
     guard let splashScreen = splashScreenView else { return }
 
     splashScreen.frame = parentView.bounds

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/SplashScreenManagerTests.swift
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/SplashScreenManagerTests.swift
@@ -10,9 +10,16 @@ import XCTest
 /// A mock `Bundle` subclass.
 ///
 /// By default, lacks the `UILaunchStoryboardName` key in its Info.plist.
-final class MockBundle: Bundle {
+final class MockBundle: Bundle, @unchecked Sendable {
   var mockInfoDictionary: [String: Any]?
   var mockPaths: [String: String] = [:]
+
+  override init(path: String) {
+    // Use the path of the test bundle to ensure valid Bundle.
+    // See: https://stackoverflow.com/questions/34898283/mocking-nsbundle-in-swift-tdd
+    let testBundle = Bundle(for: MockBundle.self)
+    super.init(path: testBundle.bundlePath)!
+  }
 
   override var infoDictionary: [String: Any]? {
     return mockInfoDictionary
@@ -28,7 +35,7 @@ class SplashScreenManagerTests: XCTestCase {
 
   /// Verifies `loadDefaultSplashScreenView` fails when the `UILaunchStoryboardName` key is missing.
   func testLoadDefaultSplashScreenViewFailsWhenNoPlistKey() {
-    let mockBundle = MockBundle()
+    let mockBundle = MockBundle(path: "")
     let manager = SplashScreenManager(bundle: mockBundle)
 
     XCTAssertFalse(manager.loadDefaultSplashScreenView())
@@ -36,7 +43,7 @@ class SplashScreenManagerTests: XCTestCase {
 
   /// Verifies `loadDefaultSplashScreenView` fails when the storyboard file is not in the bundle.
   func testLoadDefaultSplashScreenViewFailsWhenStoryboardNotFound() {
-    let mockBundle = MockBundle()
+    let mockBundle = MockBundle(path: "")
     mockBundle.mockInfoDictionary = ["UILaunchStoryboardName": "LaunchScreen"]
     let manager = SplashScreenManager(bundle: mockBundle)
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/SplashScreenManagerTests.swift
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/SplashScreenManagerTests.swift
@@ -10,7 +10,7 @@ import XCTest
 /// A mock `Bundle` subclass.
 ///
 /// By default, lacks the `UILaunchStoryboardName` key in its Info.plist.
-class MockBundle: Bundle {
+final class MockBundle: Bundle {
   var mockInfoDictionary: [String: Any]?
   var mockPaths: [String: String] = [:]
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/SplashScreenManagerTests.swift
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/SplashScreenManagerTests.swift
@@ -1,0 +1,98 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import UIKit
+import XCTest
+
+@testable import InternalFlutterSwift
+
+/// A mock `Bundle` subclass.
+///
+/// By default, lacks the `UILaunchStoryboardName` key in its Info.plist.
+class MockBundle: Bundle {
+  var mockInfoDictionary: [String: Any]?
+  var mockPaths: [String: String] = [:]
+
+  override var infoDictionary: [String: Any]? {
+    return mockInfoDictionary
+  }
+
+  override func path(forResource name: String?, ofType ext: String?) -> String? {
+    guard let name = name, let ext = ext else { return nil }
+    return mockPaths["\(name).\(ext)"]
+  }
+}
+
+class SplashScreenManagerTests: XCTestCase {
+
+  /// Verifies `loadDefaultSplashScreenView` fails when the `UILaunchStoryboardName` key is missing.
+  func testLoadDefaultSplashScreenViewFailsWhenNoPlistKey() {
+    let mockBundle = MockBundle()
+    let manager = SplashScreenManager(bundle: mockBundle)
+
+    XCTAssertFalse(manager.loadDefaultSplashScreenView())
+  }
+
+  /// Verifies `loadDefaultSplashScreenView` fails when the storyboard file is not in the bundle.
+  func testLoadDefaultSplashScreenViewFailsWhenStoryboardNotFound() {
+    let mockBundle = MockBundle()
+    mockBundle.mockInfoDictionary = ["UILaunchStoryboardName": "LaunchScreen"]
+    let manager = SplashScreenManager(bundle: mockBundle)
+
+    XCTAssertFalse(manager.loadDefaultSplashScreenView())
+  }
+
+  /// Verifies `setSplashScreenView` sets the view and applies autoresizing masks.
+  func testSetSplashScreenView() {
+    let manager = SplashScreenManager()
+    let view = UIView()
+
+    manager.splashScreenView = view
+
+    XCTAssertEqual(manager.splashScreenView, view)
+    XCTAssertEqual(view.autoresizingMask, [.flexibleWidth, .flexibleHeight])
+  }
+
+  /// Verifies setting `splashScreenView` to nil triggers its removal.
+  func testSetSplashScreenViewToNilRemovesIt() {
+    let manager = SplashScreenManager()
+    let view = UIView()
+
+    manager.splashScreenView = view
+    XCTAssertEqual(manager.splashScreenView, view)
+
+    manager.splashScreenView = nil
+    XCTAssertNil(manager.splashScreenView)
+  }
+
+  /// Verifies `removeSplashScreen` calls the completion block after fading out.
+  func testRemoveSplashScreenCallsCompletion() {
+    let manager = SplashScreenManager()
+    let view = UIView()
+    manager.splashScreenView = view
+
+    let expectation = self.expectation(description: "Completion called")
+
+    manager.removeSplashScreen {
+      expectation.fulfill()
+    }
+
+    waitForExpectations(timeout: 1.0, handler: nil)
+    XCTAssertNil(manager.splashScreenView)
+  }
+
+  /// Verifies `installSplashScreenView` adds the view to the parent view parent bounds as frame.
+  func testInstallSplashScreenView() {
+    let manager = SplashScreenManager()
+    let view = UIView()
+    manager.splashScreenView = view
+
+    let parentView = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+
+    manager.installSplashScreenView(asSubviewOf: parentView)
+
+    XCTAssertEqual(view.superview, parentView)
+    XCTAssertEqual(view.frame, parentView.bounds)
+  }
+}


### PR DESCRIPTION
This makes progress towards reducing the complexity of FlutterViewController by refactoring orthogonal functionality into separate classes.

FlutterViewController's splash screen management logic is self-contained, which makes it an ideal candidate to be extracted into its own class, and add test coverage while we're at it.

While making this change, I got hung-up on why we were explicitly removing the splash screen from the superview right before we nil it out (which also removes it from the superview), then immediately bail out. I updated the existing comments in installSplashScreenViewIfNecessary to make that a code clearer to future readers.

This also makes partial progress towards #157140 by making possible future refactoring method calls out of FlutterViewController's initialisers and dealloc. In this case `self.splashScreenManager` is technically a method call.

Issue: #157140

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] The FlutterViewController complexity is too damn high!
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md