### PR TITLE
Prevent Cubic transform from looping on out-of-range input

### DIFF
--- a/packages/flutter/lib/src/animation/curves.dart
+++ b/packages/flutter/lib/src/animation/curves.dart
@@ -401,7 +401,10 @@ class Cubic extends Curve {
 
   @override
   double transformInternal(double t) {
-    if (t.isNaN || t <= 0.0) {
+    if (t.isNaN) {
+      throw ArgumentError.value(t, 't', 'must not be NaN');
+    }
+    if (t <= 0.0) {
       return 0.0;
     }
     if (t >= 1.0) {

--- a/packages/flutter/lib/src/animation/curves.dart
+++ b/packages/flutter/lib/src/animation/curves.dart
@@ -401,6 +401,12 @@ class Cubic extends Curve {
 
   @override
   double transformInternal(double t) {
+    if (t <= 0.0) {
+      return 0.0;
+    }
+    if (t >= 1.0) {
+      return 1.0;
+    }
     var start = 0.0;
     var end = 1.0;
     while (true) {

--- a/packages/flutter/lib/src/animation/curves.dart
+++ b/packages/flutter/lib/src/animation/curves.dart
@@ -401,7 +401,7 @@ class Cubic extends Curve {
 
   @override
   double transformInternal(double t) {
-    if (t <= 0.0) {
+    if (t.isNaN || t <= 0.0) {
       return 0.0;
     }
     if (t >= 1.0) {

--- a/packages/flutter/test/animation/curves_test.dart
+++ b/packages/flutter/test/animation/curves_test.dart
@@ -184,6 +184,7 @@ void main() {
   test('Cubic transformInternal clamps values outside the unit interval', () {
     expect(Curves.easeOut.transformInternal(2.0), 1.0);
     expect(Curves.easeOut.transformInternal(-1.0), 0.0);
+    expect(Curves.easeOut.transformInternal(double.nan), 0.0);
   });
 
   test('Invalid transform parameter should assert', () {

--- a/packages/flutter/test/animation/curves_test.dart
+++ b/packages/flutter/test/animation/curves_test.dart
@@ -180,6 +180,12 @@ void main() {
     expect(test.transform(0.166666), equals(0.4));
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/171364.
+  test('Cubic transformInternal clamps values outside the unit interval', () {
+    expect(Curves.easeOut.transformInternal(2.0), 1.0);
+    expect(Curves.easeOut.transformInternal(-1.0), 0.0);
+  });
+
   test('Invalid transform parameter should assert', () {
     expect(() => const SawTooth(2).transform(-0.0001), throwsAssertionError);
     expect(() => const SawTooth(2).transform(1.0001), throwsAssertionError);

--- a/packages/flutter/test/animation/curves_test.dart
+++ b/packages/flutter/test/animation/curves_test.dart
@@ -184,7 +184,10 @@ void main() {
   test('Cubic transformInternal clamps values outside the unit interval', () {
     expect(Curves.easeOut.transformInternal(2.0), 1.0);
     expect(Curves.easeOut.transformInternal(-1.0), 0.0);
-    expect(Curves.easeOut.transformInternal(double.nan), 0.0);
+  });
+
+  test('Cubic transformInternal throws for NaN', () {
+    expect(() => Curves.easeOut.transformInternal(double.nan), throwsArgumentError);
   });
 
   test('Invalid transform parameter should assert', () {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/171364

`Cubic.transformInternal` uses a binary search over the unit interval to invert the curve x-coordinate. In debug mode, `Curve.transform` asserts that callers pass values in `[0, 1]`. In profile/release, that assert is stripped, so out-of-range inputs can reach the Cubic solver. For values below `0.0` or above `1.0`, the search converges to an endpoint but may never satisfy the error bound, which can spin indefinitely and cause an ANR.

This clamps the Cubic solver boundary to return the endpoint values for out-of-range inputs. That preserves the existing debug assertion path through `Curve.transform`, avoids a release-mode crash, and matches the boundary behavior used by other curve wrappers such as `Interval`.

Tests:
- `flutter analyze --no-pub lib/src/animation/curves.dart test/animation/curves_test.dart`
- `flutter test test/animation/curves_test.dart --plain-name="Cubic transformInternal clamps values outside the unit interval"`
- `flutter test test/animation/curves_test.dart`
- `flutter test test/animation`