### PR TITLE
Use g_realloc instead of realloc

### DIFF
--- a/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.cc
@@ -258,7 +258,8 @@ static gboolean fl_compositor_opengl_present_layers(FlCompositor* compositor,
     // If not shareable make buffer to copy frame pixels into.
     if (!self->shareable) {
       size_t data_length = width * height * 4;
-      self->pixels = static_cast<uint8_t*>(realloc(self->pixels, data_length));
+      self->pixels =
+          static_cast<uint8_t*>(g_realloc(self->pixels, data_length));
     }
   }
 

--- a/engine/src/flutter/shell/platform/linux/fl_compositor_software.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_compositor_software.cc
@@ -55,7 +55,7 @@ static gboolean fl_compositor_software_present_layers(
                                   ? cairo_image_surface_get_data(self->surface)
                                   : nullptr;
     unsigned char* data =
-        static_cast<unsigned char*>(realloc(old_data, allocation_length));
+        static_cast<unsigned char*>(g_realloc(old_data, allocation_length));
     memcpy(data, backing_store->software.allocation, allocation_length);
     cairo_surface_destroy(self->surface);
     self->surface = cairo_image_surface_create_for_data(
@@ -133,7 +133,7 @@ static void fl_compositor_software_dispose(GObject* object) {
 
   g_clear_object(&self->task_runner);
   if (self->surface != nullptr) {
-    free(cairo_image_surface_get_data(self->surface));
+    g_free(cairo_image_surface_get_data(self->surface));
   }
   g_clear_pointer(&self->surface, cairo_surface_destroy);
   g_mutex_clear(&self->frame_mutex);


### PR DESCRIPTION
If the allocation failed the existing code would return NULL, leaking the existing buffer and then likely crashing. Using g_realloc terminates the program automatically if the allocation fails.
