### PR TITLE
Update changelog with single change.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ docs/releases/Hotfix-Documentation-Best-Practices.md
 
 ## Flutter 3.41 Changes
 
+### [3.41.8](https://github.com/flutter/flutter/releases/tag/3.41.8)
+- [flutter/185150](https://github.com/flutter/flutter/releases/tag/3.41.8) When using profile mode on a physical iOS device, the app may fail to connect to the Dart VM.
+
 ### [3.41.7](https://github.com/flutter/flutter/releases/tag/3.41.7)
 - [flutter/184376](https://github.com/flutter/flutter/issues/184376) When building an iOS or macOS app, the build may fail due to git multi-pack-index error.
 - [flutter/184254](https://github.com/flutter/flutter/issues/184254) When debugging on physical iOS devices and Xcode 26.4+, app often crashes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ docs/releases/Hotfix-Documentation-Best-Practices.md
 ## Flutter 3.41 Changes
 
 ### [3.41.8](https://github.com/flutter/flutter/releases/tag/3.41.8)
-- [flutter/185150](https://github.com/flutter/flutter/releases/tag/3.41.8) When using profile mode on a physical iOS device, the app may fail to connect to the Dart VM.
+- [flutter/185150](https://github.com/flutter/flutter/issues/185150) When using profile mode on a physical iOS device, the app may fail to connect to the Dart VM.
 
 ### [3.41.7](https://github.com/flutter/flutter/releases/tag/3.41.7)
 - [flutter/184376](https://github.com/flutter/flutter/issues/184376) When building an iOS or macOS app, the build may fail due to git multi-pack-index error.


### PR DESCRIPTION
The changelong entry for the 3.41.8 stable hotfix release (https://github.com/flutter/flutter/issues/185549) for the single cherry picked PR, https://github.com/flutter/flutter/pull/185348.