### PR TITLE
Fix ellipsis before truncated hard line breaks

### DIFF
--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -429,6 +429,7 @@ class _TextPainterLayoutCacheWithOffset {
     this.textAlignment,
     this.layoutMaxWidth,
     this.contentWidth,
+    this.insertedEllipsisAt,
   ) : assert(textAlignment >= 0.0 && textAlignment <= 1.0),
       assert(!layoutMaxWidth.isNaN),
       assert(!contentWidth.isNaN);
@@ -437,6 +438,11 @@ class _TextPainterLayoutCacheWithOffset {
 
   // The input width used to lay out the paragraph.
   final double layoutMaxWidth;
+
+  // The offset of the truncating hard line break preceded by the configured
+  // ellipsis, if any.
+  final int? insertedEllipsisAt;
+  bool get hasInsertedEllipsis => insertedEllipsisAt != null;
 
   // The content width the text painter should report in TextPainter.width.
   // This is also used to compute `paintOffset`.
@@ -471,6 +477,9 @@ class _TextPainterLayoutCacheWithOffset {
   bool _resizeToFit(double minWidth, double maxWidth, TextWidthBasis widthBasis) {
     assert(layout.maxIntrinsicLineExtent.isFinite);
     assert(minWidth <= maxWidth);
+    if (hasInsertedEllipsis && maxWidth != layoutMaxWidth) {
+      return false;
+    }
     // The assumption here is that if a Paragraph's width is already >= its
     // maxIntrinsicWidth, further increasing the input width does not change its
     // layout (but may change the paint offset if it's not left-aligned). This is
@@ -1198,15 +1207,103 @@ class TextPainter {
 
   // Creates a ui.Paragraph using the current configurations in this class and
   // assign it to _paragraph.
-  ui.Paragraph _createParagraph(InlineSpan text) {
+  ui.Paragraph _createParagraph(InlineSpan text, {int? insertEllipsisBeforeNewlineAt}) {
     final builder = ui.ParagraphBuilder(_createParagraphStyle());
-    text.build(builder, textScaler: textScaler, dimensions: _placeholderDimensions);
+    final InlineSpan textToBuild = insertEllipsisBeforeNewlineAt == null
+        ? text
+        : _insertEllipsisBeforeNewline(text, insertEllipsisBeforeNewlineAt);
+    textToBuild.build(builder, textScaler: textScaler, dimensions: _placeholderDimensions);
     assert(() {
       _debugMarkNeedsLayoutCallStack = null;
       return true;
     }());
     _rebuildParagraphForPaint = false;
     return builder.build();
+  }
+
+  InlineSpan _insertEllipsisBeforeNewline(InlineSpan text, int newlineOffset) {
+    final String ellipsis = _ellipsis!;
+    final Accumulator offset = Accumulator();
+
+    InlineSpan replace(InlineSpan span) {
+      if (span is! TextSpan) {
+        offset.increment(span.toPlainText(includeSemanticsLabels: false).length);
+        return span;
+      }
+
+      bool changed = false;
+      final String? spanText = span.text;
+      String? replacedText = spanText;
+      if (spanText != null) {
+        final int spanStart = offset.value;
+        final int localOffset = newlineOffset - spanStart;
+        offset.increment(spanText.length);
+        if (localOffset >= 0 && localOffset < spanText.length) {
+          assert(WordBoundary._isNewline(spanText.codeUnitAt(localOffset)));
+          replacedText = spanText.replaceRange(localOffset, localOffset, ellipsis);
+          changed = true;
+        }
+      }
+
+      final List<InlineSpan>? children = span.children;
+      List<InlineSpan>? replacedChildren;
+      if (children != null) {
+        replacedChildren = <InlineSpan>[];
+        for (final InlineSpan child in children) {
+          final InlineSpan replacedChild = replace(child);
+          changed = changed || !identical(child, replacedChild);
+          replacedChildren.add(replacedChild);
+        }
+      }
+
+      return changed
+          ? TextSpan(
+              text: replacedText,
+              children: replacedChildren,
+              style: span.style,
+              recognizer: span.recognizer,
+              mouseCursor: span.mouseCursor,
+              onEnter: span.onEnter,
+              onExit: span.onExit,
+              semanticsLabel: span.semanticsLabel,
+              semanticsIdentifier: span.semanticsIdentifier,
+              locale: span.locale,
+              spellOut: span.spellOut,
+            )
+          : span;
+    }
+
+    return replace(text);
+  }
+
+  int? _truncatingNewlineOffset(_TextLayout layout) {
+    final ui.Paragraph paragraph = layout._paragraph;
+    if (_maxLines == null || _ellipsis == null || !paragraph.didExceedMaxLines) {
+      return null;
+    }
+
+    // SkParagraph omits later lines for maxLines, but a hard break at the end
+    // of the last visible line does not leave an overflowing glyph to ellipsize.
+    final List<ui.LineMetrics> lineMetrics = paragraph.computeLineMetrics();
+    if (lineMetrics.isEmpty || !lineMetrics.last.hardBreak) {
+      return null;
+    }
+
+    final String text = plainText;
+    int lineStart = 0;
+    for (int lineNumber = 0; lineNumber < lineMetrics.length; lineNumber += 1) {
+      final TextRange line = paragraph.getLineBoundary(TextPosition(offset: lineStart));
+      if (lineNumber == lineMetrics.length - 1) {
+        return line.end < text.length && WordBoundary._isNewline(text.codeUnitAt(line.end))
+            ? line.end
+            : null;
+      }
+      if (line.end >= text.length) {
+        return null;
+      }
+      lineStart = WordBoundary._isNewline(text.codeUnitAt(line.end)) ? line.end + 1 : line.end;
+    }
+    return null;
   }
 
   /// Computes the visual position of the glyphs for painting the text.
@@ -1249,9 +1346,13 @@ class TextPainter {
     // when the text is not left-aligned, so we don't have to deal with an
     // infinite paint offset.
     final bool adjustMaxWidth = !maxWidth.isFinite && paintOffsetAlignment != 0;
+    final bool canUseCachedIntrinsicWidth =
+        cachedLayout != null && !cachedLayout.hasInsertedEllipsis;
     final double? adjustedMaxWidth = !adjustMaxWidth
         ? maxWidth
-        : cachedLayout?.layout.maxIntrinsicLineExtent;
+        : canUseCachedIntrinsicWidth
+        ? cachedLayout.layout.maxIntrinsicLineExtent
+        : null;
     final double layoutMaxWidth = adjustedMaxWidth ?? maxWidth;
 
     // Only rebuild the paragraph when there're layout changes, even when
@@ -1261,9 +1362,25 @@ class TextPainter {
     //    the paragraph rebuilds is unnecessary)
     // 2. the user could be measuring the text layout so `paint` will never be
     //    called.
-    final ui.Paragraph paragraph = (cachedLayout?.paragraph ?? _createParagraph(text))
-      ..layout(ui.ParagraphConstraints(width: layoutMaxWidth));
-    final layout = _TextLayout._(paragraph, textDirection, this);
+    final bool canReuseCachedParagraph = canUseCachedIntrinsicWidth;
+    ui.Paragraph paragraph = canReuseCachedParagraph
+        ? cachedLayout.paragraph
+        : _createParagraph(text);
+    if (!canReuseCachedParagraph) {
+      cachedLayout?.paragraph.dispose();
+    }
+    paragraph.layout(ui.ParagraphConstraints(width: layoutMaxWidth));
+    _TextLayout layout = _TextLayout._(paragraph, textDirection, this);
+    final int? insertedEllipsisAt = _truncatingNewlineOffset(layout);
+    if (insertedEllipsisAt != null) {
+      final ui.Paragraph replacementParagraph = _createParagraph(
+        text,
+        insertEllipsisBeforeNewlineAt: insertedEllipsisAt,
+      )..layout(ui.ParagraphConstraints(width: layoutMaxWidth));
+      paragraph.dispose();
+      paragraph = replacementParagraph;
+      layout = _TextLayout._(paragraph, textDirection, this);
+    }
     final double contentWidth = layout._contentWidthFor(minWidth, maxWidth, textWidthBasis);
 
     final _TextPainterLayoutCacheWithOffset newLayoutCache;
@@ -1279,6 +1396,7 @@ class TextPainter {
         paintOffsetAlignment,
         newInputWidth,
         contentWidth,
+        insertedEllipsisAt,
       );
     } else {
       newLayoutCache = _TextPainterLayoutCacheWithOffset(
@@ -1286,6 +1404,7 @@ class TextPainter {
         paintOffsetAlignment,
         layoutMaxWidth,
         contentWidth,
+        insertedEllipsisAt,
       );
     }
     _layoutCache = newLayoutCache;
@@ -1344,8 +1463,10 @@ class TextPainter {
       // no API to only make those updates so the paragraph has to be recreated
       // and re-laid out.
       assert(!layoutCache.layoutMaxWidth.isNaN);
-      layoutCache.layout._paragraph = _createParagraph(text!)
-        ..layout(ui.ParagraphConstraints(width: layoutCache.layoutMaxWidth));
+      layoutCache.layout._paragraph = _createParagraph(
+        text!,
+        insertEllipsisBeforeNewlineAt: layoutCache.insertedEllipsisAt,
+      )..layout(ui.ParagraphConstraints(width: layoutCache.layoutMaxWidth));
       assert(paragraph.width == layoutCache.layout._paragraph.width);
       paragraph.dispose();
       assert(debugSize == size);

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -40,6 +40,19 @@ export 'package:flutter/services.dart' show TextRange, TextSelection;
 /// LibTxt's text_style.h, paragraph_style.h).
 const double kDefaultFontSize = 14.0;
 
+bool _isNewline(int codePoint) {
+  // Carriage Return is not treated as a hard line break.
+  return switch (codePoint) {
+    0x000A || // Line Feed
+    0x0085 || // New Line
+    0x000B || // Form Feed
+    0x000C || // Vertical Feed
+    0x2028 || // Line Separator
+    0x2029 => true, // Paragraph Separator
+    _ => false,
+  };
+}
+
 /// How overflowing text should be handled.
 ///
 /// A [TextOverflow] can be passed to [Text] and [RichText] via their
@@ -210,19 +223,6 @@ class WordBoundary extends TextBoundary {
       0xD800 => _codePointFromSurrogates(codeUnitAtIndex, _text.codeUnitAt(index + 1)!),
       0xDC00 => _codePointFromSurrogates(_text.codeUnitAt(index - 1)!, codeUnitAtIndex),
       _ => codeUnitAtIndex,
-    };
-  }
-
-  static bool _isNewline(int codePoint) {
-    // Carriage Return is not treated as a hard line break.
-    return switch (codePoint) {
-      0x000A || // Line Feed
-      0x0085 || // New Line
-      0x000B || // Form Feed
-      0x000C || // Vertical Feed
-      0x2028 || // Line Separator
-      0x2029 => true, // Paragraph Separator
-      _ => false,
     };
   }
 
@@ -1226,7 +1226,7 @@ class TextPainter {
     final Accumulator offset = Accumulator();
 
     InlineSpan replace(InlineSpan span) {
-      if (span is! TextSpan) {
+      if (span is! TextSpan || span.runtimeType != TextSpan) {
         offset.increment(span.toPlainText(includeSemanticsLabels: false).length);
         return span;
       }
@@ -1239,7 +1239,7 @@ class TextPainter {
         final int localOffset = newlineOffset - spanStart;
         offset.increment(spanText.length);
         if (localOffset >= 0 && localOffset < spanText.length) {
-          assert(WordBoundary._isNewline(spanText.codeUnitAt(localOffset)));
+          assert(_isNewline(spanText.codeUnitAt(localOffset)));
           replacedText = spanText.replaceRange(localOffset, localOffset, ellipsis);
           changed = true;
         }
@@ -1257,6 +1257,9 @@ class TextPainter {
       }
 
       return changed
+          // TODO(https://github.com/flutter/flutter/issues/50168): Replace this
+          // manual copy if TextSpan gains a copying API that can preserve future
+          // TextSpan properties while modifying text and children.
           ? TextSpan(
               text: replacedText,
               children: replacedChildren,
@@ -1294,14 +1297,12 @@ class TextPainter {
     for (int lineNumber = 0; lineNumber < lineMetrics.length; lineNumber += 1) {
       final TextRange line = paragraph.getLineBoundary(TextPosition(offset: lineStart));
       if (lineNumber == lineMetrics.length - 1) {
-        return line.end < text.length && WordBoundary._isNewline(text.codeUnitAt(line.end))
-            ? line.end
-            : null;
+        return line.end < text.length && _isNewline(text.codeUnitAt(line.end)) ? line.end : null;
       }
       if (line.end >= text.length) {
         return null;
       }
-      lineStart = WordBoundary._isNewline(text.codeUnitAt(line.end)) ? line.end + 1 : line.end;
+      lineStart = _isNewline(text.codeUnitAt(line.end)) ? line.end + 1 : line.end;
     }
     return null;
   }
@@ -1628,9 +1629,7 @@ class TextPainter {
   }
 
   bool _isNewlineAtOffset(int offset) =>
-      0 <= offset &&
-      offset < plainText.length &&
-      WordBoundary._isNewline(plainText.codeUnitAt(offset));
+      0 <= offset && offset < plainText.length && _isNewline(plainText.codeUnitAt(offset));
 
   // Cached caret metrics. This allows multiple invokes of [getOffsetForCaret] and
   // [getFullHeightForCaret] in a row without performing redundant and expensive

--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -988,6 +988,24 @@ void main() {
     painter.dispose();
   });
 
+  test('TextPainter paints ellipsis before an overflowing hard line break', () {
+    final painter = TextPainter(
+      text: const TextSpan(text: 'AAA\nBBB', style: TextStyle(fontSize: 10.0)),
+      textDirection: TextDirection.ltr,
+      maxLines: 1,
+      ellipsis: '\u2026',
+    )..layout(maxWidth: 100.0);
+
+    expect(painter.didExceedMaxLines, isTrue);
+    expect(painter.computeLineMetrics().single.width, 40.0);
+    expect(
+      painter.getBoxesForSelection(const TextSelection(baseOffset: 3, extentOffset: 4)).single,
+      const TextBox.fromLTRBD(30.0, 0.0, 40.0, 10.0, TextDirection.ltr),
+    );
+
+    painter.dispose();
+  });
+
   test('TextPainter intrinsic dimensions', () {
     const style = TextStyle(inherit: false, fontSize: 10.0);
     TextPainter painter;


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

This PR fixes an ellipsis rendering case where text exceeded `maxLines` because the final visible line ended at an explicit newline.

Before this change, a widget like:

```dart
Text(
  'some text that changes lines \n\n\n\n a new line',
  maxLines: 1,
  overflow: TextOverflow.ellipsis,
)
```
could render only:

`some text that changes lines
`

without an ellipsis, even though later lines were truncated.

The issue happens because the visible line ends cleanly at a hard line break, so the paragraph engine omits the later lines but has no overflowing glyph on the visible line to replace with an ellipsis.

This PR updates TextPainter to detect when maxLines truncates text immediately after a hard line break and inserts the configured ellipsis before that truncating newline for layout. This makes the visible output indicate that more text exists, for example:

`some text that changes lines…
`
<img width="338" height="84" alt="image" src="https://github.com/user-attachments/assets/05c2aa5a-2e21-4fcc-9fbf-9a98b5efeca9" />

The changes also fixes  ` maxLines: 2`

<img width="292" height="110" alt="image" src="https://github.com/user-attachments/assets/1bf72e0d-a0d7-47cc-8f8a-56d87ada1a3a" />


A regression test was added for TextPainter with AAA\nBBB, maxLines: 1, and an ellipsis. The test verifies that the paragraph still reports exceeded max lines and that the ellipsis is laid out on the visible line.

Fixes [#50168](https://github.com/flutter/flutter/issues/50168)

No changes were made to the flutter/tests repository. This is not a breaking change.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.