### PR TITLE
Ensure that vulkan_interface.h gets included before vk_mem_alloc.h

### DIFF
--- a/engine/src/flutter/flutter_vma/flutter_vma.h
+++ b/engine/src/flutter/flutter_vma/flutter_vma.h
@@ -5,6 +5,10 @@
 #ifndef FLUTTER_FLUTTER_VMA_FLUTTER_VMA_H_
 #define FLUTTER_FLUTTER_VMA_FLUTTER_VMA_H_
 
+#include "flutter/vulkan/procs/vulkan_interface.h"  // IWYU pragma: keep
+
+// vk_mem_alloc.h includes Vulkan headers, so it needs to come after
+// vulkan_interface.h.
 #include "vk_mem_alloc.h"
 
 #endif  // FLUTTER_FLUTTER_VMA_FLUTTER_VMA_H_


### PR DESCRIPTION
The flutter/vulkan/procs/vulkan_interface.h engine header sets some Vuklan defines (e.g. VK_USE_PLATFORM_FUCHSIA) that need to be set before including the Vulkan headers. However, vk_mem_alloc.h also includes the Vulkan headers, which can cause problems depending on include header order. This commit explicitly adds an include to vulkan_interface.h before vk_mem_alloc.h.