### PR TITLE
Fix expanded semantics for DatePicker mode toggle button

### DIFF
--- a/packages/flutter/lib/src/material/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/calendar_date_picker.dart
@@ -515,6 +515,7 @@ class _DatePickerModeToggleButtonState extends State<_DatePickerModeToggleButton
                 label: MaterialLocalizations.of(context).selectYearSemanticsLabel,
                 button: true,
                 container: true,
+                expanded: widget.mode == DatePickerMode.year,
                 child: SizedBox(
                   height: _subHeaderHeight,
                   child: InkWell(

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -1912,6 +1912,68 @@ void main() {
       final SemanticsData semanticsData = node.getSemanticsData();
       expect(semanticsData.flagsCollection.isFocused, Tristate.none);
     });
+
+    // Regression test for https://github.com/flutter/flutter/issues/186043.
+    testWidgets('mode toggle button exposes expanded/collapsed state', (WidgetTester tester) async {
+      final SemanticsHandle semantics = tester.ensureSemantics();
+
+      await prepareDatePicker(tester, (Future<DateTime?> date) async {
+        // The mode toggle button wraps the month/year title text. Its Semantics
+        // widget has label='Select year', button=true, and expanded reflects the
+        // current DatePickerMode (false=day/collapsed, true=year/expanded).
+        final Finder modeToggleTitle = find.text('January 2016');
+
+        // Initially in day mode — should report hasExpandedState=true, isExpanded=false.
+        expect(
+          tester.getSemantics(modeToggleTitle),
+          matchesSemantics(
+            label: 'Select year\nJanuary 2016',
+            isButton: true,
+            hasTapAction: true,
+            hasFocusAction: true,
+            isFocusable: true,
+            hasExpandedState: true,
+            isExpanded: false,
+          ),
+        );
+
+        // Tap the button to switch to year mode (expand).
+        await tester.tap(modeToggleTitle);
+        await tester.pumpAndSettle();
+
+        // Now in year mode — should report isExpanded=true.
+        expect(
+          tester.getSemantics(modeToggleTitle),
+          matchesSemantics(
+            label: 'Select year\nJanuary 2016',
+            isButton: true,
+            hasTapAction: true,
+            hasFocusAction: true,
+            isFocusable: true,
+            hasExpandedState: true,
+            isExpanded: true,
+          ),
+        );
+
+        // Tap again to collapse back to day mode.
+        await tester.tap(modeToggleTitle);
+        await tester.pumpAndSettle();
+
+        expect(
+          tester.getSemantics(modeToggleTitle),
+          matchesSemantics(
+            label: 'Select year\nJanuary 2016',
+            isButton: true,
+            hasTapAction: true,
+            hasFocusAction: true,
+            isFocusable: true,
+            hasExpandedState: true,
+            isExpanded: false,
+          ),
+        );
+      });
+      semantics.dispose();
+    });
   });
 
   group('Keyboard navigation', () {


### PR DESCRIPTION
## Description
This PR resolves a WCAG accessibility issue where the `showDatePicker` expand/collapse control (switching between day and year modes) did not announce its expanded state to screen readers.

I updated the `Semantics` widget inside `_DatePickerModeToggleButtonState` within `calendar_date_picker.dart` to include `expanded: widget.mode == DatePickerMode.year`. This ensures assistive technologies correctly announce the dialog's visual state.

## Related Issue
Fixes #173052 

## Tests
* Added a regression test to `date_picker_test.dart` to verify that the mode toggle button correctly exposes `hasExpandedState` and that `isExpanded` toggles appropriately when switching between day and year modes.