### PR TITLE
Prevent Cubic transform from looping on out-of-range input

### DIFF
--- a/packages/flutter/lib/src/animation/curves.dart
+++ b/packages/flutter/lib/src/animation/curves.dart
@@ -401,6 +401,9 @@ class Cubic extends Curve {
 
   @override
   double transformInternal(double t) {
+    if (t < 0.0 || t > 1.0) {
+      throw ArgumentError.value(t, 't', 'Cubic curve input is outside the [0, 1] range.');
+    }
     var start = 0.0;
     var end = 1.0;
     while (true) {

--- a/packages/flutter/test/animation/curves_test.dart
+++ b/packages/flutter/test/animation/curves_test.dart
@@ -180,6 +180,12 @@ void main() {
     expect(test.transform(0.166666), equals(0.4));
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/171364.
+  test('Cubic transformInternal throws for values outside the unit interval', () {
+    expect(() => Curves.easeOut.transformInternal(2.0), throwsA(isA<ArgumentError>()));
+    expect(() => Curves.easeOut.transformInternal(-1.0), throwsA(isA<ArgumentError>()));
+  });
+
   test('Invalid transform parameter should assert', () {
     expect(() => const SawTooth(2).transform(-0.0001), throwsAssertionError);
     expect(() => const SawTooth(2).transform(1.0001), throwsAssertionError);


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/171364

`Cubic.transformInternal` uses a binary search over the unit interval to invert the curve x-coordinate. In debug mode, `Curve.transform` catches out-of-range input with an assert before this method runs. In profile/release, that assert is stripped, so values outside `[0, 1]` can enter the binary search. For `t > 1` or `t < 0`, the search converges to an endpoint but never satisfies the error bound, which can spin forever and cause an ANR.

This adds a runtime range guard at the `Cubic` solver boundary so invalid inputs fail fast instead of looping indefinitely, while preserving all valid cubic outputs.

Tests:
- `flutter analyze --no-pub lib/src/animation/curves.dart test/animation/curves_test.dart`
- `flutter test test/animation/curves_test.dart --plain-name="Cubic transformInternal throws for values outside the unit interval"`
- `flutter test test/animation/curves_test.dart`
- `flutter test test/animation`