### PR TITLE
[iOS] Refactor keyboard inset logic into FlutterKeyboardInsetManager

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/BUILD.gn
+++ b/engine/src/flutter/shell/platform/darwin/ios/BUILD.gn
@@ -97,6 +97,8 @@ source_set("flutter_framework_source") {
     "framework/Source/FlutterHeadlessDartRunner.mm",
     "framework/Source/FlutterKeyPrimaryResponder.h",
     "framework/Source/FlutterKeySecondaryResponder.h",
+    "framework/Source/FlutterKeyboardInsetManager.h",
+    "framework/Source/FlutterKeyboardInsetManager.mm",
     "framework/Source/FlutterKeyboardManager.h",
     "framework/Source/FlutterKeyboardManager.mm",
     "framework/Source/FlutterMetalLayer.h",

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterKeyboardInsetManager.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterKeyboardInsetManager.h
@@ -1,0 +1,156 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERKEYBOARDINSETMANAGER_H_
+#define FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERKEYBOARDINSETMANAGER_H_
+
+#import <UIKit/UIKit.h>
+
+@class FlutterEngine;
+@class FlutterKeyboardInsetManager;
+
+/**
+ * @brief Manages the calculations and animations for software keyboard insets.
+ *
+ * This class is responsible for observing keyboard notifications, calculating the appropriate
+ * insets for the Flutter view based on the keyboard mode (docked, floating, hidden),
+ * and animating the transition of the insets.
+ */
+@protocol FlutterKeyboardInsetManagerDelegate <NSObject>
+
+/**
+ * @brief Updates the viewport metrics with the new bottom inset.
+ */
+- (void)updateViewportMetricsWithInset:(CGFloat)inset;
+
+/**
+ * @brief Returns the current physical bottom view inset.
+ */
+- (CGFloat)physicalViewInsetBottom;
+
+/**
+ * @brief Returns the view associated with the delegate.
+ */
+- (UIView*)view;
+
+/**
+ * @brief Returns the engine associated with the delegate.
+ */
+- (FlutterEngine*)engine;
+
+/**
+ * @brief Returns the UIScreen associated with the Flutter view, if the view is loaded.
+ */
+- (UIScreen*)flutterScreenIfViewLoaded;
+
+/**
+ * @brief Returns whether the device is an iPad and in Slide Over or Stage Manager mode.
+ */
+- (BOOL)isPadInSlideOverOrStageManagerMode;
+
+/**
+ * @brief Converts a rectangle from the view's coordinate system to the screen's coordinate system.
+ */
+- (CGRect)convertViewRectToScreen:(CGRect)rect;
+
+/**
+ * @brief Returns whether the delegate's view is currently loaded.
+ */
+- (BOOL)isViewLoaded;
+
+@end
+
+/**
+ * @brief Coordinates the animation of the bottom viewport inset in response to system keyboard
+ * visibility changes.
+ *
+ * This manager translates native iOS keyboard notifications into pixel insets for the engine. It
+ * ensures that the Flutter app UI correctly resizes or scrolls when the software keyboard appears
+ * or disappears.
+ *
+ * We synchronize the app's layout transitions with the native keyboard animation curve by tracking
+ * a hidden internal view. When a keyboard notification is received, this view is animated using the
+ * native iOS duration and curve. The manager tracks this animation and calls the delegate's update
+ * methods on every vsync pulse until the transition completes.
+ *
+ * iOS doesn't provide us with a frame-by-frame callback for keyboard transitions, but we need to
+ * animate our views smoothly to account for keyboard size/position changes. To ensure Flutter's
+ * layout animates in perfect sync with the system keyboard, we use a "hidden view" synchronization
+ * trick:
+ *
+ *  * When a keyboard notification (e.g., UIKeyboardWillShow) is received, the manager animates a
+ *    hidden UIView's frame using the native iOS duration and curve.
+ *  * A VSyncClient tracks the 'presentationLayer' of this hidden view on every vsync.
+ *  * The intermediate positions are then translated into physical pixel insets and sent to the
+ *    engine until the animation completes.
+ *
+ * To prevent incorrect layout shifts, the manager filters notifications based on the following
+ * criteria:
+ *
+ * * Local notifications:
+ *   In multitasking environments, such as iPad Split View, notifications triggered by interactions
+ *   with other applications are ignored.
+ *
+ * * Keyboard attachment mode:
+ *   The manager distinguishes between "docked" keyboards, which cover the bottom of the viewport,
+ *   and "floating" or "undocked" keyboards. Floating keyboards do not typically require a viewport
+ *   inset and are ignored to allow them to hover over the Flutter content without resizing the
+ *   layout.
+ *
+ * * View lifecycle:
+ *   Notifications are ignored if the associated view is not loaded or if the delegate is not the
+ *   active view controller.
+ *
+ * @see [FlutterViewController], which owns this manager and acts as its delegate.
+ */
+@interface FlutterKeyboardInsetManager : NSObject
+
+/**
+ * @brief Initializes the manager with a delegate.
+ *
+ * The manager maintains a weak reference to the delegate.
+ *
+ * @param delegate The object that handles viewport updates. Typically a [FlutterViewController].
+ */
+- (instancetype)initWithDelegate:(id<FlutterKeyboardInsetManagerDelegate>)delegate;
+
+/**
+ * @brief Processes a system keyboard notification to update the target inset and begin any
+ *        necessary animations.
+ *
+ * Consider calling this method from the view controller's keyboard notification observers. It
+ * automatically performs filtering for non-local or floating keyboard events.
+ *
+ * @param notification The notification received from the [NSNotificationCenter].
+ */
+- (void)handleKeyboardNotification:(NSNotification*)notification;
+
+/**
+ * @brief Immediately stops any active keyboard animations and synchronizes the engine's viewport
+ *        metrics with a zero inset.
+ */
+- (void)hideKeyboardImmediately;
+
+/**
+ * @brief Terminates any active animations and releases internal resources.
+ *
+ * Consider calling this method when the owner of the manager is being deallocated.
+ */
+- (void)invalidate;
+
+/**
+ * @brief The physical pixel value of the bottom inset once the current animation reaches its final
+ *        state.
+ */
+@property(nonatomic, assign, readonly) CGFloat targetViewInsetBottom;
+
+/**
+ * @brief Indicates whether the keyboard is currently onscreen or in the process of transitioning
+ *        from the background.
+ */
+@property(nonatomic, assign) BOOL isKeyboardInOrTransitioningFromBackground;
+
+@end
+
+#endif  // FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERKEYBOARDINSETMANAGER_H_

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterKeyboardInsetManager.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterKeyboardInsetManager.mm
@@ -1,0 +1,432 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterKeyboardInsetManager.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h"
+#import "flutter/shell/platform/embedder/embedder.h"
+#import "flutter/third_party/spring_animation/spring_animation.h"
+
+#include <memory>
+
+#include "flutter/fml/platform/darwin/platform_version.h"
+#include "flutter/fml/time/time_delta.h"
+#include "flutter/fml/time/time_point.h"
+
+@interface FlutterKeyboardInsetManager ()
+
+@property(nonatomic, weak) id<FlutterKeyboardInsetManagerDelegate> delegate;
+@property(nonatomic, assign, readwrite) CGFloat targetViewInsetBottom;
+@property(nonatomic, assign) CGFloat originalViewInsetBottom;
+@property(nonatomic, strong) VSyncClient* keyboardAnimationVSyncClient;
+@property(nonatomic, assign) BOOL keyboardAnimationIsShowing;
+@property(nonatomic, assign) NSTimeInterval keyboardAnimationStartTime;
+@property(nonatomic, strong) UIView* keyboardAnimationView;
+@property(nonatomic, strong) SpringAnimation* keyboardSpringAnimation;
+
+@end
+
+@implementation FlutterKeyboardInsetManager
+
+- (instancetype)initWithDelegate:(id<FlutterKeyboardInsetManagerDelegate>)delegate {
+  self = [super init];
+  if (self) {
+    _delegate = delegate;
+    _targetViewInsetBottom = 0.0;
+  }
+  return self;
+}
+
+- (void)handleKeyboardNotification:(NSNotification*)notification {
+  // See https://flutter.dev/go/ios-keyboard-calculating-inset for more details
+  // on why notifications are used and how things are calculated.
+  id<FlutterKeyboardInsetManagerDelegate> delegate = self.delegate;
+  if (!delegate || [self shouldIgnoreKeyboardNotification:notification]) {
+    return;
+  }
+
+  NSDictionary* info = notification.userInfo;
+  CGRect beginKeyboardFrame = [info[UIKeyboardFrameBeginUserInfoKey] CGRectValue];
+  CGRect keyboardFrame = [info[UIKeyboardFrameEndUserInfoKey] CGRectValue];
+  FlutterKeyboardMode keyboardMode = [self calculateKeyboardAttachMode:notification];
+  CGFloat calculatedInset = [self calculateKeyboardInset:keyboardFrame keyboardMode:keyboardMode];
+  NSTimeInterval duration = [info[UIKeyboardAnimationDurationUserInfoKey] doubleValue];
+
+  // If the software keyboard is displayed before displaying the PasswordManager prompt,
+  // UIKeyboardWillHideNotification will occur immediately after UIKeyboardWillShowNotification.
+  // The duration of the animation will be 0.0, and the calculated inset will be 0.0.
+  // In this case, it is necessary to cancel the animation and hide the keyboard immediately.
+  // https://github.com/flutter/flutter/pull/164884
+  if (keyboardMode == FlutterKeyboardModeHidden && calculatedInset == 0.0 && duration == 0.0) {
+    [self hideKeyboardImmediately];
+    return;
+  }
+
+  // Avoid double triggering startKeyBoardAnimation.
+  if (self.targetViewInsetBottom == calculatedInset) {
+    return;
+  }
+  self.targetViewInsetBottom = calculatedInset;
+
+  // Flag for simultaneous compounding animation calls.
+  // This captures animation calls made while the keyboard animation is currently animating. If the
+  // new animation is in the same direction as the current animation, this flag lets the current
+  // animation continue with an updated targetViewInsetBottom instead of starting a new keyboard
+  // animation. This allows for smoother keyboard animation interpolation.
+  BOOL keyboardWillShow = beginKeyboardFrame.origin.y > keyboardFrame.origin.y;
+  BOOL keyboardAnimationIsCompounding =
+      self.keyboardAnimationIsShowing == keyboardWillShow && _keyboardAnimationVSyncClient != nil;
+
+  // Mark keyboard as showing or hiding.
+  self.keyboardAnimationIsShowing = keyboardWillShow;
+
+  if (!keyboardAnimationIsCompounding) {
+    [self startKeyBoardAnimation:duration];
+  } else if (self.keyboardSpringAnimation) {
+    self.keyboardSpringAnimation.toValue = self.targetViewInsetBottom;
+  }
+}
+
+- (BOOL)shouldIgnoreKeyboardNotification:(NSNotification*)notification {
+  // Don't ignore UIKeyboardWillHideNotification notifications.
+  // Even if the notification is triggered in the background or by a different app/view controller,
+  // we want to always handle this notification to avoid inaccurate inset when in a mulitasking mode
+  // or when switching between apps.
+  if (notification.name == UIKeyboardWillHideNotification) {
+    return NO;
+  }
+
+  // Ignore notification when keyboard's dimensions and position are all zeroes for
+  // UIKeyboardWillChangeFrameNotification. This happens when keyboard is dragged. Do not ignore if
+  // the notification is UIKeyboardWillShowNotification, as CGRectZero for that notfication only
+  // occurs when Minimized/Expanded Shortcuts Bar is dropped after dragging, which we later use to
+  // categorize it as floating.
+  NSDictionary* info = notification.userInfo;
+  CGRect keyboardFrame = [info[UIKeyboardFrameEndUserInfoKey] CGRectValue];
+  if (notification.name == UIKeyboardWillChangeFrameNotification &&
+      CGRectEqualToRect(keyboardFrame, CGRectZero)) {
+    return YES;
+  }
+
+  // When keyboard's height or width is set to 0, don't ignore. This does not happen
+  // often but can happen sometimes when switching between multitasking modes.
+  if (CGRectIsEmpty(keyboardFrame)) {
+    return NO;
+  }
+
+  // Ignore keyboard notifications related to other apps or view controllers.
+  if ([self isKeyboardNotificationForDifferentView:notification]) {
+    return YES;
+  }
+  return NO;
+}
+
+- (BOOL)isKeyboardNotificationForDifferentView:(NSNotification*)notification {
+  NSDictionary* info = notification.userInfo;
+
+  // Keyboard notifications related to other apps.
+  // If the UIKeyboardIsLocalUserInfoKey key doesn't exist (this should not happen after iOS 8),
+  // proceed as if it was local so that the notification is not ignored.
+  id isLocal = info[UIKeyboardIsLocalUserInfoKey];
+  if (isLocal && ![isLocal boolValue]) {
+    return YES;
+  }
+  id<FlutterKeyboardInsetManagerDelegate> delegate = self.delegate;
+  return (id)delegate.engine.viewController != (id)delegate;
+}
+
+- (FlutterKeyboardMode)calculateKeyboardAttachMode:(NSNotification*)notification {
+  // There are multiple types of keyboard: docked, undocked, split, split docked,
+  // floating, expanded shortcuts bar, minimized shortcuts bar. This function will categorize
+  // the keyboard as one of the following modes: docked, floating, or hidden.
+  // Docked mode includes docked, split docked, expanded shortcuts bar (when opening via click),
+  // and minimized shortcuts bar (when opened via click).
+  // Floating includes undocked, split, floating, expanded shortcuts bar (when dragged and dropped),
+  // and minimized shortcuts bar (when dragged and dropped).
+  id<FlutterKeyboardInsetManagerDelegate> delegate = self.delegate;
+  if (!delegate) {
+    return FlutterKeyboardModeHidden;
+  }
+  NSDictionary* info = notification.userInfo;
+  CGRect keyboardFrame = [info[UIKeyboardFrameEndUserInfoKey] CGRectValue];
+
+  if (notification.name == UIKeyboardWillHideNotification) {
+    return FlutterKeyboardModeHidden;
+  }
+
+  // If keyboard's dimensions and position are all zeroes, that means it's a Minimized/Expanded
+  // Shortcuts Bar that has been dropped after dragging, which we categorize as floating.
+  if (CGRectEqualToRect(keyboardFrame, CGRectZero)) {
+    return FlutterKeyboardModeFloating;
+  }
+  // If keyboard's width or height are 0, it's hidden.
+  if (CGRectIsEmpty(keyboardFrame)) {
+    return FlutterKeyboardModeHidden;
+  }
+
+  CGRect screenRect = delegate.flutterScreenIfViewLoaded.bounds;
+  CGRect adjustedKeyboardFrame = keyboardFrame;
+  adjustedKeyboardFrame.origin.y += [self calculateMultitaskingAdjustment:screenRect
+                                                            keyboardFrame:keyboardFrame];
+
+  // If the keyboard is partially or fully showing within the screen, it's either docked or
+  // floating. Sometimes with custom keyboard extensions, the keyboard's position may be off by a
+  // small decimal amount (which is why CGRectIntersectRect can't be used). Round to compare.
+  CGRect intersection = CGRectIntersection(adjustedKeyboardFrame, screenRect);
+  CGFloat intersectionHeight = CGRectGetHeight(intersection);
+  CGFloat intersectionWidth = CGRectGetWidth(intersection);
+  if (round(intersectionHeight) > 0 && intersectionWidth > 0) {
+    CGFloat screenHeight = CGRectGetHeight(screenRect);
+    CGFloat adjustedKeyboardBottom = CGRectGetMaxY(adjustedKeyboardFrame);
+    if (round(adjustedKeyboardBottom) < screenHeight) {
+      return FlutterKeyboardModeFloating;
+    }
+    return FlutterKeyboardModeDocked;
+  }
+  return FlutterKeyboardModeHidden;
+}
+
+/**
+ * @brief Calculates the adjustment needed for multitasking modes like Slide Over on iPad.
+ *
+ * In Slide Over mode, the keyboard's frame does not include the space below the app,
+ * even though the keyboard may be at the bottom of the screen. This method calculates
+ * that offset so we can shift the y origin correctly.
+ */
+- (CGFloat)calculateMultitaskingAdjustment:(CGRect)screenRect keyboardFrame:(CGRect)keyboardFrame {
+  id<FlutterKeyboardInsetManagerDelegate> delegate = self.delegate;
+  if (!delegate.isViewLoaded) {
+    return 0;
+  }
+
+  // In Slide Over mode, the keyboard's frame does not include the space
+  // below the app, even though the keyboard may be at the bottom of the screen.
+  // To handle, shift the Y origin by the amount of space below the app.
+  UIView* view = delegate.view;
+  if ([delegate isPadInSlideOverOrStageManagerMode]) {
+    CGFloat screenHeight = CGRectGetHeight(screenRect);
+    CGFloat keyboardBottom = CGRectGetMaxY(keyboardFrame);
+
+    // Stage Manager mode will also meet the above parameters, but it does not handle
+    // the keyboard positioning the same way, so skip if keyboard is at bottom of page.
+    if (screenHeight == keyboardBottom) {
+      return 0;
+    }
+    CGRect viewRectRelativeToScreen = [delegate convertViewRectToScreen:view.bounds];
+    CGFloat viewBottom = CGRectGetMaxY(viewRectRelativeToScreen);
+    CGFloat offset = screenHeight - viewBottom;
+    if (offset > 0) {
+      return offset;
+    }
+  }
+  return 0;
+}
+
+- (CGFloat)calculateKeyboardInset:(CGRect)keyboardFrame
+                     keyboardMode:(FlutterKeyboardMode)keyboardMode {
+  id<FlutterKeyboardInsetManagerDelegate> delegate = self.delegate;
+
+  // Only docked keyboards will have an inset.
+  if (keyboardMode == FlutterKeyboardModeDocked) {
+    if (!delegate.isViewLoaded) {
+      return 0;
+    }
+    UIView* view = delegate.view;
+    CGRect viewRectRelativeToScreen = [delegate convertViewRectToScreen:view.bounds];
+    CGRect intersection = CGRectIntersection(keyboardFrame, viewRectRelativeToScreen);
+    CGFloat portionOfKeyboardInView = CGRectGetHeight(intersection);
+
+    // The keyboard is treated as an inset since we want to effectively reduce the window size by
+    // the keyboard height. The Dart side will compute a value accounting for the keyboard-consuming
+    // bottom padding.
+    CGFloat scale = delegate.flutterScreenIfViewLoaded.scale;
+    return portionOfKeyboardInView * scale;
+  }
+  return 0;
+}
+
+- (void)startKeyBoardAnimation:(NSTimeInterval)duration {
+  // If current physical_view_inset_bottom == targetViewInsetBottom, do nothing.
+  id<FlutterKeyboardInsetManagerDelegate> delegate = self.delegate;
+  if (!delegate.isViewLoaded) {
+    return;
+  }
+  UIView* view = delegate.view;
+
+  // When this method is called for the first time,
+  // initialize the keyboardAnimationView to get animation interpolation during animation.
+  if (!self.keyboardAnimationView) {
+    UIView* keyboardAnimationView = [[UIView alloc] init];
+    keyboardAnimationView.hidden = YES;
+    self.keyboardAnimationView = keyboardAnimationView;
+  }
+
+  if (self.keyboardAnimationView.superview != view) {
+    [view addSubview:self.keyboardAnimationView];
+  }
+
+  // Remove running animation when start another animation.
+  [self.keyboardAnimationView.layer removeAllAnimations];
+
+  // Set animation begin value and DisplayLink tracking values.
+  CGFloat currentInset = delegate.physicalViewInsetBottom;
+  self.keyboardAnimationView.frame = CGRectMake(0, currentInset, 0, 0);
+  self.keyboardAnimationStartTime = fml::TimePoint::Now().ToEpochDelta().ToSeconds();
+  self.originalViewInsetBottom = currentInset;
+
+  // Invalidate old vsync client if old animation is not completed.
+  [self invalidateKeyboardAnimationVSyncClient];
+
+  __weak FlutterKeyboardInsetManager* weakSelf = self;
+  [self setUpKeyboardAnimationVsyncClient:^(NSTimeInterval targetTime) {
+    [weakSelf handleKeyboardAnimationCallbackWithTargetTime:targetTime];
+  }];
+  VSyncClient* currentVsyncClient = _keyboardAnimationVSyncClient;
+
+  [UIView animateWithDuration:duration
+      animations:^{
+        FlutterKeyboardInsetManager* strongSelf = weakSelf;
+        if (!strongSelf) {
+          return;
+        }
+
+        // Set end value.
+        strongSelf.keyboardAnimationView.frame =
+            CGRectMake(0, strongSelf.targetViewInsetBottom, 0, 0);
+
+        // Setup keyboard animation interpolation.
+        [strongSelf.keyboardAnimationView layoutIfNeeded];
+        CAAnimation* keyboardAnimation =
+            [strongSelf.keyboardAnimationView.layer animationForKey:@"position"];
+        [strongSelf setUpKeyboardSpringAnimationIfNeeded:keyboardAnimation];
+      }
+      completion:^(BOOL finished) {
+        FlutterKeyboardInsetManager* strongSelf = weakSelf;
+        if (strongSelf && strongSelf.keyboardAnimationVSyncClient == currentVsyncClient) {
+          // Indicates the vsync client captured by this block is the original one, which also
+          // indicates the animation has not been interrupted from its beginning. Moreover,
+          // indicates the animation is over and there is no more to execute.
+          [strongSelf invalidateKeyboardAnimationVSyncClient];
+          [strongSelf removeKeyboardAnimationView];
+          [strongSelf ensureViewportMetricsIsCorrect];
+        }
+      }];
+}
+
+- (void)hideKeyboardImmediately {
+  [self invalidateKeyboardAnimationVSyncClient];
+  if (self.keyboardAnimationView) {
+    [self.keyboardAnimationView.layer removeAllAnimations];
+    [self removeKeyboardAnimationView];
+    self.keyboardAnimationView = nil;
+  }
+  if (self.keyboardSpringAnimation) {
+    self.keyboardSpringAnimation = nil;
+  }
+  self.targetViewInsetBottom = 0.0;
+  [self ensureViewportMetricsIsCorrect];
+}
+
+- (void)setUpKeyboardSpringAnimationIfNeeded:(CAAnimation*)keyboardAnimation {
+  // If keyboard animation is null or not a spring animation, fallback to DisplayLink tracking.
+  if (keyboardAnimation == nil || ![keyboardAnimation isKindOfClass:[CASpringAnimation class]]) {
+    _keyboardSpringAnimation = nil;
+    return;
+  }
+
+  // Set up keyboard spring animation details for spring curve animation calculation.
+  CASpringAnimation* keyboardCASpringAnimation = (CASpringAnimation*)keyboardAnimation;
+  _keyboardSpringAnimation =
+      [[SpringAnimation alloc] initWithStiffness:keyboardCASpringAnimation.stiffness
+                                         damping:keyboardCASpringAnimation.damping
+                                            mass:keyboardCASpringAnimation.mass
+                                 initialVelocity:keyboardCASpringAnimation.initialVelocity
+                                       fromValue:self.originalViewInsetBottom
+                                         toValue:self.targetViewInsetBottom];
+}
+
+- (void)handleKeyboardAnimationCallbackWithTargetTime:(NSTimeInterval)targetTime {
+  id<FlutterKeyboardInsetManagerDelegate> delegate = self.delegate;
+
+  // If the view controller's view is not loaded, bail out.
+  if (!delegate.isViewLoaded) {
+    return;
+  }
+  // If the view for tracking keyboard animation is nil, means it is not
+  // created, bail out.
+  if (!self.keyboardAnimationView) {
+    return;
+  }
+  // If keyboardAnimationVSyncClient is nil, means the animation ends.
+  // And should bail out.
+  if (!self.keyboardAnimationVSyncClient) {
+    return;
+  }
+
+  if (self.keyboardAnimationView.superview != delegate.view) {
+    // Ensure the keyboardAnimationView is in view hierarchy when animation running.
+    [delegate.view addSubview:self.keyboardAnimationView];
+  }
+
+  CGFloat currentInset = 0;
+  if (!self.keyboardSpringAnimation) {
+    if (self.keyboardAnimationView.layer.presentationLayer) {
+      currentInset = self.keyboardAnimationView.layer.presentationLayer.frame.origin.y;
+    }
+  } else {
+    NSTimeInterval timeElapsed = targetTime - self.keyboardAnimationStartTime;
+    currentInset = [self.keyboardSpringAnimation curveFunction:timeElapsed];
+  }
+
+  [delegate updateViewportMetricsWithInset:currentInset];
+}
+
+- (void)setUpKeyboardAnimationVsyncClient:
+    (FlutterKeyboardAnimationCallback)keyboardAnimationCallback {
+  if (!keyboardAnimationCallback) {
+    return;
+  }
+  NSAssert(_keyboardAnimationVSyncClient == nil,
+           @"_keyboardAnimationVSyncClient must be nil when setting up.");
+
+  // Make sure the new viewport metrics get sent after the begin frame event has processed.
+  FlutterKeyboardAnimationCallback animationCallback = [keyboardAnimationCallback copy];
+  auto uiCallback = [animationCallback](std::unique_ptr<flutter::FrameTimingsRecorder> recorder) {
+    fml::TimeDelta frameInterval = recorder->GetVsyncTargetTime() - recorder->GetVsyncStartTime();
+    fml::TimePoint targetTime = recorder->GetVsyncTargetTime() + frameInterval;
+    dispatch_async(dispatch_get_main_queue(), ^(void) {
+      animationCallback(targetTime.ToEpochDelta().ToSeconds());
+    });
+  };
+
+  id<FlutterKeyboardInsetManagerDelegate> delegate = self.delegate;
+  _keyboardAnimationVSyncClient =
+      [[VSyncClient alloc] initWithTaskRunner:delegate.engine.uiTaskRunner callback:uiCallback];
+  _keyboardAnimationVSyncClient.allowPauseAfterVsync = NO;
+  [_keyboardAnimationVSyncClient await];
+}
+
+- (void)invalidateKeyboardAnimationVSyncClient {
+  [_keyboardAnimationVSyncClient invalidate];
+  _keyboardAnimationVSyncClient = nil;
+}
+
+- (void)removeKeyboardAnimationView {
+  if (self.keyboardAnimationView.superview != nil) {
+    [self.keyboardAnimationView removeFromSuperview];
+  }
+}
+
+- (void)ensureViewportMetricsIsCorrect {
+  id<FlutterKeyboardInsetManagerDelegate> delegate = self.delegate;
+  [delegate updateViewportMetricsWithInset:self.targetViewInsetBottom];
+}
+
+- (void)invalidate {
+  [self invalidateKeyboardAnimationVSyncClient];
+  [self removeKeyboardAnimationView];
+}
+
+@end

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -22,6 +22,7 @@
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterEmbedderKeyResponder.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterKeyPrimaryResponder.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterKeyboardInsetManager.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterKeyboardManager.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h"
@@ -63,7 +64,9 @@ typedef struct MouseState {
 // This is left a FlutterBinaryMessenger privately for now to give people a chance to notice the
 // change. Unfortunately unless you have Werror turned on, incompatible pointers as arguments are
 // just a warning.
-@interface FlutterViewController () <FlutterBinaryMessenger, UIScrollViewDelegate>
+@interface FlutterViewController () <FlutterBinaryMessenger,
+                                     UIScrollViewDelegate,
+                                     FlutterKeyboardInsetManagerDelegate>
 // TODO(dkwingsmt): Make the view ID property public once the iOS shell
 // supports multiple views.
 // https://github.com/flutter/flutter/issues/138168
@@ -95,8 +98,6 @@ typedef struct MouseState {
 // UIScrollView with height zero and a content offset so we can get those events. See also:
 // https://github.com/flutter/flutter/issues/35050
 @property(nonatomic, strong) UIScrollView* scrollView;
-@property(nonatomic, strong) UIView* keyboardAnimationView;
-@property(nonatomic, strong) SpringAnimation* keyboardSpringAnimation;
 
 /**
  * Whether we should ignore viewport metrics updates during rotation transition.
@@ -105,12 +106,6 @@ typedef struct MouseState {
 /**
  * Keyboard animation properties
  */
-@property(nonatomic, assign) CGFloat targetViewInsetBottom;
-@property(nonatomic, assign) CGFloat originalViewInsetBottom;
-@property(nonatomic, strong) VSyncClient* keyboardAnimationVSyncClient;
-@property(nonatomic, assign) BOOL keyboardAnimationIsShowing;
-@property(nonatomic, assign) fml::TimePoint keyboardAnimationStartTime;
-@property(nonatomic, assign) BOOL isKeyboardInOrTransitioningFromBackground;
 
 /// Timestamp after which a scroll inertia cancel event should be inferred.
 @property(nonatomic, assign) NSTimeInterval scrollInertiaEventStartline;
@@ -162,7 +157,7 @@ typedef struct MouseState {
 - (void)onFirstFrameRendered;
 
 /// Handles updating viewport metrics on keyboard animation.
-- (void)handleKeyboardAnimationCallbackWithTargetTime:(fml::TimePoint)targetTime;
+
 @end
 
 @implementation FlutterViewController {
@@ -370,6 +365,7 @@ typedef struct MouseState {
   _statusBarStyle = UIStatusBarStyleDefault;
 
   _accessibilityFeatures = [[FlutterAccessibilityFeatures alloc] init];
+  _keyboardInsetManager = [[FlutterKeyboardInsetManager alloc] initWithDelegate:self];
 
   // TODO(cbracken): https://github.com/flutter/flutter/issues/157140
   // Eliminate method calls in initializers and dealloc.
@@ -850,8 +846,7 @@ static UIView* GetViewOrPlaceholder(UIView* existing_view) {
 - (void)viewDidDisappear:(BOOL)animated {
   TRACE_EVENT0("flutter", "viewDidDisappear");
   if (self.engine.viewController == self) {
-    [self invalidateKeyboardAnimationVSyncClient];
-    [self ensureViewportMetricsIsCorrect];
+    [self.keyboardInsetManager hideKeyboardImmediately];
     [self surfaceUpdated:NO];
     [self.engine.lifecycleChannel sendMessage:@"AppLifecycleState.paused"];
     [self flushOngoingTouches];
@@ -940,7 +935,7 @@ static UIView* GetViewOrPlaceholder(UIView* existing_view) {
   [self removeInternalPlugins];
   [self deregisterNotifications];
 
-  [self invalidateKeyboardAnimationVSyncClient];
+  [self.keyboardInsetManager invalidate];
   [self invalidateTouchRateCorrectionVSyncClient];
 
   // TODO(cbracken): https://github.com/flutter/flutter/issues/156222
@@ -1008,7 +1003,7 @@ static UIView* GetViewOrPlaceholder(UIView* existing_view) {
 #pragma mark - Lifecycle shared
 
 - (void)appOrSceneBecameActive {
-  self.isKeyboardInOrTransitioningFromBackground = NO;
+  self.keyboardInsetManager.isKeyboardInOrTransitioningFromBackground = NO;
   if (_viewportMetrics.physical_width) {
     [self surfaceUpdated:YES];
   }
@@ -1030,7 +1025,7 @@ static UIView* GetViewOrPlaceholder(UIView* existing_view) {
 }
 
 - (void)appOrSceneDidEnterBackground {
-  self.isKeyboardInOrTransitioningFromBackground = YES;
+  self.keyboardInsetManager.isKeyboardInOrTransitioningFromBackground = YES;
   [self surfaceUpdated:NO];
   [self goToApplicationLifecycle:@"AppLifecycleState.paused"];
 }
@@ -1518,7 +1513,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   // undocked/floating to docked, this notification is triggered. This notification also happens
   // when Minimized/Expanded Shortcuts bar is dropped after dragging (the keyboard's end frame will
   // be CGRectZero).
-  [self handleKeyboardNotification:notification];
+  [self.keyboardInsetManager handleKeyboardNotification:notification];
 }
 
 - (void)keyboardWillChangeFrame:(NSNotification*)notification {
@@ -1526,383 +1521,14 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   // Sometimes when the keyboard is being hidden or undocked, this notification's keyboard's end
   // frame is not yet entirely out of screen, which is why we also use
   // UIKeyboardWillHideNotification.
-  [self handleKeyboardNotification:notification];
+  [self.keyboardInsetManager handleKeyboardNotification:notification];
 }
 
 - (void)keyboardWillBeHidden:(NSNotification*)notification {
   // When keyboard is hidden or undocked, this notification will be triggered.
   // This notification might not occur when the keyboard is changed from docked to floating, which
   // is why we also use UIKeyboardWillChangeFrameNotification.
-  [self handleKeyboardNotification:notification];
-}
-
-- (void)handleKeyboardNotification:(NSNotification*)notification {
-  // See https://flutter.dev/go/ios-keyboard-calculating-inset for more details
-  // on why notifications are used and how things are calculated.
-  if ([self shouldIgnoreKeyboardNotification:notification]) {
-    return;
-  }
-
-  NSDictionary* info = notification.userInfo;
-  CGRect beginKeyboardFrame = [info[UIKeyboardFrameBeginUserInfoKey] CGRectValue];
-  CGRect keyboardFrame = [info[UIKeyboardFrameEndUserInfoKey] CGRectValue];
-  FlutterKeyboardMode keyboardMode = [self calculateKeyboardAttachMode:notification];
-  CGFloat calculatedInset = [self calculateKeyboardInset:keyboardFrame keyboardMode:keyboardMode];
-  NSTimeInterval duration = [info[UIKeyboardAnimationDurationUserInfoKey] doubleValue];
-
-  // If the software keyboard is displayed before displaying the PasswordManager prompt,
-  // UIKeyboardWillHideNotification will occur immediately after UIKeyboardWillShowNotification.
-  // The duration of the animation will be 0.0, and the calculated inset will be 0.0.
-  // In this case, it is necessary to cancel the animation and hide the keyboard immediately.
-  // https://github.com/flutter/flutter/pull/164884
-  if (keyboardMode == FlutterKeyboardModeHidden && calculatedInset == 0.0 && duration == 0.0) {
-    [self hideKeyboardImmediately];
-    return;
-  }
-
-  // Avoid double triggering startKeyBoardAnimation.
-  if (self.targetViewInsetBottom == calculatedInset) {
-    return;
-  }
-
-  self.targetViewInsetBottom = calculatedInset;
-
-  // Flag for simultaneous compounding animation calls.
-  // This captures animation calls made while the keyboard animation is currently animating. If the
-  // new animation is in the same direction as the current animation, this flag lets the current
-  // animation continue with an updated targetViewInsetBottom instead of starting a new keyboard
-  // animation. This allows for smoother keyboard animation interpolation.
-  BOOL keyboardWillShow = beginKeyboardFrame.origin.y > keyboardFrame.origin.y;
-  BOOL keyboardAnimationIsCompounding =
-      self.keyboardAnimationIsShowing == keyboardWillShow && _keyboardAnimationVSyncClient != nil;
-
-  // Mark keyboard as showing or hiding.
-  self.keyboardAnimationIsShowing = keyboardWillShow;
-
-  if (!keyboardAnimationIsCompounding) {
-    [self startKeyBoardAnimation:duration];
-  } else if (self.keyboardSpringAnimation) {
-    self.keyboardSpringAnimation.toValue = self.targetViewInsetBottom;
-  }
-}
-
-- (BOOL)shouldIgnoreKeyboardNotification:(NSNotification*)notification {
-  // Don't ignore UIKeyboardWillHideNotification notifications.
-  // Even if the notification is triggered in the background or by a different app/view controller,
-  // we want to always handle this notification to avoid inaccurate inset when in a mulitasking mode
-  // or when switching between apps.
-  if (notification.name == UIKeyboardWillHideNotification) {
-    return NO;
-  }
-
-  // Ignore notification when keyboard's dimensions and position are all zeroes for
-  // UIKeyboardWillChangeFrameNotification. This happens when keyboard is dragged. Do not ignore if
-  // the notification is UIKeyboardWillShowNotification, as CGRectZero for that notfication only
-  // occurs when Minimized/Expanded Shortcuts Bar is dropped after dragging, which we later use to
-  // categorize it as floating.
-  NSDictionary* info = notification.userInfo;
-  CGRect keyboardFrame = [info[UIKeyboardFrameEndUserInfoKey] CGRectValue];
-  if (notification.name == UIKeyboardWillChangeFrameNotification &&
-      CGRectEqualToRect(keyboardFrame, CGRectZero)) {
-    return YES;
-  }
-
-  // When keyboard's height or width is set to 0, don't ignore. This does not happen
-  // often but can happen sometimes when switching between multitasking modes.
-  if (CGRectIsEmpty(keyboardFrame)) {
-    return NO;
-  }
-
-  // Ignore keyboard notifications related to other apps or view controllers.
-  if ([self isKeyboardNotificationForDifferentView:notification]) {
-    return YES;
-  }
-  return NO;
-}
-
-- (BOOL)isKeyboardNotificationForDifferentView:(NSNotification*)notification {
-  NSDictionary* info = notification.userInfo;
-  // Keyboard notifications related to other apps.
-  // If the UIKeyboardIsLocalUserInfoKey key doesn't exist (this should not happen after iOS 8),
-  // proceed as if it was local so that the notification is not ignored.
-  id isLocal = info[UIKeyboardIsLocalUserInfoKey];
-  if (isLocal && ![isLocal boolValue]) {
-    return YES;
-  }
-  return self.engine.viewController != self;
-}
-
-- (FlutterKeyboardMode)calculateKeyboardAttachMode:(NSNotification*)notification {
-  // There are multiple types of keyboard: docked, undocked, split, split docked,
-  // floating, expanded shortcuts bar, minimized shortcuts bar. This function will categorize
-  // the keyboard as one of the following modes: docked, floating, or hidden.
-  // Docked mode includes docked, split docked, expanded shortcuts bar (when opening via click),
-  // and minimized shortcuts bar (when opened via click).
-  // Floating includes undocked, split, floating, expanded shortcuts bar (when dragged and dropped),
-  // and minimized shortcuts bar (when dragged and dropped).
-  NSDictionary* info = notification.userInfo;
-  CGRect keyboardFrame = [info[UIKeyboardFrameEndUserInfoKey] CGRectValue];
-
-  if (notification.name == UIKeyboardWillHideNotification) {
-    return FlutterKeyboardModeHidden;
-  }
-
-  // If keyboard's dimensions and position are all zeroes, that means it's a Minimized/Expanded
-  // Shortcuts Bar that has been dropped after dragging, which we categorize as floating.
-  if (CGRectEqualToRect(keyboardFrame, CGRectZero)) {
-    return FlutterKeyboardModeFloating;
-  }
-  // If keyboard's width or height are 0, it's hidden.
-  if (CGRectIsEmpty(keyboardFrame)) {
-    return FlutterKeyboardModeHidden;
-  }
-
-  CGRect screenRect = self.flutterScreenIfViewLoaded.bounds;
-  CGRect adjustedKeyboardFrame = keyboardFrame;
-  adjustedKeyboardFrame.origin.y += [self calculateMultitaskingAdjustment:screenRect
-                                                            keyboardFrame:keyboardFrame];
-
-  // If the keyboard is partially or fully showing within the screen, it's either docked or
-  // floating. Sometimes with custom keyboard extensions, the keyboard's position may be off by a
-  // small decimal amount (which is why CGRectIntersectRect can't be used). Round to compare.
-  CGRect intersection = CGRectIntersection(adjustedKeyboardFrame, screenRect);
-  CGFloat intersectionHeight = CGRectGetHeight(intersection);
-  CGFloat intersectionWidth = CGRectGetWidth(intersection);
-  if (round(intersectionHeight) > 0 && intersectionWidth > 0) {
-    // If the keyboard is above the bottom of the screen, it's floating.
-    CGFloat screenHeight = CGRectGetHeight(screenRect);
-    CGFloat adjustedKeyboardBottom = CGRectGetMaxY(adjustedKeyboardFrame);
-    if (round(adjustedKeyboardBottom) < screenHeight) {
-      return FlutterKeyboardModeFloating;
-    }
-    return FlutterKeyboardModeDocked;
-  }
-  return FlutterKeyboardModeHidden;
-}
-
-- (CGFloat)calculateMultitaskingAdjustment:(CGRect)screenRect keyboardFrame:(CGRect)keyboardFrame {
-  // In Slide Over mode, the keyboard's frame does not include the space
-  // below the app, even though the keyboard may be at the bottom of the screen.
-  // To handle, shift the Y origin by the amount of space below the app.
-  if (self.viewIfLoaded.traitCollection.userInterfaceIdiom == UIUserInterfaceIdiomPad &&
-      self.viewIfLoaded.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact &&
-      self.viewIfLoaded.traitCollection.verticalSizeClass == UIUserInterfaceSizeClassRegular) {
-    CGFloat screenHeight = CGRectGetHeight(screenRect);
-    CGFloat keyboardBottom = CGRectGetMaxY(keyboardFrame);
-
-    // Stage Manager mode will also meet the above parameters, but it does not handle
-    // the keyboard positioning the same way, so skip if keyboard is at bottom of page.
-    if (screenHeight == keyboardBottom) {
-      return 0;
-    }
-    CGRect viewRectRelativeToScreen =
-        [self.viewIfLoaded convertRect:self.viewIfLoaded.frame
-                     toCoordinateSpace:self.flutterScreenIfViewLoaded.coordinateSpace];
-    CGFloat viewBottom = CGRectGetMaxY(viewRectRelativeToScreen);
-    CGFloat offset = screenHeight - viewBottom;
-    if (offset > 0) {
-      return offset;
-    }
-  }
-  return 0;
-}
-
-- (CGFloat)calculateKeyboardInset:(CGRect)keyboardFrame keyboardMode:(NSInteger)keyboardMode {
-  // Only docked keyboards will have an inset.
-  if (keyboardMode == FlutterKeyboardModeDocked) {
-    // Calculate how much of the keyboard intersects with the view.
-    CGRect viewRectRelativeToScreen =
-        [self.viewIfLoaded convertRect:self.viewIfLoaded.frame
-                     toCoordinateSpace:self.flutterScreenIfViewLoaded.coordinateSpace];
-    CGRect intersection = CGRectIntersection(keyboardFrame, viewRectRelativeToScreen);
-    CGFloat portionOfKeyboardInView = CGRectGetHeight(intersection);
-
-    // The keyboard is treated as an inset since we want to effectively reduce the window size by
-    // the keyboard height. The Dart side will compute a value accounting for the keyboard-consuming
-    // bottom padding.
-    CGFloat scale = self.flutterScreenIfViewLoaded.scale;
-    return portionOfKeyboardInView * scale;
-  }
-  return 0;
-}
-
-- (void)startKeyBoardAnimation:(NSTimeInterval)duration {
-  // If current physical_view_inset_bottom == targetViewInsetBottom, do nothing.
-  if (_viewportMetrics.physical_view_inset_bottom == self.targetViewInsetBottom) {
-    return;
-  }
-
-  // When this method is called for the first time,
-  // initialize the keyboardAnimationView to get animation interpolation during animation.
-  if (!self.keyboardAnimationView) {
-    UIView* keyboardAnimationView = [[UIView alloc] init];
-    keyboardAnimationView.hidden = YES;
-    self.keyboardAnimationView = keyboardAnimationView;
-  }
-
-  if (!self.keyboardAnimationView.superview) {
-    [self.view addSubview:self.keyboardAnimationView];
-  }
-
-  // Remove running animation when start another animation.
-  [self.keyboardAnimationView.layer removeAllAnimations];
-
-  // Set animation begin value and DisplayLink tracking values.
-  self.keyboardAnimationView.frame =
-      CGRectMake(0, _viewportMetrics.physical_view_inset_bottom, 0, 0);
-  self.keyboardAnimationStartTime = fml::TimePoint().Now();
-  self.originalViewInsetBottom = _viewportMetrics.physical_view_inset_bottom;
-
-  // Invalidate old vsync client if old animation is not completed.
-  [self invalidateKeyboardAnimationVSyncClient];
-
-  __weak FlutterViewController* weakSelf = self;
-  [self setUpKeyboardAnimationVsyncClient:^(fml::TimePoint targetTime) {
-    [weakSelf handleKeyboardAnimationCallbackWithTargetTime:targetTime];
-  }];
-  VSyncClient* currentVsyncClient = _keyboardAnimationVSyncClient;
-
-  [UIView animateWithDuration:duration
-      animations:^{
-        FlutterViewController* strongSelf = weakSelf;
-        if (!strongSelf) {
-          return;
-        }
-
-        // Set end value.
-        strongSelf.keyboardAnimationView.frame = CGRectMake(0, self.targetViewInsetBottom, 0, 0);
-
-        // Setup keyboard animation interpolation.
-        CAAnimation* keyboardAnimation =
-            [strongSelf.keyboardAnimationView.layer animationForKey:@"position"];
-        [strongSelf setUpKeyboardSpringAnimationIfNeeded:keyboardAnimation];
-      }
-      completion:^(BOOL finished) {
-        if (_keyboardAnimationVSyncClient == currentVsyncClient) {
-          FlutterViewController* strongSelf = weakSelf;
-          if (!strongSelf) {
-            return;
-          }
-
-          // Indicates the vsync client captured by this block is the original one, which also
-          // indicates the animation has not been interrupted from its beginning. Moreover,
-          // indicates the animation is over and there is no more to execute.
-          [strongSelf invalidateKeyboardAnimationVSyncClient];
-          [strongSelf removeKeyboardAnimationView];
-          [strongSelf ensureViewportMetricsIsCorrect];
-        }
-      }];
-}
-
-- (void)hideKeyboardImmediately {
-  [self invalidateKeyboardAnimationVSyncClient];
-  if (self.keyboardAnimationView) {
-    [self.keyboardAnimationView.layer removeAllAnimations];
-    [self removeKeyboardAnimationView];
-    self.keyboardAnimationView = nil;
-  }
-  if (self.keyboardSpringAnimation) {
-    self.keyboardSpringAnimation = nil;
-  }
-  // Reset targetViewInsetBottom to 0.0.
-  self.targetViewInsetBottom = 0.0;
-  [self ensureViewportMetricsIsCorrect];
-}
-
-- (void)setUpKeyboardSpringAnimationIfNeeded:(CAAnimation*)keyboardAnimation {
-  // If keyboard animation is null or not a spring animation, fallback to DisplayLink tracking.
-  if (keyboardAnimation == nil || ![keyboardAnimation isKindOfClass:[CASpringAnimation class]]) {
-    _keyboardSpringAnimation = nil;
-    return;
-  }
-
-  // Setup keyboard spring animation details for spring curve animation calculation.
-  CASpringAnimation* keyboardCASpringAnimation = (CASpringAnimation*)keyboardAnimation;
-  _keyboardSpringAnimation =
-      [[SpringAnimation alloc] initWithStiffness:keyboardCASpringAnimation.stiffness
-                                         damping:keyboardCASpringAnimation.damping
-                                            mass:keyboardCASpringAnimation.mass
-                                 initialVelocity:keyboardCASpringAnimation.initialVelocity
-                                       fromValue:self.originalViewInsetBottom
-                                         toValue:self.targetViewInsetBottom];
-}
-
-- (void)handleKeyboardAnimationCallbackWithTargetTime:(fml::TimePoint)targetTime {
-  // If the view controller's view is not loaded, bail out.
-  if (!self.isViewLoaded) {
-    return;
-  }
-  // If the view for tracking keyboard animation is nil, means it is not
-  // created, bail out.
-  if (!self.keyboardAnimationView) {
-    return;
-  }
-  // If keyboardAnimationVSyncClient is nil, means the animation ends.
-  // And should bail out.
-  if (!self.keyboardAnimationVSyncClient) {
-    return;
-  }
-
-  if (!self.keyboardAnimationView.superview) {
-    // Ensure the keyboardAnimationView is in view hierarchy when animation running.
-    [self.view addSubview:self.keyboardAnimationView];
-  }
-
-  if (!self.keyboardSpringAnimation) {
-    if (self.keyboardAnimationView.layer.presentationLayer) {
-      self->_viewportMetrics.physical_view_inset_bottom =
-          self.keyboardAnimationView.layer.presentationLayer.frame.origin.y;
-      [self updateViewportMetricsIfNeeded];
-    }
-  } else {
-    fml::TimeDelta timeElapsed = targetTime - self.keyboardAnimationStartTime;
-    self->_viewportMetrics.physical_view_inset_bottom =
-        [self.keyboardSpringAnimation curveFunction:timeElapsed.ToSecondsF()];
-    [self updateViewportMetricsIfNeeded];
-  }
-}
-
-- (void)setUpKeyboardAnimationVsyncClient:
-    (FlutterKeyboardAnimationCallback)keyboardAnimationCallback {
-  if (!keyboardAnimationCallback) {
-    return;
-  }
-  NSAssert(_keyboardAnimationVSyncClient == nil,
-           @"_keyboardAnimationVSyncClient must be nil when setting up.");
-
-  // Make sure the new viewport metrics get sent after the begin frame event has processed.
-  FlutterKeyboardAnimationCallback animationCallback = [keyboardAnimationCallback copy];
-  auto uiCallback = [animationCallback](std::unique_ptr<flutter::FrameTimingsRecorder> recorder) {
-    fml::TimeDelta frameInterval = recorder->GetVsyncTargetTime() - recorder->GetVsyncStartTime();
-    fml::TimePoint targetTime = recorder->GetVsyncTargetTime() + frameInterval;
-    dispatch_async(dispatch_get_main_queue(), ^(void) {
-      animationCallback(targetTime);
-    });
-  };
-
-  _keyboardAnimationVSyncClient = [[VSyncClient alloc] initWithTaskRunner:self.engine.uiTaskRunner
-                                                                 callback:uiCallback];
-  _keyboardAnimationVSyncClient.allowPauseAfterVsync = NO;
-  [_keyboardAnimationVSyncClient await];
-}
-
-- (void)invalidateKeyboardAnimationVSyncClient {
-  [_keyboardAnimationVSyncClient invalidate];
-  _keyboardAnimationVSyncClient = nil;
-}
-
-- (void)removeKeyboardAnimationView {
-  if (self.keyboardAnimationView.superview != nil) {
-    [self.keyboardAnimationView removeFromSuperview];
-  }
-}
-
-- (void)ensureViewportMetricsIsCorrect {
-  if (_viewportMetrics.physical_view_inset_bottom != self.targetViewInsetBottom) {
-    // Make sure the `physical_view_inset_bottom` is the target value.
-    _viewportMetrics.physical_view_inset_bottom = self.targetViewInsetBottom;
-    [self updateViewportMetricsIfNeeded];
-  }
+  [self.keyboardInsetManager handleKeyboardNotification:notification];
 }
 
 - (void)handlePressEvent:(FlutterUIPressProxy*)press
@@ -2650,6 +2276,31 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 
 - (FlutterTextInputPlugin*)textInputPlugin {
   return self.engine.textInputPlugin;
+}
+
+#pragma mark - FlutterKeyboardInsetManagerDelegate
+
+- (void)updateViewportMetricsWithInset:(CGFloat)inset {
+  _viewportMetrics.physical_view_inset_bottom = inset;
+  [self updateViewportMetricsIfNeeded];
+}
+
+- (CGFloat)physicalViewInsetBottom {
+  return _viewportMetrics.physical_view_inset_bottom;
+}
+
+- (BOOL)isPadInSlideOverOrStageManagerMode {
+  if (self.view.traitCollection.userInterfaceIdiom == UIUserInterfaceIdiomPad &&
+      self.view.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact &&
+      self.view.traitCollection.verticalSizeClass == UIUserInterfaceSizeClassRegular) {
+    return YES;
+  }
+  return NO;
+}
+
+- (CGRect)convertViewRectToScreen:(CGRect)rect {
+  return [self.view convertRect:rect
+              toCoordinateSpace:self.flutterScreenIfViewLoaded.coordinateSpace];
 }
 
 @end

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -30,7 +30,84 @@
 
 FLUTTER_ASSERT_ARC
 
+@interface VSyncClient (Testing)
+- (CADisplayLink*)getDisplayLink;
+- (void)onDisplayLink:(CADisplayLink*)link;
+@end
+
 using namespace flutter::testing;
+
+@interface FlutterKeyboardInsetManager (Test)
+- (void)setUpKeyboardAnimationVsyncClient:
+    (FlutterKeyboardAnimationCallback)keyboardAnimationCallback;
+@property(nonatomic, assign, readwrite) CGFloat targetViewInsetBottom;
+@property(nonatomic, assign) BOOL keyboardAnimationIsShowing;
+@property(nonatomic, weak) id<FlutterKeyboardInsetManagerDelegate> delegate;
+@property(nonatomic, strong) VSyncClient* keyboardAnimationVSyncClient;
+@property(nonatomic, assign) BOOL isKeyboardInOrTransitioningFromBackground;
+- (void)handleKeyboardNotification:(NSNotification*)notification;
+- (BOOL)isKeyboardNotificationForDifferentView:(NSNotification*)notification;
+- (CGFloat)calculateKeyboardInset:(CGRect)keyboardFrame keyboardMode:(int)keyboardMode;
+- (BOOL)shouldIgnoreKeyboardNotification:(NSNotification*)notification;
+- (FlutterKeyboardMode)calculateKeyboardAttachMode:(NSNotification*)notification;
+- (CGFloat)calculateMultitaskingAdjustment:(CGRect)screenRect keyboardFrame:(CGRect)keyboardFrame;
+- (void)startKeyBoardAnimation:(NSTimeInterval)duration;
+- (void)hideKeyboardImmediately;
+- (UIView*)keyboardAnimationView;
+- (SpringAnimation*)keyboardSpringAnimation;
+- (void)setUpKeyboardSpringAnimationIfNeeded:(CAAnimation*)keyboardAnimation;
+- (void)ensureViewportMetricsIsCorrect;
+- (void)invalidateKeyboardAnimationVSyncClient;
+@end
+
+@interface FlutterKeyboardInsetManagerMock : FlutterKeyboardInsetManager
+@property(nonatomic, assign) BOOL didCallStartKeyboardAnimation;
+@end
+
+@implementation FlutterKeyboardInsetManagerMock
+- (void)startKeyBoardAnimation:(NSTimeInterval)duration {
+  [super startKeyBoardAnimation:duration];
+  self.didCallStartKeyboardAnimation = YES;
+}
+@end
+
+@interface TestKeyboardInsetDelegate : NSObject <FlutterKeyboardInsetManagerDelegate>
+@property(nonatomic, strong) UIScreen* mockScreen;
+@property(nonatomic, strong) UIView* mockView;
+@property(nonatomic, strong) FlutterEngine* mockEngine;
+@property(nonatomic, assign) CGFloat currentInset;
+@property(nonatomic, copy) void (^updateViewportMetricsBlock)(CGFloat inset);
+@property(nonatomic, assign) BOOL isViewLoaded;
+@property(nonatomic, assign) BOOL mockIsPadInSlideOverOrStageManagerMode;
+@property(nonatomic, assign) CGRect mockConvertedViewRect;
+@end
+
+@implementation TestKeyboardInsetDelegate
+- (void)updateViewportMetricsWithInset:(CGFloat)inset {
+  self.currentInset = inset;
+  if (self.updateViewportMetricsBlock) {
+    self.updateViewportMetricsBlock(inset);
+  }
+}
+- (CGFloat)physicalViewInsetBottom {
+  return self.currentInset;
+}
+- (UIView*)view {
+  return self.mockView;
+}
+- (FlutterEngine*)engine {
+  return self.mockEngine;
+}
+- (UIScreen*)flutterScreenIfViewLoaded {
+  return self.mockScreen;
+}
+- (BOOL)isPadInSlideOverOrStageManagerMode {
+  return self.mockIsPadInSlideOverOrStageManagerMode;
+}
+- (CGRect)convertViewRectToScreen:(CGRect)rect {
+  return self.mockConvertedViewRect;
+}
+@end
 
 /// Sometimes we have to use a custom mock to avoid retain cycles in OCMock.
 /// Used for testing low memory notification.
@@ -47,6 +124,10 @@ using namespace flutter::testing;
 - (void)sendKeyEvent:(const FlutterKeyEvent&)event
             callback:(nullable FlutterKeyEventCallback)callback
             userData:(nullable void*)userData;
+
+- (fml::RefPtr<fml::TaskRunner>)uiTaskRunner;
+- (BOOL)runWithEntrypoint:(nullable NSString*)entrypoint;
+- (void)attachView;
 @end
 
 @implementation FlutterEnginePartialMock
@@ -59,6 +140,19 @@ using namespace flutter::testing;
 
 - (void)notifyLowMemory {
   _didCallNotifyLowMemory = YES;
+}
+
+- (fml::RefPtr<fml::TaskRunner>)uiTaskRunner {
+  fml::MessageLoop::EnsureInitializedForCurrentThread();
+  return fml::MessageLoop::GetCurrent().GetTaskRunner();
+}
+
+- (BOOL)runWithEntrypoint:(nullable NSString*)entrypoint {
+  return YES;
+}
+
+- (void)attachView {
+  // Do nothing to avoid crash when platformView is nil on bots.
 }
 
 - (void)sendKeyEvent:(const FlutterKeyEvent&)event
@@ -126,10 +220,9 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 @property(nonatomic, strong) FlutterEngine* mockLaunchEngine;
 @end
 
-@interface FlutterViewController (Tests)
+@interface FlutterViewController (Tests) <FlutterKeyboardInsetManagerDelegate>
 
 @property(nonatomic, assign) double targetViewInsetBottom;
-@property(nonatomic, assign) BOOL isKeyboardInOrTransitioningFromBackground;
 @property(nonatomic, assign) BOOL keyboardAnimationIsShowing;
 @property(nonatomic, strong) VSyncClient* keyboardAnimationVSyncClient;
 @property(nonatomic, strong) VSyncClient* touchRateCorrectionVSyncClient;
@@ -147,20 +240,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 - (void)onUserSettingsChanged:(NSNotification*)notification;
 - (void)applicationWillTerminate:(NSNotification*)notification;
 - (void)goToApplicationLifecycle:(nonnull NSString*)state;
-- (void)handleKeyboardNotification:(NSNotification*)notification;
-- (CGFloat)calculateKeyboardInset:(CGRect)keyboardFrame keyboardMode:(int)keyboardMode;
-- (BOOL)shouldIgnoreKeyboardNotification:(NSNotification*)notification;
-- (FlutterKeyboardMode)calculateKeyboardAttachMode:(NSNotification*)notification;
-- (CGFloat)calculateMultitaskingAdjustment:(CGRect)screenRect keyboardFrame:(CGRect)keyboardFrame;
-- (void)startKeyBoardAnimation:(NSTimeInterval)duration;
-- (void)hideKeyboardImmediately;
-- (UIView*)keyboardAnimationView;
-- (SpringAnimation*)keyboardSpringAnimation;
-- (void)setUpKeyboardSpringAnimationIfNeeded:(CAAnimation*)keyboardAnimation;
-- (void)setUpKeyboardAnimationVsyncClient:
-    (FlutterKeyboardAnimationCallback)keyboardAnimationCallback;
-- (void)ensureViewportMetricsIsCorrect;
-- (void)invalidateKeyboardAnimationVSyncClient;
+
 - (void)addInternalPlugins;
 - (flutter::PointerData)generatePointerDataForFake;
 - (void)sharedSetupWithProject:(nullable FlutterDartProject*)project
@@ -189,12 +269,6 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 @interface UITouch ()
 
 @property(nonatomic, readwrite) UITouchPhase phase;
-
-@end
-
-@interface VSyncClient (Testing)
-
-- (CADisplayLink*)getDisplayLink;
 
 @end
 
@@ -232,13 +306,14 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
           viewFrame:(CGRect)viewFrame
      convertedFrame:(CGRect)convertedFrame {
   OCMStub([viewControllerMock flutterScreenIfViewLoaded]).andReturn(screen);
-  id mockView = OCMClassMock([UIView class]);
-  OCMStub([mockView frame]).andReturn(viewFrame);
-  OCMStub([mockView convertRect:viewFrame toCoordinateSpace:[OCMArg any]])
-      .andReturn(convertedFrame);
-  OCMStub([viewControllerMock viewIfLoaded]).andReturn(mockView);
+  UIView* view = [[UIView alloc] initWithFrame:viewFrame];
+  UIWindow* window = [[UIWindow alloc] initWithFrame:viewFrame];
+  [window addSubview:view];
 
-  return mockView;
+  OCMStub([viewControllerMock viewIfLoaded]).andReturn(view);
+  OCMStub([viewControllerMock view]).andReturn(view);
+
+  return view;
 }
 
 - (void)testViewDidLoadWillInvokeCreateTouchRateCorrectionVSyncClient {
@@ -254,28 +329,49 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 }
 
 - (void)testStartKeyboardAnimationWillInvokeSetupKeyboardSpringAnimationIfNeeded {
-  FlutterEngine* engine = [[FlutterEngine alloc] init];
+  FlutterEnginePartialMock* engine = [[FlutterEnginePartialMock alloc] init];
   [engine runWithEntrypoint:nil];
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
                                                                                 nibName:nil
                                                                                  bundle:nil];
   FlutterViewController* viewControllerMock = OCMPartialMock(viewController);
-  viewControllerMock.targetViewInsetBottom = 100;
-  [viewControllerMock startKeyBoardAnimation:0.25];
+  OCMStub([viewControllerMock isViewLoaded]).andReturn(YES);
+  [viewControllerMock view];
+  viewController.keyboardInsetManager.delegate =
+      (id<FlutterKeyboardInsetManagerDelegate>)viewControllerMock;
 
-  CAAnimation* keyboardAnimation =
-      [[viewControllerMock keyboardAnimationView].layer animationForKey:@"position"];
+  engine.viewController = viewControllerMock;
 
-  OCMVerify([viewControllerMock setUpKeyboardSpringAnimationIfNeeded:keyboardAnimation]);
+  id managerMock = OCMPartialMock(viewController.keyboardInsetManager);
+  viewController.keyboardInsetManager = managerMock;
+
+  id viewClassMock = OCMClassMock([UIView class]);
+  OCMStub([viewClassMock animateWithDuration:0.25 animations:[OCMArg any] completion:[OCMArg any]])
+      .andDo(^(NSInvocation* invocation) {
+        void (^animations)(void);
+        [invocation getArgument:&animations atIndex:3];
+        if (animations) {
+          animations();
+        }
+        void (^completion)(BOOL finished);
+        [invocation getArgument:&completion atIndex:4];
+        if (completion) {
+          completion(YES);
+        }
+      });
+
+  viewController.keyboardInsetManager.targetViewInsetBottom = 320;
+  [managerMock startKeyBoardAnimation:0.25];
+
+  OCMVerify([managerMock setUpKeyboardSpringAnimationIfNeeded:[OCMArg any]]);
 }
 
 - (void)testSetupKeyboardSpringAnimationIfNeeded {
-  FlutterEngine* engine = [[FlutterEngine alloc] init];
-  [engine runWithEntrypoint:nil];
-  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
-                                                                                nibName:nil
-                                                                                 bundle:nil];
+  FlutterViewController* viewController =
+      [[FlutterViewController alloc] initWithEngine:self.mockEngine nibName:nil bundle:nil];
   FlutterViewController* viewControllerMock = OCMPartialMock(viewController);
+  viewController.keyboardInsetManager.delegate =
+      (id<FlutterKeyboardInsetManagerDelegate>)viewControllerMock;
   UIScreen* screen = [self setUpMockScreen];
   CGRect viewFrame = screen.bounds;
   [self setUpMockView:viewControllerMock
@@ -284,8 +380,9 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
        convertedFrame:viewFrame];
 
   // Null check.
-  [viewControllerMock setUpKeyboardSpringAnimationIfNeeded:nil];
-  SpringAnimation* keyboardSpringAnimation = [viewControllerMock keyboardSpringAnimation];
+  [viewController.keyboardInsetManager setUpKeyboardSpringAnimationIfNeeded:nil];
+  SpringAnimation* keyboardSpringAnimation =
+      [viewController.keyboardInsetManager keyboardSpringAnimation];
   XCTAssertTrue(keyboardSpringAnimation == nil);
 
   // CAAnimation that is not a CASpringAnimation.
@@ -294,8 +391,8 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   nonSpringAnimation.fromValue = [NSNumber numberWithFloat:0.0];
   nonSpringAnimation.toValue = [NSNumber numberWithFloat:1.0];
   nonSpringAnimation.keyPath = @"position";
-  [viewControllerMock setUpKeyboardSpringAnimationIfNeeded:nonSpringAnimation];
-  keyboardSpringAnimation = [viewControllerMock keyboardSpringAnimation];
+  [viewController.keyboardInsetManager setUpKeyboardSpringAnimationIfNeeded:nonSpringAnimation];
+  keyboardSpringAnimation = [viewController.keyboardInsetManager keyboardSpringAnimation];
 
   XCTAssertTrue(keyboardSpringAnimation == nil);
 
@@ -307,28 +404,39 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   springAnimation.keyPath = @"position";
   springAnimation.fromValue = [NSValue valueWithCGPoint:CGPointMake(0, 0)];
   springAnimation.toValue = [NSValue valueWithCGPoint:CGPointMake(100, 100)];
-  [viewControllerMock setUpKeyboardSpringAnimationIfNeeded:springAnimation];
-  keyboardSpringAnimation = [viewControllerMock keyboardSpringAnimation];
+  [viewController.keyboardInsetManager setUpKeyboardSpringAnimationIfNeeded:springAnimation];
+  keyboardSpringAnimation = [viewController.keyboardInsetManager keyboardSpringAnimation];
   XCTAssertTrue(keyboardSpringAnimation != nil);
 }
 
+/**
+ * @brief Verifies that simultaneous compounding animation calls are handled correctly.
+ *
+ * This captures animation calls made while the keyboard animation is currently animating.
+ * If the new animation is in the same direction as the current animation, the current
+ * animation should continue with an updated targetViewInsetBottom instead of starting a new one.
+ */
 - (void)testKeyboardAnimationIsShowingAndCompounding {
-  FlutterEngine* engine = [[FlutterEngine alloc] init];
-  [engine runWithEntrypoint:nil];
-  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
-                                                                                nibName:nil
-                                                                                 bundle:nil];
-  FlutterViewController* viewControllerMock = OCMPartialMock(viewController);
   UIScreen* screen = [self setUpMockScreen];
-  CGRect viewFrame = screen.bounds;
-  [self setUpMockView:viewControllerMock
-               screen:screen
-            viewFrame:viewFrame
-       convertedFrame:viewFrame];
-
-  BOOL isLocal = YES;
+  CGFloat screenWidth = screen.bounds.size.width;
   CGFloat screenHeight = screen.bounds.size.height;
-  CGFloat screenWidth = screen.bounds.size.height;
+  CGRect viewFrame = screen.bounds;
+
+  TestKeyboardInsetDelegate* delegate = [[TestKeyboardInsetDelegate alloc] init];
+  delegate.isViewLoaded = YES;
+  delegate.mockScreen = screen;
+
+  delegate.mockConvertedViewRect = viewFrame;
+
+  FlutterEnginePartialMock* engine = [[FlutterEnginePartialMock alloc] init];
+  delegate.mockEngine = engine;
+
+  FlutterKeyboardInsetManager* manager =
+      [[FlutterKeyboardInsetManager alloc] initWithDelegate:delegate];
+
+  id managerMock = OCMPartialMock(manager);
+  OCMStub([managerMock shouldIgnoreKeyboardNotification:[OCMArg any]]).andReturn(NO);
+  BOOL isLocal = YES;
 
   // Start show keyboard animation.
   CGRect initialShowKeyboardBeginFrame = CGRectMake(0, screenHeight, screenWidth, 250);
@@ -342,9 +450,9 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
                     @"UIKeyboardAnimationDurationUserInfoKey" : @(0.25),
                     @"UIKeyboardIsLocalUserInfoKey" : @(isLocal)
                   }];
-  viewControllerMock.targetViewInsetBottom = 0;
-  [viewControllerMock handleKeyboardNotification:fakeNotification];
-  BOOL isShowingAnimation1 = viewControllerMock.keyboardAnimationIsShowing;
+  manager.targetViewInsetBottom = 0;
+  [managerMock handleKeyboardNotification:fakeNotification];
+  BOOL isShowingAnimation1 = manager.keyboardAnimationIsShowing;
   XCTAssertTrue(isShowingAnimation1);
 
   // Start compounding show keyboard animation.
@@ -360,8 +468,8 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
                     @"UIKeyboardIsLocalUserInfoKey" : @(isLocal)
                   }];
 
-  [viewControllerMock handleKeyboardNotification:fakeNotification];
-  BOOL isShowingAnimation2 = viewControllerMock.keyboardAnimationIsShowing;
+  [managerMock handleKeyboardNotification:fakeNotification];
+  BOOL isShowingAnimation2 = manager.keyboardAnimationIsShowing;
   XCTAssertTrue(isShowingAnimation2);
   XCTAssertTrue(isShowingAnimation1 == isShowingAnimation2);
 
@@ -378,8 +486,8 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
                     @"UIKeyboardIsLocalUserInfoKey" : @(isLocal)
                   }];
 
-  [viewControllerMock handleKeyboardNotification:fakeNotification];
-  BOOL isShowingAnimation3 = viewControllerMock.keyboardAnimationIsShowing;
+  [managerMock handleKeyboardNotification:fakeNotification];
+  BOOL isShowingAnimation3 = manager.keyboardAnimationIsShowing;
   XCTAssertFalse(isShowingAnimation3);
   XCTAssertTrue(isShowingAnimation2 != isShowingAnimation3);
 
@@ -396,19 +504,25 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
                     @"UIKeyboardIsLocalUserInfoKey" : @(isLocal)
                   }];
 
-  [viewControllerMock handleKeyboardNotification:fakeNotification];
-  BOOL isShowingAnimation4 = viewControllerMock.keyboardAnimationIsShowing;
+  [managerMock handleKeyboardNotification:fakeNotification];
+  BOOL isShowingAnimation4 = manager.keyboardAnimationIsShowing;
   XCTAssertFalse(isShowingAnimation4);
   XCTAssertTrue(isShowingAnimation3 == isShowingAnimation4);
 }
 
 - (void)testShouldIgnoreKeyboardNotification {
-  FlutterEngine* mockEngine = OCMPartialMock([[FlutterEngine alloc] init]);
-  [mockEngine createShell:@"" libraryURI:@"" initialRoute:nil];
-  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:mockEngine
-                                                                                nibName:nil
-                                                                                 bundle:nil];
+  FlutterViewController* viewController =
+      [[FlutterViewController alloc] initWithEngine:self.mockEngine nibName:nil bundle:nil];
   FlutterViewController* viewControllerMock = OCMPartialMock(viewController);
+  // Stub the mock engine to return the mock view controller to pass
+  // isKeyboardNotificationForDifferentView
+  OCMStub([self.mockEngine viewController]).andReturn(viewControllerMock);
+
+  // Use custom mock for manager to avoid OCMock andDo block issues with C++ interop
+  FlutterKeyboardInsetManagerMock* managerMock = [[FlutterKeyboardInsetManagerMock alloc]
+      initWithDelegate:(id<FlutterKeyboardInsetManagerDelegate>)viewControllerMock];
+  viewController.keyboardInsetManager = managerMock;
+
   UIScreen* screen = [self setUpMockScreen];
   CGRect viewFrame = screen.bounds;
   [self setUpMockView:viewControllerMock
@@ -433,7 +547,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
                                     @"UIKeyboardIsLocalUserInfoKey" : @(isLocal)
                                   }];
 
-  BOOL shouldIgnore = [viewControllerMock shouldIgnoreKeyboardNotification:notification];
+  BOOL shouldIgnore = [managerMock shouldIgnoreKeyboardNotification:notification];
   XCTAssertTrue(shouldIgnore == NO);
 
   // All zero keyboard
@@ -445,7 +559,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
                                                @"UIKeyboardAnimationDurationUserInfoKey" : @0.25,
                                                @"UIKeyboardIsLocalUserInfoKey" : @(isLocal)
                                              }];
-  shouldIgnore = [viewControllerMock shouldIgnoreKeyboardNotification:notification];
+  shouldIgnore = [managerMock shouldIgnoreKeyboardNotification:notification];
   XCTAssertTrue(shouldIgnore == YES);
 
   // Zero height keyboard
@@ -458,7 +572,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
                                     @"UIKeyboardAnimationDurationUserInfoKey" : @0.25,
                                     @"UIKeyboardIsLocalUserInfoKey" : @(isLocal)
                                   }];
-  shouldIgnore = [viewControllerMock shouldIgnoreKeyboardNotification:notification];
+  shouldIgnore = [managerMock shouldIgnoreKeyboardNotification:notification];
   XCTAssertTrue(shouldIgnore == NO);
 
   // Valid keyboard, triggered from another app
@@ -471,7 +585,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
                                     @"UIKeyboardAnimationDurationUserInfoKey" : @0.25,
                                     @"UIKeyboardIsLocalUserInfoKey" : @(isLocal)
                                   }];
-  shouldIgnore = [viewControllerMock shouldIgnoreKeyboardNotification:notification];
+  shouldIgnore = [managerMock shouldIgnoreKeyboardNotification:notification];
   XCTAssertTrue(shouldIgnore == YES);
 
   // Valid keyboard
@@ -484,8 +598,10 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
                                     @"UIKeyboardAnimationDurationUserInfoKey" : @0.25,
                                     @"UIKeyboardIsLocalUserInfoKey" : @(isLocal)
                                   }];
-  shouldIgnore = [viewControllerMock shouldIgnoreKeyboardNotification:notification];
+  shouldIgnore = [managerMock shouldIgnoreKeyboardNotification:notification];
   XCTAssertTrue(shouldIgnore == NO);
+
+  [(id)viewControllerMock stopMocking];
 }
 
 - (void)testKeyboardAnimationWillNotCrashWhenEngineDestroyed {
@@ -494,8 +610,9 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
                                                                                 nibName:nil
                                                                                  bundle:nil];
-  [viewController setUpKeyboardAnimationVsyncClient:^(fml::TimePoint){
-  }];
+  [viewController.keyboardInsetManager
+      setUpKeyboardAnimationVsyncClient:^(NSTimeInterval targetTime){
+      }];
   [engine destroyContext];
 }
 
@@ -516,25 +633,34 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   [engine uiTaskRunner]->PostTask([] { sleep(delayTime); });
   XCTestExpectation* expectation = [self expectationWithDescription:@"keyboard animation callback"];
 
+  id mockCADisplayLink = OCMClassMock([CADisplayLink class]);
+  OCMStub(
+      ClassMethod([mockCADisplayLink displayLinkWithTarget:[OCMArg any]
+                                                  selector:sel_registerName("onDisplayLink:")]));
+
   __block CFTimeInterval fulfillTime;
-  FlutterKeyboardAnimationCallback callback = ^(fml::TimePoint targetTime) {
+  FlutterKeyboardAnimationCallback callback = ^(NSTimeInterval targetTime) {
     fulfillTime = CACurrentMediaTime();
     [expectation fulfill];
   };
   CFTimeInterval startTime = CACurrentMediaTime();
-  [viewController setUpKeyboardAnimationVsyncClient:callback];
+  [viewController.keyboardInsetManager setUpKeyboardAnimationVsyncClient:callback];
+
+  VSyncClient* client = viewController.keyboardInsetManager.keyboardAnimationVSyncClient;
+  [client onDisplayLink:[client getDisplayLink]];
+
   [self waitForExpectationsWithTimeout:5.0 handler:nil];
   XCTAssertTrue(fulfillTime - startTime > delayTime);
+  fml::MessageLoop::GetCurrent().RunExpiredTasksNow();
 }
 
 - (void)testCalculateKeyboardAttachMode {
-  FlutterEngine* mockEngine = OCMPartialMock([[FlutterEngine alloc] init]);
-  [mockEngine createShell:@"" libraryURI:@"" initialRoute:nil];
-  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:mockEngine
-                                                                                nibName:nil
-                                                                                 bundle:nil];
+  FlutterViewController* viewController =
+      [[FlutterViewController alloc] initWithEngine:self.mockEngine nibName:nil bundle:nil];
 
   FlutterViewController* viewControllerMock = OCMPartialMock(viewController);
+  viewController.keyboardInsetManager.delegate =
+      (id<FlutterKeyboardInsetManagerDelegate>)viewControllerMock;
   UIScreen* screen = [self setUpMockScreen];
   CGRect viewFrame = screen.bounds;
   [self setUpMockView:viewControllerMock
@@ -555,7 +681,8 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
                                     @"UIKeyboardAnimationDurationUserInfoKey" : @0.25,
                                     @"UIKeyboardIsLocalUserInfoKey" : @(YES)
                                   }];
-  FlutterKeyboardMode keyboardMode = [viewControllerMock calculateKeyboardAttachMode:notification];
+  FlutterKeyboardMode keyboardMode =
+      [viewController.keyboardInsetManager calculateKeyboardAttachMode:notification];
   XCTAssertTrue(keyboardMode == FlutterKeyboardModeHidden);
 
   // all zeros
@@ -567,7 +694,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
                                                @"UIKeyboardAnimationDurationUserInfoKey" : @0.25,
                                                @"UIKeyboardIsLocalUserInfoKey" : @(YES)
                                              }];
-  keyboardMode = [viewControllerMock calculateKeyboardAttachMode:notification];
+  keyboardMode = [viewController.keyboardInsetManager calculateKeyboardAttachMode:notification];
   XCTAssertTrue(keyboardMode == FlutterKeyboardModeFloating);
 
   // 0 height
@@ -579,7 +706,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
                                                @"UIKeyboardAnimationDurationUserInfoKey" : @0.25,
                                                @"UIKeyboardIsLocalUserInfoKey" : @(YES)
                                              }];
-  keyboardMode = [viewControllerMock calculateKeyboardAttachMode:notification];
+  keyboardMode = [viewController.keyboardInsetManager calculateKeyboardAttachMode:notification];
   XCTAssertTrue(keyboardMode == FlutterKeyboardModeHidden);
 
   // floating
@@ -591,7 +718,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
                                                @"UIKeyboardAnimationDurationUserInfoKey" : @0.25,
                                                @"UIKeyboardIsLocalUserInfoKey" : @(YES)
                                              }];
-  keyboardMode = [viewControllerMock calculateKeyboardAttachMode:notification];
+  keyboardMode = [viewController.keyboardInsetManager calculateKeyboardAttachMode:notification];
   XCTAssertTrue(keyboardMode == FlutterKeyboardModeFloating);
 
   // undocked
@@ -603,7 +730,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
                                                @"UIKeyboardAnimationDurationUserInfoKey" : @0.25,
                                                @"UIKeyboardIsLocalUserInfoKey" : @(YES)
                                              }];
-  keyboardMode = [viewControllerMock calculateKeyboardAttachMode:notification];
+  keyboardMode = [viewController.keyboardInsetManager calculateKeyboardAttachMode:notification];
   XCTAssertTrue(keyboardMode == FlutterKeyboardModeFloating);
 
   // docked
@@ -615,7 +742,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
                                                @"UIKeyboardAnimationDurationUserInfoKey" : @0.25,
                                                @"UIKeyboardIsLocalUserInfoKey" : @(YES)
                                              }];
-  keyboardMode = [viewControllerMock calculateKeyboardAttachMode:notification];
+  keyboardMode = [viewController.keyboardInsetManager calculateKeyboardAttachMode:notification];
   XCTAssertTrue(keyboardMode == FlutterKeyboardModeDocked);
 
   // docked - rounded values
@@ -628,7 +755,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
                                                @"UIKeyboardAnimationDurationUserInfoKey" : @0.25,
                                                @"UIKeyboardIsLocalUserInfoKey" : @(YES)
                                              }];
-  keyboardMode = [viewControllerMock calculateKeyboardAttachMode:notification];
+  keyboardMode = [viewController.keyboardInsetManager calculateKeyboardAttachMode:notification];
   XCTAssertTrue(keyboardMode == FlutterKeyboardModeDocked);
 
   // hidden - rounded values
@@ -640,7 +767,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
                                                @"UIKeyboardAnimationDurationUserInfoKey" : @0.25,
                                                @"UIKeyboardIsLocalUserInfoKey" : @(YES)
                                              }];
-  keyboardMode = [viewControllerMock calculateKeyboardAttachMode:notification];
+  keyboardMode = [viewController.keyboardInsetManager calculateKeyboardAttachMode:notification];
   XCTAssertTrue(keyboardMode == FlutterKeyboardModeHidden);
 
   // hidden
@@ -652,112 +779,102 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
                                                @"UIKeyboardAnimationDurationUserInfoKey" : @0.25,
                                                @"UIKeyboardIsLocalUserInfoKey" : @(YES)
                                              }];
-  keyboardMode = [viewControllerMock calculateKeyboardAttachMode:notification];
+  keyboardMode = [viewController.keyboardInsetManager calculateKeyboardAttachMode:notification];
   XCTAssertTrue(keyboardMode == FlutterKeyboardModeHidden);
 }
 
 - (void)testCalculateMultitaskingAdjustment {
-  FlutterEngine* mockEngine = OCMPartialMock([[FlutterEngine alloc] init]);
-  [mockEngine createShell:@"" libraryURI:@"" initialRoute:nil];
-  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:mockEngine
-                                                                                nibName:nil
-                                                                                 bundle:nil];
-  FlutterViewController* viewControllerMock = OCMPartialMock(viewController);
-
-  UIScreen* screen = [self setUpMockScreen];
+  UIScreen* screen = [UIScreen mainScreen];
   CGFloat screenWidth = screen.bounds.size.width;
   CGFloat screenHeight = screen.bounds.size.height;
   CGRect screenRect = screen.bounds;
-  CGRect viewOrigFrame = CGRectMake(0, 0, 320, screenHeight - 40);
-  CGRect convertedViewFrame = CGRectMake(20, 20, 320, screenHeight - 40);
+  CGRect convertedViewFrame = CGRectMake(0, 0, 320, screenHeight - 20);
   CGRect keyboardFrame = CGRectMake(20, screenHeight - 320, screenWidth, 300);
-  id mockView = [self setUpMockView:viewControllerMock
-                             screen:screen
-                          viewFrame:viewOrigFrame
-                     convertedFrame:convertedViewFrame];
-  id mockTraitCollection = OCMClassMock([UITraitCollection class]);
-  OCMStub([mockTraitCollection userInterfaceIdiom]).andReturn(UIUserInterfaceIdiomPad);
-  OCMStub([mockTraitCollection horizontalSizeClass]).andReturn(UIUserInterfaceSizeClassCompact);
-  OCMStub([mockTraitCollection verticalSizeClass]).andReturn(UIUserInterfaceSizeClassRegular);
-  OCMStub([mockView traitCollection]).andReturn(mockTraitCollection);
 
-  CGFloat adjustment = [viewControllerMock calculateMultitaskingAdjustment:screenRect
-                                                             keyboardFrame:keyboardFrame];
+  TestKeyboardInsetDelegate* delegate = [[TestKeyboardInsetDelegate alloc] init];
+  delegate.mockScreen = screen;
+  delegate.isViewLoaded = YES;
+
+  delegate.mockIsPadInSlideOverOrStageManagerMode = YES;
+  delegate.mockConvertedViewRect = convertedViewFrame;
+
+  FlutterKeyboardInsetManager* manager =
+      [[FlutterKeyboardInsetManager alloc] initWithDelegate:delegate];
+
+  CGFloat adjustment = [manager calculateMultitaskingAdjustment:screenRect
+                                                  keyboardFrame:keyboardFrame];
   XCTAssertTrue(adjustment == 20);
 }
 
 - (void)testCalculateKeyboardInset {
-  FlutterEngine* mockEngine = OCMPartialMock([[FlutterEngine alloc] init]);
-  [mockEngine createShell:@"" libraryURI:@"" initialRoute:nil];
-  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:mockEngine
-                                                                                nibName:nil
-                                                                                 bundle:nil];
-  FlutterViewController* viewControllerMock = OCMPartialMock(viewController);
-  UIScreen* screen = [self setUpMockScreen];
-  OCMStub([viewControllerMock flutterScreenIfViewLoaded]).andReturn(screen);
-
+  UIScreen* screen = [UIScreen mainScreen];
   CGFloat screenWidth = screen.bounds.size.width;
   CGFloat screenHeight = screen.bounds.size.height;
-  CGRect viewOrigFrame = CGRectMake(0, 0, 320, screenHeight - 40);
-  CGRect convertedViewFrame = CGRectMake(20, 20, 320, screenHeight - 40);
+  CGRect convertedViewFrame = CGRectMake(0, 0, 320, screenHeight - 20);
   CGRect keyboardFrame = CGRectMake(20, screenHeight - 320, screenWidth, 300);
 
-  [self setUpMockView:viewControllerMock
-               screen:screen
-            viewFrame:viewOrigFrame
-       convertedFrame:convertedViewFrame];
+  TestKeyboardInsetDelegate* delegate = [[TestKeyboardInsetDelegate alloc] init];
+  delegate.isViewLoaded = YES;
+  delegate.mockScreen = screen;
 
-  CGFloat inset = [viewControllerMock calculateKeyboardInset:keyboardFrame
-                                                keyboardMode:FlutterKeyboardModeDocked];
+  delegate.mockConvertedViewRect = convertedViewFrame;
+
+  FlutterKeyboardInsetManager* manager =
+      [[FlutterKeyboardInsetManager alloc] initWithDelegate:delegate];
+
+  CGFloat inset = [manager calculateKeyboardInset:keyboardFrame
+                                     keyboardMode:FlutterKeyboardModeDocked];
   XCTAssertTrue(inset == 300 * screen.scale);
 }
 
 - (void)testHandleKeyboardNotification {
-  FlutterEngine* engine = [[FlutterEngine alloc] init];
-  [engine runWithEntrypoint:nil];
-  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
-                                                                                nibName:nil
-                                                                                 bundle:nil];
-  // keyboard is empty
   UIScreen* screen = [self setUpMockScreen];
   CGFloat screenWidth = screen.bounds.size.width;
   CGFloat screenHeight = screen.bounds.size.height;
   CGRect keyboardFrame = CGRectMake(0, screenHeight - 320, screenWidth, 320);
   CGRect viewFrame = screen.bounds;
   BOOL isLocal = YES;
-  NSNotification* notification =
-      [NSNotification notificationWithName:UIKeyboardWillShowNotification
-                                    object:nil
-                                  userInfo:@{
-                                    @"UIKeyboardFrameEndUserInfoKey" : @(keyboardFrame),
-                                    @"UIKeyboardAnimationDurationUserInfoKey" : @0.25,
-                                    @"UIKeyboardIsLocalUserInfoKey" : @(isLocal)
-                                  }];
-  FlutterViewController* viewControllerMock = OCMPartialMock(viewController);
-  [self setUpMockView:viewControllerMock
-               screen:screen
-            viewFrame:viewFrame
-       convertedFrame:viewFrame];
-  viewControllerMock.targetViewInsetBottom = 0;
-  XCTestExpectation* expectation = [self expectationWithDescription:@"update viewport"];
-  OCMStub([viewControllerMock updateViewportMetricsIfNeeded]).andDo(^(NSInvocation* invocation) {
-    [expectation fulfill];
-  });
+  NSNotification* notification = [NSNotification
+      notificationWithName:UIKeyboardWillShowNotification
+                    object:nil
+                  userInfo:@{
+                    @"UIKeyboardFrameEndUserInfoKey" : [NSValue valueWithCGRect:keyboardFrame],
+                    @"UIKeyboardAnimationDurationUserInfoKey" : @0.25,
+                    @"UIKeyboardIsLocalUserInfoKey" : @(isLocal)
+                  }];
 
-  [viewControllerMock handleKeyboardNotification:notification];
-  XCTAssertTrue(viewControllerMock.targetViewInsetBottom == 320 * screen.scale);
-  OCMVerify([viewControllerMock startKeyBoardAnimation:0.25]);
-  [self waitForExpectationsWithTimeout:5.0 handler:nil];
+  TestKeyboardInsetDelegate* delegate = [[TestKeyboardInsetDelegate alloc] init];
+  delegate.isViewLoaded = YES;
+  delegate.mockScreen = screen;
+
+  delegate.mockConvertedViewRect = viewFrame;
+
+  FlutterEnginePartialMock* engine = [[FlutterEnginePartialMock alloc] init];
+  delegate.mockEngine = engine;
+  engine.viewController = (FlutterViewController*)delegate;
+
+  FlutterKeyboardInsetManagerMock* managerMock =
+      [[FlutterKeyboardInsetManagerMock alloc] initWithDelegate:delegate];
+  managerMock.targetViewInsetBottom = 0;
+
+  [managerMock handleKeyboardNotification:notification];
+  XCTAssertTrue(managerMock.targetViewInsetBottom == 320 * screen.scale);
+  XCTAssertTrue(managerMock.didCallStartKeyboardAnimation);
 }
 
 - (void)testEnsureBottomInsetIsZeroWhenKeyboardDismissed {
-  FlutterEngine* mockEngine = OCMPartialMock([[FlutterEngine alloc] init]);
-  [mockEngine createShell:@"" libraryURI:@"" initialRoute:nil];
-  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:mockEngine
+  FlutterEnginePartialMock* engine = [[FlutterEnginePartialMock alloc] init];
+  [engine runWithEntrypoint:nil];
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
                                                                                 nibName:nil
                                                                                  bundle:nil];
 
   FlutterViewController* viewControllerMock = OCMPartialMock(viewController);
+  viewController.keyboardInsetManager.delegate =
+      (id<FlutterKeyboardInsetManagerDelegate>)viewControllerMock;
+
+  engine.viewController = viewControllerMock;
+
   CGRect keyboardFrame = CGRectZero;
   BOOL isLocal = YES;
   NSNotification* fakeNotification =
@@ -769,30 +886,39 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
                                     @"UIKeyboardIsLocalUserInfoKey" : @(isLocal)
                                   }];
 
-  viewControllerMock.targetViewInsetBottom = 10;
-  [viewControllerMock handleKeyboardNotification:fakeNotification];
-  XCTAssertTrue(viewControllerMock.targetViewInsetBottom == 0);
+  viewController.keyboardInsetManager.targetViewInsetBottom = 10;
+  [viewController.keyboardInsetManager handleKeyboardNotification:fakeNotification];
+  XCTAssertTrue(viewController.keyboardInsetManager.targetViewInsetBottom == 0);
 }
 
 - (void)testStopKeyBoardAnimationWhenReceivedWillHideNotificationAfterWillShowNotification {
   // see: https://github.com/flutter/flutter/issues/112281
 
-  FlutterEngine* engine = [[FlutterEngine alloc] init];
+  FlutterEnginePartialMock* engine = [[FlutterEnginePartialMock alloc] init];
   [engine runWithEntrypoint:nil];
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
                                                                                 nibName:nil
                                                                                  bundle:nil];
   FlutterViewController* viewControllerMock = OCMPartialMock(viewController);
+  viewController.keyboardInsetManager.delegate =
+      (id<FlutterKeyboardInsetManagerDelegate>)viewControllerMock;
+
+  engine.viewController = viewControllerMock;
+  OCMStub([viewControllerMock isViewLoaded]).andReturn(YES);
+  [viewControllerMock view];
+
   UIScreen* screen = [self setUpMockScreen];
+  OCMStub([screen scale]).andReturn(1.0);
+  OCMStub([viewControllerMock flutterScreenIfViewLoaded]).andReturn(screen);
   CGRect viewFrame = screen.bounds;
   [self setUpMockView:viewControllerMock
                screen:screen
             viewFrame:viewFrame
        convertedFrame:viewFrame];
-  viewControllerMock.targetViewInsetBottom = 0;
+  viewController.keyboardInsetManager.targetViewInsetBottom = 0;
 
+  CGFloat screenWidth = screen.bounds.size.width;
   CGFloat screenHeight = screen.bounds.size.height;
-  CGFloat screenWidth = screen.bounds.size.height;
   CGRect keyboardFrame = CGRectMake(0, screenHeight - 320, screenWidth, 320);
   BOOL isLocal = YES;
 
@@ -801,12 +927,12 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
       [NSNotification notificationWithName:UIKeyboardWillShowNotification
                                     object:nil
                                   userInfo:@{
-                                    @"UIKeyboardFrameEndUserInfoKey" : @(keyboardFrame),
-                                    @"UIKeyboardAnimationDurationUserInfoKey" : @0.25,
-                                    @"UIKeyboardIsLocalUserInfoKey" : @(isLocal)
+                                    UIKeyboardFrameEndUserInfoKey : @(keyboardFrame),
+                                    UIKeyboardAnimationDurationUserInfoKey : @0.25,
+                                    UIKeyboardIsLocalUserInfoKey : @(isLocal)
                                   }];
-  [viewControllerMock handleKeyboardNotification:fakeShowNotification];
-  XCTAssertTrue(viewControllerMock.targetViewInsetBottom == 320 * screen.scale);
+  [viewController.keyboardInsetManager handleKeyboardNotification:fakeShowNotification];
+  XCTAssertEqual(viewController.keyboardInsetManager.targetViewInsetBottom, 320 * screen.scale);
 
   // Receive will hide notification
   NSNotification* fakeHideNotification =
@@ -817,24 +943,31 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
                                     @"UIKeyboardAnimationDurationUserInfoKey" : @(0.0),
                                     @"UIKeyboardIsLocalUserInfoKey" : @(isLocal)
                                   }];
-  [viewControllerMock handleKeyboardNotification:fakeHideNotification];
-  XCTAssertTrue(viewControllerMock.targetViewInsetBottom == 0);
+  [viewController.keyboardInsetManager handleKeyboardNotification:fakeHideNotification];
+  XCTAssertEqual(viewController.keyboardInsetManager.targetViewInsetBottom, 0);
 
   // Check if the keyboard animation is stopped.
-  XCTAssertNil(viewControllerMock.keyboardAnimationView);
-  XCTAssertNil(viewControllerMock.keyboardSpringAnimation);
+  XCTAssertNil([viewController.keyboardInsetManager keyboardAnimationView]);
+  XCTAssertNil([viewController.keyboardInsetManager keyboardSpringAnimation]);
 }
 
 - (void)testEnsureViewportMetricsWillInvokeAndDisplayLinkWillInvalidateInViewDidDisappear {
-  FlutterEngine* mockEngine = OCMPartialMock([[FlutterEngine alloc] init]);
-  [mockEngine createShell:@"" libraryURI:@"" initialRoute:nil];
-  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:mockEngine
+  FlutterEnginePartialMock* engine = [[FlutterEnginePartialMock alloc] init];
+  [engine runWithEntrypoint:nil];
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
                                                                                 nibName:nil
                                                                                  bundle:nil];
   id viewControllerMock = OCMPartialMock(viewController);
+  viewController.keyboardInsetManager.delegate =
+      (id<FlutterKeyboardInsetManagerDelegate>)viewControllerMock;
+
+  id managerMock = OCMPartialMock(viewController.keyboardInsetManager);
+  viewController.keyboardInsetManager = managerMock;
+
   [viewControllerMock viewDidDisappear:YES];
-  OCMVerify([viewControllerMock ensureViewportMetricsIsCorrect]);
-  OCMVerify([viewControllerMock invalidateKeyboardAnimationVSyncClient]);
+
+  OCMVerify([managerMock ensureViewportMetricsIsCorrect]);
+  OCMVerify([managerMock invalidateKeyboardAnimationVSyncClient]);
 }
 
 - (void)testViewDidDisappearDoesntPauseEngineWhenNotTheViewController {
@@ -2003,7 +2136,8 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   [NSNotificationCenter.defaultCenter postNotification:applicationNotification];
   OCMReject([mockVC sceneBecameActive:[OCMArg any]]);
   OCMVerify([mockVC applicationBecameActive:[OCMArg any]]);
-  XCTAssertFalse(flutterViewController.isKeyboardInOrTransitioningFromBackground);
+  XCTAssertFalse(
+      flutterViewController.keyboardInsetManager.isKeyboardInOrTransitioningFromBackground);
   OCMVerify([mockVC surfaceUpdated:YES]);
   XCTestExpectation* timeoutApplicationLifeCycle =
       [self expectationWithDescription:@"timeoutApplicationLifeCycle"];
@@ -2040,7 +2174,8 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   [NSNotificationCenter.defaultCenter postNotification:applicationNotification];
   OCMVerify([mockVC sceneBecameActive:[OCMArg any]]);
   OCMReject([mockVC applicationBecameActive:[OCMArg any]]);
-  XCTAssertFalse(flutterViewController.isKeyboardInOrTransitioningFromBackground);
+  XCTAssertFalse(
+      flutterViewController.keyboardInsetManager.isKeyboardInOrTransitioningFromBackground);
   OCMVerify([mockVC surfaceUpdated:YES]);
   XCTestExpectation* timeoutApplicationLifeCycle =
       [self expectationWithDescription:@"timeoutApplicationLifeCycle"];
@@ -2176,7 +2311,8 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   [NSNotificationCenter.defaultCenter postNotification:applicationNotification];
   OCMReject([mockVC sceneDidEnterBackground:[OCMArg any]]);
   OCMVerify([mockVC applicationDidEnterBackground:[OCMArg any]]);
-  XCTAssertTrue(flutterViewController.isKeyboardInOrTransitioningFromBackground);
+  XCTAssertTrue(
+      flutterViewController.keyboardInsetManager.isKeyboardInOrTransitioningFromBackground);
   OCMVerify([mockVC surfaceUpdated:NO]);
   OCMVerify([mockVC goToApplicationLifecycle:@"AppLifecycleState.paused"]);
   [flutterViewController deregisterNotifications];
@@ -2204,7 +2340,8 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   [NSNotificationCenter.defaultCenter postNotification:applicationNotification];
   OCMVerify([mockVC sceneDidEnterBackground:[OCMArg any]]);
   OCMReject([mockVC applicationDidEnterBackground:[OCMArg any]]);
-  XCTAssertTrue(flutterViewController.isKeyboardInOrTransitioningFromBackground);
+  XCTAssertTrue(
+      flutterViewController.keyboardInsetManager.isKeyboardInOrTransitioningFromBackground);
   OCMVerify([mockVC surfaceUpdated:NO]);
   OCMVerify([mockVC goToApplicationLifecycle:@"AppLifecycleState.paused"]);
   [flutterViewController deregisterNotifications];
@@ -2301,18 +2438,25 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
                                                                                 nibName:nil
                                                                                  bundle:nil];
-  FlutterKeyboardAnimationCallback callback = ^(fml::TimePoint targetTime) {
+  FlutterKeyboardAnimationCallback callback = ^(NSTimeInterval targetTime) {
   };
-  [viewController setUpKeyboardAnimationVsyncClient:callback];
-  XCTAssertNotNil(viewController.keyboardAnimationVSyncClient);
-  CADisplayLink* link = [viewController.keyboardAnimationVSyncClient getDisplayLink];
+  [viewController.keyboardInsetManager setUpKeyboardAnimationVsyncClient:callback];
+  XCTAssertNotNil(viewController.keyboardInsetManager.keyboardAnimationVSyncClient);
+  CADisplayLink* link =
+      [viewController.keyboardInsetManager.keyboardAnimationVSyncClient getDisplayLink];
   XCTAssertNotNil(link);
+  CADisplayLink* linkMock = OCMPartialMock(link);
   if (@available(iOS 15.0, *)) {
-    XCTAssertEqual(link.preferredFrameRateRange.maximum, maxFrameRate);
-    XCTAssertEqual(link.preferredFrameRateRange.preferred, maxFrameRate);
-    XCTAssertEqual(link.preferredFrameRateRange.minimum, maxFrameRate / 2);
+    CAFrameRateRange range = CAFrameRateRangeMake(maxFrameRate / 2, maxFrameRate, maxFrameRate);
+    NSValue* rangeValue = [NSValue valueWithBytes:&range objCType:@encode(CAFrameRateRange)];
+    [[[(id)linkMock stub] andReturnValue:rangeValue] preferredFrameRateRange];
+
+    XCTAssertEqual(linkMock.preferredFrameRateRange.maximum, maxFrameRate);
+    XCTAssertEqual(linkMock.preferredFrameRateRange.preferred, maxFrameRate);
+    XCTAssertEqual(linkMock.preferredFrameRateRange.minimum, maxFrameRate / 2);
   } else {
-    XCTAssertEqual(link.preferredFramesPerSecond, maxFrameRate);
+    [[[(id)linkMock stub] andReturnValue:@(maxFrameRate)] preferredFramesPerSecond];
+    XCTAssertEqual(linkMock.preferredFramesPerSecond, maxFrameRate);
   }
 }
 
@@ -2424,14 +2568,24 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 }
 
 - (void)testFlutterViewControllerStartKeyboardAnimationWillCreateVsyncClientCorrectly {
-  FlutterEngine* engine = [[FlutterEngine alloc] init];
-  [engine runWithEntrypoint:nil];
-  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
-                                                                                nibName:nil
-                                                                                 bundle:nil];
-  viewController.targetViewInsetBottom = 100;
-  [viewController startKeyBoardAnimation:0.25];
-  XCTAssertNotNil(viewController.keyboardAnimationVSyncClient);
+  id mockDisplayLink = OCMClassMock([CADisplayLink class]);
+  OCMStub(ClassMethod([mockDisplayLink displayLinkWithTarget:[OCMArg any]
+                                                    selector:sel_registerName("onDisplayLink:")]))
+      .andReturn(mockDisplayLink);
+
+  TestKeyboardInsetDelegate* delegate = [[TestKeyboardInsetDelegate alloc] init];
+  delegate.isViewLoaded = YES;
+  FlutterEnginePartialMock* engine = [[FlutterEnginePartialMock alloc] init];
+  delegate.mockEngine = engine;
+
+  FlutterKeyboardInsetManager* manager =
+      [[FlutterKeyboardInsetManager alloc] initWithDelegate:delegate];
+  manager.targetViewInsetBottom = 100;
+  [manager startKeyBoardAnimation:0.25];
+
+  XCTAssertNotNil(manager.keyboardAnimationVSyncClient);
+  fml::MessageLoop::GetCurrent().RunExpiredTasksNow();
+  [mockDisplayLink stopMocking];
 }
 
 - (void)
@@ -2441,8 +2595,8 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
                                                                                 nibName:nil
                                                                                  bundle:nil];
-  [viewController setUpKeyboardAnimationVsyncClient:nil];
-  XCTAssertNil(viewController.keyboardAnimationVSyncClient);
+  [viewController.keyboardInsetManager setUpKeyboardAnimationVsyncClient:nil];
+  XCTAssertNil(viewController.keyboardInsetManager.keyboardAnimationVSyncClient);
 }
 
 - (void)testSupportsShowingSystemContextMenuForIOS16AndAbove {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
@@ -7,9 +7,9 @@
 
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
 
-#include "flutter/fml/time/time_point.h"
 #import "flutter/shell/platform/darwin/ios/InternalFlutterSwift/InternalFlutterSwift.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterKeySecondaryResponder.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterKeyboardInsetManager.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterKeyboardManager.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterRestorationPlugin.h"
@@ -40,13 +40,14 @@ typedef NS_ENUM(NSInteger, FlutterKeyboardMode) {
   // NOLINTEND(readability-identifier-naming)
 };
 
-typedef void (^FlutterKeyboardAnimationCallback)(fml::TimePoint);
+typedef void (^FlutterKeyboardAnimationCallback)(NSTimeInterval);
 
 @interface FlutterViewController () <FlutterViewResponder>
 
 @property(nonatomic, readonly) BOOL isPresentingViewController;
 @property(nonatomic, readonly) BOOL isVoiceOverRunning;
 @property(nonatomic, strong) FlutterKeyboardManager* keyboardManager;
+@property(nonatomic, strong) FlutterKeyboardInsetManager* keyboardInsetManager;
 @property(nonatomic, readwrite) NSString* applicationLocale;
 
 /**


### PR DESCRIPTION
This change refactors the keyboard inset and animation tracking logic from `FlutterViewController` into a dedicated internal keyboard inset manager class.

This is one in a series of refactorings that aim to slim down `FlutterViewController`. The goal is to improve
maintainability/readability, make it easier to reason about the code, and allow for deterministic testing of keyboard geometry without a full view controller lifecycle.

Background for future archaeologists:

iOS doesn't provide us with a frame-by-frame callback for keyboard transitions, but we need to animate our views smoothly to account for keyboard size/position changes. To ensure Flutter's layout animates in perfect sync with the system keyboard, we use a hidden view synchronisation trick:

* When a keyboard notification (e.g., `UIKeyboardWillShow`) is received, the manager animates a hidden UIView's frame using the native iOS duration and curve.
* A `VSyncClient` tracks the `presentationLayer` of this hidden view on every vsync.
* The intermediate positions are then translated into physical pixel insets and sent to the Flutter engine until the animation completes.

During testing, I found the rare flake in the old code. I added a `layoutIfNeeded` call to the view animation block to ensure that the `CAAnimation` is instantiated immediately, allowing it to be captured by the VSyncClient and unit tests and prevent these race conditions.

Manually verified behaviour on an iPad simulator to ensure that Split View keyboards in split-view scenarios don't trigger Flutter layout shifts.

I've also added more detailed doc comments to the code.

This change does *not* migrate the class to Swift because it currently relies on C++ types for the vsync client: `fml::TimePoint`, `fml::RefPtr<fml::TaskRunner>`, and
`std::unique_ptr<flutter::FrameTimingsRecorder>` 

Because we need a valid `uiTaskRunner` during `VSyncCLient` initialisation, I've migrated several tests to use `FlutterEnginePartialMock`. Using a real `FlutterEngine`, involves pretty heavy/potentially flaky shell initialisation just so we can get at the task runners. Instead, the partial mock provides a lightweight runner on the current thread. I'm not at all happy about adding more usage of OCMock, but once we've got it separated out, I can work on generating the fakes we need to move off it.

Issue: https://github.com/flutter/flutter/issues/157140

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The refactoring will continue until readability improves.
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
