### PR TITLE
[iOS] Add runtime warning for legacy plugin registration

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -249,12 +249,22 @@ static NSString* const kBackgroundFetchCapatibility = @"fetch";
   }
 }
 
+- (FlutterEngine*)acquireLaunchEngine {
+  [FlutterLogger
+      logWarning:
+          @"Registering plugins before a FlutterViewController is available is a "
+          @"deprecated behavior. Consider conforming to FlutterImplicitEngineDelegate "
+          @"and implementing didInitializeImplicitFlutterEngine instead. "
+          @"See https://docs.flutter.dev/release/breaking-changes/uiscenedelegate for details."];
+  return [self.launchEngine acquireEngine];
+}
+
 - (NSObject<FlutterPluginRegistrar>*)registrarForPlugin:(NSString*)pluginKey {
   FlutterViewController* flutterRootViewController = [self rootFlutterViewController];
   if (flutterRootViewController) {
     return [[flutterRootViewController pluginRegistry] registrarForPlugin:pluginKey];
   }
-  return [[self.launchEngine acquireEngine] registrarForPlugin:pluginKey];
+  return [[self acquireLaunchEngine] registrarForPlugin:pluginKey];
 }
 
 - (BOOL)hasPlugin:(NSString*)pluginKey {
@@ -262,7 +272,7 @@ static NSString* const kBackgroundFetchCapatibility = @"fetch";
   if (flutterRootViewController) {
     return [[flutterRootViewController pluginRegistry] hasPlugin:pluginKey];
   }
-  return [[self.launchEngine acquireEngine] hasPlugin:pluginKey];
+  return [[self acquireLaunchEngine] hasPlugin:pluginKey];
 }
 
 - (NSObject*)valuePublishedByPlugin:(NSString*)pluginKey {
@@ -270,7 +280,7 @@ static NSString* const kBackgroundFetchCapatibility = @"fetch";
   if (flutterRootViewController) {
     return [[flutterRootViewController pluginRegistry] valuePublishedByPlugin:pluginKey];
   }
-  return [[self.launchEngine acquireEngine] valuePublishedByPlugin:pluginKey];
+  return [[self acquireLaunchEngine] valuePublishedByPlugin:pluginKey];
 }
 
 #pragma mark - Selectors handling

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
@@ -5,6 +5,7 @@
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
 
+#import "flutter/shell/platform/darwin/common/test_utils_swift/test_utils_swift.h"
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterAppDelegate.h"
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h"
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
@@ -230,6 +231,19 @@ FLUTTER_ASSERT_ARC
   }
   // A retain cycle would keep this alive.
   XCTAssertNil(appDelegate);
+}
+
+// Verifies that acquireLaunchEngine logs a warning when called before
+// a FlutterViewController is available.
+- (void)testAcquireLaunchEngineLogsWarning {
+  FlutterStringOutputWriter* writer = [[FlutterStringOutputWriter alloc] init];
+  writer.expectedOutput = @"Registering plugins before a FlutterViewController is available";
+  FlutterLogger.outputWriter = writer;
+
+  [self.appDelegate acquireLaunchEngine];
+  XCTAssertTrue(writer.gotExpectedOutput, @"Expected warning was not logged");
+
+  FlutterLogger.outputWriter = nil;
 }
 
 @end

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
@@ -236,14 +236,15 @@ FLUTTER_ASSERT_ARC
 // Verifies that acquireLaunchEngine logs a warning when called before
 // a FlutterViewController is available.
 - (void)testAcquireLaunchEngineLogsWarning {
+  id<FlutterOutputWriter> savedWriter = FlutterLogger.outputWriter;
+
   FlutterStringOutputWriter* writer = [[FlutterStringOutputWriter alloc] init];
   writer.expectedOutput = @"Registering plugins before a FlutterViewController is available";
   FlutterLogger.outputWriter = writer;
-
   [self.appDelegate acquireLaunchEngine];
   XCTAssertTrue(writer.gotExpectedOutput, @"Expected warning was not logged");
 
-  FlutterLogger.outputWriter = nil;
+  FlutterLogger.outputWriter = savedWriter;
 }
 
 @end

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate_Test.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate_Test.h
@@ -5,10 +5,15 @@
 #ifndef FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERAPPDELEGATE_TEST_H_
 #define FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERAPPDELEGATE_TEST_H_
 
+#import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterAppDelegate.h"
+
+@class FlutterEngine;
 @class FlutterViewController;
 
 @interface FlutterAppDelegate (Test)
+
 @property(nonatomic, copy) FlutterViewController* (^rootFlutterViewControllerGetter)(void);
+- (FlutterEngine*)acquireLaunchEngine;
 
 @end
 


### PR DESCRIPTION
Adds a runtime warning when plugins are registered before a FlutterViewController is available -- i.e. when the `LaunchEngine` fallback is used to generate an engine lazily. Points developers at the `UISceneDelegate` migration guide.

Fixes: https://github.com/flutter/flutter/issues/169678

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] Documentation makes it happen. Documentation. Writing together. [ref](https://youtu.be/gR34PJOl3K8?si=FQ59w3LWaelH6i2g)
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
