### PR TITLE
Remove semantics_tester import from autocomplete_test.dart

### DIFF
--- a/packages/flutter/test/material/autocomplete_test.dart
+++ b/packages/flutter/test/material/autocomplete_test.dart
@@ -6,8 +6,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/semantics_tester.dart';
-
 class User {
   const User({required this.email, required this.name});
 
@@ -821,7 +819,7 @@ void main() {
   testWidgets('Autocomplete suggestions are hit-tested before ListTiles', (
     WidgetTester tester,
   ) async {
-    final semantics = SemanticsTester(tester);
+    final SemanticsHandle handle = tester.ensureSemantics();
 
     await tester.pumpWidget(
       MaterialApp(
@@ -853,7 +851,7 @@ void main() {
     await tester.pump();
 
     expect(find.widgetWithText(TextField, 'Cherry'), findsOneWidget);
-    semantics.dispose();
+    handle.dispose();
   });
 
   testWidgets('Autocomplete renders at zero area', (WidgetTester tester) async {

--- a/packages/flutter/test/material/autocomplete_test.dart
+++ b/packages/flutter/test/material/autocomplete_test.dart
@@ -820,38 +820,40 @@ void main() {
     WidgetTester tester,
   ) async {
     final SemanticsHandle handle = tester.ensureSemantics();
-
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: Column(
-            children: <Widget>[
-              Autocomplete<String>(
-                optionsBuilder: (TextEditingValue textEditingValue) {
-                  const options = <String>['Apple', 'Banana', 'Cherry'];
-                  return options.where(
-                    (String option) => option.toLowerCase().contains(textEditingValue.text),
-                  );
-                },
-              ),
-              for (int i = 0; i < 3; i++) ListTile(title: Text('Item $i'), onTap: () {}),
-            ],
+    try {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Column(
+              children: <Widget>[
+                Autocomplete<String>(
+                  optionsBuilder: (TextEditingValue textEditingValue) {
+                    const options = <String>['Apple', 'Banana', 'Cherry'];
+                    return options.where(
+                      (String option) => option.toLowerCase().contains(textEditingValue.text),
+                    );
+                  },
+                ),
+                for (int i = 0; i < 3; i++) ListTile(title: Text('Item $i'), onTap: () {}),
+              ],
+            ),
           ),
         ),
-      ),
-    );
+      );
 
-    await tester.tap(find.byType(TextField));
-    await tester.pump();
+      await tester.tap(find.byType(TextField));
+      await tester.pump();
 
-    final Finder cherryFinder = find.text('Cherry');
-    expect(cherryFinder, findsOneWidget);
+      final Finder cherryFinder = find.text('Cherry');
+      expect(cherryFinder, findsOneWidget);
 
-    await tester.tap(cherryFinder);
-    await tester.pump();
+      await tester.tap(cherryFinder);
+      await tester.pump();
 
-    expect(find.widgetWithText(TextField, 'Cherry'), findsOneWidget);
-    handle.dispose();
+      expect(find.widgetWithText(TextField, 'Cherry'), findsOneWidget);
+    } finally {
+      handle.dispose();
+    }
   });
 
   testWidgets('Autocomplete renders at zero area', (WidgetTester tester) async {


### PR DESCRIPTION
Part of #182636

## Summary

Remove the `semantics_tester.dart` cross-import from `autocomplete_test.dart`.

## What changed

* Replaced `SemanticsTester(tester)` with `tester.ensureSemantics()` in the `Autocomplete suggestions are hit-tested before ListTiles` test (the only site using this import); the test only enables/disposes semantics and does not assert on the semantics tree
* Removed the `../widgets/semantics_tester.dart` import

## Testing

* `../../bin/flutter analyze test/material/autocomplete_test.dart`
* `../../bin/flutter test test/material/autocomplete_test.dart`