### PR TITLE
Fix AnimatedList.separated assertion when re-inserting after a removeItem

### DIFF
--- a/packages/flutter/lib/src/widgets/animated_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/animated_scroll_view.dart
@@ -698,11 +698,13 @@ abstract class _AnimatedScrollViewState<T extends _AnimatedScrollView> extends S
       _sliverAnimatedMultiBoxKey.currentState!.insertItem(index, duration: duration);
     } else {
       final int itemIndex = _computeItemIndex(index);
+      final int visibleItemsCount = _visibleItemsCount;
+      final int separatedItemsCount = visibleItemsCount - visibleItemsCount ~/ 2;
+      final isNewLastIndex = index == separatedItemsCount;
       _sliverAnimatedMultiBoxKey.currentState!.insertItem(itemIndex, duration: duration);
-      if (_visibleItemsCount > 1) {
-        // Because `insertItem` moves the items after the index, we need to insert the separator
-        // at the same index as the item. If there is only one item, we don't need to insert a separator.
-        _sliverAnimatedMultiBoxKey.currentState!.insertItem(itemIndex, duration: duration);
+      if (visibleItemsCount > 0) {
+        final int separatorIndex = isNewLastIndex ? itemIndex : itemIndex + 1;
+        _sliverAnimatedMultiBoxKey.currentState!.insertItem(separatorIndex, duration: duration);
       }
     }
   }
@@ -813,14 +815,15 @@ abstract class _AnimatedScrollViewState<T extends _AnimatedScrollView> extends S
     // with the corresponding builders.
     final int visibleItemsCount = _visibleItemsCount;
     for (int index = visibleItemsCount - 1; index >= 0; index--) {
-      if (index.isEven) {
+      final int itemIndex = _sliverAnimatedMultiBoxKey.currentState!._indexToItemIndex(index);
+      if (itemIndex.isEven) {
         _sliverAnimatedMultiBoxKey.currentState!.removeItem(index, builder, duration: duration);
       } else {
         // The index of the separator's corresponding item
-        final int itemIndex = index ~/ 2;
+        final int separatorIndex = itemIndex ~/ 2;
         _sliverAnimatedMultiBoxKey.currentState!.removeItem(
           index,
-          _toRemovedItemBuilder(removedSeparatorBuilder, itemIndex),
+          _toRemovedItemBuilder(removedSeparatorBuilder, separatorIndex),
           duration: duration,
         );
       }

--- a/packages/flutter/lib/src/widgets/animated_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/animated_scroll_view.dart
@@ -699,7 +699,7 @@ abstract class _AnimatedScrollViewState<T extends _AnimatedScrollView> extends S
     } else {
       final int itemIndex = _computeItemIndex(index);
       _sliverAnimatedMultiBoxKey.currentState!.insertItem(itemIndex, duration: duration);
-      if (_itemsCount > 1) {
+      if (_visibleItemsCount > 1) {
         // Because `insertItem` moves the items after the index, we need to insert the separator
         // at the same index as the item. If there is only one item, we don't need to insert a separator.
         _sliverAnimatedMultiBoxKey.currentState!.insertItem(itemIndex, duration: duration);
@@ -722,7 +722,7 @@ abstract class _AnimatedScrollViewState<T extends _AnimatedScrollView> extends S
       _sliverAnimatedMultiBoxKey.currentState!.insertAllItems(index, length, duration: duration);
     } else {
       final int itemIndex = _computeItemIndex(index);
-      final int lengthWithSeparators = _itemsCount == 0 ? length * 2 - 1 : length * 2;
+      final int lengthWithSeparators = _visibleItemsCount == 0 ? length * 2 - 1 : length * 2;
       _sliverAnimatedMultiBoxKey.currentState!.insertAllItems(
         itemIndex,
         lengthWithSeparators,
@@ -756,11 +756,11 @@ abstract class _AnimatedScrollViewState<T extends _AnimatedScrollView> extends S
       // There are no separators. Remove only the item.
       _sliverAnimatedMultiBoxKey.currentState!.removeItem(index, builder, duration: duration);
     } else {
-      final int itemIndex = _computeItemIndex(index);
       // Children animating out from earlier removeItem calls still count
       // towards [_itemsCount], so subtract them to recognize the new tail
       // of the visible list while a previous removal is still in flight.
-      final int visibleItemsCount = _itemsCount - _outgoingItemsCount;
+      final int visibleItemsCount = _visibleItemsCount;
+      final int itemIndex = _computeItemIndex(index);
       // Remove the item
       _sliverAnimatedMultiBoxKey.currentState!.removeItem(itemIndex, builder, duration: duration);
       if (visibleItemsCount > 1) {
@@ -811,7 +811,8 @@ abstract class _AnimatedScrollViewState<T extends _AnimatedScrollView> extends S
 
     // There are separators. We need to remove items and separators separately
     // with the corresponding builders.
-    for (int index = _itemsCount - 1; index >= 0; index--) {
+    final int visibleItemsCount = _visibleItemsCount;
+    for (int index = visibleItemsCount - 1; index >= 0; index--) {
       if (index.isEven) {
         _sliverAnimatedMultiBoxKey.currentState!.removeItem(index, builder, duration: duration);
       } else {
@@ -828,10 +829,12 @@ abstract class _AnimatedScrollViewState<T extends _AnimatedScrollView> extends S
 
   int get _itemsCount => _sliverAnimatedMultiBoxKey.currentState!._itemsCount;
 
-  /// The number of underlying entries that are still live (not currently
-  /// animating out). The sliver-level [_SliverAnimatedMultiBoxAdaptorState.insertItem]
-  /// and [_SliverAnimatedMultiBoxAdaptorState.removeItem] APIs are documented
-  /// to operate in this space (the comment on
+  /// The number of underlying entries that are still live.
+  ///
+  /// This excludes entries that are currently animating out. The sliver-level
+  /// [_SliverAnimatedMultiBoxAdaptorState.insertItem] and
+  /// [_SliverAnimatedMultiBoxAdaptorState.removeItem] APIs are documented to
+  /// operate in this space (the comment on
   /// [_SliverAnimatedMultiBoxAdaptorState._indexToItemIndex] notes that index
   /// parameters are defined as if the remove operation removed the
   /// corresponding entry immediately), so separator-aware index translation

--- a/packages/flutter/lib/src/widgets/animated_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/animated_scroll_view.dart
@@ -828,16 +828,25 @@ abstract class _AnimatedScrollViewState<T extends _AnimatedScrollView> extends S
 
   int get _itemsCount => _sliverAnimatedMultiBoxKey.currentState!._itemsCount;
 
-  int get _outgoingItemsCount => _sliverAnimatedMultiBoxKey.currentState!._outgoingItems.length;
+  /// The number of underlying entries that are still live (not currently
+  /// animating out). The sliver-level [_SliverAnimatedMultiBoxAdaptorState.insertItem]
+  /// and [_SliverAnimatedMultiBoxAdaptorState.removeItem] APIs are documented
+  /// to operate in this space (the comment on
+  /// [_SliverAnimatedMultiBoxAdaptorState._indexToItemIndex] notes that index
+  /// parameters are defined as if the remove operation removed the
+  /// corresponding entry immediately), so separator-aware index translation
+  /// must also be computed against it.
+  int get _visibleItemsCount =>
+      _itemsCount - _sliverAnimatedMultiBoxKey.currentState!._outgoingItems.length;
 
   // Helper method to compute the index for the item to insert or remove considering the separators in between.
   int _computeItemIndex(int index) {
     if (index == 0) {
       return index;
     }
-    final int itemsAndSeparatorsCount = _itemsCount;
+    final int itemsAndSeparatorsCount = _visibleItemsCount;
     final int separatorsCount = itemsAndSeparatorsCount ~/ 2;
-    final int separatedItemsCount = _itemsCount - separatorsCount;
+    final int separatedItemsCount = itemsAndSeparatorsCount - separatorsCount;
 
     final isNewLastIndex = index == separatedItemsCount;
     final int indexAdjustedForSeparators = index * 2;

--- a/packages/flutter/test/widgets/animated_list_test.dart
+++ b/packages/flutter/test/widgets/animated_list_test.dart
@@ -1331,6 +1331,153 @@ void main() {
     },
   );
 
+  testWidgets(
+    'AnimatedList.separated keeps separators correct when inserting while removals are outgoing',
+    (WidgetTester tester) async {
+      late GlobalKey<AnimatedListState> listKey;
+
+      Widget itemBuilder(BuildContext context, int index, Animation<double> animation) {
+        return SizedBox(height: 40.0, child: Text('item $index'));
+      }
+
+      Widget separatorBuilder(BuildContext context, int index, Animation<double> animation) {
+        return SizedBox(height: 8.0, child: Text('sep $index'));
+      }
+
+      AnimatedRemovedItemBuilder removedBuilder(String text) {
+        return (BuildContext context, Animation<double> animation) {
+          return SizedBox(height: 40.0, child: Text(text));
+        };
+      }
+
+      Future<void> pumpSeparatedList(int initialItemCount) async {
+        listKey = GlobalKey<AnimatedListState>();
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: AnimatedList.separated(
+              key: listKey,
+              initialItemCount: initialItemCount,
+              itemBuilder: itemBuilder,
+              separatorBuilder: separatorBuilder,
+              removedSeparatorBuilder: separatorBuilder,
+            ),
+          ),
+        );
+      }
+
+      List<String> visibleText() {
+        return tester
+            .widgetList<Text>(
+              find.descendant(of: find.byType(SliverAnimatedList), matching: find.byType(Text)),
+            )
+            .map((Text text) => text.data!)
+            .toList();
+      }
+
+      await pumpSeparatedList(1);
+      listKey.currentState!.removeItem(
+        0,
+        removedBuilder('removed item'),
+        duration: const Duration(milliseconds: 100),
+      );
+      listKey.currentState!.insertItem(0, duration: const Duration(milliseconds: 100));
+
+      await tester.pumpAndSettle();
+      expect(tester.takeException(), isNull);
+      expect(visibleText(), <String>['item 0']);
+
+      await pumpSeparatedList(1);
+      listKey.currentState!.removeItem(
+        0,
+        removedBuilder('removed item'),
+        duration: const Duration(milliseconds: 100),
+      );
+      listKey.currentState!.insertAllItems(0, 2, duration: const Duration(milliseconds: 100));
+
+      await tester.pumpAndSettle();
+      expect(tester.takeException(), isNull);
+      expect(visibleText(), <String>['item 0', 'sep 0', 'item 1']);
+    },
+  );
+
+  testWidgets(
+    'AnimatedList.separated removes remaining visible entries while removals are outgoing',
+    (WidgetTester tester) async {
+      late GlobalKey<AnimatedListState> listKey;
+
+      Widget itemBuilder(BuildContext context, int index, Animation<double> animation) {
+        return SizedBox(height: 40.0, child: Text('item $index'));
+      }
+
+      Widget separatorBuilder(BuildContext context, int index, Animation<double> animation) {
+        return SizedBox(height: 8.0, child: Text('sep $index'));
+      }
+
+      AnimatedRemovedItemBuilder removedBuilder(String text) {
+        return (BuildContext context, Animation<double> animation) {
+          return SizedBox(height: 40.0, child: Text(text));
+        };
+      }
+
+      Future<void> pumpSeparatedList() async {
+        listKey = GlobalKey<AnimatedListState>();
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: AnimatedList.separated(
+              key: listKey,
+              initialItemCount: 2,
+              itemBuilder: itemBuilder,
+              separatorBuilder: separatorBuilder,
+              removedSeparatorBuilder: separatorBuilder,
+            ),
+          ),
+        );
+      }
+
+      List<String> visibleText() {
+        return tester
+            .widgetList<Text>(
+              find.descendant(of: find.byType(SliverAnimatedList), matching: find.byType(Text)),
+            )
+            .map((Text text) => text.data!)
+            .toList();
+      }
+
+      await pumpSeparatedList();
+      listKey.currentState!.removeItem(
+        1,
+        removedBuilder('removed item 1'),
+        duration: const Duration(milliseconds: 100),
+      );
+      listKey.currentState!.removeItem(
+        0,
+        removedBuilder('removed item 0'),
+        duration: const Duration(milliseconds: 100),
+      );
+
+      await tester.pumpAndSettle();
+      expect(tester.takeException(), isNull);
+      expect(visibleText(), isEmpty);
+
+      await pumpSeparatedList();
+      listKey.currentState!.removeItem(
+        1,
+        removedBuilder('removed item 1'),
+        duration: const Duration(milliseconds: 100),
+      );
+      listKey.currentState!.removeAllItems(
+        removedBuilder('removed all items'),
+        duration: const Duration(milliseconds: 100),
+      );
+
+      await tester.pumpAndSettle();
+      expect(tester.takeException(), isNull);
+      expect(visibleText(), isEmpty);
+    },
+  );
+
   testWidgets('AnimatedList does not crash at zero area', (WidgetTester tester) async {
     tester.view.physicalSize = Size.zero;
     final controller = ScrollController();

--- a/packages/flutter/test/widgets/animated_list_test.dart
+++ b/packages/flutter/test/widgets/animated_list_test.dart
@@ -1279,6 +1279,58 @@ void main() {
     },
   );
 
+  // Regression test for https://github.com/flutter/flutter/issues/179029.
+  testWidgets(
+    'AnimatedList.separated does not throw when removing then re-inserting the last item before the removal animation completes',
+    (WidgetTester tester) async {
+      final listKey = GlobalKey<AnimatedListState>();
+      const initialItemCount = 2;
+
+      Widget itemBuilder(BuildContext context, int index, Animation<double> animation) {
+        return SizedBox(height: 40.0, child: Text('item $index'));
+      }
+
+      Widget separatorBuilder(BuildContext context, int index, Animation<double> animation) {
+        return SizedBox(height: 8.0, child: Text('sep $index'));
+      }
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: AnimatedList.separated(
+            key: listKey,
+            initialItemCount: initialItemCount,
+            itemBuilder: itemBuilder,
+            separatorBuilder: separatorBuilder,
+            removedSeparatorBuilder: separatorBuilder,
+          ),
+        ),
+      );
+
+      listKey.currentState!.removeItem(
+        initialItemCount - 1,
+        (BuildContext context, Animation<double> animation) =>
+            const SizedBox(height: 40.0, child: Text('removed')),
+        duration: const Duration(milliseconds: 100),
+      );
+      listKey.currentState!.insertItem(
+        initialItemCount - 1,
+        duration: const Duration(milliseconds: 100),
+      );
+
+      await tester.pumpAndSettle();
+      expect(tester.takeException(), isNull);
+
+      final List<String> visible = tester
+          .widgetList<Text>(
+            find.descendant(of: find.byType(SliverAnimatedList), matching: find.byType(Text)),
+          )
+          .map((Text text) => text.data!)
+          .toList();
+      expect(visible, <String>['item 0', 'sep 0', 'item 1']);
+    },
+  );
+
   testWidgets('AnimatedList does not crash at zero area', (WidgetTester tester) async {
     tester.view.physicalSize = Size.zero;
     final controller = ScrollController();

--- a/packages/flutter/test/widgets/animated_list_test.dart
+++ b/packages/flutter/test/widgets/animated_list_test.dart
@@ -1401,6 +1401,67 @@ void main() {
     },
   );
 
+  testWidgets('AnimatedList.separated keeps item animation when removing an incoming item', (
+    WidgetTester tester,
+  ) async {
+    final listKey = GlobalKey<AnimatedListState>();
+    final items = <String>['A', 'B'];
+    Animation<double>? insertedItemAnimation;
+    Animation<double>? insertedSeparatorAnimation;
+    Animation<double>? removedItemAnimation;
+    Animation<double>? removedSeparatorAnimation;
+
+    Widget itemBuilder(BuildContext context, int index, Animation<double> animation) {
+      if (items[index] == 'C') {
+        insertedItemAnimation = animation;
+      }
+      return SizedBox(height: 40.0, child: Text('item ${items[index]}'));
+    }
+
+    Widget separatorBuilder(BuildContext context, int index, Animation<double> animation) {
+      if (items[index] == 'C') {
+        insertedSeparatorAnimation = animation;
+      }
+      return SizedBox(height: 8.0, child: Text('sep ${items[index]}'));
+    }
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: AnimatedList.separated(
+          key: listKey,
+          initialItemCount: items.length,
+          itemBuilder: itemBuilder,
+          separatorBuilder: separatorBuilder,
+          removedSeparatorBuilder: (BuildContext context, int index, Animation<double> animation) {
+            removedSeparatorAnimation = animation;
+            return SizedBox(height: 8.0, child: Text('removed sep $index'));
+          },
+        ),
+      ),
+    );
+
+    items.insert(1, 'C');
+    listKey.currentState!.insertItem(1, duration: const Duration(seconds: 1));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(insertedItemAnimation, isNotNull);
+    expect(insertedSeparatorAnimation, isNotNull);
+
+    final Animation<double> expectedItemAnimation = insertedItemAnimation!;
+    final Animation<double> expectedSeparatorAnimation = insertedSeparatorAnimation!;
+
+    items.removeAt(1);
+    listKey.currentState!.removeItem(1, (BuildContext context, Animation<double> animation) {
+      removedItemAnimation = animation;
+      return const SizedBox(height: 40.0, child: Text('removed item C'));
+    }, duration: const Duration(seconds: 1));
+    await tester.pump();
+
+    expect(removedItemAnimation, same(expectedItemAnimation));
+    expect(removedSeparatorAnimation, same(expectedSeparatorAnimation));
+  });
+
   testWidgets(
     'AnimatedList.separated removes remaining visible entries while removals are outgoing',
     (WidgetTester tester) async {
@@ -1475,6 +1536,51 @@ void main() {
       await tester.pumpAndSettle();
       expect(tester.takeException(), isNull);
       expect(visibleText(), isEmpty);
+    },
+  );
+
+  testWidgets(
+    'AnimatedList.separated removeAllItems keeps separator indexes while removals are outgoing',
+    (WidgetTester tester) async {
+      final listKey = GlobalKey<AnimatedListState>();
+      final removedSeparatorIndexes = <int>[];
+
+      Widget itemBuilder(BuildContext context, int index, Animation<double> animation) {
+        return SizedBox(height: 40.0, child: Text('item $index'));
+      }
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: AnimatedList.separated(
+            key: listKey,
+            initialItemCount: 3,
+            itemBuilder: itemBuilder,
+            separatorBuilder: (BuildContext context, int index, Animation<double> animation) {
+              return SizedBox(height: 8.0, child: Text('sep $index'));
+            },
+            removedSeparatorBuilder:
+                (BuildContext context, int index, Animation<double> animation) {
+                  removedSeparatorIndexes.add(index);
+                  return SizedBox(height: 8.0, child: Text('removed sep $index'));
+                },
+          ),
+        ),
+      );
+
+      listKey.currentState!.removeItem(0, (BuildContext context, Animation<double> animation) {
+        return const SizedBox(height: 40.0, child: Text('removed item 0'));
+      }, duration: const Duration(seconds: 1));
+      await tester.pump();
+      expect(removedSeparatorIndexes, <int>[0]);
+      removedSeparatorIndexes.clear();
+
+      listKey.currentState!.removeAllItems((BuildContext context, Animation<double> animation) {
+        return const SizedBox(height: 40.0, child: Text('removed item'));
+      }, duration: const Duration(seconds: 1));
+      await tester.pump();
+
+      expect(removedSeparatorIndexes, contains(1));
     },
   );
 


### PR DESCRIPTION
## Description

Fixes the assertion failure reported in #179029.

When a user calls `AnimatedList.separated`'s `removeItem` and then `insertItem` for the same position before the removal animation finishes, the framework throws:

```
'package:flutter/src/widgets/animated_scroll_view.dart': Failed assertion: line 1355 pos 12:
'itemIndex >= 0 && itemIndex <= _itemsCount': is not true.
```

(Stack frame: `_SliverAnimatedMultiBoxAdaptorState.insertItem` → `_AnimatedScrollViewState.insertItem`.)

## Root cause

`_AnimatedScrollViewState._computeItemIndex` translates a user-facing index into the sliver-level index that `SliverAnimatedList` consumes. It computed the separator-aware mapping from `_itemsCount`, the total number of underlying entries. That total includes entries that are still animating out (`_outgoingItems`), but the sliver-level `insertItem`/`removeItem` APIs are documented to operate as if outgoing items had already been removed (see the comment on `_SliverAnimatedMultiBoxAdaptorState._indexToItemIndex`).

When outgoing items are present, `_computeItemIndex` therefore returned an index that was already too large for the live list. The sliver then shifted that index up further by `_indexToItemIndex` to skip the outgoing entries, producing a value past the assertion's allowed range.

This matches the precedent set in 61fff253ea2a (#176452, "Fix(AnimatedScrollView): exclude outgoing items in removeAllItems"), which subtracted `_outgoingItems.length` from `_itemsCount` to drive `removeAllItems` against the visible count.

## Fix

Add a `_visibleItemsCount` getter that returns `_itemsCount - _outgoingItems.length` and use it in `_computeItemIndex`. No behavior change when no animations are in flight.

## Tests

Added a regression test in `test/widgets/animated_list_test.dart` that reproduces the issue's scenario verbatim:

- 2-item separated list.
- `removeItem(last)` immediately followed by `insertItem(last)` (no `pump` in between).
- `pumpAndSettle()` and assert: no exception thrown, and the final visible state is `['item 0', 'sep 0', 'item 1']`.

The existing `AnimatedList.separated` test (the only one in the file that exercises separator handling) continues to pass; all 18 prior tests in `animated_list_test.dart` and the 15 in `animated_grid_test.dart` (which shares the fixed code path) still pass. Analyzer is clean on both touched files.

Fixes #179029