### PR TITLE
Adapt the Metal shader library output list for debug versus release mode

### DIFF
--- a/engine/src/flutter/impeller/tools/metal_library.gni
+++ b/engine/src/flutter/impeller/tools/metal_library.gni
@@ -39,13 +39,8 @@ template("metal_library") {
     inputs = invoker.sources + [ "//flutter/impeller/tools/metal_library.py" ]
 
     metal_library_path = "$root_out_dir/shaders/$metal_library_name.metallib"
-    metal_library_symbols_path =
-        "$root_out_dir/shaders/$metal_library_name.metallibsym"
 
-    outputs = [
-      metal_library_path,
-      metal_library_symbols_path,
-    ]
+    outputs = [ metal_library_path ]
 
     script = "//flutter/impeller/tools/metal_library.py"
 
@@ -61,6 +56,8 @@ template("metal_library") {
 
     if (impeller_debug) {
       args += [ "--debug" ]
+    } else {
+      outputs += [ "$root_out_dir/shaders/$metal_library_name.metallibsym" ]
     }
 
     if (is_ios) {

--- a/engine/src/flutter/impeller/tools/metal_library.py
+++ b/engine/src/flutter/impeller/tools/metal_library.py
@@ -94,7 +94,7 @@ def main():
   else:
     command += [
         # Record symbols in a separate *.metallibsym file.
-        '-frecord-sources=flat'
+        '-frecord-sources=flat',
     ]
 
   # Select the Metal standard and the minimum supported OS versions.

--- a/engine/src/flutter/impeller/tools/metal_library.py
+++ b/engine/src/flutter/impeller/tools/metal_library.py
@@ -80,8 +80,6 @@ def main():
       '-Oz',
       # Allow aggressive, lossy floating-point optimizations.
       '-ffast-math',
-      # Record symbols in a separate *.metallibsym file.
-      '-frecord-sources=flat',
       '-MF',
       args.depfile,
       '-o',
@@ -92,6 +90,11 @@ def main():
     command += [
         '-g',
         '-frecord-sources',
+    ]
+  else:
+    command += [
+        # Record symbols in a separate *.metallibsym file.
+        '-frecord-sources=flat'
     ]
 
   # Select the Metal standard and the minimum supported OS versions.


### PR DESCRIPTION
https://github.com/flutter/flutter/pull/185629 changed the metal_library build template to embed symbols within the shader library file when building in debug and profile modes.  Release mode will continue to generate a separate symbol file.

This PR updates the template's output list to match the actual outputs so that rebuilds will not run unncessary actions.  It also changes the metal_library build script to pass only one value for the "-frecord-sources" flag that controls the output of symbols.