### PR TITLE
Tolerate floating-point rounding in paintImage centerSlice assertion

### DIFF
--- a/packages/flutter/lib/src/painting/decoration_image.dart
+++ b/packages/flutter/lib/src/painting/decoration_image.dart
@@ -576,10 +576,11 @@ void paintImage({
     // as we apply a nine-patch stretch. A tolerance is used to absorb
     // floating-point rounding from the `inputSize / scale * scale` round trip
     // when the image's pixel dimensions are not evenly divisible by `scale`.
+    final sourceInputDelta = (sourceSize - inputSize) as Offset;
     assert(
       !sliceFits ||
-          ((sourceSize.width - inputSize.width).abs() <= precisionErrorTolerance &&
-              (sourceSize.height - inputSize.height).abs() <= precisionErrorTolerance),
+          (sourceInputDelta.dx.abs() <= precisionErrorTolerance &&
+              sourceInputDelta.dy.abs() <= precisionErrorTolerance),
       'centerSlice was used with a BoxFit that does not guarantee that the image is fully visible.',
     );
   }

--- a/packages/flutter/lib/src/painting/decoration_image.dart
+++ b/packages/flutter/lib/src/painting/decoration_image.dart
@@ -553,10 +553,16 @@ void paintImage({
   Size outputSize = rect.size;
   var inputSize = Size(image.width.toDouble(), image.height.toDouble());
   Offset? sliceBorder;
+  // Tracks whether the destination rect is large enough to fit the
+  // centerSlice's outer borders. When it is not, [applyBoxFit] is called with
+  // a non-positive size and degenerates to [Size.zero], which would otherwise
+  // trip the source/input-size assertion below for an unrelated reason.
+  var sliceFits = true;
   if (centerSlice != null) {
     sliceBorder = inputSize / scale - centerSlice.size as Offset;
     outputSize = outputSize - sliceBorder as Size;
     inputSize = inputSize - sliceBorder * scale as Size;
+    sliceFits = outputSize.width > 0.0 && outputSize.height > 0.0;
   }
   fit ??= centerSlice == null ? BoxFit.scaleDown : BoxFit.fill;
   assert(centerSlice == null || (fit != BoxFit.none && fit != BoxFit.cover));
@@ -567,9 +573,13 @@ void paintImage({
     outputSize += sliceBorder!;
     destinationSize += sliceBorder;
     // We don't have the ability to draw a subset of the image at the same time
-    // as we apply a nine-patch stretch.
+    // as we apply a nine-patch stretch. A tolerance is used to absorb
+    // floating-point rounding from the `inputSize / scale * scale` round trip
+    // when the image's pixel dimensions are not evenly divisible by `scale`.
     assert(
-      sourceSize == inputSize,
+      !sliceFits ||
+          ((sourceSize.width - inputSize.width).abs() <= precisionErrorTolerance &&
+              (sourceSize.height - inputSize.height).abs() <= precisionErrorTolerance),
       'centerSlice was used with a BoxFit that does not guarantee that the image is fully visible.',
     );
   }

--- a/packages/flutter/test/painting/paint_image_test.dart
+++ b/packages/flutter/test/painting/paint_image_test.dart
@@ -20,10 +20,12 @@ class TestCanvas implements Canvas {
 void main() {
   late ui.Image image300x300;
   late ui.Image image300x200;
+  late ui.Image image208x142;
 
   setUpAll(() async {
     image300x300 = await createTestImage(width: 300, height: 300, cache: false);
     image300x200 = await createTestImage(width: 300, height: 200, cache: false);
+    image208x142 = await createTestImage(width: 208, height: 142, cache: false);
   });
 
   setUp(() {
@@ -178,6 +180,48 @@ void main() {
     expect(command.positionalArguments[0], equals(image300x300));
     expect(command.positionalArguments[1], equals(const Rect.fromLTRB(100.0, 80.0, 500.0, 520.0)));
     expect(command.positionalArguments[2], equals(const Rect.fromLTRB(20.0, 40.0, 860.0, 840.0)));
+  });
+
+  test('centerSlice tolerates floating-point rounding when scale divides unevenly', () async {
+    // Regression test for https://github.com/flutter/flutter/issues/27827.
+    // With image=208x142, scale=3 and a centerSlice large enough that the
+    // destination rect still encloses the borders, `inputSize / scale * scale`
+    // does not exactly round-trip through floating-point. The strict-equality
+    // assertion that used to live here would fail by a few ULPs.
+    final canvas = TestCanvas();
+    paintImage(
+      canvas: canvas,
+      rect: const Rect.fromLTWH(0.0, 0.0, 200.0, 100.0),
+      image: image208x142,
+      scale: 3.0,
+      centerSlice: const Rect.fromLTRB(15.0, 15.0, 17.0, 17.0),
+    );
+
+    final Invocation command = canvas.invocations.firstWhere((Invocation invocation) {
+      return invocation.memberName == #drawImageNine;
+    });
+    expect(command.positionalArguments[0], equals(image208x142));
+  });
+
+  test('centerSlice does not throw when the destination rect is smaller than the slice borders', () async {
+    // Regression test for https://github.com/flutter/flutter/issues/27827.
+    // With a 100x46 rect and a 208x142 image at scale 3, subtracting the
+    // slice borders from `outputSize` makes it non-positive. `applyBoxFit`
+    // then degenerates to `Size.zero` and the legacy strict-equality
+    // assertion fired against the inner-input size for that unrelated reason.
+    final canvas = TestCanvas();
+    paintImage(
+      canvas: canvas,
+      rect: const Rect.fromLTWH(0.0, 0.0, 100.0, 46.0),
+      image: image208x142,
+      scale: 3.0,
+      centerSlice: const Rect.fromLTRB(15.5, 15.5, 16.5, 16.5),
+    );
+
+    final Invocation command = canvas.invocations.firstWhere((Invocation invocation) {
+      return invocation.memberName == #drawImageNine;
+    });
+    expect(command.positionalArguments[0], equals(image208x142));
   });
 
   testWidgets('Reports Image painting', (WidgetTester tester) async {

--- a/packages/flutter/test/painting/paint_image_test.dart
+++ b/packages/flutter/test/painting/paint_image_test.dart
@@ -203,26 +203,29 @@ void main() {
     expect(command.positionalArguments[0], equals(image208x142));
   });
 
-  test('centerSlice does not throw when the destination rect is smaller than the slice borders', () async {
-    // Regression test for https://github.com/flutter/flutter/issues/27827.
-    // With a 100x46 rect and a 208x142 image at scale 3, subtracting the
-    // slice borders from `outputSize` makes it non-positive. `applyBoxFit`
-    // then degenerates to `Size.zero` and the legacy strict-equality
-    // assertion fired against the inner-input size for that unrelated reason.
-    final canvas = TestCanvas();
-    paintImage(
-      canvas: canvas,
-      rect: const Rect.fromLTWH(0.0, 0.0, 100.0, 46.0),
-      image: image208x142,
-      scale: 3.0,
-      centerSlice: const Rect.fromLTRB(15.5, 15.5, 16.5, 16.5),
-    );
+  test(
+    'centerSlice does not throw when the destination rect is smaller than the slice borders',
+    () async {
+      // Regression test for https://github.com/flutter/flutter/issues/27827.
+      // With a 100x46 rect and a 208x142 image at scale 3, subtracting the
+      // slice borders from `outputSize` makes it non-positive. `applyBoxFit`
+      // then degenerates to `Size.zero` and the legacy strict-equality
+      // assertion fired against the inner-input size for that unrelated reason.
+      final canvas = TestCanvas();
+      paintImage(
+        canvas: canvas,
+        rect: const Rect.fromLTWH(0.0, 0.0, 100.0, 46.0),
+        image: image208x142,
+        scale: 3.0,
+        centerSlice: const Rect.fromLTRB(15.5, 15.5, 16.5, 16.5),
+      );
 
-    final Invocation command = canvas.invocations.firstWhere((Invocation invocation) {
-      return invocation.memberName == #drawImageNine;
-    });
-    expect(command.positionalArguments[0], equals(image208x142));
-  });
+      final Invocation command = canvas.invocations.firstWhere((Invocation invocation) {
+        return invocation.memberName == #drawImageNine;
+      });
+      expect(command.positionalArguments[0], equals(image208x142));
+    },
+  );
 
   testWidgets('Reports Image painting', (WidgetTester tester) async {
     late ImageSizeInfo imageSizeInfo;


### PR DESCRIPTION
## Summary

`paintImage` uses a strict `==` comparison between `sourceSize` and `inputSize` to verify that the chosen `BoxFit` does not drop image pixels when `centerSlice` is set. The check has two failure modes that aren't actually bugs in the caller:

1. When the image's pixel dimensions are not evenly divisible by `scale`, the `inputSize / scale * scale` round trip lands a few ULPs away from the original `inputSize`. The assertion fires under strict equality even though the math is correct.
2. When the destination rect is too small to fit the `centerSlice` borders, `outputSize` becomes non-positive and `applyBoxFit` short-circuits to `Size.zero`. The assertion then compares `(0,0)` against the inner-input size and fires for a reason unrelated to what it is meant to catch (this is the configuration in the linked issue's repro).

This change:
- Compares with `precisionErrorTolerance` instead of `==`, absorbing the FP rounding.
- Skips the assertion entirely when the centerSlice borders can't fit the destination rect (so the assertion no longer fires for the degenerate case it wasn't designed to police).

The original safety check — that the chosen `BoxFit` didn't shrink the source — is preserved for the cases it was meant to catch.

## Test plan

- [x] Added `centerSlice tolerates floating-point rounding when scale divides unevenly` — exercises the FP-tolerance path with a destination rect large enough to enclose the borders.
- [x] Added `centerSlice does not throw when the destination rect is smaller than the slice borders` — reproduces the exact configuration in the linked issue (208×142 image, scale 3, 1×1 centerSlice into a 100×46 rect) which previously failed the assertion.
- [x] `flutter test packages/flutter/test/painting/paint_image_test.dart` — all tests pass.
- [x] `flutter test packages/flutter/test/painting/decoration_test.dart packages/flutter/test/rendering/image_test.dart` — pass.
- [x] `flutter analyze` — no issues on the changed files.

Fixes flutter#27827