### PR TITLE
Detached traversal child should update its traversal parent

### DIFF
--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -5021,7 +5021,7 @@ class SemanticsOwner extends ChangeNotifier {
     final SemanticsUpdateBuilder builder = SemanticsBinding.instance.createSemanticsUpdateBuilder();
 
     for (final node in visitedNodes) {
-      assert(node.parent?._dirty != true); // could be null (no parent) or false (not dirty)
+      assert(node == this.rootSemanticsNode || (node.parent != null && node.parent!._dirty != true));
       // The _serialize() method marks the node as not dirty, and
       // recurses through the tree to do a deep serialization of all
       // contiguous dirty nodes. This means that when we return here,

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -4996,8 +4996,9 @@ class SemanticsOwner extends ChangeNotifier {
           );
           _traversalParentNodes[node.traversalParentIdentifier!] = node;
         } else if (isTraversalChild) {
-          _traversalChildNodes[node.traversalChildIdentifier!] ??= <SemanticsNode>{};
-          _traversalChildNodes[node.traversalChildIdentifier!]!.add(node);
+          _traversalChildNodes
+              .putIfAbsent(node.traversalChildIdentifier!, () => <SemanticsNode>{})
+              .add(node);
         }
 
         if (!kIsWeb) {

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -3286,6 +3286,9 @@ class SemanticsNode with DiagnosticableTreeMixin {
     for (final Set<SemanticsNode> childSet in owner!._traversalChildNodes.values) {
       childSet.removeWhere((SemanticsNode node) => node == this);
     }
+    owner!._traversalChildNodes.removeWhere(
+      (Object key, Set<SemanticsNode> value) => value.isEmpty,
+    );
 
     _owner = null;
     assert(parent == null || attached == parent!.attached);
@@ -4957,6 +4960,7 @@ class SemanticsOwner extends ChangeNotifier {
           .toList();
       _dirtyNodes.clear();
       _detachedNodes.clear();
+      localDirtyNodes.sort((SemanticsNode a, SemanticsNode b) => a.depth - b.depth);
       visitedNodes.addAll(localDirtyNodes);
       for (final node in localDirtyNodes) {
         assert(node._dirty);
@@ -4977,47 +4981,42 @@ class SemanticsOwner extends ChangeNotifier {
         for (final Set<SemanticsNode> childSet in _traversalChildNodes.values) {
           childSet.removeWhere((SemanticsNode oldNode) => node == oldNode);
         }
-      }
-    }
+        _traversalChildNodes.removeWhere((Object key, Set<SemanticsNode> value) => value.isEmpty);
+        final bool isTraversalParent = node._isTraversalParent;
+        final bool isTraversalChild = node._isTraversalChild;
 
-    for (final node in visitedNodes) {
-      final bool isTraversalParent = node._isTraversalParent;
-      final bool isTraversalChild = node._isTraversalChild;
+        // If the node is a traversal parent, then add it to the
+        // _traversalParentNodes map for later grafting. Similarly, add the node
+        // to the _traversalChildNodes map if it is a traversal child.
+        if (isTraversalParent) {
+          assert(
+            !_traversalParentNodes.containsKey(node._traversalParentIdentifier) ||
+                _traversalParentNodes[node.traversalParentIdentifier!] == node,
+            'The traversalParentIdentifier must be unique. No two semantics nodes can share the same traversalParentIdentifier.',
+          );
+          _traversalParentNodes[node.traversalParentIdentifier!] = node;
+        } else if (isTraversalChild) {
+          _traversalChildNodes[node.traversalChildIdentifier!] ??= <SemanticsNode>{};
+          _traversalChildNodes[node.traversalChildIdentifier!]!.add(node);
+        }
 
-      // If the node is a traversal parent, then add it to the
-      // _traversalParentNodes map for later grafting. Similarly, add the node
-      // to the _traversalChildNodes map if it is a traversal child.
-      if (isTraversalParent) {
-        assert(
-          !_traversalParentNodes.containsKey(node._traversalParentIdentifier) ||
-              _traversalParentNodes[node.traversalParentIdentifier!] == node,
-          'The traversalParentIdentifier must be unique. No two semantics nodes can share the same traversalParentIdentifier.',
-        );
-        _traversalParentNodes[node.traversalParentIdentifier!] = node;
-      } else if (isTraversalChild) {
-        _traversalChildNodes[node.traversalChildIdentifier!] ??= <SemanticsNode>{};
-        _traversalChildNodes[node.traversalChildIdentifier!]!.add(node);
-      }
-    }
-
-    if (!kIsWeb) {
-      for (var index = 0; index < visitedNodes.length; index += 1) {
-        final SemanticsNode node = visitedNodes[index];
-        if (node._isTraversalChild) {
-          // If the node has a non-null `_traversalChildIdentifier`, it indicates
-          // that its hit-test parent and traversal parent are different, and
-          // its traversal parent should update its children to include this node.
-          // Therefore, its traversal parent node should be visited for later
-          // grafting, in order to generate a correct `childrenInTraversalOrder`.
-          // This is typically used in `OverlayPortal` widget.
-          final SemanticsNode? parentNode = _traversalParentNodes[node.traversalChildIdentifier];
-          if (parentNode != null && !visitedNodes.contains(parentNode)) {
-            parentNode._markDirty();
-            visitedNodes.add(parentNode);
+        if (!kIsWeb) {
+          if (node._isTraversalChild) {
+            // If the node has a non-null `_traversalChildIdentifier`, it indicates
+            // that its hit-test parent and traversal parent are different, and
+            // its traversal parent should update its children to include this node.
+            // Therefore, its traversal parent node should be visited for later
+            // grafting, in order to generate a correct `childrenInTraversalOrder`.
+            // This is typically used in `OverlayPortal` widget.
+            final SemanticsNode? parentNode = _traversalParentNodes[node.traversalChildIdentifier];
+            if (parentNode != null && !visitedNodes.contains(parentNode)) {
+              parentNode._markDirty();
+            }
           }
         }
       }
     }
+
     visitedNodes.sort((SemanticsNode a, SemanticsNode b) => a.depth - b.depth);
     final SemanticsUpdateBuilder builder = SemanticsBinding.instance.createSemanticsUpdateBuilder();
 

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -3276,6 +3276,10 @@ class SemanticsNode with DiagnosticableTreeMixin {
     owner!._nodes.remove(id);
     owner!._detachedNodes.add(this);
 
+    if (_traversalChildIdentifier case final Object identifier?) {
+      owner!._traversalParentNodes[identifier]?._markDirty();
+    }
+
     // Clean up the according entry in owner._traversalParentNodes map.
     owner!._traversalParentNodes.removeWhere((Object key, SemanticsNode node) => node == this);
     // Clean up this node from the value set in owner._traversalChildNodes map.

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -5001,7 +5001,7 @@ class SemanticsOwner extends ChangeNotifier {
     }
 
     if (!kIsWeb) {
-      for (int index = 0; index < visitedNodes.length; index += 1) {
+      for (var index = 0; index < visitedNodes.length; index += 1) {
         final SemanticsNode node = visitedNodes[index];
         if (node._isTraversalChild) {
           // If the node has a non-null `_traversalChildIdentifier`, it indicates

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -5022,7 +5022,7 @@ class SemanticsOwner extends ChangeNotifier {
     final SemanticsUpdateBuilder builder = SemanticsBinding.instance.createSemanticsUpdateBuilder();
 
     for (final node in visitedNodes) {
-      assert(node == this.rootSemanticsNode || (node.parent != null && node.parent!._dirty != true));
+      assert(node == rootSemanticsNode || (node.parent != null && !node.parent!._dirty));
       // The _serialize() method marks the node as not dirty, and
       // recurses through the tree to do a deep serialization of all
       // contiguous dirty nodes. This means that when we return here,

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -5022,7 +5022,12 @@ class SemanticsOwner extends ChangeNotifier {
     final SemanticsUpdateBuilder builder = SemanticsBinding.instance.createSemanticsUpdateBuilder();
 
     for (final node in visitedNodes) {
-      assert(node == rootSemanticsNode || (node.parent != null && !node.parent!._dirty));
+      // TODO(QuncCccccc): Add an assert that each non-root node has a
+      // non-dirty parent. This currently fails in view-related tests such as
+      // test/widgets/view_test.dart's "correctly switches between view
+      // configurations" when switching view configurations during semantics
+      // updates.
+      assert(node.parent?._dirty != true); // could be null (no parent) or false (not dirty)
       // The _serialize() method marks the node as not dirty, and
       // recurses through the tree to do a deep serialization of all
       // contiguous dirty nodes. This means that when we return here,

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -4053,7 +4053,7 @@ class SemanticsNode with DiagnosticableTreeMixin {
   }
 
   void _addToUpdate(SemanticsUpdateBuilder builder, Set<int> customSemanticsActionIdsUpdate) {
-    assert(_dirty || _isTraversalParent);
+    assert(_dirty);
     final SemanticsData data = getSemanticsData();
     assert(() {
       final FlutterError? error = _DebugSemanticsRoleChecks._checkSemanticsData(this);
@@ -4957,7 +4957,6 @@ class SemanticsOwner extends ChangeNotifier {
           .toList();
       _dirtyNodes.clear();
       _detachedNodes.clear();
-      localDirtyNodes.sort((SemanticsNode a, SemanticsNode b) => a.depth - b.depth);
       visitedNodes.addAll(localDirtyNodes);
       for (final node in localDirtyNodes) {
         assert(node._dirty);
@@ -4981,39 +4980,9 @@ class SemanticsOwner extends ChangeNotifier {
       }
     }
 
-    visitedNodes.sort((SemanticsNode a, SemanticsNode b) => a.depth - b.depth);
-    final SemanticsUpdateBuilder builder = SemanticsBinding.instance.createSemanticsUpdateBuilder();
-
-    final updatedVisitedNodes = <SemanticsNode>[];
-
     for (final node in visitedNodes) {
       final bool isTraversalParent = node._isTraversalParent;
       final bool isTraversalChild = node._isTraversalChild;
-
-      if (kIsWeb) {
-        updatedVisitedNodes.add(node);
-      } else {
-        if (!isTraversalParent && !isTraversalChild) {
-          updatedVisitedNodes.add(node);
-          continue;
-        }
-
-        if (isTraversalChild) {
-          // If the node has a non-null `_traversalChildIdentifier`, it indicates
-          // that its hit-test parent and traversal parent are different, and
-          // its traversal parent should update its children to include this node.
-          // Therefore, its traversal parent node should be added to the
-          // `updatedVisitedNodes` list for later grafting, in order to generate
-          // a correct `childrenIntraversalOrder`. This is typically used in
-          // `OverlayPortal` widget.
-          final SemanticsNode? parentNode = _traversalParentNodes[node.traversalChildIdentifier];
-          if (parentNode != null && !updatedVisitedNodes.contains(parentNode)) {
-            updatedVisitedNodes.add(parentNode);
-          }
-        }
-
-        updatedVisitedNodes.add(node);
-      }
 
       // If the node is a traversal parent, then add it to the
       // _traversalParentNodes map for later grafting. Similarly, add the node
@@ -5031,16 +5000,29 @@ class SemanticsOwner extends ChangeNotifier {
       }
     }
 
-    for (final node in updatedVisitedNodes) {
-      assert(
-        node.parent?._dirty != true || node._isTraversalParent,
-      ); // could be null (no parent) or false (not dirty)
+    if (!kIsWeb) {
+      for (int index = 0; index < visitedNodes.length; index += 1) {
+        final SemanticsNode node = visitedNodes[index];
+        if (node._isTraversalChild) {
+          // If the node has a non-null `_traversalChildIdentifier`, it indicates
+          // that its hit-test parent and traversal parent are different, and
+          // its traversal parent should update its children to include this node.
+          // Therefore, its traversal parent node should be visited for later
+          // grafting, in order to generate a correct `childrenInTraversalOrder`.
+          // This is typically used in `OverlayPortal` widget.
+          final SemanticsNode? parentNode = _traversalParentNodes[node.traversalChildIdentifier];
+          if (parentNode != null && !visitedNodes.contains(parentNode)) {
+            parentNode._markDirty();
+            visitedNodes.add(parentNode);
+          }
+        }
+      }
+    }
+    visitedNodes.sort((SemanticsNode a, SemanticsNode b) => a.depth - b.depth);
+    final SemanticsUpdateBuilder builder = SemanticsBinding.instance.createSemanticsUpdateBuilder();
 
-      // The traversalParentNode is added to updatedVisitedNodes for later
-      // grafting; its traversalChildren should be grafted to its children in
-      // the traversal order. This grafting process is skipped on web because
-      // the traversal order will be handled in the web engine.
-      final bool needUpdateTraversalParent = !kIsWeb && node._isTraversalParent;
+    for (final node in visitedNodes) {
+      assert(node.parent?._dirty != true); // could be null (no parent) or false (not dirty)
       // The _serialize() method marks the node as not dirty, and
       // recurses through the tree to do a deep serialization of all
       // contiguous dirty nodes. This means that when we return here,
@@ -5051,7 +5033,7 @@ class SemanticsOwner extends ChangeNotifier {
       // calls reset() on its SemanticsNode if onlyChanges isn't set,
       // which happens e.g. when the node is no longer contributing
       // semantics).
-      if ((node._dirty || needUpdateTraversalParent) && node.attached) {
+      if (node._dirty && node.attached) {
         node._addToUpdate(builder, customSemanticsActionIds);
       }
     }

--- a/packages/flutter/test/semantics/semantics_update_test.dart
+++ b/packages/flutter/test/semantics/semantics_update_test.dart
@@ -279,9 +279,9 @@ void main() {
       builder: (BuildContext context) {
         return OverlayPortal(
           controller: controller,
-          child: TextButton(onPressed: () {}, child: const Text('anchor')),
+          child: TestButton(onPressed: () {}, child: const Text('anchor')),
           overlayChildBuilder: (BuildContext context) {
-            return TextButton(onPressed: () {}, child: const Text('menu item'));
+            return TestButton(onPressed: () {}, child: const Text('menu item'));
           },
         );
       },
@@ -331,6 +331,7 @@ void main() {
       }),
       isTrue,
     );
+    SemanticsUpdateBuilderSpy.observations.clear();
     handle.dispose();
   }, skip: kIsWeb); // intended: the web engine handles the traversal order itself.
 }

--- a/packages/flutter/test/semantics/semantics_update_test.dart
+++ b/packages/flutter/test/semantics/semantics_update_test.dart
@@ -266,6 +266,73 @@ void main() {
     SemanticsUpdateBuilderSpy.observations.clear();
     handle.dispose();
   }, skip: kIsWeb); // intended: the web engine handles the transform calculation itself.
+
+  testWidgets('Semantics update removes detached OverlayPortal traversal child', (
+    WidgetTester tester,
+  ) async {
+    final SemanticsHandle handle = tester.ensureSemantics();
+    await tester.pumpWidget(const Placeholder(), phase: EnginePhase.build);
+    SemanticsUpdateBuilderSpy.observations.clear();
+
+    final controller = OverlayPortalController()..show();
+    final entry = OverlayEntry(
+      builder: (BuildContext context) {
+        return OverlayPortal(
+          controller: controller,
+          child: TextButton(onPressed: () {}, child: const Text('anchor')),
+          overlayChildBuilder: (BuildContext context) {
+            return TextButton(onPressed: () {}, child: const Text('menu item'));
+          },
+        );
+      },
+    );
+    addTearDown(() {
+      entry
+        ..remove()
+        ..dispose();
+    });
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Overlay(initialEntries: <OverlayEntry>[entry]),
+      ),
+    );
+
+    final int anchorId = SemanticsUpdateBuilderSpy.observations.entries.singleWhere((
+      MapEntry<int, SemanticsNodeUpdateObservation> entry,
+    ) {
+      return entry.value.label == 'anchor';
+    }).key;
+    final int menuItemId = SemanticsUpdateBuilderSpy.observations.entries.singleWhere((
+      MapEntry<int, SemanticsNodeUpdateObservation> entry,
+    ) {
+      return entry.value.label == 'menu item';
+    }).key;
+    expect(
+      SemanticsUpdateBuilderSpy.observations.values.any((
+        SemanticsNodeUpdateObservation observation,
+      ) {
+        return observation.childrenInTraversalOrder.contains(menuItemId);
+      }),
+      isTrue,
+    );
+
+    SemanticsUpdateBuilderSpy.observations.clear();
+    controller.hide();
+    await tester.pump();
+
+    expect(SemanticsUpdateBuilderSpy.observations.containsKey(menuItemId), isFalse);
+    expect(
+      SemanticsUpdateBuilderSpy.observations.values.any((
+        SemanticsNodeUpdateObservation observation,
+      ) {
+        return listEquals(observation.childrenInTraversalOrder, <int>[anchorId]);
+      }),
+      isTrue,
+    );
+    handle.dispose();
+  }, skip: kIsWeb); // intended: the web engine handles the traversal order itself.
 }
 
 class SemanticsUpdateTestBinding extends AutomatedTestWidgetsFlutterBinding {

--- a/packages/flutter/test/semantics/semantics_update_test.dart
+++ b/packages/flutter/test/semantics/semantics_update_test.dart
@@ -331,6 +331,14 @@ void main() {
       }),
       isTrue,
     );
+    expect(
+      SemanticsUpdateBuilderSpy.observations.values.any((
+        SemanticsNodeUpdateObservation observation,
+      ) {
+        return observation.childrenInTraversalOrder.contains(menuItemId);
+      }),
+      isFalse,
+    );
     SemanticsUpdateBuilderSpy.observations.clear();
     handle.dispose();
   }, skip: kIsWeb); // intended: the web engine handles the traversal order itself.


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/185784

When a traversal child is detached, its traversal parent was not marked dirty. So the framework didn't send an updated childrenInTraversalOrder for traversal parent. On the engine side, the out-of-dated subtree is still reachable, so Talkback still read invisible items after the menu closed.

This PR is to update the _dirtyNodes list when a traversal child is detached. When a traversal child is detached, its traversal parent will be marked dirty and added to the _dirtyNodes list to update its childrenInTraversalOrder.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
