### PR TITLE
[a11y] Mark SemanticsNode dirty when customSemanticsActions change 

### DIFF
--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -3356,7 +3356,7 @@ class SemanticsNode with DiagnosticableTreeMixin {
         _traversalParentIdentifier != config._traversalParentIdentifier ||
         _minValue != config._minValue ||
         _maxValue != config._maxValue ||
-        !const MapEquality<CustomSemanticsAction, VoidCallback>().equals(
+        !mapEquals<CustomSemanticsAction, VoidCallback>(
           _customSemanticsActions,
           config._customSemanticsActions,
         );

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -3355,7 +3355,11 @@ class SemanticsNode with DiagnosticableTreeMixin {
         _traversalChildIdentifier != config._traversalChildIdentifier ||
         _traversalParentIdentifier != config._traversalParentIdentifier ||
         _minValue != config._minValue ||
-        _maxValue != config._maxValue;
+        _maxValue != config._maxValue ||
+        !const MapEquality<CustomSemanticsAction, VoidCallback>().equals(
+          _customSemanticsActions,
+          config._customSemanticsActions,
+        );
   }
 
   // TAGS, LABELS, ACTIONS

--- a/packages/flutter/test/semantics/semantics_test.dart
+++ b/packages/flutter/test/semantics/semantics_test.dart
@@ -465,6 +465,31 @@ void main() {
       expect(node.role, config.role);
       expect(node.debugIsDirty, isTrue);
     });
+
+    test('updateWith marks node as dirty when customSemanticsActions changes', () {
+      final owner = SemanticsOwner(onSemanticsUpdate: (SemanticsUpdate update) {});
+      final node = SemanticsNode.root(owner: owner)
+        ..rect = const Rect.fromLTRB(0.0, 0.0, 10.0, 10.0);
+
+      const action1 = CustomSemanticsAction(label: 'Action 1');
+      final config1 = SemanticsConfiguration()
+        ..isSemanticBoundary = true
+        ..customSemanticsActions = <CustomSemanticsAction, VoidCallback>{action1: () {}};
+
+      node.updateWith(config: config1);
+      expect(node.debugIsDirty, isTrue);
+
+      owner.sendSemanticsUpdate();
+      expect(node.debugIsDirty, isFalse);
+
+      const action2 = CustomSemanticsAction(label: 'Action 2');
+      final config2 = SemanticsConfiguration()
+        ..isSemanticBoundary = true
+        ..customSemanticsActions = <CustomSemanticsAction, VoidCallback>{action2: () {}};
+
+      node.updateWith(config: config2);
+      expect(node.debugIsDirty, isTrue);
+    });
   });
 
   test('toStringDeep() does not throw with transform == null', () {


### PR DESCRIPTION
fix: https://github.com/flutter/flutter/issues/149613 

 Updated SemanticsNode._isDifferentFromCurrentSemanticAnnotation in semantics.dart to check _customSemanticsActions

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
