### PR TITLE
[Impeller] Always use RGBA8888 format in the Skia bitmap used to draw a color glyph atlas

### DIFF
--- a/engine/src/flutter/impeller/display_list/aiks_dl_text_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_text_unittests.cc
@@ -1055,20 +1055,5 @@ TEST_P(AiksTest, TextWithNonUniformScale) {
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
-TEST_P(AiksTest, TextDrawEmoji) {
-  DisplayListBuilder builder;
-
-  DlPaint paint;
-  paint.setColor(DlColor::kWhite());
-  builder.DrawPaint(paint);
-
-  // Draw a U+1F600 grinning face emoji.
-  ASSERT_TRUE(RenderTextInCanvasSkia(GetContext(), builder, "\xF0\x9F\x98\x80",
-                                     "NotoColorEmoji.ttf",
-                                     TextRenderOptions{.font_size = 200}));
-
-  ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
-}
-
 }  // namespace testing
 }  // namespace impeller

--- a/engine/src/flutter/impeller/display_list/aiks_dl_text_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_text_unittests.cc
@@ -1055,5 +1055,20 @@ TEST_P(AiksTest, TextWithNonUniformScale) {
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
+TEST_P(AiksTest, TextDrawEmoji) {
+  DisplayListBuilder builder;
+
+  DlPaint paint;
+  paint.setColor(DlColor::kWhite());
+  builder.DrawPaint(paint);
+
+  // Draw a U+1F600 grinning face emoji.
+  ASSERT_TRUE(RenderTextInCanvasSkia(GetContext(), builder, "\xF0\x9F\x98\x80",
+                                     "NotoColorEmoji.ttf",
+                                     TextRenderOptions{.font_size = 200}));
+
+  ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/engine/src/flutter/impeller/typographer/backends/skia/typographer_context_skia.cc
+++ b/engine/src/flutter/impeller/typographer/backends/skia/typographer_context_skia.cc
@@ -38,7 +38,6 @@
 #include "third_party/skia/include/core/SkCanvas.h"
 #include "third_party/skia/include/core/SkColor.h"
 #include "third_party/skia/include/core/SkFont.h"
-#include "third_party/skia/include/core/SkImageInfo.h"
 #include "third_party/skia/include/core/SkPaint.h"
 #include "third_party/skia/include/core/SkSize.h"
 #include "third_party/skia/include/core/SkSurface.h"
@@ -86,7 +85,8 @@ TypographerContextSkia::CreateGlyphAtlasContext(GlyphAtlas::Type type) const {
   return std::make_shared<GlyphAtlasContext>(type);
 }
 
-static SkImageInfo GetImageInfo(const GlyphAtlas& atlas, Size size) {
+SkImageInfo TypographerContextSkia::GetImageInfo(const GlyphAtlas& atlas,
+                                                 Size size) {
   switch (atlas.GetType()) {
     case GlyphAtlas::Type::kAlphaBitmap:
       return SkImageInfo::MakeA8(SkISize{static_cast<int32_t>(size.width),
@@ -276,7 +276,8 @@ static bool BulkUpdateAtlasBitmap(const GlyphAtlas& atlas,
   bool has_color = atlas.GetType() == GlyphAtlas::Type::kColorBitmap;
 
   SkBitmap bitmap;
-  bitmap.setInfo(GetImageInfo(atlas, Size(texture->GetSize())));
+  bitmap.setInfo(
+      TypographerContextSkia::GetImageInfo(atlas, Size(texture->GetSize())));
   if (!bitmap.tryAllocPixels()) {
     return false;
   }
@@ -353,7 +354,7 @@ static bool UpdateAtlasBitmap(const GlyphAtlas& atlas,
     size.height += 2;
 
     SkBitmap bitmap;
-    bitmap.setInfo(GetImageInfo(atlas, size));
+    bitmap.setInfo(TypographerContextSkia::GetImageInfo(atlas, size));
     if (!bitmap.tryAllocPixels()) {
       return false;
     }

--- a/engine/src/flutter/impeller/typographer/backends/skia/typographer_context_skia.cc
+++ b/engine/src/flutter/impeller/typographer/backends/skia/typographer_context_skia.cc
@@ -92,8 +92,9 @@ static SkImageInfo GetImageInfo(const GlyphAtlas& atlas, Size size) {
       return SkImageInfo::MakeA8(SkISize{static_cast<int32_t>(size.width),
                                          static_cast<int32_t>(size.height)});
     case GlyphAtlas::Type::kColorBitmap:
-      return SkImageInfo::Make(size.width, size.height, kRGBA_8888_SkColorType,
-                               kPremul_SkAlphaType);
+      return SkImageInfo::Make(SkISize{static_cast<int32_t>(size.width),
+                                       static_cast<int32_t>(size.height)},
+                               kRGBA_8888_SkColorType, kPremul_SkAlphaType);
   }
   FML_UNREACHABLE();
 }

--- a/engine/src/flutter/impeller/typographer/backends/skia/typographer_context_skia.cc
+++ b/engine/src/flutter/impeller/typographer/backends/skia/typographer_context_skia.cc
@@ -92,7 +92,8 @@ static SkImageInfo GetImageInfo(const GlyphAtlas& atlas, Size size) {
       return SkImageInfo::MakeA8(SkISize{static_cast<int32_t>(size.width),
                                          static_cast<int32_t>(size.height)});
     case GlyphAtlas::Type::kColorBitmap:
-      return SkImageInfo::MakeN32Premul(size.width, size.height);
+      return SkImageInfo::Make(size.width, size.height, kRGBA_8888_SkColorType,
+                               kPremul_SkAlphaType);
   }
   FML_UNREACHABLE();
 }

--- a/engine/src/flutter/impeller/typographer/backends/skia/typographer_context_skia.h
+++ b/engine/src/flutter/impeller/typographer/backends/skia/typographer_context_skia.h
@@ -6,6 +6,7 @@
 #define FLUTTER_IMPELLER_TYPOGRAPHER_BACKENDS_SKIA_TYPOGRAPHER_CONTEXT_SKIA_H_
 
 #include "impeller/typographer/typographer_context.h"
+#include "third_party/skia/include/core/SkImageInfo.h"
 
 namespace impeller {
 
@@ -28,6 +29,9 @@ class TypographerContextSkia : public TypographerContext {
       HostBuffer& host_buffer,
       const std::shared_ptr<GlyphAtlasContext>& atlas_context,
       const std::vector<RenderableText>& renderable_texts) const override;
+
+  // Visible for testing.
+  static SkImageInfo GetImageInfo(const GlyphAtlas& atlas, Size size);
 
  private:
   static std::pair<std::vector<FontGlyphPair>, std::vector<Rect>>

--- a/engine/src/flutter/impeller/typographer/typographer_unittests.cc
+++ b/engine/src/flutter/impeller/typographer/typographer_unittests.cc
@@ -542,6 +542,27 @@ TEST_P(TypographerTest, InvalidAtlasForcesRepopulation) {
   EXPECT_TRUE(second_atlas_context->GetGlyphAtlas()->IsValid());
 }
 
+TEST_P(TypographerTest, ColorBitmapAtlasSkiaBitmapIsRGBA8888) {
+  auto context = TypographerContextSkia::Make();
+  auto atlas_context =
+      context->CreateGlyphAtlasContext(GlyphAtlas::Type::kColorBitmap);
+  auto data_host_buffer = HostBuffer::Create(
+      GetContext()->GetResourceAllocator(), GetContext()->GetIdleWaiter(),
+      GetContext()->GetCapabilities()->GetMinimumUniformAlignment());
+  ASSERT_TRUE(context && context->IsValid());
+  SkFont sk_font = flutter::testing::CreateTestFontOfSize(12);
+  auto blob = SkTextBlob::MakeFromString("A", sk_font);
+  ASSERT_TRUE(blob);
+  auto atlas =
+      CreateGlyphAtlas(*GetContext(), context.get(), *data_host_buffer,
+                       GlyphAtlas::Type::kColorBitmap, Matrix(), atlas_context,
+                       MakeTextFrameFromTextBlobSkia(blob));
+
+  SkImageInfo image_info =
+      TypographerContextSkia::GetImageInfo(*atlas, Size{100, 100});
+  EXPECT_EQ(image_info.colorType(), kRGBA_8888_SkColorType);
+}
+
 }  // namespace testing
 }  // namespace impeller
 


### PR DESCRIPTION
Impeller declares color bitmap glyph atlas textures as PixelFormat::kR8G8B8A8UNormInt.  But it was creating the Skia bitmap for this texture using SkImageInfo::MakeN32Premul.  The Skia N32 format may be either BGRA8888 or RGBA8888 depending on what is preferred by the platform.

This PR ensures that the Skia bitmap will use RGBA8888 on all platforms.

Fixes https://github.com/flutter/flutter/issues/185602