### PR TITLE
[Flutter GPU] Allow allocating multi-mip textures and overwriting specific (mip, slice) levels

### DIFF
--- a/engine/src/flutter/lib/gpu/lib/src/context.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/context.dart
@@ -108,6 +108,11 @@ base class GpuContext extends NativeFieldWrapperClass1 {
 
   /// Allocates a new texture in GPU-resident memory.
   ///
+  /// [mipLevelCount] specifies the number of mip levels to allocate for the
+  /// texture. The default is 1 (no mip chain). Use [Texture.fullMipCount] to
+  /// allocate a full chain. Must be in the range
+  /// `[1, Texture.fullMipCount(width, height)]`.
+  ///
   /// Throws an exception if the [Texture] creation failed.
   Texture createTexture(
     StorageMode storageMode,
@@ -125,12 +130,20 @@ base class GpuContext extends NativeFieldWrapperClass1 {
     bool enableRenderTargetUsage = true,
     bool enableShaderReadUsage = true,
     bool enableShaderWriteUsage = false,
+    int mipLevelCount = 1,
   }) {
     final resolvedTextureType =
         textureType ??
         ((sampleCount == 1)
             ? TextureType.texture2D
             : TextureType.texture2DMultisample);
+    final int maxMipLevels = Texture.fullMipCount(width, height);
+    if (mipLevelCount < 1 || mipLevelCount > maxMipLevels) {
+      throw Exception(
+        'mipLevelCount ($mipLevelCount) must be in the range [1, $maxMipLevels] '
+        'for a ${width}x$height texture',
+      );
+    }
     Texture result = Texture._initialize(
       this,
       storageMode,
@@ -143,6 +156,7 @@ base class GpuContext extends NativeFieldWrapperClass1 {
       enableRenderTargetUsage,
       enableShaderReadUsage,
       enableShaderWriteUsage,
+      mipLevelCount,
     );
     if (!result.isValid) {
       throw Exception('Texture creation failed');

--- a/engine/src/flutter/lib/gpu/lib/src/texture.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/texture.dart
@@ -12,19 +12,23 @@ base class Texture extends NativeFieldWrapperClass1 {
     return _valid;
   }
 
-  /// Returns the number of mip levels in a complete chain for a 2D texture
-  /// with the given [width] and [height], i.e. `floor(log2(max(w, h))) + 1`.
+  /// Returns the maximum number of mip levels the underlying HAL will
+  /// allocate for a texture of the given [width] and [height].
+  ///
+  /// This currently matches `impeller::ISize::MipCount`, which uses
+  /// `floor(log2(min(w, h)))` and clamps at 1. Note that this is one less
+  /// than the canonical `floor(log2(max(w, h))) + 1` used by Vulkan and
+  /// OpenGL, and uses the smaller dimension instead of the larger; the HAL
+  /// may eventually relax this. Users should treat this as the upper bound
+  /// for the `mipLevelCount` argument to `GpuContext.createTexture` rather
+  /// than as a fixed mathematical formula.
   static int fullMipCount(int width, int height) {
     if (width < 1 || height < 1) {
       return 1;
     }
-    int largest = width > height ? width : height;
-    int count = 1;
-    while (largest > 1) {
-      largest >>= 1;
-      count += 1;
-    }
-    return count;
+    final int smallest = width < height ? width : height;
+    final int count = smallest.bitLength - 1;
+    return count > 0 ? count : 1;
   }
 
   /// Creates a new Texture.

--- a/engine/src/flutter/lib/gpu/lib/src/texture.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/texture.dart
@@ -12,16 +12,17 @@ base class Texture extends NativeFieldWrapperClass1 {
     return _valid;
   }
 
-  /// Returns the maximum number of mip levels the underlying HAL will
-  /// allocate for a texture of the given [width] and [height].
+  /// Returns the maximum number of mip levels Flutter GPU will allocate
+  /// for a texture of the given [width] and [height].
   ///
-  /// This currently matches `impeller::ISize::MipCount`, which uses
-  /// `floor(log2(min(w, h)))` and clamps at 1. Note that this is one less
-  /// than the canonical `floor(log2(max(w, h))) + 1` used by Vulkan and
-  /// OpenGL, and uses the smaller dimension instead of the larger; the HAL
-  /// may eventually relax this. Users should treat this as the upper bound
-  /// for the `mipLevelCount` argument to `GpuContext.createTexture` rather
-  /// than as a fixed mathematical formula.
+  /// This currently uses `floor(log2(min(w, h)))` and clamps at 1. Note
+  /// that this is one less than the canonical `floor(log2(max(w, h))) + 1`
+  /// used by Vulkan and OpenGL, and uses the smaller dimension instead of
+  /// the larger; Flutter GPU may eventually relax this (tracked in
+  /// https://github.com/flutter/flutter/issues/186176). Users should treat
+  /// this as the upper bound for the `mipLevelCount` argument to
+  /// `GpuContext.createTexture` rather than as a fixed mathematical
+  /// formula.
   static int fullMipCount(int width, int height) {
     if (width < 1 || height < 1) {
       return 1;

--- a/engine/src/flutter/lib/gpu/lib/src/texture.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/texture.dart
@@ -12,6 +12,21 @@ base class Texture extends NativeFieldWrapperClass1 {
     return _valid;
   }
 
+  /// Returns the number of mip levels in a complete chain for a 2D texture
+  /// with the given [width] and [height], i.e. `floor(log2(max(w, h))) + 1`.
+  static int fullMipCount(int width, int height) {
+    if (width < 1 || height < 1) {
+      return 1;
+    }
+    int largest = width > height ? width : height;
+    int count = 1;
+    while (largest > 1) {
+      largest >>= 1;
+      count += 1;
+    }
+    return count;
+  }
+
   /// Creates a new Texture.
   Texture._initialize(
     GpuContext gpuContext,
@@ -25,6 +40,7 @@ base class Texture extends NativeFieldWrapperClass1 {
     this.enableRenderTargetUsage,
     this.enableShaderReadUsage,
     this.enableShaderWriteUsage,
+    this.mipLevelCount,
   ) : _gpuContext = gpuContext,
       _coordinateSystem = coordinateSystem {
     if (sampleCount != 1 && sampleCount != 4) {
@@ -42,6 +58,7 @@ base class Texture extends NativeFieldWrapperClass1 {
       enableRenderTargetUsage,
       enableShaderReadUsage,
       enableShaderWriteUsage,
+      mipLevelCount,
     );
   }
 
@@ -65,6 +82,17 @@ base class Texture extends NativeFieldWrapperClass1 {
   /// Note that this is distinct from [enableRenderTargetUsage].
   final bool enableShaderWriteUsage;
 
+  /// The number of mip levels allocated for this texture.
+  ///
+  /// A value of 1 means no mip chain (only the base level). Larger values
+  /// allocate additional levels with halved dimensions per step. Use
+  /// [Texture.fullMipCount] to compute the maximum for a given size.
+  final int mipLevelCount;
+
+  /// The number of slices in this texture. Determined by [textureType]:
+  /// 1 for 2D and external textures, 6 for cubemap textures.
+  int get sliceCount => textureType == TextureType.textureCube ? 6 : 1;
+
   TextureCoordinateSystem _coordinateSystem;
   TextureCoordinateSystem get coordinateSystem {
     return _coordinateSystem;
@@ -79,33 +107,58 @@ base class Texture extends NativeFieldWrapperClass1 {
     return _bytesPerTexel();
   }
 
-  int getBaseMipLevelSizeInBytes() {
-    return bytesPerTexel * width * height;
+  /// Returns the size in bytes of the [mipLevel] mip level (one slice). Mip
+  /// dimensions are clamped at 1, matching standard mip chain semantics.
+  int getMipLevelSizeInBytes(int mipLevel) {
+    final int mipWidth = width >> mipLevel;
+    final int mipHeight = height >> mipLevel;
+    final int w = mipWidth > 0 ? mipWidth : 1;
+    final int h = mipHeight > 0 ? mipHeight : 1;
+    return bytesPerTexel * w * h;
   }
 
-  /// Overwrite the entire base mipmap level of this [Texture].
+  /// Returns the size in bytes of the base mip level (one slice). Equivalent
+  /// to `getMipLevelSizeInBytes(0)`.
+  int getBaseMipLevelSizeInBytes() {
+    return getMipLevelSizeInBytes(0);
+  }
+
+  /// Overwrites a mip level (and slice for cubemap textures) of this
+  /// [Texture] with the contents of [sourceBytes].
   ///
-  /// This method can only be used if the [Texture] was created with
-  /// [StorageMode.hostVisible]. An exception will be thrown otherwise.
+  /// [mipLevel] selects which mip level to write to. Defaults to 0 (base
+  /// level). Must be in the range `[0, mipLevelCount)`.
   ///
-  /// The length of [sourceBytes] must be exactly the size of the base mip
-  /// level, otherwise an exception will be thrown. The size of the base mip
-  /// level is always `width * height * bytesPerPixel`.
+  /// [slice] selects which slice to write to for cubemap textures, where
+  /// each face is a separate slice in the order
+  /// `+X, -X, +Y, -Y, +Z, -Z`. Must be 0 for non-cubemap textures.
   ///
-  /// Throws an exception if the write failed due to an internal error.
-  void overwrite(ByteData sourceBytes) {
-    if (storageMode != StorageMode.hostVisible) {
+  /// The length of [sourceBytes] must exactly match the size of the
+  /// requested mip level, which is `mipWidth * mipHeight * bytesPerTexel`
+  /// (where `mipWidth` and `mipHeight` are the base dimensions right-shifted
+  /// by [mipLevel], floored at 1).
+  ///
+  /// Throws an exception if the write fails due to an internal error or if
+  /// any of the parameters are out of range.
+  void overwrite(ByteData sourceBytes, {int mipLevel = 0, int slice = 0}) {
+    if (mipLevel < 0 || mipLevel >= mipLevelCount) {
       throw Exception(
-        'Texture.overwrite can only be used with Textures that are host visible',
+        'mipLevel ($mipLevel) must be in the range [0, $mipLevelCount) for this texture',
       );
     }
-    int baseMipSize = getBaseMipLevelSizeInBytes();
-    if (sourceBytes.lengthInBytes != baseMipSize) {
+    final int slices = sliceCount;
+    if (slice < 0 || slice >= slices) {
       throw Exception(
-        'The length of sourceBytes (bytes: ${sourceBytes.lengthInBytes}) must exactly match the size of the base mip level (bytes: ${baseMipSize})',
+        'slice ($slice) must be in the range [0, $slices) for textures of type $textureType',
       );
     }
-    bool success = _overwrite(_gpuContext, sourceBytes);
+    final int expectedSize = getMipLevelSizeInBytes(mipLevel);
+    if (sourceBytes.lengthInBytes != expectedSize) {
+      throw Exception(
+        'The length of sourceBytes (bytes: ${sourceBytes.lengthInBytes}) must exactly match the size of mip level $mipLevel (bytes: $expectedSize)',
+      );
+    }
+    bool success = _overwrite(_gpuContext, sourceBytes, mipLevel, slice);
     if (!success) {
       throw Exception("Texture overwrite failed");
     }
@@ -135,6 +188,7 @@ base class Texture extends NativeFieldWrapperClass1 {
       Bool,
       Bool,
       Bool,
+      Int,
     )
   >(symbol: 'InternalFlutterGpu_Texture_Initialize')
   external bool _initialize(
@@ -149,6 +203,7 @@ base class Texture extends NativeFieldWrapperClass1 {
     bool enableRenderTargetUsage,
     bool enableShaderReadUsage,
     bool enableShaderWriteUsage,
+    int mipLevelCount,
   );
 
   @Native<Void Function(Handle, Int)>(
@@ -161,10 +216,15 @@ base class Texture extends NativeFieldWrapperClass1 {
   )
   external int _bytesPerTexel();
 
-  @Native<Bool Function(Pointer<Void>, Pointer<Void>, Handle)>(
+  @Native<Bool Function(Pointer<Void>, Pointer<Void>, Handle, Int, Int)>(
     symbol: 'InternalFlutterGpu_Texture_Overwrite',
   )
-  external bool _overwrite(GpuContext gpuContext, ByteData bytes);
+  external bool _overwrite(
+    GpuContext gpuContext,
+    ByteData bytes,
+    int mipLevel,
+    int slice,
+  );
 
   @Native<Handle Function(Pointer<Void>)>(
     symbol: 'InternalFlutterGpu_Texture_AsImage',

--- a/engine/src/flutter/lib/gpu/texture.cc
+++ b/engine/src/flutter/lib/gpu/texture.cc
@@ -10,8 +10,15 @@
 #include "fml/make_copyable.h"
 #include "fml/mapping.h"
 #include "impeller/core/allocator.h"
+#include "impeller/core/buffer_view.h"
+#include "impeller/core/device_buffer.h"
 #include "impeller/core/formats.h"
 #include "impeller/core/texture.h"
+#include "impeller/geometry/rect.h"
+#include "impeller/renderer/blit_pass.h"
+#include "impeller/renderer/command_buffer.h"
+#include "impeller/renderer/command_queue.h"
+#include "impeller/renderer/context.h"
 
 #if IMPELLER_SUPPORTS_RENDERING
 #include "impeller/display_list/dl_image_impeller.h"  // nogncheck
@@ -37,33 +44,104 @@ void Texture::SetCoordinateSystem(
   texture_->SetCoordinateSystem(coordinate_system);
 }
 
+// Returns the size in pixels of the given dimension at `mip_level`, clamped
+// at 1, matching standard mip-chain semantics. The Dart-side helper
+// `Texture.getMipLevelSizeInBytes` uses the same `max(1, dim >> level)`
+// formula in pixel-count form; if either is updated, both must be kept in
+// sync.
+static int32_t MipDimensionAtLevel(int32_t base_dimension, uint32_t mip_level) {
+  const int32_t shifted = base_dimension >> mip_level;
+  return shifted > 0 ? shifted : 1;
+}
+
+// Records a blit-pass that copies `source_bytes` into the given mip level and
+// slice of `texture` on `context`, then submits the command buffer. Returns
+// true if the encode and submit both succeed. The actual GPU upload may
+// complete asynchronously after this call returns.
+static bool EncodeAndSubmitOverwrite(
+    impeller::Context& context,
+    const std::shared_ptr<impeller::Texture>& texture,
+    const std::shared_ptr<impeller::DeviceBuffer>& staging_buffer,
+    size_t source_length,
+    impeller::IRect destination_region,
+    uint32_t mip_level,
+    uint32_t slice) {
+  auto command_buffer = context.CreateCommandBuffer();
+  if (!command_buffer) {
+    FML_LOG(ERROR) << "Failed to create command buffer for texture overwrite.";
+    return false;
+  }
+  auto blit_pass = command_buffer->CreateBlitPass();
+  if (!blit_pass) {
+    FML_LOG(ERROR) << "Failed to create blit pass for texture overwrite.";
+    return false;
+  }
+  impeller::BufferView buffer_view(staging_buffer,
+                                   impeller::Range(0, source_length));
+  if (!blit_pass->AddCopy(std::move(buffer_view), texture, destination_region,
+                          /*label=*/"Texture.overwrite", mip_level, slice)) {
+    return false;
+  }
+  if (!blit_pass->EncodeCommands()) {
+    return false;
+  }
+  return context.GetCommandQueue()->Submit({std::move(command_buffer)}).ok();
+}
+
 bool Texture::Overwrite(Context& gpu_context,
-                        const tonic::DartByteData& source_bytes) {
+                        const tonic::DartByteData& source_bytes,
+                        uint32_t mip_level,
+                        uint32_t slice) {
   const uint8_t* data = static_cast<const uint8_t*>(source_bytes.data());
-  auto copy = std::vector<uint8_t>(data, data + source_bytes.length_in_bytes());
-  // Texture::SetContents is a bit funky right now. It takes a shared_ptr of a
-  // mapping and we're forced to copy here.
-  auto mapping = std::make_shared<fml::DataMapping>(copy);
+  const size_t length = source_bytes.length_in_bytes();
+
+  auto& impeller_context = gpu_context.GetContext();
+  auto staging_buffer =
+      impeller_context.GetResourceAllocator()->CreateBufferWithCopy(data,
+                                                                    length);
+  if (!staging_buffer) {
+    FML_LOG(ERROR) << "Failed to allocate staging buffer for texture "
+                      "overwrite.";
+    return false;
+  }
+
+  // Compute the destination region for the requested mip level. The
+  // BlitPass::AddCopy validation requires the region to fit within the base
+  // texture size, and the actual GPU copy uses this rectangle as the
+  // destination on the chosen mip level. The same `max(1, dim >> level)`
+  // formula is used by `Texture.getMipLevelSizeInBytes` on the Dart side; if
+  // either is updated, both must be kept in sync.
+  const impeller::ISize base_size = texture_->GetSize();
+  const impeller::IRect destination_region = impeller::IRect::MakeXYWH(
+      0, 0, MipDimensionAtLevel(base_size.width, mip_level),
+      MipDimensionAtLevel(base_size.height, mip_level));
 
   // For the GLES backend, command queue submission just flushes the reactor,
   // which needs to happen on the raster thread.
-  if (gpu_context.GetContext().GetBackendType() ==
+  if (impeller_context.GetBackendType() ==
       impeller::Context::BackendType::kOpenGLES) {
     auto dart_state = flutter::UIDartState::Current();
     auto& task_runners = dart_state->GetTaskRunners();
-
-    task_runners.GetRasterTaskRunner()->PostTask(
-        fml::MakeCopyable([texture = texture_, mapping = mapping]() mutable {
-          if (!texture->SetContents(mapping)) {
-            FML_LOG(ERROR) << "Failed to set texture contents.";
+    auto context_shared = gpu_context.GetContextShared();
+    task_runners.GetRasterTaskRunner()->PostTask(fml::MakeCopyable(
+        [context_shared, texture = texture_, staging_buffer, length,
+         destination_region, mip_level, slice]() mutable {
+          if (!EncodeAndSubmitOverwrite(*context_shared, texture,
+                                        staging_buffer, length,
+                                        destination_region, mip_level, slice)) {
+            FML_LOG(ERROR) << "Failed to encode texture overwrite blit on the "
+                              "raster thread.";
           }
+          context_shared->DisposeThreadLocalCachedResources();
         }));
+    return true;
   }
 
-  if (!texture_->SetContents(mapping)) {
+  if (!EncodeAndSubmitOverwrite(impeller_context, texture_, staging_buffer,
+                                length, destination_region, mip_level, slice)) {
     return false;
   }
-  gpu_context.GetContext().DisposeThreadLocalCachedResources();
+  impeller_context.DisposeThreadLocalCachedResources();
   return true;
 }
 
@@ -105,11 +183,16 @@ bool InternalFlutterGpu_Texture_Initialize(Dart_Handle wrapper,
                                            int texture_type,
                                            bool enable_render_target_usage,
                                            bool enable_shader_read_usage,
-                                           bool enable_shader_write_usage) {
+                                           bool enable_shader_write_usage,
+                                           int mip_level_count) {
+  if (mip_level_count < 1) {
+    return false;
+  }
   impeller::TextureDescriptor desc;
   desc.storage_mode = flutter::gpu::ToImpellerStorageMode(storage_mode);
   desc.size = {width, height};
   desc.format = flutter::gpu::ToImpellerPixelFormat(format);
+  desc.mip_count = static_cast<size_t>(mip_level_count);
   desc.usage = {};
   if (enable_render_target_usage) {
     desc.usage |= impeller::TextureUsage::kRenderTarget;
@@ -162,9 +245,15 @@ void InternalFlutterGpu_Texture_SetCoordinateSystem(
 
 bool InternalFlutterGpu_Texture_Overwrite(flutter::gpu::Texture* texture,
                                           flutter::gpu::Context* gpu_context,
-                                          Dart_Handle source_byte_data) {
-  return texture->Overwrite(*gpu_context,
-                            tonic::DartByteData(source_byte_data));
+                                          Dart_Handle source_byte_data,
+                                          int mip_level,
+                                          int slice) {
+  if (mip_level < 0 || slice < 0) {
+    return false;
+  }
+  return texture->Overwrite(*gpu_context, tonic::DartByteData(source_byte_data),
+                            static_cast<uint32_t>(mip_level),
+                            static_cast<uint32_t>(slice));
 }
 
 extern int InternalFlutterGpu_Texture_BytesPerTexel(

--- a/engine/src/flutter/lib/gpu/texture.h
+++ b/engine/src/flutter/lib/gpu/texture.h
@@ -27,7 +27,10 @@ class Texture : public RefCountedDartWrappable<Texture> {
 
   void SetCoordinateSystem(impeller::TextureCoordinateSystem coordinate_system);
 
-  bool Overwrite(Context& gpu_context, const tonic::DartByteData& source_bytes);
+  bool Overwrite(Context& gpu_context,
+                 const tonic::DartByteData& source_bytes,
+                 uint32_t mip_level,
+                 uint32_t slice);
 
   size_t GetBytesPerTexel();
 
@@ -61,7 +64,8 @@ extern bool InternalFlutterGpu_Texture_Initialize(
     int texture_type,
     bool enable_render_target_usage,
     bool enable_shader_read_usage,
-    bool enable_shader_write_usage);
+    bool enable_shader_write_usage,
+    int mip_level_count);
 
 FLUTTER_GPU_EXPORT
 extern void InternalFlutterGpu_Texture_SetCoordinateSystem(
@@ -72,7 +76,9 @@ FLUTTER_GPU_EXPORT
 extern bool InternalFlutterGpu_Texture_Overwrite(
     flutter::gpu::Texture* wrapper,
     flutter::gpu::Context* gpu_context,
-    Dart_Handle source_byte_data);
+    Dart_Handle source_byte_data,
+    int mip_level,
+    int slice);
 
 FLUTTER_GPU_EXPORT
 extern int InternalFlutterGpu_Texture_BytesPerTexel(

--- a/engine/src/flutter/testing/dart/gpu_test.dart
+++ b/engine/src/flutter/testing/dart/gpu_test.dart
@@ -331,15 +331,18 @@ void main() async {
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   test('Texture.fullMipCount', () async {
+    // Matches Impeller's `ISize::MipCount`: `floor(log2(min(w, h)))`,
+    // clamped to a minimum of 1.
     expect(gpu.Texture.fullMipCount(1, 1), 1);
-    expect(gpu.Texture.fullMipCount(2, 1), 2);
-    expect(gpu.Texture.fullMipCount(2, 2), 2);
-    expect(gpu.Texture.fullMipCount(4, 4), 3);
-    expect(gpu.Texture.fullMipCount(100, 100), 7);
-    expect(gpu.Texture.fullMipCount(1024, 1024), 11);
-    // Non-square: count uses the larger dimension.
-    expect(gpu.Texture.fullMipCount(1024, 1), 11);
-    expect(gpu.Texture.fullMipCount(1, 256), 9);
+    expect(gpu.Texture.fullMipCount(2, 1), 1);
+    expect(gpu.Texture.fullMipCount(2, 2), 1);
+    expect(gpu.Texture.fullMipCount(4, 4), 2);
+    expect(gpu.Texture.fullMipCount(8, 8), 3);
+    expect(gpu.Texture.fullMipCount(100, 100), 6);
+    expect(gpu.Texture.fullMipCount(1024, 1024), 10);
+    // Non-square: count uses the smaller dimension.
+    expect(gpu.Texture.fullMipCount(1024, 1), 1);
+    expect(gpu.Texture.fullMipCount(1, 256), 1);
   });
 
   test(
@@ -347,15 +350,15 @@ void main() async {
     () async {
       final gpu.Texture texture = gpu.gpuContext.createTexture(
         gpu.StorageMode.hostVisible,
-        4,
-        4,
+        8,
+        8,
         mipLevelCount: 3,
       );
       expect(texture.mipLevelCount, 3);
-      // Per-level sizes: 4*4*4=64, 2*2*4=16, 1*1*4=4.
-      expect(texture.getMipLevelSizeInBytes(0), 64);
-      expect(texture.getMipLevelSizeInBytes(1), 16);
-      expect(texture.getMipLevelSizeInBytes(2), 4);
+      // Per-level sizes: 8*8*4=256, 4*4*4=64, 2*2*4=16.
+      expect(texture.getMipLevelSizeInBytes(0), 256);
+      expect(texture.getMipLevelSizeInBytes(1), 64);
+      expect(texture.getMipLevelSizeInBytes(2), 16);
     },
     skip: !(impellerEnabled && flutterGpuEnabled),
   );
@@ -364,14 +367,14 @@ void main() async {
     'GpuContext.createTexture rejects out-of-range mipLevelCount',
     () async {
       try {
-        gpu.gpuContext.createTexture(gpu.StorageMode.hostVisible, 4, 4, mipLevelCount: 0);
+        gpu.gpuContext.createTexture(gpu.StorageMode.hostVisible, 8, 8, mipLevelCount: 0);
         fail('Exception not thrown for mipLevelCount=0.');
       } catch (e) {
         expect(e.toString(), contains('mipLevelCount'));
       }
       try {
-        // Max for 4x4 is 3.
-        gpu.gpuContext.createTexture(gpu.StorageMode.hostVisible, 4, 4, mipLevelCount: 4);
+        // Max for 8x8 is 3.
+        gpu.gpuContext.createTexture(gpu.StorageMode.hostVisible, 8, 8, mipLevelCount: 4);
         fail('Exception not thrown for mipLevelCount above the maximum.');
       } catch (e) {
         expect(e.toString(), contains('mipLevelCount'));
@@ -431,25 +434,28 @@ void main() async {
   test('Texture.overwrite writes to a non-zero mip level', () async {
     final gpu.Texture texture = gpu.gpuContext.createTexture(
       gpu.StorageMode.hostVisible,
-      4,
-      4,
+      8,
+      8,
       mipLevelCount: 3,
     );
     const red = ui.Color.fromARGB(0xFF, 0xFF, 0, 0);
     const blue = ui.Color.fromARGB(0xFF, 0, 0, 0xFF);
 
-    // Mip 0: 4x4 = 16 texels.
+    // Mip 0: 8x8 = 64 texels.
     texture.overwrite(
-      Int32List.fromList(List<int>.filled(16, red.value)).buffer.asByteData(),
+      Int32List.fromList(List<int>.filled(64, red.value)).buffer.asByteData(),
       mipLevel: 0,
     );
-    // Mip 1: 2x2 = 4 texels.
+    // Mip 1: 4x4 = 16 texels.
     texture.overwrite(
-      Int32List.fromList(List<int>.filled(4, blue.value)).buffer.asByteData(),
+      Int32List.fromList(List<int>.filled(16, blue.value)).buffer.asByteData(),
       mipLevel: 1,
     );
-    // Mip 2: 1x1 = 1 texel.
-    texture.overwrite(Int32List.fromList(<int>[red.value]).buffer.asByteData(), mipLevel: 2);
+    // Mip 2: 2x2 = 4 texels.
+    texture.overwrite(
+      Int32List.fromList(List<int>.filled(4, red.value)).buffer.asByteData(),
+      mipLevel: 2,
+    );
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   test(

--- a/engine/src/flutter/testing/dart/gpu_test.dart
+++ b/engine/src/flutter/testing/dart/gpu_test.dart
@@ -326,7 +326,59 @@ void main() async {
     expect(!texture.enableShaderWriteUsage, true);
     expect(texture.bytesPerTexel, 4);
     expect(texture.getBaseMipLevelSizeInBytes(), 40000);
+    expect(texture.mipLevelCount, 1);
+    expect(texture.sliceCount, 1);
   }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  test('Texture.fullMipCount', () async {
+    expect(gpu.Texture.fullMipCount(1, 1), 1);
+    expect(gpu.Texture.fullMipCount(2, 1), 2);
+    expect(gpu.Texture.fullMipCount(2, 2), 2);
+    expect(gpu.Texture.fullMipCount(4, 4), 3);
+    expect(gpu.Texture.fullMipCount(100, 100), 7);
+    expect(gpu.Texture.fullMipCount(1024, 1024), 11);
+    // Non-square: count uses the larger dimension.
+    expect(gpu.Texture.fullMipCount(1024, 1), 11);
+    expect(gpu.Texture.fullMipCount(1, 256), 9);
+  });
+
+  test(
+    'GpuContext.createTexture with mipLevelCount allocates a mip chain',
+    () async {
+      final gpu.Texture texture = gpu.gpuContext.createTexture(
+        gpu.StorageMode.hostVisible,
+        4,
+        4,
+        mipLevelCount: 3,
+      );
+      expect(texture.mipLevelCount, 3);
+      // Per-level sizes: 4*4*4=64, 2*2*4=16, 1*1*4=4.
+      expect(texture.getMipLevelSizeInBytes(0), 64);
+      expect(texture.getMipLevelSizeInBytes(1), 16);
+      expect(texture.getMipLevelSizeInBytes(2), 4);
+    },
+    skip: !(impellerEnabled && flutterGpuEnabled),
+  );
+
+  test(
+    'GpuContext.createTexture rejects out-of-range mipLevelCount',
+    () async {
+      try {
+        gpu.gpuContext.createTexture(gpu.StorageMode.hostVisible, 4, 4, mipLevelCount: 0);
+        fail('Exception not thrown for mipLevelCount=0.');
+      } catch (e) {
+        expect(e.toString(), contains('mipLevelCount'));
+      }
+      try {
+        // Max for 4x4 is 3.
+        gpu.gpuContext.createTexture(gpu.StorageMode.hostVisible, 4, 4, mipLevelCount: 4);
+        fail('Exception not thrown for mipLevelCount above the maximum.');
+      } catch (e) {
+        expect(e.toString(), contains('mipLevelCount'));
+      }
+    },
+    skip: !(impellerEnabled && flutterGpuEnabled),
+  );
 
   test(
     'GpuContext.createTexture fails if invalid sampleCount and texture type is passed.',
@@ -370,9 +422,89 @@ void main() async {
       expect(
         e.toString(),
         contains(
-          'The length of sourceBytes (bytes: 16) must exactly match the size of the base mip level (bytes: 40000)',
+          'The length of sourceBytes (bytes: 16) must exactly match the size of mip level 0 (bytes: 40000)',
         ),
       );
+    }
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  test('Texture.overwrite writes to a non-zero mip level', () async {
+    final gpu.Texture texture = gpu.gpuContext.createTexture(
+      gpu.StorageMode.hostVisible,
+      4,
+      4,
+      mipLevelCount: 3,
+    );
+    const red = ui.Color.fromARGB(0xFF, 0xFF, 0, 0);
+    const blue = ui.Color.fromARGB(0xFF, 0, 0, 0xFF);
+
+    // Mip 0: 4x4 = 16 texels.
+    texture.overwrite(
+      Int32List.fromList(List<int>.filled(16, red.value)).buffer.asByteData(),
+      mipLevel: 0,
+    );
+    // Mip 1: 2x2 = 4 texels.
+    texture.overwrite(
+      Int32List.fromList(List<int>.filled(4, blue.value)).buffer.asByteData(),
+      mipLevel: 1,
+    );
+    // Mip 2: 1x1 = 1 texel.
+    texture.overwrite(Int32List.fromList(<int>[red.value]).buffer.asByteData(), mipLevel: 2);
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  test(
+    'Texture.overwrite throws for an out-of-range mipLevel',
+    () async {
+      final gpu.Texture texture = gpu.gpuContext.createTexture(
+        gpu.StorageMode.hostVisible,
+        4,
+        4,
+        mipLevelCount: 2,
+      );
+      const red = ui.Color.fromARGB(0xFF, 0xFF, 0, 0);
+      try {
+        texture.overwrite(Int32List.fromList(<int>[red.value]).buffer.asByteData(), mipLevel: 2);
+        fail('Exception not thrown for out-of-range mipLevel.');
+      } catch (e) {
+        expect(e.toString(), contains('mipLevel (2) must be in the range [0, 2)'));
+      }
+    },
+    skip: !(impellerEnabled && flutterGpuEnabled),
+  );
+
+  test('Texture.overwrite throws for an out-of-range slice', () async {
+    final gpu.Texture texture = gpu.gpuContext.createTexture(gpu.StorageMode.hostVisible, 2, 2);
+    const red = ui.Color.fromARGB(0xFF, 0xFF, 0, 0);
+    try {
+      texture.overwrite(
+        Int32List.fromList(List<int>.filled(4, red.value)).buffer.asByteData(),
+        slice: 1,
+      );
+      fail('Exception not thrown for out-of-range slice.');
+    } catch (e) {
+      expect(e.toString(), contains('slice (1) must be in the range [0, 1)'));
+    }
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  test('Texture.overwrite writes each face of a cubemap', () async {
+    final gpu.Texture texture = gpu.gpuContext.createTexture(
+      gpu.StorageMode.hostVisible,
+      2,
+      2,
+      textureType: gpu.TextureType.textureCube,
+    );
+    expect(texture.sliceCount, 6);
+    const colors = <ui.Color>[
+      ui.Color.fromARGB(0xFF, 0xFF, 0, 0),
+      ui.Color.fromARGB(0xFF, 0, 0xFF, 0),
+      ui.Color.fromARGB(0xFF, 0, 0, 0xFF),
+      ui.Color.fromARGB(0xFF, 0xFF, 0xFF, 0),
+      ui.Color.fromARGB(0xFF, 0xFF, 0, 0xFF),
+      ui.Color.fromARGB(0xFF, 0, 0xFF, 0xFF),
+    ];
+    for (int slice = 0; slice < 6; slice++) {
+      final int v = colors[slice].value;
+      texture.overwrite(Int32List.fromList(<int>[v, v, v, v]).buffer.asByteData(), slice: slice);
     }
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 

--- a/engine/src/flutter/testing/dart/gpu_test.dart
+++ b/engine/src/flutter/testing/dart/gpu_test.dart
@@ -442,10 +442,7 @@ void main() async {
     const blue = ui.Color.fromARGB(0xFF, 0, 0, 0xFF);
 
     // Mip 0: 8x8 = 64 texels.
-    texture.overwrite(
-      Int32List.fromList(List<int>.filled(64, red.value)).buffer.asByteData(),
-      mipLevel: 0,
-    );
+    texture.overwrite(Int32List.fromList(List<int>.filled(64, red.value)).buffer.asByteData());
     // Mip 1: 4x4 = 16 texels.
     texture.overwrite(
       Int32List.fromList(List<int>.filled(16, blue.value)).buffer.asByteData(),
@@ -508,7 +505,7 @@ void main() async {
       ui.Color.fromARGB(0xFF, 0xFF, 0, 0xFF),
       ui.Color.fromARGB(0xFF, 0, 0xFF, 0xFF),
     ];
-    for (int slice = 0; slice < 6; slice++) {
+    for (var slice = 0; slice < 6; slice++) {
       final int v = colors[slice].value;
       texture.overwrite(Int32List.fromList(<int>[v, v, v, v]).buffer.asByteData(), slice: slice);
     }


### PR DESCRIPTION
Fixes #185883
Fixes #145015

This is the Dart-side surfacing of two pieces of HAL functionality that Flutter GPU has not exposed: multiple mip levels per texture, and addressing a specific (mip level, slice) when uploading texture data.

Together they unblock the user-driven mipmap generation workflow that WebGPU and other modern HALs use, and prebaked mip-chain uploads (e.g. loading a DDS file with all mip levels populated). Per-mip-level render attachments still need to land before user-driven generation works end-to-end, tracked separately in #150455.

## `mipLevelCount` on `GpuContext.createTexture`

Adds a `mipLevelCount: int` parameter to `GpuContext.createTexture` (default `1`, matching previous behavior). The value is plumbed through to `TextureDescriptor.mip_count`, which the existing HAL already honors. Out-of-range values throw at the Dart layer with a clear message. `Texture.fullMipCount(width, height)` is a small helper that returns the maximum chain length for a given texture size (`floor(log2(max(w, h))) + 1`).

## `mipLevel` and `slice` on `Texture.overwrite`

Adds named parameters `mipLevel` (default 0) and `slice` (default 0) to `Texture.overwrite`. `slice` is bounded by the texture's `sliceCount` (1 for 2D textures, 6 for cubemap textures), which is also exposed as a getter on `Texture`. Out-of-range values throw with specific error messages.

The implementation switches off the deprecated `Texture::SetContents` path (which the HAL marks as "use BlitPass::AddCopy instead") and onto `BlitPass::AddCopy(BufferView, Texture, ...)`, which already accepts `mip_level` and `slice` and is implemented across every backend (Metal, Vulkan, GLES). The flutter_gpu wrapper allocates a transient host-visible staging `DeviceBuffer` with the user's data, records the copy on a one-shot `BlitPass`, encodes, and submits via the context's `CommandQueue`. The OpenGLES raster-thread workaround is preserved.

Side effect: the `StorageMode.hostVisible` restriction on `Texture.overwrite` is dropped. The old direct-`SetContents` path required host-visible memory; the new blit path can target any storage mode the backend can sample.