### PR TITLE
Fix SelectionArea crash after selected list content scrolls away

### DIFF
--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1776,12 +1776,16 @@ class SelectableRegionState extends State<SelectableRegion>
 
   /// The line height at the start of the current selection.
   double get startGlyphHeight {
-    return _selectionDelegate.value.startSelectionPoint!.lineHeight;
+    return _selectionDelegate.value.startSelectionPoint?.lineHeight ??
+        _selectionDelegate.value.endSelectionPoint?.lineHeight ??
+        0.0;
   }
 
   /// The line height at the end of the current selection.
   double get endGlyphHeight {
-    return _selectionDelegate.value.endSelectionPoint!.lineHeight;
+    return _selectionDelegate.value.endSelectionPoint?.lineHeight ??
+        _selectionDelegate.value.startSelectionPoint?.lineHeight ??
+        0.0;
   }
 
   /// Returns the local coordinates of the endpoints of the current selection.
@@ -1789,8 +1793,8 @@ class SelectableRegionState extends State<SelectableRegion>
     final SelectionPoint? start = _selectionDelegate.value.startSelectionPoint;
     final SelectionPoint? end = _selectionDelegate.value.endSelectionPoint;
     late List<TextSelectionPoint> points;
-    final Offset startLocalPosition = start?.localPosition ?? end!.localPosition;
-    final Offset endLocalPosition = end?.localPosition ?? start!.localPosition;
+    final Offset startLocalPosition = start?.localPosition ?? end?.localPosition ?? Offset.zero;
+    final Offset endLocalPosition = end?.localPosition ?? start?.localPosition ?? Offset.zero;
     if (startLocalPosition.dy > endLocalPosition.dy) {
       points = <TextSelectionPoint>[
         TextSelectionPoint(endLocalPosition, TextDirection.ltr),
@@ -2179,30 +2183,34 @@ class StaticSelectionContainerDelegate extends MultiSelectableSelectionContainer
     if (currentSelectionStartIndex != -1 &&
         selectables[currentSelectionStartIndex].value.hasSelection) {
       final Selectable start = selectables[currentSelectionStartIndex];
-      final Offset localStartEdge =
-          start.value.startSelectionPoint!.localPosition +
-          Offset(0, -start.value.startSelectionPoint!.lineHeight / 2);
-      updateLastSelectionEdgeLocation(
-        globalSelectionEdgeLocation: MatrixUtils.transformPoint(
-          start.getTransformTo(null),
-          localStartEdge,
-        ),
-        forEnd: false,
-      );
+      final SelectionPoint? startSelectionPoint = start.value.startSelectionPoint;
+      if (startSelectionPoint != null) {
+        final Offset localStartEdge =
+            startSelectionPoint.localPosition + Offset(0, -startSelectionPoint.lineHeight / 2);
+        updateLastSelectionEdgeLocation(
+          globalSelectionEdgeLocation: MatrixUtils.transformPoint(
+            start.getTransformTo(null),
+            localStartEdge,
+          ),
+          forEnd: false,
+        );
+      }
     }
     if (currentSelectionEndIndex != -1 &&
         selectables[currentSelectionEndIndex].value.hasSelection) {
       final Selectable end = selectables[currentSelectionEndIndex];
-      final Offset localEndEdge =
-          end.value.endSelectionPoint!.localPosition +
-          Offset(0, -end.value.endSelectionPoint!.lineHeight / 2);
-      updateLastSelectionEdgeLocation(
-        globalSelectionEdgeLocation: MatrixUtils.transformPoint(
-          end.getTransformTo(null),
-          localEndEdge,
-        ),
-        forEnd: true,
-      );
+      final SelectionPoint? endSelectionPoint = end.value.endSelectionPoint;
+      if (endSelectionPoint != null) {
+        final Offset localEndEdge =
+            endSelectionPoint.localPosition + Offset(0, -endSelectionPoint.lineHeight / 2);
+        updateLastSelectionEdgeLocation(
+          globalSelectionEdgeLocation: MatrixUtils.transformPoint(
+            end.getTransformTo(null),
+            localEndEdge,
+          ),
+          forEnd: true,
+        );
+      }
     }
   }
 

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1794,7 +1794,7 @@ class SelectableRegionState extends State<SelectableRegion>
     final SelectionPoint? end = _selectionDelegate.value.endSelectionPoint;
     late List<TextSelectionPoint> points;
     final Offset startLocalPosition = start?.localPosition ?? end?.localPosition ?? Offset.zero;
-    final Offset endLocalPosition = end?.localPosition ?? start?.localPosition ?? Offset.zero;
+    final Offset endLocalPosition = end?.localPosition ?? startLocalPosition;
     if (startLocalPosition.dy > endLocalPosition.dy) {
       points = <TextSelectionPoint>[
         TextSelectionPoint(endLocalPosition, TextDirection.ltr),

--- a/packages/flutter/test/material/selection_area_test.dart
+++ b/packages/flutter/test/material/selection_area_test.dart
@@ -66,45 +66,6 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  // Regression test for https://github.com/flutter/flutter/issues/124078.
-  testWidgets('SelectionArea does not crash when selected list content scrolls out of view', (
-    WidgetTester tester,
-  ) async {
-    final controller = ScrollController();
-    addTearDown(controller.dispose);
-
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: SelectionArea(
-            child: ListView.builder(
-              controller: controller,
-              itemExtent: 100.0,
-              itemCount: 20,
-              itemBuilder: (BuildContext context, int index) {
-                return Center(child: Text('Item $index'));
-              },
-            ),
-          ),
-        ),
-      ),
-    );
-
-    final SelectableRegionState state = tester.state<SelectableRegionState>(
-      find.byType(SelectableRegion),
-    );
-    state.selectAll(SelectionChangedCause.toolbar);
-    await tester.pump();
-    expect(tester.takeException(), isNull);
-
-    controller.jumpTo(1000.0);
-    await tester.pump();
-
-    expect(() => state.contextMenuAnchors, returnsNormally);
-    expect(tester.takeException(), isNull);
-    expect(find.text('Item 10'), findsOneWidget);
-  });
-
   // Regression test for https://github.com/flutter/flutter/issues/111370
   testWidgets(
     'Handle is correctly transformed when the text is inside of a FittedBox ',

--- a/packages/flutter/test/material/selection_area_test.dart
+++ b/packages/flutter/test/material/selection_area_test.dart
@@ -66,6 +66,45 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/124078.
+  testWidgets('SelectionArea does not crash when selected list content scrolls out of view', (
+    WidgetTester tester,
+  ) async {
+    final controller = ScrollController();
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SelectionArea(
+            child: ListView.builder(
+              controller: controller,
+              itemExtent: 100.0,
+              itemCount: 20,
+              itemBuilder: (BuildContext context, int index) {
+                return Center(child: Text('Item $index'));
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final SelectableRegionState state = tester.state<SelectableRegionState>(
+      find.byType(SelectableRegion),
+    );
+    state.selectAll(SelectionChangedCause.toolbar);
+    await tester.pump();
+    expect(tester.takeException(), isNull);
+
+    controller.jumpTo(1000.0);
+    await tester.pump();
+
+    expect(() => state.contextMenuAnchors, returnsNormally);
+    expect(tester.takeException(), isNull);
+    expect(find.text('Item 10'), findsOneWidget);
+  });
+
   // Regression test for https://github.com/flutter/flutter/issues/111370
   testWidgets(
     'Handle is correctly transformed when the text is inside of a FittedBox ',

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -1115,6 +1115,43 @@ void main() {
   );
 
   group('SelectionArea integration', () {
+    // Regression test for https://github.com/flutter/flutter/issues/124078.
+    testWidgets('SelectableRegion does not crash when selected list content scrolls out of view', (
+      WidgetTester tester,
+    ) async {
+      final controller = ScrollController();
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: _selectableRegion(
+            child: ListView.builder(
+              controller: controller,
+              itemExtent: 100.0,
+              itemCount: 20,
+              itemBuilder: (BuildContext context, int index) {
+                return Center(child: Text('Item $index'));
+              },
+            ),
+          ),
+        ),
+      );
+
+      final SelectableRegionState state = tester.state<SelectableRegionState>(
+        find.byType(SelectableRegion),
+      );
+      state.selectAll(SelectionChangedCause.toolbar);
+      await tester.pump();
+      expect(tester.takeException(), isNull);
+
+      controller.jumpTo(1000.0);
+      await tester.pump();
+
+      expect(() => state.contextMenuAnchors, returnsNormally);
+      expect(tester.takeException(), isNull);
+      expect(find.text('Item 10'), findsOneWidget);
+    });
+
     testWidgets(
       'selection is not cleared when app loses focus on desktop',
       (WidgetTester tester) async {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/124078

When SelectableRegion/SelectionArea selects content in a lazily built scrollable, the selected start or end edge can be recycled out of the viewport. The selection geometry may still represent an active selection while one or both selection points are temporarily null. The context-menu anchor path and the cached edge update path were force-unwrapping those points, which could throw when the toolbar rebuilt after scrolling.

This change makes those paths tolerate missing edge geometry by falling back to the visible opposite edge when available, or a zero-sized anchor when both edges are unavailable, and skips cached edge updates for edges whose point is currently unavailable.

Added a regression test that selects all visible ListView content, scrolls it out of view, and verifies context menu anchors remain safe.

Tests:
- flutter analyze --no-pub lib/src/widgets/selectable_region.dart test/widgets/selectable_region_test.dart
- flutter test test/widgets/selectable_region_test.dart --plain-name="SelectableRegion does not crash when selected list content scrolls out of view"
- flutter test test/widgets/selectable_region_test.dart