### PR TITLE
Add alignment to SliverConstrainedCrossAxis

### DIFF
--- a/packages/flutter/lib/src/rendering/proxy_sliver.dart
+++ b/packages/flutter/lib/src/rendering/proxy_sliver.dart
@@ -450,9 +450,14 @@ class RenderSliverConstrainedCrossAxis extends RenderProxySliver {
   /// Creates a render object that constrains the cross axis extent of its sliver child.
   ///
   /// The [maxExtent] parameter must be nonnegative.
-  RenderSliverConstrainedCrossAxis({required double maxExtent})
-    : _maxExtent = maxExtent,
-      assert(maxExtent >= 0.0);
+  RenderSliverConstrainedCrossAxis({
+    required double maxExtent,
+    AlignmentGeometry? alignment,
+    TextDirection? textDirection,
+  }) : assert(maxExtent >= 0.0),
+       _maxExtent = maxExtent,
+       _alignment = alignment,
+       _textDirection = textDirection;
 
   /// The cross axis extent to apply to the sliver child.
   ///
@@ -467,6 +472,61 @@ class RenderSliverConstrainedCrossAxis extends RenderProxySliver {
     markNeedsLayout();
   }
 
+  /// How to align the sliver within the cross axis.
+  ///
+  /// For example, if the [alignment] is [Alignment.center], the sliver will
+  /// be centered within the [SliverConstraints.crossAxisExtent].
+  ///
+  /// If this is null, the sliver is positioned at the start of the cross axis
+  /// (0.0). If the sliver consumes the full cross axis extent, the alignment
+  /// has no effect.
+  AlignmentGeometry? get alignment => _alignment;
+  AlignmentGeometry? _alignment;
+  set alignment(AlignmentGeometry? value) {
+    if (_alignment == value) {
+      return;
+    }
+    _alignment = value;
+    _markNeedResolution();
+  }
+
+  /// The direction in which text flows, used to resolve [alignment].
+  TextDirection? get textDirection => _textDirection;
+  TextDirection? _textDirection;
+  set textDirection(TextDirection? value) {
+    if (_textDirection == value) {
+      return;
+    }
+    _textDirection = value;
+    _markNeedResolution();
+  }
+
+  void _markNeedResolution() {
+    _resolvedAlignment = null;
+    markNeedsLayout();
+  }
+
+  Alignment? _resolvedAlignment;
+  Alignment? get _resolvedAlignmentValue =>
+      _resolvedAlignment ??= alignment?.resolve(textDirection);
+
+  Offset get _alignmentOffset {
+    final Alignment? resolvedAlignment = _resolvedAlignmentValue;
+    if (resolvedAlignment == null) {
+      return Offset.zero;
+    }
+    final double childCrossAxisExtent =
+        child!.geometry!.crossAxisExtent ?? child!.constraints.crossAxisExtent;
+    final double freeSpace = constraints.crossAxisExtent - childCrossAxisExtent;
+    if (freeSpace <= 0.0) {
+      return Offset.zero;
+    }
+    return switch (constraints.axis) {
+      Axis.vertical => Offset((resolvedAlignment.x + 1.0) / 2.0 * freeSpace, 0.0),
+      Axis.horizontal => Offset(0.0, (resolvedAlignment.y + 1.0) / 2.0 * freeSpace),
+    };
+  }
+
   @override
   void performLayout() {
     assert(child != null);
@@ -476,9 +536,59 @@ class RenderSliverConstrainedCrossAxis extends RenderProxySliver {
       parentUsesSize: true,
     );
     final SliverGeometry childLayoutGeometry = child!.geometry!;
-    geometry = childLayoutGeometry.copyWith(
-      crossAxisExtent: min(_maxExtent, constraints.crossAxisExtent),
+    if (alignment == null) {
+      geometry = childLayoutGeometry.copyWith(
+        crossAxisExtent: child!.geometry!.crossAxisExtent ?? child!.constraints.crossAxisExtent,
+      );
+    } else {
+      geometry = childLayoutGeometry.copyWith(crossAxisExtent: constraints.crossAxisExtent);
+    }
+  }
+
+  @override
+  void paint(PaintingContext context, Offset offset) {
+    if (child != null && geometry!.visible) {
+      context.paintChild(child!, offset + _alignmentOffset);
+    }
+  }
+
+  @override
+  bool hitTestChildren(
+    SliverHitTestResult result, {
+    required double mainAxisPosition,
+    required double crossAxisPosition,
+  }) {
+    if (child != null) {
+      final Offset offset = _alignmentOffset;
+      return child!.hitTest(
+        result,
+        mainAxisPosition: mainAxisPosition,
+        crossAxisPosition:
+            crossAxisPosition -
+            switch (constraints.axis) {
+              Axis.vertical => offset.dx,
+              Axis.horizontal => offset.dy,
+            },
+      );
+    }
+    return false;
+  }
+
+  @override
+  void applyPaintTransform(RenderSliver child, Matrix4 transform) {
+    assert(child == this.child);
+    final Offset offset = _alignmentOffset;
+    transform.translate(offset.dx, offset.dy);
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DoubleProperty('maxExtent', maxExtent));
+    properties.add(
+      DiagnosticsProperty<AlignmentGeometry>('alignment', alignment, defaultValue: null),
     );
+    properties.add(EnumProperty<TextDirection>('textDirection', textDirection, defaultValue: null));
   }
 }
 

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -1647,12 +1647,27 @@ class SliverConstrainedCrossAxis extends StatelessWidget {
   /// Creates a sliver that constrains the cross axis extent of its sliver child.
   ///
   /// The [maxExtent] parameter is required and must be nonnegative.
-  const SliverConstrainedCrossAxis({super.key, required this.maxExtent, required this.sliver});
+  const SliverConstrainedCrossAxis({
+    super.key,
+    required this.maxExtent,
+    this.alignment,
+    required this.sliver,
+  }) : assert(maxExtent >= 0.0);
 
   /// The cross axis extent to apply to the sliver child.
   ///
   /// This value must be nonnegative.
   final double maxExtent;
+
+  /// How to align the sliver within the cross axis.
+  ///
+  /// For example, if the [alignment] is [Alignment.center], the [sliver] will
+  /// be centered within the [SliverConstraints.crossAxisExtent].
+  ///
+  /// If this is null, the sliver is positioned at the start of the cross axis
+  /// (0.0). If the sliver consumes the full cross axis extent, the alignment
+  /// has no effect.
+  final AlignmentGeometry? alignment;
 
   /// The widget below this widget in the tree.
   ///
@@ -1662,7 +1677,21 @@ class SliverConstrainedCrossAxis extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return _SliverZeroFlexParentDataWidget(
-      sliver: _SliverConstrainedCrossAxis(maxExtent: maxExtent, sliver: sliver),
+      sliver: _SliverConstrainedCrossAxis(
+        maxExtent: maxExtent,
+        alignment: alignment,
+        textDirection: alignment != null ? Directionality.maybeOf(context) : null,
+        sliver: sliver,
+      ),
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DoubleProperty('maxExtent', maxExtent));
+    properties.add(
+      DiagnosticsProperty<AlignmentGeometry>('alignment', alignment, defaultValue: null),
     );
   }
 }
@@ -1690,23 +1719,40 @@ class _SliverZeroFlexParentDataWidget extends ParentDataWidget<SliverPhysicalPar
 }
 
 class _SliverConstrainedCrossAxis extends SingleChildRenderObjectWidget {
-  const _SliverConstrainedCrossAxis({required this.maxExtent, required Widget sliver})
-    : assert(maxExtent >= 0.0),
-      super(child: sliver);
+  const _SliverConstrainedCrossAxis({
+    required this.maxExtent,
+    this.alignment,
+    this.textDirection,
+    required Widget sliver,
+  }) : assert(maxExtent >= 0.0),
+       super(child: sliver);
 
   /// The cross axis extent to apply to the sliver child.
   ///
   /// This value must be nonnegative.
   final double maxExtent;
 
+  /// How to align the child within the cross axis.
+  final AlignmentGeometry? alignment;
+
+  /// The direction in which text flows, used to resolve [alignment].
+  final TextDirection? textDirection;
+
   @override
   RenderSliverConstrainedCrossAxis createRenderObject(BuildContext context) {
-    return RenderSliverConstrainedCrossAxis(maxExtent: maxExtent);
+    return RenderSliverConstrainedCrossAxis(
+      maxExtent: maxExtent,
+      alignment: alignment,
+      textDirection: textDirection,
+    );
   }
 
   @override
   void updateRenderObject(BuildContext context, RenderSliverConstrainedCrossAxis renderObject) {
-    renderObject.maxExtent = maxExtent;
+    renderObject
+      ..maxExtent = maxExtent
+      ..alignment = alignment
+      ..textDirection = textDirection;
   }
 }
 

--- a/packages/flutter/test/widgets/sliver_constrained_cross_axis_test.dart
+++ b/packages/flutter/test/widgets/sliver_constrained_cross_axis_test.dart
@@ -13,24 +13,24 @@ void main() {
   testWidgets('SliverConstrainedCrossAxis basic test', (WidgetTester tester) async {
     await tester.pumpWidget(_buildSliverConstrainedCrossAxis(maxExtent: 50));
 
-    final RenderBox box = tester.renderObject(find.byType(Container));
+    final RenderBox box = tester.renderObject<RenderBox>(find.byType(Container));
     expect(box.size.height, 100);
     expect(box.size.width, 50);
 
-    final RenderSliver sliver = tester.renderObject(find.byType(SliverToBoxAdapter));
+    final RenderSliver sliver = tester.renderObject<RenderSliver>(find.byType(SliverToBoxAdapter));
     expect(sliver.geometry!.paintExtent, equals(100));
   });
 
   testWidgets('SliverConstrainedCrossAxis updates correctly', (WidgetTester tester) async {
     await tester.pumpWidget(_buildSliverConstrainedCrossAxis(maxExtent: 50));
 
-    final RenderBox box1 = tester.renderObject(find.byType(Container));
+    final RenderBox box1 = tester.renderObject<RenderBox>(find.byType(Container));
     expect(box1.size.height, 100);
     expect(box1.size.width, 50);
 
     await tester.pumpWidget(_buildSliverConstrainedCrossAxis(maxExtent: 80));
 
-    final RenderBox box2 = tester.renderObject(find.byType(Container));
+    final RenderBox box2 = tester.renderObject<RenderBox>(find.byType(Container));
     expect(box2.size.height, 100);
     expect(box2.size.width, 80);
   });
@@ -40,7 +40,7 @@ void main() {
   ) async {
     await tester.pumpWidget(_buildSliverConstrainedCrossAxis(maxExtent: 400));
 
-    final RenderBox box = tester.renderObject(find.byType(Container));
+    final RenderBox box = tester.renderObject<RenderBox>(find.byType(Container));
     expect(box.size.height, 100);
     expect(box.size.width, VIEWPORT_WIDTH);
   });
@@ -52,42 +52,350 @@ void main() {
       _buildSliverConstrainedCrossAxis(maxExtent: 50, scrollDirection: Axis.horizontal),
     );
 
-    final RenderBox box = tester.renderObject(find.byType(Container));
+    final RenderBox box = tester.renderObject<RenderBox>(find.byType(Container));
     expect(box.size.height, 50);
   });
 
   testWidgets('SliverConstrainedCrossAxis sets its own flex to 0', (WidgetTester tester) async {
     await tester.pumpWidget(_buildSliverConstrainedCrossAxis(maxExtent: 50));
 
-    final RenderSliver sliver = tester.renderObject(find.byType(SliverConstrainedCrossAxis));
+    final RenderSliver sliver = tester.renderObject<RenderSliver>(
+      find.byType(SliverConstrainedCrossAxis),
+    );
     expect((sliver.parentData! as SliverPhysicalParentData).crossAxisFlex, equals(0));
   });
-}
 
-Widget _buildSliverConstrainedCrossAxis({
-  required double maxExtent,
-  Axis scrollDirection = Axis.vertical,
-}) {
-  return Directionality(
-    textDirection: TextDirection.ltr,
-    child: Center(
-      child: SizedBox(
-        width: VIEWPORT_WIDTH,
-        height: VIEWPORT_HEIGHT,
+  testWidgets('SliverConstrainedCrossAxis defaults to zero alignment', (WidgetTester tester) async {
+    await tester.pumpWidget(_buildSliverConstrainedCrossAxis(maxExtent: 50));
+
+    final RenderBox box = tester.renderObject<RenderBox>(find.byType(Container));
+    expect(box.size.width, 50);
+    final Offset scrollViewOffset = tester.getTopLeft(find.byType(CustomScrollView));
+    expect(tester.getTopLeft(find.byType(Container)), scrollViewOffset);
+  });
+
+  testWidgets('SliverConstrainedCrossAxis center alignment', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      _buildSliverConstrainedCrossAxis(
+        maxExtent: 100,
+        textDirection: TextDirection.ltr,
+        alignment: Alignment.center,
+      ),
+    );
+
+    final RenderBox box = tester.renderObject<RenderBox>(find.byType(Container));
+    expect(box.size.width, 100);
+    final Offset scrollViewOffset = tester.getTopLeft(find.byType(CustomScrollView));
+    // (300 - 100) / 2 = 100
+    expect(tester.getTopLeft(find.byType(Container)), scrollViewOffset + const Offset(100, 0));
+  });
+
+  testWidgets('SliverConstrainedCrossAxis end alignment', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      _buildSliverConstrainedCrossAxis(
+        maxExtent: 100,
+        textDirection: TextDirection.ltr,
+        alignment: Alignment.centerRight,
+      ),
+    );
+
+    final RenderBox box = tester.renderObject<RenderBox>(find.byType(Container));
+    expect(box.size.width, 100);
+    final Offset scrollViewOffset = tester.getTopLeft(find.byType(CustomScrollView));
+    // 300 - 100 = 200
+    expect(tester.getTopLeft(find.byType(Container)), scrollViewOffset + const Offset(200, 0));
+  });
+
+  testWidgets('SliverConstrainedCrossAxis directional alignment LTR', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      _buildSliverConstrainedCrossAxis(
+        maxExtent: 100,
+        textDirection: TextDirection.ltr,
+        alignment: AlignmentDirectional.centerEnd,
+      ),
+    );
+
+    final RenderBox box = tester.renderObject<RenderBox>(find.byType(Container));
+    expect(box.size.width, 100);
+    final Offset scrollViewOffset = tester.getTopLeft(find.byType(CustomScrollView));
+    // Start is left, end is right. 300 - 100 = 200
+    expect(tester.getTopLeft(find.byType(Container)), scrollViewOffset + const Offset(200, 0));
+  });
+
+  testWidgets('SliverConstrainedCrossAxis directional alignment RTL', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      _buildSliverConstrainedCrossAxis(
+        maxExtent: 100,
+        alignment: AlignmentDirectional.centerEnd,
+        textDirection: TextDirection.rtl,
+      ),
+    );
+
+    final RenderBox box = tester.renderObject<RenderBox>(find.byType(Container));
+    expect(box.size.width, 100);
+    final Offset scrollViewOffset = tester.getTopLeft(find.byType(CustomScrollView));
+    // End is visual left (0).
+    expect(tester.getTopLeft(find.byType(Container)), scrollViewOffset + Offset.zero);
+  });
+
+  testWidgets('SliverConstrainedCrossAxis horizontal scroll alignment', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      _buildSliverConstrainedCrossAxis(
+        maxExtent: 100,
+        textDirection: TextDirection.ltr,
+        alignment: Alignment.bottomCenter, // Use non-centered alignment
+        scrollDirection: Axis.horizontal,
+      ),
+    );
+
+    final RenderBox box = tester.renderObject<RenderBox>(find.byType(Container));
+    // In horizontal scroll, cross axis is vertical. VIEWPORT_HEIGHT = 500.
+    expect(box.size.height, 100);
+    final Offset scrollViewOffset = tester.getTopLeft(find.byType(CustomScrollView));
+    // (500 - 100) * 1.0 = 400. Bottom is 1.0.
+    expect(tester.getTopLeft(find.byType(Container)), scrollViewOffset + const Offset(0, 400));
+  });
+
+  testWidgets(
+    'SliverConstrainedCrossAxis does not require TextDirection for non-directional alignment',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const Directionality(
+          textDirection: TextDirection.ltr,
+          child: CustomScrollView(
+            slivers: <Widget>[
+              SliverConstrainedCrossAxis(
+                maxExtent: 100,
+                alignment: Alignment.center,
+                sliver: SliverToBoxAdapter(child: SizedBox(height: 100, width: 100)),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      final RenderBox box = tester.renderObject<RenderBox>(find.byType(SizedBox));
+      expect(box.size.width, 100);
+      final Offset scrollViewOffset = tester.getTopLeft(find.byType(CustomScrollView));
+      // Default test viewport is 800x600. (800 - 100) / 2 = 350
+      expect(tester.getTopLeft(find.byType(SizedBox)), scrollViewOffset + const Offset(350, 0));
+    },
+  );
+
+  testWidgets('SliverConstrainedCrossAxis hit testing', (WidgetTester tester) async {
+    var tapCount = 0;
+    await tester.pumpWidget(
+      _buildSliverConstrainedCrossAxis(
+        maxExtent: 100,
+        textDirection: TextDirection.ltr,
+        alignment: Alignment.center,
+        onTap: () => tapCount++,
+      ),
+    );
+
+    final Offset scrollViewOffset = tester.getTopLeft(find.byType(CustomScrollView));
+
+    // Tap at center (visual 150, 50). Child is at [100, 200] in X.
+    await tester.tapAt(scrollViewOffset + const Offset(150, 50));
+    expect(tapCount, 1);
+
+    // Tap at visual left (50, 50). Should NOT hit child.
+    await tester.tapAt(scrollViewOffset + const Offset(50, 50));
+    expect(tapCount, 1);
+
+    // Tap at visual right (250, 50). Should NOT hit child.
+    await tester.tapAt(scrollViewOffset + const Offset(250, 50));
+    expect(tapCount, 1);
+  });
+
+  testWidgets(
+    'SliverConstrainedCrossAxis asserts during layout when alignment requires TextDirection but none is provided',
+    (WidgetTester tester) async {
+      final exceptions = <Object>[];
+      final void Function(FlutterErrorDetails details) oldHandler = FlutterError.onError!;
+      FlutterError.onError = (FlutterErrorDetails details) {
+        exceptions.add(details.exception);
+      };
+
+      try {
+        await tester.pumpWidget(
+          const Directionality(
+            textDirection: TextDirection.ltr,
+            child: CustomScrollView(
+              slivers: <Widget>[
+                _TestSliverConstrainedCrossAxis(
+                  maxExtent: 100,
+                  alignment: AlignmentDirectional.centerEnd,
+                  sliver: SliverToBoxAdapter(child: SizedBox(height: 100, width: 100)),
+                ),
+              ],
+            ),
+          ),
+        );
+      } finally {
+        FlutterError.onError = oldHandler;
+      }
+
+      expect(exceptions, isNotEmpty);
+      expect(exceptions.first, isA<AssertionError>());
+    },
+  );
+
+  testWidgets('RenderSliverConstrainedCrossAxis uses child constraints for alignment fallback', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
         child: CustomScrollView(
-          scrollDirection: scrollDirection,
           slivers: <Widget>[
             SliverConstrainedCrossAxis(
-              maxExtent: maxExtent,
-              sliver: SliverToBoxAdapter(
-                child: scrollDirection == Axis.vertical
-                    ? Container(height: 100)
-                    : Container(width: 100),
+              maxExtent: 100.0,
+              alignment: Alignment.center,
+              sliver: _SliverNoGeometryExtent(
+                child: SliverToBoxAdapter(child: SizedBox(width: 50.0, height: 50.0)),
               ),
             ),
           ],
         ),
       ),
-    ),
+    );
+
+    final Offset scrollViewOffset = tester.getTopLeft(find.byType(CustomScrollView));
+    // Viewport width is 800. maxExtent is 100.
+    // The _SliverNoGeometryExtent will have constraints.crossAxisExtent = 100.
+    // Since it doesn't report crossAxisExtent in geometry, alignment uses 100.
+    // (800 - 100) / 2 = 350.
+    expect(tester.getTopLeft(find.byType(SizedBox)), scrollViewOffset + const Offset(350, 0));
+  });
+
+  testWidgets('SliverConstrainedCrossAxis alignment inside SliverCrossAxisGroup', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: SizedBox(
+            width: 300,
+            height: 500,
+            child: CustomScrollView(
+              slivers: <Widget>[
+                SliverCrossAxisGroup(
+                  slivers: <Widget>[
+                    SliverConstrainedCrossAxis(
+                      maxExtent: 100,
+                      alignment: Alignment.center,
+                      sliver: SliverToBoxAdapter(
+                        child: Container(height: 100, color: const Color(0xFF0000FF)),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final RenderBox container = tester.renderObject<RenderBox>(find.byType(Container));
+    final Offset scrollViewOffset = tester.getTopLeft(find.byType(CustomScrollView));
+
+    // The group provides 300px cross-axis extent.
+    // SliverConstrainedCrossAxis takes all 300px because it has an alignment.
+    // The child is 100px wide and centered.
+    // (300 - 100) / 2 = 100px offset.
+    expect(container.size.width, 100);
+    expect(tester.getTopLeft(find.byType(Container)), scrollViewOffset + const Offset(100, 0));
+
+    final RenderSliver sliver = tester.renderObject<RenderSliver>(
+      find.byType(SliverConstrainedCrossAxis),
+    );
+    // It should report the full cross-axis extent to the group.
+    expect(sliver.geometry!.crossAxisExtent, 300);
+  });
+}
+
+class _SliverNoGeometryExtent extends SingleChildRenderObjectWidget {
+  const _SliverNoGeometryExtent({required Widget child}) : super(child: child);
+
+  @override
+  RenderSliver createRenderObject(BuildContext context) => _RenderSliverNoGeometryExtent();
+}
+
+class _RenderSliverNoGeometryExtent extends RenderProxySliver {
+  @override
+  void performLayout() {
+    child!.layout(constraints, parentUsesSize: true);
+    final SliverGeometry childLayoutGeometry = child!.geometry!;
+    geometry = SliverGeometry(
+      scrollExtent: childLayoutGeometry.scrollExtent,
+      paintExtent: childLayoutGeometry.paintExtent,
+      paintOrigin: childLayoutGeometry.paintOrigin,
+      layoutExtent: childLayoutGeometry.layoutExtent,
+      maxPaintExtent: childLayoutGeometry.maxPaintExtent,
+      maxScrollObstructionExtent: childLayoutGeometry.maxScrollObstructionExtent,
+      hitTestExtent: childLayoutGeometry.hitTestExtent,
+      visible: childLayoutGeometry.visible,
+      hasVisualOverflow: childLayoutGeometry.hasVisualOverflow,
+      scrollOffsetCorrection: childLayoutGeometry.scrollOffsetCorrection,
+      cacheExtent: childLayoutGeometry.cacheExtent,
+    );
+  }
+}
+
+class _TestSliverConstrainedCrossAxis extends SingleChildRenderObjectWidget {
+  const _TestSliverConstrainedCrossAxis({
+    required this.maxExtent,
+    this.alignment,
+    required Widget sliver,
+  }) : super(child: sliver);
+
+  final double maxExtent;
+  final AlignmentGeometry? alignment;
+
+  @override
+  RenderSliverConstrainedCrossAxis createRenderObject(BuildContext context) {
+    return RenderSliverConstrainedCrossAxis(maxExtent: maxExtent, alignment: alignment);
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, RenderSliverConstrainedCrossAxis renderObject) {
+    renderObject
+      ..maxExtent = maxExtent
+      ..alignment = alignment;
+  }
+}
+
+Widget _buildSliverConstrainedCrossAxis({
+  required double maxExtent,
+  AlignmentGeometry? alignment,
+  TextDirection? textDirection,
+  Axis scrollDirection = Axis.vertical,
+  VoidCallback? onTap,
+}) {
+  final Widget result = CustomScrollView(
+    scrollDirection: scrollDirection,
+    slivers: <Widget>[
+      SliverConstrainedCrossAxis(
+        maxExtent: maxExtent,
+        alignment: alignment,
+        sliver: SliverToBoxAdapter(
+          child: GestureDetector(
+            onTap: onTap,
+            child: scrollDirection == Axis.vertical
+                ? Container(height: 100, color: const Color(0xFF0000FF))
+                : Container(width: 100, color: const Color(0xFF0000FF)),
+          ),
+        ),
+      ),
+    ],
   );
+
+  final Widget sizedResult = Center(
+    child: SizedBox(width: VIEWPORT_WIDTH, height: VIEWPORT_HEIGHT, child: result),
+  );
+
+  return Directionality(textDirection: textDirection ?? TextDirection.ltr, child: sizedResult);
 }

--- a/packages/flutter/test/widgets/sliver_constrained_cross_axis_test.dart
+++ b/packages/flutter/test/widgets/sliver_constrained_cross_axis_test.dart
@@ -271,7 +271,9 @@ void main() {
     expect(tester.getTopLeft(find.byType(SizedBox)), scrollViewOffset + const Offset(350, 0));
   });
 
-  testWidgets('SliverConstrainedCrossAxis alignment inside SliverCrossAxisGroup', (WidgetTester tester) async {
+  testWidgets('SliverConstrainedCrossAxis alignment inside SliverCrossAxisGroup', (
+    WidgetTester tester,
+  ) async {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,


### PR DESCRIPTION
This PR adds an alignment property to SliverConstrainedCrossAxis, allowing slivers with constrained cross-axis extents to be aligned within the available space of a CustomScrollView or SliverCrossAxisGroup.

   - RenderSliverConstrainedCrossAxis:
       - Implemented alignment and textDirection logic.
       - Updated layout to report the full crossAxisExtent to the parent when an alignment is
         provided, allowing "room" for alignment displacement.
       - Added support for painting, hit testing, and paint transforms for the aligned child.
   - SliverConstrainedCrossAxis (Widget):
       - Exposed alignment.
       - Handles automatic TextDirection resolution when needed.
   - SliverCrossAxisGroup Compatibility:
       - Verified that an aligned SliverConstrainedCrossAxis correctly expands to fill its allocated
         space in a group while accurately positioning its child.

  Fixes #184472

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
