### PR TITLE
Modify analyze.dart to have flags to run only or exclude each verification step. 

### DIFF
--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -130,188 +130,11 @@ Future<void> run(List<String> arguments, {List<Validation>? validationsForTestin
 
   final List<Validation> validations =
       validationsForTesting ??
-      <Validation>[
-        Validation(
-          'release-branch',
-          'Release branch validation',
-          () => verifyReleaseBranchState(flutterRoot),
-        ),
-        Validation(
-          'target-platform',
-          'TargetPlatform tool/framework consistency',
-          () => verifyTargetPlatform(flutterRoot),
-        ),
-        Validation(
-          'tool-end-to-end',
-          'All tool test files end in _test.dart...',
-          () => verifyToolTestsEndInTestDart(flutterRoot),
-        ),
-        Validation('no-sync-star-async-star', 'No sync*/async*', () async {
-          await verifyNoSyncAsyncStar(flutterPackages);
-          await verifyNoSyncAsyncStar(flutterExamples, minimumMatches: 200);
-        }),
-        Validation(
-          'no-runtime-type',
-          'No runtimeType in toString...',
-          () => verifyNoRuntimeTypeInToString(flutterRoot),
-        ),
-        Validation(
-          'no-checked-mode',
-          'Debug mode instead of checked mode...',
-          () => verifyNoCheckedMode(flutterRoot),
-        ),
-        Validation(
-          'issue-links',
-          'Links for creating GitHub issues...',
-          () => verifyIssueLinks(flutterRoot),
-        ),
-        Validation(
-          'repository-links',
-          'Links to repositories...',
-          () => verifyRepositoryLinks(flutterRoot),
-        ),
-        Validation('no-binaries', 'Unexpected binaries...', () => verifyNoBinaries(flutterRoot)),
-        Validation(
-          'no-trailing-spaces',
-          'Trailing spaces...',
-          () => verifyNoTrailingSpaces(flutterRoot),
-        ),
-        Validation(
-          'spaces-after-flow',
-          'Spaces after flow control statements...',
-          () => verifySpacesAfterFlowControlStatements(flutterRoot),
-        ),
-        Validation('deprecations', 'Deprecations...', () => verifyDeprecations(flutterRoot)),
-        Validation('golden-tags', 'Goldens...', () => verifyGoldenTags(flutterPackages)),
-        Validation(
-          'skip-test-comments',
-          'Skip test comments...',
-          () => verifySkipTestComments(flutterRoot),
-        ),
-        Validation('no-missing-license', 'Licenses...', () => verifyNoMissingLicense(flutterRoot)),
-        Validation('no-test-imports', 'Test imports...', () => verifyNoTestImports(flutterRoot)),
-        Validation(
-          'no-bad-imports-flutter',
-          'Bad imports (framework)...',
-          () => verifyNoBadImportsInFlutter(flutterRoot),
-        ),
-        Validation(
-          'no-bad-imports-tools',
-          'Bad imports (tools)...',
-          () => verifyNoBadImportsInFlutterTools(flutterRoot),
-        ),
-        Validation(
-          'internationalization',
-          'Internationalization...',
-          () => verifyInternationalizations(flutterRoot, dart),
-        ),
-        Validation(
-          'stock-app-localizations',
-          'Localization files of stocks app...',
-          () => verifyStockAppLocalizations(flutterRoot),
-        ),
-        Validation(
-          'integration-timeouts',
-          'Integration test timeouts...',
-          () => verifyIntegrationTestTimeouts(flutterRoot),
-        ),
-        Validation(
-          'null-fields',
-          'null initialized debug fields...',
-          () => verifyNullInitializedDebugExpensiveFields(flutterRoot),
-        ),
-        Validation('taboo', 'Taboo words...', () => verifyTabooDocumentation(flutterRoot)),
-        Validation('lint-kotlin', 'Lint Kotlin files...', () => lintKotlinFiles(flutterRoot)),
-        Validation(
-          'lint-kotlin-templates',
-          'Lint generated Kotlin files from templates...',
-          () => lintKotlinTemplatedFiles(flutterRoot),
-        ),
-        Validation(
-          'update-packages',
-          'Package dependencies...',
-          () => runCommand(flutter, <String>['update-packages'], workingDirectory: flutterRoot),
-        ),
-        Validation('package-allowlist', 'Package Allowlist...', () => _checkConsumerDependencies()),
-        Validation('dart-analysis', 'Dart analysis...', () async {
-          dartAnalyzeResult = await _runFlutterAnalyze(
-            flutterRoot,
-            options: <String>['--flutter-repo', ...passthroughArguments],
-          );
-        }),
-        Validation(
-          'format',
-          'Check formatting of Dart files...',
-          () => runCommand(dart, <String>[
-            '--enable-asserts',
-            path.join(flutterRoot, 'dev', 'tools', 'bin', 'format.dart'),
-          ], workingDirectory: flutterRoot),
-        ),
-        Validation(
-          'private-lints',
-          'Private lints...',
-          () => _verifyPrivateLints(flutterRoot, dartAnalyzeResult),
-        ),
-        Validation(
-          'executable-allowlist',
-          'Executable allowlist...',
-          () => _checkForNewExecutables(),
-        ),
-        Validation(
-          'dart-analysis-watch',
-          'Dart analysis (with --watch)...',
-          () => _runFlutterAnalyze(
-            flutterRoot,
-            failureMessage: 'Dart analyzer failed when --watch was used.',
-            options: <String>['--flutter-repo', '--watch', '--benchmark', ...passthroughArguments],
-          ),
-        ),
-        Validation(
-          'snippets',
-          'Snippet code...',
-          () => runCommand(dart, <String>[
-            '--enable-asserts',
-            path.join(flutterRoot, 'dev', 'bots', 'analyze_snippet_code.dart'),
-            '--verbose',
-          ], workingDirectory: flutterRoot),
-        ),
-        Validation(
-          'code-samples',
-          'Code sample link validation...',
-          () => runCommand(dart, <String>[
-            '--enable-asserts',
-            path.join(flutterRoot, 'dev', 'bots', 'check_code_samples.dart'),
-          ], workingDirectory: flutterRoot),
-        ),
-        Validation(
-          'mega-gallery',
-          'Dart analysis (mega gallery)...',
-          () => _verifyMegaGallery(flutterRoot, dart, passthroughArguments),
-        ),
-        Validation(
-          'gen-defaults-names',
-          'Correct file names in gen_defaults.dart...',
-          () => verifyTokenTemplatesUpdateCorrectFiles(flutterRoot),
-        ),
-        Validation(
-          'gen-defaults-up-to-date',
-          'Material library files are up-to-date with token template files...',
-          () => verifyMaterialFilesAreUpToDateWithTemplateFiles(flutterRoot, dart),
-        ),
-        Validation(
-          'integration-templates',
-          'Up to date integration test template files...',
-          () => verifyIntegrationTestTemplateFiles(flutterRoot),
-        ),
-        Validation(
-          'cross-imports',
-          'Cross-import test validation...',
-          () => runCommand(dart, <String>[
-            '--enable-asserts',
-            path.join(flutterRoot, 'dev', 'bots', 'check_tests_cross_imports.dart'),
-          ], workingDirectory: flutterRoot),
-        ),
-      ];
+      _getValidations(
+        passthroughArguments: passthroughArguments,
+        getDartAnalyzeResult: () => dartAnalyzeResult,
+        onDartAnalyzeResult: (CommandResult? result) => dartAnalyzeResult = result,
+      );
 
   final seenNames = <String>{};
   for (final validation in validations) {
@@ -329,10 +152,18 @@ Future<void> run(List<String> arguments, {List<Validation>? validationsForTestin
       return;
     }
     if (arg.startsWith('--only=')) {
+      if (onlyRules.isNotEmpty) {
+        foundError(<String>['The --only argument must not be used more than once.']);
+        return;
+      }
       onlyRules = arg.substring('--only='.length).split(',');
       continue;
     }
     if (arg.startsWith('--skip=')) {
+      if (skipRules.isNotEmpty) {
+        foundError(<String>['The --skip argument must not be used more than once.']);
+        return;
+      }
       skipRules = arg.substring('--skip='.length).split(',');
       continue;
     }
@@ -369,6 +200,192 @@ Future<void> run(List<String> arguments, {List<Validation>? validationsForTestin
       await validation.callback();
     }
   }
+}
+
+List<Validation> _getValidations({
+  required List<String> passthroughArguments,
+  required CommandResult? Function() getDartAnalyzeResult,
+  required void Function(CommandResult?) onDartAnalyzeResult,
+}) {
+  return <Validation>[
+    Validation(
+      'release-branch',
+      'Release branch validation',
+      () => verifyReleaseBranchState(flutterRoot),
+    ),
+    Validation(
+      'target-platform',
+      'TargetPlatform tool/framework consistency',
+      () => verifyTargetPlatform(flutterRoot),
+    ),
+    Validation(
+      'tool-end-to-end',
+      'All tool test files end in _test.dart...',
+      () => verifyToolTestsEndInTestDart(flutterRoot),
+    ),
+    Validation('no-sync-star-async-star', 'No sync*/async*', () async {
+      await verifyNoSyncAsyncStar(flutterPackages);
+      await verifyNoSyncAsyncStar(flutterExamples, minimumMatches: 200);
+    }),
+    Validation(
+      'no-runtime-type',
+      'No runtimeType in toString...',
+      () => verifyNoRuntimeTypeInToString(flutterRoot),
+    ),
+    Validation(
+      'no-checked-mode',
+      'Debug mode instead of checked mode...',
+      () => verifyNoCheckedMode(flutterRoot),
+    ),
+    Validation(
+      'issue-links',
+      'Links for creating GitHub issues...',
+      () => verifyIssueLinks(flutterRoot),
+    ),
+    Validation(
+      'repository-links',
+      'Links to repositories...',
+      () => verifyRepositoryLinks(flutterRoot),
+    ),
+    Validation('no-binaries', 'Unexpected binaries...', () => verifyNoBinaries(flutterRoot)),
+    Validation(
+      'no-trailing-spaces',
+      'Trailing spaces...',
+      () => verifyNoTrailingSpaces(flutterRoot),
+    ),
+    Validation(
+      'spaces-after-flow',
+      'Spaces after flow control statements...',
+      () => verifySpacesAfterFlowControlStatements(flutterRoot),
+    ),
+    Validation('deprecations', 'Deprecations...', () => verifyDeprecations(flutterRoot)),
+    Validation('golden-tags', 'Goldens...', () => verifyGoldenTags(flutterPackages)),
+    Validation(
+      'skip-test-comments',
+      'Skip test comments...',
+      () => verifySkipTestComments(flutterRoot),
+    ),
+    Validation('no-missing-license', 'Licenses...', () => verifyNoMissingLicense(flutterRoot)),
+    Validation('no-test-imports', 'Test imports...', () => verifyNoTestImports(flutterRoot)),
+    Validation(
+      'no-bad-imports-flutter',
+      'Bad imports (framework)...',
+      () => verifyNoBadImportsInFlutter(flutterRoot),
+    ),
+    Validation(
+      'no-bad-imports-tools',
+      'Bad imports (tools)...',
+      () => verifyNoBadImportsInFlutterTools(flutterRoot),
+    ),
+    Validation(
+      'internationalization',
+      'Internationalization...',
+      () => verifyInternationalizations(flutterRoot, dart),
+    ),
+    Validation(
+      'stock-app-localizations',
+      'Localization files of stocks app...',
+      () => verifyStockAppLocalizations(flutterRoot),
+    ),
+    Validation(
+      'integration-timeouts',
+      'Integration test timeouts...',
+      () => verifyIntegrationTestTimeouts(flutterRoot),
+    ),
+    Validation(
+      'null-fields',
+      'null initialized debug fields...',
+      () => verifyNullInitializedDebugExpensiveFields(flutterRoot),
+    ),
+    Validation('taboo', 'Taboo words...', () => verifyTabooDocumentation(flutterRoot)),
+    Validation('lint-kotlin', 'Lint Kotlin files...', () => lintKotlinFiles(flutterRoot)),
+    Validation(
+      'lint-kotlin-templates',
+      'Lint generated Kotlin files from templates...',
+      () => lintKotlinTemplatedFiles(flutterRoot),
+    ),
+    Validation(
+      'update-packages',
+      'Package dependencies...',
+      () => runCommand(flutter, <String>['update-packages'], workingDirectory: flutterRoot),
+    ),
+    Validation('package-allowlist', 'Package Allowlist...', () => _checkConsumerDependencies()),
+    Validation('dart-analysis', 'Dart analysis...', () async {
+      final CommandResult result = await _runFlutterAnalyze(
+        flutterRoot,
+        options: <String>['--flutter-repo', ...passthroughArguments],
+      );
+      onDartAnalyzeResult(result);
+    }),
+    Validation(
+      'format',
+      'Check formatting of Dart files...',
+      () => runCommand(dart, <String>[
+        '--enable-asserts',
+        path.join(flutterRoot, 'dev', 'tools', 'bin', 'format.dart'),
+      ], workingDirectory: flutterRoot),
+    ),
+    Validation(
+      'private-lints',
+      'Private lints...',
+      () => _verifyPrivateLints(flutterRoot, getDartAnalyzeResult()),
+    ),
+    Validation('executable-allowlist', 'Executable allowlist...', () => _checkForNewExecutables()),
+    Validation(
+      'dart-analysis-watch',
+      'Dart analysis (with --watch)...',
+      () => _runFlutterAnalyze(
+        flutterRoot,
+        failureMessage: 'Dart analyzer failed when --watch was used.',
+        options: <String>['--flutter-repo', '--watch', '--benchmark', ...passthroughArguments],
+      ),
+    ),
+    Validation(
+      'snippets',
+      'Snippet code...',
+      () => runCommand(dart, <String>[
+        '--enable-asserts',
+        path.join(flutterRoot, 'dev', 'bots', 'analyze_snippet_code.dart'),
+        '--verbose',
+      ], workingDirectory: flutterRoot),
+    ),
+    Validation(
+      'code-samples',
+      'Code sample link validation...',
+      () => runCommand(dart, <String>[
+        '--enable-asserts',
+        path.join(flutterRoot, 'dev', 'bots', 'check_code_samples.dart'),
+      ], workingDirectory: flutterRoot),
+    ),
+    Validation(
+      'mega-gallery',
+      'Dart analysis (mega gallery)...',
+      () => _verifyMegaGallery(flutterRoot, dart, passthroughArguments),
+    ),
+    Validation(
+      'gen-defaults-names',
+      'Correct file names in gen_defaults.dart...',
+      () => verifyTokenTemplatesUpdateCorrectFiles(flutterRoot),
+    ),
+    Validation(
+      'gen-defaults-up-to-date',
+      'Material library files are up-to-date with token template files...',
+      () => verifyMaterialFilesAreUpToDateWithTemplateFiles(flutterRoot, dart),
+    ),
+    Validation(
+      'integration-templates',
+      'Up to date integration test template files...',
+      () => verifyIntegrationTestTemplateFiles(flutterRoot),
+    ),
+    Validation(
+      'cross-imports',
+      'Cross-import test validation...',
+      () => runCommand(dart, <String>[
+        '--enable-asserts',
+        path.join(flutterRoot, 'dev', 'bots', 'check_tests_cross_imports.dart'),
+      ], workingDirectory: flutterRoot),
+    ),
+  ];
 }
 
 // TESTS
@@ -2887,7 +2904,17 @@ bool _isGeneratedPluginRegistrant(File file) {
 }
 
 Future<void> _verifyPrivateLints(String flutterRoot, CommandResult? dartAnalyzeResult) async {
-  if (dartAnalyzeResult == null || dartAnalyzeResult.exitCode == 0) {
+  if (dartAnalyzeResult == null) {
+    foundError(<String>[
+      'The "dart-analysis" rule must run before "private-lints".',
+      'Ensure "dart-analysis" is not skipped and is included in --only if used.',
+    ]);
+    return;
+  }
+  // Only run the private lints when the code is free of type errors. The
+  // lints are easier to write when they can assume, for example, there is no
+  // inheritance cycles.
+  if (dartAnalyzeResult.exitCode == 0) {
     final rules = <AnalyzeRule>[
       noDoubleClamp,
       noStopwatches,

--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -85,7 +85,37 @@ String? _getDartSdkFromArguments(List<String> arguments) {
   return result;
 }
 
-Future<void> run(List<String> arguments) async {
+void _printHelp(List<Validation> validations) {
+  print('Usage: dart dev/bots/analyze.dart [arguments]');
+  print('');
+  print('Options:');
+  print('  -h, --help                  Show this help message.');
+  print('  --only=rule1,rule2,...      Run only the specified validations.');
+  print('  --skip=rule1,rule2,...      Skip the specified validations.');
+  print('');
+  print('Available rules:');
+  for (final validation in validations) {
+    print('  ${validation.name.padRight(25)} ${validation.description}');
+  }
+}
+
+/// Represents a specific validation step in the analyze script.
+@visibleForTesting
+class Validation {
+  /// Creates a new validation step.
+  const Validation(this.name, this.description, this.callback);
+
+  /// The short name of the rule used for filtering with --only or --skip.
+  final String name;
+
+  /// A human-readable description of the validation step.
+  final String description;
+
+  /// The function that performs the validation.
+  final Future<void> Function() callback;
+}
+
+Future<void> run(List<String> arguments, {List<Validation>? validationsForTesting}) async {
   var assertsEnabled = false;
   assert(() {
     assertsEnabled = true;
@@ -95,207 +125,250 @@ Future<void> run(List<String> arguments) async {
     foundError(<String>['The analyze.dart script must be run with --enable-asserts.']);
   }
 
-  printProgress('Release branch validation');
-  await verifyReleaseBranchState(flutterRoot);
+  CommandResult? dartAnalyzeResult;
+  final passthroughArguments = <String>[];
 
-  printProgress('TargetPlatform tool/framework consistency');
-  await verifyTargetPlatform(flutterRoot);
+  final List<Validation> validations =
+      validationsForTesting ??
+      <Validation>[
+        Validation(
+          'release-branch',
+          'Release branch validation',
+          () => verifyReleaseBranchState(flutterRoot),
+        ),
+        Validation(
+          'target-platform',
+          'TargetPlatform tool/framework consistency',
+          () => verifyTargetPlatform(flutterRoot),
+        ),
+        Validation(
+          'tool-end-to-end',
+          'All tool test files end in _test.dart...',
+          () => verifyToolTestsEndInTestDart(flutterRoot),
+        ),
+        Validation('no-sync-star-async-star', 'No sync*/async*', () async {
+          await verifyNoSyncAsyncStar(flutterPackages);
+          await verifyNoSyncAsyncStar(flutterExamples, minimumMatches: 200);
+        }),
+        Validation(
+          'no-runtime-type',
+          'No runtimeType in toString...',
+          () => verifyNoRuntimeTypeInToString(flutterRoot),
+        ),
+        Validation(
+          'no-checked-mode',
+          'Debug mode instead of checked mode...',
+          () => verifyNoCheckedMode(flutterRoot),
+        ),
+        Validation(
+          'issue-links',
+          'Links for creating GitHub issues...',
+          () => verifyIssueLinks(flutterRoot),
+        ),
+        Validation(
+          'repository-links',
+          'Links to repositories...',
+          () => verifyRepositoryLinks(flutterRoot),
+        ),
+        Validation('no-binaries', 'Unexpected binaries...', () => verifyNoBinaries(flutterRoot)),
+        Validation(
+          'no-trailing-spaces',
+          'Trailing spaces...',
+          () => verifyNoTrailingSpaces(flutterRoot),
+        ),
+        Validation(
+          'spaces-after-flow',
+          'Spaces after flow control statements...',
+          () => verifySpacesAfterFlowControlStatements(flutterRoot),
+        ),
+        Validation('deprecations', 'Deprecations...', () => verifyDeprecations(flutterRoot)),
+        Validation('golden-tags', 'Goldens...', () => verifyGoldenTags(flutterPackages)),
+        Validation(
+          'skip-test-comments',
+          'Skip test comments...',
+          () => verifySkipTestComments(flutterRoot),
+        ),
+        Validation('no-missing-license', 'Licenses...', () => verifyNoMissingLicense(flutterRoot)),
+        Validation('no-test-imports', 'Test imports...', () => verifyNoTestImports(flutterRoot)),
+        Validation(
+          'no-bad-imports-flutter',
+          'Bad imports (framework)...',
+          () => verifyNoBadImportsInFlutter(flutterRoot),
+        ),
+        Validation(
+          'no-bad-imports-tools',
+          'Bad imports (tools)...',
+          () => verifyNoBadImportsInFlutterTools(flutterRoot),
+        ),
+        Validation(
+          'internationalization',
+          'Internationalization...',
+          () => verifyInternationalizations(flutterRoot, dart),
+        ),
+        Validation(
+          'stock-app-localizations',
+          'Localization files of stocks app...',
+          () => verifyStockAppLocalizations(flutterRoot),
+        ),
+        Validation(
+          'integration-timeouts',
+          'Integration test timeouts...',
+          () => verifyIntegrationTestTimeouts(flutterRoot),
+        ),
+        Validation(
+          'null-fields',
+          'null initialized debug fields...',
+          () => verifyNullInitializedDebugExpensiveFields(flutterRoot),
+        ),
+        Validation('taboo', 'Taboo words...', () => verifyTabooDocumentation(flutterRoot)),
+        Validation('lint-kotlin', 'Lint Kotlin files...', () => lintKotlinFiles(flutterRoot)),
+        Validation(
+          'lint-kotlin-templates',
+          'Lint generated Kotlin files from templates...',
+          () => lintKotlinTemplatedFiles(flutterRoot),
+        ),
+        Validation(
+          'update-packages',
+          'Package dependencies...',
+          () => runCommand(flutter, <String>['update-packages'], workingDirectory: flutterRoot),
+        ),
+        Validation('package-allowlist', 'Package Allowlist...', () => _checkConsumerDependencies()),
+        Validation('dart-analysis', 'Dart analysis...', () async {
+          dartAnalyzeResult = await _runFlutterAnalyze(
+            flutterRoot,
+            options: <String>['--flutter-repo', ...passthroughArguments],
+          );
+        }),
+        Validation(
+          'format',
+          'Check formatting of Dart files...',
+          () => runCommand(dart, <String>[
+            '--enable-asserts',
+            path.join(flutterRoot, 'dev', 'tools', 'bin', 'format.dart'),
+          ], workingDirectory: flutterRoot),
+        ),
+        Validation(
+          'private-lints',
+          'Private lints...',
+          () => _verifyPrivateLints(flutterRoot, dartAnalyzeResult),
+        ),
+        Validation(
+          'executable-allowlist',
+          'Executable allowlist...',
+          () => _checkForNewExecutables(),
+        ),
+        Validation(
+          'dart-analysis-watch',
+          'Dart analysis (with --watch)...',
+          () => _runFlutterAnalyze(
+            flutterRoot,
+            failureMessage: 'Dart analyzer failed when --watch was used.',
+            options: <String>['--flutter-repo', '--watch', '--benchmark', ...passthroughArguments],
+          ),
+        ),
+        Validation(
+          'snippets',
+          'Snippet code...',
+          () => runCommand(dart, <String>[
+            '--enable-asserts',
+            path.join(flutterRoot, 'dev', 'bots', 'analyze_snippet_code.dart'),
+            '--verbose',
+          ], workingDirectory: flutterRoot),
+        ),
+        Validation(
+          'code-samples',
+          'Code sample link validation...',
+          () => runCommand(dart, <String>[
+            '--enable-asserts',
+            path.join(flutterRoot, 'dev', 'bots', 'check_code_samples.dart'),
+          ], workingDirectory: flutterRoot),
+        ),
+        Validation(
+          'mega-gallery',
+          'Dart analysis (mega gallery)...',
+          () => _verifyMegaGallery(flutterRoot, dart, passthroughArguments),
+        ),
+        Validation(
+          'gen-defaults-names',
+          'Correct file names in gen_defaults.dart...',
+          () => verifyTokenTemplatesUpdateCorrectFiles(flutterRoot),
+        ),
+        Validation(
+          'gen-defaults-up-to-date',
+          'Material library files are up-to-date with token template files...',
+          () => verifyMaterialFilesAreUpToDateWithTemplateFiles(flutterRoot, dart),
+        ),
+        Validation(
+          'integration-templates',
+          'Up to date integration test template files...',
+          () => verifyIntegrationTestTemplateFiles(flutterRoot),
+        ),
+        Validation(
+          'cross-imports',
+          'Cross-import test validation...',
+          () => runCommand(dart, <String>[
+            '--enable-asserts',
+            path.join(flutterRoot, 'dev', 'bots', 'check_tests_cross_imports.dart'),
+          ], workingDirectory: flutterRoot),
+        ),
+      ];
 
-  printProgress('All tool test files end in _test.dart...');
-  await verifyToolTestsEndInTestDart(flutterRoot);
-
-  printProgress('No sync*/async*');
-  await verifyNoSyncAsyncStar(flutterPackages);
-  await verifyNoSyncAsyncStar(flutterExamples, minimumMatches: 200);
-
-  printProgress('No runtimeType in toString...');
-  await verifyNoRuntimeTypeInToString(flutterRoot);
-
-  printProgress('Debug mode instead of checked mode...');
-  await verifyNoCheckedMode(flutterRoot);
-
-  printProgress('Links for creating GitHub issues...');
-  await verifyIssueLinks(flutterRoot);
-
-  printProgress('Links to repositories...');
-  await verifyRepositoryLinks(flutterRoot);
-
-  printProgress('Unexpected binaries...');
-  await verifyNoBinaries(flutterRoot);
-
-  printProgress('Trailing spaces...');
-  await verifyNoTrailingSpaces(
-    flutterRoot,
-  ); // assumes no unexpected binaries, so should be after verifyNoBinaries
-
-  printProgress('Spaces after flow control statements...');
-  await verifySpacesAfterFlowControlStatements(flutterRoot);
-
-  printProgress('Deprecations...');
-  await verifyDeprecations(flutterRoot);
-
-  printProgress('Goldens...');
-  await verifyGoldenTags(flutterPackages);
-
-  printProgress('Skip test comments...');
-  await verifySkipTestComments(flutterRoot);
-
-  printProgress('Licenses...');
-  await verifyNoMissingLicense(flutterRoot);
-
-  printProgress('Test imports...');
-  await verifyNoTestImports(flutterRoot);
-
-  printProgress('Bad imports (framework)...');
-  await verifyNoBadImportsInFlutter(flutterRoot);
-
-  printProgress('Bad imports (tools)...');
-  await verifyNoBadImportsInFlutterTools(flutterRoot);
-
-  printProgress('Internationalization...');
-  await verifyInternationalizations(flutterRoot, dart);
-
-  printProgress('Localization files of stocks app...');
-  await verifyStockAppLocalizations(flutterRoot);
-
-  printProgress('Integration test timeouts...');
-  await verifyIntegrationTestTimeouts(flutterRoot);
-
-  printProgress('null initialized debug fields...');
-  await verifyNullInitializedDebugExpensiveFields(flutterRoot);
-
-  printProgress('Taboo words...');
-  await verifyTabooDocumentation(flutterRoot);
-
-  printProgress('Lint Kotlin files...');
-  await lintKotlinFiles(flutterRoot);
-
-  printProgress('Lint generated Kotlin files from templates...');
-  await lintKotlinTemplatedFiles(flutterRoot);
-
-  // Ensure that all package dependencies are in sync.
-  printProgress('Package dependencies...');
-  await runCommand(flutter, <String>['update-packages'], workingDirectory: flutterRoot);
-
-  /// Ensure that no new dependencies have been accidentally
-  /// added to core packages.
-  printProgress('Package Allowlist...');
-  await _checkConsumerDependencies();
-
-  // Analyze all the Dart code in the repo.
-  printProgress('Dart analysis...');
-  final CommandResult dartAnalyzeResult = await _runFlutterAnalyze(
-    flutterRoot,
-    options: <String>['--flutter-repo', ...arguments],
-  );
-
-  printProgress('Check formatting of Dart files...');
-  await runCommand(dart, <String>[
-    '--enable-asserts',
-    path.join(flutterRoot, 'dev', 'tools', 'bin', 'format.dart'),
-  ], workingDirectory: flutterRoot);
-
-  if (dartAnalyzeResult.exitCode == 0) {
-    // Only run the private lints when the code is free of type errors. The
-    // lints are easier to write when they can assume, for example, there is no
-    // inheritance cycles.
-    final rules = <AnalyzeRule>[
-      noDoubleClamp,
-      noStopwatches,
-      renderBoxIntrinsicCalculation,
-      protectPublicStateSubtypes,
-    ];
-    final String ruleNames = rules.map((AnalyzeRule rule) => '\n * $rule').join();
-    printProgress('Analyzing code in the framework with the following rules:$ruleNames');
-    await analyzeWithRules(
-      flutterRoot,
-      rules,
-      includePaths: const <String>['packages/flutter/lib'],
-      excludePaths: const <String>['packages/flutter/lib/fix_data'],
-    );
-    final testRules = <AnalyzeRule>[noStopwatches];
-    final String testRuleNames = testRules.map((AnalyzeRule rule) => '\n * $rule').join();
-    printProgress('Analyzing code in the test folder with the following rules:$testRuleNames');
-    await analyzeWithRules(flutterRoot, testRules, includePaths: <String>['packages/flutter/test']);
-    final toolRules = <AnalyzeRule>[AvoidFutureCatchError()];
-    final String toolRuleNames = toolRules.map((AnalyzeRule rule) => '\n * $rule').join();
-    printProgress('Analyzing code in the tool with the following rules:$toolRuleNames');
-    await analyzeWithRules(
-      flutterRoot,
-      toolRules,
-      includePaths: const <String>['packages/flutter_tools/lib', 'packages/flutter_tools/test'],
-    );
-  } else {
-    printProgress(
-      'Skipped performing further analysis in the framework because "flutter analyze" finished with a non-zero exit code.',
-    );
+  final seenNames = <String>{};
+  for (final validation in validations) {
+    if (!seenNames.add(validation.name)) {
+      foundError(<String>['Duplicate validation name "${validation.name}" found in analyze.dart.']);
+    }
   }
 
-  printProgress('Executable allowlist...');
-  await _checkForNewExecutables();
+  var onlyRules = <String>[];
+  var skipRules = <String>[];
 
-  // Try with the --watch analyzer, to make sure it returns success also.
-  // The --benchmark argument exits after one run.
-  // We specify a failureMessage so that the actual output is muted in the case where _runFlutterAnalyze above already failed.
-  printProgress('Dart analysis (with --watch)...');
-  await _runFlutterAnalyze(
-    flutterRoot,
-    failureMessage: 'Dart analyzer failed when --watch was used.',
-    options: <String>['--flutter-repo', '--watch', '--benchmark', ...arguments],
-  );
-
-  // Analyze the code in `{@tool snippet}` sections in the repo.
-  printProgress('Snippet code...');
-  await runCommand(dart, <String>[
-    '--enable-asserts',
-    path.join(flutterRoot, 'dev', 'bots', 'analyze_snippet_code.dart'),
-    '--verbose',
-  ], workingDirectory: flutterRoot);
-
-  // Make sure that all of the existing samples are linked from at least one API doc comment.
-  printProgress('Code sample link validation...');
-  await runCommand(dart, <String>[
-    '--enable-asserts',
-    path.join(flutterRoot, 'dev', 'bots', 'check_code_samples.dart'),
-  ], workingDirectory: flutterRoot);
-
-  // Try analysis against a big version of the gallery; generate into a temporary directory.
-  printProgress('Dart analysis (mega gallery)...');
-  final Directory outDir = Directory.systemTemp.createTempSync('flutter_mega_gallery.');
-  try {
-    await runCommand(dart, <String>[
-      path.join(flutterRoot, 'dev', 'tools', 'mega_gallery.dart'),
-      '--out',
-      outDir.path,
-    ], workingDirectory: flutterRoot);
-    await _runFlutterAnalyze(
-      outDir.path,
-      failureMessage: 'Dart analyzer failed on mega_gallery benchmark.',
-      options: <String>['--watch', '--benchmark', ...arguments],
-    );
-  } finally {
-    outDir.deleteSync(recursive: true);
+  for (final arg in arguments) {
+    if (arg == '-h' || arg == '--help') {
+      _printHelp(validations);
+      return;
+    }
+    if (arg.startsWith('--only=')) {
+      onlyRules = arg.substring('--only='.length).split(',');
+      continue;
+    }
+    if (arg.startsWith('--skip=')) {
+      skipRules = arg.substring('--skip='.length).split(',');
+      continue;
+    }
+    passthroughArguments.add(arg);
   }
 
-  // Ensure gen_default links the correct files
-  printProgress('Correct file names in gen_defaults.dart...');
-  await verifyTokenTemplatesUpdateCorrectFiles(flutterRoot);
+  if (onlyRules.isNotEmpty && skipRules.isNotEmpty) {
+    foundError(<String>['Cannot use both --only and --skip at the same time.']);
+    return;
+  }
 
-  // Ensure material library files are up-to-date with the token template files.
-  printProgress('Material library files are up-to-date with token template files...');
-  await verifyMaterialFilesAreUpToDateWithTemplateFiles(flutterRoot, dart);
+  final Set<String> validNames = validations.map((Validation v) => v.name).toSet();
 
-  // Ensure integration test files are up-to-date with the app template.
-  printProgress('Up to date integration test template files...');
-  await verifyIntegrationTestTemplateFiles(flutterRoot);
+  for (final rule in onlyRules) {
+    if (!validNames.contains(rule)) {
+      foundError(<String>['Unknown rule "$rule" passed to --only.']);
+      return;
+    }
+  }
+  for (final rule in skipRules) {
+    if (!validNames.contains(rule)) {
+      foundError(<String>['Unknown rule "$rule" passed to --skip.']);
+      return;
+    }
+  }
 
-  // Check for cross-library imports in tests. For example,
-  // widget library tests should not import the Material library.
-  printProgress('Cross-import test validation...');
-  await runCommand(dart, <String>[
-    '--enable-asserts',
-    path.join(flutterRoot, 'dev', 'bots', 'check_tests_cross_imports.dart'),
-  ], workingDirectory: flutterRoot);
+  for (final validation in validations) {
+    final bool shouldRun = onlyRules.isNotEmpty
+        ? onlyRules.contains(validation.name)
+        : !skipRules.contains(validation.name);
+
+    if (shouldRun) {
+      printProgress('${validation.description} [${validation.name}]');
+      await validation.callback();
+    }
+  }
 }
 
 // TESTS
@@ -2811,4 +2884,57 @@ bool _isGeneratedPluginRegistrant(File file) {
           filename == 'generated_plugin_registrant.dart' ||
           filename == 'generated_plugin_registrant.h' ||
           filename == 'generated_plugin_registrant.cc');
+}
+
+Future<void> _verifyPrivateLints(String flutterRoot, CommandResult? dartAnalyzeResult) async {
+  if (dartAnalyzeResult == null || dartAnalyzeResult.exitCode == 0) {
+    final rules = <AnalyzeRule>[
+      noDoubleClamp,
+      noStopwatches,
+      renderBoxIntrinsicCalculation,
+      protectPublicStateSubtypes,
+    ];
+    final String ruleNames = rules.map((AnalyzeRule rule) => '\n * $rule').join();
+    printProgress('Analyzing code in the framework with the following rules:$ruleNames');
+    await analyzeWithRules(
+      flutterRoot,
+      rules,
+      includePaths: const <String>['packages/flutter/lib'],
+      excludePaths: const <String>['packages/flutter/lib/fix_data'],
+    );
+    final testRules = <AnalyzeRule>[noStopwatches];
+    final String testRuleNames = testRules.map((AnalyzeRule rule) => '\n * $rule').join();
+    printProgress('Analyzing code in the test folder with the following rules:$testRuleNames');
+    await analyzeWithRules(flutterRoot, testRules, includePaths: <String>['packages/flutter/test']);
+    final toolRules = <AnalyzeRule>[AvoidFutureCatchError()];
+    final String toolRuleNames = toolRules.map((AnalyzeRule rule) => '\n * $rule').join();
+    printProgress('Analyzing code in the tool with the following rules:$toolRuleNames');
+    await analyzeWithRules(
+      flutterRoot,
+      toolRules,
+      includePaths: const <String>['packages/flutter_tools/lib', 'packages/flutter_tools/test'],
+    );
+  }
+}
+
+Future<void> _verifyMegaGallery(
+  String flutterRoot,
+  String dart,
+  List<String> passthroughArguments,
+) async {
+  final Directory outDir = Directory.systemTemp.createTempSync('flutter_mega_gallery.');
+  try {
+    await runCommand(dart, <String>[
+      path.join(flutterRoot, 'dev', 'tools', 'mega_gallery.dart'),
+      '--out',
+      outDir.path,
+    ], workingDirectory: flutterRoot);
+    await _runFlutterAnalyze(
+      outDir.path,
+      failureMessage: 'Dart analyzer failed on mega_gallery benchmark.',
+      options: <String>['--watch', '--benchmark', ...passthroughArguments],
+    );
+  } finally {
+    outDir.deleteSync(recursive: true);
+  }
 }

--- a/dev/bots/test/analyze-gen-defaults/packages/flutter/lib/src/material/chip.dart
+++ b/dev/bots/test/analyze-gen-defaults/packages/flutter/lib/src/material/chip.dart
@@ -13,7 +13,7 @@ final _ChipDefaultsM3 _chipDefaultsM3 = _ChipDefaultsM3();
 //   dev/tools/gen_defaults/bin/gen_defaults.dart.
 
 class _ChipDefaultsM3 {
-  final String testString = 'This is chip_template.dart class.';
+  final String testString = 'This is chip.dart class.';
 }
 
 // END GENERATED TOKEN PROPERTIES - Chip

--- a/dev/bots/test/analyze-gen-defaults/packages/flutter/lib/src/material/chip.dart
+++ b/dev/bots/test/analyze-gen-defaults/packages/flutter/lib/src/material/chip.dart
@@ -13,7 +13,7 @@ final _ChipDefaultsM3 _chipDefaultsM3 = _ChipDefaultsM3();
 //   dev/tools/gen_defaults/bin/gen_defaults.dart.
 
 class _ChipDefaultsM3 {
-  final String testString = 'This is chip.dart class.';
+  final String testString = 'This is chip_template.dart class.';
 }
 
 // END GENERATED TOKEN PROPERTIES - Chip

--- a/dev/bots/test/analyze_test.dart
+++ b/dev/bots/test/analyze_test.dart
@@ -397,4 +397,69 @@ void main() {
       '╚═══════════════════════════════════════════════════════════════════════════════\n',
     );
   });
+
+  test('analyze.dart - help flag', () async {
+    final String result = await capture(() async {
+      await run(<String>['-h']);
+    });
+    expect(result, contains('Usage: dart dev/bots/analyze.dart [arguments]'));
+    expect(result, contains('Options:'));
+    expect(result, contains('Available rules:'));
+  });
+
+  test('analyze.dart - --only flag', () async {
+    final executed = <String>[];
+    final dummyValidations = <Validation>[
+      Validation('rule1', 'Rule 1', () async {
+        executed.add('rule1');
+      }),
+      Validation('rule2', 'Rule 2', () async {
+        executed.add('rule2');
+      }),
+    ];
+
+    await capture(() async {
+      await run(<String>['--only=rule1'], validationsForTesting: dummyValidations);
+    });
+
+    expect(executed, <String>['rule1']);
+  });
+
+  test('analyze.dart - --skip flag', () async {
+    final executed = <String>[];
+    final dummyValidations = <Validation>[
+      Validation('rule1', 'Rule 1', () async {
+        executed.add('rule1');
+      }),
+      Validation('rule2', 'Rule 2', () async {
+        executed.add('rule2');
+      }),
+    ];
+
+    await capture(() async {
+      await run(<String>['--skip=rule1'], validationsForTesting: dummyValidations);
+    });
+
+    expect(executed, <String>['rule2']);
+  });
+
+  test('analyze.dart - --only and --skip mutually exclusive', () async {
+    final dummyValidations = <Validation>[Validation('rule1', 'Rule 1', () async {})];
+
+    final String result = await capture(() async {
+      await run(<String>['--only=rule1', '--skip=rule1'], validationsForTesting: dummyValidations);
+    }, shouldHaveErrors: true);
+
+    expect(result, contains('Cannot use both --only and --skip at the same time.'));
+  });
+
+  test('analyze.dart - invalid rule name', () async {
+    final dummyValidations = <Validation>[Validation('rule1', 'Rule 1', () async {})];
+
+    final String result = await capture(() async {
+      await run(<String>['--only=invalid'], validationsForTesting: dummyValidations);
+    }, shouldHaveErrors: true);
+
+    expect(result, contains('Unknown rule "invalid" passed to --only.'));
+  });
 }

--- a/dev/bots/test/analyze_test.dart
+++ b/dev/bots/test/analyze_test.dart
@@ -462,4 +462,66 @@ void main() {
 
     expect(result, contains('Unknown rule "invalid" passed to --only.'));
   });
+
+  test('analyze.dart - --only flag with multiple comma-separated values', () async {
+    final executed = <String>[];
+    final dummyValidations = <Validation>[
+      Validation('rule1', 'Rule 1', () async {
+        executed.add('rule1');
+      }),
+      Validation('rule2', 'Rule 2', () async {
+        executed.add('rule2');
+      }),
+      Validation('rule3', 'Rule 3', () async {
+        executed.add('rule3');
+      }),
+    ];
+
+    await capture(() async {
+      await run(<String>['--only=rule1,rule3'], validationsForTesting: dummyValidations);
+    });
+
+    expect(executed, <String>['rule1', 'rule3']);
+  });
+
+  test('analyze.dart - --skip flag with multiple comma-separated values', () async {
+    final executed = <String>[];
+    final dummyValidations = <Validation>[
+      Validation('rule1', 'Rule 1', () async {
+        executed.add('rule1');
+      }),
+      Validation('rule2', 'Rule 2', () async {
+        executed.add('rule2');
+      }),
+      Validation('rule3', 'Rule 3', () async {
+        executed.add('rule3');
+      }),
+    ];
+
+    await capture(() async {
+      await run(<String>['--skip=rule1,rule3'], validationsForTesting: dummyValidations);
+    });
+
+    expect(executed, <String>['rule2']);
+  });
+
+  test('analyze.dart - --only flag passed multiple times errors', () async {
+    final dummyValidations = <Validation>[Validation('rule1', 'Rule 1', () async {})];
+
+    final String result = await capture(() async {
+      await run(<String>['--only=rule1', '--only=rule1'], validationsForTesting: dummyValidations);
+    }, shouldHaveErrors: true);
+
+    expect(result, contains('The --only argument must not be used more than once.'));
+  });
+
+  test('analyze.dart - --skip flag passed multiple times errors', () async {
+    final dummyValidations = <Validation>[Validation('rule1', 'Rule 1', () async {})];
+
+    final String result = await capture(() async {
+      await run(<String>['--skip=rule1', '--skip=rule1'], validationsForTesting: dummyValidations);
+    }, shouldHaveErrors: true);
+
+    expect(result, contains('The --skip argument must not be used more than once.'));
+  });
 }


### PR DESCRIPTION
Default behavior should be unchanged for backwards compatibility. 
Added a Verification class for each verification step with a name that can be passed to new flags. 
New flags allow you to run only a subset or to exclude slow analyze steps. 
New help flag that describes how to use the analyze.dart code. 
Broke out the 2 inline verification steps into new methods. 

AI: Assisted pr, antigravity, dragonally

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
