### PR TITLE
Add null check for `hitTestTransform`

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -3060,6 +3060,10 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
       if (inverseTransform == null) {
         inverseTransform = new float[16];
       }
+      if (hitTestTransform == null) {
+        hitTestTransform = new float[16];
+        Matrix.setIdentityM(hitTestTransform, 0);
+      }
       if (!Matrix.invertM(inverseTransform, 0, hitTestTransform, 0)) {
         Arrays.fill(inverseTransform, 0);
       }

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -2119,6 +2119,43 @@ public class AccessibilityBridgeTest {
   }
 
   @Test
+  public void itDoesNotCrashWhenHitTestingChildWithUninitializedTransform() {
+        // Regression test for https://github.com/flutter/flutter/issues/184810.
+    // When an OverlayPortal grafts a semantics node as a traversal child of one parent
+    // and a hit-test child of another, the engine may create the node via
+    // getOrCreateSemanticsNode before its own updateWith() has been called, leaving
+    // hitTestTransform null. A subsequent hover event must not crash.
+    AccessibilityViewEmbedder mockViewEmbedder = mock(AccessibilityViewEmbedder.class);
+    AccessibilityManager mockManager = mock(AccessibilityManager.class);
+    View mockRootView = mock(View.class);
+    Context context = mock(Context.class);
+    when(mockRootView.getContext()).thenReturn(context);
+    when(context.getPackageName()).thenReturn("test");
+    when(mockManager.isTouchExplorationEnabled()).thenReturn(true);
+    AccessibilityBridge accessibilityBridge =
+        setUpBridge(mockRootView, mockManager, mockViewEmbedder);
+
+    // Build a root node that references a phantom child (id=1) whose data is not
+    // in the update buffer. This simulates the scenario where a parent's updateWith()
+    // creates the child via getOrCreateSemanticsNode but the child never receives its
+    // own updateWith(), leaving hitTestTransform as null.
+    TestSemanticsNode root = new TestSemanticsNode();
+    root.id = 0;
+    root.left = 0;
+    root.top = 0;
+    root.bottom = 20;
+    root.right = 20;
+    root.phantomChildIds.add(1);
+    TestSemanticsUpdate testSemanticsUpdate = root.toUpdate();
+    testSemanticsUpdate.sendUpdateToBridge(accessibilityBridge);
+
+    // Fire a hover event within the root's bounds. Before the fix, this would crash
+    // with a NullPointerException in ensureInverseTransform because the phantom child's
+    // hitTestTransform was never initialized.
+    accessibilityBridge.onAccessibilityHoverEvent(MotionEvent.obtain(1, 1, 1, 10, 10, 0));
+  }
+
+  @Test
   public void itProducesPlatformViewNodeForHybridComposition() {
     PlatformViewsAccessibilityDelegate accessibilityDelegate =
         mock(PlatformViewsAccessibilityDelegate.class);
@@ -3320,6 +3357,7 @@ public class AccessibilityBridgeTest {
         };
 
     final List<TestSemanticsNode> children = new ArrayList<TestSemanticsNode>();
+    final List<Integer> phantomChildIds = new ArrayList<Integer>();
 
     public void addChild(TestSemanticsNode child) {
       children.add(child);
@@ -3411,14 +3449,20 @@ public class AccessibilityBridgeTest {
         bytes.putFloat(hitTestTransform[i]);
       }
       // children in traversal order.
-      bytes.putInt(children.size());
+      bytes.putInt(children.size() + phantomChildIds.size());
       for (TestSemanticsNode node : children) {
         bytes.putInt(node.id);
       }
+      for (int phantomId : phantomChildIds) {
+        bytes.putInt(phantomId);
+      }
       // children in hit test order.
-      bytes.putInt(children.size());
+      bytes.putInt(children.size() + phantomChildIds.size());
       for (TestSemanticsNode node : children) {
         bytes.putInt(node.id);
+      }
+      for (int phantomId : phantomChildIds) {
+        bytes.putInt(phantomId);
       }
       // custom actions
       bytes.putInt(0);

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -2120,11 +2120,6 @@ public class AccessibilityBridgeTest {
 
   @Test
   public void itDoesNotCrashWhenHitTestingChildWithUninitializedTransform() {
-        // Regression test for https://github.com/flutter/flutter/issues/184810.
-    // When an OverlayPortal grafts a semantics node as a traversal child of one parent
-    // and a hit-test child of another, the engine may create the node via
-    // getOrCreateSemanticsNode before its own updateWith() has been called, leaving
-    // hitTestTransform null. A subsequent hover event must not crash.
     AccessibilityViewEmbedder mockViewEmbedder = mock(AccessibilityViewEmbedder.class);
     AccessibilityManager mockManager = mock(AccessibilityManager.class);
     View mockRootView = mock(View.class);
@@ -2149,9 +2144,7 @@ public class AccessibilityBridgeTest {
     TestSemanticsUpdate testSemanticsUpdate = root.toUpdate();
     testSemanticsUpdate.sendUpdateToBridge(accessibilityBridge);
 
-    // Fire a hover event within the root's bounds. Before the fix, this would crash
-    // with a NullPointerException in ensureInverseTransform because the phantom child's
-    // hitTestTransform was never initialized.
+    // Fire a hover event within the root's bounds.
     accessibilityBridge.onAccessibilityHoverEvent(MotionEvent.obtain(1, 1, 1, 10, 10, 0));
   }
 


### PR DESCRIPTION
This PR is to avoid the crash when `hitTestTransform` is null.

This is to partially fix https://github.com/flutter/flutter/issues/184810. The fix on the framework side still need more investigation.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

