### PR TITLE
Fix pointer position

### DIFF
--- a/engine/src/flutter/shell/platform/windows/flutter_window.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_window.cc
@@ -545,10 +545,10 @@ FlutterWindow::HandleMessage(UINT const message,
     case WM_POINTERUPDATE:
     case WM_POINTERUP:
     case WM_POINTERLEAVE: {
-      x_pos = GET_X_LPARAM(lparam);
-      y_pos = GET_Y_LPARAM(lparam);
-      auto const x = static_cast<double>(x_pos);
-      auto const y = static_cast<double>(y_pos);
+      POINT pt = {GET_X_LPARAM(lparam), GET_Y_LPARAM(lparam)};
+      ScreenToClient(window_handle_, &pt);
+      auto const x = static_cast<double>(pt.x);
+      auto const y = static_cast<double>(pt.y);
       auto const pointerId = GET_POINTERID_WPARAM(wparam);
       POINTER_INFO pointerInfo;
       if (windows_proc_table_->GetPointerInfo(pointerId, &pointerInfo)) {

--- a/engine/src/flutter/shell/platform/windows/flutter_window_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_window_unittests.cc
@@ -83,6 +83,30 @@ class MockFlutterWindow : public FlutterWindow {
   FML_DISALLOW_COPY_AND_ASSIGN(MockFlutterWindow);
 };
 
+LRESULT InjectPointerMessageWithClientPoint(MockFlutterWindow& window,
+                                            UINT message,
+                                            WPARAM wparam,
+                                            int x,
+                                            int y) {
+  HWND flutter_window = window.FlutterWindow::GetWindowHandle();
+  HWND parent_window =
+      CreateWindowEx(0, L"STATIC", L"", WS_POPUP, 100, 100, 300, 300, nullptr,
+                     nullptr, GetModuleHandle(nullptr), nullptr);
+  EXPECT_NE(parent_window, nullptr);
+  EXPECT_NE(SetParent(flutter_window, parent_window), nullptr);
+  EXPECT_TRUE(SetWindowPos(flutter_window, nullptr, 0, 0, 100, 100,
+                           SWP_NOZORDER | SWP_NOACTIVATE));
+
+  POINT point = {x, y};
+  EXPECT_TRUE(ClientToScreen(flutter_window, &point));
+  LRESULT result =
+      window.InjectWindowMessage(message, wparam, MAKELPARAM(point.x, point.y));
+
+  EXPECT_NE(SetParent(flutter_window, HWND_MESSAGE), nullptr);
+  DestroyWindow(parent_window);
+  return result;
+}
+
 class MockFlutterWindowsView : public FlutterWindowsView {
  public:
   MockFlutterWindowsView(FlutterWindowsEngine* engine,
@@ -297,9 +321,8 @@ TEST_F(FlutterWindowTest, OnStylusPointerDown) {
 
   UINT32 pointerId = 1;
   WPARAM wparam = static_cast<WPARAM>(pointerId);
-  LPARAM lparam = MAKELPARAM(10, 10);
-
-  win32window.InjectWindowMessage(WM_POINTERDOWN, wparam, lparam);
+  InjectPointerMessageWithClientPoint(win32window, WM_POINTERDOWN, wparam, 10,
+                                      10);
 }
 
 TEST_F(FlutterWindowTest, OnStylusPointerMove) {
@@ -335,9 +358,8 @@ TEST_F(FlutterWindowTest, OnStylusPointerMove) {
 
   UINT32 pointerId = 1;
   WPARAM wparam = static_cast<WPARAM>(pointerId);
-  LPARAM lparam = MAKELPARAM(15, 20);
-
-  win32window.InjectWindowMessage(WM_POINTERUPDATE, wparam, lparam);
+  InjectPointerMessageWithClientPoint(win32window, WM_POINTERUPDATE, wparam, 15,
+                                      20);
 }
 
 TEST_F(FlutterWindowTest, OnStylusPointerUp) {
@@ -373,9 +395,8 @@ TEST_F(FlutterWindowTest, OnStylusPointerUp) {
 
   UINT32 pointerId = 1;
   WPARAM wparam = static_cast<WPARAM>(pointerId);
-  LPARAM lparam = MAKELPARAM(25, 30);
-
-  win32window.InjectWindowMessage(WM_POINTERUP, wparam, lparam);
+  InjectPointerMessageWithClientPoint(win32window, WM_POINTERUP, wparam, 25,
+                                      30);
 }
 
 TEST_F(FlutterWindowTest, OnStylusPointerLeave) {
@@ -410,9 +431,8 @@ TEST_F(FlutterWindowTest, OnStylusPointerLeave) {
 
   UINT32 pointerId = 1;
   WPARAM wparam = static_cast<WPARAM>(pointerId);
-  LPARAM lparam = MAKELPARAM(35, 40);
-
-  win32window.InjectWindowMessage(WM_POINTERLEAVE, wparam, lparam);
+  InjectPointerMessageWithClientPoint(win32window, WM_POINTERLEAVE, wparam, 35,
+                                      40);
 }
 
 TEST_F(FlutterWindowTest, OnStylusPointerHover) {
@@ -454,8 +474,8 @@ TEST_F(FlutterWindowTest, OnStylusPointerHover) {
 
   UINT32 pointerId = 1;
   WPARAM wparam = static_cast<WPARAM>(pointerId);
-  LPARAM lparam = MAKELPARAM(45, 50);
-  win32window.InjectWindowMessage(WM_POINTERDOWN, wparam, lparam);
+  InjectPointerMessageWithClientPoint(win32window, WM_POINTERDOWN, wparam, 45,
+                                      50);
 
   // Now expect OnPointerMove to be called for hover events
   EXPECT_CALL(delegate, OnPointerMove(45, 50, kFlutterPointerDeviceKindStylus,
@@ -463,7 +483,8 @@ TEST_F(FlutterWindowTest, OnStylusPointerHover) {
       .Times(1);
 
   // Inject WM_POINTERUPDATE message (hover event)
-  win32window.InjectWindowMessage(WM_POINTERUPDATE, wparam, lparam);
+  InjectPointerMessageWithClientPoint(win32window, WM_POINTERUPDATE, wparam, 45,
+                                      50);
 }
 
 TEST_F(FlutterWindowTest, OnMousePointerDown) {
@@ -490,9 +511,8 @@ TEST_F(FlutterWindowTest, OnMousePointerDown) {
 
   UINT32 pointerId = 1;
   WPARAM wparam = static_cast<WPARAM>(pointerId);
-  LPARAM lparam = MAKELPARAM(45, 50);
-
-  win32window.InjectWindowMessage(WM_POINTERDOWN, wparam, lparam);
+  InjectPointerMessageWithClientPoint(win32window, WM_POINTERDOWN, wparam, 45,
+                                      50);
 }
 
 TEST_F(FlutterWindowTest, OnTouchPointerDown) {
@@ -519,9 +539,8 @@ TEST_F(FlutterWindowTest, OnTouchPointerDown) {
 
   UINT32 pointerId = 1;
   WPARAM wparam = static_cast<WPARAM>(pointerId);
-  LPARAM lparam = MAKELPARAM(55, 60);
-
-  win32window.InjectWindowMessage(WM_POINTERDOWN, wparam, lparam);
+  InjectPointerMessageWithClientPoint(win32window, WM_POINTERDOWN, wparam, 55,
+                                      60);
 }
 
 TEST_F(FlutterWindowTest, PointerMessageScreenCoordinatesAreConvertedToClient) {

--- a/engine/src/flutter/shell/platform/windows/flutter_window_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_window_unittests.cc
@@ -524,6 +524,55 @@ TEST_F(FlutterWindowTest, OnTouchPointerDown) {
   win32window.InjectWindowMessage(WM_POINTERDOWN, wparam, lparam);
 }
 
+TEST_F(FlutterWindowTest, PointerMessageScreenCoordinatesAreConvertedToClient) {
+  constexpr int kClientX = 15;
+  constexpr int kClientY = 20;
+
+  auto mock_proc_table = std::make_shared<MockWindowsProcTable>();
+
+  EXPECT_CALL(*mock_proc_table, GetPointerInfo(_, _))
+      .WillRepeatedly([](UINT32 pointer_id, POINTER_INFO* pointer_info) {
+        if (pointer_info != nullptr) {
+          pointer_info->pointerType = PT_TOUCH;
+          pointer_info->pointerId = pointer_id;
+          pointer_info->pointerFlags = POINTER_FLAG_INCONTACT;
+        }
+        return TRUE;
+      });
+
+  MockFlutterWindow win32window(100, 100, mock_proc_table);
+  MockWindowBindingHandlerDelegate delegate;
+  EXPECT_CALL(win32window, OnWindowStateEvent).Times(AnyNumber());
+  EXPECT_CALL(delegate, OnWindowStateEvent).Times(AnyNumber());
+  win32window.SetView(&delegate);
+
+  HWND parent_window =
+      CreateWindowEx(0, L"STATIC", L"", WS_POPUP, 100, 100, 300, 300, nullptr,
+                     nullptr, GetModuleHandle(nullptr), nullptr);
+  ASSERT_NE(parent_window, nullptr);
+
+  HWND flutter_window = win32window.FlutterWindow::GetWindowHandle();
+  ASSERT_NE(flutter_window, nullptr);
+  ASSERT_NE(SetParent(flutter_window, parent_window), nullptr);
+  ASSERT_TRUE(SetWindowPos(flutter_window, nullptr, 25, 35, 100, 100,
+                           SWP_NOZORDER | SWP_NOACTIVATE));
+
+  POINT pointer_point = {kClientX, kClientY};
+  ASSERT_TRUE(ClientToScreen(flutter_window, &pointer_point));
+
+  EXPECT_CALL(delegate,
+              OnPointerDown(kClientX, kClientY, kFlutterPointerDeviceKindTouch,
+                            kDefaultPointerDeviceId,
+                            kFlutterPointerButtonMousePrimary, 0, 0))
+      .Times(1);
+
+  win32window.InjectWindowMessage(WM_POINTERDOWN, /*wparam=*/1,
+                                  MAKELPARAM(pointer_point.x, pointer_point.y));
+
+  EXPECT_NE(SetParent(flutter_window, HWND_MESSAGE), nullptr);
+  DestroyWindow(parent_window);
+}
+
 // Tests that calls to OnScroll in turn calls GetScrollOffsetMultiplier
 // for mapping scroll ticks to pixels.
 TEST_F(FlutterWindowTest, OnScrollCallsGetScrollOffsetMultiplier) {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->
Closes #184954.

<img width="2560" height="1528" alt="grafik" src="https://github.com/user-attachments/assets/f9ea4170-bb26-49bd-8384-270aa76d04fb" />

This pull requests fixes a regression in the POINTER input event handling that was introduced with the stylus support. The regression caused the pointer position to be global instead of relative to the window, which broke touch and stylus input handling in many applications.
Thanks to @dkmcgowan for suggesting a fix. I have updated my flutter input demo to also see the pointer position.
I tested it with the latest flutter master branch which shows the incorrect pointer position, and with my patch which shows the correct pointer position.

This fix should also be backported to the beta branch to ensure that it is included in the next stable release, as it affects a wide range of applications that rely on pointer input events.

For testing this pr, i used my flutter input demo project which can be found here: https://github.com/CodeDoctorDE/flutter-input-demo/tree/ad61c7d6f5011594a90cbb2b9840904144f877b5

PS: I run `et build` to build the engine and it took over 1 1/2 hours to complete. I'm not sure if this is expected or if there is a more efficient way to build the engine to test changes. Any tips on how to speed up the build process would be appreciated.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
