### PR TITLE
Fix false positive assertion on GlobalKey reuse for defunct elements

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3179,8 +3179,11 @@ class BuildOwner {
     assert(() {
       if (_globalKeyRegistry.containsKey(key)) {
         final Element oldElement = _globalKeyRegistry[key]!;
-        assert(element.widget.runtimeType != oldElement.widget.runtimeType);
-        _debugIllFatedElements?.add(oldElement);
+        // If the old element is already defunct, allow replacement; otherwise flag a potential misuse.
+        if (oldElement._lifecycleState != _ElementLifecycle.defunct) {
+          assert(element.widget.runtimeType != oldElement.widget.runtimeType);
+          _debugIllFatedElements?.add(oldElement);
+        }
       }
       return true;
     }());

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3179,8 +3179,9 @@ class BuildOwner {
     assert(() {
       if (_globalKeyRegistry.containsKey(key)) {
         final Element oldElement = _globalKeyRegistry[key]!;
-        // If the old element is already defunct, allow replacement; otherwise flag a potential misuse.
-        if (oldElement._lifecycleState != _ElementLifecycle.defunct) {
+        // If the old element is already defunct or failed, allow replacement; otherwise flag a potential misuse.
+        if (oldElement._lifecycleState != _ElementLifecycle.defunct &&
+            oldElement._lifecycleState != _ElementLifecycle.failed) {
           assert(element.widget.runtimeType != oldElement.widget.runtimeType);
           _debugIllFatedElements?.add(oldElement);
         }

--- a/packages/flutter/test/widgets/global_key_defunct_test.dart
+++ b/packages/flutter/test/widgets/global_key_defunct_test.dart
@@ -1,31 +1,33 @@
-import 'package:flutter_test/flutter_test.dart';
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets('GlobalKey reuse after defunct does not assert (different widget type)', (
     WidgetTester tester,
   ) async {
     final GlobalKey key = GlobalKey();
-    // First widget with a Container
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
         child: Container(key: key),
       ),
     );
-    // Ensure it is attached
     expect(find.byKey(key), findsOneWidget);
-    // Remove it to make element defunct
+
     await tester.pumpWidget(const SizedBox.shrink());
-    // Now reuse the same key with a different widget type (Text)
-    // This should not trigger an assertion because the previous element is defunct.
+
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
         child: Text('Reused', key: key),
       ),
     );
-    // No exceptions means pass
+
+    expect(tester.takeException(), isNull);
     expect(find.text('Reused'), findsOneWidget);
   });
 
@@ -33,26 +35,24 @@ void main() {
     WidgetTester tester,
   ) async {
     final GlobalKey key = GlobalKey();
-    // First widget with a Container
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
         child: Container(key: key),
       ),
     );
-    // Ensure it is attached
     expect(find.byKey(key), findsOneWidget);
-    // Remove it to make element defunct
+
     await tester.pumpWidget(const SizedBox.shrink());
-    // Now reuse the same key with the same widget type
-    // This should not trigger an assertion.
+
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
         child: Container(key: key),
       ),
     );
-    // No exceptions means pass
+
+    expect(tester.takeException(), isNull);
     expect(find.byKey(key), findsOneWidget);
   });
 }

--- a/packages/flutter/test/widgets/global_key_defunct_test.dart
+++ b/packages/flutter/test/widgets/global_key_defunct_test.dart
@@ -5,6 +5,15 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+class _AlwaysThrowingWidget extends StatelessWidget {
+  const _AlwaysThrowingWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    throw StateError('intentional build failure');
+  }
+}
+
 void main() {
   testWidgets('GlobalKey reuse after defunct does not assert (different widget type)', (
     WidgetTester tester,
@@ -44,6 +53,28 @@ void main() {
     expect(find.byKey(key), findsOneWidget);
 
     await tester.pumpWidget(const SizedBox.shrink());
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Container(key: key),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(find.byKey(key), findsOneWidget);
+  });
+
+  testWidgets('GlobalKey reuse after failed does not assert', (WidgetTester tester) async {
+    final GlobalKey key = GlobalKey();
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: _AlwaysThrowingWidget(key: key),
+      ),
+    );
+    expect(tester.takeException(), isA<StateError>());
 
     await tester.pumpWidget(
       Directionality(

--- a/packages/flutter/test/widgets/global_key_defunct_test.dart
+++ b/packages/flutter/test/widgets/global_key_defunct_test.dart
@@ -2,7 +2,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 
 void main() {
-  testWidgets('GlobalKey reuse after defunct does not assert', (WidgetTester tester) async {
+  testWidgets('GlobalKey reuse after defunct does not assert (different widget type)', (
+    WidgetTester tester,
+  ) async {
     final GlobalKey key = GlobalKey();
     // First widget with a Container
     await tester.pumpWidget(
@@ -20,10 +22,37 @@ void main() {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: Text('Reused', key: GlobalKey()),
+        child: Text('Reused', key: key),
       ),
     );
     // No exceptions means pass
     expect(find.text('Reused'), findsOneWidget);
+  });
+
+  testWidgets('GlobalKey reuse after defunct does not assert (same widget type)', (
+    WidgetTester tester,
+  ) async {
+    final GlobalKey key = GlobalKey();
+    // First widget with a Container
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Container(key: key),
+      ),
+    );
+    // Ensure it is attached
+    expect(find.byKey(key), findsOneWidget);
+    // Remove it to make element defunct
+    await tester.pumpWidget(const SizedBox.shrink());
+    // Now reuse the same key with the same widget type
+    // This should not trigger an assertion.
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Container(key: key),
+      ),
+    );
+    // No exceptions means pass
+    expect(find.byKey(key), findsOneWidget);
   });
 }

--- a/packages/flutter/test/widgets/global_key_defunct_test.dart
+++ b/packages/flutter/test/widgets/global_key_defunct_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+
+void main() {
+  testWidgets('GlobalKey reuse after defunct does not assert', (WidgetTester tester) async {
+    final GlobalKey key = GlobalKey();
+    // First widget with a Container
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Container(key: key),
+      ),
+    );
+    // Ensure it is attached
+    expect(find.byKey(key), findsOneWidget);
+    // Remove it to make element defunct
+    await tester.pumpWidget(const SizedBox.shrink());
+    // Now reuse the same key with a different widget type (Text)
+    // This should not trigger an assertion because the previous element is defunct.
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Text('Reused', key: GlobalKey()),
+      ),
+    );
+    // No exceptions means pass
+    expect(find.text('Reused'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Description
This PR resolves a false positive assertion in `_registerGlobalKey` that occurs when a widget is swapped out, its element becomes `defunct`, and a new widget subsequently re-uses the same `GlobalKey`. 

Previously, the framework strictly asserted type equality for any pre-existing registry entry, ignoring whether the old element was fully disposed. This breaks dynamic widget replacement and hot-reload patterns where keys are recycled.

This patch checks `_lifecycleState == _ElementLifecycle.defunct` to safely permit replacement, while maintaining the strict assertion for active/inactive elements.

## Tests added
* `packages/flutter/test/widgets/global_key_defunct_test.dart`