### PR TITLE
Deprecate `CurvedAnimation.reverseCurve` for `AsymmetricCurvedAnimation`

### DIFF
--- a/packages/flutter/lib/src/animation/animation.dart
+++ b/packages/flutter/lib/src/animation/animation.dart
@@ -337,8 +337,9 @@ abstract class Animation<T> extends Listenable implements ValueListenable<T> {
   ///  * [Animatable.animate], which does the same thing.
   ///  * [AnimationController], which is usually used to drive animations.
   ///  * [CurvedAnimation], an alternative to [CurveTween] for applying easing
-  ///    curves, which supports distinct curves in the forward direction and the
-  ///    reverse direction.
+  ///    curves.
+  ///  * [AsymmetricCurvedAnimation], which supports different curves in the
+  ///    forward direction and the reverse direction.
   ///  * [Animatable.fromCallback], which allows creating an [Animatable] from an
   ///    arbitrary transformation.
   @optionalTypeArgs

--- a/packages/flutter/lib/src/animation/animation.dart
+++ b/packages/flutter/lib/src/animation/animation.dart
@@ -253,7 +253,7 @@ abstract class Animation<T> extends Listenable implements ValueListenable<T> {
   /// {@macro flutter.animation.AnimationStatus.isForwardOrCompleted}
   bool get isForwardOrCompleted => status.isForwardOrCompleted;
 
-  /// Chains a [Tween] (or [CurveTween]) to this [Animation].
+  /// Chains a [Tween] (for example, [CurveTween]) to this [Animation].
   ///
   /// This method is only valid for `Animation<double>` instances (i.e. when `T`
   /// is `double`). This means, for instance, that it can be called on
@@ -336,10 +336,8 @@ abstract class Animation<T> extends Listenable implements ValueListenable<T> {
   ///
   ///  * [Animatable.animate], which does the same thing.
   ///  * [AnimationController], which is usually used to drive animations.
-  ///  * [CurvedAnimation], an alternative to [CurveTween] for applying easing
-  ///    curves.
-  ///  * [AsymmetricCurvedAnimation], which supports different curves in the
-  ///    forward direction and the reverse direction.
+  ///  * [CurvedAnimation], an alternative to [CurveTween] for applying a
+  ///    curve to an animation.
   ///  * [Animatable.fromCallback], which allows creating an [Animatable] from an
   ///    arbitrary transformation.
   @optionalTypeArgs

--- a/packages/flutter/lib/src/animation/animations.dart
+++ b/packages/flutter/lib/src/animation/animations.dart
@@ -406,6 +406,14 @@ class CurvedAnimation extends AsymmetricCurvedAnimation {
     'This feature was deprecated after v3.44.0-0.2.pre.',
   )
   Curve? get reverseCurve => super.reverseCurve;
+
+  @override
+  @Deprecated(
+    'Switch to AsymmetricCurvedAnimation if you need different forward & backward animations. '
+    'In the future, CurvedAnimation will only support a single curve for improved memory efficiency. '
+    'This feature was deprecated after v3.44.0-0.2.pre.',
+  )
+  set reverseCurve(Curve? value) => super.reverseCurve = value;
 }
 
 /// An animation that applies different curves to its [parent] animation

--- a/packages/flutter/lib/src/animation/animations.dart
+++ b/packages/flutter/lib/src/animation/animations.dart
@@ -348,10 +348,6 @@ class ReverseAnimation extends Animation<double>
 /// this object. Do not create a [CurvedAnimation] inside a `build` method
 /// because it would leak any added listeners on every rebuild.
 ///
-/// In a future Flutter release, the deprecated [reverseCurve] parameter will
-/// be removed and you will no longer need to call [dispose] on the
-/// [CurvedAnimation].
-///
 /// {@tool snippet}
 ///
 /// The following code snippet shows how you can apply a curve to a linear

--- a/packages/flutter/lib/src/animation/animations.dart
+++ b/packages/flutter/lib/src/animation/animations.dart
@@ -268,8 +268,8 @@ class ProxyAnimation extends Animation<double>
 ///
 ///  * [Curve.flipped] and [FlippedCurve], which provide a similar effect but on
 ///    [Curve]s.
-///  * [CurvedAnimation], which can take separate curves for when the animation
-///    is going forward than for when it is going in reverse.
+///  * [AsymmetricCurvedAnimation], which can take separate curves for when
+///    the animation is going forward or in reverse.
 class ReverseAnimation extends Animation<double>
     with AnimationLazyListenerMixin, AnimationLocalStatusListenersMixin {
   /// Creates a reverse animation.
@@ -328,8 +328,9 @@ class ReverseAnimation extends Animation<double>
 /// An animation that applies a curve to another animation.
 ///
 /// [CurvedAnimation] is useful when you want to apply a non-linear [Curve] to
-/// an animation object, especially if you want different curves when the
-/// animation is going forward vs when it is going backward.
+/// an animation object.
+/// If you want different curves when the animation is going forward vs when it
+/// is going backward, use [AsymmetricCurvedAnimation] instead.
 ///
 /// Depending on the given curve, the output of the [CurvedAnimation] could have
 /// a wider range than its input. For example, elastic curves such as
@@ -346,6 +347,10 @@ class ReverseAnimation extends Animation<double>
 /// not needed, prefer `parent.drive(CurveTween(curve: curve))` which does not
 /// require separate disposal.
 ///
+/// In a future Flutter release, the deprecated [reverseCurve] parameter will
+/// be removed and you will no longer need to call [dispose] on the
+/// [CurvedAnimation].
+///
 /// {@tool snippet}
 ///
 /// The following code snippet shows how you can apply a curve to a linear
@@ -358,46 +363,28 @@ class ReverseAnimation extends Animation<double>
 /// );
 /// ```
 /// {@end-tool}
-/// {@tool snippet}
-///
-/// This second code snippet shows how to apply a different curve in the forward
-/// direction than in the reverse direction. This can't be done using a
-/// [CurveTween] (since [Tween]s are not aware of the animation direction when
-/// they are applied).
-///
-/// ```dart
-/// final Animation<double> animation = CurvedAnimation(
-///   parent: controller,
-///   curve: Curves.easeIn,
-///   reverseCurve: Curves.easeOut,
-/// );
-/// ```
-/// {@end-tool}
-///
-/// By default, the [reverseCurve] matches the forward [curve].
 ///
 /// See also:
 ///
-///  * [CurveTween], for an alternative way of expressing the first sample
-///    above.
+///  * [CurveTween], for an alternative way of expressing the sample above.
+///  * [AsymmetricCurvedAnimation], for an alternative that supports different
+///    curves for forward and reverse directions.
 ///  * [AnimationController], for examples of creating and disposing of an
 ///    [AnimationController].
 ///  * [Curve.flipped] and [FlippedCurve], which provide the reverse of a
 ///    [Curve].
-class CurvedAnimation extends Animation<double> with AnimationWithParentMixin<double> {
+class CurvedAnimation extends AsymmetricCurvedAnimation {
   /// Creates a curved animation.
-  CurvedAnimation({required this.parent, required this.curve, this.reverseCurve}) {
-    assert(debugMaybeDispatchCreated('animation', 'CurvedAnimation', this));
-    _updateCurveDirection(parent.status);
-    parent.addStatusListener(_updateCurveDirection);
-  }
-
-  /// The animation to which this animation applies a curve.
-  @override
-  final Animation<double> parent;
-
-  /// The curve to use in the forward direction.
-  Curve curve;
+  CurvedAnimation({
+    required super.parent,
+    required super.curve,
+    @Deprecated(
+      'Switch to AsymmetricCurvedAnimation if you need different forward & backward animations. '
+      'In the future, CurvedAnimation will only support a single curve for improved memory efficiency. '
+      'This feature was deprecated after v3.44.0-0.2.pre.',
+    )
+    super.reverseCurve,
+  });
 
   /// The curve to use in the reverse direction.
   ///
@@ -414,6 +401,86 @@ class CurvedAnimation extends Animation<double> with AnimationWithParentMixin<do
   /// disposal.
   ///
   /// If this field is null, uses [curve] in both directions.
+  @override
+  @Deprecated(
+    'Switch to AsymmetricCurvedAnimation if you need different forward & backward animations. '
+    'In the future, CurvedAnimation will only support a single curve for improved memory efficiency. '
+    'This feature was deprecated after v3.44.0-0.2.pre.',
+  )
+  Curve? get reverseCurve => super.reverseCurve;
+}
+
+/// An animation that applies different curves to its [parent] animation
+/// depending on whether it's going forwards or backwards.
+///
+/// [AsymmetricCurvedAnimation] operates by adding listeners to its [parent].
+/// Therefore, you shouldn't re-instantiate it every build to avoid unnecessary
+/// listener additions and potential memory leaks. Remember to dispose it
+/// (or its [parent]) when it's no longer needed.
+///
+/// Depending on the given curve, the output of this animation could have
+/// a wider range than its input. For example, elastic curves such as
+/// [Curves.elasticIn] will significantly overshoot or undershoot the default
+/// range of 0.0 to 1.0.
+///
+/// {@tool snippet}
+///
+/// This code snippet shows how to apply a different curve in the forward
+/// direction than in the reverse direction. This can't be done using a
+/// [CurveTween] (since [Tween]s are not aware of the animation direction when
+/// they are applied).
+///
+/// ```dart
+/// final Animation<double> animation = AsymmetricCurvedAnimation(
+///   parent: controller,
+///   curve: Curves.easeIn,
+///   reverseCurve: Curves.easeOut,
+/// );
+/// ```
+/// {@end-tool}
+///
+/// If [reverseCurve] is null, [curve] will be used in both directions.
+/// If you don't need [reverseCurve] at all, consider using [CurvedAnimation]
+/// instead.
+///
+/// See also:
+///
+///  * [CurvedAnimation], for a single-direction curved animation.
+///  * [AnimationController], for examples of creating and disposing of an
+///    [AnimationController].
+///  * [Curve.flipped] and [FlippedCurve], which provide the reverse of a
+///    [Curve].
+class AsymmetricCurvedAnimation extends Animation<double> with AnimationWithParentMixin<double> {
+  /// Creates an asymmetric curved animation.
+  AsymmetricCurvedAnimation({required this.parent, required this.curve, this.reverseCurve}) {
+    assert(debugMaybeDispatchCreated('animation', 'AsymmetricCurvedAnimation', this));
+    _updateCurveDirection(parent.status);
+    parent.addStatusListener(_updateCurveDirection);
+  }
+
+  /// The animation to which this animation applies a curve.
+  @override
+  final Animation<double> parent;
+
+  /// The curve to use in the forward direction.
+  Curve curve;
+
+  /// The curve to use in the reverse direction.
+  ///
+  /// If the parent animation changes direction without first reaching the
+  /// [AnimationStatus.completed] or [AnimationStatus.dismissed] status, the
+  /// [AsymmetricCurvedAnimation] stays on the same curve (albeit in the
+  /// opposite direction) to avoid visual discontinuities.
+  ///
+  /// Because [AsymmetricCurvedAnimation] adds listeners to its parent, it must
+  /// be created once (for example, in [State.initState]) and disposed in
+  /// [State.dispose]. Do not recreate it on every build as it would leak any
+  /// added listeners on every rebuild.
+  ///
+  /// If [reverseCurve] is not needed, prefer [CurvedAnimation] over
+  /// [AsymmetricCurvedAnimation] for memory efficiency.
+  ///
+  /// If this field is null, uses [curve] in both directions.
   Curve? reverseCurve;
 
   /// The direction used to select the current curve.
@@ -423,7 +490,7 @@ class CurvedAnimation extends Animation<double> with AnimationWithParentMixin<do
   /// animation is used to animate.
   AnimationStatus? _curveDirection;
 
-  /// True if this CurvedAnimation has been disposed.
+  /// True if this AsymmetricCurvedAnimation has been disposed.
   bool isDisposed = false;
 
   void _updateCurveDirection(AnimationStatus status) {
@@ -434,7 +501,7 @@ class CurvedAnimation extends Animation<double> with AnimationWithParentMixin<do
     return reverseCurve == null || (_curveDirection ?? parent.status) != AnimationStatus.reverse;
   }
 
-  /// Cleans up any listeners added by this CurvedAnimation.
+  /// Cleans up any listeners added by this AsymmetricCurvedAnimation.
   void dispose() {
     assert(debugMaybeDispatchDisposed(this));
     isDisposed = true;

--- a/packages/flutter/lib/src/animation/animations.dart
+++ b/packages/flutter/lib/src/animation/animations.dart
@@ -371,18 +371,41 @@ class ReverseAnimation extends Animation<double>
 ///    [AnimationController].
 ///  * [Curve.flipped] and [FlippedCurve], which provide the reverse of a
 ///    [Curve].
-class CurvedAnimation extends AsymmetricCurvedAnimation {
+class CurvedAnimation extends Animation<double> with AnimationWithParentMixin<double> {
   /// Creates a curved animation.
   CurvedAnimation({
-    required super.parent,
-    required super.curve,
+    required Animation<double> parent,
+    required Curve curve,
     @Deprecated(
       'Switch to AsymmetricCurvedAnimation if you need different forward & backward animations. '
       'In the future, CurvedAnimation will only support a single curve for improved memory efficiency. '
       'This feature was deprecated after v3.44.0-0.2.pre.',
     )
-    super.reverseCurve,
-  });
+    Curve? reverseCurve,
+  }) : _proxy = AsymmetricCurvedAnimation(parent: parent, curve: curve, reverseCurve: reverseCurve);
+
+  /// The underlying animation that (currently) implements the behaviour
+  /// of [CurvedAnimation].
+  ///
+  /// [AsymmetricCurvedAnimation] is used so this renamed API acts
+  /// near-identically to the old API to reduce breaking change impact.
+  /// In a future update, [CurvedAnimation] will shed its [reverseCurve]
+  /// functionality and remove this field.
+  ///
+  /// While [_proxy] may be considered the true "parent" of this animation,
+  /// the [parent] field is also being proxied to avoid API breakage.
+  /// Aside from the naming, it actually makes no difference whether
+  /// [_proxy] or [parent] is exposed as [AnimationWithParentMixin.parent]
+  /// because the listeners can be notified through either one.
+  late final AsymmetricCurvedAnimation _proxy;
+
+  /// The animation to which this animation applies a curve.
+  @override
+  Animation<double> get parent => _proxy.parent;
+
+  /// The curve to use in the forward direction.
+  Curve get curve => _proxy.curve;
+  set curve(Curve value) => _proxy.curve = value;
 
   /// The curve to use in the reverse direction.
   ///
@@ -399,21 +422,30 @@ class CurvedAnimation extends AsymmetricCurvedAnimation {
   /// disposal.
   ///
   /// If this field is null, uses [curve] in both directions.
-  @override
   @Deprecated(
     'Switch to AsymmetricCurvedAnimation if you need different forward & backward animations. '
     'In the future, CurvedAnimation will only support a single curve for improved memory efficiency. '
     'This feature was deprecated after v3.44.0-0.2.pre.',
   )
-  Curve? get reverseCurve => super.reverseCurve;
+  Curve? get reverseCurve => _proxy.reverseCurve;
+  @Deprecated(
+    'Switch to AsymmetricCurvedAnimation if you need different forward & backward animations. '
+    'In the future, CurvedAnimation will only support a single curve for improved memory efficiency. '
+    'This feature was deprecated after v3.44.0-0.2.pre.',
+  )
+  set reverseCurve(Curve? value) => _proxy.reverseCurve = value;
+
+  /// True if this [CurvedAnimation] has been disposed.
+  bool get isDisposed => _proxy.isDisposed;
+
+  /// Cleans up any listeners added by this [CurvedAnimation].
+  void dispose() => _proxy.dispose();
 
   @override
-  @Deprecated(
-    'Switch to AsymmetricCurvedAnimation if you need different forward & backward animations. '
-    'In the future, CurvedAnimation will only support a single curve for improved memory efficiency. '
-    'This feature was deprecated after v3.44.0-0.2.pre.',
-  )
-  set reverseCurve(Curve? value) => super.reverseCurve = value;
+  double get value => _proxy.value;
+
+  @override
+  String toString() => _proxy.toString();
 }
 
 /// An animation that applies different curves to its [parent] animation
@@ -497,7 +529,7 @@ class AsymmetricCurvedAnimation extends Animation<double> with AnimationWithPare
   /// animation is used to animate.
   AnimationStatus? _curveDirection;
 
-  /// True if this AsymmetricCurvedAnimation has been disposed.
+  /// True if this [AsymmetricCurvedAnimation] has been disposed.
   bool isDisposed = false;
 
   void _updateCurveDirection(AnimationStatus status) {
@@ -508,7 +540,7 @@ class AsymmetricCurvedAnimation extends Animation<double> with AnimationWithPare
     return reverseCurve == null || (_curveDirection ?? parent.status) != AnimationStatus.reverse;
   }
 
-  /// Cleans up any listeners added by this AsymmetricCurvedAnimation.
+  /// Cleans up any listeners added by this [AsymmetricCurvedAnimation].
   void dispose() {
     assert(debugMaybeDispatchDisposed(this));
     isDisposed = true;

--- a/packages/flutter/lib/src/animation/animations.dart
+++ b/packages/flutter/lib/src/animation/animations.dart
@@ -343,9 +343,7 @@ class ReverseAnimation extends Animation<double>
 /// any listeners that it may have added. Disposing the
 /// parent animation (typically the [AnimationController]) will also clean up
 /// this object. Do not create a [CurvedAnimation] inside a `build` method
-/// because it would leak any added listeners on every rebuild. If [reverseCurve] is
-/// not needed, prefer `parent.drive(CurveTween(curve: curve))` which does not
-/// require separate disposal.
+/// because it would leak any added listeners on every rebuild.
 ///
 /// In a future Flutter release, the deprecated [reverseCurve] parameter will
 /// be removed and you will no longer need to call [dispose] on the
@@ -478,7 +476,8 @@ class AsymmetricCurvedAnimation extends Animation<double> with AnimationWithPare
   /// added listeners on every rebuild.
   ///
   /// If [reverseCurve] is not needed, prefer [CurvedAnimation] over
-  /// [AsymmetricCurvedAnimation] for memory efficiency.
+  /// [AsymmetricCurvedAnimation] for memory efficiency improvements
+  /// coming in future Flutter releases.
   ///
   /// If this field is null, uses [curve] in both directions.
   Curve? reverseCurve;

--- a/packages/flutter/lib/src/animation/animations.dart
+++ b/packages/flutter/lib/src/animation/animations.dart
@@ -329,6 +329,7 @@ class ReverseAnimation extends Animation<double>
 ///
 /// [CurvedAnimation] is useful when you want to apply a non-linear [Curve] to
 /// an animation object.
+///
 /// If you want different curves when the animation is going forward vs when it
 /// is going backward, use [AsymmetricCurvedAnimation] instead.
 ///

--- a/packages/flutter/lib/src/animation/animations.dart
+++ b/packages/flutter/lib/src/animation/animations.dart
@@ -436,9 +436,15 @@ class CurvedAnimation extends Animation<double> with AnimationWithParentMixin<do
   set reverseCurve(Curve? value) => _proxy.reverseCurve = value;
 
   /// True if this [CurvedAnimation] has been disposed.
+  // TODO(team-framework): Deprecate once `CurvedAnimation.reverseCurve`
+  // is removed:
+  // https://github.com/flutter/flutter/issues/185468.
   bool get isDisposed => _proxy.isDisposed;
 
   /// Cleans up any listeners added by this [CurvedAnimation].
+  // TODO(team-framework): Deprecate once `CurvedAnimation.reverseCurve`
+  // is removed:
+  // https://github.com/flutter/flutter/issues/185468.
   void dispose() => _proxy.dispose();
 
   @override

--- a/packages/flutter/lib/src/animation/animations.dart
+++ b/packages/flutter/lib/src/animation/animations.dart
@@ -379,7 +379,7 @@ class CurvedAnimation extends Animation<double> with AnimationWithParentMixin<do
     @Deprecated(
       'Switch to AsymmetricCurvedAnimation if you need different forward & backward animations. '
       'In the future, CurvedAnimation will only support a single curve for improved memory efficiency. '
-      'This feature was deprecated after v3.44.0-0.2.pre.',
+      'This feature was deprecated after v3.45.0-0.1.pre.',
     )
     Curve? reverseCurve,
   }) : _proxy = AsymmetricCurvedAnimation(parent: parent, curve: curve, reverseCurve: reverseCurve);

--- a/packages/flutter/lib/src/animation/animations.dart
+++ b/packages/flutter/lib/src/animation/animations.dart
@@ -431,7 +431,7 @@ class CurvedAnimation extends Animation<double> with AnimationWithParentMixin<do
   @Deprecated(
     'Switch to AsymmetricCurvedAnimation if you need different forward & backward animations. '
     'In the future, CurvedAnimation will only support a single curve for improved memory efficiency. '
-    'This feature was deprecated after v3.44.0-0.2.pre.',
+    'This feature was deprecated after v3.45.0-0.1.pre.',
   )
   set reverseCurve(Curve? value) => _proxy.reverseCurve = value;
 

--- a/packages/flutter/lib/src/animation/animations.dart
+++ b/packages/flutter/lib/src/animation/animations.dart
@@ -379,7 +379,7 @@ class CurvedAnimation extends Animation<double> with AnimationWithParentMixin<do
     @Deprecated(
       'Switch to AsymmetricCurvedAnimation if you need different forward & backward animations. '
       'In the future, CurvedAnimation will only support a single curve for improved memory efficiency. '
-      'This feature was deprecated after v3.45.0-0.1.pre.',
+      'This feature was deprecated after v3.46.0-0.2.pre.',
     )
     Curve? reverseCurve,
   }) : _proxy = AsymmetricCurvedAnimation(parent: parent, curve: curve, reverseCurve: reverseCurve);
@@ -428,13 +428,13 @@ class CurvedAnimation extends Animation<double> with AnimationWithParentMixin<do
   @Deprecated(
     'Switch to AsymmetricCurvedAnimation if you need different forward & backward animations. '
     'In the future, CurvedAnimation will only support a single curve for improved memory efficiency. '
-    'This feature was deprecated after v3.45.0-0.1.pre.',
+    'This feature was deprecated after v3.46.0-0.2.pre.',
   )
   Curve? get reverseCurve => _proxy.reverseCurve;
   @Deprecated(
     'Switch to AsymmetricCurvedAnimation if you need different forward & backward animations. '
     'In the future, CurvedAnimation will only support a single curve for improved memory efficiency. '
-    'This feature was deprecated after v3.45.0-0.1.pre.',
+    'This feature was deprecated after v3.46.0-0.2.pre.',
   )
   set reverseCurve(Curve? value) => _proxy.reverseCurve = value;
 

--- a/packages/flutter/lib/src/animation/animations.dart
+++ b/packages/flutter/lib/src/animation/animations.dart
@@ -425,7 +425,7 @@ class CurvedAnimation extends Animation<double> with AnimationWithParentMixin<do
   @Deprecated(
     'Switch to AsymmetricCurvedAnimation if you need different forward & backward animations. '
     'In the future, CurvedAnimation will only support a single curve for improved memory efficiency. '
-    'This feature was deprecated after v3.44.0-0.2.pre.',
+    'This feature was deprecated after v3.45.0-0.1.pre.',
   )
   Curve? get reverseCurve => _proxy.reverseCurve;
   @Deprecated(

--- a/packages/flutter/lib/src/animation/animations.dart
+++ b/packages/flutter/lib/src/animation/animations.dart
@@ -339,6 +339,9 @@ class ReverseAnimation extends Animation<double>
 ///
 /// If you want to apply a [Curve] to a [Tween], consider using [CurveTween].
 ///
+// TODO(team-framework): Remove this paragraph once `CurvedAnimation.reverseCurve`
+// is removed:
+// https://github.com/flutter/flutter/issues/185468.
 /// A [CurvedAnimation] should be disposed when no longer needed to clean up
 /// any listeners that it may have added. Disposing the
 /// parent animation (typically the [AnimationController]) will also clean up

--- a/packages/flutter/lib/src/animation/animations.dart
+++ b/packages/flutter/lib/src/animation/animations.dart
@@ -397,6 +397,9 @@ class CurvedAnimation extends Animation<double> with AnimationWithParentMixin<do
   /// Aside from the naming, it actually makes no difference whether
   /// [_proxy] or [parent] is exposed as [AnimationWithParentMixin.parent]
   /// because the listeners can be notified through either one.
+  // TODO(team-framework): Remove once `CurvedAnimation.reverseCurve`
+  // is removed:
+  // https://github.com/flutter/flutter/issues/185468.
   late final AsymmetricCurvedAnimation _proxy;
 
   /// The animation to which this animation applies a curve.

--- a/packages/flutter/lib/src/animation/animations.dart
+++ b/packages/flutter/lib/src/animation/animations.dart
@@ -451,10 +451,12 @@ class CurvedAnimation extends Animation<double> with AnimationWithParentMixin<do
 /// An animation that applies different curves to its [parent] animation
 /// depending on whether it's going forwards or backwards.
 ///
-/// [AsymmetricCurvedAnimation] operates by adding listeners to its [parent].
-/// Therefore, you shouldn't re-instantiate it every build to avoid unnecessary
-/// listener additions and potential memory leaks. Remember to dispose it
-/// (or its [parent]) when it's no longer needed.
+/// An [AsymmetricCurvedAnimation] should be disposed when no longer needed to
+/// clean up the listeners it adds to its [parent].
+/// Disposing the [parent] animation (typically the [AnimationController]) will
+/// also clean up this object.
+/// Do not create an [AsymmetricCurvedAnimation] inside a `build` method
+/// because it would leak its added listeners on every rebuild.
 ///
 /// Depending on the given curve, the output of this animation could have
 /// a wider range than its input. For example, elastic curves such as

--- a/packages/flutter/lib/src/animation/curves.dart
+++ b/packages/flutter/lib/src/animation/curves.dart
@@ -98,7 +98,7 @@ abstract class Curve extends ParametricCurve<double> {
 
   /// Returns a new curve that is the reversed inversion of this one.
   ///
-  /// This is often useful with [CurvedAnimation.reverseCurve].
+  /// This is often useful with [AsymmetricCurvedAnimation.reverseCurve].
   ///
   /// {@animation 464 192 https://flutter.github.io/assets-for-api-docs/assets/animation/curve_bounce_in.mp4}
   /// {@animation 464 192 https://flutter.github.io/assets-for-api-docs/assets/animation/curve_flipped.mp4}
@@ -107,7 +107,8 @@ abstract class Curve extends ParametricCurve<double> {
   ///
   ///  * [FlippedCurve], the class that is used to implement this getter.
   ///  * [ReverseAnimation], which reverses an [Animation] rather than a [Curve].
-  ///  * [CurvedAnimation], which can take a separate curve and reverse curve.
+  ///  * [AsymmetricCurvedAnimation], which supports different curves in the
+  ///    forward direction and the reverse direction.
   Curve get flipped => FlippedCurve(this);
 }
 
@@ -1226,7 +1227,7 @@ class CatmullRomCurve extends Curve {
 ///
 /// This is the class used to implement the [flipped] getter on curves.
 ///
-/// This is often useful with [CurvedAnimation.reverseCurve].
+/// This is often useful with [AsymmetricCurvedAnimation.reverseCurve].
 ///
 /// {@animation 464 192 https://flutter.github.io/assets-for-api-docs/assets/animation/curve_bounce_in.mp4}
 /// {@animation 464 192 https://flutter.github.io/assets-for-api-docs/assets/animation/curve_flipped.mp4}
@@ -1235,7 +1236,8 @@ class CatmullRomCurve extends Curve {
 ///
 ///  * [Curve.flipped], which provides the [FlippedCurve] of a [Curve].
 ///  * [ReverseAnimation], which reverses an [Animation] rather than a [Curve].
-///  * [CurvedAnimation], which can take a separate curve and reverse curve.
+///  * [AsymmetricCurvedAnimation], which supports different curves in the
+///    forward direction and the reverse direction.
 class FlippedCurve extends Curve {
   /// Creates a flipped curve.
   const FlippedCurve(this.curve);

--- a/packages/flutter/lib/src/animation/tween.dart
+++ b/packages/flutter/lib/src/animation/tween.dart
@@ -533,10 +533,6 @@ class ConstantTween<T> extends Tween<T> {
 /// Unlike [CurvedAnimation], a [CurveTween] does not add listeners or hold
 /// state, so it does not need to be disposed.
 ///
-/// ([CurvedAnimation] also has the additional ability of having different
-/// curves when the animation is going forward vs when it is going backward,
-/// which can be useful in some scenarios.)
-///
 /// {@tool snippet}
 ///
 /// The following code snippet shows how you can apply a curve to a linear
@@ -552,6 +548,8 @@ class ConstantTween<T> extends Tween<T> {
 /// See also:
 ///
 ///  * [CurvedAnimation], for an alternative way of expressing the sample above.
+///  * [AsymmetricCurvedAnimation], which supports different curves in the
+///    forward direction and the reverse direction.
 ///  * [AnimationController], for examples of creating and disposing of an
 ///    [AnimationController].
 class CurveTween extends Animatable<double> {

--- a/packages/flutter/lib/src/animation/tween.dart
+++ b/packages/flutter/lib/src/animation/tween.dart
@@ -530,6 +530,9 @@ class ConstantTween<T> extends Tween<T> {
 /// This class differs from [CurvedAnimation] in that [CurvedAnimation] applies
 /// a curve to an existing [Animation] object whereas [CurveTween] can be
 /// chained with another [Tween] prior to receiving the underlying [Animation].
+// TODO(team-framework): Remove this sentence once `CurvedAnimation.reverseCurve`
+// is removed:
+// https://github.com/flutter/flutter/issues/185468.
 /// Unlike [CurvedAnimation], a [CurveTween] does not add listeners or hold
 /// state, so it does not need to be disposed.
 ///

--- a/packages/flutter/test/animation/animations_test.dart
+++ b/packages/flutter/test/animation/animations_test.dart
@@ -28,10 +28,12 @@ void main() {
     expect(kAlwaysCompleteAnimation, hasOneLineDescription);
     expect(kAlwaysDismissedAnimation, hasOneLineDescription);
     expect(const AlwaysStoppedAnimation<double>(0.5), hasOneLineDescription);
-    var curvedAnimation = CurvedAnimation(parent: kAlwaysDismissedAnimation, curve: Curves.ease);
+
+    final curvedAnimation = CurvedAnimation(parent: kAlwaysDismissedAnimation, curve: Curves.ease);
     expect(curvedAnimation, hasOneLineDescription);
     curvedAnimation.reverseCurve = Curves.elasticOut;
     expect(curvedAnimation, hasOneLineDescription);
+
     final controller = AnimationController(
       duration: const Duration(milliseconds: 500),
       vsync: const TestVSync(),
@@ -39,12 +41,12 @@ void main() {
     controller
       ..value = 0.5
       ..reverse();
-    curvedAnimation = CurvedAnimation(
+    final asymmetricCurvedAnimation = AsymmetricCurvedAnimation(
       parent: controller,
       curve: Curves.ease,
       reverseCurve: Curves.elasticOut,
     );
-    expect(curvedAnimation, hasOneLineDescription);
+    expect(asymmetricCurvedAnimation, hasOneLineDescription);
     controller.stop();
   });
 
@@ -280,11 +282,7 @@ FlutterError
       reverseDuration: const Duration(milliseconds: 50),
       vsync: const TestVSync(),
     );
-    final curved = CurvedAnimation(
-      parent: controller,
-      curve: Curves.linear,
-      reverseCurve: Curves.linear,
-    );
+    final curved = CurvedAnimation(parent: controller, curve: Curves.linear);
 
     controller.forward();
     tick(Duration.zero);
@@ -323,7 +321,7 @@ FlutterError
     expect(curved.value, moreOrLessEquals(0.0));
   });
 
-  test('CurvedAnimation stops listening to parent when disposed.', () async {
+  test('AsymmetricCurvedAnimation stops listening to parent when disposed.', () async {
     const forwardCurve = Interval(0.0, 0.5);
     const reverseCurve = Interval(0.5, 1.0);
 
@@ -332,7 +330,7 @@ FlutterError
       reverseDuration: const Duration(milliseconds: 100),
       vsync: const TestVSync(),
     );
-    final curved = CurvedAnimation(
+    final curved = AsymmetricCurvedAnimation(
       parent: controller,
       curve: forwardCurve,
       reverseCurve: reverseCurve,
@@ -498,17 +496,17 @@ FlutterError
     expect(animation.value, 10.0);
   });
 
-  test('$CurvedAnimation dispatches memory events', () async {
+  test('$AsymmetricCurvedAnimation dispatches memory events', () async {
     await expectLater(
       await memoryEvents(
-        () => CurvedAnimation(
+        () => AsymmetricCurvedAnimation(
           parent: AnimationController(
             duration: const Duration(milliseconds: 100),
             vsync: const TestVSync(),
           ),
           curve: Curves.linear,
         ).dispose(),
-        CurvedAnimation,
+        AsymmetricCurvedAnimation,
       ),
       areCreateAndDispose,
     );

--- a/packages/flutter/test/animation/animations_test.dart
+++ b/packages/flutter/test/animation/animations_test.dart
@@ -276,6 +276,32 @@ FlutterError
     );
   });
 
+  test('AsymmetricCurvedAnimation with bogus curve', () {
+    final controller = AnimationController(vsync: const TestVSync());
+    final curved = AsymmetricCurvedAnimation(parent: controller, curve: const BogusCurve());
+    FlutterError? error;
+    try {
+      curved.value;
+    } on FlutterError catch (e) {
+      error = e;
+    }
+    expect(error, isNotNull);
+    expect(
+      error!.toStringDeep(),
+      // RegExp matcher is required here due to flutter web and flutter mobile generating
+      // slightly different floating point numbers
+      // in Flutter web 0.0 sometimes just appears as 0. or 0
+      matches(
+        RegExp(r'''
+FlutterError
+   Invalid curve endpoint at \d+(\.\d*)?\.
+   Curves must map 0\.0 to near zero and 1\.0 to near one but
+   BogusCurve mapped \d+(\.\d*)? to \d+(\.\d*)?, which is near \d+(\.\d*)?\.
+''', multiLine: true),
+      ),
+    );
+  });
+
   test('CurvedAnimation running with different forward and reverse durations.', () {
     final controller = AnimationController(
       duration: const Duration(milliseconds: 100),
@@ -283,6 +309,51 @@ FlutterError
       vsync: const TestVSync(),
     );
     final curved = CurvedAnimation(parent: controller, curve: Curves.linear);
+
+    controller.forward();
+    tick(Duration.zero);
+    tick(const Duration(milliseconds: 10));
+    expect(curved.value, moreOrLessEquals(0.1));
+    tick(const Duration(milliseconds: 20));
+    expect(curved.value, moreOrLessEquals(0.2));
+    tick(const Duration(milliseconds: 30));
+    expect(curved.value, moreOrLessEquals(0.3));
+    tick(const Duration(milliseconds: 40));
+    expect(curved.value, moreOrLessEquals(0.4));
+    tick(const Duration(milliseconds: 50));
+    expect(curved.value, moreOrLessEquals(0.5));
+    tick(const Duration(milliseconds: 60));
+    expect(curved.value, moreOrLessEquals(0.6));
+    tick(const Duration(milliseconds: 70));
+    expect(curved.value, moreOrLessEquals(0.7));
+    tick(const Duration(milliseconds: 80));
+    expect(curved.value, moreOrLessEquals(0.8));
+    tick(const Duration(milliseconds: 90));
+    expect(curved.value, moreOrLessEquals(0.9));
+    tick(const Duration(milliseconds: 100));
+    expect(curved.value, moreOrLessEquals(1.0));
+    controller.reverse();
+    tick(const Duration(milliseconds: 110));
+    expect(curved.value, moreOrLessEquals(1.0));
+    tick(const Duration(milliseconds: 120));
+    expect(curved.value, moreOrLessEquals(0.8));
+    tick(const Duration(milliseconds: 130));
+    expect(curved.value, moreOrLessEquals(0.6));
+    tick(const Duration(milliseconds: 140));
+    expect(curved.value, moreOrLessEquals(0.4));
+    tick(const Duration(milliseconds: 150));
+    expect(curved.value, moreOrLessEquals(0.2));
+    tick(const Duration(milliseconds: 160));
+    expect(curved.value, moreOrLessEquals(0.0));
+  });
+
+  test('AsymmetricCurvedAnimation running with different forward and reverse durations.', () {
+    final controller = AnimationController(
+      duration: const Duration(milliseconds: 100),
+      reverseDuration: const Duration(milliseconds: 50),
+      vsync: const TestVSync(),
+    );
+    final curved = AsymmetricCurvedAnimation(parent: controller, curve: Curves.linear);
 
     controller.forward();
     tick(Duration.zero);
@@ -369,7 +440,11 @@ FlutterError
       vsync: const TestVSync(),
     );
     final reversed = ReverseAnimation(
-      CurvedAnimation(parent: controller, curve: Curves.linear, reverseCurve: Curves.linear),
+      AsymmetricCurvedAnimation(
+        parent: controller,
+        curve: Curves.linear,
+        reverseCurve: Curves.linear,
+      ),
     );
 
     controller.forward();
@@ -494,6 +569,25 @@ FlutterError
 
     controller.value = 1.0;
     expect(animation.value, 10.0);
+  });
+
+  // During the migration period, [CurvedAnimation] is mimicking
+  // [AsymmetricCurvedAnimation]: verify it's disposed.
+  // This test can be removed after the migration period.
+  test('$CurvedAnimation disposes its internal AsymmetricCurvedAnimation', () async {
+    await expectLater(
+      await memoryEvents(
+        () => CurvedAnimation(
+          parent: AnimationController(
+            duration: const Duration(milliseconds: 100),
+            vsync: const TestVSync(),
+          ),
+          curve: Curves.linear,
+        ).dispose(),
+        AsymmetricCurvedAnimation,
+      ),
+      areCreateAndDispose,
+    );
   });
 
   test('$AsymmetricCurvedAnimation dispatches memory events', () async {


### PR DESCRIPTION
This is the [first step](https://github.com/flutter/flutter/issues/185468#issuecomment-4347693535) in fixing a confusing API prone to memory leaks.
Here we deprecate `CurvedAnimation.reverseCurve`. If it's needed, users should use `AsymmetricCurvedAnimation` instead of `CurvedAnimation` as described in the [migration guide PR](https://github.com/flutter/website/pull/13347).

Related issues:
- Closes https://github.com/flutter/flutter/issues/187546, which is the first half of https://github.com/flutter/flutter/issues/185468
- Could help with https://github.com/flutter/flutter/issues/150771

There is no data-driven fix since changing a constructor isn't supported: https://github.com/dart-lang/sdk/issues/50011#issuecomment-1290832831.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

<!--
If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.
-->

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
