### PR TITLE
Fix sdfs being enabled for MacOS regardless of FLTEnableSDFs value

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4162,6 +4162,16 @@ targets:
     properties:
       task_name: hello_world_macos__compile
 
+  - name: Mac hello_world_impeller_macos_sdfs
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    bringup: true
+    properties:
+      tags: >
+        ["devicelab", "mac"]
+      task_name: hello_world_macos_impeller_macos_sdfs
+
   - name: Mac integration_ui_test_test_macos
     recipe: devicelab/devicelab_drone
     presubmit: false

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -277,6 +277,7 @@
 /dev/devicelab/bin/tasks/gradle_plugin_fat_apk_test.dart @gmackall @flutter/plugin
 /dev/devicelab/bin/tasks/gradle_plugin_light_apk_test.dart @gmackall @flutter/plugin
 /dev/devicelab/bin/tasks/hello_world_macos__compile.dart @cbracken @flutter/desktop
+/dev/devicelab/bin/tasks/hello_world_macos_impeller_macos_sdfs.dart @b-luk @flutter/desktop
 /dev/devicelab/bin/tasks/hello_world_win_desktop__compile.dart @yaakovschectman @flutter/desktop
 /dev/devicelab/bin/tasks/hot_mode_dev_cycle_ios_simulator.dart @louisehsu @flutter/tool
 /dev/devicelab/bin/tasks/hot_mode_dev_cycle_macos_target__benchmark.dart @cbracken @flutter/tool

--- a/dev/devicelab/bin/tasks/hello_world_impeller_macos_sdfs.dart
+++ b/dev/devicelab/bin/tasks/hello_world_impeller_macos_sdfs.dart
@@ -1,0 +1,136 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_devicelab/framework/devices.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/framework/task_result.dart';
+import 'package:flutter_devicelab/framework/utils.dart';
+import 'package:path/path.dart' as path;
+import 'package:xml/xml.dart';
+
+Future<TaskResult> run() async {
+  deviceOperatingSystem = DeviceOperatingSystem.macos;
+
+  final Directory appDir = dir(path.join(flutterDirectory.path, 'examples/hello_world'));
+  final String plistPath = path.join(appDir.path, 'macos', 'Runner', 'Info.plist');
+  final plistFile = File(plistPath);
+
+  if (!plistFile.existsSync()) {
+    return TaskResult.failure('Info.plist not found at $plistPath');
+  }
+
+  var res = TaskResult.success(null);
+
+  try {
+    await inDirectory(appDir, () async {
+      await flutter('packages', options: <String>['get']);
+
+      // Step 1: Test without flag
+      final Process process1 = await startFlutter(
+        'run',
+        options: <String>['--enable-impeller', '-d', 'macos'],
+      );
+
+      final completer1 = Completer<void>();
+      var sawMetalMessage = false;
+
+      final StreamSubscription<String> subscription1 = process1.stdout
+          .transform(utf8.decoder)
+          .transform(const LineSplitter())
+          .listen((String line) {
+            print('[STDOUT 1]: $line');
+            if (line.contains('Using the Impeller rendering backend (Metal).')) {
+              sawMetalMessage = true;
+              if (!completer1.isCompleted) {
+                completer1.complete();
+              }
+            }
+          });
+
+      await Future.any(<Future<void>>[
+        completer1.future,
+        Future<void>.delayed(const Duration(minutes: 2)),
+      ]);
+
+      process1.stdin.writeln('q');
+      await process1.exitCode;
+      await subscription1.cancel();
+
+      if (!sawMetalMessage) {
+        res = TaskResult.failure(
+          'Did not see "Using the Impeller rendering backend (Metal)." in output',
+        );
+        return; // Exit early if first step fails
+      }
+
+      // Step 2: Modify Info.plist to enable SDFS
+      final String xmlStr = plistFile.readAsStringSync();
+      final xmlDoc = XmlDocument.parse(xmlStr);
+      final XmlElement dictNode = xmlDoc.findAllElements('dict').first;
+
+      dictNode.children.add(
+        XmlElement(XmlName('key'), <XmlAttribute>[], <XmlNode>[
+          XmlText('FLTEnableSDFs'),
+        ], /*isSelfClosing=*/ false),
+      );
+      dictNode.children.add(XmlElement(XmlName('true')));
+
+      plistFile.writeAsStringSync(xmlDoc.toXmlString(pretty: true, indent: '    '));
+
+      // Run again with flag
+      final Process process2 = await startFlutter(
+        'run',
+        options: <String>['--enable-impeller', '-d', 'macos'],
+      );
+
+      final completer2 = Completer<void>();
+      var sawSdfsMessage = false;
+
+      final StreamSubscription<String> subscription2 = process2.stdout
+          .transform(utf8.decoder)
+          .transform(const LineSplitter())
+          .listen((String line) {
+            print('[STDOUT 2]: $line');
+            if (line.contains('Using the Impeller rendering backend (MetalSDF).')) {
+              sawSdfsMessage = true;
+              if (!completer2.isCompleted) {
+                completer2.complete();
+              }
+            }
+          });
+
+      await Future.any(<Future<void>>[
+        completer2.future,
+        Future<void>.delayed(const Duration(minutes: 2)),
+      ]);
+
+      process2.stdin.writeln('q');
+      await process2.exitCode;
+      await subscription2.cancel();
+
+      if (!sawSdfsMessage) {
+        res = TaskResult.failure(
+          'Did not see "Using the Impeller rendering backend (MetalSDF)." in output',
+        );
+      }
+    });
+  } catch (e) {
+    res = TaskResult.failure('Test failed with exception: $e');
+  } finally {
+    // Restore Info.plist
+    if (plistFile.existsSync()) {
+      await exec('git', <String>['checkout', plistPath]);
+    }
+  }
+
+  return res;
+}
+
+Future<void> main() async {
+  await task(run);
+}

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -677,8 +677,11 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
       std::find(switches.begin(), switches.end(), "--enable-impeller=true") != switches.end()) {
     switches.push_back("--enable-impeller=true");
   }
-  switches.push_back(_project.enableSDFs ? "--impeller-use-sdfs=true"
-                                         : "--impeller-use-sdfs=false");
+
+  if (_project.enableSDFs ||
+      std::find(switches.begin(), switches.end(), "--impeller-use-sdfs=true") != switches.end()) {
+    switches.push_back("--impeller-use-sdfs=true");
+  }
 
   if (_project.enableFlutterGPU ||
       std::find(switches.begin(), switches.end(), "--enable-flutter-gpu=true") != switches.end()) {


### PR DESCRIPTION
This changes the `_project.enableSDFs` check in the MacOS FlutterEngine.mm to be the same as the checks for `_project.enableImpeller` and `_project.enableFlutterGPU` next to it.

Instead of setting `--impeller-use-sdfs=true` or `--impeller-use-sdfs=false` depending on `_project.enableSDFs`, only set `--impeller-use-sdfs=true` for true, and leave the flag out when it is false.

The flag is checked by
https://github.com/flutter/flutter/blob/d3757dafb0f28934fe2312fd3d50a721b03bfd8b/engine/src/flutter/shell/common/switches.cc#L553-L560
which uses `command_line.HasOption()`. This checks only for the existence of the flag. The value of the flag (true or false) is entirely ignored. So this would enable SDFs whether we passed in `--impeller-use-sdfs=true` or `--impeller-use-sdfs=false`.

If we actually wanted to check the value of the flag, we should use `CommandLine::GetOptionValue()` or `CommandLine::GetOptionValueWithDefault()` instead. It's misleading to pass the flag with a true/false value that is ignored and make the switch get set to true for either one. For consistency with the other flag's I'm leaving this behavior as-is.

Also for consistency with the other flags, I'm leaving the `|| std::find(switches.begin(), switches.end(), "--impeller-use-sdfs=true") != switches.end()` check. But this check seems completely redundant/useless to me.

Fixes https://github.com/flutter/flutter/issues/185562


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
