### PR TITLE
[web] Fix multi-view sizing race condition (State isolation approach)

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/compositing/offscreen_canvas_rasterizer.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/compositing/offscreen_canvas_rasterizer.dart
@@ -23,10 +23,6 @@ class OffscreenCanvasRasterizer extends Rasterizer {
   @visibleForTesting
   SurfaceProvider get surfaceProvider => _surfaceProvider;
 
-  /// This is an SkSurface backed by an OffScreenCanvas. This single Surface is
-  /// used to render to many RenderCanvases to produce the rendered scene.
-  late final OffscreenSurface offscreenSurface = _surfaceProvider.createSurface();
-
   @override
   OffscreenCanvasViewRasterizer createViewRasterizer(EngineFlutterView view) {
     return _viewRasterizers.putIfAbsent(view, () => OffscreenCanvasViewRasterizer(view, this));
@@ -59,6 +55,9 @@ class OffscreenCanvasViewRasterizer extends ViewRasterizer {
 
   final OffscreenCanvasRasterizer rasterizer;
 
+  /// This is an SkSurface backed by an OffScreenCanvas.
+  late final OffscreenSurface offscreenSurface = rasterizer._surfaceProvider.createSurface();
+
   @override
   final DisplayCanvasFactory<RenderCanvas> displayFactory = DisplayCanvasFactory<RenderCanvas>(
     createCanvas: () => RenderCanvas(),
@@ -66,7 +65,7 @@ class OffscreenCanvasViewRasterizer extends ViewRasterizer {
 
   @override
   Future<void> prepareToDraw() async {
-    await rasterizer.offscreenSurface.setSize(currentFrameSize);
+    await offscreenSurface.setSize(currentFrameSize);
   }
 
   @override
@@ -80,16 +79,16 @@ class OffscreenCanvasViewRasterizer extends ViewRasterizer {
     }
     recorder?.recordRasterStart();
     if (browserSupportsCreateImageBitmap) {
-      final List<DomImageBitmap> bitmaps = await rasterizer.offscreenSurface
+      final List<DomImageBitmap> bitmaps = await offscreenSurface
           .rasterizeToImageBitmaps(pictures);
       for (var i = 0; i < displayCanvases.length; i++) {
         (displayCanvases[i] as RenderCanvas).render(bitmaps[i]);
       }
     } else {
       for (var i = 0; i < displayCanvases.length; i++) {
-        await rasterizer.offscreenSurface.rasterizeToCanvas(pictures[i]);
+        await offscreenSurface.rasterizeToCanvas(pictures[i]);
         (displayCanvases[i] as RenderCanvas).renderWithNoBitmapSupport(
-          rasterizer.offscreenSurface.canvasImageSource,
+          offscreenSurface.canvasImageSource,
           currentFrameSize.height,
           currentFrameSize,
         );

--- a/engine/src/flutter/lib/web_ui/test/ui/multi_view_sizing_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/ui/multi_view_sizing_test.dart
@@ -1,0 +1,82 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/src/engine.dart';
+import 'package:ui/ui.dart' as ui;
+
+import '../common/test_initialization.dart';
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+void testMain() {
+  group('MultiView Sizing', () {
+    setUpUnitTests(withImplicitView: true);
+
+    test('canvases for multiple views have correct sizes', () async {
+      // Create two views with different sizes.
+      final host1 = createDomElement('view-1');
+      host1.style
+        ..width = '100px'
+        ..height = '100px'
+        ..display = 'block';
+      domDocument.body!.append(host1);
+      final view1 = EngineFlutterView(EnginePlatformDispatcher.instance, host1);
+      EnginePlatformDispatcher.instance.viewManager.registerView(view1);
+
+      final host2 = createDomElement('view-2');
+      host2.style
+        ..width = '200px'
+        ..height = '200px'
+        ..display = 'block';
+      domDocument.body!.append(host2);
+      final view2 = EngineFlutterView(EnginePlatformDispatcher.instance, host2);
+      EnginePlatformDispatcher.instance.viewManager.registerView(view2);
+
+      // Create a simple scene.
+      ui.Scene createScene(ui.Color color, ui.Size size) {
+        final recorder = ui.PictureRecorder();
+        final canvas = ui.Canvas(recorder, ui.Offset.zero & size);
+        canvas.drawRect(ui.Offset.zero & size, ui.Paint()..color = color);
+        final picture = recorder.endRecording();
+        final sb = ui.SceneBuilder();
+        sb.addPicture(ui.Offset.zero, picture);
+        return sb.build();
+      }
+
+      final scene1 = createScene(const ui.Color(0xFFFF0000), const ui.Size(100, 100));
+      final scene2 = createScene(const ui.Color(0xFF00FF00), const ui.Size(200, 200));
+
+      // Render both scenes.
+      // We render them in the same turn to increase chance of interference if there's no locking.
+      final Future<void> r1 = renderer.renderScene(scene1, view1);
+      final Future<void> r2 = renderer.renderScene(scene2, view2);
+      await Future.wait(<Future<void>>[r1, r2]);
+
+      // Verify canvas sizes.
+      DomHTMLCanvasElement getCanvas(EngineFlutterView view) {
+        final canvas = view.dom.renderingHost.querySelector('canvas');
+        if (canvas == null) {
+          throw Exception('Canvas not found for view ${view.viewId}');
+        }
+        return canvas as DomHTMLCanvasElement;
+      }
+
+      final canvas1 = getCanvas(view1);
+      final canvas2 = getCanvas(view2);
+
+      final dpr = EngineFlutterDisplay.instance.devicePixelRatio;
+      expect(canvas1.width, 100 * dpr);
+      expect(canvas1.height, 100 * dpr);
+      expect(canvas2.width, 200 * dpr);
+      expect(canvas2.height, 200 * dpr);
+
+      host1.remove();
+      host2.remove();
+    });
+  });
+}


### PR DESCRIPTION
## Summary
  This PR resolves the multi-view sizing regression reported in https://github.com/flutter/flutter/issues/185034. The issue stemmed from multiple views sharing a single `OffscreenSurface` instance. Concurrent or interleaved rendering calls would cause the surface to be resized for one view while another view was still expecting its own dimensions.

## Design
  This approach isolates the rendering state by giving every `OffscreenCanvasViewRasterizer` its own dedicated `OffscreenSurface`. By moving the surface ownership from the `Rasterizer` (singleton-like) to the `ViewRasterizer` (per-view), we eliminate contention and the possibility of cross-view interference.

 ## Pros:
   * Better performance as views do not need to wait for each other to render.
   * Architecturally cleaner state management for multi-view.

 ## Cons/Risks:
   * Increased memory usage per view.
   * Risk of hitting browser WebGL context limits if the user opens a large number of views (e.g., >10).

##  Testing
   * Verified via new test `engine/src/flutter/lib/web_ui/test/ui/multi_view_sizing_test.dart`.