### PR TITLE
Fix App binary path for SwiftPM Add2App on macOS

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_swift_package.dart
+++ b/packages/flutter_tools/lib/src/commands/build_swift_package.dart
@@ -1957,6 +1957,9 @@ class FlutterNativeIntegrationSwiftPackage {
     );
     scriptsTemplate.render(scriptsDirectory, <String, Object>{
       'flutterFrameworkName': _targetPlatform.binaryName,
+      'flutterFrameworkBinaryPath': _targetPlatform == FlutterDarwinPlatform.macos
+          ? 'Versions/A/${_targetPlatform.binaryName}'
+          : _targetPlatform.binaryName,
       'infoPlistPath': _targetPlatform == FlutterDarwinPlatform.macos
           ? 'Versions/A/Resources/Info.plist'
           : 'Info.plist',

--- a/packages/flutter_tools/lib/src/commands/build_swift_package.dart
+++ b/packages/flutter_tools/lib/src/commands/build_swift_package.dart
@@ -1960,6 +1960,9 @@ class FlutterNativeIntegrationSwiftPackage {
       'infoPlistPath': _targetPlatform == FlutterDarwinPlatform.macos
           ? 'Versions/A/Resources/Info.plist'
           : 'Info.plist',
+      'appFrameworkBinaryPath': _targetPlatform == FlutterDarwinPlatform.macos
+          ? 'Versions/A/App'
+          : 'App',
     }, printStatusWhenWriting: false);
   }
 

--- a/packages/flutter_tools/templates/add_to_app/darwin/Scripts/FlutterAssembleInputs.xcfilelist.tmpl
+++ b/packages/flutter_tools/templates/add_to_app/darwin/Scripts/FlutterAssembleInputs.xcfilelist.tmpl
@@ -1,7 +1,7 @@
-$(BUILT_PRODUCTS_DIR)/{{flutterFrameworkName}}.framework/{{flutterFrameworkName}}
+$(BUILT_PRODUCTS_DIR)/{{flutterFrameworkName}}.framework/{{flutterFrameworkBinaryPath}}
 $(BUILT_PRODUCTS_DIR)/{{flutterFrameworkName}}.framework/{{infoPlistPath}}
 $(BUILT_PRODUCTS_DIR)/App.framework/{{appFrameworkBinaryPath}}
-$(TARGET_BUILD_DIR)/$(FRAMEWORKS_FOLDER_PATH)/{{flutterFrameworkName}}.framework/{{flutterFrameworkName}}
+$(TARGET_BUILD_DIR)/$(FRAMEWORKS_FOLDER_PATH)/{{flutterFrameworkName}}.framework/{{flutterFrameworkBinaryPath}}
 $(TARGET_BUILD_DIR)/$(FRAMEWORKS_FOLDER_PATH)/{{flutterFrameworkName}}.framework/{{infoPlistPath}}
 $(TARGET_BUILD_DIR)/$(FRAMEWORKS_FOLDER_PATH)/{{flutterFrameworkName}}.framework/_CodeSignature/CodeResources
 $(TARGET_BUILD_DIR)/$(FRAMEWORKS_FOLDER_PATH)/App.framework/{{appFrameworkBinaryPath}}

--- a/packages/flutter_tools/templates/add_to_app/darwin/Scripts/FlutterAssembleInputs.xcfilelist.tmpl
+++ b/packages/flutter_tools/templates/add_to_app/darwin/Scripts/FlutterAssembleInputs.xcfilelist.tmpl
@@ -1,8 +1,8 @@
 $(BUILT_PRODUCTS_DIR)/{{flutterFrameworkName}}.framework/{{flutterFrameworkName}}
 $(BUILT_PRODUCTS_DIR)/{{flutterFrameworkName}}.framework/{{infoPlistPath}}
-$(BUILT_PRODUCTS_DIR)/App.framework/App
+$(BUILT_PRODUCTS_DIR)/App.framework/{{appFrameworkBinaryPath}}
 $(TARGET_BUILD_DIR)/$(FRAMEWORKS_FOLDER_PATH)/{{flutterFrameworkName}}.framework/{{flutterFrameworkName}}
 $(TARGET_BUILD_DIR)/$(FRAMEWORKS_FOLDER_PATH)/{{flutterFrameworkName}}.framework/{{infoPlistPath}}
 $(TARGET_BUILD_DIR)/$(FRAMEWORKS_FOLDER_PATH)/{{flutterFrameworkName}}.framework/_CodeSignature/CodeResources
-$(TARGET_BUILD_DIR)/$(FRAMEWORKS_FOLDER_PATH)/App.framework/App
+$(TARGET_BUILD_DIR)/$(FRAMEWORKS_FOLDER_PATH)/App.framework/{{appFrameworkBinaryPath}}
 $(TARGET_BUILD_DIR)/$(FRAMEWORKS_FOLDER_PATH)/App.framework/_CodeSignature/CodeResources

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_swift_package_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_swift_package_test.dart
@@ -3297,7 +3297,16 @@ public func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
         expect(scriptsDirectory.childFile('FlutterAssembleInputs.xcfilelist'), exists);
         expect(
           scriptsDirectory.childFile('FlutterAssembleInputs.xcfilelist').readAsStringSync(),
-          contains(r'$(BUILT_PRODUCTS_DIR)/App.framework/App'),
+          r'''
+$(BUILT_PRODUCTS_DIR)/Flutter.framework/Flutter
+$(BUILT_PRODUCTS_DIR)/Flutter.framework/Info.plist
+$(BUILT_PRODUCTS_DIR)/App.framework/App
+$(TARGET_BUILD_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Flutter.framework/Flutter
+$(TARGET_BUILD_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Flutter.framework/Info.plist
+$(TARGET_BUILD_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Flutter.framework/_CodeSignature/CodeResources
+$(TARGET_BUILD_DIR)/$(FRAMEWORKS_FOLDER_PATH)/App.framework/App
+$(TARGET_BUILD_DIR)/$(FRAMEWORKS_FOLDER_PATH)/App.framework/_CodeSignature/CodeResources
+''',
         );
 
         expect(flutterIntegrationPackage.childFile('Package.swift'), exists);
@@ -3540,7 +3549,16 @@ let package = Package(
         expect(scriptsDirectory.childFile('FlutterAssembleInputs.xcfilelist'), exists);
         expect(
           scriptsDirectory.childFile('FlutterAssembleInputs.xcfilelist').readAsStringSync(),
-          contains(r'$(BUILT_PRODUCTS_DIR)/App.framework/Versions/A/App'),
+          r'''
+$(BUILT_PRODUCTS_DIR)/FlutterMacOS.framework/Versions/A/FlutterMacOS
+$(BUILT_PRODUCTS_DIR)/FlutterMacOS.framework/Versions/A/Resources/Info.plist
+$(BUILT_PRODUCTS_DIR)/App.framework/Versions/A/App
+$(TARGET_BUILD_DIR)/$(FRAMEWORKS_FOLDER_PATH)/FlutterMacOS.framework/Versions/A/FlutterMacOS
+$(TARGET_BUILD_DIR)/$(FRAMEWORKS_FOLDER_PATH)/FlutterMacOS.framework/Versions/A/Resources/Info.plist
+$(TARGET_BUILD_DIR)/$(FRAMEWORKS_FOLDER_PATH)/FlutterMacOS.framework/_CodeSignature/CodeResources
+$(TARGET_BUILD_DIR)/$(FRAMEWORKS_FOLDER_PATH)/App.framework/Versions/A/App
+$(TARGET_BUILD_DIR)/$(FRAMEWORKS_FOLDER_PATH)/App.framework/_CodeSignature/CodeResources
+''',
         );
 
         expect(flutterIntegrationPackage.childFile('Package.swift'), exists);

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_swift_package_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_swift_package_test.dart
@@ -3293,6 +3293,13 @@ public func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
           highestSupportedVersion: FlutterDarwinPlatform.ios.supportedPackagePlatform,
         );
 
+        final Directory scriptsDirectory = outputDirectory.childDirectory('Scripts');
+        expect(scriptsDirectory.childFile('FlutterAssembleInputs.xcfilelist'), exists);
+        expect(
+          scriptsDirectory.childFile('FlutterAssembleInputs.xcfilelist').readAsStringSync(),
+          contains(r'$(BUILT_PRODUCTS_DIR)/App.framework/App'),
+        );
+
         expect(flutterIntegrationPackage.childFile('Package.swift'), exists);
         expect(flutterIntegrationPackage.childFile('Package.swift').readAsStringSync(), '''
 // swift-tools-version: 5.9
@@ -3527,6 +3534,13 @@ let package = Package(
           outputDirectory: outputDirectory,
           flutterIntegrationPackage: flutterIntegrationPackage,
           highestSupportedVersion: FlutterDarwinPlatform.macos.supportedPackagePlatform,
+        );
+
+        final Directory scriptsDirectory = outputDirectory.childDirectory('Scripts');
+        expect(scriptsDirectory.childFile('FlutterAssembleInputs.xcfilelist'), exists);
+        expect(
+          scriptsDirectory.childFile('FlutterAssembleInputs.xcfilelist').readAsStringSync(),
+          contains(r'$(BUILT_PRODUCTS_DIR)/App.framework/Versions/A/App'),
         );
 
         expect(flutterIntegrationPackage.childFile('Package.swift'), exists);


### PR DESCRIPTION
Apparently Xcode Run Script don't work with the binary symlink in macOS framework. So this PR updates it to use the direct path

Fixes https://github.com/flutter/flutter/issues/185837.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
