### PR TITLE
[framework] Fix TestSemantics self-comparison bugs and stray comma

### DIFF
--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -508,7 +508,7 @@ class TestSemantics {
       );
     }
 
-    if (controlsNodes != controlsNodes && !setEquals(controlsNodes, node.controlsNodes)) {
+    if (controlsNodes != node.controlsNodes && !setEquals(controlsNodes, node.controlsNodes)) {
       return fail(
         'expected node id $id to controls nodes $controlsNodes but found controlling nodes ${node.controlsNodes}',
       );


### PR DESCRIPTION
## Description

Fixes three bugs in `semantics_tester.dart`:

1. **L511**: `controlsNodes != controlsNodes` → `controlsNodes != node.controlsNodes`
   - Was comparing the value to itself (always false)

2. **L718-719**: `(second[i]).locale != (second[i]).locale` → `(second[i]).locale != (first[i]).locale`
   - Was comparing second to itself instead of first

3. **L1183**: Stray comma in assert puts `minValue != null || maxValue != null` into the error message string instead of being part of the condition

Closes #185900