### PR TITLE
init

### DIFF
--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -197,7 +197,7 @@ Future<XcodeBuildResult> buildXcodeProject({
   }
 
   await removeExtendedAttributes(
-    app.project.parent.directory,
+    app.project.hostAppRoot,
     globals.processUtils,
     globals.logger,
   );


### PR DESCRIPTION
Fixes #183662 

| Run Number | Before (Seconds) | After (Seconds) |
| :--- | :--- | :--- |
| 1 | 9.0 | 9.4 |
| 2 | 8.0 | 8.0 |
| 3 | 7.6 | 7.8 |
| 4 | 8.1 | 7.4 |
| 5 | 7.6 | 7.7 |
| 6 | 8.0 | 8.3 |
| 7 | 7.4 | 7.3 |
| 8 | 7.4 | 7.5 |
| 9 | 10.0 | 7.6 |
| 10 | 7.0 | 7.7 |
| 11 | 7.1 | 7.9 |
| 12 | 8.0 | 8.0 |
| 13 | 7.9 | 7.0 |
| 14 | 8.9 | 7.1 |
| 15 | 8.2 | 8.0 |
| 16 | 8.5 | 7.7 |
| 17 | 7.4 | 8.5 |
| 18 | 7.8 | 7.9 |
| 19 | 7.8 | 7.9 |
| 20 | 9.1 | 7.6 |
| **Average** | **8.04** | **7.77** |

This change runs xattr only on app.project.appHost instead of the entire build folder. There's a little itty bitty bit of performance improvement. I ran `flutter ios build` using a script, with cooldowns in between to avoid thermal throttling.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
