### PR TITLE
fix: resolve TestSemantics comparison and assert issues

### DIFF
--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -508,7 +508,7 @@ class TestSemantics {
       );
     }
 
-    if (controlsNodes != node.controlsNode && !setEquals(controlsNodes, node.controlsNodes)) {
+    if (controlsNodes != node.controlsNodes && !setEquals(controlsNodes, node.controlsNodes)) {
       return fail(
         'expected node id $id to controls nodes $controlsNodes but found controlling nodes ${node.controlsNodes}',
       );

--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -508,7 +508,7 @@ class TestSemantics {
       );
     }
 
-    if (controlsNodes != controlsNodes && !setEquals(controlsNodes, node.controlsNodes)) {
+    if (controlsNodes != node.controlsNode && !setEquals(controlsNodes, node.controlsNodes)) {
       return fail(
         'expected node id $id to controls nodes $controlsNodes but found controlling nodes ${node.controlsNodes}',
       );
@@ -716,7 +716,7 @@ class SemanticsTester {
           (second[i] is! LocaleStringAttribute ||
               second[i].range != first[i].range ||
               (second[i] as LocaleStringAttribute).locale !=
-                  (second[i] as LocaleStringAttribute).locale)) {
+                  (first[i] as LocaleStringAttribute).locale)) {
         return false;
       }
     }
@@ -1167,22 +1167,22 @@ class _IncludesNodeWith extends Matcher {
     this.minValue,
     this.maxValue,
   }) : assert(
-         label != null ||
-             value != null ||
-             actions != null ||
-             flags != null ||
-             flagsCollection != null ||
-             tags != null ||
-             increasedValue != null ||
-             decreasedValue != null ||
-             scrollPosition != null ||
-             scrollExtentMax != null ||
-             scrollExtentMin != null ||
-             maxValueLength != null ||
-             currentValueLength != null ||
-             inputType != null,
-         minValue != null || maxValue != null,
-       );
+  (label != null ||
+      value != null ||
+      actions != null ||
+      flags != null ||
+      flagsCollection != null ||
+      tags != null ||
+      increasedValue != null ||
+      decreasedValue != null ||
+      scrollPosition != null ||
+      scrollExtentMax != null ||
+      scrollExtentMin != null ||
+      maxValueLength != null ||
+      currentValueLength != null ||
+      inputType != null) &&
+  (minValue != null || maxValue != null),
+);
   final AttributedString? attributedLabel;
   final AttributedString? attributedValue;
   final AttributedString? attributedHint;

--- a/packages/flutter/test/widgets/semantics_tester_test.dart
+++ b/packages/flutter/test/widgets/semantics_tester_test.dart
@@ -149,4 +149,34 @@ void main() {
     );
     semantics.dispose();
   });
+
+  testWidgets('TestSemantics detects different locales correctly', (WidgetTester tester) async {
+  final first = TestSemantics(
+    id: 1,
+    label: 'Hello',
+    locale: const Locale('en'),
+  );
+
+  final second = TestSemantics(
+    id: 1,
+    label: 'Hello',
+    locale: const Locale('fr'),
+  );
+
+  expect(first, isNot(equals(second)));
+});
+
+  testWidgets('TestSemantics detects different controlNodes correctly', (WidgetTester tester) async {
+  final first = TestSemantics(
+    id: 1,
+    controlsNodes: <String>{'1', '2'},
+  );
+
+  final second = TestSemantics(
+    id: 1,
+    controlsNodes: <String>{'3', '4'},
+  );
+
+  expect(first, isNot(equals(second)));
+});
 }


### PR DESCRIPTION
## Description

Fixes multiple issues in `TestSemantics` where incorrect comparisons
and an invalid assert condition resulted in unintended behavior.

Changes include:

* Corrected comparison of `LocaleStringAttribute.locale` to avoid
  comparing a value with itself
* Fixed incorrect comparison of `controlsNodes` with itself
* Updated assert statement to properly combine conditions using `&&`
  instead of passing multiple arguments

These fixes improve correctness and prevent logical errors in
semantics testing.

## Issues fixed by this PR

Fixes https://github.com/flutter/flutter/issues/185900

## Pre-launch Checklist

* [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
* [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
* [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
* [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
* [x] I signed the [CLA].
* [x] I listed at least one issue that this PR fixes in the description above.
* [ ] I updated/added relevant documentation (doc comments with `///`).
* [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
* [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
* [x] All existing and new tests are passing.
