### PR TITLE
[web] Fix multi-view sizing race condition (Minimum size approach)

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
@@ -234,12 +234,13 @@ class CanvasKitRenderer extends Renderer {
     required bool transferOwnership,
   }) async {
     if (!transferOwnership) {
-      final DomImageBitmap bitmap = await createImageBitmap(object, (
+      final DomImageBitmap bitmap = await createImageBitmap(
+        object,
         x: 0,
         y: 0,
         width: width,
         height: height,
-      ));
+      );
       return createImageFromImageBitmap(bitmap);
     }
     SkImage? skImage;

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/surface.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/surface.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 import 'dart:js_interop';
+import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:meta/meta.dart';
@@ -207,6 +208,18 @@ abstract class CkSurface extends Surface {
   }
 
   @override
+  void setMinimumSize(BitmapSize size) {
+    if (size.width <= _currentSize.width && size.height <= _currentSize.height) {
+      return;
+    }
+    final newSize = BitmapSize(
+      math.max(size.width, _currentSize.width),
+      math.max(size.height, _currentSize.height),
+    );
+    setSize(newSize);
+  }
+
+  @override
   Future<void> recreateContextForCanvas(DomEventTarget newCanvas) async {
     // The old Skia surface is now invalid and should be disposed.
     _skSurface?.dispose();
@@ -279,12 +292,25 @@ class CkOffscreenSurface extends CkSurface implements OffscreenSurface {
   }
 
   @override
-  Future<List<DomImageBitmap>> rasterizeToImageBitmaps(List<ui.Picture> pictures) async {
+  Future<List<DomImageBitmap>> rasterizeToImageBitmaps(
+    List<ui.Picture> pictures, {
+    BitmapSize? size,
+  }) async {
     await _initialized.future;
     final bitmaps = <DomImageBitmap>[];
     for (final picture in pictures) {
       await rasterizeToCanvas(picture);
-      bitmaps.add(await createImageBitmap(_canvas));
+      if (size != null) {
+        bitmaps.add(await createImageBitmap(
+          _canvas,
+          x: 0,
+          y: 0,
+          width: size.width,
+          height: size.height,
+        ));
+      } else {
+        bitmaps.add(await createImageBitmap(_canvas));
+      }
     }
     return bitmaps;
   }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/compositing/offscreen_canvas_rasterizer.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/compositing/offscreen_canvas_rasterizer.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:meta/meta.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui;
@@ -26,6 +28,25 @@ class OffscreenCanvasRasterizer extends Rasterizer {
   /// This is an SkSurface backed by an OffScreenCanvas. This single Surface is
   /// used to render to many RenderCanvases to produce the rendered scene.
   late final OffscreenSurface offscreenSurface = _surfaceProvider.createSurface();
+
+  /// A lock to ensure that only one view is using the [offscreenSurface] at a
+  /// time.
+  ///
+  /// Since the [offscreenSurface] is shared across all views, we must ensure
+  /// that we only render one view at a time.
+  Future<void> _lock = Future<void>.value();
+
+  Future<T> synchronized<T>(Future<T> Function() computation) async {
+    final Future<void> oldLock = _lock;
+    final Completer<void> completer = Completer<void>();
+    _lock = completer.future;
+    await oldLock;
+    try {
+      return await computation();
+    } finally {
+      completer.complete();
+    }
+  }
 
   @override
   OffscreenCanvasViewRasterizer createViewRasterizer(EngineFlutterView view) {
@@ -65,8 +86,13 @@ class OffscreenCanvasViewRasterizer extends ViewRasterizer {
   );
 
   @override
+  Future<void> draw(LayerTree layerTree, FrameTimingRecorder? recorder) {
+    return rasterizer.synchronized(() => super.draw(layerTree, recorder));
+  }
+
+  @override
   Future<void> prepareToDraw() async {
-    await rasterizer.offscreenSurface.setSize(currentFrameSize);
+    await rasterizer.offscreenSurface.setMinimumSize(currentFrameSize);
   }
 
   @override
@@ -81,7 +107,7 @@ class OffscreenCanvasViewRasterizer extends ViewRasterizer {
     recorder?.recordRasterStart();
     if (browserSupportsCreateImageBitmap) {
       final List<DomImageBitmap> bitmaps = await rasterizer.offscreenSurface
-          .rasterizeToImageBitmaps(pictures);
+          .rasterizeToImageBitmaps(pictures, size: currentFrameSize);
       for (var i = 0; i < displayCanvases.length; i++) {
         (displayCanvases[i] as RenderCanvas).render(bitmaps[i]);
       }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/compositing/surface.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/compositing/surface.dart
@@ -66,6 +66,13 @@ abstract class Surface {
   /// Sets the size of the underlying canvas.
   FutureOr<void> setSize(BitmapSize size);
 
+  /// Sets the minimum size of the underlying canvas.
+  ///
+  /// If the current size is already larger than or equal to [size], this method
+  /// does nothing. Otherwise, it resizes the canvas to be at least as large
+  /// as [size].
+  FutureOr<void> setMinimumSize(BitmapSize size);
+
   /// Converts a `ui.Image` into a `ByteData` object in the specified format.
   Future<ByteData?> rasterizeImage(ui.Image image, ui.ImageByteFormat format);
 
@@ -108,7 +115,12 @@ abstract class Surface {
 abstract class OffscreenSurface extends Surface {
   /// Rasterizes the given list of [pictures] into a list of `DomImageBitmap`
   /// objects.
-  Future<List<DomImageBitmap>> rasterizeToImageBitmaps(List<ui.Picture> pictures);
+  ///
+  /// If [size] is provided, the returned bitmaps will be of that size.
+  Future<List<DomImageBitmap>> rasterizeToImageBitmaps(
+    List<ui.Picture> pictures, {
+    BitmapSize? size,
+  });
 }
 
 /// A rendering surface that is also a `DisplayCanvas`.

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/dom.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/dom.dart
@@ -261,15 +261,23 @@ external DomSymbol get domSymbol;
 @JS('createImageBitmap')
 external JSPromise<JSAny?> _createImageBitmap(JSAny source, [int x, int y, int width, int height]);
 Future<DomImageBitmap> createImageBitmap(
-  JSAny source, [
-  ({int x, int y, int width, int height})? bounds,
-]) {
+  JSAny source, {
+  int? x,
+  int? y,
+  int? width,
+  int? height,
+}) {
+  assert(
+    (x == null && y == null && width == null && height == null) ||
+        (x != null && y != null && width != null && height != null),
+    'All or none of x, y, width, and height must be provided.',
+  );
   if (debugThrowOnCreateImageBitmapIfDisabled && !browserSupportsCreateImageBitmap) {
     throw UnsupportedError('createImageBitmap is not supported in this browser');
   }
   JSPromise<JSAny?> jsPromise;
-  if (bounds != null) {
-    jsPromise = _createImageBitmap(source, bounds.x, bounds.y, bounds.width, bounds.height);
+  if (x != null) {
+    jsPromise = _createImageBitmap(source, x, y!, width!, height!);
   } else {
     jsPromise = _createImageBitmap(source);
   }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
@@ -454,12 +454,14 @@ class SkwasmRenderer extends Renderer {
     required bool transferOwnership,
   }) async {
     if (!transferOwnership || (isMultiThreaded && !_isTransferable(textureSource))) {
-      textureSource = (await createImageBitmap(textureSource, (
+      textureSource = await createImageBitmap(
+        textureSource,
         x: 0,
         y: 0,
         width: width,
         height: height,
-      ))).toJSAnyShallow;
+      );
+
     }
     return SkwasmImage(
       imageCreateFromTextureSource(

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/surface.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/surface.dart
@@ -6,6 +6,7 @@ import 'dart:_wasm';
 import 'dart:async';
 import 'dart:ffi';
 import 'dart:js_interop';
+import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:ui/src/engine.dart';
@@ -172,7 +173,10 @@ class SkwasmSurface implements OffscreenSurface {
   }
 
   @override
-  Future<List<DomImageBitmap>> rasterizeToImageBitmaps(List<ui.Picture> pictures) async {
+  Future<List<DomImageBitmap>> rasterizeToImageBitmaps(
+    List<ui.Picture> pictures, {
+    BitmapSize? size,
+  }) async {
     await initialized;
     final int callbackId = withStackScope((StackScope scope) {
       final Pointer<PictureHandle> pictureHandles = scope
@@ -190,7 +194,26 @@ class SkwasmSurface implements OffscreenSurface {
       rasterStartMicros: (rasterResult.rasterStartMilliseconds * 1000).toInt(),
       rasterEndMicros: (rasterResult.rasterEndMilliseconds * 1000).toInt(),
     );
-    return result.imageBitmaps;
+
+    final List<DomImageBitmap> imageBitmaps = result.imageBitmaps;
+    if (size != null) {
+      final croppedBitmaps = <DomImageBitmap>[];
+      for (final bitmap in imageBitmaps) {
+        if (bitmap.width != size.width || bitmap.height != size.height) {
+          croppedBitmaps.add(await createImageBitmap(
+            bitmap,
+            x: 0,
+            y: 0,
+            width: size.width.toInt(),
+            height: size.height.toInt(),
+          ));
+        } else {
+          croppedBitmaps.add(bitmap);
+        }
+      }
+      return croppedBitmaps;
+    }
+    return imageBitmaps;
   }
 
   @override
@@ -216,6 +239,18 @@ class SkwasmSurface implements OffscreenSurface {
     _currentSize = size;
     final int callbackId = surfaceSetSize(handle, size.width, size.height);
     await SkwasmCallbackHandler.instance.registerCallback(callbackId);
+  }
+
+  @override
+  Future<void> setMinimumSize(BitmapSize size) async {
+    if (size.width <= _currentSize.width && size.height <= _currentSize.height) {
+      return;
+    }
+    final newSize = BitmapSize(
+      math.max(size.width, _currentSize.width),
+      math.max(size.height, _currentSize.height),
+    );
+    await setSize(newSize);
   }
 
   @override

--- a/engine/src/flutter/lib/web_ui/test/engine/compositing/render_canvas_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/compositing/render_canvas_test.dart
@@ -22,12 +22,13 @@ void testMain() {
     });
 
     Future<DomImageBitmap> newBitmap(int width, int height) async {
-      return createImageBitmap(createBlankDomImageData(width, height) as JSAny, (
+      return createImageBitmap(
+        createBlankDomImageData(width, height) as JSAny,
         x: 0,
         y: 0,
         width: width,
         height: height,
-      ));
+      );
     }
 
     // Regression test for https://github.com/flutter/flutter/issues/75286

--- a/engine/src/flutter/lib/web_ui/test/ui/codecs_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/ui/codecs_test.dart
@@ -286,12 +286,13 @@ class BitmapTestCodec extends TestCodec {
 
     await imageElement.decode();
 
-    final DomImageBitmap bitmap = await createImageBitmap(imageElement, (
+    final DomImageBitmap bitmap = await createImageBitmap(
+      imageElement,
       x: 0,
       y: 0,
       width: imageElement.naturalWidth.toInt(),
       height: imageElement.naturalHeight.toInt(),
-    ));
+    );
 
     final ui.Image image = await codecFactory(bitmap);
     return BitmapSingleFrameCodec(bitmap, image);

--- a/engine/src/flutter/lib/web_ui/test/ui/image_texture_source_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/ui/image_texture_source_test.dart
@@ -62,7 +62,7 @@ Future<void> testMain() async {
     );
     await completer.future;
 
-    final DomImageBitmap bitmap = await createImageBitmap(image, (x: 0, y: 0, width: 1, height: 1));
+    final DomImageBitmap bitmap = await createImageBitmap(image, x: 0, y: 0, width: 1, height: 1);
 
     final ui.Image uiImage = await ui_web.createImageFromTextureSource(
       bitmap,

--- a/engine/src/flutter/lib/web_ui/test/ui/multi_view_sizing_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/ui/multi_view_sizing_test.dart
@@ -1,0 +1,82 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/src/engine.dart';
+import 'package:ui/ui.dart' as ui;
+
+import '../common/test_initialization.dart';
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+void testMain() {
+  group('MultiView Sizing', () {
+    setUpUnitTests(withImplicitView: true);
+
+    test('canvases for multiple views have correct sizes', () async {
+      // Create two views with different sizes.
+      final host1 = createDomElement('view-1');
+      host1.style
+        ..width = '100px'
+        ..height = '100px'
+        ..display = 'block';
+      domDocument.body!.append(host1);
+      final view1 = EngineFlutterView(EnginePlatformDispatcher.instance, host1);
+      EnginePlatformDispatcher.instance.viewManager.registerView(view1);
+
+      final host2 = createDomElement('view-2');
+      host2.style
+        ..width = '200px'
+        ..height = '200px'
+        ..display = 'block';
+      domDocument.body!.append(host2);
+      final view2 = EngineFlutterView(EnginePlatformDispatcher.instance, host2);
+      EnginePlatformDispatcher.instance.viewManager.registerView(view2);
+
+      // Create a simple scene.
+      ui.Scene createScene(ui.Color color, ui.Size size) {
+        final recorder = ui.PictureRecorder();
+        final canvas = ui.Canvas(recorder, ui.Offset.zero & size);
+        canvas.drawRect(ui.Offset.zero & size, ui.Paint()..color = color);
+        final picture = recorder.endRecording();
+        final sb = ui.SceneBuilder();
+        sb.addPicture(ui.Offset.zero, picture);
+        return sb.build();
+      }
+
+      final scene1 = createScene(const ui.Color(0xFFFF0000), const ui.Size(100, 100));
+      final scene2 = createScene(const ui.Color(0xFF00FF00), const ui.Size(200, 200));
+
+      // Render both scenes.
+      // We render them in the same turn to increase chance of interference if there's no locking.
+      final Future<void> r1 = renderer.renderScene(scene1, view1);
+      final Future<void> r2 = renderer.renderScene(scene2, view2);
+      await Future.wait(<Future<void>>[r1, r2]);
+
+      // Verify canvas sizes.
+      DomHTMLCanvasElement getCanvas(EngineFlutterView view) {
+        final canvas = view.dom.renderingHost.querySelector('canvas');
+        if (canvas == null) {
+          throw Exception('Canvas not found for view ${view.viewId}');
+        }
+        return canvas as DomHTMLCanvasElement;
+      }
+
+      final canvas1 = getCanvas(view1);
+      final canvas2 = getCanvas(view2);
+
+      final dpr = EngineFlutterDisplay.instance.devicePixelRatio;
+      expect(canvas1.width, 100 * dpr);
+      expect(canvas1.height, 100 * dpr);
+      expect(canvas2.width, 200 * dpr);
+      expect(canvas2.height, 200 * dpr);
+
+      host1.remove();
+      host2.remove();
+    });
+  });
+}


### PR DESCRIPTION
## Summary
This PR fixes the multi-view sizing regression (https://github.com/flutter/flutter/issues/185034) by optimizing how the shared OffscreenCanvas is managed. Instead of resizing the canvas for every view, we allow it to grow to the maximum required size and use createImageBitmap cropping to extract the correct region for each view.

## Design
   1. **Shared Growing Surface**: I updated `OffscreenCanvasRasterizer` to maintain a single surface that uses a new `setMinimumSize` method. This prevents unnecessary shrinking and re-initialization of the WebGL context.
   2. **Sub-region Extraction**: `OffscreenSurface.rasterizeToImageBitmaps` now accepts an optional size.
       * **In CanvasKit**, we use the native `createImageBitmap` bounds parameters.
       * **In Skwasm**, we extract the bitmap from Wasm and then perform a JS-side crop if the dimensions don't match.
   3. **Synchronization**: A lock is used to ensure that View A's content is snapshotted before View B begins drawing on the same shared canvas.
   4. **API Optimization**: I refactored the `createImageBitmap` wrapper in `dom.dart` to use named parameters, improving readability and avoiding record allocations on every frame.

## Pros:
   * **Context Efficiency**: Maintains a single WebGL context, ensuring the app won't hit browser-imposed context limits (crucial for apps with many
     views).
   * **Reduced Overhead**: Surface only grows, avoiding the expensive "stop-the-world" cost of recreating Skia surfaces and WebGL contexts when switching
     between views of different sizes.
   * **Deterministic Sizing**: Guarantees that each view gets a bitmap of the exact size it requested, regardless of the size of the shared canvas.

## Cons:
   * **Serialization**: Views are rendered sequentially due to the shared canvas. While faster than Approach 1, it still doesn't support true parallel
     rendering across views.
   * **Cropping Cost**: Adds a small overhead for the createImageBitmap cropping operation, though this is generally highly optimized by browsers.

## Testing
   * Added `engine/src/flutter/lib/web_ui/test/ui/multi_view_sizing_test.dart`.
   * Verified the fix across canvaskit and skwasm renderers.