### PR TITLE
[github]fix git ls-file glob pattern in labeler.yml instruction

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,7 +3,7 @@
 # found in the LICENSE file.
 
 # See https://github.com/actions/labeler/blob/main/README.md for docs.
-# Use git ls-files '<pattern>' to see the list of matching files.
+# Use git ls-files ':(glob)<pattern>' to see the list of matching files.
 
 'a: accessibility':
   - changed-files:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,7 +4,7 @@
 # These names are just suggestions. It is fine to have your changes
 # reviewed by someone else.
 #
-# Use git ls-files '<pattern>' without a / prefix to see the list of matching files.
+# Use git ls-files ':(glob)<pattern>' without a / prefix to see the list of matching files.
 
 /engine/src/build/config/ios/** @vashworth
 /packages/flutter_tools/templates/module/ios/ @vashworth


### PR DESCRIPTION

This instruction gives too lenient result.

For example:
```
git ls-files 'dev/integration_tests/*macos*/**/*'
```
is supposed to print empty result, but instead, it prints these files:

```
dev/integration_tests/channels/macos/Flutter/Flutter-Debug.xcconfig
dev/integration_tests/channels/macos/Flutter/Flutter-Release.xcconfig
dev/integration_tests/channels/macos/Runner.xcodeproj/project.pbxproj
dev/integration_tests/channels/macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
dev/integration_tests/channels/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
dev/integration_tests/channels/macos/Runner.xcworkspace/contents.xcworkspacedata
dev/integration_tests/channels/macos/Runner.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
dev/integration_tests/channels/macos/Runner/AppDelegate.swift
```

This is wrong - macos is not an immediate subfolder under dev/integration_tests, so it shouldn't match.

## Fix:
Change the instruction to either:

`git ls-files ':(glob)dev/integration_tests/*macos*/**/*'`

Or just:

`print -l dev/integration_tests/*macos*/**/*`


Fixes https://github.com/flutter/flutter/issues/185494

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
