### PR TITLE
Add logging to figure out jvm crashes for `hot_mode_tests`

### DIFF
--- a/dev/devicelab/lib/tasks/hot_mode_tests.dart
+++ b/dev/devicelab/lib/tasks/hot_mode_tests.dart
@@ -354,7 +354,7 @@ Future<void> _checkAppRunning(bool shouldBeRunning) async {
 /// Checks the android directory for JVM crash logs and prints their content.
 void _checkAndPrintJvmCrashLogs() {
   try {
-    final Directory androidDir = Directory(path.join(_editedFlutterGalleryDir.path, 'android'));
+    final androidDir = Directory(path.join(_editedFlutterGalleryDir.path, 'android'));
     if (!androidDir.existsSync()) {
       return;
     }

--- a/dev/devicelab/lib/tasks/hot_mode_tests.dart
+++ b/dev/devicelab/lib/tasks/hot_mode_tests.dart
@@ -351,17 +351,22 @@ Future<void> _checkAppRunning(bool shouldBeRunning) async {
   throw TaskResult.failure('Flutter Gallery app is ${shouldBeRunning ? 'not' : 'still'} running');
 }
 
+/// Checks the android directory for JVM crash logs and prints their content.
 void _checkAndPrintJvmCrashLogs() {
-  final androidDir = Directory(path.join(_editedFlutterGalleryDir.path, 'android'));
-  if (!androidDir.existsSync()) {
-    return;
-  }
-  for (final FileSystemEntity entity in androidDir.listSync()) {
-    if (entity is File && path.basename(entity.path).startsWith('hs_err_pid')) {
-      print('\n\n================ JVM CRASH LOG DETECTED ================');
-      print('File: ${entity.path}');
-      print(entity.readAsStringSync());
-      print('========================================================\n\n');
+  try {
+    final Directory androidDir = Directory(path.join(_editedFlutterGalleryDir.path, 'android'));
+    if (!androidDir.existsSync()) {
+      return;
     }
+    for (final FileSystemEntity entity in androidDir.listSync()) {
+      if (entity is File && path.basename(entity.path).startsWith('hs_err_pid')) {
+        print('\n\n================ JVM CRASH LOG DETECTED ================');
+        print('File: ${entity.path}');
+        print(entity.readAsStringSync());
+        print('========================================================\n\n');
+      }
+    }
+  } catch (e) {
+    print('Error while looking for JVM crash logs: $e');
   }
 }

--- a/dev/devicelab/lib/tasks/hot_mode_tests.dart
+++ b/dev/devicelab/lib/tasks/hot_mode_tests.dart
@@ -187,7 +187,14 @@ TaskFunction createHotModeTest({
                 );
 
             await Future.wait<void>(<Future<void>>[stdoutDone.future, stderrDone.future]);
-            await process.exitCode;
+
+            final int exitCode = await process.exitCode;
+            if (exitCode != 0) {
+              _checkAndPrintJvmCrashLogs();
+              throw TaskResult.failure(
+                'flutter run (fresh restart) failed with exit code $exitCode',
+              );
+            }
 
             freshRestartReloadsData =
                 json.decode(benchmarkFile.readAsStringSync()) as Map<String, dynamic>;
@@ -312,7 +319,13 @@ Future<Map<String, dynamic>> captureReloadData({
       .listen((String line) => print('stderr: $line'), onDone: stderrDone.complete);
 
   await Future.wait<void>(<Future<void>>[stdoutDone.future, stderrDone.future]);
-  await process.exitCode;
+
+  final int exitCode = await process.exitCode;
+  if (exitCode != 0) {
+    _checkAndPrintJvmCrashLogs();
+    throw TaskResult.failure('flutter run failed with exit code $exitCode');
+  }
+
   final result = json.decode(benchmarkFile.readAsStringSync()) as Map<String, dynamic>;
   benchmarkFile.deleteSync();
   return result;
@@ -336,4 +349,19 @@ Future<void> _checkAppRunning(bool shouldBeRunning) async {
   }
   print(galleryProcesses.join('\n'));
   throw TaskResult.failure('Flutter Gallery app is ${shouldBeRunning ? 'not' : 'still'} running');
+}
+
+void _checkAndPrintJvmCrashLogs() {
+  final androidDir = Directory(path.join(_editedFlutterGalleryDir.path, 'android'));
+  if (!androidDir.existsSync()) {
+    return;
+  }
+  for (final FileSystemEntity entity in androidDir.listSync()) {
+    if (entity is File && path.basename(entity.path).startsWith('hs_err_pid')) {
+      print('\n\n================ JVM CRASH LOG DETECTED ================');
+      print('File: ${entity.path}');
+      print(entity.readAsStringSync());
+      print('========================================================\n\n');
+    }
+  }
 }


### PR DESCRIPTION
Prints out the jvm crash seen here:
`JVM crash log found: file:///opt/s/w/ir/x/t/gallery_workspace/edited_flutter_gallery/android/hs_err_pid50777.log`
https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8683419392623582177/+/u/step_is_flaky:_run_hot_mode_dev_cycle__benchmark/stdout

in most of the flaking tests. Maybe will help us find the root cause.