### PR TITLE
Make logger a public getter in mixin to fix crash

### DIFF
--- a/packages/flutter_tools/lib/src/base/dds.dart
+++ b/packages/flutter_tools/lib/src/base/dds.dart
@@ -44,7 +44,7 @@ DDSLauncherCallback ddsLauncherCallback = DartDevelopmentServiceLauncher.start;
 /// Helper class to launch a [DartDevelopmentServiceLauncher]. Allows for us to
 /// mock out this functionality for testing purposes.
 class DartDevelopmentService with DartDevelopmentServiceLocalOperationsMixin {
-  DartDevelopmentService({required Logger logger}) : _logger = logger;
+  DartDevelopmentService({required this.logger});
 
   DartDevelopmentServiceLauncher? _ddsInstance;
 
@@ -61,7 +61,7 @@ class DartDevelopmentService with DartDevelopmentServiceLocalOperationsMixin {
   final _completer = Completer<void>();
 
   @override
-  final Logger _logger;
+  final Logger logger;
 
   @override
   Future<void> startDartDevelopmentService(
@@ -82,7 +82,7 @@ class DartDevelopmentService with DartDevelopmentServiceLocalOperationsMixin {
           .host,
       port: ddsPort ?? 0,
     );
-    _logger.printTrace(
+    logger.printTrace(
       'Launching a Dart Developer Service (DDS) instance at $ddsUri, '
       'connecting to VM service at $vmServiceUri.',
     );
@@ -107,7 +107,7 @@ class DartDevelopmentService with DartDevelopmentServiceLocalOperationsMixin {
       );
       unawaited(_ddsInstance!.done.whenComplete(completeFuture));
     } on DartDevelopmentServiceException catch (e) {
-      _logger.printTrace('Warning: Failed to start DDS: ${e.message}');
+      logger.printTrace('Warning: Failed to start DDS: ${e.message}');
       if (e is ExistingDartDevelopmentServiceException) {
         _existingDdsUri = e.ddsUri;
       }
@@ -124,7 +124,7 @@ class DartDevelopmentService with DartDevelopmentServiceLocalOperationsMixin {
 mixin DartDevelopmentServiceLocalOperationsMixin {
   Uri? get uri;
   Uri? get devToolsUri;
-  Logger get _logger;
+  Logger get logger;
 
   /// Used to confirm `launchDevToolsInBrowser` is called in tests.
   @visibleForTesting
@@ -169,7 +169,7 @@ mixin DartDevelopmentServiceLocalOperationsMixin {
       return false;
     }
     assert(devToolsUri != null);
-    _logger.printStatus('Launching Flutter DevTools for ${device.device!.name} at $devToolsUri');
+    logger.printStatus('Launching Flutter DevTools for ${device.device!.name} at $devToolsUri');
     unawaited(Chrome.start(<String>[devToolsUri!.toString()]));
     return true;
   }
@@ -193,7 +193,7 @@ mixin DartDevelopmentServiceLocalOperationsMixin {
       await flutterDevice.vmService?.findExtensionIsolate(extension);
       return true;
     } on VmServiceDisappearedException {
-      _logger.printTrace(
+      logger.printTrace(
         'The VM Service for ${flutterDevice.device} disappeared while trying to'
         ' find the $extension service extension. Skipping subsequent DevTools '
         'setup for this device.',
@@ -226,7 +226,7 @@ mixin DartDevelopmentServiceLocalOperationsMixin {
         params: <String, dynamic>{'value': uri.toString()},
       );
     } on Exception catch (e) {
-      _logger.printError(
+      logger.printError(
         'Failed to set DevTools server address: $e. Deep links to'
         ' DevTools will not show in Flutter errors.',
       );
@@ -244,8 +244,8 @@ mixin DartDevelopmentServiceLocalOperationsMixin {
         params: <String, dynamic>{'value': uri.toString()},
       );
     } on Exception catch (e) {
-      _logger.printError(e.toString());
-      _logger.printError(
+      logger.printError(e.toString());
+      logger.printError(
         'Failed to set vm service URI: $e. Deep links to DevTools'
         ' will not show in Flutter errors.',
       );

--- a/packages/flutter_tools/lib/src/base/dds.dart
+++ b/packages/flutter_tools/lib/src/base/dds.dart
@@ -36,6 +36,8 @@ typedef DDSLauncherCallback =
       String? google3WorkspaceRoot,
     });
 
+typedef StartChromeCallback = Future<io.Process> Function(List<String> urls, {List<String> args});
+
 // TODO(fujino): This should be direct injected, rather than mutable global state.
 /// Used by tests to override the DDS spawn behavior for mocking purposes.
 @visibleForTesting
@@ -163,14 +165,17 @@ mixin DartDevelopmentServiceLocalOperationsMixin {
 
   /// Launches a DevTools instance connected to the DDS instance connected to
   /// [device] in Chrome.
-  bool launchDevToolsInBrowser(FlutterDevice device) {
+  bool launchDevToolsInBrowser(
+    FlutterDevice device, {
+    @visibleForTesting StartChromeCallback startChrome = Chrome.start,
+  }) {
     _calledLaunchDevToolsInBrowser = true;
     if (devToolsUri == null) {
       return false;
     }
     assert(devToolsUri != null);
     logger.printStatus('Launching Flutter DevTools for ${device.device!.name} at $devToolsUri');
-    unawaited(Chrome.start(<String>[devToolsUri!.toString()]));
+    unawaited(startChrome(<String>[devToolsUri!.toString()]));
     return true;
   }
 

--- a/packages/flutter_tools/lib/src/proxied_devices/devices.dart
+++ b/packages/flutter_tools/lib/src/proxied_devices/devices.dart
@@ -54,7 +54,6 @@ class ProxiedDevices extends PollingDeviceDiscovery {
   /// [DaemonConnection] used to communicate with the daemon.
   final DaemonConnection connection;
 
-  @override
   final Logger logger;
 
   final bool _deltaFileTransfer;

--- a/packages/flutter_tools/lib/src/proxied_devices/devices.dart
+++ b/packages/flutter_tools/lib/src/proxied_devices/devices.dart
@@ -44,18 +44,17 @@ class ProxiedDevices extends PollingDeviceDiscovery {
     this.connection, {
     bool deltaFileTransfer = true,
     bool enableDdsProxy = false,
-    required Logger logger,
+    required this.logger,
     FileTransfer fileTransfer = const FileTransfer(),
   }) : _deltaFileTransfer = deltaFileTransfer,
        _enableDdsProxy = enableDdsProxy,
-       _logger = logger,
        _fileTransfer = fileTransfer,
        super('Proxied devices');
 
   /// [DaemonConnection] used to communicate with the daemon.
   final DaemonConnection connection;
 
-  final Logger _logger;
+  final Logger logger;
 
   final bool _deltaFileTransfer;
 
@@ -133,7 +132,7 @@ class ProxiedDevices extends PollingDeviceDiscovery {
       supportsFlutterExit: _cast<bool>(capabilities['flutterExit']),
       supportsScreenshot: _cast<bool>(capabilities['screenshot']),
       supportsHardwareRendering: _cast<bool>(capabilities['hardwareRendering']),
-      logger: _logger,
+      logger: logger,
       fileTransfer: _fileTransfer,
     );
   }
@@ -148,7 +147,7 @@ class ProxiedDevices extends PollingDeviceDiscovery {
     } on String catch (e) {
       // Daemon actually does throw string types.
       if (e.contains('command not understood')) {
-        _logger.printTrace(
+        logger.printTrace(
           'The daemon is on an older version that does not support `device.getDiagnostics`.',
         );
         // Silently ignore.

--- a/packages/flutter_tools/lib/src/proxied_devices/devices.dart
+++ b/packages/flutter_tools/lib/src/proxied_devices/devices.dart
@@ -54,6 +54,7 @@ class ProxiedDevices extends PollingDeviceDiscovery {
   /// [DaemonConnection] used to communicate with the daemon.
   final DaemonConnection connection;
 
+  @override
   final Logger logger;
 
   final bool _deltaFileTransfer;
@@ -804,18 +805,18 @@ class ProxiedDartDevelopmentService
   ProxiedDartDevelopmentService(
     this.connection,
     this.deviceId, {
-    required Logger logger,
+    required this.logger,
     required ProxiedPortForwarder proxiedPortForwarder,
     required ProxiedPortForwarder devicePortForwarder,
     @visibleForTesting DartDevelopmentService? localDds,
-  }) : _logger = logger,
-       _proxiedPortForwarder = proxiedPortForwarder,
+  }) : _proxiedPortForwarder = proxiedPortForwarder,
        _devicePortForwarder = devicePortForwarder,
        _localDds = localDds ?? DartDevelopmentService(logger: logger);
 
   final String deviceId;
 
-  final Logger _logger;
+  @override
+  final Logger logger;
 
   /// [DaemonConnection] used to communicate with the daemon.
   final DaemonConnection connection;
@@ -886,7 +887,7 @@ class ProxiedDartDevelopmentService
     }
 
     if (remoteVMServicePort == null) {
-      _logger.printTrace('VM service port is not a forwarded port. Start DDS locally.');
+      logger.printTrace('VM service port is not a forwarded port. Start DDS locally.');
       await startLocalDds();
       return;
     }
@@ -941,12 +942,12 @@ class ProxiedDartDevelopmentService
     }
 
     if (remoteUriStr == null) {
-      _logger.printTrace('Remote daemon cannot start DDS. Start a local DDS instead.');
+      logger.printTrace('Remote daemon cannot start DDS. Start a local DDS instead.');
       await startLocalDds();
       return;
     }
 
-    _logger.printTrace('Remote DDS started on $remoteUriStr.');
+    logger.printTrace('Remote DDS started on $remoteUriStr.');
 
     // Forward the port.
     final Uri remoteUri = Uri.parse(remoteUriStr);
@@ -957,8 +958,8 @@ class ProxiedDartDevelopmentService
     );
 
     _localUri = remoteUri.replace(port: localPort);
-    _logger.printTrace('Local port forwarded DDS on $_localUri.');
-    _logger.sendEvent('device.proxied_dds_forwarded', <String, String>{
+    logger.printTrace('Local port forwarded DDS on $_localUri.');
+    logger.sendEvent('device.proxied_dds_forwarded', <String, String>{
       'deviceId': deviceId,
       'remoteUri': remoteUri.toString(),
       'localUri': _localUri!.toString(),

--- a/packages/flutter_tools/test/general.shard/proxied_devices/proxied_devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/proxied_devices/proxied_devices_test.dart
@@ -881,8 +881,7 @@ void main() {
       expect(dds.devToolsUri, Uri.parse('http://127.0.0.1:300/devtools'));
 
       final launchedUrls = <String>[];
-      final flutterDevice = FakeFlutterDevice()
-        ..device = FakeDevice('test_device', 'device');
+      final flutterDevice = FakeFlutterDevice()..device = FakeDevice('test_device', 'device');
 
       final bool result = dds.launchDevToolsInBrowser(
         flutterDevice,
@@ -908,8 +907,7 @@ void main() {
         devicePortForwarder: devicePortForwarder,
       );
 
-      final flutterDevice = FakeFlutterDevice()
-        ..device = FakeDevice('test_device', 'device');
+      final flutterDevice = FakeFlutterDevice()..device = FakeDevice('test_device', 'device');
 
       final bool result = dds.launchDevToolsInBrowser(flutterDevice);
 

--- a/packages/flutter_tools/test/general.shard/proxied_devices/proxied_devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/proxied_devices/proxied_devices_test.dart
@@ -849,6 +849,73 @@ void main() {
         expect(localDds.shutdownCalled, true);
       },
     );
+
+    testWithoutContext('launchDevToolsInBrowser calls startChrome', () async {
+      final portForwarder = FakeProxiedPortForwarder();
+      portForwarder.originalRemotePortReturnValue = 100;
+      portForwarder.forwardReturnValue = 200;
+      final devicePortForwarder = FakeProxiedPortForwarder();
+      final dds = ProxiedDartDevelopmentService(
+        clientDaemonConnection,
+        'test_id',
+        logger: bufferLogger,
+        proxiedPortForwarder: portForwarder,
+        devicePortForwarder: devicePortForwarder,
+      );
+
+      final Stream<DaemonMessage> broadcastOutput = serverDaemonConnection.incomingCommands
+          .asBroadcastStream();
+
+      final Future<void> startFuture = dds.startDartDevelopmentService(
+        Uri.parse('http://127.0.0.1:100/fake'),
+        enableDevTools: true,
+      );
+
+      final DaemonMessage startMessage = await broadcastOutput.first;
+      serverDaemonConnection.sendResponse(startMessage.data['id']!, <String, Object?>{
+        'ddsUri': 'http://127.0.0.1:300/remote',
+        'devToolsUri': 'http://127.0.0.1:300/devtools',
+      });
+
+      await startFuture;
+      expect(dds.devToolsUri, Uri.parse('http://127.0.0.1:300/devtools'));
+
+      final List<String> launchedUrls = <String>[];
+      final FakeFlutterDevice flutterDevice = FakeFlutterDevice()
+        ..device = FakeDevice('test_device', 'device');
+
+      final bool result = dds.launchDevToolsInBrowser(
+        flutterDevice,
+        startChrome: (List<String> urls, {List<String>? args}) async {
+          launchedUrls.addAll(urls);
+          return FakeProcess();
+        },
+      );
+
+      expect(result, true);
+      expect(launchedUrls, <String>['http://127.0.0.1:300/devtools']);
+      expect(dds.calledLaunchDevToolsInBrowser, true);
+    });
+
+    testWithoutContext('launchDevToolsInBrowser returns false if devToolsUri is null', () async {
+      final portForwarder = FakeProxiedPortForwarder();
+      final devicePortForwarder = FakeProxiedPortForwarder();
+      final dds = ProxiedDartDevelopmentService(
+        clientDaemonConnection,
+        'test_id',
+        logger: bufferLogger,
+        proxiedPortForwarder: portForwarder,
+        devicePortForwarder: devicePortForwarder,
+      );
+
+      final FakeFlutterDevice flutterDevice = FakeFlutterDevice()
+        ..device = FakeDevice('test_device', 'device');
+
+      final bool result = dds.launchDevToolsInBrowser(flutterDevice);
+
+      expect(result, false);
+      expect(dds.calledLaunchDevToolsInBrowser, true);
+    });
   });
 
   group('ProxiedVMServiceDiscoveryForAttach', () {
@@ -1278,5 +1345,12 @@ class FakeVMServiceDiscoveryForAttach extends Fake implements VMServiceDiscovery
   @override
   Stream<Uri> uris;
 }
+
+class FakeFlutterDevice extends Fake implements FlutterDevice {
+  @override
+  Device? device;
+}
+
+class FakeProcess extends Fake implements Process {}
 
 class TestException implements Exception {}

--- a/packages/flutter_tools/test/general.shard/proxied_devices/proxied_devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/proxied_devices/proxied_devices_test.dart
@@ -880,8 +880,8 @@ void main() {
       await startFuture;
       expect(dds.devToolsUri, Uri.parse('http://127.0.0.1:300/devtools'));
 
-      final List<String> launchedUrls = <String>[];
-      final FakeFlutterDevice flutterDevice = FakeFlutterDevice()
+      final launchedUrls = <String>[];
+      final flutterDevice = FakeFlutterDevice()
         ..device = FakeDevice('test_device', 'device');
 
       final bool result = dds.launchDevToolsInBrowser(
@@ -908,7 +908,7 @@ void main() {
         devicePortForwarder: devicePortForwarder,
       );
 
-      final FakeFlutterDevice flutterDevice = FakeFlutterDevice()
+      final flutterDevice = FakeFlutterDevice()
         ..device = FakeDevice('test_device', 'device');
 
       final bool result = dds.launchDevToolsInBrowser(flutterDevice);


### PR DESCRIPTION
This mixin is used in another class, and it cannot access the _logger field from another file (which is private to that file), and caused a crash.

Make it a public getter to avoid crashing.
