### PR TITLE
[macOS] Remove warning when running with merged threads.

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -749,8 +749,16 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
   }
 
   if (!mergedPlatformUIThread) {
-    NSLog(@"Running with unmerged UI and platform thread. "
-           "This will be removed in a future release.");
+    NSLog(@"Warning: Merged threads is disabled. Running Flutter without merged threads is "
+           "deprecated and will be unsupported in a future release.\n"
+           "\n"
+           "To turn on merged threads, update your macos/Runner/Info.plist file:\n"
+           "\n"
+           "  <key>FLTEnableMergedPlatformUIThread</key>\n"
+           "  <true/>\n"
+           "\n"
+           "If you disabled merged threads to work around an issue, please report it here: "
+           "https://github.com/flutter/flutter/issues/150525.");
   }
 
   // The task description needs to be created separately for platform task

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -748,8 +748,9 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
     mergedPlatformUIThread = enableMergedPlatformUIThread.boolValue;
   }
 
-  if (mergedPlatformUIThread) {
-    NSLog(@"Running with merged UI and platform thread. Experimental.");
+  if (!mergedPlatformUIThread) {
+    NSLog(@"Running with unmerged UI and platform thread. "
+           "This will be removed in a future release.");
   }
 
   // The task description needs to be created separately for platform task


### PR DESCRIPTION
The engine has been running with merged threads by default probably fora year now, this message is obsolete.

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
