### PR TITLE
[Impeller] Clarify CoversArea behavior and change arg to IRect

### DIFF
--- a/engine/src/flutter/impeller/entity/contents/solid_color_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/solid_color_contents.cc
@@ -81,7 +81,7 @@ std::optional<Color> SolidColorContents::AsBackgroundColor(
   if (geometry == nullptr) {
     return std::nullopt;
   }
-  Rect target_rect = Rect::MakeSize(target_size);
+  IRect target_rect = IRect::MakeSize(target_size);
   return geometry->CoversArea(entity.GetTransform(), target_rect)
              ? GetColor()
              : std::optional<Color>();

--- a/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.cc
@@ -145,7 +145,7 @@ std::optional<Color> UberSDFContents::AsBackgroundColor(
   if (geometry == nullptr) {
     return std::nullopt;
   }
-  Rect target_rect = Rect::MakeSize(target_size);
+  IRect target_rect = IRect::MakeSize(target_size);
   return geometry->CoversArea(entity.GetTransform(), target_rect)
              ? GetColor()
              : std::optional<Color>();

--- a/engine/src/flutter/impeller/entity/geometry/arc_geometry.cc
+++ b/engine/src/flutter/impeller/entity/geometry/arc_geometry.cc
@@ -77,7 +77,7 @@ std::optional<Rect> ArcGeometry::GetCoverage(const Matrix& transform) const {
       transform);
 }
 
-bool ArcGeometry::CoversArea(const Matrix& transform, const Rect& rect) const {
+bool ArcGeometry::CoversArea(const Matrix& transform, const IRect& rect) const {
   return false;
 }
 

--- a/engine/src/flutter/impeller/entity/geometry/arc_geometry.h
+++ b/engine/src/flutter/impeller/entity/geometry/arc_geometry.h
@@ -23,7 +23,7 @@ class ArcGeometry final : public Geometry {
   ~ArcGeometry() override;
 
   // |Geometry|
-  bool CoversArea(const Matrix& transform, const Rect& rect) const override;
+  bool CoversArea(const Matrix& transform, const IRect& rect) const override;
 
   // |Geometry|
   bool IsAxisAlignedRect() const override;

--- a/engine/src/flutter/impeller/entity/geometry/circle_geometry.cc
+++ b/engine/src/flutter/impeller/entity/geometry/circle_geometry.cc
@@ -96,7 +96,7 @@ std::optional<Rect> CircleGeometry::GetCoverage(const Matrix& transform) const {
 }
 
 bool CircleGeometry::CoversArea(const Matrix& transform,
-                                const Rect& rect) const {
+                                const IRect& rect) const {
   return false;
 }
 

--- a/engine/src/flutter/impeller/entity/geometry/circle_geometry.h
+++ b/engine/src/flutter/impeller/entity/geometry/circle_geometry.h
@@ -22,7 +22,7 @@ class CircleGeometry final : public Geometry {
   ~CircleGeometry() override;
 
   // |Geometry|
-  bool CoversArea(const Matrix& transform, const Rect& rect) const override;
+  bool CoversArea(const Matrix& transform, const IRect& rect) const override;
 
   // |Geometry|
   bool IsAxisAlignedRect() const override;

--- a/engine/src/flutter/impeller/entity/geometry/cover_geometry.cc
+++ b/engine/src/flutter/impeller/entity/geometry/cover_geometry.cc
@@ -39,7 +39,7 @@ std::optional<Rect> CoverGeometry::GetCoverage(const Matrix& transform) const {
 }
 
 bool CoverGeometry::CoversArea(const Matrix& transform,
-                               const Rect& rect) const {
+                               const IRect& rect) const {
   return true;
 }
 

--- a/engine/src/flutter/impeller/entity/geometry/cover_geometry.h
+++ b/engine/src/flutter/impeller/entity/geometry/cover_geometry.h
@@ -18,7 +18,7 @@ class CoverGeometry final : public Geometry {
   ~CoverGeometry() override = default;
 
   // |Geometry|
-  bool CoversArea(const Matrix& transform, const Rect& rect) const override;
+  bool CoversArea(const Matrix& transform, const IRect& rect) const override;
 
   bool CanApplyMaskFilter() const override;
 

--- a/engine/src/flutter/impeller/entity/geometry/ellipse_geometry.cc
+++ b/engine/src/flutter/impeller/entity/geometry/ellipse_geometry.cc
@@ -28,7 +28,7 @@ std::optional<Rect> EllipseGeometry::GetCoverage(
 }
 
 bool EllipseGeometry::CoversArea(const Matrix& transform,
-                                 const Rect& rect) const {
+                                 const IRect& rect) const {
   return false;
 }
 

--- a/engine/src/flutter/impeller/entity/geometry/ellipse_geometry.h
+++ b/engine/src/flutter/impeller/entity/geometry/ellipse_geometry.h
@@ -25,7 +25,7 @@ class EllipseGeometry final : public Geometry {
   ~EllipseGeometry() override = default;
 
   // |Geometry|
-  bool CoversArea(const Matrix& transform, const Rect& rect) const override;
+  bool CoversArea(const Matrix& transform, const IRect& rect) const override;
 
   // |Geometry|
   bool IsAxisAlignedRect() const override;

--- a/engine/src/flutter/impeller/entity/geometry/fill_path_geometry.cc
+++ b/engine/src/flutter/impeller/entity/geometry/fill_path_geometry.cc
@@ -81,7 +81,7 @@ std::optional<Rect> FillPathSourceGeometry::GetCoverage(
 }
 
 bool FillPathSourceGeometry::CoversArea(const Matrix& transform,
-                                        const Rect& rect) const {
+                                        const IRect& rect) const {
   if (!inner_rect_.has_value()) {
     return false;
   }

--- a/engine/src/flutter/impeller/entity/geometry/fill_path_geometry.h
+++ b/engine/src/flutter/impeller/entity/geometry/fill_path_geometry.h
@@ -21,7 +21,7 @@ class FillPathSourceGeometry : public Geometry {
   ~FillPathSourceGeometry() override;
 
   // |Geometry|
-  bool CoversArea(const Matrix& transform, const Rect& rect) const override;
+  bool CoversArea(const Matrix& transform, const IRect& rect) const override;
 
  protected:
   explicit FillPathSourceGeometry(std::optional<Rect> inner_rect);

--- a/engine/src/flutter/impeller/entity/geometry/geometry.cc
+++ b/engine/src/flutter/impeller/entity/geometry/geometry.cc
@@ -133,7 +133,7 @@ std::unique_ptr<Geometry> Geometry::MakeRoundSuperellipse(
   return std::make_unique<RoundSuperellipseGeometry>(rect, corner_radius);
 }
 
-bool Geometry::CoversArea(const Matrix& transform, const Rect& rect) const {
+bool Geometry::CoversArea(const Matrix& transform, const IRect& rect) const {
   return false;
 }
 

--- a/engine/src/flutter/impeller/entity/geometry/geometry.h
+++ b/engine/src/flutter/impeller/entity/geometry/geometry.h
@@ -109,16 +109,24 @@ class Geometry {
                                            Scalar stroke_width);
 
   /// @brief    Determines if this geometry, transformed by the given
-  ///           `transform`, will completely cover all surface area of the given
-  ///           `rect`.
+  ///           `transform`, will completely cover all of the pixels
+  ///           within the given integer `rect`.
   ///
-  ///           This is a conservative estimate useful for certain
-  ///           optimizations.
+  ///           The integer `rect`, by definition, will contain all of
+  ///           the area covered by any pixel within its boundary.
   ///
-  /// @returns  `true` if the transformed geometry is guaranteed to cover the
-  ///           given `rect`. May return `false` in many undetected cases where
+  ///           The return value can be a conservative estimate which
+  ///           will still be useful for certain optimizations. It may
+  ///           return `false` for obscure cases that might actually contain
+  ///           all of the pixels if it is too computationally costly
+  ///           to prove containment, but it should never return 'true'
+  ///           unless the implementation can prove that all pixels are
+  ///           fully covered (rendered) by the geometry.
+  ///
+  /// @returns  `true` if the transformed geometry is guaranteed to cover
+  ///           the given `rect`. May return `false` in some cases where
   ///           the transformed geometry does in fact cover the `rect`.
-  virtual bool CoversArea(const Matrix& transform, const Rect& rect) const;
+  virtual bool CoversArea(const Matrix& transform, const IRect& rect) const;
 
   virtual bool IsAxisAlignedRect() const;
 

--- a/engine/src/flutter/impeller/entity/geometry/geometry_unittests.cc
+++ b/engine/src/flutter/impeller/entity/geometry/geometry_unittests.cc
@@ -75,10 +75,10 @@ namespace testing {
 
 TEST(EntityGeometryTest, RectGeometryCoversArea) {
   auto geometry = Geometry::MakeRect(Rect::MakeLTRB(0, 0, 100, 100));
-  ASSERT_TRUE(geometry->CoversArea({}, Rect::MakeLTRB(0, 0, 100, 100)));
-  ASSERT_FALSE(geometry->CoversArea({}, Rect::MakeLTRB(-1, 0, 100, 100)));
-  ASSERT_TRUE(geometry->CoversArea({}, Rect::MakeLTRB(1, 1, 100, 100)));
-  ASSERT_TRUE(geometry->CoversArea({}, Rect()));
+  ASSERT_TRUE(geometry->CoversArea({}, IRect::MakeLTRB(0, 0, 100, 100)));
+  ASSERT_FALSE(geometry->CoversArea({}, IRect::MakeLTRB(-1, 0, 100, 100)));
+  ASSERT_TRUE(geometry->CoversArea({}, IRect::MakeLTRB(1, 1, 100, 100)));
+  ASSERT_TRUE(geometry->CoversArea({}, IRect()));
 }
 
 TEST(EntityGeometryTest, UberSDFGeometryPaddingIsAdjustedByInverseMaxBasis) {
@@ -125,10 +125,10 @@ TEST(EntityGeometryTest, FillPathGeometryCoversArea) {
                   .TakePath();
   auto geometry = Geometry::MakeFillPath(
       path, /* inner rect */ Rect::MakeLTRB(0, 0, 100, 100));
-  ASSERT_TRUE(geometry->CoversArea({}, Rect::MakeLTRB(0, 0, 100, 100)));
-  ASSERT_FALSE(geometry->CoversArea({}, Rect::MakeLTRB(-1, 0, 100, 100)));
-  ASSERT_TRUE(geometry->CoversArea({}, Rect::MakeLTRB(1, 1, 100, 100)));
-  ASSERT_TRUE(geometry->CoversArea({}, Rect()));
+  ASSERT_TRUE(geometry->CoversArea({}, IRect::MakeLTRB(0, 0, 100, 100)));
+  ASSERT_FALSE(geometry->CoversArea({}, IRect::MakeLTRB(-1, 0, 100, 100)));
+  ASSERT_TRUE(geometry->CoversArea({}, IRect::MakeLTRB(1, 1, 100, 100)));
+  ASSERT_TRUE(geometry->CoversArea({}, IRect()));
 }
 
 TEST(EntityGeometryTest, FillPathGeometryCoversAreaNoInnerRect) {
@@ -136,10 +136,10 @@ TEST(EntityGeometryTest, FillPathGeometryCoversAreaNoInnerRect) {
                   .AddRect(Rect::MakeLTRB(0, 0, 100, 100))
                   .TakePath();
   auto geometry = Geometry::MakeFillPath(path);
-  ASSERT_FALSE(geometry->CoversArea({}, Rect::MakeLTRB(0, 0, 100, 100)));
-  ASSERT_FALSE(geometry->CoversArea({}, Rect::MakeLTRB(-1, 0, 100, 100)));
-  ASSERT_FALSE(geometry->CoversArea({}, Rect::MakeLTRB(1, 1, 100, 100)));
-  ASSERT_FALSE(geometry->CoversArea({}, Rect()));
+  ASSERT_FALSE(geometry->CoversArea({}, IRect::MakeLTRB(0, 0, 100, 100)));
+  ASSERT_FALSE(geometry->CoversArea({}, IRect::MakeLTRB(-1, 0, 100, 100)));
+  ASSERT_FALSE(geometry->CoversArea({}, IRect::MakeLTRB(1, 1, 100, 100)));
+  ASSERT_FALSE(geometry->CoversArea({}, IRect()));
 }
 
 TEST(EntityGeometryTest, FillArcGeometryCoverage) {
@@ -521,18 +521,18 @@ TEST(EntityGeometryTest, FillRoundRectGeometryCoversArea) {
   FillRoundRectGeometry geom(round_rect);
 
   // Tall middle rect should barely be covered.
-  EXPECT_TRUE(geom.CoversArea({}, Rect::MakeLTRB(103, 100, 196, 200)));
-  EXPECT_FALSE(geom.CoversArea({}, Rect::MakeLTRB(102, 100, 196, 200)));
-  EXPECT_FALSE(geom.CoversArea({}, Rect::MakeLTRB(103, 99, 196, 200)));
-  EXPECT_FALSE(geom.CoversArea({}, Rect::MakeLTRB(103, 100, 197, 200)));
-  EXPECT_FALSE(geom.CoversArea({}, Rect::MakeLTRB(103, 100, 196, 201)));
+  EXPECT_TRUE(geom.CoversArea({}, IRect::MakeLTRB(103, 100, 196, 200)));
+  EXPECT_FALSE(geom.CoversArea({}, IRect::MakeLTRB(102, 100, 196, 200)));
+  EXPECT_FALSE(geom.CoversArea({}, IRect::MakeLTRB(103, 99, 196, 200)));
+  EXPECT_FALSE(geom.CoversArea({}, IRect::MakeLTRB(103, 100, 197, 200)));
+  EXPECT_FALSE(geom.CoversArea({}, IRect::MakeLTRB(103, 100, 196, 201)));
 
   // Wide middle rect should barely be covered.
-  EXPECT_TRUE(geom.CoversArea({}, Rect::MakeLTRB(100, 112, 200, 186)));
-  EXPECT_FALSE(geom.CoversArea({}, Rect::MakeLTRB(99, 112, 200, 186)));
-  EXPECT_FALSE(geom.CoversArea({}, Rect::MakeLTRB(100, 111, 200, 186)));
-  EXPECT_FALSE(geom.CoversArea({}, Rect::MakeLTRB(100, 112, 201, 186)));
-  EXPECT_FALSE(geom.CoversArea({}, Rect::MakeLTRB(100, 112, 200, 187)));
+  EXPECT_TRUE(geom.CoversArea({}, IRect::MakeLTRB(100, 112, 200, 186)));
+  EXPECT_FALSE(geom.CoversArea({}, IRect::MakeLTRB(99, 112, 200, 186)));
+  EXPECT_FALSE(geom.CoversArea({}, IRect::MakeLTRB(100, 111, 200, 186)));
+  EXPECT_FALSE(geom.CoversArea({}, IRect::MakeLTRB(100, 112, 201, 186)));
+  EXPECT_FALSE(geom.CoversArea({}, IRect::MakeLTRB(100, 112, 200, 187)));
 }
 
 TEST(EntityGeometryTest, LineGeometryCoverage) {
@@ -540,38 +540,38 @@ TEST(EntityGeometryTest, LineGeometryCoverage) {
     auto geometry = Geometry::MakeLine(  //
         {10, 10}, {20, 10}, {.width = 2, .cap = Cap::kButt});
     EXPECT_EQ(geometry->GetCoverage({}), Rect::MakeLTRB(10, 9, 20, 11));
-    EXPECT_TRUE(geometry->CoversArea({}, Rect::MakeLTRB(10, 9, 20, 11)));
+    EXPECT_TRUE(geometry->CoversArea({}, IRect::MakeLTRB(10, 9, 20, 11)));
   }
 
   {
     auto geometry = Geometry::MakeLine(  //
         {10, 10}, {20, 10}, {.width = 2, .cap = Cap::kSquare});
     EXPECT_EQ(geometry->GetCoverage({}), Rect::MakeLTRB(9, 9, 21, 11));
-    EXPECT_TRUE(geometry->CoversArea({}, Rect::MakeLTRB(9, 9, 21, 11)));
+    EXPECT_TRUE(geometry->CoversArea({}, IRect::MakeLTRB(9, 9, 21, 11)));
   }
 
   {
     auto geometry = Geometry::MakeLine(  //
         {10, 10}, {10, 20}, {.width = 2, .cap = Cap::kButt});
     EXPECT_EQ(geometry->GetCoverage({}), Rect::MakeLTRB(9, 10, 11, 20));
-    EXPECT_TRUE(geometry->CoversArea({}, Rect::MakeLTRB(9, 10, 11, 20)));
+    EXPECT_TRUE(geometry->CoversArea({}, IRect::MakeLTRB(9, 10, 11, 20)));
   }
 
   {
     auto geometry = Geometry::MakeLine(  //
         {10, 10}, {10, 20}, {.width = 2, .cap = Cap::kSquare});
     EXPECT_EQ(geometry->GetCoverage({}), Rect::MakeLTRB(9, 9, 11, 21));
-    EXPECT_TRUE(geometry->CoversArea({}, Rect::MakeLTRB(9, 9, 11, 21)));
+    EXPECT_TRUE(geometry->CoversArea({}, IRect::MakeLTRB(9, 9, 11, 21)));
   }
 }
 
 TEST(EntityGeometryTest, RoundRectGeometryCoversArea) {
   auto geometry =
       Geometry::MakeRoundRect(Rect::MakeLTRB(0, 0, 100, 100), Size(20, 20));
-  EXPECT_FALSE(geometry->CoversArea({}, Rect::MakeLTRB(15, 15, 85, 85)));
-  EXPECT_TRUE(geometry->CoversArea({}, Rect::MakeLTRB(20, 20, 80, 80)));
-  EXPECT_TRUE(geometry->CoversArea({}, Rect::MakeLTRB(30, 1, 70, 99)));
-  EXPECT_TRUE(geometry->CoversArea({}, Rect::MakeLTRB(1, 30, 99, 70)));
+  EXPECT_FALSE(geometry->CoversArea({}, IRect::MakeLTRB(15, 15, 85, 85)));
+  EXPECT_TRUE(geometry->CoversArea({}, IRect::MakeLTRB(20, 20, 80, 80)));
+  EXPECT_TRUE(geometry->CoversArea({}, IRect::MakeLTRB(30, 1, 70, 99)));
+  EXPECT_TRUE(geometry->CoversArea({}, IRect::MakeLTRB(1, 30, 99, 70)));
 }
 
 TEST(EntityGeometryTest, GeometryResultHasReasonableDefaults) {

--- a/engine/src/flutter/impeller/entity/geometry/line_geometry.cc
+++ b/engine/src/flutter/impeller/entity/geometry/line_geometry.cc
@@ -167,7 +167,8 @@ std::optional<Rect> LineGeometry::GetCoverage(const Matrix& transform) const {
   return Rect::MakePointBounds(std::begin(corners), std::end(corners));
 }
 
-bool LineGeometry::CoversArea(const Matrix& transform, const Rect& rect) const {
+bool LineGeometry::CoversArea(const Matrix& transform,
+                              const IRect& rect) const {
   if (!transform.IsTranslationScaleOnly() || !IsAxisAlignedRect()) {
     return false;
   }

--- a/engine/src/flutter/impeller/entity/geometry/line_geometry.h
+++ b/engine/src/flutter/impeller/entity/geometry/line_geometry.h
@@ -18,7 +18,7 @@ class LineGeometry final : public Geometry {
   static Scalar ComputePixelHalfWidth(const Matrix& transform, Scalar width);
 
   // |Geometry|
-  bool CoversArea(const Matrix& transform, const Rect& rect) const override;
+  bool CoversArea(const Matrix& transform, const IRect& rect) const override;
 
   // |Geometry|
   bool IsAxisAlignedRect() const override;

--- a/engine/src/flutter/impeller/entity/geometry/rect_geometry.cc
+++ b/engine/src/flutter/impeller/entity/geometry/rect_geometry.cc
@@ -35,7 +35,7 @@ std::optional<Rect> FillRectGeometry::GetCoverage(
 }
 
 bool FillRectGeometry::CoversArea(const Matrix& transform,
-                                  const Rect& rect) const {
+                                  const IRect& rect) const {
   if (!transform.IsTranslationScaleOnly()) {
     return false;
   }

--- a/engine/src/flutter/impeller/entity/geometry/rect_geometry.h
+++ b/engine/src/flutter/impeller/entity/geometry/rect_geometry.h
@@ -17,7 +17,7 @@ class FillRectGeometry final : public Geometry {
   ~FillRectGeometry() override;
 
   // |Geometry|
-  bool CoversArea(const Matrix& transform, const Rect& rect) const override;
+  bool CoversArea(const Matrix& transform, const IRect& rect) const override;
 
   // |Geometry|
   bool IsAxisAlignedRect() const override;

--- a/engine/src/flutter/impeller/entity/geometry/round_rect_geometry.cc
+++ b/engine/src/flutter/impeller/entity/geometry/round_rect_geometry.cc
@@ -27,7 +27,7 @@ std::optional<Rect> RoundRectGeometry::GetCoverage(
 }
 
 bool RoundRectGeometry::CoversArea(const Matrix& transform,
-                                   const Rect& rect) const {
+                                   const IRect& rect) const {
   if (!transform.IsTranslationScaleOnly()) {
     return false;
   }
@@ -71,7 +71,7 @@ const PathSource& FillRoundRectGeometry::GetSource() const {
 }
 
 bool FillRoundRectGeometry::CoversArea(const Matrix& transform,
-                                       const Rect& rect) const {
+                                       const IRect& rect) const {
   // Similar procedure to |RoundRectGeometry| except that we have different
   // radii at every corner.
   if (!transform.IsTranslationScaleOnly()) {

--- a/engine/src/flutter/impeller/entity/geometry/round_rect_geometry.h
+++ b/engine/src/flutter/impeller/entity/geometry/round_rect_geometry.h
@@ -29,7 +29,7 @@ class RoundRectGeometry final : public Geometry {
   ~RoundRectGeometry() override;
 
   // |Geometry|
-  bool CoversArea(const Matrix& transform, const Rect& rect) const override;
+  bool CoversArea(const Matrix& transform, const IRect& rect) const override;
 
   // |Geometry|
   bool IsAxisAlignedRect() const override;
@@ -61,7 +61,7 @@ class FillRoundRectGeometry final : public FillPathSourceGeometry {
   explicit FillRoundRectGeometry(const RoundRect& round_rect);
 
   // |Geometry|
-  bool CoversArea(const Matrix& transform, const Rect& rect) const override;
+  bool CoversArea(const Matrix& transform, const IRect& rect) const override;
 
  protected:
   // |FillPathSourceGeometry|

--- a/engine/src/flutter/impeller/entity/geometry/round_superellipse_geometry.cc
+++ b/engine/src/flutter/impeller/entity/geometry/round_superellipse_geometry.cc
@@ -441,7 +441,7 @@ std::optional<Rect> RoundSuperellipseGeometry::GetCoverage(
 }
 
 bool RoundSuperellipseGeometry::CoversArea(const Matrix& transform,
-                                           const Rect& rect) const {
+                                           const IRect& rect) const {
   if (!transform.IsTranslationScaleOnly()) {
     return false;
   }

--- a/engine/src/flutter/impeller/entity/geometry/round_superellipse_geometry.h
+++ b/engine/src/flutter/impeller/entity/geometry/round_superellipse_geometry.h
@@ -35,7 +35,7 @@ class RoundSuperellipseGeometry final : public Geometry {
   ~RoundSuperellipseGeometry() override;
 
   // |Geometry|
-  bool CoversArea(const Matrix& transform, const Rect& rect) const override;
+  bool CoversArea(const Matrix& transform, const IRect& rect) const override;
 
   // |Geometry|
   bool IsAxisAlignedRect() const override;

--- a/engine/src/flutter/impeller/entity/geometry/superellipse_geometry.cc
+++ b/engine/src/flutter/impeller/entity/geometry/superellipse_geometry.cc
@@ -102,7 +102,7 @@ std::optional<Rect> SuperellipseGeometry::GetCoverage(
 }
 
 bool SuperellipseGeometry::CoversArea(const Matrix& transform,
-                                      const Rect& rect) const {
+                                      const IRect& rect) const {
   return false;
 }
 

--- a/engine/src/flutter/impeller/entity/geometry/superellipse_geometry.h
+++ b/engine/src/flutter/impeller/entity/geometry/superellipse_geometry.h
@@ -31,7 +31,7 @@ class SuperellipseGeometry final : public Geometry {
   ~SuperellipseGeometry() override;
 
   // |Geometry|
-  bool CoversArea(const Matrix& transform, const Rect& rect) const override;
+  bool CoversArea(const Matrix& transform, const IRect& rect) const override;
 
   // |Geometry|
   bool IsAxisAlignedRect() const override;

--- a/engine/src/flutter/impeller/entity/geometry/uber_sdf_geometry.cc
+++ b/engine/src/flutter/impeller/entity/geometry/uber_sdf_geometry.cc
@@ -33,7 +33,7 @@ std::optional<Rect> UberSDFGeometry::GetCoverage(
 }
 
 bool UberSDFGeometry::CoversArea(const Matrix& transform,
-                                 const Rect& rect) const {
+                                 const IRect& rect) const {
   if (params_.type == UberSDFParameters::Type::kRect && !params_.stroke &&
       transform.IsTranslationScaleOnly()) {
     // The SDF is a filled axis-aligned rectangle. It "covers" the input rect if

--- a/engine/src/flutter/impeller/entity/geometry/uber_sdf_geometry.h
+++ b/engine/src/flutter/impeller/entity/geometry/uber_sdf_geometry.h
@@ -30,7 +30,7 @@ class UberSDFGeometry final : public Geometry {
   std::optional<Rect> GetCoverage(const Matrix& transform) const override;
 
   // |Geometry|
-  bool CoversArea(const Matrix& transform, const Rect& rect) const override;
+  bool CoversArea(const Matrix& transform, const IRect& rect) const override;
 
   // |Geometry|
   bool IsAxisAlignedRect() const override;

--- a/engine/src/flutter/impeller/geometry/rect.h
+++ b/engine/src/flutter/impeller/geometry/rect.h
@@ -302,6 +302,16 @@ struct TRect {
                             o.bottom_ <= bottom_));
   }
 
+  template <class U, class FT = T>
+  [[nodiscard]] constexpr std::enable_if_t<std::is_floating_point_v<FT>, bool>
+  Contains(const TRect<U>& o) const {
+    return !this->IsEmpty() &&                         //
+           (o.IsEmpty() || (o.GetLeft() >= left_ &&    //
+                            o.GetTop() >= top_ &&      //
+                            o.GetRight() <= right_ &&  //
+                            o.GetBottom() <= bottom_));
+  }
+
   /// @brief  Returns true if all of the fields of this floating point
   ///         rectangle are finite.
   ///

--- a/engine/src/flutter/impeller/geometry/rect_unittests.cc
+++ b/engine/src/flutter/impeller/geometry/rect_unittests.cc
@@ -1444,6 +1444,18 @@ TEST(RectTest, ContainsFloatingPoint) {
   EXPECT_TRUE(rect1.Contains(rect2));
 }
 
+TEST(RectTest, FloatContainsInteger) {
+  auto rect1 =
+      Rect::MakeLTRB(472.599945f, 440.999969f, 1574.80005f, 1094.000000f);
+  EXPECT_TRUE(rect1.Contains(IRect::MakeLTRB(473, 441, 1574, 1094)));
+
+  // Now test failure to contain same rect expanded by 1 on each side
+  EXPECT_FALSE(rect1.Contains(IRect::MakeLTRB(472, 441, 1574, 1094)));
+  EXPECT_FALSE(rect1.Contains(IRect::MakeLTRB(473, 440, 1574, 1094)));
+  EXPECT_FALSE(rect1.Contains(IRect::MakeLTRB(473, 441, 1575, 1094)));
+  EXPECT_FALSE(rect1.Contains(IRect::MakeLTRB(473, 441, 1574, 1095)));
+}
+
 template <typename R>
 static constexpr inline R flip_lr(R rect) {
   return R::MakeLTRB(rect.GetRight(), rect.GetTop(),  //


### PR DESCRIPTION
While reviewing https://github.com/flutter/flutter/pull/185760 it became clear that callers of the `Geometry::CoversArea` method were constructing floating point rectangles when their query related to a simple whole-integer region of pixels and that implementations might complicate themselves in order to verify containment of arbitrary floating point regions due to a lack of clarity in the method's documentation and argument types.

This PR updates the method signature to take an `IRect` instead of a `Rect` and clarifies that the argument will (implicitly) contain a region of whole pixels to be covered by the geometry.

A new `Rect::Contains(IRect)` method enables the containment tests without having to convert the argument. Tests are included for this new method.

Fixes: https://github.com/flutter/flutter/issues/186014

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.