### PR TITLE
Fixes Impeller Frame capture scope for macOS.

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/metal/context_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/context_mtl.mm
@@ -488,6 +488,8 @@ ImpellerMetalCaptureManager::ImpellerMetalCaptureManager(id<MTLDevice> device) {
   current_capture_scope_ = [[MTLCaptureManager sharedCaptureManager]
       newCaptureScopeWithDevice:device];
   [current_capture_scope_ setLabel:@"Impeller Frame"];
+  [[MTLCaptureManager sharedCaptureManager]
+      setDefaultCaptureScope:current_capture_scope_];
 }
 
 bool ImpellerMetalCaptureManager::CaptureScopeActive() const {

--- a/engine/src/flutter/shell/gpu/gpu_surface_metal_impeller.mm
+++ b/engine/src/flutter/shell/gpu/gpu_surface_metal_impeller.mm
@@ -71,12 +71,14 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalImpeller::AcquireFrame(const DlISiz
     return std::make_unique<SurfaceFrame>(
         nullptr, SurfaceFrame::FramebufferInfo(),
         [](const SurfaceFrame& surface_frame, DlCanvas* canvas) { return true; },
-        [context = aiks_context_->GetContext()](const SurfaceFrame& surface_frame) {
 #ifdef IMPELLER_DEBUG
+        [context = aiks_context_->GetContext()](const SurfaceFrame& surface_frame) {
           impeller::ContextMTL::Cast(*context).GetCaptureManager()->FinishCapture();
-#endif  // IMPELLER_DEBUG
           return true;
         },
+#else
+        [](const SurfaceFrame& surface_frame) { return true; },
+#endif  // IMPELLER_DEBUG
         frame_size);
   }
 

--- a/engine/src/flutter/shell/gpu/gpu_surface_metal_impeller.mm
+++ b/engine/src/flutter/shell/gpu/gpu_surface_metal_impeller.mm
@@ -65,10 +65,19 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalImpeller::AcquireFrame(const DlISiz
   }
 
   if (!render_to_surface_) {
+#ifdef IMPELLER_DEBUG
+    impeller::ContextMTL::Cast(*aiks_context_->GetContext()).GetCaptureManager()->StartCapture();
+#endif  // IMPELLER_DEBUG
     return std::make_unique<SurfaceFrame>(
         nullptr, SurfaceFrame::FramebufferInfo(),
         [](const SurfaceFrame& surface_frame, DlCanvas* canvas) { return true; },
-        [](const SurfaceFrame& surface_frame) { return true; }, frame_size);
+        [context = aiks_context_->GetContext()](const SurfaceFrame& surface_frame) {
+#ifdef IMPELLER_DEBUG
+          impeller::ContextMTL::Cast(*context).GetCaptureManager()->FinishCapture();
+#endif  // IMPELLER_DEBUG
+          return true;
+        },
+        frame_size);
   }
 
   switch (render_target_type_) {


### PR DESCRIPTION
Before this capturing a GPU frame in Xcode would just hang because StartCapture and StopCapture were not being called.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
