### PR TITLE
feat: make SystemContextMenuController.isVisible part of the public API

### DIFF
--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -2895,7 +2895,12 @@ class SystemContextMenuController with SystemContextMenuClient, Diagnosticable {
 
   /// Indicates whether the system context menu managed by this controller is
   /// currently being displayed to the user.
-  @visibleForTesting
+  ///
+  /// This can be used to avoid redundant calls to [show] or [hide]. For
+  /// example, when reacting to layout changes (such as a stretchable text
+  /// field) the caller may want to skip calling [show] if the menu is already
+  /// visible at the desired target [Rect], to prevent the menu from briefly
+  /// flashing in and out.
   bool get isVisible => this == _lastShown && !_hiddenBySystem;
 
   /// After calling [dispose], this instance can no longer be used.

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -2896,11 +2896,17 @@ class SystemContextMenuController with SystemContextMenuClient, Diagnosticable {
   /// Indicates whether the system context menu managed by this controller is
   /// currently being displayed to the user.
   ///
-  /// This can be used to avoid redundant calls to [show] or [hide]. For
-  /// example, when reacting to layout changes (such as a stretchable text
-  /// field) the caller may want to skip calling [show] if the menu is already
-  /// visible at the desired target [Rect], to prevent the menu from briefly
-  /// flashing in and out.
+  /// This is a coarse visible/hidden flag — it does not record _where_ the
+  /// menu is currently anchored. Callers that need to compare the current
+  /// anchor to a new target [Rect] (for example, to avoid re-showing the menu
+  /// when only sub-pixel layout changes have occurred) must track the last
+  /// [Rect] passed to [show] themselves and combine that with [isVisible].
+  ///
+  /// This is useful for avoiding redundant calls to [show] or [hide]. For
+  /// example, when reacting to layout changes from a stretchable text field
+  /// the caller can skip calling [show] when the menu is already visible at
+  /// the same target rect, preventing the menu from briefly flashing in and
+  /// out.
   bool get isVisible => this == _lastShown && !_hiddenBySystem;
 
   /// After calling [dispose], this instance can no longer be used.


### PR DESCRIPTION
## Description

`SystemContextMenuController.isVisible` was annotated with `@visibleForTesting`, which meant production code could only access it with a lint warning. There are legitimate use cases for accessing this state outside of tests.

This PR removes the `@visibleForTesting` annotation and expands the docstring to describe the intended use case.

### Use case

When building a stretchable text field (e.g. Liquid Glass), small sub-pixel changes to the target `Rect` cause `show()` to hide and re-show the system context menu, producing visible flashing. With public access to `isVisible`, callers can skip redundant `show()` calls when the menu is already visible at the desired target.

### Behavior change

None. The runtime behavior of `isVisible` is unchanged — only the visibility of the API is widened.

### Tests

Existing tests in `packages/flutter/test/services/system_context_menu_controller_test.dart` cover the `isVisible` getter (14 assertions across 14 test cases). All pass with this change.

```
00:00 +14: All tests passed!
```

Fixes #179263

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.