### PR TITLE
SECURITY: ignore client customTool in debug adapters

### DIFF
--- a/packages/flutter_tools/lib/src/debug_adapters/README.md
+++ b/packages/flutter_tools/lib/src/debug_adapters/README.md
@@ -29,8 +29,8 @@ Arguments common to both `launchRequest` and `attachRequest` are:
 - `List<String>? additionalProjectPaths` - paths of any projects (outside of `cwd`) that are open in the users workspace
 - `String? cwd` - the working directory for the Flutter process to be spawned in
 - `List<String>? toolArgs` - arguments for the `flutter run`, `flutter attach` or `flutter test` commands
-- `String? customTool` - an optional tool to run instead of `flutter` - the custom tool must be completely compatible with the tool/command it is replacing
-- `int? customToolReplacesArgs` - the number of arguments to delete from the beginning of the argument list when invoking `customTool` - e.g. setting `customTool` to `flutter_test_wrapper` and `customToolReplacesArgs` to `1` for a test run would invoke `flutter_test_wrapper foo_test.dart` instead of `flutter test foo_test.dart` (if larger than the number of computed arguments all arguments will be removed, if not supplied will default to `0`)
+- `String? customTool` - legacy protocol field retained for compatibility only; it is ignored by the debug adapters
+- `int? customToolReplacesArgs` - legacy protocol field retained for compatibility only; it is ignored by the debug adapters
 
 Arguments specific to `launchRequest` are:
 

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -9,7 +9,6 @@ import 'package:vm_service/vm_service.dart' as vm;
 
 import '../base/io.dart';
 import '../base/process.dart';
-import '../cache.dart';
 import '../convert.dart';
 import '../globals.dart' as globals show fs;
 import 'error_formatter.dart';
@@ -267,11 +266,7 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter with VmServiceInfoFile
     String? targetProgram,
     List<String>? userArgs,
   }) async {
-    final String executable = fileSystem.path.join(
-      Cache.flutterRoot!,
-      'bin',
-      platform.isWindows ? 'flutter.bat' : 'flutter',
-    );
+    final String executable = flutterExecutable;
 
     final processArgs = <String>[
       ...toolArgs,

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:math' as math;
 
 import 'package:dds/dap.dart' hide PidTracker;
 import 'package:vm_service/vm_service.dart' as vm;
@@ -157,8 +156,6 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter with VmServiceInfoFile
 
     await _startProcess(
       toolArgs: toolArgs,
-      customTool: args.customTool,
-      customToolReplacesArgs: args.customToolReplacesArgs,
       userToolArgs: args.toolArgs,
       targetProgram: args.program,
     );
@@ -257,8 +254,6 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter with VmServiceInfoFile
 
     await _startProcess(
       toolArgs: toolArgs,
-      customTool: args.customTool,
-      customToolReplacesArgs: args.customToolReplacesArgs,
       targetProgram: args.program,
       userToolArgs: args.toolArgs,
       userArgs: args.args,
@@ -267,25 +262,16 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter with VmServiceInfoFile
 
   /// Starts the `flutter` process to run/attach to the required app.
   Future<void> _startProcess({
-    required String? customTool,
-    required int? customToolReplacesArgs,
     required List<String> toolArgs,
     required List<String>? userToolArgs,
     String? targetProgram,
     List<String>? userArgs,
   }) async {
-    // Handle customTool and deletion of any arguments for it.
-    final String executable =
-        customTool ??
-        fileSystem.path.join(
-          Cache.flutterRoot!,
-          'bin',
-          platform.isWindows ? 'flutter.bat' : 'flutter',
-        );
-    final removeArgs = customToolReplacesArgs;
-    if (customTool != null && removeArgs != null) {
-      toolArgs.removeRange(0, math.min(removeArgs, toolArgs.length));
-    }
+    final String executable = fileSystem.path.join(
+      Cache.flutterRoot!,
+      'bin',
+      platform.isWindows ? 'flutter.bat' : 'flutter',
+    );
 
     final processArgs = <String>[
       ...toolArgs,

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter_args.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter_args.dart
@@ -73,10 +73,10 @@ class FlutterAttachRequestArguments extends DartCommonLaunchAttachRequestArgumen
   @override
   Map<String, Object?> toJson() => <String, Object?>{
     ...super.toJson(),
-    'toolArgs': toolArgs,
-    'customTool': customTool,
-    'customToolReplacesArgs': customToolReplacesArgs,
-    'vmServiceUri': vmServiceUri,
+    if (toolArgs != null) 'toolArgs': toolArgs,
+    if (customTool != null) 'customTool': customTool,
+    if (customToolReplacesArgs != null) 'customToolReplacesArgs': customToolReplacesArgs,
+    if (vmServiceUri != null) 'vmServiceUri': vmServiceUri,
   };
 }
 
@@ -142,11 +142,11 @@ class FlutterLaunchRequestArguments extends DartCommonLaunchAttachRequestArgumen
   @override
   Map<String, Object?> toJson() => <String, Object?>{
     ...super.toJson(),
-    'noDebug': noDebug,
-    'program': program,
-    'args': args,
-    'toolArgs': toolArgs,
-    'customTool': customTool,
-    'customToolReplacesArgs': customToolReplacesArgs,
+    if (noDebug != null) 'noDebug': noDebug,
+    if (program != null) 'program': program,
+    if (args != null) 'args': args,
+    if (toolArgs != null) 'toolArgs': toolArgs,
+    if (customTool != null) 'customTool': customTool,
+    if (customToolReplacesArgs != null) 'customToolReplacesArgs': customToolReplacesArgs,
   };
 }

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter_args.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter_args.dart
@@ -2,7 +2,52 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
 import 'package:dds/dap.dart';
+
+// SECURITY NOTE: This file previously allowed arbitrary execution via the `customTool` field.
+// The `customTool` must be an absolute path to prevent Remote Code Execution (RCE).
+
+/// Validates that the `customTool` argument, if provided, is an absolute path
+/// and that it refers to an allowed SDK tool. Throws a [FormatException] on
+/// validation failure. Messages intentionally avoid echoing the full path.
+void _validateCustomTool(String? tool) {
+  if (tool == null) return;
+
+  // Simple absolute‑path check for POSIX and Windows.
+  final isAbsolute = tool.startsWith('/') || RegExp(r'^[a-zA-Z]:[\\/]').hasMatch(tool);
+  if (!isAbsolute) {
+    throw FormatException(
+      'The supplied customTool path is not absolute; refusing to accept non-absolute paths for security reasons.',
+    );
+  }
+
+  // Basic allowlist of tool basenames that are safe to invoke from the adapter.
+  const allowedBasenames = <String>{'flutter', 'dart', 'pub', 'dartanalyzer', 'dartdev'};
+  final basename = tool.split(Platform.pathSeparator).last.toLowerCase();
+  if (!allowedBasenames.contains(basename)) {
+    throw FormatException(
+      'The customTool "$basename" is not an allowed tool. Only SDK tools are permitted.',
+    );
+  }
+
+  // Verify the file exists and (on POSIX) is executable.
+  try {
+    final file = File(tool);
+    if (!file.existsSync()) {
+      throw FormatException('The customTool does not exist (redacted)');
+    }
+    if (!Platform.isWindows) {
+      final mode = file.statSync().mode;
+      // Check owner/group/other execute bits.
+      if ((mode & 0x49) == 0) {
+        throw FormatException('The customTool is not executable (redacted)');
+      }
+    }
+  } on FileSystemException {
+    throw FormatException('Unable to validate the customTool path');
+  }
+}
 
 /// An implementation of [AttachRequestArguments] that includes all fields used by the Flutter debug adapter.
 ///
@@ -30,7 +75,9 @@ class FlutterAttachRequestArguments extends DartCommonLaunchAttachRequestArgumen
     super.evaluateToStringInDebugViews,
     super.sendLogsToClient,
     super.sendCustomProgressEvents,
-  });
+  }) {
+    _validateCustomTool(customTool);
+  }
 
   FlutterAttachRequestArguments.fromMap(super.obj)
     : toolArgs = (obj['toolArgs'] as List<Object?>?)?.cast<String>(),
@@ -39,7 +86,9 @@ class FlutterAttachRequestArguments extends DartCommonLaunchAttachRequestArgumen
       vmServiceUri = obj['vmServiceUri'] as String?,
       vmServiceInfoFile = obj['vmServiceInfoFile'] as String?,
       program = obj['program'] as String?,
-      super.fromMap();
+      super.fromMap() {
+    _validateCustomTool(customTool);
+  }
 
   factory FlutterAttachRequestArguments.fromJson(Map<String, Object?> obj) =
       FlutterAttachRequestArguments.fromMap;
@@ -81,10 +130,10 @@ class FlutterAttachRequestArguments extends DartCommonLaunchAttachRequestArgumen
   @override
   Map<String, Object?> toJson() => <String, Object?>{
     ...super.toJson(),
-    'toolArgs': ?toolArgs,
-    'customTool': ?customTool,
-    'customToolReplacesArgs': ?customToolReplacesArgs,
-    'vmServiceUri': ?vmServiceUri,
+    'toolArgs': toolArgs,
+    'customTool': customTool,
+    'customToolReplacesArgs': customToolReplacesArgs,
+    'vmServiceUri': vmServiceUri,
   };
 }
 
@@ -114,7 +163,9 @@ class FlutterLaunchRequestArguments extends DartCommonLaunchAttachRequestArgumen
     super.evaluateToStringInDebugViews,
     super.sendLogsToClient,
     super.sendCustomProgressEvents,
-  });
+  }) {
+    _validateCustomTool(customTool);
+  }
 
   FlutterLaunchRequestArguments.fromMap(super.obj)
     : noDebug = obj['noDebug'] as bool?,
@@ -123,7 +174,9 @@ class FlutterLaunchRequestArguments extends DartCommonLaunchAttachRequestArgumen
       toolArgs = (obj['toolArgs'] as List<Object?>?)?.cast<String>(),
       customTool = obj['customTool'] as String?,
       customToolReplacesArgs = obj['customToolReplacesArgs'] as int?,
-      super.fromMap();
+      super.fromMap() {
+    _validateCustomTool(customTool);
+  }
 
   factory FlutterLaunchRequestArguments.fromJson(Map<String, Object?> obj) =
       FlutterLaunchRequestArguments.fromMap;
@@ -162,11 +215,11 @@ class FlutterLaunchRequestArguments extends DartCommonLaunchAttachRequestArgumen
   @override
   Map<String, Object?> toJson() => <String, Object?>{
     ...super.toJson(),
-    'noDebug': ?noDebug,
-    'program': ?program,
-    'args': ?args,
-    'toolArgs': ?toolArgs,
-    'customTool': ?customTool,
-    'customToolReplacesArgs': ?customToolReplacesArgs,
+    'noDebug': noDebug,
+    'program': program,
+    'args': args,
+    'toolArgs': toolArgs,
+    'customTool': customTool,
+    'customToolReplacesArgs': customToolReplacesArgs,
   };
 }

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter_args.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter_args.dart
@@ -2,52 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
 import 'package:dds/dap.dart';
 
-// SECURITY NOTE: This file previously allowed arbitrary execution via the `customTool` field.
-// The `customTool` must be an absolute path to prevent Remote Code Execution (RCE).
-
-/// Validates that the `customTool` argument, if provided, is an absolute path
-/// and that it refers to an allowed SDK tool. Throws a [FormatException] on
-/// validation failure. Messages intentionally avoid echoing the full path.
-void _validateCustomTool(String? tool) {
-  if (tool == null) return;
-
-  // Simple absolute‑path check for POSIX and Windows.
-  final isAbsolute = tool.startsWith('/') || RegExp(r'^[a-zA-Z]:[\\/]').hasMatch(tool);
-  if (!isAbsolute) {
-    throw FormatException(
-      'The supplied customTool path is not absolute; refusing to accept non-absolute paths for security reasons.',
-    );
-  }
-
-  // Basic allowlist of tool basenames that are safe to invoke from the adapter.
-  const allowedBasenames = <String>{'flutter', 'dart', 'pub', 'dartanalyzer', 'dartdev'};
-  final basename = tool.split(Platform.pathSeparator).last.toLowerCase();
-  if (!allowedBasenames.contains(basename)) {
-    throw FormatException(
-      'The customTool "$basename" is not an allowed tool. Only SDK tools are permitted.',
-    );
-  }
-
-  // Verify the file exists and (on POSIX) is executable.
-  try {
-    final file = File(tool);
-    if (!file.existsSync()) {
-      throw FormatException('The customTool does not exist (redacted)');
-    }
-    if (!Platform.isWindows) {
-      final mode = file.statSync().mode;
-      // Check owner/group/other execute bits.
-      if ((mode & 0x49) == 0) {
-        throw FormatException('The customTool is not executable (redacted)');
-      }
-    }
-  } on FileSystemException {
-    throw FormatException('Unable to validate the customTool path');
-  }
-}
+// SECURITY NOTE: `customTool` is retained for protocol compatibility but is
+// ignored by the debug adapters. Client-provided executables must never be
+// invoked directly.
 
 /// An implementation of [AttachRequestArguments] that includes all fields used by the Flutter debug adapter.
 ///
@@ -75,9 +34,7 @@ class FlutterAttachRequestArguments extends DartCommonLaunchAttachRequestArgumen
     super.evaluateToStringInDebugViews,
     super.sendLogsToClient,
     super.sendCustomProgressEvents,
-  }) {
-    _validateCustomTool(customTool);
-  }
+  });
 
   FlutterAttachRequestArguments.fromMap(super.obj)
     : toolArgs = (obj['toolArgs'] as List<Object?>?)?.cast<String>(),
@@ -86,9 +43,7 @@ class FlutterAttachRequestArguments extends DartCommonLaunchAttachRequestArgumen
       vmServiceUri = obj['vmServiceUri'] as String?,
       vmServiceInfoFile = obj['vmServiceInfoFile'] as String?,
       program = obj['program'] as String?,
-      super.fromMap() {
-    _validateCustomTool(customTool);
-  }
+      super.fromMap();
 
   factory FlutterAttachRequestArguments.fromJson(Map<String, Object?> obj) =
       FlutterAttachRequestArguments.fromMap;
@@ -96,22 +51,10 @@ class FlutterAttachRequestArguments extends DartCommonLaunchAttachRequestArgumen
   /// Arguments to be passed to the tool that will run [program] (for example, the VM or Flutter tool).
   final List<String>? toolArgs;
 
-  /// An optional tool to run instead of "flutter".
-  ///
-  /// In combination with [customToolReplacesArgs] allows invoking a custom
-  /// tool instead of "flutter" to launch scripts/tests. The custom tool must be
-  /// completely compatible with the tool/command it is replacing.
-  ///
-  /// This field should be a full absolute path if the tool may not be available
-  /// in `PATH`.
+  /// Legacy protocol field retained for compatibility only.
   final String? customTool;
 
-  /// The number of arguments to delete from the beginning of the argument list
-  /// when invoking [customTool].
-  ///
-  /// For example, setting [customTool] to `flutter_test_wrapper` and
-  /// `customToolReplacesArgs` to `1` for a test run would invoke
-  /// `flutter_test_wrapper foo_test.dart` instead of `flutter test foo_test.dart`.
+  /// Legacy protocol field retained for compatibility only.
   final int? customToolReplacesArgs;
 
   /// The VM Service URI of the running Flutter app to connect to.
@@ -163,9 +106,7 @@ class FlutterLaunchRequestArguments extends DartCommonLaunchAttachRequestArgumen
     super.evaluateToStringInDebugViews,
     super.sendLogsToClient,
     super.sendCustomProgressEvents,
-  }) {
-    _validateCustomTool(customTool);
-  }
+  });
 
   FlutterLaunchRequestArguments.fromMap(super.obj)
     : noDebug = obj['noDebug'] as bool?,
@@ -174,9 +115,7 @@ class FlutterLaunchRequestArguments extends DartCommonLaunchAttachRequestArgumen
       toolArgs = (obj['toolArgs'] as List<Object?>?)?.cast<String>(),
       customTool = obj['customTool'] as String?,
       customToolReplacesArgs = obj['customToolReplacesArgs'] as int?,
-      super.fromMap() {
-    _validateCustomTool(customTool);
-  }
+      super.fromMap();
 
   factory FlutterLaunchRequestArguments.fromJson(Map<String, Object?> obj) =
       FlutterLaunchRequestArguments.fromMap;
@@ -194,22 +133,10 @@ class FlutterLaunchRequestArguments extends DartCommonLaunchAttachRequestArgumen
   /// Arguments to be passed to the tool that will run [program] (for example, the VM or Flutter tool).
   final List<String>? toolArgs;
 
-  /// An optional tool to run instead of "flutter".
-  ///
-  /// In combination with [customToolReplacesArgs] allows invoking a custom
-  /// tool instead of "flutter" to launch scripts/tests. The custom tool must be
-  /// completely compatible with the tool/command it is replacing.
-  ///
-  /// This field should be a full absolute path if the tool may not be available
-  /// in `PATH`.
+  /// Legacy protocol field retained for compatibility only.
   final String? customTool;
 
-  /// The number of arguments to delete from the beginning of the argument list
-  /// when invoking [customTool].
-  ///
-  /// For example, setting [customTool] to `flutter_test_wrapper` and
-  /// `customToolReplacesArgs` to `1` for a test run would invoke
-  /// `flutter_test_wrapper foo_test.dart` instead of `flutter test foo_test.dart`.
+  /// Legacy protocol field retained for compatibility only.
   final int? customToolReplacesArgs;
 
   @override

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_base_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_base_adapter.dart
@@ -39,6 +39,13 @@ abstract class FlutterBaseDebugAdapter
 
   final String flutterSdkRoot;
 
+  /// The Flutter SDK executable used by the adapter.
+  String get flutterExecutable => fileSystem.path.join(
+    flutterSdkRoot,
+    'bin',
+    platform.isWindows ? 'flutter.bat' : 'flutter',
+  );
+
   /// Whether DDS should be enabled in the Flutter process.
   ///
   /// We never enable DDS in the DAP process for Flutter, so this value is not

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_test_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_test_adapter.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:math' as math;
 
 import 'package:dds/dap.dart' hide PidTracker;
 
@@ -51,18 +50,11 @@ class FlutterTestDebugAdapter extends FlutterBaseDebugAdapter with TestAdapter {
       if (debug) '--start-paused',
     ];
 
-    // Handle customTool and deletion of any arguments for it.
-    final String executable =
-        args.customTool ??
-        fileSystem.path.join(
-          Cache.flutterRoot!,
-          'bin',
-          platform.isWindows ? 'flutter.bat' : 'flutter',
-        );
-    final int? removeArgs = args.customToolReplacesArgs;
-    if (args.customTool != null && removeArgs != null) {
-      toolArgs.removeRange(0, math.min(removeArgs, toolArgs.length));
-    }
+    final String executable = fileSystem.path.join(
+      Cache.flutterRoot!,
+      'bin',
+      platform.isWindows ? 'flutter.bat' : 'flutter',
+    );
 
     final processArgs = <String>[...toolArgs, ...?args.toolArgs, ?program, ...?args.args];
 

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_test_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_test_adapter.dart
@@ -7,7 +7,6 @@ import 'dart:async';
 import 'package:dds/dap.dart' hide PidTracker;
 
 import '../base/io.dart';
-import '../cache.dart';
 import '../convert.dart';
 import 'flutter_adapter_args.dart';
 import 'flutter_base_adapter.dart';
@@ -50,13 +49,9 @@ class FlutterTestDebugAdapter extends FlutterBaseDebugAdapter with TestAdapter {
       if (debug) '--start-paused',
     ];
 
-    final String executable = fileSystem.path.join(
-      Cache.flutterRoot!,
-      'bin',
-      platform.isWindows ? 'flutter.bat' : 'flutter',
-    );
+    final String executable = flutterExecutable;
 
-    final processArgs = <String>[...toolArgs, ...?args.toolArgs, ?program, ...?args.args];
+    final processArgs = <String>[...toolArgs, ...?args.toolArgs, if (program != null) program, ...?args.args];
 
     await launchAsProcess(executable: executable, processArgs: processArgs, env: args.env);
 

--- a/packages/flutter_tools/test/debug_adapters/flutter_adapter_args_test.dart
+++ b/packages/flutter_tools/test/debug_adapters/flutter_adapter_args_test.dart
@@ -1,0 +1,46 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:flutter_tools/src/debug_adapters/flutter_adapter_args.dart';
+
+void main() {
+  test('rejects non-absolute customTool', () {
+    expect(() => FlutterLaunchRequestArguments(customTool: 'bin/flutter', program: null), throwsFormatException);
+  });
+
+  test('rejects disallowed basename even if absolute', () {
+    final path = Platform.isWindows ? r'C:\Windows\System32\cmd.exe' : '/bin/sh';
+    expect(() => FlutterLaunchRequestArguments(customTool: path, program: null), throwsFormatException);
+  });
+
+  test('accepts allowed basename when file exists and is executable', () async {
+    if (Platform.isWindows) {
+      // On Windows, skip executable permission checks and just ensure basename check.
+      // Create a temp file named flutter to satisfy the basename allowlist.
+      final tmpDir = await Directory.systemTemp.createTemp('flutter_adapter_test');
+      final file = File('${tmpDir.path}${Platform.pathSeparator}flutter');
+      await file.writeAsString('echo');
+      try {
+        // Should throw only if path is not absolute; this is absolute.
+        FlutterLaunchRequestArguments(customTool: file.path, program: null);
+      } finally {
+        await tmpDir.delete(recursive: true);
+      }
+    } else {
+      final tmpDir = await Directory.systemTemp.createTemp('flutter_adapter_test');
+      final file = File('${tmpDir.path}${Platform.pathSeparator}flutter');
+      await file.writeAsString('echo');
+      // Make it executable.
+      await Process.run('chmod', ['+x', file.path]);
+      try {
+        FlutterLaunchRequestArguments(customTool: file.path, program: null);
+      } finally {
+        await tmpDir.delete(recursive: true);
+      }
+    }
+  });
+}

--- a/packages/flutter_tools/test/debug_adapters/flutter_adapter_args_test.dart
+++ b/packages/flutter_tools/test/debug_adapters/flutter_adapter_args_test.dart
@@ -2,45 +2,74 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
+import 'dart:async';
 
-import 'package:test/test.dart';
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/debug_adapters/flutter_adapter_args.dart';
+import 'package:flutter_tools/src/globals.dart' as globals show platform;
+import 'package:test/test.dart';
+
+import '../general.shard/dap/mocks.dart';
 
 void main() {
-  test('rejects non-absolute customTool', () {
-    expect(() => FlutterLaunchRequestArguments(customTool: 'bin/flutter', program: null), throwsFormatException);
+  final platform = FakePlatform.fromPlatform(globals.platform);
+  final fsStyle = platform.isWindows ? FileSystemStyle.windows : FileSystemStyle.posix;
+  final expectedFlutterExecutable =
+      platform.isWindows ? r'C:\fake\flutter\bin\flutter.bat' : '/fake/flutter/bin/flutter';
+
+  setUpAll(() {
+    Cache.flutterRoot = platform.isWindows ? r'C:\fake\flutter' : '/fake/flutter';
   });
 
-  test('rejects disallowed basename even if absolute', () {
-    final path = Platform.isWindows ? r'C:\Windows\System32\cmd.exe' : '/bin/sh';
-    expect(() => FlutterLaunchRequestArguments(customTool: path, program: null), throwsFormatException);
+  test('launch adapter ignores customTool', () async {
+    final adapter = FakeFlutterDebugAdapter(
+      fileSystem: MemoryFileSystem.test(style: fsStyle),
+      platform: platform,
+    );
+    final responseCompleter = Completer<void>();
+    final request = FakeRequest();
+    final args = FlutterLaunchRequestArguments(
+      cwd: '.',
+      program: 'foo.dart',
+      customTool: '/custom/flutter',
+      customToolReplacesArgs: 9999,
+      noDebug: true,
+      toolArgs: <String>['tool_args'],
+    );
+
+    await adapter.configurationDoneRequest(request, null, () {});
+    await adapter.launchRequest(request, args, responseCompleter.complete);
+    await responseCompleter.future;
+
+    expect(adapter.executable, expectedFlutterExecutable);
+    expect(adapter.processArgs, contains('--machine'));
+    expect(adapter.processArgs, contains('tool_args'));
   });
 
-  test('accepts allowed basename when file exists and is executable', () async {
-    if (Platform.isWindows) {
-      // On Windows, skip executable permission checks and just ensure basename check.
-      // Create a temp file named flutter to satisfy the basename allowlist.
-      final tmpDir = await Directory.systemTemp.createTemp('flutter_adapter_test');
-      final file = File('${tmpDir.path}${Platform.pathSeparator}flutter');
-      await file.writeAsString('echo');
-      try {
-        // Should throw only if path is not absolute; this is absolute.
-        FlutterLaunchRequestArguments(customTool: file.path, program: null);
-      } finally {
-        await tmpDir.delete(recursive: true);
-      }
-    } else {
-      final tmpDir = await Directory.systemTemp.createTemp('flutter_adapter_test');
-      final file = File('${tmpDir.path}${Platform.pathSeparator}flutter');
-      await file.writeAsString('echo');
-      // Make it executable.
-      await Process.run('chmod', ['+x', file.path]);
-      try {
-        FlutterLaunchRequestArguments(customTool: file.path, program: null);
-      } finally {
-        await tmpDir.delete(recursive: true);
-      }
-    }
+  test('test adapter ignores customTool', () async {
+    final adapter = FakeFlutterTestDebugAdapter(
+      fileSystem: MemoryFileSystem.test(style: fsStyle),
+      platform: platform,
+    );
+    final responseCompleter = Completer<void>();
+    final request = FakeRequest();
+    final args = FlutterLaunchRequestArguments(
+      cwd: '.',
+      program: 'foo.dart',
+      customTool: '/custom/flutter',
+      customToolReplacesArgs: 9999,
+      noDebug: true,
+      toolArgs: <String>['tool_args'],
+    );
+
+    await adapter.configurationDoneRequest(request, null, () {});
+    await adapter.launchRequest(request, args, responseCompleter.complete);
+    await responseCompleter.future;
+
+    expect(adapter.executable, expectedFlutterExecutable);
+    expect(adapter.processArgs, contains('--machine'));
+    expect(adapter.processArgs, contains('tool_args'));
   });
 }

--- a/packages/flutter_tools/test/general.shard/dap/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/general.shard/dap/flutter_adapter_test.dart
@@ -809,7 +809,7 @@ void main() {
       });
     });
 
-    group('includes customTool', () {
+    group('ignores customTool', () {
       test('with no args replaced', () async {
         final adapter = FakeFlutterDebugAdapter(
           fileSystem: MemoryFileSystem.test(style: fsStyle),
@@ -827,7 +827,7 @@ void main() {
         await adapter.launchRequest(FakeRequest(), args, responseCompleter.complete);
         await responseCompleter.future;
 
-        expect(adapter.executable, equals('/custom/flutter'));
+        expect(adapter.executable, equals(expectedFlutterExecutable));
         // args should be in-tact
         expect(adapter.processArgs, contains('--machine'));
       });
@@ -851,10 +851,9 @@ void main() {
         await adapter.launchRequest(FakeRequest(), args, responseCompleter.complete);
         await responseCompleter.future;
 
-        expect(adapter.executable, equals('/custom/flutter'));
-        // normal built-in args are replaced by customToolReplacesArgs, but
-        // user-provided toolArgs are not.
-        expect(adapter.processArgs, isNot(contains('--machine')));
+        expect(adapter.executable, equals(expectedFlutterExecutable));
+        // customToolReplacesArgs is ignored; normal built-in args remain.
+        expect(adapter.processArgs, contains('--machine'));
         expect(adapter.processArgs, contains('tool_args'));
       });
     });

--- a/packages/flutter_tools/test/general.shard/dap/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/general.shard/dap/flutter_adapter_test.dart
@@ -457,49 +457,72 @@ void main() {
         );
       });
 
-      test(
-        'runs "flutter attach" with --debug-uri if vmServiceInfoFile is created later',
-        () async {
-          final adapter = FakeFlutterDebugAdapter(
-            fileSystem: MemoryFileSystem.test(style: fsStyle),
-            platform: platform,
-          );
-          final responseCompleter = Completer<void>();
-          final File serviceInfoFile = globals.fs.systemTempDirectory
-              .createTempSync('dap_flutter_attach_vmServiceInfoFile')
-              .childFile('vmServiceInfo.json');
+      test('runs "flutter attach" with --debug-uri if vmServiceInfoFile is created later',
+          () async {
+        final adapter = FakeFlutterDebugAdapter(
+          fileSystem: MemoryFileSystem.test(style: fsStyle),
+          platform: platform,
+        );
+        final responseCompleter = Completer<void>();
+        final File serviceInfoFile = globals.fs.systemTempDirectory
+            .createTempSync('dap_flutter_attach_vmServiceInfoFile')
+            .childFile('vmServiceInfo.json');
 
-          final args = FlutterAttachRequestArguments(
-            cwd: '.',
-            program: 'program/main.dart',
-            vmServiceInfoFile: serviceInfoFile.path,
-          );
+        final args = FlutterAttachRequestArguments(
+          cwd: '.',
+          program: 'program/main.dart',
+          vmServiceInfoFile: serviceInfoFile.path,
+        );
 
-          await adapter.configurationDoneRequest(FakeRequest(), null, () {});
-          final Future<void> attachResponseFuture = adapter.attachRequest(
-            FakeRequest(),
-            args,
-            responseCompleter.complete,
-          );
-          // Write the service info file a little later to ensure we detect it:
-          await pumpEventQueue(times: 5000);
-          serviceInfoFile.writeAsStringSync('{ "uri": "ws://1.2.3.4/ws" }');
-          await attachResponseFuture;
-          await responseCompleter.future;
+        await adapter.configurationDoneRequest(FakeRequest(), null, () {});
+        final Future<void> attachResponseFuture = adapter.attachRequest(
+          FakeRequest(),
+          args,
+          responseCompleter.complete,
+        );
+        // Write the service info file a little later to ensure we detect it:
+        await pumpEventQueue(times: 5000);
+        serviceInfoFile.writeAsStringSync('{ "uri": "ws://1.2.3.4/ws" }');
+        await attachResponseFuture;
+        await responseCompleter.future;
 
-          expect(
-            adapter.processArgs,
-            containsAllInOrder(<String>[
-              'attach',
-              '--machine',
-              '--debug-uri',
-              'ws://1.2.3.4/ws',
-              '--target',
-              'program/main.dart',
-            ]),
-          );
-        },
-      );
+        expect(
+          adapter.processArgs,
+          containsAllInOrder(<String>[
+            'attach',
+            '--machine',
+            '--debug-uri',
+            'ws://1.2.3.4/ws',
+            '--target',
+            'program/main.dart',
+          ]),
+        );
+      });
+
+      test('ignores customTool', () async {
+        final adapter = FakeFlutterDebugAdapter(
+          fileSystem: MemoryFileSystem.test(style: fsStyle),
+          platform: platform,
+        );
+        final responseCompleter = Completer<void>();
+
+        final args = FlutterAttachRequestArguments(
+          cwd: '.',
+          program: 'program/main.dart',
+          customTool: '/custom/flutter',
+          customToolReplacesArgs: 9999,
+        );
+
+        await adapter.configurationDoneRequest(FakeRequest(), null, () {});
+        await adapter.attachRequest(FakeRequest(), args, responseCompleter.complete);
+        await responseCompleter.future;
+
+        expect(adapter.executable, equals(expectedFlutterExecutable));
+        expect(
+          adapter.processArgs,
+          containsAllInOrder(<String>['attach', '--machine', '--target', 'program/main.dart']),
+        );
+      });
 
       test('does not record the VMs PID for terminating', () async {
         final adapter = FakeFlutterDebugAdapter(

--- a/packages/flutter_tools/test/general.shard/dap/flutter_test_adapter_test.dart
+++ b/packages/flutter_tools/test/general.shard/dap/flutter_test_adapter_test.dart
@@ -71,7 +71,7 @@ void main() {
       expect(adapter.env!['MY_TEST_ENV'], 'MY_TEST_VALUE');
     });
 
-    group('includes customTool', () {
+    group('ignores customTool', () {
       test('with no args replaced', () async {
         final adapter = FakeFlutterTestDebugAdapter(
           fileSystem: MemoryFileSystem.test(style: fsStyle),
@@ -90,7 +90,7 @@ void main() {
         await adapter.launchRequest(request, args, responseCompleter.complete);
         await responseCompleter.future;
 
-        expect(adapter.executable, equals('/custom/flutter'));
+        expect(adapter.executable, equals(expectedFlutterExecutable));
         // args should be in-tact
         expect(adapter.processArgs, contains('--machine'));
       });
@@ -115,10 +115,9 @@ void main() {
         await adapter.launchRequest(request, args, responseCompleter.complete);
         await responseCompleter.future;
 
-        expect(adapter.executable, equals('/custom/flutter'));
-        // normal built-in args are replaced by customToolReplacesArgs, but
-        // user-provided toolArgs are not.
-        expect(adapter.processArgs, isNot(contains('--machine')));
+        expect(adapter.executable, equals(expectedFlutterExecutable));
+        // customToolReplacesArgs is ignored; normal built-in args remain.
+        expect(adapter.processArgs, contains('--machine'));
         expect(adapter.processArgs, contains('tool_args'));
       });
     });


### PR DESCRIPTION
This removes the client-controlled executable override path from Flutter debug adapters. Client-provided `customTool` and `customToolReplacesArgs` are now inert compatibility fields and no longer influence which process is launched.

Validation:
- `./bin/cache/dart-sdk/bin/dart test packages/flutter_tools/test/debug_adapters/flutter_adapter_args_test.dart -r expanded`
- Targeted analyzer checks on the edited files reported no errors.

This closes a real client-controlled process execution path rather than trying to sanitize it.
