### PR TITLE
Add blendMode parameter to RawImage and RenderImage

### DIFF
--- a/packages/flutter/lib/src/rendering/image.dart
+++ b/packages/flutter/lib/src/rendering/image.dart
@@ -42,6 +42,7 @@ class RenderImage extends RenderBox {
     bool invertColors = false,
     bool isAntiAlias = false,
     FilterQuality filterQuality = FilterQuality.medium,
+    BlendMode blendMode = BlendMode.srcOver,
   }) : _image = image,
        _width = width,
        _height = height,
@@ -57,7 +58,8 @@ class RenderImage extends RenderBox {
        _invertColors = invertColors,
        _textDirection = textDirection,
        _isAntiAlias = isAntiAlias,
-       _filterQuality = filterQuality {
+       _filterQuality = filterQuality,
+       _blendMode = blendMode {
     _updateColorFilter();
   }
 
@@ -213,6 +215,24 @@ class RenderImage extends RenderBox {
     }
     _colorBlendMode = value;
     _updateColorFilter();
+    markNeedsPaint();
+  }
+
+  /// Used to combine the image with the destination when painting onto the
+  /// canvas. This is forwarded to [paintImage].
+  ///
+  /// Defaults to [BlendMode.srcOver].
+  ///
+  /// See also:
+  ///
+  ///  * [BlendMode], which includes an illustration of the effect of each blend mode.
+  BlendMode get blendMode => _blendMode;
+  BlendMode _blendMode;
+  set blendMode(BlendMode value) {
+    if (value == _blendMode) {
+      return;
+    }
+    _blendMode = value;
     markNeedsPaint();
   }
 
@@ -440,6 +460,7 @@ class RenderImage extends RenderBox {
       invertColors: invertColors,
       filterQuality: _filterQuality,
       isAntiAlias: _isAntiAlias,
+      blendMode: _blendMode,
     );
   }
 
@@ -472,5 +493,6 @@ class RenderImage extends RenderBox {
     properties.add(EnumProperty<TextDirection>('textDirection', textDirection, defaultValue: null));
     properties.add(DiagnosticsProperty<bool>('invertColors', invertColors));
     properties.add(EnumProperty<FilterQuality>('filterQuality', filterQuality));
+    properties.add(EnumProperty<BlendMode>('blendMode', blendMode, defaultValue: BlendMode.srcOver));
   }
 }

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -6753,6 +6753,7 @@ class RawImage extends LeafRenderObjectWidget {
     this.invertColors = false,
     this.filterQuality = FilterQuality.medium,
     this.isAntiAlias = false,
+    this.blendMode = BlendMode.srcOver,
   });
 
   /// The image to display.
@@ -6887,6 +6888,16 @@ class RawImage extends LeafRenderObjectWidget {
   /// Anti-aliasing alleviates the sawtooth artifact when the image is rotated.
   final bool isAntiAlias;
 
+  /// Used to combine the image with the destination when painting onto the
+  /// canvas. This is forwarded to [paintImage].
+  ///
+  /// Defaults to [BlendMode.srcOver].
+  ///
+  /// See also:
+  ///
+  ///  * [BlendMode], which includes an illustration of the effect of each blend mode.
+  final BlendMode blendMode;
+
   @override
   RenderImage createRenderObject(BuildContext context) {
     assert((!matchTextDirection && alignment is Alignment) || debugCheckHasDirectionality(context));
@@ -6915,6 +6926,7 @@ class RawImage extends LeafRenderObjectWidget {
       invertColors: invertColors,
       isAntiAlias: isAntiAlias,
       filterQuality: filterQuality,
+      blendMode: blendMode,
     );
   }
 
@@ -6944,7 +6956,8 @@ class RawImage extends LeafRenderObjectWidget {
           : null
       ..invertColors = invertColors
       ..isAntiAlias = isAntiAlias
-      ..filterQuality = filterQuality;
+      ..filterQuality = filterQuality
+      ..blendMode = blendMode;
   }
 
   @override
@@ -6974,6 +6987,7 @@ class RawImage extends LeafRenderObjectWidget {
     );
     properties.add(DiagnosticsProperty<bool>('invertColors', invertColors));
     properties.add(EnumProperty<FilterQuality>('filterQuality', filterQuality));
+    properties.add(EnumProperty<BlendMode>('blendMode', blendMode, defaultValue: BlendMode.srcOver));
   }
 }
 

--- a/packages/flutter/test/rendering/image_test.dart
+++ b/packages/flutter/test/rendering/image_test.dart
@@ -215,6 +215,18 @@ Future<void> main() async {
     expect(image.colorBlendMode, BlendMode.color);
   });
 
+  test('RenderImage blendMode defaults to BlendMode.srcOver', () {
+    final image = RenderImage();
+    expect(image.blendMode, BlendMode.srcOver);
+  });
+
+  test('RenderImage blendMode can be set via constructor and setter', () {
+    final image = RenderImage(blendMode: BlendMode.plus);
+    expect(image.blendMode, BlendMode.plus);
+    image.blendMode = BlendMode.multiply;
+    expect(image.blendMode, BlendMode.multiply);
+  });
+
   test('RenderImage disposes its image', () async {
     final ui.Image image = await createTestImage(width: 10, height: 10, cache: false);
     expect(image.debugGetOpenHandleStackTraces()!.length, 1);

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -3124,6 +3124,29 @@ void main() {
     // Also check takeException as a standard backup.
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets('RawImage forwards default blendMode to RenderImage', (WidgetTester tester) async {
+    final ui.Image image = await createTestImage(width: 10, height: 10);
+    addTearDown(image.dispose);
+
+    await tester.pumpWidget(RawImage(image: image));
+
+    final RenderImage renderImage = tester.renderObject(find.byType(RawImage));
+    expect(renderImage.blendMode, BlendMode.srcOver);
+  });
+
+  testWidgets('RawImage forwards custom blendMode to RenderImage', (WidgetTester tester) async {
+    final ui.Image image = await createTestImage(width: 10, height: 10);
+    addTearDown(image.dispose);
+
+    await tester.pumpWidget(RawImage(image: image, blendMode: BlendMode.plus));
+
+    final RenderImage renderImage = tester.renderObject(find.byType(RawImage));
+    expect(renderImage.blendMode, BlendMode.plus);
+
+    await tester.pumpWidget(RawImage(image: image, blendMode: BlendMode.multiply));
+    expect(renderImage.blendMode, BlendMode.multiply);
+  });
 }
 
 @immutable


### PR DESCRIPTION
`RawImage` and its `RenderImage` render object both delegate their painting to `paintImage`, which already accepts a `blendMode` parameter that controls the `Paint.blendMode` used when compositing the image onto the canvas. Neither widget exposed this parameter though, so the blend mode was always stuck on the default `BlendMode.srcOver`. That made it awkward to use `RawImage` for effects like crossfading where `BlendMode.plus` is the natural fit, even though the underlying painting code fully supports it.

This PR threads a new `blendMode` parameter through `RawImage`, `RenderImage`, and the `paintImage` call. The default value is `BlendMode.srcOver`, matching the existing `paintImage` default, so behavior is unchanged for every existing caller. The implementation follows the same pattern used by `filterQuality` and other non-nullable enum properties on `RenderImage` (constructor argument, private field with getter/setter that calls `markNeedsPaint`, forwarded in `paint`, and reported via `debugFillProperties`).

Tests cover both the default value and a custom value being forwarded through to `RenderImage` from `RawImage`, plus the same on `RenderImage` directly.

Fixes https://github.com/flutter/flutter/issues/145614

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
