### PR TITLE
ref: migrate internal uses of `CurvedAnimation`

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/src/cubic_bezier.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/cubic_bezier.dart
@@ -108,7 +108,7 @@ class Point {
 
 class AnimatedBezierState extends State<AnimatedBezier> with SingleTickerProviderStateMixin {
   late AnimationController controller;
-  late CurvedAnimation curve;
+  late ReversibleCurvedAnimation curve;
   bool isPlaying = false;
   List<List<Point>> pointList = <List<Point>>[<Point>[], <Point>[], <Point>[], <Point>[]];
   bool isReversed = false;
@@ -299,7 +299,9 @@ class AnimatedBezierState extends State<AnimatedBezier> with SingleTickerProvide
     // This code uses a manual listener for historical reasons and will remain
     // in order to preserve compatibility with the history of measurements for
     // this benchmark.
-    curve = CurvedAnimation(parent: controller, curve: Curves.linear)
+    // We could also switch to CurveTween for efficiency but haven't done so
+    // for the same reason.
+    curve = ReversibleCurvedAnimation(parent: controller, curve: Curves.linear, reverseCurve: null)
       ..addListener(() {
         setState(() {});
       })

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/backdrop_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/backdrop_demo.dart
@@ -203,14 +203,11 @@ class BackdropTitle extends AnimatedWidget {
       child: Stack(
         children: <Widget>[
           Opacity(
-            opacity: CurvedAnimation(
-              parent: ReverseAnimation(animation),
-              curve: const Interval(0.5, 1.0),
-            ).value,
+            opacity: const Interval(0.5, 1.0).transform(1 - animation.value),
             child: const Text('Select a Category'),
           ),
           Opacity(
-            opacity: CurvedAnimation(parent: animation, curve: const Interval(0.5, 1.0)).value,
+            opacity: const Interval(0.5, 1.0).transform(animation.value),
             child: const Text('Asset Viewer'),
           ),
         ],

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/drawer_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/drawer_demo.dart
@@ -26,6 +26,10 @@ class _DrawerDemoState extends State<DrawerDemo> with TickerProviderStateMixin {
 
   static const List<String> _drawerContents = <String>['A', 'B', 'C', 'D', 'E'];
 
+  static final Animatable<double> _drawerContentsTween = Tween<double>(
+    begin: 1.0,
+    end: 0.0,
+  ).chain(CurveTween(curve: Curves.fastOutSlowIn));
   static final Animatable<Offset> _drawerDetailsTween = Tween<Offset>(
     begin: const Offset(0.0, -1.0),
     end: Offset.zero,
@@ -40,10 +44,7 @@ class _DrawerDemoState extends State<DrawerDemo> with TickerProviderStateMixin {
   void initState() {
     super.initState();
     _controller = AnimationController(vsync: this, duration: const Duration(milliseconds: 200));
-    _drawerContentsOpacity = CurvedAnimation(
-      parent: ReverseAnimation(_controller),
-      curve: Curves.fastOutSlowIn,
-    );
+    _drawerContentsOpacity = _controller.drive(_drawerContentsTween);
     _drawerDetailsPosition = _controller.drive(_drawerDetailsTween);
   }
 

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/progress_indicator_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/progress_indicator_demo.dart
@@ -30,7 +30,7 @@ class _ProgressIndicatorDemoState extends State<ProgressIndicatorDemo>
     )..forward();
 
     _animation =
-        CurvedAnimation(
+        ReversibleCurvedAnimation(
           parent: _controller,
           curve: const Interval(0.0, 0.9, curve: Curves.fastOutSlowIn),
           reverseCurve: Curves.fastOutSlowIn,

--- a/dev/integration_tests/flutter_gallery/lib/demo/shrine/backdrop.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/shrine/backdrop.dart
@@ -104,10 +104,9 @@ class _BackdropTitle extends AnimatedWidget {
 
   @override
   Widget build(BuildContext context) {
-    final Animation<double> animation = CurvedAnimation(
-      parent: listenable as Animation<double>,
+    final Animation<double> animation = CurveTween(
       curve: const Interval(0.0, 0.78),
-    );
+    ).animate(listenable as Animation<double>);
 
     return DefaultTextStyle(
       style: Theme.of(context).primaryTextTheme.titleLarge!,
@@ -143,10 +142,7 @@ class _BackdropTitle extends AnimatedWidget {
           Stack(
             children: <Widget>[
               Opacity(
-                opacity: CurvedAnimation(
-                  parent: ReverseAnimation(animation),
-                  curve: const Interval(0.5, 1.0),
-                ).value,
+                opacity: const Interval(0.5, 1.0).transform(1 - animation.value),
                 child: FractionalTranslation(
                   translation: Tween<Offset>(
                     begin: Offset.zero,
@@ -156,7 +152,7 @@ class _BackdropTitle extends AnimatedWidget {
                 ),
               ),
               Opacity(
-                opacity: CurvedAnimation(parent: animation, curve: const Interval(0.5, 1.0)).value,
+                opacity: const Interval(0.5, 1.0).transform(animation.value),
                 child: FractionalTranslation(
                   translation: Tween<Offset>(
                     begin: const Offset(-0.25, 0.0),
@@ -243,7 +239,7 @@ class _BackdropState extends State<Backdrop> with SingleTickerProviderStateMixin
       secondCurve = _kDecelerateCurve;
       firstWeight = _kPeakVelocityTime;
       secondWeight = 1.0 - _kPeakVelocityTime;
-      animation = CurvedAnimation(parent: _controller!.view, curve: const Interval(0.0, 0.78));
+      animation = CurveTween(curve: const Interval(0.0, 0.78)).animate(_controller!);
     } else {
       // These values are only used when the controller runs from t=1.0 to t=0.0
       firstCurve = _kDecelerateCurve.flipped;

--- a/dev/integration_tests/flutter_gallery/lib/demo/shrine/expanding_bottom_sheet.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/shrine/expanding_bottom_sheet.dart
@@ -124,12 +124,9 @@ class ExpandingBottomSheetState extends State<ExpandingBottomSheet> with TickerP
   Animation<double> _getWidthAnimation(double screenWidth) {
     if (_controller.status == AnimationStatus.forward) {
       // Opening animation
-      return Tween<double>(begin: _width, end: screenWidth).animate(
-        CurvedAnimation(
-          parent: _controller.view,
-          curve: const Interval(0.0, 0.3, curve: Curves.fastOutSlowIn),
-        ),
-      );
+      return Tween<double>(begin: _width, end: screenWidth)
+          .chain(CurveTween(curve: const Interval(0.0, 0.3, curve: Curves.fastOutSlowIn)))
+          .animate(_controller);
     } else {
       // Closing animation
       return _getEmphasizedEasingAnimation(
@@ -137,7 +134,7 @@ class ExpandingBottomSheetState extends State<ExpandingBottomSheet> with TickerP
         peak: _getPeakPoint(begin: _width, end: screenWidth),
         end: screenWidth,
         isForward: false,
-        parent: CurvedAnimation(parent: _controller.view, curve: const Interval(0.0, 0.87)),
+        parent: CurveTween(curve: const Interval(0.0, 0.87)).animate(_controller),
       );
     }
   }
@@ -145,7 +142,6 @@ class ExpandingBottomSheetState extends State<ExpandingBottomSheet> with TickerP
   Animation<double> _getHeightAnimation(double screenHeight) {
     if (_controller.status == AnimationStatus.forward) {
       // Opening animation
-
       return _getEmphasizedEasingAnimation(
         begin: _kCartHeight,
         peak: _kCartHeight + (screenHeight - _kCartHeight) * _kPeakVelocityProgress,
@@ -155,26 +151,18 @@ class ExpandingBottomSheetState extends State<ExpandingBottomSheet> with TickerP
       );
     } else {
       // Closing animation
-      return Tween<double>(begin: _kCartHeight, end: screenHeight).animate(
-        CurvedAnimation(
-          parent: _controller.view,
-          curve: const Interval(0.434, 1.0), // not used
-          // only the reverseCurve will be used
-          reverseCurve: Interval(0.434, 1.0, curve: Curves.fastOutSlowIn.flipped),
-        ),
-      );
+      return Tween<double>(begin: _kCartHeight, end: screenHeight)
+          .chain(CurveTween(curve: Interval(0.434, 1.0, curve: Curves.fastOutSlowIn.flipped)))
+          .animate(_controller);
     }
   }
 
   // Animation of the cut corner. It's cut when closed and not cut when open.
   Animation<double> _getShapeAnimation() {
     if (_controller.status == AnimationStatus.forward) {
-      return Tween<double>(begin: _kCornerRadius, end: 0.0).animate(
-        CurvedAnimation(
-          parent: _controller.view,
-          curve: const Interval(0.0, 0.3, curve: Curves.fastOutSlowIn),
-        ),
-      );
+      return Tween<double>(begin: _kCornerRadius, end: 0.0)
+          .chain(CurveTween(curve: const Interval(0.0, 0.3, curve: Curves.fastOutSlowIn)))
+          .animate(_controller);
     } else {
       return _getEmphasizedEasingAnimation(
         begin: _kCornerRadius,
@@ -187,23 +175,23 @@ class ExpandingBottomSheetState extends State<ExpandingBottomSheet> with TickerP
   }
 
   Animation<double> _getThumbnailOpacityAnimation() {
-    return Tween<double>(begin: 1.0, end: 0.0).animate(
-      CurvedAnimation(
-        parent: _controller.view,
-        curve: _controller.status == AnimationStatus.forward
-            ? const Interval(0.0, 0.3)
-            : const Interval(0.532, 0.766),
-      ),
-    );
+    return Tween<double>(begin: 1.0, end: 0.0)
+        .chain(
+          CurveTween(
+            curve: _controller.status == AnimationStatus.forward
+                ? const Interval(0.0, 0.3)
+                : const Interval(0.532, 0.766),
+          ),
+        )
+        .animate(_controller);
   }
 
   Animation<double> _getCartOpacityAnimation() {
-    return CurvedAnimation(
-      parent: _controller.view,
+    return CurveTween(
       curve: _controller.status == AnimationStatus.forward
           ? const Interval(0.3, 0.6)
           : const Interval(0.766, 1.0),
-    );
+    ).animate(_controller);
   }
 
   // Returns the correct width of the ExpandingBottomSheet based on the number of
@@ -405,17 +393,14 @@ class _ProductThumbnailRowState extends State<ProductThumbnailRow> {
   }
 
   Widget _buildThumbnail(BuildContext context, int index, Animation<double> animation) {
-    final Animation<double> thumbnailSize = Tween<double>(begin: 0.8, end: 1.0).animate(
-      CurvedAnimation(
-        curve: const Interval(0.33, 1.0, curve: Curves.easeIn),
-        parent: animation,
-      ),
-    );
+    final Animation<double> thumbnailSize = Tween<double>(
+      begin: 0.8,
+      end: 1.0,
+    ).chain(CurveTween(curve: const Interval(0.33, 1.0, curve: Curves.easeIn))).animate(animation);
 
-    final Animation<double> opacity = CurvedAnimation(
+    final Animation<double> opacity = CurveTween(
       curve: const Interval(0.33, 1.0),
-      parent: animation,
-    );
+    ).animate(animation);
 
     return ProductThumbnail(thumbnailSize, opacity, _productWithId(_list[index]));
   }

--- a/dev/integration_tests/flutter_gallery/lib/gallery/backdrop.dart
+++ b/dev/integration_tests/flutter_gallery/lib/gallery/backdrop.dart
@@ -86,15 +86,8 @@ class _CrossFadeTransition extends AnimatedWidget {
   Widget build(BuildContext context) {
     final progress = listenable as Animation<double>;
 
-    final double opacity1 = CurvedAnimation(
-      parent: ReverseAnimation(progress),
-      curve: const Interval(0.5, 1.0),
-    ).value;
-
-    final double opacity2 = CurvedAnimation(
-      parent: progress,
-      curve: const Interval(0.5, 1.0),
-    ).value;
+    final double opacity1 = const Interval(0.5, 1.0).transform(1 - progress.value);
+    final double opacity2 = const Interval(0.5, 1.0).transform(progress.value);
 
     return Stack(
       alignment: alignment,

--- a/dev/integration_tests/flutter_gallery/lib/gallery/home.dart
+++ b/dev/integration_tests/flutter_gallery/lib/gallery/home.dart
@@ -363,7 +363,7 @@ class _GalleryHomeState extends State<GalleryHome> with SingleTickerProviderStat
         children: <Widget>[
           home,
           FadeTransition(
-            opacity: CurvedAnimation(parent: _controller, curve: Curves.easeInOut),
+            opacity: CurveTween(curve: Curves.easeInOut).animate(_controller),
             child: const Banner(message: 'PREVIEW', location: BannerLocation.topEnd),
           ),
         ],

--- a/dev/integration_tests/new_gallery/lib/demos/material/progress_indicator_demo.dart
+++ b/dev/integration_tests/new_gallery/lib/demos/material/progress_indicator_demo.dart
@@ -32,7 +32,7 @@ class _ProgressIndicatorDemoState extends State<ProgressIndicatorDemo>
     )..forward();
 
     _animation =
-        CurvedAnimation(
+        ReversibleCurvedAnimation(
           parent: _controller,
           curve: const Interval(0.0, 0.9, curve: Curves.fastOutSlowIn),
           reverseCurve: Curves.fastOutSlowIn,
@@ -47,7 +47,7 @@ class _ProgressIndicatorDemoState extends State<ProgressIndicatorDemo>
 
   @override
   void dispose() {
-    _controller.stop();
+    _controller.dispose();
     super.dispose();
   }
 

--- a/dev/integration_tests/new_gallery/lib/feature_discovery/animation.dart
+++ b/dev/integration_tests/new_gallery/lib/feature_discovery/animation.dart
@@ -32,24 +32,18 @@ class Animations {
       case FeatureDiscoveryStatus.closed:
         return const AlwaysStoppedAnimation<double>(0);
       case FeatureDiscoveryStatus.open:
-        return Tween<double>(begin: 0, end: backgroundMaxOpacity).animate(
-          CurvedAnimation(
-            parent: openController,
-            curve: const Interval(0, 0.5, curve: Curves.ease),
-          ),
-        );
+        return Tween<double>(begin: 0, end: backgroundMaxOpacity)
+            .chain(CurveTween(curve: const Interval(0, 0.5, curve: Curves.ease)))
+            .animate(openController);
       case FeatureDiscoveryStatus.tap:
         return Tween<double>(
           begin: backgroundMaxOpacity,
           end: 0,
-        ).animate(CurvedAnimation(parent: tapController, curve: Curves.ease));
+        ).chain(CurveTween(curve: Curves.ease)).animate(tapController);
       case FeatureDiscoveryStatus.dismiss:
-        return Tween<double>(begin: backgroundMaxOpacity, end: 0).animate(
-          CurvedAnimation(
-            parent: dismissController,
-            curve: const Interval(0.2, 1.0, curve: Curves.ease),
-          ),
-        );
+        return Tween<double>(begin: backgroundMaxOpacity, end: 0)
+            .chain(CurveTween(curve: const Interval(0.2, 1.0, curve: Curves.ease)))
+            .animate(dismissController);
       case FeatureDiscoveryStatus.ripple:
         return const AlwaysStoppedAnimation<double>(backgroundMaxOpacity);
     }
@@ -60,22 +54,19 @@ class Animations {
       case FeatureDiscoveryStatus.closed:
         return const AlwaysStoppedAnimation<double>(0);
       case FeatureDiscoveryStatus.open:
-        return Tween<double>(begin: 0, end: backgroundRadiusMax).animate(
-          CurvedAnimation(
-            parent: openController,
-            curve: const Interval(0, 0.5, curve: Curves.ease),
-          ),
-        );
+        return Tween<double>(begin: 0, end: backgroundRadiusMax)
+            .chain(CurveTween(curve: const Interval(0, 0.5, curve: Curves.ease)))
+            .animate(openController);
       case FeatureDiscoveryStatus.tap:
         return Tween<double>(
           begin: backgroundRadiusMax,
           end: backgroundRadiusMax + backgroundTapRadius,
-        ).animate(CurvedAnimation(parent: tapController, curve: Curves.ease));
+        ).chain(CurveTween(curve: Curves.ease)).animate(tapController);
       case FeatureDiscoveryStatus.dismiss:
         return Tween<double>(
           begin: backgroundRadiusMax,
           end: 0,
-        ).animate(CurvedAnimation(parent: dismissController, curve: Curves.ease));
+        ).chain(CurveTween(curve: Curves.ease)).animate(dismissController);
       case FeatureDiscoveryStatus.ripple:
         return AlwaysStoppedAnimation<double>(backgroundRadiusMax);
     }
@@ -86,22 +77,19 @@ class Animations {
       case FeatureDiscoveryStatus.closed:
         return AlwaysStoppedAnimation<Offset>(start);
       case FeatureDiscoveryStatus.open:
-        return Tween<Offset>(begin: start, end: end).animate(
-          CurvedAnimation(
-            parent: openController,
-            curve: const Interval(0, 0.5, curve: Curves.ease),
-          ),
-        );
+        return Tween<Offset>(begin: start, end: end)
+            .chain(CurveTween(curve: const Interval(0, 0.5, curve: Curves.ease)))
+            .animate(openController);
       case FeatureDiscoveryStatus.tap:
         return Tween<Offset>(
           begin: end,
           end: start,
-        ).animate(CurvedAnimation(parent: tapController, curve: Curves.ease));
+        ).chain(CurveTween(curve: Curves.ease)).animate(tapController);
       case FeatureDiscoveryStatus.dismiss:
         return Tween<Offset>(
           begin: end,
           end: start,
-        ).animate(CurvedAnimation(parent: dismissController, curve: Curves.ease));
+        ).chain(CurveTween(curve: Curves.ease)).animate(dismissController);
       case FeatureDiscoveryStatus.ripple:
         return AlwaysStoppedAnimation<Offset>(end);
     }
@@ -112,26 +100,17 @@ class Animations {
       case FeatureDiscoveryStatus.closed:
         return const AlwaysStoppedAnimation<double>(0);
       case FeatureDiscoveryStatus.open:
-        return Tween<double>(begin: 0, end: 1.0).animate(
-          CurvedAnimation(
-            parent: openController,
-            curve: const Interval(0.4, 0.7, curve: Curves.ease),
-          ),
-        );
+        return Tween<double>(begin: 0, end: 1.0)
+            .chain(CurveTween(curve: const Interval(0.4, 0.7, curve: Curves.ease)))
+            .animate(openController);
       case FeatureDiscoveryStatus.tap:
-        return Tween<double>(begin: 1.0, end: 0).animate(
-          CurvedAnimation(
-            parent: tapController,
-            curve: const Interval(0, 0.4, curve: Curves.ease),
-          ),
-        );
+        return Tween<double>(begin: 1.0, end: 0)
+            .chain(CurveTween(curve: const Interval(0, 0.4, curve: Curves.ease)))
+            .animate(tapController);
       case FeatureDiscoveryStatus.dismiss:
-        return Tween<double>(begin: 1.0, end: 0).animate(
-          CurvedAnimation(
-            parent: dismissController,
-            curve: const Interval(0, 0.4, curve: Curves.ease),
-          ),
-        );
+        return Tween<double>(begin: 1.0, end: 0)
+            .chain(CurveTween(curve: const Interval(0, 0.4, curve: Curves.ease)))
+            .animate(dismissController);
       case FeatureDiscoveryStatus.ripple:
         return const AlwaysStoppedAnimation<double>(1.0);
     }
@@ -140,12 +119,9 @@ class Animations {
   Animation<double> rippleOpacity(FeatureDiscoveryStatus status) {
     switch (status) {
       case FeatureDiscoveryStatus.ripple:
-        return Tween<double>(begin: rippleMaxOpacity, end: 0).animate(
-          CurvedAnimation(
-            parent: rippleController,
-            curve: const Interval(0.3, 0.8, curve: Curves.ease),
-          ),
-        );
+        return Tween<double>(begin: rippleMaxOpacity, end: 0)
+            .chain(CurveTween(curve: const Interval(0.3, 0.8, curve: Curves.ease)))
+            .animate(rippleController);
       case FeatureDiscoveryStatus.closed:
       case FeatureDiscoveryStatus.open:
       case FeatureDiscoveryStatus.tap:
@@ -158,12 +134,9 @@ class Animations {
     switch (status) {
       case FeatureDiscoveryStatus.ripple:
         if (rippleController.value >= 0.3 && rippleController.value <= 0.8) {
-          return Tween<double>(begin: tapTargetMaxRadius, end: 79.0).animate(
-            CurvedAnimation(
-              parent: rippleController,
-              curve: const Interval(0.3, 0.8, curve: Curves.ease),
-            ),
-          );
+          return Tween<double>(begin: tapTargetMaxRadius, end: 79.0)
+              .chain(CurveTween(curve: const Interval(0.3, 0.8, curve: Curves.ease)))
+              .animate(rippleController);
         }
         return const AlwaysStoppedAnimation<double>(tapTargetMaxRadius);
       case FeatureDiscoveryStatus.closed:
@@ -179,26 +152,17 @@ class Animations {
       case FeatureDiscoveryStatus.closed:
         return const AlwaysStoppedAnimation<double>(0);
       case FeatureDiscoveryStatus.open:
-        return Tween<double>(begin: 0, end: 1.0).animate(
-          CurvedAnimation(
-            parent: openController,
-            curve: const Interval(0, 0.4, curve: Curves.ease),
-          ),
-        );
+        return Tween<double>(begin: 0, end: 1.0)
+            .chain(CurveTween(curve: const Interval(0, 0.4, curve: Curves.ease)))
+            .animate(openController);
       case FeatureDiscoveryStatus.tap:
-        return Tween<double>(begin: 1.0, end: 0).animate(
-          CurvedAnimation(
-            parent: tapController,
-            curve: const Interval(0.1, 0.6, curve: Curves.ease),
-          ),
-        );
+        return Tween<double>(begin: 1.0, end: 0)
+            .chain(CurveTween(curve: const Interval(0.1, 0.6, curve: Curves.ease)))
+            .animate(tapController);
       case FeatureDiscoveryStatus.dismiss:
-        return Tween<double>(begin: 1.0, end: 0).animate(
-          CurvedAnimation(
-            parent: dismissController,
-            curve: const Interval(0.2, 0.8, curve: Curves.ease),
-          ),
-        );
+        return Tween<double>(begin: 1.0, end: 0)
+            .chain(CurveTween(curve: const Interval(0.2, 0.8, curve: Curves.ease)))
+            .animate(dismissController);
       case FeatureDiscoveryStatus.ripple:
         return const AlwaysStoppedAnimation<double>(1.0);
     }
@@ -209,39 +173,30 @@ class Animations {
       case FeatureDiscoveryStatus.closed:
         return const AlwaysStoppedAnimation<double>(tapTargetMinRadius);
       case FeatureDiscoveryStatus.open:
-        return Tween<double>(begin: tapTargetMinRadius, end: tapTargetMaxRadius).animate(
-          CurvedAnimation(
-            parent: openController,
-            curve: const Interval(0, 0.4, curve: Curves.ease),
-          ),
-        );
+        return Tween<double>(begin: tapTargetMinRadius, end: tapTargetMaxRadius)
+            .chain(CurveTween(curve: const Interval(0, 0.4, curve: Curves.ease)))
+            .animate(openController);
       case FeatureDiscoveryStatus.ripple:
         if (rippleController.value < 0.3) {
-          return Tween<double>(begin: tapTargetMaxRadius, end: tapTargetRippleRadius).animate(
-            CurvedAnimation(
-              parent: rippleController,
-              curve: const Interval(0, 0.3, curve: Curves.ease),
-            ),
-          );
+          return Tween<double>(begin: tapTargetMaxRadius, end: tapTargetRippleRadius)
+              .chain(CurveTween(curve: const Interval(0, 0.3, curve: Curves.ease)))
+              .animate(rippleController);
         } else if (rippleController.value < 0.6) {
-          return Tween<double>(begin: tapTargetRippleRadius, end: tapTargetMaxRadius).animate(
-            CurvedAnimation(
-              parent: rippleController,
-              curve: const Interval(0.3, 0.6, curve: Curves.ease),
-            ),
-          );
+          return Tween<double>(begin: tapTargetRippleRadius, end: tapTargetMaxRadius)
+              .chain(CurveTween(curve: const Interval(0.3, 0.6, curve: Curves.ease)))
+              .animate(rippleController);
         }
         return const AlwaysStoppedAnimation<double>(tapTargetMaxRadius);
       case FeatureDiscoveryStatus.tap:
         return Tween<double>(
           begin: tapTargetMaxRadius,
           end: tapTargetMinRadius,
-        ).animate(CurvedAnimation(parent: tapController, curve: Curves.ease));
+        ).chain(CurveTween(curve: Curves.ease)).animate(tapController);
       case FeatureDiscoveryStatus.dismiss:
         return Tween<double>(
           begin: tapTargetMaxRadius,
           end: tapTargetMinRadius,
-        ).animate(CurvedAnimation(parent: dismissController, curve: Curves.ease));
+        ).chain(CurveTween(curve: Curves.ease)).animate(dismissController);
     }
   }
 }

--- a/dev/integration_tests/new_gallery/lib/pages/backdrop.dart
+++ b/dev/integration_tests/new_gallery/lib/pages/backdrop.dart
@@ -77,31 +77,25 @@ class _BackdropState extends State<Backdrop> with TickerProviderStateMixin {
 
   Animation<RelativeRect> _slideDownSettingsPageAnimation(BoxConstraints constraints) {
     return RelativeRectTween(
-      begin: RelativeRect.fromLTRB(0, -constraints.maxHeight, 0, 0),
-      end: RelativeRect.fill,
-    ).animate(
-      CurvedAnimation(
-        parent: _settingsPanelController,
-        curve: const Interval(0.0, 0.4, curve: Curves.ease),
-      ),
-    );
+          begin: RelativeRect.fromLTRB(0, -constraints.maxHeight, 0, 0),
+          end: RelativeRect.fill,
+        )
+        .chain(CurveTween(curve: const Interval(0.0, 0.4, curve: Curves.ease)))
+        .animate(_settingsPanelController);
   }
 
   Animation<RelativeRect> _slideDownHomePageAnimation(BoxConstraints constraints) {
     return RelativeRectTween(
-      begin: RelativeRect.fill,
-      end: RelativeRect.fromLTRB(
-        0,
-        constraints.biggest.height - galleryHeaderHeight,
-        0,
-        -galleryHeaderHeight,
-      ),
-    ).animate(
-      CurvedAnimation(
-        parent: _settingsPanelController,
-        curve: const Interval(0.0, 0.4, curve: Curves.ease),
-      ),
-    );
+          begin: RelativeRect.fill,
+          end: RelativeRect.fromLTRB(
+            0,
+            constraints.biggest.height - galleryHeaderHeight,
+            0,
+            -galleryHeaderHeight,
+          ),
+        )
+        .chain(CurveTween(curve: const Interval(0.0, 0.4, curve: Curves.ease)))
+        .animate(_settingsPanelController);
   }
 
   Widget _buildStack(BuildContext context, BoxConstraints constraints) {
@@ -176,10 +170,7 @@ class _BackdropState extends State<Backdrop> with TickerProviderStateMixin {
                 alignment: Directionality.of(context) == TextDirection.ltr
                     ? Alignment.topRight
                     : Alignment.topLeft,
-                scale: CurvedAnimation(
-                  parent: _settingsPanelController,
-                  curve: Curves.fastOutSlowIn,
-                ),
+                scale: _settingsPanelController.drive(CurveTween(curve: Curves.fastOutSlowIn)),
                 child: Align(
                   alignment: AlignmentDirectional.topEnd,
                   child: Material(

--- a/dev/integration_tests/new_gallery/lib/pages/home.dart
+++ b/dev/integration_tests/new_gallery/lib/pages/home.dart
@@ -562,16 +562,17 @@ class _AnimatedCategoryItem extends StatelessWidget {
     required double startDelayFraction,
     required this.controller,
     required this.child,
-  }) : topPaddingAnimation = Tween<double>(begin: 60.0, end: 0.0).animate(
-         CurvedAnimation(
-           parent: controller,
-           curve: Interval(
-             0.000 + startDelayFraction,
-             0.400 + startDelayFraction,
-             curve: Curves.ease,
-           ),
-         ),
-       );
+  }) : topPaddingAnimation = Tween<double>(begin: 60.0, end: 0.0)
+           .chain(
+             CurveTween(
+               curve: Interval(
+                 0.000 + startDelayFraction,
+                 0.400 + startDelayFraction,
+                 curve: Curves.ease,
+               ),
+             ),
+           )
+           .animate(controller);
 
   final Widget child;
   final AnimationController controller;
@@ -595,12 +596,9 @@ class _AnimatedCategoryItem extends StatelessWidget {
 /// Animates the carousel to come in from the right.
 class _AnimatedCarousel extends StatelessWidget {
   _AnimatedCarousel({required this.child, required this.controller})
-    : startPositionAnimation = Tween<double>(begin: 1.0, end: 0.0).animate(
-        CurvedAnimation(
-          parent: controller,
-          curve: const Interval(0.200, 0.800, curve: Curves.ease),
-        ),
-      );
+    : startPositionAnimation = Tween<double>(begin: 1.0, end: 0.0)
+          .chain(CurveTween(curve: const Interval(0.200, 0.800, curve: Curves.ease)))
+          .animate(controller);
 
   final Widget child;
   final AnimationController controller;
@@ -637,12 +635,9 @@ class _AnimatedCarousel extends StatelessWidget {
 /// Animates a carousel card to come in from the right.
 class _AnimatedCarouselCard extends StatelessWidget {
   _AnimatedCarouselCard({required this.child, required this.controller})
-    : startPaddingAnimation = Tween<double>(begin: _horizontalPadding, end: 0.0).animate(
-        CurvedAnimation(
-          parent: controller,
-          curve: const Interval(0.900, 1.000, curve: Curves.ease),
-        ),
-      );
+    : startPaddingAnimation = Tween<double>(begin: _horizontalPadding, end: 0.0)
+          .chain(CurveTween(curve: const Interval(0.900, 1.000, curve: Curves.ease)))
+          .animate(controller);
 
   final Widget child;
   final AnimationController controller;

--- a/dev/integration_tests/new_gallery/lib/pages/settings.dart
+++ b/dev/integration_tests/new_gallery/lib/pages/settings.dart
@@ -55,9 +55,8 @@ class _SettingsPageState extends State<SettingsPage> {
     // When closing settings, also shrink expanded setting.
     widget.animationController.addStatusListener(_closeSettingId);
 
-    _staggerSettingsItemsAnimation = CurvedAnimation(
-      parent: widget.animationController,
-      curve: const Interval(0.4, 1.0, curve: Curves.ease),
+    _staggerSettingsItemsAnimation = widget.animationController.drive(
+      CurveTween(curve: const Interval(0.4, 1.0, curve: Curves.ease)),
     );
   }
 

--- a/dev/integration_tests/new_gallery/lib/pages/splash.dart
+++ b/dev/integration_tests/new_gallery/lib/pages/splash.dart
@@ -87,7 +87,7 @@ class _SplashPageState extends State<SplashPage> with SingleTickerProviderStateM
     return RelativeRectTween(
       begin: RelativeRect.fill,
       end: RelativeRect.fromLTRB(0, height, 0, 0),
-    ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeInOut));
+    ).chain(CurveTween(curve: Curves.easeInOut)).animate(_controller);
   }
 
   @override

--- a/dev/integration_tests/new_gallery/lib/studies/rally/charts/pie_chart.dart
+++ b/dev/integration_tests/new_gallery/lib/studies/rally/charts/pie_chart.dart
@@ -73,13 +73,10 @@ class _RallyPieChartState extends State<RallyPieChart> with SingleTickerProvider
   void initState() {
     super.initState();
     controller = AnimationController(duration: const Duration(milliseconds: 600), vsync: this);
-    animation = CurvedAnimation(
-      parent: TweenSequence<double>(<TweenSequenceItem<double>>[
-        TweenSequenceItem<double>(tween: Tween<double>(begin: 0, end: 0), weight: 1),
-        TweenSequenceItem<double>(tween: Tween<double>(begin: 0, end: 1), weight: 1.5),
-      ]).animate(controller),
-      curve: Curves.decelerate,
-    );
+    animation = TweenSequence<double>(<TweenSequenceItem<double>>[
+      TweenSequenceItem<double>(tween: Tween<double>(begin: 0, end: 0), weight: 1),
+      TweenSequenceItem<double>(tween: Tween<double>(begin: 0, end: 1), weight: 1.5),
+    ]).chain(CurveTween(curve: Curves.decelerate)).animate(controller);
     controller.forward();
   }
 

--- a/dev/integration_tests/new_gallery/lib/studies/reply/adaptive_nav.dart
+++ b/dev/integration_tests/new_gallery/lib/studies/reply/adaptive_nav.dart
@@ -443,23 +443,10 @@ class _MobileNavState extends State<_MobileNav> with TickerProviderStateMixin {
       duration: const Duration(milliseconds: 250),
     );
 
-    _drawerCurve = CurvedAnimation(
-      parent: _drawerController,
-      curve: Easing.legacy,
-      reverseCurve: Easing.legacy.flipped,
-    );
-
-    _dropArrowCurve = CurvedAnimation(
-      parent: _dropArrowController,
-      curve: Easing.legacy,
-      reverseCurve: Easing.legacy.flipped,
-    );
-
-    _bottomAppBarCurve = CurvedAnimation(
-      parent: _bottomAppBarController,
-      curve: Easing.legacy,
-      reverseCurve: Easing.legacy.flipped,
-    );
+    final curveTween = CurveTween(curve: Easing.legacy);
+    _drawerCurve = curveTween.animate(_drawerController);
+    _dropArrowCurve = curveTween.animate(_dropArrowController);
+    _bottomAppBarCurve = curveTween.animate(_bottomAppBarController);
   }
 
   @override

--- a/dev/integration_tests/new_gallery/lib/studies/shrine/backdrop.dart
+++ b/dev/integration_tests/new_gallery/lib/studies/shrine/backdrop.dart
@@ -70,10 +70,9 @@ class _BackdropTitle extends AnimatedWidget {
 
   @override
   Widget build(BuildContext context) {
-    final Animation<double> animation = CurvedAnimation(
-      parent: listenable as Animation<double>,
+    final Animation<double> animation = CurveTween(
       curve: const Interval(0, 0.78),
-    );
+    ).animate(listenable as Animation<double>);
 
     final textDirectionScalar = Directionality.of(context) == TextDirection.ltr ? 1 : -1;
 
@@ -128,10 +127,7 @@ class _BackdropTitle extends AnimatedWidget {
           Stack(
             children: <Widget>[
               Opacity(
-                opacity: CurvedAnimation(
-                  parent: ReverseAnimation(animation),
-                  curve: const Interval(0.5, 1),
-                ).value,
+                opacity: const Interval(0.5, 1).transform(1 - animation.value),
                 child: FractionalTranslation(
                   translation: Tween<Offset>(
                     begin: Offset.zero,
@@ -141,7 +137,7 @@ class _BackdropTitle extends AnimatedWidget {
                 ),
               ),
               Opacity(
-                opacity: CurvedAnimation(parent: animation, curve: const Interval(0.5, 1)).value,
+                opacity: const Interval(0.5, 1).transform(animation.value),
                 child: FractionalTranslation(
                   translation: Tween<Offset>(
                     begin: Offset(-0.25 * textDirectionScalar, 0),
@@ -222,7 +218,7 @@ class _BackdropState extends State<Backdrop> with SingleTickerProviderStateMixin
       secondCurve = _decelerateCurve;
       firstWeight = _peakVelocityTime;
       secondWeight = 1 - _peakVelocityTime;
-      animation = CurvedAnimation(parent: _controller.view, curve: const Interval(0, 0.78));
+      animation = _controller.drive(CurveTween(curve: const Interval(0, 0.78)));
     } else {
       // These values are only used when the controller runs from t=1.0 to t=0.0
       firstCurve = _decelerateCurve.flipped;

--- a/dev/integration_tests/new_gallery/lib/studies/shrine/expanding_bottom_sheet.dart
+++ b/dev/integration_tests/new_gallery/lib/studies/shrine/expanding_bottom_sheet.dart
@@ -144,12 +144,9 @@ class ExpandingBottomSheetState extends State<ExpandingBottomSheet> {
   Animation<double> _getWidthAnimation(double screenWidth) {
     if (_controller.status == AnimationStatus.forward) {
       // Opening animation
-      return Tween<double>(begin: _width, end: screenWidth).animate(
-        CurvedAnimation(
-          parent: _controller.view,
-          curve: const Interval(0, 0.3, curve: Curves.fastOutSlowIn),
-        ),
-      );
+      return Tween<double>(begin: _width, end: screenWidth)
+          .chain(CurveTween(curve: const Interval(0, 0.3, curve: Curves.fastOutSlowIn)))
+          .animate(_controller);
     } else {
       // Closing animation
       return _getEmphasizedEasingAnimation(
@@ -157,7 +154,7 @@ class ExpandingBottomSheetState extends State<ExpandingBottomSheet> {
         peak: _getPeakPoint(begin: _width, end: screenWidth),
         end: screenWidth,
         isForward: false,
-        parent: CurvedAnimation(parent: _controller.view, curve: const Interval(0, 0.87)),
+        parent: CurveTween(curve: const Interval(0, 0.87)).animate(_controller),
       );
     }
   }
@@ -175,14 +172,9 @@ class ExpandingBottomSheetState extends State<ExpandingBottomSheet> {
       );
     } else {
       // Closing animation
-      return Tween<double>(begin: _height, end: screenHeight).animate(
-        CurvedAnimation(
-          parent: _controller.view,
-          curve: const Interval(0.434, 1), // not used
-          // only the reverseCurve will be used
-          reverseCurve: Interval(0.434, 1, curve: Curves.fastOutSlowIn.flipped),
-        ),
-      );
+      return Tween<double>(begin: _height, end: screenHeight)
+          .chain(CurveTween(curve: Interval(0.434, 1, curve: Curves.fastOutSlowIn.flipped)))
+          .animate(_controller);
     }
   }
 
@@ -202,14 +194,9 @@ class ExpandingBottomSheetState extends State<ExpandingBottomSheet> {
       );
     } else {
       // Closing animation
-      return Tween<double>(begin: collapsedGapHeight, end: expandedGapHeight).animate(
-        CurvedAnimation(
-          parent: _controller.view,
-          curve: const Interval(0.434, 1), // not used
-          // only the reverseCurve will be used
-          reverseCurve: Interval(0.434, 1, curve: Curves.fastOutSlowIn.flipped),
-        ),
-      );
+      return Tween<double>(begin: collapsedGapHeight, end: expandedGapHeight)
+          .chain(CurveTween(curve: Interval(0.434, 1, curve: Curves.fastOutSlowIn.flipped)))
+          .animate(_controller);
     }
   }
 
@@ -220,12 +207,9 @@ class ExpandingBottomSheetState extends State<ExpandingBottomSheet> {
     final double cornerRadius = isDesktop ? _desktopCornerRadius : _mobileCornerRadius;
 
     if (_controller.status == AnimationStatus.forward) {
-      return Tween<double>(begin: cornerRadius, end: 0).animate(
-        CurvedAnimation(
-          parent: _controller.view,
-          curve: const Interval(0, 0.3, curve: Curves.fastOutSlowIn),
-        ),
-      );
+      return Tween<double>(begin: cornerRadius, end: 0)
+          .chain(CurveTween(curve: const Interval(0, 0.3, curve: Curves.fastOutSlowIn)))
+          .animate(_controller);
     } else {
       return _getEmphasizedEasingAnimation(
         begin: cornerRadius,
@@ -244,12 +228,9 @@ class ExpandingBottomSheetState extends State<ExpandingBottomSheet> {
     final double cornerRadius = isDesktop ? _desktopCornerRadius : 0.0;
 
     if (_controller.status == AnimationStatus.forward) {
-      return Tween<double>(begin: cornerRadius, end: 0).animate(
-        CurvedAnimation(
-          parent: _controller.view,
-          curve: const Interval(0, 0.3, curve: Curves.fastOutSlowIn),
-        ),
-      );
+      return Tween<double>(begin: cornerRadius, end: 0)
+          .chain(CurveTween(curve: const Interval(0, 0.3, curve: Curves.fastOutSlowIn)))
+          .animate(_controller);
     } else {
       return _getEmphasizedEasingAnimation(
         begin: cornerRadius,
@@ -262,23 +243,23 @@ class ExpandingBottomSheetState extends State<ExpandingBottomSheet> {
   }
 
   Animation<double> _getThumbnailOpacityAnimation() {
-    return Tween<double>(begin: 1, end: 0).animate(
-      CurvedAnimation(
-        parent: _controller.view,
-        curve: _controller.status == AnimationStatus.forward
-            ? const Interval(0, 0.3)
-            : const Interval(0.532, 0.766),
-      ),
-    );
+    return Tween<double>(begin: 1, end: 0)
+        .chain(
+          CurveTween(
+            curve: _controller.status == AnimationStatus.forward
+                ? const Interval(0, 0.3)
+                : const Interval(0.532, 0.766),
+          ),
+        )
+        .animate(_controller);
   }
 
   Animation<double> _getCartOpacityAnimation() {
-    return CurvedAnimation(
-      parent: _controller.view,
+    return CurveTween(
       curve: _controller.status == AnimationStatus.forward
           ? const Interval(0.3, 0.6)
           : const Interval(0.766, 1),
-    );
+    ).animate(_controller);
   }
 
   // Returns the correct width of the ExpandingBottomSheet based on the number of
@@ -562,17 +543,12 @@ class _ProductThumbnailRowState extends State<ProductThumbnailRow> {
   }
 
   Widget _buildThumbnail(BuildContext context, int index, Animation<double> animation) {
-    final Animation<double> thumbnailSize = Tween<double>(begin: 0.8, end: 1).animate(
-      CurvedAnimation(
-        curve: const Interval(0.33, 1, curve: Curves.easeIn),
-        parent: animation,
-      ),
-    );
+    final Animation<double> thumbnailSize = Tween<double>(
+      begin: 0.8,
+      end: 1,
+    ).chain(CurveTween(curve: const Interval(0.33, 1, curve: Curves.easeIn))).animate(animation);
 
-    final Animation<double> opacity = CurvedAnimation(
-      curve: const Interval(0.33, 1),
-      parent: animation,
-    );
+    final Animation<double> opacity = CurveTween(curve: const Interval(0.33, 1)).animate(animation);
 
     return ProductThumbnail(thumbnailSize, opacity, _productWithId(_list[index]));
   }

--- a/dev/manual_tests/lib/material_arc.dart
+++ b/dev/manual_tests/lib/material_arc.dart
@@ -110,7 +110,7 @@ class _PointDemo extends StatefulWidget {
 class _PointDemoState extends State<_PointDemo> {
   final GlobalKey _painterKey = GlobalKey();
 
-  CurvedAnimation? _animation;
+  Animation<double>? _animation;
   _DragTarget? _dragTarget;
   Size? _screenSize;
   Offset? _begin;
@@ -119,7 +119,7 @@ class _PointDemoState extends State<_PointDemo> {
   @override
   void initState() {
     super.initState();
-    _animation = CurvedAnimation(parent: widget.controller, curve: Curves.fastOutSlowIn);
+    _animation = CurveTween(curve: Curves.fastOutSlowIn).animate(widget.controller);
   }
 
   @override
@@ -274,10 +274,9 @@ class _RectangleDemo extends StatefulWidget {
 class _RectangleDemoState extends State<_RectangleDemo> {
   final GlobalKey _painterKey = GlobalKey();
 
-  late final CurvedAnimation _animation = CurvedAnimation(
-    parent: widget.controller,
+  late final Animation<double> _animation = CurveTween(
     curve: Curves.fastOutSlowIn,
-  );
+  ).animate(widget.controller);
   _DragTarget? _dragTarget;
   Size? _screenSize;
   Rect? _begin;

--- a/examples/api/lib/animation/curves/curve2_d.0.dart
+++ b/examples/api/lib/animation/curves/curve2_d.0.dart
@@ -65,10 +65,13 @@ class _FollowCurve2DState extends State<FollowCurve2D>
   void initState() {
     super.initState();
     controller = AnimationController(duration: widget.duration, vsync: this);
-    animation = CurvedAnimation(parent: controller, curve: widget.curve);
+    animation = controller.drive(CurveTween(curve: widget.curve));
     // Have the controller repeat indefinitely. If you want it to "bounce" back
     // and forth, set the reverse parameter to true.
     controller.repeat();
+    // This is just for demo purposes. It's more efficient to use one of
+    // Flutter's transition widgets like [AlignTransition] rather than calling
+    // [setState] repeatedly.
     controller.addListener(() => setState(() {}));
   }
 

--- a/examples/api/lib/widgets/animated_grid/animated_grid.0.dart
+++ b/examples/api/lib/widgets/animated_grid/animated_grid.0.dart
@@ -220,9 +220,8 @@ class CardItem extends StatelessWidget {
     return Padding(
       padding: const .all(2.0),
       child: ScaleTransition(
-        scale: CurvedAnimation(
-          parent: animation,
-          curve: removing ? Curves.easeInOut : Curves.bounceOut,
+        scale: animation.drive(
+          CurveTween(curve: removing ? Curves.easeInOut : Curves.bounceOut),
         ),
         child: GestureDetector(
           behavior: HitTestBehavior.opaque,

--- a/examples/api/lib/widgets/animated_grid/sliver_animated_grid.0.dart
+++ b/examples/api/lib/widgets/animated_grid/sliver_animated_grid.0.dart
@@ -220,9 +220,8 @@ class CardItem extends StatelessWidget {
     return Padding(
       padding: const .only(left: 2.0, right: 2.0, top: 2.0),
       child: ScaleTransition(
-        scale: CurvedAnimation(
-          parent: animation,
-          curve: removing ? Curves.easeInOut : Curves.bounceOut,
+        scale: animation.drive(
+          CurveTween(curve: removing ? Curves.easeInOut : Curves.bounceOut),
         ),
         child: GestureDetector(
           onTap: onTap,

--- a/examples/api/lib/widgets/raw_menu_anchor/raw_menu_anchor.3.dart
+++ b/examples/api/lib/widgets/raw_menu_anchor/raw_menu_anchor.3.dart
@@ -128,7 +128,7 @@ class Menu extends StatefulWidget {
 class MenuState extends State<Menu> with SingleTickerProviderStateMixin {
   final MenuController menuController = MenuController();
   late final AnimationController animationController;
-  late final CurvedAnimation animation;
+  late final Animation<double> animation;
   bool get isSubmenu => MenuController.maybeOf(context) != null;
   AnimationStatus get animationStatus => animationController.status;
 
@@ -147,16 +147,14 @@ class MenuState extends State<Menu> with SingleTickerProviderStateMixin {
           }
         });
 
-    animation = CurvedAnimation(
-      parent: animationController,
-      curve: Curves.easeOutQuart,
+    animation = animationController.drive(
+      CurveTween(curve: Curves.easeOutQuart),
     );
   }
 
   @override
   void dispose() {
     animationController.dispose();
-    animation.dispose();
     super.dispose();
   }
 

--- a/examples/api/lib/widgets/routes/flexible_route_transitions.0.dart
+++ b/examples/api/lib/widgets/routes/flexible_route_transitions.0.dart
@@ -154,16 +154,12 @@ class _VerticalPageTransition extends StatelessWidget {
     required Animation<double> primaryRouteAnimation,
     required this.secondaryRouteAnimation,
     required this.child,
-  }) : _primaryPositionAnimation = CurvedAnimation(
-         parent: primaryRouteAnimation,
-         curve: _curve,
-         reverseCurve: _curve,
-       ).drive(_kBottomUpTween),
-       _secondaryPositionAnimation = CurvedAnimation(
-         parent: secondaryRouteAnimation,
-         curve: _curve,
-         reverseCurve: _curve,
-       ).drive(_kTopDownTween);
+  }) : _primaryPositionAnimation = _kBottomUpTween
+           .chain(CurveTween(curve: _curve))
+           .animate(primaryRouteAnimation),
+       _secondaryPositionAnimation = _kTopDownTween
+           .chain(CurveTween(curve: _curve))
+           .animate(secondaryRouteAnimation);
 
   final Animation<Offset> _primaryPositionAnimation;
 

--- a/examples/api/lib/widgets/routes/flexible_route_transitions.1.dart
+++ b/examples/api/lib/widgets/routes/flexible_route_transitions.1.dart
@@ -364,16 +364,12 @@ class _VerticalPageTransition extends StatelessWidget {
     required Animation<double> primaryRouteAnimation,
     required this.secondaryRouteAnimation,
     required this.child,
-  }) : _primaryPositionAnimation = CurvedAnimation(
-         parent: primaryRouteAnimation,
-         curve: _curve,
-         reverseCurve: _curve,
-       ).drive(_kBottomUpTween),
-       _secondaryPositionAnimation = CurvedAnimation(
-         parent: secondaryRouteAnimation,
-         curve: _curve,
-         reverseCurve: _curve,
-       ).drive(_kTopDownTween);
+  }) : _primaryPositionAnimation = _kBottomUpTween
+           .chain(CurveTween(curve: _curve))
+           .animate(primaryRouteAnimation),
+       _secondaryPositionAnimation = _kTopDownTween
+           .chain(CurveTween(curve: _curve))
+           .animate(secondaryRouteAnimation);
 
   final Animation<Offset> _primaryPositionAnimation;
 

--- a/examples/api/lib/widgets/transitions/align_transition.0.dart
+++ b/examples/api/lib/widgets/transitions/align_transition.0.dart
@@ -37,7 +37,7 @@ class _AlignTransitionExampleState extends State<AlignTransitionExample>
   late final Animation<AlignmentGeometry> _animation = Tween<AlignmentGeometry>(
     begin: Alignment.bottomLeft,
     end: Alignment.center,
-  ).animate(CurvedAnimation(parent: _controller, curve: Curves.decelerate));
+  ).chain(CurveTween(curve: Curves.decelerate)).animate(_controller);
 
   @override
   void dispose() {

--- a/examples/api/lib/widgets/transitions/default_text_style_transition.0.dart
+++ b/examples/api/lib/widgets/transitions/default_text_style_transition.0.dart
@@ -31,8 +31,7 @@ class _DefaultTextStyleTransitionExampleState
     extends State<DefaultTextStyleTransitionExample>
     with TickerProviderStateMixin {
   late AnimationController _controller;
-  late TextStyleTween _styleTween;
-  late CurvedAnimation _curvedAnimation;
+  late Animation<TextStyle> _animation;
 
   @override
   void initState() {
@@ -41,7 +40,7 @@ class _DefaultTextStyleTransitionExampleState
       duration: const Duration(seconds: 2),
       vsync: this,
     )..repeat(reverse: true);
-    _styleTween = TextStyleTween(
+    final styleTween = TextStyleTween(
       begin: const TextStyle(
         fontSize: 50,
         color: Colors.blue,
@@ -49,10 +48,9 @@ class _DefaultTextStyleTransitionExampleState
       ),
       end: const TextStyle(fontSize: 50, color: Colors.red, fontWeight: .w100),
     );
-    _curvedAnimation = CurvedAnimation(
-      parent: _controller,
-      curve: Curves.elasticInOut,
-    );
+    _animation = styleTween
+        .chain(CurveTween(curve: Curves.elasticInOut))
+        .animate(_controller);
   }
 
   @override
@@ -65,7 +63,7 @@ class _DefaultTextStyleTransitionExampleState
   Widget build(BuildContext context) {
     return Center(
       child: DefaultTextStyleTransition(
-        style: _styleTween.animate(_curvedAnimation),
+        style: _animation,
         child: const Text('Flutter'),
       ),
     );

--- a/examples/api/lib/widgets/transitions/fade_transition.0.dart
+++ b/examples/api/lib/widgets/transitions/fade_transition.0.dart
@@ -45,10 +45,6 @@ class _FadeTransitionExampleState extends State<FadeTransitionExample>
     duration: widget.duration,
     vsync: this,
   )..repeat(reverse: true);
-  late final CurvedAnimation _animation = CurvedAnimation(
-    parent: _controller,
-    curve: widget.curve,
-  );
 
   @override
   void didUpdateWidget(FadeTransitionExample oldWidget) {
@@ -59,15 +55,10 @@ class _FadeTransitionExampleState extends State<FadeTransitionExample>
         ..duration = widget.duration
         ..repeat(reverse: true);
     }
-
-    if (oldWidget.curve != widget.curve) {
-      _animation.curve = widget.curve;
-    }
   }
 
   @override
   void dispose() {
-    _animation.dispose();
     _controller.dispose();
     super.dispose();
   }
@@ -77,7 +68,7 @@ class _FadeTransitionExampleState extends State<FadeTransitionExample>
     return ColoredBox(
       color: Colors.white,
       child: FadeTransition(
-        opacity: _animation,
+        opacity: _controller.drive(CurveTween(curve: widget.curve)),
         child: const Padding(padding: .all(8), child: FlutterLogo()),
       ),
     );

--- a/examples/api/lib/widgets/transitions/matrix_transition.0.dart
+++ b/examples/api/lib/widgets/transitions/matrix_transition.0.dart
@@ -32,7 +32,6 @@ class MatrixTransitionExample extends StatefulWidget {
 class _MatrixTransitionExampleState extends State<MatrixTransitionExample>
     with TickerProviderStateMixin {
   late AnimationController _controller;
-  late Animation<double> _animation;
 
   @override
   void initState() {
@@ -41,7 +40,6 @@ class _MatrixTransitionExampleState extends State<MatrixTransitionExample>
       duration: const Duration(seconds: 2),
       vsync: this,
     )..repeat();
-    _animation = CurvedAnimation(parent: _controller, curve: Curves.linear);
   }
 
   @override
@@ -55,7 +53,7 @@ class _MatrixTransitionExampleState extends State<MatrixTransitionExample>
     return Scaffold(
       body: Center(
         child: MatrixTransition(
-          animation: _animation,
+          animation: _controller.drive(CurveTween(curve: Curves.linear)),
           child: const Padding(
             padding: .all(8.0),
             child: FlutterLogo(size: 150.0),

--- a/examples/api/lib/widgets/transitions/positioned_transition.0.dart
+++ b/examples/api/lib/widgets/transitions/positioned_transition.0.dart
@@ -54,25 +54,22 @@ class _PositionedTransitionExampleState
             PositionedTransition(
               rect:
                   RelativeRectTween(
-                    begin: RelativeRect.fromSize(
-                      const Rect.fromLTWH(0, 0, smallLogo, smallLogo),
-                      biggest,
-                    ),
-                    end: RelativeRect.fromSize(
-                      Rect.fromLTWH(
-                        biggest.width - bigLogo,
-                        biggest.height - bigLogo,
-                        bigLogo,
-                        bigLogo,
-                      ),
-                      biggest,
-                    ),
-                  ).animate(
-                    CurvedAnimation(
-                      parent: _controller,
-                      curve: Curves.elasticInOut,
-                    ),
-                  ),
+                        begin: RelativeRect.fromSize(
+                          const Rect.fromLTWH(0, 0, smallLogo, smallLogo),
+                          biggest,
+                        ),
+                        end: RelativeRect.fromSize(
+                          Rect.fromLTWH(
+                            biggest.width - bigLogo,
+                            biggest.height - bigLogo,
+                            bigLogo,
+                            bigLogo,
+                          ),
+                          biggest,
+                        ),
+                      )
+                      .chain(CurveTween(curve: Curves.elasticInOut))
+                      .animate(_controller),
               child: const Padding(padding: .all(8), child: FlutterLogo()),
             ),
           ],

--- a/examples/api/lib/widgets/transitions/relative_positioned_transition.0.dart
+++ b/examples/api/lib/widgets/transitions/relative_positioned_transition.0.dart
@@ -55,19 +55,16 @@ class _RelativePositionedTransitionExampleState
               size: biggest,
               rect:
                   RectTween(
-                    begin: const Rect.fromLTWH(0, 0, bigLogo, bigLogo),
-                    end: Rect.fromLTWH(
-                      biggest.width - smallLogo,
-                      biggest.height - smallLogo,
-                      smallLogo,
-                      smallLogo,
-                    ),
-                  ).animate(
-                    CurvedAnimation(
-                      parent: _controller,
-                      curve: Curves.elasticInOut,
-                    ),
-                  ),
+                        begin: const Rect.fromLTWH(0, 0, bigLogo, bigLogo),
+                        end: Rect.fromLTWH(
+                          biggest.width - smallLogo,
+                          biggest.height - smallLogo,
+                          smallLogo,
+                          smallLogo,
+                        ),
+                      )
+                      .chain(CurveTween(curve: Curves.elasticInOut))
+                      .animate(_controller),
               child: const Padding(padding: .all(8), child: FlutterLogo()),
             ),
           ],

--- a/examples/api/lib/widgets/transitions/rotation_transition.0.dart
+++ b/examples/api/lib/widgets/transitions/rotation_transition.0.dart
@@ -33,10 +33,6 @@ class _RotationTransitionExampleState extends State<RotationTransitionExample>
     duration: const Duration(seconds: 2),
     vsync: this,
   )..repeat(reverse: true);
-  late final Animation<double> _animation = CurvedAnimation(
-    parent: _controller,
-    curve: Curves.elasticOut,
-  );
 
   @override
   void dispose() {
@@ -49,7 +45,7 @@ class _RotationTransitionExampleState extends State<RotationTransitionExample>
     return Scaffold(
       body: Center(
         child: RotationTransition(
-          turns: _animation,
+          turns: _controller.drive(CurveTween(curve: Curves.elasticOut)),
           child: const Padding(
             padding: .all(8.0),
             child: FlutterLogo(size: 150.0),

--- a/examples/api/lib/widgets/transitions/scale_transition.0.dart
+++ b/examples/api/lib/widgets/transitions/scale_transition.0.dart
@@ -32,10 +32,6 @@ class _ScaleTransitionExampleState extends State<ScaleTransitionExample>
     duration: const Duration(seconds: 2),
     vsync: this,
   )..repeat(reverse: true);
-  late final Animation<double> _animation = CurvedAnimation(
-    parent: _controller,
-    curve: Curves.fastOutSlowIn,
-  );
 
   @override
   void dispose() {
@@ -48,7 +44,7 @@ class _ScaleTransitionExampleState extends State<ScaleTransitionExample>
     return Scaffold(
       body: Center(
         child: ScaleTransition(
-          scale: _animation,
+          scale: _controller.drive(CurveTween(curve: Curves.fastOutSlowIn)),
           child: const Padding(
             padding: .all(8.0),
             child: FlutterLogo(size: 150.0),

--- a/examples/api/lib/widgets/transitions/size_transition.0.dart
+++ b/examples/api/lib/widgets/transitions/size_transition.0.dart
@@ -32,10 +32,6 @@ class _SizeTransitionExampleState extends State<SizeTransitionExample>
     duration: const Duration(seconds: 3),
     vsync: this,
   )..repeat();
-  late final Animation<double> _animation = CurvedAnimation(
-    parent: _controller,
-    curve: Curves.fastOutSlowIn,
-  );
 
   @override
   void dispose() {
@@ -47,7 +43,7 @@ class _SizeTransitionExampleState extends State<SizeTransitionExample>
   Widget build(BuildContext context) {
     return Scaffold(
       body: SizeTransition(
-        sizeFactor: _animation,
+        sizeFactor: _controller.drive(CurveTween(curve: Curves.fastOutSlowIn)),
         axis: .horizontal,
         alignment: .topLeft,
         child: const Center(child: FlutterLogo(size: 200.0)),

--- a/examples/api/lib/widgets/transitions/slide_transition.0.dart
+++ b/examples/api/lib/widgets/transitions/slide_transition.0.dart
@@ -35,10 +35,10 @@ class _SlideTransitionExampleState extends State<SlideTransitionExample>
     duration: const Duration(seconds: 2),
     vsync: this,
   )..repeat(reverse: true);
-  late final Animation<Offset> _offsetAnimation = Tween<Offset>(
-    begin: Offset.zero,
+  final _positionTween = Tween<Offset>(
+    begin: .zero,
     end: const Offset(1.5, 0.0),
-  ).animate(CurvedAnimation(parent: _controller, curve: Curves.elasticIn));
+  );
 
   @override
   void dispose() {
@@ -49,7 +49,9 @@ class _SlideTransitionExampleState extends State<SlideTransitionExample>
   @override
   Widget build(BuildContext context) {
     return SlideTransition(
-      position: _offsetAnimation,
+      position: _positionTween
+          .chain(CurveTween(curve: Curves.elasticIn))
+          .animate(_controller),
       child: const Padding(padding: .all(8.0), child: FlutterLogo(size: 150.0)),
     );
   }

--- a/examples/api/lib/widgets/transitions/sliver_fade_transition.0.dart
+++ b/examples/api/lib/widgets/transitions/sliver_fade_transition.0.dart
@@ -37,15 +37,11 @@ class _SliverFadeTransitionExampleState
     duration: const Duration(milliseconds: 1000),
     vsync: this,
   );
-  late final Animation<double> animation = CurvedAnimation(
-    parent: controller,
-    curve: Curves.easeIn,
-  );
 
   @override
   void initState() {
     super.initState();
-    animation.addStatusListener((AnimationStatus status) {
+    controller.addStatusListener((AnimationStatus status) {
       if (status == AnimationStatus.completed) {
         controller.reverse();
       } else if (status == AnimationStatus.dismissed) {
@@ -66,7 +62,7 @@ class _SliverFadeTransitionExampleState
     return CustomScrollView(
       slivers: <Widget>[
         SliverFadeTransition(
-          opacity: animation,
+          opacity: controller.drive(CurveTween(curve: Curves.easeIn)),
           sliver: SliverFixedExtentList.builder(
             itemExtent: 100.0,
             itemCount: 5,

--- a/examples/api/test/widgets/transitions/rotation_transition.0_test.dart
+++ b/examples/api/test/widgets/transitions/rotation_transition.0_test.dart
@@ -12,15 +12,6 @@ void main() {
     WidgetTester tester,
   ) async {
     await tester.pumpWidget(const example.RotationTransitionExampleApp());
-    expect(
-      find.byWidgetPredicate(
-        (Widget widget) =>
-            widget is RotationTransition &&
-            widget.turns is CurvedAnimation &&
-            (widget.turns as CurvedAnimation).curve == Curves.elasticOut,
-      ),
-      findsOneWidget,
-    );
     expect(find.byType(FlutterLogo), findsOneWidget);
     expect(find.byType(Padding), findsAtLeast(1));
     expect(
@@ -31,33 +22,21 @@ void main() {
       findsOneWidget,
     );
 
-    expect(
-      find.byWidgetPredicate(
-        (Widget widget) =>
-            widget is RotationTransition &&
-            widget.turns is CurvedAnimation &&
-            widget.turns.value == 0.0 &&
-            widget.turns.status == AnimationStatus.forward,
-      ),
-      findsOneWidget,
+    expect(find.byType(RotationTransition), findsOneWidget);
+    final transition = tester.widget<RotationTransition>(
+      find.byType(RotationTransition),
     );
+    expect(transition.turns.status, AnimationStatus.forward);
+    expect(transition.turns.value, 0.0);
 
     await tester.pump();
     await tester.pump(const Duration(seconds: 3));
     await tester.pump();
 
+    expect(transition.turns.status, AnimationStatus.reverse);
     expect(
-      find.byWidgetPredicate(
-        (Widget widget) =>
-            widget is RotationTransition &&
-            widget.turns is CurvedAnimation &&
-            (widget.turns as CurvedAnimation).parent is AnimationController &&
-            ((widget.turns as CurvedAnimation).parent as AnimationController)
-                    .value ==
-                0.5 &&
-            widget.turns.status == AnimationStatus.reverse,
-      ),
-      findsOneWidget,
+      transition.turns.value,
+      moreOrLessEquals(Curves.elasticOut.transform(0.5)),
     );
   });
 }

--- a/examples/api/test/widgets/transitions/scale_transition.0_test.dart
+++ b/examples/api/test/widgets/transitions/scale_transition.0_test.dart
@@ -19,14 +19,19 @@ void main() {
       ),
       findsOneWidget,
     );
+
+    final transition = tester.widget<ScaleTransition>(
+      find.byType(ScaleTransition),
+    );
+    expect(transition.scale.value, 0.0);
+
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump();
+
     expect(
-      find.byWidgetPredicate(
-        (Widget widget) =>
-            widget is ScaleTransition &&
-            widget.scale is CurvedAnimation &&
-            (widget.scale as CurvedAnimation).curve == Curves.fastOutSlowIn,
-      ),
-      findsOneWidget,
+      transition.scale.value,
+      moreOrLessEquals(Curves.fastOutSlowIn.transform(0.5)),
     );
   });
 

--- a/examples/api/test/widgets/transitions/size_transition.0_test.dart
+++ b/examples/api/test/widgets/transitions/size_transition.0_test.dart
@@ -19,10 +19,14 @@ void main() {
       ),
       findsOneWidget,
     );
+
     expect(find.byType(SizeTransition), findsOneWidget);
+    final transition = tester.widget<SizeTransition>(
+      find.byType(SizeTransition),
+    );
 
     expect(
-      tester.widget(find.byType(SizeTransition)),
+      transition,
       isA<SizeTransition>()
           .having(
             (SizeTransition transition) => transition.axis,
@@ -33,26 +37,16 @@ void main() {
             (SizeTransition transition) => transition.alignment,
             'alignment',
             Alignment.topLeft,
-          )
-          .having(
-            (SizeTransition transition) => transition.sizeFactor,
-            'factor',
-            isA<CurvedAnimation>()
-                .having(
-                  (CurvedAnimation animation) => animation.curve,
-                  'curve',
-                  Curves.fastOutSlowIn,
-                )
-                .having(
-                  (CurvedAnimation animation) => animation.parent,
-                  'paren',
-                  isA<AnimationController>().having(
-                    (AnimationController controller) => controller.duration,
-                    'duration',
-                    const Duration(seconds: 3),
-                  ),
-                ),
           ),
+    );
+
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 3) ~/ 2);
+    await tester.pump();
+
+    expect(
+      transition.sizeFactor.value,
+      moreOrLessEquals(Curves.fastOutSlowIn.transform(0.5)),
     );
   });
 }

--- a/packages/flutter/lib/animation.dart
+++ b/packages/flutter/lib/animation.dart
@@ -77,7 +77,7 @@
 /// an [Animatable] (see below) changes the range of animation values to a
 /// different range or type (for example to animate [Color]s or [Rect]s).
 /// Furthermore, a [Curve] can be applied to the animation by wrapping it in a
-/// [CurvedAnimation]. Instead of linearly increasing the animation value, a
+/// [ReversibleCurvedAnimation]. Instead of linearly increasing the animation value, a
 /// curved animation changes its value according to the provided curve. The
 /// framework ships with many built-in curves (see [Curves]). As an example,
 /// [Curves.easeOutCubic] increases the animation value quickly at the beginning

--- a/packages/flutter/lib/fix_data/fix_animation.yaml
+++ b/packages/flutter/lib/fix_data/fix_animation.yaml
@@ -1,0 +1,51 @@
+# Copyright 2014 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# For details regarding the *Flutter Fix* feature, see
+# https://flutter.dev/to/flutter-fix
+
+# Please add new fixes to the top of the file, separated by one blank line
+# from other fixes. In a comment, include a link to the PR where the change
+# requiring the fix was made.
+
+# Every fix must be tested. See the flutter/packages/flutter/test_fixes/README.md
+# file for instructions on testing these data driven fixes.
+
+# For documentation about this file format, see
+# https://dart.dev/go/data-driven-fixes.
+
+# * Fixes in this file are from the Animation library. *
+
+version: 1
+transforms:
+  # Change made in [...] // TODO(adil192): link PR
+  - title: "Rename to ReversibleCurvedAnimation"
+    date: 2026-04-23
+    element:
+      # TODO(adil192): Find out what libraries export CurvedAnimation
+      uris: [ 'animation.dart' ]
+      constructor: ''
+      inClass: 'CurvedAnimation'
+    oneOf:
+      - if: "reverseCurve != '' && reverseCurve != curve"
+        changes:
+          - kind: 'replacedBy'
+            newElement:
+              uris: [ 'animation.dart' ]
+              constructor: ''
+              inClass: 'ReversibleCurvedAnimation'
+      # Otherwise, migrate to this expression. But it's not possible as a data-driven fix yet.
+      #     '{% parent %}.drive(CurveTween(curve: {% curve %}))'
+    variables:
+      parent:
+        kind: fragment
+        value: 'arguments[parent]'
+      curve:
+        kind: fragment
+        value: 'arguments[curve]'
+      reverseCurve:
+        kind: fragment
+        value: 'arguments[reverseCurve]'
+
+# Before adding a new fix: read instructions at the top of this file.

--- a/packages/flutter/lib/src/animation/animation.dart
+++ b/packages/flutter/lib/src/animation/animation.dart
@@ -105,14 +105,14 @@ typedef ValueListenableTransformer<T> = T Function(T);
 /// (which is itself an [Animation<double>])
 /// created by a [State] that implements [TickerProvider].
 /// Further animations might be derived from that animation
-/// by using e.g. [Tween] or [CurvedAnimation].
+/// by using e.g. [Tween] or [ReversibleCurvedAnimation].
 /// The animations might be used to configure an [AnimatedWidget]
 /// (using one of its many subclasses like [FadeTransition]),
 /// or their values might be used directly.
 ///
 /// For example, the [AnimationController] may represent
 /// the abstract progress of the animation from 0.0 to 1.0;
-/// then a [CurvedAnimation] might apply an easing curve;
+/// then a [ReversibleCurvedAnimation] might apply an easing curve;
 /// and a [SizeTween] and [ColorTween] might each be applied to that
 /// to produce an [Animation<Size>] and an [Animation<Color>] that control
 /// a widget shrinking and changing color as the animation proceeds.
@@ -257,7 +257,7 @@ abstract class Animation<T> extends Listenable implements ValueListenable<T> {
   ///
   /// This method is only valid for `Animation<double>` instances (i.e. when `T`
   /// is `double`). This means, for instance, that it can be called on
-  /// [AnimationController] objects, as well as [CurvedAnimation]s,
+  /// [AnimationController] objects, as well as [ReversibleCurvedAnimation]s,
   /// [ProxyAnimation]s, [ReverseAnimation]s, [TrainHoppingAnimation]s, etc.
   ///
   /// It returns an [Animation] specialized to the same type, `U`, as the
@@ -336,7 +336,7 @@ abstract class Animation<T> extends Listenable implements ValueListenable<T> {
   ///
   ///  * [Animatable.animate], which does the same thing.
   ///  * [AnimationController], which is usually used to drive animations.
-  ///  * [CurvedAnimation], an alternative to [CurveTween] for applying easing
+  ///  * [ReversibleCurvedAnimation], an alternative to [CurveTween] for applying easing
   ///    curves, which supports distinct curves in the forward direction and the
   ///    reverse direction.
   ///  * [Animatable.fromCallback], which allows creating an [Animatable] from an

--- a/packages/flutter/lib/src/animation/animations.dart
+++ b/packages/flutter/lib/src/animation/animations.dart
@@ -8,6 +8,8 @@ library;
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/src/animation/tween.dart';
+import 'package:flutter/src/widgets/framework.dart';
 
 import 'animation.dart';
 import 'curves.dart';
@@ -268,8 +270,8 @@ class ProxyAnimation extends Animation<double>
 ///
 ///  * [Curve.flipped] and [FlippedCurve], which provide a similar effect but on
 ///    [Curve]s.
-///  * [CurvedAnimation], which can take separate curves for when the animation
-///    is going forward than for when it is going in reverse.
+///  * [ReversibleCurvedAnimation], which can take separate curves for when the
+///    animation is going forward than for when it is going in reverse.
 class ReverseAnimation extends Animation<double>
     with AnimationLazyListenerMixin, AnimationLocalStatusListenersMixin {
   /// Creates a reverse animation.
@@ -325,67 +327,68 @@ class ReverseAnimation extends Animation<double>
   }
 }
 
-/// An animation that applies a curve to another animation.
+/// An animation that applies different curves to its [parent] animation
+/// depending on whether it's going forwards or backwards.
 ///
-/// [CurvedAnimation] is useful when you want to apply a non-linear [Curve] to
-/// an animation object, especially if you want different curves when the
-/// animation is going forward vs when it is going backward.
-///
-/// Depending on the given curve, the output of the [CurvedAnimation] could have
-/// a wider range than its input. For example, elastic curves such as
-/// [Curves.elasticIn] will significantly overshoot or undershoot the default
-/// range of 0.0 to 1.0.
-///
-/// If you want to apply a [Curve] to a [Tween], consider using [CurveTween].
-///
-/// A [CurvedAnimation] should be disposed when no longer needed to clean up
-/// any listeners that it may have added. Disposing the
-/// parent animation (typically the [AnimationController]) will also clean up
-/// this object. Do not create a [CurvedAnimation] inside a `build` method
-/// because it would leak any added listeners on every rebuild. If [reverseCurve] is
-/// not needed, prefer `parent.drive(CurveTween(curve: curve))` which does not
-/// require separate disposal.
+/// This class has been deprecated for API clarity:
+/// - If you need different forward and backward curves,
+///   this class was renamed to [ReversibleCurvedAnimation].
+///   The constructor's [reverseCurve] is now required, but can still be null.
+/// - If you only use a single curve,
+///   consider switching to [CurveTween] to avoid memory leaks
+///   (see the snippet below).
 ///
 /// {@tool snippet}
 ///
-/// The following code snippet shows how you can apply a curve to a linear
-/// animation produced by an [AnimationController] `controller`.
+/// This code snippet shows how to migrate from [CurvedAnimation] to [CurveTween].
+/// The latter is less verbose and could be made stateless.
 ///
 /// ```dart
-/// final Animation<double> animation = CurvedAnimation(
-///   parent: controller,
-///   curve: Curves.ease,
-/// );
+/// class _MyOldWidgetState extends State<MyWidget> {
+///   late final curvedAnimation = CurvedAnimation(
+///     widget.animationController,
+///     curve: Curves.easeInOut,
+///   );
+///
+///   @override
+///   Widget build(BuildContext context) {
+///     return FadeTransition(opacity: curvedAnimation, child: widget.child);
+///   }
+///
+///   @override
+///   void dispose() {
+///     curvedAnimation.dispose();
+///   }
+/// }
+///
+/// class _MyNewWidgetState extends State<MyWidget> {
+///   @override
+///   Widget build(BuildContext context) {
+///     return FadeTransition(
+///       // You don't need to dispose this `drive` animation.
+///       opacity: widget.animationController.drive(
+///         CurveTween(curve: Curves.easeInOut),
+///       ),
+///       child: widget.child,
+///     );
+///   }
+/// }
 /// ```
 /// {@end-tool}
-/// {@tool snippet}
-///
-/// This second code snippet shows how to apply a different curve in the forward
-/// direction than in the reverse direction. This can't be done using a
-/// [CurveTween] (since [Tween]s are not aware of the animation direction when
-/// they are applied).
-///
-/// ```dart
-/// final Animation<double> animation = CurvedAnimation(
-///   parent: controller,
-///   curve: Curves.easeIn,
-///   reverseCurve: Curves.easeOut,
-/// );
-/// ```
-/// {@end-tool}
-///
-/// By default, the [reverseCurve] matches the forward [curve].
-///
-/// See also:
-///
-///  * [CurveTween], for an alternative way of expressing the first sample
-///    above.
-///  * [AnimationController], for examples of creating and disposing of an
-///    [AnimationController].
-///  * [Curve.flipped] and [FlippedCurve], which provide the reverse of a
-///    [Curve].
+@Deprecated(
+  'Switch to ReversibleCurvedAnimation if you need different forward & backward animations, '
+  'or switch to CurveTween if you only need one curve. '
+  'Using CurveTween where possible can reduce boilerplate and memory consumption. '
+  'This feature was deprecated after v3.44.0-0.2.pre.',
+)
 class CurvedAnimation extends Animation<double> with AnimationWithParentMixin<double> {
   /// Creates a curved animation.
+  @Deprecated(
+    'Switch to ReversibleCurvedAnimation if you need different forward & backward animations, '
+    'or switch to CurveTween if you only need one curve. '
+    'Using CurveTween where possible can reduce boilerplate and memory consumption. '
+    'This feature was deprecated after v3.44.0-0.2.pre.',
+  )
   CurvedAnimation({required this.parent, required this.curve, this.reverseCurve}) {
     assert(debugMaybeDispatchCreated('animation', 'CurvedAnimation', this));
     _updateCurveDirection(parent.status);
@@ -478,6 +481,97 @@ class CurvedAnimation extends Animation<double> with AnimationWithParentMixin<do
     }
     return '$parent\u27A9$curve/$reverseCurve\u2092\u2099';
   }
+}
+
+/// An animation that applies different curves to its [parent] animation
+/// depending on whether it's going forwards or backwards.
+///
+/// [ReversibleCurvedAnimation] operates by adding listeners to its [parent].
+/// Therefore, you shouldn't re-instantiating it every build, and you should
+/// dipose it (or its [parent]) when you're done.
+///
+/// Depending on the given curve, the output of this animation could have
+/// a wider range than its input. For example, elastic curves such as
+/// [Curves.elasticIn] will significantly overshoot or undershoot the default
+/// range of 0.0 to 1.0.
+///
+/// {@tool snippet}
+///
+/// This code snippet shows how to apply a different curve in the forward
+/// direction than in the reverse direction. This can't be done using a
+/// [CurveTween] (since [Tween]s are not aware of the animation direction when
+/// they are applied).
+///
+/// ```dart
+/// final Animation<double> animation = ReversibleCurvedAnimation(
+///   parent: controller,
+///   curve: Curves.easeIn,
+///   reverseCurve: Curves.easeOut,
+/// );
+/// ```
+/// {@end-tool}
+///
+/// If [reverseCurve] is not specified,
+/// [curve] will be used in both forward and backward directions.
+/// If you don't need [reverseCurve] at all, consider using [CurveTween]
+/// instead (see the snippet below).
+///
+/// {@tool snippet}
+///
+/// This code snippet shows how to migrate from [ReversibleCurvedAnimation] to [CurveTween].
+/// The latter is less verbose and could be made stateless.
+///
+/// ```dart
+/// class _MyOldWidgetState extends State<MyWidget> {
+///   late final curvedAnimation = ReversibleCurvedAnimation(
+///     widget.animationController,
+///     curve: Curves.easeInOut,
+///     reverseCurve: null,
+///   );
+///
+///   @override
+///   Widget build(BuildContext context) {
+///     return FadeTransition(opacity: curvedAnimation, child: widget.child);
+///   }
+///
+///   @override
+///   void dispose() {
+///     curvedAnimation.dispose();
+///   }
+/// }
+///
+/// class _MyNewWidgetState extends State<MyWidget> {
+///   @override
+///   Widget build(BuildContext context) {
+///     return FadeTransition(
+///       // You don't need to dispose this `drive` animation.
+///       opacity: widget.animationController.drive(
+///         CurveTween(curve: Curves.easeInOut),
+///       ),
+///       child: widget.child,
+///     );
+///   }
+/// }
+/// ```
+/// {@end-tool}
+///
+/// See also:
+///
+///  * [CurveTween], for a single-curve alternative that doesn't need
+///    disposing.
+///  * [AnimationController], for examples of creating and disposing of an
+///    [AnimationController].
+///  * [Curve.flipped] and [FlippedCurve], which provide the reverse of a
+///    [Curve].
+// Maintainer note: This extends the old deprecated class to preserve types in
+// old code (e.g. `animation is CurvedAnimation`).
+class ReversibleCurvedAnimation extends CurvedAnimation {
+  /// Creates a curved animation with a forward [curve] and a [reverseCurve].
+  ReversibleCurvedAnimation({
+    required super.parent,
+    required super.curve,
+    required super.reverseCurve,
+  });
 }
 
 enum _TrainHoppingMode { minimize, maximize }

--- a/packages/flutter/lib/src/animation/animations.dart
+++ b/packages/flutter/lib/src/animation/animations.dart
@@ -340,7 +340,7 @@ class ReverseAnimation extends Animation<double>
 ///
 /// {@tool snippet}
 ///
-/// This code snippet shows how to migrate from [CurvedAnimation] to [CurveTween].
+/// This code snippet shows how to migrate from [ReversibleCurvedAnimation] to [CurveTween].
 /// The latter is less verbose and could be made stateless.
 ///
 /// ```dart
@@ -406,10 +406,10 @@ class CurvedAnimation extends Animation<double> with AnimationWithParentMixin<do
   ///
   /// If the parent animation changes direction without first reaching the
   /// [AnimationStatus.completed] or [AnimationStatus.dismissed] status, the
-  /// [CurvedAnimation] stays on the same curve (albeit in the opposite
+  /// [ReversibleCurvedAnimation] stays on the same curve (albeit in the opposite
   /// direction) to avoid visual discontinuities.
   ///
-  /// Because [CurvedAnimation] may add listeners to its parent, it must be
+  /// Because [ReversibleCurvedAnimation] may add listeners to its parent, it must be
   /// created once (for example in [State.initState]) and disposed in
   /// [State.dispose]. Do not recreate it on every build as it would leak any
   /// added listeners on every rebuild. If [reverseCurve] is not needed, prefer

--- a/packages/flutter/lib/src/animation/curves.dart
+++ b/packages/flutter/lib/src/animation/curves.dart
@@ -98,7 +98,7 @@ abstract class Curve extends ParametricCurve<double> {
 
   /// Returns a new curve that is the reversed inversion of this one.
   ///
-  /// This is often useful with [CurvedAnimation.reverseCurve].
+  /// This is often useful with [ReversibleCurvedAnimation.reverseCurve].
   ///
   /// {@animation 464 192 https://flutter.github.io/assets-for-api-docs/assets/animation/curve_bounce_in.mp4}
   /// {@animation 464 192 https://flutter.github.io/assets-for-api-docs/assets/animation/curve_flipped.mp4}
@@ -107,7 +107,7 @@ abstract class Curve extends ParametricCurve<double> {
   ///
   ///  * [FlippedCurve], the class that is used to implement this getter.
   ///  * [ReverseAnimation], which reverses an [Animation] rather than a [Curve].
-  ///  * [CurvedAnimation], which can take a separate curve and reverse curve.
+  ///  * [ReversibleCurvedAnimation], which can take a separate curve and reverse curve.
   Curve get flipped => FlippedCurve(this);
 }
 
@@ -1217,7 +1217,7 @@ class CatmullRomCurve extends Curve {
 ///
 /// This is the class used to implement the [flipped] getter on curves.
 ///
-/// This is often useful with [CurvedAnimation.reverseCurve].
+/// This is often useful with [ReversibleCurvedAnimation.reverseCurve].
 ///
 /// {@animation 464 192 https://flutter.github.io/assets-for-api-docs/assets/animation/curve_bounce_in.mp4}
 /// {@animation 464 192 https://flutter.github.io/assets-for-api-docs/assets/animation/curve_flipped.mp4}
@@ -1226,7 +1226,7 @@ class CatmullRomCurve extends Curve {
 ///
 ///  * [Curve.flipped], which provides the [FlippedCurve] of a [Curve].
 ///  * [ReverseAnimation], which reverses an [Animation] rather than a [Curve].
-///  * [CurvedAnimation], which can take a separate curve and reverse curve.
+///  * [ReversibleCurvedAnimation], which can take a separate curve and reverse curve.
 class FlippedCurve extends Curve {
   /// Creates a flipped curve.
   const FlippedCurve(this.curve);

--- a/packages/flutter/lib/src/animation/tween.dart
+++ b/packages/flutter/lib/src/animation/tween.dart
@@ -527,13 +527,13 @@ class ConstantTween<T> extends Tween<T> {
 
 /// Transforms the value of the given animation by the given curve.
 ///
-/// This class differs from [CurvedAnimation] in that [CurvedAnimation] applies
+/// This class differs from [ReversibleCurvedAnimation] in that [ReversibleCurvedAnimation] applies
 /// a curve to an existing [Animation] object whereas [CurveTween] can be
 /// chained with another [Tween] prior to receiving the underlying [Animation].
-/// Unlike [CurvedAnimation], a [CurveTween] does not add listeners or hold
+/// Unlike [ReversibleCurvedAnimation], a [CurveTween] does not add listeners or hold
 /// state, so it does not need to be disposed.
 ///
-/// ([CurvedAnimation] also has the additional ability of having different
+/// ([ReversibleCurvedAnimation] also has the additional ability of having different
 /// curves when the animation is going forward vs when it is going backward,
 /// which can be useful in some scenarios.)
 ///
@@ -551,7 +551,7 @@ class ConstantTween<T> extends Tween<T> {
 ///
 /// See also:
 ///
-///  * [CurvedAnimation], for an alternative way of expressing the sample above.
+///  * [ReversibleCurvedAnimation], for an alternative way of expressing the sample above.
 ///  * [AnimationController], for examples of creating and disposing of an
 ///    [AnimationController].
 class CurveTween extends Animatable<double> {

--- a/packages/flutter/lib/src/rendering/animated_size.dart
+++ b/packages/flutter/lib/src/rendering/animated_size.dart
@@ -84,7 +84,8 @@ class RenderAnimatedSize extends RenderAligningShiftedBox {
     Clip clipBehavior = Clip.hardEdge,
     VoidCallback? onEnd,
   }) : _vsync = vsync,
-       _clipBehavior = clipBehavior {
+       _clipBehavior = clipBehavior,
+       _onEnd = onEnd {
     _controller =
         AnimationController(vsync: vsync, duration: duration, reverseDuration: reverseDuration)
           ..addListener(() {
@@ -92,8 +93,7 @@ class RenderAnimatedSize extends RenderAligningShiftedBox {
               markNeedsLayout();
             }
           });
-    _animation = CurvedAnimation(parent: _controller, curve: curve);
-    _onEnd = onEnd;
+    this.curve = curve;
   }
 
   /// When asserts are enabled, returns the animation controller that is used
@@ -113,24 +113,8 @@ class RenderAnimatedSize extends RenderAligningShiftedBox {
     return controller;
   }
 
-  /// When asserts are enabled, returns the animation that drives the resizing.
-  ///
-  /// Otherwise, returns null.
-  ///
-  /// This getter is intended for use in framework unit tests. Applications must
-  /// not depend on its value.
-  @visibleForTesting
-  CurvedAnimation? get debugAnimation {
-    CurvedAnimation? animation;
-    assert(() {
-      animation = _animation;
-      return true;
-    }());
-    return animation;
-  }
-
   late final AnimationController _controller;
-  late final CurvedAnimation _animation;
+  late Animation<double> _animation;
 
   final SizeTween _sizeTween = SizeTween();
   late bool _hasVisualOverflow;
@@ -162,12 +146,14 @@ class RenderAnimatedSize extends RenderAligningShiftedBox {
   }
 
   /// The curve of the animation.
-  Curve get curve => _animation.curve;
+  Curve get curve => _curve!;
+  Curve? _curve;
   set curve(Curve value) {
-    if (value == _animation.curve) {
+    if (value == _curve) {
       return;
     }
-    _animation.curve = value;
+    _curve = value;
+    _animation = CurveTween(curve: curve).animate(_controller);
   }
 
   /// {@macro flutter.material.Material.clipBehavior}
@@ -424,7 +410,6 @@ class RenderAnimatedSize extends RenderAligningShiftedBox {
   void dispose() {
     _clipRectLayer.layer = null;
     _controller.dispose();
-    _animation.dispose();
     super.dispose();
   }
 }

--- a/packages/flutter/lib/src/widgets/animated_switcher.dart
+++ b/packages/flutter/lib/src/widgets/animated_switcher.dart
@@ -29,7 +29,7 @@ class _ChildEntry {
   final AnimationController controller;
 
   // The (curved) animation being used to drive the transition.
-  final CurvedAnimation animation;
+  final ReversibleCurvedAnimation animation;
 
   // The currently built transition for this child.
   Widget transition;
@@ -314,7 +314,7 @@ class _AnimatedSwitcherState extends State<AnimatedSwitcher> with TickerProvider
       reverseDuration: widget.reverseDuration,
       vsync: this,
     );
-    final animation = CurvedAnimation(
+    final animation = ReversibleCurvedAnimation(
       parent: controller,
       curve: widget.switchInCurve,
       reverseCurve: widget.switchOutCurve,
@@ -337,7 +337,7 @@ class _AnimatedSwitcherState extends State<AnimatedSwitcher> with TickerProvider
     required Widget child,
     required AnimatedSwitcherTransitionBuilder builder,
     required AnimationController controller,
-    required CurvedAnimation animation,
+    required ReversibleCurvedAnimation animation,
   }) {
     final entry = _ChildEntry(
       widgetChild: child,

--- a/packages/flutter/lib/src/widgets/expansible.dart
+++ b/packages/flutter/lib/src/widgets/expansible.dart
@@ -361,7 +361,7 @@ class Expansible extends StatefulWidget {
 
 class _ExpansibleState extends State<Expansible> with SingleTickerProviderStateMixin {
   late AnimationController _animationController;
-  late CurvedAnimation _heightFactor;
+  late ReversibleCurvedAnimation _heightFactor;
 
   Duration get _duration {
     return widget.animationStyle?.duration ?? widget.duration;
@@ -388,7 +388,7 @@ class _ExpansibleState extends State<Expansible> with SingleTickerProviderStateM
       widget.controller.collapse();
     }
     final heightFactorTween = Tween<double>(begin: 0.0, end: 1.0);
-    _heightFactor = CurvedAnimation(
+    _heightFactor = ReversibleCurvedAnimation(
       parent: _animationController.drive(heightFactorTween),
       curve: _curve,
       reverseCurve: _reverseCurve,

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -468,7 +468,7 @@ class _HeroFlightManifest {
 
   Object get tag => fromHero.widget.tag;
 
-  CurvedAnimation? _animation;
+  ReversibleCurvedAnimation? _animation;
 
   Animation<double> get animation {
     final Curve curve, reverseCurve;
@@ -484,7 +484,7 @@ class _HeroFlightManifest {
         reverseCurve = fromHero.widget.reverseCurve ?? curve.flipped;
     }
 
-    return _animation ??= CurvedAnimation(
+    return _animation ??= ReversibleCurvedAnimation(
       parent: parent,
       curve: curve,
       reverseCurve: isDiverted ? null : reverseCurve,

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -367,7 +367,7 @@ abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
 
   /// The animation driving this widget's implicit animations.
   Animation<double> get animation => _animation;
-  late CurvedAnimation _animation = _createCurve();
+  late Animation<double> _animation = _createCurve();
 
   @protected
   @override
@@ -387,7 +387,6 @@ abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
   void didUpdateWidget(T oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.curve != oldWidget.curve) {
-      _animation.dispose();
       _animation = _createCurve();
     }
     controller.duration = widget.duration;
@@ -406,14 +405,13 @@ abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
     }
   }
 
-  CurvedAnimation _createCurve() {
-    return CurvedAnimation(parent: controller, curve: widget.curve);
+  Animation<double> _createCurve() {
+    return CurveTween(curve: widget.curve).animate(controller);
   }
 
   @protected
   @override
   void dispose() {
-    _animation.dispose();
     controller.dispose();
     super.dispose();
   }

--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -849,7 +849,7 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
         _animation = Tween<Offset>(
           begin: translation,
           end: Offset(frictionSimulationX.finalX, frictionSimulationY.finalX),
-        ).animate(CurvedAnimation(parent: _controller, curve: Curves.decelerate));
+        ).chain(CurveTween(curve: Curves.decelerate)).animate(_controller);
         _controller.duration = Duration(milliseconds: (tFinal * 1000).round());
         _animation!.addListener(_handleInertiaAnimation);
         _controller.forward();
@@ -872,7 +872,7 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
         _scaleAnimation = Tween<double>(
           begin: scale,
           end: frictionSimulation.x(tFinal),
-        ).animate(CurvedAnimation(parent: _scaleController, curve: Curves.decelerate));
+        ).chain(CurveTween(curve: Curves.decelerate)).animate(_scaleController);
         _scaleController.duration = Duration(milliseconds: (tFinal * 1000).round());
         _scaleAnimation!.addListener(_handleScaleAnimation);
         _scaleController.forward();

--- a/packages/flutter/lib/src/widgets/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/widgets/overscroll_indicator.dart
@@ -332,7 +332,7 @@ class _GlowController extends ChangeNotifier {
       ChangeNotifier.maybeDispatchObjectCreation(this);
     }
     _glowController = AnimationController(vsync: vsync)..addStatusListener(_changePhase);
-    _decelerator = CurvedAnimation(parent: _glowController, curve: Curves.decelerate)
+    _decelerator = _glowController.drive(CurveTween(curve: Curves.decelerate))
       ..addListener(notifyListeners);
     _glowOpacity = _decelerator.drive(_glowOpacityTween);
     _glowSize = _decelerator.drive(_glowSizeTween);
@@ -347,7 +347,7 @@ class _GlowController extends ChangeNotifier {
   double _paintOffsetScrollPixels = 0.0;
 
   // animation values
-  late final CurvedAnimation _decelerator;
+  late final Animation<double> _decelerator;
   final Tween<double> _glowOpacityTween = Tween<double>(begin: 0.0, end: 0.0);
   late final Animation<double> _glowOpacity;
   final Tween<double> _glowSizeTween = Tween<double>(begin: 0.0, end: 0.0);
@@ -403,7 +403,6 @@ class _GlowController extends ChangeNotifier {
   @override
   void dispose() {
     _glowController.dispose();
-    _decelerator.dispose();
     _displacementTicker.dispose();
     _pullRecedeTimer?.cancel();
     super.dispose();

--- a/packages/flutter/lib/src/widgets/page_transitions_builder.dart
+++ b/packages/flutter/lib/src/widgets/page_transitions_builder.dart
@@ -197,8 +197,8 @@ class _OpenUpwardsPageTransition extends StatefulWidget {
 }
 
 class _OpenUpwardsPageTransitionState extends State<_OpenUpwardsPageTransition> {
-  late CurvedAnimation _primaryAnimation;
-  late CurvedAnimation _secondaryTranslationCurvedAnimation;
+  late ReversibleCurvedAnimation _primaryAnimation;
+  late ReversibleCurvedAnimation _secondaryTranslationCurvedAnimation;
 
   @override
   void initState() {
@@ -217,12 +217,12 @@ class _OpenUpwardsPageTransitionState extends State<_OpenUpwardsPageTransition> 
   }
 
   void _setAnimations() {
-    _primaryAnimation = CurvedAnimation(
+    _primaryAnimation = ReversibleCurvedAnimation(
       parent: widget.animation,
       curve: _OpenUpwardsPageTransition._transitionCurve,
       reverseCurve: _OpenUpwardsPageTransition._transitionCurve.flipped,
     );
-    _secondaryTranslationCurvedAnimation = CurvedAnimation(
+    _secondaryTranslationCurvedAnimation = ReversibleCurvedAnimation(
       parent: widget.secondaryAnimation,
       curve: _OpenUpwardsPageTransition._transitionCurve,
       reverseCurve: _OpenUpwardsPageTransition._transitionCurve.flipped,

--- a/packages/flutter/lib/src/widgets/raw_tooltip.dart
+++ b/packages/flutter/lib/src/widgets/raw_tooltip.dart
@@ -548,11 +548,10 @@ class RawTooltipState extends State<RawTooltip> with SingleTickerProviderStateMi
     )..addStatusListener(_handleStatusChanged);
   }
 
-  CurvedAnimation? _backingOverlayAnimation;
-  CurvedAnimation get _overlayAnimation {
-    return _backingOverlayAnimation ??= CurvedAnimation(
-      parent: _controller,
-      curve: widget.animationStyle.curve ?? _kDefaultAnimationStyle.curve!,
+  Animation<double>? _backingOverlayAnimation;
+  Animation<double> get _overlayAnimation {
+    return _backingOverlayAnimation ??= _controller.drive(
+      CurveTween(curve: widget.animationStyle.curve ?? _kDefaultAnimationStyle.curve!),
     );
   }
 
@@ -850,7 +849,6 @@ class RawTooltipState extends State<RawTooltip> with SingleTickerProviderStateMi
     _tapRecognizer?.dispose();
     _timer?.cancel();
     _backingController?.dispose();
-    _backingOverlayAnimation?.dispose();
     super.dispose();
   }
 

--- a/packages/flutter/lib/src/widgets/repeating_animation_builder.dart
+++ b/packages/flutter/lib/src/widgets/repeating_animation_builder.dart
@@ -124,13 +124,13 @@ class RepeatingAnimationBuilder<T extends Object> extends StatefulWidget {
 class _RepeatingAnimationBuilderState<T extends Object> extends State<RepeatingAnimationBuilder<T>>
     with SingleTickerProviderStateMixin {
   late final AnimationController _controller;
-  late final CurvedAnimation _curvedAnimation;
+  late final Animation<double> _curvedAnimation;
 
   @override
   void initState() {
     super.initState();
     _controller = AnimationController(duration: widget.duration, vsync: this);
-    _curvedAnimation = CurvedAnimation(parent: _controller, curve: widget.curve);
+    _curvedAnimation = _controller.drive(CurveTween(curve: widget.curve));
 
     if (!widget.paused) {
       _controller.repeat(reverse: widget.repeatMode == RepeatMode.reverse);
@@ -146,7 +146,7 @@ class _RepeatingAnimationBuilderState<T extends Object> extends State<RepeatingA
     }
 
     if (widget.curve != oldWidget.curve) {
-      _curvedAnimation.curve = widget.curve;
+      _curvedAnimation = _controller.drive(CurveTween(curve: widget.curve));
     }
 
     if (widget.paused) {
@@ -169,7 +169,6 @@ class _RepeatingAnimationBuilderState<T extends Object> extends State<RepeatingA
 
   @override
   void dispose() {
-    _curvedAnimation.dispose();
     _controller.dispose();
     super.dispose();
   }

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -1361,7 +1361,7 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
   ScrollController? _cachedController;
   Timer? _fadeoutTimer;
   late AnimationController _fadeoutAnimationController;
-  late CurvedAnimation _fadeoutOpacityAnimation;
+  late Animation<double> _fadeoutOpacityAnimation;
   final GlobalKey _scrollbarPainterKey = GlobalKey();
   bool _hoverIsActive = false;
   Drag? _thumbDrag;
@@ -1416,10 +1416,9 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
     super.initState();
     _fadeoutAnimationController = AnimationController(vsync: this, duration: widget.fadeDuration)
       ..addStatusListener(_validateInteractions);
-    _fadeoutOpacityAnimation = CurvedAnimation(
-      parent: _fadeoutAnimationController,
+    _fadeoutOpacityAnimation = CurveTween(
       curve: Curves.fastOutSlowIn,
-    );
+    ).animate(_fadeoutAnimationController);
     scrollbarPainter = ScrollbarPainter(
       color: widget.thumbColor ?? const Color(0x66BCBCBC),
       fadeoutOpacityAnimation: _fadeoutOpacityAnimation,
@@ -2217,7 +2216,6 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
     _fadeoutAnimationController.dispose();
     _fadeoutTimer?.cancel();
     scrollbarPainter.dispose();
-    _fadeoutOpacityAnimation.dispose();
     super.dispose();
   }
 

--- a/packages/flutter/lib/src/widgets/sliver_tree.dart
+++ b/packages/flutter/lib/src/widgets/sliver_tree.dart
@@ -593,7 +593,7 @@ class TreeSliver<T> extends StatefulWidget {
 // Used in _SliverTreeState for code simplicity.
 typedef _AnimationRecord = ({
   AnimationController controller,
-  CurvedAnimation animation,
+  Animation<double> animation,
   UniqueKey key,
 });
 
@@ -693,7 +693,6 @@ class _TreeSliverState<T> extends State<TreeSliver<T>>
   void dispose() {
     _treeController!._state = null;
     for (final _AnimationRecord record in _currentAnimationForParent.values) {
-      record.animation.dispose();
       record.controller.dispose();
     }
     super.dispose();
@@ -860,10 +859,6 @@ class _TreeSliverState<T> extends State<TreeSliver<T>>
       if (widget.onNodeToggle != null) {
         widget.onNodeToggle!(node);
       }
-      if (_currentAnimationForParent[node] != null) {
-        // Dispose of the old animation if this node was already animating.
-        _currentAnimationForParent[node]!.animation.dispose();
-      }
 
       // If animation is disabled or the duration is zero, we skip the animation
       // and immediately update the active nodes. This prevents the app from freezing
@@ -887,7 +882,6 @@ class _TreeSliverState<T> extends State<TreeSliver<T>>
               switch (status) {
                 case AnimationStatus.dismissed:
                 case AnimationStatus.completed:
-                  _currentAnimationForParent[node]!.animation.dispose();
                   _currentAnimationForParent[node]!.controller.dispose();
                   _currentAnimationForParent.remove(node);
                   _updateActiveAnimations();
@@ -916,9 +910,8 @@ class _TreeSliverState<T> extends State<TreeSliver<T>>
         case AnimationStatus.completed:
       }
 
-      final newAnimation = CurvedAnimation(
-        parent: controller,
-        curve: widget.toggleAnimationStyle?.curve ?? TreeSliver.defaultAnimationCurve,
+      final Animation<double> newAnimation = controller.drive(
+        CurveTween(curve: widget.toggleAnimationStyle?.curve ?? TreeSliver.defaultAnimationCurve),
       );
       _currentAnimationForParent[node] = (
         controller: controller,

--- a/packages/flutter/lib/src/widgets/toggleable.dart
+++ b/packages/flutter/lib/src/widgets/toggleable.dart
@@ -53,8 +53,8 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
   /// animation has a value of 1.0. When the control is changing from inactive
   /// to active (or vice versa), [value] is the target value and this animation
   /// gradually updates from 0.0 to 1.0 (or vice versa).
-  CurvedAnimation get position => _position;
-  late CurvedAnimation _position;
+  ReversibleCurvedAnimation get position => _position;
+  late ReversibleCurvedAnimation _position;
 
   /// Used by subclasses to control the radial reaction animation.
   ///
@@ -73,8 +73,8 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
   ///
   /// To paint the actual radial reaction, [ToggleablePainter.paintRadialReaction]
   /// may be used.
-  CurvedAnimation get reaction => _reaction;
-  late CurvedAnimation _reaction;
+  Animation<double> get reaction => _reaction;
+  late Animation<double> _reaction;
 
   /// Controls the radial reaction's opacity animation for hover changes.
   ///
@@ -84,8 +84,8 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
   ///
   /// To paint the actual radial reaction, [ToggleablePainter.paintRadialReaction]
   /// may be used.
-  CurvedAnimation get reactionHoverFade => _reactionHoverFade;
-  late CurvedAnimation _reactionHoverFade;
+  Animation<double> get reactionHoverFade => _reactionHoverFade;
+  late Animation<double> _reactionHoverFade;
   late AnimationController _reactionHoverFadeController;
 
   /// Controls the radial reaction's opacity animation for focus changes.
@@ -95,8 +95,8 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
   ///
   /// To paint the actual radial reaction, [ToggleablePainter.paintRadialReaction]
   /// may be used.
-  CurvedAnimation get reactionFocusFade => _reactionFocusFade;
-  late CurvedAnimation _reactionFocusFade;
+  Animation<double> get reactionFocusFade => _reactionFocusFade;
+  late Animation<double> _reactionFocusFade;
   late AnimationController _reactionFocusFadeController;
 
   /// The amount of time a circular ink response should take to expand to its
@@ -154,30 +154,28 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
       value: value == false ? 0.0 : 1.0,
       vsync: this,
     );
-    _position = CurvedAnimation(
+    _position = ReversibleCurvedAnimation(
       parent: _positionController,
       curve: Curves.easeIn,
       reverseCurve: Curves.easeOut,
     );
     _reactionController = AnimationController(duration: _reactionAnimationDuration, vsync: this);
-    _reaction = CurvedAnimation(parent: _reactionController, curve: Curves.fastOutSlowIn);
+    _reaction = _reactionController.drive(CurveTween(curve: Curves.fastOutSlowIn));
     _reactionHoverFadeController = AnimationController(
       duration: _kReactionFadeDuration,
       value: _hovering || _focused ? 1.0 : 0.0,
       vsync: this,
     );
-    _reactionHoverFade = CurvedAnimation(
-      parent: _reactionHoverFadeController,
-      curve: Curves.fastOutSlowIn,
+    _reactionHoverFade = _reactionHoverFadeController.drive(
+      CurveTween(curve: Curves.fastOutSlowIn),
     );
     _reactionFocusFadeController = AnimationController(
       duration: _kReactionFadeDuration,
       value: _hovering || _focused ? 1.0 : 0.0,
       vsync: this,
     );
-    _reactionFocusFade = CurvedAnimation(
-      parent: _reactionFocusFadeController,
-      curve: Curves.fastOutSlowIn,
+    _reactionFocusFade = _reactionFocusFadeController.drive(
+      CurveTween(curve: Curves.fastOutSlowIn),
     );
   }
 
@@ -207,14 +205,11 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
 
   @override
   void dispose() {
-    _positionController.dispose();
     _position.dispose();
+    _positionController.dispose();
     _reactionController.dispose();
-    _reaction.dispose();
     _reactionHoverFadeController.dispose();
-    _reactionHoverFade.dispose();
     _reactionFocusFadeController.dispose();
-    _reactionFocusFade.dispose();
     super.dispose();
   }
 

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -170,7 +170,7 @@ typedef DelegatedTransitionBuilder =
 /// left, and in left-to-right text, positive x offsets move towards the right.
 ///
 /// Here's an illustration of the [SlideTransition] widget, with its [position]
-/// animated by a [CurvedAnimation] set to [Curves.elasticIn]:
+/// animated by a [ReversibleCurvedAnimation] set to [Curves.elasticIn]:
 /// {@animation 300 378 https://flutter.github.io/assets-for-api-docs/assets/widgets/slide_transition.mp4}
 ///
 /// {@tool dartpad}
@@ -330,7 +330,7 @@ class MatrixTransition extends AnimatedWidget {
 /// Animates the scale of a transformed widget.
 ///
 /// Here's an illustration of the [ScaleTransition] widget, with it's [scale]
-/// animated by a [CurvedAnimation] set to [Curves.fastOutSlowIn]:
+/// animated by a [ReversibleCurvedAnimation] set to [Curves.fastOutSlowIn]:
 /// {@animation 300 378 https://flutter.github.io/assets-for-api-docs/assets/widgets/scale_transition.mp4}
 ///
 /// {@tool dartpad}
@@ -373,7 +373,7 @@ class ScaleTransition extends MatrixTransition {
 /// Animates the rotation of a widget.
 ///
 /// Here's an illustration of the [RotationTransition] widget, with it's [turns]
-/// animated by a [CurvedAnimation] set to [Curves.elasticOut]:
+/// animated by a [ReversibleCurvedAnimation] set to [Curves.elasticOut]:
 /// {@animation 300 378 https://flutter.github.io/assets-for-api-docs/assets/widgets/rotation_transition.mp4}
 ///
 /// {@tool dartpad}
@@ -422,7 +422,7 @@ class RotationTransition extends MatrixTransition {
 /// nothing.
 ///
 /// Here's an illustration of the [SizeTransition] widget, with it's [sizeFactor]
-/// animated by a [CurvedAnimation] set to [Curves.fastOutSlowIn]:
+/// animated by a [ReversibleCurvedAnimation] set to [Curves.fastOutSlowIn]:
 /// {@animation 300 378 https://flutter.github.io/assets-for-api-docs/assets/widgets/size_transition.mp4}
 ///
 /// {@tool dartpad}
@@ -551,7 +551,7 @@ class SizeTransition extends AnimatedWidget {
 /// {@youtube 560 315 https://www.youtube.com/watch?v=rLwWVbv3xDQ}
 ///
 /// Here's an illustration of the [FadeTransition] widget, with it's [opacity]
-/// animated by a [CurvedAnimation] set to [Curves.fastOutSlowIn]:
+/// animated by a [ReversibleCurvedAnimation] set to [Curves.fastOutSlowIn]:
 ///
 /// {@tool dartpad}
 /// The following code implements the [FadeTransition] using
@@ -649,7 +649,7 @@ class FadeTransition extends SingleChildRenderObjectWidget {
 /// {@end-tool}
 ///
 /// Here's an illustration of the [FadeTransition] widget, the [RenderBox]
-/// equivalent widget, with it's [opacity] animated by a [CurvedAnimation] set
+/// equivalent widget, with it's [opacity] animated by a [ReversibleCurvedAnimation] set
 /// to [Curves.fastOutSlowIn]:
 ///
 /// {@animation 300 378 https://flutter.github.io/assets-for-api-docs/assets/widgets/fade_transition.mp4}
@@ -760,7 +760,7 @@ class RelativeRectTween extends Tween<RelativeRect> {
 /// Only works if it's the child of a [Stack].
 ///
 /// Here's an illustration of the [PositionedTransition] widget, with it's [rect]
-/// animated by a [CurvedAnimation] set to [Curves.elasticInOut]:
+/// animated by a [ReversibleCurvedAnimation] set to [Curves.elasticInOut]:
 /// {@animation 300 378 https://flutter.github.io/assets-for-api-docs/assets/widgets/positioned_transition.mp4}
 ///
 /// {@tool dartpad}
@@ -813,7 +813,7 @@ class PositionedTransition extends AnimatedWidget {
 /// Only works if it's the child of a [Stack].
 ///
 /// Here's an illustration of the [RelativePositionedTransition] widget, with it's [rect]
-/// animated by a [CurvedAnimation] set to [Curves.elasticInOut]:
+/// animated by a [ReversibleCurvedAnimation] set to [Curves.elasticInOut]:
 /// {@animation 300 378 https://flutter.github.io/assets-for-api-docs/assets/widgets/relative_positioned_transition.mp4}
 ///
 /// {@tool dartpad}
@@ -884,7 +884,7 @@ class RelativePositionedTransition extends AnimatedWidget {
 /// of its [Decoration].
 ///
 /// Here's an illustration of the [DecoratedBoxTransition] widget, with it's
-/// [decoration] animated by a [CurvedAnimation] set to [Curves.decelerate]:
+/// [decoration] animated by a [ReversibleCurvedAnimation] set to [Curves.decelerate]:
 /// {@animation 300 378 https://flutter.github.io/assets-for-api-docs/assets/widgets/decorated_box_transition.mp4}
 ///
 /// {@tool dartpad}
@@ -936,7 +936,7 @@ class DecoratedBoxTransition extends AnimatedWidget {
 /// Animated version of an [Align] that animates its [Align.alignment] property.
 ///
 /// Here's an illustration of the [DecoratedBoxTransition] widget, with it's
-/// [DecoratedBoxTransition.decoration] animated by a [CurvedAnimation] set to
+/// [DecoratedBoxTransition.decoration] animated by a [ReversibleCurvedAnimation] set to
 /// [Curves.decelerate]:
 ///
 /// {@animation 300 378 https://flutter.github.io/assets-for-api-docs/assets/widgets/align_transition.mp4}

--- a/packages/flutter/test/animation/animations_test.dart
+++ b/packages/flutter/test/animation/animations_test.dart
@@ -28,7 +28,11 @@ void main() {
     expect(kAlwaysCompleteAnimation, hasOneLineDescription);
     expect(kAlwaysDismissedAnimation, hasOneLineDescription);
     expect(const AlwaysStoppedAnimation<double>(0.5), hasOneLineDescription);
-    var curvedAnimation = CurvedAnimation(parent: kAlwaysDismissedAnimation, curve: Curves.ease);
+    var curvedAnimation = ReversibleCurvedAnimation(
+      parent: kAlwaysDismissedAnimation,
+      curve: Curves.ease,
+      reverseCurve: null,
+    );
     expect(curvedAnimation, hasOneLineDescription);
     curvedAnimation.reverseCurve = Curves.elasticOut;
     expect(curvedAnimation, hasOneLineDescription);
@@ -39,7 +43,7 @@ void main() {
     controller
       ..value = 0.5
       ..reverse();
-    curvedAnimation = CurvedAnimation(
+    curvedAnimation = ReversibleCurvedAnimation(
       parent: controller,
       curve: Curves.ease,
       reverseCurve: Curves.elasticOut,
@@ -248,9 +252,13 @@ void main() {
     expect(log, isEmpty);
   });
 
-  test('CurvedAnimation with bogus curve', () {
+  test('ReversibleCurvedAnimation with bogus curve', () {
     final controller = AnimationController(vsync: const TestVSync());
-    final curved = CurvedAnimation(parent: controller, curve: const BogusCurve());
+    final curved = ReversibleCurvedAnimation(
+      parent: controller,
+      curve: const BogusCurve(),
+      reverseCurve: null,
+    );
     FlutterError? error;
     try {
       curved.value;
@@ -274,13 +282,13 @@ FlutterError
     );
   });
 
-  test('CurvedAnimation running with different forward and reverse durations.', () {
+  test('ReversibleCurvedAnimation running with different forward and reverse durations.', () {
     final controller = AnimationController(
       duration: const Duration(milliseconds: 100),
       reverseDuration: const Duration(milliseconds: 50),
       vsync: const TestVSync(),
     );
-    final curved = CurvedAnimation(
+    final curved = ReversibleCurvedAnimation(
       parent: controller,
       curve: Curves.linear,
       reverseCurve: Curves.linear,
@@ -323,7 +331,7 @@ FlutterError
     expect(curved.value, moreOrLessEquals(0.0));
   });
 
-  test('CurvedAnimation stops listening to parent when disposed.', () async {
+  test('ReversibleCurvedAnimation stops listening to parent when disposed.', () async {
     const forwardCurve = Interval(0.0, 0.5);
     const reverseCurve = Interval(0.5, 1.0);
 
@@ -332,7 +340,7 @@ FlutterError
       reverseDuration: const Duration(milliseconds: 100),
       vsync: const TestVSync(),
     );
-    final curved = CurvedAnimation(
+    final curved = ReversibleCurvedAnimation(
       parent: controller,
       curve: forwardCurve,
       reverseCurve: reverseCurve,
@@ -371,7 +379,11 @@ FlutterError
       vsync: const TestVSync(),
     );
     final reversed = ReverseAnimation(
-      CurvedAnimation(parent: controller, curve: Curves.linear, reverseCurve: Curves.linear),
+      ReversibleCurvedAnimation(
+        parent: controller,
+        curve: Curves.linear,
+        reverseCurve: Curves.linear,
+      ),
     );
 
     controller.forward();
@@ -498,17 +510,18 @@ FlutterError
     expect(animation.value, 10.0);
   });
 
-  test('$CurvedAnimation dispatches memory events', () async {
+  test('$ReversibleCurvedAnimation dispatches memory events', () async {
     await expectLater(
       await memoryEvents(
-        () => CurvedAnimation(
+        () => ReversibleCurvedAnimation(
           parent: AnimationController(
             duration: const Duration(milliseconds: 100),
             vsync: const TestVSync(),
           ),
           curve: Curves.linear,
+          reverseCurve: null,
         ).dispose(),
-        CurvedAnimation,
+        ReversibleCurvedAnimation,
       ),
       areCreateAndDispose,
     );

--- a/packages/flutter/test/widgets/animated_size_test.dart
+++ b/packages/flutter/test/widgets/animated_size_test.dart
@@ -453,7 +453,7 @@ void main() {
       );
     });
 
-    testWidgets('disposes animation and controller', (WidgetTester tester) async {
+    testWidgets('disposes controller', (WidgetTester tester) async {
       await tester.pumpWidget(
         const Center(
           child: AnimatedSize(
@@ -467,8 +467,6 @@ void main() {
 
       await tester.pumpWidget(const Center());
 
-      expect(box.debugAnimation, isNotNull);
-      expect(box.debugAnimation!.isDisposed, isTrue);
       expect(box.debugController, isNotNull);
       expect(
         () => box.debugController!.dispose(),

--- a/packages/flutter/test/widgets/implicit_animations_test.dart
+++ b/packages/flutter/test/widgets/implicit_animations_test.dart
@@ -609,7 +609,9 @@ void main() {
     await tapTest2and3(tester, widgetFinder, mockOnEndFunction);
   });
 
-  testWidgets('Ensure CurvedAnimations are disposed on widget change', (WidgetTester tester) async {
+  testWidgets('Ensure ReversibleCurvedAnimations are disposed on widget change', (
+    WidgetTester tester,
+  ) async {
     final key = GlobalKey<ImplicitlyAnimatedWidgetState<AnimatedOpacity>>();
     final curve = ValueNotifier<Curve>(const Interval(0.0, 0.5));
     addTearDown(curve.dispose);
@@ -634,7 +636,7 @@ void main() {
       fail('animation was null!');
     }
 
-    final firstCurvedAnimation = firstAnimation as CurvedAnimation;
+    final firstCurvedAnimation = firstAnimation as ReversibleCurvedAnimation;
 
     expect(firstCurvedAnimation.isDisposed, isFalse);
 
@@ -647,7 +649,7 @@ void main() {
       fail('animation was null!');
     }
 
-    final secondCurvedAnimation = secondAnimation as CurvedAnimation;
+    final secondCurvedAnimation = secondAnimation as ReversibleCurvedAnimation;
 
     expect(firstState, equals(secondState));
     expect(firstAnimation, isNot(equals(secondAnimation)));

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -2870,7 +2870,8 @@ class TestPageRouteBuilder extends PageRouteBuilder<void> {
 
   @override
   Animation<double> createAnimation() {
-    return CurvedAnimation(parent: super.createAnimation(), curve: Curves.easeOutExpo);
+    final Animation<double> parent = super.createAnimation();
+    return CurveTween(curve: Curves.easeOutExpo).animate(parent);
   }
 }
 

--- a/packages/flutter/test/widgets/transitions_test.dart
+++ b/packages/flutter/test/widgets/transitions_test.dart
@@ -84,8 +84,7 @@ void main() {
     });
 
     testWidgets('animations work with curves test', (WidgetTester tester) async {
-      final curvedAnimation = CurvedAnimation(parent: controller, curve: Curves.easeOut);
-      addTearDown(curvedAnimation.dispose);
+      final Animation<double> curvedAnimation = CurveTween(curve: Curves.easeOut).animate(controller);
       final Animation<Decoration> curvedDecorationAnimation = decorationTween.animate(
         curvedAnimation,
       );

--- a/packages/flutter/test_fixes/animation/curved_animation_with_matching_curves.dart
+++ b/packages/flutter/test_fixes/animation/curved_animation_with_matching_curves.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/animation.dart';
+
+void main() {
+  final animationController = AnimationController();
+  // This should become:
+  // `final animation = animationController.drive(CurveTween(curve: Curves.easeIn));`
+  // or
+  // `final animation = CurveTween(curve: Curves.easeIn).animate(animationController);`
+  // but the data-driven fix isn't implemented yet.
+  final animation = CurvedAnimation(
+    parent: animationController,
+    curve: Curves.easeIn,
+    reverseCurve: Curves.easeIn,
+  );
+}

--- a/packages/flutter/test_fixes/animation/curved_animation_with_matching_curves.dart.expect
+++ b/packages/flutter/test_fixes/animation/curved_animation_with_matching_curves.dart.expect
@@ -1,0 +1,15 @@
+import 'package:flutter/animation.dart';
+
+void main() {
+  final animationController = AnimationController();
+  // This should become:
+  // `final animation = animationController.drive(CurveTween(curve: Curves.easeIn));`
+  // or
+  // `final animation = CurveTween(curve: Curves.easeIn).animate(animationController);`
+  // but the data-driven fix isn't implemented yet.
+  final animation = CurvedAnimation(
+    parent: animationController,
+    curve: Curves.easeIn,
+    reverseCurve: Curves.easeIn,
+  );
+}

--- a/packages/flutter/test_fixes/animation/curved_animation_with_one_curve.dart
+++ b/packages/flutter/test_fixes/animation/curved_animation_with_one_curve.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/animation.dart';
+
+void main() {
+  final animationController = AnimationController();
+  // This should become:
+  // `final animation = animationController.drive(CurveTween(curve: Curves.easeIn));`
+  // or
+  // `final animation = CurveTween(curve: Curves.easeIn).animate(animationController);`
+  // but the data-driven fix isn't implemented yet.
+  final animation = CurvedAnimation(parent: animationController, curve: Curves.easeIn);
+}

--- a/packages/flutter/test_fixes/animation/curved_animation_with_one_curve.dart.expect
+++ b/packages/flutter/test_fixes/animation/curved_animation_with_one_curve.dart.expect
@@ -1,0 +1,11 @@
+import 'package:flutter/animation.dart';
+
+void main() {
+  final animationController = AnimationController();
+  // This should become:
+  // `final animation = animationController.drive(CurveTween(curve: Curves.easeIn));`
+  // or
+  // `final animation = CurveTween(curve: Curves.easeIn).animate(animationController);`
+  // but the data-driven fix isn't implemented yet.
+  final animation = CurvedAnimation(parent: animationController, curve: Curves.easeIn);
+}

--- a/packages/flutter/test_fixes/animation/curved_animation_with_two_curves.dart
+++ b/packages/flutter/test_fixes/animation/curved_animation_with_two_curves.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/animation.dart';
+
+void main() {
+  final animationController = AnimationController();
+  final animation = CurvedAnimation(
+    parent: animationController,
+    curve: Curves.easeIn,
+    reverseCurve: Curves.easeOut,
+  );
+}

--- a/packages/flutter/test_fixes/animation/curved_animation_with_two_curves.dart.expect
+++ b/packages/flutter/test_fixes/animation/curved_animation_with_two_curves.dart.expect
@@ -1,0 +1,10 @@
+import 'package:flutter/animation.dart';
+
+void main() {
+  final animationController = AnimationController();
+  final animation = ReversibleCurvedAnimation(
+    parent: animationController,
+    curve: Curves.easeIn,
+    reverseCurve: Curves.easeOut,
+  );
+}


### PR DESCRIPTION
This PR follows up on #185501.

Thanks to the better API from #185501, a few memory leaks were identified and fixed here. E.g. in `InteractiveViewer`, a new `CurvedAnimation` was created after every pan/scale gesture. These would accrue with no disposal until the entire InteractiveViewer was disposed. 

Draft status:
- I've kept this PR separate to #185501 to make review easier. (Of course, if reviewers prefer this as one big PR, I can combine this with #185501.)
- I'll rebase it and remove the draft status after #185501 gets merged.

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*
**TODO(adil192): Create an issue for this migration** 

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or **I am not using AI tools**.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
