### PR TITLE
Skip SwiftPM plugin schemes when doing flutter clean

### DIFF
--- a/packages/flutter_tools/lib/src/commands/clean.dart
+++ b/packages/flutter_tools/lib/src/commands/clean.dart
@@ -12,6 +12,7 @@ import '../build_info.dart';
 import '../globals.dart' as globals;
 import '../ios/xcodeproj.dart';
 import '../macos/xcode.dart';
+import '../plugins.dart';
 import '../project.dart';
 import '../runner/flutter_command.dart';
 
@@ -122,7 +123,23 @@ class CleanCommand extends FlutterCommand {
           buildDirectory: globals.fs.directory(xcodeProject.darwinPlatform.buildDirectory()),
         );
       } else {
+        final plugins = <Plugin>[];
+        try {
+          plugins.addAll(await xcodeProject.getPlugins());
+        } on Object catch (error) {
+          globals.printTrace('Failed to get plugins during xcode clean: $error');
+        }
+
+        final ignoredSchemes = <String>{
+          'FlutterGeneratedPluginSwiftPackage',
+          'FlutterFramework',
+          for (final plugin in plugins) ...<String>[plugin.name, plugin.name.replaceAll('_', '-')],
+        };
+
         for (final String scheme in projectInfo.schemes) {
+          if (ignoredSchemes.contains(scheme)) {
+            continue;
+          }
           await xcodeProjectInterpreter.cleanWorkspace(
             xcodeWorkspace.path,
             scheme,

--- a/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
@@ -441,6 +441,8 @@ class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterprete
     return XcodeProjectInfo(const <String>[], const <String>[], <String>[
       'Runner',
       'custom-scheme',
+      'FlutterGeneratedPluginSwiftPackage',
+      'FlutterFramework',
     ], BufferLogger.test());
   }
 


### PR DESCRIPTION
This PR resolves the severe performance regression during the flutter clean command on projects that use Swift Package Manager (SPM).

Xcode creates an individual scheme for every single plugin dependency. Previously, flutter clean would loop through and clean every one of these schemes sequentially via xcodebuild clean. This PR resolves the bottleneck by gathering the active plugin names in the workspace and explicitly excluding them along with internal Flutter schemes (FlutterGeneratedPluginSwiftPackage and FlutterFramework)

I also verified with a project with about 2 plugins and confirm the time reduces from 7 to about 4 seconds

Fixes #183946 

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
