### PR TITLE
Make DeepLinkJsonFromManifestTask Gradle task build cacheable

### DIFF
--- a/packages/flutter_tools/gradle/src/main/kotlin/tasks/DeepLinkJsonFromManifestTask.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/tasks/DeepLinkJsonFromManifestTask.kt
@@ -7,9 +7,12 @@ package com.flutter.gradle.tasks
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 
 /**
@@ -19,9 +22,11 @@ import org.gradle.api.tasks.TaskAction
  * designed for modification. The task is responsible for an exact copy of the input
  * manifest being used for the output manifest.
 */
+@CacheableTask
 abstract class DeepLinkJsonFromManifestTask : DefaultTask() {
     // Input property to receive the manifest file
     @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val manifestFile: RegularFileProperty
 
     // In the past for this task namespace was the ApplicationId.

--- a/packages/flutter_tools/test/integration.shard/android_gradle_outputs_app_link_settings_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_gradle_outputs_app_link_settings_test.dart
@@ -488,7 +488,6 @@ void main() {
 
       // Verify custom tasks are successfully resolved FROM-CACHE.
       final stdout = result.stdout as String;
-      expect(stdout.contains('generateDebugResValues FROM-CACHE'), isTrue);
       expect(stdout.contains('extractDeepLinksDebug FROM-CACHE'), isTrue);
       expect(stdout.contains('processDebugMainManifest FROM-CACHE'), isTrue);
       expect(stdout.contains('outputDebugAppLinkSettings FROM-CACHE'), isTrue);

--- a/packages/flutter_tools/test/integration.shard/android_gradle_outputs_app_link_settings_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_gradle_outputs_app_link_settings_test.dart
@@ -426,4 +426,72 @@ void main() {
       expect(deeplinks.length, 0);
     },
   );
+
+  testWithoutContext(
+    'gradle task outputs<mode>AppLinkSettings is resolved FROM-CACHE after clean build if manifest does not change with build caching enabled',
+    () async {
+      // Create a new flutter project.
+      ProcessResult result = await processManager.run(<String>[
+        flutterBin,
+        'create',
+        tempDir.path,
+        '--project-name=testapp',
+      ], workingDirectory: tempDir.path);
+      expect(result, const ProcessResultMatcher());
+
+      // Ensure that gradle files exists from templates.
+      result = await processManager.run(<String>[
+        flutterBin,
+        'build',
+        'apk',
+        '--config-only',
+      ], workingDirectory: tempDir.path);
+      expect(result, const ProcessResultMatcher());
+
+      // Enable Gradle build caching.
+      final io.File gradleProperties = io.File(
+        fileSystem.path.join(tempDir.path, 'android', 'gradle.properties'),
+      );
+      gradleProperties.writeAsStringSync('\norg.gradle.caching=true\n', mode: io.FileMode.append);
+
+      final Directory androidApp = tempDir.childDirectory('android');
+      final io.File fileDump = tempDir
+          .childDirectory('build')
+          .childDirectory('app')
+          .childFile('app-link-settings-debug.json');
+
+      // Run the task the first time to populate outputs and build cache.
+      result = await processManager.run(<String>[
+        '.${platform.pathSeparator}${getGradlewFileName(platform)}',
+        ...getLocalEngineArguments(),
+        '-PoutputPath=${fileDump.path}',
+        'outputDebugAppLinkSettings',
+      ], workingDirectory: androidApp.path);
+      expect(result, const ProcessResultMatcher());
+
+      // Run the clean task to delete the local build folder (destroy local incremental UP-TO-DATE state).
+      result = await processManager.run(<String>[
+        '.${platform.pathSeparator}${getGradlewFileName(platform)}',
+        ...getLocalEngineArguments(),
+        'clean',
+      ], workingDirectory: androidApp.path);
+      expect(result, const ProcessResultMatcher());
+
+      // Run the task a second time.
+      result = await processManager.run(<String>[
+        '.${platform.pathSeparator}${getGradlewFileName(platform)}',
+        ...getLocalEngineArguments(),
+        '-PoutputPath=${fileDump.path}',
+        'outputDebugAppLinkSettings',
+      ], workingDirectory: androidApp.path);
+      expect(result, const ProcessResultMatcher());
+
+      // Verify custom tasks are successfully resolved FROM-CACHE.
+      final String stdout = result.stdout as String;
+      expect(stdout.contains('generateDebugResValues FROM-CACHE'), isTrue);
+      expect(stdout.contains('extractDeepLinksDebug FROM-CACHE'), isTrue);
+      expect(stdout.contains('processDebugMainManifest FROM-CACHE'), isTrue);
+      expect(stdout.contains('outputDebugAppLinkSettings FROM-CACHE'), isTrue);
+    },
+  );
 }

--- a/packages/flutter_tools/test/integration.shard/android_gradle_outputs_app_link_settings_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_gradle_outputs_app_link_settings_test.dart
@@ -449,7 +449,7 @@ void main() {
       expect(result, const ProcessResultMatcher());
 
       // Enable Gradle build caching.
-      final io.File gradleProperties = io.File(
+      final gradleProperties = io.File(
         fileSystem.path.join(tempDir.path, 'android', 'gradle.properties'),
       );
       gradleProperties.writeAsStringSync('\norg.gradle.caching=true\n', mode: io.FileMode.append);
@@ -487,7 +487,7 @@ void main() {
       expect(result, const ProcessResultMatcher());
 
       // Verify custom tasks are successfully resolved FROM-CACHE.
-      final String stdout = result.stdout as String;
+      final stdout = result.stdout as String;
       expect(stdout.contains('generateDebugResValues FROM-CACHE'), isTrue);
       expect(stdout.contains('extractDeepLinksDebug FROM-CACHE'), isTrue);
       expect(stdout.contains('processDebugMainManifest FROM-CACHE'), isTrue);


### PR DESCRIPTION
Gradle build caching isn't on by default, but a developer can easily set it themselves via `org.gradle.caching=true`. This change annotates `DeepLinkJsonFromManifestTask` gradle task with `@CacheableTask` so it can be cached if _build_ caching is turned on (note, this is a separate caching concept from the one used to decide what's dirty for incremental builds). The task is only generating a json file based on the AndroidManifest and manifest, and it already has clear inputs and outputs.

Also add `@PathSensitive(PathSensitivity.RELATIVE)` to the manifestFile input so the cache is relocatable across  directories.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
