### PR TITLE
Avoid CurvedAnimation leak during InteractiveViewer fling inertia

### DIFF
--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -849,7 +849,7 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
         _animation = Tween<Offset>(
           begin: translation,
           end: Offset(frictionSimulationX.finalX, frictionSimulationY.finalX),
-        ).animate(CurvedAnimation(parent: _controller, curve: Curves.decelerate));
+        ).chain(CurveTween(curve: Curves.decelerate)).animate(_controller);
         _controller.duration = Duration(milliseconds: (tFinal * 1000).round());
         _animation!.addListener(_handleInertiaAnimation);
         _controller.forward();
@@ -872,7 +872,7 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
         _scaleAnimation = Tween<double>(
           begin: scale,
           end: frictionSimulation.x(tFinal),
-        ).animate(CurvedAnimation(parent: _scaleController, curve: Curves.decelerate));
+        ).chain(CurveTween(curve: Curves.decelerate)).animate(_scaleController);
         _scaleController.duration = Duration(milliseconds: (tFinal * 1000).round());
         _scaleAnimation!.addListener(_handleScaleAnimation);
         _scaleController.forward();

--- a/packages/flutter/test/widgets/interactive_viewer_test.dart
+++ b/packages/flutter/test/widgets/interactive_viewer_test.dart
@@ -4,10 +4,12 @@
 
 import 'dart:math' as math;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 import 'package:vector_math/vector_math_64.dart' show Matrix4, Quad, Vector3;
 
 import 'gesture_utils.dart';
@@ -1732,6 +1734,27 @@ void main() {
         transformationController.value.getMaxScaleOnAxis(),
         moreOrLessEquals(1.9984509673751225),
       );
+    });
+
+    // Regression test for https://github.com/flutter/flutter/issues/185825.
+    testWidgets('Fling inertia does not repeatedly allocate CurvedAnimation', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        InteractiveViewer(
+          transformationController: transformationController,
+          child: const SizedBox(width: 2000.0, height: 2000.0),
+        ),
+      );
+
+      final List<ObjectEvent> events = await memoryEvents(() async {
+        for (var i = 0; i < 10; i += 1) {
+          await tester.fling(find.byType(InteractiveViewer), const Offset(0, -100), 3000);
+          await tester.pump();
+        }
+      }, CurvedAnimation);
+
+      expect(events, isEmpty);
     });
   });
 


### PR DESCRIPTION
## Issue

Fixes #185825.

`InteractiveViewer._onScaleEnd` creates a fresh `CurvedAnimation` every time pan or scale inertia starts:

```dart
Tween<Offset>(...).animate(CurvedAnimation(parent: _controller, curve: Curves.decelerate))
```

Those `CurvedAnimation` instances add status listeners to their parent controller and are never disposed. Repeated fling gestures therefore repeatedly allocate disposable animation wrappers and leave them attached until the parent controller is disposed.

## Fix

Use `CurveTween(curve: Curves.decelerate)` in the inertia animation chains instead. This preserves the same decelerate curve while avoiding `CurvedAnimation` ownership/disposal entirely, matching the guidance in `CurvedAnimation`'s own dartdoc for cases that do not need a `reverseCurve`.

Both pan inertia and scale inertia now use:

```dart
Tween<...>(...).chain(CurveTween(curve: Curves.decelerate)).animate(controller)
```

## Tests

Added a regression test in `test/widgets/interactive_viewer_test.dart` that repeatedly flings an `InteractiveViewer` while collecting memory allocation events for `CurvedAnimation`.

Without the fix, the test observes 10 `ObjectCreated` events. With the fix, no `CurvedAnimation` objects are created during fling inertia.

Verified locally:

- `flutter test test/widgets/interactive_viewer_test.dart --plain-name='Fling inertia does not repeatedly allocate CurvedAnimation'`
- `flutter test test/widgets/interactive_viewer_test.dart`
- `flutter analyze --no-pub lib/src/widgets/interactive_viewer.dart test/widgets/interactive_viewer_test.dart`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
