### PR TITLE
Update iOS section of AppLocalizations template to current Xcode workflow

### DIFF
--- a/dev/benchmarks/test_apps/stocks/lib/i18n/stock_strings.dart
+++ b/dev/benchmarks/test_apps/stocks/lib/i18n/stock_strings.dart
@@ -50,23 +50,24 @@ import 'stock_strings_es.dart';
 ///
 /// ## iOS Applications
 ///
-/// iOS applications define key application metadata, including supported
-/// locales, in an Info.plist file that is built into the application bundle.
-/// To configure the locales supported by your app, you’ll need to edit this
-/// file.
+/// To ensure the App Store entry correctly displays the supported
+/// languages, add them to your Xcode project.
 ///
-/// First, open your project’s ios/Runner.xcworkspace Xcode workspace file.
-/// Then, in the Project Navigator, open the Info.plist file under the Runner
-/// project’s Runner folder.
+/// To configure the locales supported by the app, follow these instructions:
 ///
-/// Next, select the Information Property List item, select Add Item from the
-/// Editor menu, then select Localizations from the pop-up menu.
+/// 1. Open your project's `ios/Runner.xcworkspace` Xcode workspace file.
 ///
-/// Select and expand the newly-created Localizations item then, for each
-/// locale your application supports, add a new item and select the locale
-/// you wish to add from the pop-up menu in the Value field. This list should
-/// be consistent with the languages listed in the StockStrings.supportedLocales
-/// property.
+/// 2. In the **Project Navigator**, select the `Runner` project
+///    file under **Projects**.
+///
+/// 3. Select the `Info` tab in the project editor.
+///
+/// 4. In the **Localizations** section, click the `Add` button
+///    (`+`) to add the supported languages and regions to your
+///    project.
+///
+/// This list should be consistent with the languages listed in the
+/// StockStrings.supportedLocales property.
 abstract class StockStrings {
   StockStrings(String locale) : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 

--- a/dev/integration_tests/new_gallery/lib/gallery_localizations.dart
+++ b/dev/integration_tests/new_gallery/lib/gallery_localizations.dart
@@ -45,23 +45,24 @@ import 'gallery_localizations_en.dart';
 ///
 /// ## iOS Applications
 ///
-/// iOS applications define key application metadata, including supported
-/// locales, in an Info.plist file that is built into the application bundle.
-/// To configure the locales supported by your app, you’ll need to edit this
-/// file.
+/// To ensure the App Store entry correctly displays the supported
+/// languages, add them to your Xcode project.
 ///
-/// First, open your project’s ios/Runner.xcworkspace Xcode workspace file.
-/// Then, in the Project Navigator, open the Info.plist file under the Runner
-/// project’s Runner folder.
+/// To configure the locales supported by the app, follow these instructions:
 ///
-/// Next, select the Information Property List item, select Add Item from the
-/// Editor menu, then select Localizations from the pop-up menu.
+/// 1. Open your project's `ios/Runner.xcworkspace` Xcode workspace file.
 ///
-/// Select and expand the newly-created Localizations item then, for each
-/// locale your application supports, add a new item and select the locale
-/// you wish to add from the pop-up menu in the Value field. This list should
-/// be consistent with the languages listed in the GalleryLocalizations.supportedLocales
-/// property.
+/// 2. In the **Project Navigator**, select the `Runner` project
+///    file under **Projects**.
+///
+/// 3. Select the `Info` tab in the project editor.
+///
+/// 4. In the **Localizations** section, click the `Add` button
+///    (`+`) to add the supported languages and regions to your
+///    project.
+///
+/// This list should be consistent with the languages listed in the
+/// GalleryLocalizations.supportedLocales property.
 abstract class GalleryLocalizations {
   GalleryLocalizations(String locale) : localeName = intl.Intl.canonicalizedLocale(locale);
 

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n_templates.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n_templates.dart
@@ -54,23 +54,24 @@ import 'package:intl/intl.dart' as intl;
 ///
 /// ## iOS Applications
 ///
-/// iOS applications define key application metadata, including supported
-/// locales, in an Info.plist file that is built into the application bundle.
-/// To configure the locales supported by your app, you’ll need to edit this
-/// file.
+/// To ensure the App Store entry correctly displays the supported
+/// languages, add the supported languages in the Xcode project.
 ///
-/// First, open your project’s ios/Runner.xcworkspace Xcode workspace file.
-/// Then, in the Project Navigator, open the Info.plist file under the Runner
-/// project’s Runner folder.
+/// To configure the locales supported by the app, follow these instructions:
 ///
-/// Next, select the Information Property List item, select Add Item from the
-/// Editor menu, then select Localizations from the pop-up menu.
+/// 1. Open your project's `ios/Runner.xcodeproj` Xcode file.
 ///
-/// Select and expand the newly-created Localizations item then, for each
-/// locale your application supports, add a new item and select the locale
-/// you wish to add from the pop-up menu in the Value field. This list should
-/// be consistent with the languages listed in the @(class).supportedLocales
-/// property.
+/// 2. In the **Project Navigator**, select the `Runner` project
+///    file under **Projects**.
+///
+/// 3. Select the `Info` tab in the project editor.
+///
+/// 4. In the **Localizations** section, click the `Add` button
+///    (`+`) to add the supported languages and regions to your
+///    project.
+///
+/// This list should be consistent with the languages listed in the
+/// @(class).supportedLocales property.
 abstract class @(class) {
   @(class)(String locale) : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n_templates.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n_templates.dart
@@ -55,11 +55,11 @@ import 'package:intl/intl.dart' as intl;
 /// ## iOS Applications
 ///
 /// To ensure the App Store entry correctly displays the supported
-/// languages, add the supported languages in the Xcode project.
+/// languages, add them to your Xcode project.
 ///
 /// To configure the locales supported by the app, follow these instructions:
 ///
-/// 1. Open your project's `ios/Runner.xcodeproj` Xcode file.
+/// 1. Open your project's `ios/Runner.xcworkspace` Xcode workspace file.
 ///
 /// 2. In the **Project Navigator**, select the `Runner` project
 ///    file under **Projects**.


### PR DESCRIPTION
## Description

The `fileTemplate` constant in `packages/flutter_tools/lib/src/localizations/gen_l10n_templates.dart` carries the doc comment that ships at the top of every generated `AppLocalizations` class. Its `## iOS Applications` section still describes the old `Info.plist` based workflow (open `ios/Runner.xcworkspace`, locate the `Information Property List` item, add a `Localizations` entry there). Every project that runs `flutter gen-l10n` ends up with stale iOS setup instructions in its generated localization file.

This PR replaces that paragraph with the project based workflow that matches the current Flutter site documentation: open `ios/Runner.xcodeproj`, select the Runner project, open the `Info` tab, and add supported languages and regions under the `Localizations` section. The wording follows the guidance at https://docs.flutter.dev/ui/internationalization#localizing-for-ios-updating-the-ios-app-bundle and the text proposed by the reporter on the issue.

The change is doc-only inside a template string. There is no code behavior change.

Fixes https://github.com/flutter/flutter/issues/184916

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt]. This PR is test-exempt because it corrects documentation text only inside a template string, with no behavioral changes to any code.
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md