### PR TITLE
feat: change maxLines and minLines to double in material TextField

### DIFF
--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -11,7 +11,7 @@ library;
 
 import 'dart:ui' as ui show BoxHeightStyle, BoxWidthStyle;
 
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/cupertino.dart';h
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
@@ -511,12 +511,12 @@ class TextField extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.maxLines}
   ///  * [expands], which determines whether the field should fill the height of
   ///    its parent.
-  final int? maxLines;
+  final double? maxLines;
 
   /// {@macro flutter.widgets.editableText.minLines}
   ///  * [expands], which determines whether the field should fill the height of
   ///    its parent.
-  final int? minLines;
+  final double? minLines;
 
   /// {@macro flutter.widgets.editableText.expands}
   final bool expands;

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -11,7 +11,7 @@ library;
 
 import 'dart:ui' as ui show BoxHeightStyle, BoxWidthStyle;
 
-import 'package:flutter/cupertino.dart';h
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';


### PR DESCRIPTION
## Description

This PR changes the type of `maxLines` and `minLines` properties in `material/TextField` from `int?` to `double?`.

This allows developers to set fractional maximum number of lines for a TextField. When using a fractional value like `5.5`, users can immediately see that there is more content to scroll to, improving usability.

Fixes #35064

## Changes

- Changed `final int? maxLines` to `final double? double` in `packages/flutter/lib/src/material/text_field.dart`
- - Changed `final int? minLines` to `final double? minLines` in `packages/flutter/lib/src/material/text_field.dart`
## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] - [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] - [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] - [ ] I signed the [CLA].
- [ ] - [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] - [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] - [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] - [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] - [ ] All existing and new tests are passing.