### PR TITLE
feat(services): expose SystemChrome.preferredOrientations getter

### DIFF
--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -545,11 +545,39 @@ abstract final class SystemChrome {
   /// Should you decide to opt out of multitasking you can do this by
   /// setting "Requires full screen" to true in the Xcode Deployment Info.
   static Future<void> setPreferredOrientations(List<DeviceOrientation> orientations) async {
+    _preferredOrientations = List<DeviceOrientation>.unmodifiable(orientations);
     await SystemChannels.platform.invokeMethod<void>(
       'SystemChrome.setPreferredOrientations',
       _stringify(orientations),
     );
   }
+
+  /// The orientations most recently passed to [setPreferredOrientations], or
+  /// null if [setPreferredOrientations] has not yet been called during this
+  /// app session.
+  ///
+  /// This is useful for save/restore patterns: read the current preference,
+  /// apply a temporary preference (e.g. to lock a single screen to portrait),
+  /// and on dispose restore the previous list.
+  ///
+  /// {@tool snippet}
+  ///
+  /// ```dart
+  /// final List<DeviceOrientation>? saved = SystemChrome.preferredOrientations;
+  /// await SystemChrome.setPreferredOrientations(<DeviceOrientation>[
+  ///   DeviceOrientation.portraitUp,
+  /// ]);
+  /// // ... later, when the screen is dismissed ...
+  /// await SystemChrome.setPreferredOrientations(saved ?? const <DeviceOrientation>[]);
+  /// ```
+  /// {@end-tool}
+  ///
+  /// The returned list is unmodifiable. The value reflects what Flutter most
+  /// recently asked the operating system for; the OS may apply additional
+  /// constraints (for example on Android 16 large-screen devices, see the
+  /// [setPreferredOrientations] documentation).
+  static List<DeviceOrientation>? get preferredOrientations => _preferredOrientations;
+  static List<DeviceOrientation>? _preferredOrientations;
 
   /// Specifies the description of the current state of the application as it
   /// pertains to the application switcher (also known as "recent tasks").

--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -579,6 +579,15 @@ abstract final class SystemChrome {
   static List<DeviceOrientation>? get preferredOrientations => _preferredOrientations;
   static List<DeviceOrientation>? _preferredOrientations;
 
+  /// Resets [preferredOrientations] back to `null` (its "never set" state).
+  ///
+  /// Intended for tests that mutate global [SystemChrome] state and want to
+  /// avoid leaking that state into other tests in the same process.
+  @visibleForTesting
+  static void debugResetPreferredOrientations() {
+    _preferredOrientations = null;
+  }
+
   /// Specifies the description of the current state of the application as it
   /// pertains to the application switcher (also known as "recent tasks").
   ///

--- a/packages/flutter/test/services/system_chrome_test.dart
+++ b/packages/flutter/test/services/system_chrome_test.dart
@@ -109,9 +109,10 @@ void main() {
   });
 
   group('preferredOrientations', () {
-    setUp(() {
-      // Reset cached state so each test starts from the "never set" state and
-      // mutations don't leak to other tests in the same process.
+    setUpAll(() {
+      // Reset cached state once before the group runs so any leftover state
+      // from earlier tests in the file is cleared. Per-test cleanup is handled
+      // by `tearDown` below.
       SystemChrome.debugResetPreferredOrientations();
     });
 

--- a/packages/flutter/test/services/system_chrome_test.dart
+++ b/packages/flutter/test/services/system_chrome_test.dart
@@ -108,6 +108,55 @@ void main() {
     );
   });
 
+  test('preferredOrientations returns the latest set value', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (MethodCall methodCall) async => null,
+    );
+
+    await SystemChrome.setPreferredOrientations(<DeviceOrientation>[
+      DeviceOrientation.portraitUp,
+      DeviceOrientation.portraitDown,
+    ]);
+
+    expect(SystemChrome.preferredOrientations, <DeviceOrientation>[
+      DeviceOrientation.portraitUp,
+      DeviceOrientation.portraitDown,
+    ]);
+
+    // A second call replaces the cached value rather than appending.
+    await SystemChrome.setPreferredOrientations(<DeviceOrientation>[DeviceOrientation.landscapeLeft]);
+    expect(SystemChrome.preferredOrientations, <DeviceOrientation>[
+      DeviceOrientation.landscapeLeft,
+    ]);
+
+    // The empty list (defer to OS default) is preserved as an empty list, not null.
+    await SystemChrome.setPreferredOrientations(const <DeviceOrientation>[]);
+    expect(SystemChrome.preferredOrientations, isEmpty);
+    expect(SystemChrome.preferredOrientations, isNotNull);
+  });
+
+  test('preferredOrientations returns an unmodifiable copy', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (MethodCall methodCall) async => null,
+    );
+
+    final source = <DeviceOrientation>[DeviceOrientation.portraitUp];
+    await SystemChrome.setPreferredOrientations(source);
+
+    // The returned list is detached from the caller's input — mutating the
+    // source after the call must not affect the cached list.
+    source.add(DeviceOrientation.landscapeLeft);
+    expect(SystemChrome.preferredOrientations, <DeviceOrientation>[DeviceOrientation.portraitUp]);
+
+    // The returned list itself is unmodifiable.
+    expect(
+      () => SystemChrome.preferredOrientations!.add(DeviceOrientation.landscapeRight),
+      throwsUnsupportedError,
+    );
+  });
+
   test('setApplicationSwitcherDescription control test', () async {
     final log = <MethodCall>[];
 

--- a/packages/flutter/test/services/system_chrome_test.dart
+++ b/packages/flutter/test/services/system_chrome_test.dart
@@ -108,53 +108,86 @@ void main() {
     );
   });
 
-  test('preferredOrientations returns the latest set value', () async {
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
-      SystemChannels.platform,
-      (MethodCall methodCall) async => null,
-    );
+  group('preferredOrientations', () {
+    setUp(() {
+      // Reset cached state so each test starts from the "never set" state and
+      // mutations don't leak to other tests in the same process.
+      SystemChrome.debugResetPreferredOrientations();
+    });
 
-    await SystemChrome.setPreferredOrientations(<DeviceOrientation>[
-      DeviceOrientation.portraitUp,
-      DeviceOrientation.portraitDown,
-    ]);
+    tearDown(SystemChrome.debugResetPreferredOrientations);
 
-    expect(SystemChrome.preferredOrientations, <DeviceOrientation>[
-      DeviceOrientation.portraitUp,
-      DeviceOrientation.portraitDown,
-    ]);
+    test('is null before setPreferredOrientations is ever called', () {
+      expect(SystemChrome.preferredOrientations, isNull);
+    });
 
-    // A second call replaces the cached value rather than appending.
-    await SystemChrome.setPreferredOrientations(<DeviceOrientation>[DeviceOrientation.landscapeLeft]);
-    expect(SystemChrome.preferredOrientations, <DeviceOrientation>[
-      DeviceOrientation.landscapeLeft,
-    ]);
+    test('returns the latest set value', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (MethodCall methodCall) async => null,
+      );
 
-    // The empty list (defer to OS default) is preserved as an empty list, not null.
-    await SystemChrome.setPreferredOrientations(const <DeviceOrientation>[]);
-    expect(SystemChrome.preferredOrientations, isEmpty);
-    expect(SystemChrome.preferredOrientations, isNotNull);
-  });
+      await SystemChrome.setPreferredOrientations(<DeviceOrientation>[
+        DeviceOrientation.portraitUp,
+        DeviceOrientation.portraitDown,
+      ]);
 
-  test('preferredOrientations returns an unmodifiable copy', () async {
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
-      SystemChannels.platform,
-      (MethodCall methodCall) async => null,
-    );
+      expect(SystemChrome.preferredOrientations, <DeviceOrientation>[
+        DeviceOrientation.portraitUp,
+        DeviceOrientation.portraitDown,
+      ]);
 
-    final source = <DeviceOrientation>[DeviceOrientation.portraitUp];
-    await SystemChrome.setPreferredOrientations(source);
+      // A second call replaces the cached value rather than appending.
+      await SystemChrome.setPreferredOrientations(<DeviceOrientation>[
+        DeviceOrientation.landscapeLeft,
+      ]);
+      expect(SystemChrome.preferredOrientations, <DeviceOrientation>[
+        DeviceOrientation.landscapeLeft,
+      ]);
 
-    // The returned list is detached from the caller's input — mutating the
-    // source after the call must not affect the cached list.
-    source.add(DeviceOrientation.landscapeLeft);
-    expect(SystemChrome.preferredOrientations, <DeviceOrientation>[DeviceOrientation.portraitUp]);
+      // The empty list (defer to OS default) is preserved as an empty list, not null.
+      await SystemChrome.setPreferredOrientations(const <DeviceOrientation>[]);
+      expect(SystemChrome.preferredOrientations, isEmpty);
+      expect(SystemChrome.preferredOrientations, isNotNull);
+    });
 
-    // The returned list itself is unmodifiable.
-    expect(
-      () => SystemChrome.preferredOrientations!.add(DeviceOrientation.landscapeRight),
-      throwsUnsupportedError,
-    );
+    test('returns an unmodifiable copy', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (MethodCall methodCall) async => null,
+      );
+
+      final source = <DeviceOrientation>[DeviceOrientation.portraitUp];
+      await SystemChrome.setPreferredOrientations(source);
+
+      // The returned list is detached from the caller's input — mutating the
+      // source after the call must not affect the cached list.
+      source.add(DeviceOrientation.landscapeLeft);
+      expect(SystemChrome.preferredOrientations, <DeviceOrientation>[
+        DeviceOrientation.portraitUp,
+      ]);
+
+      // The returned list itself is unmodifiable.
+      expect(
+        () => SystemChrome.preferredOrientations!.add(DeviceOrientation.landscapeRight),
+        throwsUnsupportedError,
+      );
+    });
+
+    test('debugResetPreferredOrientations clears cached state', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (MethodCall methodCall) async => null,
+      );
+
+      await SystemChrome.setPreferredOrientations(<DeviceOrientation>[
+        DeviceOrientation.portraitUp,
+      ]);
+      expect(SystemChrome.preferredOrientations, isNotNull);
+
+      SystemChrome.debugResetPreferredOrientations();
+      expect(SystemChrome.preferredOrientations, isNull);
+    });
   });
 
   test('setApplicationSwitcherDescription control test', () async {


### PR DESCRIPTION
## Description

There was no way to read back which orientations had been requested via `SystemChrome.setPreferredOrientations`. This made common save/restore patterns awkward — a screen wanting to lock to portrait could not record the previous setting in order to restore it on dispose.

This PR caches the last value passed to `setPreferredOrientations` in the framework and exposes it via a new static getter:

```dart
final List<DeviceOrientation>? saved = SystemChrome.preferredOrientations;
await SystemChrome.setPreferredOrientations(<DeviceOrientation>[
  DeviceOrientation.portraitUp,
]);
// ... later, on dispose ...
await SystemChrome.setPreferredOrientations(saved ?? const <DeviceOrientation>[]);
```

### Behavior

* New static getter `SystemChrome.preferredOrientations` returns the last list passed to `setPreferredOrientations`, or `null` if it has not been called this session.
* The cached value is stored as an unmodifiable copy so subsequent mutations to the caller's source list cannot retroactively change what the getter returns.
* The empty list (defer to OS default) is preserved as an empty list rather than `null` — this distinguishes \"explicitly set to OS default\" from \"never set\".
* The cached value reflects what Flutter most recently asked the OS for; the OS may apply additional constraints (e.g. on Android 16 large-screen devices). The doc comment notes this.

### Tests

Added 2 new tests covering:
* The cached list updates on each call (no append/leak between calls)
* The empty list is round-tripped, distinguished from never-set
* Mutations to the caller's input do not leak into the cached list
* The returned list itself throws `UnsupportedError` on mutation

```
00:00 +17: All tests passed!
```

Fixes #95719

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.