### PR TITLE
[a11y assessment app] Use default color for banner

### DIFF
--- a/dev/a11y_assessments/lib/use_cases/material_banner.dart
+++ b/dev/a11y_assessments/lib/use_cases/material_banner.dart
@@ -53,7 +53,6 @@ class MainWidgetState extends State<MainWidget> {
         padding: const EdgeInsets.all(20),
         content: const Text('Hello, I am a Material Banner'),
         leading: const Icon(Icons.agriculture_outlined),
-        backgroundColor: Colors.yellowAccent,
         actions: <Widget>[
           TextButton(
             focusNode: dismissButtonFocusNode,

--- a/dev/a11y_assessments/test/accessibility_guideline_test.dart
+++ b/dev/a11y_assessments/test/accessibility_guideline_test.dart
@@ -31,51 +31,57 @@ void main() {
   });
 
   for (final UseCase useCase in useCases) {
-    testWidgets('testing accessibility guideline for ${useCase.name}', (WidgetTester tester) async {
-      await tester.pumpWidget(const App(initialTags: <Tag>{}));
+    for (final Brightness brightness in Brightness.values) {
+      testWidgets('testing accessibility guideline for ${useCase.name} - ${brightness.name}', (
+        WidgetTester tester,
+      ) async {
+        tester.platformDispatcher.platformBrightnessTestValue = brightness;
+        addTearDown(tester.platformDispatcher.clearAllTestValues);
+        await tester.pumpWidget(const App(initialTags: <Tag>{}));
 
-      final ScrollController controller = tester
-          .state<HomePageState>(find.byType(HomePage))
-          .scrollController;
-      while (find.byKey(Key(useCase.name)).evaluate().isEmpty) {
-        controller.jumpTo(controller.offset + 400);
-        await tester.pumpAndSettle();
-      }
-      await tester.tap(find.byKey(Key(useCase.name)));
-      await tester.pumpAndSettle();
-
-      await _expectMeetsGuidelines(tester);
-
-      // After checking the guideline for the main page,
-      // iterate through all tappable semantic nodes on the current screen.
-      // Tap each one (excluding the back button) to navigate deeper into the app
-      // and re-run the accessibility checks. This assumes that tapping a target
-      // does not remove other tappable targets from the screen, which is true
-      // for the a11y assessment app's current structure.
-      final SemanticsFinder tappables = find.semantics.byAction(SemanticsAction.tap);
-      final int tappableCount = tappables.evaluate().length;
-
-      for (var i = 0; i < tappableCount; i++) {
-        final FinderBase<SemanticsNode> tappable = tappables.at(i);
-        final SemanticsNode node = tappable.evaluate().first;
-
-        // We do not want to tap the back button or close button, as that will pop the page
-        // and disrupt the current test flow.
-        if (node.tooltip == 'Back' || node.label == 'Close') {
-          continue;
+        final ScrollController controller = tester
+            .state<HomePageState>(find.byType(HomePage))
+            .scrollController;
+        while (find.byKey(Key(useCase.name)).evaluate().isEmpty) {
+          controller.jumpTo(controller.offset + 400);
+          await tester.pumpAndSettle();
         }
-        tester.semantics.tap(tappable);
+        await tester.tap(find.byKey(Key(useCase.name)));
         await tester.pumpAndSettle();
 
-        // Re-check the accessibility guidelines after the tap action.
-        // The DatePicker use case has known issues with tap target sizes
-        // So we skip these checks for this use case .
-        await _expectMeetsGuidelines(
-          tester,
-          skipTapTarget: useCase.name == DatePickerUseCase().name,
-        );
-      }
-    });
+        await _expectMeetsGuidelines(tester);
+
+        // After checking the guideline for the main page,
+        // iterate through all tappable semantic nodes on the current screen.
+        // Tap each one (excluding the back button) to navigate deeper into the app
+        // and re-run the accessibility checks. This assumes that tapping a target
+        // does not remove other tappable targets from the screen, which is true
+        // for the a11y assessment app's current structure.
+        final SemanticsFinder tappables = find.semantics.byAction(SemanticsAction.tap);
+        final int tappableCount = tappables.evaluate().length;
+
+        for (var i = 0; i < tappableCount; i++) {
+          final FinderBase<SemanticsNode> tappable = tappables.at(i);
+          final SemanticsNode node = tappable.evaluate().first;
+
+          // We do not want to tap the back button or close button, as that will pop the page
+          // and disrupt the current test flow.
+          if (node.tooltip == 'Back' || node.label == 'Close') {
+            continue;
+          }
+          tester.semantics.tap(tappable);
+          await tester.pumpAndSettle();
+
+          // Re-check the accessibility guidelines after the tap action.
+          // The DatePicker use case has known issues with tap target sizes
+          // So we skip these checks for this use case .
+          await _expectMeetsGuidelines(
+            tester,
+            skipTapTarget: useCase.name == DatePickerUseCase().name,
+          );
+        }
+      });
+    }
   }
 }
 


### PR DESCRIPTION
yellow is bad in dark mode. 
also update a11y guideline test to include dark mode, so color contrast will be tested in dark mode.

fix:https://github.com/flutter/flutter/issues/185776

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
