### PR TITLE
tool: Skip cached engine artifacts with local engine

### DIFF
--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -767,9 +767,9 @@ class Cache {
         _logger.printTrace('Artifact $artifact is not required, skipping update.');
         continue;
       }
-      if (isLocalEngine && artifact is EngineCachedArtifact) {
+      if (isLocalEngine && (artifact is EngineCachedArtifact || artifact.name == 'engine_stamp')) {
         _logger.printTrace(
-          'Artifact $artifact is an engine artifact and local engine is provided, skipping update.',
+          'Artifact $artifact is an engine artifact or stamp and local engine is provided, skipping update.',
         );
         continue;
       }

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -15,7 +15,9 @@ import 'package:file/memory.dart';
 import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 
+import 'artifacts.dart';
 import 'base/common.dart';
+import 'base/context.dart';
 import 'base/error_handling_io.dart';
 import 'base/file_system.dart';
 import 'base/io.dart'
@@ -758,10 +760,17 @@ class Cache {
     Set<DevelopmentArtifact> requiredArtifacts,
   ) async {
     final artifactsToUpdate = <ArtifactSet>[];
+    final isLocalEngine = context.get<Artifacts>()?.localEngineInfo != null;
 
     for (final ArtifactSet artifact in _artifacts) {
       if (!requiredArtifacts.contains(artifact.developmentArtifact)) {
         _logger.printTrace('Artifact $artifact is not required, skipping update.');
+        continue;
+      }
+      if (isLocalEngine && artifact is EngineCachedArtifact) {
+        _logger.printTrace(
+          'Artifact $artifact is an engine artifact and local engine is provided, skipping update.',
+        );
         continue;
       }
       if (await artifact.isUpToDate(_fileSystem)) {

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -281,6 +281,26 @@ void main() {
       overrides: <Type, Generator>{Artifacts: () => FakeLocalEngineArtifacts()},
     );
 
+    testUsingContext(
+      'should skip engine_stamp artifact when local engine is provided',
+      () async {
+        final artifact1 = FakeSecondaryCachedArtifact()..upToDate = false;
+        final fileSystem = MemoryFileSystem.test();
+        final artifact2 = FakeEngineStampArtifact()..upToDate = false;
+
+        final cacheWithArtifacts = Cache.test(
+          fileSystem: fileSystem,
+          artifacts: <CachedArtifact>[artifact1, artifact2],
+          processManager: FakeProcessManager.any(),
+        );
+
+        await cacheWithArtifacts.updateAll(<DevelopmentArtifact>{DevelopmentArtifact.universal});
+        expect(artifact1.didUpdate, true);
+        expect(artifact2.didUpdate, false);
+      },
+      overrides: <Type, Generator>{Artifacts: () => FakeLocalEngineArtifacts()},
+    );
+
     testWithoutContext(
       "getter dyLdLibEntry concatenates the output of each artifact's dyLdLibEntry getter",
       () async {
@@ -1785,6 +1805,9 @@ class FakeSecondaryCachedArtifact extends Fake implements CachedArtifact {
   Exception? updateException;
 
   @override
+  String get name => 'fake';
+
+  @override
   Future<bool> isUpToDate(FileSystem fileSystem) async => upToDate;
 
   @override
@@ -1859,6 +1882,31 @@ class FakeEngineCachedArtifact extends EngineCachedArtifact {
 
   @override
   List<String> getPackageDirs() => <String>[];
+}
+
+class FakeEngineStampArtifact extends Fake implements CachedArtifact {
+  bool upToDate = false;
+  bool didUpdate = false;
+
+  @override
+  String get name => 'engine_stamp';
+
+  @override
+  DevelopmentArtifact get developmentArtifact => DevelopmentArtifact.universal;
+
+  @override
+  Future<bool> isUpToDate(FileSystem fileSystem) async => upToDate;
+
+  @override
+  Future<void> update(
+    ArtifactUpdater artifactUpdater,
+    Logger logger,
+    FileSystem fileSystem,
+    OperatingSystemUtils operatingSystemUtils, {
+    bool offline = false,
+  }) async {
+    didUpdate = true;
+  }
 }
 
 class FakeSecondaryCache extends Fake implements Cache {

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -244,7 +244,7 @@ void main() {
       expect(await cache.isUpToDate(), isTrue);
     });
 
-    testWithoutContext('should update cached artifacts which are not up to date', () async {
+    testUsingContext('should update cached artifacts which are not up to date', () async {
       final artifact1 = FakeSecondaryCachedArtifact()..upToDate = true;
       final artifact2 = FakeSecondaryCachedArtifact()..upToDate = false;
       final FileSystem fileSystem = MemoryFileSystem.test();
@@ -327,7 +327,7 @@ void main() {
       },
     );
 
-    testWithoutContext('failed storage.googleapis.com download shows China warning', () async {
+    testUsingContext('failed storage.googleapis.com download shows China warning', () async {
       final InternetAddress address = (await InternetAddress.lookup(
         'storage.googleapis.com',
       )).first;

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -7,6 +7,7 @@ import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/android/android_sdk.dart';
+import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
@@ -258,6 +259,27 @@ void main() {
       expect(artifact1.didUpdate, false);
       expect(artifact2.didUpdate, true);
     });
+
+    testUsingContext(
+      'should skip EngineCachedArtifacts when local engine is provided',
+      () async {
+        final artifact1 = FakeSecondaryCachedArtifact()..upToDate = false;
+        final fileSystem = MemoryFileSystem.test();
+        final cache = Cache.test(fileSystem: fileSystem, processManager: FakeProcessManager.any());
+        final artifact2 = FakeEngineCachedArtifact(cache)..upToDate = false;
+
+        final cacheWithArtifacts = Cache.test(
+          fileSystem: fileSystem,
+          artifacts: <CachedArtifact>[artifact1, artifact2],
+          processManager: FakeProcessManager.any(),
+        );
+
+        await cacheWithArtifacts.updateAll(<DevelopmentArtifact>{DevelopmentArtifact.universal});
+        expect(artifact1.didUpdate, true);
+        expect(artifact2.didUpdate, false);
+      },
+      overrides: <Type, Generator>{Artifacts: () => FakeLocalEngineArtifacts()},
+    );
 
     testWithoutContext(
       "getter dyLdLibEntry concatenates the output of each artifact's dyLdLibEntry getter",
@@ -1795,6 +1817,48 @@ class FakeIosUsbArtifacts extends Fake implements IosUsbArtifacts {
 
   @override
   String stampName = 'ios-usb';
+}
+
+class FakeLocalEngineArtifacts extends Fake implements Artifacts {
+  @override
+  LocalEngineInfo get localEngineInfo => const LocalEngineInfo(
+    targetOutPath: 'out/android_debug_unopt',
+    hostOutPath: 'out/host_debug_unopt',
+  );
+
+  @override
+  bool get usesLocalArtifacts => true;
+}
+
+class FakeEngineCachedArtifact extends EngineCachedArtifact {
+  FakeEngineCachedArtifact(Cache cache)
+    : super('fake_engine', cache, DevelopmentArtifact.universal);
+
+  bool didUpdate = false;
+  bool upToDate = false;
+
+  @override
+  Future<bool> isUpToDate(FileSystem fileSystem) async => upToDate;
+
+  @override
+  Future<void> update(
+    ArtifactUpdater artifactUpdater,
+    Logger logger,
+    FileSystem fileSystem,
+    OperatingSystemUtils operatingSystemUtils, {
+    bool offline = false,
+  }) async {
+    didUpdate = true;
+  }
+
+  @override
+  List<List<String>> getBinaryDirs() => <List<String>>[];
+
+  @override
+  List<String> getLicenseDirs() => <String>[];
+
+  @override
+  List<String> getPackageDirs() => <String>[];
 }
 
 class FakeSecondaryCache extends Fake implements Cache {


### PR DESCRIPTION
This makes it so we don't try to download cached engine artifacts if we are supplying a local engine.

This fixes the requirement to use `FLUTTER_PREBUILT_ENGINE_VERSION` when supplying a local engine, which is a huge gotcha and pain.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
