### PR TITLE
[Breaking Change] Rename `CurvedAnimation` to `ReversibleCurvedAnimation` for disambiguation

### DIFF
--- a/packages/flutter/lib/fix_data/fix_animation.yaml
+++ b/packages/flutter/lib/fix_data/fix_animation.yaml
@@ -1,0 +1,50 @@
+# Copyright 2014 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# For details regarding the *Flutter Fix* feature, see
+# https://flutter.dev/to/flutter-fix
+
+# Please add new fixes to the top of the file, separated by one blank line
+# from other fixes. In a comment, include a link to the PR where the change
+# requiring the fix was made.
+
+# Every fix must be tested. See the flutter/packages/flutter/test_fixes/README.md
+# file for instructions on testing these data driven fixes.
+
+# For documentation about this file format, see
+# https://dart.dev/go/data-driven-fixes.
+
+# * Fixes in this file are from the Animation library. *
+
+version: 1
+transforms:
+  # Change made in https://github.com/flutter/flutter/pull/185501
+  - title: "Rename to ReversibleCurvedAnimation"
+    date: 2026-04-23
+    element:
+      uris: [ 'animation.dart', 'widgets.dart', 'material.dart', 'cupertino.dart' ]
+      constructor: ''
+      inClass: 'CurvedAnimation'
+    oneOf:
+      - if: "reverseCurve != '' && reverseCurve != curve"
+        changes:
+          - kind: 'replacedBy'
+            newElement:
+              uris: [ 'animation.dart', 'widgets.dart', 'material.dart', 'cupertino.dart' ]
+              constructor: ''
+              inClass: 'ReversibleCurvedAnimation'
+      # Otherwise, migrate to this expression. But it's not possible as a data-driven fix yet.
+      #     '{% parent %}.drive(CurveTween(curve: {% curve %}))'
+    variables:
+      parent:
+        kind: fragment
+        value: 'arguments[parent]'
+      curve:
+        kind: fragment
+        value: 'arguments[curve]'
+      reverseCurve:
+        kind: fragment
+        value: 'arguments[reverseCurve]'
+
+# Before adding a new fix: read instructions at the top of this file.

--- a/packages/flutter/lib/src/animation/animations.dart
+++ b/packages/flutter/lib/src/animation/animations.dart
@@ -8,6 +8,8 @@ library;
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/src/animation/tween.dart';
+import 'package:flutter/src/widgets/framework.dart';
 
 import 'animation.dart';
 import 'curves.dart';
@@ -268,8 +270,8 @@ class ProxyAnimation extends Animation<double>
 ///
 ///  * [Curve.flipped] and [FlippedCurve], which provide a similar effect but on
 ///    [Curve]s.
-///  * [CurvedAnimation], which can take separate curves for when the animation
-///    is going forward than for when it is going in reverse.
+///  * [ReversibleCurvedAnimation], which can take separate curves for when the
+///    animation is going forward than for when it is going in reverse.
 class ReverseAnimation extends Animation<double>
     with AnimationLazyListenerMixin, AnimationLocalStatusListenersMixin {
   /// Creates a reverse animation.
@@ -325,67 +327,68 @@ class ReverseAnimation extends Animation<double>
   }
 }
 
-/// An animation that applies a curve to another animation.
+/// An animation that applies different curves to its [parent] animation
+/// depending on whether it's going forwards or backwards.
 ///
-/// [CurvedAnimation] is useful when you want to apply a non-linear [Curve] to
-/// an animation object, especially if you want different curves when the
-/// animation is going forward vs when it is going backward.
-///
-/// Depending on the given curve, the output of the [CurvedAnimation] could have
-/// a wider range than its input. For example, elastic curves such as
-/// [Curves.elasticIn] will significantly overshoot or undershoot the default
-/// range of 0.0 to 1.0.
-///
-/// If you want to apply a [Curve] to a [Tween], consider using [CurveTween].
-///
-/// A [CurvedAnimation] should be disposed when no longer needed to clean up
-/// any listeners that it may have added. Disposing the
-/// parent animation (typically the [AnimationController]) will also clean up
-/// this object. Do not create a [CurvedAnimation] inside a `build` method
-/// because it would leak any added listeners on every rebuild. If [reverseCurve] is
-/// not needed, prefer `parent.drive(CurveTween(curve: curve))` which does not
-/// require separate disposal.
+/// This class has been deprecated for API clarity:
+/// - If you need different forward and backward curves,
+///   this class was renamed to [ReversibleCurvedAnimation].
+///   The constructor's [reverseCurve] is now required, but can still be null.
+/// - If you only use a single curve,
+///   consider switching to [CurveTween] to avoid memory leaks
+///   (see the snippet below).
 ///
 /// {@tool snippet}
 ///
-/// The following code snippet shows how you can apply a curve to a linear
-/// animation produced by an [AnimationController] `controller`.
+/// This code snippet shows how to migrate from [CurvedAnimation] to [CurveTween].
+/// The latter is less verbose and could be made stateless.
 ///
 /// ```dart
-/// final Animation<double> animation = CurvedAnimation(
-///   parent: controller,
-///   curve: Curves.ease,
-/// );
+/// class _MyOldWidgetState extends State<MyWidget> {
+///   late final curvedAnimation = CurvedAnimation(
+///     widget.animationController,
+///     curve: Curves.easeInOut,
+///   );
+///
+///   @override
+///   Widget build(BuildContext context) {
+///     return FadeTransition(opacity: curvedAnimation, child: widget.child);
+///   }
+///
+///   @override
+///   void dispose() {
+///     curvedAnimation.dispose();
+///   }
+/// }
+///
+/// class _MyNewWidgetState extends State<MyWidget> {
+///   @override
+///   Widget build(BuildContext context) {
+///     return FadeTransition(
+///       // You don't need to dispose this `drive` animation.
+///       opacity: widget.animationController.drive(
+///         CurveTween(curve: Curves.easeInOut),
+///       ),
+///       child: widget.child,
+///     );
+///   }
+/// }
 /// ```
 /// {@end-tool}
-/// {@tool snippet}
-///
-/// This second code snippet shows how to apply a different curve in the forward
-/// direction than in the reverse direction. This can't be done using a
-/// [CurveTween] (since [Tween]s are not aware of the animation direction when
-/// they are applied).
-///
-/// ```dart
-/// final Animation<double> animation = CurvedAnimation(
-///   parent: controller,
-///   curve: Curves.easeIn,
-///   reverseCurve: Curves.easeOut,
-/// );
-/// ```
-/// {@end-tool}
-///
-/// By default, the [reverseCurve] matches the forward [curve].
-///
-/// See also:
-///
-///  * [CurveTween], for an alternative way of expressing the first sample
-///    above.
-///  * [AnimationController], for examples of creating and disposing of an
-///    [AnimationController].
-///  * [Curve.flipped] and [FlippedCurve], which provide the reverse of a
-///    [Curve].
+@Deprecated(
+  'Switch to ReversibleCurvedAnimation if you need different forward & backward animations, '
+  'or switch to CurveTween if you only need one curve. '
+  'Using CurveTween where possible can reduce boilerplate and memory consumption. '
+  'This feature was deprecated after v3.44.0-0.2.pre.',
+)
 class CurvedAnimation extends Animation<double> with AnimationWithParentMixin<double> {
   /// Creates a curved animation.
+  @Deprecated(
+    'Switch to ReversibleCurvedAnimation if you need different forward & backward animations, '
+    'or switch to CurveTween if you only need one curve. '
+    'Using CurveTween where possible can reduce boilerplate and memory consumption. '
+    'This feature was deprecated after v3.44.0-0.2.pre.',
+  )
   CurvedAnimation({required this.parent, required this.curve, this.reverseCurve}) {
     assert(debugMaybeDispatchCreated('animation', 'CurvedAnimation', this));
     _updateCurveDirection(parent.status);
@@ -478,6 +481,97 @@ class CurvedAnimation extends Animation<double> with AnimationWithParentMixin<do
     }
     return '$parent\u27A9$curve/$reverseCurve\u2092\u2099';
   }
+}
+
+/// An animation that applies different curves to its [parent] animation
+/// depending on whether it's going forwards or backwards.
+///
+/// [ReversibleCurvedAnimation] operates by adding listeners to its [parent].
+/// Therefore, you shouldn't re-instantiating it every build, and you should
+/// dipose it (or its [parent]) when you're done.
+///
+/// Depending on the given curve, the output of this animation could have
+/// a wider range than its input. For example, elastic curves such as
+/// [Curves.elasticIn] will significantly overshoot or undershoot the default
+/// range of 0.0 to 1.0.
+///
+/// {@tool snippet}
+///
+/// This code snippet shows how to apply a different curve in the forward
+/// direction than in the reverse direction. This can't be done using a
+/// [CurveTween] (since [Tween]s are not aware of the animation direction when
+/// they are applied).
+///
+/// ```dart
+/// final Animation<double> animation = ReversibleCurvedAnimation(
+///   parent: controller,
+///   curve: Curves.easeIn,
+///   reverseCurve: Curves.easeOut,
+/// );
+/// ```
+/// {@end-tool}
+///
+/// If [reverseCurve] is not specified,
+/// [curve] will be used in both forward and backward directions.
+/// If you don't need [reverseCurve] at all, consider using [CurveTween]
+/// instead (see the snippet below).
+///
+/// {@tool snippet}
+///
+/// This code snippet shows how to migrate from [ReversibleCurvedAnimation] to [CurveTween].
+/// The latter is less verbose and could be made stateless.
+///
+/// ```dart
+/// class _MyOldWidgetState extends State<MyWidget> {
+///   late final curvedAnimation = ReversibleCurvedAnimation(
+///     widget.animationController,
+///     curve: Curves.easeInOut,
+///     reverseCurve: null,
+///   );
+///
+///   @override
+///   Widget build(BuildContext context) {
+///     return FadeTransition(opacity: curvedAnimation, child: widget.child);
+///   }
+///
+///   @override
+///   void dispose() {
+///     curvedAnimation.dispose();
+///   }
+/// }
+///
+/// class _MyNewWidgetState extends State<MyWidget> {
+///   @override
+///   Widget build(BuildContext context) {
+///     return FadeTransition(
+///       // You don't need to dispose this `drive` animation.
+///       opacity: widget.animationController.drive(
+///         CurveTween(curve: Curves.easeInOut),
+///       ),
+///       child: widget.child,
+///     );
+///   }
+/// }
+/// ```
+/// {@end-tool}
+///
+/// See also:
+///
+///  * [CurveTween], for a single-curve alternative that doesn't need
+///    disposing.
+///  * [AnimationController], for examples of creating and disposing of an
+///    [AnimationController].
+///  * [Curve.flipped] and [FlippedCurve], which provide the reverse of a
+///    [Curve].
+// Maintainer note: This extends the old deprecated class to preserve types in
+// old code (e.g. `animation is CurvedAnimation`).
+class ReversibleCurvedAnimation extends CurvedAnimation {
+  /// Creates a curved animation with a forward [curve] and a [reverseCurve].
+  ReversibleCurvedAnimation({
+    required super.parent,
+    required super.curve,
+    required super.reverseCurve,
+  });
 }
 
 enum _TrainHoppingMode { minimize, maximize }

--- a/packages/flutter/lib/src/animation/animations.dart
+++ b/packages/flutter/lib/src/animation/animations.dart
@@ -8,12 +8,11 @@ library;
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/src/animation/tween.dart';
-import 'package:flutter/src/widgets/framework.dart';
 
 import 'animation.dart';
 import 'curves.dart';
 import 'listener_helpers.dart';
+import 'tween.dart';
 
 export 'dart:ui' show VoidCallback;
 
@@ -346,7 +345,7 @@ class ReverseAnimation extends Animation<double>
 /// ```dart
 /// class _MyOldWidgetState extends State<MyWidget> {
 ///   late final curvedAnimation = CurvedAnimation(
-///     widget.animationController,
+///     parent: widget.animationController,
 ///     curve: Curves.easeInOut,
 ///   );
 ///
@@ -487,8 +486,8 @@ class CurvedAnimation extends Animation<double> with AnimationWithParentMixin<do
 /// depending on whether it's going forwards or backwards.
 ///
 /// [ReversibleCurvedAnimation] operates by adding listeners to its [parent].
-/// Therefore, you shouldn't re-instantiating it every build, and you should
-/// dipose it (or its [parent]) when you're done.
+/// Therefore, you shouldn't re-instantiate it every build, and you should
+/// [dispose] it (or its [parent]) when you're done.
 ///
 /// Depending on the given curve, the output of this animation could have
 /// a wider range than its input. For example, elastic curves such as
@@ -511,7 +510,7 @@ class CurvedAnimation extends Animation<double> with AnimationWithParentMixin<do
 /// ```
 /// {@end-tool}
 ///
-/// If [reverseCurve] is not specified,
+/// If [reverseCurve] is null,
 /// [curve] will be used in both forward and backward directions.
 /// If you don't need [reverseCurve] at all, consider using [CurveTween]
 /// instead (see the snippet below).
@@ -524,7 +523,7 @@ class CurvedAnimation extends Animation<double> with AnimationWithParentMixin<do
 /// ```dart
 /// class _MyOldWidgetState extends State<MyWidget> {
 ///   late final curvedAnimation = ReversibleCurvedAnimation(
-///     widget.animationController,
+///     parent: widget.animationController,
 ///     curve: Curves.easeInOut,
 ///     reverseCurve: null,
 ///   );

--- a/packages/flutter/test/animation/animations_test.dart
+++ b/packages/flutter/test/animation/animations_test.dart
@@ -28,7 +28,11 @@ void main() {
     expect(kAlwaysCompleteAnimation, hasOneLineDescription);
     expect(kAlwaysDismissedAnimation, hasOneLineDescription);
     expect(const AlwaysStoppedAnimation<double>(0.5), hasOneLineDescription);
-    var curvedAnimation = CurvedAnimation(parent: kAlwaysDismissedAnimation, curve: Curves.ease);
+    var curvedAnimation = ReversibleCurvedAnimation(
+      parent: kAlwaysDismissedAnimation,
+      curve: Curves.ease,
+      reverseCurve: null,
+    );
     expect(curvedAnimation, hasOneLineDescription);
     curvedAnimation.reverseCurve = Curves.elasticOut;
     expect(curvedAnimation, hasOneLineDescription);
@@ -39,7 +43,7 @@ void main() {
     controller
       ..value = 0.5
       ..reverse();
-    curvedAnimation = CurvedAnimation(
+    curvedAnimation = ReversibleCurvedAnimation(
       parent: controller,
       curve: Curves.ease,
       reverseCurve: Curves.elasticOut,
@@ -248,9 +252,13 @@ void main() {
     expect(log, isEmpty);
   });
 
-  test('CurvedAnimation with bogus curve', () {
+  test('ReversibleCurvedAnimation with bogus curve', () {
     final controller = AnimationController(vsync: const TestVSync());
-    final curved = CurvedAnimation(parent: controller, curve: const BogusCurve());
+    final curved = ReversibleCurvedAnimation(
+      parent: controller,
+      curve: const BogusCurve(),
+      reverseCurve: null,
+    );
     FlutterError? error;
     try {
       curved.value;
@@ -274,13 +282,13 @@ FlutterError
     );
   });
 
-  test('CurvedAnimation running with different forward and reverse durations.', () {
+  test('ReversibleCurvedAnimation running with different forward and reverse durations.', () {
     final controller = AnimationController(
       duration: const Duration(milliseconds: 100),
       reverseDuration: const Duration(milliseconds: 50),
       vsync: const TestVSync(),
     );
-    final curved = CurvedAnimation(
+    final curved = ReversibleCurvedAnimation(
       parent: controller,
       curve: Curves.linear,
       reverseCurve: Curves.linear,
@@ -323,7 +331,7 @@ FlutterError
     expect(curved.value, moreOrLessEquals(0.0));
   });
 
-  test('CurvedAnimation stops listening to parent when disposed.', () async {
+  test('ReversibleCurvedAnimation stops listening to parent when disposed.', () async {
     const forwardCurve = Interval(0.0, 0.5);
     const reverseCurve = Interval(0.5, 1.0);
 
@@ -332,7 +340,7 @@ FlutterError
       reverseDuration: const Duration(milliseconds: 100),
       vsync: const TestVSync(),
     );
-    final curved = CurvedAnimation(
+    final curved = ReversibleCurvedAnimation(
       parent: controller,
       curve: forwardCurve,
       reverseCurve: reverseCurve,
@@ -371,7 +379,11 @@ FlutterError
       vsync: const TestVSync(),
     );
     final reversed = ReverseAnimation(
-      CurvedAnimation(parent: controller, curve: Curves.linear, reverseCurve: Curves.linear),
+      ReversibleCurvedAnimation(
+        parent: controller,
+        curve: Curves.linear,
+        reverseCurve: Curves.linear,
+      ),
     );
 
     controller.forward();
@@ -498,17 +510,18 @@ FlutterError
     expect(animation.value, 10.0);
   });
 
-  test('$CurvedAnimation dispatches memory events', () async {
+  test('$ReversibleCurvedAnimation dispatches memory events', () async {
     await expectLater(
       await memoryEvents(
-        () => CurvedAnimation(
+        () => ReversibleCurvedAnimation(
           parent: AnimationController(
             duration: const Duration(milliseconds: 100),
             vsync: const TestVSync(),
           ),
           curve: Curves.linear,
+          reverseCurve: null,
         ).dispose(),
-        CurvedAnimation,
+        ReversibleCurvedAnimation,
       ),
       areCreateAndDispose,
     );

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -2870,7 +2870,11 @@ class TestPageRouteBuilder extends PageRouteBuilder<void> {
 
   @override
   Animation<double> createAnimation() {
-    return CurvedAnimation(parent: super.createAnimation(), curve: Curves.easeOutExpo);
+    return ReversibleCurvedAnimation(
+      parent: super.createAnimation(),
+      curve: Curves.easeOutExpo,
+      reverseCurve: null,
+    );
   }
 }
 

--- a/packages/flutter/test/widgets/transitions_test.dart
+++ b/packages/flutter/test/widgets/transitions_test.dart
@@ -84,7 +84,11 @@ void main() {
     });
 
     testWidgets('animations work with curves test', (WidgetTester tester) async {
-      final curvedAnimation = CurvedAnimation(parent: controller, curve: Curves.easeOut);
+      final curvedAnimation = ReversibleCurvedAnimation(
+        parent: controller,
+        curve: Curves.easeOut,
+        reverseCurve: null,
+      );
       addTearDown(curvedAnimation.dispose);
       final Animation<Decoration> curvedDecorationAnimation = decorationTween.animate(
         curvedAnimation,

--- a/packages/flutter/test_fixes/animation/curved_animation_with_matching_curves.dart
+++ b/packages/flutter/test_fixes/animation/curved_animation_with_matching_curves.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/animation.dart';
+
+void main() {
+  final animationController = AnimationController();
+  // This should become:
+  // `final animation = animationController.drive(CurveTween(curve: Curves.easeIn));`
+  // or
+  // `final animation = CurveTween(curve: Curves.easeIn).animate(animationController);`
+  // but the data-driven fix isn't implemented yet.
+  final animation = CurvedAnimation(
+    parent: animationController,
+    curve: Curves.easeIn,
+    reverseCurve: Curves.easeIn,
+  );
+}

--- a/packages/flutter/test_fixes/animation/curved_animation_with_matching_curves.dart.expect
+++ b/packages/flutter/test_fixes/animation/curved_animation_with_matching_curves.dart.expect
@@ -1,0 +1,15 @@
+import 'package:flutter/animation.dart';
+
+void main() {
+  final animationController = AnimationController();
+  // This should become:
+  // `final animation = animationController.drive(CurveTween(curve: Curves.easeIn));`
+  // or
+  // `final animation = CurveTween(curve: Curves.easeIn).animate(animationController);`
+  // but the data-driven fix isn't implemented yet.
+  final animation = CurvedAnimation(
+    parent: animationController,
+    curve: Curves.easeIn,
+    reverseCurve: Curves.easeIn,
+  );
+}

--- a/packages/flutter/test_fixes/animation/curved_animation_with_one_curve.dart
+++ b/packages/flutter/test_fixes/animation/curved_animation_with_one_curve.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/animation.dart';
+
+void main() {
+  final animationController = AnimationController();
+  // This should become:
+  // `final animation = animationController.drive(CurveTween(curve: Curves.easeIn));`
+  // or
+  // `final animation = CurveTween(curve: Curves.easeIn).animate(animationController);`
+  // but the data-driven fix isn't implemented yet.
+  final animation = CurvedAnimation(parent: animationController, curve: Curves.easeIn);
+}

--- a/packages/flutter/test_fixes/animation/curved_animation_with_one_curve.dart.expect
+++ b/packages/flutter/test_fixes/animation/curved_animation_with_one_curve.dart.expect
@@ -1,0 +1,11 @@
+import 'package:flutter/animation.dart';
+
+void main() {
+  final animationController = AnimationController();
+  // This should become:
+  // `final animation = animationController.drive(CurveTween(curve: Curves.easeIn));`
+  // or
+  // `final animation = CurveTween(curve: Curves.easeIn).animate(animationController);`
+  // but the data-driven fix isn't implemented yet.
+  final animation = CurvedAnimation(parent: animationController, curve: Curves.easeIn);
+}

--- a/packages/flutter/test_fixes/animation/curved_animation_with_two_curves.dart
+++ b/packages/flutter/test_fixes/animation/curved_animation_with_two_curves.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/animation.dart';
+
+void main() {
+  final animationController = AnimationController();
+  final animation = CurvedAnimation(
+    parent: animationController,
+    curve: Curves.easeIn,
+    reverseCurve: Curves.easeOut,
+  );
+}

--- a/packages/flutter/test_fixes/animation/curved_animation_with_two_curves.dart.expect
+++ b/packages/flutter/test_fixes/animation/curved_animation_with_two_curves.dart.expect
@@ -1,0 +1,10 @@
+import 'package:flutter/animation.dart';
+
+void main() {
+  final animationController = AnimationController();
+  final animation = ReversibleCurvedAnimation(
+    parent: animationController,
+    curve: Curves.easeIn,
+    reverseCurve: Curves.easeOut,
+  );
+}


### PR DESCRIPTION
This PR solves the ambiguity and functional overlap between `CurvedAnimation` and `CurveTween`.
`CurvedAnimation` has been renamed to `ReversibleCurvedAnimation`, and its constructor now makes `reverseCurve` a required argument.

I believe this breaking change is needed to "break the API and make it good". It brings up several bad examples in this repo that would leak memory due to undisposed `CurvedAnimation`s, and it makes it easy for a user to pick the right option for their needs. In fact, every single use of `CurvedAnimation` in the examples was unnecessary and could be replaced with the more efficient and succinct `CurveTween`, and a few memory leaks were exposed by this change (fixed in my followup PR https://github.com/flutter/flutter/pull/185576).

Related issues:
- Resolves https://github.com/flutter/flutter/issues/185468.
- See previous discussion in https://github.com/flutter/flutter/issues/183292.
- Could help with https://github.com/flutter/flutter/issues/6792. Only the controller needs to be managed and disposed, while the CurveTween's animation is stateless.
- Could help with https://github.com/flutter/flutter/issues/150771

Dependent PRs: 
- Internal migration: https://github.com/flutter/flutter/pull/185576
- Migration instructions: https://github.com/flutter/website/pull/13310 

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or **I am not using AI tools**.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
  - Tracking data driven fix support in https://github.com/dart-lang/sdk/issues/63242
- [x] All existing and new tests are passing.

<!--
If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.
-->

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
