### PR TITLE
Add await mechanism to setClipboard in android_semantics_integration test

### DIFF
--- a/dev/integration_tests/android_semantics_testing/android/app/src/main/java/com/yourcompany/platforminteraction/MainActivity.java
+++ b/dev/integration_tests/android_semantics_testing/android/app/src/main/java/com/yourcompany/platforminteraction/MainActivity.java
@@ -72,9 +72,31 @@ public class MainActivity extends FlutterActivity {
             @SuppressWarnings("unchecked")
             String message = (String) data.get("message");
             ClipboardManager clipboard = (ClipboardManager) getSystemService(Context.CLIPBOARD_SERVICE);
+
+            if (clipboard.hasPrimaryClip()) {
+                ClipData currentClip = clipboard.getPrimaryClip();
+                if (currentClip != null && currentClip.getItemCount() > 0) {
+                    CharSequence text = currentClip.getItemAt(0).getText();
+                    if (text != null && text.length() > 0) {
+                        result.success(null);
+                        return;
+                    }
+                }
+            }
+
+            // To avoid race conditions during integration tests, wait until the system has
+            // completed the clipboard update before returning success to the test runner.
+            ClipboardManager.OnPrimaryClipChangedListener listener = new ClipboardManager.OnPrimaryClipChangedListener() {
+                @Override
+                public void onPrimaryClipChanged() {
+                    clipboard.removePrimaryClipChangedListener(this);
+                    result.success(null);
+                }
+            };
+
+            clipboard.addPrimaryClipChangedListener(listener);
             ClipData clip = ClipData.newPlainText("message", message);
             clipboard.setPrimaryClip(clip);
-            result.success(null);
             return;
         }
         result.notImplemented();

--- a/dev/integration_tests/android_semantics_testing/android/app/src/main/java/com/yourcompany/platforminteraction/MainActivity.java
+++ b/dev/integration_tests/android_semantics_testing/android/app/src/main/java/com/yourcompany/platforminteraction/MainActivity.java
@@ -77,7 +77,8 @@ public class MainActivity extends FlutterActivity {
                 ClipData currentClip = clipboard.getPrimaryClip();
                 if (currentClip != null && currentClip.getItemCount() > 0) {
                     CharSequence text = currentClip.getItemAt(0).getText();
-                    if (text != null && text.length() > 0) {
+                    if (text != null && text.toString().equals(message)) {
+                        // The clipboard already has the expected value, no need to set it.
                         result.success(null);
                         return;
                     }
@@ -89,8 +90,16 @@ public class MainActivity extends FlutterActivity {
             ClipboardManager.OnPrimaryClipChangedListener listener = new ClipboardManager.OnPrimaryClipChangedListener() {
                 @Override
                 public void onPrimaryClipChanged() {
-                    clipboard.removePrimaryClipChangedListener(this);
-                    result.success(null);
+                    ClipData currentClip = clipboard.getPrimaryClip();
+                    if (currentClip != null && currentClip.getItemCount() > 0) {
+                        CharSequence text = currentClip.getItemAt(0).getText();
+                        // Verify if the clipboard has the correct value before returning success to the test runner.
+                        if (text != null && text.toString().equals(message)) {
+                            clipboard.removePrimaryClipChangedListener(this);
+                            result.success(null);
+                            return;
+                        }
+                    }
                 }
             };
 

--- a/dev/integration_tests/android_semantics_testing/integration_test/main_test.dart
+++ b/dev/integration_tests/android_semantics_testing/integration_test/main_test.dart
@@ -61,6 +61,27 @@ Future<AndroidSemanticsNode> getSemantics(Finder finder, WidgetTester tester) as
   return AndroidSemanticsNode.deserialize(await completer.future);
 }
 
+// Accessibility updates and clipboard actions are asynchronous on Android and
+// can take time to propagate. This helper polls the expectation to give the
+// system time to update the semantics tree.
+Future<void> expectWithRetry(
+  Future<AndroidSemanticsNode> Function() getSemantics,
+  Matcher matcher,
+  WidgetTester tester,
+) async {
+  TestFailure? lastException;
+  for (var i = 0; i < 10; i++) {
+    try {
+      expect(await getSemantics(), matcher);
+      return;
+    } on TestFailure catch (e) {
+      lastException = e;
+    }
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+  throw lastException!;
+}
+
 Future<void> main() async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
@@ -106,8 +127,8 @@ Future<void> main() async {
         await tester.tap(normalTextField);
         await tester.pumpAndSettle();
 
-        expect(
-          await getSemantics(normalTextField, tester),
+        await expectWithRetry(
+          () => getSemantics(normalTextField, tester),
           hasAndroidSemantics(
             className: AndroidClassName.editText,
             isFocusable: true,
@@ -123,13 +144,14 @@ Future<void> main() async {
             // We can't predict the a11y focus when the screen changes.
             ignoredActions: ignoredAccessibilityFocusActions,
           ),
+          tester,
         );
 
         await tester.enterText(normalTextField, 'hello world');
         await tester.pumpAndSettle();
 
-        expect(
-          await getSemantics(normalTextField, tester),
+        await expectWithRetry(
+          () => getSemantics(normalTextField, tester),
           hasAndroidSemantics(
             text: 'hello world',
             className: AndroidClassName.editText,
@@ -147,6 +169,7 @@ Future<void> main() async {
             // We can't predict the a11y focus when the screen changes.
             ignoredActions: ignoredAccessibilityFocusActions,
           ),
+          tester,
         );
       }, timeout: Timeout.none);
 
@@ -174,8 +197,8 @@ Future<void> main() async {
         await tester.tap(passwordTextField);
         await tester.pumpAndSettle();
 
-        expect(
-          await getSemantics(passwordTextField, tester),
+        await expectWithRetry(
+          () => getSemantics(passwordTextField, tester),
           hasAndroidSemantics(
             className: AndroidClassName.editText,
             isFocusable: true,
@@ -191,13 +214,14 @@ Future<void> main() async {
             // We can't predict the a11y focus when the screen changes.
             ignoredActions: ignoredAccessibilityFocusActions,
           ),
+          tester,
         );
 
         await tester.enterText(passwordTextField, 'hello world');
         await tester.pumpAndSettle();
 
-        expect(
-          await getSemantics(passwordTextField, tester),
+        await expectWithRetry(
+          () => getSemantics(passwordTextField, tester),
           hasAndroidSemantics(
             text: '\u{2022}' * ('hello world'.length),
             className: AndroidClassName.editText,
@@ -215,6 +239,7 @@ Future<void> main() async {
             // We can't predict the a11y focus when the screen changes.
             ignoredActions: ignoredAccessibilityFocusActions,
           ),
+          tester,
         );
       }, timeout: Timeout.none);
     });

--- a/dev/integration_tests/android_semantics_testing/integration_test/main_test.dart
+++ b/dev/integration_tests/android_semantics_testing/integration_test/main_test.dart
@@ -61,27 +61,6 @@ Future<AndroidSemanticsNode> getSemantics(Finder finder, WidgetTester tester) as
   return AndroidSemanticsNode.deserialize(await completer.future);
 }
 
-// Accessibility updates and clipboard actions are asynchronous on Android and
-// can take time to propagate. This helper polls the expectation to give the
-// system time to update the semantics tree.
-Future<void> expectWithRetry(
-  Future<AndroidSemanticsNode> Function() getSemantics,
-  Matcher matcher,
-  WidgetTester tester,
-) async {
-  TestFailure? lastException;
-  for (var i = 0; i < 10; i++) {
-    try {
-      expect(await getSemantics(), matcher);
-      return;
-    } on TestFailure catch (e) {
-      lastException = e;
-    }
-    await tester.pump(const Duration(milliseconds: 100));
-  }
-  throw lastException!;
-}
-
 Future<void> main() async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
@@ -127,8 +106,8 @@ Future<void> main() async {
         await tester.tap(normalTextField);
         await tester.pumpAndSettle();
 
-        await expectWithRetry(
-          () => getSemantics(normalTextField, tester),
+        expect(
+          await getSemantics(normalTextField, tester),
           hasAndroidSemantics(
             className: AndroidClassName.editText,
             isFocusable: true,
@@ -144,14 +123,13 @@ Future<void> main() async {
             // We can't predict the a11y focus when the screen changes.
             ignoredActions: ignoredAccessibilityFocusActions,
           ),
-          tester,
         );
 
         await tester.enterText(normalTextField, 'hello world');
         await tester.pumpAndSettle();
 
-        await expectWithRetry(
-          () => getSemantics(normalTextField, tester),
+        expect(
+          await getSemantics(normalTextField, tester),
           hasAndroidSemantics(
             text: 'hello world',
             className: AndroidClassName.editText,
@@ -169,7 +147,6 @@ Future<void> main() async {
             // We can't predict the a11y focus when the screen changes.
             ignoredActions: ignoredAccessibilityFocusActions,
           ),
-          tester,
         );
       }, timeout: Timeout.none);
 
@@ -197,8 +174,8 @@ Future<void> main() async {
         await tester.tap(passwordTextField);
         await tester.pumpAndSettle();
 
-        await expectWithRetry(
-          () => getSemantics(passwordTextField, tester),
+        expect(
+          await getSemantics(passwordTextField, tester),
           hasAndroidSemantics(
             className: AndroidClassName.editText,
             isFocusable: true,
@@ -214,14 +191,13 @@ Future<void> main() async {
             // We can't predict the a11y focus when the screen changes.
             ignoredActions: ignoredAccessibilityFocusActions,
           ),
-          tester,
         );
 
         await tester.enterText(passwordTextField, 'hello world');
         await tester.pumpAndSettle();
 
-        await expectWithRetry(
-          () => getSemantics(passwordTextField, tester),
+        expect(
+          await getSemantics(passwordTextField, tester),
           hasAndroidSemantics(
             text: '\u{2022}' * ('hello world'.length),
             className: AndroidClassName.editText,
@@ -239,7 +215,6 @@ Future<void> main() async {
             // We can't predict the a11y focus when the screen changes.
             ignoredActions: ignoredAccessibilityFocusActions,
           ),
-          tester,
         );
       }, timeout: Timeout.none);
     });


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

fixes https://github.com/flutter/flutter/issues/184755

The failure suggest there may be race condition when setClipboard async update the OS while TextField receive canPaste signal. Adding an await mechanism to see if that eliminate the race condition.


## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
