### PR TITLE
Check cross imports test subfolders

### DIFF
--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -234,7 +234,7 @@ class TestsCrossImportChecker {
   /// Returns the error message for the given known paths that no longer have a
   /// cross import.
   ///
-  /// `library` must not be `_Library.Material`, because Material is allowed to
+  /// The [library] must not be [_MaterialLibrary], because Material is allowed to
   /// cross-import.
   static String _getFixedImportError(Set<String> fixedPaths, _Library library) {
     assert(fixedPaths.isNotEmpty);
@@ -245,9 +245,8 @@ class TestsCrossImportChecker {
       buffer.writeln('  $path');
     }
     final String knownListName = switch (library) {
-      _Library.widgets => 'knownWidgetsCrossImports',
-      _Library.cupertino => 'knownCupertinoCrossImports',
-      _Library.material => throw UnimplementedError(
+      _CupertinoLibrary() || _OtherLibrary() => library.crossImportsListSymbolName,
+      _MaterialLibrary() => throw UnimplementedError(
         'Material is responsible for testing its interactions with Cupertino, so it is allowed to cross-import.',
       ),
     };
@@ -385,22 +384,69 @@ class TestsCrossImportChecker {
 }
 
 /// The libraries that we are concerned with cross importing.
-enum _Library {
-  widgets(directory: 'widgets', name: 'Widgets', import: "import 'package:flutter/widgets.dart'"),
-  material(
-    directory: 'material',
-    name: 'Material',
-    import: "import 'package:flutter/material.dart'",
-  ),
-  cupertino(
-    directory: 'cupertino',
-    name: 'Cupertino',
-    import: "import 'package:flutter/cupertino.dart'",
-  );
+sealed class _Library {
+  const _Library(this.name);
 
-  const _Library({required this.directory, required this.name, required this.import});
-
-  final String directory;
+  /// The short name of the library, for example `flutter/test/widgets`.
   final String name;
-  final String import;
+
+  static const String cupertinoImport = "import 'package:flutter/cupertino.dart'";
+  static const String materialImport = "import 'package:flutter/material.dart'";
+
+  /// Whether this library is allowed to import Cupertino.
+  bool get canImportCupertino;
+
+  /// Whether this library is allowed to import Material.
+  bool get canImportMaterial;
+
+  /// The name of the variable in [TestsCrossImportChecker]
+  /// that contains the list of known cross imports for this library.
+  ///
+  /// This is used for reporting mismatched cross imports.
+  String get crossImportsListSymbolName;
+}
+
+/// The Material library, also known as `flutter/material`.
+final class _MaterialLibrary extends _Library {
+  const _MaterialLibrary() : super('flutter/test/material');
+
+  @override
+  bool get canImportCupertino => true;
+
+  @override
+  bool get canImportMaterial => true;
+
+  @override
+  String get crossImportsListSymbolName {
+    throw UnsupportedError('Material is allowed to cross-import.');
+  }
+}
+
+/// The Cupertino library, also known as `flutter/cupertino`.
+final class _CupertinoLibrary extends _Library {
+  const _CupertinoLibrary() : super('flutter/test/cupertino');
+
+  @override
+  String get crossImportsListSymbolName => 'knownCupertinoCrossImports';
+
+  @override
+  bool get canImportCupertino => true;
+
+  @override
+  bool get canImportMaterial => false;
+}
+
+/// Any library that is not [_MaterialLibrary] or [_CupertinoLibrary],
+/// such as `flutter/widgets` or `flutter/services`.
+final class _OtherLibrary extends _Library {
+  const _OtherLibrary(super.name, this.crossImportsListSymbolName);
+
+  @override
+  final String crossImportsListSymbolName;
+
+  @override
+  bool get canImportCupertino => false;
+
+  @override
+  bool get canImportMaterial => false;
 }

--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -287,14 +287,10 @@ class TestsCrossImportChecker {
     for (final path in fixedPaths) {
       buffer.writeln('  $path');
     }
-    final String knownListName = switch (library) {
-      _CupertinoLibrary() || _OtherLibrary() => library.crossImportsListSymbolName,
-      _MaterialLibrary() => throw UnimplementedError(
-        'Material is responsible for testing its interactions with Cupertino, so it is allowed to cross-import.',
-      ),
-    };
     buffer.writeln('However, they now need to be removed from the');
-    buffer.write('$knownListName list in the script /dev/bots/check_tests_cross_imports.dart.');
+    buffer.write(
+      '${library.crossImportsListSymbolName} list in the script /dev/bots/check_tests_cross_imports.dart.',
+    );
     return buffer.toString().trimRight();
   }
 
@@ -472,22 +468,18 @@ sealed class _Library {
   ///
   /// This is used for reporting mismatched cross imports.
   String get crossImportsListSymbolName {
-    if (this is _MaterialLibrary) {
-      throw UnsupportedError('Material is allowed to cross-import.');
-    }
-
-    if (this is _CupertinoLibrary) {
-      return 'knownCupertinoCrossImports';
-    }
-
     return switch (name) {
       'packages/flutter/test' => 'knownFlutterSlashTestCrossImports',
       'packages/flutter/test/animation' => 'knownAnimationCrossImports',
+      'packages/flutter/test/cupertino' => 'knownCupertinoCrossImports',
       'packages/flutter/test/dart' => 'knownDartCrossImports',
       'packages/flutter/test/examples' => 'knownExamplesCrossImports',
       'packages/flutter/test/foundation' => 'knownFoundationCrossImports',
       'packages/flutter/test/gestures' => 'knownGesturesCrossImports',
       'packages/flutter/test/harness' => 'knownHarnessCrossImports',
+      'packages/flutter/test/material' => throw UnimplementedError(
+        'Material is responsible for testing its interactions with Cupertino, so it is allowed to cross-import.',
+      ),
       'packages/flutter/test/painting' => 'knownPaintingCrossImports',
       'packages/flutter/test/physics' => 'knownPhysicsCrossImports',
       'packages/flutter/test/rendering' => 'knownRenderingCrossImports',

--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -204,6 +204,37 @@ class TestsCrossImportChecker {
     return knownPaths.difference(testPaths);
   }
 
+  /// Get the [Map] of files, per [_Library], of the files that have cross imports on Material and Cupertino.
+  static Map<_Library, _CrossImportingFiles> _getCrossImports(Map<_Library, Set<File>> libraries) {
+    final Map<_Library, _CrossImportingFiles> crossImports = {};
+
+    for (final MapEntry<_Library, Set<File>> entry in libraries.entries) {
+      final Set<File> cupertinoImports = {};
+      final Set<File> materialImports = {};
+
+      for (final File file in entry.value) {
+        final String contents = file.readAsStringSync();
+
+        if (!entry.key.canImport(_LibraryImportStatement.cupertino) &&
+            contents.contains(_LibraryImportStatement.cupertino.importString)) {
+          cupertinoImports.add(file);
+        }
+
+        if (!entry.key.canImport(_LibraryImportStatement.material) &&
+            contents.contains(_LibraryImportStatement.material.importString)) {
+          materialImports.add(file);
+        }
+      }
+
+      crossImports[entry.key] = (
+        cupertinoImports: cupertinoImports,
+        materialImports: materialImports,
+      );
+    }
+
+    return crossImports;
+  }
+
   /// Returns the [Set] of files that are not in [knownPaths].
   static Set<File> _getUnknowns(Set<String> knownPaths, Set<File> files) {
     return files.where((File file) {
@@ -214,13 +245,6 @@ class TestsCrossImportChecker {
       final String comparablePath = file.absolute.path.substring(index).replaceAll(r'\', '/');
       return !knownPaths.contains(comparablePath);
     }).toSet();
-  }
-
-  /// Returns true only if [file] contains the given [importString].
-  static bool _containsImport(File file, {required String importString}) {
-    final String contents = file.readAsStringSync();
-
-    return contents.contains(importString);
   }
 
   /// Returns the error message for the given [fixedPaths] that no longer have a
@@ -311,17 +335,8 @@ class TestsCrossImportChecker {
     final Map<_Library, Set<File>> filesByLibrary = _getTestFiles();
 
     // Find all cross imports.
-    final Set<File> widgetsTestsImportingMaterial = _getFilesWithImports(
-      filesByLibrary[_Library.widgets]!,
-      _Library.material,
-    );
-    final Set<File> widgetsTestsImportingCupertino = _getFilesWithImports(
-      filesByLibrary[_Library.widgets]!,
-      _Library.cupertino,
-    );
-    final Set<File> cupertinoTestsImportingMaterial = _getFilesWithImports(
-      filesByLibrary[_Library.cupertino]!,
-      _Library.material,
+    final Map<_Library, _CrossImportingFiles> crossImportsPerLibrary = _getCrossImports(
+      filesByLibrary,
     );
 
     // Find any cross imports that are not in the known list.
@@ -393,6 +408,9 @@ class TestsCrossImportChecker {
     return valid;
   }
 }
+
+/// The set of files that import Cupertino and Material for a given [_Library].
+typedef _CrossImportingFiles = ({Set<File> cupertinoImports, Set<File> materialImports});
 
 enum _LibraryImportStatement {
   material('Material', "import 'package:flutter/material.dart'"),

--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -204,16 +204,7 @@ class TestsCrossImportChecker {
     return knownPaths.difference(testPaths);
   }
 
-  /// Returns a list of files in the given directory optionally matching the
-  /// given filenamePattern.
-  static List<File> _getFiles(Directory directory, [Pattern? filenamePattern]) {
-    return [
-      for (final File file in directory.listSync(recursive: true).whereType<File>())
-        if (filenamePattern == null || file.absolute.path.contains(filenamePattern)) file,
-    ];
-  }
-
-  /// Returns the Set of files that are not in knownPaths.
+  /// Returns the [Set] of files that are not in [knownPaths].
   static Set<File> _getUnknowns(Set<String> knownPaths, Set<File> files) {
     return files.where((File file) {
       final int index = file.absolute.path.indexOf(_flutterTestPrefix);
@@ -225,24 +216,11 @@ class TestsCrossImportChecker {
     }).toSet();
   }
 
-  /// Get a list of all the filenames in the source directory
-  /// that end in ".dart".
-  static Set<File> _getTestFiles(Directory directory, _Library library) {
-    return _getFiles(directory.childDirectory(library.directory), RegExp(r'\.dart$')).toSet();
-  }
+  /// Returns true only if [file] contains the given [importString].
+  static bool _containsImport(File file, {required String importString}) {
+    final String contents = file.readAsStringSync();
 
-  /// Returns true only if the file imports the given Library.
-  static bool _containsImport(File testFile, _Library library) {
-    final String contents = testFile.readAsStringSync();
-    return contents.contains(library.import);
-  }
-
-  /// Returns a Set of all Files that import the given Library.
-  static Set<File> _getFilesWithImports(Set<File> testFiles, _Library library) {
-    return {
-      for (final File testFile in testFiles)
-        if (_containsImport(testFile, library)) testFile,
-    };
+    return contents.contains(importString);
   }
 
   /// Returns the error message for the given known paths that no longer have a
@@ -272,6 +250,31 @@ class TestsCrossImportChecker {
   /// Returns the [file]'s relative path, relative to [flutterRoot].
   String _getRelativePath(File file) {
     return path.relative(file.absolute.path, from: flutterRoot.absolute.path);
+  }
+
+  /// Get a list of all the filenames that end in ".dart", grouped by library.
+  Map<_Library, Set<File>> _getTestFiles() {
+    final dartFilePattern = RegExp(r'\.dart$');
+    final Map<_Library, Set<File>> mapping = {_Library.flutterSlashTest: {}};
+
+    // List the files directly under `flutter/test` and then walk the subdirectories.
+    for (final FileSystemEntity fileOrDirectory in testsDirectory.listSync()) {
+      if (fileOrDirectory is File && fileOrDirectory.absolute.path.contains(dartFilePattern)) {
+        mapping[_Library.flutterSlashTest]?.add(fileOrDirectory);
+
+        continue;
+      }
+
+      if (fileOrDirectory is Directory) {
+        final _Library library = _Library.fromDirectory(fileOrDirectory, flutterRoot: flutterRoot);
+        mapping[library] = {
+          for (final File file in fileOrDirectory.listSync(recursive: true).whereType<File>())
+            if (file.absolute.path.contains(dartFilePattern)) file,
+        };
+      }
+    }
+
+    return mapping;
   }
 
   /// Returns the import error for the `files` in `testLibrary` which import
@@ -308,10 +311,7 @@ class TestsCrossImportChecker {
   bool check() {
     filesystem.currentDirectory = flutterRoot;
 
-    final filesByLibrary = <_Library, Set<File>>{};
-    for (final _Library library in _Library.values) {
-      filesByLibrary[library] = _getTestFiles(testsDirectory, library);
-    }
+    final Map<_Library, Set<File>> filesByLibrary = _getTestFiles();
 
     // Find all cross imports.
     final Set<File> widgetsTestsImportingMaterial = _getFilesWithImports(
@@ -406,6 +406,12 @@ sealed class _Library {
 
   static const String cupertinoImport = "import 'package:flutter/cupertino.dart'";
   static const String materialImport = "import 'package:flutter/material.dart'";
+
+  /// The library for `flutter/test`.
+  static const _OtherLibrary flutterSlashTest = _OtherLibrary(
+    'flutter/test',
+    'knownFlutterSlashTestCrossImports',
+  );
 
   /// Whether this library is allowed to import Cupertino.
   bool get canImportCupertino;

--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -465,10 +465,9 @@ sealed class _Library {
       throw ArgumentError('Directory must be inside ${flutterRoot.absolute.path}.', 'directory');
     }
 
-    final String relativePath = path.relative(
-      directory.absolute.path,
-      from: flutterRoot.absolute.path,
-    );
+    final String relativePath = path
+        .relative(directory.absolute.path, from: flutterRoot.absolute.path)
+        .replaceAll(Platform.pathSeparator, '/');
 
     return switch (relativePath) {
       'packages/flutter/test/material' => const _MaterialLibrary(),

--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -172,13 +172,27 @@ class TestsCrossImportChecker {
   // See https://github.com/flutter/flutter/issues/177028.
   static final Set<String> knownFlutterSlashTestCrossImports = <String>{};
 
-  static final Set<String> _knownCrossImports = knownWidgetsCrossImports.union(
-    knownCupertinoCrossImports,
-  );
+  static final Set<String> _knownCrossImports = {
+    ...knownFlutterSlashTestCrossImports,
+    ...knownWidgetsCrossImports,
+    ...knownAnimationCrossImports,
+    ...knownCupertinoCrossImports,
+    ...knownDartCrossImports,
+    ...knownExamplesCrossImports,
+    ...knownFoundationCrossImports,
+    ...knownGesturesCrossImports,
+    ...knownHarnessCrossImports,
+    ...knownPaintingCrossImports,
+    ...knownPhysicsCrossImports,
+    ...knownRenderingCrossImports,
+    ...knownSchedulerCrossImports,
+    ...knownSemanticsCrossImports,
+    ...knownServicesCrossImports,
+  };
 
   static final RegExp _flutterTestPrefix = RegExp(r'packages[/\\]flutter[/\\]test');
 
-  /// Returns the Set of paths in `knownPaths` that are not in `files`.
+  /// Returns the [Set] of paths in [knownPaths] that are not in [files].
   static Set<String> _differencePaths(Set<String> knownPaths, Set<File> files) {
     final Set<String> testPaths = files.map((File file) {
       final int index = file.absolute.path.indexOf(_flutterTestPrefix);

--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -223,7 +223,7 @@ class TestsCrossImportChecker {
     return contents.contains(importString);
   }
 
-  /// Returns the error message for the given known paths that no longer have a
+  /// Returns the error message for the given [fixedPaths] that no longer have a
   /// cross import.
   ///
   /// The [library] must not be [_MaterialLibrary], because Material is allowed to
@@ -277,29 +277,26 @@ class TestsCrossImportChecker {
     return mapping;
   }
 
-  /// Returns the import error for the `files` in `testLibrary` which import
-  /// `importedLibrary`.
+  /// Returns the import error for the [files] in [testLibrary] which contain the given [importStatement].
   ///
-  /// Import errors only occur when Widgets imports Material or Cupertino, and
-  /// when Cupertino imports Material.
+  /// Import errors only occur when:
+  /// - any library that is not Material or Cupertino, imports Material or Cupertino
+  /// - Cupertino imports Material
   String _getImportError({
     required Set<File> files,
     required _Library testLibrary,
-    required _Library importedLibrary,
+    required _LibraryImportStatement importStatement,
   }) {
     assert(
-      switch ((testLibrary, importedLibrary)) {
-        (_Library.widgets, _Library.material) => true,
-        (_Library.widgets, _Library.cupertino) => true,
-        (_Library.cupertino, _Library.material) => true,
-        (_, _) => false,
-      },
+      !testLibrary.canImport(importStatement),
       'Import errors only occur when Widgets imports Material or Cupertino, and when Cupertino imports Material.',
     );
+
+    final String importedLibraryName = importStatement.readableName;
     final buffer = StringBuffer(
       files.length < 2
-          ? 'The following test in ${testLibrary.name} has a disallowed import of ${importedLibrary.name}. Refactor it or move it to ${importedLibrary.name}.\n'
-          : 'The following ${files.length} tests in ${testLibrary.name} have a disallowed import of ${importedLibrary.name}. Refactor them or move them to ${importedLibrary.name}.\n',
+          ? 'The following test in ${testLibrary.name} has a disallowed import of $importedLibraryName. Refactor it or move it to $importedLibraryName.\n'
+          : 'The following ${files.length} tests in ${testLibrary.name} have a disallowed import of $importedLibraryName. Refactor them or move them to $importedLibraryName.\n',
     );
     for (final file in files) {
       buffer.writeln('  ${_getRelativePath(file)}');
@@ -397,6 +394,16 @@ class TestsCrossImportChecker {
   }
 }
 
+enum _LibraryImportStatement {
+  material('Material', "import 'package:flutter/material.dart'"),
+  cupertino('Cupertino', "import 'package:flutter/cupertino.dart'");
+
+  const _LibraryImportStatement(this.readableName, this.importString);
+
+  final String readableName;
+  final String importString;
+}
+
 /// The libraries that we are concerned with cross importing.
 sealed class _Library {
   const _Library(this.name);
@@ -404,37 +411,32 @@ sealed class _Library {
   /// The short name of the library, for example `flutter/test/widgets`.
   final String name;
 
-  static const String cupertinoImport = "import 'package:flutter/cupertino.dart'";
-  static const String materialImport = "import 'package:flutter/material.dart'";
-
   /// The library for `flutter/test`.
   static const _OtherLibrary flutterSlashTest = _OtherLibrary(
     'flutter/test',
     'knownFlutterSlashTestCrossImports',
   );
 
-  /// Whether this library is allowed to import Cupertino.
-  bool get canImportCupertino;
-
-  /// Whether this library is allowed to import Material.
-  bool get canImportMaterial;
-
   /// The name of the variable in [TestsCrossImportChecker]
   /// that contains the list of known cross imports for this library.
   ///
   /// This is used for reporting mismatched cross imports.
   String get crossImportsListSymbolName;
+
+  /// Returns whether this library can contain the given [import].
+  bool canImport(_LibraryImportStatement import) {
+    return switch (this) {
+      _MaterialLibrary() =>
+        import == _LibraryImportStatement.material || import == _LibraryImportStatement.cupertino,
+      _CupertinoLibrary() => import == _LibraryImportStatement.cupertino,
+      _OtherLibrary() => false,
+    };
+  }
 }
 
 /// The Material library, also known as `flutter/material`.
 final class _MaterialLibrary extends _Library {
   const _MaterialLibrary() : super('flutter/test/material');
-
-  @override
-  bool get canImportCupertino => true;
-
-  @override
-  bool get canImportMaterial => true;
 
   @override
   String get crossImportsListSymbolName {
@@ -448,12 +450,6 @@ final class _CupertinoLibrary extends _Library {
 
   @override
   String get crossImportsListSymbolName => 'knownCupertinoCrossImports';
-
-  @override
-  bool get canImportCupertino => true;
-
-  @override
-  bool get canImportMaterial => false;
 }
 
 /// Any library that is not [_MaterialLibrary] or [_CupertinoLibrary],
@@ -463,10 +459,4 @@ final class _OtherLibrary extends _Library {
 
   @override
   final String crossImportsListSymbolName;
-
-  @override
-  bool get canImportCupertino => false;
-
-  @override
-  bool get canImportMaterial => false;
 }

--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -235,6 +235,33 @@ class TestsCrossImportChecker {
     return crossImports;
   }
 
+  /// Get the list of known cross imports for the given [library].
+  static Set<String> _getKnownCrossImportsForLibrary(_Library library) {
+    // Material is allowed to cross import.
+    if (library is _MaterialLibrary) {
+      return const <String>{};
+    }
+
+    return switch (library.crossImportsListSymbolName) {
+      'knownFlutterSlashTestCrossImports' => knownFlutterSlashTestCrossImports,
+      'knownAnimationCrossImports' => knownAnimationCrossImports,
+      'knownCupertinoCrossImports' => knownCupertinoCrossImports,
+      'knownDartCrossImports' => knownDartCrossImports,
+      'knownExamplesCrossImports' => knownExamplesCrossImports,
+      'knownFoundationCrossImports' => knownFoundationCrossImports,
+      'knownGesturesCrossImports' => knownGesturesCrossImports,
+      'knownHarnessCrossImports' => knownHarnessCrossImports,
+      'knownPaintingCrossImports' => knownPaintingCrossImports,
+      'knownPhysicsCrossImports' => knownPhysicsCrossImports,
+      'knownRenderingCrossImports' => knownRenderingCrossImports,
+      'knownSchedulerCrossImports' => knownSchedulerCrossImports,
+      'knownSemanticsCrossImports' => knownSemanticsCrossImports,
+      'knownServicesCrossImports' => knownServicesCrossImports,
+      'knownWidgetsCrossImports' => knownWidgetsCrossImports,
+      _ => throw ArgumentError('Unknown library: ${library.name}', 'library'),
+    };
+  }
+
   /// Returns the [Set] of files that are not in [knownPaths].
   static Set<File> _getUnknowns(Set<String> knownPaths, Set<File> files) {
     return files.where((File file) {
@@ -339,9 +366,9 @@ class TestsCrossImportChecker {
       filesByLibrary,
     );
 
-    // Find any cross imports that are not in the known list.
     var valid = true;
 
+    // Find any cross imports that are not in the known list.
     for (final MapEntry<_Library, _CrossImportingFiles> entry in crossImportsPerLibrary.entries) {
       final Set<File> unknownCupertinoImports = _getUnknowns(
         _knownCrossImports,
@@ -379,21 +406,20 @@ class TestsCrossImportChecker {
     // TODO(justinmc): Remove this after all known cross imports have been
     // fixed.
     // See https://github.com/flutter/flutter/issues/177028.
-    final Set<String> fixedWidgetsCrossImports = _differencePaths(
-      knownWidgetsCrossImports,
-      widgetsTestsImportingMaterial.union(widgetsTestsImportingCupertino),
-    );
-    if (fixedWidgetsCrossImports.isNotEmpty) {
-      valid = false;
-      foundError(_getFixedImportError(fixedWidgetsCrossImports, _Library.widgets).split('\n'));
-    }
-    final Set<String> fixedCupertinoCrossImports = _differencePaths(
-      knownCupertinoCrossImports,
-      cupertinoTestsImportingMaterial,
-    );
-    if (fixedCupertinoCrossImports.isNotEmpty) {
-      valid = false;
-      foundError(_getFixedImportError(fixedCupertinoCrossImports, _Library.cupertino).split('\n'));
+    for (final MapEntry<_Library, _CrossImportingFiles> entry in crossImportsPerLibrary.entries) {
+      final Set<File> crossImportsForLibrary = entry.value.cupertinoImports.union(
+        entry.value.materialImports,
+      );
+      final Set<String> knownCrossImportsForLibrary = _getKnownCrossImportsForLibrary(entry.key);
+      final Set<String> fixedCrossImports = _differencePaths(
+        knownCrossImportsForLibrary,
+        crossImportsForLibrary,
+      );
+
+      if (fixedCrossImports.isNotEmpty) {
+        valid = false;
+        foundError(_getFixedImportError(fixedCrossImports, entry.key).split('\n'));
+      }
     }
 
     return valid;

--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -306,18 +306,19 @@ class TestsCrossImportChecker {
   /// Get a list of all the filenames that end in ".dart", grouped by library.
   Map<_Library, Set<File>> _getTestFiles() {
     final dartFilePattern = RegExp(r'\.dart$');
-    final Map<_Library, Set<File>> mapping = {_Library.flutterSlashTest: {}};
+    const _Library flutterTest = _OtherLibrary('packages/flutter/test');
+    final Map<_Library, Set<File>> mapping = {flutterTest: {}};
 
-    // List the files directly under `flutter/test` and then walk the subdirectories.
+    // List the files directly under `packages/flutter/test` and then walk the subdirectories.
     for (final FileSystemEntity fileOrDirectory in testsDirectory.listSync()) {
       if (fileOrDirectory is File && fileOrDirectory.absolute.path.contains(dartFilePattern)) {
-        mapping[_Library.flutterSlashTest]?.add(fileOrDirectory);
+        mapping[flutterTest]?.add(fileOrDirectory);
 
         continue;
       }
 
       if (fileOrDirectory is Directory) {
-        final _Library library = _Library.fromDirectory(fileOrDirectory, flutterRoot: flutterRoot);
+        final library = _Library.fromDirectory(fileOrDirectory, flutterRoot: flutterRoot);
         mapping[library] = {
           for (final File file in fileOrDirectory.listSync(recursive: true).whereType<File>())
             if (file.absolute.path.contains(dartFilePattern)) file,
@@ -443,20 +444,60 @@ enum _LibraryImportStatement {
 sealed class _Library {
   const _Library(this.name);
 
-  /// The short name of the library, for example `flutter/test/widgets`.
-  final String name;
+  /// Construct a [_Library] from a given [directory].
+  ///
+  /// The [directory] must be inside the [flutterRoot].
+  factory _Library.fromDirectory(Directory directory, {required Directory flutterRoot}) {
+    if (!directory.absolute.path.startsWith(flutterRoot.absolute.path)) {
+      throw ArgumentError('Directory must be inside ${flutterRoot.absolute.path}.', 'directory');
+    }
 
-  /// The library for `flutter/test`.
-  static const _OtherLibrary flutterSlashTest = _OtherLibrary(
-    'flutter/test',
-    'knownFlutterSlashTestCrossImports',
-  );
+    final String relativePath = path.relative(
+      directory.absolute.path,
+      from: flutterRoot.absolute.path,
+    );
+
+    return switch (relativePath) {
+      'packages/flutter/test/material' => const _MaterialLibrary(),
+      'packages/flutter/test/cupertino' => const _CupertinoLibrary(),
+      _ => _OtherLibrary(relativePath),
+    };
+  }
+
+  /// The short name of the library, for example `packages/flutter/test/widgets`.
+  final String name;
 
   /// The name of the variable in [TestsCrossImportChecker]
   /// that contains the list of known cross imports for this library.
   ///
   /// This is used for reporting mismatched cross imports.
-  String get crossImportsListSymbolName;
+  String get crossImportsListSymbolName {
+    if (this is _MaterialLibrary) {
+      throw UnsupportedError('Material is allowed to cross-import.');
+    }
+
+    if (this is _CupertinoLibrary) {
+      return 'knownCupertinoCrossImports';
+    }
+
+    return switch (name) {
+      'packages/flutter/test' => 'knownFlutterSlashTestCrossImports',
+      'packages/flutter/test/animation' => 'knownAnimationCrossImports',
+      'packages/flutter/test/dart' => 'knownDartCrossImports',
+      'packages/flutter/test/examples' => 'knownExamplesCrossImports',
+      'packages/flutter/test/foundation' => 'knownFoundationCrossImports',
+      'packages/flutter/test/gestures' => 'knownGesturesCrossImports',
+      'packages/flutter/test/harness' => 'knownHarnessCrossImports',
+      'packages/flutter/test/painting' => 'knownPaintingCrossImports',
+      'packages/flutter/test/physics' => 'knownPhysicsCrossImports',
+      'packages/flutter/test/rendering' => 'knownRenderingCrossImports',
+      'packages/flutter/test/scheduler' => 'knownSchedulerCrossImports',
+      'packages/flutter/test/semantics' => 'knownSemanticsCrossImports',
+      'packages/flutter/test/services' => 'knownServicesCrossImports',
+      'packages/flutter/test/widgets' => 'knownWidgetsCrossImports',
+      _ => throw UnimplementedError('Unknown library: $name'),
+    };
+  }
 
   /// Returns whether this library can contain the given [import].
   bool canImport(_LibraryImportStatement import) {
@@ -469,29 +510,18 @@ sealed class _Library {
   }
 }
 
-/// The Material library, also known as `flutter/material`.
+/// The Material library, also known as `packages/flutter/test/material`.
 final class _MaterialLibrary extends _Library {
-  const _MaterialLibrary() : super('flutter/test/material');
-
-  @override
-  String get crossImportsListSymbolName {
-    throw UnsupportedError('Material is allowed to cross-import.');
-  }
+  const _MaterialLibrary() : super('packages/flutter/test/material');
 }
 
-/// The Cupertino library, also known as `flutter/cupertino`.
+/// The Cupertino library, also known as `packages/flutter/test/cupertino`.
 final class _CupertinoLibrary extends _Library {
-  const _CupertinoLibrary() : super('flutter/test/cupertino');
-
-  @override
-  String get crossImportsListSymbolName => 'knownCupertinoCrossImports';
+  const _CupertinoLibrary() : super('packages/flutter/test/cupertino');
 }
 
 /// Any library that is not [_MaterialLibrary] or [_CupertinoLibrary],
-/// such as `flutter/widgets` or `flutter/services`.
+/// such as `packages/flutter/test/widgets` or `packages/flutter/test/services`.
 final class _OtherLibrary extends _Library {
-  const _OtherLibrary(super.name, this.crossImportsListSymbolName);
-
-  @override
-  final String crossImportsListSymbolName;
+  const _OtherLibrary(super.name);
 }

--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -235,33 +235,6 @@ class TestsCrossImportChecker {
     return crossImports;
   }
 
-  /// Get the list of known cross imports for the given [library].
-  static Set<String> _getKnownCrossImportsForLibrary(_Library library) {
-    // Material is allowed to cross import.
-    if (library is _MaterialLibrary) {
-      return const <String>{};
-    }
-
-    return switch (library.crossImportsListSymbolName) {
-      'knownFlutterSlashTestCrossImports' => knownFlutterSlashTestCrossImports,
-      'knownAnimationCrossImports' => knownAnimationCrossImports,
-      'knownCupertinoCrossImports' => knownCupertinoCrossImports,
-      'knownDartCrossImports' => knownDartCrossImports,
-      'knownExamplesCrossImports' => knownExamplesCrossImports,
-      'knownFoundationCrossImports' => knownFoundationCrossImports,
-      'knownGesturesCrossImports' => knownGesturesCrossImports,
-      'knownHarnessCrossImports' => knownHarnessCrossImports,
-      'knownPaintingCrossImports' => knownPaintingCrossImports,
-      'knownPhysicsCrossImports' => knownPhysicsCrossImports,
-      'knownRenderingCrossImports' => knownRenderingCrossImports,
-      'knownSchedulerCrossImports' => knownSchedulerCrossImports,
-      'knownSemanticsCrossImports' => knownSemanticsCrossImports,
-      'knownServicesCrossImports' => knownServicesCrossImports,
-      'knownWidgetsCrossImports' => knownWidgetsCrossImports,
-      _ => throw ArgumentError('Unknown library: ${library.name}', 'library'),
-    };
-  }
-
   /// Returns the [Set] of files that are not in [knownPaths].
   static Set<File> _getUnknowns(Set<String> knownPaths, Set<File> files) {
     return files.where((File file) {
@@ -407,7 +380,7 @@ class TestsCrossImportChecker {
       final Set<File> crossImportsForLibrary = entry.value.cupertinoImports.union(
         entry.value.materialImports,
       );
-      final Set<String> knownCrossImportsForLibrary = _getKnownCrossImportsForLibrary(entry.key);
+      final Set<String> knownCrossImportsForLibrary = entry.key.knownCrossImports;
       final Set<String> fixedCrossImports = _differencePaths(
         knownCrossImportsForLibrary,
         crossImportsForLibrary,
@@ -477,7 +450,7 @@ sealed class _Library {
       'packages/flutter/test/foundation' => 'knownFoundationCrossImports',
       'packages/flutter/test/gestures' => 'knownGesturesCrossImports',
       'packages/flutter/test/harness' => 'knownHarnessCrossImports',
-      'packages/flutter/test/material' => throw UnimplementedError(
+      'packages/flutter/test/material' => throw UnsupportedError(
         'Material is responsible for testing its interactions with Cupertino, so it is allowed to cross-import.',
       ),
       'packages/flutter/test/painting' => 'knownPaintingCrossImports',
@@ -487,6 +460,34 @@ sealed class _Library {
       'packages/flutter/test/semantics' => 'knownSemanticsCrossImports',
       'packages/flutter/test/services' => 'knownServicesCrossImports',
       'packages/flutter/test/widgets' => 'knownWidgetsCrossImports',
+      _ => throw UnimplementedError('Unknown library: $name'),
+    };
+  }
+
+  /// Get the list of known cross imports for this [_Library].
+  Set<String> get knownCrossImports {
+    // Material is allowed to cross import.
+    if (this is _MaterialLibrary) {
+      return const <String>{};
+    }
+
+    return switch (crossImportsListSymbolName) {
+      'knownFlutterSlashTestCrossImports' =>
+        TestsCrossImportChecker.knownFlutterSlashTestCrossImports,
+      'knownAnimationCrossImports' => TestsCrossImportChecker.knownAnimationCrossImports,
+      'knownCupertinoCrossImports' => TestsCrossImportChecker.knownCupertinoCrossImports,
+      'knownDartCrossImports' => TestsCrossImportChecker.knownDartCrossImports,
+      'knownExamplesCrossImports' => TestsCrossImportChecker.knownExamplesCrossImports,
+      'knownFoundationCrossImports' => TestsCrossImportChecker.knownFoundationCrossImports,
+      'knownGesturesCrossImports' => TestsCrossImportChecker.knownGesturesCrossImports,
+      'knownHarnessCrossImports' => TestsCrossImportChecker.knownHarnessCrossImports,
+      'knownPaintingCrossImports' => TestsCrossImportChecker.knownPaintingCrossImports,
+      'knownPhysicsCrossImports' => TestsCrossImportChecker.knownPhysicsCrossImports,
+      'knownRenderingCrossImports' => TestsCrossImportChecker.knownRenderingCrossImports,
+      'knownSchedulerCrossImports' => TestsCrossImportChecker.knownSchedulerCrossImports,
+      'knownSemanticsCrossImports' => TestsCrossImportChecker.knownSemanticsCrossImports,
+      'knownServicesCrossImports' => TestsCrossImportChecker.knownServicesCrossImports,
+      'knownWidgetsCrossImports' => TestsCrossImportChecker.knownWidgetsCrossImports,
       _ => throw UnimplementedError('Unknown library: $name'),
     };
   }

--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -193,12 +193,10 @@ class TestsCrossImportChecker {
   /// Returns a list of files in the given directory optionally matching the
   /// given filenamePattern.
   static List<File> _getFiles(Directory directory, [Pattern? filenamePattern]) {
-    return directory.listSync(recursive: true).whereType<File>().where((File file) {
-      if (filenamePattern == null) {
-        return true;
-      }
-      return file.absolute.path.contains(filenamePattern);
-    }).toList();
+    return [
+      for (final File file in directory.listSync(recursive: true).whereType<File>())
+        if (filenamePattern == null || file.absolute.path.contains(filenamePattern)) file,
+    ];
   }
 
   /// Returns the Set of files that are not in knownPaths.
@@ -216,7 +214,7 @@ class TestsCrossImportChecker {
   /// Get a list of all the filenames in the source directory that end in
   /// "_test.dart".
   static Set<File> _getTestFiles(Directory directory, _Library library) {
-    return _getFiles(directory.childDirectory(library.directory), RegExp(r'_test\.dart$')).toSet();
+    return _getFiles(directory.childDirectory(library.directory), RegExp(r'\.dart$')).toSet();
   }
 
   /// Returns true only if the file imports the given Library.
@@ -227,13 +225,10 @@ class TestsCrossImportChecker {
 
   /// Returns a Set of all Files that import the given Library.
   static Set<File> _getFilesWithImports(Set<File> testFiles, _Library library) {
-    final filesWithCrossImports = <File>{};
-    for (final testFile in testFiles) {
-      if (_containsImport(testFile, library)) {
-        filesWithCrossImports.add(testFile);
-      }
-    }
-    return filesWithCrossImports;
+    return {
+      for (final File testFile in testFiles)
+        if (_containsImport(testFile, library)) testFile,
+    };
   }
 
   /// Returns the error message for the given known paths that no longer have a

--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -341,47 +341,38 @@ class TestsCrossImportChecker {
 
     // Find any cross imports that are not in the known list.
     var valid = true;
-    final Set<File> unknownWidgetsTestsImportingMaterial = _getUnknowns(
-      _knownCrossImports,
-      widgetsTestsImportingMaterial,
-    );
-    if (unknownWidgetsTestsImportingMaterial.isNotEmpty) {
-      valid = false;
-      foundError(
-        _getImportError(
-          files: unknownWidgetsTestsImportingMaterial,
-          testLibrary: _Library.widgets,
-          importedLibrary: _Library.material,
-        ).split('\n'),
+
+    for (final MapEntry<_Library, _CrossImportingFiles> entry in crossImportsPerLibrary.entries) {
+      final Set<File> unknownCupertinoImports = _getUnknowns(
+        _knownCrossImports,
+        entry.value.cupertinoImports,
       );
-    }
-    final Set<File> unknownWidgetsTestsImportingCupertino = _getUnknowns(
-      _knownCrossImports,
-      widgetsTestsImportingCupertino,
-    );
-    if (unknownWidgetsTestsImportingCupertino.isNotEmpty) {
-      valid = false;
-      foundError(
-        _getImportError(
-          files: unknownWidgetsTestsImportingCupertino,
-          testLibrary: _Library.widgets,
-          importedLibrary: _Library.cupertino,
-        ).split('\n'),
+      final Set<File> unknownMaterialImports = _getUnknowns(
+        _knownCrossImports,
+        entry.value.materialImports,
       );
-    }
-    final Set<File> unknownCupertinoTestsImportingMaterial = _getUnknowns(
-      _knownCrossImports,
-      cupertinoTestsImportingMaterial,
-    );
-    if (unknownCupertinoTestsImportingMaterial.isNotEmpty) {
-      valid = false;
-      foundError(
-        _getImportError(
-          files: unknownCupertinoTestsImportingMaterial,
-          testLibrary: _Library.cupertino,
-          importedLibrary: _Library.material,
-        ).split('\n'),
-      );
+
+      if (unknownMaterialImports.isNotEmpty) {
+        valid = false;
+        foundError(
+          _getImportError(
+            files: unknownMaterialImports,
+            testLibrary: entry.key,
+            importStatement: _LibraryImportStatement.material,
+          ).split('\n'),
+        );
+      }
+
+      if (unknownCupertinoImports.isNotEmpty) {
+        valid = false;
+        foundError(
+          _getImportError(
+            files: unknownCupertinoImports,
+            testLibrary: entry.key,
+            importStatement: _LibraryImportStatement.cupertino,
+          ).split('\n'),
+        );
+      }
     }
 
     // Find any known cross imports that weren't found, and are therefore fixed.

--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -65,7 +65,7 @@ void main(List<String> args) {
   reportSuccessAndExit('No errors were detected with test cross imports.');
 }
 
-/// Checks the tests in the Widgets and Cupertino libraries for cross imports.
+/// Checks the tests in the `flutter/test/**` libraries for cross imports.
 ///
 /// Excludes known tests that contain cross imports, i.e.
 /// [TestsCrossImportChecker.knownWidgetsCrossImports] and
@@ -85,6 +85,7 @@ void main(List<String> args) {
 ///  - Tests that cover interoperability between Material and Cupertino should
 ///  go in Material.
 ///  - The Widgets library and tests should never import Cupertino or Material.
+///  - Libraries that do not have anything to do with Cupertino or Material should never import them.
 class TestsCrossImportChecker {
   TestsCrossImportChecker({
     required this.testsDirectory,
@@ -137,17 +138,28 @@ class TestsCrossImportChecker {
     'packages/flutter/test/widgets/form_test.dart',
   };
 
-  /// These Cupertino tests are known to have cross imports. These cross imports
+  /// These tests are known to have cross imports. These cross imports
   /// should all eventually be resolved, but until they are we allow them, so
   /// that we can catch any new cross imports that are added.
   ///
-  /// See also:
-  ///
-  ///  * [knownWidgetsCrossImports], which is like this list, but for
-  ///    Widgets tests importing Material or Cupertino.
+  /// Each set corresponds to a subdirectory under `flutter/test`,
+  /// for example `knownWidgetsCrossImports` corresponds to `flutter/test/widgets`
+  /// and `knownSchedulerCrossImports` corresponds to `flutter/test/scheduler`.
   // TODO(justinmc): Fix all of these tests so there are no cross imports.
   // See https://github.com/flutter/flutter/issues/177028.
+  static final Set<String> knownAnimationCrossImports = <String>{};
   static final Set<String> knownCupertinoCrossImports = <String>{};
+  static final Set<String> knownDartCrossImports = <String>{};
+  static final Set<String> knownExamplesCrossImports = <String>{};
+  static final Set<String> knownFoundationCrossImports = <String>{};
+  static final Set<String> knownGesturesCrossImports = <String>{};
+  static final Set<String> knownHarnessCrossImports = <String>{};
+  static final Set<String> knownPaintingCrossImports = <String>{};
+  static final Set<String> knownPhysicsCrossImports = <String>{};
+  static final Set<String> knownRenderingCrossImports = <String>{};
+  static final Set<String> knownSchedulerCrossImports = <String>{};
+  static final Set<String> knownSemanticsCrossImports = <String>{};
+  static final Set<String> knownServicesCrossImports = <String>{};
 
   static final Set<String> _knownCrossImports = knownWidgetsCrossImports.union(
     knownCupertinoCrossImports,
@@ -177,7 +189,7 @@ class TestsCrossImportChecker {
     }).toList();
   }
 
-  /// Returns the Set of Files that are not in knownPaths.
+  /// Returns the Set of files that are not in knownPaths.
   static Set<File> _getUnknowns(Set<String> knownPaths, Set<File> files) {
     return files.where((File file) {
       final prefix = RegExp(r'packages[/\\]flutter[/\\]test');

--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -211,8 +211,8 @@ class TestsCrossImportChecker {
     }).toSet();
   }
 
-  /// Get a list of all the filenames in the source directory that end in
-  /// "_test.dart".
+  /// Get a list of all the filenames in the source directory
+  /// that end in ".dart".
   static Set<File> _getTestFiles(Directory directory, _Library library) {
     return _getFiles(directory.childDirectory(library.directory), RegExp(r'\.dart$')).toSet();
   }
@@ -256,10 +256,9 @@ class TestsCrossImportChecker {
     return buffer.toString().trimRight();
   }
 
-  /// Returns the File's relative path.
-  String _getRelativePath(File file, [Directory? root]) {
-    root ??= flutterRoot;
-    return path.relative(file.absolute.path, from: root.absolute.path);
+  /// Returns the [file]'s relative path, relative to [flutterRoot].
+  String _getRelativePath(File file) {
+    return path.relative(file.absolute.path, from: flutterRoot.absolute.path);
   }
 
   /// Returns the import error for the `files` in `testLibrary` which import

--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -179,7 +179,6 @@ class TestsCrossImportChecker {
     'packages/flutter/test/painting/continuous_rectangle_border_test.dart',
     'packages/flutter/test/painting/colors_test.dart',
     'packages/flutter/test/painting/star_border_test.dart',
-    'packages/flutter/test/painting/system_fonts_test.dart',
   };
   static final Set<String> knownPhysicsCrossImports = <String>{};
   static final Set<String> knownRenderingCrossImports = <String>{
@@ -354,7 +353,8 @@ class TestsCrossImportChecker {
   }) {
     assert(
       !testLibrary.canImport(importStatement),
-      'Import errors only occur when Widgets imports Material or Cupertino, and when Cupertino imports Material.',
+      'any library that is not Material or Cupertino, imports Material or Cupertino, '
+      'and when Cupertino imports Material.',
     );
 
     final String importedLibraryName = importStatement.readableName;

--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -242,7 +242,7 @@ class TestsCrossImportChecker {
       if (index < 0) {
         throw ArgumentError('All files must include $_flutterTestPrefix in their path.', 'files');
       }
-      return file.absolute.path.substring(index).replaceAll(r'\', '/');
+      return file.absolute.path.substring(index).replaceAll(Platform.pathSeparator, '/');
     }).toSet();
     return knownPaths.difference(testPaths);
   }
@@ -285,7 +285,9 @@ class TestsCrossImportChecker {
       if (index < 0) {
         throw ArgumentError('All files must include $_flutterTestPrefix in their path.', 'files');
       }
-      final String comparablePath = file.absolute.path.substring(index).replaceAll(r'\', '/');
+      final String comparablePath = file.absolute.path
+          .substring(index)
+          .replaceAll(Platform.pathSeparator, '/');
       return !knownPaths.contains(comparablePath);
     }).toSet();
   }
@@ -364,7 +366,7 @@ class TestsCrossImportChecker {
           : 'The following ${files.length} tests in ${testLibrary.name} have a disallowed import of $importedLibraryName. Refactor them or move them to $importedLibraryName.\n',
     );
     for (final file in files) {
-      buffer.writeln('  ${_getRelativePath(file)}');
+      buffer.writeln('  ${_getRelativePath(file).replaceAll(Platform.pathSeparator, '/')}');
     }
     return buffer.toString().trimRight();
   }

--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -161,6 +161,17 @@ class TestsCrossImportChecker {
   static final Set<String> knownSemanticsCrossImports = <String>{};
   static final Set<String> knownServicesCrossImports = <String>{};
 
+  /// These tests are known to have cross imports. These cross imports
+  /// should all eventually be resolved, but until they are we allow them, so
+  /// that we can catch any new cross imports that are added.
+  ///
+  /// This set corresponds to violations in `packages/flutter/test` itself,
+  /// for the lists for the subdirectories of `packages/flutter/test`,
+  /// see [knownWidgetsCrossImports] and related lists.
+  // TODO(justinmc): Fix all of these tests so there are no cross imports.
+  // See https://github.com/flutter/flutter/issues/177028.
+  static final Set<String> knownFlutterSlashTestCrossImports = <String>{};
+
   static final Set<String> _knownCrossImports = knownWidgetsCrossImports.union(
     knownCupertinoCrossImports,
   );

--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -136,6 +136,8 @@ class TestsCrossImportChecker {
     'packages/flutter/test/widgets/navigator_restoration_test.dart',
     'packages/flutter/test/widgets/scrollable_semantics_test.dart',
     'packages/flutter/test/widgets/form_test.dart',
+    'packages/flutter/test/widgets/text_selection_toolbar_utils.dart',
+    'packages/flutter/test/widgets/live_text_utils.dart',
   };
 
   /// These tests are known to have cross imports. These cross imports
@@ -147,19 +149,61 @@ class TestsCrossImportChecker {
   /// and `knownSchedulerCrossImports` corresponds to `flutter/test/scheduler`.
   // TODO(justinmc): Fix all of these tests so there are no cross imports.
   // See https://github.com/flutter/flutter/issues/177028.
-  static final Set<String> knownAnimationCrossImports = <String>{};
+  static final Set<String> knownAnimationCrossImports = <String>{
+    'packages/flutter/test/animation/animation_sheet_test.dart',
+    'packages/flutter/test/animation/live_binding_test.dart',
+  };
   static final Set<String> knownCupertinoCrossImports = <String>{};
   static final Set<String> knownDartCrossImports = <String>{};
   static final Set<String> knownExamplesCrossImports = <String>{};
-  static final Set<String> knownFoundationCrossImports = <String>{};
-  static final Set<String> knownGesturesCrossImports = <String>{};
+  static final Set<String> knownFoundationCrossImports = <String>{
+    'packages/flutter/test/foundation/diagnostics_json_test.dart',
+  };
+  static final Set<String> knownGesturesCrossImports = <String>{
+    'packages/flutter/test/gestures/transformed_monodrag_test.dart',
+    'packages/flutter/test/gestures/transformed_scale_test.dart',
+    'packages/flutter/test/gestures/force_press_test.dart',
+    'packages/flutter/test/gestures/transformed_double_tap_test.dart',
+    'packages/flutter/test/gestures/gesture_config_regression_test.dart',
+    'packages/flutter/test/gestures/monodrag_test.dart',
+    'packages/flutter/test/gestures/transformed_long_press_test.dart',
+    'packages/flutter/test/gestures/transformed_tap_test.dart',
+  };
   static final Set<String> knownHarnessCrossImports = <String>{};
-  static final Set<String> knownPaintingCrossImports = <String>{};
+  static final Set<String> knownPaintingCrossImports = <String>{
+    'packages/flutter/test/painting/system_fonts_test.dart',
+    'packages/flutter/test/painting/paint_image_test.dart',
+    'packages/flutter/test/painting/box_painter_test.dart',
+    'packages/flutter/test/painting/decoration_image_lerp_test.dart',
+    'packages/flutter/test/painting/_network_image_test_web.dart',
+    'packages/flutter/test/painting/continuous_rectangle_border_test.dart',
+    'packages/flutter/test/painting/colors_test.dart',
+    'packages/flutter/test/painting/star_border_test.dart',
+    'packages/flutter/test/painting/system_fonts_test.dart',
+  };
   static final Set<String> knownPhysicsCrossImports = <String>{};
-  static final Set<String> knownRenderingCrossImports = <String>{};
+  static final Set<String> knownRenderingCrossImports = <String>{
+    'packages/flutter/test/rendering/aligning_shifted_box_baseline_test.dart',
+    'packages/flutter/test/rendering/localized_fonts_test.dart',
+    'packages/flutter/test/rendering/editable_gesture_test.dart',
+    'packages/flutter/test/rendering/box_test.dart',
+    'packages/flutter/test/rendering/pipeline_owner_tree_test.dart',
+    'packages/flutter/test/rendering/proxy_getters_and_setters_test.dart',
+    'packages/flutter/test/rendering/view_chrome_style_test.dart',
+    'packages/flutter/test/rendering/proxy_box_test.dart',
+    'packages/flutter/test/rendering/sliver_tree_test.dart',
+    'packages/flutter/test/rendering/editable_test.dart',
+    'packages/flutter/test/rendering/object_test.dart',
+  };
   static final Set<String> knownSchedulerCrossImports = <String>{};
-  static final Set<String> knownSemanticsCrossImports = <String>{};
-  static final Set<String> knownServicesCrossImports = <String>{};
+  static final Set<String> knownSemanticsCrossImports = <String>{
+    'packages/flutter/test/semantics/traversal_order_test.dart',
+    'packages/flutter/test/semantics/semantics_update_test.dart',
+    'packages/flutter/test/semantics/semantics_owner_test.dart',
+  };
+  static final Set<String> knownServicesCrossImports = <String>{
+    'packages/flutter/test/services/system_context_menu_controller_test.dart',
+  };
 
   /// These tests are known to have cross imports. These cross imports
   /// should all eventually be resolved, but until they are we allow them, so

--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -176,13 +176,14 @@ class TestsCrossImportChecker {
     knownCupertinoCrossImports,
   );
 
+  static final RegExp _flutterTestPrefix = RegExp(r'packages[/\\]flutter[/\\]test');
+
   /// Returns the Set of paths in `knownPaths` that are not in `files`.
   static Set<String> _differencePaths(Set<String> knownPaths, Set<File> files) {
     final Set<String> testPaths = files.map((File file) {
-      final prefix = RegExp(r'packages[/\\]flutter[/\\]test');
-      final int index = file.absolute.path.indexOf(prefix);
+      final int index = file.absolute.path.indexOf(_flutterTestPrefix);
       if (index < 0) {
-        throw ArgumentError('All files must include $prefix in their path.', 'files');
+        throw ArgumentError('All files must include $_flutterTestPrefix in their path.', 'files');
       }
       return file.absolute.path.substring(index).replaceAll(r'\', '/');
     }).toSet();
@@ -203,10 +204,9 @@ class TestsCrossImportChecker {
   /// Returns the Set of files that are not in knownPaths.
   static Set<File> _getUnknowns(Set<String> knownPaths, Set<File> files) {
     return files.where((File file) {
-      final prefix = RegExp(r'packages[/\\]flutter[/\\]test');
-      final int index = file.absolute.path.indexOf(prefix);
+      final int index = file.absolute.path.indexOf(_flutterTestPrefix);
       if (index < 0) {
-        throw ArgumentError('All files must include $prefix in their path.', 'files');
+        throw ArgumentError('All files must include $_flutterTestPrefix in their path.', 'files');
       }
       final String comparablePath = file.absolute.path.substring(index).replaceAll(r'\', '/');
       return !knownPaths.contains(comparablePath);

--- a/dev/bots/test/check_tests_cross_imports_test.dart
+++ b/dev/bots/test/check_tests_cross_imports_test.dart
@@ -90,7 +90,7 @@ void main() {
     });
 
     test('unknown $libraryName cross import of Material', () async {
-      final String extra = 'packages/flutter/$libraryName/foo_test.dart'.replaceAll(
+      final String extra = 'packages/$libraryName/foo_test.dart'.replaceAll(
         '/',
         Platform.isWindows ? r'\' : '/',
       );
@@ -106,7 +106,7 @@ void main() {
       final String lines =
           <String>[
                 '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
-                '║ The following test in $libraryName has a disallowed import of Material. Refactor it or move it to Material.',
+                '║ The following test in packages/$libraryName has a disallowed import of Material. Refactor it or move it to Material.',
                 '║   $extra',
                 '╚═══════════════════════════════════════════════════════════════════════════════',
               ]
@@ -119,7 +119,7 @@ void main() {
     });
 
     test('unknown $libraryName cross import of Cupertino', () async {
-      final String extra = 'packages/flutter/$libraryName/foo_test.dart'.replaceAll(
+      final String extra = 'packages/$libraryName/foo_test.dart'.replaceAll(
         '/',
         Platform.isWindows ? r'\' : '/',
       );
@@ -139,7 +139,7 @@ void main() {
       final String lines =
           <String>[
                 '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
-                '║ The following test in $libraryName has a disallowed import of Cupertino. Refactor it or move it to Cupertino.',
+                '║ The following test in packages/$libraryName has a disallowed import of Cupertino. Refactor it or move it to Cupertino.',
                 '║   $extra',
                 '╚═══════════════════════════════════════════════════════════════════════════════',
               ]
@@ -149,7 +149,7 @@ void main() {
               .join('\n');
       expect(result, equals('$lines\n'));
       expect(success, isFalse);
-    }, skip: libraryName == 'test/cupertino'); // [intended]: Cupertino can import itself
+    }, skip: libraryName == 'flutter/test/cupertino'); // [intended]: Cupertino can import itself
   }
 }
 
@@ -297,20 +297,20 @@ class _CrossImportsTestDirectories {
 
   Directory testFilesDirectoryFor(String libraryName) {
     return switch (libraryName) {
-      'test/animation' => testAnimationDirectory,
-      'test/cupertino' => testCupertinoDirectory,
-      'test/dart' => testDartDirectory,
-      'test/examples' => testExamplesDirectory,
-      'test/foundation' => testFoundationDirectory,
-      'test/gestures' => testGesturesDirectory,
-      'test/harness' => testHarnessDirectory,
-      'test/painting' => testPaintingDirectory,
-      'test/physics' => testPhysicsDirectory,
-      'test/rendering' => testRenderingDirectory,
-      'test/scheduler' => testSchedulerDirectory,
-      'test/semantics' => testSemanticsDirectory,
-      'test/services' => testServicesDirectory,
-      'test/widgets' => testWidgetsDirectory,
+      'flutter/test/animation' => testAnimationDirectory,
+      'flutter/test/cupertino' => testCupertinoDirectory,
+      'flutter/test/dart' => testDartDirectory,
+      'flutter/test/examples' => testExamplesDirectory,
+      'flutter/test/foundation' => testFoundationDirectory,
+      'flutter/test/gestures' => testGesturesDirectory,
+      'flutter/test/harness' => testHarnessDirectory,
+      'flutter/test/painting' => testPaintingDirectory,
+      'flutter/test/physics' => testPhysicsDirectory,
+      'flutter/test/rendering' => testRenderingDirectory,
+      'flutter/test/scheduler' => testSchedulerDirectory,
+      'flutter/test/semantics' => testSemanticsDirectory,
+      'flutter/test/services' => testServicesDirectory,
+      'flutter/test/widgets' => testWidgetsDirectory,
       _ => throw ArgumentError('Unknown library name: $libraryName'),
     };
   }
@@ -324,19 +324,19 @@ class _CrossImportsTestDirectories {
 // - the actual known cross imports list for that library
 // dart format off
 final crossImportsTestCases = <(String, String, Set<String>)>[
-  ('test/animation', 'knownAnimationCrossImports', TestsCrossImportChecker.knownAnimationCrossImports),
-  ('test/cupertino', 'knownCupertinoCrossImports', TestsCrossImportChecker.knownCupertinoCrossImports),
-  ('test/dart', 'knownDartCrossImports', TestsCrossImportChecker.knownDartCrossImports),
-  ('test/examples', 'knownExamplesCrossImports', TestsCrossImportChecker.knownExamplesCrossImports),
-  ('test/foundation', 'knownFoundationCrossImports', TestsCrossImportChecker.knownFoundationCrossImports),
-  ('test/gestures', 'knownGesturesCrossImports', TestsCrossImportChecker.knownGesturesCrossImports),
-  ('test/harness', 'knownHarnessCrossImports', TestsCrossImportChecker.knownHarnessCrossImports),
-  ('test/painting', 'knownPaintingCrossImports', TestsCrossImportChecker.knownPaintingCrossImports),
-  ('test/physics', 'knownPhysicsCrossImports', TestsCrossImportChecker.knownPhysicsCrossImports),
-  ('test/rendering', 'knownRenderingCrossImports', TestsCrossImportChecker.knownRenderingCrossImports),
-  ('test/scheduler', 'knownSchedulerCrossImports', TestsCrossImportChecker.knownSchedulerCrossImports),
-  ('test/semantics', 'knownSemanticsCrossImports', TestsCrossImportChecker.knownSemanticsCrossImports),
-  ('test/services', 'knownServicesCrossImports', TestsCrossImportChecker.knownServicesCrossImports),
-  ('test/widgets', 'knownWidgetsCrossImports', TestsCrossImportChecker.knownWidgetsCrossImports),
+  ('flutter/test/animation', 'knownAnimationCrossImports', TestsCrossImportChecker.knownAnimationCrossImports),
+  ('flutter/test/cupertino', 'knownCupertinoCrossImports', TestsCrossImportChecker.knownCupertinoCrossImports),
+  ('flutter/test/dart', 'knownDartCrossImports', TestsCrossImportChecker.knownDartCrossImports),
+  ('flutter/test/examples', 'knownExamplesCrossImports', TestsCrossImportChecker.knownExamplesCrossImports),
+  ('flutter/test/foundation', 'knownFoundationCrossImports', TestsCrossImportChecker.knownFoundationCrossImports),
+  ('flutter/test/gestures', 'knownGesturesCrossImports', TestsCrossImportChecker.knownGesturesCrossImports),
+  ('flutter/test/harness', 'knownHarnessCrossImports', TestsCrossImportChecker.knownHarnessCrossImports),
+  ('flutter/test/painting', 'knownPaintingCrossImports', TestsCrossImportChecker.knownPaintingCrossImports),
+  ('flutter/test/physics', 'knownPhysicsCrossImports', TestsCrossImportChecker.knownPhysicsCrossImports),
+  ('flutter/test/rendering', 'knownRenderingCrossImports', TestsCrossImportChecker.knownRenderingCrossImports),
+  ('flutter/test/scheduler', 'knownSchedulerCrossImports', TestsCrossImportChecker.knownSchedulerCrossImports),
+  ('flutter/test/semantics', 'knownSemanticsCrossImports', TestsCrossImportChecker.knownSemanticsCrossImports),
+  ('flutter/test/services', 'knownServicesCrossImports', TestsCrossImportChecker.knownServicesCrossImports),
+  ('flutter/test/widgets', 'knownWidgetsCrossImports', TestsCrossImportChecker.knownWidgetsCrossImports),
 ];
 // dart format on

--- a/dev/bots/test/check_tests_cross_imports_test.dart
+++ b/dev/bots/test/check_tests_cross_imports_test.dart
@@ -97,7 +97,7 @@ void main() {
     test('unknown $libraryName cross import of Material', () async {
       final String extra = 'packages/$libraryName/foo_test.dart'.replaceAll(
         '/',
-        Platform.isWindows ? r'\' : '/',
+        Platform.pathSeparator,
       );
       final Directory testFilesDirectory = checkerDirectories.testFilesDirectoryFor(
         libraryName,
@@ -119,7 +119,7 @@ void main() {
                 '╚═══════════════════════════════════════════════════════════════════════════════',
               ]
               .map((String line) {
-                return line.replaceAll('/', Platform.isWindows ? r'\' : '/');
+                return line.replaceAll('/', Platform.pathSeparator);
               })
               .join('\n');
       expect(result, equals('$lines\n'));
@@ -129,7 +129,7 @@ void main() {
     test('unknown $libraryName cross import of Cupertino', () async {
       final String extra = 'packages/$libraryName/foo_test.dart'.replaceAll(
         '/',
-        Platform.isWindows ? r'\' : '/',
+        Platform.pathSeparator,
       );
       final Directory testFilesDirectory = checkerDirectories.testFilesDirectoryFor(
         libraryName,
@@ -155,7 +155,7 @@ void main() {
                 '╚═══════════════════════════════════════════════════════════════════════════════',
               ]
               .map((String line) {
-                return line.replaceAll('/', Platform.isWindows ? r'\' : '/');
+                return line.replaceAll('/', Platform.pathSeparator);
               })
               .join('\n');
       expect(result, equals('$lines\n'));
@@ -196,12 +196,15 @@ Future<String> capture(AsyncVoidCallback callback, {bool shouldHaveErrors = fals
 }
 
 File getFile(String filepath, Directory directory) {
-  final String platformFilepath = filepath.replaceAll('/', Platform.isWindows ? r'\' : '/');
-  final int overlapIndex = platformFilepath.lastIndexOf(directory.basename);
+  final String platformFilepath = filepath.replaceAll('/', Platform.pathSeparator);
+  final String searchPattern = directory.basename + Platform.pathSeparator;
+  final int overlapIndex = platformFilepath.lastIndexOf(searchPattern);
+
   if (overlapIndex < 0) {
     throw ArgumentError('filepath $filepath must be located in directory ${directory.path}.');
   }
-  final String filename = platformFilepath.substring(overlapIndex + directory.basename.length + 1);
+
+  final String filename = platformFilepath.substring(overlapIndex + searchPattern.length);
   return directory.childFile(filename);
 }
 

--- a/dev/bots/test/check_tests_cross_imports_test.dart
+++ b/dev/bots/test/check_tests_cross_imports_test.dart
@@ -29,7 +29,7 @@ void main() {
   late Directory testServicesDirectory;
   late Directory testWidgetsDirectory;
 
-  void buildTestFiles({
+  void buildKnownCrossImportTestFiles({
     Set<String> excludes = const <String>{},
     Set<String> extraWidgetsImportingMaterial = const <String>{},
     Set<String> extraWidgetsImportingCupertino = const <String>{},
@@ -113,7 +113,7 @@ void main() {
   });
 
   test('when only all knowns have cross imports', () async {
-    buildTestFiles();
+    buildKnownCrossImportTestFiles();
     bool? success;
     final String result = await capture(() async {
       success = checker.check();
@@ -150,7 +150,7 @@ void main() {
 
       final String excludedSample = knownCrossImports.first;
 
-      buildTestFiles(excludes: <String>{excludedSample});
+      buildKnownCrossImportTestFiles(excludes: <String>{excludedSample});
 
       bool? success;
       final String result = await capture(() async {
@@ -174,7 +174,7 @@ void main() {
       '/',
       Platform.isWindows ? r'\' : '/',
     );
-    buildTestFiles(extraWidgetsImportingMaterial: <String>{extra});
+    buildKnownCrossImportTestFiles(extraWidgetsImportingMaterial: <String>{extra});
     bool? success;
     final String result = await capture(() async {
       success = checker.check();
@@ -199,7 +199,7 @@ void main() {
       '/',
       Platform.isWindows ? r'\' : '/',
     );
-    buildTestFiles();
+    buildKnownCrossImportTestFiles();
     writeImportInFiles(<String>{extra}, inDirectory: testCupertinoDirectory);
     bool? success;
     final String result = await capture(() async {
@@ -225,7 +225,7 @@ void main() {
       '/',
       Platform.isWindows ? r'\' : '/',
     );
-    buildTestFiles(extraWidgetsImportingCupertino: <String>{extra});
+    buildKnownCrossImportTestFiles(extraWidgetsImportingCupertino: <String>{extra});
     bool? success;
     final String result = await capture(() async {
       success = checker.check();

--- a/dev/bots/test/check_tests_cross_imports_test.dart
+++ b/dev/bots/test/check_tests_cross_imports_test.dart
@@ -108,26 +108,104 @@ void main() {
     expect(success, isTrue);
   });
 
-  // dart format off
-  final fixedCrossImportsTestCases = <(String, String, Set<String>)>[
-    ('test/animation', 'knownAnimationCrossImports', TestsCrossImportChecker.knownAnimationCrossImports),
-    ('test/cupertino', 'knownCupertinoCrossImports', TestsCrossImportChecker.knownCupertinoCrossImports),
-    ('test/dart', 'knownDartCrossImports', TestsCrossImportChecker.knownDartCrossImports),
-    ('test/examples', 'knownExamplesCrossImports', TestsCrossImportChecker.knownExamplesCrossImports),
-    ('test/foundation', 'knownFoundationCrossImports', TestsCrossImportChecker.knownFoundationCrossImports),
-    ('test/gestures', 'knownGesturesCrossImports', TestsCrossImportChecker.knownGesturesCrossImports),
-    ('test/harness', 'knownHarnessCrossImports', TestsCrossImportChecker.knownHarnessCrossImports),
-    ('test/painting', 'knownPaintingCrossImports', TestsCrossImportChecker.knownPaintingCrossImports),
-    ('test/physics', 'knownPhysicsCrossImports', TestsCrossImportChecker.knownPhysicsCrossImports),
-    ('test/rendering', 'knownRenderingCrossImports', TestsCrossImportChecker.knownRenderingCrossImports),
-    ('test/scheduler', 'knownSchedulerCrossImports', TestsCrossImportChecker.knownSchedulerCrossImports),
-    ('test/semantics', 'knownSemanticsCrossImports', TestsCrossImportChecker.knownSemanticsCrossImports),
-    ('test/services', 'knownServicesCrossImports', TestsCrossImportChecker.knownServicesCrossImports),
-    ('test/widgets', 'knownWidgetsCrossImports', TestsCrossImportChecker.knownWidgetsCrossImports),
+  final fixedCrossImportsTestCases = <(String, String, Set<String>, Directory)>[
+    (
+      'test/animation',
+      'knownAnimationCrossImports',
+      TestsCrossImportChecker.knownAnimationCrossImports,
+      testAnimationDirectory,
+    ),
+    (
+      'test/cupertino',
+      'knownCupertinoCrossImports',
+      TestsCrossImportChecker.knownCupertinoCrossImports,
+      testCupertinoDirectory,
+    ),
+    (
+      'test/dart',
+      'knownDartCrossImports',
+      TestsCrossImportChecker.knownDartCrossImports,
+      testDartDirectory,
+    ),
+    (
+      'test/examples',
+      'knownExamplesCrossImports',
+      TestsCrossImportChecker.knownExamplesCrossImports,
+      testExamplesDirectory,
+    ),
+    (
+      'test/foundation',
+      'knownFoundationCrossImports',
+      TestsCrossImportChecker.knownFoundationCrossImports,
+      testFoundationDirectory,
+    ),
+    (
+      'test/gestures',
+      'knownGesturesCrossImports',
+      TestsCrossImportChecker.knownGesturesCrossImports,
+      testGesturesDirectory,
+    ),
+    (
+      'test/harness',
+      'knownHarnessCrossImports',
+      TestsCrossImportChecker.knownHarnessCrossImports,
+      testHarnessDirectory,
+    ),
+    (
+      'test/painting',
+      'knownPaintingCrossImports',
+      TestsCrossImportChecker.knownPaintingCrossImports,
+      testPaintingDirectory,
+    ),
+    (
+      'test/physics',
+      'knownPhysicsCrossImports',
+      TestsCrossImportChecker.knownPhysicsCrossImports,
+      testPhysicsDirectory,
+    ),
+    (
+      'test/rendering',
+      'knownRenderingCrossImports',
+      TestsCrossImportChecker.knownRenderingCrossImports,
+      testRenderingDirectory,
+    ),
+    (
+      'test/scheduler',
+      'knownSchedulerCrossImports',
+      TestsCrossImportChecker.knownSchedulerCrossImports,
+      testSchedulerDirectory,
+    ),
+    (
+      'test/semantics',
+      'knownSemanticsCrossImports',
+      TestsCrossImportChecker.knownSemanticsCrossImports,
+      testSemanticsDirectory,
+    ),
+    (
+      'test/services',
+      'knownServicesCrossImports',
+      TestsCrossImportChecker.knownServicesCrossImports,
+      testServicesDirectory,
+    ),
+    (
+      'test/widgets',
+      'knownWidgetsCrossImports',
+      TestsCrossImportChecker.knownWidgetsCrossImports,
+      testWidgetsDirectory,
+    ),
   ];
-  // dart format on
 
-  for (final (String libraryName, String knownCrossImportsListName, Set<String> knownCrossImports)
+  final disallowedImportCases = <(String, String)>[
+    ('Material', "import 'package:flutter/material.dart';"),
+    ('Cupertino', "import 'package:flutter/cupertino.dart';"),
+  ];
+
+  for (final (
+        String libraryName,
+        String knownCrossImportsListName,
+        Set<String> knownCrossImports,
+        Directory testFilesDirectory,
+      )
       in fixedCrossImportsTestCases) {
     test('when not all $libraryName knowns have cross imports', () async {
       if (knownCrossImports.isEmpty) {

--- a/dev/bots/test/check_tests_cross_imports_test.dart
+++ b/dev/bots/test/check_tests_cross_imports_test.dart
@@ -149,7 +149,7 @@ void main() {
               .join('\n');
       expect(result, equals('$lines\n'));
       expect(success, isFalse);
-    });
+    }, skip: libraryName == 'test/cupertino'); // [intended]: Cupertino can import itself
   }
 }
 

--- a/dev/bots/test/check_tests_cross_imports_test.dart
+++ b/dev/bots/test/check_tests_cross_imports_test.dart
@@ -69,30 +69,30 @@ void main() {
 
   for (final (String libraryName, String knownCrossImportsListName, Set<String> knownCrossImports)
       in crossImportsTestCases) {
-    test('when not all $libraryName knowns have cross imports', () async {
-      if (knownCrossImports.isEmpty) {
-        return;
-      }
+    test(
+      'when not all $libraryName knowns have cross imports',
+      () async {
+        final String excludedSample = knownCrossImports.first;
 
-      final String excludedSample = knownCrossImports.first;
+        buildKnownCrossImportTestFiles(excludes: <String>{excludedSample});
 
-      buildKnownCrossImportTestFiles(excludes: <String>{excludedSample});
-
-      bool? success;
-      final String result = await capture(() async {
-        success = checker.check();
-      }, shouldHaveErrors: true);
-      final String lines = <String>[
-        '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
-        '║ Huzzah! The following tests in $libraryName no longer contain cross imports!',
-        '║   $excludedSample',
-        '║ However, they now need to be removed from the',
-        '║ $knownCrossImportsListName list in the script /dev/bots/check_tests_cross_imports.dart.',
-        '╚═══════════════════════════════════════════════════════════════════════════════',
-      ].join('\n');
-      expect(result, equals('$lines\n'));
-      expect(success, isFalse);
-    });
+        bool? success;
+        final String result = await capture(() async {
+          success = checker.check();
+        }, shouldHaveErrors: true);
+        final String lines = <String>[
+          '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
+          '║ Huzzah! The following tests in $libraryName no longer contain cross imports!',
+          '║   $excludedSample',
+          '║ However, they now need to be removed from the',
+          '║ $knownCrossImportsListName list in the script /dev/bots/check_tests_cross_imports.dart.',
+          '╚═══════════════════════════════════════════════════════════════════════════════',
+        ].join('\n');
+        expect(result, equals('$lines\n'));
+        expect(success, isFalse);
+      },
+      skip: knownCrossImports.isEmpty,
+    ); // [intended]: No message is needed when there are no known cross imports.
 
     test('unknown $libraryName cross import of Material', () async {
       final String extra = 'packages/$libraryName/foo_test.dart'.replaceAll(

--- a/dev/bots/test/check_tests_cross_imports_test.dart
+++ b/dev/bots/test/check_tests_cross_imports_test.dart
@@ -14,39 +14,8 @@ import 'common.dart';
 
 void main() {
   late TestsCrossImportChecker checker;
-  late Directory testCupertinoDirectory;
-  late Directory testAnimationDirectory;
-  late Directory testDartDirectory;
-  late Directory testExamplesDirectory;
-  late Directory testFoundationDirectory;
-  late Directory testGesturesDirectory;
-  late Directory testHarnessDirectory;
-  late Directory testPaintingDirectory;
-  late Directory testPhysicsDirectory;
-  late Directory testRenderingDirectory;
-  late Directory testSchedulerDirectory;
-  late Directory testSemanticsDirectory;
-  late Directory testServicesDirectory;
-  late Directory testWidgetsDirectory;
 
   void buildKnownCrossImportTestFiles({Set<String> excludes = const <String>{}}) {
-    final knownFiles = <Directory, Set<String>>{
-      testCupertinoDirectory: TestsCrossImportChecker.knownCupertinoCrossImports,
-      testAnimationDirectory: TestsCrossImportChecker.knownAnimationCrossImports,
-      testDartDirectory: TestsCrossImportChecker.knownDartCrossImports,
-      testExamplesDirectory: TestsCrossImportChecker.knownExamplesCrossImports,
-      testFoundationDirectory: TestsCrossImportChecker.knownFoundationCrossImports,
-      testGesturesDirectory: TestsCrossImportChecker.knownGesturesCrossImports,
-      testHarnessDirectory: TestsCrossImportChecker.knownHarnessCrossImports,
-      testPaintingDirectory: TestsCrossImportChecker.knownPaintingCrossImports,
-      testPhysicsDirectory: TestsCrossImportChecker.knownPhysicsCrossImports,
-      testRenderingDirectory: TestsCrossImportChecker.knownRenderingCrossImports,
-      testSchedulerDirectory: TestsCrossImportChecker.knownSchedulerCrossImports,
-      testSemanticsDirectory: TestsCrossImportChecker.knownSemanticsCrossImports,
-      testServicesDirectory: TestsCrossImportChecker.knownServicesCrossImports,
-      testWidgetsDirectory: TestsCrossImportChecker.knownWidgetsCrossImports,
-    };
-
     for (final MapEntry<Directory, Set<String>>(key: Directory directory, value: Set<String> files)
         in knownFiles.entries) {
       for (final filepath in files) {
@@ -72,24 +41,7 @@ void main() {
     final Directory testsDir =
         flutterRoot.childDirectory('packages').childDirectory('flutter').childDirectory('test')
           ..createSync(recursive: true);
-
-    testAnimationDirectory = testsDir.childDirectory('animation')..createSync(recursive: true);
-    testCupertinoDirectory = testsDir.childDirectory('cupertino')..createSync(recursive: true);
-    testDartDirectory = testsDir.childDirectory('dart')..createSync(recursive: true);
-    testExamplesDirectory = testsDir.childDirectory('examples')..createSync(recursive: true);
-    testFoundationDirectory = testsDir.childDirectory('foundation')..createSync(recursive: true);
-    testGesturesDirectory = testsDir.childDirectory('gestures')..createSync(recursive: true);
-    testHarnessDirectory = testsDir.childDirectory('harness')..createSync(recursive: true);
-    // tests/material sits between tests/harness and tests/painting,
-    // but the test does not need a reference to the directory.
     testsDir.childDirectory('material').createSync(recursive: true);
-    testPaintingDirectory = testsDir.childDirectory('painting')..createSync(recursive: true);
-    testPhysicsDirectory = testsDir.childDirectory('physics')..createSync(recursive: true);
-    testRenderingDirectory = testsDir.childDirectory('rendering')..createSync(recursive: true);
-    testSchedulerDirectory = testsDir.childDirectory('scheduler')..createSync(recursive: true);
-    testSemanticsDirectory = testsDir.childDirectory('semantics')..createSync(recursive: true);
-    testServicesDirectory = testsDir.childDirectory('services')..createSync(recursive: true);
-    testWidgetsDirectory = testsDir.childDirectory('widgets')..createSync(recursive: true);
 
     checker = TestsCrossImportChecker(
       testsDirectory: testsDir,
@@ -107,93 +59,6 @@ void main() {
     expect(result, equals(''));
     expect(success, isTrue);
   });
-
-  final fixedCrossImportsTestCases = <(String, String, Set<String>, Directory)>[
-    (
-      'test/animation',
-      'knownAnimationCrossImports',
-      TestsCrossImportChecker.knownAnimationCrossImports,
-      testAnimationDirectory,
-    ),
-    (
-      'test/cupertino',
-      'knownCupertinoCrossImports',
-      TestsCrossImportChecker.knownCupertinoCrossImports,
-      testCupertinoDirectory,
-    ),
-    (
-      'test/dart',
-      'knownDartCrossImports',
-      TestsCrossImportChecker.knownDartCrossImports,
-      testDartDirectory,
-    ),
-    (
-      'test/examples',
-      'knownExamplesCrossImports',
-      TestsCrossImportChecker.knownExamplesCrossImports,
-      testExamplesDirectory,
-    ),
-    (
-      'test/foundation',
-      'knownFoundationCrossImports',
-      TestsCrossImportChecker.knownFoundationCrossImports,
-      testFoundationDirectory,
-    ),
-    (
-      'test/gestures',
-      'knownGesturesCrossImports',
-      TestsCrossImportChecker.knownGesturesCrossImports,
-      testGesturesDirectory,
-    ),
-    (
-      'test/harness',
-      'knownHarnessCrossImports',
-      TestsCrossImportChecker.knownHarnessCrossImports,
-      testHarnessDirectory,
-    ),
-    (
-      'test/painting',
-      'knownPaintingCrossImports',
-      TestsCrossImportChecker.knownPaintingCrossImports,
-      testPaintingDirectory,
-    ),
-    (
-      'test/physics',
-      'knownPhysicsCrossImports',
-      TestsCrossImportChecker.knownPhysicsCrossImports,
-      testPhysicsDirectory,
-    ),
-    (
-      'test/rendering',
-      'knownRenderingCrossImports',
-      TestsCrossImportChecker.knownRenderingCrossImports,
-      testRenderingDirectory,
-    ),
-    (
-      'test/scheduler',
-      'knownSchedulerCrossImports',
-      TestsCrossImportChecker.knownSchedulerCrossImports,
-      testSchedulerDirectory,
-    ),
-    (
-      'test/semantics',
-      'knownSemanticsCrossImports',
-      TestsCrossImportChecker.knownSemanticsCrossImports,
-      testSemanticsDirectory,
-    ),
-    (
-      'test/services',
-      'knownServicesCrossImports',
-      TestsCrossImportChecker.knownServicesCrossImports,
-      testServicesDirectory,
-    ),
-    (
-      'test/widgets',
-      'knownWidgetsCrossImports',
-      TestsCrossImportChecker.knownWidgetsCrossImports,
-      testWidgetsDirectory,
-    ),
-  ];
 
   for (final (
         String libraryName,
@@ -254,38 +119,38 @@ void main() {
       expect(result, equals('$lines\n'));
       expect(success, isFalse);
     });
+
+    test('unknown $libraryName cross import of Cupertino', () async {
+      final String extra = 'packages/flutter/$libraryName/foo_test.dart'.replaceAll(
+        '/',
+        Platform.isWindows ? r'\' : '/',
+      );
+      buildKnownCrossImportTestFiles();
+      writeImportInFiles(
+        <String>{extra},
+        inDirectory: testFilesDirectory,
+        importString: "import 'package:flutter/cupertino.dart';",
+      );
+
+      bool? success;
+      final String result = await capture(() async {
+        success = checker.check();
+      }, shouldHaveErrors: true);
+      final String lines =
+          <String>[
+                '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
+                '║ The following test in $libraryName has a disallowed import of Cupertino. Refactor it or move it to Cupertino.',
+                '║   $extra',
+                '╚═══════════════════════════════════════════════════════════════════════════════',
+              ]
+              .map((String line) {
+                return line.replaceAll('/', Platform.isWindows ? r'\' : '/');
+              })
+              .join('\n');
+      expect(result, equals('$lines\n'));
+      expect(success, isFalse);
+    });
   }
-
-  test('unknown Widgets cross import of Cupertino', () async {
-    final String extra = 'packages/flutter/test/widgets/foo_test.dart'.replaceAll(
-      '/',
-      Platform.isWindows ? r'\' : '/',
-    );
-    buildKnownCrossImportTestFiles();
-    writeImportInFiles(
-      <String>{extra},
-      inDirectory: testWidgetsDirectory,
-      importString: "import 'package:flutter/cupertino.dart';",
-    );
-
-    bool? success;
-    final String result = await capture(() async {
-      success = checker.check();
-    }, shouldHaveErrors: true);
-    final String lines =
-        <String>[
-              '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
-              '║ The following test in Widgets has a disallowed import of Cupertino. Refactor it or move it to Cupertino.',
-              '║   $extra',
-              '╚═══════════════════════════════════════════════════════════════════════════════',
-            ]
-            .map((String line) {
-              return line.replaceAll('/', Platform.isWindows ? r'\' : '/');
-            })
-            .join('\n');
-    expect(result, equals('$lines\n'));
-    expect(success, isFalse);
-  });
 }
 
 typedef AsyncVoidCallback = Future<void> Function();
@@ -349,4 +214,174 @@ void writeImportInFiles(
   for (final filepath in filePaths) {
     writeImport(getFile(filepath, inDirectory), importString);
   }
+}
+
+// A utility that keeps track of the directories under test,
+// to avoid having to late initialize them individually in `setUp()`.
+class _CrossImportsTestDirectories {
+  const _CrossImportsTestDirectories._({
+    required this.testAnimationDirectory,
+    required this.testCupertinoDirectory,
+    required this.testDartDirectory,
+    required this.testExamplesDirectory,
+    required this.testFoundationDirectory,
+    required this.testGesturesDirectory,
+    required this.testHarnessDirectory,
+    required this.testPaintingDirectory,
+    required this.testPhysicsDirectory,
+    required this.testRenderingDirectory,
+    required this.testSchedulerDirectory,
+    required this.testSemanticsDirectory,
+    required this.testServicesDirectory,
+    required this.testWidgetsDirectory,
+  });
+
+  factory _CrossImportsTestDirectories(Directory testsDir) {
+    return _CrossImportsTestDirectories._(
+      testAnimationDirectory: testsDir.childDirectory('animation')..createSync(recursive: true),
+      testCupertinoDirectory: testsDir.childDirectory('cupertino')..createSync(recursive: true),
+      testDartDirectory: testsDir.childDirectory('dart')..createSync(recursive: true),
+      testExamplesDirectory: testsDir.childDirectory('examples')..createSync(recursive: true),
+      testFoundationDirectory: testsDir.childDirectory('foundation')..createSync(recursive: true),
+      testGesturesDirectory: testsDir.childDirectory('gestures')..createSync(recursive: true),
+      testHarnessDirectory: testsDir.childDirectory('harness')..createSync(recursive: true),
+      testPaintingDirectory: testsDir.childDirectory('painting')..createSync(recursive: true),
+      testPhysicsDirectory: testsDir.childDirectory('physics')..createSync(recursive: true),
+      testRenderingDirectory: testsDir.childDirectory('rendering')..createSync(recursive: true),
+      testSchedulerDirectory: testsDir.childDirectory('scheduler')..createSync(recursive: true),
+      testSemanticsDirectory: testsDir.childDirectory('semantics')..createSync(recursive: true),
+      testServicesDirectory: testsDir.childDirectory('services')..createSync(recursive: true),
+      testWidgetsDirectory: testsDir.childDirectory('widgets')..createSync(recursive: true),
+    );
+  }
+
+  final Directory testAnimationDirectory;
+  final Directory testCupertinoDirectory;
+  final Directory testDartDirectory;
+  final Directory testExamplesDirectory;
+  final Directory testFoundationDirectory;
+  final Directory testGesturesDirectory;
+  final Directory testHarnessDirectory;
+  final Directory testPaintingDirectory;
+  final Directory testPhysicsDirectory;
+  final Directory testRenderingDirectory;
+  final Directory testSchedulerDirectory;
+  final Directory testSemanticsDirectory;
+  final Directory testServicesDirectory;
+  final Directory testWidgetsDirectory;
+
+  /// A mapping of test cases for the cross imports checker.
+  ///
+  /// Each entry contains:
+  /// - a shortened directory name of the test folder for the library, without the `flutter/` prefix
+  /// - the name of the known cross imports list variable in `check_tests_cross_imports.dart` for that library
+  /// - the actual known cross imports list for that library
+  /// - the directory containing the test files for that library
+  Iterable<(String, String, Set<String>, Directory)> get crossImportsTestCases {
+    return <(String, String, Set<String>, Directory)>[
+      (
+        'test/animation',
+        'knownAnimationCrossImports',
+        TestsCrossImportChecker.knownAnimationCrossImports,
+        testAnimationDirectory,
+      ),
+      (
+        'test/cupertino',
+        'knownCupertinoCrossImports',
+        TestsCrossImportChecker.knownCupertinoCrossImports,
+        testCupertinoDirectory,
+      ),
+      (
+        'test/dart',
+        'knownDartCrossImports',
+        TestsCrossImportChecker.knownDartCrossImports,
+        testDartDirectory,
+      ),
+      (
+        'test/examples',
+        'knownExamplesCrossImports',
+        TestsCrossImportChecker.knownExamplesCrossImports,
+        testExamplesDirectory,
+      ),
+      (
+        'test/foundation',
+        'knownFoundationCrossImports',
+        TestsCrossImportChecker.knownFoundationCrossImports,
+        testFoundationDirectory,
+      ),
+      (
+        'test/gestures',
+        'knownGesturesCrossImports',
+        TestsCrossImportChecker.knownGesturesCrossImports,
+        testGesturesDirectory,
+      ),
+      (
+        'test/harness',
+        'knownHarnessCrossImports',
+        TestsCrossImportChecker.knownHarnessCrossImports,
+        testHarnessDirectory,
+      ),
+      (
+        'test/painting',
+        'knownPaintingCrossImports',
+        TestsCrossImportChecker.knownPaintingCrossImports,
+        testPaintingDirectory,
+      ),
+      (
+        'test/physics',
+        'knownPhysicsCrossImports',
+        TestsCrossImportChecker.knownPhysicsCrossImports,
+        testPhysicsDirectory,
+      ),
+      (
+        'test/rendering',
+        'knownRenderingCrossImports',
+        TestsCrossImportChecker.knownRenderingCrossImports,
+        testRenderingDirectory,
+      ),
+      (
+        'test/scheduler',
+        'knownSchedulerCrossImports',
+        TestsCrossImportChecker.knownSchedulerCrossImports,
+        testSchedulerDirectory,
+      ),
+      (
+        'test/semantics',
+        'knownSemanticsCrossImports',
+        TestsCrossImportChecker.knownSemanticsCrossImports,
+        testSemanticsDirectory,
+      ),
+      (
+        'test/services',
+        'knownServicesCrossImports',
+        TestsCrossImportChecker.knownServicesCrossImports,
+        testServicesDirectory,
+      ),
+      (
+        'test/widgets',
+        'knownWidgetsCrossImports',
+        TestsCrossImportChecker.knownWidgetsCrossImports,
+        testWidgetsDirectory,
+      ),
+    ];
+  }
+
+  /// A mapping of the `flutter/test/xyz` directories,
+  /// to their corresponding known imports list in `check_tests_cross_imports.dart`.
+  Map<Directory, Set<String>> get knownFiles => <Directory, Set<String>>{
+    testCupertinoDirectory: TestsCrossImportChecker.knownCupertinoCrossImports,
+    testAnimationDirectory: TestsCrossImportChecker.knownAnimationCrossImports,
+    testDartDirectory: TestsCrossImportChecker.knownDartCrossImports,
+    testExamplesDirectory: TestsCrossImportChecker.knownExamplesCrossImports,
+    testFoundationDirectory: TestsCrossImportChecker.knownFoundationCrossImports,
+    testGesturesDirectory: TestsCrossImportChecker.knownGesturesCrossImports,
+    testHarnessDirectory: TestsCrossImportChecker.knownHarnessCrossImports,
+    testPaintingDirectory: TestsCrossImportChecker.knownPaintingCrossImports,
+    testPhysicsDirectory: TestsCrossImportChecker.knownPhysicsCrossImports,
+    testRenderingDirectory: TestsCrossImportChecker.knownRenderingCrossImports,
+    testSchedulerDirectory: TestsCrossImportChecker.knownSchedulerCrossImports,
+    testSemanticsDirectory: TestsCrossImportChecker.knownSemanticsCrossImports,
+    testServicesDirectory: TestsCrossImportChecker.knownServicesCrossImports,
+    testWidgetsDirectory: TestsCrossImportChecker.knownWidgetsCrossImports,
+  };
 }

--- a/dev/bots/test/check_tests_cross_imports_test.dart
+++ b/dev/bots/test/check_tests_cross_imports_test.dart
@@ -17,8 +17,12 @@ void main() {
   late _CrossImportsTestDirectories checkerDirectories;
 
   void buildKnownCrossImportTestFiles({Set<String> excludes = const <String>{}}) {
+    final Map<Directory, Set<String>> knownFiles = checkerDirectories.getKnownFiles(
+      checker.testsDirectory,
+    );
+
     for (final MapEntry<Directory, Set<String>>(key: Directory directory, value: Set<String> files)
-        in checkerDirectories.knownFiles.entries) {
+        in knownFiles.entries) {
       for (final filepath in files) {
         if (excludes.contains(filepath)) {
           continue;
@@ -39,17 +43,18 @@ void main() {
     )..createSync(recursive: true);
     fs.currentDirectory = flutterRoot;
 
-    final Directory testDir =
+    final Directory testsDirectory =
         flutterRoot.childDirectory('packages').childDirectory('flutter').childDirectory('test')
           ..createSync(recursive: true);
-    testDir.childDirectory('material').createSync(recursive: true);
+    testsDirectory.childDirectory('material').createSync(recursive: true);
 
     checker = TestsCrossImportChecker(
-      testsDirectory: testDir,
+      testsDirectory: testsDirectory,
       flutterRoot: flutterRoot,
       filesystem: fs,
     );
-    checkerDirectories = _CrossImportsTestDirectories(testDir)..createTestDirectories();
+    checkerDirectories = _CrossImportsTestDirectories(testsDirectory)
+      ..createTestDirectories(testsDirectory);
   });
 
   test('when only all knowns have cross imports', () async {
@@ -94,7 +99,10 @@ void main() {
         '/',
         Platform.isWindows ? r'\' : '/',
       );
-      final Directory testFilesDirectory = checkerDirectories.testFilesDirectoryFor(libraryName);
+      final Directory testFilesDirectory = checkerDirectories.testFilesDirectoryFor(
+        libraryName,
+        checker.testsDirectory,
+      );
 
       buildKnownCrossImportTestFiles();
       writeImportInFiles(<String>{extra}, inDirectory: testFilesDirectory);
@@ -123,7 +131,10 @@ void main() {
         '/',
         Platform.isWindows ? r'\' : '/',
       );
-      final Directory testFilesDirectory = checkerDirectories.testFilesDirectoryFor(libraryName);
+      final Directory testFilesDirectory = checkerDirectories.testFilesDirectoryFor(
+        libraryName,
+        checker.testsDirectory,
+      );
 
       buildKnownCrossImportTestFiles();
       writeImportInFiles(
@@ -219,22 +230,22 @@ void writeImportInFiles(
 // A utility that keeps track of the directories under test,
 // to avoid having to late initialize them individually in `setUp()`.
 class _CrossImportsTestDirectories {
-  factory _CrossImportsTestDirectories(Directory testsDir) {
+  factory _CrossImportsTestDirectories(Directory testsDirectory) {
     return _CrossImportsTestDirectories._(
-      testAnimationDirectory: testsDir.childDirectory('animation'),
-      testCupertinoDirectory: testsDir.childDirectory('cupertino'),
-      testDartDirectory: testsDir.childDirectory('dart'),
-      testExamplesDirectory: testsDir.childDirectory('examples'),
-      testFoundationDirectory: testsDir.childDirectory('foundation'),
-      testGesturesDirectory: testsDir.childDirectory('gestures'),
-      testHarnessDirectory: testsDir.childDirectory('harness'),
-      testPaintingDirectory: testsDir.childDirectory('painting'),
-      testPhysicsDirectory: testsDir.childDirectory('physics'),
-      testRenderingDirectory: testsDir.childDirectory('rendering'),
-      testSchedulerDirectory: testsDir.childDirectory('scheduler'),
-      testSemanticsDirectory: testsDir.childDirectory('semantics'),
-      testServicesDirectory: testsDir.childDirectory('services'),
-      testWidgetsDirectory: testsDir.childDirectory('widgets'),
+      testAnimationDirectory: testsDirectory.childDirectory('animation'),
+      testCupertinoDirectory: testsDirectory.childDirectory('cupertino'),
+      testDartDirectory: testsDirectory.childDirectory('dart'),
+      testExamplesDirectory: testsDirectory.childDirectory('examples'),
+      testFoundationDirectory: testsDirectory.childDirectory('foundation'),
+      testGesturesDirectory: testsDirectory.childDirectory('gestures'),
+      testHarnessDirectory: testsDirectory.childDirectory('harness'),
+      testPaintingDirectory: testsDirectory.childDirectory('painting'),
+      testPhysicsDirectory: testsDirectory.childDirectory('physics'),
+      testRenderingDirectory: testsDirectory.childDirectory('rendering'),
+      testSchedulerDirectory: testsDirectory.childDirectory('scheduler'),
+      testSemanticsDirectory: testsDirectory.childDirectory('semantics'),
+      testServicesDirectory: testsDirectory.childDirectory('services'),
+      testWidgetsDirectory: testsDirectory.childDirectory('widgets'),
     );
   }
 
@@ -271,32 +282,44 @@ class _CrossImportsTestDirectories {
   final Directory testWidgetsDirectory;
 
   /// A mapping of the `flutter/test/xyz` directories,
-  /// to their corresponding known imports list in `check_tests_cross_imports.dart`.
-  Map<Directory, Set<String>> get knownFiles => <Directory, Set<String>>{
-    testCupertinoDirectory: TestsCrossImportChecker.knownCupertinoCrossImports,
-    testAnimationDirectory: TestsCrossImportChecker.knownAnimationCrossImports,
-    testDartDirectory: TestsCrossImportChecker.knownDartCrossImports,
-    testExamplesDirectory: TestsCrossImportChecker.knownExamplesCrossImports,
-    testFoundationDirectory: TestsCrossImportChecker.knownFoundationCrossImports,
-    testGesturesDirectory: TestsCrossImportChecker.knownGesturesCrossImports,
-    testHarnessDirectory: TestsCrossImportChecker.knownHarnessCrossImports,
-    testPaintingDirectory: TestsCrossImportChecker.knownPaintingCrossImports,
-    testPhysicsDirectory: TestsCrossImportChecker.knownPhysicsCrossImports,
-    testRenderingDirectory: TestsCrossImportChecker.knownRenderingCrossImports,
-    testSchedulerDirectory: TestsCrossImportChecker.knownSchedulerCrossImports,
-    testSemanticsDirectory: TestsCrossImportChecker.knownSemanticsCrossImports,
-    testServicesDirectory: TestsCrossImportChecker.knownServicesCrossImports,
-    testWidgetsDirectory: TestsCrossImportChecker.knownWidgetsCrossImports,
-  };
+  /// to their corresponding known imports list in `check_tests_cross_imports.dart`,
+  /// including `flutter/test` itself.
+  Map<Directory, Set<String>> getKnownFiles(Directory flutterTestDirectory) {
+    return <Directory, Set<String>>{
+      flutterTestDirectory: TestsCrossImportChecker.knownFlutterSlashTestCrossImports,
+      testCupertinoDirectory: TestsCrossImportChecker.knownCupertinoCrossImports,
+      testAnimationDirectory: TestsCrossImportChecker.knownAnimationCrossImports,
+      testDartDirectory: TestsCrossImportChecker.knownDartCrossImports,
+      testExamplesDirectory: TestsCrossImportChecker.knownExamplesCrossImports,
+      testFoundationDirectory: TestsCrossImportChecker.knownFoundationCrossImports,
+      testGesturesDirectory: TestsCrossImportChecker.knownGesturesCrossImports,
+      testHarnessDirectory: TestsCrossImportChecker.knownHarnessCrossImports,
+      testPaintingDirectory: TestsCrossImportChecker.knownPaintingCrossImports,
+      testPhysicsDirectory: TestsCrossImportChecker.knownPhysicsCrossImports,
+      testRenderingDirectory: TestsCrossImportChecker.knownRenderingCrossImports,
+      testSchedulerDirectory: TestsCrossImportChecker.knownSchedulerCrossImports,
+      testSemanticsDirectory: TestsCrossImportChecker.knownSemanticsCrossImports,
+      testServicesDirectory: TestsCrossImportChecker.knownServicesCrossImports,
+      testWidgetsDirectory: TestsCrossImportChecker.knownWidgetsCrossImports,
+    };
+  }
 
-  void createTestDirectories() {
+  void createTestDirectories(Directory flutterTestDirectory) {
+    final Map<Directory, Set<String>> knownFiles = getKnownFiles(flutterTestDirectory);
+
     for (final Directory directory in knownFiles.keys) {
+      // The `flutter/test` directory is created in `setUp()`.
+      if (directory == flutterTestDirectory) {
+        continue;
+      }
+
       directory.createSync(recursive: true);
     }
   }
 
-  Directory testFilesDirectoryFor(String libraryName) {
+  Directory testFilesDirectoryFor(String libraryName, Directory flutterTestDirectory) {
     return switch (libraryName) {
+      'flutter/test' => flutterTestDirectory,
       'flutter/test/animation' => testAnimationDirectory,
       'flutter/test/cupertino' => testCupertinoDirectory,
       'flutter/test/dart' => testDartDirectory,
@@ -319,11 +342,12 @@ class _CrossImportsTestDirectories {
 // A mapping of test cases for the cross imports checker.
 //
 // Each entry contains:
-// - a shortened directory name of the test folder for the library, without the `flutter/` prefix
+// - a shortened directory name of the test folder for the library
 // - the name of the known cross imports list variable in `check_tests_cross_imports.dart` for that library
 // - the actual known cross imports list for that library
 // dart format off
 final crossImportsTestCases = <(String, String, Set<String>)>[
+  ('flutter/test', 'knownFlutterSlashTestCrossImports', TestsCrossImportChecker.knownFlutterSlashTestCrossImports),
   ('flutter/test/animation', 'knownAnimationCrossImports', TestsCrossImportChecker.knownAnimationCrossImports),
   ('flutter/test/cupertino', 'knownCupertinoCrossImports', TestsCrossImportChecker.knownCupertinoCrossImports),
   ('flutter/test/dart', 'knownDartCrossImports', TestsCrossImportChecker.knownDartCrossImports),

--- a/dev/bots/test/check_tests_cross_imports_test.dart
+++ b/dev/bots/test/check_tests_cross_imports_test.dart
@@ -14,14 +14,11 @@ import 'common.dart';
 
 void main() {
   late TestsCrossImportChecker checker;
-  late Directory flutterTestDirectory;
+  late _CrossImportsTestDirectories checkerDirectories;
 
-  void buildKnownCrossImportTestFiles(
-    Map<Directory, Set<String>> knownFiles, {
-    Set<String> excludes = const <String>{},
-  }) {
+  void buildKnownCrossImportTestFiles({Set<String> excludes = const <String>{}}) {
     for (final MapEntry<Directory, Set<String>>(key: Directory directory, value: Set<String> files)
-        in knownFiles.entries) {
+        in checkerDirectories.knownFiles.entries) {
       for (final filepath in files) {
         if (excludes.contains(filepath)) {
           continue;
@@ -42,22 +39,21 @@ void main() {
     )..createSync(recursive: true);
     fs.currentDirectory = flutterRoot;
 
-    flutterTestDirectory =
+    final Directory testDir =
         flutterRoot.childDirectory('packages').childDirectory('flutter').childDirectory('test')
           ..createSync(recursive: true);
-    flutterTestDirectory.childDirectory('material').createSync(recursive: true);
+    testDir.childDirectory('material').createSync(recursive: true);
 
     checker = TestsCrossImportChecker(
-      testsDirectory: flutterTestDirectory,
+      testsDirectory: testDir,
       flutterRoot: flutterRoot,
       filesystem: fs,
     );
+    checkerDirectories = _CrossImportsTestDirectories(testDir)..createTestDirectories();
   });
 
   test('when only all knowns have cross imports', () async {
-    final checkerDirectories = _CrossImportsTestDirectories(flutterTestDirectory);
-
-    buildKnownCrossImportTestFiles(checkerDirectories.knownFiles);
+    buildKnownCrossImportTestFiles();
     bool? success;
     final String result = await capture(() async {
       success = checker.check();
@@ -66,13 +62,8 @@ void main() {
     expect(success, isTrue);
   });
 
-  for (final (
-        String libraryName,
-        String knownCrossImportsListName,
-        Set<String> knownCrossImports,
-        Directory testFilesDirectory,
-      )
-      in fixedCrossImportsTestCases) {
+  for (final (String libraryName, String knownCrossImportsListName, Set<String> knownCrossImports)
+      in crossImportsTestCases) {
     test('when not all $libraryName knowns have cross imports', () async {
       if (knownCrossImports.isEmpty) {
         return;
@@ -103,6 +94,7 @@ void main() {
         '/',
         Platform.isWindows ? r'\' : '/',
       );
+      final Directory testFilesDirectory = checkerDirectories.testFilesDirectoryFor(libraryName);
 
       buildKnownCrossImportTestFiles();
       writeImportInFiles(<String>{extra}, inDirectory: testFilesDirectory);
@@ -131,6 +123,8 @@ void main() {
         '/',
         Platform.isWindows ? r'\' : '/',
       );
+      final Directory testFilesDirectory = checkerDirectories.testFilesDirectoryFor(libraryName);
+
       buildKnownCrossImportTestFiles();
       writeImportInFiles(
         <String>{extra},
@@ -225,6 +219,25 @@ void writeImportInFiles(
 // A utility that keeps track of the directories under test,
 // to avoid having to late initialize them individually in `setUp()`.
 class _CrossImportsTestDirectories {
+  factory _CrossImportsTestDirectories(Directory testsDir) {
+    return _CrossImportsTestDirectories._(
+      testAnimationDirectory: testsDir.childDirectory('animation'),
+      testCupertinoDirectory: testsDir.childDirectory('cupertino'),
+      testDartDirectory: testsDir.childDirectory('dart'),
+      testExamplesDirectory: testsDir.childDirectory('examples'),
+      testFoundationDirectory: testsDir.childDirectory('foundation'),
+      testGesturesDirectory: testsDir.childDirectory('gestures'),
+      testHarnessDirectory: testsDir.childDirectory('harness'),
+      testPaintingDirectory: testsDir.childDirectory('painting'),
+      testPhysicsDirectory: testsDir.childDirectory('physics'),
+      testRenderingDirectory: testsDir.childDirectory('rendering'),
+      testSchedulerDirectory: testsDir.childDirectory('scheduler'),
+      testSemanticsDirectory: testsDir.childDirectory('semantics'),
+      testServicesDirectory: testsDir.childDirectory('services'),
+      testWidgetsDirectory: testsDir.childDirectory('widgets'),
+    );
+  }
+
   const _CrossImportsTestDirectories._({
     required this.testAnimationDirectory,
     required this.testCupertinoDirectory,
@@ -242,25 +255,6 @@ class _CrossImportsTestDirectories {
     required this.testWidgetsDirectory,
   });
 
-  factory _CrossImportsTestDirectories(Directory testsDir) {
-    return _CrossImportsTestDirectories._(
-      testAnimationDirectory: testsDir.childDirectory('animation')..createSync(recursive: true),
-      testCupertinoDirectory: testsDir.childDirectory('cupertino')..createSync(recursive: true),
-      testDartDirectory: testsDir.childDirectory('dart')..createSync(recursive: true),
-      testExamplesDirectory: testsDir.childDirectory('examples')..createSync(recursive: true),
-      testFoundationDirectory: testsDir.childDirectory('foundation')..createSync(recursive: true),
-      testGesturesDirectory: testsDir.childDirectory('gestures')..createSync(recursive: true),
-      testHarnessDirectory: testsDir.childDirectory('harness')..createSync(recursive: true),
-      testPaintingDirectory: testsDir.childDirectory('painting')..createSync(recursive: true),
-      testPhysicsDirectory: testsDir.childDirectory('physics')..createSync(recursive: true),
-      testRenderingDirectory: testsDir.childDirectory('rendering')..createSync(recursive: true),
-      testSchedulerDirectory: testsDir.childDirectory('scheduler')..createSync(recursive: true),
-      testSemanticsDirectory: testsDir.childDirectory('semantics')..createSync(recursive: true),
-      testServicesDirectory: testsDir.childDirectory('services')..createSync(recursive: true),
-      testWidgetsDirectory: testsDir.childDirectory('widgets')..createSync(recursive: true),
-    );
-  }
-
   final Directory testAnimationDirectory;
   final Directory testCupertinoDirectory;
   final Directory testDartDirectory;
@@ -275,102 +269,6 @@ class _CrossImportsTestDirectories {
   final Directory testSemanticsDirectory;
   final Directory testServicesDirectory;
   final Directory testWidgetsDirectory;
-
-  /// A mapping of test cases for the cross imports checker.
-  ///
-  /// Each entry contains:
-  /// - a shortened directory name of the test folder for the library, without the `flutter/` prefix
-  /// - the name of the known cross imports list variable in `check_tests_cross_imports.dart` for that library
-  /// - the actual known cross imports list for that library
-  /// - the directory containing the test files for that library
-  Iterable<(String, String, Set<String>, Directory)> get crossImportsTestCases {
-    return <(String, String, Set<String>, Directory)>[
-      (
-        'test/animation',
-        'knownAnimationCrossImports',
-        TestsCrossImportChecker.knownAnimationCrossImports,
-        testAnimationDirectory,
-      ),
-      (
-        'test/cupertino',
-        'knownCupertinoCrossImports',
-        TestsCrossImportChecker.knownCupertinoCrossImports,
-        testCupertinoDirectory,
-      ),
-      (
-        'test/dart',
-        'knownDartCrossImports',
-        TestsCrossImportChecker.knownDartCrossImports,
-        testDartDirectory,
-      ),
-      (
-        'test/examples',
-        'knownExamplesCrossImports',
-        TestsCrossImportChecker.knownExamplesCrossImports,
-        testExamplesDirectory,
-      ),
-      (
-        'test/foundation',
-        'knownFoundationCrossImports',
-        TestsCrossImportChecker.knownFoundationCrossImports,
-        testFoundationDirectory,
-      ),
-      (
-        'test/gestures',
-        'knownGesturesCrossImports',
-        TestsCrossImportChecker.knownGesturesCrossImports,
-        testGesturesDirectory,
-      ),
-      (
-        'test/harness',
-        'knownHarnessCrossImports',
-        TestsCrossImportChecker.knownHarnessCrossImports,
-        testHarnessDirectory,
-      ),
-      (
-        'test/painting',
-        'knownPaintingCrossImports',
-        TestsCrossImportChecker.knownPaintingCrossImports,
-        testPaintingDirectory,
-      ),
-      (
-        'test/physics',
-        'knownPhysicsCrossImports',
-        TestsCrossImportChecker.knownPhysicsCrossImports,
-        testPhysicsDirectory,
-      ),
-      (
-        'test/rendering',
-        'knownRenderingCrossImports',
-        TestsCrossImportChecker.knownRenderingCrossImports,
-        testRenderingDirectory,
-      ),
-      (
-        'test/scheduler',
-        'knownSchedulerCrossImports',
-        TestsCrossImportChecker.knownSchedulerCrossImports,
-        testSchedulerDirectory,
-      ),
-      (
-        'test/semantics',
-        'knownSemanticsCrossImports',
-        TestsCrossImportChecker.knownSemanticsCrossImports,
-        testSemanticsDirectory,
-      ),
-      (
-        'test/services',
-        'knownServicesCrossImports',
-        TestsCrossImportChecker.knownServicesCrossImports,
-        testServicesDirectory,
-      ),
-      (
-        'test/widgets',
-        'knownWidgetsCrossImports',
-        TestsCrossImportChecker.knownWidgetsCrossImports,
-        testWidgetsDirectory,
-      ),
-    ];
-  }
 
   /// A mapping of the `flutter/test/xyz` directories,
   /// to their corresponding known imports list in `check_tests_cross_imports.dart`.
@@ -390,4 +288,55 @@ class _CrossImportsTestDirectories {
     testServicesDirectory: TestsCrossImportChecker.knownServicesCrossImports,
     testWidgetsDirectory: TestsCrossImportChecker.knownWidgetsCrossImports,
   };
+
+  void createTestDirectories() {
+    for (final Directory directory in knownFiles.keys) {
+      directory.createSync(recursive: true);
+    }
+  }
+
+  Directory testFilesDirectoryFor(String libraryName) {
+    return switch (libraryName) {
+      'test/animation' => testAnimationDirectory,
+      'test/cupertino' => testCupertinoDirectory,
+      'test/dart' => testDartDirectory,
+      'test/examples' => testExamplesDirectory,
+      'test/foundation' => testFoundationDirectory,
+      'test/gestures' => testGesturesDirectory,
+      'test/harness' => testHarnessDirectory,
+      'test/painting' => testPaintingDirectory,
+      'test/physics' => testPhysicsDirectory,
+      'test/rendering' => testRenderingDirectory,
+      'test/scheduler' => testSchedulerDirectory,
+      'test/semantics' => testSemanticsDirectory,
+      'test/services' => testServicesDirectory,
+      'test/widgets' => testWidgetsDirectory,
+      _ => throw ArgumentError('Unknown library name: $libraryName'),
+    };
+  }
 }
+
+// A mapping of test cases for the cross imports checker.
+//
+// Each entry contains:
+// - a shortened directory name of the test folder for the library, without the `flutter/` prefix
+// - the name of the known cross imports list variable in `check_tests_cross_imports.dart` for that library
+// - the actual known cross imports list for that library
+// dart format off
+final crossImportsTestCases = <(String, String, Set<String>)>[
+  ('test/animation', 'knownAnimationCrossImports', TestsCrossImportChecker.knownAnimationCrossImports),
+  ('test/cupertino', 'knownCupertinoCrossImports', TestsCrossImportChecker.knownCupertinoCrossImports),
+  ('test/dart', 'knownDartCrossImports', TestsCrossImportChecker.knownDartCrossImports),
+  ('test/examples', 'knownExamplesCrossImports', TestsCrossImportChecker.knownExamplesCrossImports),
+  ('test/foundation', 'knownFoundationCrossImports', TestsCrossImportChecker.knownFoundationCrossImports),
+  ('test/gestures', 'knownGesturesCrossImports', TestsCrossImportChecker.knownGesturesCrossImports),
+  ('test/harness', 'knownHarnessCrossImports', TestsCrossImportChecker.knownHarnessCrossImports),
+  ('test/painting', 'knownPaintingCrossImports', TestsCrossImportChecker.knownPaintingCrossImports),
+  ('test/physics', 'knownPhysicsCrossImports', TestsCrossImportChecker.knownPhysicsCrossImports),
+  ('test/rendering', 'knownRenderingCrossImports', TestsCrossImportChecker.knownRenderingCrossImports),
+  ('test/scheduler', 'knownSchedulerCrossImports', TestsCrossImportChecker.knownSchedulerCrossImports),
+  ('test/semantics', 'knownSemanticsCrossImports', TestsCrossImportChecker.knownSemanticsCrossImports),
+  ('test/services', 'knownServicesCrossImports', TestsCrossImportChecker.knownServicesCrossImports),
+  ('test/widgets', 'knownWidgetsCrossImports', TestsCrossImportChecker.knownWidgetsCrossImports),
+];
+// dart format on

--- a/dev/bots/test/check_tests_cross_imports_test.dart
+++ b/dev/bots/test/check_tests_cross_imports_test.dart
@@ -14,27 +14,20 @@ import 'common.dart';
 
 void main() {
   late TestsCrossImportChecker checker;
-  late Directory testWidgetsDirectory;
   late Directory testCupertinoDirectory;
-
-  // Writes a Material import into the given file.
-  void writeImport(File file, [String importString = "import 'package:flutter/material.dart';"]) {
-    file
-      ..createSync(recursive: true)
-      ..writeAsStringSync(importString);
-  }
-
-  File getFile(String filepath, Directory directory) {
-    final String platformFilepath = filepath.replaceAll('/', Platform.isWindows ? r'\' : '/');
-    final int overlapIndex = platformFilepath.lastIndexOf(directory.basename);
-    if (overlapIndex < 0) {
-      throw ArgumentError('filepath $filepath must be located in directory ${directory.path}.');
-    }
-    final String filename = platformFilepath.substring(
-      overlapIndex + directory.basename.length + 1,
-    );
-    return directory.childFile(filename);
-  }
+  late Directory testAnimationDirectory;
+  late Directory testDartDirectory;
+  late Directory testExamplesDirectory;
+  late Directory testFoundationDirectory;
+  late Directory testGesturesDirectory;
+  late Directory testHarnessDirectory;
+  late Directory testPaintingDirectory;
+  late Directory testPhysicsDirectory;
+  late Directory testRenderingDirectory;
+  late Directory testSchedulerDirectory;
+  late Directory testSemanticsDirectory;
+  late Directory testServicesDirectory;
+  late Directory testWidgetsDirectory;
 
   void buildTestFiles({
     Set<String> excludes = const <String>{},
@@ -43,8 +36,20 @@ void main() {
     Set<String> extraWidgetsImportingCupertino = const <String>{},
   }) {
     final knownFiles = <Directory, Set<String>>{
-      testWidgetsDirectory: TestsCrossImportChecker.knownWidgetsCrossImports,
       testCupertinoDirectory: TestsCrossImportChecker.knownCupertinoCrossImports,
+      testAnimationDirectory: TestsCrossImportChecker.knownAnimationCrossImports,
+      testDartDirectory: TestsCrossImportChecker.knownDartCrossImports,
+      testExamplesDirectory: TestsCrossImportChecker.knownExamplesCrossImports,
+      testFoundationDirectory: TestsCrossImportChecker.knownFoundationCrossImports,
+      testGesturesDirectory: TestsCrossImportChecker.knownGesturesCrossImports,
+      testHarnessDirectory: TestsCrossImportChecker.knownHarnessCrossImports,
+      testPaintingDirectory: TestsCrossImportChecker.knownPaintingCrossImports,
+      testPhysicsDirectory: TestsCrossImportChecker.knownPhysicsCrossImports,
+      testRenderingDirectory: TestsCrossImportChecker.knownRenderingCrossImports,
+      testSchedulerDirectory: TestsCrossImportChecker.knownSchedulerCrossImports,
+      testSemanticsDirectory: TestsCrossImportChecker.knownSemanticsCrossImports,
+      testServicesDirectory: TestsCrossImportChecker.knownServicesCrossImports,
+      testWidgetsDirectory: TestsCrossImportChecker.knownWidgetsCrossImports,
     };
 
     for (final MapEntry<Directory, Set<String>>(key: Directory directory, value: Set<String> files)
@@ -82,16 +87,30 @@ void main() {
     )..createSync(recursive: true);
     fs.currentDirectory = flutterRoot;
 
-    final Directory testsDirectory =
+    final Directory testsDir =
         flutterRoot.childDirectory('packages').childDirectory('flutter').childDirectory('test')
           ..createSync(recursive: true);
-    testWidgetsDirectory = testsDirectory.childDirectory('widgets')..createSync(recursive: true);
-    testsDirectory.childDirectory('material').createSync(recursive: true);
-    testCupertinoDirectory = testsDirectory.childDirectory('cupertino')
-      ..createSync(recursive: true);
+
+    testAnimationDirectory = testsDir.childDirectory('animation')..createSync(recursive: true);
+    testCupertinoDirectory = testsDir.childDirectory('cupertino')..createSync(recursive: true);
+    testDartDirectory = testsDir.childDirectory('dart')..createSync(recursive: true);
+    testExamplesDirectory = testsDir.childDirectory('examples')..createSync(recursive: true);
+    testFoundationDirectory = testsDir.childDirectory('foundation')..createSync(recursive: true);
+    testGesturesDirectory = testsDir.childDirectory('gestures')..createSync(recursive: true);
+    testHarnessDirectory = testsDir.childDirectory('harness')..createSync(recursive: true);
+    // tests/material sits between tests/harness and tests/painting,
+    // but the test does not need a reference to the directory.
+    testsDir.childDirectory('material').createSync(recursive: true);
+    testPaintingDirectory = testsDir.childDirectory('painting')..createSync(recursive: true);
+    testPhysicsDirectory = testsDir.childDirectory('physics')..createSync(recursive: true);
+    testRenderingDirectory = testsDir.childDirectory('rendering')..createSync(recursive: true);
+    testSchedulerDirectory = testsDir.childDirectory('scheduler')..createSync(recursive: true);
+    testSemanticsDirectory = testsDir.childDirectory('semantics')..createSync(recursive: true);
+    testServicesDirectory = testsDir.childDirectory('services')..createSync(recursive: true);
+    testWidgetsDirectory = testsDir.childDirectory('widgets')..createSync(recursive: true);
 
     checker = TestsCrossImportChecker(
-      testsDirectory: testsDirectory,
+      testsDirectory: testsDir,
       flutterRoot: flutterRoot,
       filesystem: fs,
     );
@@ -252,5 +271,37 @@ Future<String> capture(AsyncVoidCallback callback, {bool shouldHaveErrors = fals
     return buffer.toString().replaceAll(RegExp(r'(\x9B|\x1B\[)[0-?]{1,3}[ -/]*[@-~]'), '');
   } else {
     return buffer.toString();
+  }
+}
+
+File getFile(String filepath, Directory directory) {
+  final String platformFilepath = filepath.replaceAll('/', Platform.isWindows ? r'\' : '/');
+  final int overlapIndex = platformFilepath.lastIndexOf(directory.basename);
+  if (overlapIndex < 0) {
+    throw ArgumentError('filepath $filepath must be located in directory ${directory.path}.');
+  }
+  final String filename = platformFilepath.substring(overlapIndex + directory.basename.length + 1);
+  return directory.childFile(filename);
+}
+
+/// Writes [importString] into the given file.
+///
+/// The default [importString] is `import 'package:flutter/material.dart';`.
+void writeImport(File file, [String importString = "import 'package:flutter/material.dart';"]) {
+  file
+    ..createSync(recursive: true)
+    ..writeAsStringSync(importString);
+}
+
+/// Writes [importString] into the given [filePaths] in [inDirectory].
+///
+/// The default [importString] is `import 'package:flutter/material.dart';`.
+void writeImportInFiles(
+  Iterable<String> filePaths, {
+  required Directory inDirectory,
+  String importString = "import 'package:flutter/material.dart';",
+}) {
+  for (final filepath in filePaths) {
+    writeImport(getFile(filepath, inDirectory), importString);
   }
 }

--- a/dev/bots/test/check_tests_cross_imports_test.dart
+++ b/dev/bots/test/check_tests_cross_imports_test.dart
@@ -122,46 +122,52 @@ void main() {
     expect(success, isTrue);
   });
 
-  test('when not all widgets knowns have cross imports', () async {
-    final String excluded = TestsCrossImportChecker.knownWidgetsCrossImports.first;
-    buildTestFiles(excludes: <String>{excluded});
-    bool? success;
-    final String result = await capture(() async {
-      success = checker.check();
-    }, shouldHaveErrors: true);
-    final String lines = <String>[
-      '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
-      '║ Huzzah! The following tests in Widgets no longer contain cross imports!',
-      '║   $excluded',
-      '║ However, they now need to be removed from the',
-      '║ knownWidgetsCrossImports list in the script /dev/bots/check_tests_cross_imports.dart.',
-      '╚═══════════════════════════════════════════════════════════════════════════════',
-    ].join('\n');
-    expect(result, equals('$lines\n'));
-    expect(success, isFalse);
-  });
+  // dart format off
+  final fixedCrossImportsTestCases = <(String, String, Set<String>)>[
+    ('test/animation', 'knownAnimationCrossImports', TestsCrossImportChecker.knownAnimationCrossImports),
+    ('test/cupertino', 'knownCupertinoCrossImports', TestsCrossImportChecker.knownCupertinoCrossImports),
+    ('test/dart', 'knownDartCrossImports', TestsCrossImportChecker.knownDartCrossImports),
+    ('test/examples', 'knownExamplesCrossImports', TestsCrossImportChecker.knownExamplesCrossImports),
+    ('test/foundation', 'knownFoundationCrossImports', TestsCrossImportChecker.knownFoundationCrossImports),
+    ('test/gestures', 'knownGesturesCrossImports', TestsCrossImportChecker.knownGesturesCrossImports),
+    ('test/harness', 'knownHarnessCrossImports', TestsCrossImportChecker.knownHarnessCrossImports),
+    ('test/painting', 'knownPaintingCrossImports', TestsCrossImportChecker.knownPaintingCrossImports),
+    ('test/physics', 'knownPhysicsCrossImports', TestsCrossImportChecker.knownPhysicsCrossImports),
+    ('test/rendering', 'knownRenderingCrossImports', TestsCrossImportChecker.knownRenderingCrossImports),
+    ('test/scheduler', 'knownSchedulerCrossImports', TestsCrossImportChecker.knownSchedulerCrossImports),
+    ('test/semantics', 'knownSemanticsCrossImports', TestsCrossImportChecker.knownSemanticsCrossImports),
+    ('test/services', 'knownServicesCrossImports', TestsCrossImportChecker.knownServicesCrossImports),
+    ('test/widgets', 'knownWidgetsCrossImports', TestsCrossImportChecker.knownWidgetsCrossImports),
+  ];
+  // dart format on
 
-  test('when not all cupertino knowns have cross imports', () async {
-    if (TestsCrossImportChecker.knownCupertinoCrossImports.isEmpty) {
-      return;
-    }
-    final String excluded = TestsCrossImportChecker.knownCupertinoCrossImports.first;
-    buildTestFiles(excludes: <String>{excluded});
-    bool? success;
-    final String result = await capture(() async {
-      success = checker.check();
-    }, shouldHaveErrors: true);
-    final String lines = <String>[
-      '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
-      '║ Huzzah! The following tests in Cupertino no longer contain cross imports!',
-      '║   $excluded',
-      '║ However, they now need to be removed from the',
-      '║ knownCupertinoCrossImports list in the script /dev/bots/check_tests_cross_imports.dart.',
-      '╚═══════════════════════════════════════════════════════════════════════════════',
-    ].join('\n');
-    expect(result, equals('$lines\n'));
-    expect(success, isFalse);
-  });
+  for (final (String libraryName, String knownCrossImportsListName, Set<String> knownCrossImports)
+      in fixedCrossImportsTestCases) {
+    test('when not all $libraryName knowns have cross imports', () async {
+      if (knownCrossImports.isEmpty) {
+        return;
+      }
+
+      final String excludedSample = knownCrossImports.first;
+
+      buildTestFiles(excludes: <String>{excludedSample});
+
+      bool? success;
+      final String result = await capture(() async {
+        success = checker.check();
+      }, shouldHaveErrors: true);
+      final String lines = <String>[
+        '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
+        '║ Huzzah! The following tests in $libraryName no longer contain cross imports!',
+        '║   $excludedSample',
+        '║ However, they now need to be removed from the',
+        '║ $knownCrossImportsListName list in the script /dev/bots/check_tests_cross_imports.dart.',
+        '╚═══════════════════════════════════════════════════════════════════════════════',
+      ].join('\n');
+      expect(result, equals('$lines\n'));
+      expect(success, isFalse);
+    });
+  }
 
   test('unknown Widgets cross import of Material', () async {
     final String extra = 'packages/flutter/test/widgets/foo_test.dart'.replaceAll(
@@ -188,31 +194,6 @@ void main() {
     expect(success, isFalse);
   });
 
-  test('unknown Widgets cross import of Cupertino', () async {
-    final String extra = 'packages/flutter/test/widgets/foo_test.dart'.replaceAll(
-      '/',
-      Platform.isWindows ? r'\' : '/',
-    );
-    buildTestFiles(extraWidgetsImportingCupertino: <String>{extra});
-    bool? success;
-    final String result = await capture(() async {
-      success = checker.check();
-    }, shouldHaveErrors: true);
-    final String lines =
-        <String>[
-              '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
-              '║ The following test in Widgets has a disallowed import of Cupertino. Refactor it or move it to Cupertino.',
-              '║   $extra',
-              '╚═══════════════════════════════════════════════════════════════════════════════',
-            ]
-            .map((String line) {
-              return line.replaceAll('/', Platform.isWindows ? r'\' : '/');
-            })
-            .join('\n');
-    expect(result, equals('$lines\n'));
-    expect(success, isFalse);
-  });
-
   test('unknown Cupertino cross importing Material', () async {
     final String extra = 'packages/flutter/test/cupertino/foo_test.dart'.replaceAll(
       '/',
@@ -228,6 +209,31 @@ void main() {
         <String>[
               '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
               '║ The following test in Cupertino has a disallowed import of Material. Refactor it or move it to Material.',
+              '║   $extra',
+              '╚═══════════════════════════════════════════════════════════════════════════════',
+            ]
+            .map((String line) {
+              return line.replaceAll('/', Platform.isWindows ? r'\' : '/');
+            })
+            .join('\n');
+    expect(result, equals('$lines\n'));
+    expect(success, isFalse);
+  });
+
+  test('unknown Widgets cross import of Cupertino', () async {
+    final String extra = 'packages/flutter/test/widgets/foo_test.dart'.replaceAll(
+      '/',
+      Platform.isWindows ? r'\' : '/',
+    );
+    buildTestFiles(extraWidgetsImportingCupertino: <String>{extra});
+    bool? success;
+    final String result = await capture(() async {
+      success = checker.check();
+    }, shouldHaveErrors: true);
+    final String lines =
+        <String>[
+              '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
+              '║ The following test in Widgets has a disallowed import of Cupertino. Refactor it or move it to Cupertino.',
               '║   $extra',
               '╚═══════════════════════════════════════════════════════════════════════════════',
             ]

--- a/dev/bots/test/check_tests_cross_imports_test.dart
+++ b/dev/bots/test/check_tests_cross_imports_test.dart
@@ -14,8 +14,12 @@ import 'common.dart';
 
 void main() {
   late TestsCrossImportChecker checker;
+  late Directory flutterTestDirectory;
 
-  void buildKnownCrossImportTestFiles({Set<String> excludes = const <String>{}}) {
+  void buildKnownCrossImportTestFiles(
+    Map<Directory, Set<String>> knownFiles, {
+    Set<String> excludes = const <String>{},
+  }) {
     for (final MapEntry<Directory, Set<String>>(key: Directory directory, value: Set<String> files)
         in knownFiles.entries) {
       for (final filepath in files) {
@@ -38,20 +42,22 @@ void main() {
     )..createSync(recursive: true);
     fs.currentDirectory = flutterRoot;
 
-    final Directory testsDir =
+    flutterTestDirectory =
         flutterRoot.childDirectory('packages').childDirectory('flutter').childDirectory('test')
           ..createSync(recursive: true);
-    testsDir.childDirectory('material').createSync(recursive: true);
+    flutterTestDirectory.childDirectory('material').createSync(recursive: true);
 
     checker = TestsCrossImportChecker(
-      testsDirectory: testsDir,
+      testsDirectory: flutterTestDirectory,
       flutterRoot: flutterRoot,
       filesystem: fs,
     );
   });
 
   test('when only all knowns have cross imports', () async {
-    buildKnownCrossImportTestFiles();
+    final checkerDirectories = _CrossImportsTestDirectories(flutterTestDirectory);
+
+    buildKnownCrossImportTestFiles(checkerDirectories.knownFiles);
     bool? success;
     final String result = await capture(() async {
       success = checker.check();

--- a/dev/bots/test/check_tests_cross_imports_test.dart
+++ b/dev/bots/test/check_tests_cross_imports_test.dart
@@ -29,11 +29,7 @@ void main() {
   late Directory testServicesDirectory;
   late Directory testWidgetsDirectory;
 
-  void buildKnownCrossImportTestFiles({
-    Set<String> excludes = const <String>{},
-    Set<String> extraWidgetsImportingMaterial = const <String>{},
-    Set<String> extraWidgetsImportingCupertino = const <String>{},
-  }) {
+  void buildKnownCrossImportTestFiles({Set<String> excludes = const <String>{}}) {
     final knownFiles = <Directory, Set<String>>{
       testCupertinoDirectory: TestsCrossImportChecker.knownCupertinoCrossImports,
       testAnimationDirectory: TestsCrossImportChecker.knownAnimationCrossImports,
@@ -59,16 +55,6 @@ void main() {
         }
         writeImport(getFile(filepath, directory));
       }
-    }
-
-    for (final filepath in extraWidgetsImportingMaterial) {
-      writeImport(getFile(filepath, testWidgetsDirectory));
-    }
-    for (final filepath in extraWidgetsImportingCupertino) {
-      writeImport(
-        getFile(filepath, testWidgetsDirectory),
-        "import 'package:flutter/cupertino.dart';",
-      );
     }
   }
 
@@ -174,7 +160,9 @@ void main() {
       '/',
       Platform.isWindows ? r'\' : '/',
     );
-    buildKnownCrossImportTestFiles(extraWidgetsImportingMaterial: <String>{extra});
+    buildKnownCrossImportTestFiles();
+    writeImportInFiles(<String>{extra}, inDirectory: testWidgetsDirectory);
+
     bool? success;
     final String result = await capture(() async {
       success = checker.check();
@@ -201,6 +189,7 @@ void main() {
     );
     buildKnownCrossImportTestFiles();
     writeImportInFiles(<String>{extra}, inDirectory: testCupertinoDirectory);
+
     bool? success;
     final String result = await capture(() async {
       success = checker.check();
@@ -225,7 +214,13 @@ void main() {
       '/',
       Platform.isWindows ? r'\' : '/',
     );
-    buildKnownCrossImportTestFiles(extraWidgetsImportingCupertino: <String>{extra});
+    buildKnownCrossImportTestFiles();
+    writeImportInFiles(
+      <String>{extra},
+      inDirectory: testWidgetsDirectory,
+      importString: "import 'package:flutter/cupertino.dart';",
+    );
+
     bool? success;
     final String result = await capture(() async {
       success = checker.check();

--- a/dev/bots/test/check_tests_cross_imports_test.dart
+++ b/dev/bots/test/check_tests_cross_imports_test.dart
@@ -31,7 +31,6 @@ void main() {
 
   void buildTestFiles({
     Set<String> excludes = const <String>{},
-    Set<String> extraCupertinos = const <String>{},
     Set<String> extraWidgetsImportingMaterial = const <String>{},
     Set<String> extraWidgetsImportingCupertino = const <String>{},
   }) {
@@ -70,9 +69,6 @@ void main() {
         getFile(filepath, testWidgetsDirectory),
         "import 'package:flutter/cupertino.dart';",
       );
-    }
-    for (final filepath in extraCupertinos) {
-      writeImport(getFile(filepath, testCupertinoDirectory));
     }
   }
 
@@ -222,7 +218,8 @@ void main() {
       '/',
       Platform.isWindows ? r'\' : '/',
     );
-    buildTestFiles(extraCupertinos: <String>{extra});
+    buildTestFiles();
+    writeImportInFiles(<String>{extra}, inDirectory: testCupertinoDirectory);
     bool? success;
     final String result = await capture(() async {
       success = checker.check();

--- a/dev/bots/test/check_tests_cross_imports_test.dart
+++ b/dev/bots/test/check_tests_cross_imports_test.dart
@@ -195,11 +195,6 @@ void main() {
     ),
   ];
 
-  final disallowedImportCases = <(String, String)>[
-    ('Material', "import 'package:flutter/material.dart';"),
-    ('Cupertino', "import 'package:flutter/cupertino.dart';"),
-  ];
-
   for (final (
         String libraryName,
         String knownCrossImportsListName,
@@ -231,61 +226,35 @@ void main() {
       expect(result, equals('$lines\n'));
       expect(success, isFalse);
     });
+
+    test('unknown $libraryName cross import of Material', () async {
+      final String extra = 'packages/flutter/$libraryName/foo_test.dart'.replaceAll(
+        '/',
+        Platform.isWindows ? r'\' : '/',
+      );
+
+      buildKnownCrossImportTestFiles();
+      writeImportInFiles(<String>{extra}, inDirectory: testFilesDirectory);
+
+      bool? success;
+      final String result = await capture(() async {
+        success = checker.check();
+      }, shouldHaveErrors: true);
+      final String lines =
+          <String>[
+                '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
+                '║ The following test in $libraryName has a disallowed import of Material. Refactor it or move it to Material.',
+                '║   $extra',
+                '╚═══════════════════════════════════════════════════════════════════════════════',
+              ]
+              .map((String line) {
+                return line.replaceAll('/', Platform.isWindows ? r'\' : '/');
+              })
+              .join('\n');
+      expect(result, equals('$lines\n'));
+      expect(success, isFalse);
+    });
   }
-
-  test('unknown Widgets cross import of Material', () async {
-    final String extra = 'packages/flutter/test/widgets/foo_test.dart'.replaceAll(
-      '/',
-      Platform.isWindows ? r'\' : '/',
-    );
-    buildKnownCrossImportTestFiles();
-    writeImportInFiles(<String>{extra}, inDirectory: testWidgetsDirectory);
-
-    bool? success;
-    final String result = await capture(() async {
-      success = checker.check();
-    }, shouldHaveErrors: true);
-    final String lines =
-        <String>[
-              '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
-              '║ The following test in Widgets has a disallowed import of Material. Refactor it or move it to Material.',
-              '║   $extra',
-              '╚═══════════════════════════════════════════════════════════════════════════════',
-            ]
-            .map((String line) {
-              return line.replaceAll('/', Platform.isWindows ? r'\' : '/');
-            })
-            .join('\n');
-    expect(result, equals('$lines\n'));
-    expect(success, isFalse);
-  });
-
-  test('unknown Cupertino cross importing Material', () async {
-    final String extra = 'packages/flutter/test/cupertino/foo_test.dart'.replaceAll(
-      '/',
-      Platform.isWindows ? r'\' : '/',
-    );
-    buildKnownCrossImportTestFiles();
-    writeImportInFiles(<String>{extra}, inDirectory: testCupertinoDirectory);
-
-    bool? success;
-    final String result = await capture(() async {
-      success = checker.check();
-    }, shouldHaveErrors: true);
-    final String lines =
-        <String>[
-              '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
-              '║ The following test in Cupertino has a disallowed import of Material. Refactor it or move it to Material.',
-              '║   $extra',
-              '╚═══════════════════════════════════════════════════════════════════════════════',
-            ]
-            .map((String line) {
-              return line.replaceAll('/', Platform.isWindows ? r'\' : '/');
-            })
-            .join('\n');
-    expect(result, equals('$lines\n'));
-    expect(success, isFalse);
-  });
 
   test('unknown Widgets cross import of Cupertino', () async {
     final String extra = 'packages/flutter/test/widgets/foo_test.dart'.replaceAll(

--- a/dev/bots/test/check_tests_cross_imports_test.dart
+++ b/dev/bots/test/check_tests_cross_imports_test.dart
@@ -124,6 +124,40 @@ void main() {
       expect(success, isFalse);
     });
 
+    test('multiple unknown $libraryName cross imports of Material', () async {
+      final Set<String> extras = {
+        '$libraryName/foo_test.dart'.replaceAll('/', Platform.pathSeparator),
+        '$libraryName/bar_test.dart'.replaceAll('/', Platform.pathSeparator),
+      };
+
+      final Directory testFilesDirectory = checkerDirectories.testFilesDirectoryFor(
+        libraryName,
+        checker.testsDirectory,
+      );
+
+      buildKnownCrossImportTestFiles();
+      writeImportInFiles(extras, inDirectory: testFilesDirectory);
+
+      bool? success;
+      final String result = await capture(() async {
+        success = checker.check();
+      }, shouldHaveErrors: true);
+      final String lines =
+          <String>[
+                '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
+                '║ The following 2 tests in $libraryName have a disallowed import of Material. Refactor them or move them to Material.',
+                '║   ${extras.first}',
+                '║   ${extras.last}',
+                '╚═══════════════════════════════════════════════════════════════════════════════',
+              ]
+              .map((String line) {
+                return line.replaceAll('/', Platform.pathSeparator);
+              })
+              .join('\n');
+      expect(result, equals('$lines\n'));
+      expect(success, isFalse);
+    });
+
     test(
       'unknown $libraryName cross import of Cupertino',
       () async {
@@ -149,6 +183,47 @@ void main() {
                   '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
                   '║ The following test in $libraryName has a disallowed import of Cupertino. Refactor it or move it to Cupertino.',
                   '║   $extra',
+                  '╚═══════════════════════════════════════════════════════════════════════════════',
+                ]
+                .map((String line) {
+                  return line.replaceAll('/', Platform.pathSeparator);
+                })
+                .join('\n');
+        expect(result, equals('$lines\n'));
+        expect(success, isFalse);
+      },
+      skip: libraryName == 'packages/flutter/test/cupertino',
+    ); // [intended]: Cupertino can import itself
+
+    test(
+      'multiple unknown $libraryName cross imports of Cupertino',
+      () async {
+        final Set<String> extras = {
+          '$libraryName/foo_test.dart'.replaceAll('/', Platform.pathSeparator),
+          '$libraryName/bar_test.dart'.replaceAll('/', Platform.pathSeparator),
+        };
+        final Directory testFilesDirectory = checkerDirectories.testFilesDirectoryFor(
+          libraryName,
+          checker.testsDirectory,
+        );
+
+        buildKnownCrossImportTestFiles();
+        writeImportInFiles(
+          extras,
+          inDirectory: testFilesDirectory,
+          importString: "import 'package:flutter/cupertino.dart';",
+        );
+
+        bool? success;
+        final String result = await capture(() async {
+          success = checker.check();
+        }, shouldHaveErrors: true);
+        final String lines =
+            <String>[
+                  '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
+                  '║ The following 2 tests in $libraryName have a disallowed import of Cupertino. Refactor them or move them to Cupertino.',
+                  '║   ${extras.first}',
+                  '║   ${extras.last}',
                   '╚═══════════════════════════════════════════════════════════════════════════════',
                 ]
                 .map((String line) {

--- a/dev/bots/test/check_tests_cross_imports_test.dart
+++ b/dev/bots/test/check_tests_cross_imports_test.dart
@@ -95,10 +95,7 @@ void main() {
     ); // [intended]: No message is needed when there are no known cross imports.
 
     test('unknown $libraryName cross import of Material', () async {
-      final Set<String> extras = {
-        'packages/$libraryName/foo_test.dart'.replaceAll('/', Platform.pathSeparator),
-        'packages/$libraryName/foo_test_utils.dart'.replaceAll('/', Platform.pathSeparator),
-      };
+      final String extra = '$libraryName/foo_test.dart'.replaceAll('/', Platform.pathSeparator);
 
       final Directory testFilesDirectory = checkerDirectories.testFilesDirectoryFor(
         libraryName,
@@ -106,7 +103,7 @@ void main() {
       );
 
       buildKnownCrossImportTestFiles();
-      writeImportInFiles(extras, inDirectory: testFilesDirectory);
+      writeImportInFiles(<String>{extra}, inDirectory: testFilesDirectory);
 
       bool? success;
       final String result = await capture(() async {
@@ -115,9 +112,8 @@ void main() {
       final String lines =
           <String>[
                 '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
-                '║ The following test in packages/$libraryName has a disallowed import of Material. Refactor it or move it to Material.',
-                '║   ${extras.first}',
-                '║   ${extras.last}',
+                '║ The following test in $libraryName has a disallowed import of Material. Refactor it or move it to Material.',
+                '║   $extra',
                 '╚═══════════════════════════════════════════════════════════════════════════════',
               ]
               .map((String line) {
@@ -131,10 +127,7 @@ void main() {
     test(
       'unknown $libraryName cross import of Cupertino',
       () async {
-        final Set<String> extras = {
-          'packages/$libraryName/foo_test.dart'.replaceAll('/', Platform.pathSeparator),
-          'packages/$libraryName/foo_test_utils.dart'.replaceAll('/', Platform.pathSeparator),
-        };
+        final String extra = '$libraryName/foo_test.dart'.replaceAll('/', Platform.pathSeparator);
         final Directory testFilesDirectory = checkerDirectories.testFilesDirectoryFor(
           libraryName,
           checker.testsDirectory,
@@ -142,7 +135,7 @@ void main() {
 
         buildKnownCrossImportTestFiles();
         writeImportInFiles(
-          extras,
+          <String>{extra},
           inDirectory: testFilesDirectory,
           importString: "import 'package:flutter/cupertino.dart';",
         );
@@ -154,9 +147,8 @@ void main() {
         final String lines =
             <String>[
                   '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
-                  '║ The following test in packages/$libraryName has a disallowed import of Cupertino. Refactor it or move it to Cupertino.',
-                  '║   ${extras.first}',
-                  '║   ${extras.last}',
+                  '║ The following test in $libraryName has a disallowed import of Cupertino. Refactor it or move it to Cupertino.',
+                  '║   $extra',
                   '╚═══════════════════════════════════════════════════════════════════════════════',
                 ]
                 .map((String line) {

--- a/dev/bots/test/check_tests_cross_imports_test.dart
+++ b/dev/bots/test/check_tests_cross_imports_test.dart
@@ -115,7 +115,7 @@ void main() {
     );
 
     test('unknown $libraryName cross import of Material', () async {
-      final String extra = '$libraryName/foo_test.dart'.replaceAll('/', Platform.pathSeparator);
+      final testDartFile = '$libraryName/foo_test.dart';
 
       final Directory testFilesDirectory = checkerDirectories.testFilesDirectoryFor(
         libraryName,
@@ -123,32 +123,25 @@ void main() {
       );
 
       buildKnownCrossImportTestFiles();
-      writeImportInFiles(<String>{extra}, inDirectory: testFilesDirectory);
+      writeImportInFiles({testDartFile}, inDirectory: testFilesDirectory);
 
       bool? success;
       final String result = await capture(() async {
         success = checker.check();
       }, shouldHaveErrors: true);
-      final String lines =
-          <String>[
-                '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
-                '║ The following test in $libraryName has a disallowed import of Material. Refactor it or move it to Material.',
-                '║   $extra',
-                '╚═══════════════════════════════════════════════════════════════════════════════',
-              ]
-              .map((String line) {
-                return line.replaceAll('/', Platform.pathSeparator);
-              })
-              .join('\n');
+      final String lines = <String>[
+        '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
+        '║ The following test in $libraryName has a disallowed import of Material. Refactor it or move it to Material.',
+        '║   $testDartFile',
+        '╚═══════════════════════════════════════════════════════════════════════════════',
+      ].join('\n');
       expect(result, equals('$lines\n'));
       expect(success, isFalse);
     });
 
     test('multiple unknown $libraryName cross imports of Material', () async {
-      final Set<String> extras = {
-        '$libraryName/foo_test.dart'.replaceAll('/', Platform.pathSeparator),
-        '$libraryName/bar_test.dart'.replaceAll('/', Platform.pathSeparator),
-      };
+      final testDartFileOne = '$libraryName/foo_test.dart';
+      final testDartFileTwo = '$libraryName/bar_test.dart';
 
       final Directory testFilesDirectory = checkerDirectories.testFilesDirectoryFor(
         libraryName,
@@ -156,30 +149,25 @@ void main() {
       );
 
       buildKnownCrossImportTestFiles();
-      writeImportInFiles(extras, inDirectory: testFilesDirectory);
+      writeImportInFiles({testDartFileOne, testDartFileTwo}, inDirectory: testFilesDirectory);
 
       bool? success;
       final String result = await capture(() async {
         success = checker.check();
       }, shouldHaveErrors: true);
-      final String lines =
-          <String>[
-                '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
-                '║ The following 2 tests in $libraryName have a disallowed import of Material. Refactor them or move them to Material.',
-                '║   ${extras.first}',
-                '║   ${extras.last}',
-                '╚═══════════════════════════════════════════════════════════════════════════════',
-              ]
-              .map((String line) {
-                return line.replaceAll('/', Platform.pathSeparator);
-              })
-              .join('\n');
+      final String lines = <String>[
+        '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
+        '║ The following 2 tests in $libraryName have a disallowed import of Material. Refactor them or move them to Material.',
+        '║   $testDartFileOne',
+        '║   $testDartFileTwo',
+        '╚═══════════════════════════════════════════════════════════════════════════════',
+      ].join('\n');
       expect(result, equals('$lines\n'));
       expect(success, isFalse);
     });
 
     test('unknown $libraryName cross import of Material in non-test file', () async {
-      final String extra = '$libraryName/foo_utils.dart'.replaceAll('/', Platform.pathSeparator);
+      final testDartFile = '$libraryName/foo_utils.dart';
 
       final Directory testFilesDirectory = checkerDirectories.testFilesDirectoryFor(
         libraryName,
@@ -187,23 +175,18 @@ void main() {
       );
 
       buildKnownCrossImportTestFiles();
-      writeImportInFiles(<String>{extra}, inDirectory: testFilesDirectory);
+      writeImportInFiles(<String>{testDartFile}, inDirectory: testFilesDirectory);
 
       bool? success;
       final String result = await capture(() async {
         success = checker.check();
       }, shouldHaveErrors: true);
-      final String lines =
-          <String>[
-                '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
-                '║ The following test in $libraryName has a disallowed import of Material. Refactor it or move it to Material.',
-                '║   $extra',
-                '╚═══════════════════════════════════════════════════════════════════════════════',
-              ]
-              .map((String line) {
-                return line.replaceAll('/', Platform.pathSeparator);
-              })
-              .join('\n');
+      final String lines = <String>[
+        '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
+        '║ The following test in $libraryName has a disallowed import of Material. Refactor it or move it to Material.',
+        '║   $testDartFile',
+        '╚═══════════════════════════════════════════════════════════════════════════════',
+      ].join('\n');
       expect(result, equals('$lines\n'));
       expect(success, isFalse);
     });
@@ -211,7 +194,7 @@ void main() {
     test(
       'unknown $libraryName cross import of Cupertino',
       () async {
-        final String extra = '$libraryName/foo_test.dart'.replaceAll('/', Platform.pathSeparator);
+        final testDartFile = '$libraryName/foo_test.dart';
         final Directory testFilesDirectory = checkerDirectories.testFilesDirectoryFor(
           libraryName,
           checker.testsDirectory,
@@ -219,7 +202,7 @@ void main() {
 
         buildKnownCrossImportTestFiles();
         writeImportInFiles(
-          <String>{extra},
+          <String>{testDartFile},
           inDirectory: testFilesDirectory,
           importString: "import 'package:flutter/cupertino.dart';",
         );
@@ -228,17 +211,12 @@ void main() {
         final String result = await capture(() async {
           success = checker.check();
         }, shouldHaveErrors: true);
-        final String lines =
-            <String>[
-                  '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
-                  '║ The following test in $libraryName has a disallowed import of Cupertino. Refactor it or move it to Cupertino.',
-                  '║   $extra',
-                  '╚═══════════════════════════════════════════════════════════════════════════════',
-                ]
-                .map((String line) {
-                  return line.replaceAll('/', Platform.pathSeparator);
-                })
-                .join('\n');
+        final String lines = <String>[
+          '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
+          '║ The following test in $libraryName has a disallowed import of Cupertino. Refactor it or move it to Cupertino.',
+          '║   $testDartFile',
+          '╚═══════════════════════════════════════════════════════════════════════════════',
+        ].join('\n');
         expect(result, equals('$lines\n'));
         expect(success, isFalse);
       },
@@ -248,10 +226,9 @@ void main() {
     test(
       'multiple unknown $libraryName cross imports of Cupertino',
       () async {
-        final Set<String> extras = {
-          '$libraryName/foo_test.dart'.replaceAll('/', Platform.pathSeparator),
-          '$libraryName/bar_test.dart'.replaceAll('/', Platform.pathSeparator),
-        };
+        final testDartFileOne = '$libraryName/foo_test.dart';
+        final testDartFileTwo = '$libraryName/bar_test.dart';
+
         final Directory testFilesDirectory = checkerDirectories.testFilesDirectoryFor(
           libraryName,
           checker.testsDirectory,
@@ -259,7 +236,7 @@ void main() {
 
         buildKnownCrossImportTestFiles();
         writeImportInFiles(
-          extras,
+          {testDartFileOne, testDartFileTwo},
           inDirectory: testFilesDirectory,
           importString: "import 'package:flutter/cupertino.dart';",
         );
@@ -268,18 +245,13 @@ void main() {
         final String result = await capture(() async {
           success = checker.check();
         }, shouldHaveErrors: true);
-        final String lines =
-            <String>[
-                  '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
-                  '║ The following 2 tests in $libraryName have a disallowed import of Cupertino. Refactor them or move them to Cupertino.',
-                  '║   ${extras.first}',
-                  '║   ${extras.last}',
-                  '╚═══════════════════════════════════════════════════════════════════════════════',
-                ]
-                .map((String line) {
-                  return line.replaceAll('/', Platform.pathSeparator);
-                })
-                .join('\n');
+        final String lines = <String>[
+          '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
+          '║ The following 2 tests in $libraryName have a disallowed import of Cupertino. Refactor them or move them to Cupertino.',
+          '║   $testDartFileOne',
+          '║   $testDartFileTwo',
+          '╚═══════════════════════════════════════════════════════════════════════════════',
+        ].join('\n');
         expect(result, equals('$lines\n'));
         expect(success, isFalse);
       },
@@ -289,7 +261,7 @@ void main() {
     test(
       'unknown $libraryName cross import of Cupertino in non-test file',
       () async {
-        final String extra = '$libraryName/foo_utils.dart'.replaceAll('/', Platform.pathSeparator);
+        final testDartFile = '$libraryName/foo_utils.dart';
         final Directory testFilesDirectory = checkerDirectories.testFilesDirectoryFor(
           libraryName,
           checker.testsDirectory,
@@ -297,7 +269,7 @@ void main() {
 
         buildKnownCrossImportTestFiles();
         writeImportInFiles(
-          <String>{extra},
+          <String>{testDartFile},
           inDirectory: testFilesDirectory,
           importString: "import 'package:flutter/cupertino.dart';",
         );
@@ -306,17 +278,12 @@ void main() {
         final String result = await capture(() async {
           success = checker.check();
         }, shouldHaveErrors: true);
-        final String lines =
-            <String>[
-                  '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
-                  '║ The following test in $libraryName has a disallowed import of Cupertino. Refactor it or move it to Cupertino.',
-                  '║   $extra',
-                  '╚═══════════════════════════════════════════════════════════════════════════════',
-                ]
-                .map((String line) {
-                  return line.replaceAll('/', Platform.pathSeparator);
-                })
-                .join('\n');
+        final String lines = <String>[
+          '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
+          '║ The following test in $libraryName has a disallowed import of Cupertino. Refactor it or move it to Cupertino.',
+          '║   $testDartFile',
+          '╚═══════════════════════════════════════════════════════════════════════════════',
+        ].join('\n');
         expect(result, equals('$lines\n'));
         expect(success, isFalse);
       },

--- a/dev/bots/test/check_tests_cross_imports_test.dart
+++ b/dev/bots/test/check_tests_cross_imports_test.dart
@@ -111,8 +111,8 @@ void main() {
         expect(result, equals('$lines\n'));
         expect(success, isFalse);
       },
-      skip: knownCrossImports.isEmpty,
-    ); // [intended]: No message is needed when there are no known cross imports.
+      skip: knownCrossImports.isEmpty, // [intended]: Nothing to log if there are no known imports
+    );
 
     test('unknown $libraryName cross import of Material', () async {
       final String extra = '$libraryName/foo_test.dart'.replaceAll('/', Platform.pathSeparator);
@@ -242,8 +242,8 @@ void main() {
         expect(result, equals('$lines\n'));
         expect(success, isFalse);
       },
-      skip: libraryName == 'packages/flutter/test/cupertino',
-    ); // [intended]: Cupertino can import itself
+      skip: isCupertino(libraryName), // [intended]: Cupertino can import itself
+    );
 
     test(
       'multiple unknown $libraryName cross imports of Cupertino',
@@ -283,8 +283,8 @@ void main() {
         expect(result, equals('$lines\n'));
         expect(success, isFalse);
       },
-      skip: libraryName == 'packages/flutter/test/cupertino',
-    ); // [intended]: Cupertino can import itself
+      skip: isCupertino(libraryName), // [intended]: Cupertino can import itself
+    );
 
     test(
       'unknown $libraryName cross import of Cupertino in non-test file',
@@ -320,8 +320,8 @@ void main() {
         expect(result, equals('$lines\n'));
         expect(success, isFalse);
       },
-      skip: libraryName == 'packages/flutter/test/cupertino',
-    ); // [intended]: Cupertino can import itself
+      skip: isCupertino(libraryName), // [intended]: Cupertino can import itself
+    );
   }
 }
 
@@ -355,6 +355,9 @@ Future<String> capture(AsyncVoidCallback callback, {bool shouldHaveErrors = fals
     return buffer.toString();
   }
 }
+
+/// Returns whether the given [libraryName] matches the Cupertino library under `flutter/test`.
+bool isCupertino(String libraryName) => libraryName == 'packages/flutter/test/cupertino';
 
 File getFile(String filepath, Directory directory) {
   final String platformFilepath = filepath.replaceAll('/', Platform.pathSeparator);

--- a/dev/bots/test/check_tests_cross_imports_test.dart
+++ b/dev/bots/test/check_tests_cross_imports_test.dart
@@ -67,6 +67,26 @@ void main() {
     expect(success, isTrue);
   });
 
+  test('non-Dart files are ignored', () async {
+    buildKnownCrossImportTestFiles();
+
+    checker.testsDirectory.childFile('README.md')
+      ..createSync()
+      ..writeAsStringSync("import 'package:flutter/material.dart';");
+
+    expect(checker.check(), isTrue);
+  });
+
+  test('non-Dart files with .dart in the filename are ignored', () async {
+    buildKnownCrossImportTestFiles();
+
+    checker.testsDirectory.childFile('foo.dart.md')
+      ..createSync()
+      ..writeAsStringSync("import 'package:flutter/material.dart';");
+
+    expect(checker.check(), isTrue);
+  });
+
   for (final (String libraryName, String knownCrossImportsListName, Set<String> knownCrossImports)
       in crossImportsTestCases) {
     test(

--- a/dev/bots/test/check_tests_cross_imports_test.dart
+++ b/dev/bots/test/check_tests_cross_imports_test.dart
@@ -158,6 +158,36 @@ void main() {
       expect(success, isFalse);
     });
 
+    test('unknown $libraryName cross import of Material in non-test file', () async {
+      final String extra = '$libraryName/foo_utils.dart'.replaceAll('/', Platform.pathSeparator);
+
+      final Directory testFilesDirectory = checkerDirectories.testFilesDirectoryFor(
+        libraryName,
+        checker.testsDirectory,
+      );
+
+      buildKnownCrossImportTestFiles();
+      writeImportInFiles(<String>{extra}, inDirectory: testFilesDirectory);
+
+      bool? success;
+      final String result = await capture(() async {
+        success = checker.check();
+      }, shouldHaveErrors: true);
+      final String lines =
+          <String>[
+                '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
+                '║ The following test in $libraryName has a disallowed import of Material. Refactor it or move it to Material.',
+                '║   $extra',
+                '╚═══════════════════════════════════════════════════════════════════════════════',
+              ]
+              .map((String line) {
+                return line.replaceAll('/', Platform.pathSeparator);
+              })
+              .join('\n');
+      expect(result, equals('$lines\n'));
+      expect(success, isFalse);
+    });
+
     test(
       'unknown $libraryName cross import of Cupertino',
       () async {
@@ -224,6 +254,43 @@ void main() {
                   '║ The following 2 tests in $libraryName have a disallowed import of Cupertino. Refactor them or move them to Cupertino.',
                   '║   ${extras.first}',
                   '║   ${extras.last}',
+                  '╚═══════════════════════════════════════════════════════════════════════════════',
+                ]
+                .map((String line) {
+                  return line.replaceAll('/', Platform.pathSeparator);
+                })
+                .join('\n');
+        expect(result, equals('$lines\n'));
+        expect(success, isFalse);
+      },
+      skip: libraryName == 'packages/flutter/test/cupertino',
+    ); // [intended]: Cupertino can import itself
+
+    test(
+      'unknown $libraryName cross import of Cupertino in non-test file',
+      () async {
+        final String extra = '$libraryName/foo_utils.dart'.replaceAll('/', Platform.pathSeparator);
+        final Directory testFilesDirectory = checkerDirectories.testFilesDirectoryFor(
+          libraryName,
+          checker.testsDirectory,
+        );
+
+        buildKnownCrossImportTestFiles();
+        writeImportInFiles(
+          <String>{extra},
+          inDirectory: testFilesDirectory,
+          importString: "import 'package:flutter/cupertino.dart';",
+        );
+
+        bool? success;
+        final String result = await capture(() async {
+          success = checker.check();
+        }, shouldHaveErrors: true);
+        final String lines =
+            <String>[
+                  '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
+                  '║ The following test in $libraryName has a disallowed import of Cupertino. Refactor it or move it to Cupertino.',
+                  '║   $extra',
                   '╚═══════════════════════════════════════════════════════════════════════════════',
                 ]
                 .map((String line) {

--- a/dev/bots/test/check_tests_cross_imports_test.dart
+++ b/dev/bots/test/check_tests_cross_imports_test.dart
@@ -128,42 +128,46 @@ void main() {
       expect(success, isFalse);
     });
 
-    test('unknown $libraryName cross import of Cupertino', () async {
-      final Set<String> extras = {
-        'packages/$libraryName/foo_test.dart'.replaceAll('/', Platform.pathSeparator),
-        'packages/$libraryName/foo_test_utils.dart'.replaceAll('/', Platform.pathSeparator),
-      };
-      final Directory testFilesDirectory = checkerDirectories.testFilesDirectoryFor(
-        libraryName,
-        checker.testsDirectory,
-      );
+    test(
+      'unknown $libraryName cross import of Cupertino',
+      () async {
+        final Set<String> extras = {
+          'packages/$libraryName/foo_test.dart'.replaceAll('/', Platform.pathSeparator),
+          'packages/$libraryName/foo_test_utils.dart'.replaceAll('/', Platform.pathSeparator),
+        };
+        final Directory testFilesDirectory = checkerDirectories.testFilesDirectoryFor(
+          libraryName,
+          checker.testsDirectory,
+        );
 
-      buildKnownCrossImportTestFiles();
-      writeImportInFiles(
-        extras,
-        inDirectory: testFilesDirectory,
-        importString: "import 'package:flutter/cupertino.dart';",
-      );
+        buildKnownCrossImportTestFiles();
+        writeImportInFiles(
+          extras,
+          inDirectory: testFilesDirectory,
+          importString: "import 'package:flutter/cupertino.dart';",
+        );
 
-      bool? success;
-      final String result = await capture(() async {
-        success = checker.check();
-      }, shouldHaveErrors: true);
-      final String lines =
-          <String>[
-                '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
-                '║ The following test in packages/$libraryName has a disallowed import of Cupertino. Refactor it or move it to Cupertino.',
-                '║   ${extras.first}',
-                '║   ${extras.last}',
-                '╚═══════════════════════════════════════════════════════════════════════════════',
-              ]
-              .map((String line) {
-                return line.replaceAll('/', Platform.pathSeparator);
-              })
-              .join('\n');
-      expect(result, equals('$lines\n'));
-      expect(success, isFalse);
-    }, skip: libraryName == 'flutter/test/cupertino'); // [intended]: Cupertino can import itself
+        bool? success;
+        final String result = await capture(() async {
+          success = checker.check();
+        }, shouldHaveErrors: true);
+        final String lines =
+            <String>[
+                  '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
+                  '║ The following test in packages/$libraryName has a disallowed import of Cupertino. Refactor it or move it to Cupertino.',
+                  '║   ${extras.first}',
+                  '║   ${extras.last}',
+                  '╚═══════════════════════════════════════════════════════════════════════════════',
+                ]
+                .map((String line) {
+                  return line.replaceAll('/', Platform.pathSeparator);
+                })
+                .join('\n');
+        expect(result, equals('$lines\n'));
+        expect(success, isFalse);
+      },
+      skip: libraryName == 'packages/flutter/test/cupertino',
+    ); // [intended]: Cupertino can import itself
   }
 }
 
@@ -325,21 +329,21 @@ class _CrossImportsTestDirectories {
 
   Directory testFilesDirectoryFor(String libraryName, Directory flutterTestDirectory) {
     return switch (libraryName) {
-      'flutter/test' => flutterTestDirectory,
-      'flutter/test/animation' => testAnimationDirectory,
-      'flutter/test/cupertino' => testCupertinoDirectory,
-      'flutter/test/dart' => testDartDirectory,
-      'flutter/test/examples' => testExamplesDirectory,
-      'flutter/test/foundation' => testFoundationDirectory,
-      'flutter/test/gestures' => testGesturesDirectory,
-      'flutter/test/harness' => testHarnessDirectory,
-      'flutter/test/painting' => testPaintingDirectory,
-      'flutter/test/physics' => testPhysicsDirectory,
-      'flutter/test/rendering' => testRenderingDirectory,
-      'flutter/test/scheduler' => testSchedulerDirectory,
-      'flutter/test/semantics' => testSemanticsDirectory,
-      'flutter/test/services' => testServicesDirectory,
-      'flutter/test/widgets' => testWidgetsDirectory,
+      'packages/flutter/test' => flutterTestDirectory,
+      'packages/flutter/test/animation' => testAnimationDirectory,
+      'packages/flutter/test/cupertino' => testCupertinoDirectory,
+      'packages/flutter/test/dart' => testDartDirectory,
+      'packages/flutter/test/examples' => testExamplesDirectory,
+      'packages/flutter/test/foundation' => testFoundationDirectory,
+      'packages/flutter/test/gestures' => testGesturesDirectory,
+      'packages/flutter/test/harness' => testHarnessDirectory,
+      'packages/flutter/test/painting' => testPaintingDirectory,
+      'packages/flutter/test/physics' => testPhysicsDirectory,
+      'packages/flutter/test/rendering' => testRenderingDirectory,
+      'packages/flutter/test/scheduler' => testSchedulerDirectory,
+      'packages/flutter/test/semantics' => testSemanticsDirectory,
+      'packages/flutter/test/services' => testServicesDirectory,
+      'packages/flutter/test/widgets' => testWidgetsDirectory,
       _ => throw ArgumentError('Unknown library name: $libraryName'),
     };
   }
@@ -353,20 +357,20 @@ class _CrossImportsTestDirectories {
 // - the actual known cross imports list for that library
 // dart format off
 final crossImportsTestCases = <(String, String, Set<String>)>[
-  ('flutter/test', 'knownFlutterSlashTestCrossImports', TestsCrossImportChecker.knownFlutterSlashTestCrossImports),
-  ('flutter/test/animation', 'knownAnimationCrossImports', TestsCrossImportChecker.knownAnimationCrossImports),
-  ('flutter/test/cupertino', 'knownCupertinoCrossImports', TestsCrossImportChecker.knownCupertinoCrossImports),
-  ('flutter/test/dart', 'knownDartCrossImports', TestsCrossImportChecker.knownDartCrossImports),
-  ('flutter/test/examples', 'knownExamplesCrossImports', TestsCrossImportChecker.knownExamplesCrossImports),
-  ('flutter/test/foundation', 'knownFoundationCrossImports', TestsCrossImportChecker.knownFoundationCrossImports),
-  ('flutter/test/gestures', 'knownGesturesCrossImports', TestsCrossImportChecker.knownGesturesCrossImports),
-  ('flutter/test/harness', 'knownHarnessCrossImports', TestsCrossImportChecker.knownHarnessCrossImports),
-  ('flutter/test/painting', 'knownPaintingCrossImports', TestsCrossImportChecker.knownPaintingCrossImports),
-  ('flutter/test/physics', 'knownPhysicsCrossImports', TestsCrossImportChecker.knownPhysicsCrossImports),
-  ('flutter/test/rendering', 'knownRenderingCrossImports', TestsCrossImportChecker.knownRenderingCrossImports),
-  ('flutter/test/scheduler', 'knownSchedulerCrossImports', TestsCrossImportChecker.knownSchedulerCrossImports),
-  ('flutter/test/semantics', 'knownSemanticsCrossImports', TestsCrossImportChecker.knownSemanticsCrossImports),
-  ('flutter/test/services', 'knownServicesCrossImports', TestsCrossImportChecker.knownServicesCrossImports),
-  ('flutter/test/widgets', 'knownWidgetsCrossImports', TestsCrossImportChecker.knownWidgetsCrossImports),
+  ('packages/flutter/test', 'knownFlutterSlashTestCrossImports', TestsCrossImportChecker.knownFlutterSlashTestCrossImports),
+  ('packages/flutter/test/animation', 'knownAnimationCrossImports', TestsCrossImportChecker.knownAnimationCrossImports),
+  ('packages/flutter/test/cupertino', 'knownCupertinoCrossImports', TestsCrossImportChecker.knownCupertinoCrossImports),
+  ('packages/flutter/test/dart', 'knownDartCrossImports', TestsCrossImportChecker.knownDartCrossImports),
+  ('packages/flutter/test/examples', 'knownExamplesCrossImports', TestsCrossImportChecker.knownExamplesCrossImports),
+  ('packages/flutter/test/foundation', 'knownFoundationCrossImports', TestsCrossImportChecker.knownFoundationCrossImports),
+  ('packages/flutter/test/gestures', 'knownGesturesCrossImports', TestsCrossImportChecker.knownGesturesCrossImports),
+  ('packages/flutter/test/harness', 'knownHarnessCrossImports', TestsCrossImportChecker.knownHarnessCrossImports),
+  ('packages/flutter/test/painting', 'knownPaintingCrossImports', TestsCrossImportChecker.knownPaintingCrossImports),
+  ('packages/flutter/test/physics', 'knownPhysicsCrossImports', TestsCrossImportChecker.knownPhysicsCrossImports),
+  ('packages/flutter/test/rendering', 'knownRenderingCrossImports', TestsCrossImportChecker.knownRenderingCrossImports),
+  ('packages/flutter/test/scheduler', 'knownSchedulerCrossImports', TestsCrossImportChecker.knownSchedulerCrossImports),
+  ('packages/flutter/test/semantics', 'knownSemanticsCrossImports', TestsCrossImportChecker.knownSemanticsCrossImports),
+  ('packages/flutter/test/services', 'knownServicesCrossImports', TestsCrossImportChecker.knownServicesCrossImports),
+  ('packages/flutter/test/widgets', 'knownWidgetsCrossImports', TestsCrossImportChecker.knownWidgetsCrossImports),
 ];
 // dart format on

--- a/dev/bots/test/check_tests_cross_imports_test.dart
+++ b/dev/bots/test/check_tests_cross_imports_test.dart
@@ -95,17 +95,18 @@ void main() {
     ); // [intended]: No message is needed when there are no known cross imports.
 
     test('unknown $libraryName cross import of Material', () async {
-      final String extra = 'packages/$libraryName/foo_test.dart'.replaceAll(
-        '/',
-        Platform.pathSeparator,
-      );
+      final Set<String> extras = {
+        'packages/$libraryName/foo_test.dart'.replaceAll('/', Platform.pathSeparator),
+        'packages/$libraryName/foo_test_utils.dart'.replaceAll('/', Platform.pathSeparator),
+      };
+
       final Directory testFilesDirectory = checkerDirectories.testFilesDirectoryFor(
         libraryName,
         checker.testsDirectory,
       );
 
       buildKnownCrossImportTestFiles();
-      writeImportInFiles(<String>{extra}, inDirectory: testFilesDirectory);
+      writeImportInFiles(extras, inDirectory: testFilesDirectory);
 
       bool? success;
       final String result = await capture(() async {
@@ -115,7 +116,8 @@ void main() {
           <String>[
                 '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
                 '║ The following test in packages/$libraryName has a disallowed import of Material. Refactor it or move it to Material.',
-                '║   $extra',
+                '║   ${extras.first}',
+                '║   ${extras.last}',
                 '╚═══════════════════════════════════════════════════════════════════════════════',
               ]
               .map((String line) {
@@ -127,10 +129,10 @@ void main() {
     });
 
     test('unknown $libraryName cross import of Cupertino', () async {
-      final String extra = 'packages/$libraryName/foo_test.dart'.replaceAll(
-        '/',
-        Platform.pathSeparator,
-      );
+      final Set<String> extras = {
+        'packages/$libraryName/foo_test.dart'.replaceAll('/', Platform.pathSeparator),
+        'packages/$libraryName/foo_test_utils.dart'.replaceAll('/', Platform.pathSeparator),
+      };
       final Directory testFilesDirectory = checkerDirectories.testFilesDirectoryFor(
         libraryName,
         checker.testsDirectory,
@@ -138,7 +140,7 @@ void main() {
 
       buildKnownCrossImportTestFiles();
       writeImportInFiles(
-        <String>{extra},
+        extras,
         inDirectory: testFilesDirectory,
         importString: "import 'package:flutter/cupertino.dart';",
       );
@@ -151,7 +153,8 @@ void main() {
           <String>[
                 '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
                 '║ The following test in packages/$libraryName has a disallowed import of Cupertino. Refactor it or move it to Cupertino.',
-                '║   $extra',
+                '║   ${extras.first}',
+                '║   ${extras.last}',
                 '╚═══════════════════════════════════════════════════════════════════════════════',
               ]
               .map((String line) {


### PR DESCRIPTION
This PR extends the tests cross imports check to also verify cross imports in `flutter/test` itself and its subdirectories. It now also validates `.dart` files, such as `flutter/test/gesture_utils.dart`, instead of only `_test.dart` files.

The underlying test was rewritten a bit to accomodate this.
The known cross imports have been rebaselined, to account for the new checks.

Currently the cross imports check does not validate subdirectories of `flutter/test/xyz` (for example `flutter/test/gestures/utils`), because at this time there are no such subdirectories, beyond directories inside `flutter/test` itself. 

Fixes https://github.com/flutter/flutter/issues/185464

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
