### PR TITLE
[flutter_tools] Preprovision Android NDK only for flavored builds

### DIFF
--- a/dev/devicelab/bin/tasks/gradle_plugin_fat_apk_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_plugin_fat_apk_test.dart
@@ -154,15 +154,12 @@ Future<void> main() async {
         section('AGP cxx build artifacts');
 
         final String defaultPath = path.join(project.rootPath, 'android', 'app', '.cxx');
-
         final String modifiedPath = path.join(project.rootPath, 'build', '.cxx');
         if (Directory(defaultPath).existsSync()) {
           throw TaskResult.failure('Producing unexpected build artifacts in $defaultPath');
         }
-        if (!Directory(modifiedPath).existsSync()) {
-          throw TaskResult.failure(
-            'Not producing external native build output directory in $modifiedPath',
-          );
+        if (Directory(modifiedPath).existsSync()) {
+          throw TaskResult.failure('Producing unexpected build artifacts in $modifiedPath');
         }
       });
 

--- a/dev/devicelab/bin/tasks/gradle_plugin_fat_apk_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_plugin_fat_apk_test.dart
@@ -158,8 +158,10 @@ Future<void> main() async {
         if (Directory(defaultPath).existsSync()) {
           throw TaskResult.failure('Producing unexpected build artifacts in $defaultPath');
         }
-        if (Directory(modifiedPath).existsSync()) {
-          throw TaskResult.failure('Producing unexpected build artifacts in $modifiedPath');
+        if (!Directory(modifiedPath).existsSync()) {
+          throw TaskResult.failure(
+            'Not producing external native build output directory in $modifiedPath',
+          );
         }
       });
 

--- a/packages/flutter_tools/gradle/src/main/kotlin/FlutterPlugin.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/FlutterPlugin.kt
@@ -299,6 +299,7 @@ class FlutterPlugin : Plugin<Project> {
         FlutterPluginUtils.addTaskForKGPVersion(projectToAddTasksTo)
         if (FlutterPluginUtils.isFlutterAppProject(projectToAddTasksTo)) {
             FlutterPluginUtils.addTaskForPrintBuildVariants(projectToAddTasksTo)
+            FlutterPluginUtils.addTaskForPrintNdkVersion(projectToAddTasksTo)
             FlutterPluginUtils.addTasksForOutputsAppLinkSettings(projectToAddTasksTo)
         }
 

--- a/packages/flutter_tools/gradle/src/main/kotlin/FlutterPluginUtils.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/FlutterPluginUtils.kt
@@ -39,6 +39,9 @@ object FlutterPluginUtils {
     internal const val PROP_LOCAL_ENGINE_BUILD_MODE = "local-engine-build-mode"
     internal const val PROP_TARGET_PLATFORM = "target-platform"
     internal const val PROP_DISABLE_ABI_FILTERING = "disable-abi-filtering"
+    internal const val PROP_PREPROVISIONED_NDK_VERSION = "flutter-preprovisioned-ndk-version"
+    internal const val TASK_PRINT_NDK_VERSION = "printNdkVersion"
+    internal const val NDK_VERSION_OUTPUT_PREFIX = "NdkVersion: "
 
     /**
      * The URL for documentation for general information on migration to built-in Kotlin.
@@ -787,6 +790,14 @@ object FlutterPluginUtils {
         gradleProject: Project,
         flutterSdkRootPath: String
     ) {
+        if (isFlutterAppProject(gradleProject) && isInvokingMetadataNdkVersionTask(gradleProject)) {
+            return
+        }
+
+        if (isFlutterAppProject(gradleProject) && hasPreprovisionedNdkVersion(gradleProject)) {
+            return
+        }
+
         // If the project is already configuring a native build, we don't need to do anything.
         val gradleProjectAndroidExtension = getLegacyAndroidExtension(gradleProject)
         val forcingNotRequired: Boolean =
@@ -828,6 +839,18 @@ object FlutterPluginUtils {
             )
         }
     }
+
+    @JvmStatic
+    @JvmName("hasPreprovisionedNdkVersion")
+    internal fun hasPreprovisionedNdkVersion(project: Project): Boolean =
+        project.findProperty(PROP_PREPROVISIONED_NDK_VERSION)?.toString() != null
+
+    @JvmStatic
+    @JvmName("isInvokingMetadataNdkVersionTask")
+    internal fun isInvokingMetadataNdkVersionTask(project: Project): Boolean =
+        project.gradle.startParameter.taskNames.any { taskName ->
+            taskName == TASK_PRINT_NDK_VERSION || taskName.endsWith(":$TASK_PRINT_NDK_VERSION")
+        }
 
     @JvmStatic
     @JvmName("isFlutterAppProject")
@@ -957,6 +980,27 @@ object FlutterPluginUtils {
                 variantNames.get().forEach { name ->
                     println("BuildVariant: $name")
                 }
+            }
+        }
+    }
+
+    // Add a task that can be called on Flutter projects that prints the effective ndkVersion
+    // configured for the Android app.
+    //
+    // This task prints the version in this format:
+    //
+    // NdkVersion: 28.2.13676358
+    //
+    // Format of the output of this task is used by Flutter tool Android NDK preflight.
+    @JvmStatic
+    @JvmName("addTaskForPrintNdkVersion")
+    internal fun addTaskForPrintNdkVersion(project: Project) {
+        val androidExtension = getAndroidApplicationExtension(project)
+        project.tasks.register(TASK_PRINT_NDK_VERSION) {
+            description = "Prints out the configured ndkVersion for this Android project"
+            doLast {
+                val configuredNdkVersion = androidExtension.ndkVersion ?: FlutterExtension().ndkVersion
+                println("$NDK_VERSION_OUTPUT_PREFIX$configuredNdkVersion")
             }
         }
     }

--- a/packages/flutter_tools/gradle/src/main/kotlin/FlutterPluginUtils.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/FlutterPluginUtils.kt
@@ -999,7 +999,7 @@ object FlutterPluginUtils {
         project.tasks.register(TASK_PRINT_NDK_VERSION) {
             description = "Prints out the configured ndkVersion for this Android project"
             doLast {
-                val configuredNdkVersion = androidExtension.ndkVersion ?: FlutterExtension().ndkVersion
+                val configuredNdkVersion = androidExtension.ndkVersion ?: getFlutterExtensionOrNull(project)?.ndkVersion
                 println("$NDK_VERSION_OUTPUT_PREFIX$configuredNdkVersion")
             }
         }

--- a/packages/flutter_tools/gradle/src/test/kotlin/FlutterPluginTest.kt
+++ b/packages/flutter_tools/gradle/src/test/kotlin/FlutterPluginTest.kt
@@ -122,6 +122,7 @@ class FlutterPluginTest {
         verify { project.tasks.register("generateLockfiles", any()) }
         verify { project.tasks.register("javaVersion", any()) }
         verify { project.tasks.register("printBuildVariants", any()) }
+        verify { project.tasks.register("printNdkVersion", any()) }
     }
 
     @Test

--- a/packages/flutter_tools/gradle/src/test/kotlin/FlutterPluginUtilsTest.kt
+++ b/packages/flutter_tools/gradle/src/test/kotlin/FlutterPluginUtilsTest.kt
@@ -1616,6 +1616,7 @@ class FlutterPluginUtilsTest {
         val project = mockk<Project>()
         val mockCmakeOptions = mockk<CmakeOptions>()
         val mockDefaultConfig = mockk<DefaultConfig>()
+        every { project.extensions.findByType(ApplicationExtension::class.java) } returns null
         every {
             project.extensions
                 .findByType(BaseExtension::class.java)!!
@@ -1635,12 +1636,57 @@ class FlutterPluginUtilsTest {
     }
 
     @Test
+    fun `forceNdkDownload skips when project has a preprovisioned ndk property`() {
+        val project = mockk<Project>()
+        val mockCmakeOptions = mockk<CmakeOptions>()
+        val mockDefaultConfig = mockk<DefaultConfig>()
+        every {
+            project.extensions
+                .findByType(BaseExtension::class.java)!!
+                .externalNativeBuild.cmake
+        } returns mockCmakeOptions
+        every { project.extensions.findByType(BaseExtension::class.java)!!.defaultConfig } returns mockDefaultConfig
+        every { mockCmakeOptions.path } returns null
+        every { project.findProperty(FlutterPluginUtils.PROP_PREPROVISIONED_NDK_VERSION) } returns "29.0.13846066"
+        every { project.gradle.startParameter.taskNames } returns emptyList()
+        every { project.extensions.findByType(ApplicationExtension::class.java) } returns mockk(relaxed = true)
+
+        FlutterPluginUtils.forceNdkDownload(project, "/base/path")
+
+        verify(exactly = 0) { mockCmakeOptions.path(any()) }
+        verify { mockDefaultConfig wasNot called }
+    }
+
+    @Test
+    fun `forceNdkDownload skips when invoking the ndk metadata task`() {
+        val project = mockk<Project>()
+        val mockCmakeOptions = mockk<CmakeOptions>()
+        val mockDefaultConfig = mockk<DefaultConfig>()
+        every {
+            project.extensions
+                .findByType(BaseExtension::class.java)!!
+                .externalNativeBuild.cmake
+        } returns mockCmakeOptions
+        every { project.extensions.findByType(BaseExtension::class.java)!!.defaultConfig } returns mockDefaultConfig
+        every { mockCmakeOptions.path } returns null
+        every { project.findProperty(FlutterPluginUtils.PROP_PREPROVISIONED_NDK_VERSION) } returns null
+        every { project.gradle.startParameter.taskNames } returns listOf(FlutterPluginUtils.TASK_PRINT_NDK_VERSION)
+        every { project.extensions.findByType(ApplicationExtension::class.java) } returns mockk(relaxed = true)
+
+        FlutterPluginUtils.forceNdkDownload(project, "/base/path")
+
+        verify(exactly = 0) { mockCmakeOptions.path(any()) }
+        verify { mockDefaultConfig wasNot called }
+    }
+
+    @Test
     fun `forceNdkDownload sets externalNativeBuild properties`() {
         val project = mockk<Project>()
         val mockCmakeOptions = mockk<CmakeOptions>()
         val mockDefaultConfig = mockk<DefaultConfig>()
         val mockDirectoryProperty = mockk<DirectoryProperty>()
         val mockDirectory = mockk<Directory>()
+        every { project.extensions.findByType(ApplicationExtension::class.java) } returns null
         every {
             project.extensions
                 .findByType(BaseExtension::class.java)!!
@@ -1681,6 +1727,29 @@ class FlutterPluginUtilsTest {
                 "--no-warn-unused-cli",
                 "-DCMAKE_BUILD_TYPE=Debug"
             )
+        }
+    }
+
+    @Test
+    fun `addTaskForPrintNdkVersion adds task for printing ndk version`() {
+        val project = mockk<Project>()
+        val androidExtension = mockk<ApplicationExtension>()
+        every { androidExtension.ndkVersion } returns "29.0.13846066"
+        every { project.extensions.getByType(ApplicationExtension::class.java) } returns androidExtension
+        every { project.tasks.register(any(), any<Action<Task>>()) } returns mockk()
+        val captureSlot = slot<Action<Task>>()
+
+        FlutterPluginUtils.addTaskForPrintNdkVersion(project)
+
+        verify { project.tasks.register("printNdkVersion", capture(captureSlot)) }
+        val mockTask = mockk<Task>()
+        every { mockTask.description = any() } returns Unit
+        every { mockTask.doLast(any<Action<Task>>()) } returns mockk()
+
+        captureSlot.captured.execute(mockTask)
+
+        verify {
+            mockTask.description = "Prints out the configured ndkVersion for this Android project"
         }
     }
 

--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -353,64 +353,69 @@ class AndroidSdk {
   /// 5. Look for the default install location inside the Android SDK:
   ///    [directory]/ndk/\<version\>/. If multiple versions exist, use the
   ///    newest.
+  Iterable<Directory> getNdkDirectoriesInResolutionOrder({Platform? platform, Config? config}) {
+    platform ??= globals.platform;
+    config ??= globals.config;
+
+    final ndkDirectories = <Directory>[];
+    String? androidNdkHomeDir;
+    if (config.containsKey('android-ndk')) {
+      androidNdkHomeDir = config.getValue('android-ndk') as String?;
+    } else if (platform.environment.containsKey(kAndroidNdkHome)) {
+      androidNdkHomeDir = platform.environment[kAndroidNdkHome];
+    } else if (platform.environment.containsKey(kAndroidNdkPath)) {
+      androidNdkHomeDir = platform.environment[kAndroidNdkPath];
+    } else if (platform.environment.containsKey(kAndroidNdkRoot)) {
+      androidNdkHomeDir = platform.environment[kAndroidNdkRoot];
+    }
+    if (androidNdkHomeDir != null) {
+      ndkDirectories.add(directory.fileSystem.directory(androidNdkHomeDir));
+    }
+
+    // Look for the default install location of the NDK inside the Android
+    // SDK when installed through `sdkmanager` or Android studio.
+    final Directory ndk = directory.childDirectory('ndk');
+    if (!ndk.existsSync()) {
+      return ndkDirectories;
+    }
+    final List<Version> ndkVersions =
+        ndk
+            .listSync()
+            .map((FileSystemEntity entity) {
+              try {
+                return Version.parse(entity.basename);
+              } on Exception {
+                return null;
+              }
+            })
+            .whereType<Version>()
+            .toList()
+          // Use latest NDK first.
+          ..sort((Version a, Version b) => -a.compareTo(b));
+    for (final ndkVersion in ndkVersions) {
+      ndkDirectories.add(ndk.childDirectory(ndkVersion.toString()));
+    }
+    return ndkDirectories;
+  }
+
   String? getNdkBinaryPath(String binaryName, {Platform? platform, Config? config}) {
     platform ??= globals.platform;
     config ??= globals.config;
-    Directory? findAndroidNdkHomeDir() {
-      String? androidNdkHomeDir;
-      if (config!.containsKey('android-ndk')) {
-        androidNdkHomeDir = config.getValue('android-ndk') as String?;
-      } else if (platform!.environment.containsKey(kAndroidNdkHome)) {
-        androidNdkHomeDir = platform.environment[kAndroidNdkHome];
-      } else if (platform.environment.containsKey(kAndroidNdkPath)) {
-        androidNdkHomeDir = platform.environment[kAndroidNdkPath];
-      } else if (platform.environment.containsKey(kAndroidNdkRoot)) {
-        androidNdkHomeDir = platform.environment[kAndroidNdkRoot];
+    for (final Directory androidNdkHomeDir in getNdkDirectoriesInResolutionOrder(
+      platform: platform,
+      config: config,
+    )) {
+      final File executable = androidNdkHomeDir
+          .childDirectory('toolchains')
+          .childDirectory('llvm')
+          .childDirectory('prebuilt')
+          .childDirectory(_llvmHostDirectoryName[platform.operatingSystem]!)
+          .childDirectory('bin')
+          .childFile(binaryName);
+      if (executable.existsSync()) {
+        // LLVM missing in this NDK version.
+        return executable.path;
       }
-      if (androidNdkHomeDir != null) {
-        return directory.fileSystem.directory(androidNdkHomeDir);
-      }
-
-      // Look for the default install location of the NDK inside the Android
-      // SDK when installed through `sdkmanager` or Android studio.
-      final Directory ndk = directory.childDirectory('ndk');
-      if (!ndk.existsSync()) {
-        return null;
-      }
-      final List<Version> ndkVersions =
-          ndk
-              .listSync()
-              .map((FileSystemEntity entity) {
-                try {
-                  return Version.parse(entity.basename);
-                } on Exception {
-                  return null;
-                }
-              })
-              .whereType<Version>()
-              .toList()
-            // Use latest NDK first.
-            ..sort((Version a, Version b) => -a.compareTo(b));
-      if (ndkVersions.isEmpty) {
-        return null;
-      }
-      return ndk.childDirectory(ndkVersions.first.toString());
-    }
-
-    final Directory? androidNdkHomeDir = findAndroidNdkHomeDir();
-    if (androidNdkHomeDir == null) {
-      return null;
-    }
-    final File executable = androidNdkHomeDir
-        .childDirectory('toolchains')
-        .childDirectory('llvm')
-        .childDirectory('prebuilt')
-        .childDirectory(_llvmHostDirectoryName[platform.operatingSystem]!)
-        .childDirectory('bin')
-        .childFile(binaryName);
-    if (executable.existsSync()) {
-      // LLVM missing in this NDK version.
-      return executable.path;
     }
     return null;
   }
@@ -552,6 +557,41 @@ class AndroidSdk {
 
   @override
   String toString() => 'AndroidSdk: $directory';
+}
+
+extension AndroidSdkNdkHelpers on AndroidSdk {
+  /// Returns whether the Android SDK already contains the requested NDK version.
+  bool hasNdkVersion(String version) {
+    final Directory ndkDirectory = directory.childDirectory('ndk').childDirectory(version);
+    return ndkDirectory.childFile('source.properties').existsSync();
+  }
+
+  /// Installs a specific Android SDK component with sdkmanager.
+  Future<RunResult> installSdkComponent(
+    String component, {
+    Java? java,
+    ProcessUtils? processUtils,
+  }) async {
+    processUtils ??= globals.processUtils;
+    final String? executable = sdkManagerPath;
+    if (executable == null || !globals.processManager.canRun(executable)) {
+      throwToolExit(
+        'Android sdkmanager not found. Update to the latest Android SDK and ensure that '
+        'the cmdline-tools are installed to resolve this.',
+      );
+    }
+    return processUtils.run(<String>[
+      executable,
+      '--sdk_root=${directory.path}',
+      '--install',
+      component,
+    ], environment: java?.environment);
+  }
+
+  /// Installs the requested NDK version via sdkmanager.
+  Future<RunResult> installNdkVersion(String version, {Java? java, ProcessUtils? processUtils}) {
+    return installSdkComponent('ndk;$version', java: java, processUtils: processUtils);
+  }
 }
 
 class AndroidSdkVersion implements Comparable<AndroidSdkVersion> {

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -30,6 +30,7 @@ import '../flutter_manifest.dart';
 import '../globals.dart' as globals;
 import '../project.dart';
 import 'android_builder.dart';
+import 'android_sdk.dart';
 import 'android_studio.dart';
 import 'gradle_errors.dart';
 import 'gradle_utils.dart';
@@ -55,6 +56,10 @@ import 'migrations/top_level_gradle_build_file_migration.dart';
 final _kBuildVariantRegex = RegExp('^BuildVariant: (?<$_kBuildVariantRegexGroupName>.*)\$');
 const _kBuildVariantRegexGroupName = 'variant';
 const _kBuildVariantTaskName = 'printBuildVariants';
+final _kNdkVersionRegex = RegExp('^NdkVersion: (?<$_kNdkVersionRegexGroupName>.*)\$');
+const _kNdkVersionRegexGroupName = 'ndkVersion';
+const _kNdkVersionTaskName = 'printNdkVersion';
+const _kPreprovisionedNdkVersionProperty = 'flutter-preprovisioned-ndk-version';
 @visibleForTesting
 const failedToStripDebugSymbolsErrorMessage = r'''
 Release app bundle failed to strip debug symbols from native libraries.
@@ -273,6 +278,7 @@ class AndroidGradleBuilder implements AndroidBuilder {
     required FlutterProject project,
     required List<GradleHandledError> localGradleErrors,
     required String gradleExecutablePath,
+    bool printOutput = true,
     int retry = 0,
     VoidCallback? preRunTask,
     VoidCallback? postRunTask,
@@ -335,7 +341,7 @@ class AndroidGradleBuilder implements AndroidBuilder {
         }
       }
       // Pipe stdout/stderr from Gradle.
-      return line;
+      return printOutput ? line : null;
     }
 
     final Status status = _logger.startProgress("Running Gradle task '$taskName'...");
@@ -395,6 +401,7 @@ class AndroidGradleBuilder implements AndroidBuilder {
               postRunTask: postRunTask,
               localGradleErrors: localGradleErrors,
               gradleExecutablePath: gradleExecutablePath,
+              printOutput: printOutput,
               retry: retry,
               project: project,
               maxRetries: maxRetries,
@@ -567,6 +574,16 @@ class AndroidGradleBuilder implements AndroidBuilder {
     }
     if (androidBuildInfo.splitPerAbi) {
       options.add('-Psplit-per-abi=true');
+    }
+    final String? preprovisionedNdkVersion = _shouldPreprovisionAndroidNdk(buildInfo)
+        ? await _preprovisionAndroidNdkIfNeeded(
+            project: project,
+            gradleExecutablePath: gradleExecutablePath,
+            buildInfo: buildInfo,
+          )
+        : null;
+    if (preprovisionedNdkVersion != null) {
+      options.add('-P$_kPreprovisionedNdkVersionProperty=$preprovisionedNdkVersion');
     }
     late Stopwatch sw;
     final int exitCode = await _runGradleTask(
@@ -905,6 +922,129 @@ class AndroidGradleBuilder implements AndroidBuilder {
       'Built ${_fileSystem.path.relative(repoDirectory.path)}',
       color: TerminalColor.green,
     );
+  }
+
+  Future<String?> _preprovisionAndroidNdkIfNeeded({
+    required FlutterProject project,
+    required String gradleExecutablePath,
+    required BuildInfo buildInfo,
+  }) async {
+    final AndroidSdk? androidSdk = globals.androidSdk;
+    if (androidSdk == null || !androidSdk.directory.existsSync()) {
+      return null;
+    }
+
+    final String? requiredNdkVersion = await _getNdkVersion(
+      project: project,
+      gradleExecutablePath: gradleExecutablePath,
+      buildInfo: buildInfo,
+    );
+    if (requiredNdkVersion == null) {
+      return null;
+    }
+
+    if (androidSdk.hasNdkVersion(requiredNdkVersion)) {
+      return requiredNdkVersion;
+    }
+
+    if (!androidSdk.cmdlineToolsAvailable) {
+      throwToolExit(
+        'Android sdkmanager not found. Update to the latest Android SDK and ensure that '
+        'the cmdline-tools are installed to resolve this.',
+      );
+    }
+
+    if (!androidSdk.licensesAvailable) {
+      throwToolExit(
+        'Unable to download needed Android SDK components because the Android SDK licenses have '
+        'not been accepted.\n\nTo resolve this, please run the following command in a Terminal:\n'
+        'flutter doctor --android-licenses',
+      );
+    }
+
+    final Status status = _logger.startProgress(
+      "Ensuring Android NDK '$requiredNdkVersion' is installed...",
+    );
+    try {
+      final RunResult result = await androidSdk.installNdkVersion(
+        requiredNdkVersion,
+        java: _java,
+        processUtils: _processUtils,
+      );
+      if (result.exitCode != 0) {
+        _logger.printTrace(
+          'Android sdkmanager failed while installing NDK $requiredNdkVersion.\n'
+          'stdout: ${result.stdout}\n'
+          'stderr: ${result.stderr}',
+        );
+        throwToolExit(
+          'Unable to download needed Android NDK $requiredNdkVersion.\n'
+          'Please check that the Android SDK command-line tools are installed and that SDK '
+          'licenses have been accepted with `flutter doctor --android-licenses`.',
+        );
+      }
+    } finally {
+      status.stop();
+    }
+
+    if (!androidSdk.hasNdkVersion(requiredNdkVersion)) {
+      throwToolExit(
+        'Android NDK $requiredNdkVersion could not be found in ${androidSdk.directory.path} '
+        'after sdkmanager completed.',
+      );
+    }
+
+    return requiredNdkVersion;
+  }
+
+  Future<String?> _getNdkVersion({
+    required FlutterProject project,
+    required String gradleExecutablePath,
+    required BuildInfo buildInfo,
+  }) async {
+    late Stopwatch sw;
+    var exitCode = 1;
+    String? result;
+
+    try {
+      exitCode = await _runGradleTask(
+        _kNdkVersionTaskName,
+        preRunTask: () {
+          sw = Stopwatch()..start();
+        },
+        postRunTask: () {
+          final Duration elapsedDuration = sw.elapsed;
+          _analytics.send(
+            Event.timing(
+              workflow: 'print',
+              variableName: 'android ndk version',
+              elapsedMilliseconds: elapsedDuration.inMilliseconds,
+            ),
+          );
+        },
+        options: <String>[
+          '-q',
+          if (buildInfo.androidSkipBuildDependencyValidation) '-PskipDependencyChecks=true',
+        ],
+        project: project,
+        localGradleErrors: gradleErrors,
+        gradleExecutablePath: gradleExecutablePath,
+        printOutput: false,
+        outputParser: (String line) {
+          if (_kNdkVersionRegex.firstMatch(line) case final RegExpMatch match) {
+            result = match.namedGroup(_kNdkVersionRegexGroupName);
+          }
+        },
+      );
+    } on Error catch (error) {
+      _logger.printTrace('Failed to query Android ndkVersion: $error');
+    }
+
+    if (exitCode != 0) {
+      return null;
+    }
+
+    return result;
   }
 
   @override
@@ -1363,4 +1503,9 @@ String _getTargetPlatformByLocalEnginePath(String engineOutPath) {
     result = 'android-arm64';
   }
   return result;
+}
+
+bool _shouldPreprovisionAndroidNdk(BuildInfo buildInfo) {
+  final String? flavor = buildInfo.flavor;
+  return flavor != null && flavor.isNotEmpty;
 }

--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -655,6 +655,9 @@ final missingNdkSourcePropertiesFile = GradleHandledError(
     ${globals.logger.terminal.warningMark} This is likely due to a malformed download of the NDK.
     This can be fixed by deleting the local NDK copy at: $path
     and allowing the Android Gradle Plugin to automatically re-download it.
+
+    If this keeps happening after a clean retry, Flutter's tool-side Android NDK provisioning
+    may have failed or been skipped before Gradle fell back to AGP's automatic download path.
     ''', title: _boxTitle);
         return GradleBuildStatus.exit;
       },

--- a/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
@@ -1499,7 +1499,7 @@ void main() {
               .directory(fileSystem.path.join(sdkPath(), 'cmdline-tools', 'latest', 'bin'))
               .childFile(apkAnalyzerBinaryName)
               .createSync(recursive: true);
-          final AndroidSdk sdk = AndroidSdk(
+          final sdk = AndroidSdk(
             fileSystem.directory(sdkPath()),
             java: FakeJava(),
             fileSystem: fileSystem,
@@ -1591,7 +1591,7 @@ void main() {
               .directory(fileSystem.path.join(sdkPath(), 'cmdline-tools', 'latest', 'bin'))
               .childFile(apkAnalyzerBinaryName)
               .createSync(recursive: true);
-          final AndroidSdk sdk = AndroidSdk(
+          final sdk = AndroidSdk(
             fileSystem.directory(sdkPath()),
             java: FakeJava(),
             fileSystem: fileSystem,

--- a/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
@@ -20,12 +20,14 @@ import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/base/user_messages.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/project.dart';
 import 'package:test/fake.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/context.dart' as test_context;
 import '../../src/fake_process_manager.dart';
 import '../../src/fakes.dart';
 
@@ -58,6 +60,362 @@ void main() {
         fakeFlutterVersion: FakeFlutterVersion(),
       );
     });
+
+    String sdkPath() => fileSystem.directory('android-sdk').absolute.path;
+    String missingSdkPath() => fileSystem.directory('nonexistent-android-sdk').absolute.path;
+    String sdkManagerPath() => fileSystem.path.join(
+      sdkPath(),
+      'cmdline-tools',
+      'latest',
+      'bin',
+      globals.platform.isWindows ? 'sdkmanager.bat' : 'sdkmanager',
+    );
+    String sdkLicensesPath() => fileSystem.path.join(sdkPath(), 'licenses');
+    String ndkPath(String version) => fileSystem.path.join(sdkPath(), 'ndk', version);
+    String apkAnalyzerPath() =>
+        fileSystem.path.join(sdkPath(), 'cmdline-tools', 'latest', 'bin', apkAnalyzerBinaryName);
+
+    void testUsingContext(
+      String description,
+      dynamic Function() body, {
+      Map<Type, Generator> overrides = const <Type, Generator>{},
+    }) {
+      test_context.testUsingContext(
+        description,
+        body,
+        overrides: <Type, Generator>{
+          AndroidSdk: () => AndroidSdk(
+            fileSystem.directory(missingSdkPath()),
+            java: FakeJava(),
+            fileSystem: fileSystem,
+          ),
+          ProcessManager: () => processManager,
+          ...overrides,
+        },
+      );
+    }
+
+    late AndroidSdk sdkForPreprovisionBuild;
+    testUsingContext(
+      'build apk preprovisions the configured ndk and passes the gradle property',
+      () async {
+        final builder = AndroidGradleBuilder(
+          java: FakeJava(),
+          logger: logger,
+          processManager: processManager,
+          fileSystem: fileSystem,
+          artifacts: Artifacts.test(),
+          analytics: fakeAnalytics,
+          gradleUtils: FakeGradleUtils(),
+          platform: FakePlatform(),
+          androidStudio: FakeAndroidStudio(),
+        );
+        processManager.addCommand(
+          const FakeCommand(
+            command: <String>['gradlew', '-q', 'printNdkVersion'],
+            stdout: 'NdkVersion: 29.0.13846066\n',
+          ),
+        );
+        processManager.addCommand(
+          FakeCommand(
+            command: <String>[
+              sdkManagerPath(),
+              '--sdk_root=${sdkPath()}',
+              '--install',
+              'ndk;29.0.13846066',
+            ],
+            onRun: (_) {
+              fileSystem
+                  .directory(ndkPath('29.0.13846066'))
+                  .childFile('source.properties')
+                  .createSync(recursive: true);
+            },
+          ),
+        );
+        processManager.addCommand(
+          const FakeCommand(
+            command: <String>[
+              'gradlew',
+              '-q',
+              '-Ptarget-platform=android-arm,android-arm64,android-x64',
+              '-Ptarget=lib/main.dart',
+              '-Pbase-application-name=android.app.Application',
+              '-Pdart-obfuscation=false',
+              '-Ptrack-widget-creation=false',
+              '-Ptree-shake-icons=false',
+              '-Pflutter-preprovisioned-ndk-version=29.0.13846066',
+              'assembleDevRelease',
+            ],
+          ),
+        );
+
+        fileSystem.file('android/gradlew').createSync(recursive: true);
+        fileSystem.directory('android').childFile('gradle.properties').createSync(recursive: true);
+        fileSystem.file('android/build.gradle').createSync(recursive: true);
+        fileSystem.directory('android').childDirectory('app').childFile('build.gradle')
+          ..createSync(recursive: true)
+          ..writeAsStringSync('apply from: irrelevant/flutter.gradle');
+        fileSystem
+            .directory('build')
+            .childDirectory('app')
+            .childDirectory('outputs')
+            .childDirectory('flutter-apk')
+            .childFile('app-dev-release.apk')
+            .createSync(recursive: true);
+
+        final FlutterProject project = FlutterProject.fromDirectoryTest(
+          fileSystem.currentDirectory,
+        );
+        project.android.appManifestFile
+          ..createSync(recursive: true)
+          ..writeAsStringSync(minimalV2EmbeddingManifest);
+
+        await builder.buildGradleApp(
+          project: project,
+          androidBuildInfo: const AndroidBuildInfo(
+            BuildInfo(
+              BuildMode.release,
+              'dev',
+              treeShakeIcons: false,
+              packageConfigPath: '.dart_tool/package_config.json',
+            ),
+          ),
+          target: 'lib/main.dart',
+          isBuildingBundle: false,
+          configOnly: false,
+          localGradleErrors: const <GradleHandledError>[],
+        );
+
+        expect(sdkForPreprovisionBuild.hasNdkVersion('29.0.13846066'), isTrue);
+        expect(processManager, hasNoRemainingExpectations);
+      },
+      overrides: <Type, Generator>{
+        AndroidSdk: () {
+          fileSystem.directory(sdkPath()).createSync(recursive: true);
+          fileSystem.directory(sdkLicensesPath()).createSync(recursive: true);
+          fileSystem
+              .directory(fileSystem.path.join(sdkPath(), 'cmdline-tools', 'latest', 'bin'))
+              .childFile(globals.platform.isWindows ? 'sdkmanager.bat' : 'sdkmanager')
+              .createSync(recursive: true);
+          sdkForPreprovisionBuild = AndroidSdk(
+            fileSystem.directory(sdkPath()),
+            java: FakeJava(),
+            fileSystem: fileSystem,
+          );
+          return sdkForPreprovisionBuild;
+        },
+        AndroidStudio: () => FakeAndroidStudio(),
+      },
+    );
+
+    testUsingContext(
+      'build apk forwards skip dependency checks to printNdkVersion',
+      () async {
+        final builder = AndroidGradleBuilder(
+          java: FakeJava(),
+          logger: logger,
+          processManager: processManager,
+          fileSystem: fileSystem,
+          artifacts: Artifacts.test(),
+          analytics: fakeAnalytics,
+          gradleUtils: FakeGradleUtils(),
+          platform: FakePlatform(),
+          androidStudio: FakeAndroidStudio(),
+        );
+        processManager.addCommand(
+          const FakeCommand(
+            command: <String>['gradlew', '-q', '-PskipDependencyChecks=true', 'printNdkVersion'],
+            stdout: 'NdkVersion: 29.0.13846066\n',
+          ),
+        );
+        processManager.addCommand(
+          FakeCommand(
+            command: <String>[
+              sdkManagerPath(),
+              '--sdk_root=${sdkPath()}',
+              '--install',
+              'ndk;29.0.13846066',
+            ],
+            onRun: (_) {
+              fileSystem
+                  .directory(ndkPath('29.0.13846066'))
+                  .childFile('source.properties')
+                  .createSync(recursive: true);
+            },
+          ),
+        );
+        processManager.addCommand(
+          const FakeCommand(
+            command: <String>[
+              'gradlew',
+              '-q',
+              '-PskipDependencyChecks=true',
+              '-Ptarget-platform=android-arm,android-arm64,android-x64',
+              '-Ptarget=lib/main.dart',
+              '-Pbase-application-name=android.app.Application',
+              '-Pdart-obfuscation=false',
+              '-Ptrack-widget-creation=false',
+              '-Ptree-shake-icons=false',
+              '-Pflutter-preprovisioned-ndk-version=29.0.13846066',
+              'assembleDevRelease',
+            ],
+          ),
+        );
+
+        fileSystem.file('android/gradlew').createSync(recursive: true);
+        fileSystem.directory('android').childFile('gradle.properties').createSync(recursive: true);
+        fileSystem.file('android/build.gradle').createSync(recursive: true);
+        fileSystem.directory('android').childDirectory('app').childFile('build.gradle')
+          ..createSync(recursive: true)
+          ..writeAsStringSync('apply from: irrelevant/flutter.gradle');
+        fileSystem
+            .directory('build')
+            .childDirectory('app')
+            .childDirectory('outputs')
+            .childDirectory('flutter-apk')
+            .childFile('app-dev-release.apk')
+            .createSync(recursive: true);
+
+        final FlutterProject project = FlutterProject.fromDirectoryTest(
+          fileSystem.currentDirectory,
+        );
+        project.android.appManifestFile
+          ..createSync(recursive: true)
+          ..writeAsStringSync(minimalV2EmbeddingManifest);
+
+        await builder.buildGradleApp(
+          project: project,
+          androidBuildInfo: const AndroidBuildInfo(
+            BuildInfo(
+              BuildMode.release,
+              'dev',
+              treeShakeIcons: false,
+              packageConfigPath: '.dart_tool/package_config.json',
+              androidSkipBuildDependencyValidation: true,
+            ),
+          ),
+          target: 'lib/main.dart',
+          isBuildingBundle: false,
+          configOnly: false,
+          localGradleErrors: const <GradleHandledError>[],
+        );
+
+        expect(processManager, hasNoRemainingExpectations);
+      },
+      overrides: <Type, Generator>{
+        AndroidSdk: () {
+          fileSystem.directory(sdkPath()).createSync(recursive: true);
+          fileSystem.directory(sdkLicensesPath()).createSync(recursive: true);
+          fileSystem
+              .directory(fileSystem.path.join(sdkPath(), 'cmdline-tools', 'latest', 'bin'))
+              .childFile(globals.platform.isWindows ? 'sdkmanager.bat' : 'sdkmanager')
+              .createSync(recursive: true);
+          return AndroidSdk(
+            fileSystem.directory(sdkPath()),
+            java: FakeJava(),
+            fileSystem: fileSystem,
+          );
+        },
+        AndroidStudio: () => FakeAndroidStudio(),
+      },
+    );
+
+    late AndroidSdk sdkForFailedQuery;
+    testUsingContext(
+      'build apk continues without ndk property when printNdkVersion fails',
+      () async {
+        final builder = AndroidGradleBuilder(
+          java: FakeJava(),
+          logger: logger,
+          processManager: processManager,
+          fileSystem: fileSystem,
+          artifacts: Artifacts.test(),
+          analytics: fakeAnalytics,
+          gradleUtils: FakeGradleUtils(),
+          platform: FakePlatform(),
+          androidStudio: FakeAndroidStudio(),
+        );
+        processManager.addCommand(
+          const FakeCommand(
+            command: <String>['gradlew', '-q', 'printNdkVersion'],
+            stderr: 'Task failed\n',
+            exitCode: 1,
+          ),
+        );
+        processManager.addCommand(
+          const FakeCommand(
+            command: <String>[
+              'gradlew',
+              '-q',
+              '-Ptarget-platform=android-arm,android-arm64,android-x64',
+              '-Ptarget=lib/main.dart',
+              '-Pbase-application-name=android.app.Application',
+              '-Pdart-obfuscation=false',
+              '-Ptrack-widget-creation=false',
+              '-Ptree-shake-icons=false',
+              'assembleDevRelease',
+            ],
+          ),
+        );
+
+        fileSystem.file('android/gradlew').createSync(recursive: true);
+        fileSystem.directory('android').childFile('gradle.properties').createSync(recursive: true);
+        fileSystem.file('android/build.gradle').createSync(recursive: true);
+        fileSystem.directory('android').childDirectory('app').childFile('build.gradle')
+          ..createSync(recursive: true)
+          ..writeAsStringSync('apply from: irrelevant/flutter.gradle');
+        fileSystem
+            .directory('build')
+            .childDirectory('app')
+            .childDirectory('outputs')
+            .childDirectory('flutter-apk')
+            .childFile('app-dev-release.apk')
+            .createSync(recursive: true);
+
+        final FlutterProject project = FlutterProject.fromDirectoryTest(
+          fileSystem.currentDirectory,
+        );
+        project.android.appManifestFile
+          ..createSync(recursive: true)
+          ..writeAsStringSync(minimalV2EmbeddingManifest);
+
+        await builder.buildGradleApp(
+          project: project,
+          androidBuildInfo: const AndroidBuildInfo(
+            BuildInfo(
+              BuildMode.release,
+              'dev',
+              treeShakeIcons: false,
+              packageConfigPath: '.dart_tool/package_config.json',
+            ),
+          ),
+          target: 'lib/main.dart',
+          isBuildingBundle: false,
+          configOnly: false,
+          localGradleErrors: const <GradleHandledError>[],
+        );
+
+        expect(sdkForFailedQuery.hasNdkVersion('29.0.13846066'), isFalse);
+        expect(processManager, hasNoRemainingExpectations);
+      },
+      overrides: <Type, Generator>{
+        AndroidSdk: () {
+          fileSystem.directory(sdkPath()).createSync(recursive: true);
+          fileSystem.directory(sdkLicensesPath()).createSync(recursive: true);
+          fileSystem
+              .directory(fileSystem.path.join(sdkPath(), 'cmdline-tools', 'latest', 'bin'))
+              .childFile(globals.platform.isWindows ? 'sdkmanager.bat' : 'sdkmanager')
+              .createSync(recursive: true);
+          sdkForFailedQuery = AndroidSdk(
+            fileSystem.directory(sdkPath()),
+            java: FakeJava(),
+            fileSystem: fileSystem,
+          );
+          return sdkForFailedQuery;
+        },
+        AndroidStudio: () => FakeAndroidStudio(),
+      },
+    );
 
     testUsingContext(
       'Can immediately tool exit on recognized exit code/stderr',
@@ -921,16 +1279,10 @@ void main() {
 
           createSharedGradleFiles();
           final File aabFile = createAabFile(BuildMode.release);
-          final AndroidSdk sdk = AndroidSdk.locateAndroidSdk()!;
 
           processManager.addCommand(
             FakeCommand(
-              command: <String>[
-                sdk.getCmdlineToolsPath(apkAnalyzerBinaryName)!,
-                'files',
-                'list',
-                aabFile.path,
-              ],
+              command: <String>[apkAnalyzerPath(), 'files', 'list', aabFile.path],
               stdout: apkanalyzerOutputWithSymFiles,
             ),
           );
@@ -963,7 +1315,22 @@ void main() {
             localGradleErrors: <GradleHandledError>[],
           );
         },
-        overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()},
+        overrides: <Type, Generator>{
+          AndroidSdk: () {
+            fileSystem.directory(sdkPath()).createSync(recursive: true);
+            fileSystem
+                .directory(fileSystem.path.join(sdkPath(), 'cmdline-tools', 'latest', 'bin'))
+                .childFile(apkAnalyzerBinaryName)
+                .createSync(recursive: true);
+            return AndroidSdk(
+              fileSystem.directory(sdkPath()),
+              java: FakeJava(),
+              fileSystem: fileSystem,
+            );
+          },
+          AndroidStudio: () => FakeAndroidStudio(),
+          ProcessManager: () => processManager,
+        },
       );
 
       testUsingContext(
@@ -986,16 +1353,10 @@ void main() {
 
           createSharedGradleFiles();
           final File aabFile = createAabFile(BuildMode.release);
-          final AndroidSdk sdk = AndroidSdk.locateAndroidSdk()!;
 
           processManager.addCommand(
             FakeCommand(
-              command: <String>[
-                sdk.getCmdlineToolsPath(apkAnalyzerBinaryName)!,
-                'files',
-                'list',
-                aabFile.path,
-              ],
+              command: <String>[apkAnalyzerPath(), 'files', 'list', aabFile.path],
               stdout: apkanalyzerOutputWithDebugInfoAndSymFiles,
             ),
           );
@@ -1028,7 +1389,22 @@ void main() {
             localGradleErrors: <GradleHandledError>[],
           );
         },
-        overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()},
+        overrides: <Type, Generator>{
+          AndroidSdk: () {
+            fileSystem.directory(sdkPath()).createSync(recursive: true);
+            fileSystem
+                .directory(fileSystem.path.join(sdkPath(), 'cmdline-tools', 'latest', 'bin'))
+                .childFile(apkAnalyzerBinaryName)
+                .createSync(recursive: true);
+            return AndroidSdk(
+              fileSystem.directory(sdkPath()),
+              java: FakeJava(),
+              fileSystem: fileSystem,
+            );
+          },
+          AndroidStudio: () => FakeAndroidStudio(),
+          ProcessManager: () => processManager,
+        },
       );
 
       testUsingContext(
@@ -1080,7 +1456,21 @@ void main() {
             localGradleErrors: <GradleHandledError>[],
           );
         },
-        overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()},
+        overrides: <Type, Generator>{
+          AndroidSdk: () {
+            fileSystem.directory(sdkPath()).createSync(recursive: true);
+            fileSystem
+                .directory(fileSystem.path.join(sdkPath(), 'cmdline-tools', 'latest', 'bin'))
+                .childFile(apkAnalyzerBinaryName)
+                .createSync(recursive: true);
+            return AndroidSdk(
+              fileSystem.directory(sdkPath()),
+              java: FakeJava(),
+              fileSystem: fileSystem,
+            );
+          },
+          AndroidStudio: () => FakeAndroidStudio(),
+        },
       );
 
       testUsingContext(
@@ -1104,7 +1494,16 @@ void main() {
           createSharedGradleFiles();
           final File aabFile = createAabFile(BuildMode.release);
 
-          final AndroidSdk sdk = AndroidSdk.locateAndroidSdk()!;
+          fileSystem.directory(sdkPath()).createSync(recursive: true);
+          fileSystem
+              .directory(fileSystem.path.join(sdkPath(), 'cmdline-tools', 'latest', 'bin'))
+              .childFile(apkAnalyzerBinaryName)
+              .createSync(recursive: true);
+          final AndroidSdk sdk = AndroidSdk(
+            fileSystem.directory(sdkPath()),
+            java: FakeJava(),
+            fileSystem: fileSystem,
+          );
 
           processManager.addCommand(
             FakeCommand(
@@ -1149,7 +1548,21 @@ void main() {
             throwsToolExit(message: failedToStripDebugSymbolsErrorMessage),
           );
         },
-        overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()},
+        overrides: <Type, Generator>{
+          AndroidSdk: () {
+            fileSystem.directory(sdkPath()).createSync(recursive: true);
+            fileSystem
+                .directory(fileSystem.path.join(sdkPath(), 'cmdline-tools', 'latest', 'bin'))
+                .childFile(apkAnalyzerBinaryName)
+                .createSync(recursive: true);
+            return AndroidSdk(
+              fileSystem.directory(sdkPath()),
+              java: FakeJava(),
+              fileSystem: fileSystem,
+            );
+          },
+          AndroidStudio: () => FakeAndroidStudio(),
+        },
       );
 
       testUsingContext(
@@ -1173,7 +1586,16 @@ void main() {
           createSharedGradleFiles();
           final File aabFile = createAabFile(BuildMode.release);
 
-          final AndroidSdk sdk = AndroidSdk.locateAndroidSdk()!;
+          fileSystem.directory(sdkPath()).createSync(recursive: true);
+          fileSystem
+              .directory(fileSystem.path.join(sdkPath(), 'cmdline-tools', 'latest', 'bin'))
+              .childFile(apkAnalyzerBinaryName)
+              .createSync(recursive: true);
+          final AndroidSdk sdk = AndroidSdk(
+            fileSystem.directory(sdkPath()),
+            java: FakeJava(),
+            fileSystem: fileSystem,
+          );
 
           processManager.addCommand(
             FakeCommand(

--- a/packages/flutter_tools/test/integration.shard/android_gradle_print_ndk_version_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_gradle_print_ndk_version_test.dart
@@ -1,0 +1,65 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:file/file.dart';
+import 'package:flutter_tools/src/android/gradle_utils.dart' show getGradlewFileName;
+import 'package:flutter_tools/src/base/io.dart';
+
+import '../src/common.dart';
+import 'test_utils.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = createResolvedTempDirectorySync('run_test.');
+  });
+
+  tearDown(() async {
+    tryToDelete(tempDir);
+  });
+
+  testWithoutContext(
+    'gradle task exists named printNdkVersion that prints the effective ndk version',
+    () async {
+      ProcessResult result = await processManager.run(<String>[
+        flutterBin,
+        'create',
+        tempDir.path,
+        '--project-name=testapp',
+      ], workingDirectory: tempDir.path);
+      expect(result.exitCode, 0, reason: 'stdout: ${result.stdout}\nstderr: ${result.stderr}');
+
+      result = await processManager.run(<String>[
+        flutterBin,
+        'build',
+        'apk',
+        '--config-only',
+      ], workingDirectory: tempDir.path);
+      expect(result.exitCode, 0, reason: 'stdout: ${result.stdout}\nstderr: ${result.stderr}');
+
+      final Directory androidApp = tempDir.childDirectory('android');
+      result = await processManager.run(<String>[
+        '.${platform.pathSeparator}${getGradlewFileName(platform)}',
+        ...getLocalEngineArguments(),
+        '-q',
+        'printNdkVersion',
+      ], workingDirectory: androidApp.path);
+      expect(result.exitCode, 0);
+
+      final List<String> actualLines = LineSplitter.split(result.stdout.toString()).toList();
+      final Iterable<String> ndkVersionLines = actualLines.where(
+        (String line) => line.startsWith('NdkVersion: '),
+      );
+      expect(ndkVersionLines.length, 1, reason: 'actual: $actualLines');
+      expect(
+        ndkVersionLines.single.length,
+        greaterThan('NdkVersion: '.length),
+        reason: 'actual: $actualLines',
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary
Relands Android NDK preprovisioning in a narrower form so it only applies to flavored builds.

## Context
The original change landed in flutter/flutter#183555 and was later reverted in flutter/flutter#185439 after it turned out the preflight path was being attached too broadly.

This reland keeps the intended flavored-build behavior, but avoids applying the same path to unflavored and module builds.

Fixes flutter/flutter#185212.

## Validation
- `android_gradle_builder_test.dart`
- Windows ordinary APK/AAB: `printNdkVersion` absent
- Windows flavored APK/AAB: `printNdkVersion` present and flavored preprovisioning path applied
- Windows module APK: `printNdkVersion` absent
- Windows devicelab: `basic_material_app_win__compile`
- Windows devicelab: `flutter_gallery_win__compile`

## Notes
The module AAB debug-symbol-strip failure reproduces before flutter/flutter#183555, on the revert branch from flutter/flutter#185439, and with this reland, so that issue appears unrelated and pre-existing.
