### PR TITLE
[skwasm] Chunk drawAtlas/drawRawAtlas to avoid wasm stack overflow

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/canvas.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/canvas.dart
@@ -379,8 +379,48 @@ class SkwasmCanvas implements LayerCanvas {
     paintDispose(paintHandle);
   }
 
+  // Maximum number of entries we forward to a single `canvasDrawAtlas` call.
+  // The native conversion helpers write into the wasm stack via
+  // `withStackScope` / `_emscripten_stack_alloc`, whose total budget is the
+  // Emscripten default 64 KiB. Each entry costs up to
+  // 16 (RSTransform) + 16 (Rect) + 4 (Color) = 36 bytes, so beyond ~1800
+  // entries the conversion overflows the wasm stack into the heap and the
+  // next `malloc` traps with `RuntimeError: memory access out of bounds`
+  // (typically surfacing inside `paint_create` immediately after the
+  // conversions, see https://github.com/flutter/flutter/issues/185995).
+  // 1024 keeps every batch comfortably below 36 KiB.
+  static const int _drawAtlasMaxBatchSize = 1024;
+
   @override
   void drawAtlas(
+    ui.Image atlas,
+    List<ui.RSTransform> transforms,
+    List<ui.Rect> rects,
+    List<ui.Color>? colors,
+    ui.BlendMode? blendMode,
+    ui.Rect? cullRect,
+    ui.Paint paint,
+  ) {
+    final int n = transforms.length;
+    if (n <= _drawAtlasMaxBatchSize) {
+      _drawAtlasBatch(atlas, transforms, rects, colors, blendMode, cullRect, paint);
+      return;
+    }
+    for (int i = 0; i < n; i += _drawAtlasMaxBatchSize) {
+      final int end = i + _drawAtlasMaxBatchSize < n ? i + _drawAtlasMaxBatchSize : n;
+      _drawAtlasBatch(
+        atlas,
+        transforms.sublist(i, end),
+        rects.sublist(i, end),
+        colors?.sublist(i, end),
+        blendMode,
+        cullRect,
+        paint,
+      );
+    }
+  }
+
+  void _drawAtlasBatch(
     ui.Image atlas,
     List<ui.RSTransform> transforms,
     List<ui.Rect> rects,
@@ -414,6 +454,34 @@ class SkwasmCanvas implements LayerCanvas {
 
   @override
   void drawRawAtlas(
+    ui.Image atlas,
+    Float32List rstTransforms,
+    Float32List rects,
+    Int32List? colors,
+    ui.BlendMode? blendMode,
+    ui.Rect? cullRect,
+    ui.Paint paint,
+  ) {
+    final int n = rstTransforms.length ~/ 4;
+    if (n <= _drawAtlasMaxBatchSize) {
+      _drawRawAtlasBatch(atlas, rstTransforms, rects, colors, blendMode, cullRect, paint);
+      return;
+    }
+    for (int i = 0; i < n; i += _drawAtlasMaxBatchSize) {
+      final int end = i + _drawAtlasMaxBatchSize < n ? i + _drawAtlasMaxBatchSize : n;
+      _drawRawAtlasBatch(
+        atlas,
+        rstTransforms.sublist(i * 4, end * 4),
+        rects.sublist(i * 4, end * 4),
+        colors == null ? null : colors.sublist(i, end),
+        blendMode,
+        cullRect,
+        paint,
+      );
+    }
+  }
+
+  void _drawRawAtlasBatch(
     ui.Image atlas,
     Float32List rstTransforms,
     Float32List rects,

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/canvas.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/canvas.dart
@@ -471,9 +471,9 @@ class SkwasmCanvas implements LayerCanvas {
       final int end = i + _drawAtlasMaxBatchSize < n ? i + _drawAtlasMaxBatchSize : n;
       _drawRawAtlasBatch(
         atlas,
-        rstTransforms.sublist(i * 4, end * 4),
-        rects.sublist(i * 4, end * 4),
-        colors == null ? null : colors.sublist(i, end),
+        Float32List.sublistView(rstTransforms, i * 4, end * 4),
+        Float32List.sublistView(rects, i * 4, end * 4),
+        colors == null ? null : Int32List.sublistView(colors, i, end),
         blendMode,
         cullRect,
         paint,


### PR DESCRIPTION
Fixes #185995.

## Summary

`SkwasmCanvas.drawAtlas` (and `drawRawAtlas`) crash with `RuntimeError: memory access out of bounds` whenever the caller passes more than ~2000 entries — a routine batch size for tilemap renderers (e.g. `package:flame_tiled` `SpriteBatch.render` on a 64×64 map sends 4096 entries in one call).

The root cause is that the native conversion helpers write into the wasm stack via `withStackScope` + `_emscripten_stack_alloc`, whose total budget is the Emscripten default of 64 KiB. Each entry costs up to 16 (RSTransform) + 16 (Rect) + 4 (Color) = 36 bytes. 4096 entries → ~144 KiB, which overflows the stack into the heap. The `malloc` call that follows the conversions traps; in practice this surfaces inside `paint_create` (called from `paint.toRawPaint()`) immediately after the conversions, see the trace in the linked issue.

## Fix

Cap each `canvasDrawAtlas` invocation at 1024 entries (~36 KiB worst case, comfortably within the 64 KiB wasm stack) and dispatch larger calls as a sequence of batched native draws. No public API change; behaviour is identical for callers that already stay below the cap.

## Caveats / better fixes welcome

This is the minimal-risk, drop-in fix and unblocks the very nasty surface-on-`malloc` crash that's currently silent until `drawAtlas` happens. There are at least two more general approaches I'd be happy to follow up with if maintainers prefer:

1. **Engine-side**: add `-sSTACK_SIZE=262144` (or higher) to `engine/src/flutter/skwasm/BUILD.gn` `ldflags`. Single-line, but kicks the limit up rather than removing it.
2. **`StackScope` heap fallback**: in `lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_memory.dart`, when the requested `stackAlloc` size would exceed `emscripten_stack_get_free()`, fall back to `malloc` and free at scope exit. Most general — also covers `drawPoints`, `drawRawPoints`, `drawVertices` and any future consumer.

I went with the chunking approach in this PR because (a) it's the smallest and most localised diff, and (b) the corruption-then-trap-on-next-malloc symptom is misleading enough that I think shipping the fix sooner has real value, even if a fuller solution lands later.

## Test plan

- Repro case from the issue (Dart-only `Canvas.drawAtlas` with 4096 transforms) goes from crash → renders correctly.
- Real game (`package:flame` 1.37.0 + `package:flame_tiled` 3.1.1, 64×64 tilemap, collection tileset): goes from crash on first frame → full-FPS render with `useAtlas: true` (default) under `flutter run -d chrome --wasm` with `renderer: skwasm` in `flutter_bootstrap.js`.
- Verified by recompiling `dart2wasm_platform.dill` locally with this patch (`kernel_worker_aot.dart.snapshot` against `flutter_web_sdk/libraries.json`) and running the game against the patched dill.
- I have not run the upstream engine unit tests for this change — happy to wait on CI feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
