### PR TITLE
Fix text selection handle drag jumps

### DIFF
--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -689,11 +689,11 @@ class TextSelectionOverlay {
   }
 
   // The contact position of the gesture at the current end handle location, in
-  // global coordinates. Updated when the handle moves.
+  // RenderEditable local coordinates. Updated when the handle moves.
   late double _endHandleDragPosition;
 
   // The distance from _endHandleDragPosition to the center of the line that it
-  // corresponds to, in global coordinates.
+  // corresponds to, in RenderEditable local coordinates.
   late double _endHandleDragTarget;
 
   // The initial selection when a selection handle drag has started.
@@ -714,20 +714,19 @@ class TextSelectionOverlay {
       return;
     }
 
-    _endHandleDragPosition = details.globalPosition.dy;
+    _endHandleDragPosition = renderObject.globalToLocal(details.globalPosition).dy;
 
     // Use local coordinates when dealing with line height. because in case of a
     // scale transformation, the line height will also be scaled.
     final double centerOfLineLocal =
         _selectionOverlay.selectionEndpoints.last.point.dy - renderObject.preferredLineHeight / 2;
-    final double centerOfLineGlobal = renderObject.localToGlobal(Offset(0.0, centerOfLineLocal)).dy;
-    _endHandleDragTarget = centerOfLineGlobal - details.globalPosition.dy;
+    _endHandleDragTarget = centerOfLineLocal - _endHandleDragPosition;
     // Instead of finding the TextPosition at the handle's location directly,
     // use the vertical center of the line that it points to. This is because
     // selection handles typically hang above or below the line that they point
     // to.
     final TextPosition position = renderObject.getPositionForPoint(
-      Offset(details.globalPosition.dx, centerOfLineGlobal),
+      renderObject.localToGlobal(Offset(0.0, centerOfLineLocal)),
     );
 
     // The drag start selection is only utilized on Apple platforms.
@@ -781,18 +780,28 @@ class TextSelectionOverlay {
 
     final double nextEndHandleDragPositionLocal = _getHandleDy(
       localPosition.dy,
-      renderObject.globalToLocal(Offset(0.0, _endHandleDragPosition)).dy,
+      _endHandleDragPosition,
     );
-    _endHandleDragPosition = renderObject
-        .localToGlobal(Offset(0.0, nextEndHandleDragPositionLocal))
-        .dy;
+    _endHandleDragPosition = nextEndHandleDragPositionLocal;
 
-    final handleTargetGlobal = Offset(
-      details.globalPosition.dx,
-      _endHandleDragPosition + _endHandleDragTarget,
+    final Offset handleTargetGlobal = renderObject.localToGlobal(
+      Offset(localPosition.dx, _endHandleDragPosition + _endHandleDragTarget),
     );
 
     final TextPosition position = renderObject.getPositionForPoint(handleTargetGlobal);
+    if ((defaultTargetPlatform == TargetPlatform.iOS ||
+            defaultTargetPlatform == TargetPlatform.macOS) &&
+        ((details.delta.dy < 0.0 && position.offset > _selection.extentOffset) ||
+            (details.delta.dy > 0.0 && position.offset < _selection.extentOffset))) {
+      return;
+    }
+    final double currentCenterOfLineLocal =
+        _selectionOverlay.selectionEndpoints.last.point.dy - renderObject.preferredLineHeight / 2;
+    final double candidateCenterOfLineLocal = renderObject.getLocalRectForCaret(position).center.dy;
+    if ((details.delta.dy < 0.0 && candidateCenterOfLineLocal > currentCenterOfLineLocal) ||
+        (details.delta.dy > 0.0 && candidateCenterOfLineLocal < currentCenterOfLineLocal)) {
+      return;
+    }
 
     final TextSelection newSelection;
     switch (defaultTargetPlatform) {
@@ -861,11 +870,11 @@ class TextSelectionOverlay {
   }
 
   // The contact position of the gesture at the current start handle location,
-  // in global coordinates. Updated when the handle moves.
+  // in RenderEditable local coordinates. Updated when the handle moves.
   late double _startHandleDragPosition;
 
   // The distance from _startHandleDragPosition to the center of the line that
-  // it corresponds to, in global coordinates.
+  // it corresponds to, in RenderEditable local coordinates.
   late double _startHandleDragTarget;
 
   void _handleSelectionStartHandleDragStart(DragStartDetails details) {
@@ -873,20 +882,19 @@ class TextSelectionOverlay {
       return;
     }
 
-    _startHandleDragPosition = details.globalPosition.dy;
+    _startHandleDragPosition = renderObject.globalToLocal(details.globalPosition).dy;
 
     // Use local coordinates when dealing with line height. because in case of a
     // scale transformation, the line height will also be scaled.
     final double centerOfLineLocal =
         _selectionOverlay.selectionEndpoints.first.point.dy - renderObject.preferredLineHeight / 2;
-    final double centerOfLineGlobal = renderObject.localToGlobal(Offset(0.0, centerOfLineLocal)).dy;
-    _startHandleDragTarget = centerOfLineGlobal - details.globalPosition.dy;
+    _startHandleDragTarget = centerOfLineLocal - _startHandleDragPosition;
     // Instead of finding the TextPosition at the handle's location directly,
     // use the vertical center of the line that it points to. This is because
     // selection handles typically hang above or below the line that they point
     // to.
     final TextPosition position = renderObject.getPositionForPoint(
-      Offset(details.globalPosition.dx, centerOfLineGlobal),
+      renderObject.localToGlobal(Offset(0.0, centerOfLineLocal)),
     );
 
     // The drag start selection is only utilized on Apple platforms.
@@ -914,16 +922,26 @@ class TextSelectionOverlay {
     final Offset localPosition = renderObject.globalToLocal(details.globalPosition);
     final double nextStartHandleDragPositionLocal = _getHandleDy(
       localPosition.dy,
-      renderObject.globalToLocal(Offset(0.0, _startHandleDragPosition)).dy,
+      _startHandleDragPosition,
     );
-    _startHandleDragPosition = renderObject
-        .localToGlobal(Offset(0.0, nextStartHandleDragPositionLocal))
-        .dy;
-    final handleTargetGlobal = Offset(
-      details.globalPosition.dx,
-      _startHandleDragPosition + _startHandleDragTarget,
+    _startHandleDragPosition = nextStartHandleDragPositionLocal;
+    final Offset handleTargetGlobal = renderObject.localToGlobal(
+      Offset(localPosition.dx, _startHandleDragPosition + _startHandleDragTarget),
     );
     final TextPosition position = renderObject.getPositionForPoint(handleTargetGlobal);
+    if ((defaultTargetPlatform == TargetPlatform.iOS ||
+            defaultTargetPlatform == TargetPlatform.macOS) &&
+        ((details.delta.dy < 0.0 && position.offset > _selection.extentOffset) ||
+            (details.delta.dy > 0.0 && position.offset < _selection.extentOffset))) {
+      return;
+    }
+    final double currentCenterOfLineLocal =
+        _selectionOverlay.selectionEndpoints.first.point.dy - renderObject.preferredLineHeight / 2;
+    final double candidateCenterOfLineLocal = renderObject.getLocalRectForCaret(position).center.dy;
+    if ((details.delta.dy < 0.0 && candidateCenterOfLineLocal > currentCenterOfLineLocal) ||
+        (details.delta.dy > 0.0 && candidateCenterOfLineLocal < currentCenterOfLineLocal)) {
+      return;
+    }
 
     final TextSelection newSelection;
     switch (defaultTargetPlatform) {

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -62,6 +62,43 @@ enum HandlePositionInViewport { leftEdge, rightEdge, within }
 
 typedef _VoidFutureCallback = Future<void> Function();
 
+class _VisibleTextSelectionHandleControls extends TextSelectionControls
+    with TextSelectionHandleControls {
+  _VisibleTextSelectionHandleControls();
+
+  final Key leftHandleKey = UniqueKey();
+  final Key rightHandleKey = UniqueKey();
+  final Key collapsedHandleKey = UniqueKey();
+
+  @override
+  Widget buildHandle(
+    BuildContext context,
+    TextSelectionHandleType type,
+    double textLineHeight, [
+    VoidCallback? onTap,
+  ]) {
+    return ColoredBox(
+      key: switch (type) {
+        TextSelectionHandleType.left => leftHandleKey,
+        TextSelectionHandleType.right => rightHandleKey,
+        TextSelectionHandleType.collapsed => collapsedHandleKey,
+      },
+      color: const Color(0x01000000),
+      child: const SizedBox.square(dimension: 20.0),
+    );
+  }
+
+  @override
+  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
+    return Offset.zero;
+  }
+
+  @override
+  Size getHandleSize(double textLineHeight) {
+    return const Size.square(20.0);
+  }
+}
+
 TextEditingValue collapsedAtEnd(String text) {
   return TextEditingValue(
     text: text,
@@ -9233,6 +9270,78 @@ void main() {
       expect(controller.value.selection.baseOffset, 0);
     },
     skip: kIsWeb, // [intended] on web these keys are handled by the browser.
+    variant: const TargetPlatformVariant(<TargetPlatform>{
+      TargetPlatform.iOS,
+      TargetPlatform.macOS,
+    }),
+  );
+
+  testWidgets(
+    'dragging selection handle upward scrolls multiline field steadily on Apple platforms',
+    (WidgetTester tester) async {
+      controller.text = List<String>.filled(80, 'line of editable text').join('\n');
+      final scrollController = ScrollController();
+      final selectionControls = _VisibleTextSelectionHandleControls();
+      addTearDown(scrollController.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Align(
+            alignment: Alignment.topLeft,
+            child: SizedBox(
+              width: 240,
+              child: EditableText(
+                maxLines: 6,
+                controller: controller,
+                scrollController: scrollController,
+                showSelectionHandles: true,
+                autofocus: true,
+                focusNode: focusNode,
+                style: Typography.material2018(platform: defaultTargetPlatform).black.titleMedium!,
+                cursorColor: Colors.blue,
+                backgroundCursorColor: Colors.grey,
+                selectionControls: selectionControls,
+                keyboardType: TextInputType.multiline,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final EditableTextState state = tester.state(find.byType(EditableText));
+      const selectedWordStart = 1339;
+      const selectedWordEnd = 1343;
+      state.userUpdateTextEditingValue(
+        controller.value.copyWith(
+          selection: const TextSelection(
+            baseOffset: selectedWordStart,
+            extentOffset: selectedWordEnd,
+          ),
+        ),
+        SelectionChangedCause.longPress,
+      );
+      await tester.pump();
+
+      expect(find.byKey(selectionControls.leftHandleKey), findsOneWidget);
+      final TestGesture gesture = await tester.startGesture(
+        tester.getCenter(find.byKey(selectionControls.leftHandleKey)),
+      );
+      addTearDown(gesture.removePointer);
+
+      final offsets = <double>[scrollController.offset];
+      for (var index = 0; index < 8; index += 1) {
+        await gesture.moveBy(const Offset(0.0, -18.0));
+        await tester.pump();
+        offsets.add(scrollController.offset);
+      }
+      await gesture.up();
+
+      for (var index = 1; index < offsets.length; index += 1) {
+        expect(offsets[index], lessThanOrEqualTo(offsets[index - 1]));
+      }
+    },
+    skip: kIsWeb, // [intended] on web these selection handles are handled by the browser.
     variant: const TargetPlatformVariant(<TargetPlatform>{
       TargetPlatform.iOS,
       TargetPlatform.macOS,


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/132047

Selection handle drags kept their handle contact position in global coordinates. When dragging a handle caused the editable to scroll, the next drag update converted that stale global position through the updated transform and could resolve the handle target to a line in the opposite direction, causing the scroll offset to jump.

This keeps the drag contact position and line-center target in the RenderEditable local coordinate space, and ignores candidate updates that move opposite to the handle drag direction.

Tests run:
- `../../bin/flutter analyze --no-pub lib/src/widgets/text_selection.dart test/widgets/editable_text_test.dart`
- `../../bin/flutter test test/widgets/editable_text_test.dart --plain-name="dragging selection handle upward scrolls multiline field steadily on Apple platforms"`
- `../../bin/flutter test test/widgets/text_selection_test.dart --plain-name="can trigger selection handle drag"`