### PR TITLE
[a11y] Add support for high contrast themes in the a11y assessments app 

### DIFF
--- a/dev/a11y_assessments/lib/main.dart
+++ b/dev/a11y_assessments/lib/main.dart
@@ -15,6 +15,32 @@ void main() {
   }
 }
 
+ThemeData _buildTheme({required Brightness brightness, double contrastLevel = 0.0}) {
+  final scheme = ColorScheme.fromSeed(
+    brightness: brightness,
+    seedColor: const Color(0xff6750a4),
+    contrastLevel: contrastLevel,
+  );
+  return ThemeData(
+    colorScheme: scheme,
+    appBarTheme: AppBarTheme(backgroundColor: scheme.primary, foregroundColor: scheme.onPrimary),
+    pageTransitionsTheme: PageTransitionsTheme(
+      builders: <TargetPlatform, PageTransitionsBuilder>{
+        for (final TargetPlatform platform in TargetPlatform.values)
+          platform: const FadeForwardsPageTransitionsBuilder(),
+      },
+    ),
+  );
+}
+
+final ThemeData _lightTheme = _buildTheme(brightness: Brightness.light);
+final ThemeData _darkTheme = _buildTheme(brightness: Brightness.dark);
+final ThemeData _highContrastTheme = _buildTheme(brightness: Brightness.light, contrastLevel: 1.0);
+final ThemeData _highContrastDarkTheme = _buildTheme(
+  brightness: Brightness.dark,
+  contrastLevel: 1.0,
+);
+
 class App extends StatelessWidget {
   const App({super.key, this.initialTags = const <Tag>{Tag.batch2}});
 
@@ -22,20 +48,6 @@ class App extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final lightTheme = ThemeData(
-      colorScheme: ColorScheme.fromSeed(
-        seedColor: const Color(0xff6750a4),
-        contrastLevel: MediaQuery.highContrastOf(context) ? 1.0 : 0.0,
-      ),
-    );
-    final darkTheme = ThemeData(
-      colorScheme: ColorScheme.fromSeed(
-        brightness: Brightness.dark,
-        seedColor: const Color(0xff6750a4),
-        contrastLevel: MediaQuery.highContrastOf(context) ? 1.0 : 0.0,
-      ),
-    );
-
     final routes = Map<String, WidgetBuilder>.fromEntries(
       useCases.map(
         (UseCase useCase) => MapEntry<String, WidgetBuilder>(
@@ -48,8 +60,10 @@ class App extends StatelessWidget {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       title: 'Accessibility Assessments Home Page',
-      theme: lightTheme,
-      darkTheme: darkTheme,
+      theme: _lightTheme,
+      darkTheme: _darkTheme,
+      highContrastTheme: _highContrastTheme,
+      highContrastDarkTheme: _highContrastDarkTheme,
       routes: <String, WidgetBuilder>{
         '/': (_) => HomePage(initialTags: initialTags),
         ...routes,

--- a/dev/a11y_assessments/lib/use_cases/about_list_tile.dart
+++ b/dev/a11y_assessments/lib/use_cases/about_list_tile.dart
@@ -29,10 +29,7 @@ class MainWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     final String pageTitle = getUseCaseName(AboutListTileUseCase());
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo')),
-      ),
+      appBar: AppBar(title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo'))),
       body: ListView(
         children: const <Widget>[
           AboutListTile(

--- a/dev/a11y_assessments/lib/use_cases/action_chip.dart
+++ b/dev/a11y_assessments/lib/use_cases/action_chip.dart
@@ -37,10 +37,7 @@ class MainWidgetState extends State<MainWidget> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo')),
-      ),
+      appBar: AppBar(title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo'))),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,

--- a/dev/a11y_assessments/lib/use_cases/app_bar.dart
+++ b/dev/a11y_assessments/lib/use_cases/app_bar.dart
@@ -42,12 +42,8 @@ class MainWidgetState extends State<MainWidget> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: <PreferredSizeWidget>[
+        AppBar(title: Semantics(headingLevel: 1, child: const Text('AppBar'))),
         AppBar(
-          backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-          title: Semantics(headingLevel: 1, child: const Text('AppBar')),
-        ),
-        AppBar(
-          backgroundColor: Theme.of(context).colorScheme.inversePrimary,
           title: Semantics(headingLevel: 1, child: const Text('AppBar')),
           actions: <Widget>[
             IconButton(
@@ -69,7 +65,6 @@ class MainWidgetState extends State<MainWidget> {
                     builder: (BuildContext context) {
                       return Scaffold(
                         appBar: AppBar(
-                          backgroundColor: Theme.of(context).colorScheme.inversePrimary,
                           title: Semantics(headingLevel: 1, child: const Text('Next Page')),
                         ),
                         body: const Center(
@@ -84,14 +79,13 @@ class MainWidgetState extends State<MainWidget> {
           ],
         ),
         AppBar(
-          backgroundColor: Theme.of(context).colorScheme.inversePrimary,
           title: Semantics(headingLevel: 1, child: const Text('AppBar')),
           actions: <Widget>[
             for (final String label in const <String>['Action 1', 'Action 2'])
               TextButton(
                 onPressed: () {},
                 style: TextButton.styleFrom(
-                  foregroundColor: Theme.of(context).colorScheme.onPrimaryContainer,
+                  foregroundColor: Theme.of(context).colorScheme.onPrimary,
                 ),
                 child: Text(label),
               ),

--- a/dev/a11y_assessments/lib/use_cases/auto_complete.dart
+++ b/dev/a11y_assessments/lib/use_cases/auto_complete.dart
@@ -53,10 +53,7 @@ class _MainWidgetState extends State<_MainWidget> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo')),
-      ),
+      appBar: AppBar(title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo'))),
       body: Center(
         child: Semantics(
           container: true,

--- a/dev/a11y_assessments/lib/use_cases/back_button.dart
+++ b/dev/a11y_assessments/lib/use_cases/back_button.dart
@@ -35,10 +35,7 @@ class MainWidgetState extends State<MainWidget> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo')),
-      ),
+      appBar: AppBar(title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo'))),
       body: const Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,

--- a/dev/a11y_assessments/lib/use_cases/badge.dart
+++ b/dev/a11y_assessments/lib/use_cases/badge.dart
@@ -35,10 +35,7 @@ class MainWidgetState extends State<MainWidget> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo')),
-      ),
+      appBar: AppBar(title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo'))),
       body: const Center(
         child: Badge(
           label: Text(

--- a/dev/a11y_assessments/lib/use_cases/card.dart
+++ b/dev/a11y_assessments/lib/use_cases/card.dart
@@ -37,10 +37,7 @@ class MainWidgetState extends State<MainWidget> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo')),
-      ),
+      appBar: AppBar(title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo'))),
       body: const Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,

--- a/dev/a11y_assessments/lib/use_cases/close_button.dart
+++ b/dev/a11y_assessments/lib/use_cases/close_button.dart
@@ -36,7 +36,6 @@ class MainWidgetState extends State<MainWidget> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
         title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo')),
         automaticallyImplyLeading: false,
       ),

--- a/dev/a11y_assessments/lib/use_cases/date_picker.dart
+++ b/dev/a11y_assessments/lib/use_cases/date_picker.dart
@@ -35,10 +35,7 @@ class _MainWidgetState extends State<_MainWidget> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo')),
-      ),
+      appBar: AppBar(title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo'))),
       body: Center(
         child: TextButton(
           onPressed: () => showDatePicker(

--- a/dev/a11y_assessments/lib/use_cases/dialog.dart
+++ b/dev/a11y_assessments/lib/use_cases/dialog.dart
@@ -30,10 +30,7 @@ class _MainWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo')),
-      ),
+      appBar: AppBar(title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo'))),
       body: Center(
         child: TextButton(
           onPressed: () => showDialog<String>(

--- a/dev/a11y_assessments/lib/use_cases/drawer.dart
+++ b/dev/a11y_assessments/lib/use_cases/drawer.dart
@@ -37,10 +37,7 @@ class _DrawerExampleState extends State<DrawerExample> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo')),
-      ),
+      appBar: AppBar(title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo'))),
       endDrawer: Drawer(
         child: ListView(
           padding: EdgeInsets.zero,

--- a/dev/a11y_assessments/lib/use_cases/elevated_button.dart
+++ b/dev/a11y_assessments/lib/use_cases/elevated_button.dart
@@ -35,10 +35,7 @@ class MainWidgetState extends State<MainWidget> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo')),
-      ),
+      appBar: AppBar(title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo'))),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,

--- a/dev/a11y_assessments/lib/use_cases/expansion_tile.dart
+++ b/dev/a11y_assessments/lib/use_cases/expansion_tile.dart
@@ -37,10 +37,7 @@ class _ExpansionTileExampleState extends State<ExpansionTileExample> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo')),
-      ),
+      appBar: AppBar(title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo'))),
       body: Column(
         children: <Widget>[
           const ExpansionTile(

--- a/dev/a11y_assessments/lib/use_cases/filled_button.dart
+++ b/dev/a11y_assessments/lib/use_cases/filled_button.dart
@@ -35,10 +35,7 @@ class MainWidgetState extends State<MainWidget> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo')),
-      ),
+      appBar: AppBar(title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo'))),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,

--- a/dev/a11y_assessments/lib/use_cases/floating_action_button.dart
+++ b/dev/a11y_assessments/lib/use_cases/floating_action_button.dart
@@ -36,10 +36,7 @@ class MainWidgetState extends State<MainWidget> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo')),
-      ),
+      appBar: AppBar(title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo'))),
       body: Center(child: Text('Tap count: $_tapCount')),
       floatingActionButton: FloatingActionButton(
         onPressed: () {

--- a/dev/a11y_assessments/lib/use_cases/icon_button.dart
+++ b/dev/a11y_assessments/lib/use_cases/icon_button.dart
@@ -35,10 +35,7 @@ class MainWidgetState extends State<MainWidget> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo')),
-      ),
+      appBar: AppBar(title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo'))),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,

--- a/dev/a11y_assessments/lib/use_cases/material_banner.dart
+++ b/dev/a11y_assessments/lib/use_cases/material_banner.dart
@@ -69,10 +69,7 @@ class MainWidgetState extends State<MainWidget> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo')),
-      ),
+      appBar: AppBar(title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo'))),
       body: Center(
         child: ElevatedButton(
           focusNode: showButtonFocusNode,

--- a/dev/a11y_assessments/lib/use_cases/navigation_bar.dart
+++ b/dev/a11y_assessments/lib/use_cases/navigation_bar.dart
@@ -37,10 +37,7 @@ class MainWidgetState extends State<MainWidget> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo')),
-      ),
+      appBar: AppBar(title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo'))),
       bottomNavigationBar: NavigationBar(
         onDestinationSelected: (int index) {
           setState(() {

--- a/dev/a11y_assessments/lib/use_cases/navigation_drawer.dart
+++ b/dev/a11y_assessments/lib/use_cases/navigation_drawer.dart
@@ -64,10 +64,7 @@ class _NavigationDrawerExampleState extends State<NavigationDrawerExample> {
   Widget buildDrawerScaffold(BuildContext context) {
     return Scaffold(
       key: scaffoldKey,
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo')),
-      ),
+      appBar: AppBar(title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo'))),
       body: SafeArea(
         bottom: false,
         top: false,

--- a/dev/a11y_assessments/lib/use_cases/outlined_button.dart
+++ b/dev/a11y_assessments/lib/use_cases/outlined_button.dart
@@ -35,10 +35,7 @@ class MainWidgetState extends State<MainWidget> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo')),
-      ),
+      appBar: AppBar(title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo'))),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,

--- a/dev/a11y_assessments/lib/use_cases/popup_menu_button.dart
+++ b/dev/a11y_assessments/lib/use_cases/popup_menu_button.dart
@@ -36,10 +36,7 @@ class MainWidgetState extends State<MainWidget> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo')),
-      ),
+      appBar: AppBar(title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo'))),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,

--- a/dev/a11y_assessments/lib/use_cases/range_slider.dart
+++ b/dev/a11y_assessments/lib/use_cases/range_slider.dart
@@ -37,10 +37,7 @@ class MainWidgetState extends State<MainWidget> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo')),
-      ),
+      appBar: AppBar(title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo'))),
       body: Center(
         child: RangeSlider(
           values: _currentRangeValues,

--- a/dev/a11y_assessments/lib/use_cases/segmented_button.dart
+++ b/dev/a11y_assessments/lib/use_cases/segmented_button.dart
@@ -36,10 +36,7 @@ class MainWidgetState extends State<MainWidget> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo')),
-      ),
+      appBar: AppBar(title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo'))),
       body: Center(
         child: SegmentedButton<String>(
           segments: const <ButtonSegment<String>>[

--- a/dev/a11y_assessments/lib/use_cases/slider.dart
+++ b/dev/a11y_assessments/lib/use_cases/slider.dart
@@ -37,10 +37,7 @@ class MainWidgetState extends State<MainWidget> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(headingLevel: 1, child: Text('$pageTitle demo')),
-      ),
+      appBar: AppBar(title: Semantics(headingLevel: 1, child: Text('$pageTitle demo'))),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,

--- a/dev/a11y_assessments/lib/use_cases/snack_bar.dart
+++ b/dev/a11y_assessments/lib/use_cases/snack_bar.dart
@@ -35,10 +35,7 @@ class MainWidgetState extends State<MainWidget> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo')),
-      ),
+      appBar: AppBar(title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo'))),
       body: Center(
         child: Column(
           children: <Widget>[

--- a/dev/a11y_assessments/lib/use_cases/switch_list_tile.dart
+++ b/dev/a11y_assessments/lib/use_cases/switch_list_tile.dart
@@ -38,10 +38,7 @@ class _SwitchListTileExampleState extends State<SwitchListTileExample> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo')),
-      ),
+      appBar: AppBar(title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo'))),
       body: Center(
         child: Column(
           children: <Widget>[

--- a/dev/a11y_assessments/lib/use_cases/text_button.dart
+++ b/dev/a11y_assessments/lib/use_cases/text_button.dart
@@ -37,10 +37,7 @@ class MainWidgetState extends State<MainWidget> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo')),
-      ),
+      appBar: AppBar(title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo'))),
       body: Form(
         key: _formKey,
         child: Column(

--- a/dev/a11y_assessments/lib/use_cases/text_field.dart
+++ b/dev/a11y_assessments/lib/use_cases/text_field.dart
@@ -30,10 +30,7 @@ class _MainWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo')),
-      ),
+      appBar: AppBar(title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo'))),
       body: ListView(
         children: <Widget>[
           Semantics(

--- a/dev/a11y_assessments/lib/use_cases/text_field_password.dart
+++ b/dev/a11y_assessments/lib/use_cases/text_field_password.dart
@@ -30,10 +30,7 @@ class _MainWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo')),
-      ),
+      appBar: AppBar(title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo'))),
       body: ListView(
         children: const <Widget>[
           TextField(

--- a/dev/a11y_assessments/lib/use_cases/toggle_buttons.dart
+++ b/dev/a11y_assessments/lib/use_cases/toggle_buttons.dart
@@ -36,10 +36,7 @@ class MainWidgetState extends State<MainWidget> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo')),
-      ),
+      appBar: AppBar(title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo'))),
       body: Center(
         child: ToggleButtons(
           isSelected: _selected,

--- a/dev/a11y_assessments/test/home_page_test.dart
+++ b/dev/a11y_assessments/test/home_page_test.dart
@@ -50,7 +50,7 @@ void main() {
       isDark: false,
       contrastLevel: 1.0,
     );
-    final ColorScheme appScheme = app.theme!.colorScheme;
+    final ColorScheme appScheme = app.highContrastTheme!.colorScheme;
 
     expect(appScheme.primary.value, MaterialDynamicColors.primary.getArgb(highContrastScheme));
     expect(appScheme.onPrimary.value, MaterialDynamicColors.onPrimary.getArgb(highContrastScheme));


### PR DESCRIPTION

The app bar was using`backgroundColor:  inversePrimary` before.  the inversePrimary color doesn't change in high contrast mode.  update it to use primary and onPrimary.
Also added PageTransition 


## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
