### PR TITLE
Document super call order for State.didChangeDependencies

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1479,7 +1479,7 @@ abstract class State<T extends StatefulWidget> with Diagnosticable {
   /// expensive to do for every build.
   ///
   /// Implementations of this method should start with a call to the inherited
-  /// method, as in [super.didChangeDependencies].
+  /// method, as in `super.didChangeDependencies`.
   @protected
   @mustCallSuper
   void didChangeDependencies() {}

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1479,7 +1479,7 @@ abstract class State<T extends StatefulWidget> with Diagnosticable {
   /// expensive to do for every build.
   ///
   /// Implementations of this method should start with a call to the inherited
-  /// method, as in `super.didChangeDependencies()`.
+  /// method, as in [super.didChangeDependencies].
   @protected
   @mustCallSuper
   void didChangeDependencies() {}

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1477,6 +1477,9 @@ abstract class State<T extends StatefulWidget> with Diagnosticable {
   /// this method because they need to do some expensive work (e.g., network
   /// fetches) when their dependencies change, and that work would be too
   /// expensive to do for every build.
+  ///
+  /// Implementations of this method should start with a call to the inherited
+  /// method, as in `super.didChangeDependencies()`.
   @protected
   @mustCallSuper
   void didChangeDependencies() {}


### PR DESCRIPTION
The doc comment on `State.didChangeDependencies` is silent about where overrides should place the `super.didChangeDependencies()` call, even though `@mustCallSuper` is set on it. The sibling lifecycle hook `State.initState` already documents this convention, so the two methods read inconsistently and contributors hitting `didChangeDependencies` for the first time have to guess.

This PR adds a short note to the dartdoc that mirrors the wording on `initState`, telling implementations to start with a call to the inherited method (`super.didChangeDependencies()`). It is a documentation-only change to `packages/flutter/lib/src/widgets/framework.dart`. There is no behavior change, no API change, and no new public surface.

Fixes #28925.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt]. This PR is test-exempt because it only edits documentation text in a dartdoc comment, with no behavioral or API changes.
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
