### PR TITLE
Fix inconsistent macOS text stroke weights by supporting light/dark glyph separation in glyph atlas

### DIFF
--- a/engine/src/flutter/impeller/display_list/aiks_dl_text_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_text_unittests.cc
@@ -733,10 +733,10 @@ TEST_P(AiksTest, TextContentsMismatchedTransformTest) {
   Point preroll_point = Point{23, 45};
   {
     aiks_context.GetContentContext().GetLazyGlyphAtlas()->AddTextFrame(
-        text_frame,     //
-        preroll_point,  //
-        preroll_matrix,
-        std::nullopt  //
+        text_frame,        //
+        preroll_point,     //
+        preroll_matrix,    //
+        GlyphProperties{}  //
     );
   }
 
@@ -765,6 +765,48 @@ TEST_P(AiksTest, TextContentsMismatchedTransformTest) {
 
   EXPECT_TRUE(text_contents.Render(aiks_context.GetContentContext(), entity,
                                    *render_pass));
+}
+
+TEST_P(AiksTest, CanRenderTextFrameWithThinLightAndDarkColors) {
+  DisplayListBuilder builder;
+  DlPaint paint;
+  paint.setColor(DlColor::ARGB(1, 0.1, 0.1, 0.1));
+  builder.DrawPaint(paint);
+
+  auto mapping =
+      flutter::testing::OpenFixtureAsSkData("RobotoSlab-VariableFont_wght.ttf");
+  ASSERT_TRUE(mapping);
+  sk_sp<SkFontMgr> font_mgr = txt::GetDefaultFontManager();
+
+  // Set the variation axis for weight to 100 (typically "Thin").
+  SkFontArguments::VariationPosition::Coordinate weight_coord{
+      SkSetFourByteTag('w', 'g', 'h', 't'), 100.0f};
+  SkFontArguments args;
+  args.setVariationDesignPosition({&weight_coord, 1});
+
+  SkFont thin_font(font_mgr->makeFromData(mapping)->makeClone(args), 25);
+
+  // Render light text
+  ASSERT_TRUE(RenderTextInCanvasSkia(
+      GetContext(), builder, "the quick brown fox jumped over the lazy dog!.?",
+      "RobotoSlab-VariableFont_wght.ttf",
+      TextRenderOptions{.color = DlColor::kWhite(),
+                        .position = DlPoint(100, 200)},
+      thin_font));
+
+  // Render dark text on a light background
+  DlPaint dart_text_background_paint;
+  dart_text_background_paint.setColor(DlColor::ARGB(1, 0.9, 0.9, 0.9));
+  builder.DrawRect(DlRect::MakeXYWH(50, 250, 900, 100),
+                   dart_text_background_paint);
+  ASSERT_TRUE(RenderTextInCanvasSkia(
+      GetContext(), builder, "the quick brown fox jumped over the lazy dog!.?",
+      "RobotoSlab-VariableFont_wght.ttf",
+      TextRenderOptions{.color = DlColor::kDarkGreen(),
+                        .position = DlPoint(100, 300)},
+      thin_font));
+
+  ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
 TEST_P(AiksTest, TextWithShadowCache) {

--- a/engine/src/flutter/impeller/display_list/dl_dispatcher.cc
+++ b/engine/src/flutter/impeller/display_list/dl_dispatcher.cc
@@ -1104,9 +1104,9 @@ void FirstPassDispatcher::drawText(const std::shared_ptr<flutter::DlText>& text,
   if (text_frame->HasColor()) {
     // Alpha is always applied when rendering, remove it here so
     // we do not double-apply the alpha.
-    properties.color = paint_.color.WithAlpha(1.0);
+    properties.tone_or_color = paint_.color.WithAlpha(1.0);
   } else {
-    properties.SetIsLight(paint_.color);
+    properties.tone_or_color = GlyphProperties::ComputeTone(paint_.color);
   }
 
   renderer_.GetLazyGlyphAtlas()->AddTextFrame(text_frame,   //

--- a/engine/src/flutter/impeller/display_list/dl_dispatcher.cc
+++ b/engine/src/flutter/impeller/display_list/dl_dispatcher.cc
@@ -1105,15 +1105,14 @@ void FirstPassDispatcher::drawText(const std::shared_ptr<flutter::DlText>& text,
     // Alpha is always applied when rendering, remove it here so
     // we do not double-apply the alpha.
     properties.color = paint_.color.WithAlpha(1.0);
+  } else {
+    properties.SetIsLight(paint_.color);
   }
 
-  renderer_.GetLazyGlyphAtlas()->AddTextFrame(
-      text_frame,   //
-      Point(x, y),  //
-      matrix_,
-      (properties.stroke.has_value() || text_frame->HasColor())  //
-          ? std::optional<GlyphProperties>(properties)           //
-          : std::nullopt                                         //
+  renderer_.GetLazyGlyphAtlas()->AddTextFrame(text_frame,   //
+                                              Point(x, y),  //
+                                              matrix_,      //
+                                              properties    //
   );
 }
 

--- a/engine/src/flutter/impeller/entity/contents/text_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/text_contents.cc
@@ -70,6 +70,8 @@ void TextContents::SetTextProperties(
     // Alpha is always applied when rendering, remove it here so
     // we do not double-apply the alpha.
     properties_.color = color.WithAlpha(1.0);
+  } else {
+    properties_.SetIsLight(color);
   }
   properties_.stroke = stroke;
 }
@@ -90,14 +92,13 @@ Scalar AttractToOne(Scalar x) {
 
 }  // namespace
 
-void TextContents::ComputeVertexData(
-    VS::PerVertexData* vtx_contents,
-    const Matrix& entity_transform,
-    const std::shared_ptr<TextFrame>& frame,
-    Point position,
-    const Matrix& screen_transform,
-    std::optional<GlyphProperties> glyph_properties,
-    const std::shared_ptr<GlyphAtlas>& atlas) {
+void TextContents::ComputeVertexData(VS::PerVertexData* vtx_contents,
+                                     const Matrix& entity_transform,
+                                     const std::shared_ptr<TextFrame>& frame,
+                                     Point position,
+                                     const Matrix& screen_transform,
+                                     GlyphProperties glyph_properties,
+                                     const std::shared_ptr<GlyphAtlas>& atlas) {
   // Common vertex information for all glyphs.
   // All glyphs are given the same vertex information in the form of a
   // unit-sized quad. The size of the glyph is specified in per instance data
@@ -334,7 +335,7 @@ bool TextContents::Render(const ContentContext& renderer,
                           /*frame=*/frame_,
                           /*position=*/position_,
                           /*screen_transform=*/screen_transform_,
-                          /*glyph_properties=*/GetGlyphProperties(),
+                          /*glyph_properties=*/properties_,
                           /*atlas=*/atlas);
       });
   BufferView index_buffer_view = indexes_host_buffer.Emplace(
@@ -357,12 +358,6 @@ bool TextContents::Render(const ContentContext& renderer,
   pass.SetElementCount(index_count);
 
   return pass.Draw().ok();
-}
-
-std::optional<GlyphProperties> TextContents::GetGlyphProperties() const {
-  return (properties_.stroke || frame_->HasColor())
-             ? std::optional<GlyphProperties>(properties_)
-             : std::nullopt;
 }
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/entity/contents/text_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/text_contents.cc
@@ -69,9 +69,9 @@ void TextContents::SetTextProperties(
   if (frame_->HasColor()) {
     // Alpha is always applied when rendering, remove it here so
     // we do not double-apply the alpha.
-    properties_.color = color.WithAlpha(1.0);
+    properties_.tone_or_color = color.WithAlpha(1.0);
   } else {
-    properties_.SetIsLight(color);
+    properties_.tone_or_color = GlyphProperties::ComputeTone(color);
   }
   properties_.stroke = stroke;
 }

--- a/engine/src/flutter/impeller/entity/contents/text_contents.h
+++ b/engine/src/flutter/impeller/entity/contents/text_contents.h
@@ -95,12 +95,10 @@ class TextContents final : public Contents {
       const std::shared_ptr<TextFrame>& frame,
       Point position,
       const Matrix& screen_transform,
-      std::optional<GlyphProperties> glyph_properties,
+      GlyphProperties glyph_properties,
       const std::shared_ptr<GlyphAtlas>& atlas);
 
  private:
-  std::optional<GlyphProperties> GetGlyphProperties() const;
-
   std::shared_ptr<TextFrame> frame_;
   Scalar inherited_opacity_ = 1.0;
   Point position_;

--- a/engine/src/flutter/impeller/entity/contents/text_contents_unittests.cc
+++ b/engine/src/flutter/impeller/entity/contents/text_contents_unittests.cc
@@ -133,7 +133,7 @@ TEST_P(TextContentsTest, SimpleComputeVertexData) {
                                   /*frame=*/text_frame,
                                   /*position=*/Point(0, 0),
                                   /*screen_transform=*/Matrix(),
-                                  /*glyph_properties=*/std::nullopt,
+                                  /*glyph_properties=*/GlyphProperties{},
                                   /*atlas=*/atlas);
 
   Rect position_rect = PerVertexDataPositionToRect(data.begin());
@@ -174,7 +174,7 @@ TEST_P(TextContentsTest, SimpleComputeVertexData2x) {
       /*frame=*/text_frame,
       /*position=*/Point(0, 0),
       /*screen_transform=*/render_transform,
-      /*glyph_properties=*/std::nullopt,
+      /*glyph_properties=*/GlyphProperties{},
       /*atlas=*/atlas);
 
   Rect position_rect = PerVertexDataPositionToRect(data.begin());
@@ -216,7 +216,7 @@ TEST_P(TextContentsTest, MaintainsShape) {
           /*frame=*/text_frame,
           /*position=*/Point(0, 0),
           /*screen_transform=*/transform,
-          /*glyph_properties=*/std::nullopt,
+          /*glyph_properties=*/GlyphProperties{},
           /*atlas=*/atlas);
       position_rect[0] = PerVertexDataPositionToRect(data.begin());
       uv_rect[0] = PerVertexDataUVToRect(data.begin(), texture_size);
@@ -259,7 +259,7 @@ TEST_P(TextContentsTest, SimpleSubpixel) {
       /*frame=*/text_frame,
       /*position=*/offset,
       /*screen_transform=*/Matrix(),
-      /*glyph_properties=*/std::nullopt,
+      /*glyph_properties=*/GlyphProperties{},
       /*atlas=*/atlas);
 
   Rect position_rect = PerVertexDataPositionToRect(data.begin());
@@ -302,7 +302,7 @@ TEST_P(TextContentsTest, SimpleSubpixel3x) {
       /*frame=*/text_frame,
       /*position=*/offset,
       /*screen_transform=*/transform,
-      /*glyph_properties=*/std::nullopt,
+      /*glyph_properties=*/GlyphProperties{},
       /*atlas=*/atlas);
 
   Rect position_rect = PerVertexDataPositionToRect(data.begin());
@@ -346,7 +346,7 @@ TEST_P(TextContentsTest, SimpleSubpixel26) {
       /*frame=*/text_frame,
       /*position=*/offset,
       /*screen_transform=*/Matrix(),
-      /*glyph_properties=*/std::nullopt,
+      /*glyph_properties=*/GlyphProperties{},
       /*atlas=*/atlas);
 
   Rect position_rect = PerVertexDataPositionToRect(data.begin());
@@ -388,7 +388,7 @@ TEST_P(TextContentsTest, SimpleSubpixel80) {
       /*frame=*/text_frame,
       /*position=*/offset,
       /*screen_transform=*/Matrix(),
-      /*glyph_properties=*/std::nullopt,
+      /*glyph_properties=*/GlyphProperties{},
       /*atlas=*/atlas);
 
   Rect position_rect = PerVertexDataPositionToRect(data.begin());

--- a/engine/src/flutter/impeller/fixtures/BUILD.gn
+++ b/engine/src/flutter/impeller/fixtures/BUILD.gn
@@ -137,6 +137,7 @@ test_fixtures("file_fixtures") {
     "//flutter/txt/third_party/fonts/NotoColorEmoji.ttf",
     "//flutter/txt/third_party/fonts/Roboto-Medium.ttf",
     "//flutter/txt/third_party/fonts/Roboto-Regular.ttf",
+    "//flutter/txt/third_party/fonts/RobotoSlab-VariableFont_wght.ttf",
     "airplane.jpg",
     "array_assignment.frag",
     "array_initializer_with_constants.frag",

--- a/engine/src/flutter/impeller/geometry/color.h
+++ b/engine/src/flutter/impeller/geometry/color.h
@@ -261,6 +261,11 @@ struct Color {
     return result[3] << 24 | result[0] << 16 | result[1] << 8 | result[2];
   }
 
+  template <typename H>
+  friend H AbslHashValue(H h, const Color& c) {
+    return H::combine(std::move(h), c.ToARGB());
+  }
+
   static constexpr Color White() { return {1.0f, 1.0f, 1.0f, 1.0f}; }
 
   static constexpr Color Black() { return {0.0f, 0.0f, 0.0f, 1.0f}; }

--- a/engine/src/flutter/impeller/typographer/backends/skia/typographer_context_skia.cc
+++ b/engine/src/flutter/impeller/typographer/backends/skia/typographer_context_skia.cc
@@ -8,7 +8,6 @@
 #include <cstdint>
 #include <memory>
 #include <numeric>
-#include <optional>
 #include <utility>
 #include <vector>
 
@@ -34,6 +33,7 @@
 #include "impeller/typographer/rectangle_packer.h"
 #include "impeller/typographer/typographer_context.h"
 
+#include "third_party/abseil-cpp/absl/status/statusor.h"
 #include "third_party/skia/include/core/SkBitmap.h"
 #include "third_party/skia/include/core/SkBlendMode.h"
 #include "third_party/skia/include/core/SkCanvas.h"
@@ -89,18 +89,18 @@ bool HasLightGlyphs(const GlyphAtlas& atlas,
 }
 
 // Create an A8 bitmap from an color bitmap.
-//
-// Returns an empty optional if the bitmap cannot be created.
-std::optional<SkBitmap> ToA8Bitmap(const SkBitmap& src) {
+absl::StatusOr<SkBitmap> ToA8Bitmap(const SkBitmap& src) {
   FML_DCHECK(src.colorType() == kRGBA_8888_SkColorType);
 
   SkBitmap a8_bitmap;
   a8_bitmap.setInfo(SkImageInfo::MakeA8(src.width(), src.height()));
   if (!a8_bitmap.tryAllocPixels()) {
-    return std::nullopt;
+    return absl::Status(absl::StatusCode::kInternal,
+                        "Failed to allocate pixels for A8 bitmap");
   }
   if (!src.readPixels(a8_bitmap.pixmap())) {
-    return std::nullopt;
+    return absl::Status(absl::StatusCode::kInternal,
+                        "Failed to read pixels into A8 bitmap");
   }
   return a8_bitmap;
 }
@@ -353,11 +353,12 @@ static bool BulkUpdateAtlasBitmap(const GlyphAtlas& atlas,
   }
 
   if (has_light_glyphs) {
-    auto a8_bitmap = ToA8Bitmap(bitmap);
-    if (!a8_bitmap.has_value()) {
+    auto a8_bitmap_status = ToA8Bitmap(bitmap);
+    if (!a8_bitmap_status.ok()) {
+      VALIDATION_LOG << a8_bitmap_status.status().message();
       return false;
     }
-    bitmap = a8_bitmap.value();
+    bitmap = a8_bitmap_status.value();
   }
 
   // Writing to a malloc'd buffer and then copying to the staging buffers
@@ -425,11 +426,12 @@ static bool UpdateAtlasBitmap(const GlyphAtlas& atlas,
               pair.glyph.properties);
 
     if (is_light_glyph) {
-      auto a8_bitmap = ToA8Bitmap(bitmap);
-      if (!a8_bitmap.has_value()) {
+      auto a8_bitmap_status = ToA8Bitmap(bitmap);
+      if (!a8_bitmap_status.ok()) {
+        VALIDATION_LOG << a8_bitmap_status.status().message();
         return false;
       }
-      bitmap = a8_bitmap.value();
+      bitmap = a8_bitmap_status.value();
     }
 
     // Writing to a malloc'd buffer and then copying to the staging buffers

--- a/engine/src/flutter/impeller/typographer/backends/skia/typographer_context_skia.cc
+++ b/engine/src/flutter/impeller/typographer/backends/skia/typographer_context_skia.cc
@@ -70,6 +70,26 @@ SkPaint::Join ToSkiaJoin(Join join) {
   }
   FML_UNREACHABLE();
 }
+
+// Create an A8 bitmap by copying the alpha channel from an RGBA_8888 bitmap.
+SkBitmap RGBAToA8(const SkBitmap& rgba_bitmap) {
+  SkBitmap a8_bitmap;
+  a8_bitmap.setInfo(
+      SkImageInfo::MakeA8(rgba_bitmap.width(), rgba_bitmap.height()));
+  a8_bitmap.allocPixels();
+
+  size_t total_pixels = rgba_bitmap.width() * rgba_bitmap.height();
+  const uint8_t* src_bytes =
+      static_cast<const uint8_t*>(rgba_bitmap.getAddr(0, 0));
+  uint8_t* dst_pixels = static_cast<uint8_t*>(a8_bitmap.getAddr(0, 0));
+  for (size_t i = 0; i < total_pixels; ++i) {
+    // Copy alpha channel from RGBA to A8. The alpha channel is the 4th byte
+    // (index 3) of each 4-byte pixel from the RGBA_8888 src.
+    dst_pixels[i] = src_bytes[i * 4 + 3];
+  }
+
+  return a8_bitmap;
+}
 }  // namespace
 
 std::shared_ptr<TypographerContext> TypographerContextSkia::Make() {
@@ -86,15 +106,20 @@ TypographerContextSkia::CreateGlyphAtlasContext(GlyphAtlas::Type type) const {
 }
 
 SkImageInfo TypographerContextSkia::GetImageInfo(const GlyphAtlas& atlas,
-                                                 Size size) {
+                                                 Size size,
+                                                 bool support_light_glyphs) {
+  SkISize skia_size = {static_cast<int32_t>(size.width),
+                       static_cast<int32_t>(size.height)};
+
   switch (atlas.GetType()) {
     case GlyphAtlas::Type::kAlphaBitmap:
-      return SkImageInfo::MakeA8(SkISize{static_cast<int32_t>(size.width),
-                                         static_cast<int32_t>(size.height)});
+      return support_light_glyphs
+                 ? SkImageInfo::Make(skia_size, kRGBA_8888_SkColorType,
+                                     kPremul_SkAlphaType)
+                 : SkImageInfo::MakeA8(skia_size);
     case GlyphAtlas::Type::kColorBitmap:
-      return SkImageInfo::Make(SkISize{static_cast<int32_t>(size.width),
-                                       static_cast<int32_t>(size.height)},
-                               kRGBA_8888_SkColorType, kPremul_SkAlphaType);
+      return SkImageInfo::Make(skia_size, kRGBA_8888_SkColorType,
+                               kPremul_SkAlphaType);
   }
   FML_UNREACHABLE();
 }
@@ -215,8 +240,7 @@ static void DrawGlyph(SkCanvas* canvas,
                       const ScaledFont& scaled_font,
                       const SubpixelGlyph& glyph,
                       const Rect& scaled_bounds,
-                      const std::optional<GlyphProperties>& prop,
-                      bool has_color) {
+                      const GlyphProperties& prop) {
   const auto& metrics = scaled_font.font.GetMetrics();
   SkGlyphID glyph_id = glyph.glyph.index;
 
@@ -229,23 +253,19 @@ static void DrawGlyph(SkCanvas* canvas,
   sk_font.setSubpixel(true);
   sk_font.setSize(sk_font.getSize() * static_cast<Scalar>(scaled_font.scale));
 
-  auto glyph_color = prop.has_value() ? prop->color.ToARGB() : SK_ColorBLACK;
+  auto glyph_color = prop.is_light ? SK_ColorWHITE : prop.color.ToARGB();
 
   SkPaint glyph_paint;
   glyph_paint.setColor(glyph_color);
   glyph_paint.setBlendMode(SkBlendMode::kSrc);
-  if (prop.has_value()) {
-    auto stroke = prop->stroke;
-    if (stroke.has_value()) {
-      glyph_paint.setStroke(true);
-      glyph_paint.setStrokeWidth(stroke->width *
-                                 static_cast<Scalar>(scaled_font.scale));
-      glyph_paint.setStrokeCap(ToSkiaCap(stroke->cap));
-      glyph_paint.setStrokeJoin(ToSkiaJoin(stroke->join));
-      glyph_paint.setStrokeMiter(stroke->miter_limit);
-    } else {
-      glyph_paint.setStroke(false);
-    }
+  if (prop.stroke.has_value()) {
+    auto stroke = prop.stroke;
+    glyph_paint.setStroke(true);
+    glyph_paint.setStrokeWidth(stroke->width *
+                               static_cast<Scalar>(scaled_font.scale));
+    glyph_paint.setStrokeCap(ToSkiaCap(stroke->cap));
+    glyph_paint.setStrokeJoin(ToSkiaJoin(stroke->join));
+    glyph_paint.setStrokeMiter(stroke->miter_limit);
   }
   canvas->save();
   Point subpixel_offset = SubpixelPositionToPoint(glyph.subpixel_offset);
@@ -273,11 +293,19 @@ static bool BulkUpdateAtlasBitmap(const GlyphAtlas& atlas,
                                   size_t end_index) {
   TRACE_EVENT0("impeller", __FUNCTION__);
 
-  bool has_color = atlas.GetType() == GlyphAtlas::Type::kColorBitmap;
+  bool has_light_glyphs = false;
+  if (atlas.GetType() == GlyphAtlas::Type::kAlphaBitmap) {
+    for (size_t i = start_index; i < end_index; i++) {
+      if (new_pairs[i].glyph.properties.is_light) {
+        has_light_glyphs = true;
+        break;
+      }
+    }
+  }
 
   SkBitmap bitmap;
-  bitmap.setInfo(
-      TypographerContextSkia::GetImageInfo(atlas, Size(texture->GetSize())));
+  bitmap.setInfo(TypographerContextSkia::GetImageInfo(
+      atlas, Size(texture->GetSize()), has_light_glyphs));
   if (!bitmap.tryAllocPixels()) {
     return false;
   }
@@ -305,8 +333,11 @@ static bool BulkUpdateAtlasBitmap(const GlyphAtlas& atlas,
     }
 
     DrawGlyph(canvas, SkPoint::Make(pos.GetLeft(), pos.GetTop()),
-              pair.scaled_font, pair.glyph, bounds, pair.glyph.properties,
-              has_color);
+              pair.scaled_font, pair.glyph, bounds, pair.glyph.properties);
+  }
+
+  if (has_light_glyphs) {
+    bitmap = RGBAToA8(bitmap);
   }
 
   // Writing to a malloc'd buffer and then copying to the staging buffers
@@ -333,8 +364,6 @@ static bool UpdateAtlasBitmap(const GlyphAtlas& atlas,
                               size_t end_index) {
   TRACE_EVENT0("impeller", __FUNCTION__);
 
-  bool has_color = atlas.GetType() == GlyphAtlas::Type::kColorBitmap;
-
   for (size_t i = start_index; i < end_index; i++) {
     const FontGlyphPair& pair = new_pairs[i];
     auto data = atlas.FindFontGlyphBounds(pair);
@@ -354,7 +383,9 @@ static bool UpdateAtlasBitmap(const GlyphAtlas& atlas,
     size.height += 2;
 
     SkBitmap bitmap;
-    bitmap.setInfo(TypographerContextSkia::GetImageInfo(atlas, size));
+    bool is_light_glyph = pair.glyph.properties.is_light;
+    bitmap.setInfo(
+        TypographerContextSkia::GetImageInfo(atlas, size, is_light_glyph));
     if (!bitmap.tryAllocPixels()) {
       return false;
     }
@@ -369,7 +400,11 @@ static bool UpdateAtlasBitmap(const GlyphAtlas& atlas,
     }
 
     DrawGlyph(canvas, SkPoint::Make(1, 1), pair.scaled_font, pair.glyph, bounds,
-              pair.glyph.properties, has_color);
+              pair.glyph.properties);
+
+    if (is_light_glyph) {
+      bitmap = RGBAToA8(bitmap);
+    }
 
     // Writing to a malloc'd buffer and then copying to the staging buffers
     // benchmarks as substantially faster on a number of Android devices.
@@ -402,12 +437,12 @@ static Rect ComputeGlyphSize(const SkFont& font,
                              Scalar scale) {
   SkRect scaled_bounds;
   SkPaint glyph_paint;
-  if (glyph.properties.has_value() && glyph.properties->stroke) {
+  if (glyph.properties.stroke.has_value()) {
     glyph_paint.setStroke(true);
-    glyph_paint.setStrokeWidth(glyph.properties->stroke->width * scale);
-    glyph_paint.setStrokeCap(ToSkiaCap(glyph.properties->stroke->cap));
-    glyph_paint.setStrokeJoin(ToSkiaJoin(glyph.properties->stroke->join));
-    glyph_paint.setStrokeMiter(glyph.properties->stroke->miter_limit);
+    glyph_paint.setStrokeWidth(glyph.properties.stroke->width * scale);
+    glyph_paint.setStrokeCap(ToSkiaCap(glyph.properties.stroke->cap));
+    glyph_paint.setStrokeJoin(ToSkiaJoin(glyph.properties.stroke->join));
+    glyph_paint.setStrokeMiter(glyph.properties.stroke->miter_limit);
   }
   // Get bounds for a single glyph
   font.getBounds({&glyph.glyph.index, 1}, {&scaled_bounds, 1}, &glyph_paint);

--- a/engine/src/flutter/impeller/typographer/backends/skia/typographer_context_skia.cc
+++ b/engine/src/flutter/impeller/typographer/backends/skia/typographer_context_skia.cc
@@ -70,26 +70,6 @@ SkPaint::Join ToSkiaJoin(Join join) {
   }
   FML_UNREACHABLE();
 }
-
-// Create an A8 bitmap by copying the alpha channel from an RGBA_8888 bitmap.
-SkBitmap RGBAToA8(const SkBitmap& rgba_bitmap) {
-  SkBitmap a8_bitmap;
-  a8_bitmap.setInfo(
-      SkImageInfo::MakeA8(rgba_bitmap.width(), rgba_bitmap.height()));
-  a8_bitmap.allocPixels();
-
-  size_t total_pixels = rgba_bitmap.width() * rgba_bitmap.height();
-  const uint8_t* src_bytes =
-      static_cast<const uint8_t*>(rgba_bitmap.getAddr(0, 0));
-  uint8_t* dst_pixels = static_cast<uint8_t*>(a8_bitmap.getAddr(0, 0));
-  for (size_t i = 0; i < total_pixels; ++i) {
-    // Copy alpha channel from RGBA to A8. The alpha channel is the 4th byte
-    // (index 3) of each 4-byte pixel from the RGBA_8888 src.
-    dst_pixels[i] = src_bytes[i * 4 + 3];
-  }
-
-  return a8_bitmap;
-}
 }  // namespace
 
 std::shared_ptr<TypographerContext> TypographerContextSkia::Make() {
@@ -337,7 +317,10 @@ static bool BulkUpdateAtlasBitmap(const GlyphAtlas& atlas,
   }
 
   if (has_light_glyphs) {
-    bitmap = RGBAToA8(bitmap);
+    SkBitmap a8_bitmap;
+    if (bitmap.extractAlpha(&a8_bitmap)) {
+      bitmap = a8_bitmap;
+    }
   }
 
   // Writing to a malloc'd buffer and then copying to the staging buffers
@@ -403,7 +386,10 @@ static bool UpdateAtlasBitmap(const GlyphAtlas& atlas,
               pair.glyph.properties);
 
     if (is_light_glyph) {
-      bitmap = RGBAToA8(bitmap);
+      SkBitmap a8_bitmap;
+      if (bitmap.extractAlpha(&a8_bitmap)) {
+        bitmap = a8_bitmap;
+      }
     }
 
     // Writing to a malloc'd buffer and then copying to the staging buffers

--- a/engine/src/flutter/impeller/typographer/backends/skia/typographer_context_skia.cc
+++ b/engine/src/flutter/impeller/typographer/backends/skia/typographer_context_skia.cc
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <memory>
 #include <numeric>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -69,6 +70,21 @@ SkPaint::Join ToSkiaJoin(Join join) {
       return SkPaint::Join::kBevel_Join;
   }
   FML_UNREACHABLE();
+}
+
+// Create an A8 bitmap from an existing bitmap.
+//
+// Returns an empty optional if the bitmap cannot be created.
+std::optional<SkBitmap> ToA8Bitmap(const SkBitmap& src) {
+  SkBitmap a8_bitmap;
+  a8_bitmap.setInfo(SkImageInfo::MakeA8(src.width(), src.height()));
+  if (!a8_bitmap.tryAllocPixels()) {
+    return std::nullopt;
+  }
+  if (!src.readPixels(a8_bitmap.pixmap())) {
+    return std::nullopt;
+  }
+  return a8_bitmap;
 }
 }  // namespace
 
@@ -317,11 +333,11 @@ static bool BulkUpdateAtlasBitmap(const GlyphAtlas& atlas,
   }
 
   if (has_light_glyphs) {
-    SkBitmap a8_bitmap;
-    if (!bitmap.extractAlpha(&a8_bitmap)) {
+    auto a8_bitmap = ToA8Bitmap(bitmap);
+    if (!a8_bitmap.has_value()) {
       return false;
     }
-    bitmap = a8_bitmap;
+    bitmap = a8_bitmap.value();
   }
 
   // Writing to a malloc'd buffer and then copying to the staging buffers
@@ -387,11 +403,11 @@ static bool UpdateAtlasBitmap(const GlyphAtlas& atlas,
               pair.glyph.properties);
 
     if (is_light_glyph) {
-      SkBitmap a8_bitmap;
-      if (!bitmap.extractAlpha(&a8_bitmap)) {
+      auto a8_bitmap = ToA8Bitmap(bitmap);
+      if (!a8_bitmap.has_value()) {
         return false;
       }
-      bitmap = a8_bitmap;
+      bitmap = a8_bitmap.value();
     }
 
     // Writing to a malloc'd buffer and then copying to the staging buffers

--- a/engine/src/flutter/impeller/typographer/backends/skia/typographer_context_skia.cc
+++ b/engine/src/flutter/impeller/typographer/backends/skia/typographer_context_skia.cc
@@ -80,7 +80,8 @@ bool HasLightGlyphs(const GlyphAtlas& atlas,
     return false;
   }
   for (size_t i = start_index; i < end_index; i++) {
-    if (new_pairs[i].glyph.properties.is_light) {
+    if (new_pairs[i].glyph.properties.tone_or_color ==
+        GlyphProperties::kLightTone) {
       return true;
     }
   }
@@ -267,7 +268,15 @@ static void DrawGlyph(SkCanvas* canvas,
   sk_font.setSubpixel(true);
   sk_font.setSize(sk_font.getSize() * static_cast<Scalar>(scaled_font.scale));
 
-  auto glyph_color = prop.is_light ? SK_ColorWHITE : prop.color.ToARGB();
+  SkColor glyph_color;
+  if (prop.tone_or_color == GlyphProperties::kDarkTone) {
+    glyph_color = SK_ColorBLACK;
+  } else if (prop.tone_or_color == GlyphProperties::kLightTone) {
+    glyph_color = SK_ColorWHITE;
+  } else {
+    FML_DCHECK(std::holds_alternative<Color>(prop.tone_or_color));
+    glyph_color = std::get<Color>(prop.tone_or_color).ToARGB();
+  }
 
   SkPaint glyph_paint;
   glyph_paint.setColor(glyph_color);
@@ -394,7 +403,9 @@ static bool UpdateAtlasBitmap(const GlyphAtlas& atlas,
     size.height += 2;
 
     SkBitmap bitmap;
-    bool is_light_glyph = pair.glyph.properties.is_light;
+    bool is_light_glyph =
+        pair.glyph.properties.tone_or_color == GlyphProperties::kLightTone;
+
     bitmap.setInfo(
         TypographerContextSkia::GetImageInfo(atlas, size, is_light_glyph));
     if (!bitmap.tryAllocPixels()) {

--- a/engine/src/flutter/impeller/typographer/backends/skia/typographer_context_skia.cc
+++ b/engine/src/flutter/impeller/typographer/backends/skia/typographer_context_skia.cc
@@ -72,10 +72,27 @@ SkPaint::Join ToSkiaJoin(Join join) {
   FML_UNREACHABLE();
 }
 
-// Create an A8 bitmap from an existing bitmap.
+bool HasLightGlyphs(const GlyphAtlas& atlas,
+                    const std::vector<FontGlyphPair>& new_pairs,
+                    size_t start_index,
+                    size_t end_index) {
+  if (atlas.GetType() != GlyphAtlas::Type::kAlphaBitmap) {
+    return false;
+  }
+  for (size_t i = start_index; i < end_index; i++) {
+    if (new_pairs[i].glyph.properties.is_light) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Create an A8 bitmap from an color bitmap.
 //
 // Returns an empty optional if the bitmap cannot be created.
 std::optional<SkBitmap> ToA8Bitmap(const SkBitmap& src) {
+  FML_DCHECK(src.colorType() == kRGBA_8888_SkColorType);
+
   SkBitmap a8_bitmap;
   a8_bitmap.setInfo(SkImageInfo::MakeA8(src.width(), src.height()));
   if (!a8_bitmap.tryAllocPixels()) {
@@ -86,6 +103,7 @@ std::optional<SkBitmap> ToA8Bitmap(const SkBitmap& src) {
   }
   return a8_bitmap;
 }
+
 }  // namespace
 
 std::shared_ptr<TypographerContext> TypographerContextSkia::Make() {
@@ -289,15 +307,8 @@ static bool BulkUpdateAtlasBitmap(const GlyphAtlas& atlas,
                                   size_t end_index) {
   TRACE_EVENT0("impeller", __FUNCTION__);
 
-  bool has_light_glyphs = false;
-  if (atlas.GetType() == GlyphAtlas::Type::kAlphaBitmap) {
-    for (size_t i = start_index; i < end_index; i++) {
-      if (new_pairs[i].glyph.properties.is_light) {
-        has_light_glyphs = true;
-        break;
-      }
-    }
-  }
+  bool has_light_glyphs =
+      HasLightGlyphs(atlas, new_pairs, start_index, end_index);
 
   SkBitmap bitmap;
   bitmap.setInfo(TypographerContextSkia::GetImageInfo(

--- a/engine/src/flutter/impeller/typographer/backends/skia/typographer_context_skia.cc
+++ b/engine/src/flutter/impeller/typographer/backends/skia/typographer_context_skia.cc
@@ -318,9 +318,10 @@ static bool BulkUpdateAtlasBitmap(const GlyphAtlas& atlas,
 
   if (has_light_glyphs) {
     SkBitmap a8_bitmap;
-    if (bitmap.extractAlpha(&a8_bitmap)) {
-      bitmap = a8_bitmap;
+    if (!bitmap.extractAlpha(&a8_bitmap)) {
+      return false;
     }
+    bitmap = a8_bitmap;
   }
 
   // Writing to a malloc'd buffer and then copying to the staging buffers
@@ -387,9 +388,10 @@ static bool UpdateAtlasBitmap(const GlyphAtlas& atlas,
 
     if (is_light_glyph) {
       SkBitmap a8_bitmap;
-      if (bitmap.extractAlpha(&a8_bitmap)) {
-        bitmap = a8_bitmap;
+      if (!bitmap.extractAlpha(&a8_bitmap)) {
+        return false;
       }
+      bitmap = a8_bitmap;
     }
 
     // Writing to a malloc'd buffer and then copying to the staging buffers

--- a/engine/src/flutter/impeller/typographer/backends/skia/typographer_context_skia.h
+++ b/engine/src/flutter/impeller/typographer/backends/skia/typographer_context_skia.h
@@ -31,7 +31,9 @@ class TypographerContextSkia : public TypographerContext {
       const std::vector<RenderableText>& renderable_texts) const override;
 
   // Visible for testing.
-  static SkImageInfo GetImageInfo(const GlyphAtlas& atlas, Size size);
+  static SkImageInfo GetImageInfo(const GlyphAtlas& atlas,
+                                  Size size,
+                                  bool support_light_glyphs);
 
  private:
   static std::pair<std::vector<FontGlyphPair>, std::vector<Rect>>

--- a/engine/src/flutter/impeller/typographer/font_glyph_pair.h
+++ b/engine/src/flutter/impeller/typographer/font_glyph_pair.h
@@ -34,9 +34,11 @@ struct GlyphProperties {
   /// Sets the is_light property based on the luminance of the color.
   void SetIsLight(const Color& c) {
 #if defined(FML_OS_MACOSX)
-    // Luminance from https://www.w3.org/TR/WCAG20/#relativeluminancedef
-    Scalar luminance = c.red * 0.2126f + c.green * 0.7152f + c.blue * 0.0722f;
-    is_light = (luminance > 0.5f);
+    // Uses BT.709 luma coefficients
+    // (https://en.wikipedia.org/wiki/Rec._709#Luma_coefficients) to determine
+    // whether a color is light or dark.
+    Scalar luma = c.red * 0.2126f + c.green * 0.7152f + c.blue * 0.0722f;
+    is_light = (luma > 0.5f);
 #endif
   }
 

--- a/engine/src/flutter/impeller/typographer/font_glyph_pair.h
+++ b/engine/src/flutter/impeller/typographer/font_glyph_pair.h
@@ -32,8 +32,10 @@ struct GlyphProperties {
   bool is_light = false;
 
   /// Sets the is_light property based on the luminance of the color.
+  ///
+  /// No-op on platforms other than MacOS.
   void SetIsLight(const Color& c) {
-#if defined(FML_OS_MACOSX)
+#if FML_OS_MACOSX && !FML_OS_IOS
     // Uses BT.709 luma coefficients
     // (https://en.wikipedia.org/wiki/Rec._709#Luma_coefficients) to determine
     // whether a color is light or dark.

--- a/engine/src/flutter/impeller/typographer/font_glyph_pair.h
+++ b/engine/src/flutter/impeller/typographer/font_glyph_pair.h
@@ -6,6 +6,7 @@
 #define FLUTTER_IMPELLER_TYPOGRAPHER_FONT_GLYPH_PAIR_H_
 
 #include <optional>
+#include <variant>
 
 #include "impeller/geometry/color.h"
 #include "impeller/geometry/rational.h"
@@ -17,38 +18,46 @@
 namespace impeller {
 
 struct GlyphProperties {
-  Color color = Color::Black();
+  enum class Tone {
+    kDark,
+    kLight,
+  };
+
+  using ToneOrColor = std::variant<Tone, Color>;
+  static constexpr ToneOrColor kDarkTone{Tone::kDark};
+  static constexpr ToneOrColor kLightTone{Tone::kLight};
+
+  // The tone or color of the glyph. Defaults to Tone::kDark.
+  //
+  // For alpha-channel-only glyphs, this stores a Tone (kDark or kLight). Use
+  // `ComputeTone` to determine the tone from a color.
+  //
+  // For glyphs with a built-in color, this stores the specific Color.
+  ToneOrColor tone_or_color;
   std::optional<StrokeParameters> stroke;
 
-  // Whether the glyph is created by rendering light (white) text, as opposed to
-  // rendering dark (black) text.
+  // Computes a Tone from a color. Use to set `tone_or_color` for an alpha-only
+  // Glyph.
   //
-  // This is only used for MacOS. Apple's CoreText renders light and dark text
-  // differently, so different glyphs are required for light and dark text. On
-  // other platforms, is_light is always false.
-  //
-  // This is only used for alpha-channel-only glyphs. It is not used for color
-  // glyphs.
-  bool is_light = false;
-
-  /// Sets the is_light property based on the luminance of the color.
-  ///
-  /// No-op on platforms other than MacOS.
-  void SetIsLight(const Color& c) {
+  // kLight is only used for macOS, where Apple's CoreText renders dark and
+  // light text differently, requiring different glyphs for each. On other
+  // platforms, this always returns kDark.
+  static Tone ComputeTone(const Color& c) {
 #if FML_OS_MACOSX && !FML_OS_IOS
     // Uses BT.709 luma coefficients
     // (https://en.wikipedia.org/wiki/Rec._709#Luma_coefficients) to determine
     // whether a color is light or dark.
     Scalar luma = c.red * 0.2126f + c.green * 0.7152f + c.blue * 0.0722f;
-    is_light = (luma > 0.5f);
+    return (luma > 0.5f) ? Tone::kLight : Tone::kDark;
+#else
+    return Tone::kDark;
 #endif
   }
 
   struct Equal {
     inline bool operator()(const impeller::GlyphProperties& lhs,
                            const impeller::GlyphProperties& rhs) const {
-      return lhs.color.ToARGB() == rhs.color.ToARGB() &&
-             lhs.stroke == rhs.stroke && lhs.is_light == rhs.is_light;
+      return lhs.tone_or_color == rhs.tone_or_color && lhs.stroke == rhs.stroke;
     }
   };
 };
@@ -126,9 +135,8 @@ struct SubpixelGlyph {
       stroke = sg.properties.stroke.value();
     }
     return H::combine(std::move(h), sg.glyph.index, sg.subpixel_offset,
-                      sg.properties.color.ToARGB(), has_stroke, stroke.cap,
-                      stroke.join, stroke.miter_limit, stroke.width,
-                      sg.properties.is_light);
+                      sg.properties.tone_or_color, has_stroke, stroke.cap,
+                      stroke.join, stroke.miter_limit, stroke.width);
   }
 
   struct Equal {

--- a/engine/src/flutter/impeller/typographer/font_glyph_pair.h
+++ b/engine/src/flutter/impeller/typographer/font_glyph_pair.h
@@ -20,11 +20,31 @@ struct GlyphProperties {
   Color color = Color::Black();
   std::optional<StrokeParameters> stroke;
 
+  // Whether the glyph is created by rendering light (white) text, as opposed to
+  // rendering dark (black) text.
+  //
+  // This is only used for MacOS. Apple's CoreText renders light and dark text
+  // differently, so different glyphs are required for light and dark text. On
+  // other platforms, is_light is always false.
+  //
+  // This is only used for alpha-channel-only glyphs. It is not used for color
+  // glyphs.
+  bool is_light = false;
+
+  /// Sets the is_light property based on the luminance of the color.
+  void SetIsLight(const Color& c) {
+#if defined(FML_OS_MACOSX)
+    // Luminance from https://www.w3.org/TR/WCAG20/#relativeluminancedef
+    Scalar luminance = c.red * 0.2126f + c.green * 0.7152f + c.blue * 0.0722f;
+    is_light = (luminance > 0.5f);
+#endif
+  }
+
   struct Equal {
     inline bool operator()(const impeller::GlyphProperties& lhs,
                            const impeller::GlyphProperties& rhs) const {
       return lhs.color.ToARGB() == rhs.color.ToARGB() &&
-             lhs.stroke == rhs.stroke;
+             lhs.stroke == rhs.stroke && lhs.is_light == rhs.is_light;
     }
   };
 };
@@ -85,28 +105,26 @@ enum SubpixelPosition : uint8_t {
 struct SubpixelGlyph {
   Glyph glyph;
   SubpixelPosition subpixel_offset;
-  std::optional<GlyphProperties> properties;
+  GlyphProperties properties;
 
   SubpixelGlyph(Glyph p_glyph,
                 SubpixelPosition p_subpixel_offset,
-                std::optional<GlyphProperties> p_properties)
+                GlyphProperties p_properties)
       : glyph(p_glyph),
         subpixel_offset(p_subpixel_offset),
         properties(p_properties) {}
 
   template <typename H>
   friend H AbslHashValue(H h, const SubpixelGlyph& sg) {
-    if (!sg.properties.has_value()) {
-      return H::combine(std::move(h), sg.glyph.index, sg.subpixel_offset);
-    }
     StrokeParameters stroke;
-    bool has_stroke = sg.properties->stroke.has_value();
+    bool has_stroke = sg.properties.stroke.has_value();
     if (has_stroke) {
-      stroke = sg.properties->stroke.value();
+      stroke = sg.properties.stroke.value();
     }
     return H::combine(std::move(h), sg.glyph.index, sg.subpixel_offset,
-                      sg.properties->color.ToARGB(), has_stroke, stroke.cap,
-                      stroke.join, stroke.miter_limit, stroke.width);
+                      sg.properties.color.ToARGB(), has_stroke, stroke.cap,
+                      stroke.join, stroke.miter_limit, stroke.width,
+                      sg.properties.is_light);
   }
 
   struct Equal {
@@ -115,17 +133,10 @@ struct SubpixelGlyph {
       // Check simple non-optionals first.
       if (lhs.glyph.index != rhs.glyph.index ||
           lhs.glyph.type != rhs.glyph.type ||
-          lhs.subpixel_offset != rhs.subpixel_offset ||
-          // Mixmatch properties.
-          lhs.properties.has_value() != rhs.properties.has_value()) {
+          lhs.subpixel_offset != rhs.subpixel_offset) {
         return false;
       }
-      if (lhs.properties.has_value()) {
-        // Both have properties.
-        return GlyphProperties::Equal{}(lhs.properties.value(),
-                                        rhs.properties.value());
-      }
-      return true;
+      return GlyphProperties::Equal{}(lhs.properties, rhs.properties);
     }
   };
 };

--- a/engine/src/flutter/impeller/typographer/lazy_glyph_atlas.cc
+++ b/engine/src/flutter/impeller/typographer/lazy_glyph_atlas.cc
@@ -31,11 +31,10 @@ LazyGlyphAtlas::LazyGlyphAtlas(
 
 LazyGlyphAtlas::~LazyGlyphAtlas() = default;
 
-void LazyGlyphAtlas::AddTextFrame(
-    const std::shared_ptr<TextFrame>& frame,
-    Point position,
-    const Matrix& transform,
-    const std::optional<GlyphProperties>& properties) {
+void LazyGlyphAtlas::AddTextFrame(const std::shared_ptr<TextFrame>& frame,
+                                  Point position,
+                                  const Matrix& transform,
+                                  const GlyphProperties& properties) {
   FML_DCHECK(alpha_data_.atlas == nullptr && color_data_.atlas == nullptr);
   AtlasData& data = GetData(frame->GetAtlasType());
   data.renderable_frames.emplace_back(

--- a/engine/src/flutter/impeller/typographer/lazy_glyph_atlas.h
+++ b/engine/src/flutter/impeller/typographer/lazy_glyph_atlas.h
@@ -23,7 +23,7 @@ class LazyGlyphAtlas {
   void AddTextFrame(const std::shared_ptr<TextFrame>& frame,
                     Point position,
                     const Matrix& transform,
-                    const std::optional<GlyphProperties>& properties);
+                    const GlyphProperties& properties);
 
   void ResetTextFrames();
 

--- a/engine/src/flutter/impeller/typographer/typographer_context.h
+++ b/engine/src/flutter/impeller/typographer/typographer_context.h
@@ -26,7 +26,7 @@ struct RenderableText {
 
   /// The properties needed for rendering stroked text and/or the color
   /// needed to cache a TextFrame where HasColor() == true.
-  const std::optional<GlyphProperties> properties;
+  const GlyphProperties properties;
 };
 
 //------------------------------------------------------------------------------

--- a/engine/src/flutter/impeller/typographer/typographer_unittests.cc
+++ b/engine/src/flutter/impeller/typographer/typographer_unittests.cc
@@ -40,6 +40,7 @@ static std::shared_ptr<GlyphAtlas> CreateGlyphAtlas(
   RenderableText render_frame{
       .text_frame = frame,
       .origin_transform = transform,
+      .properties = GlyphProperties{},
   };
   return typographer_context->CreateGlyphAtlas(context, type, data_host_buffer,
                                                atlas_context, {render_frame});
@@ -53,7 +54,7 @@ static std::shared_ptr<GlyphAtlas> CreateGlyphAtlas(
     const Matrix& transform,
     const std::shared_ptr<GlyphAtlasContext>& atlas_context,
     const std::vector<std::shared_ptr<TextFrame>>& frames,
-    const std::vector<std::optional<GlyphProperties>>& properties) {
+    const std::vector<GlyphProperties>& properties) {
   size_t offset = 0;
   std::vector<RenderableText> render_frames;
   render_frames.reserve(frames.size());
@@ -327,7 +328,7 @@ TEST_P(TypographerTest, GlyphColorIsPartOfCacheKey) {
       SkTextBlob::MakeFromString("😂", emoji_font));
   auto frame_2 = MakeTextFrameFromTextBlobSkia(
       SkTextBlob::MakeFromString("😂", emoji_font));
-  std::vector<std::optional<GlyphProperties>> properties = {
+  std::vector<GlyphProperties> properties = {
       GlyphProperties{.color = Color::Red()},
       GlyphProperties{.color = Color::Blue()},
   };
@@ -359,7 +360,7 @@ TEST_P(TypographerTest, GlyphColorIsIgnoredForNonEmojiFonts) {
       MakeTextFrameFromTextBlobSkia(SkTextBlob::MakeFromString("A", sk_font));
   auto frame_2 =
       MakeTextFrameFromTextBlobSkia(SkTextBlob::MakeFromString("A", sk_font));
-  std::vector<std::optional<GlyphProperties>> properties = {
+  std::vector<GlyphProperties> properties = {
       GlyphProperties{},
       GlyphProperties{},
   };
@@ -370,6 +371,42 @@ TEST_P(TypographerTest, GlyphColorIsIgnoredForNonEmojiFonts) {
                        {frame, frame_2}, properties);
 
   EXPECT_EQ(next_atlas->GetGlyphCount(), 1u);
+}
+
+TEST_P(TypographerTest, GlyphIsLightIsPartOfCacheKey) {
+  auto data_host_buffer = HostBuffer::Create(
+      GetContext()->GetResourceAllocator(), GetContext()->GetIdleWaiter(),
+      GetContext()->GetCapabilities()->GetMinimumUniformAlignment());
+  auto context = TypographerContextSkia::Make();
+  auto atlas_context =
+      context->CreateGlyphAtlasContext(GlyphAtlas::Type::kAlphaBitmap);
+
+  SkFont sk_font = flutter::testing::CreateTestFontOfSize(12);
+  auto blob1 = SkTextBlob::MakeFromString("A", sk_font);
+  auto blob2 = SkTextBlob::MakeFromString("A", sk_font);
+  auto frame1 = MakeTextFrameFromTextBlobSkia(blob1);
+  auto frame2 = MakeTextFrameFromTextBlobSkia(blob2);
+
+  std::vector<GlyphProperties> properties = {
+      GlyphProperties{},
+      GlyphProperties{},
+  };
+  // One light color, one dark color
+  properties[0].SetIsLight(Color::Beige());
+  properties[1].SetIsLight(Color::Crimson());
+
+  auto next_atlas =
+      CreateGlyphAtlas(*GetContext(), context.get(), *data_host_buffer,
+                       GlyphAtlas::Type::kAlphaBitmap, Matrix(), atlas_context,
+                       {frame1, frame2}, properties);
+
+#if defined(FML_OS_MACOSX)
+  // On Apple platforms, they should be separated into 2 entries
+  EXPECT_EQ(next_atlas->GetGlyphCount(), 2u);
+#else
+  // On other platforms, both are classified as "dark" (false) and share 1 entry
+  EXPECT_EQ(next_atlas->GetGlyphCount(), 1u);
+#endif
 }
 
 TEST_P(TypographerTest, RectanglePackerAddsNonoverlapingRectangles) {
@@ -558,8 +595,50 @@ TEST_P(TypographerTest, ColorBitmapAtlasSkiaBitmapIsRGBA8888) {
                        GlyphAtlas::Type::kColorBitmap, Matrix(), atlas_context,
                        MakeTextFrameFromTextBlobSkia(blob));
 
-  SkImageInfo image_info =
-      TypographerContextSkia::GetImageInfo(*atlas, Size{100, 100});
+  SkImageInfo image_info = TypographerContextSkia::GetImageInfo(
+      *atlas, Size{100, 100}, /*support_light_glyphs=*/false);
+  EXPECT_EQ(image_info.colorType(), kRGBA_8888_SkColorType);
+}
+
+TEST_P(TypographerTest, AlphaBitmapAtlasSkiaBitmapIsA8) {
+  auto context = TypographerContextSkia::Make();
+  auto atlas_context =
+      context->CreateGlyphAtlasContext(GlyphAtlas::Type::kAlphaBitmap);
+  auto data_host_buffer = HostBuffer::Create(
+      GetContext()->GetResourceAllocator(), GetContext()->GetIdleWaiter(),
+      GetContext()->GetCapabilities()->GetMinimumUniformAlignment());
+  ASSERT_TRUE(context && context->IsValid());
+  SkFont sk_font = flutter::testing::CreateTestFontOfSize(12);
+  auto blob = SkTextBlob::MakeFromString("A", sk_font);
+  ASSERT_TRUE(blob);
+  auto atlas =
+      CreateGlyphAtlas(*GetContext(), context.get(), *data_host_buffer,
+                       GlyphAtlas::Type::kAlphaBitmap, Matrix(), atlas_context,
+                       MakeTextFrameFromTextBlobSkia(blob));
+
+  SkImageInfo image_info = TypographerContextSkia::GetImageInfo(
+      *atlas, Size{100, 100}, /*support_light_glyphs=*/false);
+  EXPECT_EQ(image_info.colorType(), kAlpha_8_SkColorType);
+}
+
+TEST_P(TypographerTest, AlphaBitmapAtlasWithLightGlyphsSkiaBitmapIsRGBA8888) {
+  auto context = TypographerContextSkia::Make();
+  auto atlas_context =
+      context->CreateGlyphAtlasContext(GlyphAtlas::Type::kAlphaBitmap);
+  auto data_host_buffer = HostBuffer::Create(
+      GetContext()->GetResourceAllocator(), GetContext()->GetIdleWaiter(),
+      GetContext()->GetCapabilities()->GetMinimumUniformAlignment());
+  ASSERT_TRUE(context && context->IsValid());
+  SkFont sk_font = flutter::testing::CreateTestFontOfSize(12);
+  auto blob = SkTextBlob::MakeFromString("A", sk_font);
+  ASSERT_TRUE(blob);
+  auto atlas =
+      CreateGlyphAtlas(*GetContext(), context.get(), *data_host_buffer,
+                       GlyphAtlas::Type::kAlphaBitmap, Matrix(), atlas_context,
+                       MakeTextFrameFromTextBlobSkia(blob));
+
+  SkImageInfo image_info = TypographerContextSkia::GetImageInfo(
+      *atlas, Size{100, 100}, /*support_light_glyphs=*/true);
   EXPECT_EQ(image_info.colorType(), kRGBA_8888_SkColorType);
 }
 

--- a/engine/src/flutter/impeller/typographer/typographer_unittests.cc
+++ b/engine/src/flutter/impeller/typographer/typographer_unittests.cc
@@ -329,8 +329,8 @@ TEST_P(TypographerTest, GlyphColorIsPartOfCacheKey) {
   auto frame_2 = MakeTextFrameFromTextBlobSkia(
       SkTextBlob::MakeFromString("😂", emoji_font));
   std::vector<GlyphProperties> properties = {
-      GlyphProperties{.color = Color::Red()},
-      GlyphProperties{.color = Color::Blue()},
+      GlyphProperties{.tone_or_color = Color::Red()},
+      GlyphProperties{.tone_or_color = Color::Blue()},
   };
 
   auto next_atlas =
@@ -392,8 +392,8 @@ TEST_P(TypographerTest, GlyphIsLightIsPartOfCacheKey) {
       GlyphProperties{},
   };
   // One light color, one dark color
-  properties[0].SetIsLight(Color::Beige());
-  properties[1].SetIsLight(Color::Crimson());
+  properties[0].tone_or_color = GlyphProperties::ComputeTone(Color::Beige());
+  properties[1].tone_or_color = GlyphProperties::ComputeTone(Color::Crimson());
 
   auto next_atlas =
       CreateGlyphAtlas(*GetContext(), context.get(), *data_host_buffer,


### PR DESCRIPTION
This PR addresses #185790 where text rendered using the Impeller backend on macOS exhibits inconsistent stroke weights, particularly with light text on dark backgrounds.

## Cause

Apple's CoreText applies different font smoothing and antialiasing depending on whether text is light or dark. Visually, dark text on a light background looks heavier than light text on a dark background. CoreText tries to account for this and make light/dark text at the same size have a similar visual weight by automatically dilating light text and eroding dark text.

Prior to this PR, our (non-color) glyph atlases are based on drawing a black glyph using Skia, which uses CoreText as its underlying text renderer on macOS. So our glyphs all are eroded by CoreText, based on the incorrect assumption that they are always displayed as dark text. As a result, our light glyphs end up wispy and inconsistently stroked. Light text already appears optically lighter weight, and then CoreText erodes them even further based on incorrectly rendering them with dark-text weighting.

## Fix

- On macOS, update `GlyphProperties` to calculate whether a glyph is "light" based on the luminance of its color. This is stored in a new `is_light` property. This ensures that the same character rendered with a light color and a dark color will result in two separate entries in the glyph atlas.
- Render light glyphs as white during atlas generation to trigger the correct CoreText smoothing for light glyphs.
  - Dark glyphs retain the existing behavior and are rendered by having Skia render a black glyph on an A8 bitmap.
  - Light glyphs must be rendered as white on a full-color bitmap. This is because when Skia renders to an A8 bitmap (like for the dark glyph case), it is hard coded to render the glyph as black on white (from [here](https://skia.googlesource.com/skia.git/+/100292563cb53a2489841b389ec3aff111efaf87/src/ports/SkScalerContext_mac_ct.cpp#242)). So for light glyphs, render them into an RGBA bitmap and then convert it to an A8 bitmap to be copied into the glyph atlas.

Additionally, this PR refactors the usage of `std::optional<GlyphProperties>` to just be `GlyphProperties`. A nullopt value was treated exactly the same as a default `GlyphProperties`: color is black and stroke is null. So the optionality didn't add anything. It required a lot of unnecessary and confusing branching that made the code harder to follow, especially with this added `is_light` property.

Fixes #185790

This PR makes this change only for macOS. We can also consider whether to do this on iOS. iOS also uses Apple's CoreText, so the same erosion issues with dark text apply on iOS. However, all modern iOS devices are hi-dpi displays which use UI scaling. This mitigates most of the visual inconsistencies that we see on macOS when running apps on a non-UI-upscaled display. We would have to weigh whether the negative performance impact of this change is worth it for iOS. Whether or not to expand this to iOS is out of scope for this PR.

## Newly added `AiksTest.CanRenderTextFrameWithThinLightAndDarkColors` golden test

This shows the golden screenshot before this change (top half) and after this change (bottom half). Light text is now heavier weight and more consistently stroked. Dark text is unchanged.
<img height="400" alt="image" src="https://github.com/user-attachments/assets/d013603b-11b5-4154-bfda-71431b2ed855" />

## Flutter "New Gallery" app screenshots

All of these screenshots compare:
 - Top row: Dark mode
 - Bottom row: Light mode
 - Left: Before this PR, rendering with Impeller
 - Middle: After this PR, rendering with Impeller
 - Right: Rendering with Skia. It is a not a goal to replicate Skia's rendering exactly. But Skia's rendering is provided here for comparison.

### Home screen
- In both dark and light mode, light text in the "Reply" card is now thicker.
- In dark mode, light text like in the "Shrine" card and in the category titles (Material, Cupertino, Styles & Other) are thicker. In light mode, this text is dark and is unaffected.
<img height="200" alt="image" src="https://github.com/user-attachments/assets/08b59953-116e-4ae9-b96a-08241761b6e0" />

### "About Flutter Gallery" modal
- In dark mode, the text is now thicker and more consistently stroked.
- Light mode is unaffected.
<img height="200" alt="image" src="https://github.com/user-attachments/assets/a3d15bab-8374-4ee8-8923-40cb03985ee9" />

### Settings screen, normal text scaling
- In dark mode, the text is now thicker and more consistently stroked.
- Light mode is unaffected.
<img height="200" alt="image" src="https://github.com/user-attachments/assets/41fae470-ce6e-478c-8b2d-eaddd02c3bed" />

### Settings screen, small text scaling
- In dark mode, wispy-ness of small text is even more apparent in the old version.
- Light mode is unaffected.
<img height="200" alt="image" src="https://github.com/user-attachments/assets/e648388c-4b46-437b-8532-bfe606c8ab71" />

### Settings screen, large text scaling
- In dark mode, large text is very readable even in the old version. In the new version it is noticeably thicker, but whether it looks better is more subjective than in the examples with smaller and thinner text.
- Light mode is unaffected.
<img height="200" alt="image" src="https://github.com/user-attachments/assets/b209a725-75f5-4a80-8ae8-5c98432f1850" />



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
