### PR TITLE
[iOS] Migrate to explicit VSyncClient initialisers

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterKeyboardInsetManager.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterKeyboardInsetManager.mm
@@ -402,9 +402,11 @@
       animationCallback(projectedTargetTime);
     });
   };
-  _keyboardAnimationVSyncClient =
-      [[FlutterVSyncClient alloc] initWithTaskRunner:delegate.engine.uiTaskRunner
-                                            callback:vsyncCallback];
+  _keyboardAnimationVSyncClient = [[FlutterVSyncClient alloc]
+                initWithTaskRunner:delegate.engine.uiTaskRunner
+      isVariableRefreshRateEnabled:FlutterDisplayLinkManager.maxRefreshRateEnabledOnIPhone
+                    maxRefreshRate:FlutterDisplayLinkManager.displayRefreshRate
+                          callback:vsyncCallback];
   _keyboardAnimationVSyncClient.allowPauseAfterVsync = NO;
   [_keyboardAnimationVSyncClient await];
 }

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterVSyncClient+FML.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterVSyncClient+FML.h
@@ -15,17 +15,6 @@
 
 //------------------------------------------------------------------------------
 /// @brief      Initializes the vsync client with a C++ task runner and task callback.
-///             Refresh rate will default to the system settings.
-///             This is for backward-compatibility and should not be used in new code.
-///
-/// @param      task_runner The C++ task runner to use for posting tasks.
-/// @param      callback    The C++ callback to invoke when a vsync signal is received.
-///
-- (instancetype)initWithTaskRunnerPtr:(fml::RefPtr<fml::TaskRunner>)task_runner
-                             callback:(flutter::VsyncWaiter::Callback)callback;
-
-//------------------------------------------------------------------------------
-/// @brief      Initializes the vsync client with a C++ task runner and task callback.
 ///             This is for backward-compatibility and should not be used in new code.
 ///
 /// @param      task_runner                  The C++ task runner to use for posting tasks.

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterVSyncClient.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterVSyncClient.h
@@ -66,16 +66,6 @@ NS_SWIFT_NAME(VSyncClient)
 @property(nonatomic, assign) BOOL allowPauseAfterVsync;
 
 //------------------------------------------------------------------------------
-/// @brief      Initializes the vsync client. Refresh rate will default to the system settings.
-///
-/// @param      taskRunner The task runner to use for posting tasks.
-/// @param      callback   The callback to invoke when a vsync signal is received.
-///
-- (instancetype)initWithTaskRunner:(FlutterFMLTaskRunner*)taskRunner
-                          callback:(void (^)(CFTimeInterval startTime,
-                                             CFTimeInterval targetTime))callback;
-
-//------------------------------------------------------------------------------
 /// @brief      Initializes the vsync client.
 ///
 /// @param      taskRunner                   The task runner to use for posting tasks.

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterVSyncClient.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterVSyncClient.mm
@@ -51,14 +51,6 @@ NSString* const kCADisableMinimumFrameDurationOnPhoneKey = @"CADisableMinimumFra
   return self;
 }
 
-- (instancetype)initWithTaskRunnerPtr:(fml::RefPtr<fml::TaskRunner>)task_runner
-                             callback:(flutter::VsyncWaiter::Callback)callback {
-  return [self initWithTaskRunnerPtr:task_runner
-        isVariableRefreshRateEnabled:FlutterDisplayLinkManager.maxRefreshRateEnabledOnIPhone
-                      maxRefreshRate:FlutterDisplayLinkManager.displayRefreshRate
-                            callback:std::move(callback)];
-}
-
 - (instancetype)initWithTaskRunner:(FlutterFMLTaskRunner*)taskRunner
       isVariableRefreshRateEnabled:(BOOL)isVariableRefreshRateEnabled
                     maxRefreshRate:(double)maxRefreshRate
@@ -74,15 +66,6 @@ NSString* const kCADisableMinimumFrameDurationOnPhoneKey = @"CADisableMinimumFra
         isVariableRefreshRateEnabled:isVariableRefreshRateEnabled
                       maxRefreshRate:maxRefreshRate
                             callback:cpp_callback];
-}
-
-- (instancetype)initWithTaskRunner:(FlutterFMLTaskRunner*)taskRunner
-                          callback:(void (^)(CFTimeInterval startTime,
-                                             CFTimeInterval targetTime))callback {
-  return [self initWithTaskRunner:taskRunner
-      isVariableRefreshRateEnabled:FlutterDisplayLinkManager.maxRefreshRateEnabledOnIPhone
-                    maxRefreshRate:FlutterDisplayLinkManager.displayRefreshRate
-                          callback:callback];
 }
 
 - (void)setMaxRefreshRate:(double)refreshRate {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1302,9 +1302,11 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
       ^(CFTimeInterval startTime, CFTimeInterval targetTime) {
         // Do nothing in this block. Just trigger system to callback touch events with correct rate.
       };
-  _touchRateCorrectionVSyncClient =
-      [[FlutterVSyncClient alloc] initWithTaskRunner:self.engine.platformTaskRunner
-                                            callback:callback];
+  _touchRateCorrectionVSyncClient = [[FlutterVSyncClient alloc]
+                initWithTaskRunner:self.engine.platformTaskRunner
+      isVariableRefreshRateEnabled:FlutterDisplayLinkManager.maxRefreshRateEnabledOnIPhone
+                    maxRefreshRate:FlutterDisplayLinkManager.displayRefreshRate
+                          callback:callback];
   _touchRateCorrectionVSyncClient.allowPauseAfterVsync = NO;
 }
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/VSyncClientTest.swift
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/VSyncClientTest.swift
@@ -18,7 +18,11 @@ class VSyncClientTest: XCTestCase {
   }
 
   func testSetAllowPauseAfterVsyncCorrect() {
-    let vsyncClient = VSyncClient(taskRunner: threadTaskRunner) { _, _ in }!
+    let vsyncClient = VSyncClient(
+      taskRunner: threadTaskRunner,
+      isVariableRefreshRateEnabled: false,
+      maxRefreshRate: 60.0
+    ) { _, _ in }!
     let link = vsyncClient.displayLink
 
     vsyncClient.allowPauseAfterVsync = false
@@ -70,7 +74,11 @@ class VSyncClientTest: XCTestCase {
   }
 
   func testAwaitAndPauseWillWorkCorrectly() {
-    let vsyncClient = VSyncClient(taskRunner: threadTaskRunner) { _, _ in }!
+    let vsyncClient = VSyncClient(
+      taskRunner: threadTaskRunner,
+      isVariableRefreshRateEnabled: false,
+      maxRefreshRate: 60.0
+    ) { _, _ in }!
     let link = vsyncClient.displayLink
 
     XCTAssertTrue(link.isPaused)
@@ -86,7 +94,11 @@ class VSyncClientTest: XCTestCase {
 
     autoreleasepool {
       let vsyncExpectation = expectation(description: "vsync")
-      let client = VSyncClient(taskRunner: threadTaskRunner) { _, _ in
+      let client = VSyncClient(
+        taskRunner: threadTaskRunner,
+        isVariableRefreshRateEnabled: false,
+        maxRefreshRate: 60.0
+      ) { _, _ in
         vsyncExpectation.fulfill()
       }!
       weakClient = client

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
@@ -22,8 +22,11 @@ VsyncWaiterIOS::VsyncWaiterIOS(const flutter::TaskRunners& task_runners)
     const fml::TimePoint target_time = recorder->GetVsyncTargetTime();
     FireCallback(start_time, target_time, true);
   };
-  client_ = [[FlutterVSyncClient alloc] initWithTaskRunnerPtr:task_runners_.GetUITaskRunner()
-                                                     callback:callback];
+  client_ = [[FlutterVSyncClient alloc]
+             initWithTaskRunnerPtr:task_runners_.GetUITaskRunner()
+      isVariableRefreshRateEnabled:FlutterDisplayLinkManager.maxRefreshRateEnabledOnIPhone
+                    maxRefreshRate:FlutterDisplayLinkManager.displayRefreshRate
+                          callback:std::move(callback)];
   max_refresh_rate_ = FlutterDisplayLinkManager.displayRefreshRate;
 }
 


### PR DESCRIPTION
Migrates `FlutterVSyncClient` to use explicit designated initialisers and removes the convenience initialisers that implicitly injected refresh rate details from `FlutterDisplayLinkManager`.

Previously, `FlutterVSyncClient` provided initializers that defaulted the refresh rate settings by reading directly from `FlutterDisplayLinkManager` which created an implicit dependency on global state and made the class harder to test in isolation or with specific configurations.

Issue: https://github.com/flutter/flutter/issues/112232

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
