### PR TITLE
Fix self-comparison and assert typos in TestSemantics

### DIFF
--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -1183,6 +1183,11 @@ class _IncludesNodeWith extends Matcher {
              inputType != null ||
              minValue != null ||
              maxValue != null,
+         'At least one matcher field must be non-null so the matcher checks for at least one '
+         'property of a semantics node. Pass any of `label`, `value`, `actions`, `flags`, '
+         '`flagsCollection`, `tags`, `increasedValue`, `decreasedValue`, `scrollPosition`, '
+         '`scrollExtentMax`, `scrollExtentMin`, `maxValueLength`, `currentValueLength`, '
+         '`inputType`, `minValue`, or `maxValue`.',
        );
   final AttributedString? attributedLabel;
   final AttributedString? attributedValue;

--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -508,7 +508,7 @@ class TestSemantics {
       );
     }
 
-    if (controlsNodes != controlsNodes && !setEquals(controlsNodes, node.controlsNodes)) {
+    if (controlsNodes != null && !setEquals(controlsNodes, node.controlsNodes)) {
       return fail(
         'expected node id $id to controls nodes $controlsNodes but found controlling nodes ${node.controlsNodes}',
       );
@@ -715,7 +715,7 @@ class SemanticsTester {
       if (first[i] is LocaleStringAttribute &&
           (second[i] is! LocaleStringAttribute ||
               second[i].range != first[i].range ||
-              (second[i] as LocaleStringAttribute).locale !=
+              (first[i] as LocaleStringAttribute).locale !=
                   (second[i] as LocaleStringAttribute).locale)) {
         return false;
       }
@@ -1180,8 +1180,9 @@ class _IncludesNodeWith extends Matcher {
              scrollExtentMin != null ||
              maxValueLength != null ||
              currentValueLength != null ||
-             inputType != null,
-         minValue != null || maxValue != null,
+             inputType != null ||
+             minValue != null ||
+             maxValue != null,
        );
   final AttributedString? attributedLabel;
   final AttributedString? attributedValue;

--- a/packages/flutter/test/widgets/semantics_tester_test.dart
+++ b/packages/flutter/test/widgets/semantics_tester_test.dart
@@ -5,6 +5,7 @@
 import 'dart:ui';
 
 import 'package:flutter/gestures.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -147,6 +148,101 @@ void main() {
         ),
       ),
     );
+    semantics.dispose();
+  });
+
+  testWidgets('Semantics tester compares controlsNodes', (WidgetTester tester) async {
+    final semantics = SemanticsTester(tester);
+
+    await tester.pumpWidget(
+      Semantics(container: true, controlsNodes: const <String>{'actual'}, child: Container()),
+    );
+
+    final expectedSemantics = TestSemantics.root(
+      children: <TestSemantics>[
+        TestSemantics.rootChild(
+          id: 1,
+          rect: TestSemantics.fullScreen,
+          controlsNodes: const <String>{'expected'},
+        ),
+      ],
+    );
+
+    expect(semantics, isNot(hasSemantics(expectedSemantics)));
+    semantics.dispose();
+  });
+
+  testWidgets('Semantics tester compares attributed string locales', (WidgetTester tester) async {
+    final semantics = SemanticsTester(tester);
+
+    await tester.pumpWidget(
+      Semantics(
+        container: true,
+        attributedLabel: AttributedString(
+          'label',
+          attributes: <StringAttribute>[
+            LocaleStringAttribute(
+              locale: const Locale('en'),
+              range: const TextRange(start: 0, end: 5),
+            ),
+          ],
+        ),
+        textDirection: TextDirection.ltr,
+        child: Container(),
+      ),
+    );
+
+    expect(
+      semantics,
+      includesNodeWith(
+        label: 'label',
+        attributedLabel: AttributedString(
+          'label',
+          attributes: <StringAttribute>[
+            LocaleStringAttribute(
+              locale: const Locale('en'),
+              range: const TextRange(start: 0, end: 5),
+            ),
+          ],
+        ),
+      ),
+    );
+    expect(
+      semantics,
+      isNot(
+        includesNodeWith(
+          label: 'label',
+          attributedLabel: AttributedString(
+            'label',
+            attributes: <StringAttribute>[
+              LocaleStringAttribute(
+                locale: const Locale('es'),
+                range: const TextRange(start: 0, end: 5),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    semantics.dispose();
+  });
+
+  testWidgets('includesNodeWith accepts minValue and maxValue', (WidgetTester tester) async {
+    final semantics = SemanticsTester(tester);
+
+    await tester.pumpWidget(
+      Semantics(
+        container: true,
+        value: '5',
+        minValue: '0',
+        maxValue: '10',
+        textDirection: TextDirection.ltr,
+        child: Container(),
+      ),
+    );
+
+    expect(semantics, includesNodeWith(minValue: '0'));
+    expect(semantics, includesNodeWith(maxValue: '10'));
     semantics.dispose();
   });
 }


### PR DESCRIPTION
Fixes #185900

## Summary

Three small bugs in `packages/flutter/test/widgets/semantics_tester.dart` where the code accidentally compared a value to itself or shifted part of a logical expression into an assert message.

## What changed

1. **`controlsNodes` self-comparison** (line 511). The guard `controlsNodes != controlsNodes` is always `false`, so the `setEquals(...)` mismatch path was unreachable. Replaced with `controlsNodes != null`, matching the null-guard style used by neighbouring optional fields (e.g. `headingLevel`, `tags`, `scrollPosition`).
2. **`LocaleStringAttribute.locale` self-comparison** (line 718). `(second[i] as LocaleStringAttribute).locale != (second[i] as LocaleStringAttribute).locale` was always `false`. Changed the left-hand side to `first[i]` to actually compare the two attributes' locales, mirroring the existing `second[i].range != first[i].range` check immediately above.
3. **Stray comma in `_IncludesNodeWith` assert** (line 1183). The comma after `inputType != null` made `minValue != null || maxValue != null` the assert *message* argument (a `bool` rather than a `String`). Replaced the comma with `||` so `minValue` / `maxValue` count as valid constructor arguments, matching the matcher's other named parameters.

No tests pass `controlsNodes` or `LocaleStringAttribute` to these matchers today, so these fixes only restore intended behaviour without disturbing existing assertions.

## Testing

* `../../bin/flutter analyze test/widgets/semantics_tester.dart`
* `../../bin/flutter test test/widgets/semantics_tester_test.dart`
* `../../bin/flutter test test/widgets/semantics_tester_generate_test_semantics_expression_for_current_semantics_tree_test.dart`
* `../../bin/flutter test test/widgets/semantics_test.dart`