### PR TITLE
[Impeller] Vulkan: don't drop user-supplied viewport X, Y, and depth range

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles_unittests.cc
@@ -350,5 +350,29 @@ TEST_F(RenderPassGLESViewportTest,
   EXPECT_TRUE(reactor->React());
 }
 
+// Sibling regression guard for the bug fixed alongside this test on the
+// Vulkan backend. The GLES backend has always honored the X offset; this
+// asserts that explicitly so a future change can't silently regress it.
+TEST_F(RenderPassGLESViewportTest, ViewportWithNonZeroXOffsetReachesGL) {
+  auto ctx = CreateRenderPassGLESContext();
+  testing::NiceMock<MockGLESImpl>& mock_gl_impl_ref = ctx.mock_gl_impl_ref;
+  std::shared_ptr<RenderPass>& render_pass = ctx.render_pass;
+  std::shared_ptr<PipelineGLES>& pipeline = ctx.pipeline;
+  std::shared_ptr<ReactorGLES>& reactor = ctx.reactor;
+
+  render_pass->SetPipeline(PipelineRef(pipeline));
+  render_pass->SetElementCount(1);
+  render_pass->SetIndexBuffer({}, IndexType::kNone);
+  render_pass->SetViewport(
+      Viewport{Rect::MakeXYWH(25, 0, 50, 100), DepthRange{0.0f, 1.0f}});
+  EXPECT_TRUE(render_pass->Draw().ok());
+
+  EXPECT_CALL(mock_gl_impl_ref, Viewport(_, _, _, _)).Times(0);
+  EXPECT_CALL(mock_gl_impl_ref, Viewport(25, 0, 50, 100)).Times(1);
+
+  EXPECT_TRUE(render_pass->EncodeCommands());
+  EXPECT_TRUE(reactor->React());
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -49,6 +49,22 @@ static vk::ClearDepthStencilValue VKClearValueFromDepthStencil(uint32_t stencil,
   return value;
 }
 
+/// Converts an Impeller `Viewport` to a `vk::Viewport`. Impeller specifies
+/// viewports in top-left-origin framebuffer coordinates, so the
+/// negative-height trick from VK_KHR_maintenance1 is used to flip the Y axis
+/// to match the GL convention that the rest of the engine assumes (NDC +Y
+/// maps to the smaller framebuffer Y).
+static vk::Viewport ToVkViewport(const Viewport& viewport) {
+  const auto& rect = viewport.rect;
+  return vk::Viewport()
+      .setX(rect.GetX())
+      .setY(rect.GetY() + rect.GetHeight())
+      .setWidth(rect.GetWidth())
+      .setHeight(-rect.GetHeight())
+      .setMinDepth(viewport.depth_range.z_near)
+      .setMaxDepth(viewport.depth_range.z_far);
+}
+
 static size_t GetVKClearValues(
     const RenderTarget& target,
     std::array<vk::ClearValue, kMaxAttachments>& values) {
@@ -240,12 +256,7 @@ RenderPassVK::RenderPassVK(const std::shared_ptr<const Context>& context,
 
   // Set the initial viewport.
   const auto vp = Viewport{.rect = Rect::MakeSize(target_size)};
-  vk::Viewport viewport = vk::Viewport()
-                              .setWidth(vp.rect.GetWidth())
-                              .setHeight(-vp.rect.GetHeight())
-                              .setY(vp.rect.GetHeight())
-                              .setMinDepth(0.0f)
-                              .setMaxDepth(1.0f);
+  vk::Viewport viewport = ToVkViewport(vp);
   command_buffer_vk_.setViewport(0, 1, &viewport);
 
   // Set the initial scissor.
@@ -387,12 +398,7 @@ void RenderPassVK::SetBaseVertex(uint64_t value) {
 
 // |RenderPass|
 void RenderPassVK::SetViewport(Viewport viewport) {
-  vk::Viewport viewport_vk = vk::Viewport()
-                                 .setWidth(viewport.rect.GetWidth())
-                                 .setHeight(-viewport.rect.GetHeight())
-                                 .setY(viewport.rect.GetHeight())
-                                 .setMinDepth(0.0f)
-                                 .setMaxDepth(1.0f);
+  vk::Viewport viewport_vk = ToVkViewport(viewport);
   command_buffer_vk_.setViewport(0, 1, &viewport_vk);
 }
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk_unittests.cc
@@ -69,7 +69,8 @@ TEST(RenderPassVK, SetViewportPropagatesAllUserSuppliedFields) {
   // we can isolate the call under test.
   VkCommandBuffer raw_cmd_buffer =
       CommandBufferVK::Cast(*cmd_buffer).GetCommandBuffer();
-  std::vector<VkViewport>& recorded = GetRecordedViewports(raw_cmd_buffer);
+  const std::vector<VkViewport>& recorded =
+      GetRecordedViewports(raw_cmd_buffer);
   ASSERT_EQ(recorded.size(), 1u);  // Initial full-target viewport.
 
   render_pass->SetViewport(Viewport{

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk_unittests.cc
@@ -5,6 +5,7 @@
 #include "flutter/testing/testing.h"  // IWYU pragma: keep
 #include "gtest/gtest.h"
 #include "impeller/core/formats.h"
+#include "impeller/renderer/backend/vulkan/command_buffer_vk.h"
 #include "impeller/renderer/backend/vulkan/render_pass_builder_vk.h"
 #include "impeller/renderer/backend/vulkan/render_pass_vk.h"
 #include "impeller/renderer/backend/vulkan/test/mock_vulkan.h"
@@ -47,6 +48,45 @@ TEST(RenderPassVK, DoesNotRedundantlySetStencil) {
   EXPECT_EQ(std::count(called_functions->begin(), called_functions->end(),
                        "vkCmdSetStencilReference"),
             2);
+}
+
+// Regression guard for the bug where `RenderPassVK::SetViewport` silently
+// dropped the user's X and Y offsets and the depth range, only honoring
+// width and height.
+TEST(RenderPassVK, SetViewportPropagatesAllUserSuppliedFields) {
+  std::shared_ptr<ContextVK> context = MockVulkanContextBuilder().Build();
+  auto cmd_buffer = context->CreateCommandBuffer();
+
+  RenderTargetAllocator allocator(context->GetResourceAllocator());
+  RenderTarget target = allocator.CreateOffscreenMSAA(*context, {100, 100},
+                                                      /*mip_count=*/1);
+
+  std::shared_ptr<RenderPass> render_pass =
+      cmd_buffer->CreateRenderPass(target);
+
+  // The render pass constructor sets an initial full-target viewport. Capture
+  // a reference to the recorded viewport list before the user-driven call so
+  // we can isolate the call under test.
+  VkCommandBuffer raw_cmd_buffer =
+      CommandBufferVK::Cast(*cmd_buffer).GetCommandBuffer();
+  std::vector<VkViewport>& recorded = GetRecordedViewports(raw_cmd_buffer);
+  ASSERT_EQ(recorded.size(), 1u);  // Initial full-target viewport.
+
+  render_pass->SetViewport(Viewport{
+      .rect = Rect::MakeXYWH(25, 10, 50, 80),
+      .depth_range = DepthRange{.z_near = 0.25f, .z_far = 0.75f},
+  });
+
+  ASSERT_EQ(recorded.size(), 2u);
+  const VkViewport& vp = recorded[1];
+  EXPECT_FLOAT_EQ(vp.x, 25.0f);
+  // Y is computed for the negative-height Y-flip: `y + height` of the
+  // original rect.
+  EXPECT_FLOAT_EQ(vp.y, 90.0f);
+  EXPECT_FLOAT_EQ(vp.width, 50.0f);
+  EXPECT_FLOAT_EQ(vp.height, -80.0f);
+  EXPECT_FLOAT_EQ(vp.minDepth, 0.25f);
+  EXPECT_FLOAT_EQ(vp.maxDepth, 0.75f);
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
@@ -26,6 +26,7 @@ struct MockCommandBuffer {
       : called_functions_(std::move(called_functions)) {}
   std::shared_ptr<std::vector<std::string>> called_functions_;
   std::vector<VkImageMemoryBarrier> image_memory_barriers_;
+  std::vector<VkViewport> recorded_viewports_;
 };
 
 struct MockQueryPool {};
@@ -569,6 +570,9 @@ void vkCmdSetViewport(VkCommandBuffer commandBuffer,
   MockCommandBuffer* mock_command_buffer =
       reinterpret_cast<MockCommandBuffer*>(commandBuffer);
   mock_command_buffer->called_functions_->push_back("vkCmdSetViewport");
+  for (uint32_t i = 0; i < viewportCount; ++i) {
+    mock_command_buffer->recorded_viewports_.push_back(pViewports[i]);
+  }
 }
 
 void vkFreeCommandBuffers(VkDevice device,
@@ -1109,6 +1113,12 @@ std::vector<VkImageMemoryBarrier>& GetImageMemoryBarriers(
   MockCommandBuffer* mock_command_buffer =
       reinterpret_cast<MockCommandBuffer*>(buffer);
   return mock_command_buffer->image_memory_barriers_;
+}
+
+std::vector<VkViewport>& GetRecordedViewports(VkCommandBuffer buffer) {
+  MockCommandBuffer* mock_command_buffer =
+      reinterpret_cast<MockCommandBuffer*>(buffer);
+  return mock_command_buffer->recorded_viewports_;
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
@@ -1115,7 +1115,7 @@ std::vector<VkImageMemoryBarrier>& GetImageMemoryBarriers(
   return mock_command_buffer->image_memory_barriers_;
 }
 
-std::vector<VkViewport>& GetRecordedViewports(VkCommandBuffer buffer) {
+const std::vector<VkViewport>& GetRecordedViewports(VkCommandBuffer buffer) {
   MockCommandBuffer* mock_command_buffer =
       reinterpret_cast<MockCommandBuffer*>(buffer);
   return mock_command_buffer->recorded_viewports_;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.h
@@ -159,6 +159,10 @@ void SetSwapchainImageSize(ISize size);
 std::vector<VkImageMemoryBarrier>& GetImageMemoryBarriers(
     VkCommandBuffer buffer);
 
+/// @brief Returns the viewports passed to `vkCmdSetViewport` calls on the
+///        given command buffer, in call order.
+std::vector<VkViewport>& GetRecordedViewports(VkCommandBuffer buffer);
+
 }  // namespace testing
 }  // namespace impeller
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.h
@@ -161,7 +161,7 @@ std::vector<VkImageMemoryBarrier>& GetImageMemoryBarriers(
 
 /// @brief Returns the viewports passed to `vkCmdSetViewport` calls on the
 ///        given command buffer, in call order.
-std::vector<VkViewport>& GetRecordedViewports(VkCommandBuffer buffer);
+const std::vector<VkViewport>& GetRecordedViewports(VkCommandBuffer buffer);
 
 }  // namespace testing
 }  // namespace impeller


### PR DESCRIPTION
Fixes #185885

`RenderPassVK::SetViewport` builds a `vk::Viewport` via chained setters that never invoke `.setX(...)`. Because `vk::Viewport()` default-initializes `x` to `0.0f`, the user's X is silently dropped. Y is also effectively dropped (the existing code calls `setY(rect.GetHeight())` to perform the negative-height Y-flip, never reading `rect.GetY()`), and `minDepth` / `maxDepth` are hardcoded to 0/1, ignoring the user's `DepthRange`.

The bug has been present since `e7be989feb1c` ("Reland: Encode directly to command buffer.", 2024-01-19).

## Goldens

Once this lands, the existing Vulkan golden for `flutter_gpu_test_viewport.png` will need to be re-uploaded on Skia Gold to match the corrected output. The `flutter_gpu_test_viewport` test in `gpu_test.dart` is currently disabled on GLES (re-enabled in #185879); both backends will produce the same correct render after this PR plus #185879 land.