### PR TITLE
Update hidden clipboard input on web when 'copy' event is fired

### DIFF
--- a/packages/flutter/lib/src/web.dart
+++ b/packages/flutter/lib/src/web.dart
@@ -57,6 +57,7 @@ extension type Document._(JSObject _) implements JSObject {
   external Element createElement(String localName, [JSAny options]);
   external Range createRange();
   external HTMLHeadElement? get head;
+  external HTMLElement? get body;
 }
 
 extension type DOMTokenList._(JSObject _) implements JSObject {

--- a/packages/flutter/lib/src/web.dart
+++ b/packages/flutter/lib/src/web.dart
@@ -74,6 +74,7 @@ extension type Event._(JSObject _) implements JSObject {}
 
 extension type EventTarget._(JSObject _) implements JSObject {
   external void addEventListener(String type, EventListener? callback, [JSAny options]);
+  external void removeEventListener(String type, EventListener? callback, [JSAny options]);
 }
 
 extension type HTMLElement._(JSObject _) implements Element, JSObject {

--- a/packages/flutter/lib/src/web.dart
+++ b/packages/flutter/lib/src/web.dart
@@ -57,6 +57,7 @@ extension type Document._(JSObject _) implements JSObject {
   external Element createElement(String localName, [JSAny options]);
   external Range createRange();
   external HTMLHeadElement? get head;
+  external HTMLElement? get body;
 }
 
 extension type DOMTokenList._(JSObject _) implements JSObject {
@@ -73,6 +74,7 @@ extension type Event._(JSObject _) implements JSObject {}
 
 extension type EventTarget._(JSObject _) implements JSObject {
   external void addEventListener(String type, EventListener? callback, [JSAny options]);
+  external void removeEventListener(String type, EventListener? callback, [JSAny options]);
 }
 
 extension type HTMLElement._(JSObject _) implements Element, JSObject {

--- a/packages/flutter/lib/src/web.dart
+++ b/packages/flutter/lib/src/web.dart
@@ -53,11 +53,11 @@ extension type CSSStyleSheet._(JSObject _) implements JSObject {
   external int insertRule(String rule, [int index]);
 }
 
-extension type Document._(JSObject _) implements JSObject {
+extension type Document._(JSObject _) implements EventTarget, JSObject {
   external Element createElement(String localName, [JSAny options]);
   external Range createRange();
   external HTMLHeadElement? get head;
-  external HTMLElement? get body;
+  external Element? querySelector(String selectors);
 }
 
 extension type DOMTokenList._(JSObject _) implements JSObject {

--- a/packages/flutter/lib/src/widgets/_platform_selectable_region_context_menu_io.dart
+++ b/packages/flutter/lib/src/widgets/_platform_selectable_region_context_menu_io.dart
@@ -31,6 +31,8 @@ class PlatformSelectableRegionContextMenu extends StatelessWidget {
   PlatformSelectableRegionContextMenu({
     // ignore: avoid_unused_constructor_parameters
     required Widget child,
+    // ignore: avoid_unused_constructor_parameters
+    required SelectionContainerDelegate client,
     super.key,
   });
 

--- a/packages/flutter/lib/src/widgets/_platform_selectable_region_context_menu_io.dart
+++ b/packages/flutter/lib/src/widgets/_platform_selectable_region_context_menu_io.dart
@@ -31,8 +31,6 @@ class PlatformSelectableRegionContextMenu extends StatelessWidget {
   PlatformSelectableRegionContextMenu({
     // ignore: avoid_unused_constructor_parameters
     required Widget child,
-    // ignore: avoid_unused_constructor_parameters
-    required SelectionContainerDelegate client,
     super.key,
   });
 
@@ -47,6 +45,10 @@ class PlatformSelectableRegionContextMenu extends StatelessWidget {
   /// This should only be used for testing.
   @visibleForTesting
   static SelectionContainerDelegate? get debugActiveClient => throw UnimplementedError();
+
+  /// Whether the document copy listener is attached.
+  @visibleForTesting
+  static bool get debugIsCopyEventListenerAttached => false;
 
   /// Override this to provide a custom implementation of `ui_web.platformViewRegistry.registerViewFactory`.
   ///

--- a/packages/flutter/lib/src/widgets/_platform_selectable_region_context_menu_web.dart
+++ b/packages/flutter/lib/src/widgets/_platform_selectable_region_context_menu_web.dart
@@ -29,7 +29,7 @@ const String _kClassRule =
 ''';
 const int _kRightClickButton = 2;
 
-typedef _WebSelectionCallBack = void Function(web.HTMLElement, web.MouseEvent);
+typedef _WebSelectionCallBack = void Function(web.HTMLElement, [web.MouseEvent]);
 
 /// Function signature for `ui_web.platformViewRegistry.registerViewFactory`.
 @visibleForTesting
@@ -86,16 +86,20 @@ class PlatformSelectableRegionContextMenu extends StatelessWidget {
   static void _register() {
     assert(_registeredViewType == null);
     _registeredViewType = _registerWebSelectionCallback((
-      web.HTMLElement element,
-      web.MouseEvent event,
-    ) {
+      web.HTMLElement element, [
+      web.MouseEvent? event,
+    ]) {
       final SelectionContainerDelegate? client = _activeClient;
       if (client != null) {
-        // Converts the html right click event to flutter coordinate.
-        final localOffset = Offset(event.offsetX.toDouble(), event.offsetY.toDouble());
-        final Matrix4 transform = client.getTransformTo(null);
-        final Offset globalOffset = MatrixUtils.transformPoint(transform, localOffset);
-        client.dispatchSelectionEvent(SelectWordSelectionEvent(globalPosition: globalOffset));
+        // If we were triggered by a right click, select the word
+        if (event != null) {
+          // Converts the html right click event to flutter coordinate.
+          final localOffset = Offset(event.offsetX.toDouble(), event.offsetY.toDouble());
+          final Matrix4 transform = client.getTransformTo(null);
+          final Offset globalOffset = MatrixUtils.transformPoint(transform, localOffset);
+          client.dispatchSelectionEvent(SelectWordSelectionEvent(globalPosition: globalOffset));
+        }
+
         // The innerText must contain the text in order to be selected by
         // the browser.
         element.innerText = client.getSelectedContent()?.plainText ?? '';
@@ -134,6 +138,14 @@ class PlatformSelectableRegionContextMenu extends StatelessWidget {
             return;
           }
           callback(htmlElement, mouseEvent);
+        }.toJS,
+      );
+      // TODO(dantup): Should we be doing this here? When is it unregistered?
+      //  What when there are multiple?
+      web.document.body?.addEventListener(
+        'copy',
+        (web.Event event) {
+          callback(htmlElement);
         }.toJS,
       );
       return htmlElement;

--- a/packages/flutter/lib/src/widgets/_platform_selectable_region_context_menu_web.dart
+++ b/packages/flutter/lib/src/widgets/_platform_selectable_region_context_menu_web.dart
@@ -29,7 +29,7 @@ const String _kClassRule =
 ''';
 const int _kRightClickButton = 2;
 
-typedef _WebSelectionCallBack = void Function(web.HTMLElement, web.MouseEvent?);
+typedef _WebSelectionCallBack = void Function(web.HTMLElement, web.MouseEvent);
 
 /// Function signature for `ui_web.platformViewRegistry.registerViewFactory`.
 @visibleForTesting
@@ -37,9 +37,13 @@ typedef RegisterViewFactory = void Function(String, Object Function(int viewId),
 
 /// See `_platform_selectable_region_context_menu_io.dart` for full
 /// documentation.
-class PlatformSelectableRegionContextMenu extends StatelessWidget {
+class PlatformSelectableRegionContextMenu extends StatefulWidget {
   /// See `_platform_selectable_region_context_menu_io.dart`.
-  PlatformSelectableRegionContextMenu({required this.child, super.key}) {
+  PlatformSelectableRegionContextMenu({
+    required this.child,
+    required SelectionContainerDelegate client,
+    super.key,
+  }) : _client = client {
     if (_registeredViewType == null) {
       _register();
     }
@@ -48,20 +52,42 @@ class PlatformSelectableRegionContextMenu extends StatelessWidget {
   /// See `_platform_selectable_region_context_menu_io.dart`.
   final Widget child;
 
+  /// The [SelectionContainerDelegate] for this region.
+  final SelectionContainerDelegate _client;
+
   /// See `_platform_selectable_region_context_menu_io.dart`.
   // ignore: use_setters_to_change_properties
-  static void attach(SelectionContainerDelegate client) {
-    _activeClient = client;
+  static void attach(SelectionContainerDelegate activeClient) {
+    _activeClient = activeClient;
+    _activeElement = _elementsByClient[activeClient];
   }
 
   /// See `_platform_selectable_region_context_menu_io.dart`.
-  static void detach(SelectionContainerDelegate client) {
-    if (_activeClient != client) {
+  static void detach(SelectionContainerDelegate activeClient) {
+    if (_activeClient != activeClient) {
       _activeClient = null;
+      _activeElement = null;
     }
   }
 
+  /// The currently active [SelectionContainerDelegate].
   static SelectionContainerDelegate? _activeClient;
+
+  /// The hidden element for [_activeClient].
+  static web.HTMLElement? _activeElement;
+
+  /// The next ID assigned to be assigned to next State instance to allow
+  /// looking up the client for that instance.
+  static int _nextElementId = 0;
+
+  /// A mapping from element IDs (see [_nextElementId]) to
+  /// [SelectionContainerDelegate]s.
+  static final Map<int, SelectionContainerDelegate> _clientsByElementId =
+      <int, SelectionContainerDelegate>{};
+
+  /// A mapping of [SelectionContainerDelegate]s to their hidden elements.
+  static final Map<SelectionContainerDelegate, web.HTMLElement> _elementsByClient =
+      <SelectionContainerDelegate, web.HTMLElement>{};
 
   // Keeps track if this widget has already registered its view factories or not.
   static String? _registeredViewType;
@@ -80,42 +106,64 @@ class PlatformSelectableRegionContextMenu extends StatelessWidget {
   @visibleForTesting
   static void debugResetRegistry() {
     _registeredViewType = null;
+    _activeClient = null;
+    _activeElement = null;
+    _nextElementId = 0;
+    _clientsByElementId.clear();
+    _elementsByClient.clear();
+    web.document.body?.removeEventListener('copy', _copyEventHandler);
   }
 
   // Registers the view factories for the interceptor widgets.
   static void _register() {
     assert(_registeredViewType == null);
+    web.document.body?.addEventListener('copy', _copyEventHandler);
     _registeredViewType = _registerWebSelectionCallback((
       web.HTMLElement element,
-      // event will be the mouse event if the callback was triggered by
-      // right-clicking and `null` if triggered another way (such as a `copy`
-      // event).
-      web.MouseEvent? event,
+      web.MouseEvent event,
     ) {
       final SelectionContainerDelegate? client = _activeClient;
       if (client != null) {
-        // If we were triggered by a right click, select the word
-        if (event != null) {
-          // Converts the html right click event to flutter coordinate.
-          final localOffset = Offset(event.offsetX.toDouble(), event.offsetY.toDouble());
-          final Matrix4 transform = client.getTransformTo(null);
-          final Offset globalOffset = MatrixUtils.transformPoint(transform, localOffset);
-          client.dispatchSelectionEvent(SelectWordSelectionEvent(globalPosition: globalOffset));
+        _activeElement = element;
 
-          // Programmatically select the dom element in browser.
-          final web.Range range = web.document.createRange()..selectNode(element);
+        // Converts the html right click event to flutter coordinate.
+        final localOffset = Offset(event.offsetX.toDouble(), event.offsetY.toDouble());
+        final Matrix4 transform = client.getTransformTo(null);
+        final Offset globalOffset = MatrixUtils.transformPoint(transform, localOffset);
+        client.dispatchSelectionEvent(SelectWordSelectionEvent(globalPosition: globalOffset));
 
-          web.window.getSelection()
-            ?..removeAllRanges()
-            ..addRange(range);
-        }
-
-        // The innerText must contain the text in order to be selected by
-        // the browser.
-        element.innerText = client.getSelectedContent()?.plainText ?? '';
+        _syncDomSelection(client, element);
       }
     });
   }
+
+  /// Syncs the selection from [client] into the hidden [element].
+  static void _syncDomSelection(SelectionContainerDelegate client, web.HTMLElement element) {
+    // The innerText must contain the text in order to be selected by
+    // the browser.
+    element.innerText = client.getSelectedContent()?.plainText ?? '';
+
+    // Programmatically select the dom element in browser.
+    final web.Range range = web.document.createRange()..selectNode(element);
+
+    web.window.getSelection()
+      ?..removeAllRanges()
+      ..addRange(range);
+  }
+
+  /// A handler for the document copy event to ensure the appropriate hidden
+  /// element is updated.
+  ///
+  /// Registered in [_register] and unregistered in [debugResetRegistry].
+  static final JSExportedDartFunction<Null Function(web.Event event)> _copyEventHandler =
+      (web.Event event) {
+        final SelectionContainerDelegate? client = _activeClient;
+        final web.HTMLElement? element = _activeElement;
+        if (client == null || element == null) {
+          return;
+        }
+        _syncDomSelection(client, element);
+      }.toJS;
 
   static String _registerWebSelectionCallback(_WebSelectionCallBack callback) {
     // Create css style for _kClassName.
@@ -132,6 +180,17 @@ class PlatformSelectableRegionContextMenu extends StatelessWidget {
         ..style.height = '100%'
         ..classList.add(_kClassName);
 
+      // Keep track of this hidden element by the States element ID.
+      final creationParams = params as Map<Object?, Object?>?;
+      final elementId = creationParams?['elementId'] as int?;
+      final SelectionContainerDelegate? client = _clientsByElementId[elementId];
+      if (client != null) {
+        _elementsByClient[client] = htmlElement;
+        if (_activeClient == client) {
+          _activeElement = htmlElement;
+        }
+      }
+
       htmlElement.addEventListener(
         'mousedown',
         (web.Event event) {
@@ -143,19 +202,36 @@ class PlatformSelectableRegionContextMenu extends StatelessWidget {
           callback(htmlElement, mouseEvent);
         }.toJS,
       );
-      // TODO(dantup): Using htmlElement doesn't seem to work, but body does?
-      //   is it ebcause at this point there isn't a real selection/focus for
-      //   the browser to know to target it?
-      // htmlElement.addEventListener(
-      web.document.body?.addEventListener(
-        'copy',
-        (web.Event event) {
-          callback(htmlElement, null);
-        }.toJS,
-      );
       return htmlElement;
     }, isVisible: false);
     return _viewType;
+  }
+
+  @override
+  State<PlatformSelectableRegionContextMenu> createState() =>
+      _PlatformSelectableRegionContextMenuState();
+}
+
+class _PlatformSelectableRegionContextMenuState extends State<PlatformSelectableRegionContextMenu> {
+  /// A unique ID that can be used to link this state back to the corresponding
+  /// [SelectionContainerDelegate].
+  late final int _elementId;
+
+  @override
+  void initState() {
+    super.initState();
+    _elementId = PlatformSelectableRegionContextMenu._nextElementId++;
+    PlatformSelectableRegionContextMenu._clientsByElementId[_elementId] = widget._client;
+  }
+
+  @override
+  void dispose() {
+    PlatformSelectableRegionContextMenu._clientsByElementId.remove(_elementId);
+    PlatformSelectableRegionContextMenu._elementsByClient.remove(widget._client);
+    if (PlatformSelectableRegionContextMenu._activeClient == widget._client) {
+      PlatformSelectableRegionContextMenu._activeElement = null;
+    }
+    super.dispose();
   }
 
   @override
@@ -163,8 +239,13 @@ class PlatformSelectableRegionContextMenu extends StatelessWidget {
     return Stack(
       fit: StackFit.passthrough,
       children: <Widget>[
-        const Positioned.fill(child: HtmlElementView(viewType: _viewType)),
-        child,
+        Positioned.fill(
+          child: HtmlElementView(
+            viewType: _viewType,
+            creationParams: <String, int>{'elementId': _elementId},
+          ),
+        ),
+        widget.child,
       ],
     );
   }

--- a/packages/flutter/lib/src/widgets/_platform_selectable_region_context_menu_web.dart
+++ b/packages/flutter/lib/src/widgets/_platform_selectable_region_context_menu_web.dart
@@ -29,7 +29,7 @@ const String _kClassRule =
 ''';
 const int _kRightClickButton = 2;
 
-typedef _WebSelectionCallBack = void Function(web.HTMLElement, [web.MouseEvent]);
+typedef _WebSelectionCallBack = void Function(web.HTMLElement, web.MouseEvent?);
 
 /// Function signature for `ui_web.platformViewRegistry.registerViewFactory`.
 @visibleForTesting
@@ -86,9 +86,12 @@ class PlatformSelectableRegionContextMenu extends StatelessWidget {
   static void _register() {
     assert(_registeredViewType == null);
     _registeredViewType = _registerWebSelectionCallback((
-      web.HTMLElement element, [
+      web.HTMLElement element,
+      // event will be the mouse event if the callback was triggered by
+      // right-clicking and `null` if triggered another way (such as a `copy`
+      // event).
       web.MouseEvent? event,
-    ]) {
+    ) {
       final SelectionContainerDelegate? client = _activeClient;
       if (client != null) {
         // If we were triggered by a right click, select the word
@@ -98,18 +101,18 @@ class PlatformSelectableRegionContextMenu extends StatelessWidget {
           final Matrix4 transform = client.getTransformTo(null);
           final Offset globalOffset = MatrixUtils.transformPoint(transform, localOffset);
           client.dispatchSelectionEvent(SelectWordSelectionEvent(globalPosition: globalOffset));
+
+          // Programmatically select the dom element in browser.
+          final web.Range range = web.document.createRange()..selectNode(element);
+
+          web.window.getSelection()
+            ?..removeAllRanges()
+            ..addRange(range);
         }
 
         // The innerText must contain the text in order to be selected by
         // the browser.
         element.innerText = client.getSelectedContent()?.plainText ?? '';
-
-        // Programmatically select the dom element in browser.
-        final web.Range range = web.document.createRange()..selectNode(element);
-
-        web.window.getSelection()
-          ?..removeAllRanges()
-          ..addRange(range);
       }
     });
   }
@@ -140,12 +143,14 @@ class PlatformSelectableRegionContextMenu extends StatelessWidget {
           callback(htmlElement, mouseEvent);
         }.toJS,
       );
-      // TODO(dantup): Should we be doing this here? When is it unregistered?
-      //  What when there are multiple?
+      // TODO(dantup): Using htmlElement doesn't seem to work, but body does?
+      //   is it ebcause at this point there isn't a real selection/focus for
+      //   the browser to know to target it?
+      // htmlElement.addEventListener(
       web.document.body?.addEventListener(
         'copy',
         (web.Event event) {
-          callback(htmlElement);
+          callback(htmlElement, null);
         }.toJS,
       );
       return htmlElement;

--- a/packages/flutter/lib/src/widgets/_platform_selectable_region_context_menu_web.dart
+++ b/packages/flutter/lib/src/widgets/_platform_selectable_region_context_menu_web.dart
@@ -37,9 +37,13 @@ typedef RegisterViewFactory = void Function(String, Object Function(int viewId),
 
 /// See `_platform_selectable_region_context_menu_io.dart` for full
 /// documentation.
-class PlatformSelectableRegionContextMenu extends StatelessWidget {
+class PlatformSelectableRegionContextMenu extends StatefulWidget {
   /// See `_platform_selectable_region_context_menu_io.dart`.
-  PlatformSelectableRegionContextMenu({required this.child, super.key}) {
+  PlatformSelectableRegionContextMenu({
+    required this.child,
+    required SelectionContainerDelegate client,
+    super.key,
+  }) : _client = client {
     if (_registeredViewType == null) {
       _register();
     }
@@ -48,20 +52,42 @@ class PlatformSelectableRegionContextMenu extends StatelessWidget {
   /// See `_platform_selectable_region_context_menu_io.dart`.
   final Widget child;
 
+  /// The [SelectionContainerDelegate] for this region.
+  final SelectionContainerDelegate _client;
+
   /// See `_platform_selectable_region_context_menu_io.dart`.
   // ignore: use_setters_to_change_properties
-  static void attach(SelectionContainerDelegate client) {
-    _activeClient = client;
+  static void attach(SelectionContainerDelegate activeClient) {
+    _activeClient = activeClient;
+    _activeElement = _elementsByClient[activeClient];
   }
 
   /// See `_platform_selectable_region_context_menu_io.dart`.
-  static void detach(SelectionContainerDelegate client) {
-    if (_activeClient == client) {
+  static void detach(SelectionContainerDelegate activeClient) {
+    if (_activeClient != activeClient) {
       _activeClient = null;
+      _activeElement = null;
     }
   }
 
+  /// The currently active [SelectionContainerDelegate].
   static SelectionContainerDelegate? _activeClient;
+
+  /// The hidden element for [_activeClient].
+  static web.HTMLElement? _activeElement;
+
+  /// The next ID assigned to be assigned to next State instance to allow
+  /// looking up the client for that instance.
+  static int _nextElementId = 0;
+
+  /// A mapping from element IDs (see [_nextElementId]) to
+  /// [SelectionContainerDelegate]s.
+  static final Map<int, SelectionContainerDelegate> _clientsByElementId =
+      <int, SelectionContainerDelegate>{};
+
+  /// A mapping of [SelectionContainerDelegate]s to their hidden elements.
+  static final Map<SelectionContainerDelegate, web.HTMLElement> _elementsByClient =
+      <SelectionContainerDelegate, web.HTMLElement>{};
 
   /// The client currently attached to the [PlatformSelectableRegionContextMenu].
   ///
@@ -86,35 +112,76 @@ class PlatformSelectableRegionContextMenu extends StatelessWidget {
   @visibleForTesting
   static void debugResetRegistry() {
     _registeredViewType = null;
+    _activeClient = null;
+    _activeElement = null;
+    _nextElementId = 0;
+    _clientsByElementId.clear();
+    _elementsByClient.clear();
+    debugPrint('removing copy handler');
+    web.document.body?.removeEventListener('copy', _copyEventHandler);
   }
 
   // Registers the view factories for the interceptor widgets.
   static void _register() {
     assert(_registeredViewType == null);
+    debugPrint('adding copy handler');
+    web.document.body?.addEventListener('copy', _copyEventHandler);
+    web.document.body?.addEventListener(
+      'copy',
+      () {
+        debugPrint('running second copyt handler');
+      }.toJS,
+    );
     _registeredViewType = _registerWebSelectionCallback((
       web.HTMLElement element,
       web.MouseEvent event,
     ) {
+      debugPrint('running selection handler');
       final SelectionContainerDelegate? client = _activeClient;
       if (client != null) {
+        _activeElement = element;
         // Converts the html right click event to flutter coordinate.
         final localOffset = Offset(event.offsetX.toDouble(), event.offsetY.toDouble());
         final Matrix4 transform = client.getTransformTo(null);
         final Offset globalOffset = MatrixUtils.transformPoint(transform, localOffset);
         client.dispatchSelectionEvent(SelectWordSelectionEvent(globalPosition: globalOffset));
-        // The innerText must contain the text in order to be selected by
-        // the browser.
-        element.innerText = client.getSelectedContent()?.plainText ?? '';
 
-        // Programmatically select the dom element in browser.
-        final web.Range range = web.document.createRange()..selectNode(element);
-
-        web.window.getSelection()
-          ?..removeAllRanges()
-          ..addRange(range);
+        _syncDomSelection(client, element);
       }
     });
   }
+
+  /// Syncs the selection from [client] into the hidden [element].
+  static void _syncDomSelection(SelectionContainerDelegate client, web.HTMLElement element) {
+    debugPrint('syncing dom');
+    // The innerText must contain the text in order to be selected by
+    // the browser.
+    final String? newText = client.getSelectedContent()?.plainText;
+    debugPrint('new selection is: "$newText"');
+    element.innerText = newText ?? '';
+
+    // Programmatically select the dom element in browser.
+    final web.Range range = web.document.createRange()..selectNode(element);
+
+    web.window.getSelection()
+      ?..removeAllRanges()
+      ..addRange(range);
+  }
+
+  /// A handler for the document copy event to ensure the appropriate hidden
+  /// element is updated.
+  ///
+  /// Registered in [_register] and unregistered in [debugResetRegistry].
+  static final JSExportedDartFunction<Null Function(web.Event event)> _copyEventHandler =
+      (web.Event event) {
+        debugPrint('running copy handler');
+        final SelectionContainerDelegate? client = _activeClient;
+        final web.HTMLElement? element = _activeElement;
+        if (client == null || element == null) {
+          return;
+        }
+        _syncDomSelection(client, element);
+      }.toJS;
 
   static String _registerWebSelectionCallback(_WebSelectionCallBack callback) {
     // Create css style for _kClassName.
@@ -130,6 +197,17 @@ class PlatformSelectableRegionContextMenu extends StatelessWidget {
         ..style.width = '100%'
         ..style.height = '100%'
         ..classList.add(_kClassName);
+
+      // Keep track of this hidden element by the States element ID.
+      final creationParams = params as Map<Object?, Object?>?;
+      final elementId = creationParams?['elementId'] as int?;
+      final SelectionContainerDelegate? client = _clientsByElementId[elementId];
+      if (client != null) {
+        _elementsByClient[client] = htmlElement;
+        if (_activeClient == client) {
+          _activeElement = htmlElement;
+        }
+      }
 
       htmlElement.addEventListener(
         'mousedown',
@@ -148,12 +226,44 @@ class PlatformSelectableRegionContextMenu extends StatelessWidget {
   }
 
   @override
+  State<PlatformSelectableRegionContextMenu> createState() =>
+      _PlatformSelectableRegionContextMenuState();
+}
+
+class _PlatformSelectableRegionContextMenuState extends State<PlatformSelectableRegionContextMenu> {
+  /// A unique ID that can be used to link this state back to the corresponding
+  /// [SelectionContainerDelegate].
+  late final int _elementId;
+
+  @override
+  void initState() {
+    super.initState();
+    _elementId = PlatformSelectableRegionContextMenu._nextElementId++;
+    PlatformSelectableRegionContextMenu._clientsByElementId[_elementId] = widget._client;
+  }
+
+  @override
+  void dispose() {
+    PlatformSelectableRegionContextMenu._clientsByElementId.remove(_elementId);
+    PlatformSelectableRegionContextMenu._elementsByClient.remove(widget._client);
+    if (PlatformSelectableRegionContextMenu._activeClient == widget._client) {
+      PlatformSelectableRegionContextMenu._activeElement = null;
+    }
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Stack(
       fit: StackFit.passthrough,
       children: <Widget>[
-        const Positioned.fill(child: HtmlElementView(viewType: _viewType)),
-        child,
+        Positioned.fill(
+          child: HtmlElementView(
+            viewType: _viewType,
+            creationParams: <String, int>{'elementId': _elementId},
+          ),
+        ),
+        widget.child,
       ],
     );
   }

--- a/packages/flutter/lib/src/widgets/_platform_selectable_region_context_menu_web.dart
+++ b/packages/flutter/lib/src/widgets/_platform_selectable_region_context_menu_web.dart
@@ -37,13 +37,9 @@ typedef RegisterViewFactory = void Function(String, Object Function(int viewId),
 
 /// See `_platform_selectable_region_context_menu_io.dart` for full
 /// documentation.
-class PlatformSelectableRegionContextMenu extends StatefulWidget {
+class PlatformSelectableRegionContextMenu extends StatelessWidget {
   /// See `_platform_selectable_region_context_menu_io.dart`.
-  PlatformSelectableRegionContextMenu({
-    required this.child,
-    required SelectionContainerDelegate client,
-    super.key,
-  }) : _client = client {
+  PlatformSelectableRegionContextMenu({required this.child, super.key}) {
     if (_registeredViewType == null) {
       _register();
     }
@@ -52,48 +48,56 @@ class PlatformSelectableRegionContextMenu extends StatefulWidget {
   /// See `_platform_selectable_region_context_menu_io.dart`.
   final Widget child;
 
-  /// The [SelectionContainerDelegate] for this region.
-  final SelectionContainerDelegate _client;
-
   /// See `_platform_selectable_region_context_menu_io.dart`.
   // ignore: use_setters_to_change_properties
-  static void attach(SelectionContainerDelegate activeClient) {
-    _activeClient = activeClient;
-    _activeElement = _elementsByClient[activeClient];
-  }
-
-  /// See `_platform_selectable_region_context_menu_io.dart`.
-  static void detach(SelectionContainerDelegate activeClient) {
-    if (_activeClient != activeClient) {
-      _activeClient = null;
-      _activeElement = null;
+  static void attach(SelectionContainerDelegate client) {
+    _activeClient = client;
+    if (!_copyEventListenerAttached) {
+      web.document.addEventListener('copy', _onCopy);
+      _copyEventListenerAttached = true;
     }
   }
 
-  /// The currently active [SelectionContainerDelegate].
+  /// See `_platform_selectable_region_context_menu_io.dart`.
+  static void detach(SelectionContainerDelegate client) {
+    if (_activeClient == client) {
+      _activeClient = null;
+      web.document.removeEventListener('copy', _onCopy);
+      _copyEventListenerAttached = false;
+    }
+  }
+
   static SelectionContainerDelegate? _activeClient;
+  static bool _copyEventListenerAttached = false;
 
-  /// The hidden element for [_activeClient].
-  static web.HTMLElement? _activeElement;
+  static final JSExportedDartFunction _onCopy = (web.Event event) {
+    final SelectionContainerDelegate? client = _activeClient;
+    final element = web.document.querySelector('.$_kClassName') as web.HTMLElement?;
+    if (client != null && element != null) {
+      _synchronizeDomSelection(element, client);
+    }
+  }.toJS;
 
-  /// The next ID assigned to be assigned to next State instance to allow
-  /// looking up the client for that instance.
-  static int _nextElementId = 0;
+  static void _synchronizeDomSelection(web.HTMLElement element, SelectionContainerDelegate client) {
+    // The innerText must contain the text in order to be selected by the browser.
+    element.innerText = client.getSelectedContent()?.plainText ?? '';
 
-  /// A mapping from element IDs (see [_nextElementId]) to
-  /// [SelectionContainerDelegate]s.
-  static final Map<int, SelectionContainerDelegate> _clientsByElementId =
-      <int, SelectionContainerDelegate>{};
-
-  /// A mapping of [SelectionContainerDelegate]s to their hidden elements.
-  static final Map<SelectionContainerDelegate, web.HTMLElement> _elementsByClient =
-      <SelectionContainerDelegate, web.HTMLElement>{};
+    // Programmatically select the DOM element in browser.
+    final web.Range range = web.document.createRange()..selectNode(element);
+    web.window.getSelection()
+      ?..removeAllRanges()
+      ..addRange(range);
+  }
 
   /// The client currently attached to the [PlatformSelectableRegionContextMenu].
   ///
   /// This should only be used for testing.
   @visibleForTesting
   static SelectionContainerDelegate? get debugActiveClient => _activeClient;
+
+  /// Whether the document copy listener is attached.
+  @visibleForTesting
+  static bool get debugIsCopyEventListenerAttached => _copyEventListenerAttached;
 
   // Keeps track if this widget has already registered its view factories or not.
   static String? _registeredViewType;
@@ -112,76 +116,26 @@ class PlatformSelectableRegionContextMenu extends StatefulWidget {
   @visibleForTesting
   static void debugResetRegistry() {
     _registeredViewType = null;
-    _activeClient = null;
-    _activeElement = null;
-    _nextElementId = 0;
-    _clientsByElementId.clear();
-    _elementsByClient.clear();
-    debugPrint('removing copy handler');
-    web.document.body?.removeEventListener('copy', _copyEventHandler);
   }
 
   // Registers the view factories for the interceptor widgets.
   static void _register() {
     assert(_registeredViewType == null);
-    debugPrint('adding copy handler');
-    web.document.body?.addEventListener('copy', _copyEventHandler);
-    web.document.body?.addEventListener(
-      'copy',
-      () {
-        debugPrint('running second copyt handler');
-      }.toJS,
-    );
     _registeredViewType = _registerWebSelectionCallback((
       web.HTMLElement element,
       web.MouseEvent event,
     ) {
-      debugPrint('running selection handler');
       final SelectionContainerDelegate? client = _activeClient;
       if (client != null) {
-        _activeElement = element;
         // Converts the html right click event to flutter coordinate.
         final localOffset = Offset(event.offsetX.toDouble(), event.offsetY.toDouble());
         final Matrix4 transform = client.getTransformTo(null);
         final Offset globalOffset = MatrixUtils.transformPoint(transform, localOffset);
         client.dispatchSelectionEvent(SelectWordSelectionEvent(globalPosition: globalOffset));
-
-        _syncDomSelection(client, element);
+        _synchronizeDomSelection(element, client);
       }
     });
   }
-
-  /// Syncs the selection from [client] into the hidden [element].
-  static void _syncDomSelection(SelectionContainerDelegate client, web.HTMLElement element) {
-    debugPrint('syncing dom');
-    // The innerText must contain the text in order to be selected by
-    // the browser.
-    final String? newText = client.getSelectedContent()?.plainText;
-    debugPrint('new selection is: "$newText"');
-    element.innerText = newText ?? '';
-
-    // Programmatically select the dom element in browser.
-    final web.Range range = web.document.createRange()..selectNode(element);
-
-    web.window.getSelection()
-      ?..removeAllRanges()
-      ..addRange(range);
-  }
-
-  /// A handler for the document copy event to ensure the appropriate hidden
-  /// element is updated.
-  ///
-  /// Registered in [_register] and unregistered in [debugResetRegistry].
-  static final JSExportedDartFunction<Null Function(web.Event event)> _copyEventHandler =
-      (web.Event event) {
-        debugPrint('running copy handler');
-        final SelectionContainerDelegate? client = _activeClient;
-        final web.HTMLElement? element = _activeElement;
-        if (client == null || element == null) {
-          return;
-        }
-        _syncDomSelection(client, element);
-      }.toJS;
 
   static String _registerWebSelectionCallback(_WebSelectionCallBack callback) {
     // Create css style for _kClassName.
@@ -197,17 +151,6 @@ class PlatformSelectableRegionContextMenu extends StatefulWidget {
         ..style.width = '100%'
         ..style.height = '100%'
         ..classList.add(_kClassName);
-
-      // Keep track of this hidden element by the States element ID.
-      final creationParams = params as Map<Object?, Object?>?;
-      final elementId = creationParams?['elementId'] as int?;
-      final SelectionContainerDelegate? client = _clientsByElementId[elementId];
-      if (client != null) {
-        _elementsByClient[client] = htmlElement;
-        if (_activeClient == client) {
-          _activeElement = htmlElement;
-        }
-      }
 
       htmlElement.addEventListener(
         'mousedown',
@@ -226,44 +169,12 @@ class PlatformSelectableRegionContextMenu extends StatefulWidget {
   }
 
   @override
-  State<PlatformSelectableRegionContextMenu> createState() =>
-      _PlatformSelectableRegionContextMenuState();
-}
-
-class _PlatformSelectableRegionContextMenuState extends State<PlatformSelectableRegionContextMenu> {
-  /// A unique ID that can be used to link this state back to the corresponding
-  /// [SelectionContainerDelegate].
-  late final int _elementId;
-
-  @override
-  void initState() {
-    super.initState();
-    _elementId = PlatformSelectableRegionContextMenu._nextElementId++;
-    PlatformSelectableRegionContextMenu._clientsByElementId[_elementId] = widget._client;
-  }
-
-  @override
-  void dispose() {
-    PlatformSelectableRegionContextMenu._clientsByElementId.remove(_elementId);
-    PlatformSelectableRegionContextMenu._elementsByClient.remove(widget._client);
-    if (PlatformSelectableRegionContextMenu._activeClient == widget._client) {
-      PlatformSelectableRegionContextMenu._activeElement = null;
-    }
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
     return Stack(
       fit: StackFit.passthrough,
       children: <Widget>[
-        Positioned.fill(
-          child: HtmlElementView(
-            viewType: _viewType,
-            creationParams: <String, int>{'elementId': _elementId},
-          ),
-        ),
-        widget.child,
+        const Positioned.fill(child: HtmlElementView(viewType: _viewType)),
+        child,
       ],
     );
   }

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -536,9 +536,11 @@ class SelectableRegionState extends State<SelectableRegion>
         _selectionStatusNotifier.value = SelectableRegionSelectionStatus.changing;
         _finalizeSelectableRegionStatus();
       }
-    }
-    if (_webContextMenuEnabled) {
-      PlatformSelectableRegionContextMenu.attach(_selectionDelegate);
+    } else {
+      // has focus
+      if (_webContextMenuEnabled) {
+        PlatformSelectableRegionContextMenu.attach(_selectionDelegate);
+      }
     }
   }
 
@@ -1953,7 +1955,7 @@ class SelectableRegionState extends State<SelectableRegion>
       child: SelectionContainer(registrar: this, delegate: _selectionDelegate, child: widget.child),
     );
     if (_webContextMenuEnabled) {
-      result = PlatformSelectableRegionContextMenu(child: result);
+      result = PlatformSelectableRegionContextMenu(client: _selectionDelegate, child: result);
     }
     return TapRegion(
       groupId: SelectableRegion,

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -351,7 +351,10 @@ class SelectableRegionState extends State<SelectableRegion>
     implements SelectionRegistrar {
   late final Map<Type, Action<Intent>> _actions = <Type, Action<Intent>>{
     SelectAllTextIntent: _makeOverridable(_SelectAllAction(this)),
-    CopySelectionTextIntent: _makeOverridable(_CopySelectionAction(this)),
+    // TODO(dantup): Uncommenting this does not result in Cmd+C being handled
+    //  natively. Is _makeOverridable necessary for web?
+    // TODO(dantup): This needs to be conditional only for web.
+    // CopySelectionTextIntent: _makeOverridable(DoNothingAction()),
     ExtendSelectionToNextWordBoundaryOrCaretLocationIntent: _makeOverridable(
       _GranularlyExtendSelectionAction<ExtendSelectionToNextWordBoundaryOrCaretLocationIntent>(
         this,
@@ -1968,7 +1971,7 @@ class SelectableRegionState extends State<SelectableRegion>
       child: SelectionContainer(registrar: this, delegate: _selectionDelegate, child: widget.child),
     );
     if (_webContextMenuEnabled) {
-      result = PlatformSelectableRegionContextMenu(child: result);
+      result = PlatformSelectableRegionContextMenu(client: _selectionDelegate, child: result);
     }
     return TapRegion(
       groupId: SelectableRegion,

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -351,10 +351,7 @@ class SelectableRegionState extends State<SelectableRegion>
     implements SelectionRegistrar {
   late final Map<Type, Action<Intent>> _actions = <Type, Action<Intent>>{
     SelectAllTextIntent: _makeOverridable(_SelectAllAction(this)),
-    // TODO(dantup): Uncommenting this does not result in Cmd+C being handled
-    //  natively. Is _makeOverridable necessary for web?
-    // TODO(dantup): This needs to be conditional only for web.
-    // CopySelectionTextIntent: _makeOverridable(DoNothingAction()),
+    CopySelectionTextIntent: _makeOverridable(_CopySelectionAction(this)),
     ExtendSelectionToNextWordBoundaryOrCaretLocationIntent: _makeOverridable(
       _GranularlyExtendSelectionAction<ExtendSelectionToNextWordBoundaryOrCaretLocationIntent>(
         this,
@@ -1971,7 +1968,7 @@ class SelectableRegionState extends State<SelectableRegion>
       child: SelectionContainer(registrar: this, delegate: _selectionDelegate, child: widget.child),
     );
     if (_webContextMenuEnabled) {
-      result = PlatformSelectableRegionContextMenu(client: _selectionDelegate, child: result);
+      result = PlatformSelectableRegionContextMenu(child: result);
     }
     return TapRegion(
       groupId: SelectableRegion,

--- a/packages/flutter/test/widgets/selectable_region_context_menu_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_context_menu_test.dart
@@ -14,6 +14,7 @@ import 'package:web/web.dart' as web;
 
 import 'selectable_region_test.dart' show textOffsetToPosition;
 import 'web_platform_view_registry_utils.dart';
+import 'widgets_app_tester.dart';
 
 extension on web.HTMLCollection {
   Iterable<web.Element?> get iterable =>
@@ -53,7 +54,7 @@ void main() {
     final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
 
     await tester.pumpWidget(
-      MaterialApp(
+      TestWidgetsApp(
         home: SelectableRegion(
           selectionControls: EmptyTextSelectionControls(),
           child: const Placeholder(),
@@ -74,7 +75,7 @@ void main() {
 
   testWidgets('only one <style> is inserted into the DOM', (WidgetTester tester) async {
     await tester.pumpWidget(
-      MaterialApp(
+      TestWidgetsApp(
         home: ListView(
           children: <Widget>[
             SelectableRegion(
@@ -107,10 +108,10 @@ void main() {
     addTearDown(focusNode.dispose);
     final spy = UniqueKey();
     await tester.pumpWidget(
-      MaterialApp(
+      TestWidgetsApp(
         home: SelectableRegion(
           focusNode: focusNode,
-          selectionControls: materialTextSelectionControls,
+          selectionControls: emptyTextSelectionControls,
           child: SelectionSpy(key: spy),
         ),
       ),
@@ -148,7 +149,7 @@ void main() {
     final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
 
     await tester.pumpWidget(
-      MaterialApp(
+      TestWidgetsApp(
         home: SelectableRegion(
           selectionControls: emptyTextSelectionControls,
           child: const SizedBox.shrink(),
@@ -179,7 +180,7 @@ void main() {
     final focusNode = FocusNode();
     addTearDown(focusNode.dispose);
     await tester.pumpWidget(
-      MaterialApp(
+      TestWidgetsApp(
         home: Column(
           children: [
             SelectableRegion(

--- a/packages/flutter/test/widgets/selectable_region_context_menu_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_context_menu_test.dart
@@ -12,6 +12,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:web/web.dart' as web;
 
+import 'selectable_region_test.dart' show textOffsetToPosition;
 import 'web_platform_view_registry_utils.dart';
 
 extension on web.HTMLCollection {
@@ -166,6 +167,62 @@ void main() {
       element.dispatchEvent(event);
       expect(event.defaultPrevented, isTrue);
     }
+  }, variant: _browserContextMenuEnabledVariants);
+
+  // Ensure that if execCommand('copy') is called, it triggers an update of the
+  // hidden input so that the correct selected text is written to the clipboard.
+  //
+  // Regression test for https://github.com/flutter/flutter/issues/182756
+  testWidgets('copy event triggers update of hidden input', (WidgetTester tester) async {
+    final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
+
+    final focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Column(
+          children: [
+            SelectableRegion(
+              selectionControls: emptyTextSelectionControls,
+              child: const Text('Some text before'),
+            ),
+            SelectableRegion(
+              focusNode: focusNode,
+              selectionControls: emptyTextSelectionControls,
+              child: const Text('Some example text'),
+            ),
+            SelectableRegion(
+              selectionControls: emptyTextSelectionControls,
+              child: const Text('Some text after'),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    final element = fakePlatformViewRegistry.getViewById(currentViewId + 1) as web.HTMLElement;
+    expect(element, isNotNull);
+
+    // Select the text
+    final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(
+      find.descendant(of: find.text('Some example text'), matching: find.byType(RichText)),
+    );
+    final Offset exampleWordStart = textOffsetToPosition(paragraph, 'Some '.length);
+    final Offset exampleWordEnd = textOffsetToPosition(paragraph, 'Some example'.length);
+    final TestGesture gesture = await tester.startGesture(exampleWordStart);
+    addTearDown(gesture.removePointer);
+    await tester.pump(const Duration(milliseconds: 500));
+    await gesture.moveTo(exampleWordEnd);
+    await tester.pump(const Duration(milliseconds: 500));
+    await gesture.up();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    focusNode.requestFocus();
+    await tester.pump();
+
+    // Dispatch the copy command on the document.
+    element.ownerDocument!.body!.dispatchEvent(web.Event('copy'));
+    expect(element.innerText, anyOf('example', 'example '));
   }, variant: _browserContextMenuEnabledVariants);
 }
 

--- a/packages/flutter/test/widgets/selectable_region_context_menu_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_context_menu_test.dart
@@ -171,60 +171,142 @@ void main() {
   }, variant: _browserContextMenuEnabledVariants);
 
   // Ensure that if execCommand('copy') is called, it triggers an update of the
-  // hidden input so that the correct selected text is written to the clipboard.
-  //
-  // Regression test for https://github.com/flutter/flutter/issues/182756
-  testWidgets('copy event triggers update of hidden input', (WidgetTester tester) async {
-    final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
+  // hidden element so that the correct selected text is written to the clipboard.
+  testWidgets('copy event triggers update of hidden element', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: SelectableRegion(
+          selectionControls: emptyTextSelectionControls,
+          child: const Text('Some example text'),
+        ),
+      ),
+    );
 
-    final focusNode = FocusNode();
-    addTearDown(focusNode.dispose);
+    // Select the text.
+    await _selectText(tester, 'Some example text', 'example');
+    await tester.pump();
+
+    // Dispatch the copy command on the document.
+    web.document.body!.dispatchEvent(web.Event('copy'));
+
+    // Verify the hidden element.
+    final web.HTMLElement element = _hiddenElements(fakePlatformViewRegistry).single;
+    expect(element.innerText, anyOf('example', 'example '));
+  }, variant: _browserContextMenuEnabledVariants);
+
+  testWidgets('copy event updates only the focused region', (WidgetTester tester) async {
     await tester.pumpWidget(
       TestWidgetsApp(
         home: Column(
-          children: [
+          children: <Widget>[
             SelectableRegion(
+              // focusNode: firstFocusNode,
               selectionControls: emptyTextSelectionControls,
-              child: const Text('Some text before'),
+              child: const Text('first region text'),
             ),
             SelectableRegion(
-              focusNode: focusNode,
+              // focusNode: secondFocusNode,
               selectionControls: emptyTextSelectionControls,
-              child: const Text('Some example text'),
+              child: const Text('second region text'),
             ),
             SelectableRegion(
+              // focusNode: thirdFocusNode,
               selectionControls: emptyTextSelectionControls,
-              child: const Text('Some text after'),
+              child: const Text('third region text'),
             ),
           ],
         ),
       ),
     );
 
-    final element = fakePlatformViewRegistry.getViewById(currentViewId + 1) as web.HTMLElement;
-    expect(element, isNotNull);
-
-    // Select the text
-    final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(
-      find.descendant(of: find.text('Some example text'), matching: find.byType(RichText)),
-    );
-    final Offset exampleWordStart = textOffsetToPosition(paragraph, 'Some '.length);
-    final Offset exampleWordEnd = textOffsetToPosition(paragraph, 'Some example'.length);
-    final TestGesture gesture = await tester.startGesture(exampleWordStart);
-    addTearDown(gesture.removePointer);
-    await tester.pump(const Duration(milliseconds: 500));
-    await gesture.moveTo(exampleWordEnd);
-    await tester.pump(const Duration(milliseconds: 500));
-    await gesture.up();
-    await tester.pump(const Duration(milliseconds: 500));
-
-    focusNode.requestFocus();
+    await _selectText(tester, 'second region text', 'second');
     await tester.pump();
 
-    // Dispatch the copy command on the document.
-    element.ownerDocument!.body!.dispatchEvent(web.Event('copy'));
-    expect(element.innerText, anyOf('example', 'example '));
+    web.document.body!.dispatchEvent(web.Event('copy'));
+
+    final List<web.HTMLElement> elements = _hiddenElements(fakePlatformViewRegistry);
+    expect(elements, hasLength(3));
+    expect(elements[0].innerText, isEmpty);
+    expect(elements[1].innerText, anyOf('second', 'second '));
+    expect(elements[2].innerText, isEmpty);
   }, variant: _browserContextMenuEnabledVariants);
+
+  testWidgets(
+    'disposed region does not continue responding to copy events',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: Column(
+            children: <Widget>[
+              SelectableRegion(
+                // focusNode: firstFocusNode,
+                selectionControls: emptyTextSelectionControls,
+                child: const Text('keep this region'),
+              ),
+              SelectableRegion(
+                // focusNode: secondFocusNode,
+                selectionControls: emptyTextSelectionControls,
+                child: const Text('remove this region'),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      final List<web.HTMLElement> initialElements = _hiddenElements(fakePlatformViewRegistry);
+      expect(initialElements, hasLength(2));
+      final web.HTMLElement removedElement = initialElements[1];
+
+      await _selectText(tester, 'remove this region', 'remove');
+      await tester.pump();
+      web.document.body!.dispatchEvent(web.Event('copy'));
+      expect(removedElement.innerText, anyOf('remove', 'remove '));
+
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: SelectableRegion(
+            selectionControls: emptyTextSelectionControls,
+            child: const Text('keep this region'),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await _selectText(tester, 'keep this region', 'keep');
+      await tester.pump();
+
+      web.document.body!.dispatchEvent(web.Event('copy'));
+
+      expect(removedElement.innerText, anyOf('remove', 'remove '));
+      expect(_hiddenElements(fakePlatformViewRegistry), hasLength(1));
+      expect(_hiddenElements(fakePlatformViewRegistry).single.innerText, anyOf('keep', 'keep '));
+    },
+    variant: _browserContextMenuEnabledVariants,
+  );
+}
+
+/// Returns the hidden elements used for holding the selected text for copying.
+List<web.HTMLElement> _hiddenElements(FakePlatformViewRegistry fakePlatformViewRegistry) {
+  return fakePlatformViewRegistry.views.map((view) => view.htmlElement as web.HTMLElement).toList();
+}
+
+/// Selects the text [selection] inside [text] by tapping and dragging over it.
+Future<void> _selectText(WidgetTester tester, String text, String selection) async {
+  final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(
+    find.descendant(of: find.text(text), matching: find.byType(RichText)),
+  );
+  final int startIndex = text.indexOf(selection);
+  expect(startIndex, isNonNegative);
+  final Offset start = textOffsetToPosition(paragraph, startIndex);
+  final Offset end = textOffsetToPosition(paragraph, startIndex + selection.length);
+
+  final TestGesture gesture = await tester.startGesture(start);
+  addTearDown(gesture.removePointer);
+  await tester.pump(const Duration(milliseconds: 500));
+  await gesture.moveTo(end);
+  await tester.pump(const Duration(milliseconds: 500));
+  await gesture.up();
+  await tester.pump(const Duration(milliseconds: 500));
 }
 
 void removeAllStyleElements() {

--- a/packages/flutter/test/widgets/selectable_region_context_menu_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_context_menu_test.dart
@@ -15,6 +15,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:web/web.dart' as web;
 
 import 'editable_text_tester.dart';
+import 'selectable_region_test.dart' show textOffsetToPosition;
 import 'web_platform_view_registry_utils.dart';
 
 extension on web.HTMLCollection {
@@ -480,6 +481,142 @@ void main() {
     await tester.pumpAndSettle();
     expect(tester.takeException(), isNull);
   }, variant: _browserContextMenuEnabledVariants);
+
+  // Ensure that if execCommand('copy') is called, it triggers an update of the
+  // hidden element so that the correct selected text is written to the clipboard.
+  testWidgets('copy event triggers update of hidden element', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: SelectableRegion(
+          selectionControls: emptyTextSelectionControls,
+          child: const Text('Some example text'),
+        ),
+      ),
+    );
+
+    // Select the text.
+    await _selectText(tester, 'Some example text', 'example');
+    await tester.pump();
+
+    // Dispatch the copy command on the document.
+    web.document.body!.dispatchEvent(web.Event('copy'));
+
+    // Verify the hidden element.
+    final web.HTMLElement element = _hiddenElements(fakePlatformViewRegistry).single;
+    expect(element.innerText, anyOf('example', 'example '));
+  }, variant: _browserContextMenuEnabledVariants);
+
+  testWidgets('copy event updates only the focused region', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: Column(
+          children: <Widget>[
+            SelectableRegion(
+              // focusNode: firstFocusNode,
+              selectionControls: emptyTextSelectionControls,
+              child: const Text('first region text'),
+            ),
+            SelectableRegion(
+              // focusNode: secondFocusNode,
+              selectionControls: emptyTextSelectionControls,
+              child: const Text('second region text'),
+            ),
+            SelectableRegion(
+              // focusNode: thirdFocusNode,
+              selectionControls: emptyTextSelectionControls,
+              child: const Text('third region text'),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    await _selectText(tester, 'second region text', 'second');
+    await tester.pump();
+
+    web.document.body!.dispatchEvent(web.Event('copy'));
+
+    final List<web.HTMLElement> elements = _hiddenElements(fakePlatformViewRegistry);
+    expect(elements, hasLength(3));
+    expect(elements[0].innerText, isEmpty);
+    expect(elements[1].innerText, anyOf('second', 'second '));
+    expect(elements[2].innerText, isEmpty);
+  }, variant: _browserContextMenuEnabledVariants);
+
+  testWidgets('disposed region does not continue responding to copy events', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: Column(
+          children: <Widget>[
+            SelectableRegion(
+              // focusNode: firstFocusNode,
+              selectionControls: emptyTextSelectionControls,
+              child: const Text('keep this region'),
+            ),
+            SelectableRegion(
+              // focusNode: secondFocusNode,
+              selectionControls: emptyTextSelectionControls,
+              child: const Text('remove this region'),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    final List<web.HTMLElement> initialElements = _hiddenElements(fakePlatformViewRegistry);
+    expect(initialElements, hasLength(2));
+    final web.HTMLElement removedElement = initialElements[1];
+
+    await _selectText(tester, 'remove this region', 'remove');
+    await tester.pump();
+    web.document.body!.dispatchEvent(web.Event('copy'));
+    expect(removedElement.innerText, anyOf('remove', 'remove '));
+
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: SelectableRegion(
+          selectionControls: emptyTextSelectionControls,
+          child: const Text('keep this region'),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    await _selectText(tester, 'keep this region', 'keep');
+    await tester.pump();
+
+    web.document.body!.dispatchEvent(web.Event('copy'));
+
+    expect(removedElement.innerText, anyOf('remove', 'remove '));
+    expect(_hiddenElements(fakePlatformViewRegistry), hasLength(1));
+    expect(_hiddenElements(fakePlatformViewRegistry).single.innerText, anyOf('keep', 'keep '));
+  }, variant: _browserContextMenuEnabledVariants);
+}
+
+/// Returns the hidden elements used for holding the selected text for copying.
+List<web.HTMLElement> _hiddenElements(FakePlatformViewRegistry fakePlatformViewRegistry) {
+  return fakePlatformViewRegistry.views.map((view) => view.htmlElement as web.HTMLElement).toList();
+}
+
+/// Selects the text [selection] inside [text] by tapping and dragging over it.
+Future<void> _selectText(WidgetTester tester, String text, String selection) async {
+  final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(
+    find.descendant(of: find.text(text), matching: find.byType(RichText)),
+  );
+  final int startIndex = text.indexOf(selection);
+  expect(startIndex, isNonNegative);
+  final Offset start = textOffsetToPosition(paragraph, startIndex);
+  final Offset end = textOffsetToPosition(paragraph, startIndex + selection.length);
+
+  final TestGesture gesture = await tester.startGesture(start);
+  addTearDown(gesture.removePointer);
+  await tester.pump(const Duration(milliseconds: 500));
+  await gesture.moveTo(end);
+  await tester.pump(const Duration(milliseconds: 500));
+  await gesture.up();
+  await tester.pump(const Duration(milliseconds: 500));
 }
 
 void removeAllStyleElements() {

--- a/packages/flutter/test/widgets/selectable_region_context_menu_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_context_menu_test.dart
@@ -15,7 +15,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:web/web.dart' as web;
 
 import 'editable_text_tester.dart';
-import 'selectable_region_test.dart' show textOffsetToPosition;
 import 'web_platform_view_registry_utils.dart';
 
 extension on web.HTMLCollection {
@@ -156,6 +155,68 @@ void main() {
     expect(selectWordEvent, isNotNull);
     expect((selectWordEvent!.globalPosition.dx - 200).abs() < precisionErrorTolerance, isTrue);
     expect((selectWordEvent.globalPosition.dy - 300).abs() < precisionErrorTolerance, isTrue);
+  }, variant: _browserContextMenuEnabledVariants);
+
+  testWidgets('copy event synchronizes the active SelectableRegion without a mouse event', (
+    WidgetTester tester,
+  ) async {
+    final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
+    final focusNodeA = FocusNode();
+    final focusNodeB = FocusNode();
+    addTearDown(focusNodeA.dispose);
+    addTearDown(focusNodeB.dispose);
+
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: Column(
+          children: <Widget>[
+            SelectableRegion(
+              focusNode: focusNodeA,
+              selectionControls: emptyTextSelectionControls,
+              child: const Text('first selection'),
+            ),
+            SelectableRegion(
+              focusNode: focusNodeB,
+              selectionControls: emptyTextSelectionControls,
+              child: const Text('second selection'),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    // Mount the fake platform-view element so the document copy handler can
+    // find and update it.
+    final element = fakePlatformViewRegistry.getViewById(currentViewId + 1) as web.HTMLElement;
+    web.document.body!.append(element);
+    addTearDown(() => element.remove());
+
+    Future<void> selectRegion(FocusNode focusNode) async {
+      focusNode.requestFocus();
+      await tester.pump();
+      PlatformSelectableRegionContextMenu.debugActiveClient!.dispatchSelectionEvent(
+        const SelectAllSelectionEvent(),
+      );
+    }
+
+    // Select all text in the first region, then copy it without a mouse event.
+    await selectRegion(focusNodeA);
+    web.document.dispatchEvent(web.ClipboardEvent('copy'));
+    await tester.pump();
+    expect(element.innerText, 'first selection');
+    expect(web.window.getSelection()?.toString(), 'first selection');
+
+    // Select all text in the second region, then copy it without a mouse event.
+    await selectRegion(focusNodeB);
+    web.document.dispatchEvent(web.ClipboardEvent('copy'));
+    await tester.pump();
+    expect(element.innerText, 'second selection');
+    expect(web.window.getSelection()?.toString(), 'second selection');
+
+    // Veryify we dispose the listener when the widgets are removed.
+    expect(PlatformSelectableRegionContextMenu.debugIsCopyEventListenerAttached, isTrue);
+    await tester.pumpWidget(const TestWidgetsApp(home: SizedBox.shrink()));
+    expect(PlatformSelectableRegionContextMenu.debugIsCopyEventListenerAttached, isFalse);
   }, variant: _browserContextMenuEnabledVariants);
 
   // Regression test for https://github.com/flutter/flutter/issues/189575.
@@ -342,6 +403,7 @@ void main() {
     await tester.pumpWidget(const TestWidgetsApp(home: SizedBox.shrink()));
 
     expect(PlatformSelectableRegionContextMenu.debugActiveClient, isNull);
+    expect(PlatformSelectableRegionContextMenu.debugIsCopyEventListenerAttached, isFalse);
   }, variant: _browserContextMenuEnabledVariants);
 
   group('when the browser context menu is disabled after attaching', () {
@@ -481,142 +543,6 @@ void main() {
     await tester.pumpAndSettle();
     expect(tester.takeException(), isNull);
   }, variant: _browserContextMenuEnabledVariants);
-
-  // Ensure that if execCommand('copy') is called, it triggers an update of the
-  // hidden element so that the correct selected text is written to the clipboard.
-  testWidgets('copy event triggers update of hidden element', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      TestWidgetsApp(
-        home: SelectableRegion(
-          selectionControls: emptyTextSelectionControls,
-          child: const Text('Some example text'),
-        ),
-      ),
-    );
-
-    // Select the text.
-    await _selectText(tester, 'Some example text', 'example');
-    await tester.pump();
-
-    // Dispatch the copy command on the document.
-    web.document.body!.dispatchEvent(web.Event('copy'));
-
-    // Verify the hidden element.
-    final web.HTMLElement element = _hiddenElements(fakePlatformViewRegistry).single;
-    expect(element.innerText, anyOf('example', 'example '));
-  }, variant: _browserContextMenuEnabledVariants);
-
-  testWidgets('copy event updates only the focused region', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      TestWidgetsApp(
-        home: Column(
-          children: <Widget>[
-            SelectableRegion(
-              // focusNode: firstFocusNode,
-              selectionControls: emptyTextSelectionControls,
-              child: const Text('first region text'),
-            ),
-            SelectableRegion(
-              // focusNode: secondFocusNode,
-              selectionControls: emptyTextSelectionControls,
-              child: const Text('second region text'),
-            ),
-            SelectableRegion(
-              // focusNode: thirdFocusNode,
-              selectionControls: emptyTextSelectionControls,
-              child: const Text('third region text'),
-            ),
-          ],
-        ),
-      ),
-    );
-
-    await _selectText(tester, 'second region text', 'second');
-    await tester.pump();
-
-    web.document.body!.dispatchEvent(web.Event('copy'));
-
-    final List<web.HTMLElement> elements = _hiddenElements(fakePlatformViewRegistry);
-    expect(elements, hasLength(3));
-    expect(elements[0].innerText, isEmpty);
-    expect(elements[1].innerText, anyOf('second', 'second '));
-    expect(elements[2].innerText, isEmpty);
-  }, variant: _browserContextMenuEnabledVariants);
-
-  testWidgets('disposed region does not continue responding to copy events', (
-    WidgetTester tester,
-  ) async {
-    await tester.pumpWidget(
-      TestWidgetsApp(
-        home: Column(
-          children: <Widget>[
-            SelectableRegion(
-              // focusNode: firstFocusNode,
-              selectionControls: emptyTextSelectionControls,
-              child: const Text('keep this region'),
-            ),
-            SelectableRegion(
-              // focusNode: secondFocusNode,
-              selectionControls: emptyTextSelectionControls,
-              child: const Text('remove this region'),
-            ),
-          ],
-        ),
-      ),
-    );
-
-    final List<web.HTMLElement> initialElements = _hiddenElements(fakePlatformViewRegistry);
-    expect(initialElements, hasLength(2));
-    final web.HTMLElement removedElement = initialElements[1];
-
-    await _selectText(tester, 'remove this region', 'remove');
-    await tester.pump();
-    web.document.body!.dispatchEvent(web.Event('copy'));
-    expect(removedElement.innerText, anyOf('remove', 'remove '));
-
-    await tester.pumpWidget(
-      TestWidgetsApp(
-        home: SelectableRegion(
-          selectionControls: emptyTextSelectionControls,
-          child: const Text('keep this region'),
-        ),
-      ),
-    );
-    await tester.pump();
-
-    await _selectText(tester, 'keep this region', 'keep');
-    await tester.pump();
-
-    web.document.body!.dispatchEvent(web.Event('copy'));
-
-    expect(removedElement.innerText, anyOf('remove', 'remove '));
-    expect(_hiddenElements(fakePlatformViewRegistry), hasLength(1));
-    expect(_hiddenElements(fakePlatformViewRegistry).single.innerText, anyOf('keep', 'keep '));
-  }, variant: _browserContextMenuEnabledVariants);
-}
-
-/// Returns the hidden elements used for holding the selected text for copying.
-List<web.HTMLElement> _hiddenElements(FakePlatformViewRegistry fakePlatformViewRegistry) {
-  return fakePlatformViewRegistry.views.map((view) => view.htmlElement as web.HTMLElement).toList();
-}
-
-/// Selects the text [selection] inside [text] by tapping and dragging over it.
-Future<void> _selectText(WidgetTester tester, String text, String selection) async {
-  final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(
-    find.descendant(of: find.text(text), matching: find.byType(RichText)),
-  );
-  final int startIndex = text.indexOf(selection);
-  expect(startIndex, isNonNegative);
-  final Offset start = textOffsetToPosition(paragraph, startIndex);
-  final Offset end = textOffsetToPosition(paragraph, startIndex + selection.length);
-
-  final TestGesture gesture = await tester.startGesture(start);
-  addTearDown(gesture.removePointer);
-  await tester.pump(const Duration(milliseconds: 500));
-  await gesture.moveTo(end);
-  await tester.pump(const Duration(milliseconds: 500));
-  await gesture.up();
-  await tester.pump(const Duration(milliseconds: 500));
 }
 
 void removeAllStyleElements() {


### PR DESCRIPTION
If `document.body.execComand("copy")` is called, we need to ensure the hidden input used to handle copied input is updated by handling the "copy" event dispatched to the body.

Fixes https://github.com/flutter/flutter/issues/182756

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.