### PR TITLE
fix(test): correct three TestSemantics typo bugs in semantics_tester.dart

### DIFF
--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -508,7 +508,7 @@ class TestSemantics {
       );
     }
 
-    if (controlsNodes != controlsNodes && !setEquals(controlsNodes, node.controlsNodes)) {
+    if (controlsNodes != null && !setEquals(controlsNodes, node.controlsNodes)) {
       return fail(
         'expected node id $id to controls nodes $controlsNodes but found controlling nodes ${node.controlsNodes}',
       );
@@ -715,7 +715,7 @@ class SemanticsTester {
       if (first[i] is LocaleStringAttribute &&
           (second[i] is! LocaleStringAttribute ||
               second[i].range != first[i].range ||
-              (second[i] as LocaleStringAttribute).locale !=
+              (first[i] as LocaleStringAttribute).locale !=
                   (second[i] as LocaleStringAttribute).locale)) {
         return false;
       }
@@ -1180,8 +1180,9 @@ class _IncludesNodeWith extends Matcher {
              scrollExtentMin != null ||
              maxValueLength != null ||
              currentValueLength != null ||
-             inputType != null,
-         minValue != null || maxValue != null,
+             inputType != null ||
+             minValue != null ||
+             maxValue != null,
        );
   final AttributedString? attributedLabel;
   final AttributedString? attributedValue;


### PR DESCRIPTION
Fixes #185900.

Three blatant self-comparison / stray-comma bugs in `packages/flutter/test/widgets/semantics_tester.dart` that silently disable matcher checks. All flagged in the issue.

## 1. `controlsNodes != controlsNodes` (line 511)

```dart
-    if (controlsNodes != controlsNodes && !setEquals(controlsNodes, node.controlsNodes)) {
+    if (controlsNodes != null && !setEquals(controlsNodes, node.controlsNodes)) {
```

The first conjunct is always `false`, so the whole guard short-circuits and the controls-nodes mismatch check **never fires**. Replaced with the standard `controlsNodes != null && !setEquals(...)` guard, matching the existing `tags` handling in `_IncludesNodeWith` (line 827-829) for consistency.

## 2. Locale self-comparison in `_attributedStringsAreEqual` (line 718-719)

```dart
-              (second[i] as LocaleStringAttribute).locale !=
+              (first[i] as LocaleStringAttribute).locale !=
                   (second[i] as LocaleStringAttribute).locale)) {
```

Both sides of the locale `!=` cast `second[i]`, so two `LocaleStringAttribute`s with different locales but identical ranges were silently treated as equal. First side should be `first[i]`.

## 3. Stray comma in `_IncludesNodeWith` assert (line 1183-1185)

```dart
   }) : assert(
          label != null ||
              ...
              currentValueLength != null ||
-             inputType != null,
-         minValue != null || maxValue != null,
+             inputType != null ||
+             minValue != null ||
+             maxValue != null,
        );
```

The comma split the single boolean expression into `(condition, message)`, with `minValue != null || maxValue != null` ending up as the assert's failure-message argument (which expects a `String`). Net effect: a matcher constructed with **only** `minValue` or **only** `maxValue` would still trip the "must specify at least one property" assertion. Merging the two clauses with `||` restores the intended OR.

## Scope

Minimal — same file, three changes that match the issue's three numbered items. The issue also mentions PR #185736 copies `TestSemantics` into the Material library; happy to follow up with a mirror fix there once this lands (or fold it in if maintainers prefer a single PR — let me know).