### PR TITLE
Adds vm services to override font scaler

### DIFF
--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -17,6 +17,7 @@
 library;
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:developer' as developer;
 import 'dart:ui'
     show
@@ -791,6 +792,42 @@ mixin WidgetsBinding
             default:
               throw Exception('unknown type: $type');
           }
+        },
+      );
+
+      registerServiceExtension(
+        name: WidgetsServiceExtensions.fontScaler.name,
+        callback: (Map<String, String> parameters) async {
+          if (parameters.containsKey('value')) {
+            final String value = parameters['value']!;
+            if (value.isEmpty || value == 'null') {
+              debugTextScalerOverride = null;
+            } else {
+              try {
+                final decoded = json.decode(value) as Map<String, dynamic>;
+                final table = <double, double>{};
+                decoded.forEach((String k, dynamic v) {
+                  final double key = double.parse(k);
+                  final double val = v is num ? v.toDouble() : double.parse(v.toString());
+                  table[key] = val;
+                });
+                debugTextScalerOverride = DebugNonlinearTextScaler(table);
+              } catch (e) {
+                throw Exception('Invalid font scaler table format: $value');
+              }
+            }
+            await _forceRebuild();
+          }
+          final TextScaler? currentScaler = debugTextScalerOverride;
+          return <String, dynamic>{
+            'value': currentScaler is DebugNonlinearTextScaler
+                ? json.encode(
+                    currentScaler.table.map(
+                      (k, v) => MapEntry<String, String>(k.toString(), v.toString()),
+                    ),
+                  )
+                : 'null',
+          };
         },
       );
     }

--- a/packages/flutter/lib/src/widgets/debug.dart
+++ b/packages/flutter/lib/src/widgets/debug.dart
@@ -529,6 +529,10 @@ bool debugCheckHasOverlay(BuildContext context) {
   return true;
 }
 
+/// A setting that can be used to override the [TextScaler] exposed
+/// from [MediaQueryData.textScaler].
+TextScaler? debugTextScalerOverride;
+
 /// Returns true if none of the widget library debug variables have been changed.
 ///
 /// This function is used by the test framework to ensure that debug variables
@@ -543,10 +547,87 @@ bool debugAssertAllWidgetVarsUnset(String reason) {
         debugPrintGlobalKeyedWidgetLifecycle ||
         debugProfileBuildsEnabled ||
         debugHighlightDeprecatedWidgets ||
-        debugProfileBuildsEnabledUserWidgets) {
+        debugProfileBuildsEnabledUserWidgets ||
+        debugTextScalerOverride != null) {
       throw FlutterError(reason);
     }
     return true;
   }());
   return true;
+}
+
+/// A [TextScaler] used for debugging that scales the incoming font size non-linearly
+/// based on the given lookup table.
+class DebugNonlinearTextScaler extends TextScaler {
+  /// Creates a new nonlinear text scaler for debugging purposes.
+  DebugNonlinearTextScaler(this.table) : assert(table.isNotEmpty);
+
+  /// The lookup table of unscaled font sizes to scaled font sizes.
+  final Map<double, double> table;
+
+  @override
+  double get textScaleFactor {
+    // 14.0 is the default font size used by the framework as a baseline
+    // for calculating the text scale factor estimate.
+    return scale(14.0) / 14.0;
+  }
+
+  @override
+  double scale(double fontSize) {
+    assert(fontSize >= 0);
+    assert(fontSize.isFinite);
+    if (table.length == 1) {
+      final MapEntry<double, double> entry = table.entries.first;
+      if (entry.key == 0.0) {
+        return fontSize;
+      }
+      return fontSize * (entry.value / entry.key);
+    }
+
+    final List<double> keys = table.keys.toList()..sort();
+    if (table.containsKey(fontSize)) {
+      return table[fontSize]!;
+    }
+
+    if (fontSize < keys.first) {
+      final double x1 = keys[0];
+      final double y1 = table[x1]!;
+      final double x2 = keys[1];
+      final double y2 = table[x2]!;
+      return y1 + (fontSize - x1) * (y2 - y1) / (x2 - x1);
+    }
+
+    if (fontSize > keys.last) {
+      final double x1 = keys[keys.length - 2];
+      final double y1 = table[x1]!;
+      final double x2 = keys[keys.length - 1];
+      final double y2 = table[x2]!;
+      return y1 + (fontSize - x1) * (y2 - y1) / (x2 - x1);
+    }
+
+    for (var i = 0; i < keys.length - 1; i++) {
+      if (fontSize >= keys[i] && fontSize <= keys[i + 1]) {
+        final double x1 = keys[i];
+        final double y1 = table[x1]!;
+        final double x2 = keys[i + 1];
+        final double y2 = table[x2]!;
+        return y1 + (fontSize - x1) * (y2 - y1) / (x2 - x1);
+      }
+    }
+    return fontSize;
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    return other is DebugNonlinearTextScaler && mapEquals(other.table, table);
+  }
+
+  @override
+  int get hashCode => Object.hashAll(table.entries.map((e) => Object.hash(e.key, e.value)));
+
+  @override
+  String toString() => 'nonlinear text scaler ($table)';
 }

--- a/packages/flutter/lib/src/widgets/debug.dart
+++ b/packages/flutter/lib/src/widgets/debug.dart
@@ -560,10 +560,14 @@ bool debugAssertAllWidgetVarsUnset(String reason) {
 /// based on the given lookup table.
 class DebugNonlinearTextScaler extends TextScaler {
   /// Creates a new nonlinear text scaler for debugging purposes.
-  DebugNonlinearTextScaler(this.table) : assert(table.isNotEmpty);
+  DebugNonlinearTextScaler(this.table)
+    : _sortedKeys = table.keys.toList()..sort(),
+      assert(table.isNotEmpty);
 
   /// The lookup table of unscaled font sizes to scaled font sizes.
   final Map<double, double> table;
+
+  final List<double> _sortedKeys;
 
   @override
   double get textScaleFactor {
@@ -584,7 +588,7 @@ class DebugNonlinearTextScaler extends TextScaler {
       return fontSize * (entry.value / entry.key);
     }
 
-    final List<double> keys = table.keys.toList()..sort();
+    final List<double> keys = _sortedKeys;
     if (table.containsKey(fontSize)) {
       return table[fontSize]!;
     }
@@ -626,7 +630,7 @@ class DebugNonlinearTextScaler extends TextScaler {
   }
 
   @override
-  int get hashCode => Object.hashAll(table.entries.map((e) => Object.hash(e.key, e.value)));
+  int get hashCode => Object.hashAll(_sortedKeys.map((double key) => Object.hash(key, table[key])));
 
   @override
   String toString() => 'nonlinear text scaler ($table)';

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -2378,10 +2378,13 @@ class _MediaQueryFromViewState extends State<_MediaQueryFromView> with WidgetsBi
     MediaQueryData effectiveData = _data!;
     // If we get our platformBrightness from the PlatformDispatcher (i.e. we have no parentData) replace it
     // with the debugBrightnessOverride in non-release mode.
-    if (!kReleaseMode &&
-        _parentData == null &&
-        effectiveData.platformBrightness != debugBrightnessOverride) {
-      effectiveData = effectiveData.copyWith(platformBrightness: debugBrightnessOverride);
+    if (!kReleaseMode && _parentData == null) {
+      if (effectiveData.platformBrightness != debugBrightnessOverride) {
+        effectiveData = effectiveData.copyWith(platformBrightness: debugBrightnessOverride);
+      }
+      if (debugTextScalerOverride != null) {
+        effectiveData = effectiveData.copyWith(textScaler: debugTextScalerOverride);
+      }
     }
     return MediaQuery(data: effectiveData, child: widget.child);
   }

--- a/packages/flutter/lib/src/widgets/service_extensions.dart
+++ b/packages/flutter/lib/src/widgets/service_extensions.dart
@@ -122,6 +122,14 @@ enum WidgetsServiceExtensions {
   /// * [WidgetsBinding.initServiceExtensions], where the service extension is
   ///   registered.
   accessibilityEvaluations,
+
+  /// Name of service extension that, when called, will adjust the font scaler.
+  ///
+  /// See also:
+  ///
+  /// * [WidgetsBinding.initServiceExtensions], where the service extension is
+  ///   registered.
+  fontScaler,
 }
 
 /// Service extension constants for the Widget Inspector.

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -203,7 +203,7 @@ void main() {
     // framework, excluding any that are for the widget inspector (see
     // widget_inspector_test.dart for tests of the ext.flutter.inspector service
     // extensions). Any test counted here must be tested in this file!
-    const serviceExtensionCount = 31;
+    const serviceExtensionCount = 32;
 
     // The tests are in the widgets/accessibility_evaluations_service_extension_test.dart
     // They can't be moved here because they need to run in a WidgetTester environment.
@@ -1448,5 +1448,64 @@ void main() {
     expect(serverAddress, 'http://127.0.0.1:54000/kMUMseKAnog=/');
 
     testedExtensions.add(FoundationServiceExtensions.connectedVmServiceUri.name);
+  });
+
+  test('Service extensions - fontScaler', () async {
+    addTearDown(() => debugTextScalerOverride = null);
+    Map<String, dynamic> result;
+
+    expect(debugTextScalerOverride, isNull);
+
+    result = await binding.testExtension(
+      WidgetsServiceExtensions.fontScaler.name,
+      <String, String>{},
+    );
+    expect(result, <String, String>{'value': 'null'});
+    expect(debugTextScalerOverride, isNull);
+
+    result = await binding.testExtension(WidgetsServiceExtensions.fontScaler.name, <String, String>{
+      'value': '{"1.0":1.0,"2.0":2.5}',
+    });
+    expect(result, <String, String>{'value': '{"1.0":"1.0","2.0":"2.5"}'});
+    expect(debugTextScalerOverride, isA<DebugNonlinearTextScaler>());
+    expect((debugTextScalerOverride! as DebugNonlinearTextScaler).table, <double, double>{
+      1.0: 1.0,
+      2.0: 2.5,
+    });
+    expect(debugTextScalerOverride!.scale(1.0), 1.0);
+    expect(debugTextScalerOverride!.scale(2.0), 2.5);
+
+    result = await binding.testExtension(
+      WidgetsServiceExtensions.fontScaler.name,
+      <String, String>{},
+    );
+    expect(result, <String, String>{'value': '{"1.0":"1.0","2.0":"2.5"}'});
+
+    result = await binding.testExtension(WidgetsServiceExtensions.fontScaler.name, <String, String>{
+      'value': 'null',
+    });
+    expect(result, <String, String>{'value': 'null'});
+    expect(debugTextScalerOverride, isNull);
+
+    result = await binding.testExtension(WidgetsServiceExtensions.fontScaler.name, <String, String>{
+      'value': '{"1.0":1.0}',
+    });
+    expect(result, <String, String>{'value': '{"1.0":"1.0"}'});
+    expect(debugTextScalerOverride, isNotNull);
+
+    result = await binding.testExtension(WidgetsServiceExtensions.fontScaler.name, <String, String>{
+      'value': '',
+    });
+    expect(result, <String, String>{'value': 'null'});
+    expect(debugTextScalerOverride, isNull);
+
+    expect(
+      () => binding.testExtension(WidgetsServiceExtensions.fontScaler.name, <String, String>{
+        'value': 'invalid',
+      }),
+      throwsA(isA<Exception>()),
+    );
+
+    testedExtensions.add(WidgetsServiceExtensions.fontScaler.name);
   });
 }

--- a/packages/flutter/test/widgets/debug_test.dart
+++ b/packages/flutter/test/widgets/debug_test.dart
@@ -327,4 +327,31 @@ void main() {
     renderObject = tester.firstRenderObject(find.byType(CompositedTransformFollower));
     expect(renderObject.debugLayer?.debugCreator, isNotNull);
   });
+
+  group('DebugNonlinearTextScaler', () {
+    test('scales with exact mapping', () {
+      final scaler = DebugNonlinearTextScaler(<double, double>{10: 12, 14: 18, 20: 24});
+      expect(scaler.scale(10), 12);
+      expect(scaler.scale(14), 18);
+      expect(scaler.scale(20), 24);
+    });
+
+    test('interpolates linearly between bounds', () {
+      final scaler = DebugNonlinearTextScaler(<double, double>{10: 12, 20: 24});
+      // Midpoint interpolation: x=15 -> y = 12 + (15-10)*(24-12)/(20-10) = 18
+      expect(scaler.scale(15), 18);
+    });
+
+    test('extrapolates below first bound', () {
+      final scaler = DebugNonlinearTextScaler(<double, double>{10: 12, 20: 24});
+      // Extrapolate to x=5 -> y = 12 + (5-10)*(24-12)/(20-10) = 12 - 5*1.2 = 6
+      expect(scaler.scale(5), 6);
+    });
+
+    test('extrapolates above last bound', () {
+      final scaler = DebugNonlinearTextScaler(<double, double>{10: 12, 20: 24});
+      // Extrapolate to x=25 -> y = 24 + (25-20)*(24-12)/(20-10) = 24 + 5*1.2 = 30
+      expect(scaler.scale(25), 30);
+    });
+  });
 }

--- a/packages/flutter/test/widgets/media_query_test.dart
+++ b/packages/flutter/test/widgets/media_query_test.dart
@@ -2058,4 +2058,39 @@ void main() {
     expect(widthBuildCount, 2);
     expect(heightBuildCount, 2);
   });
+
+  testWidgets('MediaQuery.fromView respects debugTextScalerOverride', (WidgetTester tester) async {
+    addTearDown(() => debugTextScalerOverride = null);
+    expect(debugTextScalerOverride, isNull);
+
+    late MediaQueryData data;
+    await tester.pumpWidget(
+      MediaQuery.fromView(
+        view: tester.view,
+        child: Builder(
+          builder: (BuildContext context) {
+            data = MediaQuery.of(context);
+            return const Placeholder();
+          },
+        ),
+      ),
+    );
+
+    expect(data.textScaler, isSystemTextScaler(withScaleFactor: 1.0));
+
+    debugTextScalerOverride = const TextScaler.linear(2.5);
+    await tester.pumpWidget(
+      MediaQuery.fromView(
+        view: tester.view,
+        child: Builder(
+          builder: (BuildContext context) {
+            data = MediaQuery.of(context);
+            return const Placeholder();
+          },
+        ),
+      ),
+    );
+
+    expect(data.textScaler, const TextScaler.linear(2.5));
+  });
 }

--- a/packages/flutter/test/widgets/media_query_test.dart
+++ b/packages/flutter/test/widgets/media_query_test.dart
@@ -2092,5 +2092,7 @@ void main() {
     );
 
     expect(data.textScaler, const TextScaler.linear(2.5));
+
+    debugTextScalerOverride = null;
   });
 }


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

fixes https://github.com/flutter/flutter/issues/170695

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
