### PR TITLE
Fix datepicker semantics

### DIFF
--- a/packages/flutter/lib/src/material/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/calendar_date_picker.dart
@@ -515,6 +515,7 @@ class _DatePickerModeToggleButtonState extends State<_DatePickerModeToggleButton
                 label: MaterialLocalizations.of(context).selectYearSemanticsLabel,
                 button: true,
                 container: true,
+                expanded: _controller.isForwardOrCompleted,
                 child: SizedBox(
                   height: _subHeaderHeight,
                   child: InkWell(

--- a/packages/flutter/test/material/calendar_date_picker_test.dart
+++ b/packages/flutter/test/material/calendar_date_picker_test.dart
@@ -1005,6 +1005,7 @@ void main() {
             hasTapAction: true,
             hasFocusAction: true,
             isFocusable: true,
+            hasExpandedState: true,
           ),
         );
 
@@ -1496,6 +1497,8 @@ void main() {
             hasTapAction: true,
             hasFocusAction: true,
             isFocusable: true,
+            isExpanded: true,
+            hasExpandedState: true,
           ),
         );
 
@@ -1543,61 +1546,59 @@ void main() {
       });
 
       // This is a regression test for https://github.com/flutter/flutter/issues/143439.
-      testWidgets(
-        'Selected date Semantics announcement on onDateChanged',
-        (WidgetTester tester) async {
-          final SemanticsHandle semantics = tester.ensureSemantics();
-          const localizations = DefaultMaterialLocalizations();
-          final initialDate = DateTime(2016, DateTime.january, 15);
-          DateTime? selectedDate;
+      testWidgets('Selected date Semantics announcement on onDateChanged', (
+        WidgetTester tester,
+      ) async {
+        final SemanticsHandle semantics = tester.ensureSemantics();
+        const localizations = DefaultMaterialLocalizations();
+        final initialDate = DateTime(2016, DateTime.january, 15);
+        DateTime? selectedDate;
 
-          await tester.pumpWidget(
-            calendarDatePicker(
-              initialDate: initialDate,
-              onDateChanged: (DateTime value) {
-                selectedDate = value;
-              },
-            ),
-          );
+        await tester.pumpWidget(
+          calendarDatePicker(
+            initialDate: initialDate,
+            onDateChanged: (DateTime value) {
+              selectedDate = value;
+            },
+          ),
+        );
 
-          final bool isToday = DateUtils.isSameDay(initialDate, selectedDate);
-          final semanticLabelSuffix = isToday ? ', ${localizations.currentDateLabel}' : '';
+        final bool isToday = DateUtils.isSameDay(initialDate, selectedDate);
+        final semanticLabelSuffix = isToday ? ', ${localizations.currentDateLabel}' : '';
 
-          // The initial date should be announced.
-          expect(
-            tester.takeAnnouncements().last,
-            isAccessibilityAnnouncement(
-              '${localizations.formatFullDate(initialDate)}$semanticLabelSuffix',
-            ),
-          );
+        // The initial date should be announced.
+        expect(
+          tester.takeAnnouncements().last,
+          isAccessibilityAnnouncement(
+            '${localizations.formatFullDate(initialDate)}$semanticLabelSuffix',
+          ),
+        );
 
-          // Select a new date.
-          await tester.tap(find.text('20'));
-          await tester.pumpAndSettle();
+        // Select a new date.
+        await tester.tap(find.text('20'));
+        await tester.pumpAndSettle();
 
-          // The selected date should be announced.
-          expect(
-            tester.takeAnnouncements().last,
-            isAccessibilityAnnouncement(
-              '${localizations.selectedDateLabel} ${localizations.formatFullDate(selectedDate!)}$semanticLabelSuffix',
-            ),
-          );
+        // The selected date should be announced.
+        expect(
+          tester.takeAnnouncements().last,
+          isAccessibilityAnnouncement(
+            '${localizations.selectedDateLabel} ${localizations.formatFullDate(selectedDate!)}$semanticLabelSuffix',
+          ),
+        );
 
-          // Select the initial date.
-          await tester.tap(find.text('15'));
+        // Select the initial date.
+        await tester.tap(find.text('15'));
 
-          // The initial date should be announced as selected.
-          expect(
-            tester.takeAnnouncements().first,
-            isAccessibilityAnnouncement(
-              '${localizations.selectedDateLabel} ${localizations.formatFullDate(initialDate)}$semanticLabelSuffix',
-            ),
-          );
+        // The initial date should be announced as selected.
+        expect(
+          tester.takeAnnouncements().first,
+          isAccessibilityAnnouncement(
+            '${localizations.selectedDateLabel} ${localizations.formatFullDate(initialDate)}$semanticLabelSuffix',
+          ),
+        );
 
-          semantics.dispose();
-        },
-        variant: TargetPlatformVariant.desktop(),
-      );
+        semantics.dispose();
+      }, variant: TargetPlatformVariant.desktop());
     });
 
     // This is a regression test for https://github.com/flutter/flutter/issues/141350.
@@ -1788,77 +1789,69 @@ void main() {
       variant: TargetPlatformVariant.only(TargetPlatform.android),
     );
 
-    testWidgets(
-      'Month navigation announcement on Android',
-      (WidgetTester tester) async {
-        final SemanticsHandle semantics = tester.ensureSemantics();
-        final initialDate = DateTime(2016, DateTime.january, 15);
+    testWidgets('Month navigation announcement on Android', (WidgetTester tester) async {
+      final SemanticsHandle semantics = tester.ensureSemantics();
+      final initialDate = DateTime(2016, DateTime.january, 15);
 
-        await tester.pumpWidget(
-          MediaQuery(
-            data: const MediaQueryData(supportsAnnounce: true),
-            child: calendarDatePicker(initialDate: initialDate),
-          ),
-        );
+      await tester.pumpWidget(
+        MediaQuery(
+          data: const MediaQueryData(supportsAnnounce: true),
+          child: calendarDatePicker(initialDate: initialDate),
+        ),
+      );
 
-        // Clear any initial announcements.
-        tester.takeAnnouncements();
+      // Clear any initial announcements.
+      tester.takeAnnouncements();
 
-        // Tap next month.
-        await tester.tap(nextMonthIcon);
-        await tester.pumpAndSettle();
+      // Tap next month.
+      await tester.tap(nextMonthIcon);
+      await tester.pumpAndSettle();
 
-        const expectedLabel = 'February 2016';
-        expect(tester.takeAnnouncements(), [
-          isAccessibilityAnnouncement(expectedLabel, textDirection: TextDirection.ltr),
-        ]);
+      const expectedLabel = 'February 2016';
+      expect(tester.takeAnnouncements(), [
+        isAccessibilityAnnouncement(expectedLabel, textDirection: TextDirection.ltr),
+      ]);
 
-        semantics.dispose();
-      },
-      variant: TargetPlatformVariant.only(TargetPlatform.android),
-    );
+      semantics.dispose();
+    }, variant: TargetPlatformVariant.only(TargetPlatform.android));
 
-    testWidgets(
-      'Mode toggle announcement on Android',
-      (WidgetTester tester) async {
-        final SemanticsHandle semantics = tester.ensureSemantics();
-        final initialDate = DateTime(2016, DateTime.january, 15);
+    testWidgets('Mode toggle announcement on Android', (WidgetTester tester) async {
+      final SemanticsHandle semantics = tester.ensureSemantics();
+      final initialDate = DateTime(2016, DateTime.january, 15);
 
-        await tester.pumpWidget(
-          MediaQuery(
-            data: const MediaQueryData(supportsAnnounce: true),
-            child: calendarDatePicker(initialDate: initialDate),
-          ),
-        );
+      await tester.pumpWidget(
+        MediaQuery(
+          data: const MediaQueryData(supportsAnnounce: true),
+          child: calendarDatePicker(initialDate: initialDate),
+        ),
+      );
 
-        // Clear any initial announcements.
-        tester.takeAnnouncements();
+      // Clear any initial announcements.
+      tester.takeAnnouncements();
 
-        // Switch to year mode.
-        final Finder modeToggleButton = find.byWidgetPredicate(
-          (Widget widget) => widget.runtimeType.toString() == '_DatePickerModeToggleButton',
-        );
-        await tester.tap(modeToggleButton);
-        await tester.pumpAndSettle();
+      // Switch to year mode.
+      final Finder modeToggleButton = find.byWidgetPredicate(
+        (Widget widget) => widget.runtimeType.toString() == '_DatePickerModeToggleButton',
+      );
+      await tester.tap(modeToggleButton);
+      await tester.pumpAndSettle();
 
-        const yearLabel = '2016';
-        expect(tester.takeAnnouncements(), [
-          isAccessibilityAnnouncement(yearLabel, textDirection: TextDirection.ltr),
-        ]);
+      const yearLabel = '2016';
+      expect(tester.takeAnnouncements(), [
+        isAccessibilityAnnouncement(yearLabel, textDirection: TextDirection.ltr),
+      ]);
 
-        // Switch back to day mode.
-        await tester.tap(modeToggleButton);
-        await tester.pumpAndSettle();
+      // Switch back to day mode.
+      await tester.tap(modeToggleButton);
+      await tester.pumpAndSettle();
 
-        const dayLabel = 'January 2016';
-        expect(tester.takeAnnouncements(), [
-          isAccessibilityAnnouncement(dayLabel, textDirection: TextDirection.ltr),
-        ]);
+      const dayLabel = 'January 2016';
+      expect(tester.takeAnnouncements(), [
+        isAccessibilityAnnouncement(dayLabel, textDirection: TextDirection.ltr),
+      ]);
 
-        semantics.dispose();
-      },
-      variant: TargetPlatformVariant.only(TargetPlatform.android),
-    );
+      semantics.dispose();
+    }, variant: TargetPlatformVariant.only(TargetPlatform.android));
   });
 
   group('when supportsAnnounce is false, use live region to announce', () {
@@ -1890,96 +1883,88 @@ void main() {
       semantics.dispose();
     }, variant: TargetPlatformVariant.only(TargetPlatform.android));
 
-    testWidgets(
-      'Month navigation announcement on Android',
-      (WidgetTester tester) async {
-        final SemanticsHandle semantics = tester.ensureSemantics();
-        final initialDate = DateTime(2016, DateTime.january, 15);
+    testWidgets('Month navigation announcement on Android', (WidgetTester tester) async {
+      final SemanticsHandle semantics = tester.ensureSemantics();
+      final initialDate = DateTime(2016, DateTime.january, 15);
 
-        await tester.pumpWidget(
-          MediaQuery(
-            data: const MediaQueryData(),
-            child: calendarDatePicker(initialDate: initialDate),
-          ),
-        );
+      await tester.pumpWidget(
+        MediaQuery(
+          data: const MediaQueryData(),
+          child: calendarDatePicker(initialDate: initialDate),
+        ),
+      );
 
-        // Tap next month.
-        await tester.tap(nextMonthIcon);
-        await tester.pumpAndSettle();
+      // Tap next month.
+      await tester.tap(nextMonthIcon);
+      await tester.pumpAndSettle();
 
-        // The _MonthPicker live region should be updated.
-        // Verify that the live region exists and has the correct label.
-        const expectedLabel = 'February 2016';
-        final Finder liveRegionFinder = find.byWidgetPredicate(
-          (Widget widget) =>
-              widget is Semantics &&
-              widget.properties.label == expectedLabel &&
-              (widget.properties.liveRegion ?? false),
-        );
-        expect(
-          tester.getSemantics(liveRegionFinder),
-          matchesSemantics(label: expectedLabel, isLiveRegion: true),
-        );
+      // The _MonthPicker live region should be updated.
+      // Verify that the live region exists and has the correct label.
+      const expectedLabel = 'February 2016';
+      final Finder liveRegionFinder = find.byWidgetPredicate(
+        (Widget widget) =>
+            widget is Semantics &&
+            widget.properties.label == expectedLabel &&
+            (widget.properties.liveRegion ?? false),
+      );
+      expect(
+        tester.getSemantics(liveRegionFinder),
+        matchesSemantics(label: expectedLabel, isLiveRegion: true),
+      );
 
-        semantics.dispose();
-      },
-      variant: TargetPlatformVariant.only(TargetPlatform.android),
-    );
+      semantics.dispose();
+    }, variant: TargetPlatformVariant.only(TargetPlatform.android));
 
-    testWidgets(
-      'Mode toggle announcement on Android',
-      (WidgetTester tester) async {
-        final SemanticsHandle semantics = tester.ensureSemantics();
-        final initialDate = DateTime(2016, DateTime.january, 15);
+    testWidgets('Mode toggle announcement on Android', (WidgetTester tester) async {
+      final SemanticsHandle semantics = tester.ensureSemantics();
+      final initialDate = DateTime(2016, DateTime.january, 15);
 
-        await tester.pumpWidget(
-          MediaQuery(
-            data: const MediaQueryData(),
-            child: calendarDatePicker(initialDate: initialDate),
-          ),
-        );
+      await tester.pumpWidget(
+        MediaQuery(
+          data: const MediaQueryData(),
+          child: calendarDatePicker(initialDate: initialDate),
+        ),
+      );
 
-        // Switch to year mode.
-        final Finder modeToggleButton = find.byWidgetPredicate(
-          (Widget widget) => widget.runtimeType.toString() == '_DatePickerModeToggleButton',
-        );
-        await tester.tap(modeToggleButton);
-        await tester.pumpAndSettle();
+      // Switch to year mode.
+      final Finder modeToggleButton = find.byWidgetPredicate(
+        (Widget widget) => widget.runtimeType.toString() == '_DatePickerModeToggleButton',
+      );
+      await tester.tap(modeToggleButton);
+      await tester.pumpAndSettle();
 
-        // Verify that the live region exists and has the correct label.
-        const yearLabel = '2016';
-        final Finder yearLiveRegionFinder = find.byWidgetPredicate(
-          (Widget widget) =>
-              widget is Semantics &&
-              widget.properties.label == yearLabel &&
-              (widget.properties.liveRegion ?? false),
-        );
-        expect(
-          tester.getSemantics(yearLiveRegionFinder),
-          matchesSemantics(label: yearLabel, isLiveRegion: true),
-        );
+      // Verify that the live region exists and has the correct label.
+      const yearLabel = '2016';
+      final Finder yearLiveRegionFinder = find.byWidgetPredicate(
+        (Widget widget) =>
+            widget is Semantics &&
+            widget.properties.label == yearLabel &&
+            (widget.properties.liveRegion ?? false),
+      );
+      expect(
+        tester.getSemantics(yearLiveRegionFinder),
+        matchesSemantics(label: yearLabel, isLiveRegion: true),
+      );
 
-        // Switch back to day mode.
-        await tester.tap(modeToggleButton);
-        await tester.pumpAndSettle();
+      // Switch back to day mode.
+      await tester.tap(modeToggleButton);
+      await tester.pumpAndSettle();
 
-        // Verify that the live region exists and has the correct label.
-        const dayLabel = 'January 2016';
-        final Finder dayLiveRegionFinder = find.byWidgetPredicate(
-          (Widget widget) =>
-              widget is Semantics &&
-              widget.properties.label == dayLabel &&
-              (widget.properties.liveRegion ?? false),
-        );
-        expect(
-          tester.getSemantics(dayLiveRegionFinder),
-          matchesSemantics(label: dayLabel, isLiveRegion: true),
-        );
+      // Verify that the live region exists and has the correct label.
+      const dayLabel = 'January 2016';
+      final Finder dayLiveRegionFinder = find.byWidgetPredicate(
+        (Widget widget) =>
+            widget is Semantics &&
+            widget.properties.label == dayLabel &&
+            (widget.properties.liveRegion ?? false),
+      );
+      expect(
+        tester.getSemantics(dayLiveRegionFinder),
+        matchesSemantics(label: dayLabel, isLiveRegion: true),
+      );
 
-        semantics.dispose();
-      },
-      variant: TargetPlatformVariant.only(TargetPlatform.android),
-    );
+      semantics.dispose();
+    }, variant: TargetPlatformVariant.only(TargetPlatform.android));
   });
 
   group('YearPicker', () {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

fixes https://github.com/flutter/flutter/issues/173052

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
