### PR TITLE
[CP-stable] [AGP 9] Update AGP Error With Flutter Docs (#185043)

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -663,6 +663,14 @@ final missingNdkSourcePropertiesFile = GradleHandledError(
   eventLabel: 'ndk-missing-source-properties-file',
 );
 
+/// The URL for documentation on migrating to built-in Kotlin.
+const String kMigrateToBuiltInKotlinDocsUrl =
+    'https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin';
+
+/// The URL for documentation on opting out of the new AGP DSL.
+const String kOptOutOfNewDslDocsUrl =
+    'https://developer.android.com/build/releases/agp-9-0-0-release-notes';
+
 /// Handler when applying the kotlin-android plugin results in a build failure. This failure occurs when
 /// using AGP 9+ because built-in Kotlin has become the default behavior.
 @visibleForTesting
@@ -674,13 +682,11 @@ final applyingKotlinAndroidPluginErrorHandler = GradleHandledError(
   },
   handler:
       ({required String line, required FlutterProject project, required bool usesAndroidX}) async {
-        final File appGradleFile = project.android.appGradleFile;
-        globals.printBox(
-          '''
-${globals.logger.terminal.warningMark} Starting AGP 9+, the default has become built-in Kotlin. This results in a build failure when applying the kotlin-android plugin at ${appGradleFile.path}.
-\nTo resolve this, migrate to built-in Kotlin. For instructions on how to migrate, see: https://docs.flutter.dev/release/breaking-changes/migrate-to-agp-9''',
-          title: _boxTitle,
-        );
+        globals.printBox('''
+${globals.logger.terminal.warningMark} Starting AGP 9+, the default has become built-in Kotlin.
+This results in a build failure when applying the kotlin-android plugin.
+To resolve this, migrate to built-in Kotlin.
+\nFor instructions on how to migrate, see: $kMigrateToBuiltInKotlinDocsUrl''', title: _boxTitle);
 
         return GradleBuildStatus.exit;
       },
@@ -701,8 +707,10 @@ final useNewAgpDslErrorHandler = GradleHandledError(
         final File appGradleFile = project.android.appGradleFile;
         globals.printBox(
           '''
-${globals.logger.terminal.warningMark} Starting AGP 9+, only the new DSL interface will be read. This results in a build failure when applying the Flutter Gradle plugin at ${appGradleFile.path}.
-\nTo resolve this update flutter or opt out of `android.newDsl`. For instructions on how to opt out, see: https://docs.flutter.dev/release/breaking-changes/migrate-to-agp-9
+${globals.logger.terminal.warningMark} Starting AGP 9+, only the new DSL interface will be read.
+This results in a build failure when applying the Flutter Gradle plugin at ${appGradleFile.path}.
+\nTo resolve this update flutter or opt out of `android.newDsl`.
+For instructions on how to opt out, see: $kOptOutOfNewDslDocsUrl
 \nIf you are not upgrading to AGP 9+, run `flutter analyze --suggestions` to check for incompatible dependencies.''',
           title: _boxTitle,
         );

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -1654,8 +1654,13 @@ An exception occurred applying plugin request [id: 'kotlin-android']
         testLogger.statusText,
         contains('Starting AGP 9+, the default has become built-in Kotlin.'),
       );
-      expect(testLogger.statusText, contains('This results in a build failure'));
-      expect(testLogger.statusText, contains('when applying the kotlin-android plugin'));
+      expect(
+        testLogger.statusText,
+        contains(' This results in a build failure when applying the kotlin-android plugin'),
+      );
+      expect(testLogger.statusText, contains('applying the kotlin-android plugin'));
+      expect(testLogger.statusText, contains('For instructions on how to migrate, see:'));
+      expect(testLogger.statusText, contains(kMigrateToBuiltInKotlinDocsUrl));
     },
     overrides: <Type, Generator>{
       GradleUtils: () => FakeGradleUtils(),
@@ -1691,10 +1696,16 @@ An exception occurred applying plugin request [id: 'dev.flutter.flutter-gradle-p
         testLogger.statusText,
         contains('Starting AGP 9+, only the new DSL interface will be read.'),
       );
-      expect(testLogger.statusText, contains('This results in a build failure'));
-      expect(testLogger.statusText, contains('when applying the Flutter Gradle plugin'));
-      expect(testLogger.statusText, contains('If you are not upgrading to AGP 9+'));
-      expect(testLogger.statusText, contains('run `flutter analyze --suggestions`'));
+      expect(
+        testLogger.statusText,
+        contains('This results in a build failure when applying the Flutter Gradle plugin'),
+      );
+      expect(testLogger.statusText, contains('For instructions on how to opt out, see:'));
+      expect(testLogger.statusText, contains(kOptOutOfNewDslDocsUrl));
+      expect(
+        testLogger.statusText,
+        contains('If you are not upgrading to AGP 9+, run `flutter analyze --suggestions`'),
+      );
     },
     overrides: <Type, Generator>{
       GradleUtils: () => FakeGradleUtils(),


### PR DESCRIPTION
AGP is ready to use. Developers should not be running into this error at all due to support that has been added for Built-in Kotlin https://github.com/flutter/flutter/issues/184836. But in the event that they do run into this error, they will be guided to the right docs: https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin.

**Issue Link:**
What is the link to the issue this cherry-pick is addressing?

https://github.com/flutter/flutter/issues/186097

**Impacted Users:** Flutter Android devs who have updated to AGP 9+ and are applying the Kotlin Gradle Plugin. Users only see this error message if they still somehow receive the android provided error message even after we added support for both Built-in Kotlin and KGP.

**Impact Description:** To communicate AGP is ready to use and to add useful [Flutter docs for migration to Built-in Kotlin](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin).

**Changelog Description:**
[flutter/186097](https://github.com/flutter/flutter/issues/186097): For Flutter apps on AGP 9+ and opted-in to built-in Kotlin without proper migration and the Flutter support for both Built-in Kotlin and KGP fails [here](https://github.com/flutter/flutter/issues/184836), we will provide a Flutter error message.

Workaround: Updating error message so N/A

**Risk:** Very low risk
**Test Coverage:** yes confident
**Validation Steps:** unit tests or trigger the Android provided error (highly unlikely given we added support)