### PR TITLE
fix: MergeSemantics dispatches correct handler for specific custom action

### DIFF
--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -5039,20 +5039,32 @@ class SemanticsOwner extends ChangeNotifier {
 
   SemanticsActionHandler? _getSemanticsActionHandlerForId(int id, SemanticsAction action, [Object? args]) {
     SemanticsNode? result = _nodes[id];
-    if (result != null && result.isPartOfNodeMerging && !result._canPerformAction(action)) {
+
+    // For SemanticsAction.customAction the requested action ID is carried in
+    // args.  Resolve it once here so both the outer guard and the descendant
+    // walk can check the *specific* action rather than any custom action.
+    final CustomSemanticsAction? requestedCustomAction =
+        (action == SemanticsAction.customAction && args is int)
+            ? CustomSemanticsAction.getAction(args)
+            : null;
+
+    // Returns true only when [node] can handle the specific action being
+    // requested.  For customAction, _canPerformAction alone is insufficient
+    // because it returns true for any node that owns *any* custom action —
+    // we must also confirm the node owns the particular requested action.
+    bool nodeHandlesAction(SemanticsNode node) {
+      if (!node._canPerformAction(action)) {
+        return false;
+      }
+      if (requestedCustomAction != null) {
+        return node._customSemanticsActions.containsKey(requestedCustomAction);
+      }
+      return true;
+    }
+
+    if (result != null && result.isPartOfNodeMerging && !nodeHandlesAction(result)) {
       result._visitDescendants((SemanticsNode node) {
-        if (node._canPerformAction(action)) {
-          // For customAction, verify the node handles the *specific* custom
-          // action being requested, not just any custom action.  Without this
-          // check the walk stops at the first descendant that owns any custom
-          // action and the wrong (or no) handler is returned when multiple
-          // descendants each register different custom actions.
-          if (action == SemanticsAction.customAction && args is int) {
-            final CustomSemanticsAction? customAction = CustomSemanticsAction.getAction(args);
-            if (customAction != null && !node._customSemanticsActions.containsKey(customAction)) {
-              return true; // continue walk — this node doesn't own this specific action
-            }
-          }
+        if (nodeHandlesAction(node)) {
           result = node;
           return false; // found node, abort walk
         }

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -5037,11 +5037,22 @@ class SemanticsOwner extends ChangeNotifier {
     notifyListeners();
   }
 
-  SemanticsActionHandler? _getSemanticsActionHandlerForId(int id, SemanticsAction action) {
+  SemanticsActionHandler? _getSemanticsActionHandlerForId(int id, SemanticsAction action, [Object? args]) {
     SemanticsNode? result = _nodes[id];
     if (result != null && result.isPartOfNodeMerging && !result._canPerformAction(action)) {
       result._visitDescendants((SemanticsNode node) {
         if (node._canPerformAction(action)) {
+          // For customAction, verify the node handles the *specific* custom
+          // action being requested, not just any custom action.  Without this
+          // check the walk stops at the first descendant that owns any custom
+          // action and the wrong (or no) handler is returned when multiple
+          // descendants each register different custom actions.
+          if (action == SemanticsAction.customAction && args is int) {
+            final CustomSemanticsAction? customAction = CustomSemanticsAction.getAction(args);
+            if (customAction != null && !node._customSemanticsActions.containsKey(customAction)) {
+              return true; // continue walk — this node doesn't own this specific action
+            }
+          }
           result = node;
           return false; // found node, abort walk
         }
@@ -5062,7 +5073,7 @@ class SemanticsOwner extends ChangeNotifier {
   /// If the given `action` requires arguments they need to be passed in via
   /// the `args` parameter.
   void performAction(int id, SemanticsAction action, [Object? args]) {
-    final SemanticsActionHandler? handler = _getSemanticsActionHandlerForId(id, action);
+    final SemanticsActionHandler? handler = _getSemanticsActionHandlerForId(id, action, args);
     if (handler != null) {
       handler(args);
       return;

--- a/packages/flutter/test/semantics/semantics_test.dart
+++ b/packages/flutter/test/semantics/semantics_test.dart
@@ -939,6 +939,59 @@ void main() {
     expect(tapped, isTrue);
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/183833
+  test('performAction dispatches the correct custom action when multiple descendants have different custom actions', () {
+    var outerActivated = false;
+    var innerActivated = false;
+
+    const outerAction = CustomSemanticsAction(label: 'Outer action');
+    const innerAction = CustomSemanticsAction(label: 'Inner action');
+
+    final owner = SemanticsOwner(onSemanticsUpdate: (SemanticsUpdate update) {});
+    addTearDown(owner.dispose);
+
+    // Build: root → merge node → outer node → inner node
+    final root = SemanticsNode.root(owner: owner)
+      ..rect = const Rect.fromLTRB(0.0, 0.0, 100.0, 100.0);
+
+    final mergeNode = SemanticsNode()..rect = const Rect.fromLTRB(0.0, 0.0, 100.0, 100.0);
+    final outerNode = SemanticsNode()..rect = const Rect.fromLTRB(0.0, 0.0, 100.0, 100.0);
+    final innerNode = SemanticsNode()..rect = const Rect.fromLTRB(0.0, 0.0, 100.0, 100.0);
+
+    final innerConfig = SemanticsConfiguration()
+      ..isSemanticBoundary = true
+      ..customSemanticsActions = <CustomSemanticsAction, VoidCallback>{
+        innerAction: () => innerActivated = true,
+      };
+    final outerConfig = SemanticsConfiguration()
+      ..isSemanticBoundary = true
+      ..customSemanticsActions = <CustomSemanticsAction, VoidCallback>{
+        outerAction: () => outerActivated = true,
+      };
+    final mergeConfig = SemanticsConfiguration()
+      ..isSemanticBoundary = true
+      ..isMergingSemanticsOfDescendants = true;
+    final rootConfig = SemanticsConfiguration()..isSemanticBoundary = true;
+
+    innerNode.updateWith(config: innerConfig, childrenInInversePaintOrder: <SemanticsNode>[]);
+    outerNode.updateWith(config: outerConfig, childrenInInversePaintOrder: <SemanticsNode>[innerNode]);
+    mergeNode.updateWith(config: mergeConfig, childrenInInversePaintOrder: <SemanticsNode>[outerNode]);
+    root.updateWith(config: rootConfig, childrenInInversePaintOrder: <SemanticsNode>[mergeNode]);
+
+    final int innerActionId = CustomSemanticsAction.getIdentifier(innerAction);
+    final int outerActionId = CustomSemanticsAction.getIdentifier(outerAction);
+
+    // Dispatching the inner action should invoke the inner callback, not the outer.
+    owner.performAction(mergeNode.id, SemanticsAction.customAction, innerActionId);
+    expect(innerActivated, isTrue, reason: 'inner action callback should have been called');
+    expect(outerActivated, isFalse, reason: 'outer action callback should not have been called');
+
+    // Dispatching the outer action should invoke the outer callback, not the inner.
+    owner.performAction(mergeNode.id, SemanticsAction.customAction, outerActionId);
+    expect(outerActivated, isTrue, reason: 'outer action callback should have been called');
+    expect(innerActivated, isTrue, reason: 'inner action callback should still be true from before');
+  });
+
   test('Tags show up in debug properties', () {
     final actionNode = SemanticsNode()..tags = <SemanticsTag>{RenderViewport.useTwoPaneSemantics};
 

--- a/packages/flutter/test/semantics/semantics_test.dart
+++ b/packages/flutter/test/semantics/semantics_test.dart
@@ -992,6 +992,59 @@ void main() {
     expect(innerActivated, isTrue, reason: 'inner action callback should still be true from before');
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/183833
+  // Covers the case where the merge root itself owns a custom action that is
+  // different from the one being dispatched.  The outer guard must not stop
+  // the search prematurely just because the root has *some* custom action.
+  test('performAction walks into descendants when merge root has a different custom action', () {
+    var rootActivated = false;
+    var childActivated = false;
+
+    const rootAction = CustomSemanticsAction(label: 'Root action');
+    const childAction = CustomSemanticsAction(label: 'Child action');
+
+    final owner = SemanticsOwner(onSemanticsUpdate: (SemanticsUpdate update) {});
+    addTearDown(owner.dispose);
+
+    // Build: root → merge node (has rootAction) → child node (has childAction)
+    final root = SemanticsNode.root(owner: owner)
+      ..rect = const Rect.fromLTRB(0.0, 0.0, 100.0, 100.0);
+
+    final mergeNode = SemanticsNode()..rect = const Rect.fromLTRB(0.0, 0.0, 100.0, 100.0);
+    final childNode = SemanticsNode()..rect = const Rect.fromLTRB(0.0, 0.0, 100.0, 100.0);
+
+    final childConfig = SemanticsConfiguration()
+      ..isSemanticBoundary = true
+      ..customSemanticsActions = <CustomSemanticsAction, VoidCallback>{
+        childAction: () => childActivated = true,
+      };
+    final mergeConfig = SemanticsConfiguration()
+      ..isSemanticBoundary = true
+      ..isMergingSemanticsOfDescendants = true
+      ..customSemanticsActions = <CustomSemanticsAction, VoidCallback>{
+        rootAction: () => rootActivated = true,
+      };
+    final rootConfig = SemanticsConfiguration()..isSemanticBoundary = true;
+
+    childNode.updateWith(config: childConfig, childrenInInversePaintOrder: <SemanticsNode>[]);
+    mergeNode.updateWith(config: mergeConfig, childrenInInversePaintOrder: <SemanticsNode>[childNode]);
+    root.updateWith(config: rootConfig, childrenInInversePaintOrder: <SemanticsNode>[mergeNode]);
+
+    final int rootActionId = CustomSemanticsAction.getIdentifier(rootAction);
+    final int childActionId = CustomSemanticsAction.getIdentifier(childAction);
+
+    // Dispatching childAction must reach the child even though the merge root
+    // itself also has a custom action (rootAction).
+    owner.performAction(mergeNode.id, SemanticsAction.customAction, childActionId);
+    expect(childActivated, isTrue, reason: 'child action callback should have been called');
+    expect(rootActivated, isFalse, reason: 'root action callback should not have been called');
+
+    // Dispatching rootAction must stay on the merge root node.
+    owner.performAction(mergeNode.id, SemanticsAction.customAction, rootActionId);
+    expect(rootActivated, isTrue, reason: 'root action callback should have been called');
+    expect(childActivated, isTrue, reason: 'child action callback should still be true from before');
+  });
+
   test('Tags show up in debug properties', () {
     final actionNode = SemanticsNode()..tags = <SemanticsTag>{RenderViewport.useTwoPaneSemantics};
 


### PR DESCRIPTION
## Description

Fixes a bug where `MergeSemantics` with multiple descendants each registering **different** `CustomSemanticsAction`s would silently invoke the wrong callback (or no callback at all) when a non-first custom action was triggered by an accessibility service.

### Root cause

`SemanticsOwner._getSemanticsActionHandlerForId` walks descendants to find the handler for a merged node. The walk stopped at the **first** descendant that `_canPerformAction(SemanticsAction.customAction)`, regardless of which specific custom action was requested. Since `_canPerformAction` checks only whether _any_ custom action exists on that node, the outer node was always returned — even when the inner node owned the specific action being dispatched.

### Fix

Pass `args` (the custom action ID) through to `_getSemanticsActionHandlerForId`. When `action == SemanticsAction.customAction`, the walk now skips any node whose `_customSemanticsActions` map does not contain the specific requested action, continuing until the correct node is found.

The fix is a targeted 7-line change with no impact on non-custom-action dispatch paths.

### Before / After

```dart
// Two nested Semantics each with a different CustomSemanticsAction.
MergeSemantics(
  child: Semantics(
    customSemanticsActions: {outerAction: () => print('outer')},
    child: Semantics(
      customSemanticsActions: {innerAction: () => print('inner')},
      child: const Text('Test'),
    ),
  ),
)
```

| Action triggered | Before | After |
|---|---|---|
| `outerAction` | ✅ `outer` printed | ✅ `outer` printed |
| `innerAction` | ❌ Nothing printed | ✅ `inner` printed |

## Tests

Added a regression test in `test/semantics/semantics_test.dart` that directly calls `SemanticsOwner.performAction` with each action ID and asserts the correct callback fires.

All 47 existing semantics tests continue to pass.

Fixes https://github.com/flutter/flutter/issues/183833