### PR TITLE
fix:`DropdownMenuFormField` missing leading icon

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -403,6 +403,9 @@ class DropdownMenu<T> extends StatefulWidget {
 
   /// The builder function used to create the [InputDecoration] passed to the text field.
   ///
+  /// If a value is provided for this property and the resulting [InputDecoration.prefixIcon]
+  /// is null, [leadingIcon] is assigned as the prefix icon.
+  ///
   /// If a value is provided for this property and the resulting [InputDecoration.suffixIcon]
   /// is null, a default [IconButton] is assigned as the suffix icon. This button's icon will
   /// use [trailingIcon] and [selectedTrailingIcon] if those are explicitly defined; otherwise,
@@ -1234,6 +1237,9 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
         final DropdownMenuDecorationBuilder decorationBuilder =
             widget.decorationBuilder ?? _buildDefaultDecoration;
         InputDecoration decoration = decorationBuilder(context, controller);
+        if (decoration.prefixIcon == null) {
+          decoration = decoration.copyWith(prefixIcon: widget.leadingIcon);
+        }
         // If no suffixIcon is provided, the default IconButton is used for convenience.
         if (decoration.suffixIcon == null) {
           decoration = decoration.copyWith(

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -403,8 +403,8 @@ class DropdownMenu<T> extends StatefulWidget {
 
   /// The builder function used to create the [InputDecoration] passed to the text field.
   ///
-  /// If a value is provided for this property and the resulting [InputDecoration.prefixIcon]
-  /// is null, [leadingIcon] is assigned as the prefix icon.
+  /// If the resulting [InputDecoration.prefixIcon] is null, [leadingIcon] is
+  /// assigned as the prefix icon.
   ///
   /// If a value is provided for this property and the resulting [InputDecoration.suffixIcon]
   /// is null, a default [IconButton] is assigned as the suffix icon. This button's icon will

--- a/packages/flutter/test/material/dropdown_menu_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_form_field_test.dart
@@ -175,6 +175,32 @@ void main() {
     expect(dropdownMenu.leadingIcon, leadingIcon);
   });
 
+  testWidgets('leadingIcon is shown in the text field prefix decoration', (
+    WidgetTester tester,
+  ) async {
+    const Widget leadingIcon = Icon(Icons.check);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: DropdownMenuFormField<MenuItem>(
+            leadingIcon: leadingIcon,
+            dropdownMenuEntries: menuEntries,
+          ),
+        ),
+      ),
+    );
+
+    final TextField textField = tester.widget(find.byType(TextField));
+    final Widget? prefixIcon = textField.decoration?.prefixIcon;
+    expect(prefixIcon, isNotNull);
+    final Finder prefixCheckIcon = find.descendant(
+      of: find.byWidget(prefixIcon!),
+      matching: find.byIcon(Icons.check),
+    );
+    expect(prefixCheckIcon, findsOneWidget);
+  });
+
   testWidgets('Passes trailingIcon to underlying DropdownMenu', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

Fixes a regression where `DropdownMenuFormField.leadingIcon` was not shown in the field.

`DropdownMenuFormField` took a leadingIcon, but didn’t actually show it in the field. This change makes it behave like trailingIcon, so the leading icon now shows up as the default prefix icon.

Fixes #185416


**With only leadingIcon** 
<img width="1155" height="457" alt="Screenshot 2026-04-23 at 00 21 31" src="https://github.com/user-attachments/assets/5e344ae6-4411-4526-bf4b-d158498f4c75" />


**decorationBuilder has higher priority than leading icon.**
<img width="1288" height="560" alt="Screenshot 2026-04-23 at 00 21 11" src="https://github.com/user-attachments/assets/e5bb8fd6-0a16-4733-9b26-8f3cb4583bf0" />

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.



<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
