### PR TITLE
[Flutter GPU] Carry vec_size & columns in shader bundle uniform metadata

### DIFF
--- a/engine/src/flutter/impeller/compiler/reflector.cc
+++ b/engine/src/flutter/impeller/compiler/reflector.cc
@@ -556,6 +556,8 @@ std::shared_ptr<ShaderBundleData> Reflector::GenerateShaderBundleData() const {
       uniform_struct_field.element_size_in_bytes = struct_member.size;
       uniform_struct_field.total_size_in_bytes = struct_member.byte_length;
       uniform_struct_field.array_elements = struct_member.array_elements;
+      uniform_struct_field.vec_size = struct_member.vec_size;
+      uniform_struct_field.columns = struct_member.columns;
       uniform_struct.fields.push_back(uniform_struct_field);
     }
     uniform_struct.size_in_bytes = size_in_bytes;
@@ -937,6 +939,8 @@ std::vector<StructMember> Reflector::ReadStructMembers(
           /*p_array_elements=*/count,
           /*p_element_padding=*/8,
           /*p_float_type=*/"ShaderFloatType::kMat2",
+          /*p_vec_size=*/2,
+          /*p_columns=*/2,
       });
       current_byte_offset += total_length;
       continue;
@@ -961,6 +965,8 @@ std::vector<StructMember> Reflector::ReadStructMembers(
           /*p_array_elements=*/count,
           /*p_element_padding=*/4,
           /*p_float_type=*/"ShaderFloatType::kMat3",
+          /*p_vec_size=*/3,
+          /*p_columns=*/3,
       });
       current_byte_offset += total_length;
       continue;
@@ -985,6 +991,8 @@ std::vector<StructMember> Reflector::ReadStructMembers(
           /*p_array_elements=*/array_elements,
           /*p_element_padding=*/element_padding,
           /*p_float_type=*/"ShaderFloatType::kMat4",
+          /*p_vec_size=*/4,
+          /*p_columns=*/4,
       });
       current_byte_offset += stride * array_elements.value_or(1);
       continue;
@@ -1008,6 +1016,9 @@ std::vector<StructMember> Reflector::ReadStructMembers(
           /*p_byte_length=*/stride * array_elements.value_or(1),
           /*p_array_elements=*/array_elements,
           /*p_element_padding=*/element_padding,
+          /*p_float_type=*/std::nullopt,
+          /*p_vec_size=*/2,
+          /*p_columns=*/1,
       });
       current_byte_offset += stride * array_elements.value_or(1);
       continue;
@@ -1031,6 +1042,9 @@ std::vector<StructMember> Reflector::ReadStructMembers(
           /*p_byte_length=*/stride * array_elements.value_or(1),
           /*p_array_elements=*/array_elements,
           /*p_element_padding=*/element_padding,
+          /*p_float_type=*/std::nullopt,
+          /*p_vec_size=*/2,
+          /*p_columns=*/1,
       });
       current_byte_offset += stride * array_elements.value_or(1);
       continue;
@@ -1054,6 +1068,8 @@ std::vector<StructMember> Reflector::ReadStructMembers(
           /*p_array_elements=*/array_elements,
           /*p_element_padding=*/element_padding,
           /*p_float_type=*/"ShaderFloatType::kVec2",
+          /*p_vec_size=*/2,
+          /*p_columns=*/1,
       });
       current_byte_offset += stride * array_elements.value_or(1);
       continue;
@@ -1077,6 +1093,8 @@ std::vector<StructMember> Reflector::ReadStructMembers(
           /*p_array_elements=*/array_elements,
           /*p_element_padding=*/element_padding,
           /*p_float_type=*/"ShaderFloatType::kVec3",
+          /*p_vec_size=*/3,
+          /*p_columns=*/1,
       });
       current_byte_offset += stride * array_elements.value_or(1);
       continue;
@@ -1100,6 +1118,8 @@ std::vector<StructMember> Reflector::ReadStructMembers(
           /*p_array_elements=*/array_elements,
           /*p_element_padding=*/element_padding,
           /*p_float_type=*/"ShaderFloatType::kVec4",
+          /*p_vec_size=*/4,
+          /*p_columns=*/1,
       });
       current_byte_offset += stride * array_elements.value_or(1);
       continue;
@@ -1123,6 +1143,9 @@ std::vector<StructMember> Reflector::ReadStructMembers(
           /*p_byte_length=*/stride * array_elements.value_or(1),
           /*p_array_elements=*/array_elements,
           /*p_element_padding=*/element_padding,
+          /*p_float_type=*/std::nullopt,
+          /*p_vec_size=*/2,
+          /*p_columns=*/1,
       });
       current_byte_offset += stride * array_elements.value_or(1);
       continue;
@@ -1146,6 +1169,9 @@ std::vector<StructMember> Reflector::ReadStructMembers(
           /*p_byte_length=*/stride * array_elements.value_or(1),
           /*p_array_elements=*/array_elements,
           /*p_element_padding=*/element_padding,
+          /*p_float_type=*/std::nullopt,
+          /*p_vec_size=*/3,
+          /*p_columns=*/1,
       });
       current_byte_offset += stride * array_elements.value_or(1);
       continue;
@@ -1169,6 +1195,9 @@ std::vector<StructMember> Reflector::ReadStructMembers(
           /*p_byte_length=*/stride * array_elements.value_or(1),
           /*p_array_elements=*/array_elements,
           /*p_element_padding=*/element_padding,
+          /*p_float_type=*/std::nullopt,
+          /*p_vec_size=*/4,
+          /*p_columns=*/1,
       });
       current_byte_offset += stride * array_elements.value_or(1);
       continue;
@@ -1202,6 +1231,8 @@ std::vector<StructMember> Reflector::ReadStructMembers(
             /*p_array_elements=*/array_elements,
             /*p_element_padding=*/element_padding,
             /*p_float_type=*/float_type,
+            /*p_vec_size=*/1,
+            /*p_columns=*/1,
         });
         current_byte_offset += stride * array_elements.value_or(1);
         continue;

--- a/engine/src/flutter/impeller/compiler/reflector.h
+++ b/engine/src/flutter/impeller/compiler/reflector.h
@@ -40,6 +40,13 @@ struct StructMember {
   std::optional<size_t> array_elements = std::nullopt;
   size_t element_padding = 0u;
   std::optional<std::string> float_type = std::nullopt;
+  // Component count of a single column. For non-matrix types this is the
+  // vector length; for matrices this is the row count. Combined with
+  // `columns`, this disambiguates types that share the same `size`, e.g.
+  // vec4 and mat2.
+  size_t vec_size = 0u;
+  // The number of columns. 1 for scalars and vectors; N for an NxN matrix.
+  size_t columns = 0u;
   UnderlyingType underlying_type = UnderlyingType::kOther;
 
   static std::string BaseTypeToString(spirv_cross::SPIRType::BaseType type) {
@@ -137,6 +144,11 @@ struct StructMember {
   /// @param p_element_padding The padding in bytes after each array
   /// element to satisfy alignment requirements (stride - size).
   /// @param p_float_type The float type of the member.
+  /// @param p_vec_size The component count of a single column (vector
+  /// length for non-matrix types, row count for matrices). 0 if not
+  /// applicable.
+  /// @param p_columns The number of columns. 1 for scalars and vectors;
+  /// N for an NxN matrix. 0 if not applicable.
   /// @param p_underlying_type The underlying type category, used for
   /// runtime validation.
   StructMember(std::string p_type,
@@ -148,6 +160,8 @@ struct StructMember {
                std::optional<size_t> p_array_elements,
                size_t p_element_padding,
                std::optional<std::string> p_float_type = std::nullopt,
+               size_t p_vec_size = 0u,
+               size_t p_columns = 0u,
                UnderlyingType p_underlying_type = UnderlyingType::kOther)
       : type(std::move(p_type)),
         base_type(p_base_type),
@@ -158,6 +172,8 @@ struct StructMember {
         array_elements(p_array_elements),
         element_padding(p_element_padding),
         float_type(std::move(p_float_type)),
+        vec_size(p_vec_size),
+        columns(p_columns),
         underlying_type(DetermineUnderlyingType(p_base_type)) {}
 };
 

--- a/engine/src/flutter/impeller/compiler/shader_bundle_data.cc
+++ b/engine/src/flutter/impeller/compiler/shader_bundle_data.cc
@@ -189,6 +189,8 @@ ShaderBundleData::CreateFlatbuffer() const {
       field_desc->element_size_in_bytes = field.element_size_in_bytes;
       field_desc->total_size_in_bytes = field.total_size_in_bytes;
       field_desc->array_elements = field.array_elements.value_or(0);
+      field_desc->vec_size = field.vec_size;
+      field_desc->columns = field.columns;
       desc->fields.push_back(std::move(field_desc));
     }
 

--- a/engine/src/flutter/impeller/compiler/shader_bundle_data.h
+++ b/engine/src/flutter/impeller/compiler/shader_bundle_data.h
@@ -25,6 +25,11 @@ class ShaderBundleData {
     size_t element_size_in_bytes = 0u;
     size_t total_size_in_bytes = 0u;
     std::optional<size_t> array_elements = std::nullopt;
+    // Component count of a single column. For non-matrix types this is the
+    // vector length; for matrices this is the row count.
+    size_t vec_size = 0u;
+    // The number of columns. 1 for scalars and vectors; N for an NxN matrix.
+    size_t columns = 0u;
   };
 
   struct ShaderUniformStruct {

--- a/engine/src/flutter/impeller/compiler/shader_bundle_unittests.cc
+++ b/engine/src/flutter/impeller/compiler/shader_bundle_unittests.cc
@@ -8,6 +8,7 @@
 #include "flutter/testing/testing.h"
 #include "impeller/compiler/source_options.h"
 #include "impeller/compiler/types.h"
+#include "impeller/core/shader_types.h"
 #include "impeller/shader_bundle/shader_bundle_flatbuffers.h"
 
 namespace impeller {
@@ -190,6 +191,8 @@ TEST(ShaderBundleTest, GenerateShaderBundleFlatbufferProducesCorrectResult) {
   EXPECT_EQ(mvp->element_size_in_bytes, 64u);
   EXPECT_EQ(mvp->total_size_in_bytes, 64u);
   EXPECT_EQ(mvp->array_elements, 0u);
+  EXPECT_EQ(mvp->vec_size, 4u);
+  EXPECT_EQ(mvp->columns, 4u);
   const auto& color = vert_info->fields[1];
   EXPECT_STREQ(color->name.c_str(), "color");
   EXPECT_EQ(color->type, fb::shaderbundle::UniformDataType::kFloat);
@@ -197,6 +200,8 @@ TEST(ShaderBundleTest, GenerateShaderBundleFlatbufferProducesCorrectResult) {
   EXPECT_EQ(color->element_size_in_bytes, 16u);
   EXPECT_EQ(color->total_size_in_bytes, 16u);
   EXPECT_EQ(color->array_elements, 0u);
+  EXPECT_EQ(color->vec_size, 4u);
+  EXPECT_EQ(color->columns, 1u);
 
   // --------------------------------------------------------------------------
   /// Verify fragment shader.
@@ -212,6 +217,42 @@ TEST(ShaderBundleTest, GenerateShaderBundleFlatbufferProducesCorrectResult) {
 
   // Uniforms.
   ASSERT_EQ(fragment->metal_desktop->inputs.size(), 0u);
+}
+
+TEST(ShaderBundleTest, DeriveShaderFloatTypeFromDimensions) {
+  // Non-float types always map to nullopt.
+  EXPECT_EQ(DeriveShaderFloatType(ShaderType::kSignedInt, 1, 1), std::nullopt);
+  EXPECT_EQ(DeriveShaderFloatType(ShaderType::kUnsignedInt, 4, 1),
+            std::nullopt);
+  EXPECT_EQ(DeriveShaderFloatType(ShaderType::kBoolean, 1, 1), std::nullopt);
+
+  // Scalar and vector floats (columns == 1).
+  EXPECT_EQ(DeriveShaderFloatType(ShaderType::kFloat, 1, 1),
+            ShaderFloatType::kFloat);
+  EXPECT_EQ(DeriveShaderFloatType(ShaderType::kFloat, 2, 1),
+            ShaderFloatType::kVec2);
+  EXPECT_EQ(DeriveShaderFloatType(ShaderType::kFloat, 3, 1),
+            ShaderFloatType::kVec3);
+  EXPECT_EQ(DeriveShaderFloatType(ShaderType::kFloat, 4, 1),
+            ShaderFloatType::kVec4);
+
+  // Square matrices (vec_size == columns).
+  EXPECT_EQ(DeriveShaderFloatType(ShaderType::kFloat, 2, 2),
+            ShaderFloatType::kMat2);
+  EXPECT_EQ(DeriveShaderFloatType(ShaderType::kFloat, 3, 3),
+            ShaderFloatType::kMat3);
+  EXPECT_EQ(DeriveShaderFloatType(ShaderType::kFloat, 4, 4),
+            ShaderFloatType::kMat4);
+
+  // Non-square matrices and unsupported shapes return nullopt.
+  EXPECT_EQ(DeriveShaderFloatType(ShaderType::kFloat, 3, 2), std::nullopt);
+  EXPECT_EQ(DeriveShaderFloatType(ShaderType::kFloat, 2, 3), std::nullopt);
+  EXPECT_EQ(DeriveShaderFloatType(ShaderType::kFloat, 5, 1), std::nullopt);
+
+  // Zero values (legacy bundle defaults) map to nullopt.
+  EXPECT_EQ(DeriveShaderFloatType(ShaderType::kFloat, 0, 0), std::nullopt);
+  EXPECT_EQ(DeriveShaderFloatType(ShaderType::kFloat, 0, 1), std::nullopt);
+  EXPECT_EQ(DeriveShaderFloatType(ShaderType::kFloat, 1, 0), std::nullopt);
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/core/shader_types.h
+++ b/engine/src/flutter/impeller/core/shader_types.h
@@ -82,6 +82,48 @@ struct ShaderStructMemberMetadata {
   std::optional<ShaderFloatType> float_type;
 };
 
+/// @brief Derive the `ShaderFloatType` from the base `ShaderType` and
+///        the (vec_size, columns) dimensions reported by SPIR-V Cross.
+///
+/// `vec_size` is the component count of a single column (the vector length
+/// for non-matrix types, the row count for matrices). `columns` is 1 for
+/// vectors and N for an NxN matrix. Returns `std::nullopt` for non-float
+/// types and for shapes that don't map to a `ShaderFloatType`.
+constexpr std::optional<ShaderFloatType> DeriveShaderFloatType(ShaderType type,
+                                                               size_t vec_size,
+                                                               size_t columns) {
+  if (type != ShaderType::kFloat) {
+    return std::nullopt;
+  }
+  if (columns == 1) {
+    switch (vec_size) {
+      case 1:
+        return ShaderFloatType::kFloat;
+      case 2:
+        return ShaderFloatType::kVec2;
+      case 3:
+        return ShaderFloatType::kVec3;
+      case 4:
+        return ShaderFloatType::kVec4;
+      default:
+        return std::nullopt;
+    }
+  }
+  if (vec_size == columns) {
+    switch (vec_size) {
+      case 2:
+        return ShaderFloatType::kMat2;
+      case 3:
+        return ShaderFloatType::kMat3;
+      case 4:
+        return ShaderFloatType::kMat4;
+      default:
+        return std::nullopt;
+    }
+  }
+  return std::nullopt;
+}
+
 struct ShaderMetadata {
   // This must match the uniform name in the shader program.
   std::string name;

--- a/engine/src/flutter/impeller/entity/contents/runtime_effect_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/runtime_effect_contents.cc
@@ -118,38 +118,9 @@ static std::unique_ptr<ShaderMetadata> MakeShaderMetadata(
   size_t member_size = uniform.dimensions.rows * uniform.dimensions.cols *
                        (uniform.bit_width / 8u);
 
-  ShaderType shader_type = GetShaderType(uniform.type);
-  std::optional<ShaderFloatType> float_type;
-  if (shader_type == ShaderType::kFloat) {
-    if (uniform.dimensions.cols == 1) {
-      switch (uniform.dimensions.rows) {
-        case 1:
-          float_type = ShaderFloatType::kFloat;
-          break;
-        case 2:
-          float_type = ShaderFloatType::kVec2;
-          break;
-        case 3:
-          float_type = ShaderFloatType::kVec3;
-          break;
-        case 4:
-          float_type = ShaderFloatType::kVec4;
-          break;
-      }
-    } else if (uniform.dimensions.rows == uniform.dimensions.cols) {
-      switch (uniform.dimensions.rows) {
-        case 2:
-          float_type = ShaderFloatType::kMat2;
-          break;
-        case 3:
-          float_type = ShaderFloatType::kMat3;
-          break;
-        case 4:
-          float_type = ShaderFloatType::kMat4;
-          break;
-      }
-    }
-  }
+  const ShaderType shader_type = GetShaderType(uniform.type);
+  const std::optional<ShaderFloatType> float_type = DeriveShaderFloatType(
+      shader_type, uniform.dimensions.rows, uniform.dimensions.cols);
 
   metadata->members.emplace_back(ShaderStructMemberMetadata{
       .type = shader_type,                                      //

--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.h
@@ -20,6 +20,7 @@ namespace testing {
 FML_TEST_CLASS(BufferBindingsGLESTest, BindUniformData);
 FML_TEST_CLASS(BufferBindingsGLESTest, BindArrayData);
 FML_TEST_CLASS(BufferBindingsGLESTest, BindUniformDataVerticesAndMatrices);
+FML_TEST_CLASS(BufferBindingsGLESTest, BindUniformFailsWithoutFloatType);
 }  // namespace testing
 
 //------------------------------------------------------------------------------
@@ -56,6 +57,8 @@ class BufferBindingsGLES {
   FML_FRIEND_TEST(testing::BufferBindingsGLESTest, BindArrayData);
   FML_FRIEND_TEST(testing::BufferBindingsGLESTest,
                   BindUniformDataVerticesAndMatrices);
+  FML_FRIEND_TEST(testing::BufferBindingsGLESTest,
+                  BindUniformFailsWithoutFloatType);
   //----------------------------------------------------------------------------
   /// @brief      The arguments to glVertexAttribPointer.
   ///

--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles_unittests.cc
@@ -146,5 +146,43 @@ TEST(BufferBindingsGLESTest, BindUniformDataVerticesAndMatrices) {
                                        Range{0, 1}));
 }
 
+// Regression guard: a float uniform that arrives at the GLES backend without
+// `float_type` populated must be rejected rather than silently dispatched to
+// the wrong glUniform call. This is the fault mode that motivated the schema
+// extension; if a future change forgets to populate `float_type` (in the
+// shader bundle loader, runtime effects, or anywhere else), this test
+// catches it at unit-test time instead of at runtime.
+TEST(BufferBindingsGLESTest, BindUniformFailsWithoutFloatType) {
+  BufferBindingsGLES bindings;
+  absl::flat_hash_map<std::string, GLint> uniform_bindings;
+  uniform_bindings["SHADERMETADATA.FOOBAR"] = 1;
+  bindings.SetUniformBindings(std::move(uniform_bindings));
+  auto mock_gles_impl = std::make_unique<MockGLESImpl>();
+  std::shared_ptr<MockGLES> mock_gl = MockGLES::Init(std::move(mock_gles_impl));
+  std::vector<BufferResource> bound_buffers;
+  std::vector<TextureAndSampler> bound_textures;
+
+  ShaderMetadata shader_metadata = {
+      .name = "shader_metadata",
+      .members = {ShaderStructMemberMetadata{.type = ShaderType::kFloat,
+                                             .name = "foobar",
+                                             .offset = 0,
+                                             .size = sizeof(float),
+                                             .byte_length = sizeof(float),
+                                             .array_elements = std::nullopt,
+                                             .float_type = std::nullopt}}};
+  std::shared_ptr<ReactorGLES> reactor;
+  auto backing_store = std::make_unique<Allocation>();
+  ASSERT_TRUE(backing_store->Truncate(Bytes{sizeof(float)}));
+  DeviceBufferGLES device_buffer(DeviceBufferDescriptor{.size = sizeof(float)},
+                                 reactor, std::move(backing_store));
+  BufferView buffer_view(&device_buffer, Range(0, sizeof(float)));
+  bound_buffers.push_back(BufferResource(&shader_metadata, buffer_view));
+
+  EXPECT_FALSE(bindings.BindUniformData(mock_gl->GetProcTable(), bound_textures,
+                                        bound_buffers, Range{0, 0},
+                                        Range{0, 1}));
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/engine/src/flutter/impeller/shader_bundle/shader_bundle.fbs
+++ b/engine/src/flutter/impeller/shader_bundle/shader_bundle.fbs
@@ -8,7 +8,7 @@ namespace impeller.fb.shaderbundle;
 // incremented any time there is a change to this file which changes the
 // resulting flat buffer format.
 enum ShaderBundleFormatVersion:uint32 {
-  kVersion = 1
+  kVersion = 2
 }
 
 enum ShaderStage:byte {
@@ -71,6 +71,13 @@ table ShaderUniformStructField {
   total_size_in_bytes: uint64;
   // Zero indicates that this field is not an array element.
   array_elements: uint64;
+  // The number of components per column. For a vector this is the vector
+  // length; for a matrix this is the row count. Combined with `columns`, this
+  // disambiguates types that share the same `element_size_in_bytes`, e.g.
+  // vec4 and mat2.
+  vec_size: uint64;
+  // The number of columns. 1 for scalars and vectors; N for an NxN matrix.
+  columns: uint64;
 }
 
 table ShaderUniformStruct {

--- a/engine/src/flutter/lib/gpu/shader_library.cc
+++ b/engine/src/flutter/lib/gpu/shader_library.cc
@@ -190,7 +190,11 @@ fml::RefPtr<ShaderLibrary> ShaderLibrary::MakeFromFlatbuffer(
       impeller::fb::shaderbundle::ShaderBundleFormatVersion::kVersion);
   if (version != expected) {
     VALIDATION_LOG << "Unsupported shader bundle format version: " << version
-                   << ", expected: " << expected;
+                   << ", expected: " << expected
+                   << ". This shader bundle was compiled with an incompatible "
+                      "version of impellerc. Please rebuild the shader bundle "
+                      "with the version of impellerc that ships with the "
+                      "current Flutter SDK.";
     return nullptr;
   }
 
@@ -219,8 +223,10 @@ fml::RefPtr<ShaderLibrary> ShaderLibrary::MakeFromFlatbuffer(
         std::vector<impeller::ShaderStructMemberMetadata> members;
         if (uniform->fields() != nullptr) {
           for (const auto& struct_member : *uniform->fields()) {
+            const impeller::ShaderType type =
+                FromUniformType(struct_member->type());
             members.push_back(impeller::ShaderStructMemberMetadata{
-                .type = FromUniformType(struct_member->type()),
+                .type = type,
                 .name = struct_member->name()->c_str(),
                 .offset = static_cast<size_t>(struct_member->offset_in_bytes()),
                 .size =
@@ -231,6 +237,9 @@ fml::RefPtr<ShaderLibrary> ShaderLibrary::MakeFromFlatbuffer(
                     struct_member->array_elements() == 0
                         ? std::optional<size_t>(std::nullopt)
                         : static_cast<size_t>(struct_member->array_elements()),
+                .float_type = impeller::DeriveShaderFloatType(
+                    type, static_cast<size_t>(struct_member->vec_size()),
+                    static_cast<size_t>(struct_member->columns())),
             });
           }
         }

--- a/engine/src/flutter/testing/dart/gpu_test.dart
+++ b/engine/src/flutter/testing/dart/gpu_test.dart
@@ -566,67 +566,57 @@ void main() async {
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   // Renders a green triangle pointing downwards.
-  test(
-    'Can render triangle',
-    () async {
-      final RenderPassState state = createSimpleRenderPass();
-      drawTriangle(state, Colors.lime);
-      state.commandBuffer.submit();
+  test('Can render triangle', () async {
+    final RenderPassState state = createSimpleRenderPass();
+    drawTriangle(state, Colors.lime);
+    state.commandBuffer.submit();
 
-      final ui.Image image = state.renderTexture.asImage();
-      await comparer.addGoldenImage(image, 'flutter_gpu_test_triangle.png');
-    },
-    // TODO(b-luk): https://github.com/flutter/flutter/issues/183530 Re-enable for opengles.
-    skip: !(impellerEnabled && flutterGpuEnabled) || impellerBackend == 'opengles',
-  );
+    final ui.Image image = state.renderTexture.asImage();
+    await comparer.addGoldenImage(image, 'flutter_gpu_test_triangle.png');
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   // Renders a green triangle pointing downwards using polygon mode line.
-  test(
-    'Can render triangle with polygon mode line.',
-    () async {
-      final RenderPassState state = createSimpleRenderPass();
+  test('Can render triangle with polygon mode line.', () async {
+    final RenderPassState state = createSimpleRenderPass();
 
-      final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
-      state.renderPass.bindPipeline(pipeline);
+    final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
+    state.renderPass.bindPipeline(pipeline);
 
-      // Configure blending with defaults (just to test the bindings).
-      state.renderPass.setColorBlendEnable(true);
-      state.renderPass.setColorBlendEquation(gpu.ColorBlendEquation());
+    // Configure blending with defaults (just to test the bindings).
+    state.renderPass.setColorBlendEnable(true);
+    state.renderPass.setColorBlendEquation(gpu.ColorBlendEquation());
 
-      // Set polygon mode.
-      state.renderPass.setPolygonMode(gpu.PolygonMode.line);
+    // Set polygon mode.
+    state.renderPass.setPolygonMode(gpu.PolygonMode.line);
 
-      final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
-      final gpu.BufferView vertices = transients.emplace(
-        float32(<double>[
-          -0.5, 0.5, //
-          0.0, -0.5, //
-          0.5, 0.5, //
-        ]),
-      );
-      final gpu.BufferView vertInfoData = transients.emplace(
-        float32(<double>[
-          1, 0, 0, 0, // mvp
-          0, 1, 0, 0, // mvp
-          0, 0, 1, 0, // mvp
-          0, 0, 0, 1, // mvp
-          0, 1, 0, 1, // color
-        ]),
-      );
-      state.renderPass.bindVertexBuffer(vertices, 3);
+    final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
+    final gpu.BufferView vertices = transients.emplace(
+      float32(<double>[
+        -0.5, 0.5, //
+        0.0, -0.5, //
+        0.5, 0.5, //
+      ]),
+    );
+    final gpu.BufferView vertInfoData = transients.emplace(
+      float32(<double>[
+        1, 0, 0, 0, // mvp
+        0, 1, 0, 0, // mvp
+        0, 0, 1, 0, // mvp
+        0, 0, 0, 1, // mvp
+        0, 1, 0, 1, // color
+      ]),
+    );
+    state.renderPass.bindVertexBuffer(vertices, 3);
 
-      final gpu.UniformSlot vertInfo = pipeline.vertexShader.getUniformSlot('VertInfo');
-      state.renderPass.bindUniform(vertInfo, vertInfoData);
-      state.renderPass.draw();
+    final gpu.UniformSlot vertInfo = pipeline.vertexShader.getUniformSlot('VertInfo');
+    state.renderPass.bindUniform(vertInfo, vertInfoData);
+    state.renderPass.draw();
 
-      state.commandBuffer.submit();
+    state.commandBuffer.submit();
 
-      final ui.Image image = state.renderTexture.asImage();
-      await comparer.addGoldenImage(image, 'flutter_gpu_test_triangle_polygon_mode.png');
-    },
-    // TODO(b-luk): https://github.com/flutter/flutter/issues/183530 Re-enable for opengles.
-    skip: !(impellerEnabled && flutterGpuEnabled) || impellerBackend == 'opengles',
-  );
+    final ui.Image image = state.renderTexture.asImage();
+    await comparer.addGoldenImage(image, 'flutter_gpu_test_triangle_polygon_mode.png');
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   // Renders a green triangle pointing downwards, with 4xMSAA.
   test(
@@ -639,10 +629,7 @@ void main() async {
       final ui.Image image = state.renderTexture.asImage();
       await comparer.addGoldenImage(image, 'flutter_gpu_test_triangle_msaa.png');
     },
-    // TODO(b-luk): https://github.com/flutter/flutter/issues/183530 Re-enable for opengles.
-    skip:
-        !(impellerEnabled && flutterGpuEnabled && gpu.gpuContext.doesSupportOffscreenMSAA) ||
-        impellerBackend == 'opengles',
+    skip: !(impellerEnabled && flutterGpuEnabled && gpu.gpuContext.doesSupportOffscreenMSAA),
   );
 
   test(
@@ -666,141 +653,131 @@ void main() async {
   );
 
   // Renders a hollow green triangle pointing downwards.
-  test(
-    'Can render hollowed out triangle using stencil ops',
-    () async {
-      final RenderPassState state = createSimpleRenderPass();
+  test('Can render hollowed out triangle using stencil ops', () async {
+    final RenderPassState state = createSimpleRenderPass();
 
-      final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
-      state.renderPass.bindPipeline(pipeline);
+    final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
+    state.renderPass.bindPipeline(pipeline);
 
-      // Configure blending with defaults (just to test the bindings).
-      state.renderPass.setColorBlendEnable(true);
-      state.renderPass.setColorBlendEquation(gpu.ColorBlendEquation());
+    // Configure blending with defaults (just to test the bindings).
+    state.renderPass.setColorBlendEnable(true);
+    state.renderPass.setColorBlendEquation(gpu.ColorBlendEquation());
 
-      final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
-      final gpu.BufferView vertices = transients.emplace(
-        float32(<double>[
-          -0.5, 0.5, //
-          0.0, -0.5, //
-          0.5, 0.5, //
-        ]),
-      );
-      final gpu.BufferView innerClipVertInfo = transients.emplace(
-        float32(<double>[
-          0.5, 0, 0, 0, // mvp
-          0, 0.5, 0, 0, // mvp
-          0, 0, 0.5, 0, // mvp
-          0, 0, 0, 1, // mvp
-          0, 1, 0, 1, // color
-        ]),
-      );
-      final gpu.BufferView outerGreenVertInfo = transients.emplace(
-        float32(<double>[
-          1, 0, 0, 0, // mvp
-          0, 1, 0, 0, // mvp
-          0, 0, 1, 0, // mvp
-          0, 0, 0, 1, // mvp
-          0, 1, 0, 1, // color
-        ]),
-      );
-      state.renderPass.bindVertexBuffer(vertices, 3);
-
-      final gpu.UniformSlot vertInfo = pipeline.vertexShader.getUniformSlot('VertInfo');
-
-      // First, punch out a scaled down triangle in the stencil buffer.
-      // Since the stencil buffer is initialized to 0, we set the stencil ref to 1
-      // and the compare to `equial`, which will result in the stencil test
-      // failing. But on failure, we increment the stencil in order to punch out
-      // the triangle.
-
-      state.renderPass.bindUniform(vertInfo, innerClipVertInfo);
-      state.renderPass.setStencilReference(1);
-      state.renderPass.setStencilConfig(
-        gpu.StencilConfig(
-          compareFunction: gpu.CompareFunction.equal,
-          stencilFailureOperation: gpu.StencilOperation.incrementClamp,
-        ),
-      );
-      state.renderPass.draw();
-
-      // Next, render the outer triangle with the stencil ref set to zero, so that
-      // the stencil test passes everywhere except where the inner triangle was
-      // punched out.
-
-      state.renderPass.setStencilReference(0);
-      // Set the stencil config to turn off the increment. For this golden test
-      // we technically don't need to do this, but we do it here just to exercise
-      // the API.
-      state.renderPass.setStencilConfig(
-        gpu.StencilConfig(compareFunction: gpu.CompareFunction.equal),
-      );
-      state.renderPass.bindUniform(vertInfo, outerGreenVertInfo);
-      state.renderPass.draw();
-
-      state.commandBuffer.submit();
-
-      final ui.Image image = state.renderTexture.asImage();
-      await comparer.addGoldenImage(image, 'flutter_gpu_test_triangle_stencil.png');
-    },
-    // TODO(b-luk): https://github.com/flutter/flutter/issues/183530 Re-enable for opengles.
-    skip: !(impellerEnabled && flutterGpuEnabled) || impellerBackend == 'opengles',
-  );
-
-  test(
-    'Drawing respects cull mode',
-    () async {
-      final RenderPassState state = createSimpleRenderPass();
-
-      final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
-      state.renderPass.bindPipeline(pipeline);
-
-      state.renderPass.setColorBlendEnable(true);
-      state.renderPass.setColorBlendEquation(gpu.ColorBlendEquation());
-
-      final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
-      // Counter-clockwise triangle.
-      final triangle = <double>[
+    final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
+    final gpu.BufferView vertices = transients.emplace(
+      float32(<double>[
         -0.5, 0.5, //
         0.0, -0.5, //
         0.5, 0.5, //
-      ];
-      final gpu.BufferView vertices = transients.emplace(float32(triangle));
+      ]),
+    );
+    final gpu.BufferView innerClipVertInfo = transients.emplace(
+      float32(<double>[
+        0.5, 0, 0, 0, // mvp
+        0, 0.5, 0, 0, // mvp
+        0, 0, 0.5, 0, // mvp
+        0, 0, 0, 1, // mvp
+        0, 1, 0, 1, // color
+      ]),
+    );
+    final gpu.BufferView outerGreenVertInfo = transients.emplace(
+      float32(<double>[
+        1, 0, 0, 0, // mvp
+        0, 1, 0, 0, // mvp
+        0, 0, 1, 0, // mvp
+        0, 0, 0, 1, // mvp
+        0, 1, 0, 1, // color
+      ]),
+    );
+    state.renderPass.bindVertexBuffer(vertices, 3);
 
-      void drawTriangle(Vector4 color) {
-        final gpu.BufferView vertInfoUboFront = transients.emplace(
-          unlitUBO(Matrix4.identity(), color),
-        );
+    final gpu.UniformSlot vertInfo = pipeline.vertexShader.getUniformSlot('VertInfo');
 
-        final gpu.UniformSlot vertInfo = pipeline.vertexShader.getUniformSlot('VertInfo');
-        state.renderPass.bindVertexBuffer(vertices, 3);
-        state.renderPass.bindUniform(vertInfo, vertInfoUboFront);
-        state.renderPass.draw();
-      }
+    // First, punch out a scaled down triangle in the stencil buffer.
+    // Since the stencil buffer is initialized to 0, we set the stencil ref to 1
+    // and the compare to `equial`, which will result in the stencil test
+    // failing. But on failure, we increment the stencil in order to punch out
+    // the triangle.
 
-      // Draw the green rectangle.
-      // Defaults to clockwise winding order. So frontface culling should not
-      // impact the green triangle.
-      state.renderPass.setCullMode(gpu.CullMode.frontFace);
-      drawTriangle(Colors.lime);
+    state.renderPass.bindUniform(vertInfo, innerClipVertInfo);
+    state.renderPass.setStencilReference(1);
+    state.renderPass.setStencilConfig(
+      gpu.StencilConfig(
+        compareFunction: gpu.CompareFunction.equal,
+        stencilFailureOperation: gpu.StencilOperation.incrementClamp,
+      ),
+    );
+    state.renderPass.draw();
 
-      // Backface cull a red triangle.
-      state.renderPass.setCullMode(gpu.CullMode.backFace);
-      drawTriangle(Colors.red);
+    // Next, render the outer triangle with the stencil ref set to zero, so that
+    // the stencil test passes everywhere except where the inner triangle was
+    // punched out.
 
-      // Invert the winding mode and frontface cull a red rectangle.
-      state.renderPass.setWindingOrder(gpu.WindingOrder.counterClockwise);
-      state.renderPass.setCullMode(gpu.CullMode.frontFace);
-      drawTriangle(Colors.red);
+    state.renderPass.setStencilReference(0);
+    // Set the stencil config to turn off the increment. For this golden test
+    // we technically don't need to do this, but we do it here just to exercise
+    // the API.
+    state.renderPass.setStencilConfig(
+      gpu.StencilConfig(compareFunction: gpu.CompareFunction.equal),
+    );
+    state.renderPass.bindUniform(vertInfo, outerGreenVertInfo);
+    state.renderPass.draw();
 
-      state.commandBuffer.submit();
+    state.commandBuffer.submit();
 
-      final ui.Image image = state.renderTexture.asImage();
-      await comparer.addGoldenImage(image, 'flutter_gpu_test_cull_mode.png');
-    },
-    // TODO(b-luk): https://github.com/flutter/flutter/issues/183530 Re-enable for opengles.
-    skip: !(impellerEnabled && flutterGpuEnabled) || impellerBackend == 'opengles',
-  );
+    final ui.Image image = state.renderTexture.asImage();
+    await comparer.addGoldenImage(image, 'flutter_gpu_test_triangle_stencil.png');
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  test('Drawing respects cull mode', () async {
+    final RenderPassState state = createSimpleRenderPass();
+
+    final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
+    state.renderPass.bindPipeline(pipeline);
+
+    state.renderPass.setColorBlendEnable(true);
+    state.renderPass.setColorBlendEquation(gpu.ColorBlendEquation());
+
+    final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
+    // Counter-clockwise triangle.
+    final triangle = <double>[
+      -0.5, 0.5, //
+      0.0, -0.5, //
+      0.5, 0.5, //
+    ];
+    final gpu.BufferView vertices = transients.emplace(float32(triangle));
+
+    void drawTriangle(Vector4 color) {
+      final gpu.BufferView vertInfoUboFront = transients.emplace(
+        unlitUBO(Matrix4.identity(), color),
+      );
+
+      final gpu.UniformSlot vertInfo = pipeline.vertexShader.getUniformSlot('VertInfo');
+      state.renderPass.bindVertexBuffer(vertices, 3);
+      state.renderPass.bindUniform(vertInfo, vertInfoUboFront);
+      state.renderPass.draw();
+    }
+
+    // Draw the green rectangle.
+    // Defaults to clockwise winding order. So frontface culling should not
+    // impact the green triangle.
+    state.renderPass.setCullMode(gpu.CullMode.frontFace);
+    drawTriangle(Colors.lime);
+
+    // Backface cull a red triangle.
+    state.renderPass.setCullMode(gpu.CullMode.backFace);
+    drawTriangle(Colors.red);
+
+    // Invert the winding mode and frontface cull a red rectangle.
+    state.renderPass.setWindingOrder(gpu.WindingOrder.counterClockwise);
+    state.renderPass.setCullMode(gpu.CullMode.frontFace);
+    drawTriangle(Colors.red);
+
+    state.commandBuffer.submit();
+
+    final ui.Image image = state.renderTexture.asImage();
+    await comparer.addGoldenImage(image, 'flutter_gpu_test_cull_mode.png');
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   // Renders a hexagon using line strip primitive type.
   test(
@@ -857,56 +834,50 @@ void main() async {
       final ui.Image image = state.renderTexture.asImage();
       await comparer.addGoldenImage(image, 'flutter_gpu_test_hexgon_line_strip.png');
     },
-    // TODO(b-luk): https://github.com/flutter/flutter/issues/183530 Re-enable for opengles.
-    skip: !(impellerEnabled && flutterGpuEnabled) || impellerBackend == 'opengles',
+    skip: !(impellerEnabled && flutterGpuEnabled),
   );
 
   // Renders the middle part triangle using scissor.
-  test(
-    'Can render portion of the triangle using scissor',
-    () async {
-      final RenderPassState state = createSimpleRenderPass();
+  test('Can render portion of the triangle using scissor', () async {
+    final RenderPassState state = createSimpleRenderPass();
 
-      final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
-      state.renderPass.bindPipeline(pipeline);
+    final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
+    state.renderPass.bindPipeline(pipeline);
 
-      // Configure blending with defaults (just to test the bindings).
-      state.renderPass.setColorBlendEnable(true);
-      state.renderPass.setColorBlendEquation(gpu.ColorBlendEquation());
+    // Configure blending with defaults (just to test the bindings).
+    state.renderPass.setColorBlendEnable(true);
+    state.renderPass.setColorBlendEquation(gpu.ColorBlendEquation());
 
-      // Set primitive type.
-      state.renderPass.setPrimitiveType(gpu.PrimitiveType.triangle);
+    // Set primitive type.
+    state.renderPass.setPrimitiveType(gpu.PrimitiveType.triangle);
 
-      // Set scissor.
-      state.renderPass.setScissor(gpu.Scissor(x: 25, width: 50, height: 100));
+    // Set scissor.
+    state.renderPass.setScissor(gpu.Scissor(x: 25, width: 50, height: 100));
 
-      final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
-      final gpu.BufferView vertices = transients.emplace(
-        float32(<double>[-1.0, -1.0, 0.0, 1.0, 1.0, -1.0]),
-      );
-      final gpu.BufferView vertInfoData = transients.emplace(
-        float32(<double>[
-          1, 0, 0, 0, // mvp
-          0, 1, 0, 0, // mvp
-          0, 0, 1, 0, // mvp
-          0, 0, 0, 1, // mvp
-          0, 1, 0, 1, // color
-        ]),
-      );
-      state.renderPass.bindVertexBuffer(vertices, 3);
+    final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
+    final gpu.BufferView vertices = transients.emplace(
+      float32(<double>[-1.0, -1.0, 0.0, 1.0, 1.0, -1.0]),
+    );
+    final gpu.BufferView vertInfoData = transients.emplace(
+      float32(<double>[
+        1, 0, 0, 0, // mvp
+        0, 1, 0, 0, // mvp
+        0, 0, 1, 0, // mvp
+        0, 0, 0, 1, // mvp
+        0, 1, 0, 1, // color
+      ]),
+    );
+    state.renderPass.bindVertexBuffer(vertices, 3);
 
-      final gpu.UniformSlot vertInfo = pipeline.vertexShader.getUniformSlot('VertInfo');
-      state.renderPass.bindUniform(vertInfo, vertInfoData);
-      state.renderPass.draw();
+    final gpu.UniformSlot vertInfo = pipeline.vertexShader.getUniformSlot('VertInfo');
+    state.renderPass.bindUniform(vertInfo, vertInfoData);
+    state.renderPass.draw();
 
-      state.commandBuffer.submit();
+    state.commandBuffer.submit();
 
-      final ui.Image image = state.renderTexture.asImage();
-      await comparer.addGoldenImage(image, 'flutter_gpu_test_scissor.png');
-    },
-    // TODO(b-luk): https://github.com/flutter/flutter/issues/183530 Re-enable for opengles.
-    skip: !(impellerEnabled && flutterGpuEnabled) || impellerBackend == 'opengles',
-  );
+    final ui.Image image = state.renderTexture.asImage();
+    await comparer.addGoldenImage(image, 'flutter_gpu_test_scissor.png');
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   test(
     'RenderPass.setScissor doesnt throw for valid values',
@@ -967,49 +938,44 @@ void main() async {
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   // Renders the middle part triangle using viewport.
-  test(
-    'Can render portion of the triangle using viewport',
-    () async {
-      final RenderPassState state = createSimpleRenderPass();
+  test('Can render portion of the triangle using viewport', () async {
+    final RenderPassState state = createSimpleRenderPass();
 
-      final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
-      state.renderPass.bindPipeline(pipeline);
+    final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
+    state.renderPass.bindPipeline(pipeline);
 
-      // Configure blending with defaults (just to test the bindings).
-      state.renderPass.setColorBlendEnable(true);
-      state.renderPass.setColorBlendEquation(gpu.ColorBlendEquation());
+    // Configure blending with defaults (just to test the bindings).
+    state.renderPass.setColorBlendEnable(true);
+    state.renderPass.setColorBlendEquation(gpu.ColorBlendEquation());
 
-      // Set primitive type.
-      state.renderPass.setPrimitiveType(gpu.PrimitiveType.triangle);
+    // Set primitive type.
+    state.renderPass.setPrimitiveType(gpu.PrimitiveType.triangle);
 
-      // Set viewport.
-      state.renderPass.setViewport(gpu.Viewport(x: 25, width: 50, height: 100));
+    // Set viewport.
+    state.renderPass.setViewport(gpu.Viewport(x: 25, width: 50, height: 100));
 
-      final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
-      final gpu.BufferView vertices = transients.emplace(
-        float32(<double>[-1.0, -1.0, 0.0, 1.0, 1.0, -1.0]),
-      );
-      final gpu.BufferView vertInfoData = transients.emplace(
-        float32(<double>[
-          1, 0, 0, 0, // mvp
-          0, 1, 0, 0, // mvp
-          0, 0, 1, 0, // mvp
-          0, 0, 0, 1, // mvp
-          0, 1, 0, 1, // color
-        ]),
-      );
-      state.renderPass.bindVertexBuffer(vertices, 3);
+    final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
+    final gpu.BufferView vertices = transients.emplace(
+      float32(<double>[-1.0, -1.0, 0.0, 1.0, 1.0, -1.0]),
+    );
+    final gpu.BufferView vertInfoData = transients.emplace(
+      float32(<double>[
+        1, 0, 0, 0, // mvp
+        0, 1, 0, 0, // mvp
+        0, 0, 1, 0, // mvp
+        0, 0, 0, 1, // mvp
+        0, 1, 0, 1, // color
+      ]),
+    );
+    state.renderPass.bindVertexBuffer(vertices, 3);
 
-      final gpu.UniformSlot vertInfo = pipeline.vertexShader.getUniformSlot('VertInfo');
-      state.renderPass.bindUniform(vertInfo, vertInfoData);
-      state.renderPass.draw();
+    final gpu.UniformSlot vertInfo = pipeline.vertexShader.getUniformSlot('VertInfo');
+    state.renderPass.bindUniform(vertInfo, vertInfoData);
+    state.renderPass.draw();
 
-      state.commandBuffer.submit();
+    state.commandBuffer.submit();
 
-      final ui.Image image = state.renderTexture.asImage();
-      await comparer.addGoldenImage(image, 'flutter_gpu_test_viewport.png');
-    },
-    // TODO(b-luk): https://github.com/flutter/flutter/issues/183530 Re-enable for opengles.
-    skip: !(impellerEnabled && flutterGpuEnabled) || impellerBackend == 'opengles',
-  );
+    final ui.Image image = state.renderTexture.asImage();
+    await comparer.addGoldenImage(image, 'flutter_gpu_test_viewport.png');
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
 }


### PR DESCRIPTION
Flutter GPU shader bundles serialize uniform struct field metadata via a flatbuffer schema (`shader_bundle.fbs`) that carries per-field type and size information, but does not carry the underlying vector/column dimensions. This is enough to bind uniforms on Metal and Vulkan, but it isn't enough to distinguish shapes that share the same `element_size_in_bytes`, most notably `vec4` vs `mat2`. The GLES backend uses `ShaderStructMemberMetadata::float_type` to pick the right `glUniform*` call, and the bundle loader had no way to populate it.

PR #182229 ("Turns on most of fragment_shader_test.dart for opengles") introduced `ShaderFloatType`, the GLES validation that requires it, and the fix for runtime effect shaders (`runtime_effect_contents.cc`), but the equivalent fix for the Flutter GPU shader bundle loader (`lib/gpu/shader_library.cc`) was not made. As a result, every flutter_gpu app with a uniform block crashes the GLES backend on all platforms (Windows ANGLE, Linux GLES, Android GLES) with:

```
[ERROR:flutter/impeller/renderer/backend/gles/buffer_bindings_gles.cc(409)]
Break on 'ImpellerValidationBreak' to inspect point of failure: Float uniform should have a float type.
```

## Approach

The size-only signal already carried by the bundle is not sufficient to derive `float_type` correctly for `mat2` and `mat3`, which would otherwise collide with `vec2` arrays and `vec3` arrays. (impellerc serializes a `mat2` uniform with `element_size_in_bytes = 8` and `array_elements = 2`, which is the same shape as a length-2 `vec2` array. Same story for `mat3`.) To fix this without regressing matrix-typed uniforms, this PR extends the schema to carry `vec_size` and `columns` (matching what `ShaderInput` already does for vertex inputs), and uses them to derive `float_type` in the bundle loader via the same shape-based dispatch that runtime effects already use.

The shader bundle format version is bumped from 1 to 2 because old bundles do not carry the new fields. Old bundles loaded against a new engine fail with a clear error pointing at the impellerc/SDK version mismatch, rather than silently rendering with the wrong `glUniform*` call.

## Tests

- `shader_bundle_unittests.cc`: verify the bundle carries `vec_size` and `columns` for the existing `mvp` (mat4) and `color` (vec4) test fixtures. Exhaustively cover `DeriveShaderFloatType` for float scalars, all vector sizes, all square matrices, non-square shapes, non-float types, and zero (legacy bundle) values.
- `buffer_bindings_gles_unittests.cc`: regression guard asserting that the GLES backend rejects a float uniform that arrives without `float_type` populated. If a future change forgets to populate `float_type` in any code path (shader bundle loader, runtime effects, or anything else), this test catches it at unit-test time instead of at runtime.
- `gpu_test.dart`: the eight re-enabled tests cover triangle rendering, polygon mode, MSAA, indexed draw, stencil, cull mode, scissor, and viewport on the opengles backend, end-to-end through the bundle loader.

## Issues

Fixes #184953
Fixes #183530

May also resolve the following issues, all of which surface as GLES uniform binding failures and share the same root-cause family. To be verified against the linked reproducers after merge:

- #176875
- #164438
- #164745

This supersedes the smaller fix in [`bdero/flutter-gpu-float-types`](https://github.com/bdero/flutter/tree/bdero/flutter-gpu-float-types) (draft #185874), which derived `float_type` from `element_size_in_bytes` only and would have misclassified `mat2`/`mat3` as `vec2`/`vec3`.