### PR TITLE
Add EditableText.unfocusedSelectionColor for view-unfocus styling

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -861,6 +861,7 @@ class EditableText extends StatefulWidget {
     bool? showCursor,
     this.showSelectionHandles = false,
     this.selectionColor,
+    this.unfocusedSelectionColor,
     this.selectionControls,
     TextInputType? keyboardType,
     this.textInputAction,
@@ -1371,6 +1372,28 @@ class EditableText extends StatefulWidget {
   /// [CupertinoThemeData.primaryColor] with 20% opacity. For [TextField]s, the
   /// value is set to the ambient [TextSelectionThemeData.selectionColor].
   final Color? selectionColor;
+
+  /// The color to use when painting the selection while the
+  /// [FlutterView] containing this widget does not have window focus.
+  ///
+  /// On desktop platforms, native text fields typically render their selection
+  /// in a desaturated color (often a neutral grey) when their window loses
+  /// focus, indicating that the selection is "inactive". Setting this property
+  /// allows a Flutter [EditableText] to follow that convention.
+  ///
+  /// If this property is null, the [selectionColor] is used regardless of the
+  /// view's focus state, preserving the previous behavior.
+  ///
+  /// View focus changes are observed via
+  /// [WidgetsBindingObserver.didChangeViewFocus]; this widget assumes the
+  /// view is focused at startup, so the unfocused color only takes effect
+  /// after the framework has dispatched at least one view focus event.
+  ///
+  /// See also:
+  ///
+  ///  * [WidgetsBindingObserver.didChangeViewFocus], which delivers the focus
+  ///    state changes.
+  final Color? unfocusedSelectionColor;
 
   /// {@template flutter.widgets.editableText.selectionControls}
   /// Optional delegate for building the text selection handles.
@@ -2487,6 +2510,21 @@ class EditableText extends StatefulWidget {
   }
 }
 
+// A lightweight [WidgetsBindingObserver] that only relays
+// [didChangeViewFocus] events to a callback. Used by [EditableTextState] to
+// observe view focus independently of the conditional observer registration
+// in [EditableTextState._handleFocusChanged].
+class _ViewFocusObserver with WidgetsBindingObserver {
+  _ViewFocusObserver(this._onViewFocusChanged);
+
+  final ValueChanged<ui.ViewFocusEvent> _onViewFocusChanged;
+
+  @override
+  void didChangeViewFocus(ui.ViewFocusEvent event) {
+    _onViewFocusChanged(event);
+  }
+}
+
 /// State for an [EditableText].
 class EditableTextState extends State<EditableText>
     with
@@ -3287,6 +3325,7 @@ class EditableTextState extends State<EditableText>
     _spellCheckConfiguration = _inferSpellCheckConfiguration(widget.spellCheckConfiguration);
     _appLifecycleListener = AppLifecycleListener(onResume: _onResume);
     _initProcessTextActions();
+    WidgetsBinding.instance.addObserver(_viewFocusObserver);
   }
 
   void _onResume() {
@@ -3545,6 +3584,7 @@ class EditableTextState extends State<EditableText>
     _selectionOverlay = null;
     widget.focusNode.removeListener(_handleFocusChanged);
     WidgetsBinding.instance.removeObserver(this);
+    WidgetsBinding.instance.removeObserver(_viewFocusObserver);
     _liveTextInputStatus?.removeListener(_onChangedLiveTextInputStatus);
     _liveTextInputStatus?.dispose();
     clipboardStatus.removeListener(_onChangedClipboardStatus);
@@ -4554,6 +4594,35 @@ class EditableTextState extends State<EditableText>
   }
 
   late double _lastBottomViewInset;
+
+  // Tracks whether the [FlutterView] containing this widget currently has
+  // window focus. Updated via [_ViewFocusObserver]; consumed by [build] when
+  // [EditableText.unfocusedSelectionColor] is provided. Defaults to `true`
+  // because there is no synchronous way to query the initial focus state
+  // and the overwhelmingly common case is that the view starts focused.
+  bool _viewFocused = true;
+
+  // Always-registered observer dedicated to tracking view focus. It cannot be
+  // [this] because [_handleFocusChanged] toggles [WidgetsBinding] observation
+  // based on the [TextField]'s own focus state, which can desync the
+  // EditableText from view focus events triggered while the field is parked.
+  late final _ViewFocusObserver _viewFocusObserver = _ViewFocusObserver(_handleViewFocusChanged);
+
+  void _handleViewFocusChanged(ui.ViewFocusEvent event) {
+    if (!mounted) {
+      return;
+    }
+    final int currentViewId = View.of(context).viewId;
+    if (event.viewId != currentViewId) {
+      return;
+    }
+    final nextFocused = event.state == ui.ViewFocusState.focused;
+    if (_viewFocused != nextFocused) {
+      setState(() {
+        _viewFocused = nextFocused;
+      });
+    }
+  }
 
   @override
   void didChangeMetrics() {
@@ -5895,7 +5964,10 @@ class EditableTextState extends State<EditableText>
                                         _selectionOverlay?.spellCheckToolbarIsVisible ?? false
                                         ? _spellCheckConfiguration.misspelledSelectionColor ??
                                               widget.selectionColor
-                                        : widget.selectionColor,
+                                        : (_viewFocused
+                                              ? widget.selectionColor
+                                              : (widget.unfocusedSelectionColor ??
+                                                    widget.selectionColor)),
                                     textScaler: effectiveTextScaler,
                                     textAlign: widget.textAlign,
                                     textDirection: _textDirection,

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -3325,7 +3325,10 @@ class EditableTextState extends State<EditableText>
     _spellCheckConfiguration = _inferSpellCheckConfiguration(widget.spellCheckConfiguration);
     _appLifecycleListener = AppLifecycleListener(onResume: _onResume);
     _initProcessTextActions();
-    WidgetsBinding.instance.addObserver(_viewFocusObserver);
+    if (widget.unfocusedSelectionColor != null) {
+      WidgetsBinding.instance.addObserver(_viewFocusObserver);
+      _viewFocusObserverRegistered = true;
+    }
   }
 
   void _onResume() {
@@ -3477,6 +3480,19 @@ class EditableTextState extends State<EditableText>
       _currentAutofillScope?.register(_effectiveAutofillClient);
     }
 
+    final wantsViewFocusObserver = widget.unfocusedSelectionColor != null;
+    if (wantsViewFocusObserver != _viewFocusObserverRegistered) {
+      if (wantsViewFocusObserver) {
+        WidgetsBinding.instance.addObserver(_viewFocusObserver);
+      } else {
+        WidgetsBinding.instance.removeObserver(_viewFocusObserver);
+        // Reset to the default so the next time the feature is enabled, the
+        // view is assumed focused until we hear otherwise.
+        _viewFocused = true;
+      }
+      _viewFocusObserverRegistered = wantsViewFocusObserver;
+    }
+
     if (widget.focusNode != oldWidget.focusNode) {
       oldWidget.focusNode.removeListener(_handleFocusChanged);
       widget.focusNode.addListener(_handleFocusChanged);
@@ -3584,7 +3600,9 @@ class EditableTextState extends State<EditableText>
     _selectionOverlay = null;
     widget.focusNode.removeListener(_handleFocusChanged);
     WidgetsBinding.instance.removeObserver(this);
-    WidgetsBinding.instance.removeObserver(_viewFocusObserver);
+    if (_viewFocusObserverRegistered) {
+      WidgetsBinding.instance.removeObserver(_viewFocusObserver);
+    }
     _liveTextInputStatus?.removeListener(_onChangedLiveTextInputStatus);
     _liveTextInputStatus?.dispose();
     clipboardStatus.removeListener(_onChangedClipboardStatus);
@@ -4602,11 +4620,14 @@ class EditableTextState extends State<EditableText>
   // and the overwhelmingly common case is that the view starts focused.
   bool _viewFocused = true;
 
-  // Always-registered observer dedicated to tracking view focus. It cannot be
-  // [this] because [_handleFocusChanged] toggles [WidgetsBinding] observation
-  // based on the [TextField]'s own focus state, which can desync the
-  // EditableText from view focus events triggered while the field is parked.
+  // Observer dedicated to tracking view focus. It cannot be [this] because
+  // [_handleFocusChanged] toggles [WidgetsBinding] observation based on the
+  // [TextField]'s own focus state, which can desync the EditableText from
+  // view focus events triggered while the field is parked. Lazily created
+  // and only registered while [EditableText.unfocusedSelectionColor] is
+  // non-null, so apps that don't use the feature pay no cost.
   late final _ViewFocusObserver _viewFocusObserver = _ViewFocusObserver(_handleViewFocusChanged);
+  bool _viewFocusObserverRegistered = false;
 
   void _handleViewFocusChanged(ui.ViewFocusEvent event) {
     if (!mounted) {
@@ -5965,9 +5986,9 @@ class EditableTextState extends State<EditableText>
                                         ? _spellCheckConfiguration.misspelledSelectionColor ??
                                               widget.selectionColor
                                         : (_viewFocused
-                                              ? widget.selectionColor
-                                              : (widget.unfocusedSelectionColor ??
-                                                    widget.selectionColor)),
+                                                  ? null
+                                                  : widget.unfocusedSelectionColor) ??
+                                              widget.selectionColor,
                                     textScaler: effectiveTextScaler,
                                     textAlign: widget.textAlign,
                                     textDirection: _textDirection,

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -4630,7 +4630,7 @@ class EditableTextState extends State<EditableText>
   bool _viewFocusObserverRegistered = false;
 
   void _handleViewFocusChanged(ui.ViewFocusEvent event) {
-    if (!mounted) {
+    if (!mounted || widget.unfocusedSelectionColor == null) {
       return;
     }
     final int currentViewId = View.of(context).viewId;
@@ -5985,9 +5985,7 @@ class EditableTextState extends State<EditableText>
                                         _selectionOverlay?.spellCheckToolbarIsVisible ?? false
                                         ? _spellCheckConfiguration.misspelledSelectionColor ??
                                               widget.selectionColor
-                                        : (_viewFocused
-                                                  ? null
-                                                  : widget.unfocusedSelectionColor) ??
+                                        : (_viewFocused ? null : widget.unfocusedSelectionColor) ??
                                               widget.selectionColor,
                                     textScaler: effectiveTextScaler,
                                     textAlign: widget.textAlign,

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -631,6 +631,93 @@ void main() {
     expect(render.backgroundCursorColor, Colors.green);
   });
 
+  group('unfocusedSelectionColor', () {
+    const focusedColor = Color(0xFF112233);
+    const unfocusedColor = Color(0xFF445566);
+
+    Widget buildEditable({Color? unfocusedSelectionColor}) {
+      return MediaQuery(
+        data: const MediaQueryData(),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: EditableText(
+            controller: controller,
+            backgroundCursorColor: Colors.grey,
+            focusNode: focusNode,
+            style: textStyle,
+            cursorColor: cursorColor,
+            selectionColor: focusedColor,
+            unfocusedSelectionColor: unfocusedSelectionColor,
+          ),
+        ),
+      );
+    }
+
+    void dispatchViewFocus(WidgetTester tester, {required ViewFocusState state, int? viewId}) {
+      WidgetsBinding.instance.handleViewFocusChanged(
+        ViewFocusEvent(
+          viewId: viewId ?? tester.view.viewId,
+          state: state,
+          direction: ViewFocusDirection.undefined,
+        ),
+      );
+    }
+
+    testWidgets('uses unfocusedSelectionColor when the view loses focus', (
+      WidgetTester tester,
+    ) async {
+      controller.text = 'hello world';
+      await tester.pumpWidget(buildEditable(unfocusedSelectionColor: unfocusedColor));
+      focusNode.requestFocus();
+      await tester.pump();
+
+      final RenderEditable render = tester.allRenderObjects.whereType<RenderEditable>().first;
+      expect(render.selectionColor, focusedColor);
+
+      dispatchViewFocus(tester, state: ViewFocusState.unfocused);
+      await tester.pump();
+      expect(render.selectionColor, unfocusedColor);
+
+      dispatchViewFocus(tester, state: ViewFocusState.focused);
+      await tester.pump();
+      expect(render.selectionColor, focusedColor);
+    });
+
+    testWidgets('keeps selectionColor when unfocusedSelectionColor is null', (
+      WidgetTester tester,
+    ) async {
+      controller.text = 'hello world';
+      await tester.pumpWidget(buildEditable());
+      focusNode.requestFocus();
+      await tester.pump();
+
+      final RenderEditable render = tester.allRenderObjects.whereType<RenderEditable>().first;
+      expect(render.selectionColor, focusedColor);
+
+      dispatchViewFocus(tester, state: ViewFocusState.unfocused);
+      await tester.pump();
+      expect(render.selectionColor, focusedColor);
+    });
+
+    testWidgets('ignores ViewFocusEvent for a different viewId', (WidgetTester tester) async {
+      controller.text = 'hello world';
+      await tester.pumpWidget(buildEditable(unfocusedSelectionColor: unfocusedColor));
+      focusNode.requestFocus();
+      await tester.pump();
+
+      final RenderEditable render = tester.allRenderObjects.whereType<RenderEditable>().first;
+      expect(render.selectionColor, focusedColor);
+
+      dispatchViewFocus(
+        tester,
+        state: ViewFocusState.unfocused,
+        viewId: tester.view.viewId + 1,
+      );
+      await tester.pump();
+      expect(render.selectionColor, focusedColor);
+    });
+  });
+
   testWidgets('text keyboard is requested when maxLines is default', (WidgetTester tester) async {
     await tester.pumpWidget(
       MediaQuery(

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -708,11 +708,7 @@ void main() {
       final RenderEditable render = tester.allRenderObjects.whereType<RenderEditable>().first;
       expect(render.selectionColor, focusedColor);
 
-      dispatchViewFocus(
-        tester,
-        state: ViewFocusState.unfocused,
-        viewId: tester.view.viewId + 1,
-      );
+      dispatchViewFocus(tester, state: ViewFocusState.unfocused, viewId: tester.view.viewId + 1);
       await tester.pump();
       expect(render.selectionColor, focusedColor);
     });
@@ -9565,42 +9561,40 @@ void main() {
     }),
   );
 
-  testWidgets(
-    'single-line field cannot be scrolled with touch on iOS',
-    (WidgetTester tester) async {
-      controller.text = 'This is a long string that should overflow the TextField.';
+  testWidgets('single-line field cannot be scrolled with touch on iOS', (
+    WidgetTester tester,
+  ) async {
+    controller.text = 'This is a long string that should overflow the TextField.';
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Align(
-            alignment: Alignment.topLeft,
-            child: SizedBox(
-              width: 100,
-              child: EditableText(
-                showSelectionHandles: true,
-                controller: controller,
-                focusNode: focusNode,
-                style: Typography.material2018().black.titleMedium!.copyWith(fontFamily: 'Roboto'),
-                cursorColor: Colors.blue,
-                backgroundCursorColor: Colors.grey,
-                selectionControls: materialTextSelectionControls,
-                keyboardType: TextInputType.text,
-              ),
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox(
+            width: 100,
+            child: EditableText(
+              showSelectionHandles: true,
+              controller: controller,
+              focusNode: focusNode,
+              style: Typography.material2018().black.titleMedium!.copyWith(fontFamily: 'Roboto'),
+              cursorColor: Colors.blue,
+              backgroundCursorColor: Colors.grey,
+              selectionControls: materialTextSelectionControls,
+              keyboardType: TextInputType.text,
             ),
           ),
         ),
-      );
+      ),
+    );
 
-      final Scrollable scrollable = tester.widget<Scrollable>(find.byType(Scrollable));
-      final double initialScrollOffset = scrollable.controller!.position.pixels;
+    final Scrollable scrollable = tester.widget<Scrollable>(find.byType(Scrollable));
+    final double initialScrollOffset = scrollable.controller!.position.pixels;
 
-      await tester.drag(find.byType(EditableText), const Offset(-100.0, 0.0));
-      await tester.pumpAndSettle();
+    await tester.drag(find.byType(EditableText), const Offset(-100.0, 0.0));
+    await tester.pumpAndSettle();
 
-      expect(scrollable.controller!.position.pixels, initialScrollOffset);
-    },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-  );
+    expect(scrollable.controller!.position.pixels, initialScrollOffset);
+  }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
   testWidgets('default text selection height style', (WidgetTester tester) async {
     controller.text = 'a b c d e f g';
@@ -9641,44 +9635,40 @@ void main() {
     );
   }, variant: TargetPlatformVariant.all());
 
-  testWidgets(
-    'multi-line field can scroll with touch on iOS',
-    (WidgetTester tester) async {
-      // 3 lines of text, where the last line overflows and requires scrolling.
-      controller.text = 'XXXXX\nXXXXX\nXXXXX';
+  testWidgets('multi-line field can scroll with touch on iOS', (WidgetTester tester) async {
+    // 3 lines of text, where the last line overflows and requires scrolling.
+    controller.text = 'XXXXX\nXXXXX\nXXXXX';
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Align(
-            alignment: Alignment.topLeft,
-            child: SizedBox(
-              width: 100,
-              child: EditableText(
-                maxLines: 2,
-                showSelectionHandles: true,
-                controller: controller,
-                focusNode: focusNode,
-                style: Typography.material2018().black.titleMedium!.copyWith(fontFamily: 'Roboto'),
-                cursorColor: Colors.blue,
-                backgroundCursorColor: Colors.grey,
-                selectionControls: materialTextSelectionControls,
-                keyboardType: TextInputType.text,
-              ),
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox(
+            width: 100,
+            child: EditableText(
+              maxLines: 2,
+              showSelectionHandles: true,
+              controller: controller,
+              focusNode: focusNode,
+              style: Typography.material2018().black.titleMedium!.copyWith(fontFamily: 'Roboto'),
+              cursorColor: Colors.blue,
+              backgroundCursorColor: Colors.grey,
+              selectionControls: materialTextSelectionControls,
+              keyboardType: TextInputType.text,
             ),
           ),
         ),
-      );
+      ),
+    );
 
-      final Scrollable scrollable = tester.widget<Scrollable>(find.byType(Scrollable));
-      final double initialScrollOffset = scrollable.controller!.position.pixels;
+    final Scrollable scrollable = tester.widget<Scrollable>(find.byType(Scrollable));
+    final double initialScrollOffset = scrollable.controller!.position.pixels;
 
-      await tester.drag(find.byType(EditableText), const Offset(0.0, -100.0));
-      await tester.pumpAndSettle();
+    await tester.drag(find.byType(EditableText), const Offset(0.0, -100.0));
+    await tester.pumpAndSettle();
 
-      expect(scrollable.controller!.position.pixels, isNot(initialScrollOffset));
-    },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-  );
+    expect(scrollable.controller!.position.pixels, isNot(initialScrollOffset));
+  }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
   testWidgets("scrolling doesn't bounce", (WidgetTester tester) async {
     // 3 lines of text, where the last line overflows and requires scrolling.
@@ -17252,71 +17242,69 @@ void main() {
       expect(controller.selection, collapsedAtEnd('Flutter!').selection);
     }, variant: TargetPlatformVariant.all());
 
-    testWidgets(
-      'moving focus after the app resumed should select all the content on desktop',
-      (WidgetTester tester) async {
-        final controller1 = TextEditingController.fromValue(collapsedAtEnd('Flutter!'));
-        addTearDown(controller1.dispose);
-        final controller2 = TextEditingController.fromValue(collapsedAtEnd('Dart!'));
-        addTearDown(controller2.dispose);
-        final focusNode1 = FocusNode();
-        addTearDown(focusNode1.dispose);
-        final focusNode2 = FocusNode();
-        addTearDown(focusNode2.dispose);
+    testWidgets('moving focus after the app resumed should select all the content on desktop', (
+      WidgetTester tester,
+    ) async {
+      final controller1 = TextEditingController.fromValue(collapsedAtEnd('Flutter!'));
+      addTearDown(controller1.dispose);
+      final controller2 = TextEditingController.fromValue(collapsedAtEnd('Dart!'));
+      addTearDown(controller2.dispose);
+      final focusNode1 = FocusNode();
+      addTearDown(focusNode1.dispose);
+      final focusNode2 = FocusNode();
+      addTearDown(focusNode2.dispose);
 
-        await tester.pumpWidget(
-          MaterialApp(
-            home: Center(
-              child: Column(
-                children: <Widget>[
-                  EditableText(
-                    key: ValueKey<String>(controller1.text),
-                    controller: controller1,
-                    focusNode: focusNode1,
-                    autofocus: true,
-                    style: Typography.material2018().black.titleMedium!,
-                    cursorColor: Colors.blue,
-                    backgroundCursorColor: Colors.grey,
-                  ),
-                  EditableText(
-                    key: ValueKey<String>(controller2.text),
-                    controller: controller2,
-                    focusNode: focusNode2,
-                    style: Typography.material2018().black.titleMedium!,
-                    cursorColor: Colors.blue,
-                    backgroundCursorColor: Colors.grey,
-                  ),
-                ],
-              ),
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Center(
+            child: Column(
+              children: <Widget>[
+                EditableText(
+                  key: ValueKey<String>(controller1.text),
+                  controller: controller1,
+                  focusNode: focusNode1,
+                  autofocus: true,
+                  style: Typography.material2018().black.titleMedium!,
+                  cursorColor: Colors.blue,
+                  backgroundCursorColor: Colors.grey,
+                ),
+                EditableText(
+                  key: ValueKey<String>(controller2.text),
+                  controller: controller2,
+                  focusNode: focusNode2,
+                  style: Typography.material2018().black.titleMedium!,
+                  cursorColor: Colors.blue,
+                  backgroundCursorColor: Colors.grey,
+                ),
+              ],
             ),
           ),
-        );
+        ),
+      );
 
-        expect(focusNode1.hasFocus, true);
-        expect(focusNode2.hasFocus, false);
-        expect(controller1.selection, collapsedAtEnd('Flutter!').selection);
-        expect(controller2.selection, collapsedAtEnd('Dart!').selection);
+      expect(focusNode1.hasFocus, true);
+      expect(focusNode2.hasFocus, false);
+      expect(controller1.selection, collapsedAtEnd('Flutter!').selection);
+      expect(controller2.selection, collapsedAtEnd('Dart!').selection);
 
-        // Pause and resume the application.
-        await setAppLifecycleState(AppLifecycleState.inactive);
-        await setAppLifecycleState(AppLifecycleState.resumed);
+      // Pause and resume the application.
+      await setAppLifecycleState(AppLifecycleState.inactive);
+      await setAppLifecycleState(AppLifecycleState.resumed);
 
-        // Change focus to the second EditableText.
-        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
-        await tester.pumpAndSettle();
+      // Change focus to the second EditableText.
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pumpAndSettle();
 
-        expect(focusNode1.hasFocus, false);
-        expect(focusNode2.hasFocus, true);
-        expect(controller1.selection, collapsedAtEnd('Flutter!').selection);
+      expect(focusNode1.hasFocus, false);
+      expect(focusNode2.hasFocus, true);
+      expect(controller1.selection, collapsedAtEnd('Flutter!').selection);
 
-        // The text of the second EditableText should be entirely selected.
-        expect(
-          controller2.selection,
-          TextSelection(baseOffset: 0, extentOffset: controller2.text.length),
-        );
-      },
-      variant: TargetPlatformVariant.desktop(),
-    );
+      // The text of the second EditableText should be entirely selected.
+      expect(
+        controller2.selection,
+        TextSelection(baseOffset: 0, extentOffset: controller2.text.length),
+      );
+    }, variant: TargetPlatformVariant.desktop());
   });
 
   testWidgets('EditableText respects MediaQuery.boldText', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -716,6 +716,36 @@ void main() {
       await tester.pump();
       expect(render.selectionColor, focusedColor);
     });
+
+    testWidgets('starts observing view focus when unfocusedSelectionColor becomes non-null', (
+      WidgetTester tester,
+    ) async {
+      controller.text = 'hello world';
+      // Start without the feature opted-in: no observer is registered, so
+      // view focus events should be ignored.
+      await tester.pumpWidget(buildEditable());
+      focusNode.requestFocus();
+      await tester.pump();
+
+      final RenderEditable render = tester.allRenderObjects.whereType<RenderEditable>().first;
+      dispatchViewFocus(tester, state: ViewFocusState.unfocused);
+      await tester.pump();
+      expect(render.selectionColor, focusedColor);
+
+      // Opt in via didUpdateWidget; the observer should now be registered.
+      await tester.pumpWidget(buildEditable(unfocusedSelectionColor: unfocusedColor));
+      dispatchViewFocus(tester, state: ViewFocusState.unfocused);
+      await tester.pump();
+      expect(render.selectionColor, unfocusedColor);
+
+      // Opt back out; the observer should be removed and selection color
+      // should reset to the focused color regardless of subsequent events.
+      await tester.pumpWidget(buildEditable());
+      expect(render.selectionColor, focusedColor);
+      dispatchViewFocus(tester, state: ViewFocusState.unfocused);
+      await tester.pump();
+      expect(render.selectionColor, focusedColor);
+    });
   });
 
   testWidgets('text keyboard is requested when maxLines is default', (WidgetTester tester) async {


### PR DESCRIPTION
Part of #103446.

## Summary

On macOS / Linux / Windows / the web, native text fields desaturate their selection highlight to a neutral grey when their window loses focus. Flutter currently keeps the selection painted in the focused color regardless of `FlutterView` focus state. This PR adds the framework primitive needed to fix that:

* a new `EditableText.unfocusedSelectionColor` property
* the `WidgetsBindingObserver.didChangeViewFocus` plumbing required to switch between the focused and unfocused colors as the view's window focus changes

Material and Cupertino theme integration is intentionally left out so this change is small and focused on the framework primitive. A follow-up will wire `TextSelectionThemeData` and `CupertinoTextField` defaults through to `EditableText`.

## What changed

* `EditableText` gains an `unfocusedSelectionColor` constructor parameter and field, mirroring the docs for `selectionColor`. When null (the default), behavior is **unchanged**: `selectionColor` is used in all states.
* `EditableTextState` tracks view focus via a new private `_ViewFocusObserver` helper, registered in `initState` and removed in `dispose`, independently of the conditional `WidgetsBinding` registration in `_handleFocusChanged`. The dedicated observer is needed because `View.didChangeViewFocus` parks focus when the window loses focus, which would unregister the `EditableTextState` itself before the next view focus event arrives. Happy to discuss alternatives — e.g., we could instead unconditionally register the state with a `_hasFocus` guard added to `didChangeMetrics`, but that felt riskier than isolating the new behavior.
* When `_viewFocused` is `false` and `unfocusedSelectionColor` is set, the widget paints the selection in the unfocused color. The spell-check toolbar branch is unchanged.
* `_viewFocused` defaults to `true` because there is no synchronous API to query the initial view focus state, and the overwhelming common case is that views start focused.

## What's deliberately not in this PR

* No Material `TextSelectionThemeData.unfocusedSelectionColor` — follow-up.
* No `CupertinoTextField` / `CupertinoThemeData` integration — follow-up.
* No platform-specific default for the unfocused color (e.g., a `Colors.black26` derivation) — that's a theming decision best made in the Material/Cupertino layer.
* No change to `SelectionArea` / `SelectableText` selection rendering — out of scope; can be added similarly once this primitive lands.

## Open questions for reviewers

1. Is a separate `_ViewFocusObserver` the right pattern, or should `EditableTextState` register itself unconditionally and gate `didChangeMetrics` on `_hasFocus`?
2. Default `_viewFocused = true` vs. `false` — the former matches reality 99% of the time; the latter is "safe" but flashes the unfocused color momentarily until the first event lands. Open to feedback.
3. Naming: `unfocusedSelectionColor` reads cleanly but conflates "view unfocused" with "field unfocused". Alternatives I considered: `inactiveSelectionColor`, `viewUnfocusedSelectionColor`. Happy to rename.

## Testing

New `group('unfocusedSelectionColor', ...)` in `test/widgets/editable_text_test.dart` covers:
* Selection color swaps to `unfocusedSelectionColor` when the view becomes unfocused, and back when it refocuses
* Behavior preserved when `unfocusedSelectionColor` is null (selection color unchanged across view focus events)
* `ViewFocusEvent`s for other view IDs are ignored

Local verification:
* `flutter analyze lib/src/widgets/editable_text.dart`
* `flutter analyze test/widgets/editable_text_test.dart`
* `flutter test test/widgets/editable_text_test.dart` — 514 tests pass
* `flutter test test/widgets/text_selection_test.dart` — 69 tests pass