### PR TITLE
Skip xattr removal for Swift package cache

### DIFF
--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -9,6 +9,7 @@ import 'package:process/process.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 
 import '../artifacts.dart';
+import '../base/config.dart';
 import '../base/file_system.dart';
 import '../base/fingerprint.dart';
 import '../base/io.dart';
@@ -196,10 +197,13 @@ Future<XcodeBuildResult> buildXcodeProject({
     return XcodeBuildResult(success: false);
   }
 
-  await removeExtendedAttributes(
-    app.project.parent.directory,
-    globals.processUtils,
-    globals.logger,
+  await removeExtendedAttributesForProject(
+    xcodeProject: app.project,
+    processUtils: globals.processUtils,
+    logger: globals.logger,
+    fileSystem: globals.fs,
+    config: globals.config,
+    xcodeProjectInterpreter: globals.xcodeProjectInterpreter!,
   );
 
   final XcodeProjectInfo? projectInfo = await app.project.projectInfo();
@@ -738,6 +742,47 @@ bool publicHeadersChanged({
     fingerprinter.writeFingerprint();
   }
   return headersChanged;
+}
+
+/// Remove extended attributes from all files in the Flutter project, except the Swift package
+/// cache in the build directory.
+///
+/// Attributes must be removed from the entire project rather than just the iOS directory due to
+/// user reports. See https://github.com/flutter/flutter/pull/81435.
+Future<void> removeExtendedAttributesForProject({
+  required XcodeBasedProject xcodeProject,
+  required ProcessUtils processUtils,
+  required Logger logger,
+  required FileSystem fileSystem,
+  required Config config,
+  required XcodeProjectInterpreter xcodeProjectInterpreter,
+}) async {
+  final Directory projectDirectory = xcodeProject.parent.directory;
+  final futures = <Future<void>>[];
+
+  // Remove for all files from the project (except the build directory).
+  final Directory buildDir = fileSystem.directory(getBuildDirectory(config, fileSystem));
+  for (final FileSystemEntity entity in projectDirectory.listSync()) {
+    if (entity.absolute.path == buildDir.absolute.path) {
+      continue;
+    }
+    futures.add(removeExtendedAttributes(entity, processUtils, logger));
+  }
+
+  // Remove for all files from the iOS build directory (except the Swift package cache).
+  // We don't remove from other directories in the build directory since they should be unrelated
+  // to the iOS build.
+  final Directory iosBuildDir = fileSystem.directory(
+    getIosBuildDirectory(config: config, fileSystem: fileSystem),
+  );
+  final String swiftPackageCachePath = xcodeProjectInterpreter.swiftPackageCachePath(iosBuildDir);
+  for (final FileSystemEntity entity in iosBuildDir.listSync()) {
+    if (entity.absolute.path == swiftPackageCachePath) {
+      continue;
+    }
+    futures.add(removeExtendedAttributes(entity, processUtils, logger));
+  }
+  await Future.wait(futures);
 }
 
 /// Extended attributes can cause code signing errors. Remove them.

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -747,8 +747,12 @@ bool publicHeadersChanged({
 /// Remove extended attributes from all files in the Flutter project, except the Swift package
 /// cache in the build directory.
 ///
+/// The Swift package cache is skipped because it makes the command very slow and are not expected to
+/// need to have the attributes removed. See https://github.com/flutter/flutter/issues/183662.
+///
 /// Attributes must be removed from the entire project rather than just the iOS directory due to
-/// user reports. See https://github.com/flutter/flutter/pull/81435.
+/// user reporting images in the root of their project also need to have the attributes removed.
+/// See https://github.com/flutter/flutter/pull/81435.
 Future<void> removeExtendedAttributesForProject({
   required XcodeBasedProject xcodeProject,
   required ProcessUtils processUtils,

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -762,11 +762,13 @@ Future<void> removeExtendedAttributesForProject({
 
   // Remove for all files from the project (except the build directory).
   final Directory buildDir = fileSystem.directory(getBuildDirectory(config, fileSystem));
-  for (final FileSystemEntity entity in projectDirectory.listSync()) {
-    if (entity.absolute.path == buildDir.absolute.path) {
-      continue;
+  if (projectDirectory.existsSync()) {
+    for (final FileSystemEntity entity in projectDirectory.listSync()) {
+      if (entity.absolute.path == buildDir.absolute.path) {
+        continue;
+      }
+      futures.add(removeExtendedAttributes(entity, processUtils, logger));
     }
-    futures.add(removeExtendedAttributes(entity, processUtils, logger));
   }
 
   // Remove for all files from the iOS build directory (except the Swift package cache).
@@ -776,11 +778,13 @@ Future<void> removeExtendedAttributesForProject({
     getIosBuildDirectory(config: config, fileSystem: fileSystem),
   );
   final String swiftPackageCachePath = xcodeProjectInterpreter.swiftPackageCachePath(iosBuildDir);
-  for (final FileSystemEntity entity in iosBuildDir.listSync()) {
-    if (entity.absolute.path == swiftPackageCachePath) {
-      continue;
+  if (iosBuildDir.existsSync()) {
+    for (final FileSystemEntity entity in iosBuildDir.listSync()) {
+      if (entity.absolute.path == swiftPackageCachePath) {
+        continue;
+      }
+      futures.add(removeExtendedAttributes(entity, processUtils, logger));
     }
-    futures.add(removeExtendedAttributes(entity, processUtils, logger));
   }
   await Future.wait(futures);
 }

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -764,7 +764,7 @@ Future<void> removeExtendedAttributesForProject({
   final Directory buildDir = fileSystem.directory(getBuildDirectory(config, fileSystem));
   if (projectDirectory.existsSync()) {
     for (final FileSystemEntity entity in projectDirectory.listSync()) {
-      if (entity.absolute.path == buildDir.absolute.path) {
+      if (fileSystem.path.equals(entity.absolute.path, buildDir.absolute.path)) {
         continue;
       }
       futures.add(removeExtendedAttributes(entity, processUtils, logger));
@@ -780,7 +780,7 @@ Future<void> removeExtendedAttributesForProject({
   final String swiftPackageCachePath = xcodeProjectInterpreter.swiftPackageCachePath(iosBuildDir);
   if (iosBuildDir.existsSync()) {
     for (final FileSystemEntity entity in iosBuildDir.listSync()) {
-      if (entity.absolute.path == swiftPackageCachePath) {
+      if (fileSystem.path.equals(entity.absolute.path, swiftPackageCachePath)) {
         continue;
       }
       futures.add(removeExtendedAttributes(entity, processUtils, logger));

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -201,6 +201,11 @@ class XcodeProjectInterpreter {
     );
   }
 
+  /// Returns the absolute path to the Swift package cache directory.
+  String swiftPackageCachePath(Directory buildDirectory) {
+    return buildDirectory.childDirectory(kSwiftPackageCacheDirectoryName).absolute.path;
+  }
+
   /// Returns a list of required arguments for the `xcodebuild` Xcode project command.
   ///
   /// When [skipPackageUpdatesAndValidation] is true, it uses arguments to attempt skipping any
@@ -209,10 +214,7 @@ class XcodeProjectInterpreter {
     Directory buildDirectory, {
     bool skipPackageUpdatesAndValidation = true,
   }) {
-    final String cachePath = buildDirectory
-        .childDirectory(kSwiftPackageCacheDirectoryName)
-        .absolute
-        .path;
+    final String cachePath = swiftPackageCachePath(buildDirectory);
     return <String>[
       ...xcrunCommand(),
       'xcodebuild',

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ios_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ios_test.dart
@@ -107,13 +107,6 @@ void main() {
     createCoreMockProjectFiles();
   }
 
-  const xattrCommand1 = FakeCommand(
-    command: <String>['xattr', '-r', '-d', 'com.apple.FinderInfo', '/'],
-  );
-  const xattrCommand2 = FakeCommand(
-    command: <String>['xattr', '-r', '-d', 'com.apple.provenance', '/'],
-  );
-
   List<FakeCommand> postBuildCommands({void Function(List<String> command)? onRun}) {
     return [
       const FakeCommand(
@@ -366,9 +359,6 @@ void main() {
       FileSystem: () => fileSystem,
       Pub: ThrowingPub.new,
       ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(
           onRun: (_) {
             fileSystem
@@ -409,9 +399,6 @@ void main() {
       createMinimalMockProjectFiles();
 
       processManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(
           onRun: (_) {
             fileSystem
@@ -467,9 +454,6 @@ void main() {
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(
           disablePortPublication: true,
           onRun: (_) {
@@ -519,9 +503,6 @@ void main() {
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(
           onRun: (_) {
             fileSystem
@@ -562,9 +543,6 @@ void main() {
       );
 
       processManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(
           customNaming: true,
           onRun: (_) {
@@ -623,9 +601,6 @@ void main() {
         flutterVersion: FakeFlutterVersion(),
       );
       processManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(
           deviceId: '1234',
           onRun: (_) {
@@ -676,9 +651,6 @@ void main() {
         flutterVersion: FakeFlutterVersion(),
       );
       processManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(
           simulator: true,
           onRun: (_) {
@@ -729,9 +701,6 @@ void main() {
       );
       createMinimalMockProjectFiles();
       processManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(
           verbose: true,
           onRun: (_) {
@@ -778,9 +747,6 @@ void main() {
         flutterVersion: FakeFlutterVersion(),
       );
       processManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(
           onRun: (_) {
             fileSystem
@@ -882,9 +848,6 @@ void main() {
       overrides: <Type, Generator>{
         FileSystem: () => fileSystem,
         ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
-          xattrCommand1,
-
-          xattrCommand2,
           setUpFakeXcodeBuildHandler(
             onRun: (_) {
               fileSystem
@@ -949,9 +912,6 @@ void main() {
       overrides: <Type, Generator>{
         FileSystem: () => fileSystem,
         ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
-          xattrCommand1,
-
-          xattrCommand2,
           setUpFakeXcodeBuildHandler(
             onRun: (_) {
               fileSystem
@@ -1012,9 +972,6 @@ void main() {
           flutterVersion: FakeFlutterVersion(),
         );
         processManager.addCommands(<FakeCommand>[
-          xattrCommand1,
-
-          xattrCommand2,
           setUpFakeXcodeBuildHandler(
             exitCode: 1,
             onRun: (_) {
@@ -1068,9 +1025,6 @@ void main() {
           flutterVersion: FakeFlutterVersion(),
         );
         processManager.addCommands(<FakeCommand>[
-          xattrCommand1,
-
-          xattrCommand2,
           setUpFakeXcodeBuildHandler(
             exitCode: 1,
             onRun: (_) {
@@ -1131,9 +1085,6 @@ void main() {
           flutterVersion: FakeFlutterVersion(),
         );
         processManager.addCommands(<FakeCommand>[
-          xattrCommand1,
-
-          xattrCommand2,
           setUpFakeXcodeBuildHandler(
             exitCode: 1,
             onRun: (_) {
@@ -1199,9 +1150,6 @@ void main() {
           flutterVersion: FakeFlutterVersion(),
         );
         processManager.addCommands(<FakeCommand>[
-          xattrCommand1,
-
-          xattrCommand2,
           setUpFakeXcodeBuildHandler(exitCode: 1),
           setUpLegacyXCResultCommand(stdout: kSampleResultJsonWithIssues),
           ...postBuildCommands(),
@@ -1252,9 +1200,6 @@ void main() {
           flutterVersion: FakeFlutterVersion(),
         );
         processManager.addCommands(<FakeCommand>[
-          xattrCommand1,
-
-          xattrCommand2,
           setUpFakeXcodeBuildHandler(
             exitCode: 1,
             onRun: (_) {
@@ -1322,9 +1267,6 @@ void main() {
           flutterVersion: FakeFlutterVersion(),
         );
         processManager.addCommands(<FakeCommand>[
-          xattrCommand1,
-
-          xattrCommand2,
           setUpFakeXcodeBuildHandler(
             exitCode: 1,
             onRun: (_) {
@@ -1384,9 +1326,6 @@ void main() {
           flutterVersion: FakeFlutterVersion(),
         );
         processManager.addCommands(<FakeCommand>[
-          xattrCommand1,
-
-          xattrCommand2,
           setUpFakeXcodeBuildHandler(
             exitCode: 1,
             onRun: (_) {
@@ -1440,9 +1379,6 @@ void main() {
           flutterVersion: FakeFlutterVersion(),
         );
         processManager.addCommands(<FakeCommand>[
-          xattrCommand1,
-
-          xattrCommand2,
           // Intentionally fail the first xcodebuild command with concurrent run failure message.
           setUpFakeXcodeBuildHandler(
             exitCode: 1,
@@ -1513,9 +1449,6 @@ void main() {
           flutterVersion: FakeFlutterVersion(),
         );
         processManager.addCommands(<FakeCommand>[
-          xattrCommand1,
-
-          xattrCommand2,
           setUpFakeXcodeBuildHandler(
             exitCode: 1,
             stdout: '''
@@ -1572,9 +1505,6 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
           flutterVersion: FakeFlutterVersion(),
         );
         processManager.addCommands(<FakeCommand>[
-          xattrCommand1,
-
-          xattrCommand2,
           setUpFakeXcodeBuildHandler(
             exitCode: 1,
             onRun: (_) {
@@ -1641,9 +1571,6 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
       overrides: <Type, Generator>{
         FileSystem: () => fileSystem,
         ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
-          xattrCommand1,
-
-          xattrCommand2,
           setUpFakeXcodeBuildHandler(
             exitCode: 1,
             stdout: '''
@@ -1687,9 +1614,6 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
           flutterVersion: FakeFlutterVersion(),
         );
         processManager.addCommands(<FakeCommand>[
-          xattrCommand1,
-
-          xattrCommand2,
           setUpFakeXcodeBuildHandler(
             exitCode: 1,
             onRun: (_) {
@@ -1743,9 +1667,6 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
           flutterVersion: FakeFlutterVersion(),
         );
         processManager.addCommands(<FakeCommand>[
-          xattrCommand1,
-
-          xattrCommand2,
           setUpFakeXcodeBuildHandler(
             exitCode: 1,
             onRun: (_) {
@@ -1801,9 +1722,6 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
           flutterVersion: FakeFlutterVersion(),
         );
         processManager.addCommands(<FakeCommand>[
-          xattrCommand1,
-
-          xattrCommand2,
           setUpFakeXcodeBuildHandler(
             exitCode: 1,
             onRun: (_) {
@@ -1861,9 +1779,6 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
           flutterVersion: FakeFlutterVersion(),
         );
         processManager.addCommands(<FakeCommand>[
-          xattrCommand1,
-
-          xattrCommand2,
           setUpFakeXcodeBuildHandler(
             simulator: true,
             exitCode: 1,
@@ -1920,9 +1835,6 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
           flutterVersion: FakeFlutterVersion(),
         );
         processManager.addCommands(<FakeCommand>[
-          xattrCommand1,
-
-          xattrCommand2,
           setUpFakeXcodeBuildHandler(
             simulator: true,
             exitCode: 1,
@@ -1984,9 +1896,6 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
         );
 
         processManager.addCommands(<FakeCommand>[
-          xattrCommand1,
-
-          xattrCommand2,
           setUpFakeXcodeBuildHandler(
             simulator: true,
             exitCode: 1,
@@ -2055,9 +1964,6 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
           flutterVersion: FakeFlutterVersion(),
         );
         processManager.addCommands(<FakeCommand>[
-          xattrCommand1,
-
-          xattrCommand2,
           setUpFakeXcodeBuildHandler(simulator: true, exitCode: 1),
           setUpLegacyXCResultCommand(stdout: kSampleResultJsonWithIssues),
           ...postBuildCommands(),

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
@@ -138,13 +138,6 @@ void main() {
     createCoreMockProjectFiles();
   }
 
-  const xattrCommand1 = FakeCommand(
-    command: <String>['xattr', '-r', '-d', 'com.apple.FinderInfo', '/'],
-  );
-  const xattrCommand2 = FakeCommand(
-    command: <String>['xattr', '-r', '-d', 'com.apple.provenance', '/'],
-  );
-
   // Sets up xcresulttool command for Xcode versions below 16.
   FakeCommand setUpLegacyXCResultCommand({
     String stdout = '',
@@ -505,9 +498,6 @@ void main() {
         flutterVersion: FakeFlutterVersion(),
       );
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(),
         exportArchiveCommand(exportOptionsPlist: _exportOptionsPlist),
       ]);
@@ -554,9 +544,6 @@ void main() {
         flutterVersion: FakeFlutterVersion(),
       );
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(),
         exportArchiveCommand(
           exportOptionsPlist: _exportOptionsPlist,
@@ -624,9 +611,6 @@ void main() {
         flutterVersion: FakeFlutterVersion(),
       );
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(),
         exportArchiveCommand(
           exportOptionsPlist: _exportOptionsPlist,
@@ -694,9 +678,6 @@ void main() {
         flutterVersion: FakeFlutterVersion(),
       );
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(),
         exportArchiveCommand(
           exportOptionsPlist: _exportOptionsPlist,
@@ -763,9 +744,6 @@ void main() {
         flutterVersion: FakeFlutterVersion(),
       );
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(),
         exportArchiveCommand(exportOptionsPlist: _exportOptionsPlist),
       ]);
@@ -811,9 +789,6 @@ void main() {
         flutterVersion: FakeFlutterVersion(),
       );
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(),
         exportArchiveCommand(
           exportOptionsPlist: _exportOptionsPlist,
@@ -880,9 +855,6 @@ void main() {
         flutterVersion: FakeFlutterVersion(),
       );
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(),
         exportArchiveCommand(exportOptionsPlist: _exportOptionsPlist),
       ]);
@@ -916,9 +888,6 @@ void main() {
       };
 
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(),
         exportArchiveCommand(exportOptionsPlist: exportOptions.path),
       ]);
@@ -983,9 +952,6 @@ void main() {
         flutterVersion: FakeFlutterVersion(),
       );
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(),
         const FakeCommand(
           command: <String>[
@@ -1057,9 +1023,6 @@ void main() {
         flutterVersion: FakeFlutterVersion(),
       );
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(),
         exportArchiveCommand(
           exportOptionsPlist: _exportOptionsPlist,
@@ -1107,9 +1070,6 @@ void main() {
         flutterVersion: FakeFlutterVersion(),
       );
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(),
         exportArchiveCommand(
           exportOptionsPlist: _exportOptionsPlist,
@@ -1180,9 +1140,6 @@ void main() {
         flutterVersion: FakeFlutterVersion(),
       );
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(),
         exportArchiveCommand(
           exportOptionsPlist: _exportOptionsPlist,
@@ -1255,9 +1212,6 @@ void main() {
         flutterVersion: FakeFlutterVersion(),
       );
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(),
         exportArchiveCommand(
           exportOptionsPlist: _exportOptionsPlist,
@@ -1329,9 +1283,6 @@ void main() {
         flutterVersion: FakeFlutterVersion(),
       );
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(verbose: true),
         exportArchiveCommand(exportOptionsPlist: _exportOptionsPlist),
       ]);
@@ -1374,9 +1325,6 @@ void main() {
         flutterVersion: FakeFlutterVersion(),
       );
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(),
         exportArchiveCommand(exportOptionsPlist: _exportOptionsPlist),
       ]);
@@ -1420,9 +1368,6 @@ void main() {
         flutterVersion: FakeFlutterVersion(),
       );
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         const FakeCommand(
           command: <String>[
             'xcrun',
@@ -1544,9 +1489,6 @@ void main() {
         ..createSync(recursive: true)
         ..writeAsBytesSync(List<int>.generate(10000, (int index) => 0));
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(
           onRun: (_) {
             fileSystem.file('build/flutter_size_01/snapshot.arm64.json')
@@ -1617,9 +1559,6 @@ void main() {
         flutterVersion: FakeFlutterVersion(),
       );
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(),
         exportArchiveCommand(),
       ]);
@@ -1674,9 +1613,6 @@ void main() {
         flutterVersion: FakeFlutterVersion(),
       );
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(
           exitCode: 1,
           onRun: (_) {
@@ -1729,9 +1665,6 @@ void main() {
         flutterVersion: FakeFlutterVersion(),
       );
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(
           exitCode: 1,
           onRun: (_) {
@@ -1788,9 +1721,6 @@ void main() {
         flutterVersion: FakeFlutterVersion(),
       );
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(
           exitCode: 1,
           onRun: (_) {
@@ -1854,12 +1784,7 @@ void main() {
         cache: FakeCache(),
         flutterVersion: FakeFlutterVersion(),
       );
-      fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
-        setUpFakeXcodeBuildHandler(exitCode: 1),
-      ]);
+      fakeProcessManager.addCommands(<FakeCommand>[setUpFakeXcodeBuildHandler(exitCode: 1)]);
       createMinimalMockProjectFiles();
 
       await expectLater(
@@ -1907,9 +1832,6 @@ void main() {
         flutterVersion: FakeFlutterVersion(),
       );
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(
           exitCode: 1,
           onRun: (_) {
@@ -1959,9 +1881,6 @@ void main() {
       const plistPath =
           'build/ios/archive/Runner.xcarchive/Products/Applications/Runner.app/Info.plist';
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(
           onRun: (_) {
             fileSystem.file(plistPath).createSync(recursive: true);
@@ -2032,9 +1951,6 @@ void main() {
       const plistPath =
           'build/ios/archive/Runner.xcarchive/Products/Applications/Runner.app/Info.plist';
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(
           onRun: (_) {
             fileSystem.file(plistPath).createSync(recursive: true);
@@ -2110,9 +2026,6 @@ void main() {
       const plistPath =
           'build/ios/archive/Runner.xcarchive/Products/Applications/Runner.app/Info.plist';
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(
           onRun: (_) {
             fileSystem.file(plistPath).createSync(recursive: true);
@@ -2187,9 +2100,6 @@ void main() {
       const plistPath =
           'build/ios/archive/Runner.xcarchive/Products/Applications/Runner.app/Info.plist';
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(
           onRun: (_) {
             fileSystem.file(plistPath).createSync(recursive: true);
@@ -2250,9 +2160,6 @@ void main() {
       const plistPath =
           'build/ios/archive/Runner.xcarchive/Products/Applications/Runner.app/Info.plist';
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(
           onRun: (_) {
             fileSystem.file(plistPath).createSync(recursive: true);
@@ -2322,9 +2229,6 @@ void main() {
           '/flutter_template_images/templates/app/ios.tmpl/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-20x20@2x.png';
 
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(
           onRun: (_) {
             fileSystem.file(templateIconContentsJsonPath)
@@ -2429,9 +2333,6 @@ void main() {
           '/flutter_template_images/templates/app/ios.tmpl/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-20x20@2x.png';
 
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(
           onRun: (_) {
             fileSystem.file(templateIconContentsJsonPath)
@@ -2532,9 +2433,6 @@ void main() {
           'ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-20x20@2x.png';
 
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(
           onRun: (_) {
             fileSystem.file(projectIconContentsJsonPath)
@@ -2621,9 +2519,6 @@ void main() {
           'ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-20x20@2x.png';
 
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(
           onRun: (_) {
             fileSystem.file(projectIconContentsJsonPath)
@@ -2710,9 +2605,6 @@ void main() {
           'ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-20x20@2x.png';
 
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(
           onRun: (_) {
             fileSystem.file(projectIconContentsJsonPath)
@@ -2799,9 +2691,6 @@ void main() {
           'ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-20x20@2x.png';
 
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(
           onRun: (_) {
             // Uses unknown format version 123.
@@ -2896,9 +2785,6 @@ void main() {
       ];
 
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(
           onRun: (_) {
             // The following json contains examples of:
@@ -3029,9 +2915,6 @@ void main() {
           '/flutter_template_images/templates/app/ios.tmpl/Runner/Assets.xcassets/LaunchImage.imageset/LaunchImage@2x.png';
 
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(
           onRun: (_) {
             fileSystem.file(templateLaunchImageContentsJsonPath)
@@ -3134,9 +3017,6 @@ void main() {
           '/flutter_template_images/templates/app/ios.tmpl/Runner/Assets.xcassets/LaunchImage.imageset/LaunchImage@2x.png';
 
       fakeProcessManager.addCommands(<FakeCommand>[
-        xattrCommand1,
-
-        xattrCommand2,
         setUpFakeXcodeBuildHandler(
           onRun: (_) {
             fileSystem.file(templateLaunchImageContentsJsonPath)

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
@@ -40,18 +40,6 @@ import '../../src/fakes.dart';
 import '../../src/package_config.dart';
 import '../../src/throwing_pub.dart';
 
-// Helper to generate xattr commands for removing specific extended attributes
-List<FakeCommand> xattrCommands(FlutterProject flutterProject) {
-  return <FakeCommand>[
-    FakeCommand(
-      command: <String>['xattr', '-r', '-d', 'com.apple.FinderInfo', flutterProject.directory.path],
-    ),
-    FakeCommand(
-      command: <String>['xattr', '-r', '-d', 'com.apple.provenance', flutterProject.directory.path],
-    ),
-  ];
-}
-
 FakeCommand xattrCreatedByBuildSystemCommand(String outputDirPath) {
   return FakeCommand(
     command: <String>['xattr', '-w', 'com.apple.xcode.CreatedByBuildSystem', 'true', outputDirPath],
@@ -150,7 +138,6 @@ void main() {
           'My Super Awesome App',
         );
 
-        processManager.addCommands(xattrCommands(flutterProject));
         processManager.addCommand(const FakeCommand(command: kRunReleaseArgs));
 
         final LaunchResult launchResult = await iosDevice.startApp(
@@ -257,7 +244,6 @@ void main() {
             .directory('build/ios/Release-iphoneos/My Super Awesome App.app')
             .createSync(recursive: true);
 
-        processManager.addCommands(xattrCommands(flutterProject));
         processManager.addCommand(const FakeCommand(command: kRunReleaseArgs));
         processManager.addCommand(xattrCreatedByBuildSystemCommand('build/ios/Release-iphoneos'));
         processManager.addCommand(
@@ -345,7 +331,6 @@ void main() {
             .directory('build/ios/Release-iphoneos/My Super Awesome App.app')
             .createSync(recursive: true);
 
-        processManager.addCommands(xattrCommands(flutterProject));
         processManager.addCommand(
           const FakeCommand(
             command: <String>[
@@ -483,7 +468,6 @@ void main() {
               .childFile('FlutterPlugin.h')
               .createSync(recursive: true);
           processManager.addCommands([
-            ...xattrCommands(flutterProject),
             FakeCommand(
               command: const <String>[
                 'xcrun',
@@ -589,7 +573,6 @@ void main() {
               .childFile('FlutterPlugin.h')
               .createSync(recursive: true);
           processManager.addCommands([
-            ...xattrCommands(flutterProject),
             const FakeCommand(
               command: <String>[
                 'xcrun',
@@ -665,7 +648,6 @@ void main() {
           'My Super Awesome App',
         );
 
-        processManager.addCommands(xattrCommands(flutterProject));
         // The first xcrun call should fail with a
         // concurrent build exception.
         processManager.addCommand(
@@ -1575,6 +1557,11 @@ class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterprete
     required XcodeProjectBuildContext buildContext,
     Duration timeout = const Duration(minutes: 1),
   }) async => buildSettings;
+
+  @override
+  String swiftPackageCachePath(Directory buildDirectory) {
+    return '';
+  }
 }
 
 class FakeXcodeDebug extends Fake implements XcodeDebug {

--- a/packages/flutter_tools/test/general.shard/ios/mac_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/mac_test.dart
@@ -5,6 +5,7 @@
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/artifacts.dart';
+import 'package:flutter_tools/src/base/config.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/process.dart';
@@ -1012,6 +1013,101 @@ duplicate symbol '_$s29plugin_1_name23PluginNamePluginC9setDouble3key5valueySS_S
       expect(logger.traceText, contains('Failed to remove com.apple.provenance'));
       expect(processManager, hasNoRemainingExpectations);
     });
+
+    testWithoutContext(
+      'removeExtendedAttributesForProject removes attributes from expected files/directories',
+      () async {
+        final fs = MemoryFileSystem.test();
+
+        // Create project level entities (excluding buildDir)
+        final Directory projectDir = fs.directory('/app_name')..createSync(recursive: true);
+        fs.currentDirectory = projectDir;
+        projectDir.childFile('pubspec.yaml').createSync();
+        projectDir.childDirectory('lib').createSync();
+
+        // Create build directory level entities (excluding iosBuildDir)
+        final Directory buildDir = projectDir.childDirectory('build')..createSync(recursive: true);
+        buildDir.childDirectory('macos').createSync();
+
+        // Create iOS build directory level entities (excluding swiftPackageCacheDir)
+        final Directory iosBuildDir = buildDir.childDirectory('ios')..createSync(recursive: true);
+        iosBuildDir.childDirectory('iphoneos').createSync();
+        iosBuildDir.childDirectory('Release-iphoneos').createSync();
+
+        // swiftPackageCacheDir contains files that should NOT have attributes removed
+        final Directory swiftPackageCacheDir = iosBuildDir.childDirectory('SourcePackages');
+        swiftPackageCacheDir.createSync(recursive: true);
+
+        final processManager = FakeProcessManager.unordered(<FakeCommand>[
+          // Project files FinderInfo
+          const FakeCommand(
+            command: <String>[
+              'xattr',
+              '-r',
+              '-d',
+              'com.apple.FinderInfo',
+              '/app_name/pubspec.yaml',
+            ],
+          ),
+          const FakeCommand(
+            command: <String>[
+              'xattr',
+              '-r',
+              '-d',
+              'com.apple.provenance',
+              '/app_name/pubspec.yaml',
+            ],
+          ),
+          const FakeCommand(
+            command: <String>['xattr', '-r', '-d', 'com.apple.FinderInfo', '/app_name/lib'],
+          ),
+          const FakeCommand(
+            command: <String>['xattr', '-r', '-d', 'com.apple.provenance', '/app_name/lib'],
+          ),
+          // iOS Build directory files FinderInfo
+          const FakeCommand(
+            command: <String>['xattr', '-r', '-d', 'com.apple.FinderInfo', 'build/ios/iphoneos'],
+          ),
+          const FakeCommand(
+            command: <String>['xattr', '-r', '-d', 'com.apple.provenance', 'build/ios/iphoneos'],
+          ),
+          const FakeCommand(
+            command: <String>[
+              'xattr',
+              '-r',
+              '-d',
+              'com.apple.FinderInfo',
+              'build/ios/Release-iphoneos',
+            ],
+          ),
+          const FakeCommand(
+            command: <String>[
+              'xattr',
+              '-r',
+              '-d',
+              'com.apple.provenance',
+              'build/ios/Release-iphoneos',
+            ],
+          ),
+        ]);
+
+        final fakeFlutterProject = FakeFlutterProjectWithAbsoluteDirectory(fileSystem: fs);
+        final xcodeProject = FakeXcodeBasedProject(parent: fakeFlutterProject);
+
+        final config = Config.test(directory: fs.directory('/config_dir'), logger: logger);
+
+        await removeExtendedAttributesForProject(
+          xcodeProject: xcodeProject,
+          processUtils: ProcessUtils(processManager: processManager, logger: logger),
+          logger: logger,
+          fileSystem: fs,
+          config: config,
+          xcodeProjectInterpreter: FakeXcodeProjectInterpreter(),
+        );
+
+        expect(processManager, hasNoRemainingExpectations);
+      },
+    );
   });
 
   group('publicHeadersChanged', () {
@@ -1245,6 +1341,11 @@ class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterprete
   }) async {
     return <String>['xcrun', 'xcodebuild'];
   }
+
+  @override
+  String swiftPackageCachePath(Directory buildDirectory) {
+    return buildDirectory.childDirectory('SourcePackages').absolute.path;
+  }
 }
 
 class FakePlugin extends Fake implements Plugin {
@@ -1265,4 +1366,18 @@ class FakePlugin extends Fake implements Plugin {
   String? pluginPodspecPath(FileSystem fileSystem, String platform) {
     return 'path/to/$name/$platform/$name.podspec';
   }
+}
+
+class FakeXcodeBasedProject extends Fake implements XcodeBasedProject {
+  FakeXcodeBasedProject({required this.parent});
+
+  @override
+  final FlutterProject parent;
+}
+
+class FakeFlutterProjectWithAbsoluteDirectory extends FakeFlutterProject {
+  FakeFlutterProjectWithAbsoluteDirectory({required super.fileSystem});
+
+  @override
+  Directory get directory => fileSystem.directory('/app_name');
 }

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -2914,4 +2914,20 @@ Resolved source packages:
       throwsToolExit(),
     );
   });
+
+  testWithoutContext('swiftPackageCachePath returns the correct cache path', () {
+    final fs = MemoryFileSystem.test();
+    final Directory buildDirectory = fs.directory('/build/ios');
+    final xcodeProjectInterpreter = XcodeProjectInterpreter(
+      logger: logger,
+      fileSystem: fs,
+      platform: platform,
+      processManager: fakeProcessManager,
+      analytics: const NoOpAnalytics(),
+    );
+    expect(
+      xcodeProjectInterpreter.swiftPackageCachePath(buildDirectory),
+      '/build/ios/SourcePackages',
+    );
+  });
 }

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -420,6 +420,11 @@ class FakeXcodeProjectInterpreter implements XcodeProjectInterpreter {
   }) async {
     return <String>['xcrun', 'xcodebuild'];
   }
+
+  @override
+  String swiftPackageCachePath(Directory buildDirectory) {
+    return '';
+  }
 }
 
 /// Prevent test crashes from being reported to the crash backend.

--- a/packages/flutter_tools/test/src/fake_process_manager.dart
+++ b/packages/flutter_tools/test/src/fake_process_manager.dart
@@ -591,8 +591,6 @@ class _UnorderedProcessManager extends FakeProcessManager {
     Encoding? encoding,
     io.ProcessStartMode? mode,
   ) {
-    // ignore: avoid_print
-    print(command);
     expect(
       _commands,
       isNotEmpty,

--- a/packages/flutter_tools/test/src/fake_process_manager.dart
+++ b/packages/flutter_tools/test/src/fake_process_manager.dart
@@ -276,6 +276,18 @@ abstract class FakeProcessManager implements ProcessManager {
   /// last command and verify its execution is successful, to ensure that all
   /// the specified commands are actually called.
   factory FakeProcessManager.list(List<FakeCommand> commands) = _SequenceProcessManager;
+
+  /// A fake [ProcessManager] which responds to particular commands with
+  /// particular results, but does not enforce the order in which the commands
+  /// are run.
+  ///
+  /// On creation, pass in a list of [FakeCommand] objects. When the
+  /// [ProcessManager] methods are invoked, any of the remaining expected
+  /// [FakeCommand]s can match (otherwise the test fails).
+  ///
+  /// This is useful for testing concurrent process execution where the order
+  /// of execution is not deterministic.
+  factory FakeProcessManager.unordered(List<FakeCommand> commands) = _UnorderedProcessManager;
   factory FakeProcessManager.empty() => _SequenceProcessManager(<FakeCommand>[]);
 
   FakeProcessManager._();
@@ -500,6 +512,108 @@ class _SequenceProcessManager extends FakeProcessManager {
     );
     _commands.first._matches(command, workingDirectory, environment, encoding, mode);
     return _commands.removeAt(0);
+  }
+
+  @override
+  void addCommand(FakeCommand command) {
+    _commands.add(command);
+  }
+
+  @override
+  bool get hasRemainingExpectations => _commands.isNotEmpty;
+
+  @override
+  List<FakeCommand> get _remainingExpectations => _commands;
+}
+
+/// An implementation of [FakeProcessManager] that allows executing expected
+/// [FakeCommand]s in any order.
+class _UnorderedProcessManager extends FakeProcessManager {
+  _UnorderedProcessManager(this._commands) : super._();
+
+  final List<FakeCommand> _commands;
+
+  /// Checks if the given [command] and its execution parameters match [expected].
+  bool _commandMatches(
+    FakeCommand expected,
+    List<String> command,
+    String? workingDirectory,
+    Map<String, String>? environment,
+    Encoding? encoding,
+    io.ProcessStartMode? mode,
+  ) {
+    if (expected.command.length != command.length) {
+      return false;
+    }
+    for (var i = 0; i < expected.command.length; i++) {
+      final Pattern pattern = expected.command[i];
+      if (pattern is String) {
+        if (pattern != command[i]) {
+          return false;
+        }
+      } else if (pattern is RegExp) {
+        if (!pattern.hasMatch(command[i])) {
+          return false;
+        }
+      } else {
+        if (pattern.matchAsPrefix(command[i]) == null) {
+          return false;
+        }
+      }
+    }
+    if (expected.processStartMode != null && mode != expected.processStartMode) {
+      return false;
+    }
+    if (expected.workingDirectory != null && workingDirectory != expected.workingDirectory) {
+      return false;
+    }
+    if (expected.environment != null) {
+      if (environment == null) {
+        return false;
+      }
+      for (final String key in expected.environment!.keys) {
+        if (environment[key] != expected.environment![key]) {
+          return false;
+        }
+      }
+    }
+    if (expected.encoding != null && encoding != expected.encoding) {
+      return false;
+    }
+    return true;
+  }
+
+  @override
+  FakeCommand findCommand(
+    List<String> command,
+    String? workingDirectory,
+    Map<String, String>? environment,
+    Encoding? encoding,
+    io.ProcessStartMode? mode,
+  ) {
+    // ignore: avoid_print
+    print(command);
+    expect(
+      _commands,
+      isNotEmpty,
+      reason:
+          'ProcessManager was told to execute $command (in $workingDirectory) '
+          'but the FakeProcessManager expected no more processes.',
+    );
+
+    for (var i = 0; i < _commands.length; i++) {
+      final FakeCommand expected = _commands[i];
+      if (_commandMatches(expected, command, workingDirectory, environment, encoding, mode)) {
+        expected._matches(command, workingDirectory, environment, encoding, mode);
+        return _commands.removeAt(i);
+      }
+    }
+
+    fail(
+      'ProcessManager was told to execute $command (in $workingDirectory) '
+      'but no matching command was found in the expected list:\n'
+      '${_commands.map((c) => c.command).join('\n')}',
+    );
   }
 
   @override


### PR DESCRIPTION
We run `xattr -r -d [insert attr]` twice for the entire project. This command recursively tries to remove extended attributes from all files in the project, including the `build` directory.

After migrating to SwiftPM, we start storing remote Swift dependencies in the `build/ios/SourcePackages` directory. This can be GB worth of files. This makes the command slow.

To work around this, this PR changes it so we skip running the command on the directory and also skips running it for non-iOS build directories.

Fixes https://github.com/flutter/flutter/issues/183662.

Before: ~7.169s
After: ~0.168s

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
