### PR TITLE
Update iOS tools to fat binaries

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4927,6 +4927,10 @@ targets:
     presubmit: false
     timeout: 60
     properties:
+      $flutter/osx_sdk : >-
+        {
+          "sdk_version": "16c5032a"
+        }
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: animation_with_microtasks_perf_ios__timeline_summary

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4927,6 +4927,7 @@ targets:
     presubmit: false
     timeout: 60
     properties:
+      # TODO(vashworth): Remove this once we're confident https://github.com/flutter/flutter/issues/185384 is resolved.
       $flutter/osx_sdk : >-
         {
           "sdk_version": "16c5032a"

--- a/dev/bots/suite_runners/run_verify_binaries_codesigned_tests.dart
+++ b/dev/bots/suite_runners/run_verify_binaries_codesigned_tests.dart
@@ -14,7 +14,7 @@ import '../utils.dart';
 
 Future<void> verifyCodesignedTestRunner() async {
   printProgress('${green}Running binaries codesign verification$reset');
-  await runCommand('flutter', <String>[
+  await runCommand(path.join(flutterRoot, 'bin', 'flutter'), <String>[
     'precache',
     '--android',
     '--ios',
@@ -23,13 +23,14 @@ Future<void> verifyCodesignedTestRunner() async {
 
   await verifyExist(flutterRoot);
   await verifySignatures(flutterRoot);
+  await verifyFatBinaries(flutterRoot);
 }
 
 /// Some binaries should always be codesigned, even on master. Verify that they
 /// are codesigned and have the correct entitlements.
 Future<void> verifyPreCodesignedTestRunner() async {
   printProgress('${green}Running binaries codesign verification$reset');
-  await runCommand('flutter', <String>[
+  await runCommand(path.join(flutterRoot, 'bin', 'flutter'), <String>[
     'precache',
     '--android',
     '--ios',
@@ -38,6 +39,7 @@ Future<void> verifyPreCodesignedTestRunner() async {
 
   await verifyExist(flutterRoot);
   await verifySignatures(flutterRoot, forRelease: false);
+  await verifyFatBinaries(flutterRoot);
 }
 
 const List<String> expectedEntitlements = <String>[
@@ -333,6 +335,43 @@ Future<void> verifySignatures(
     throw Exception('Test failed because unexpected files found in the cache.');
   }
   print('Verified that files are codesigned and have expected entitlements.');
+}
+
+/// Verify that specific binaries are fat binaries containing both x86_64 and arm64 slices.
+Future<void> verifyFatBinaries(
+  String flutterRoot, {
+  @visibleForTesting ProcessManager processManager = const LocalProcessManager(),
+}) async {
+  final List<String> fatBinaries =
+      presignedBinariesWithEntitlements(flutterRoot) +
+      presignedBinariesWithoutEntitlements(flutterRoot);
+  final failedBinaries = <String>[];
+
+  for (final binaryPath in fatBinaries) {
+    print('Verifying fat binary architectures for $binaryPath');
+    final io.ProcessResult result = await processManager.run(<String>['file', binaryPath]);
+
+    if (result.exitCode != 0) {
+      print('Failed to run file command on $binaryPath');
+      failedBinaries.add(binaryPath);
+      continue;
+    }
+
+    final output = result.stdout as String;
+    final bool containsX86_64 = output.contains('x86_64');
+    final bool containsArm64 = output.contains('arm64');
+
+    if (!containsX86_64 || !containsArm64) {
+      print('Binary $binaryPath is not a fat binary containing both x86_64 and arm64.');
+      print('Output: $output');
+      failedBinaries.add(binaryPath);
+    }
+  }
+
+  if (failedBinaries.isNotEmpty) {
+    throw Exception('Failed fat binary verification for:\n${failedBinaries.join('\n')}');
+  }
+  print('All expected fat binaries verified.');
 }
 
 /// Find every binary file in the given [rootDirectory].

--- a/dev/bots/suite_runners/run_verify_binaries_codesigned_tests.dart
+++ b/dev/bots/suite_runners/run_verify_binaries_codesigned_tests.dart
@@ -352,7 +352,7 @@ Future<void> verifyFatBinaries(
     final io.ProcessResult result = await processManager.run(<String>['file', binaryPath]);
 
     if (result.exitCode != 0) {
-      print('Failed to run file command on $binaryPath');
+      print('Failed to run file command on $binaryPath: \n${result.stderr}');
       failedBinaries.add(binaryPath);
       continue;
     }

--- a/dev/bots/test/codesign_test.dart
+++ b/dev/bots/test/codesign_test.dart
@@ -282,4 +282,55 @@ void main() async {
       );
     });
   });
+
+  group('verifyFatBinaries', () {
+    test('succeeds if every binary is fat', () async {
+      final commandList = <FakeCommand>[];
+      final List<String> fatBinaries =
+          presignedBinariesWithEntitlements(flutterRoot) +
+          presignedBinariesWithoutEntitlements(flutterRoot);
+
+      for (final binaryPath in fatBinaries) {
+        commandList.add(
+          FakeCommand(
+            command: <String>['file', binaryPath],
+            stdout:
+                'Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64:Mach-O 64-bit executable arm64]',
+          ),
+        );
+      }
+      final ProcessManager processManager = FakeProcessManager.list(commandList);
+      await expectLater(verifyFatBinaries(flutterRoot, processManager: processManager), completes);
+    });
+
+    test('fails if a binary is not fat', () async {
+      final commandList = <FakeCommand>[];
+      final List<String> fatBinaries =
+          presignedBinariesWithEntitlements(flutterRoot) +
+          presignedBinariesWithoutEntitlements(flutterRoot);
+
+      if (fatBinaries.isNotEmpty) {
+        commandList.add(
+          FakeCommand(
+            command: <String>['file', fatBinaries.first],
+            stdout: 'Mach-O 64-bit executable x86_64',
+          ),
+        );
+        for (final String binaryPath in fatBinaries.skip(1)) {
+          commandList.add(
+            FakeCommand(
+              command: <String>['file', binaryPath],
+              stdout:
+                  'Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64:Mach-O 64-bit executable arm64]',
+            ),
+          );
+        }
+      }
+      final ProcessManager processManager = FakeProcessManager.list(commandList);
+      expect(
+        () async => verifyFatBinaries(flutterRoot, processManager: processManager),
+        throwsExceptionWith('Failed fat binary verification for:'),
+      );
+    });
+  });
 }

--- a/packages/flutter_tools/lib/src/flutter_cache.dart
+++ b/packages/flutter_tools/lib/src/flutter_cache.dart
@@ -865,7 +865,7 @@ class IosUsbArtifacts extends CachedArtifact {
   @visibleForTesting
   Uri get archiveUri => Uri.parse(
     '${cache.realmlessStorageBaseUrl}/flutter_infra_release/'
-    'ios-usb-dependencies${cache.useUnsignedMacBinaries ? '/unsigned' : ''}'
+    'ios-usb-dependencies/arm64_x86_64${cache.useUnsignedMacBinaries ? '/unsigned' : ''}'
     '/$name/$version/$name.zip',
   );
 }


### PR DESCRIPTION
Updates iOS tools to a new path in GCS where they are built with both x86 and arm. On ARM Apple Silicon Macs, these will run natively without requiring Rosetta.

Binaries are code-signed and fat as expected:
```
SHARD=verify_binaries_pre_codesigned bin/cache/dart-sdk/bin/dart dev/bots/test.dart
▌20:17:40▐ STARTING ANALYSIS
▌20:17:41▐ SHARD=verify_binaries_pre_codesigned
▌20:17:41▐ Running binaries codesign verification
▌20:18:30▐ Test successful.
```

Fixes https://github.com/flutter/flutter/issues/121178 and https://github.com/flutter/flutter/issues/185384

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
