### PR TITLE
[Impeller] Populate float_type when loading Flutter GPU shader bundles

### DIFF
--- a/engine/src/flutter/impeller/core/shader_types.h
+++ b/engine/src/flutter/impeller/core/shader_types.h
@@ -82,6 +82,32 @@ struct ShaderStructMemberMetadata {
   std::optional<ShaderFloatType> float_type;
 };
 
+/// @brief Derive the ShaderFloatType from the base ShaderType and element
+///        size in bytes. This is needed when loading shader metadata from
+///        formats (like shader bundles) that don't store float_type directly.
+///        Returns std::nullopt for non-float types.
+constexpr std::optional<ShaderFloatType> DeriveShaderFloatType(
+    ShaderType type,
+    size_t element_size_in_bytes) {
+  if (type != ShaderType::kFloat) {
+    return std::nullopt;
+  }
+  switch (element_size_in_bytes) {
+    case 4:
+      return ShaderFloatType::kFloat;
+    case 8:
+      return ShaderFloatType::kVec2;
+    case 12:
+      return ShaderFloatType::kVec3;
+    case 16:
+      return ShaderFloatType::kVec4;
+    case 64:
+      return ShaderFloatType::kMat4;
+    default:
+      return std::nullopt;
+  }
+}
+
 struct ShaderMetadata {
   // This must match the uniform name in the shader program.
   std::string name;

--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles_unittests.cc
@@ -146,5 +146,64 @@ TEST(BufferBindingsGLESTest, BindUniformDataVerticesAndMatrices) {
                                        Range{0, 1}));
 }
 
+TEST(BufferBindingsGLESTest, DeriveShaderFloatTypeFromElementSize) {
+  // Non-float types should always return nullopt.
+  EXPECT_EQ(DeriveShaderFloatType(ShaderType::kUnsignedInt, 4), std::nullopt);
+  EXPECT_EQ(DeriveShaderFloatType(ShaderType::kSignedInt, 4), std::nullopt);
+  EXPECT_EQ(DeriveShaderFloatType(ShaderType::kBoolean, 4), std::nullopt);
+
+  // Float types should be derived from element size.
+  EXPECT_EQ(DeriveShaderFloatType(ShaderType::kFloat, 4),
+            ShaderFloatType::kFloat);
+  EXPECT_EQ(DeriveShaderFloatType(ShaderType::kFloat, 8),
+            ShaderFloatType::kVec2);
+  EXPECT_EQ(DeriveShaderFloatType(ShaderType::kFloat, 12),
+            ShaderFloatType::kVec3);
+  EXPECT_EQ(DeriveShaderFloatType(ShaderType::kFloat, 16),
+            ShaderFloatType::kVec4);
+  EXPECT_EQ(DeriveShaderFloatType(ShaderType::kFloat, 64),
+            ShaderFloatType::kMat4);
+
+  // Unknown sizes should return nullopt.
+  EXPECT_EQ(DeriveShaderFloatType(ShaderType::kFloat, 0), std::nullopt);
+  EXPECT_EQ(DeriveShaderFloatType(ShaderType::kFloat, 32), std::nullopt);
+  EXPECT_EQ(DeriveShaderFloatType(ShaderType::kFloat, 128), std::nullopt);
+}
+
+TEST(BufferBindingsGLESTest, BindUniformFailsWithoutFloatType) {
+  // Verifies that the GLES backend rejects float uniforms that are missing
+  // float_type metadata (the bug that occurred when loading shader bundles).
+  BufferBindingsGLES bindings;
+  absl::flat_hash_map<std::string, GLint> uniform_bindings;
+  uniform_bindings["SHADERMETADATA.FOOBAR"] = 1;
+  bindings.SetUniformBindings(std::move(uniform_bindings));
+  auto mock_gles_impl = std::make_unique<MockGLESImpl>();
+
+  std::shared_ptr<MockGLES> mock_gl = MockGLES::Init(std::move(mock_gles_impl));
+  std::vector<BufferResource> bound_buffers;
+  std::vector<TextureAndSampler> bound_textures;
+
+  ShaderMetadata shader_metadata = {
+      .name = "shader_metadata",
+      .members = {ShaderStructMemberMetadata{.type = ShaderType::kFloat,
+                                             .name = "foobar",
+                                             .offset = 0,
+                                             .size = sizeof(float),
+                                             .byte_length = sizeof(float),
+                                             .array_elements = std::nullopt,
+                                             .float_type = std::nullopt}}};
+  std::shared_ptr<ReactorGLES> reactor;
+  std::shared_ptr<Allocation> backing_store = std::make_shared<Allocation>();
+  ASSERT_TRUE(backing_store->Truncate(Bytes{sizeof(float)}));
+  DeviceBufferGLES device_buffer(DeviceBufferDescriptor{.size = sizeof(float)},
+                                 reactor, backing_store);
+  BufferView buffer_view(&device_buffer, Range(0, sizeof(float)));
+  bound_buffers.push_back(BufferResource(&shader_metadata, buffer_view));
+
+  EXPECT_FALSE(bindings.BindUniformData(mock_gl->GetProcTable(), bound_textures,
+                                        bound_buffers, Range{0, 0},
+                                        Range{0, 1}));
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/engine/src/flutter/lib/gpu/shader_library.cc
+++ b/engine/src/flutter/lib/gpu/shader_library.cc
@@ -231,6 +231,9 @@ fml::RefPtr<ShaderLibrary> ShaderLibrary::MakeFromFlatbuffer(
                     struct_member->array_elements() == 0
                         ? std::optional<size_t>(std::nullopt)
                         : static_cast<size_t>(struct_member->array_elements()),
+                .float_type = impeller::DeriveShaderFloatType(
+                    FromUniformType(struct_member->type()),
+                    struct_member->element_size_in_bytes()),
             });
           }
         }


### PR DESCRIPTION
The GLES backend requires `ShaderStructMemberMetadata::float_type` to determine which `glUniform*` call to use when binding uniform data. However, when Flutter GPU loads shaders from a `.shaderbundle`, `float_type` was never populated and defaulted to `std::nullopt`, causing a fatal crash on the GLES backend on all platforms (Windows ANGLE, Linux GLES, Android GLES):

```
[ERROR:flutter/impeller/renderer/backend/gles/buffer_bindings_gles.cc(409)]
Break on 'ImpellerValidationBreak' to inspect point of failure: Float uniform should have a float type.
```

This adds `DeriveShaderFloatType()` to `shader_types.h` which infers `float_type` from the base `ShaderType` and element size in bytes (4 → `kFloat`, 8 → `kVec2`, 12 → `kVec3`, 16 → `kVec4`, 64 → `kMat4`), and uses it when loading shader bundle metadata. This matches what `runtime_effect_contents.cc` already does for runtime effect shaders.

Tests added:
- `DeriveShaderFloatTypeFromElementSize` — verifies the type derivation for all float subtypes, non-float types, and unknown sizes.
- `BindUniformFailsWithoutFloatType` — regression guard verifying the GLES backend rejects uniforms with missing `float_type` metadata.

## Issues

Fixes #184953
Fixes #183530

May also resolve the following issues, all of which surface as GLES uniform binding failures and share the same root-cause family. To be verified against the linked reproducers after merge:

- #176875
- #164438
- #164745
