### PR TITLE
Makes it so ubersdf contents can be collapsed to clear colors.

### DIFF
--- a/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.cc
@@ -128,4 +128,20 @@ bool UberSDFContents::ApplyColorFilter(
   return true;
 }
 
+std::optional<Color> UberSDFContents::AsBackgroundColor(
+    const Entity& entity,
+    ISize target_size) const {
+  if (params_.type != UberSDFParameters::Type::kRect) {
+    return std::nullopt;
+  }
+  const Geometry* geometry = GetGeometry();
+  if (geometry == nullptr) {
+    return std::nullopt;
+  }
+  Rect target_rect = Rect::MakeSize(target_size);
+  return geometry->CoversArea(entity.GetTransform(), target_rect)
+             ? GetColor()
+             : std::optional<Color>();
+}
+
 }  // namespace impeller

--- a/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.h
+++ b/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.h
@@ -36,6 +36,9 @@ class UberSDFContents : public ColorSourceContents {
 
   const Geometry* GetGeometry() const override;
 
+  std::optional<Color> AsBackgroundColor(const Entity& entity,
+                                         ISize target_size) const override;
+
  private:
   explicit UberSDFContents(const UberSDFParameters& params,
                            std::unique_ptr<Geometry> geometry);

--- a/engine/src/flutter/impeller/entity/contents/uber_sdf_contents_unittests.cc
+++ b/engine/src/flutter/impeller/entity/contents/uber_sdf_contents_unittests.cc
@@ -20,13 +20,13 @@ TEST(UberSDFContentsTest, ApplyColorFilter) {
   auto geometry = std::make_unique<UberSDFGeometry>(params);
   auto contents = UberSDFContents::Make(params, std::move(geometry));
 
-  ASSERT_EQ(contents->GetColor(), Color::Red());
+  EXPECT_EQ(contents->GetColor(), Color::Red());
 
   bool result =
       contents->ApplyColorFilter([](Color color) { return Color::Blue(); });
 
-  ASSERT_TRUE(result);
-  ASSERT_EQ(contents->GetColor(), Color::Blue());
+  EXPECT_TRUE(result);
+  EXPECT_EQ(contents->GetColor(), Color::Blue());
 }
 
 TEST(UberSDFContentsTest, AsBackgroundColor) {
@@ -40,15 +40,19 @@ TEST(UberSDFContentsTest, AsBackgroundColor) {
   entity.SetTransform(Matrix());
 
   auto bg_color = contents->AsBackgroundColor(entity, ISize(500, 500));
-  ASSERT_TRUE(bg_color.has_value());
-  ASSERT_EQ(bg_color.value(), Color::Red());
+  EXPECT_TRUE(bg_color.has_value());
+  if (bg_color.has_value()) {
+    EXPECT_EQ(bg_color.value(), Color::Red());
+  }
 
   auto small_bg_color = contents->AsBackgroundColor(entity, ISize(400, 400));
-  ASSERT_TRUE(small_bg_color.has_value());
-  ASSERT_EQ(small_bg_color.value(), Color::Red());
+  EXPECT_TRUE(small_bg_color.has_value());
+  if (small_bg_color.has_value()) {
+    EXPECT_EQ(small_bg_color.value(), Color::Red());
+  }
 
   auto huge_bg_color = contents->AsBackgroundColor(entity, ISize(600, 600));
-  ASSERT_FALSE(huge_bg_color.has_value());
+  EXPECT_FALSE(huge_bg_color.has_value());
 }
 
 TEST(UberSDFContentsTest, AsBackgroundColorExactSize) {
@@ -64,8 +68,10 @@ TEST(UberSDFContentsTest, AsBackgroundColorExactSize) {
   auto bg_color = contents->AsBackgroundColor(entity, ISize(500, 500));
   // The exact size now returns true because over-conservative AA insets are
   // removed
-  ASSERT_TRUE(bg_color.has_value());
-  ASSERT_EQ(bg_color.value(), Color::Red());
+  EXPECT_TRUE(bg_color.has_value());
+  if (bg_color.has_value()) {
+    EXPECT_EQ(bg_color.value(), Color::Red());
+  }
 }
 
 TEST(UberSDFContentsTest, AsBackgroundColorNonRect) {
@@ -81,7 +87,7 @@ TEST(UberSDFContentsTest, AsBackgroundColorNonRect) {
 
   auto circle_bg_color =
       circle_contents->AsBackgroundColor(entity, ISize(500, 500));
-  ASSERT_FALSE(circle_bg_color.has_value());
+  EXPECT_FALSE(circle_bg_color.has_value());
 }
 
 TEST(UberSDFContentsTest, AsBackgroundColorStrokedRect) {
@@ -95,7 +101,7 @@ TEST(UberSDFContentsTest, AsBackgroundColorStrokedRect) {
   entity.SetTransform(Matrix());
 
   auto bg_color = contents->AsBackgroundColor(entity, ISize(500, 500));
-  ASSERT_FALSE(bg_color.has_value());
+  EXPECT_FALSE(bg_color.has_value());
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/entity/contents/uber_sdf_contents_unittests.cc
+++ b/engine/src/flutter/impeller/entity/contents/uber_sdf_contents_unittests.cc
@@ -5,8 +5,10 @@
 #include "gtest/gtest.h"
 #include "impeller/entity/contents/uber_sdf_contents.h"
 #include "impeller/entity/contents/uber_sdf_parameters.h"
+#include "impeller/entity/entity.h"
 #include "impeller/entity/geometry/uber_sdf_geometry.h"
 #include "impeller/geometry/rect.h"
+#include "impeller/geometry/size.h"
 
 namespace impeller {
 namespace testing {
@@ -25,6 +27,75 @@ TEST(UberSDFContentsTest, ApplyColorFilter) {
 
   ASSERT_TRUE(result);
   ASSERT_EQ(contents->GetColor(), Color::Blue());
+}
+
+TEST(UberSDFContentsTest, AsBackgroundColor) {
+  auto rect = Rect::MakeXYWH(-2, -2, 504, 504);
+  auto params =
+      UberSDFParameters::MakeRect(Color::Red(), rect, /*stroke=*/std::nullopt);
+  auto geometry = std::make_unique<UberSDFGeometry>(params);
+  auto contents = UberSDFContents::Make(params, std::move(geometry));
+
+  Entity entity;
+  entity.SetTransform(Matrix());
+
+  auto bg_color = contents->AsBackgroundColor(entity, ISize(500, 500));
+  ASSERT_TRUE(bg_color.has_value());
+  ASSERT_EQ(bg_color.value(), Color::Red());
+
+  auto small_bg_color = contents->AsBackgroundColor(entity, ISize(400, 400));
+  ASSERT_TRUE(small_bg_color.has_value());
+  ASSERT_EQ(small_bg_color.value(), Color::Red());
+
+  auto huge_bg_color = contents->AsBackgroundColor(entity, ISize(600, 600));
+  ASSERT_FALSE(huge_bg_color.has_value());
+}
+
+TEST(UberSDFContentsTest, AsBackgroundColorExactSize) {
+  auto rect = Rect::MakeXYWH(0, 0, 500, 500);
+  auto params =
+      UberSDFParameters::MakeRect(Color::Red(), rect, /*stroke=*/std::nullopt);
+  auto geometry = std::make_unique<UberSDFGeometry>(params);
+  auto contents = UberSDFContents::Make(params, std::move(geometry));
+
+  Entity entity;
+  entity.SetTransform(Matrix());
+
+  auto bg_color = contents->AsBackgroundColor(entity, ISize(500, 500));
+  // The exact size now returns true because over-conservative AA insets are
+  // removed
+  ASSERT_TRUE(bg_color.has_value());
+  ASSERT_EQ(bg_color.value(), Color::Red());
+}
+
+TEST(UberSDFContentsTest, AsBackgroundColorNonRect) {
+  Entity entity;
+  entity.SetTransform(Matrix());
+
+  // Non-rect shape (Circle) should return nullopt
+  auto circle_params = UberSDFParameters::MakeCircle(
+      Color::Red(), Point(250, 250), 250.0f, /*stroke=*/std::nullopt);
+  auto circle_geometry = std::make_unique<UberSDFGeometry>(circle_params);
+  auto circle_contents =
+      UberSDFContents::Make(circle_params, std::move(circle_geometry));
+
+  auto circle_bg_color =
+      circle_contents->AsBackgroundColor(entity, ISize(500, 500));
+  ASSERT_FALSE(circle_bg_color.has_value());
+}
+
+TEST(UberSDFContentsTest, AsBackgroundColorStrokedRect) {
+  auto rect = Rect::MakeXYWH(-2, -2, 504, 504);
+  auto params = UberSDFParameters::MakeRect(Color::Red(), rect,
+                                            StrokeParameters{.width = 2.0f});
+  auto geometry = std::make_unique<UberSDFGeometry>(params);
+  auto contents = UberSDFContents::Make(params, std::move(geometry));
+
+  Entity entity;
+  entity.SetTransform(Matrix());
+
+  auto bg_color = contents->AsBackgroundColor(entity, ISize(500, 500));
+  ASSERT_FALSE(bg_color.has_value());
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/entity/contents/uber_sdf_contents_unittests.cc
+++ b/engine/src/flutter/impeller/entity/contents/uber_sdf_contents_unittests.cc
@@ -39,11 +39,7 @@ TEST(UberSDFContentsTest, AsBackgroundColor) {
   Entity entity;
   entity.SetTransform(Matrix());
 
-  auto bg_color = contents->AsBackgroundColor(entity, ISize(500, 500));
-  EXPECT_TRUE(bg_color.has_value());
-  if (bg_color.has_value()) {
-    EXPECT_EQ(bg_color.value(), Color::Red());
-  }
+  EXPECT_EQ(contents->AsBackgroundColor(entity, ISize(500, 500)), Color::Red());
 
   auto small_bg_color = contents->AsBackgroundColor(entity, ISize(400, 400));
   EXPECT_TRUE(small_bg_color.has_value());

--- a/engine/src/flutter/impeller/entity/geometry/uber_sdf_geometry.cc
+++ b/engine/src/flutter/impeller/entity/geometry/uber_sdf_geometry.cc
@@ -47,9 +47,9 @@ bool UberSDFGeometry::CoversArea(const Matrix& transform,
     // at least half a pixel on each side of the pixel centers inside it and
     // that it encloses every MSAA sample location within those pixels. This
     // means that the integer rect already meets all of the above criteria (as
-    // long as kAntialiasPixels is >= 1.0), so if the transformed geometry
+    // long as kAntialiasPixels is <= 1.0), so if the transformed geometry
     // contains the integer input rect, all pixels will be fully rendered.
-    static_assert(UberSDFParameters::kAntialiasPixels >= 1.0);
+    static_assert(UberSDFParameters::kAntialiasPixels <= 1.0);
     return Rect::MakeEllipseBounds(params_.center, params_.size)
         .TransformBounds(transform)
         .Contains(rect);

--- a/engine/src/flutter/impeller/entity/geometry/uber_sdf_geometry.cc
+++ b/engine/src/flutter/impeller/entity/geometry/uber_sdf_geometry.cc
@@ -36,8 +36,20 @@ bool UberSDFGeometry::CoversArea(const Matrix& transform,
                                  const Rect& rect) const {
   if (params_.type == UberSDFParameters::Type::kRect && !params_.stroke &&
       transform.IsTranslationScaleOnly()) {
-    // The SDF is a filled axis-aligned rectangle. It covers the input rect if
-    // the SDF's transformed bounds rect covers the input rect.
+    // The SDF is a filled axis-aligned rectangle. It "covers" the input rect if
+    // the SDF shader fully replaces the pixels contained in the rect parameter.
+    // The SDF shader is computed by the GPU at the center of the pixels it
+    // intersects and it computes a coverage for the pixels that reaches full
+    // coverage (1.0) at (aa_pixels / 2.0) inside the geometry. That coverage
+    // value will be applied for every MSAA sample intersected by the geometry.
+    //
+    // Since the input rect is an integer rect we already know that it encloses
+    // at least half a pixel on each side of the pixel centers inside it and
+    // that it encloses every MSAA sample location within those pixels. This
+    // means that the integer rect already meets all of the above criteria (as
+    // long as kAntialiasPixels is >= 1.0), so if the transformed geometry
+    // contains the integer input rect, all pixels will be fully rendered.
+    static_assert(UberSDFParameters::kAntialiasPixels >= 1.0);
     return Rect::MakeEllipseBounds(params_.center, params_.size)
         .TransformBounds(transform)
         .Contains(rect);

--- a/engine/src/flutter/impeller/entity/geometry/uber_sdf_geometry.cc
+++ b/engine/src/flutter/impeller/entity/geometry/uber_sdf_geometry.cc
@@ -37,14 +37,9 @@ bool UberSDFGeometry::CoversArea(const Matrix& transform,
   if (params_.type == UberSDFParameters::Type::kRect && !params_.stroke &&
       transform.IsTranslationScaleOnly()) {
     // The SDF is a filled axis-aligned rectangle. It covers the input rect if
-    // the SDF's transformed bounds rect covers the input rect, subtracting
-    // the AA padding from the SDF rect.
-    return GetExpandedBounds(transform)
-        .TransformAndClipBounds(transform)
-        // Subtract twice the AA padding. This subtracts the AA padding added
-        // by GetExpandedBounds, and also insets the quad by another AA padding
-        // amount to account for AA fading into the interior of the shape.
-        .Expand(-2.0f * UberSDFParameters::kAntialiasPixels)
+    // the SDF's transformed bounds rect covers the input rect.
+    return Rect::MakeEllipseBounds(params_.center, params_.size)
+        .TransformBounds(transform)
         .Contains(rect);
   }
 


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/185711

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
