### PR TITLE
Sanitize Git environment for Flutter SDK git commands

### DIFF
--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -35,6 +35,25 @@ SET engine_stamp=%cache_dir%\engine-dart-sdk.stamp
 SET engine_version_path=%cache_dir%\engine.stamp
 SET dart=%dart_sdk_path%\bin\dart.exe
 
+REM Git hooks export repository-local GIT_* variables. The Flutter SDK is a
+REM separate git checkout, so these variables must not affect git commands that
+REM operate on FLUTTER_ROOT.
+SET GIT_ALTERNATE_OBJECT_DIRECTORIES=
+SET GIT_CONFIG=
+SET GIT_CONFIG_PARAMETERS=
+SET GIT_CONFIG_COUNT=
+SET GIT_OBJECT_DIRECTORY=
+SET GIT_DIR=
+SET GIT_WORK_TREE=
+SET GIT_IMPLICIT_WORK_TREE=
+SET GIT_GRAFT_FILE=
+SET GIT_INDEX_FILE=
+SET GIT_NO_REPLACE_OBJECTS=
+SET GIT_REPLACE_REF_BASE=
+SET GIT_PREFIX=
+SET GIT_SHALLOW_FILE=
+SET GIT_COMMON_DIR=
+
 REM Ensure that bin/cache exists.
 IF NOT EXIST "%cache_dir%" MKDIR "%cache_dir%"
 

--- a/bin/internal/shared.sh
+++ b/bin/internal/shared.sh
@@ -38,6 +38,27 @@ function pub_upgrade_with_retry {
   return 0
 }
 
+function unset_repository_local_git_environment() {
+  # Git hooks export repository-local GIT_* variables. The Flutter SDK is a
+  # separate git checkout, so these variables must not affect git commands that
+  # operate on FLUTTER_ROOT.
+  unset GIT_ALTERNATE_OBJECT_DIRECTORIES
+  unset GIT_CONFIG
+  unset GIT_CONFIG_PARAMETERS
+  unset GIT_CONFIG_COUNT
+  unset GIT_OBJECT_DIRECTORY
+  unset GIT_DIR
+  unset GIT_WORK_TREE
+  unset GIT_IMPLICIT_WORK_TREE
+  unset GIT_GRAFT_FILE
+  unset GIT_INDEX_FILE
+  unset GIT_NO_REPLACE_OBJECTS
+  unset GIT_REPLACE_REF_BASE
+  unset GIT_PREFIX
+  unset GIT_SHALLOW_FILE
+  unset GIT_COMMON_DIR
+}
+
 # Trap function for removing any remaining lock file at exit.
 function _rmlock () {
   [ -n "$FLUTTER_UPGRADE_LOCK" ] && rm -rf -- "$FLUTTER_UPGRADE_LOCK"
@@ -195,6 +216,7 @@ function upgrade_flutter () (
 # entrypoints.
 function shared::execute() {
   export FLUTTER_ROOT="$(cd "${BIN_DIR}/.." ; pwd -P)"
+  unset_repository_local_git_environment
 
   # If present, run the bootstrap script first
   BOOTSTRAP_PATH="$FLUTTER_ROOT/bin/internal/bootstrap.sh"

--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -178,6 +178,9 @@ abstract class ProcessUtils {
   /// When [environment] is supplied, it is used as the environment for the child
   /// process.
   ///
+  /// When [includeParentEnvironment] is false, only [environment] is passed to
+  /// the child process.
+  ///
   /// When [timeout] is supplied, kills the child process and
   /// throws a [ProcessException] when it doesn't finish in time.
   ///
@@ -190,6 +193,7 @@ abstract class ProcessUtils {
     String? workingDirectory,
     bool allowReentrantFlutter = false,
     Map<String, String>? environment,
+    bool includeParentEnvironment = true,
     Duration? timeout,
     int timeoutRetries = 0,
   });
@@ -203,6 +207,7 @@ abstract class ProcessUtils {
     bool hideStdout = false,
     String? workingDirectory,
     Map<String, String>? environment,
+    bool includeParentEnvironment = true,
     bool allowReentrantFlutter = false,
     Encoding encoding = systemEncoding,
   });
@@ -214,6 +219,7 @@ abstract class ProcessUtils {
     String? workingDirectory,
     bool allowReentrantFlutter = false,
     Map<String, String>? environment,
+    bool includeParentEnvironment = true,
     ProcessStartMode mode = ProcessStartMode.normal,
   });
 
@@ -238,6 +244,7 @@ abstract class ProcessUtils {
     RegExp? stdoutErrorMatcher,
     StringConverter? mapFunction,
     Map<String, String>? environment,
+    bool includeParentEnvironment = true,
   });
 
   bool exitsHappySync(List<String> cli, {Map<String, String>? environment});
@@ -352,6 +359,7 @@ class _DefaultProcessUtils implements ProcessUtils {
     String? workingDirectory,
     bool allowReentrantFlutter = false,
     Map<String, String>? environment,
+    bool includeParentEnvironment = true,
     Duration? timeout,
     int timeoutRetries = 0,
   }) async {
@@ -370,6 +378,7 @@ class _DefaultProcessUtils implements ProcessUtils {
         cmd,
         workingDirectory: workingDirectory,
         environment: _environment(allowReentrantFlutter, environment),
+        includeParentEnvironment: includeParentEnvironment,
       );
       final runResult = RunResult(results, cmd);
       _logger.printTrace(runResult.toString());
@@ -394,6 +403,7 @@ class _DefaultProcessUtils implements ProcessUtils {
         workingDirectory: workingDirectory,
         allowReentrantFlutter: allowReentrantFlutter,
         environment: environment,
+        includeParentEnvironment: includeParentEnvironment,
       );
 
       final stdoutBuffer = StringBuffer();
@@ -477,6 +487,7 @@ class _DefaultProcessUtils implements ProcessUtils {
     bool hideStdout = false,
     String? workingDirectory,
     Map<String, String>? environment,
+    bool includeParentEnvironment = true,
     bool allowReentrantFlutter = false,
     Encoding encoding = systemEncoding,
   }) {
@@ -485,6 +496,7 @@ class _DefaultProcessUtils implements ProcessUtils {
       cmd,
       workingDirectory: workingDirectory,
       environment: _environment(allowReentrantFlutter, environment),
+      includeParentEnvironment: includeParentEnvironment,
       stderrEncoding: encoding,
       stdoutEncoding: encoding,
     );
@@ -532,6 +544,7 @@ class _DefaultProcessUtils implements ProcessUtils {
     String? workingDirectory,
     bool allowReentrantFlutter = false,
     Map<String, String>? environment,
+    bool includeParentEnvironment = true,
     ProcessStartMode mode = ProcessStartMode.normal,
   }) {
     _traceCommand(cmd, workingDirectory: workingDirectory);
@@ -539,6 +552,7 @@ class _DefaultProcessUtils implements ProcessUtils {
       cmd,
       workingDirectory: workingDirectory,
       environment: _environment(allowReentrantFlutter, environment),
+      includeParentEnvironment: includeParentEnvironment,
       mode: mode,
     );
   }
@@ -554,12 +568,14 @@ class _DefaultProcessUtils implements ProcessUtils {
     RegExp? stdoutErrorMatcher,
     StringConverter? mapFunction,
     Map<String, String>? environment,
+    bool includeParentEnvironment = true,
   }) async {
     final Process process = await start(
       cmd,
       workingDirectory: workingDirectory,
       allowReentrantFlutter: allowReentrantFlutter,
       environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
     );
     final StreamSubscription<String> stdoutSubscription = process.stdout
         .transform(utf8LineDecoder)

--- a/packages/flutter_tools/lib/src/git.dart
+++ b/packages/flutter_tools/lib/src/git.dart
@@ -60,7 +60,8 @@ interface class Git {
       allowedFailures: allowedFailures,
       workingDirectory: workingDirectory,
       allowReentrantFlutter: allowReentrantFlutter,
-      environment: {if (_platform.isWindows) ..._useNoGlobCygwinGit, ...?environment},
+      environment: _environment(environment),
+      includeParentEnvironment: false,
       timeout: timeout,
       timeoutRetries: timeoutRetries,
     );
@@ -90,7 +91,8 @@ interface class Git {
       allowedFailures: allowedFailures,
       hideStdout: hideStdout,
       workingDirectory: workingDirectory,
-      environment: {if (_platform.isWindows) ..._useNoGlobCygwinGit, ...?environment},
+      environment: _environment(environment),
+      includeParentEnvironment: false,
       allowReentrantFlutter: allowReentrantFlutter,
       encoding: encoding,
     );
@@ -123,9 +125,41 @@ interface class Git {
       filter: filter,
       stdoutErrorMatcher: stdoutErrorMatcher,
       mapFunction: mapFunction,
-      environment: {if (_platform.isWindows) ..._useNoGlobCygwinGit, ...?environment},
+      environment: _environment(environment),
+      includeParentEnvironment: false,
     );
   }
+
+  Map<String, String> _environment(Map<String, String>? environment) {
+    return <String, String>{
+      ..._platform.environment,
+      if (_platform.isWindows) ..._useNoGlobCygwinGit,
+      ...?environment,
+    }..removeWhere(
+      (String key, _) => _repositoryLocalEnvironmentVariables.contains(key.toUpperCase()),
+    );
+  }
+
+  // Repository-local Git environment variables can be exported by Git hooks.
+  // Flutter's internal git commands operate on explicit working directories
+  // and must not inherit another repository's git context.
+  static const _repositoryLocalEnvironmentVariables = <String>{
+    'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+    'GIT_CONFIG',
+    'GIT_CONFIG_PARAMETERS',
+    'GIT_CONFIG_COUNT',
+    'GIT_OBJECT_DIRECTORY',
+    'GIT_DIR',
+    'GIT_WORK_TREE',
+    'GIT_IMPLICIT_WORK_TREE',
+    'GIT_GRAFT_FILE',
+    'GIT_INDEX_FILE',
+    'GIT_NO_REPLACE_OBJECTS',
+    'GIT_REPLACE_REF_BASE',
+    'GIT_PREFIX',
+    'GIT_SHALLOW_FILE',
+    'GIT_COMMON_DIR',
+  };
 
   static const _useNoGlobCygwinGit = {'MSYS': 'noglob', 'CYGWIN': 'noglob'};
 }

--- a/packages/flutter_tools/test/general.shard/version_test.dart
+++ b/packages/flutter_tools/test/general.shard/version_test.dart
@@ -65,6 +65,7 @@ void main() {
     required String headRef,
     required String ancestorRef,
     required int commitsBetweenRefs,
+    Map<String, String>? environment,
   }) {
     return [
       FakeCommand(
@@ -76,11 +77,17 @@ void main() {
           '--format=%(refname:short)',
           'refs/tags/[0-9]*.*.*',
         ],
+        environment: environment,
         stdout: latestTag,
       ),
-      FakeCommand(command: ['git', 'merge-base', headRef, latestTag], stdout: ancestorRef),
+      FakeCommand(
+        command: ['git', 'merge-base', headRef, latestTag],
+        environment: environment,
+        stdout: ancestorRef,
+      ),
       FakeCommand(
         command: ['git', 'rev-list', '--count', '$ancestorRef..$headRef'],
+        environment: environment,
         stdout: '$commitsBetweenRefs',
       ),
     ];
@@ -901,6 +908,84 @@ void main() {
       expect(processManager, hasNoRemainingExpectations);
     },
     overrides: <Type, Generator>{ProcessManager: () => processManager, Cache: () => cache},
+  );
+
+  testUsingContext(
+    'version does not pass repository-local Git environment variables to git',
+    () async {
+      const expectedGitEnvironment = <String, String>{'PATH': '/usr/bin', 'CUSTOM_ENV': 'keep'};
+      processManager.addCommands(<FakeCommand>[
+        const FakeCommand(
+          command: <String>[
+            'git',
+            '-c',
+            'log.showSignature=false',
+            'log',
+            '-n',
+            '1',
+            '--pretty=format:%H',
+          ],
+          environment: expectedGitEnvironment,
+          stdout: '1234abcd',
+        ),
+        const FakeCommand(
+          command: <String>['git', 'tag', '--points-at', '1234abcd'],
+          environment: expectedGitEnvironment,
+        ),
+        ...mockGitTagHistory(
+          latestTag: '0.1.2-3',
+          headRef: '1234abcd',
+          ancestorRef: 'abcd1234',
+          commitsBetweenRefs: 170,
+          environment: expectedGitEnvironment,
+        ),
+        const FakeCommand(
+          command: <String>['git', 'symbolic-ref', '--short', 'HEAD'],
+          environment: expectedGitEnvironment,
+          stdout: 'feature-branch',
+        ),
+      ]);
+
+      final contaminatedGitEnvironment = <String, String>{
+        'PATH': '/usr/bin',
+        'CUSTOM_ENV': 'keep',
+        'GIT_ALTERNATE_OBJECT_DIRECTORIES': '/wrong/objects',
+        'GIT_CONFIG': '/wrong/config',
+        'git_config_parameters': "'user.name=wrong'",
+        'GIT_CONFIG_COUNT': '1',
+        'GIT_OBJECT_DIRECTORY': '/wrong/object-directory',
+        'GIT_DIR': '/wrong/git-dir',
+        'Git_Work_Tree': '/wrong/work-tree',
+        'GIT_IMPLICIT_WORK_TREE': '0',
+        'GIT_GRAFT_FILE': '/wrong/grafts',
+        'git_index_file': '/wrong/index',
+        'GIT_NO_REPLACE_OBJECTS': '1',
+        'GIT_REPLACE_REF_BASE': 'refs/wrong',
+        'GIT_PREFIX': 'wrong-prefix',
+        'GIT_SHALLOW_FILE': '/wrong/shallow',
+        'GIT_COMMON_DIR': '/wrong/common-dir',
+      };
+      git = Git(
+        currentPlatform: FakePlatform(environment: contaminatedGitEnvironment),
+        runProcessWith: ProcessUtils(processManager: processManager, logger: testLogger),
+      );
+
+      final fs = MemoryFileSystem.test();
+      final flutterVersion = FlutterVersion(
+        clock: _testClock,
+        fs: fs,
+        flutterRoot: '/path/to/flutter',
+        git: git,
+      );
+
+      expect(flutterVersion.getVersionString(), 'feature-branch/1234abcd');
+      expect(processManager, hasNoRemainingExpectations);
+    },
+    overrides: <Type, Generator>{
+      ProcessManager: () => processManager,
+      Cache: () => cache,
+      Git: () => git,
+    },
   );
 
   testUsingContext(


### PR DESCRIPTION
Fixes #180421.

Git hooks can export repository-local `GIT_*` variables such as `GIT_DIR`,
`GIT_WORK_TREE`, `GIT_INDEX_FILE`, and `GIT_COMMON_DIR`. When Flutter is invoked
from such a hook, those variables can leak into Flutter SDK git commands.

Because the Flutter SDK itself is a separate git checkout, inherited repository
Git environment can cause SDK version detection to read the caller repository
instead of `FLUTTER_ROOT`, producing `0.0.0-unknown` or bootstrap git errors.

This change sanitizes repository-local Git environment variables in:
- shell/batch bootstrap scripts before SDK git commands run
- the Dart `Git` wrapper used by `flutter_tools`

It also adds a regression test that verifies Flutter version detection does not
pass repository-local Git environment variables to git.

## Tests

- `FLUTTER_ROOT=/private/tmp/flutter-sanitize-git-env bin/cache/dart-sdk/bin/dart test packages/flutter_tools/test/general.shard/version_test.dart`
- `FLUTTER_ROOT=/private/tmp/flutter-sanitize-git-env bin/cache/dart-sdk/bin/dart analyze packages/flutter_tools/lib/src/base/process.dart packages/flutter_tools/lib/src/git.dart packages/flutter_tools/test/general.shard/version_test.dart`
- Manual: `./bin/flutter --version` with contaminated `GIT_DIR` / `GIT_WORK_TREE`
