### PR TITLE
Pre provision the ndk from within the FGP

### DIFF
--- a/dev/devicelab/bin/tasks/gradle_plugin_fat_apk_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_plugin_fat_apk_test.dart
@@ -151,17 +151,17 @@ Future<void> main() async {
           }
         }
 
-        section('AGP cxx build artifacts');
+        section('AGP cxx build artifacts (no dummy CMake project)');
 
         final String defaultPath = path.join(project.rootPath, 'android', 'app', '.cxx');
-
         final String modifiedPath = path.join(project.rootPath, 'build', '.cxx');
+
         if (Directory(defaultPath).existsSync()) {
           throw TaskResult.failure('Producing unexpected build artifacts in $defaultPath');
         }
-        if (!Directory(modifiedPath).existsSync()) {
+        if (Directory(modifiedPath).existsSync()) {
           throw TaskResult.failure(
-            'Not producing external native build output directory in $modifiedPath',
+            'Producing external native build output directory in $modifiedPath when it should have returned early.',
           );
         }
       });

--- a/packages/flutter_tools/gradle/src/main/kotlin/FlutterPluginUtils.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/FlutterPluginUtils.kt
@@ -800,8 +800,13 @@ object FlutterPluginUtils {
                 if (requiredNdkVersion != null && !installedNdkVersions.contains(requiredNdkVersion)) {
                     gradleProject.logger.lifecycle("Ensuring Android NDK '$requiredNdkVersion' is installed...")
                     try {
-                        gradleProject.exec {
-                            commandLine(sdkManagerPath, "--install", "ndk;$requiredNdkVersion")
+                        val process = ProcessBuilder(sdkManagerPath, "--install", "ndk;$requiredNdkVersion")
+                            .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+                            .redirectError(ProcessBuilder.Redirect.INHERIT)
+                            .start()
+                        val exitCode = process.waitFor()
+                        if (exitCode != 0) {
+                            gradleProject.logger.error("Failed to install NDK $requiredNdkVersion using sdkmanager: exit code $exitCode")
                         }
                     } catch (e: Exception) {
                         gradleProject.logger.error("Failed to install NDK $requiredNdkVersion using sdkmanager", e)

--- a/packages/flutter_tools/gradle/src/main/kotlin/FlutterPluginUtils.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/FlutterPluginUtils.kt
@@ -787,6 +787,30 @@ object FlutterPluginUtils {
         gradleProject: Project,
         flutterSdkRootPath: String
     ) {
+        val sdkManagerPath = gradleProject.findProperty("flutter.sdkManagerPath")?.toString()
+        val installedNdkVersionsStr = gradleProject.findProperty("flutter.installedNdkVersions")?.toString()
+
+        if (sdkManagerPath != null && installedNdkVersionsStr != null) {
+            // We use afterEvaluate because if called immediately we are too early in the lifecycle
+            // for AGP to have parsed the actual NDK version from the gradle files.
+            gradleProject.afterEvaluate {
+                val installedNdkVersions = installedNdkVersionsStr.split(",")
+                val requiredNdkVersion = getLegacyAndroidExtension(gradleProject).ndkVersion ?: FlutterExtension().ndkVersion
+
+                if (requiredNdkVersion != null && !installedNdkVersions.contains(requiredNdkVersion)) {
+                    gradleProject.logger.lifecycle("Ensuring Android NDK '$requiredNdkVersion' is installed...")
+                    try {
+                        gradleProject.exec {
+                            commandLine(sdkManagerPath, "--install", "ndk;$requiredNdkVersion")
+                        }
+                    } catch (e: Exception) {
+                        gradleProject.logger.error("Failed to install NDK $requiredNdkVersion using sdkmanager", e)
+                    }
+                }
+            }
+            return
+        }
+
         // If the project is already configuring a native build, we don't need to do anything.
         val gradleProjectAndroidExtension = getLegacyAndroidExtension(gradleProject)
         val forcingNotRequired: Boolean =

--- a/packages/flutter_tools/gradle/src/test/kotlin/FlutterPluginUtilsTest.kt
+++ b/packages/flutter_tools/gradle/src/test/kotlin/FlutterPluginUtilsTest.kt
@@ -1622,6 +1622,7 @@ class FlutterPluginUtilsTest {
                 .externalNativeBuild.cmake
         } returns mockCmakeOptions
         every { project.extensions.findByType(BaseExtension::class.java)!!.defaultConfig } returns mockDefaultConfig
+        every { project.findProperty(any()) } returns null
 
         every { mockCmakeOptions.path } returns fakeCmakeFile
 
@@ -1647,6 +1648,7 @@ class FlutterPluginUtilsTest {
                 .externalNativeBuild.cmake
         } returns mockCmakeOptions
         every { project.extensions.findByType(BaseExtension::class.java)!!.defaultConfig } returns mockDefaultConfig
+        every { project.findProperty(any()) } returns null
 
         val basePath = "/base/path"
         val fakeBuildPath = "/randomapp/build/app/"

--- a/packages/flutter_tools/gradle/src/test/kotlin/FlutterPluginUtilsTest.kt
+++ b/packages/flutter_tools/gradle/src/test/kotlin/FlutterPluginUtilsTest.kt
@@ -1636,6 +1636,62 @@ class FlutterPluginUtilsTest {
     }
 
     @Test
+    fun `forceNdkDownload installs required NDK version when missing`() {
+        val project = mockk<Project>()
+        val mockBaseExtension = mockk<BaseExtension>()
+        val mockExecSpec = mockk<org.gradle.process.ExecSpec>()
+        val projectActionSlot = slot<Action<Project>>()
+        val mockLogger = mockk<Logger>(relaxed = true)
+
+        every { project.findProperty("flutter.sdkManagerPath") } returns "/path/to/sdkmanager"
+        every { project.findProperty("flutter.installedNdkVersions") } returns "25.0.0,26.0.0"
+        every { project.afterEvaluate(capture(projectActionSlot)) } returns Unit
+        every { project.extensions.findByType(BaseExtension::class.java) } returns mockBaseExtension
+        every { mockBaseExtension.ndkVersion } returns "27.0.0"
+        every { project.logger } returns mockLogger
+        every { project.exec(any<Action<org.gradle.process.ExecSpec>>()) } answers {
+            val action = it.invocation.args[0] as Action<org.gradle.process.ExecSpec>
+            action.execute(mockExecSpec)
+            mockk<org.gradle.process.ExecResult>()
+        }
+        every { mockExecSpec.commandLine(any<String>(), any<String>(), any<String>()) } returns mockExecSpec
+
+        FlutterPluginUtils.forceNdkDownload(project, "ignored")
+
+        verify { project.afterEvaluate(capture(projectActionSlot)) }
+        projectActionSlot.captured.execute(project)
+
+        verify(exactly = 1) {
+            mockLogger.lifecycle("Ensuring Android NDK '27.0.0' is installed...")
+        }
+        verify(exactly = 1) {
+            mockExecSpec.commandLine("/path/to/sdkmanager", "--install", "ndk;27.0.0")
+        }
+    }
+
+    @Test
+    fun `forceNdkDownload skips NDK installation when required version is already installed`() {
+        val project = mockk<Project>()
+        val mockBaseExtension = mockk<BaseExtension>()
+        val projectActionSlot = slot<Action<Project>>()
+
+        every { project.findProperty("flutter.sdkManagerPath") } returns "/path/to/sdkmanager"
+        every { project.findProperty("flutter.installedNdkVersions") } returns "25.0.0,27.0.0"
+        every { project.afterEvaluate(capture(projectActionSlot)) } returns Unit
+        every { project.extensions.findByType(BaseExtension::class.java) } returns mockBaseExtension
+        every { mockBaseExtension.ndkVersion } returns "27.0.0"
+
+        FlutterPluginUtils.forceNdkDownload(project, "ignored")
+
+        verify { project.afterEvaluate(capture(projectActionSlot)) }
+        projectActionSlot.captured.execute(project)
+
+        verify(exactly = 0) {
+            project.exec(any<Action<org.gradle.process.ExecSpec>>())
+        }
+    }
+
+    @Test
     fun `forceNdkDownload sets externalNativeBuild properties`() {
         val project = mockk<Project>()
         val mockCmakeOptions = mockk<CmakeOptions>()

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -30,6 +30,7 @@ import '../flutter_manifest.dart';
 import '../globals.dart' as globals;
 import '../project.dart';
 import 'android_builder.dart';
+import 'android_sdk.dart';
 import 'android_studio.dart';
 import 'gradle_errors.dart';
 import 'gradle_utils.dart';
@@ -568,6 +569,25 @@ class AndroidGradleBuilder implements AndroidBuilder {
     if (androidBuildInfo.splitPerAbi) {
       options.add('-Psplit-per-abi=true');
     }
+
+    final AndroidSdk? androidSdk = globals.androidSdk;
+    if (androidSdk != null && androidSdk.directory.existsSync()) {
+      final String? sdkManagerPath = androidSdk.sdkManagerPath;
+      if (sdkManagerPath != null &&
+          androidSdk.cmdlineToolsAvailable &&
+          androidSdk.licensesAvailable) {
+        options.add('-Pflutter.sdkManagerPath=$sdkManagerPath');
+        final Directory ndkDir = androidSdk.directory.childDirectory('ndk');
+        final ndkDirs = <String>[];
+        if (ndkDir.existsSync()) {
+          ndkDirs.addAll(
+            ndkDir.listSync().whereType<Directory>().map((Directory dir) => dir.basename),
+          );
+        }
+        options.add('-Pflutter.installedNdkVersions=${ndkDirs.join(',')}');
+      }
+    }
+
     late Stopwatch sw;
     final int exitCode = await _runGradleTask(
       assembleTask,

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -166,6 +166,7 @@ class AndroidGradleBuilder implements AndroidBuilder {
     required GradleUtils gradleUtils,
     required Platform platform,
     required AndroidStudio? androidStudio,
+    required AndroidSdk? androidSdk,
   }) : _java = java,
        _logger = logger,
        _fileSystem = fileSystem,
@@ -173,10 +174,12 @@ class AndroidGradleBuilder implements AndroidBuilder {
        _analytics = analytics,
        _gradleUtils = gradleUtils,
        _androidStudio = androidStudio,
+       _androidSdk = androidSdk,
        _fileSystemUtils = FileSystemUtils(fileSystem: fileSystem, platform: platform),
        _processUtils = ProcessUtils(logger: logger, processManager: processManager);
 
   final Java? _java;
+  final AndroidSdk? _androidSdk;
   final Logger _logger;
   final ProcessUtils _processUtils;
   final FileSystem _fileSystem;
@@ -570,7 +573,7 @@ class AndroidGradleBuilder implements AndroidBuilder {
       options.add('-Psplit-per-abi=true');
     }
 
-    final AndroidSdk? androidSdk = globals.androidSdk;
+    final AndroidSdk? androidSdk = _androidSdk;
     if (androidSdk != null && androidSdk.directory.existsSync()) {
       final String? sdkManagerPath = androidSdk.sdkManagerPath;
       if (sdkManagerPath != null &&
@@ -693,19 +696,19 @@ class AndroidGradleBuilder implements AndroidBuilder {
     String aabPath,
     Iterable<AndroidArch> targetArchs,
   ) async {
-    if (globals.androidSdk == null) {
+    if (_androidSdk == null) {
       _logger.printTrace(
         'Failed to find android sdk when checking final appbundle for debug symbols.',
       );
       return false;
     }
-    if (!globals.androidSdk!.cmdlineToolsAvailable) {
+    if (!_androidSdk.cmdlineToolsAvailable) {
       _logger.printTrace(
         'Failed to find cmdline-tools when checking final appbundle for debug symbols.',
       );
       return false;
     }
-    final String? apkAnalyzerPath = globals.androidSdk!.getCmdlineToolsPath(apkAnalyzerBinaryName);
+    final String? apkAnalyzerPath = _androidSdk.getCmdlineToolsPath(apkAnalyzerBinaryName);
     if (apkAnalyzerPath == null) {
       _logger.printTrace(
         'Failed to find apkanalyzer when checking final appbundle for debug symbols.',

--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -102,6 +102,7 @@ Future<T> runInContext<T>(FutureOr<T> Function() runner, {Map<Type, Generator>? 
         gradleUtils: globals.gradleUtils!,
         platform: globals.platform,
         androidStudio: globals.androidStudio,
+        androidSdk: globals.androidSdk,
       ),
       AndroidLicenseValidator: () => AndroidLicenseValidator(
         platform: globals.platform,

--- a/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
@@ -59,112 +59,107 @@ void main() {
       );
     });
 
-    testUsingContext(
-      'Can immediately tool exit on recognized exit code/stderr',
-      () async {
-        final builder = AndroidGradleBuilder(
-          java: FakeJava(),
-          logger: logger,
-          processManager: processManager,
-          fileSystem: fileSystem,
-          artifacts: Artifacts.test(),
-          analytics: fakeAnalytics,
-          gradleUtils: FakeGradleUtils(),
-          platform: FakePlatform(),
-          androidStudio: FakeAndroidStudio(),
-        );
-        processManager.addCommand(
-          const FakeCommand(
-            command: <String>[
-              'gradlew',
-              '-q',
-              '-Ptarget-platform=android-arm,android-arm64,android-x64',
-              '-Ptarget=lib/main.dart',
-              '-Pbase-application-name=android.app.Application',
-              '-Pdart-obfuscation=false',
-              '-Ptrack-widget-creation=false',
-              '-Ptree-shake-icons=false',
-              'assembleRelease',
-            ],
-            exitCode: 1,
-            stderr: '\nSome gradle message\n',
+    testUsingContext('Can immediately tool exit on recognized exit code/stderr', () async {
+      final builder = AndroidGradleBuilder(
+        java: FakeJava(),
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(),
+        analytics: fakeAnalytics,
+        gradleUtils: FakeGradleUtils(),
+        platform: FakePlatform(),
+        androidStudio: FakeAndroidStudio(),
+        androidSdk: FakeAndroidSdk(),
+      );
+      processManager.addCommand(
+        const FakeCommand(
+          command: <String>[
+            'gradlew',
+            '-q',
+            '-Ptarget-platform=android-arm,android-arm64,android-x64',
+            '-Ptarget=lib/main.dart',
+            '-Pbase-application-name=android.app.Application',
+            '-Pdart-obfuscation=false',
+            '-Ptrack-widget-creation=false',
+            '-Ptree-shake-icons=false',
+            'assembleRelease',
+          ],
+          exitCode: 1,
+          stderr: '\nSome gradle message\n',
+        ),
+      );
+
+      fileSystem.directory('android').childFile('build.gradle').createSync(recursive: true);
+
+      fileSystem.directory('android').childFile('gradle.properties').createSync(recursive: true);
+
+      fileSystem.directory('android').childDirectory('app').childFile('build.gradle')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('apply from: irrelevant/flutter.gradle');
+
+      final FlutterProject project = FlutterProject.fromDirectoryTest(fileSystem.currentDirectory);
+      project.android.appManifestFile
+        ..createSync(recursive: true)
+        ..writeAsStringSync(minimalV2EmbeddingManifest);
+
+      var handlerCalled = false;
+      await expectLater(() async {
+        await builder.buildGradleApp(
+          project: project,
+          androidBuildInfo: const AndroidBuildInfo(
+            BuildInfo(
+              BuildMode.release,
+              null,
+              treeShakeIcons: false,
+              packageConfigPath: '.dart_tool/package_config.json',
+            ),
           ),
-        );
-
-        fileSystem.directory('android').childFile('build.gradle').createSync(recursive: true);
-
-        fileSystem.directory('android').childFile('gradle.properties').createSync(recursive: true);
-
-        fileSystem.directory('android').childDirectory('app').childFile('build.gradle')
-          ..createSync(recursive: true)
-          ..writeAsStringSync('apply from: irrelevant/flutter.gradle');
-
-        final FlutterProject project = FlutterProject.fromDirectoryTest(
-          fileSystem.currentDirectory,
-        );
-        project.android.appManifestFile
-          ..createSync(recursive: true)
-          ..writeAsStringSync(minimalV2EmbeddingManifest);
-
-        var handlerCalled = false;
-        await expectLater(() async {
-          await builder.buildGradleApp(
-            project: project,
-            androidBuildInfo: const AndroidBuildInfo(
-              BuildInfo(
-                BuildMode.release,
-                null,
-                treeShakeIcons: false,
-                packageConfigPath: '.dart_tool/package_config.json',
-              ),
+          target: 'lib/main.dart',
+          isBuildingBundle: false,
+          configOnly: false,
+          localGradleErrors: <GradleHandledError>[
+            GradleHandledError(
+              test: (String line) {
+                return line.contains('Some gradle message');
+              },
+              handler: ({String? line, FlutterProject? project, bool? usesAndroidX}) async {
+                handlerCalled = true;
+                return GradleBuildStatus.exit;
+              },
+              eventLabel: 'random-event-label',
             ),
-            target: 'lib/main.dart',
-            isBuildingBundle: false,
-            configOnly: false,
-            localGradleErrors: <GradleHandledError>[
-              GradleHandledError(
-                test: (String line) {
-                  return line.contains('Some gradle message');
-                },
-                handler: ({String? line, FlutterProject? project, bool? usesAndroidX}) async {
-                  handlerCalled = true;
-                  return GradleBuildStatus.exit;
-                },
-                eventLabel: 'random-event-label',
-              ),
-            ],
-          );
-        }, throwsToolExit(message: 'Gradle task assembleRelease failed with exit code 1'));
-
-        expect(handlerCalled, isTrue);
-
-        expect(
-          fakeAnalytics.sentEvents,
-          containsAll(<Event>[
-            Event.flutterBuildInfo(
-              label: 'app-not-using-android-x',
-              buildType: 'gradle',
-              settings: 'androidGradlePluginVersion: null',
-            ),
-            Event.flutterBuildInfo(
-              label: 'gradle-random-event-label-failure',
-              buildType: 'gradle',
-              settings: 'androidGradlePluginVersion: null',
-            ),
-          ]),
+          ],
         );
+      }, throwsToolExit(message: 'Gradle task assembleRelease failed with exit code 1'));
 
-        expect(
-          analyticsTimingEventExists(
-            sentEvents: fakeAnalytics.sentEvents,
-            workflow: 'build',
-            variableName: 'gradle',
+      expect(handlerCalled, isTrue);
+
+      expect(
+        fakeAnalytics.sentEvents,
+        containsAll(<Event>[
+          Event.flutterBuildInfo(
+            label: 'app-not-using-android-x',
+            buildType: 'gradle',
+            settings: 'androidGradlePluginVersion: null',
           ),
-          true,
-        );
-      },
-      overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()},
-    );
+          Event.flutterBuildInfo(
+            label: 'gradle-random-event-label-failure',
+            buildType: 'gradle',
+            settings: 'androidGradlePluginVersion: null',
+          ),
+        ]),
+      );
+
+      expect(
+        analyticsTimingEventExists(
+          sentEvents: fakeAnalytics.sentEvents,
+          workflow: 'build',
+          variableName: 'gradle',
+        ),
+        true,
+      );
+    }, overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()});
 
     testUsingContext(
       'Verbose mode for APKs includes Gradle stacktrace and sets debug log level',
@@ -179,6 +174,7 @@ void main() {
           gradleUtils: FakeGradleUtils(),
           platform: FakePlatform(),
           androidStudio: FakeAndroidStudio(),
+          androidSdk: FakeAndroidSdk(),
         );
         processManager.addCommand(
           const FakeCommand(
@@ -241,22 +237,122 @@ void main() {
       overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()},
     );
 
-    testUsingContext(
-      'Can retry build on recognized exit code/stderr',
-      () async {
-        final builder = AndroidGradleBuilder(
-          java: FakeJava(),
-          logger: logger,
-          processManager: processManager,
-          fileSystem: fileSystem,
-          artifacts: Artifacts.test(),
-          analytics: fakeAnalytics,
-          gradleUtils: FakeGradleUtils(),
-          platform: FakePlatform(),
-          androidStudio: FakeAndroidStudio(),
-        );
+    testUsingContext('Can retry build on recognized exit code/stderr', () async {
+      final builder = AndroidGradleBuilder(
+        java: FakeJava(),
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(),
+        analytics: fakeAnalytics,
+        gradleUtils: FakeGradleUtils(),
+        platform: FakePlatform(),
+        androidStudio: FakeAndroidStudio(),
+        androidSdk: FakeAndroidSdk(),
+      );
 
-        const fakeCmd = FakeCommand(
+      const fakeCmd = FakeCommand(
+        command: <String>[
+          'gradlew',
+          '-q',
+          '-Ptarget-platform=android-arm,android-arm64,android-x64',
+          '-Ptarget=lib/main.dart',
+          '-Pbase-application-name=android.app.Application',
+          '-Pdart-obfuscation=false',
+          '-Ptrack-widget-creation=false',
+          '-Ptree-shake-icons=false',
+          'assembleRelease',
+        ],
+        exitCode: 1,
+        stderr: '\nSome gradle message\n',
+      );
+
+      processManager.addCommand(fakeCmd);
+
+      const maxRetries = 2;
+      for (var i = 0; i < maxRetries; i++) {
+        processManager.addCommand(fakeCmd);
+      }
+
+      fileSystem.directory('android').childFile('build.gradle').createSync(recursive: true);
+
+      fileSystem.directory('android').childFile('gradle.properties').createSync(recursive: true);
+
+      fileSystem.directory('android').childDirectory('app').childFile('build.gradle')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('apply from: irrelevant/flutter.gradle');
+
+      final FlutterProject project = FlutterProject.fromDirectoryTest(fileSystem.currentDirectory);
+      project.android.appManifestFile
+        ..createSync(recursive: true)
+        ..writeAsStringSync(minimalV2EmbeddingManifest);
+
+      var testFnCalled = 0;
+      await expectLater(() async {
+        await builder.buildGradleApp(
+          maxRetries: maxRetries,
+          project: project,
+          androidBuildInfo: const AndroidBuildInfo(
+            BuildInfo(
+              BuildMode.release,
+              null,
+              treeShakeIcons: false,
+              packageConfigPath: '.dart_tool/package_config.json',
+            ),
+          ),
+          target: 'lib/main.dart',
+          isBuildingBundle: false,
+          configOnly: false,
+          localGradleErrors: <GradleHandledError>[
+            GradleHandledError(
+              test: (String line) {
+                if (line.contains('Some gradle message')) {
+                  testFnCalled++;
+                  return true;
+                }
+                return false;
+              },
+              handler: ({String? line, FlutterProject? project, bool? usesAndroidX}) async {
+                return GradleBuildStatus.retry;
+              },
+              eventLabel: 'random-event-label',
+            ),
+          ],
+        );
+      }, throwsToolExit(message: 'Gradle task assembleRelease failed with exit code 1'));
+
+      expect(logger.statusText, contains('Retrying Gradle Build: #1, wait time: 100ms'));
+      expect(logger.statusText, contains('Retrying Gradle Build: #2, wait time: 200ms'));
+
+      expect(testFnCalled, equals(maxRetries + 1));
+      expect(fakeAnalytics.sentEvents, hasLength(9));
+      expect(
+        fakeAnalytics.sentEvents,
+        contains(
+          Event.flutterBuildInfo(
+            label: 'gradle-random-event-label-failure',
+            buildType: 'gradle',
+            settings: 'androidGradlePluginVersion: null',
+          ),
+        ),
+      );
+    }, overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()});
+
+    testUsingContext('Converts recognized ProcessExceptions into tools exits', () async {
+      final builder = AndroidGradleBuilder(
+        java: FakeJava(),
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(),
+        analytics: fakeAnalytics,
+        gradleUtils: FakeGradleUtils(),
+        platform: FakePlatform(),
+        androidStudio: FakeAndroidStudio(),
+        androidSdk: FakeAndroidSdk(),
+      );
+      processManager.addCommand(
+        const FakeCommand(
           command: <String>[
             'gradlew',
             '-q',
@@ -270,318 +366,24 @@ void main() {
           ],
           exitCode: 1,
           stderr: '\nSome gradle message\n',
-        );
+        ),
+      );
 
-        processManager.addCommand(fakeCmd);
+      fileSystem.directory('android').childFile('build.gradle').createSync(recursive: true);
 
-        const maxRetries = 2;
-        for (var i = 0; i < maxRetries; i++) {
-          processManager.addCommand(fakeCmd);
-        }
+      fileSystem.directory('android').childFile('gradle.properties').createSync(recursive: true);
 
-        fileSystem.directory('android').childFile('build.gradle').createSync(recursive: true);
+      fileSystem.directory('android').childDirectory('app').childFile('build.gradle')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('apply from: irrelevant/flutter.gradle');
 
-        fileSystem.directory('android').childFile('gradle.properties').createSync(recursive: true);
+      final FlutterProject project = FlutterProject.fromDirectoryTest(fileSystem.currentDirectory);
+      project.android.appManifestFile
+        ..createSync(recursive: true)
+        ..writeAsStringSync(minimalV2EmbeddingManifest);
 
-        fileSystem.directory('android').childDirectory('app').childFile('build.gradle')
-          ..createSync(recursive: true)
-          ..writeAsStringSync('apply from: irrelevant/flutter.gradle');
-
-        final FlutterProject project = FlutterProject.fromDirectoryTest(
-          fileSystem.currentDirectory,
-        );
-        project.android.appManifestFile
-          ..createSync(recursive: true)
-          ..writeAsStringSync(minimalV2EmbeddingManifest);
-
-        var testFnCalled = 0;
-        await expectLater(() async {
-          await builder.buildGradleApp(
-            maxRetries: maxRetries,
-            project: project,
-            androidBuildInfo: const AndroidBuildInfo(
-              BuildInfo(
-                BuildMode.release,
-                null,
-                treeShakeIcons: false,
-                packageConfigPath: '.dart_tool/package_config.json',
-              ),
-            ),
-            target: 'lib/main.dart',
-            isBuildingBundle: false,
-            configOnly: false,
-            localGradleErrors: <GradleHandledError>[
-              GradleHandledError(
-                test: (String line) {
-                  if (line.contains('Some gradle message')) {
-                    testFnCalled++;
-                    return true;
-                  }
-                  return false;
-                },
-                handler: ({String? line, FlutterProject? project, bool? usesAndroidX}) async {
-                  return GradleBuildStatus.retry;
-                },
-                eventLabel: 'random-event-label',
-              ),
-            ],
-          );
-        }, throwsToolExit(message: 'Gradle task assembleRelease failed with exit code 1'));
-
-        expect(logger.statusText, contains('Retrying Gradle Build: #1, wait time: 100ms'));
-        expect(logger.statusText, contains('Retrying Gradle Build: #2, wait time: 200ms'));
-
-        expect(testFnCalled, equals(maxRetries + 1));
-        expect(fakeAnalytics.sentEvents, hasLength(9));
-        expect(
-          fakeAnalytics.sentEvents,
-          contains(
-            Event.flutterBuildInfo(
-              label: 'gradle-random-event-label-failure',
-              buildType: 'gradle',
-              settings: 'androidGradlePluginVersion: null',
-            ),
-          ),
-        );
-      },
-      overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()},
-    );
-
-    testUsingContext(
-      'Converts recognized ProcessExceptions into tools exits',
-      () async {
-        final builder = AndroidGradleBuilder(
-          java: FakeJava(),
-          logger: logger,
-          processManager: processManager,
-          fileSystem: fileSystem,
-          artifacts: Artifacts.test(),
-          analytics: fakeAnalytics,
-          gradleUtils: FakeGradleUtils(),
-          platform: FakePlatform(),
-          androidStudio: FakeAndroidStudio(),
-        );
-        processManager.addCommand(
-          const FakeCommand(
-            command: <String>[
-              'gradlew',
-              '-q',
-              '-Ptarget-platform=android-arm,android-arm64,android-x64',
-              '-Ptarget=lib/main.dart',
-              '-Pbase-application-name=android.app.Application',
-              '-Pdart-obfuscation=false',
-              '-Ptrack-widget-creation=false',
-              '-Ptree-shake-icons=false',
-              'assembleRelease',
-            ],
-            exitCode: 1,
-            stderr: '\nSome gradle message\n',
-          ),
-        );
-
-        fileSystem.directory('android').childFile('build.gradle').createSync(recursive: true);
-
-        fileSystem.directory('android').childFile('gradle.properties').createSync(recursive: true);
-
-        fileSystem.directory('android').childDirectory('app').childFile('build.gradle')
-          ..createSync(recursive: true)
-          ..writeAsStringSync('apply from: irrelevant/flutter.gradle');
-
-        final FlutterProject project = FlutterProject.fromDirectoryTest(
-          fileSystem.currentDirectory,
-        );
-        project.android.appManifestFile
-          ..createSync(recursive: true)
-          ..writeAsStringSync(minimalV2EmbeddingManifest);
-
-        var handlerCalled = false;
-        await expectLater(() async {
-          await builder.buildGradleApp(
-            project: project,
-            androidBuildInfo: const AndroidBuildInfo(
-              BuildInfo(
-                BuildMode.release,
-                null,
-                treeShakeIcons: false,
-                packageConfigPath: '.dart_tool/package_config.json',
-              ),
-            ),
-            target: 'lib/main.dart',
-            isBuildingBundle: false,
-            configOnly: false,
-            localGradleErrors: <GradleHandledError>[
-              GradleHandledError(
-                test: (String line) {
-                  return line.contains('Some gradle message');
-                },
-                handler: ({String? line, FlutterProject? project, bool? usesAndroidX}) async {
-                  handlerCalled = true;
-                  return GradleBuildStatus.exit;
-                },
-                eventLabel: 'random-event-label',
-              ),
-            ],
-          );
-        }, throwsToolExit(message: 'Gradle task assembleRelease failed with exit code 1'));
-
-        expect(handlerCalled, isTrue);
-
-        expect(fakeAnalytics.sentEvents, hasLength(3));
-        expect(
-          fakeAnalytics.sentEvents,
-          contains(
-            Event.flutterBuildInfo(
-              label: 'gradle-random-event-label-failure',
-              buildType: 'gradle',
-              settings: 'androidGradlePluginVersion: null',
-            ),
-          ),
-        );
-      },
-      overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()},
-    );
-
-    testUsingContext(
-      'rethrows unrecognized ProcessException',
-      () async {
-        final builder = AndroidGradleBuilder(
-          java: FakeJava(),
-          logger: logger,
-          processManager: processManager,
-          fileSystem: fileSystem,
-          artifacts: Artifacts.test(),
-          analytics: fakeAnalytics,
-          gradleUtils: FakeGradleUtils(),
-          platform: FakePlatform(),
-          androidStudio: FakeAndroidStudio(),
-        );
-        processManager.addCommand(
-          FakeCommand(
-            command: const <String>[
-              'gradlew',
-              '-q',
-              '-Ptarget-platform=android-arm,android-arm64,android-x64',
-              '-Ptarget=lib/main.dart',
-              '-Pbase-application-name=android.app.Application',
-              '-Pdart-obfuscation=false',
-              '-Ptrack-widget-creation=false',
-              '-Ptree-shake-icons=false',
-              'assembleRelease',
-            ],
-            exitCode: 1,
-            onRun: (_) {
-              throw const ProcessException('', <String>[], 'Unrecognized');
-            },
-          ),
-        );
-
-        fileSystem.directory('android').childFile('build.gradle').createSync(recursive: true);
-
-        fileSystem.directory('android').childFile('gradle.properties').createSync(recursive: true);
-
-        fileSystem.directory('android').childDirectory('app').childFile('build.gradle')
-          ..createSync(recursive: true)
-          ..writeAsStringSync('apply from: irrelevant/flutter.gradle');
-
-        final FlutterProject project = FlutterProject.fromDirectoryTest(
-          fileSystem.currentDirectory,
-        );
-        project.android.appManifestFile
-          ..createSync(recursive: true)
-          ..writeAsStringSync(minimalV2EmbeddingManifest);
-
-        await expectLater(() async {
-          await builder.buildGradleApp(
-            project: project,
-            androidBuildInfo: const AndroidBuildInfo(
-              BuildInfo(
-                BuildMode.release,
-                null,
-                treeShakeIcons: false,
-                packageConfigPath: '.dart_tool/package_config.json',
-              ),
-            ),
-            target: 'lib/main.dart',
-            isBuildingBundle: false,
-            configOnly: false,
-            localGradleErrors: const <GradleHandledError>[],
-          );
-        }, throwsProcessException());
-        expect(processManager, hasNoRemainingExpectations);
-      },
-      overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()},
-    );
-
-    testUsingContext(
-      'logs success event after a successful retry',
-      () async {
-        final builder = AndroidGradleBuilder(
-          java: FakeJava(),
-          logger: logger,
-          processManager: processManager,
-          fileSystem: fileSystem,
-          artifacts: Artifacts.test(),
-          analytics: fakeAnalytics,
-          gradleUtils: FakeGradleUtils(),
-          platform: FakePlatform(),
-          androidStudio: FakeAndroidStudio(),
-        );
-        processManager.addCommand(
-          const FakeCommand(
-            command: <String>[
-              'gradlew',
-              '-q',
-              '-Ptarget-platform=android-arm,android-arm64,android-x64',
-              '-Ptarget=lib/main.dart',
-              '-Pbase-application-name=android.app.Application',
-              '-Pdart-obfuscation=false',
-              '-Ptrack-widget-creation=false',
-              '-Ptree-shake-icons=false',
-              'assembleRelease',
-            ],
-            exitCode: 1,
-            stderr: '\nnSome gradle message\n',
-          ),
-        );
-        processManager.addCommand(
-          const FakeCommand(
-            command: <String>[
-              'gradlew',
-              '-q',
-              '-Ptarget-platform=android-arm,android-arm64,android-x64',
-              '-Ptarget=lib/main.dart',
-              '-Pbase-application-name=android.app.Application',
-              '-Pdart-obfuscation=false',
-              '-Ptrack-widget-creation=false',
-              '-Ptree-shake-icons=false',
-              'assembleRelease',
-            ],
-          ),
-        );
-
-        fileSystem.directory('android').childFile('build.gradle').createSync(recursive: true);
-
-        fileSystem.directory('android').childFile('gradle.properties').createSync(recursive: true);
-
-        fileSystem.directory('android').childDirectory('app').childFile('build.gradle')
-          ..createSync(recursive: true)
-          ..writeAsStringSync('apply from: irrelevant/flutter.gradle');
-
-        fileSystem
-            .directory('build')
-            .childDirectory('app')
-            .childDirectory('outputs')
-            .childDirectory('flutter-apk')
-            .childFile('app-release.apk')
-            .createSync(recursive: true);
-
-        final FlutterProject project = FlutterProject.fromDirectoryTest(
-          fileSystem.currentDirectory,
-        );
-        project.android.appManifestFile
-          ..createSync(recursive: true)
-          ..writeAsStringSync(minimalV2EmbeddingManifest);
-
+      var handlerCalled = false;
+      await expectLater(() async {
         await builder.buildGradleApp(
           project: project,
           androidBuildInfo: const AndroidBuildInfo(
@@ -601,86 +403,259 @@ void main() {
                 return line.contains('Some gradle message');
               },
               handler: ({String? line, FlutterProject? project, bool? usesAndroidX}) async {
-                return GradleBuildStatus.retry;
+                handlerCalled = true;
+                return GradleBuildStatus.exit;
               },
               eventLabel: 'random-event-label',
             ),
           ],
         );
+      }, throwsToolExit(message: 'Gradle task assembleRelease failed with exit code 1'));
 
-        expect(
-          fakeAnalytics.sentEvents,
-          contains(
-            Event.flutterBuildInfo(
-              label: 'gradle-random-event-label-success',
-              buildType: 'gradle',
-              settings: 'androidGradlePluginVersion: null',
+      expect(handlerCalled, isTrue);
+
+      expect(fakeAnalytics.sentEvents, hasLength(3));
+      expect(
+        fakeAnalytics.sentEvents,
+        contains(
+          Event.flutterBuildInfo(
+            label: 'gradle-random-event-label-failure',
+            buildType: 'gradle',
+            settings: 'androidGradlePluginVersion: null',
+          ),
+        ),
+      );
+    }, overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()});
+
+    testUsingContext('rethrows unrecognized ProcessException', () async {
+      final builder = AndroidGradleBuilder(
+        java: FakeJava(),
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(),
+        analytics: fakeAnalytics,
+        gradleUtils: FakeGradleUtils(),
+        platform: FakePlatform(),
+        androidStudio: FakeAndroidStudio(),
+        androidSdk: FakeAndroidSdk(),
+      );
+      processManager.addCommand(
+        FakeCommand(
+          command: const <String>[
+            'gradlew',
+            '-q',
+            '-Ptarget-platform=android-arm,android-arm64,android-x64',
+            '-Ptarget=lib/main.dart',
+            '-Pbase-application-name=android.app.Application',
+            '-Pdart-obfuscation=false',
+            '-Ptrack-widget-creation=false',
+            '-Ptree-shake-icons=false',
+            'assembleRelease',
+          ],
+          exitCode: 1,
+          onRun: (_) {
+            throw const ProcessException('', <String>[], 'Unrecognized');
+          },
+        ),
+      );
+
+      fileSystem.directory('android').childFile('build.gradle').createSync(recursive: true);
+
+      fileSystem.directory('android').childFile('gradle.properties').createSync(recursive: true);
+
+      fileSystem.directory('android').childDirectory('app').childFile('build.gradle')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('apply from: irrelevant/flutter.gradle');
+
+      final FlutterProject project = FlutterProject.fromDirectoryTest(fileSystem.currentDirectory);
+      project.android.appManifestFile
+        ..createSync(recursive: true)
+        ..writeAsStringSync(minimalV2EmbeddingManifest);
+
+      await expectLater(() async {
+        await builder.buildGradleApp(
+          project: project,
+          androidBuildInfo: const AndroidBuildInfo(
+            BuildInfo(
+              BuildMode.release,
+              null,
+              treeShakeIcons: false,
+              packageConfigPath: '.dart_tool/package_config.json',
             ),
           ),
+          target: 'lib/main.dart',
+          isBuildingBundle: false,
+          configOnly: false,
+          localGradleErrors: const <GradleHandledError>[],
         );
-        expect(processManager, hasNoRemainingExpectations);
-      },
-      overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()},
-    );
+      }, throwsProcessException());
+      expect(processManager, hasNoRemainingExpectations);
+    }, overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()});
 
-    testUsingContext(
-      'performs code size analysis and sends analytics',
-      () async {
-        final builder = AndroidGradleBuilder(
-          java: FakeJava(),
-          logger: logger,
-          processManager: processManager,
-          fileSystem: fileSystem,
-          artifacts: Artifacts.test(),
-          analytics: fakeAnalytics,
-          gradleUtils: FakeGradleUtils(),
-          platform: FakePlatform(environment: <String, String>{'HOME': '/home'}),
-          androidStudio: FakeAndroidStudio(),
-        );
-        processManager.addCommand(
-          const FakeCommand(
-            command: <String>[
-              'gradlew',
-              '-q',
-              '-Ptarget-platform=android-arm64',
-              '-Ptarget=lib/main.dart',
-              '-Pbase-application-name=android.app.Application',
-              '-Pdart-obfuscation=false',
-              '-Ptrack-widget-creation=false',
-              '-Ptree-shake-icons=false',
-              '-Pcode-size-directory=foo',
-              'assembleRelease',
-            ],
+    testUsingContext('logs success event after a successful retry', () async {
+      final builder = AndroidGradleBuilder(
+        java: FakeJava(),
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(),
+        analytics: fakeAnalytics,
+        gradleUtils: FakeGradleUtils(),
+        platform: FakePlatform(),
+        androidStudio: FakeAndroidStudio(),
+        androidSdk: FakeAndroidSdk(),
+      );
+      processManager.addCommand(
+        const FakeCommand(
+          command: <String>[
+            'gradlew',
+            '-q',
+            '-Ptarget-platform=android-arm,android-arm64,android-x64',
+            '-Ptarget=lib/main.dart',
+            '-Pbase-application-name=android.app.Application',
+            '-Pdart-obfuscation=false',
+            '-Ptrack-widget-creation=false',
+            '-Ptree-shake-icons=false',
+            'assembleRelease',
+          ],
+          exitCode: 1,
+          stderr: '\nnSome gradle message\n',
+        ),
+      );
+      processManager.addCommand(
+        const FakeCommand(
+          command: <String>[
+            'gradlew',
+            '-q',
+            '-Ptarget-platform=android-arm,android-arm64,android-x64',
+            '-Ptarget=lib/main.dart',
+            '-Pbase-application-name=android.app.Application',
+            '-Pdart-obfuscation=false',
+            '-Ptrack-widget-creation=false',
+            '-Ptree-shake-icons=false',
+            'assembleRelease',
+          ],
+        ),
+      );
+
+      fileSystem.directory('android').childFile('build.gradle').createSync(recursive: true);
+
+      fileSystem.directory('android').childFile('gradle.properties').createSync(recursive: true);
+
+      fileSystem.directory('android').childDirectory('app').childFile('build.gradle')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('apply from: irrelevant/flutter.gradle');
+
+      fileSystem
+          .directory('build')
+          .childDirectory('app')
+          .childDirectory('outputs')
+          .childDirectory('flutter-apk')
+          .childFile('app-release.apk')
+          .createSync(recursive: true);
+
+      final FlutterProject project = FlutterProject.fromDirectoryTest(fileSystem.currentDirectory);
+      project.android.appManifestFile
+        ..createSync(recursive: true)
+        ..writeAsStringSync(minimalV2EmbeddingManifest);
+
+      await builder.buildGradleApp(
+        project: project,
+        androidBuildInfo: const AndroidBuildInfo(
+          BuildInfo(
+            BuildMode.release,
+            null,
+            treeShakeIcons: false,
+            packageConfigPath: '.dart_tool/package_config.json',
           ),
-        );
+        ),
+        target: 'lib/main.dart',
+        isBuildingBundle: false,
+        configOnly: false,
+        localGradleErrors: <GradleHandledError>[
+          GradleHandledError(
+            test: (String line) {
+              return line.contains('Some gradle message');
+            },
+            handler: ({String? line, FlutterProject? project, bool? usesAndroidX}) async {
+              return GradleBuildStatus.retry;
+            },
+            eventLabel: 'random-event-label',
+          ),
+        ],
+      );
 
-        fileSystem.directory('android').childFile('build.gradle').createSync(recursive: true);
+      expect(
+        fakeAnalytics.sentEvents,
+        contains(
+          Event.flutterBuildInfo(
+            label: 'gradle-random-event-label-success',
+            buildType: 'gradle',
+            settings: 'androidGradlePluginVersion: null',
+          ),
+        ),
+      );
+      expect(processManager, hasNoRemainingExpectations);
+    }, overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()});
 
-        fileSystem.directory('android').childFile('gradle.properties').createSync(recursive: true);
+    testUsingContext('performs code size analysis and sends analytics', () async {
+      final builder = AndroidGradleBuilder(
+        java: FakeJava(),
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(),
+        analytics: fakeAnalytics,
+        gradleUtils: FakeGradleUtils(),
+        platform: FakePlatform(environment: <String, String>{'HOME': '/home'}),
+        androidStudio: FakeAndroidStudio(),
+        androidSdk: FakeAndroidSdk(),
+      );
+      processManager.addCommand(
+        const FakeCommand(
+          command: <String>[
+            'gradlew',
+            '-q',
+            '-Ptarget-platform=android-arm64',
+            '-Ptarget=lib/main.dart',
+            '-Pbase-application-name=android.app.Application',
+            '-Pdart-obfuscation=false',
+            '-Ptrack-widget-creation=false',
+            '-Ptree-shake-icons=false',
+            '-Pcode-size-directory=foo',
+            'assembleRelease',
+          ],
+        ),
+      );
 
-        fileSystem.directory('android').childDirectory('app').childFile('build.gradle')
-          ..createSync(recursive: true)
-          ..writeAsStringSync('apply from: irrelevant/flutter.gradle');
+      fileSystem.directory('android').childFile('build.gradle').createSync(recursive: true);
 
-        final archive = Archive()
-          ..addFile(ArchiveFile('AndroidManifest.xml', 100, List<int>.filled(100, 0)))
-          ..addFile(ArchiveFile('META-INF/CERT.RSA', 10, List<int>.filled(10, 0)))
-          ..addFile(ArchiveFile('META-INF/CERT.SF', 10, List<int>.filled(10, 0)))
-          ..addFile(ArchiveFile('lib/arm64-v8a/libapp.so', 50, List<int>.filled(50, 0)))
-          ..addFile(ArchiveFile('lib/arm64-v8a/libflutter.so', 50, List<int>.filled(50, 0)));
+      fileSystem.directory('android').childFile('gradle.properties').createSync(recursive: true);
 
-        fileSystem
-            .directory('build')
-            .childDirectory('app')
-            .childDirectory('outputs')
-            .childDirectory('flutter-apk')
-            .childFile('app-release.apk')
-          ..createSync(recursive: true)
-          ..writeAsBytesSync(ZipEncoder().encode(archive)!);
+      fileSystem.directory('android').childDirectory('app').childFile('build.gradle')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('apply from: irrelevant/flutter.gradle');
 
-        fileSystem.file('foo/snapshot.arm64-v8a.json')
-          ..createSync(recursive: true)
-          ..writeAsStringSync(r'''
+      final archive = Archive()
+        ..addFile(ArchiveFile('AndroidManifest.xml', 100, List<int>.filled(100, 0)))
+        ..addFile(ArchiveFile('META-INF/CERT.RSA', 10, List<int>.filled(10, 0)))
+        ..addFile(ArchiveFile('META-INF/CERT.SF', 10, List<int>.filled(10, 0)))
+        ..addFile(ArchiveFile('lib/arm64-v8a/libapp.so', 50, List<int>.filled(50, 0)))
+        ..addFile(ArchiveFile('lib/arm64-v8a/libflutter.so', 50, List<int>.filled(50, 0)));
+
+      fileSystem
+          .directory('build')
+          .childDirectory('app')
+          .childDirectory('outputs')
+          .childDirectory('flutter-apk')
+          .childFile('app-release.apk')
+        ..createSync(recursive: true)
+        ..writeAsBytesSync(ZipEncoder().encode(archive)!);
+
+      fileSystem.file('foo/snapshot.arm64-v8a.json')
+        ..createSync(recursive: true)
+        ..writeAsStringSync(r'''
 [
   {
     "l": "dart:_internal",
@@ -689,39 +664,35 @@ void main() {
     "s": 2400
   }
 ]''');
-        fileSystem.file('foo/trace.arm64-v8a.json')
-          ..createSync(recursive: true)
-          ..writeAsStringSync('{}');
+      fileSystem.file('foo/trace.arm64-v8a.json')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('{}');
 
-        final FlutterProject project = FlutterProject.fromDirectoryTest(
-          fileSystem.currentDirectory,
-        );
-        project.android.appManifestFile
-          ..createSync(recursive: true)
-          ..writeAsStringSync(minimalV2EmbeddingManifest);
+      final FlutterProject project = FlutterProject.fromDirectoryTest(fileSystem.currentDirectory);
+      project.android.appManifestFile
+        ..createSync(recursive: true)
+        ..writeAsStringSync(minimalV2EmbeddingManifest);
 
-        await builder.buildGradleApp(
-          project: project,
-          androidBuildInfo: const AndroidBuildInfo(
-            BuildInfo(
-              BuildMode.release,
-              null,
-              treeShakeIcons: false,
-              codeSizeDirectory: 'foo',
-              packageConfigPath: '.dart_tool/package_config.json',
-            ),
-            targetArchs: <AndroidArch>[AndroidArch.arm64_v8a],
+      await builder.buildGradleApp(
+        project: project,
+        androidBuildInfo: const AndroidBuildInfo(
+          BuildInfo(
+            BuildMode.release,
+            null,
+            treeShakeIcons: false,
+            codeSizeDirectory: 'foo',
+            packageConfigPath: '.dart_tool/package_config.json',
           ),
-          target: 'lib/main.dart',
-          isBuildingBundle: false,
-          configOnly: false,
-          localGradleErrors: <GradleHandledError>[],
-        );
+          targetArchs: <AndroidArch>[AndroidArch.arm64_v8a],
+        ),
+        target: 'lib/main.dart',
+        isBuildingBundle: false,
+        configOnly: false,
+        localGradleErrors: <GradleHandledError>[],
+      );
 
-        expect(fakeAnalytics.sentEvents, contains(Event.codeSizeAnalysis(platform: 'apk')));
-      },
-      overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()},
-    );
+      expect(fakeAnalytics.sentEvents, contains(Event.codeSizeAnalysis(platform: 'apk')));
+    }, overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()});
 
     group('Appbundle debug symbol tests', () {
       final commonCommandPortion = <String>[
@@ -914,6 +885,7 @@ void main() {
             gradleUtils: FakeGradleUtils(),
             platform: FakePlatform(environment: <String, String>{'HOME': '/home'}),
             androidStudio: FakeAndroidStudio(),
+            androidSdk: FakeAndroidSdk(),
           );
           processManager.addCommand(
             FakeCommand(command: List<String>.of(commonCommandPortion)..add('bundleRelease')),
@@ -921,7 +893,7 @@ void main() {
 
           createSharedGradleFiles();
           final File aabFile = createAabFile(BuildMode.release);
-          final AndroidSdk sdk = AndroidSdk.locateAndroidSdk()!;
+          final AndroidSdk sdk = FakeAndroidSdk();
 
           processManager.addCommand(
             FakeCommand(
@@ -979,6 +951,7 @@ void main() {
             gradleUtils: FakeGradleUtils(),
             platform: FakePlatform(environment: <String, String>{'HOME': '/home'}),
             androidStudio: FakeAndroidStudio(),
+            androidSdk: FakeAndroidSdk(),
           );
           processManager.addCommand(
             FakeCommand(command: List<String>.of(commonCommandPortion)..add('bundleRelease')),
@@ -986,7 +959,7 @@ void main() {
 
           createSharedGradleFiles();
           final File aabFile = createAabFile(BuildMode.release);
-          final AndroidSdk sdk = AndroidSdk.locateAndroidSdk()!;
+          final AndroidSdk sdk = FakeAndroidSdk();
 
           processManager.addCommand(
             FakeCommand(
@@ -1031,57 +1004,54 @@ void main() {
         overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()},
       );
 
-      testUsingContext(
-        'building a debug aab does not invoke apkanalyzer',
-        () async {
-          final builder = AndroidGradleBuilder(
-            java: FakeJava(),
-            logger: logger,
-            processManager: processManager,
-            fileSystem: fileSystem,
-            artifacts: Artifacts.test(),
-            analytics: fakeAnalytics,
-            gradleUtils: FakeGradleUtils(),
-            platform: FakePlatform(environment: <String, String>{'HOME': '/home'}),
-            androidStudio: FakeAndroidStudio(),
-          );
-          processManager.addCommand(
-            FakeCommand(command: List<String>.of(commonCommandPortion)..add('bundleDebug')),
-          );
+      testUsingContext('building a debug aab does not invoke apkanalyzer', () async {
+        final builder = AndroidGradleBuilder(
+          java: FakeJava(),
+          logger: logger,
+          processManager: processManager,
+          fileSystem: fileSystem,
+          artifacts: Artifacts.test(),
+          analytics: fakeAnalytics,
+          gradleUtils: FakeGradleUtils(),
+          platform: FakePlatform(environment: <String, String>{'HOME': '/home'}),
+          androidStudio: FakeAndroidStudio(),
+          androidSdk: FakeAndroidSdk(),
+        );
+        processManager.addCommand(
+          FakeCommand(command: List<String>.of(commonCommandPortion)..add('bundleDebug')),
+        );
 
-          createSharedGradleFiles();
-          createAabFile(BuildMode.debug);
+        createSharedGradleFiles();
+        createAabFile(BuildMode.debug);
 
-          final FlutterProject project = FlutterProject.fromDirectoryTest(
-            fileSystem.currentDirectory,
-          );
-          project.android.appManifestFile
-            ..createSync(recursive: true)
-            ..writeAsStringSync(minimalV2EmbeddingManifest);
+        final FlutterProject project = FlutterProject.fromDirectoryTest(
+          fileSystem.currentDirectory,
+        );
+        project.android.appManifestFile
+          ..createSync(recursive: true)
+          ..writeAsStringSync(minimalV2EmbeddingManifest);
 
-          await builder.buildGradleApp(
-            project: project,
-            androidBuildInfo: const AndroidBuildInfo(
-              BuildInfo(
-                BuildMode.debug,
-                null,
-                treeShakeIcons: false,
-                packageConfigPath: '.dart_tool/package_config.json',
-              ),
-              targetArchs: <AndroidArch>[
-                AndroidArch.arm64_v8a,
-                AndroidArch.armeabi_v7a,
-                AndroidArch.x86_64,
-              ],
+        await builder.buildGradleApp(
+          project: project,
+          androidBuildInfo: const AndroidBuildInfo(
+            BuildInfo(
+              BuildMode.debug,
+              null,
+              treeShakeIcons: false,
+              packageConfigPath: '.dart_tool/package_config.json',
             ),
-            target: 'lib/main.dart',
-            isBuildingBundle: true,
-            configOnly: false,
-            localGradleErrors: <GradleHandledError>[],
-          );
-        },
-        overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()},
-      );
+            targetArchs: <AndroidArch>[
+              AndroidArch.arm64_v8a,
+              AndroidArch.armeabi_v7a,
+              AndroidArch.x86_64,
+            ],
+          ),
+          target: 'lib/main.dart',
+          isBuildingBundle: true,
+          configOnly: false,
+          localGradleErrors: <GradleHandledError>[],
+        );
+      }, overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()});
 
       testUsingContext(
         'throws tool exit for missing debug symbols when building release app bundle',
@@ -1096,6 +1066,7 @@ void main() {
             gradleUtils: FakeGradleUtils(),
             platform: FakePlatform(environment: <String, String>{'HOME': '/home'}),
             androidStudio: FakeAndroidStudio(),
+            androidSdk: FakeAndroidSdk(),
           );
           processManager.addCommand(
             FakeCommand(command: List<String>.of(commonCommandPortion)..add('bundleRelease')),
@@ -1104,7 +1075,7 @@ void main() {
           createSharedGradleFiles();
           final File aabFile = createAabFile(BuildMode.release);
 
-          final AndroidSdk sdk = AndroidSdk.locateAndroidSdk()!;
+          final AndroidSdk sdk = FakeAndroidSdk();
 
           processManager.addCommand(
             FakeCommand(
@@ -1165,6 +1136,7 @@ void main() {
             gradleUtils: FakeGradleUtils(),
             platform: FakePlatform(environment: <String, String>{'HOME': '/home'}),
             androidStudio: FakeAndroidStudio(),
+            androidSdk: FakeAndroidSdk(),
           );
           processManager.addCommand(
             FakeCommand(command: List<String>.of(commonCommandPortion)..add('bundleRelease')),
@@ -1173,7 +1145,7 @@ void main() {
           createSharedGradleFiles();
           final File aabFile = createAabFile(BuildMode.release);
 
-          final AndroidSdk sdk = AndroidSdk.locateAndroidSdk()!;
+          final AndroidSdk sdk = FakeAndroidSdk();
 
           processManager.addCommand(
             FakeCommand(
@@ -1223,82 +1195,77 @@ void main() {
       );
     });
 
-    testUsingContext(
-      'indicates that an APK has been built successfully',
-      () async {
-        final builder = AndroidGradleBuilder(
-          java: FakeJava(),
-          logger: logger,
-          processManager: processManager,
-          fileSystem: fileSystem,
-          artifacts: Artifacts.test(),
-          analytics: fakeAnalytics,
-          gradleUtils: FakeGradleUtils(),
-          platform: FakePlatform(),
-          androidStudio: FakeAndroidStudio(),
-        );
-        processManager.addCommand(
-          const FakeCommand(
-            command: <String>[
-              'gradlew',
-              '-q',
-              '-Ptarget-platform=android-arm,android-arm64,android-x64',
-              '-Ptarget=lib/main.dart',
-              '-Pbase-application-name=android.app.Application',
-              '-Pdart-obfuscation=false',
-              '-Ptrack-widget-creation=false',
-              '-Ptree-shake-icons=false',
-              'assembleRelease',
-            ],
+    testUsingContext('indicates that an APK has been built successfully', () async {
+      final builder = AndroidGradleBuilder(
+        java: FakeJava(),
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(),
+        analytics: fakeAnalytics,
+        gradleUtils: FakeGradleUtils(),
+        platform: FakePlatform(),
+        androidStudio: FakeAndroidStudio(),
+        androidSdk: FakeAndroidSdk(),
+      );
+      processManager.addCommand(
+        const FakeCommand(
+          command: <String>[
+            'gradlew',
+            '-q',
+            '-Ptarget-platform=android-arm,android-arm64,android-x64',
+            '-Ptarget=lib/main.dart',
+            '-Pbase-application-name=android.app.Application',
+            '-Pdart-obfuscation=false',
+            '-Ptrack-widget-creation=false',
+            '-Ptree-shake-icons=false',
+            'assembleRelease',
+          ],
+        ),
+      );
+      fileSystem.directory('android').childFile('build.gradle').createSync(recursive: true);
+
+      fileSystem.directory('android').childFile('gradle.properties').createSync(recursive: true);
+
+      fileSystem.directory('android').childDirectory('app').childFile('build.gradle')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('apply from: irrelevant/flutter.gradle');
+
+      fileSystem
+          .directory('build')
+          .childDirectory('app')
+          .childDirectory('outputs')
+          .childDirectory('flutter-apk')
+          .childFile('app-release.apk')
+          .createSync(recursive: true);
+
+      final FlutterProject project = FlutterProject.fromDirectoryTest(fileSystem.currentDirectory);
+      project.android.appManifestFile
+        ..createSync(recursive: true)
+        ..writeAsStringSync(minimalV2EmbeddingManifest);
+
+      await builder.buildGradleApp(
+        project: project,
+        androidBuildInfo: const AndroidBuildInfo(
+          BuildInfo(
+            BuildMode.release,
+            null,
+            treeShakeIcons: false,
+            packageConfigPath: '.dart_tool/package_config.json',
           ),
-        );
-        fileSystem.directory('android').childFile('build.gradle').createSync(recursive: true);
+        ),
+        target: 'lib/main.dart',
+        isBuildingBundle: false,
+        configOnly: false,
+        localGradleErrors: const <GradleHandledError>[],
+      );
 
-        fileSystem.directory('android').childFile('gradle.properties').createSync(recursive: true);
-
-        fileSystem.directory('android').childDirectory('app').childFile('build.gradle')
-          ..createSync(recursive: true)
-          ..writeAsStringSync('apply from: irrelevant/flutter.gradle');
-
-        fileSystem
-            .directory('build')
-            .childDirectory('app')
-            .childDirectory('outputs')
-            .childDirectory('flutter-apk')
-            .childFile('app-release.apk')
-            .createSync(recursive: true);
-
-        final FlutterProject project = FlutterProject.fromDirectoryTest(
-          fileSystem.currentDirectory,
-        );
-        project.android.appManifestFile
-          ..createSync(recursive: true)
-          ..writeAsStringSync(minimalV2EmbeddingManifest);
-
-        await builder.buildGradleApp(
-          project: project,
-          androidBuildInfo: const AndroidBuildInfo(
-            BuildInfo(
-              BuildMode.release,
-              null,
-              treeShakeIcons: false,
-              packageConfigPath: '.dart_tool/package_config.json',
-            ),
-          ),
-          target: 'lib/main.dart',
-          isBuildingBundle: false,
-          configOnly: false,
-          localGradleErrors: const <GradleHandledError>[],
-        );
-
-        expect(
-          logger.statusText,
-          contains('Built build/app/outputs/flutter-apk/app-release.apk (0.0MB)'),
-        );
-        expect(processManager, hasNoRemainingExpectations);
-      },
-      overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()},
-    );
+      expect(
+        logger.statusText,
+        contains('Built build/app/outputs/flutter-apk/app-release.apk (0.0MB)'),
+      );
+      expect(processManager, hasNoRemainingExpectations);
+    }, overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()});
 
     testUsingContext('Uses namespace attribute if manifest lacks a package attribute', () async {
       final FlutterProject project = FlutterProject.fromDirectoryTest(fileSystem.currentDirectory);
@@ -1378,6 +1345,7 @@ android {
           gradleUtils: FakeGradleUtils(),
           platform: FakePlatform(),
           androidStudio: FakeAndroidStudio(),
+          androidSdk: FakeAndroidSdk(),
         );
         processManager.addCommand(
           const FakeCommand(
@@ -1419,36 +1387,33 @@ BuildVariant: paidProfile
       },
     );
 
-    testUsingContext(
-      'getBuildOptions returns empty list if gradle returns error',
-      () async {
-        final builder = AndroidGradleBuilder(
-          java: FakeJava(),
-          logger: logger,
-          processManager: processManager,
-          fileSystem: fileSystem,
-          artifacts: Artifacts.test(),
-          analytics: fakeAnalytics,
-          gradleUtils: FakeGradleUtils(),
-          platform: FakePlatform(),
-          androidStudio: FakeAndroidStudio(),
-        );
-        processManager.addCommand(
-          const FakeCommand(
-            command: <String>['gradlew', '-q', 'printBuildVariants'],
-            stderr: '''
+    testUsingContext('getBuildOptions returns empty list if gradle returns error', () async {
+      final builder = AndroidGradleBuilder(
+        java: FakeJava(),
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(),
+        analytics: fakeAnalytics,
+        gradleUtils: FakeGradleUtils(),
+        platform: FakePlatform(),
+        androidStudio: FakeAndroidStudio(),
+        androidSdk: FakeAndroidSdk(),
+      );
+      processManager.addCommand(
+        const FakeCommand(
+          command: <String>['gradlew', '-q', 'printBuildVariants'],
+          stderr: '''
 Gradle Crashed
         ''',
-            exitCode: 1,
-          ),
-        );
-        final List<String> actual = await builder.getBuildVariants(
-          project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
-        );
-        expect(actual, const <String>[]);
-      },
-      overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()},
-    );
+          exitCode: 1,
+        ),
+      );
+      final List<String> actual = await builder.getBuildVariants(
+        project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
+      );
+      expect(actual, const <String>[]);
+    }, overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()});
 
     testUsingContext(
       'can call custom gradle task outputFreeDebugAppLinkSettings and parse the result',
@@ -1468,6 +1433,7 @@ Gradle Crashed
           gradleUtils: FakeGradleUtils(),
           platform: FakePlatform(),
           androidStudio: FakeAndroidStudio(),
+          androidSdk: FakeAndroidSdk(),
         );
         processManager.addCommand(
           FakeCommand(
@@ -1514,6 +1480,7 @@ Gradle Crashed
           gradleUtils: FakeGradleUtils(),
           platform: FakePlatform(),
           androidStudio: FakeAndroidStudio(),
+          androidSdk: FakeAndroidSdk(),
         );
         processManager.addCommand(
           const FakeCommand(
@@ -1597,6 +1564,7 @@ Gradle Crashed
         gradleUtils: FakeGradleUtils(),
         platform: FakePlatform(),
         androidStudio: FakeAndroidStudio(),
+        androidSdk: FakeAndroidSdk(),
       );
       processManager.addCommands(const <FakeCommand>[
         FakeCommand(
@@ -1725,6 +1693,7 @@ Gradle Crashed
           gradleUtils: FakeGradleUtils(),
           platform: FakePlatform(),
           androidStudio: FakeAndroidStudio(),
+          androidSdk: FakeAndroidSdk(),
         );
         processManager.addCommand(
           const FakeCommand(
@@ -1779,587 +1748,55 @@ Gradle Crashed
       overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()},
     );
 
-    testUsingContext(
-      'gradle exit code and stderr is forwarded to tool exit',
-      () async {
-        final builder = AndroidGradleBuilder(
-          java: FakeJava(),
-          logger: logger,
-          processManager: processManager,
-          fileSystem: fileSystem,
-          artifacts: Artifacts.test(),
-          analytics: fakeAnalytics,
-          gradleUtils: FakeGradleUtils(),
-          platform: FakePlatform(),
-          androidStudio: FakeAndroidStudio(),
-        );
-        processManager.addCommand(
-          const FakeCommand(
-            command: <String>[
-              'gradlew',
-              '-I=/packages/flutter_tools/gradle/aar_init_script.gradle',
-              '-Pflutter-root=/',
-              '-Poutput-dir=build/',
-              '-Pis-plugin=false',
-              '-PbuildNumber=1.0',
-              '-q',
-              '-Pdart-obfuscation=false',
-              '-Ptrack-widget-creation=false',
-              '-Ptree-shake-icons=false',
-              '-Ptarget-platform=android-arm,android-arm64,android-x64',
-              'assembleAarRelease',
-            ],
-            exitCode: 108,
-            stderr: 'Gradle task assembleAarRelease failed with exit code 108.',
-          ),
-        );
+    testUsingContext('gradle exit code and stderr is forwarded to tool exit', () async {
+      final builder = AndroidGradleBuilder(
+        java: FakeJava(),
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(),
+        analytics: fakeAnalytics,
+        gradleUtils: FakeGradleUtils(),
+        platform: FakePlatform(),
+        androidStudio: FakeAndroidStudio(),
+        androidSdk: FakeAndroidSdk(),
+      );
+      processManager.addCommand(
+        const FakeCommand(
+          command: <String>[
+            'gradlew',
+            '-I=/packages/flutter_tools/gradle/aar_init_script.gradle',
+            '-Pflutter-root=/',
+            '-Poutput-dir=build/',
+            '-Pis-plugin=false',
+            '-PbuildNumber=1.0',
+            '-q',
+            '-Pdart-obfuscation=false',
+            '-Ptrack-widget-creation=false',
+            '-Ptree-shake-icons=false',
+            '-Ptarget-platform=android-arm,android-arm64,android-x64',
+            'assembleAarRelease',
+          ],
+          exitCode: 108,
+          stderr: 'Gradle task assembleAarRelease failed with exit code 108.',
+        ),
+      );
 
-        final File manifestFile = fileSystem.file('pubspec.yaml');
-        manifestFile.createSync(recursive: true);
-        manifestFile.writeAsStringSync('''
+      final File manifestFile = fileSystem.file('pubspec.yaml');
+      manifestFile.createSync(recursive: true);
+      manifestFile.writeAsStringSync('''
         flutter:
           module:
             androidPackage: com.example.test
         ''');
 
-        fileSystem.file('.android/gradlew').createSync(recursive: true);
-        fileSystem.file('.android/gradle.properties').writeAsStringSync('irrelevant');
-        fileSystem.file('.android/build.gradle').createSync(recursive: true);
-        fileSystem.directory('build/outputs/repo').createSync(recursive: true);
+      fileSystem.file('.android/gradlew').createSync(recursive: true);
+      fileSystem.file('.android/gradle.properties').writeAsStringSync('irrelevant');
+      fileSystem.file('.android/build.gradle').createSync(recursive: true);
+      fileSystem.directory('build/outputs/repo').createSync(recursive: true);
 
-        await expectLater(
-          () async => builder.buildGradleAar(
-            androidBuildInfo: const AndroidBuildInfo(
-              BuildInfo(
-                BuildMode.release,
-                null,
-                treeShakeIcons: false,
-                packageConfigPath: '.dart_tool/package_config.json',
-              ),
-            ),
-            project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
-            outputDirectory: fileSystem.directory('build/'),
-            target: '',
-            buildNumber: '1.0',
-          ),
-          throwsToolExit(
-            exitCode: 108,
-            message: 'Gradle task assembleAarRelease failed with exit code 108.',
-          ),
-        );
-        expect(processManager, hasNoRemainingExpectations);
-      },
-      overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()},
-    );
-
-    testUsingContext(
-      'build apk uses selected local engine with arm32 ABI',
-      () async {
-        final builder = AndroidGradleBuilder(
-          java: FakeJava(),
-          logger: logger,
-          processManager: processManager,
-          fileSystem: fileSystem,
-          artifacts: Artifacts.testLocalEngine(
-            localEngine: 'out/android_arm',
-            localEngineHost: 'out/host_release',
-          ),
-          analytics: fakeAnalytics,
-          gradleUtils: FakeGradleUtils(),
-          platform: FakePlatform(),
-          androidStudio: FakeAndroidStudio(),
-        );
-        processManager.addCommand(
-          const FakeCommand(
-            command: <String>[
-              'gradlew',
-              '-q',
-              '-Plocal-engine-repo=/.tmp_rand0/flutter_tool_local_engine_repo.rand0',
-              '-Plocal-engine-build-mode=release',
-              '-Plocal-engine-out=out/android_arm',
-              '-Plocal-engine-host-out=out/host_release',
-              '-Ptarget-platform=android-arm',
-              '-Ptarget=lib/main.dart',
-              '-Pbase-application-name=android.app.Application',
-              '-Pdart-obfuscation=false',
-              '-Ptrack-widget-creation=false',
-              '-Ptree-shake-icons=false',
-              'assembleRelease',
-            ],
-          ),
-        );
-
-        fileSystem.file('out/android_arm/flutter_embedding_release.pom')
-          ..createSync(recursive: true)
-          ..writeAsStringSync('''
-<?xml version="1.0" encoding="UTF-8"?>
-<project>
-  <version>1.0.0-73fd6b049a80bcea2db1f26c7cee434907cd188b</version>
-  <dependencies>
-  </dependencies>
-</project>
-''');
-        fileSystem.file('out/android_arm/armeabi_v7a_release.pom').createSync(recursive: true);
-        fileSystem.file('out/android_arm/armeabi_v7a_release.jar').createSync(recursive: true);
-        fileSystem
-            .file('out/android_arm/armeabi_v7a_release.maven-metadata.xml')
-            .createSync(recursive: true);
-        fileSystem
-            .file('out/android_arm/flutter_embedding_release.jar')
-            .createSync(recursive: true);
-        fileSystem
-            .file('out/android_arm/flutter_embedding_release.pom')
-            .createSync(recursive: true);
-        fileSystem
-            .file('out/android_arm/flutter_embedding_release.maven-metadata.xml')
-            .createSync(recursive: true);
-
-        fileSystem.file('android/gradlew').createSync(recursive: true);
-        fileSystem.directory('android').childFile('gradle.properties').createSync(recursive: true);
-        fileSystem.file('android/build.gradle').createSync(recursive: true);
-        fileSystem.directory('android').childDirectory('app').childFile('build.gradle')
-          ..createSync(recursive: true)
-          ..writeAsStringSync('apply from: irrelevant/flutter.gradle');
-        final FlutterProject project = FlutterProject.fromDirectoryTest(
-          fileSystem.currentDirectory,
-        );
-        project.android.appManifestFile
-          ..createSync(recursive: true)
-          ..writeAsStringSync(minimalV2EmbeddingManifest);
-
-        await expectLater(() async {
-          await builder.buildGradleApp(
-            project: project,
-            androidBuildInfo: const AndroidBuildInfo(
-              BuildInfo(
-                BuildMode.release,
-                null,
-                treeShakeIcons: false,
-                packageConfigPath: '.dart_tool/package_config.json',
-              ),
-            ),
-            target: 'lib/main.dart',
-            isBuildingBundle: false,
-            configOnly: false,
-            localGradleErrors: const <GradleHandledError>[],
-          );
-        }, throwsToolExit());
-        expect(processManager, hasNoRemainingExpectations);
-      },
-      overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()},
-    );
-
-    testUsingContext(
-      'build apk uses selected local engine with arm64 ABI',
-      () async {
-        final builder = AndroidGradleBuilder(
-          java: FakeJava(),
-          logger: logger,
-          processManager: processManager,
-          fileSystem: fileSystem,
-          artifacts: Artifacts.testLocalEngine(
-            localEngine: 'out/android_arm64',
-            localEngineHost: 'out/host_release',
-          ),
-          analytics: fakeAnalytics,
-          gradleUtils: FakeGradleUtils(),
-          platform: FakePlatform(),
-          androidStudio: FakeAndroidStudio(),
-        );
-        processManager.addCommand(
-          const FakeCommand(
-            command: <String>[
-              'gradlew',
-              '-q',
-              '-Plocal-engine-repo=/.tmp_rand0/flutter_tool_local_engine_repo.rand0',
-              '-Plocal-engine-build-mode=release',
-              '-Plocal-engine-out=out/android_arm64',
-              '-Plocal-engine-host-out=out/host_release',
-              '-Ptarget-platform=android-arm64',
-              '-Ptarget=lib/main.dart',
-              '-Pbase-application-name=android.app.Application',
-              '-Pdart-obfuscation=false',
-              '-Ptrack-widget-creation=false',
-              '-Ptree-shake-icons=false',
-              'assembleRelease',
-            ],
-          ),
-        );
-
-        fileSystem.file('out/android_arm64/flutter_embedding_release.pom')
-          ..createSync(recursive: true)
-          ..writeAsStringSync('''
-<?xml version="1.0" encoding="UTF-8"?>
-<project>
-  <version>1.0.0-73fd6b049a80bcea2db1f26c7cee434907cd188b</version>
-  <dependencies>
-  </dependencies>
-</project>
-''');
-        fileSystem.file('out/android_arm64/arm64_v8a_release.pom').createSync(recursive: true);
-        fileSystem.file('out/android_arm64/arm64_v8a_release.jar').createSync(recursive: true);
-        fileSystem
-            .file('out/android_arm64/arm64_v8a_release.maven-metadata.xml')
-            .createSync(recursive: true);
-        fileSystem
-            .file('out/android_arm64/flutter_embedding_release.jar')
-            .createSync(recursive: true);
-        fileSystem
-            .file('out/android_arm64/flutter_embedding_release.pom')
-            .createSync(recursive: true);
-        fileSystem
-            .file('out/android_arm64/flutter_embedding_release.maven-metadata.xml')
-            .createSync(recursive: true);
-
-        fileSystem.file('android/gradlew').createSync(recursive: true);
-        fileSystem.directory('android').childFile('gradle.properties').createSync(recursive: true);
-        fileSystem.file('android/build.gradle').createSync(recursive: true);
-        fileSystem.directory('android').childDirectory('app').childFile('build.gradle')
-          ..createSync(recursive: true)
-          ..writeAsStringSync('apply from: irrelevant/flutter.gradle');
-        final FlutterProject project = FlutterProject.fromDirectoryTest(
-          fileSystem.currentDirectory,
-        );
-        project.android.appManifestFile
-          ..createSync(recursive: true)
-          ..writeAsStringSync(minimalV2EmbeddingManifest);
-
-        await expectLater(() async {
-          await builder.buildGradleApp(
-            project: project,
-            androidBuildInfo: const AndroidBuildInfo(
-              BuildInfo(
-                BuildMode.release,
-                null,
-                treeShakeIcons: false,
-                packageConfigPath: '.dart_tool/package_config.json',
-              ),
-            ),
-            target: 'lib/main.dart',
-            isBuildingBundle: false,
-            configOnly: false,
-            localGradleErrors: const <GradleHandledError>[],
-          );
-        }, throwsToolExit());
-        expect(processManager, hasNoRemainingExpectations);
-      },
-      overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()},
-    );
-
-    testUsingContext(
-      'build apk uses selected local engine with x64 ABI',
-      () async {
-        final builder = AndroidGradleBuilder(
-          java: FakeJava(),
-          logger: logger,
-          processManager: processManager,
-          fileSystem: fileSystem,
-          artifacts: Artifacts.testLocalEngine(
-            localEngine: 'out/android_x64',
-            localEngineHost: 'out/host_release',
-          ),
-          analytics: fakeAnalytics,
-          gradleUtils: FakeGradleUtils(),
-          platform: FakePlatform(),
-          androidStudio: FakeAndroidStudio(),
-        );
-        processManager.addCommand(
-          const FakeCommand(
-            command: <String>[
-              'gradlew',
-              '-q',
-              '-Plocal-engine-repo=/.tmp_rand0/flutter_tool_local_engine_repo.rand0',
-              '-Plocal-engine-build-mode=release',
-              '-Plocal-engine-out=out/android_x64',
-              '-Plocal-engine-host-out=out/host_release',
-              '-Ptarget-platform=android-x64',
-              '-Ptarget=lib/main.dart',
-              '-Pbase-application-name=android.app.Application',
-              '-Pdart-obfuscation=false',
-              '-Ptrack-widget-creation=false',
-              '-Ptree-shake-icons=false',
-              'assembleRelease',
-            ],
-            exitCode: 1,
-          ),
-        );
-
-        fileSystem.file('out/android_x64/flutter_embedding_release.pom')
-          ..createSync(recursive: true)
-          ..writeAsStringSync('''
-<?xml version="1.0" encoding="UTF-8"?>
-<project>
-  <version>1.0.0-73fd6b049a80bcea2db1f26c7cee434907cd188b</version>
-  <dependencies>
-  </dependencies>
-</project>
-''');
-        fileSystem.file('out/android_x64/x86_64_release.pom').createSync(recursive: true);
-        fileSystem.file('out/android_x64/x86_64_release.jar').createSync(recursive: true);
-        fileSystem
-            .file('out/android_x64/x86_64_release.maven-metadata.xml')
-            .createSync(recursive: true);
-        fileSystem
-            .file('out/android_x64/flutter_embedding_release.jar')
-            .createSync(recursive: true);
-        fileSystem
-            .file('out/android_x64/flutter_embedding_release.pom')
-            .createSync(recursive: true);
-        fileSystem
-            .file('out/android_x64/flutter_embedding_release.maven-metadata.xml')
-            .createSync(recursive: true);
-
-        fileSystem.file('android/gradlew').createSync(recursive: true);
-        fileSystem.directory('android').childFile('gradle.properties').createSync(recursive: true);
-        fileSystem.file('android/build.gradle').createSync(recursive: true);
-        fileSystem.directory('android').childDirectory('app').childFile('build.gradle')
-          ..createSync(recursive: true)
-          ..writeAsStringSync('apply from: irrelevant/flutter.gradle');
-        final FlutterProject project = FlutterProject.fromDirectoryTest(
-          fileSystem.currentDirectory,
-        );
-        project.android.appManifestFile
-          ..createSync(recursive: true)
-          ..writeAsStringSync(minimalV2EmbeddingManifest);
-
-        await expectLater(() async {
-          await builder.buildGradleApp(
-            project: project,
-            androidBuildInfo: const AndroidBuildInfo(
-              BuildInfo(
-                BuildMode.release,
-                null,
-                treeShakeIcons: false,
-                packageConfigPath: '.dart_tool/package_config.json',
-              ),
-            ),
-            target: 'lib/main.dart',
-            isBuildingBundle: false,
-            configOnly: false,
-            localGradleErrors: const <GradleHandledError>[],
-          );
-        }, throwsToolExit());
-        expect(processManager, hasNoRemainingExpectations);
-      },
-      overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()},
-    );
-
-    testUsingContext(
-      'honors --no-android-gradle-daemon setting',
-      () async {
-        final builder = AndroidGradleBuilder(
-          java: FakeJava(),
-          logger: logger,
-          processManager: processManager,
-          fileSystem: fileSystem,
-          artifacts: Artifacts.test(),
-          analytics: fakeAnalytics,
-          gradleUtils: FakeGradleUtils(),
-          platform: FakePlatform(),
-          androidStudio: FakeAndroidStudio(),
-        );
-        processManager.addCommand(
-          const FakeCommand(
-            command: <String>[
-              'gradlew',
-              '-q',
-              '--no-daemon',
-              '-Ptarget-platform=android-arm,android-arm64,android-x64',
-              '-Ptarget=lib/main.dart',
-              '-Pbase-application-name=android.app.Application',
-              '-Pdart-obfuscation=false',
-              '-Ptrack-widget-creation=false',
-              '-Ptree-shake-icons=false',
-              'assembleRelease',
-            ],
-          ),
-        );
-        fileSystem.file('android/gradlew').createSync(recursive: true);
-
-        fileSystem.directory('android').childFile('gradle.properties').createSync(recursive: true);
-        fileSystem.file('android/build.gradle').createSync(recursive: true);
-        fileSystem.directory('android').childDirectory('app').childFile('build.gradle')
-          ..createSync(recursive: true)
-          ..writeAsStringSync('apply from: irrelevant/flutter.gradle');
-        final FlutterProject project = FlutterProject.fromDirectoryTest(
-          fileSystem.currentDirectory,
-        );
-        project.android.appManifestFile
-          ..createSync(recursive: true)
-          ..writeAsStringSync(minimalV2EmbeddingManifest);
-
-        await expectLater(() async {
-          await builder.buildGradleApp(
-            project: project,
-            androidBuildInfo: const AndroidBuildInfo(
-              BuildInfo(
-                BuildMode.release,
-                null,
-                treeShakeIcons: false,
-                androidGradleDaemon: false,
-                packageConfigPath: '.dart_tool/package_config.json',
-              ),
-            ),
-            target: 'lib/main.dart',
-            isBuildingBundle: false,
-            configOnly: false,
-            localGradleErrors: const <GradleHandledError>[],
-          );
-        }, throwsToolExit());
-        expect(processManager, hasNoRemainingExpectations);
-      },
-      overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()},
-    );
-
-    testUsingContext(
-      'honors --android-project-cache-dir setting',
-      () async {
-        final builder = AndroidGradleBuilder(
-          java: FakeJava(),
-          logger: logger,
-          processManager: processManager,
-          fileSystem: fileSystem,
-          artifacts: Artifacts.test(),
-          analytics: fakeAnalytics,
-          gradleUtils: FakeGradleUtils(),
-          platform: FakePlatform(),
-          androidStudio: FakeAndroidStudio(),
-        );
-        processManager.addCommand(
-          const FakeCommand(
-            command: <String>[
-              'gradlew',
-              '-q',
-              '-Ptarget-platform=android-arm,android-arm64,android-x64',
-              '-Ptarget=lib/main.dart',
-              '-Pbase-application-name=android.app.Application',
-              '-Pdart-obfuscation=false',
-              '-Ptrack-widget-creation=false',
-              '-Ptree-shake-icons=false',
-              '--project-cache-dir=/made/up/dir',
-              'assembleRelease',
-            ],
-          ),
-        );
-        fileSystem.file('android/gradlew').createSync(recursive: true);
-
-        fileSystem.directory('android').childFile('gradle.properties').createSync(recursive: true);
-        fileSystem.file('android/build.gradle').createSync(recursive: true);
-        fileSystem.directory('android').childDirectory('app').childFile('build.gradle')
-          ..createSync(recursive: true)
-          ..writeAsStringSync('apply from: irrelevant/flutter.gradle');
-        final FlutterProject project = FlutterProject.fromDirectoryTest(
-          fileSystem.currentDirectory,
-        );
-        project.android.appManifestFile
-          ..createSync(recursive: true)
-          ..writeAsStringSync(minimalV2EmbeddingManifest);
-
-        await expectLater(() async {
-          await builder.buildGradleApp(
-            project: project,
-            androidBuildInfo: const AndroidBuildInfo(
-              BuildInfo(
-                BuildMode.release,
-                null,
-                treeShakeIcons: false,
-                androidGradleProjectCacheDir: '/made/up/dir',
-                packageConfigPath: '.dart_tool/package_config.json',
-              ),
-            ),
-            target: 'lib/main.dart',
-            isBuildingBundle: false,
-            configOnly: false,
-            localGradleErrors: const <GradleHandledError>[],
-          );
-        }, throwsToolExit());
-        expect(processManager, hasNoRemainingExpectations);
-      },
-      overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()},
-    );
-
-    testUsingContext(
-      'build aar uses selected local engine with arm32 ABI',
-      () async {
-        final builder = AndroidGradleBuilder(
-          java: FakeJava(),
-          logger: logger,
-          processManager: processManager,
-          fileSystem: fileSystem,
-          artifacts: Artifacts.testLocalEngine(
-            localEngine: 'out/android_arm',
-            localEngineHost: 'out/host_release',
-          ),
-          analytics: fakeAnalytics,
-          gradleUtils: FakeGradleUtils(),
-          platform: FakePlatform(),
-          androidStudio: FakeAndroidStudio(),
-        );
-        processManager.addCommand(
-          const FakeCommand(
-            command: <String>[
-              'gradlew',
-              '-I=/packages/flutter_tools/gradle/aar_init_script.gradle',
-              '-Pflutter-root=/',
-              '-Poutput-dir=build/',
-              '-Pis-plugin=false',
-              '-PbuildNumber=2.0',
-              '-q',
-              '-Pdart-obfuscation=false',
-              '-Ptrack-widget-creation=false',
-              '-Ptree-shake-icons=false',
-              '-Plocal-engine-repo=/.tmp_rand0/flutter_tool_local_engine_repo.rand0',
-              '-Plocal-engine-build-mode=release',
-              '-Plocal-engine-out=out/android_arm',
-              '-Plocal-engine-host-out=out/host_release',
-              '-Ptarget-platform=android-arm',
-              'assembleAarRelease',
-            ],
-          ),
-        );
-
-        fileSystem.file('out/android_arm/flutter_embedding_release.pom')
-          ..createSync(recursive: true)
-          ..writeAsStringSync('''
-<?xml version="1.0" encoding="UTF-8"?>
-<project>
-  <version>1.0.0-73fd6b049a80bcea2db1f26c7cee434907cd188b</version>
-  <dependencies>
-  </dependencies>
-</project>
-''');
-        fileSystem.file('out/android_arm/armeabi_v7a_release.pom').createSync(recursive: true);
-        fileSystem.file('out/android_arm/armeabi_v7a_release.jar').createSync(recursive: true);
-        fileSystem
-            .file('out/android_arm/armeabi_v7a_release.maven-metadata.xml')
-            .createSync(recursive: true);
-        fileSystem
-            .file('out/android_arm/flutter_embedding_release.jar')
-            .createSync(recursive: true);
-        fileSystem
-            .file('out/android_arm/flutter_embedding_release.pom')
-            .createSync(recursive: true);
-        fileSystem
-            .file('out/android_arm/flutter_embedding_release.maven-metadata.xml')
-            .createSync(recursive: true);
-
-        final File manifestFile = fileSystem.file('pubspec.yaml');
-        manifestFile.createSync(recursive: true);
-        manifestFile.writeAsStringSync('''
-        flutter:
-          module:
-            androidPackage: com.example.test
-        ''');
-
-        fileSystem.directory('.android/gradle').createSync(recursive: true);
-        fileSystem.directory('.android/gradle/wrapper').createSync(recursive: true);
-        fileSystem.file('.android/gradlew').createSync(recursive: true);
-        fileSystem.file('.android/gradle.properties').writeAsStringSync('irrelevant');
-        fileSystem.file('.android/build.gradle').createSync(recursive: true);
-
-        fileSystem.directory('build/outputs/repo').createSync(recursive: true);
-
-        await builder.buildGradleAar(
+      await expectLater(
+        () async => builder.buildGradleAar(
           androidBuildInfo: const AndroidBuildInfo(
             BuildInfo(
               BuildMode.release,
@@ -2371,65 +1808,55 @@ Gradle Crashed
           project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
           outputDirectory: fileSystem.directory('build/'),
           target: '',
-          buildNumber: '2.0',
-        );
+          buildNumber: '1.0',
+        ),
+        throwsToolExit(
+          exitCode: 108,
+          message: 'Gradle task assembleAarRelease failed with exit code 108.',
+        ),
+      );
+      expect(processManager, hasNoRemainingExpectations);
+    }, overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()});
 
-        expect(
-          fileSystem.link(
-            'build/outputs/repo/io/flutter/flutter_embedding_release/'
-            '1.0.0-73fd6b049a80bcea2db1f26c7cee434907cd188b/'
-            'flutter_embedding_release-1.0.0-73fd6b049a80bcea2db1f26c7cee434907cd188b.pom',
-          ),
-          exists,
-        );
-        expect(processManager, hasNoRemainingExpectations);
-      },
-      overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()},
-    );
+    testUsingContext('build apk uses selected local engine with arm32 ABI', () async {
+      final builder = AndroidGradleBuilder(
+        java: FakeJava(),
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.testLocalEngine(
+          localEngine: 'out/android_arm',
+          localEngineHost: 'out/host_release',
+        ),
+        analytics: fakeAnalytics,
+        gradleUtils: FakeGradleUtils(),
+        platform: FakePlatform(),
+        androidStudio: FakeAndroidStudio(),
+        androidSdk: FakeAndroidSdk(),
+      );
+      processManager.addCommand(
+        const FakeCommand(
+          command: <String>[
+            'gradlew',
+            '-q',
+            '-Plocal-engine-repo=/.tmp_rand0/flutter_tool_local_engine_repo.rand0',
+            '-Plocal-engine-build-mode=release',
+            '-Plocal-engine-out=out/android_arm',
+            '-Plocal-engine-host-out=out/host_release',
+            '-Ptarget-platform=android-arm',
+            '-Ptarget=lib/main.dart',
+            '-Pbase-application-name=android.app.Application',
+            '-Pdart-obfuscation=false',
+            '-Ptrack-widget-creation=false',
+            '-Ptree-shake-icons=false',
+            'assembleRelease',
+          ],
+        ),
+      );
 
-    testUsingContext(
-      'build aar uses selected local engine with x64 ABI',
-      () async {
-        final builder = AndroidGradleBuilder(
-          java: FakeJava(),
-          logger: logger,
-          processManager: processManager,
-          fileSystem: fileSystem,
-          artifacts: Artifacts.testLocalEngine(
-            localEngine: 'out/android_arm64',
-            localEngineHost: 'out/host_release',
-          ),
-          analytics: fakeAnalytics,
-          gradleUtils: FakeGradleUtils(),
-          platform: FakePlatform(),
-          androidStudio: FakeAndroidStudio(),
-        );
-        processManager.addCommand(
-          const FakeCommand(
-            command: <String>[
-              'gradlew',
-              '-I=/packages/flutter_tools/gradle/aar_init_script.gradle',
-              '-Pflutter-root=/',
-              '-Poutput-dir=build/',
-              '-Pis-plugin=false',
-              '-PbuildNumber=2.0',
-              '-q',
-              '-Pdart-obfuscation=false',
-              '-Ptrack-widget-creation=false',
-              '-Ptree-shake-icons=false',
-              '-Plocal-engine-repo=/.tmp_rand0/flutter_tool_local_engine_repo.rand0',
-              '-Plocal-engine-build-mode=release',
-              '-Plocal-engine-out=out/android_arm64',
-              '-Plocal-engine-host-out=out/host_release',
-              '-Ptarget-platform=android-arm64',
-              'assembleAarRelease',
-            ],
-          ),
-        );
-
-        fileSystem.file('out/android_arm64/flutter_embedding_release.pom')
-          ..createSync(recursive: true)
-          ..writeAsStringSync('''
+      fileSystem.file('out/android_arm/flutter_embedding_release.pom')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('''
 <?xml version="1.0" encoding="UTF-8"?>
 <project>
   <version>1.0.0-73fd6b049a80bcea2db1f26c7cee434907cd188b</version>
@@ -2437,37 +1864,31 @@ Gradle Crashed
   </dependencies>
 </project>
 ''');
-        fileSystem.file('out/android_arm64/arm64_v8a_release.pom').createSync(recursive: true);
-        fileSystem.file('out/android_arm64/arm64_v8a_release.jar').createSync(recursive: true);
-        fileSystem
-            .file('out/android_arm64/arm64_v8a_release.maven-metadata.xml')
-            .createSync(recursive: true);
-        fileSystem
-            .file('out/android_arm64/flutter_embedding_release.jar')
-            .createSync(recursive: true);
-        fileSystem
-            .file('out/android_arm64/flutter_embedding_release.pom')
-            .createSync(recursive: true);
-        fileSystem
-            .file('out/android_arm64/flutter_embedding_release.maven-metadata.xml')
-            .createSync(recursive: true);
+      fileSystem.file('out/android_arm/armeabi_v7a_release.pom').createSync(recursive: true);
+      fileSystem.file('out/android_arm/armeabi_v7a_release.jar').createSync(recursive: true);
+      fileSystem
+          .file('out/android_arm/armeabi_v7a_release.maven-metadata.xml')
+          .createSync(recursive: true);
+      fileSystem.file('out/android_arm/flutter_embedding_release.jar').createSync(recursive: true);
+      fileSystem.file('out/android_arm/flutter_embedding_release.pom').createSync(recursive: true);
+      fileSystem
+          .file('out/android_arm/flutter_embedding_release.maven-metadata.xml')
+          .createSync(recursive: true);
 
-        final File manifestFile = fileSystem.file('pubspec.yaml');
-        manifestFile.createSync(recursive: true);
-        manifestFile.writeAsStringSync('''
-        flutter:
-          module:
-            androidPackage: com.example.test
-        ''');
+      fileSystem.file('android/gradlew').createSync(recursive: true);
+      fileSystem.directory('android').childFile('gradle.properties').createSync(recursive: true);
+      fileSystem.file('android/build.gradle').createSync(recursive: true);
+      fileSystem.directory('android').childDirectory('app').childFile('build.gradle')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('apply from: irrelevant/flutter.gradle');
+      final FlutterProject project = FlutterProject.fromDirectoryTest(fileSystem.currentDirectory);
+      project.android.appManifestFile
+        ..createSync(recursive: true)
+        ..writeAsStringSync(minimalV2EmbeddingManifest);
 
-        fileSystem.directory('.android/gradle').createSync(recursive: true);
-        fileSystem.directory('.android/gradle/wrapper').createSync(recursive: true);
-        fileSystem.file('.android/gradlew').createSync(recursive: true);
-        fileSystem.file('.android/gradle.properties').writeAsStringSync('irrelevant');
-        fileSystem.file('.android/build.gradle').createSync(recursive: true);
-        fileSystem.directory('build/outputs/repo').createSync(recursive: true);
-
-        await builder.buildGradleAar(
+      await expectLater(() async {
+        await builder.buildGradleApp(
+          project: project,
           androidBuildInfo: const AndroidBuildInfo(
             BuildInfo(
               BuildMode.release,
@@ -2476,68 +1897,54 @@ Gradle Crashed
               packageConfigPath: '.dart_tool/package_config.json',
             ),
           ),
-          project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
-          outputDirectory: fileSystem.directory('build/'),
-          target: '',
-          buildNumber: '2.0',
+          target: 'lib/main.dart',
+          isBuildingBundle: false,
+          configOnly: false,
+          localGradleErrors: const <GradleHandledError>[],
         );
+      }, throwsToolExit());
+      expect(processManager, hasNoRemainingExpectations);
+    }, overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()});
 
-        expect(
-          fileSystem.link(
-            'build/outputs/repo/io/flutter/flutter_embedding_release/'
-            '1.0.0-73fd6b049a80bcea2db1f26c7cee434907cd188b/'
-            'flutter_embedding_release-1.0.0-73fd6b049a80bcea2db1f26c7cee434907cd188b.pom',
-          ),
-          exists,
-        );
-        expect(processManager, hasNoRemainingExpectations);
-      },
-      overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()},
-    );
+    testUsingContext('build apk uses selected local engine with arm64 ABI', () async {
+      final builder = AndroidGradleBuilder(
+        java: FakeJava(),
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.testLocalEngine(
+          localEngine: 'out/android_arm64',
+          localEngineHost: 'out/host_release',
+        ),
+        analytics: fakeAnalytics,
+        gradleUtils: FakeGradleUtils(),
+        platform: FakePlatform(),
+        androidStudio: FakeAndroidStudio(),
+        androidSdk: FakeAndroidSdk(),
+      );
+      processManager.addCommand(
+        const FakeCommand(
+          command: <String>[
+            'gradlew',
+            '-q',
+            '-Plocal-engine-repo=/.tmp_rand0/flutter_tool_local_engine_repo.rand0',
+            '-Plocal-engine-build-mode=release',
+            '-Plocal-engine-out=out/android_arm64',
+            '-Plocal-engine-host-out=out/host_release',
+            '-Ptarget-platform=android-arm64',
+            '-Ptarget=lib/main.dart',
+            '-Pbase-application-name=android.app.Application',
+            '-Pdart-obfuscation=false',
+            '-Ptrack-widget-creation=false',
+            '-Ptree-shake-icons=false',
+            'assembleRelease',
+          ],
+        ),
+      );
 
-    testUsingContext(
-      'build aar uses selected local engine on x64 ABI',
-      () async {
-        final builder = AndroidGradleBuilder(
-          java: FakeJava(),
-          logger: logger,
-          processManager: processManager,
-          fileSystem: fileSystem,
-          artifacts: Artifacts.testLocalEngine(
-            localEngine: 'out/android_x64',
-            localEngineHost: 'out/host_release',
-          ),
-          analytics: fakeAnalytics,
-          gradleUtils: FakeGradleUtils(),
-          platform: FakePlatform(),
-          androidStudio: FakeAndroidStudio(),
-        );
-        processManager.addCommand(
-          const FakeCommand(
-            command: <String>[
-              'gradlew',
-              '-I=/packages/flutter_tools/gradle/aar_init_script.gradle',
-              '-Pflutter-root=/',
-              '-Poutput-dir=build/',
-              '-Pis-plugin=false',
-              '-PbuildNumber=2.0',
-              '-q',
-              '-Pdart-obfuscation=false',
-              '-Ptrack-widget-creation=false',
-              '-Ptree-shake-icons=false',
-              '-Plocal-engine-repo=/.tmp_rand0/flutter_tool_local_engine_repo.rand0',
-              '-Plocal-engine-build-mode=release',
-              '-Plocal-engine-out=out/android_x64',
-              '-Plocal-engine-host-out=out/host_release',
-              '-Ptarget-platform=android-x64',
-              'assembleAarRelease',
-            ],
-          ),
-        );
-
-        fileSystem.file('out/android_x64/flutter_embedding_release.pom')
-          ..createSync(recursive: true)
-          ..writeAsStringSync('''
+      fileSystem.file('out/android_arm64/flutter_embedding_release.pom')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('''
 <?xml version="1.0" encoding="UTF-8"?>
 <project>
   <version>1.0.0-73fd6b049a80bcea2db1f26c7cee434907cd188b</version>
@@ -2545,37 +1952,35 @@ Gradle Crashed
   </dependencies>
 </project>
 ''');
-        fileSystem.file('out/android_x64/x86_64_release.pom').createSync(recursive: true);
-        fileSystem.file('out/android_x64/x86_64_release.jar').createSync(recursive: true);
-        fileSystem
-            .file('out/android_x64/x86_64_release.maven-metadata.xml')
-            .createSync(recursive: true);
-        fileSystem
-            .file('out/android_x64/flutter_embedding_release.jar')
-            .createSync(recursive: true);
-        fileSystem
-            .file('out/android_x64/flutter_embedding_release.pom')
-            .createSync(recursive: true);
-        fileSystem
-            .file('out/android_x64/flutter_embedding_release.maven-metadata.xml')
-            .createSync(recursive: true);
+      fileSystem.file('out/android_arm64/arm64_v8a_release.pom').createSync(recursive: true);
+      fileSystem.file('out/android_arm64/arm64_v8a_release.jar').createSync(recursive: true);
+      fileSystem
+          .file('out/android_arm64/arm64_v8a_release.maven-metadata.xml')
+          .createSync(recursive: true);
+      fileSystem
+          .file('out/android_arm64/flutter_embedding_release.jar')
+          .createSync(recursive: true);
+      fileSystem
+          .file('out/android_arm64/flutter_embedding_release.pom')
+          .createSync(recursive: true);
+      fileSystem
+          .file('out/android_arm64/flutter_embedding_release.maven-metadata.xml')
+          .createSync(recursive: true);
 
-        final File manifestFile = fileSystem.file('pubspec.yaml');
-        manifestFile.createSync(recursive: true);
-        manifestFile.writeAsStringSync('''
-        flutter:
-          module:
-            androidPackage: com.example.test
-        ''');
+      fileSystem.file('android/gradlew').createSync(recursive: true);
+      fileSystem.directory('android').childFile('gradle.properties').createSync(recursive: true);
+      fileSystem.file('android/build.gradle').createSync(recursive: true);
+      fileSystem.directory('android').childDirectory('app').childFile('build.gradle')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('apply from: irrelevant/flutter.gradle');
+      final FlutterProject project = FlutterProject.fromDirectoryTest(fileSystem.currentDirectory);
+      project.android.appManifestFile
+        ..createSync(recursive: true)
+        ..writeAsStringSync(minimalV2EmbeddingManifest);
 
-        fileSystem.directory('.android/gradle').createSync(recursive: true);
-        fileSystem.directory('.android/gradle/wrapper').createSync(recursive: true);
-        fileSystem.file('.android/gradlew').createSync(recursive: true);
-        fileSystem.file('.android/gradle.properties').writeAsStringSync('irrelevant');
-        fileSystem.file('.android/build.gradle').createSync(recursive: true);
-        fileSystem.directory('build/outputs/repo').createSync(recursive: true);
-
-        await builder.buildGradleAar(
+      await expectLater(() async {
+        await builder.buildGradleApp(
+          project: project,
           androidBuildInfo: const AndroidBuildInfo(
             BuildInfo(
               BuildMode.release,
@@ -2584,24 +1989,535 @@ Gradle Crashed
               packageConfigPath: '.dart_tool/package_config.json',
             ),
           ),
-          project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
-          outputDirectory: fileSystem.directory('build/'),
-          target: '',
-          buildNumber: '2.0',
+          target: 'lib/main.dart',
+          isBuildingBundle: false,
+          configOnly: false,
+          localGradleErrors: const <GradleHandledError>[],
         );
+      }, throwsToolExit());
+      expect(processManager, hasNoRemainingExpectations);
+    }, overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()});
 
-        expect(
-          fileSystem.link(
-            'build/outputs/repo/io/flutter/flutter_embedding_release/'
-            '1.0.0-73fd6b049a80bcea2db1f26c7cee434907cd188b/'
-            'flutter_embedding_release-1.0.0-73fd6b049a80bcea2db1f26c7cee434907cd188b.pom',
+    testUsingContext('build apk uses selected local engine with x64 ABI', () async {
+      final builder = AndroidGradleBuilder(
+        java: FakeJava(),
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.testLocalEngine(
+          localEngine: 'out/android_x64',
+          localEngineHost: 'out/host_release',
+        ),
+        analytics: fakeAnalytics,
+        gradleUtils: FakeGradleUtils(),
+        platform: FakePlatform(),
+        androidStudio: FakeAndroidStudio(),
+        androidSdk: FakeAndroidSdk(),
+      );
+      processManager.addCommand(
+        const FakeCommand(
+          command: <String>[
+            'gradlew',
+            '-q',
+            '-Plocal-engine-repo=/.tmp_rand0/flutter_tool_local_engine_repo.rand0',
+            '-Plocal-engine-build-mode=release',
+            '-Plocal-engine-out=out/android_x64',
+            '-Plocal-engine-host-out=out/host_release',
+            '-Ptarget-platform=android-x64',
+            '-Ptarget=lib/main.dart',
+            '-Pbase-application-name=android.app.Application',
+            '-Pdart-obfuscation=false',
+            '-Ptrack-widget-creation=false',
+            '-Ptree-shake-icons=false',
+            'assembleRelease',
+          ],
+          exitCode: 1,
+        ),
+      );
+
+      fileSystem.file('out/android_x64/flutter_embedding_release.pom')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('''
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <version>1.0.0-73fd6b049a80bcea2db1f26c7cee434907cd188b</version>
+  <dependencies>
+  </dependencies>
+</project>
+''');
+      fileSystem.file('out/android_x64/x86_64_release.pom').createSync(recursive: true);
+      fileSystem.file('out/android_x64/x86_64_release.jar').createSync(recursive: true);
+      fileSystem
+          .file('out/android_x64/x86_64_release.maven-metadata.xml')
+          .createSync(recursive: true);
+      fileSystem.file('out/android_x64/flutter_embedding_release.jar').createSync(recursive: true);
+      fileSystem.file('out/android_x64/flutter_embedding_release.pom').createSync(recursive: true);
+      fileSystem
+          .file('out/android_x64/flutter_embedding_release.maven-metadata.xml')
+          .createSync(recursive: true);
+
+      fileSystem.file('android/gradlew').createSync(recursive: true);
+      fileSystem.directory('android').childFile('gradle.properties').createSync(recursive: true);
+      fileSystem.file('android/build.gradle').createSync(recursive: true);
+      fileSystem.directory('android').childDirectory('app').childFile('build.gradle')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('apply from: irrelevant/flutter.gradle');
+      final FlutterProject project = FlutterProject.fromDirectoryTest(fileSystem.currentDirectory);
+      project.android.appManifestFile
+        ..createSync(recursive: true)
+        ..writeAsStringSync(minimalV2EmbeddingManifest);
+
+      await expectLater(() async {
+        await builder.buildGradleApp(
+          project: project,
+          androidBuildInfo: const AndroidBuildInfo(
+            BuildInfo(
+              BuildMode.release,
+              null,
+              treeShakeIcons: false,
+              packageConfigPath: '.dart_tool/package_config.json',
+            ),
           ),
-          exists,
+          target: 'lib/main.dart',
+          isBuildingBundle: false,
+          configOnly: false,
+          localGradleErrors: const <GradleHandledError>[],
         );
-        expect(processManager, hasNoRemainingExpectations);
-      },
-      overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()},
-    );
+      }, throwsToolExit());
+      expect(processManager, hasNoRemainingExpectations);
+    }, overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()});
+
+    testUsingContext('honors --no-android-gradle-daemon setting', () async {
+      final builder = AndroidGradleBuilder(
+        java: FakeJava(),
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(),
+        analytics: fakeAnalytics,
+        gradleUtils: FakeGradleUtils(),
+        platform: FakePlatform(),
+        androidStudio: FakeAndroidStudio(),
+        androidSdk: FakeAndroidSdk(),
+      );
+      processManager.addCommand(
+        const FakeCommand(
+          command: <String>[
+            'gradlew',
+            '-q',
+            '--no-daemon',
+            '-Ptarget-platform=android-arm,android-arm64,android-x64',
+            '-Ptarget=lib/main.dart',
+            '-Pbase-application-name=android.app.Application',
+            '-Pdart-obfuscation=false',
+            '-Ptrack-widget-creation=false',
+            '-Ptree-shake-icons=false',
+            'assembleRelease',
+          ],
+        ),
+      );
+      fileSystem.file('android/gradlew').createSync(recursive: true);
+
+      fileSystem.directory('android').childFile('gradle.properties').createSync(recursive: true);
+      fileSystem.file('android/build.gradle').createSync(recursive: true);
+      fileSystem.directory('android').childDirectory('app').childFile('build.gradle')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('apply from: irrelevant/flutter.gradle');
+      final FlutterProject project = FlutterProject.fromDirectoryTest(fileSystem.currentDirectory);
+      project.android.appManifestFile
+        ..createSync(recursive: true)
+        ..writeAsStringSync(minimalV2EmbeddingManifest);
+
+      await expectLater(() async {
+        await builder.buildGradleApp(
+          project: project,
+          androidBuildInfo: const AndroidBuildInfo(
+            BuildInfo(
+              BuildMode.release,
+              null,
+              treeShakeIcons: false,
+              androidGradleDaemon: false,
+              packageConfigPath: '.dart_tool/package_config.json',
+            ),
+          ),
+          target: 'lib/main.dart',
+          isBuildingBundle: false,
+          configOnly: false,
+          localGradleErrors: const <GradleHandledError>[],
+        );
+      }, throwsToolExit());
+      expect(processManager, hasNoRemainingExpectations);
+    }, overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()});
+
+    testUsingContext('honors --android-project-cache-dir setting', () async {
+      final builder = AndroidGradleBuilder(
+        java: FakeJava(),
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(),
+        analytics: fakeAnalytics,
+        gradleUtils: FakeGradleUtils(),
+        platform: FakePlatform(),
+        androidStudio: FakeAndroidStudio(),
+        androidSdk: FakeAndroidSdk(),
+      );
+      processManager.addCommand(
+        const FakeCommand(
+          command: <String>[
+            'gradlew',
+            '-q',
+            '-Ptarget-platform=android-arm,android-arm64,android-x64',
+            '-Ptarget=lib/main.dart',
+            '-Pbase-application-name=android.app.Application',
+            '-Pdart-obfuscation=false',
+            '-Ptrack-widget-creation=false',
+            '-Ptree-shake-icons=false',
+            '--project-cache-dir=/made/up/dir',
+            'assembleRelease',
+          ],
+        ),
+      );
+      fileSystem.file('android/gradlew').createSync(recursive: true);
+
+      fileSystem.directory('android').childFile('gradle.properties').createSync(recursive: true);
+      fileSystem.file('android/build.gradle').createSync(recursive: true);
+      fileSystem.directory('android').childDirectory('app').childFile('build.gradle')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('apply from: irrelevant/flutter.gradle');
+      final FlutterProject project = FlutterProject.fromDirectoryTest(fileSystem.currentDirectory);
+      project.android.appManifestFile
+        ..createSync(recursive: true)
+        ..writeAsStringSync(minimalV2EmbeddingManifest);
+
+      await expectLater(() async {
+        await builder.buildGradleApp(
+          project: project,
+          androidBuildInfo: const AndroidBuildInfo(
+            BuildInfo(
+              BuildMode.release,
+              null,
+              treeShakeIcons: false,
+              androidGradleProjectCacheDir: '/made/up/dir',
+              packageConfigPath: '.dart_tool/package_config.json',
+            ),
+          ),
+          target: 'lib/main.dart',
+          isBuildingBundle: false,
+          configOnly: false,
+          localGradleErrors: const <GradleHandledError>[],
+        );
+      }, throwsToolExit());
+      expect(processManager, hasNoRemainingExpectations);
+    }, overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()});
+
+    testUsingContext('build aar uses selected local engine with arm32 ABI', () async {
+      final builder = AndroidGradleBuilder(
+        java: FakeJava(),
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.testLocalEngine(
+          localEngine: 'out/android_arm',
+          localEngineHost: 'out/host_release',
+        ),
+        analytics: fakeAnalytics,
+        gradleUtils: FakeGradleUtils(),
+        platform: FakePlatform(),
+        androidStudio: FakeAndroidStudio(),
+        androidSdk: FakeAndroidSdk(),
+      );
+      processManager.addCommand(
+        const FakeCommand(
+          command: <String>[
+            'gradlew',
+            '-I=/packages/flutter_tools/gradle/aar_init_script.gradle',
+            '-Pflutter-root=/',
+            '-Poutput-dir=build/',
+            '-Pis-plugin=false',
+            '-PbuildNumber=2.0',
+            '-q',
+            '-Pdart-obfuscation=false',
+            '-Ptrack-widget-creation=false',
+            '-Ptree-shake-icons=false',
+            '-Plocal-engine-repo=/.tmp_rand0/flutter_tool_local_engine_repo.rand0',
+            '-Plocal-engine-build-mode=release',
+            '-Plocal-engine-out=out/android_arm',
+            '-Plocal-engine-host-out=out/host_release',
+            '-Ptarget-platform=android-arm',
+            'assembleAarRelease',
+          ],
+        ),
+      );
+
+      fileSystem.file('out/android_arm/flutter_embedding_release.pom')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('''
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <version>1.0.0-73fd6b049a80bcea2db1f26c7cee434907cd188b</version>
+  <dependencies>
+  </dependencies>
+</project>
+''');
+      fileSystem.file('out/android_arm/armeabi_v7a_release.pom').createSync(recursive: true);
+      fileSystem.file('out/android_arm/armeabi_v7a_release.jar').createSync(recursive: true);
+      fileSystem
+          .file('out/android_arm/armeabi_v7a_release.maven-metadata.xml')
+          .createSync(recursive: true);
+      fileSystem.file('out/android_arm/flutter_embedding_release.jar').createSync(recursive: true);
+      fileSystem.file('out/android_arm/flutter_embedding_release.pom').createSync(recursive: true);
+      fileSystem
+          .file('out/android_arm/flutter_embedding_release.maven-metadata.xml')
+          .createSync(recursive: true);
+
+      final File manifestFile = fileSystem.file('pubspec.yaml');
+      manifestFile.createSync(recursive: true);
+      manifestFile.writeAsStringSync('''
+        flutter:
+          module:
+            androidPackage: com.example.test
+        ''');
+
+      fileSystem.directory('.android/gradle').createSync(recursive: true);
+      fileSystem.directory('.android/gradle/wrapper').createSync(recursive: true);
+      fileSystem.file('.android/gradlew').createSync(recursive: true);
+      fileSystem.file('.android/gradle.properties').writeAsStringSync('irrelevant');
+      fileSystem.file('.android/build.gradle').createSync(recursive: true);
+
+      fileSystem.directory('build/outputs/repo').createSync(recursive: true);
+
+      await builder.buildGradleAar(
+        androidBuildInfo: const AndroidBuildInfo(
+          BuildInfo(
+            BuildMode.release,
+            null,
+            treeShakeIcons: false,
+            packageConfigPath: '.dart_tool/package_config.json',
+          ),
+        ),
+        project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
+        outputDirectory: fileSystem.directory('build/'),
+        target: '',
+        buildNumber: '2.0',
+      );
+
+      expect(
+        fileSystem.link(
+          'build/outputs/repo/io/flutter/flutter_embedding_release/'
+          '1.0.0-73fd6b049a80bcea2db1f26c7cee434907cd188b/'
+          'flutter_embedding_release-1.0.0-73fd6b049a80bcea2db1f26c7cee434907cd188b.pom',
+        ),
+        exists,
+      );
+      expect(processManager, hasNoRemainingExpectations);
+    }, overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()});
+
+    testUsingContext('build aar uses selected local engine with x64 ABI', () async {
+      final builder = AndroidGradleBuilder(
+        java: FakeJava(),
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.testLocalEngine(
+          localEngine: 'out/android_arm64',
+          localEngineHost: 'out/host_release',
+        ),
+        analytics: fakeAnalytics,
+        gradleUtils: FakeGradleUtils(),
+        platform: FakePlatform(),
+        androidStudio: FakeAndroidStudio(),
+        androidSdk: FakeAndroidSdk(),
+      );
+      processManager.addCommand(
+        const FakeCommand(
+          command: <String>[
+            'gradlew',
+            '-I=/packages/flutter_tools/gradle/aar_init_script.gradle',
+            '-Pflutter-root=/',
+            '-Poutput-dir=build/',
+            '-Pis-plugin=false',
+            '-PbuildNumber=2.0',
+            '-q',
+            '-Pdart-obfuscation=false',
+            '-Ptrack-widget-creation=false',
+            '-Ptree-shake-icons=false',
+            '-Plocal-engine-repo=/.tmp_rand0/flutter_tool_local_engine_repo.rand0',
+            '-Plocal-engine-build-mode=release',
+            '-Plocal-engine-out=out/android_arm64',
+            '-Plocal-engine-host-out=out/host_release',
+            '-Ptarget-platform=android-arm64',
+            'assembleAarRelease',
+          ],
+        ),
+      );
+
+      fileSystem.file('out/android_arm64/flutter_embedding_release.pom')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('''
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <version>1.0.0-73fd6b049a80bcea2db1f26c7cee434907cd188b</version>
+  <dependencies>
+  </dependencies>
+</project>
+''');
+      fileSystem.file('out/android_arm64/arm64_v8a_release.pom').createSync(recursive: true);
+      fileSystem.file('out/android_arm64/arm64_v8a_release.jar').createSync(recursive: true);
+      fileSystem
+          .file('out/android_arm64/arm64_v8a_release.maven-metadata.xml')
+          .createSync(recursive: true);
+      fileSystem
+          .file('out/android_arm64/flutter_embedding_release.jar')
+          .createSync(recursive: true);
+      fileSystem
+          .file('out/android_arm64/flutter_embedding_release.pom')
+          .createSync(recursive: true);
+      fileSystem
+          .file('out/android_arm64/flutter_embedding_release.maven-metadata.xml')
+          .createSync(recursive: true);
+
+      final File manifestFile = fileSystem.file('pubspec.yaml');
+      manifestFile.createSync(recursive: true);
+      manifestFile.writeAsStringSync('''
+        flutter:
+          module:
+            androidPackage: com.example.test
+        ''');
+
+      fileSystem.directory('.android/gradle').createSync(recursive: true);
+      fileSystem.directory('.android/gradle/wrapper').createSync(recursive: true);
+      fileSystem.file('.android/gradlew').createSync(recursive: true);
+      fileSystem.file('.android/gradle.properties').writeAsStringSync('irrelevant');
+      fileSystem.file('.android/build.gradle').createSync(recursive: true);
+      fileSystem.directory('build/outputs/repo').createSync(recursive: true);
+
+      await builder.buildGradleAar(
+        androidBuildInfo: const AndroidBuildInfo(
+          BuildInfo(
+            BuildMode.release,
+            null,
+            treeShakeIcons: false,
+            packageConfigPath: '.dart_tool/package_config.json',
+          ),
+        ),
+        project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
+        outputDirectory: fileSystem.directory('build/'),
+        target: '',
+        buildNumber: '2.0',
+      );
+
+      expect(
+        fileSystem.link(
+          'build/outputs/repo/io/flutter/flutter_embedding_release/'
+          '1.0.0-73fd6b049a80bcea2db1f26c7cee434907cd188b/'
+          'flutter_embedding_release-1.0.0-73fd6b049a80bcea2db1f26c7cee434907cd188b.pom',
+        ),
+        exists,
+      );
+      expect(processManager, hasNoRemainingExpectations);
+    }, overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()});
+
+    testUsingContext('build aar uses selected local engine on x64 ABI', () async {
+      final builder = AndroidGradleBuilder(
+        java: FakeJava(),
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.testLocalEngine(
+          localEngine: 'out/android_x64',
+          localEngineHost: 'out/host_release',
+        ),
+        analytics: fakeAnalytics,
+        gradleUtils: FakeGradleUtils(),
+        platform: FakePlatform(),
+        androidStudio: FakeAndroidStudio(),
+        androidSdk: FakeAndroidSdk(),
+      );
+      processManager.addCommand(
+        const FakeCommand(
+          command: <String>[
+            'gradlew',
+            '-I=/packages/flutter_tools/gradle/aar_init_script.gradle',
+            '-Pflutter-root=/',
+            '-Poutput-dir=build/',
+            '-Pis-plugin=false',
+            '-PbuildNumber=2.0',
+            '-q',
+            '-Pdart-obfuscation=false',
+            '-Ptrack-widget-creation=false',
+            '-Ptree-shake-icons=false',
+            '-Plocal-engine-repo=/.tmp_rand0/flutter_tool_local_engine_repo.rand0',
+            '-Plocal-engine-build-mode=release',
+            '-Plocal-engine-out=out/android_x64',
+            '-Plocal-engine-host-out=out/host_release',
+            '-Ptarget-platform=android-x64',
+            'assembleAarRelease',
+          ],
+        ),
+      );
+
+      fileSystem.file('out/android_x64/flutter_embedding_release.pom')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('''
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <version>1.0.0-73fd6b049a80bcea2db1f26c7cee434907cd188b</version>
+  <dependencies>
+  </dependencies>
+</project>
+''');
+      fileSystem.file('out/android_x64/x86_64_release.pom').createSync(recursive: true);
+      fileSystem.file('out/android_x64/x86_64_release.jar').createSync(recursive: true);
+      fileSystem
+          .file('out/android_x64/x86_64_release.maven-metadata.xml')
+          .createSync(recursive: true);
+      fileSystem.file('out/android_x64/flutter_embedding_release.jar').createSync(recursive: true);
+      fileSystem.file('out/android_x64/flutter_embedding_release.pom').createSync(recursive: true);
+      fileSystem
+          .file('out/android_x64/flutter_embedding_release.maven-metadata.xml')
+          .createSync(recursive: true);
+
+      final File manifestFile = fileSystem.file('pubspec.yaml');
+      manifestFile.createSync(recursive: true);
+      manifestFile.writeAsStringSync('''
+        flutter:
+          module:
+            androidPackage: com.example.test
+        ''');
+
+      fileSystem.directory('.android/gradle').createSync(recursive: true);
+      fileSystem.directory('.android/gradle/wrapper').createSync(recursive: true);
+      fileSystem.file('.android/gradlew').createSync(recursive: true);
+      fileSystem.file('.android/gradle.properties').writeAsStringSync('irrelevant');
+      fileSystem.file('.android/build.gradle').createSync(recursive: true);
+      fileSystem.directory('build/outputs/repo').createSync(recursive: true);
+
+      await builder.buildGradleAar(
+        androidBuildInfo: const AndroidBuildInfo(
+          BuildInfo(
+            BuildMode.release,
+            null,
+            treeShakeIcons: false,
+            packageConfigPath: '.dart_tool/package_config.json',
+          ),
+        ),
+        project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
+        outputDirectory: fileSystem.directory('build/'),
+        target: '',
+        buildNumber: '2.0',
+      );
+
+      expect(
+        fileSystem.link(
+          'build/outputs/repo/io/flutter/flutter_embedding_release/'
+          '1.0.0-73fd6b049a80bcea2db1f26c7cee434907cd188b/'
+          'flutter_embedding_release-1.0.0-73fd6b049a80bcea2db1f26c7cee434907cd188b.pom',
+        ),
+        exists,
+      );
+      expect(processManager, hasNoRemainingExpectations);
+    }, overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()});
   });
 }
 

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:io' as io show IOSink, ProcessSignal, Stdout, StdoutException;
 
 import 'package:dds/dds_launcher.dart';
+import 'package:file/memory.dart';
 import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/android/android_studio.dart';
 import 'package:flutter_tools/src/android/java.dart';
@@ -782,6 +783,18 @@ class FakeAndroidSdk extends Fake implements AndroidSdk {
 
   @override
   AndroidSdkVersion? latestVersion;
+
+  @override
+  String? get sdkManagerPath => null;
+
+  @override
+  bool get cmdlineToolsAvailable => true;
+
+  @override
+  String? getCmdlineToolsPath(String binaryName, {bool skipOldTools = false}) => binaryName;
+
+  @override
+  Directory get directory => MemoryFileSystem.test().directory('/');
 }
 
 class FakeAndroidStudio extends Fake implements AndroidStudio {


### PR DESCRIPTION
This is inspired by https://github.com/flutter/flutter/pull/183555 

That PR took the approach of making a gradle invocation to see the AGP-determined NDK version, and using that from within the dart code of the tool to invoke the sdk manager to download the required ndk version

That approach was reverted because it required an additional gradle invocation, which has a high overhead.

This approach instead passes the path to the sdk manager, as well as the flutter tool-determined installed ndk versions, along through the main gradle invocation, and from within the main FGP application determines if we need to install an ndk version, and invokes the sdkmanager if so via the provided path.