### PR TITLE
[iOS][macOS] Handle Swift extensions in framework exports check

### DIFF
--- a/engine/src/flutter/testing/symbols/verify_exported.dart
+++ b/engine/src/flutter/testing/symbols/verify_exported.dart
@@ -109,8 +109,39 @@ int _checkIos(String outPath, String nmPath, Iterable<String> builds) {
           (entry.type == '(__DATA,__objc_data)' || entry.type == '(__DATA,__data)') &&
           (entry.name.startsWith(r'_OBJC_METACLASS_$_Flutter') ||
               entry.name.startsWith(r'_OBJC_CLASS_$_Flutter'));
+
       // Swift's name mangling uses s followed by symbol length followed by symbol.
       final swiftInternalRegExp = RegExp(r'^_\$s\d+InternalFlutterSwift');
+
+      // Swift extensions on Objective-C classes (in Swift's 'So' namespace)
+      // mangle differently than standard Swift symbols. Instead of starting
+      // with the module name (e.g. _$s25InternalFlutterSwift...), they start
+      // with the extended type (e.g. _$sSo14FlutterTracingC...) and have the
+      // module name embedded inside.
+      //
+      // The Swift compiler may compress repeated tokens in the module name
+      // (e.g. substituting 'Flutter' with 'A' in 'InternalFlutterSwiftCommon'
+      // if 'Flutter' was already used in the type name being extended.
+      //
+      // This matches extensions defined in internal modules starting with
+      // 'Internal.*Swift' such as 'InternalFlutterSwiftCommon' from our shared
+      // iOS/macOS code, which the compiler shortens to
+      // 'InternalA11SwiftCommon'.
+      //
+      // Swift encodes these as a string of ${TYPE}|${LENGTH}${Symbol}|${SUBSTITUTION}s.
+      // In the above example:
+      // * $sSo: global static function extension.
+      // * 14FlutterTracing: 14 bytes long, "FlutterTracing".
+      // * C: class
+      // * 08InternalA11SwiftCommon: [8 bytes long, "Internal"] + [substitution A
+      //   ("Flutter" from earlier in the symbol)] + [11 bytes long, "SwiftCommon"].
+      // * E: extension.
+      //
+      // Details: https://github.com/swiftlang/swift/blob/main/docs/ABI/Mangling.rst
+      final swiftInternalExtensionRegExp = RegExp(
+        r'^_\$sSo\d+[A-Za-z0-9_]+[CP]\d+Internal.*Swift.*E',
+      );
+
       final bool swiftInternalSymbol =
           (entry.type == '(__TEXT,__text)' ||
               entry.type == '(__TEXT,__const)' ||
@@ -118,7 +149,8 @@ int _checkIos(String outPath, String nmPath, Iterable<String> builds) {
               entry.type == '(__DATA_CONST,__const)' ||
               entry.type == '(__DATA,__data)' ||
               entry.type == '(__DATA,__objc_data)') &&
-          swiftInternalRegExp.hasMatch(entry.name);
+          (swiftInternalRegExp.hasMatch(entry.name) ||
+              swiftInternalExtensionRegExp.hasMatch(entry.name));
       return !(cSymbol || cInternalSymbol || objcSymbol || swiftInternalSymbol);
     });
     if (unexpectedEntries.isNotEmpty) {


### PR DESCRIPTION
Allows Swift extension symbols defined in internal modules on Objective-C classes to pass the symbol verification.
  
Swift extensions on Objective-C classes (which reside in Swift's 'So' namespace) mangle differently than standard Swift symbols. Instead of starting with the module name (e.g., `_$s25InternalFlutterSwift...`), they start with the extended type (e.g., `_$sSo14FlutterTracingC...`) and have the module name embedded inside.
  
Furthermore, the Swift compiler may compress repeated tokens in the module name (e.g., substituting 'Flutter' with 'A' in `InternalFlutterSwiftCommon` if 'Flutter' was already used in the extended type name), resulting in `InternalA11Swift` in the mangled symbol. This is pretty common in extensions since we prefix all our Obj-C types with "Flutter".

This updates this code to allow the Swift extension added in this patch to pass:
https://github.com/flutter/flutter/pull/185918

From that failure:
```sh
xcrun swift-demangle -expand '_$sSo14FlutterTracingC08InternalA11SwiftCommonE10beginScopeyAC05TraceG0CSSFZ'
```

We see:
```
Demangling for _$sSo14FlutterTracingC08InternalA11SwiftCommonE10beginScopeyAC05TraceG0CSSFZ
kind=Global
  kind=Static
    kind=Function
      kind=Extension
        kind=Module, text="InternalFlutterSwiftCommon"
        kind=Class
          kind=Module, text="__C"
          kind=Identifier, text="FlutterTracing"
      kind=Identifier, text="beginScope"
      kind=LabelList
      kind=Type
        kind=FunctionType
          kind=ArgumentTuple
            kind=Type
              kind=Structure
                kind=Module, text="Swift"
                kind=Identifier, text="String"
          kind=ReturnType
            kind=Type
              kind=Class
                kind=Module, text="InternalFlutterSwiftCommon"
                kind=Identifier, text="TraceScope"
_$sSo14FlutterTracingC08InternalA11SwiftCommonE10beginScopeyAC05TraceG0CSSFZ ---> static (extension in InternalFlutterSwiftCommon):__C.FlutterTracing.beginScope(Swift.String) -> InternalFlutterSwiftCommon.TraceScope
```

Swift has a stable ABI so these aren't at risk of changing, so this updates the regexes themselves to handle Swift extensions.

No tests because this script is itself a test.

Fixes: https://github.com/flutter/flutter/issues/186119

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
