### PR TITLE
Cache plugin registrant in test compiler

### DIFF
--- a/packages/flutter_tools/lib/src/test/test_compiler.dart
+++ b/packages/flutter_tools/lib/src/test/test_compiler.dart
@@ -6,10 +6,14 @@ import 'dart:async';
 
 import 'package:meta/meta.dart';
 
+import 'package:package_config/package_config_types.dart';
+
 import '../base/file_system.dart';
 import '../build_info.dart';
 import '../bundle.dart';
+import '../cache.dart';
 import '../compile.dart';
+import '../dart/language_version.dart';
 import '../flutter_plugins.dart';
 import '../globals.dart' as globals;
 import '../project.dart';
@@ -153,6 +157,13 @@ class TestCompiler {
   ResidentCompiler? compiler;
   late File outputDill;
 
+  /// The language version the plugin registrant was last generated for, or
+  /// `null` if it hasn't been generated yet. The plugin set is stable for the
+  /// lifetime of a single `flutter test` run, so the registrant only needs to
+  /// be regenerated when the language version of the entrypoint changes (e.g.
+  /// when test files come from packages with different `// @dart =` versions).
+  LanguageVersion? _registrantLanguageVersion;
+
   /// Compiles the Dart program (an entrypoint containing `main()`).
   Future<TestCompilerResult> compile(Uri dartEntrypointPath) {
     if (compilerController.isClosed) {
@@ -218,17 +229,29 @@ class TestCompiler {
 
       final invalidatedRegistrantFiles = <Uri>[];
       if (flutterProject != null) {
-        // Update the generated registrant to use the test target's main.
-        final String mainUriString =
-            buildInfo.packageConfig.toPackageUri(request.mainUri)?.toString() ??
-            request.mainUri.toString();
-        await generateMainDartWithPluginRegistrant(
-          flutterProject!,
-          buildInfo.packageConfig,
-          mainUriString,
-          globals.fs.file(request.mainUri),
+        final File mainFile = globals.fs.file(request.mainUri);
+        final LanguageVersion languageVersion = determineLanguageVersion(
+          mainFile,
+          buildInfo.packageConfig.packageOf(request.mainUri),
+          Cache.flutterRoot!,
         );
-        invalidatedRegistrantFiles.add(flutterProject!.dartPluginRegistrant.absolute.uri);
+        if (languageVersion != _registrantLanguageVersion) {
+          // (Re)generate the registrant. The output is keyed only on the plugin
+          // set (stable for one `flutter test` run) and the entrypoint's
+          // language version, so we can skip this work when the language
+          // version matches the previous compilation.
+          final String mainUriString =
+              buildInfo.packageConfig.toPackageUri(request.mainUri)?.toString() ??
+              request.mainUri.toString();
+          await generateMainDartWithPluginRegistrant(
+            flutterProject!,
+            buildInfo.packageConfig,
+            mainUriString,
+            mainFile,
+          );
+          invalidatedRegistrantFiles.add(flutterProject!.dartPluginRegistrant.absolute.uri);
+          _registrantLanguageVersion = languageVersion;
+        }
       }
 
       final CompilerOutput? compilerOutput = await compiler!.recompile(

--- a/packages/flutter_tools/test/general.shard/test/test_compiler_test.dart
+++ b/packages/flutter_tools/test/general.shard/test/test_compiler_test.dart
@@ -255,6 +255,138 @@ environment:
       Pub: ThrowingPub.new,
     },
   );
+
+  testUsingContext(
+    'TestCompiler reuses the generated dart_plugin_registrant across compilations',
+    () async {
+      final Directory fakeDartPlugin = fileSystem.directory('a_plugin');
+      fileSystem.file('pubspec.yaml').writeAsStringSync('''
+name: foo
+dependencies:
+  flutter:
+    sdk: flutter
+  a_plugin: 1.0.0
+''');
+      writePackageConfigFiles(
+        directory: fileSystem.currentDirectory,
+        mainLibName: 'foo',
+        packages: <String, String>{'a_plugin': '/a_plugin'},
+      );
+      fakeDartPlugin.childFile('pubspec.yaml')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('''
+name: a_plugin
+flutter:
+  plugin:
+    implements: a
+    platforms:
+      linux:
+        dartPluginClass: APlugin
+environment:
+  sdk: ^3.7.0-0
+  flutter: ">=2.5.0"
+''');
+
+      residentCompiler.compilerOutput = const CompilerOutput('abc.dill', 0, <Uri>[]);
+      final FlutterProject flutterProject = FlutterProject.fromDirectoryTest(
+        fileSystem.currentDirectory,
+      );
+      final testCompiler = FakeTestCompiler(debugBuild, flutterProject, residentCompiler);
+
+      await testCompiler.compile(Uri.parse('test/foo_test.dart'));
+      await testCompiler.compile(Uri.parse('test/bar_test.dart'));
+
+      final Uri registrantUri = flutterProject.dartPluginRegistrant.absolute.uri;
+      expect(residentCompiler.invalidatedFilesPerCall, hasLength(2));
+      expect(
+        residentCompiler.invalidatedFilesPerCall[0],
+        contains(registrantUri),
+        reason: 'first compile generates the registrant and invalidates it',
+      );
+      expect(
+        residentCompiler.invalidatedFilesPerCall[1],
+        isNot(contains(registrantUri)),
+        reason: 'subsequent compile reuses the cached registrant',
+      );
+    },
+    overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      Platform: () => linuxPlatform,
+      ProcessManager: () => FakeProcessManager.any(),
+      Logger: () => BufferLogger.test(),
+      Pub: ThrowingPub.new,
+    },
+  );
+
+  testUsingContext(
+    'TestCompiler regenerates the registrant when language version changes',
+    () async {
+      final Directory fakeDartPlugin = fileSystem.directory('a_plugin');
+      fileSystem.file('pubspec.yaml').writeAsStringSync('''
+name: foo
+dependencies:
+  flutter:
+    sdk: flutter
+  a_plugin: 1.0.0
+''');
+      writePackageConfigFiles(
+        directory: fileSystem.currentDirectory,
+        mainLibName: 'foo',
+        packages: <String, String>{'a_plugin': '/a_plugin'},
+      );
+      fakeDartPlugin.childFile('pubspec.yaml')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('''
+name: a_plugin
+flutter:
+  plugin:
+    implements: a
+    platforms:
+      linux:
+        dartPluginClass: APlugin
+environment:
+  sdk: ^3.7.0-0
+  flutter: ">=2.5.0"
+''');
+
+      // Two test files with explicit, different language version directives.
+      fileSystem.file('test/old_test.dart')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('// @dart = 3.0\nvoid main() {}\n');
+      fileSystem.file('test/new_test.dart')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('// @dart = 3.5\nvoid main() {}\n');
+
+      residentCompiler.compilerOutput = const CompilerOutput('abc.dill', 0, <Uri>[]);
+      final FlutterProject flutterProject = FlutterProject.fromDirectoryTest(
+        fileSystem.currentDirectory,
+      );
+      final testCompiler = FakeTestCompiler(debugBuild, flutterProject, residentCompiler);
+
+      await testCompiler.compile(Uri.parse('test/old_test.dart'));
+      await testCompiler.compile(Uri.parse('test/new_test.dart'));
+
+      final Uri registrantUri = flutterProject.dartPluginRegistrant.absolute.uri;
+      expect(residentCompiler.invalidatedFilesPerCall, hasLength(2));
+      expect(
+        residentCompiler.invalidatedFilesPerCall[0],
+        contains(registrantUri),
+        reason: 'first compile generates the registrant for @dart = 3.0',
+      );
+      expect(
+        residentCompiler.invalidatedFilesPerCall[1],
+        contains(registrantUri),
+        reason: 'language version changed to 3.5, registrant must be regenerated',
+      );
+    },
+    overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      Platform: () => linuxPlatform,
+      ProcessManager: () => FakeProcessManager.any(),
+      Logger: () => BufferLogger.test(),
+      Pub: ThrowingPub.new,
+    },
+  );
 }
 
 /// Override the creation of the Resident Compiler to simplify testing.
@@ -285,6 +417,7 @@ class FakeResidentCompiler extends Fake implements ResidentCompiler {
 
   CompilerOutput? compilerOutput;
   bool didShutdown = false;
+  final invalidatedFilesPerCall = <List<Uri>>[];
 
   @override
   Future<CompilerOutput?> recompile(
@@ -300,6 +433,7 @@ class FakeResidentCompiler extends Fake implements ResidentCompiler {
     Uri? nativeAssetsYaml,
     bool recompileRestart = false,
   }) async {
+    invalidatedFilesPerCall.add(invalidatedFiles ?? <Uri>[]);
     if (compilerOutput != null) {
       fileSystem!.file(compilerOutput!.outputFilename).createSync(recursive: true);
     }


### PR DESCRIPTION
Towards #69429 ("Make `flutter test` faster"). 

This change makes `TestCompiler` cache the plugin registrant instead
of regenerating it for each test file. Plugins are stable for the lifetime of a single `flutter test`
run. However, the Dart version of test files might differ, so the cache is keyed on the test file's
Dart version. 

**Benchmark**
Flutter foundation test suite (32 files, 220 tests), `flutter test -j 4`, 3 runs + 1 warmup:

|                                 | master | this PR    |
| ------------------------------- | ------ | ---------- |
| Avg compile per subsequent file | 68ms   | 55ms   |

That means the startup time for `flutter test` is reduced by ~13ms _per test file_ on my machine. That quickly adds up and significantly improves Flutter's TDD experience.

Results were generated with the following script:

<details><summary markdown="span">Benchmark</summary>

```bash
#!/usr/bin/env bash
# Reports per-run, for foundation suite, -j 4:
#   - wall      : total `flutter test` invocation time
#   - first     : compile time for the first test file (cache miss)
#   - subseq    : average compile time per subsequent file (cache hit / miss)
#   - total     : sum of all per-file compile times
#
# The "subseq" and "total" rows are the ones the PR moves; "wall" is dominated
# by test execution and is reported for completeness.

set -euo pipefail

FLUTTER_ROOT="${FLUTTER_ROOT:-$(pwd)}"
FLUTTER="$FLUTTER_ROOT/bin/flutter"
TARGET="$FLUTTER_ROOT/packages/flutter/test/foundation/"
RUNS="${RUNS:-3}"

cd "$FLUTTER_ROOT/packages/flutter"

bench_one() {
  local name="$1" log
  log=$(mktemp)
  local start end ms
  start=$(date +%s%N)
  "$FLUTTER" test -j 4 -v "$TARGET" >"$log" 2>&1
  end=$(date +%s%N)
  ms=$(( (end - start) / 1000000 ))

  local compiles n first sum rest_avg
  compiles=$(grep -oP 'Compiling .+ took \K\d+(?=ms)' "$log" || true)
  n=$(echo "$compiles" | grep -c . || true)
  first=$(echo "$compiles" | head -1)
  sum=$(echo "$compiles" | awk '{s+=$1} END{print s+0}')
  rest_avg=0
  if [[ "$n" -gt 1 ]]; then
    rest_avg=$(echo "$compiles" | tail -n +2 | awk '{s+=$1} END{print int(s/NR)}')
  fi
  printf "  %-8s wall=%5dms  first=%4dms  subseq=%3dms (n=%d)  total=%5dms\n" \
    "$name" "$ms" "$first" "$rest_avg" "$((n-1))" "$sum"
  rm -f "$log"
}

echo "Foundation suite (32 files, ~220 tests), -j 4, $RUNS runs + 1 warmup"
echo "Commit: $(cd "$FLUTTER_ROOT" && git rev-parse --short HEAD) ($(cd "$FLUTTER_ROOT" && git status --porcelain | wc -l) modified files)"
bench_one "warmup"
for i in $(seq 1 "$RUNS"); do
  bench_one "run_$i"
done
```

</details> 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.
