### PR TITLE
Accessibility: Add semanticLabel to MenuAnchor. Fixes #184876.

### DIFF
--- a/examples/api/lib/material/menu_anchor/menu_anchor.0.dart
+++ b/examples/api/lib/material/menu_anchor/menu_anchor.0.dart
@@ -111,6 +111,7 @@ class _MyCascadingMenuState extends State<MyCascadingMenu> {
       children: <Widget>[
         MenuAnchor(
           animated: true,
+          semanticLabel: 'Cascading application menu',
           onAnimationStatusChanged: (AnimationStatus status) {
             // Store the animation status so that it can be used to determine
             // whether the menu is opening or closing when the button is

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -453,7 +453,7 @@ class MenuAnchor extends StatefulWidget {
   /// closed.
   final MenuAnchorChildBuilder? builder;
 
-  /// The semantic label of the dialog used by this menu.
+  /// The semantic label of the menu.
   ///
   /// Defaults to null.
   final String? semanticLabel;
@@ -697,6 +697,27 @@ class _MenuAnchorState extends State<MenuAnchor> with SingleTickerProviderStateM
   }
 
   Widget _buildOverlay(BuildContext context, RawMenuOverlayInfo position) {
+    Widget submenu = _Submenu(
+      fadeAnimation: opacityAnimation,
+      heightAnimation: heightAnimation,
+      layerLink: widget.layerLink,
+      consumeOutsideTaps: widget.consumeOutsideTap,
+      menuScopeNode: _menuScopeNode,
+      menuStyle: widget.style,
+      clipBehavior: widget.clipBehavior,
+      menuChildren: _menuChildren,
+      crossAxisUnconstrained: widget.crossAxisUnconstrained,
+      menuPosition: position,
+      anchor: this,
+      alignmentOffset: widget.alignmentOffset ?? Offset.zero,
+      reservedPadding: widget.reservedPadding ?? const EdgeInsets.all(_kMenuViewPadding),
+    );
+
+    // Only inject the semantics node if a label is provided
+    if (widget.semanticLabel != null) {
+      submenu = Semantics(container: true, label: widget.semanticLabel, child: submenu);
+    }
+
     // ExcludeSemantics, ExcludeFocus, and IgnorePointer are used to effectively
     // disable all interactions with the menu while it is closing.
     //
@@ -707,27 +728,7 @@ class _MenuAnchorState extends State<MenuAnchor> with SingleTickerProviderStateM
       excluding: isClosingOrClosed,
       child: IgnorePointer(
         ignoring: isClosingOrClosed,
-        child: ExcludeFocus(
-          excluding: isClosingOrClosed,
-          child: Semantics(
-            label: widget.semanticLabel,
-            child: _Submenu(
-              fadeAnimation: opacityAnimation,
-              heightAnimation: heightAnimation,
-              layerLink: widget.layerLink,
-              consumeOutsideTaps: widget.consumeOutsideTap,
-              menuScopeNode: _menuScopeNode,
-              menuStyle: widget.style,
-              clipBehavior: widget.clipBehavior,
-              menuChildren: _menuChildren,
-              crossAxisUnconstrained: widget.crossAxisUnconstrained,
-              menuPosition: position,
-              anchor: this,
-              alignmentOffset: widget.alignmentOffset ?? Offset.zero,
-              reservedPadding: widget.reservedPadding ?? const EdgeInsets.all(_kMenuViewPadding),
-            ),
-          ),
-        ),
+        child: ExcludeFocus(excluding: isClosingOrClosed, child: submenu),
       ),
     );
   }

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -654,6 +654,10 @@ class _MenuAnchorState extends State<MenuAnchor> with SingleTickerProviderStateM
 
     showOverlay();
 
+    if (widget.semanticLabel != null) {
+      SemanticsService.announce(widget.semanticLabel!, Directionality.of(context));
+    }
+
     if (_animationController.isForwardOrCompleted) {
       return;
     }

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -264,6 +264,7 @@ class MenuAnchor extends StatefulWidget {
     this.onAnimationStatusChanged,
     required this.menuChildren,
     this.builder,
+    this.semanticLabel,
     this.child,
   });
 
@@ -451,6 +452,11 @@ class MenuAnchor extends StatefulWidget {
   /// If provided, the builder will be called each time the menu is opened or
   /// closed.
   final MenuAnchorChildBuilder? builder;
+
+  /// The semantic label of the dialog used by this menu.
+  ///
+  /// Defaults to null.
+  final String? semanticLabel;
 
   /// The optional child to be passed to the [builder].
   ///
@@ -703,20 +709,23 @@ class _MenuAnchorState extends State<MenuAnchor> with SingleTickerProviderStateM
         ignoring: isClosingOrClosed,
         child: ExcludeFocus(
           excluding: isClosingOrClosed,
-          child: _Submenu(
-            fadeAnimation: opacityAnimation,
-            heightAnimation: heightAnimation,
-            layerLink: widget.layerLink,
-            consumeOutsideTaps: widget.consumeOutsideTap,
-            menuScopeNode: _menuScopeNode,
-            menuStyle: widget.style,
-            clipBehavior: widget.clipBehavior,
-            menuChildren: _menuChildren,
-            crossAxisUnconstrained: widget.crossAxisUnconstrained,
-            menuPosition: position,
-            anchor: this,
-            alignmentOffset: widget.alignmentOffset ?? Offset.zero,
-            reservedPadding: widget.reservedPadding ?? const EdgeInsets.all(_kMenuViewPadding),
+          child: Semantics(
+            label: widget.semanticLabel,
+            child: _Submenu(
+              fadeAnimation: opacityAnimation,
+              heightAnimation: heightAnimation,
+              layerLink: widget.layerLink,
+              consumeOutsideTaps: widget.consumeOutsideTap,
+              menuScopeNode: _menuScopeNode,
+              menuStyle: widget.style,
+              clipBehavior: widget.clipBehavior,
+              menuChildren: _menuChildren,
+              crossAxisUnconstrained: widget.crossAxisUnconstrained,
+              menuPosition: position,
+              anchor: this,
+              alignmentOffset: widget.alignmentOffset ?? Offset.zero,
+              reservedPadding: widget.reservedPadding ?? const EdgeInsets.all(_kMenuViewPadding),
+            ),
           ),
         ),
       ),

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -7010,6 +7010,36 @@ void main() {
     await tester.pump();
     expect(find.text('X'), findsOne);
   });
+
+  testWidgets('MenuAnchor applies semanticLabel to the expanded menu overlay', (
+    WidgetTester tester,
+  ) async {
+    final SemanticsHandle handle = tester.ensureSemantics();
+    final controller = MenuController();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(
+            child: MenuAnchor(
+              controller: controller,
+              semanticLabel: 'Custom Menu Label',
+              menuChildren: const <Widget>[Text('Menu Item')],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.bySemanticsLabel('Custom Menu Label'), findsNothing);
+
+    controller.open();
+    await tester.pumpAndSettle();
+
+    expect(find.bySemanticsLabel('Custom Menu Label'), findsOneWidget);
+
+    handle.dispose();
+  });
 }
 
 List<Widget> createTestMenus({


### PR DESCRIPTION
## Description

This PR adds a `semanticLabel` property to the `MenuAnchor` widget to improve accessibility. 

Previously, there was no way to add an accessibility label to the expanded menu overlay, causing screen readers (like VoiceOver and TalkBack) to remain silent or announce unhelpful information when the menu was opened. This change passes the `semanticLabel` down to the `Semantics` node wrapping the `_Submenu` in `_buildOverlay`, ensuring the expanded menu is properly announced to users relying on accessibility tools.

## Related Issues

Fixes #184876

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md