### PR TITLE
Adds debugging information to compiled metal shaders

### DIFF
--- a/engine/src/flutter/impeller/tools/metal_library.gni
+++ b/engine/src/flutter/impeller/tools/metal_library.gni
@@ -13,6 +13,9 @@
 #
 # @param[required] metal_version  The Metal language version to compile for.
 #
+
+import("//flutter/impeller/tools/args.gni")
+
 template("metal_library") {
   assert(is_ios || is_mac)
   assert(defined(invoker.name), "Metal library name must be specified.")
@@ -33,7 +36,7 @@ template("metal_library") {
                              "args",
                            ])
 
-    inputs = invoker.sources
+    inputs = invoker.sources + [ "//flutter/impeller/tools/metal_library.py" ]
 
     metal_library_path = "$root_out_dir/shaders/$metal_library_name.metallib"
     metal_library_symbols_path =
@@ -55,6 +58,10 @@ template("metal_library") {
       rebase_path(depfile),
       "--metal-version=$metal_version",
     ]
+
+    if (impeller_debug) {
+      args += [ "--debug" ]
+    }
 
     if (is_ios) {
       if (use_ios_simulator) {

--- a/engine/src/flutter/impeller/tools/metal_library.py
+++ b/engine/src/flutter/impeller/tools/metal_library.py
@@ -42,6 +42,7 @@ def main():
   parser.add_argument(
       '--metal-version', required=True, help='The language standard version to compile for.'
   )
+  parser.add_argument('--debug', action='store_true', help='Generate debugging information.')
 
   args = parser.parse_args()
 
@@ -86,6 +87,12 @@ def main():
       '-o',
       args.output,
   ]
+
+  if args.debug:
+    command += [
+        '-g',
+        '-frecord-sources',
+    ]
 
   # Select the Metal standard and the minimum supported OS versions.
   # The Metal standard must match the specification in impellerc.


### PR DESCRIPTION
Adds metal shader debugging info.  This makes it so you can click into sources in the xcode frame debugger.  It doesn't get us line by line performance measurements though.  I couldn't figure that out yet.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
