### PR TITLE
Win32: Add FlutterDesktopPluginRegistrarGetGraphicsAdapter

### DIFF
--- a/engine/src/flutter/shell/platform/windows/client_wrapper/include/flutter/plugin_registrar_windows.h
+++ b/engine/src/flutter/shell/platform/windows/client_wrapper/include/flutter/plugin_registrar_windows.h
@@ -104,9 +104,13 @@ class PluginRegistrarWindows : public PluginRegistrar {
     }
   }
 
-  // Returns the DXGI adapter used for rendering or nullptr in case of error.
-  IDXGIAdapter* GetGraphicsAdapter() {
-    return FlutterDesktopPluginRegistrarGetGraphicsAdapter(registrar());
+  // Retrieves the DXGI adapter used for rendering. Returns true if the adapter
+  // was successfully retrieved, or false if an error occured.
+  // The caller must provide a valid pointer to an IDXGIAdapter* and is
+  // responsible for releasing the adapter.
+  bool GetGraphicsAdapter(IDXGIAdapter** adapter_out) {
+    return FlutterDesktopPluginRegistrarGetGraphicsAdapter(registrar(),
+                                                           adapter_out);
   }
 
  private:

--- a/engine/src/flutter/shell/platform/windows/client_wrapper/include/flutter/plugin_registrar_windows.h
+++ b/engine/src/flutter/shell/platform/windows/client_wrapper/include/flutter/plugin_registrar_windows.h
@@ -104,6 +104,11 @@ class PluginRegistrarWindows : public PluginRegistrar {
     }
   }
 
+  // Returns the DXGI adapter used for rendering or nullptr in case of error.
+  IDXGIAdapter* GetGraphicsAdapter() {
+    return FlutterDesktopPluginRegistrarGetGraphicsAdapter(registrar());
+  }
+
  private:
   // A FlutterDesktopWindowProcCallback implementation that forwards back to
   // a PluginRegistarWindows instance provided as |user_data|.

--- a/engine/src/flutter/shell/platform/windows/client_wrapper/plugin_registrar_windows_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/client_wrapper/plugin_registrar_windows_unittests.cc
@@ -109,7 +109,7 @@ TEST(PluginRegistrarWindowsTest, GetViewById) {
   EXPECT_EQ(registrar.GetViewById(456).get(), nullptr);
 }
 
-TEST(PluginRegistrarWindowsTest, GetGetGraphicsAdapter) {
+TEST(PluginRegistrarWindowsTest, GetGraphicsAdapter) {
   auto windows_api = std::make_unique<TestWindowsApi>();
   EXPECT_CALL(*windows_api, PluginRegistrarGetView)
       .WillRepeatedly(Return(nullptr));

--- a/engine/src/flutter/shell/platform/windows/client_wrapper/plugin_registrar_windows_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/client_wrapper/plugin_registrar_windows_unittests.cc
@@ -46,6 +46,10 @@ class TestWindowsApi : public testing::StubFlutterWindowsApi {
 
   void* last_registered_user_data() { return last_registered_user_data_; }
 
+  IDXGIAdapter* PluginRegistrarGetGraphicsAdapter() override {
+    return reinterpret_cast<IDXGIAdapter*>(10);
+  }
+
  private:
   int registered_delegate_count_ = 0;
   FlutterDesktopWindowProcCallback last_registered_delegate_ = nullptr;
@@ -103,6 +107,18 @@ TEST(PluginRegistrarWindowsTest, GetViewById) {
   EXPECT_EQ(registrar.GetView(), nullptr);
   EXPECT_NE(registrar.GetViewById(123).get(), nullptr);
   EXPECT_EQ(registrar.GetViewById(456).get(), nullptr);
+}
+
+TEST(PluginRegistrarWindowsTest, GetGetGraphicsAdapter) {
+  auto windows_api = std::make_unique<TestWindowsApi>();
+  EXPECT_CALL(*windows_api, PluginRegistrarGetView)
+      .WillRepeatedly(Return(nullptr));
+  testing::ScopedStubFlutterWindowsApi scoped_api_stub(std::move(windows_api));
+  auto test_api = static_cast<TestWindowsApi*>(scoped_api_stub.stub());
+  PluginRegistrarWindows registrar(
+      reinterpret_cast<FlutterDesktopPluginRegistrarRef>(1));
+  EXPECT_EQ(registrar.GetGraphicsAdapter(),
+            reinterpret_cast<IDXGIAdapter*>(10));
 }
 
 // Tests that the registrar runs plugin destructors before its own teardown.

--- a/engine/src/flutter/shell/platform/windows/client_wrapper/plugin_registrar_windows_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/client_wrapper/plugin_registrar_windows_unittests.cc
@@ -46,8 +46,9 @@ class TestWindowsApi : public testing::StubFlutterWindowsApi {
 
   void* last_registered_user_data() { return last_registered_user_data_; }
 
-  IDXGIAdapter* PluginRegistrarGetGraphicsAdapter() override {
-    return reinterpret_cast<IDXGIAdapter*>(10);
+  bool PluginRegistrarGetGraphicsAdapter(IDXGIAdapter** adapter_out) override {
+    *adapter_out = reinterpret_cast<IDXGIAdapter*>(10);
+    return true;
   }
 
  private:
@@ -117,8 +118,9 @@ TEST(PluginRegistrarWindowsTest, GetGraphicsAdapter) {
   auto test_api = static_cast<TestWindowsApi*>(scoped_api_stub.stub());
   PluginRegistrarWindows registrar(
       reinterpret_cast<FlutterDesktopPluginRegistrarRef>(1));
-  EXPECT_EQ(registrar.GetGraphicsAdapter(),
-            reinterpret_cast<IDXGIAdapter*>(10));
+  IDXGIAdapter* adapter = nullptr;
+  EXPECT_TRUE(registrar.GetGraphicsAdapter(&adapter));
+  EXPECT_EQ(adapter, reinterpret_cast<IDXGIAdapter*>(10));
 }
 
 // Tests that the registrar runs plugin destructors before its own teardown.

--- a/engine/src/flutter/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.cc
+++ b/engine/src/flutter/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.cc
@@ -217,12 +217,14 @@ FlutterDesktopViewRef FlutterDesktopPluginRegistrarGetViewById(
   return nullptr;
 }
 
-IDXGIAdapter* FlutterDesktopPluginRegistrarGetGraphicsAdapter(
-    FlutterDesktopPluginRegistrarRef registrar) {
+bool FlutterDesktopPluginRegistrarGetGraphicsAdapter(
+    FlutterDesktopPluginRegistrarRef registrar,
+    IDXGIAdapter** adapter_out) {
   if (s_stub_implementation) {
-    return s_stub_implementation->PluginRegistrarGetGraphicsAdapter();
+    return s_stub_implementation->PluginRegistrarGetGraphicsAdapter(
+        adapter_out);
   }
-  return nullptr;
+  return false;
 }
 
 void FlutterDesktopPluginRegistrarRegisterTopLevelWindowProcDelegate(

--- a/engine/src/flutter/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.cc
+++ b/engine/src/flutter/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.cc
@@ -217,6 +217,14 @@ FlutterDesktopViewRef FlutterDesktopPluginRegistrarGetViewById(
   return nullptr;
 }
 
+IDXGIAdapter* FlutterDesktopPluginRegistrarGetGraphicsAdapter(
+    FlutterDesktopPluginRegistrarRef registrar) {
+  if (s_stub_implementation) {
+    return s_stub_implementation->PluginRegistrarGetGraphicsAdapter();
+  }
+  return nullptr;
+}
+
 void FlutterDesktopPluginRegistrarRegisterTopLevelWindowProcDelegate(
     FlutterDesktopPluginRegistrarRef registrar,
     FlutterDesktopWindowProcCallback delegate,

--- a/engine/src/flutter/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.h
+++ b/engine/src/flutter/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.h
@@ -112,7 +112,9 @@ class StubFlutterWindowsApi {
       FlutterDesktopWindowProcCallback delegate) {}
 
   // Called for FlutterDesktopPluginRegistrarGetGraphicsAdapter.
-  virtual IDXGIAdapter* PluginRegistrarGetGraphicsAdapter() { return nullptr; }
+  virtual bool PluginRegistrarGetGraphicsAdapter(IDXGIAdapter** adapter_out) {
+    return false;
+  }
 
   // Called for FlutterDesktopEngineProcessExternalWindowMessage.
   virtual bool EngineProcessExternalWindowMessage(

--- a/engine/src/flutter/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.h
+++ b/engine/src/flutter/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.h
@@ -111,6 +111,9 @@ class StubFlutterWindowsApi {
   virtual void PluginRegistrarUnregisterTopLevelWindowProcDelegate(
       FlutterDesktopWindowProcCallback delegate) {}
 
+  // Called for FlutterDesktopPluginRegistrarGetGraphicsAdapter.
+  virtual IDXGIAdapter* PluginRegistrarGetGraphicsAdapter() { return nullptr; }
+
   // Called for FlutterDesktopEngineProcessExternalWindowMessage.
   virtual bool EngineProcessExternalWindowMessage(
       FlutterDesktopEngineRef engine,

--- a/engine/src/flutter/shell/platform/windows/flutter_windows.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows.cc
@@ -330,6 +330,12 @@ void FlutterDesktopPluginRegistrarUnregisterTopLevelWindowProcDelegate(
       ->UnregisterTopLevelWindowProcDelegate(delegate);
 }
 
+IDXGIAdapter* FlutterDesktopPluginRegistrarGetGraphicsAdapter(
+    FlutterDesktopPluginRegistrarRef registrar) {
+  return FlutterDesktopEngineGetGraphicsAdapter(
+      HandleForEngine(registrar->engine));
+}
+
 UINT FlutterDesktopGetDpiForHWND(HWND hwnd) {
   return flutter::GetDpiForHWND(hwnd);
 }

--- a/engine/src/flutter/shell/platform/windows/flutter_windows.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows.cc
@@ -330,10 +330,11 @@ void FlutterDesktopPluginRegistrarUnregisterTopLevelWindowProcDelegate(
       ->UnregisterTopLevelWindowProcDelegate(delegate);
 }
 
-IDXGIAdapter* FlutterDesktopPluginRegistrarGetGraphicsAdapter(
-    FlutterDesktopPluginRegistrarRef registrar) {
+bool FlutterDesktopPluginRegistrarGetGraphicsAdapter(
+    FlutterDesktopPluginRegistrarRef registrar,
+    IDXGIAdapter** adapter_out) {
   return FlutterDesktopEngineGetGraphicsAdapter(
-      HandleForEngine(registrar->engine));
+      HandleForEngine(registrar->engine), adapter_out);
 }
 
 UINT FlutterDesktopGetDpiForHWND(HWND hwnd) {

--- a/engine/src/flutter/shell/platform/windows/public/flutter_windows.h
+++ b/engine/src/flutter/shell/platform/windows/public/flutter_windows.h
@@ -331,6 +331,10 @@ FlutterDesktopPluginRegistrarUnregisterTopLevelWindowProcDelegate(
     FlutterDesktopPluginRegistrarRef registrar,
     FlutterDesktopWindowProcCallback delegate);
 
+// Returns the DXGI adapter used for rendering or nullptr in case of error.
+FLUTTER_EXPORT IDXGIAdapter* FlutterDesktopPluginRegistrarGetGraphicsAdapter(
+    FlutterDesktopPluginRegistrarRef registrar);
+
 // ========== Freestanding Utilities ==========
 
 // Gets the DPI for a given |hwnd|, depending on the supported APIs per

--- a/engine/src/flutter/shell/platform/windows/public/flutter_windows.h
+++ b/engine/src/flutter/shell/platform/windows/public/flutter_windows.h
@@ -331,9 +331,13 @@ FlutterDesktopPluginRegistrarUnregisterTopLevelWindowProcDelegate(
     FlutterDesktopPluginRegistrarRef registrar,
     FlutterDesktopWindowProcCallback delegate);
 
-// Returns the DXGI adapter used for rendering or nullptr in case of error.
-FLUTTER_EXPORT IDXGIAdapter* FlutterDesktopPluginRegistrarGetGraphicsAdapter(
-    FlutterDesktopPluginRegistrarRef registrar);
+// Retrieves the DXGI adapter used for rendering. Returns true if the adapter
+// was successfully retrieved, or false if an error occured.
+// The caller must provide a valid pointer to an IDXGIAdapter* and is
+// responsible for releasing the adapter.
+FLUTTER_EXPORT bool FlutterDesktopPluginRegistrarGetGraphicsAdapter(
+    FlutterDesktopPluginRegistrarRef registrar,
+    IDXGIAdapter** adapter_out);
 
 // ========== Freestanding Utilities ==========
 


### PR DESCRIPTION
https://github.com/flutter/flutter/pull/184479 has added `FlutterDesktopEngineGetGraphicsAdapter`, but plugins don't have access to engine, only plugin registrar so there's no straightforward way for plugins to get the adapter. This PR fixes this by adding `FlutterDesktopPluginRegistrarGetGraphicsAdapter`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
