### PR TITLE
Treat package:stack_trace async-gap marker as asynchronous suspension

### DIFF
--- a/packages/flutter/lib/src/foundation/stack_frame.dart
+++ b/packages/flutter/lib/src/foundation/stack_frame.dart
@@ -183,22 +183,23 @@ class StackFrame {
     );
   }
 
+  /// The async-gap marker emitted by `package:stack_trace` between Dart-VM
+  /// stack chains. Older versions of this parser asserted on this line; it is
+  /// now treated as equivalent to the VM's `<asynchronous suspension>` marker
+  /// so that already-mangled stacks (e.g. those carried by `ParallelWaitError`
+  /// or by stacks that pass through the test runner) round-trip cleanly.
+  static const String _packageStackTraceAsyncGap =
+      '===== asynchronous gap ===========================';
+
   /// Parses a single [StackFrame] from a single line of a [StackTrace].
   ///
   /// Returns null if format is not as expected.
   static StackFrame? fromStackTraceLine(String line) {
-    if (line == '<asynchronous suspension>') {
+    if (line == '<asynchronous suspension>' || line == _packageStackTraceAsyncGap) {
       return asynchronousSuspension;
     } else if (line == '...') {
       return stackOverFlowElision;
     }
-
-    assert(
-      line != '===== asynchronous gap ===========================',
-      'Got a stack frame from package:stack_trace, where a vm or web frame was expected. '
-      'This can happen if FlutterError.demangleStackTrace was not set in an environment '
-      'that propagates non-standard stack traces to the framework, such as during tests.',
-    );
 
     // Web frames.
     if (!line.startsWith('#')) {

--- a/packages/flutter/test/foundation/stack_frame_test.dart
+++ b/packages/flutter/test/foundation/stack_frame_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -78,6 +80,21 @@ void main() {
     );
   });
 
+  test('Near-miss async-gap markers are not parsed as asynchronousSuspension', () {
+    expect(
+      StackFrame.fromStackTraceLine('===== asynchronous gap =========================='),
+      isNull,
+    );
+    expect(
+      StackFrame.fromStackTraceLine('===== asynchronous gap =========================== '),
+      isNull,
+    );
+    expect(
+      StackFrame.fromStackTraceLine('===== asynchronous frame ==========================='),
+      isNull,
+    );
+  });
+
   test('debugPrintStack does not throw on a stack carrying an async-gap marker', () {
     // Regression test for https://github.com/flutter/flutter/issues/179018.
     final printed = <String?>[];
@@ -91,6 +108,29 @@ void main() {
     } finally {
       debugPrint = original;
     }
+    expect(printed, isNotEmpty);
+  });
+
+  test('debugPrintStack does not throw on a ParallelWaitError stack', () async {
+    // Regression test for https://github.com/flutter/flutter/issues/179018.
+    StackTrace? parallelWaitStack;
+    final printed = <String?>[];
+    final DebugPrintCallback original = debugPrint;
+    debugPrint = (String? message, {int? wrapWidth}) => printed.add(message);
+    try {
+      await (_function1(), _function2()).wait.then<void>(
+        (_) {},
+        onError: (Object error, StackTrace stack) {
+          expect(error, isA<ParallelWaitError<(void, void), (AsyncError?, AsyncError?)>>());
+          parallelWaitStack = stack;
+          expect(stack.toString(), contains('===== asynchronous gap ==========================='));
+          debugPrintStack(label: error.toString(), stackTrace: stack);
+        },
+      );
+    } finally {
+      debugPrint = original;
+    }
+    expect(parallelWaitStack, isNotNull);
     expect(printed, isNotEmpty);
   });
 
@@ -116,6 +156,15 @@ void main() {
   test('Parses to null for wrong format.', () {
     expect(StackFrame.fromStackTraceLine('wrong stack trace format'), null);
   });
+}
+
+Future<void> _function1() async {
+  await Future<void>.delayed(Duration.zero);
+}
+
+Future<void> _function2() async {
+  await Future<void>.delayed(Duration.zero);
+  throw Exception('function2');
 }
 
 const String stackString = '''

--- a/packages/flutter/test/foundation/stack_frame_test.dart
+++ b/packages/flutter/test/foundation/stack_frame_test.dart
@@ -61,10 +61,11 @@ void main() {
 
   test('Traces from package:stack_trace parse without throwing', () {
     // Regression test for https://github.com/flutter/flutter/issues/179018.
-    // package:stack_trace emits a literal `===== asynchronous gap ===` line
-    // between chained stacks; this parser used to assert on it. It is now
-    // treated as an asynchronous-suspension marker so callers like
-    // [debugPrintStack] do not crash on stacks that carry that format.
+    // package:stack_trace emits a literal
+    // '===== asynchronous gap ===========================' line between
+    // chained stacks; this parser used to assert on it. It is now treated as
+    // an asynchronous-suspension marker so callers like [debugPrintStack] do
+    // not crash on stacks that carry that format.
     final List<StackFrame> frames = StackFrame.fromStackString(mangledStackString);
     expect(frames, contains(StackFrame.asynchronousSuspension));
     expect(frames, isNot(isEmpty));
@@ -77,7 +78,7 @@ void main() {
     );
   });
 
-  test('debugPrintStack does not throw on a stack carrying an async-gap marker', () async {
+  test('debugPrintStack does not throw on a stack carrying an async-gap marker', () {
     // Regression test for https://github.com/flutter/flutter/issues/179018.
     final printed = <String?>[];
     final DebugPrintCallback original = debugPrint;

--- a/packages/flutter/test/foundation/stack_frame_test.dart
+++ b/packages/flutter/test/foundation/stack_frame_test.dart
@@ -59,14 +59,38 @@ void main() {
   // stack overflow, but the browser cannot - running this test in a browser
   // will cause it to become unresponsive.
 
-  test('Traces from package:stack_trace throw assertion', () {
+  test('Traces from package:stack_trace parse without throwing', () {
+    // Regression test for https://github.com/flutter/flutter/issues/179018.
+    // package:stack_trace emits a literal `===== asynchronous gap ===` line
+    // between chained stacks; this parser used to assert on it. It is now
+    // treated as an asynchronous-suspension marker so callers like
+    // [debugPrintStack] do not crash on stacks that carry that format.
+    final List<StackFrame> frames = StackFrame.fromStackString(mangledStackString);
+    expect(frames, contains(StackFrame.asynchronousSuspension));
+    expect(frames, isNot(isEmpty));
+  });
+
+  test('Async-gap marker parses to asynchronousSuspension', () {
+    expect(
+      StackFrame.fromStackTraceLine('===== asynchronous gap ==========================='),
+      StackFrame.asynchronousSuspension,
+    );
+  });
+
+  test('debugPrintStack does not throw on a stack carrying an async-gap marker', () async {
+    // Regression test for https://github.com/flutter/flutter/issues/179018.
+    final printed = <String?>[];
+    final DebugPrintCallback original = debugPrint;
+    debugPrint = (String? message, {int? wrapWidth}) => printed.add(message);
     try {
-      StackFrame.fromStackString(mangledStackString);
-      assert(false, 'StackFrame.fromStackString did not throw on a mangled stack trace');
-    } catch (e) {
-      expect(e, isA<AssertionError>());
-      expect('$e', contains('Got a stack frame from package:stack_trace'));
+      debugPrintStack(
+        label: 'ParallelWaitError-style stack',
+        stackTrace: StackTrace.fromString(mangledStackString),
+      );
+    } finally {
+      debugPrint = original;
     }
+    expect(printed, isNotEmpty);
   });
 
   test('Can parse web constructor invocation with unknown class name', () {

--- a/packages/flutter/test/foundation/stack_frame_test.dart
+++ b/packages/flutter/test/foundation/stack_frame_test.dart
@@ -7,6 +7,8 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'capture_output.dart';
+
 void main() {
   test('Parses line', () {
     expect(StackFrame.fromStackTraceLine(stackString.split('\n')[0]), stackFrames[0]);
@@ -97,39 +99,32 @@ void main() {
 
   test('debugPrintStack does not throw on a stack carrying an async-gap marker', () {
     // Regression test for https://github.com/flutter/flutter/issues/179018.
-    final printed = <String?>[];
-    final DebugPrintCallback original = debugPrint;
-    debugPrint = (String? message, {int? wrapWidth}) => printed.add(message);
-    try {
+    final List<String> printed = captureOutput(() {
       debugPrintStack(
         label: 'ParallelWaitError-style stack',
         stackTrace: StackTrace.fromString(mangledStackString),
       );
-    } finally {
-      debugPrint = original;
-    }
+    });
     expect(printed, isNotEmpty);
   });
 
   test('debugPrintStack does not throw on a ParallelWaitError stack', () async {
     // Regression test for https://github.com/flutter/flutter/issues/179018.
     StackTrace? parallelWaitStack;
-    final printed = <String?>[];
-    final DebugPrintCallback original = debugPrint;
-    debugPrint = (String? message, {int? wrapWidth}) => printed.add(message);
-    try {
-      await (_function1(), _function2()).wait.then<void>(
-        (_) {},
-        onError: (Object error, StackTrace stack) {
-          expect(error, isA<ParallelWaitError<(void, void), (AsyncError?, AsyncError?)>>());
-          parallelWaitStack = stack;
-          expect(stack.toString(), contains('===== asynchronous gap ==========================='));
-          debugPrintStack(label: error.toString(), stackTrace: stack);
-        },
-      );
-    } finally {
-      debugPrint = original;
-    }
+    final printed = <String>[];
+    await (_function1(), _function2()).wait.then<void>(
+      (_) {},
+      onError: (Object error, StackTrace stack) {
+        expect(error, isA<ParallelWaitError<(void, void), (AsyncError?, AsyncError?)>>());
+        parallelWaitStack = stack;
+        expect(stack.toString(), contains('===== asynchronous gap ==========================='));
+        printed.addAll(
+          captureOutput(() {
+            debugPrintStack(label: error.toString(), stackTrace: stack);
+          }),
+        );
+      },
+    );
     expect(parallelWaitStack, isNotNull);
     expect(printed, isNotEmpty);
   });


### PR DESCRIPTION
## Summary

`StackFrame.fromStackTraceLine` asserted whenever it encountered the literal

```
===== asynchronous gap ===========================
```

line that `package:stack_trace` emits between chained Dart-VM stacks. The assertion's diagnostic told callers to wire up `FlutterError.demangleStackTrace`, but utilities like `debugPrintStack` (and, transitively, `FlutterError.defaultStackFilter`) run the parser unconditionally on caller-supplied stacks. Anything that carries that marker — e.g. the stack inside `ParallelWaitError`, or any stack that passes through the test runner before reaching the framework — crashes before the demangle hook can intervene. The user-facing repro in the linked issue shows this with `(future1, future2).wait`'s `onError` handler.

That marker is the `package:stack_trace` equivalent of the VM's `<asynchronous suspension>` line. This change folds it into `StackFrame.asynchronousSuspension` so the boundary is preserved and parsers downstream of `fromStackTraceLine` (the default stack filter, `debugPrintStack`, etc.) round-trip cleanly without losing the async hop.

## Changes

- `packages/flutter/lib/src/foundation/stack_frame.dart` — recognize the package:stack_trace async-gap line as `asynchronousSuspension`; remove the assertion that previously rejected it.
- `packages/flutter/test/foundation/stack_frame_test.dart` — replace the legacy \"throws assertion\" test with a parse-correctness test, add a unit test for the marker, and add an end-to-end regression test that pipes a stack carrying the marker through `debugPrintStack` (the exact code path from the linked issue).

## Test plan

- [x] `flutter test packages/flutter/test/foundation/stack_frame_test.dart` — 13/13 pass.
- [x] `flutter test packages/flutter/test/foundation/` — 222/222 pass.
- [x] Reproduced the linked issue's failing test (`(f1(), f2()).wait` with `debugPrintStack` in `onError`) and verified it now passes.
- [x] `flutter analyze` on the changed files — clean.

Fixes flutter#179018