### PR TITLE
complex_layout_macos_impeller__start_up not bringup

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3856,7 +3856,6 @@ targets:
   - name: Mac_benchmark complex_layout_macos_impeller__start_up
     presubmit: false
     recipe: devicelab/devicelab_drone
-    bringup: true
     timeout: 60
     properties:
       dependencies: >-


### PR DESCRIPTION
Not flaky for the last 200 runs.