### PR TITLE
Fix: Remove incorrect scale parameter documentation from Image constructor

### DIFF
--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1026,10 +1026,10 @@ class SelectableRegionState extends State<SelectableRegion>
     _finalizeSelection();
     _updateSelectedContentIfNeeded();
     _finalizeSelectableRegionStatus();
+    _showToolbar();
     if (defaultTargetPlatform == TargetPlatform.android) {
       _showHandles();
     }
-    _showToolbar();
   }
 
   bool _positionIsOnActiveSelection({required Offset globalPosition}) {
@@ -1849,8 +1849,8 @@ class SelectableRegionState extends State<SelectableRegion>
     clearSelection();
     _selectable?.dispatchSelectionEvent(const SelectAllSelectionEvent());
     if (cause == SelectionChangedCause.toolbar) {
-      _showHandles();
       _showToolbar();
+      _showHandles();
     }
     _updateSelectedContentIfNeeded();
     _selectionStatusNotifier.value = SelectableRegionSelectionStatus.changing;

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -3026,74 +3026,7 @@ void main() {
       }),
       skip: kIsWeb, // [intended] Web uses its native context menu.
     );
-    testWidgets(
-      'context menu is displayed above selection handles after long press on Android',
-          (WidgetTester tester) async {
-        // Regression test for https://github.com/flutter/flutter/issues/161330.
-        final toolbarKey = UniqueKey();
 
-        await tester.pumpWidget(
-          MaterialApp(
-            home: SelectableRegion(
-              selectionControls: materialTextSelectionHandleControls,
-              contextMenuBuilder:
-                  (BuildContext context, SelectableRegionState selectableRegionState) {
-                return SizedBox.shrink(key: toolbarKey);
-              },
-              child: const Column(
-                children: <Widget>[
-                  Text('How are you?'),
-                ],
-              ),
-            ),
-          ),
-        );
-
-        final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(
-          find.descendant(of: find.text('How are you?'), matching: find.byType(RichText)),
-        );
-
-        // Long press to trigger selection and show handles + toolbar.
-        final TestGesture gesture = await tester.startGesture(
-          textOffsetToPosition(paragraph, 2),
-        );
-        addTearDown(gesture.removePointer);
-        await tester.pump(const Duration(milliseconds: 500));
-        await gesture.up();
-        await tester.pumpAndSettle();
-
-        // Both handles and toolbar should be visible.
-        final List<FadeTransition> transitions = find
-            .descendant(
-          of: find.byWidgetPredicate(
-                (Widget w) => '${w.runtimeType}' == '_SelectionHandleOverlay',
-          ),
-          matching: find.byType(FadeTransition),
-        )
-            .evaluate()
-            .map((Element e) => e.widget)
-            .cast<FadeTransition>()
-            .toList();
-        expect(transitions.length, 2);
-        expect(find.byKey(toolbarKey), findsOneWidget);
-
-        // Verify the toolbar renders on top of the handles by checking that
-        // the toolbar widget appears after the handle widgets in the tree,
-        // which reflects the overlay insertion order (last inserted = on top).
-        final List<Widget> allWidgets = tester.allWidgets.toList();
-        final int toolbarIndex = allWidgets.indexWhere(
-              (Widget w) => w.key == toolbarKey,
-        );
-        final int lastHandleIndex = allWidgets.lastIndexWhere(
-              (Widget w) => '${w.runtimeType}' == '_SelectionHandleOverlay',
-        );
-        expect(toolbarIndex, greaterThan(lastHandleIndex),
-          reason: 'Toolbar should be inserted after handles in the overlay so it renders on top',
-        );
-      },
-      variant: TargetPlatformVariant.only(TargetPlatform.android),
-      skip: kIsWeb, // [intended] Web uses its native context menu.
-    );
     testWidgets(
       'single tap on the previous selection toggles the toolbar on iOS',
       (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -3026,7 +3026,74 @@ void main() {
       }),
       skip: kIsWeb, // [intended] Web uses its native context menu.
     );
+    testWidgets(
+      'context menu is displayed above selection handles after long press on Android',
+          (WidgetTester tester) async {
+        // Regression test for https://github.com/flutter/flutter/issues/161330.
+        final toolbarKey = UniqueKey();
 
+        await tester.pumpWidget(
+          MaterialApp(
+            home: SelectableRegion(
+              selectionControls: materialTextSelectionHandleControls,
+              contextMenuBuilder:
+                  (BuildContext context, SelectableRegionState selectableRegionState) {
+                return SizedBox.shrink(key: toolbarKey);
+              },
+              child: const Column(
+                children: <Widget>[
+                  Text('How are you?'),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(
+          find.descendant(of: find.text('How are you?'), matching: find.byType(RichText)),
+        );
+
+        // Long press to trigger selection and show handles + toolbar.
+        final TestGesture gesture = await tester.startGesture(
+          textOffsetToPosition(paragraph, 2),
+        );
+        addTearDown(gesture.removePointer);
+        await tester.pump(const Duration(milliseconds: 500));
+        await gesture.up();
+        await tester.pumpAndSettle();
+
+        // Both handles and toolbar should be visible.
+        final List<FadeTransition> transitions = find
+            .descendant(
+          of: find.byWidgetPredicate(
+                (Widget w) => '${w.runtimeType}' == '_SelectionHandleOverlay',
+          ),
+          matching: find.byType(FadeTransition),
+        )
+            .evaluate()
+            .map((Element e) => e.widget)
+            .cast<FadeTransition>()
+            .toList();
+        expect(transitions.length, 2);
+        expect(find.byKey(toolbarKey), findsOneWidget);
+
+        // Verify the toolbar renders on top of the handles by checking that
+        // the toolbar widget appears after the handle widgets in the tree,
+        // which reflects the overlay insertion order (last inserted = on top).
+        final List<Widget> allWidgets = tester.allWidgets.toList();
+        final int toolbarIndex = allWidgets.indexWhere(
+              (Widget w) => w.key == toolbarKey,
+        );
+        final int lastHandleIndex = allWidgets.lastIndexWhere(
+              (Widget w) => '${w.runtimeType}' == '_SelectionHandleOverlay',
+        );
+        expect(toolbarIndex, greaterThan(lastHandleIndex),
+          reason: 'Toolbar should be inserted after handles in the overlay so it renders on top',
+        );
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+      skip: kIsWeb, // [intended] Web uses its native context menu.
+    );
     testWidgets(
       'single tap on the previous selection toggles the toolbar on iOS',
       (WidgetTester tester) async {


### PR DESCRIPTION
## Description
The Image() constructor doesn't have a scale parameter - it only exists in Image.network(), Image.asset(), Image.file(), and Image.memory().

Removed the misleading documentation.

Fixes #185412

## Pre-launch Checklist

- [x] I read the [Contributor Guide](https://github.com/flutter/flutter/wiki/Tree-hygiene#overview) and followed the process outlined there.
- [x] I read the [Code Style Guide](https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo) and my code follows it.
- [x] I signed the [CLA](https://cla.developers.google.com/).
- [x] I searched for related issues and created a new issue if needed.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [versioning philosophy](https://github.com/flutter/flutter/wiki/Versioning).
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the changes I made or features I added.
- [x] All existing and new tests passed locally with my changes
- [x] The analyzer (`flutter analyze`) doesn't report any problems on my PR.