### PR TITLE
[iOS] Create FlutterFMLTaskRunner(s)

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/BUILD.gn
+++ b/engine/src/flutter/shell/platform/darwin/ios/BUILD.gn
@@ -45,8 +45,12 @@ source_set("InternalFlutterSwift") {
   # Targets should only ever depend on the framework target.
   # This allows code in this target to use types declared in the bridging
   # header, but defined in the framework, while avoiding linking errors.
-  visibility = [ ":flutter_framework_source" ]
+  visibility = [
+    ":flutter_framework_source",
+    ":ios_test_flutter",
+  ]
   configs += [ "//flutter/shell/platform/darwin/common:config" ]
+  deps = [ ":flutter_engine_bindings" ]
   include_dirs = [
     "//flutter/shell/platform/darwin/common/framework/Headers",
     "//flutter/shell/platform/darwin/ios/framework/Headers",
@@ -212,23 +216,52 @@ source_set("flutter_framework_source") {
     "//flutter/third_party/icu",
     "//flutter/third_party/spring_animation",
   ]
-  public_deps = [ ":InternalFlutterSwift" ]
+  public_deps = [
+    ":InternalFlutterSwift",
+    ":flutter_engine_bindings",
+  ]
 }
 
 if (enable_ios_unittests) {
+  source_set("flutter_engine_bindings_test_helpers") {
+    testonly = true
+    visibility = [ ":*" ]
+    configs += [ "//flutter/shell/platform/darwin/common:test_config" ]
+    sources = [
+      "framework/Source/FlutterFMLTaskRunnerTestHelper.h",
+      "framework/Source/FlutterFMLTaskRunnerTestHelper.mm",
+    ]
+    deps = [
+      ":flutter_engine_bindings",
+      "//flutter/fml",
+    ]
+  }
+
   source_set("ios_test_flutter_swift") {
     testonly = true
     visibility = [ ":*" ]
     configs += [ "//flutter/shell/platform/darwin/common:test_config" ]
+    include_dirs = [
+      "//flutter/shell/platform/darwin/common/framework/Headers",
+      "//flutter/shell/platform/darwin/ios/framework/Headers",
+      "//flutter/shell/platform/darwin/ios/framework",
+    ]
+    bridge_header = "FlutterTests-Bridging-Header.h"
     sources = [
       "framework/Source/AccessibilityFeaturesTests.swift",
       "framework/Source/ConnectionCollectionTest.swift",
       "framework/Source/FakeUIPressProxy.swift",
       "framework/Source/LaunchEngineTest.swift",
       "framework/Source/SplashScreenManagerTests.swift",
+      "framework/Source/TaskRunnerTests.swift",
     ]
     frameworks = [ "XCTest.framework" ]
-    deps = [ ":flutter_framework_source" ]
+    deps = [
+      ":flutter_engine_bindings",
+      ":flutter_engine_bindings_test_helpers",
+      ":flutter_framework_source",
+      "//flutter/fml",
+    ]
   }
 
   shared_library("ios_test_flutter") {
@@ -291,6 +324,8 @@ if (enable_ios_unittests) {
       "platform_view_ios_test.mm",
     ]
     deps = [
+      ":InternalFlutterSwift",
+      ":flutter_engine_bindings_test_helpers",
       ":flutter_framework",
       ":flutter_framework_source",
       ":ios_gpu_configuration",
@@ -313,6 +348,34 @@ if (enable_ios_unittests) {
     ]
   }
 }  # if (enable_ios_unittests)
+
+source_set("flutter_engine_bindings") {
+  visibility = [ ":*" ]
+  cflags_objc = flutter_cflags_objc
+  cflags_objcc = flutter_cflags_objcc
+
+  defines = [ "FLUTTER_FRAMEWORK=1" ]
+  configs += [ "//flutter/shell/platform/darwin/common:config" ]
+  include_dirs = [
+    "//flutter/shell/platform/darwin/common/framework/Headers",
+    "//flutter/shell/platform/darwin/ios/framework/Headers",
+    "//flutter/shell/platform/darwin/ios/framework",  # For module.modulemap
+  ]
+  sources = [
+    "framework/Source/FlutterFMLTaskRunner+FML.h",
+    "framework/Source/FlutterFMLTaskRunner.h",
+    "framework/Source/FlutterFMLTaskRunner.mm",
+    "framework/Source/FlutterFMLTaskRunners.h",
+    "framework/Source/FlutterFMLTaskRunners.mm",
+  ]
+  deps = [
+    "//flutter/common",
+    "//flutter/fml",
+    "//flutter/shell/common",
+    "//flutter/shell/platform/darwin/common:framework_common",
+  ]
+  public_deps = [ "//flutter/third_party/spring_animation" ]
+}
 
 shared_library("create_flutter_framework_dylib") {
   visibility = [ ":*" ]

--- a/engine/src/flutter/shell/platform/darwin/ios/FlutterTests-Bridging-Header.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/FlutterTests-Bridging-Header.h
@@ -2,11 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_DARWIN_IOS_INTERNALFLUTTERSWIFT_BRIDGING_HEADER_H_
-#define FLUTTER_SHELL_PLATFORM_DARWIN_IOS_INTERNALFLUTTERSWIFT_BRIDGING_HEADER_H_
+#ifndef FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FLUTTERTESTS_BRIDGING_HEADER_H_
+#define FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FLUTTERTESTS_BRIDGING_HEADER_H_
 
-#import "flutter/shell/platform/darwin/ios/framework/Headers/Flutter.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunner.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunnerTestHelper.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunners.h"
 
-#endif  // FLUTTER_SHELL_PLATFORM_DARWIN_IOS_INTERNALFLUTTERSWIFT_BRIDGING_HEADER_H_
+#endif  // FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FLUTTERTESTS_BRIDGING_HEADER_H_

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunner+FML.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunner+FML.h
@@ -1,0 +1,21 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERFMLTASKRUNNER_FML_H_
+#define FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERFMLTASKRUNNER_FML_H_
+
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunner.h"
+
+#include "flutter/fml/memory/ref_ptr.h"
+#include "flutter/fml/task_runner.h"
+
+@interface FlutterFMLTaskRunner ()
+
+- (instancetype)initWithTaskRunner:(fml::RefPtr<fml::TaskRunner>)task_runner;
+
+- (fml::RefPtr<fml::TaskRunner>)taskRunner;
+
+@end
+
+#endif  // FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERFMLTASKRUNNER_FML_H_

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunner.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunner.h
@@ -1,0 +1,22 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERFMLTASKRUNNER_H_
+#define FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERFMLTASKRUNNER_H_
+
+#import <Foundation/Foundation.h>
+
+NS_SWIFT_NAME(TaskRunner)
+@interface FlutterFMLTaskRunner : NSObject
+
+- (void)postTask:(void (^)(void))task;
+- (void)runNowOrPostTask:(void (^)(void))task;
+- (void)postTaskWithDelay:(NSTimeInterval)delay
+                     task:(void (^)(void))task NS_SWIFT_NAME(postTask(delay:task:));
+
+- (BOOL)runsTasksOnCurrentThread;
+
+@end
+
+#endif  // FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERFMLTASKRUNNER_H_

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunner.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunner.mm
@@ -1,0 +1,46 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunner+FML.h"
+
+#include <utility>
+
+#include "flutter/fml/logging.h"
+
+@implementation FlutterFMLTaskRunner {
+  fml::RefPtr<fml::TaskRunner> _taskRunner;
+}
+
+- (instancetype)initWithTaskRunner:(fml::RefPtr<fml::TaskRunner>)task_runner {
+  FML_DCHECK(task_runner);
+  if (self = [super init]) {
+    _taskRunner = std::move(task_runner);
+  }
+  return self;
+}
+
+- (void)postTask:(void (^)(void))task {
+  FML_DCHECK(task);
+  _taskRunner->PostTask([task]() { task(); });
+}
+
+- (void)runNowOrPostTask:(void (^)(void))task {
+  FML_DCHECK(task);
+  fml::TaskRunner::RunNowOrPostTask(_taskRunner, [task]() { task(); });
+}
+
+- (void)postTaskWithDelay:(NSTimeInterval)delay task:(void (^)(void))task {
+  FML_DCHECK(task);
+  _taskRunner->PostDelayedTask([task]() { task(); }, fml::TimeDelta::FromSecondsF(delay));
+}
+
+- (BOOL)runsTasksOnCurrentThread {
+  return _taskRunner->RunsTasksOnCurrentThread();
+}
+
+- (fml::RefPtr<fml::TaskRunner>)taskRunner {
+  return _taskRunner;
+}
+
+@end

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunnerTestHelper.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunnerTestHelper.h
@@ -1,0 +1,32 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERFMLTASKRUNNERTESTHELPER_H_
+#define FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERFMLTASKRUNNERTESTHELPER_H_
+
+#import <Foundation/Foundation.h>
+
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunner.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunners.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FlutterFMLTaskRunnerTestHelper : NSObject
+
+/**
+ * Returns a FlutterFMLTaskRunner for the current thread.
+ */
++ (FlutterFMLTaskRunner*)makeCurrentThreadTaskRunner;
+
+/**
+ * Returns a FlutterFMLTaskRunners object where all runners point to the same task runner.
+ */
++ (FlutterFMLTaskRunners*)makeTaskRunnersWithLabel:(NSString*)label
+                                        taskRunner:(FlutterFMLTaskRunner*)taskRunner;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif  // FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERFMLTASKRUNNERTESTHELPER_H_

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunnerTestHelper.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunnerTestHelper.mm
@@ -1,0 +1,27 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunnerTestHelper.h"
+
+#include "flutter/fml/message_loop.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunner+FML.h"
+
+@implementation FlutterFMLTaskRunnerTestHelper
+
++ (FlutterFMLTaskRunner*)makeCurrentThreadTaskRunner {
+  fml::MessageLoop::EnsureInitializedForCurrentThread();
+  return [[FlutterFMLTaskRunner alloc]
+      initWithTaskRunner:fml::MessageLoop::GetCurrent().GetTaskRunner()];
+}
+
++ (FlutterFMLTaskRunners*)makeTaskRunnersWithLabel:(NSString*)label
+                                        taskRunner:(FlutterFMLTaskRunner*)taskRunner {
+  return [[FlutterFMLTaskRunners alloc] initWithLabel:label
+                                   platformTaskRunner:taskRunner
+                                     rasterTaskRunner:taskRunner
+                                         uiTaskRunner:taskRunner
+                                         ioTaskRunner:taskRunner];
+}
+
+@end

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunners+FML.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunners+FML.h
@@ -1,0 +1,17 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERFMLTASKRUNNERS_FML_H_
+#define FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERFMLTASKRUNNERS_FML_H_
+
+#include "flutter/common/task_runners.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunners.h"
+
+@interface FlutterFMLTaskRunners (FML)
+
+@property(nonatomic, readonly) const flutter::TaskRunners& taskRunners;
+
+@end
+
+#endif  // FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERFMLTASKRUNNERS_FML_H_

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunners.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunners.h
@@ -1,0 +1,33 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERFMLTASKRUNNERS_H_
+#define FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERFMLTASKRUNNERS_H_
+
+#import <Foundation/Foundation.h>
+
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunner.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+NS_SWIFT_NAME(TaskRunners)
+@interface FlutterFMLTaskRunners : NSObject
+
+@property(nonatomic, readonly) NSString* label;
+@property(nonatomic, readonly) FlutterFMLTaskRunner* platformTaskRunner;
+@property(nonatomic, readonly) FlutterFMLTaskRunner* rasterTaskRunner;
+@property(nonatomic, readonly) FlutterFMLTaskRunner* uiTaskRunner;
+@property(nonatomic, readonly) FlutterFMLTaskRunner* ioTaskRunner;
+
+- (instancetype)initWithLabel:(NSString*)label
+           platformTaskRunner:(FlutterFMLTaskRunner*)platformTaskRunner
+             rasterTaskRunner:(FlutterFMLTaskRunner*)rasterTaskRunner
+                 uiTaskRunner:(FlutterFMLTaskRunner*)uiTaskRunner
+                 ioTaskRunner:(FlutterFMLTaskRunner*)ioTaskRunner;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif  // FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERFMLTASKRUNNERS_H_

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunners.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunners.mm
@@ -1,0 +1,43 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunners.h"
+
+#include <memory>
+
+#include "flutter/common/task_runners.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunner+FML.h"
+
+@interface FlutterFMLTaskRunners () {
+  std::unique_ptr<flutter::TaskRunners> _taskRunners;
+}
+@end
+
+@implementation FlutterFMLTaskRunners
+
+- (instancetype)initWithLabel:(nonnull NSString*)label
+           platformTaskRunner:(nonnull FlutterFMLTaskRunner*)platformTaskRunner
+             rasterTaskRunner:(nonnull FlutterFMLTaskRunner*)rasterTaskRunner
+                 uiTaskRunner:(nonnull FlutterFMLTaskRunner*)uiTaskRunner
+                 ioTaskRunner:(nonnull FlutterFMLTaskRunner*)ioTaskRunner {
+  self = [super init];
+  if (self) {
+    _label = label;
+    _platformTaskRunner = platformTaskRunner;
+    _rasterTaskRunner = rasterTaskRunner;
+    _uiTaskRunner = uiTaskRunner;
+    _ioTaskRunner = ioTaskRunner;
+
+    _taskRunners = std::make_unique<flutter::TaskRunners>(
+        label.UTF8String, platformTaskRunner.taskRunner, rasterTaskRunner.taskRunner,
+        uiTaskRunner.taskRunner, ioTaskRunner.taskRunner);
+  }
+  return self;
+}
+
+- (const flutter::TaskRunners&)taskRunners {
+  return *_taskRunners;
+}
+
+@end

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/TaskRunnerTests.swift
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/TaskRunnerTests.swift
@@ -1,0 +1,40 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import InternalFlutterSwift
+import XCTest
+
+class TaskRunnerTests: XCTestCase {
+
+  func testPostTask() {
+    let taskRunner = FlutterFMLTaskRunnerTestHelper.makeCurrentThreadTaskRunner()
+
+    let expectation = self.expectation(description: "Task should be executed")
+    taskRunner.postTask {
+      expectation.fulfill()
+    }
+
+    waitForExpectations(timeout: 5.0, handler: nil)
+  }
+func testPostDelayedTask() {
+  let taskRunner = FlutterFMLTaskRunnerTestHelper.makeCurrentThreadTaskRunner()
+
+  let expectation = self.expectation(description: "Delayed task should be executed")
+  let startTime = CACurrentMediaTime()
+  taskRunner.postTask(delay: 0.1) {
+    let endTime = CACurrentMediaTime()
+    XCTAssertGreaterThanOrEqual(endTime - startTime, 0.1)
+    expectation.fulfill()
+  }
+
+  waitForExpectations(timeout: 5.0, handler: nil)
+}
+
+
+  func testRunsTasksOnCurrentThread() {
+    let taskRunner = FlutterFMLTaskRunnerTestHelper.makeCurrentThreadTaskRunner()
+
+    XCTAssertTrue(taskRunner.runsTasksOnCurrentThread())
+  }
+}


### PR DESCRIPTION
fml::TaskRunner is a core C++ dependency for asynchronous task execution across the iOS embedder. It appears frequently in Objective-C API which is problematic for adding or migrating embedder code to Swift. This class also makes heavy use of fml::TimePoint and fml::TimeDelta, and thus adds further C++ to any code making use of the task runner.

flutter::TaskRunners, is a container that groups together task runners for the platform thread, UI thread, and raster thread.

This adds FlutterFMLTaskRunner and FlutterFMLTaskRunners. Ideally, these would be named FlutterTaskRunner but that identifier is already a key part of the Embedder API. To differentiate our FML-based run loops from the Embedder API types, we add FML to the name.

The two new classes have API that is entirely free from C++ types, but for each, we introduce a category on it in the FlutterTaskRunner[s]+FML.h header that includes an initialiser that takes the associated C++ type and a getter that returns it. This allows for a stepwise migration.

This patch adds, but does not yet migrate to, the new wrapper types. I'll send follow-up patches with the migrations.

Issue: https://github.com/flutter/flutter/issues/157140

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
