### PR TITLE
Remove semantics_tester import from outlined_button_test.dart

### DIFF
--- a/packages/flutter/test/material/outlined_button_test.dart
+++ b/packages/flutter/test/material/outlined_button_test.dart
@@ -1847,32 +1847,30 @@ void main() {
     }
   });
 
-  testWidgets(
-    'OutlinedButton uses InkSparkle only for Android non-web when useMaterial3 is true',
-    (WidgetTester tester) async {
-      final theme = ThemeData();
+  testWidgets('OutlinedButton uses InkSparkle only for Android non-web when useMaterial3 is true', (
+    WidgetTester tester,
+  ) async {
+    final theme = ThemeData();
 
-      await tester.pumpWidget(
-        MaterialApp(
-          theme: theme,
-          home: Center(
-            child: OutlinedButton(onPressed: () {}, child: const Text('button')),
-          ),
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: theme,
+        home: Center(
+          child: OutlinedButton(onPressed: () {}, child: const Text('button')),
         ),
-      );
+      ),
+    );
 
-      final InkWell buttonInkWell = tester.widget<InkWell>(
-        find.descendant(of: find.byType(OutlinedButton), matching: find.byType(InkWell)),
-      );
+    final InkWell buttonInkWell = tester.widget<InkWell>(
+      find.descendant(of: find.byType(OutlinedButton), matching: find.byType(InkWell)),
+    );
 
-      if (debugDefaultTargetPlatformOverride! == TargetPlatform.android && !kIsWeb) {
-        expect(buttonInkWell.splashFactory, equals(InkSparkle.splashFactory));
-      } else {
-        expect(buttonInkWell.splashFactory, equals(InkRipple.splashFactory));
-      }
-    },
-    variant: TargetPlatformVariant.all(),
-  );
+    if (debugDefaultTargetPlatformOverride! == TargetPlatform.android && !kIsWeb) {
+      expect(buttonInkWell.splashFactory, equals(InkSparkle.splashFactory));
+    } else {
+      expect(buttonInkWell.splashFactory, equals(InkRipple.splashFactory));
+    }
+  }, variant: TargetPlatformVariant.all());
 
   testWidgets('OutlinedButton uses InkRipple when useMaterial3 is false', (
     WidgetTester tester,

--- a/packages/flutter/test/material/outlined_button_test.dart
+++ b/packages/flutter/test/material/outlined_button_test.dart
@@ -1208,42 +1208,44 @@ void main() {
 
   testWidgets('OutlinedButton contributes semantics', (WidgetTester tester) async {
     final SemanticsHandle handle = tester.ensureSemantics();
-    await tester.pumpWidget(
-      Theme(
-        data: ThemeData(useMaterial3: false),
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: Center(
-            child: OutlinedButton(
-              style: const ButtonStyle(
-                // Specifying minimumSize to mimic the original minimumSize for
-                // RaisedButton so that the corresponding button size matches
-                // the original version of this test.
-                minimumSize: MaterialStatePropertyAll<Size>(Size(88, 36)),
+    try {
+      await tester.pumpWidget(
+        Theme(
+          data: ThemeData(useMaterial3: false),
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Center(
+              child: OutlinedButton(
+                style: const ButtonStyle(
+                  // Specifying minimumSize to mimic the original minimumSize for
+                  // RaisedButton so that the corresponding button size matches
+                  // the original version of this test.
+                  minimumSize: MaterialStatePropertyAll<Size>(Size(88, 36)),
+                ),
+                onPressed: () {},
+                child: const Text('ABC'),
               ),
-              onPressed: () {},
-              child: const Text('ABC'),
             ),
           ),
         ),
-      ),
-    );
+      );
 
-    expect(
-      tester.getSemantics(find.byType(OutlinedButton)),
-      matchesSemantics(
-        label: 'ABC',
-        hasTapAction: true,
-        hasFocusAction: true,
-        hasEnabledState: true,
-        isButton: true,
-        isEnabled: true,
-        isFocusable: true,
-        size: const Size(88.0, 48.0),
-      ),
-    );
-
-    handle.dispose();
+      expect(
+        tester.getSemantics(find.byType(OutlinedButton)),
+        matchesSemantics(
+          label: 'ABC',
+          hasTapAction: true,
+          hasFocusAction: true,
+          hasEnabledState: true,
+          isButton: true,
+          isEnabled: true,
+          isFocusable: true,
+          size: const Size(88.0, 48.0),
+        ),
+      );
+    } finally {
+      handle.dispose();
+    }
   });
 
   testWidgets('When an OutlinedButton gains an icon, preserves the same SemanticsNode id', (

--- a/packages/flutter/test/material/outlined_button_test.dart
+++ b/packages/flutter/test/material/outlined_button_test.dart
@@ -13,8 +13,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/semantics_tester.dart';
-
 void main() {
   TextStyle iconStyle(WidgetTester tester, IconData icon) {
     final RichText iconRichText = tester.widget<RichText>(
@@ -1209,7 +1207,7 @@ void main() {
   });
 
   testWidgets('OutlinedButton contributes semantics', (WidgetTester tester) async {
-    final semantics = SemanticsTester(tester);
+    final SemanticsHandle handle = tester.ensureSemantics();
     await tester.pumpWidget(
       Theme(
         data: ThemeData(useMaterial3: false),
@@ -1232,29 +1230,20 @@ void main() {
     );
 
     expect(
-      semantics,
-      hasSemantics(
-        TestSemantics.root(
-          children: <TestSemantics>[
-            TestSemantics.rootChild(
-              actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.focus],
-              label: 'ABC',
-              rect: const Rect.fromLTRB(0.0, 0.0, 88.0, 48.0),
-              transform: Matrix4.translationValues(356.0, 276.0, 0.0),
-              flags: <SemanticsFlag>[
-                SemanticsFlag.hasEnabledState,
-                SemanticsFlag.isButton,
-                SemanticsFlag.isEnabled,
-                SemanticsFlag.isFocusable,
-              ],
-            ),
-          ],
-        ),
-        ignoreId: true,
+      tester.getSemantics(find.byType(OutlinedButton)),
+      matchesSemantics(
+        label: 'ABC',
+        hasTapAction: true,
+        hasFocusAction: true,
+        hasEnabledState: true,
+        isButton: true,
+        isEnabled: true,
+        isFocusable: true,
+        size: const Size(88.0, 48.0),
       ),
     );
 
-    semantics.dispose();
+    handle.dispose();
   });
 
   testWidgets('When an OutlinedButton gains an icon, preserves the same SemanticsNode id', (


### PR DESCRIPTION
Part of #182636

## Summary

Remove the `semantics_tester.dart` cross-import from `outlined_button_test.dart`.

## What changed

* Replaced the deprecated `SemanticsTester`/`TestSemantics` assertion in the `OutlinedButton contributes semantics` test with `tester.getSemantics(...)` and `matchesSemantics(...)`
* Removed the `../widgets/semantics_tester.dart` import

## Testing

* `../../bin/flutter analyze test/material/outlined_button_test.dart`
* `../../bin/flutter test test/material/outlined_button_test.dart`