### PR TITLE
Run the DisplayList Primitive Rendering benchmarks in post-submit

### DIFF
--- a/engine/src/flutter/BUILD.gn
+++ b/engine/src/flutter/BUILD.gn
@@ -159,6 +159,7 @@ group("flutter") {
       "//flutter/display_list:display_list_builder_benchmarks",
       "//flutter/display_list:display_list_region_benchmarks",
       "//flutter/display_list:display_list_transform_benchmarks",
+      "//flutter/display_list:primitive_rendering_benchmarks",
       "//flutter/fml:fml_benchmarks",
       "//flutter/impeller/geometry:geometry_benchmarks",
       "//flutter/lib/ui:ui_benchmarks",

--- a/engine/src/flutter/ci/builders/linux_host_engine_test.json
+++ b/engine/src/flutter/ci/builders/linux_host_engine_test.json
@@ -136,6 +136,7 @@
                     "flutter/display_list:display_list_builder_benchmarks",
                     "flutter/display_list:display_list_region_benchmarks",
                     "flutter/display_list:display_list_transform_benchmarks",
+                    "flutter/display_list:primitive_rendering_benchmarks",
                     "flutter/fml:fml_benchmarks",
                     "flutter/impeller/geometry:geometry_benchmarks",
                     "flutter/lib/ui:ui_benchmarks",

--- a/engine/src/flutter/ci/builders/standalone/linux_benchmarks.json
+++ b/engine/src/flutter/ci/builders/standalone/linux_benchmarks.json
@@ -28,6 +28,7 @@
             "flutter/display_list:display_list_builder_benchmarks",
             "flutter/display_list:display_list_region_benchmarks",
             "flutter/display_list:display_list_transform_benchmarks",
+            "flutter/display_list:primitive_rendering_benchmarks",
             "flutter/fml:fml_benchmarks",
             "flutter/impeller/geometry:geometry_benchmarks",
             "flutter/lib/ui:ui_benchmarks",

--- a/engine/src/flutter/display_list/BUILD.gn
+++ b/engine/src/flutter/display_list/BUILD.gn
@@ -290,12 +290,7 @@ if (enable_unittests) {
   source_set("display_list_benchmarks_source") {
     testonly = true
 
-    sources = [
-      "benchmarking/dl_benchmarks.cc",
-      "benchmarking/dl_benchmarks.h",
-    ]
-
-    deps = [
+    public_deps = [
       ":display_list",
       ":display_list_fixtures",
       "//flutter/benchmarking",
@@ -309,7 +304,7 @@ if (enable_unittests) {
     ]
 
     if (!is_wasm) {
-      deps += [
+      public_deps += [
         "$dart_src/runtime:libdart_jit",  # for tracing
       ]
     }
@@ -317,6 +312,26 @@ if (enable_unittests) {
 
   executable("display_list_benchmarks") {
     testonly = true
+
+    sources = [
+      "benchmarking/dl_benchmarks.cc",
+      "benchmarking/dl_benchmarks.h",
+    ]
+
+    if (!defined(defines)) {
+      defines = []
+    }
+    defines += [ "DISPLAY_LIST_BENCHMARK_ALL_OPS" ]
+    deps = [ ":display_list_benchmarks_source" ]
+  }
+
+  executable("primitive_rendering_benchmarks") {
+    testonly = true
+
+    sources = [
+      "benchmarking/dl_benchmarks.cc",
+      "benchmarking/dl_benchmarks.h",
+    ]
 
     deps = [ ":display_list_benchmarks_source" ]
   }

--- a/engine/src/flutter/display_list/BUILD.gn
+++ b/engine/src/flutter/display_list/BUILD.gn
@@ -318,10 +318,7 @@ if (enable_unittests) {
       "benchmarking/dl_benchmarks.h",
     ]
 
-    if (!defined(defines)) {
-      defines = []
-    }
-    defines += [ "DISPLAY_LIST_BENCHMARK_ALL_OPS" ]
+    defines = [ "DISPLAY_LIST_BENCHMARK_ALL_OPS" ]
     deps = [ ":display_list_benchmarks_source" ]
   }
 

--- a/engine/src/flutter/testing/benchmark/generate_metrics.sh
+++ b/engine/src/flutter/testing/benchmark/generate_metrics.sh
@@ -18,4 +18,5 @@ ${ENGINE_PATH}/src/out/${VARIANT}/ui_benchmarks --benchmark_format=json > ${ENGI
 ${ENGINE_PATH}/src/out/${VARIANT}/display_list_builder_benchmarks --benchmark_format=json > ${ENGINE_PATH}/src/out/${VARIANT}/display_list_builder_benchmarks.json
 ${ENGINE_PATH}/src/out/${VARIANT}/display_list_region_benchmarks --benchmark_format=json > ${ENGINE_PATH}/src/out/${VARIANT}/display_list_region_benchmarks.json
 ${ENGINE_PATH}/src/out/${VARIANT}/display_list_transform_benchmarks --benchmark_format=json > ${ENGINE_PATH}/src/out/${VARIANT}/display_list_transform_benchmarks.json
+${ENGINE_PATH}/src/out/${VARIANT}/primitive_rendering_benchmarks --benchmark_format=json > ${ENGINE_PATH}/src/out/${VARIANT}/primitive_rendering_benchmarks.json
 ${ENGINE_PATH}/src/out/${VARIANT}/geometry_benchmarks --benchmark_format=json > ${ENGINE_PATH}/src/out/${VARIANT}/geometry_benchmarks.json

--- a/engine/src/flutter/testing/benchmark/upload_metrics.sh
+++ b/engine/src/flutter/testing/benchmark/upload_metrics.sh
@@ -62,4 +62,6 @@ cd "$SCRIPT_DIR"
 "$DART" bin/parse_and_send.dart \
   --json $ENGINE_PATH/src/out/${VARIANT}/display_list_transform_benchmarks.json "$@"
 "$DART" bin/parse_and_send.dart \
+  --json $ENGINE_PATH/src/out/${VARIANT}/primitive_rendering_benchmarks.json "$@"
+"$DART" bin/parse_and_send.dart \
   --json $ENGINE_PATH/src/out/${VARIANT}/geometry_benchmarks.json "$@"


### PR DESCRIPTION
We've defined new primitive rendering benchmarks to measure our ongoing work on the shaders that render our various primitive shapes, but these benchmarks are only currently run manually. This PR adds them to the suite of benchmarks that is run on every commit on Linux and uploads their results to the GCP store that contains our benchmark history.

Currently we are not uploading those historical benchmark json result files to Skia perf, but with this change we will at least have the history for them.

Fixes: https://github.com/flutter/flutter/issues/185708

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.