### PR TITLE
[Android] Use namespaced Kotlin plugin ID in templates (#184890)

### DIFF
--- a/packages/flutter_tools/gradle/src/main/kotlin/FlutterPluginUtils.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/FlutterPluginUtils.kt
@@ -632,7 +632,7 @@ object FlutterPluginUtils {
 
             if (!hasKgpPlugin) {
                 try {
-                    pluginManager.apply("kotlin-android")
+                    pluginManager.apply("org.jetbrains.kotlin.android")
                 } catch (_: Exception) {
                     logger.quiet(
                         """

--- a/packages/flutter_tools/gradle/src/test/kotlin/FlutterPluginUtilsTest.kt
+++ b/packages/flutter_tools/gradle/src/test/kotlin/FlutterPluginUtilsTest.kt
@@ -786,8 +786,8 @@ class FlutterPluginUtilsTest {
 
             @Test
             fun `KGP regex on single line apply`() {
-                assertSingeLinePluginDetection(FlutterPluginUtils.kgpRegexKotlin, "kotlin-android", DslType.KOTLIN)
-                assertSingeLinePluginDetection(FlutterPluginUtils.kgpRegexGroovy, "kotlin-android", DslType.GROOVY)
+                assertSingeLinePluginDetection(FlutterPluginUtils.kgpRegexKotlin, "org.jetbrains.kotlin.android", DslType.KOTLIN)
+                assertSingeLinePluginDetection(FlutterPluginUtils.kgpRegexGroovy, "org.jetbrains.kotlin.android", DslType.GROOVY)
                 assertSingeLinePluginDetection(FlutterPluginUtils.kgpRegexKotlin, "org.jetbrains.kotlin.android", DslType.KOTLIN)
                 assertSingeLinePluginDetection(FlutterPluginUtils.kgpRegexGroovy, "org.jetbrains.kotlin.android", DslType.GROOVY)
             }
@@ -798,7 +798,7 @@ class FlutterPluginUtilsTest {
                     """
                     plugins {
                         id("com.android.application")
-                        id("kotlin-android")
+                        id("org.jetbrains.kotlin.android")
                     }
                     """.trimIndent()
                 assertTrue(
@@ -840,7 +840,7 @@ class FlutterPluginUtilsTest {
                     """
                     plugins {
                         id 'com.android.application'
-                        id 'kotlin-android'
+                        id 'org.jetbrains.kotlin.android'
                     }
                     """.trimIndent()
                 assertTrue(
@@ -861,7 +861,7 @@ class FlutterPluginUtilsTest {
                     """
                     plugins {
                         id 'com.android.application'
-                        alias 'kotlin-android'
+                        alias 'org.jetbrains.kotlin.android'
                     }
                     """.trimIndent()
                 assertTrue(
@@ -884,7 +884,7 @@ class FlutterPluginUtilsTest {
                 val kotlinSameLine =
                     """
                     plugins {
-                        id("com.android.application") id("kotlin-android")
+                        id("com.android.application") id("org.jetbrains.kotlin.android")
                     }
                     """.trimIndent()
 
@@ -900,7 +900,7 @@ class FlutterPluginUtilsTest {
                 val groovySameLine =
                     """
                     plugins {
-                        id 'com.android.application' id 'kotlin-android'
+                        id 'com.android.application' id 'org.jetbrains.kotlin.android'
                     }
                     """.trimIndent()
 
@@ -917,7 +917,7 @@ class FlutterPluginUtilsTest {
                     """
                     plugins {
                        id 'com.android.application'
-                       // alias 'kotlin-android'
+                       // alias 'org.jetbrains.kotlin.android'
                     }
                     """.trimIndent()
                 assertTrue(
@@ -938,7 +938,7 @@ class FlutterPluginUtilsTest {
                     """
                     // plugins {
                     //    id 'com.android.application'
-                    //    alias 'kotlin-android'
+                    //    alias 'org.jetbrains.kotlin.android'
                     // }
                     """.trimIndent()
                 assertFalse(
@@ -1010,7 +1010,7 @@ class FlutterPluginUtilsTest {
                             """
                             plugins {
                                 id("com.android.application")
-                                id("kotlin-android")
+                                id("org.jetbrains.kotlin.android")
                             }
                             """.trimIndent()
                         )
@@ -1087,8 +1087,8 @@ class FlutterPluginUtilsTest {
                 verify(exactly = 0) {
                     mockLogger.error(match { it.contains("Your app uses the following plugins") })
                 }
-                verify(exactly = 0) { appProjectPluginManager.apply("kotlin-android") }
-                verify(exactly = 1) { pluginProjectPluginManager.apply("kotlin-android") }
+                verify(exactly = 0) { appProjectPluginManager.apply("org.jetbrains.kotlin.android") }
+                verify(exactly = 1) { pluginProjectPluginManager.apply("org.jetbrains.kotlin.android") }
             }
 
             @Test
@@ -1116,7 +1116,7 @@ class FlutterPluginUtilsTest {
                             """
                             plugins {
                                 id("com.android.library")
-                                id("kotlin-android")
+                                id("org.jetbrains.kotlin.android")
                             }
                             """.trimIndent()
                         )
@@ -1184,8 +1184,8 @@ class FlutterPluginUtilsTest {
                 verify(exactly = 0) {
                     mockLogger.error(match { it.contains("Your Android app project") })
                 }
-                verify(exactly = 1) { appProjectPluginManager.apply("kotlin-android") }
-                verify(exactly = 0) { pluginProjectPluginManager.apply("kotlin-android") }
+                verify(exactly = 1) { appProjectPluginManager.apply("org.jetbrains.kotlin.android") }
+                verify(exactly = 0) { pluginProjectPluginManager.apply("org.jetbrains.kotlin.android") }
             }
 
             @Test
@@ -1200,7 +1200,7 @@ class FlutterPluginUtilsTest {
                             """
                             plugins {
                                 id("com.android.application")
-                                id("kotlin-android")
+                                id("org.jetbrains.kotlin.android")
                             }
                             """.trimIndent()
                         )
@@ -1214,7 +1214,7 @@ class FlutterPluginUtilsTest {
                             """
                             plugins {
                                 id("com.android.library")
-                                id("kotlin-android")
+                                id("org.jetbrains.kotlin.android")
                             }
                             """.trimIndent()
                         )
@@ -1290,8 +1290,8 @@ class FlutterPluginUtilsTest {
                     )
                 }
 
-                verify(exactly = 0) { appProjectPluginManager.apply("kotlin-android") }
-                verify(exactly = 0) { pluginProjectPluginManager.apply("kotlin-android") }
+                verify(exactly = 0) { appProjectPluginManager.apply("org.jetbrains.kotlin.android") }
+                verify(exactly = 0) { pluginProjectPluginManager.apply("org.jetbrains.kotlin.android") }
             }
 
             @Test
@@ -1305,7 +1305,7 @@ class FlutterPluginUtilsTest {
                         writeText(
                             """
                             apply plugin: 'com.android.application'
-                            apply plugin: 'kotlin-android'
+                            apply plugin: 'org.jetbrains.kotlin.android'
                             """.trimIndent()
                         )
                     }
@@ -1317,7 +1317,7 @@ class FlutterPluginUtilsTest {
                         writeText(
                             """
                             apply plugin: 'com.android.library'
-                            apply plugin: 'kotlin-android'
+                            apply plugin: 'org.jetbrains.kotlin.android'
                             """.trimIndent()
                         )
                     }
@@ -1405,9 +1405,9 @@ class FlutterPluginUtilsTest {
                     )
                 }
 
-                verify(exactly = 0) { appProjectPluginManager.apply("kotlin-android") }
-                verify(exactly = 0) { pluginProjectOnePluginManager.apply("kotlin-android") }
-                verify(exactly = 0) { pluginProjectTwoPluginManager.apply("kotlin-android") }
+                verify(exactly = 0) { appProjectPluginManager.apply("org.jetbrains.kotlin.android") }
+                verify(exactly = 0) { pluginProjectOnePluginManager.apply("org.jetbrains.kotlin.android") }
+                verify(exactly = 0) { pluginProjectTwoPluginManager.apply("org.jetbrains.kotlin.android") }
             }
 
             @Test
@@ -1484,8 +1484,8 @@ class FlutterPluginUtilsTest {
                     mockLogger.error(any())
                 }
 
-                verify(exactly = 1) { appProjectPluginManager.apply("kotlin-android") }
-                verify(exactly = 1) { pluginProjectPluginManager.apply("kotlin-android") }
+                verify(exactly = 1) { appProjectPluginManager.apply("org.jetbrains.kotlin.android") }
+                verify(exactly = 1) { pluginProjectPluginManager.apply("org.jetbrains.kotlin.android") }
             }
 
             @Test
@@ -1553,8 +1553,8 @@ class FlutterPluginUtilsTest {
                 every { rootProject.subprojects(capture(subprojectsActionSlot)) } returns Unit
                 every { mockGradle.projectsEvaluated(capture(projectsEvaluatedActionSlot)) } returns Unit
 
-                every { appProjectPluginManager.apply("kotlin-android") } throws Exception("KGP not on classpath")
-                every { pluginProjectPluginManager.apply("kotlin-android") } throws Exception("KGP not on classpath")
+                every { appProjectPluginManager.apply("org.jetbrains.kotlin.android") } throws Exception("KGP not on classpath")
+                every { pluginProjectPluginManager.apply("org.jetbrains.kotlin.android") } throws Exception("KGP not on classpath")
 
                 detectApplyingKotlinGradlePlugin(appProject)
 

--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -669,7 +669,7 @@ const String kMigrateToBuiltInKotlinDocsUrl =
 const String kOptOutOfNewDslDocsUrl =
     'https://developer.android.com/build/releases/agp-9-0-0-release-notes';
 
-/// Handler when applying the kotlin-android plugin results in a build failure. This failure occurs when
+/// Handler when applying the Kotlin plugin results in a build failure. This failure occurs when
 /// using AGP 9+ because built-in Kotlin has become the default behavior.
 @visibleForTesting
 final applyingKotlinAndroidPluginErrorHandler = GradleHandledError(
@@ -682,7 +682,7 @@ final applyingKotlinAndroidPluginErrorHandler = GradleHandledError(
       ({required String line, required FlutterProject project, required bool usesAndroidX}) async {
         globals.printBox('''
 ${globals.logger.terminal.warningMark} Starting AGP 9+, the default has become built-in Kotlin.
-This results in a build failure when applying the kotlin-android plugin.
+This results in a build failure when applying the Kotlin plugin.
 To resolve this, migrate to built-in Kotlin.
 \nFor instructions on how to migrate, see: $kMigrateToBuiltInKotlinDocsUrl''', title: _boxTitle);
 

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -521,7 +521,7 @@ class AndroidProject extends FlutterProjectPlatform {
   );
   static final _applicationIdPattern = RegExp('^\\s*applicationId\\s*=?\\s*[\'"](.*)[\'"]\\s*\$');
   static final _imperativeKotlinPluginPattern = RegExp(
-    '^\\s*apply plugin\\:\\s+[\'"]kotlin-android[\'"]\\s*\$',
+    '^\\s*apply plugin\\:\\s+[\'"](kotlin-android|org\\.jetbrains\\.kotlin\\.android)[\'"]\\s*\$',
   );
 
   /// Examples of strings that this regex matches:
@@ -532,8 +532,7 @@ class AndroidProject extends FlutterProjectPlatform {
   /// - `id("org.jetbrains.kotlin.android")`
   /// - `id ( "org.jetbrains.kotlin.android" )`
   static final _declarativeKotlinPluginPatterns = <RegExp>[
-    RegExp('^\\s*id\\s*\\(?\\s*[\'"]kotlin-android[\'"]\\s*\\)?\\s*\$'),
-    RegExp('^\\s*id\\s*\\(?\\s*[\'"]org.jetbrains.kotlin.android[\'"]\\s*\\)?\\s*\$'),
+    RegExp('^\\s*id\\s*\\(?\\s*[\'"](kotlin-android|org\\.jetbrains\\.kotlin\\.android)[\'"]\\s*\\)?\\s*\$'),
   ];
 
   /// Pattern used to find the assignment of the "group" property in Gradle.

--- a/packages/flutter_tools/templates/app/android-java.tmpl/app/build.gradle.kts.tmpl
+++ b/packages/flutter_tools/templates/app/android-java.tmpl/app/build.gradle.kts.tmpl
@@ -1,6 +1,6 @@
 plugins {
     id("com.android.application")
-    id("kotlin-android")
+    id("org.jetbrains.kotlin.android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
 }

--- a/packages/flutter_tools/templates/app/android-kotlin.tmpl/app/build.gradle.kts.tmpl
+++ b/packages/flutter_tools/templates/app/android-kotlin.tmpl/app/build.gradle.kts.tmpl
@@ -1,6 +1,6 @@
 plugins {
     id("com.android.application")
-    id("kotlin-android")
+    id("org.jetbrains.kotlin.android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
 }

--- a/packages/flutter_tools/templates/module/android/gradle/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/module/android/gradle/build.gradle.tmpl
@@ -8,7 +8,7 @@ allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+apply plugin: "org.jetbrains.kotlin.android"
 
 android {
     namespace = "{{androidIdentifier}}"

--- a/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/build.gradle.kts.tmpl
+++ b/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/build.gradle.kts.tmpl
@@ -23,7 +23,7 @@ allprojects {
 
 plugins {
     id("com.android.library")
-    id("kotlin-android")
+    id("org.jetbrains.kotlin.android")
 }
 
 android {

--- a/packages/flutter_tools/test/general.shard/android/android_project_migration_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_project_migration_test.dart
@@ -49,7 +49,7 @@ String sampleModuleGradleBuildFile(String minSdkVersionString) {
   return r'''
 plugins {
     id "com.android.application"
-    id "kotlin-android"
+    id "org.jetbrains.kotlin.android"
     id "dev.flutter.flutter-gradle-plugin"
 }
 
@@ -124,7 +124,7 @@ String sampleKotlinDslModuleGradleBuildFile(String minSdkVersionString) {
   return r'''
 plugins {
     id("com.android.application")
-    id("kotlin-android")
+    id("org.jetbrains.kotlin.android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
 }

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -1625,7 +1625,7 @@ A problem occurred configuring project ':app'.
   );
 
   testUsingContext(
-    'Failure to apply kotlin-android plugin',
+    'Failure to apply Kotlin plugin',
     () async {
       const applyingKotlinAndroidPluginErrorExample = r'''
 FAILURE: Build failed with an exception.
@@ -1634,8 +1634,8 @@ FAILURE: Build failed with an exception.
 Build file '/Users/jesswon/Desktop/fresh_flutter_app/android/app/build.gradle.kts'
 
 * What went wrong:
-An exception occurred applying plugin request [id: 'kotlin-android']
-> Failed to apply plugin 'kotlin-android'.
+An exception occurred applying plugin request [id: 'org.jetbrains.kotlin.android']
+> Failed to apply plugin 'org.jetbrains.kotlin.android'.
    > ⛔ Failed to apply plugin 'com.jetbrains.kotlin.android'
      The 'org.jetbrains.kotlin.android' plugin is no longer required for Kotlin support since AGP 9.0.
      Solution: Remove the 'org.jetbrains.kotlin.android' plugin from this project's build file: app/build.gradle.kts.
@@ -1656,9 +1656,9 @@ An exception occurred applying plugin request [id: 'kotlin-android']
       );
       expect(
         testLogger.statusText,
-        contains(' This results in a build failure when applying the kotlin-android plugin'),
+        contains(' This results in a build failure when applying the Kotlin plugin'),
       );
-      expect(testLogger.statusText, contains('applying the kotlin-android plugin'));
+      expect(testLogger.statusText, contains('applying the Kotlin plugin'));
       expect(testLogger.statusText, contains('For instructions on how to migrate, see:'));
       expect(testLogger.statusText, contains(kMigrateToBuiltInKotlinDocsUrl));
     },
@@ -1671,7 +1671,7 @@ An exception occurred applying plugin request [id: 'kotlin-android']
   );
 
   testUsingContext(
-    'Failure to apply kotlin-android plugin',
+    'Failure to apply Flutter Gradle plugin with new AGP DSL',
     () async {
       const useNewAgpDslErrorHandlerExample = r'''
 FAILURE: Build failed with an exception.

--- a/packages/flutter_tools/test/general.shard/project_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_test.dart
@@ -893,7 +893,7 @@ dependencies {
             gradleFileContent: () {
               return '''
 apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
+apply plugin: 'org.jetbrains.kotlin.android'
 ''';
             },
           );
@@ -919,7 +919,7 @@ apply plugin: 'kotlin-android'
               return '''
 plugins {
     id "com.android.application"
-    id "kotlin-android"
+    id "org.jetbrains.kotlin.android"
     id "dev.flutter.flutter-gradle-plugin"
 }
 ''';
@@ -947,7 +947,7 @@ plugins {
               return '''
 plugins {
     id "com.android.application"
-    id "kotlin-android"
+    id "org.jetbrains.kotlin.android"
     dev.flutter.`flutter-gradle-plugin`
 }
 ''';
@@ -986,7 +986,7 @@ plugins {
               return '''
 plugins {
     id("com.android.application")
-    id("kotlin-android")
+    id("org.jetbrains.kotlin.android")
     id("dev.flutter.flutter-gradle-plugin")
 }
 ''';

--- a/packages/flutter_tools/test/integration.shard/flutter_build_apk_split_per_abi_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_build_apk_split_per_abi_test.dart
@@ -21,7 +21,7 @@ import java.io.FileInputStream
 
 plugins {
     id("com.android.application")
-    id("kotlin-android")
+    id("org.jetbrains.kotlin.android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
 }

--- a/packages/flutter_tools/test/integration.shard/test_data/deferred_components_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/deferred_components_project.dart
@@ -144,7 +144,7 @@ tasks.register("clean", Delete) {
   String get appBuild => r'''
 plugins {
     id "com.android.application"
-    id "kotlin-android"
+    id "org.jetbrains.kotlin.android"
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id "dev.flutter.flutter-gradle-plugin"
 }


### PR DESCRIPTION
Update Flutter project templates and tool logic to use the namespaced Kotlin plugin ID 'org.jetbrains.kotlin.android' instead of the deprecated 'kotlin-android', as recommended by Android documentation. Support for the legacy ID is maintained in regex patterns to ensure backward compatibility with existing projects.

Fixes: #184890

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.
