### PR TITLE
Remove test utils cross-import from elevated_button_test

### DIFF
--- a/packages/flutter/test/material/elevated_button_test.dart
+++ b/packages/flutter/test/material/elevated_button_test.dart
@@ -8,8 +8,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/semantics_tester.dart';
-
 void main() {
   TextStyle iconStyle(WidgetTester tester, IconData icon) {
     final RichText iconRichText = tester.widget<RichText>(
@@ -949,7 +947,7 @@ void main() {
   });
 
   testWidgets('Does ElevatedButton contribute semantics', (WidgetTester tester) async {
-    final semantics = SemanticsTester(tester);
+    final SemanticsHandle handle = tester.ensureSemantics();
     await tester.pumpWidget(
       Theme(
         data: ThemeData(useMaterial3: false),
@@ -972,29 +970,20 @@ void main() {
     );
 
     expect(
-      semantics,
-      hasSemantics(
-        TestSemantics.root(
-          children: <TestSemantics>[
-            TestSemantics.rootChild(
-              actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.focus],
-              label: 'ABC',
-              rect: const Rect.fromLTRB(0.0, 0.0, 88.0, 48.0),
-              transform: Matrix4.translationValues(356.0, 276.0, 0.0),
-              flags: <SemanticsFlag>[
-                SemanticsFlag.hasEnabledState,
-                SemanticsFlag.isButton,
-                SemanticsFlag.isEnabled,
-                SemanticsFlag.isFocusable,
-              ],
-            ),
-          ],
-        ),
-        ignoreId: true,
+      tester.getSemantics(find.byType(ElevatedButton)),
+      matchesSemantics(
+        label: 'ABC',
+        rect: const Rect.fromLTRB(0.0, 0.0, 88.0, 48.0),
+        isButton: true,
+        hasEnabledState: true,
+        isEnabled: true,
+        isFocusable: true,
+        hasTapAction: true,
+        hasFocusAction: true,
       ),
     );
 
-    semantics.dispose();
+    handle.dispose();
   });
 
   testWidgets('ElevatedButton size is configurable by ThemeData.materialTapTargetSize', (


### PR DESCRIPTION
## Description

Removes the test-utils cross-import from `packages/flutter/test/material/elevated_button_test.dart`.

This updates the semantics assertion in the ElevatedButton test to use the
modern `flutter_test` semantics APIs directly:

- `tester.ensureSemantics()`
- `tester.getSemantics(...)`
- `matchesSemantics(...)`

That keeps the same test coverage while avoiding an import from
`../widgets/semantics_tester.dart`, which is part of the cross-import cleanup
tracked in #182636.

Part of #182636

## Tests

- `FLUTTER_ROOT=/Users/temoor/Documents/Codex/2026-04-23-so-i-wanna-be-contributor-on/flutter ./bin/flutter test packages/flutter/test/material/elevated_button_test.dart`
