### PR TITLE
Fix `--enable-hcpp` flag being ignored in release

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -671,6 +671,11 @@ class AndroidDevice extends Device {
         'enable-vulkan-validation',
         'true',
       ],
+      if (debuggingOptions.enableHcpp) ...<String>[
+        '--ez',
+        'enable-hcpp-and-surface-control',
+        'true',
+      ],
       if (debuggingOptions.debuggingEnabled) ...<String>[
         if (debuggingOptions.buildInfo.isDebug) ...<String>[
           ...<String>['--ez', 'enable-checked-mode', 'true'],
@@ -686,11 +691,6 @@ class AndroidDevice extends Device {
           '--es',
           'dart-flags',
           debuggingOptions.dartFlags,
-        ],
-        if (debuggingOptions.enableHcpp) ...<String>[
-          '--ez',
-          'enable-hcpp-and-surface-control',
-          'true',
         ],
         if (debuggingOptions.useTestFonts) ...<String>['--ez', 'use-test-fonts', 'true'],
         if (debuggingOptions.verboseSystemLogs) ...<String>['--ez', 'verbose-logging', 'true'],

--- a/packages/flutter_tools/test/general.shard/android/android_device_start_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_start_test.dart
@@ -64,7 +64,7 @@ void main() {
         platform: FakePlatform(),
         androidSdk: androidSdk,
       );
-      final File apkFile = fileSystem.file('app-debug.apk')..createSync();
+      final File apkFile = fileSystem.file('app-release.apk')..createSync();
       final apk = AndroidApk(
         id: 'FlutterApp',
         applicationPackage: apkFile,
@@ -89,7 +89,7 @@ void main() {
       );
       processManager.addCommand(
         const FakeCommand(
-          command: <String>['adb', '-s', '1234', 'install', '-t', '-r', 'app-debug.apk'],
+          command: <String>['adb', '-s', '1234', 'install', '-t', '-r', 'app-release.apk'],
         ),
       );
       processManager.addCommand(kShaCommand);
@@ -108,9 +108,6 @@ void main() {
             'android.intent.category.LAUNCHER',
             '-f',
             '0x20000000',
-            '--ez',
-            'enable-dart-profiling',
-            'true',
             'FlutterActivity',
           ],
         ),
@@ -119,7 +116,7 @@ void main() {
       final LaunchResult launchResult = await device.startApp(
         apk,
         prebuiltApplication: true,
-        debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+        debuggingOptions: DebuggingOptions.disabled(BuildInfo.release, enableDartProfiling: false),
         platformArgs: <String, dynamic>{},
       );
 
@@ -140,7 +137,7 @@ void main() {
         platform: FakePlatform(),
         androidSdk: androidSdk,
       );
-      final File apkFile = fileSystem.file('app-debug.apk')..createSync();
+      final File apkFile = fileSystem.file('app-release.apk')..createSync();
       final apk = AndroidApk(
         id: 'FlutterApp',
         applicationPackage: apkFile,
@@ -163,7 +160,7 @@ void main() {
       );
       processManager.addCommand(
         const FakeCommand(
-          command: <String>['adb', '-s', '1234', 'install', '-t', '-r', 'app-debug.apk'],
+          command: <String>['adb', '-s', '1234', 'install', '-t', '-r', 'app-release.apk'],
         ),
       );
       processManager.addCommand(kShaCommand);
@@ -183,9 +180,6 @@ void main() {
             '-f',
             '0x20000000',
             '--ez',
-            'enable-dart-profiling',
-            'true',
-            '--ez',
             'enable-impeller',
             'true',
             '--ez',
@@ -203,6 +197,7 @@ void main() {
           BuildInfo.release,
           enableImpeller: ImpellerStatus.enabled,
           enableHcpp: true,
+          enableDartProfiling: false,
         ),
         platformArgs: <String, dynamic>{},
       );

--- a/packages/flutter_tools/test/general.shard/android/android_device_start_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_start_test.dart
@@ -128,6 +128,90 @@ void main() {
     });
   }
 
+  testWithoutContext(
+    'AndroidDevice.startApp forwards Impeller and HCPP flags in release mode',
+    () async {
+      final device = AndroidDevice(
+        '1234',
+        modelID: 'TestModel',
+        fileSystem: fileSystem,
+        processManager: processManager,
+        logger: BufferLogger.test(),
+        platform: FakePlatform(),
+        androidSdk: androidSdk,
+      );
+      final File apkFile = fileSystem.file('app-debug.apk')..createSync();
+      final apk = AndroidApk(
+        id: 'FlutterApp',
+        applicationPackage: apkFile,
+        launchActivity: 'FlutterActivity',
+        versionCode: 1,
+      );
+
+      processManager.addCommand(kAdbVersionCommand);
+      processManager.addCommand(kStartServer);
+      processManager.addCommand(
+        const FakeCommand(
+          command: <String>['adb', '-s', '1234', 'shell', 'getprop'],
+          stdout: '[ro.product.cpu.abi]: [arm64-v8a]',
+        ),
+      );
+      processManager.addCommand(
+        const FakeCommand(
+          command: <String>['adb', '-s', '1234', 'shell', 'am', 'force-stop', 'FlutterApp'],
+        ),
+      );
+      processManager.addCommand(
+        const FakeCommand(
+          command: <String>['adb', '-s', '1234', 'install', '-t', '-r', 'app-debug.apk'],
+        ),
+      );
+      processManager.addCommand(kShaCommand);
+      processManager.addCommand(
+        const FakeCommand(
+          command: <String>[
+            'adb',
+            '-s',
+            '1234',
+            'shell',
+            'am',
+            'start',
+            '-a',
+            'android.intent.action.MAIN',
+            '-c',
+            'android.intent.category.LAUNCHER',
+            '-f',
+            '0x20000000',
+            '--ez',
+            'enable-dart-profiling',
+            'true',
+            '--ez',
+            'enable-impeller',
+            'true',
+            '--ez',
+            'enable-hcpp-and-surface-control',
+            'true',
+            'FlutterActivity',
+          ],
+        ),
+      );
+
+      final LaunchResult launchResult = await device.startApp(
+        apk,
+        prebuiltApplication: true,
+        debuggingOptions: DebuggingOptions.disabled(
+          BuildInfo.release,
+          enableImpeller: ImpellerStatus.enabled,
+          enableHcpp: true,
+        ),
+        platformArgs: <String, dynamic>{},
+      );
+
+      expect(launchResult.started, true);
+      expect(processManager, hasNoRemainingExpectations);
+    },
+  );
+
   testWithoutContext('AndroidDevice.startApp forwards all supported debugging options', () async {
     final device = AndroidDevice(
       '1234',
@@ -224,6 +308,7 @@ void main() {
           '--ez', 'purge-persistent-cache', 'true',
           '--ez', 'enable-impeller', 'true',
           '--ez', 'enable-flutter-gpu', 'true',
+          '--ez', 'enable-hcpp-and-surface-control', 'true',
           '--ez', 'enable-checked-mode', 'true',
           '--ez', 'verify-entry-points', 'true',
           '--ez', 'start-paused', 'true',
@@ -260,6 +345,7 @@ void main() {
         enableImpeller: ImpellerStatus.enabled,
         enableFlutterGpu: true,
         profileStartup: true,
+        enableHcpp: true,
       ),
       platformArgs: <String, dynamic>{},
       userIdentifier: '10',


### PR DESCRIPTION
The flag needed to be moved outside of the 
```dart
if (debuggingOptions.debuggingEnabled) {
...
}
```
block, as impeller is