### PR TITLE
Remove `currentMainUri` from `generateMainDartWithPluginRegistrant`

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/dart_plugin_registrant.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/dart_plugin_registrant.dart
@@ -38,11 +38,8 @@ class DartPluginRegistrantTarget extends Target {
     final String targetFilePath =
         environment.defines[kTargetFile] ?? environment.fileSystem.path.join('lib', 'main.dart');
     final File mainFile = environment.fileSystem.file(targetFilePath);
-    final Uri mainFileUri = mainFile.absolute.uri;
-    final String mainFileUriString =
-        packageConfig.toPackageUri(mainFileUri)?.toString() ?? mainFileUri.toString();
 
-    await generateMainDartWithPluginRegistrant(project, packageConfig, mainFileUriString, mainFile);
+    await generateMainDartWithPluginRegistrant(project, packageConfig, mainFile);
   }
 
   @override

--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -1881,8 +1881,8 @@ bool _hasPluginInlineDartImpl(Plugin plugin, String platformKey) {
 
 /// Generates the Dart plugin registrant, which allows to bind a platform
 /// implementation of a Dart only plugin to its interface.
-/// The new entrypoint wraps [currentMainUri], adds the `_PluginRegistrant` class,
-/// and writes the file to `newMainDart` at [FlutterProject.dartPluginRegistrant].
+/// The new entrypoint adds the `_PluginRegistrant` class and writes the file to
+/// `newMainDart` at [FlutterProject.dartPluginRegistrant].
 ///
 /// [mainFile] is the main entrypoint file, for example: `/<app>/lib/main.dart`.
 ///
@@ -1893,7 +1893,6 @@ bool _hasPluginInlineDartImpl(Plugin plugin, String platformKey) {
 Future<void> generateMainDartWithPluginRegistrant(
   FlutterProject rootProject,
   PackageConfig packageConfig,
-  String currentMainUri,
   File mainFile,
 ) async {
   final List<Plugin> plugins = await findPlugins(rootProject);
@@ -1907,7 +1906,6 @@ Future<void> generateMainDartWithPluginRegistrant(
     Cache.flutterRoot!,
   );
   final templateContext = <String, Object>{
-    'mainEntrypoint': currentMainUri,
     'dartLanguageVersion': entrypointVersion.toString(),
     AndroidPlugin.kConfigKey: <Object?>[],
     IOSPlugin.kConfigKey: <Object?>[],

--- a/packages/flutter_tools/lib/src/test/test_compiler.dart
+++ b/packages/flutter_tools/lib/src/test/test_compiler.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:meta/meta.dart';
-
 import 'package:package_config/package_config_types.dart';
 
 import '../base/file_system.dart';
@@ -240,13 +239,9 @@ class TestCompiler {
           // set (stable for one `flutter test` run) and the entrypoint's
           // language version, so we can skip this work when the language
           // version matches the previous compilation.
-          final String mainUriString =
-              buildInfo.packageConfig.toPackageUri(request.mainUri)?.toString() ??
-              request.mainUri.toString();
           await generateMainDartWithPluginRegistrant(
             flutterProject!,
             buildInfo.packageConfig,
-            mainUriString,
             mainFile,
           );
           invalidatedRegistrantFiles.add(flutterProject!.dartPluginRegistrant.absolute.uri);

--- a/packages/flutter_tools/test/general.shard/dart_plugin_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart_plugin_test.dart
@@ -1156,12 +1156,7 @@ void main() {
             logger: globals.logger,
             throwOnError: false,
           );
-          await generateMainDartWithPluginRegistrant(
-            flutterProject,
-            packageConfig,
-            'package:app/main.dart',
-            mainFile,
-          );
+          await generateMainDartWithPluginRegistrant(flutterProject, packageConfig, mainFile);
           expect(
             flutterProject.dartPluginRegistrant.readAsStringSync(),
             '//\n'
@@ -1281,12 +1276,7 @@ void main() {
             throwOnError: false,
           );
           await expectLater(
-            generateMainDartWithPluginRegistrant(
-              flutterProject,
-              packageConfig,
-              'package:app/main.dart',
-              mainFile,
-            ),
+            generateMainDartWithPluginRegistrant(flutterProject, packageConfig, mainFile),
             throwsToolExit(
               message:
                   'Invalid plugin specification url_launcher_macos.\n'
@@ -1324,12 +1314,7 @@ void main() {
             throwOnError: false,
           );
           await expectLater(
-            generateMainDartWithPluginRegistrant(
-              flutterProject,
-              packageConfig,
-              'package:app/main.dart',
-              mainFile,
-            ),
+            generateMainDartWithPluginRegistrant(flutterProject, packageConfig, mainFile),
             throwsToolExit(
               message:
                   'Invalid plugin specification url_launcher_macos.\n'
@@ -1361,12 +1346,7 @@ void main() {
             logger: globals.logger,
             throwOnError: false,
           );
-          await generateMainDartWithPluginRegistrant(
-            flutterProject,
-            packageConfig,
-            'package:app/main.dart',
-            mainFile,
-          );
+          await generateMainDartWithPluginRegistrant(flutterProject, packageConfig, mainFile);
           expect(flutterProject.dartPluginRegistrant.existsSync(), isFalse);
         },
         overrides: <Type, Generator>{
@@ -1401,23 +1381,13 @@ void main() {
             logger: globals.logger,
             throwOnError: false,
           );
-          await generateMainDartWithPluginRegistrant(
-            flutterProject,
-            packageConfig,
-            'package:app/main.dart',
-            mainFile,
-          );
+          await generateMainDartWithPluginRegistrant(flutterProject, packageConfig, mainFile);
           expect(flutterProject.dartPluginRegistrant.existsSync(), isTrue);
 
           // No plugins.
           createFakeDartPlugins(flutterProject, flutterManifest, fs, <String, String>{});
 
-          await generateMainDartWithPluginRegistrant(
-            flutterProject,
-            packageConfig,
-            'package:app/main.dart',
-            mainFile,
-          );
+          await generateMainDartWithPluginRegistrant(flutterProject, packageConfig, mainFile);
           expect(flutterProject.dartPluginRegistrant.existsSync(), isFalse);
         },
         overrides: <Type, Generator>{


### PR DESCRIPTION
Fixes #185600.

`currentMainUri` was unused.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

