### PR TITLE
[CP-beta] Update iOS tools to fat binaries (#185868)

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4927,6 +4927,11 @@ targets:
     presubmit: false
     timeout: 60
     properties:
+      # TODO(vashworth): Remove this once we're confident https://github.com/flutter/flutter/issues/185384 is resolved.
+      $flutter/osx_sdk : >-
+        {
+          "sdk_version": "16c5032a"
+        }
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: animation_with_microtasks_perf_ios__timeline_summary

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4927,11 +4927,6 @@ targets:
     presubmit: false
     timeout: 60
     properties:
-      # TODO(vashworth): Remove this once we're confident https://github.com/flutter/flutter/issues/185384 is resolved.
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "16c5032a"
-        }
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: animation_with_microtasks_perf_ios__timeline_summary

--- a/dev/bots/suite_runners/run_verify_binaries_codesigned_tests.dart
+++ b/dev/bots/suite_runners/run_verify_binaries_codesigned_tests.dart
@@ -14,7 +14,7 @@ import '../utils.dart';
 
 Future<void> verifyCodesignedTestRunner() async {
   printProgress('${green}Running binaries codesign verification$reset');
-  await runCommand('flutter', <String>[
+  await runCommand(path.join(flutterRoot, 'bin', 'flutter'), <String>[
     'precache',
     '--android',
     '--ios',
@@ -23,13 +23,14 @@ Future<void> verifyCodesignedTestRunner() async {
 
   await verifyExist(flutterRoot);
   await verifySignatures(flutterRoot);
+  await verifyFatBinaries(flutterRoot);
 }
 
 /// Some binaries should always be codesigned, even on master. Verify that they
 /// are codesigned and have the correct entitlements.
 Future<void> verifyPreCodesignedTestRunner() async {
   printProgress('${green}Running binaries codesign verification$reset');
-  await runCommand('flutter', <String>[
+  await runCommand(path.join(flutterRoot, 'bin', 'flutter'), <String>[
     'precache',
     '--android',
     '--ios',
@@ -38,6 +39,7 @@ Future<void> verifyPreCodesignedTestRunner() async {
 
   await verifyExist(flutterRoot);
   await verifySignatures(flutterRoot, forRelease: false);
+  await verifyFatBinaries(flutterRoot);
 }
 
 const List<String> expectedEntitlements = <String>[
@@ -333,6 +335,43 @@ Future<void> verifySignatures(
     throw Exception('Test failed because unexpected files found in the cache.');
   }
   print('Verified that files are codesigned and have expected entitlements.');
+}
+
+/// Verify that specific binaries are fat binaries containing both x86_64 and arm64 slices.
+Future<void> verifyFatBinaries(
+  String flutterRoot, {
+  @visibleForTesting ProcessManager processManager = const LocalProcessManager(),
+}) async {
+  final List<String> fatBinaries =
+      presignedBinariesWithEntitlements(flutterRoot) +
+      presignedBinariesWithoutEntitlements(flutterRoot);
+  final failedBinaries = <String>[];
+
+  for (final binaryPath in fatBinaries) {
+    print('Verifying fat binary architectures for $binaryPath');
+    final io.ProcessResult result = await processManager.run(<String>['file', binaryPath]);
+
+    if (result.exitCode != 0) {
+      print('Failed to run file command on $binaryPath: \n${result.stderr}');
+      failedBinaries.add(binaryPath);
+      continue;
+    }
+
+    final output = result.stdout as String;
+    final bool containsX86_64 = output.contains('x86_64');
+    final bool containsArm64 = output.contains('arm64');
+
+    if (!containsX86_64 || !containsArm64) {
+      print('Binary $binaryPath is not a fat binary containing both x86_64 and arm64.');
+      print('Output: $output');
+      failedBinaries.add(binaryPath);
+    }
+  }
+
+  if (failedBinaries.isNotEmpty) {
+    throw Exception('Failed fat binary verification for:\n${failedBinaries.join('\n')}');
+  }
+  print('All expected fat binaries verified.');
 }
 
 /// Find every binary file in the given [rootDirectory].

--- a/dev/bots/test/codesign_test.dart
+++ b/dev/bots/test/codesign_test.dart
@@ -282,4 +282,55 @@ void main() async {
       );
     });
   });
+
+  group('verifyFatBinaries', () {
+    test('succeeds if every binary is fat', () async {
+      final commandList = <FakeCommand>[];
+      final List<String> fatBinaries =
+          presignedBinariesWithEntitlements(flutterRoot) +
+          presignedBinariesWithoutEntitlements(flutterRoot);
+
+      for (final binaryPath in fatBinaries) {
+        commandList.add(
+          FakeCommand(
+            command: <String>['file', binaryPath],
+            stdout:
+                'Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64:Mach-O 64-bit executable arm64]',
+          ),
+        );
+      }
+      final ProcessManager processManager = FakeProcessManager.list(commandList);
+      await expectLater(verifyFatBinaries(flutterRoot, processManager: processManager), completes);
+    });
+
+    test('fails if a binary is not fat', () async {
+      final commandList = <FakeCommand>[];
+      final List<String> fatBinaries =
+          presignedBinariesWithEntitlements(flutterRoot) +
+          presignedBinariesWithoutEntitlements(flutterRoot);
+
+      if (fatBinaries.isNotEmpty) {
+        commandList.add(
+          FakeCommand(
+            command: <String>['file', fatBinaries.first],
+            stdout: 'Mach-O 64-bit executable x86_64',
+          ),
+        );
+        for (final String binaryPath in fatBinaries.skip(1)) {
+          commandList.add(
+            FakeCommand(
+              command: <String>['file', binaryPath],
+              stdout:
+                  'Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64:Mach-O 64-bit executable arm64]',
+            ),
+          );
+        }
+      }
+      final ProcessManager processManager = FakeProcessManager.list(commandList);
+      expect(
+        () async => verifyFatBinaries(flutterRoot, processManager: processManager),
+        throwsExceptionWith('Failed fat binary verification for:'),
+      );
+    });
+  });
 }

--- a/packages/flutter_tools/lib/src/flutter_cache.dart
+++ b/packages/flutter_tools/lib/src/flutter_cache.dart
@@ -864,7 +864,7 @@ class IosUsbArtifacts extends CachedArtifact {
   @visibleForTesting
   Uri get archiveUri => Uri.parse(
     '${cache.realmlessStorageBaseUrl}/flutter_infra_release/'
-    'ios-usb-dependencies${cache.useUnsignedMacBinaries ? '/unsigned' : ''}'
+    'ios-usb-dependencies/arm64_x86_64${cache.useUnsignedMacBinaries ? '/unsigned' : ''}'
     '/$name/$version/$name.zip',
   );
 }


### PR DESCRIPTION
Please fill in the form below, and a flutter domain expert will evaluate this cherry pick request.

### Issue Link:
What is the link to the issue this cherry-pick is addressing?

https://github.com/flutter/flutter/issues/121178

### Impact Description:
What is the impact (ex. visual jank on Samsung phones, app crash, cannot ship an iOS app)?
Does it impact development (ex. flutter doctor crashes when Android Studio is installed),
or the shipping of production apps (the app crashes on launch).
This information is for domain experts and release engineers to understand the consequences of saying yes or no to the cherry pick.

This build iOS tooling as fat binaries (arm and x86) so that is no longer requires Rosetta. Rosetta is being sunset and Apple is apparently already showing warnings when x86 binaries are used with Rosetta: https://www.macrumors.com/2026/02/16/macos-tahoe-26-4-rosetta-2-warnings/

### Changelog Description:
Explain this cherry pick:
* In one line that is accessible to most Flutter developers.
* That describes the state prior to the fix.
* That includes which platforms are impacted.
See [best practices](https://github.com/flutter/flutter/blob/main/docs/releases/Hotfix-Documentation-Best-Practices.md) for examples.

[flutter/121178] When running your app on a physical iOS device, binary tools used to deploy the app are only built with x86 and therefore require Rosetta.

### Workaround:
Is there a workaround for this issue?

Ignore warnings

### Risk:
What is the risk level of this cherry-pick?

  - [x] Low
  - [ ] Medium
  - [ ] High

### Test Coverage:
Are you confident that your fix is well-tested by automated tests?

  - [x] Yes
  - [ ] No

### Validation Steps:
What are the steps to validate that this fix works?

Run and deploy to an iOS device (validated by CI)