### PR TITLE
[hooks] Fix pass-through dependencies

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/depfile.dart
+++ b/packages/flutter_tools/lib/src/build_system/depfile.dart
@@ -24,13 +24,30 @@ class DepfileService {
   /// This can be overridden with the [writeEmpty] parameter when
   /// both static and runtime dependencies exist and it is not desired
   /// to force a rerun due to no depfile.
-  void writeToFile(Depfile depfile, File output, {bool writeEmpty = false}) {
+  ///
+  /// If [filterOutputs] is true, files that are listed as both inputs and
+  /// outputs in the depfile are filtered out from the outputs list before
+  /// writing to avoid circular dependency cycles in external systems like Xcode.
+  void writeToFile(
+    Depfile depfile,
+    File output, {
+    bool writeEmpty = false,
+    bool filterOutputs = false,
+  }) {
     if (depfile.inputs.isEmpty && depfile.outputs.isEmpty && !writeEmpty) {
       ErrorHandlingFileSystem.deleteIfExists(output);
       return;
     }
     final buffer = StringBuffer();
-    _writeFilesToBuffer(depfile.outputs, buffer);
+    final List<File> outputsToWrite = filterOutputs
+        ? depfile.outputs
+              .where(
+                (File file) =>
+                    !depfile.inputs.map((File f) => f.absolute.path).contains(file.absolute.path),
+              )
+              .toList()
+        : depfile.outputs;
+    _writeFilesToBuffer(outputsToWrite, buffer);
     buffer.write(': ');
     _writeFilesToBuffer(depfile.inputs, buffer);
     output.writeAsStringSync(buffer.toString());

--- a/packages/flutter_tools/lib/src/build_system/depfile.dart
+++ b/packages/flutter_tools/lib/src/build_system/depfile.dart
@@ -39,14 +39,15 @@ class DepfileService {
       return;
     }
     final buffer = StringBuffer();
-    final List<File> outputsToWrite = filterOutputs
-        ? depfile.outputs
-              .where(
-                (File file) =>
-                    !depfile.inputs.map((File f) => f.absolute.path).contains(file.absolute.path),
-              )
-              .toList()
-        : depfile.outputs;
+    final List<File> outputsToWrite;
+    if (filterOutputs) {
+      final Set<String> inputPaths = depfile.inputs.map((File f) => f.absolute.path).toSet();
+      outputsToWrite = depfile.outputs
+          .where((File file) => !inputPaths.contains(file.absolute.path))
+          .toList();
+    } else {
+      outputsToWrite = depfile.outputs;
+    }
     _writeFilesToBuffer(outputsToWrite, buffer);
     buffer.write(': ');
     _writeFilesToBuffer(depfile.inputs, buffer);

--- a/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
@@ -84,7 +84,7 @@ class BuildHooks extends Target {
     if (!outputDepfile.parent.existsSync()) {
       outputDepfile.parent.createSync(recursive: true);
     }
-    environment.depFileService.writeToFile(depfile, outputDepfile);
+    environment.depFileService.writeToFile(depfile, outputDepfile, filterOutputs: true);
   }
 
   @override
@@ -236,7 +236,7 @@ class LinkHooks extends Target {
     if (!outputDepfile.parent.existsSync()) {
       outputDepfile.parent.createSync(recursive: true);
     }
-    environment.depFileService.writeToFile(depfile, outputDepfile);
+    environment.depFileService.writeToFile(depfile, outputDepfile, filterOutputs: true);
   }
 
   @override

--- a/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
@@ -330,6 +330,7 @@ Future<DartHooksResult> runFlutterSpecificLinkHooks({
         );
       }
       dataAssets.addAll(_filterDataAssets(buildResult.encodedAssets));
+      dependencies.addAll(buildResult.dependencies);
     }
   }
 

--- a/packages/flutter_tools/test/general.shard/isolated/build_system/targets/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/build_system/targets/native_assets_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:data_assets/data_assets.dart';
 import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/artifacts.dart';
@@ -136,6 +137,74 @@ void main() {
         expect(iosEnvironment.buildDir.childFile(BuildHooks.depFilename), exists);
         expect(iosEnvironment.buildDir.childFile(InstallCodeAssets.depFilename), exists);
         expect(iosEnvironment.buildDir.childFile(InstallCodeAssets.nativeAssetsFilename), exists);
+      },
+    );
+  }
+
+  bool nativeAssetsLinkingEnabled(BuildMode buildMode) {
+    switch (buildMode) {
+      case BuildMode.debug:
+        return false;
+      case BuildMode.jitRelease:
+      case BuildMode.profile:
+      case BuildMode.release:
+        return true;
+    }
+  }
+
+  for (final buildMode in <BuildMode>[BuildMode.profile, BuildMode.debug]) {
+    final bool linkingEnabled = nativeAssetsLinkingEnabled(buildMode);
+    final testName = linkingEnabled ? 'enabled' : 'disabled';
+    testUsingContext(
+      'NativeAssets depfile filtering avoids circular cycles in Xcode when link hooks are $testName',
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+        FeatureFlags: () =>
+            TestFeatureFlags(isNativeAssetsEnabled: true, isDartDataAssetsEnabled: true),
+      },
+      () async {
+        writePackageConfigFiles(directory: iosEnvironment.projectDir, mainLibName: 'my_app');
+
+        // Force environment to use specified build mode!
+        iosEnvironment.defines[kBuildMode] = buildMode.cliName;
+
+        final String sourceAssetPath = iosEnvironment.fileSystem
+            .file('assets/translations/en.json')
+            .path;
+        iosEnvironment.fileSystem.file(sourceAssetPath).createSync(recursive: true);
+
+        final FlutterNativeAssetsBuildRunner buildRunner = FakeFlutterNativeAssetsBuildRunner(
+          packagesWithNativeAssetsResult: <String>['foo'],
+          buildResult: FakeFlutterNativeAssetsBuilderResult.fromAssets(
+            dependencies: <Uri>[Uri.file(sourceAssetPath)],
+            dataAssets: <DataAsset>[
+              DataAsset(file: Uri.file(sourceAssetPath), name: 'en.json', package: 'my_app'),
+            ],
+          ),
+          linkResult: linkingEnabled
+              ? FakeFlutterNativeAssetsBuilderResult.fromAssets(
+                  dependencies: <Uri>[Uri.file(sourceAssetPath)],
+                )
+              : const FakeFlutterNativeAssetsBuilderResult(),
+        );
+
+        final dartBuildForNative = BuildHooks(buildRunner: buildRunner);
+        await dartBuildForNative.build(iosEnvironment);
+
+        final dartLinkForNative = LinkHooks(buildRunner: buildRunner);
+        await dartLinkForNative.build(iosEnvironment);
+
+        final File depfileFile = iosEnvironment.buildDir.childFile(LinkHooks.depFilename);
+        expect(depfileFile, exists);
+
+        final String contents = depfileFile.readAsStringSync();
+        final List<String> colonSeparated = contents.split(': ');
+        expect(colonSeparated.length, 2);
+
+        final List<String> linkOutputs = _resolvedOutputs(dartLinkForNative, iosEnvironment);
+        // Verify that full source path resolved resolves to empty list after fix!
+        expect(linkOutputs, isNot(contains(sourceAssetPath)));
       },
     );
   }


### PR DESCRIPTION
Closes:

* https://github.com/flutter/flutter/issues/185738

The dependencies from build and link hooks are reported as inputs by the flutter build system to Xcode.
The assets reported from build and link hooks were reported as outputs by the Flutter build system to Xcode.
This caused issues if files just passed through hooks untouched.

We should _only_ report files as outputs if they are actually _produced_ by the hook. This means that if a file occurs in its inputs it should not occur in its outputs.

If linking is disabled, then the LinkHooks target must also report the dependencies of the BuildHooks, not only its outputs.

Note: This was likely only an issue for data assets, not for code assets. Code assets are either built from source or downloaded in the hook. Usually precompiled code-assets are _not_ part of your package sources.