### PR TITLE
[widgets] Use super parameters in missed spots

### DIFF
--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -2491,9 +2491,9 @@ class _DeferredLayout extends SingleChildRenderObjectWidget {
   const _DeferredLayout({
     // This widget must not be given a key: we currently do not support
     // reparenting between the overlayChild and child.
-    required Widget child,
+    required Widget super.child,
     this.childIdentifier,
-  }) : super(child: child);
+  });
 
   final Object? childIdentifier;
 

--- a/packages/flutter/lib/src/widgets/sliver_prototype_extent_list.dart
+++ b/packages/flutter/lib/src/widgets/sliver_prototype_extent_list.dart
@@ -251,8 +251,7 @@ class _SliverPrototypeExtentListElement extends SliverMultiBoxAdaptorElement {
 }
 
 class _RenderSliverPrototypeExtentList extends RenderSliverFixedExtentBoxAdaptor {
-  _RenderSliverPrototypeExtentList({required _SliverPrototypeExtentListElement childManager})
-    : super(childManager: childManager);
+  _RenderSliverPrototypeExtentList({required _SliverPrototypeExtentListElement super.childManager});
 
   RenderBox? _child;
   RenderBox? get child => _child;

--- a/packages/flutter/test/rendering/sliver_persistent_header_test.dart
+++ b/packages/flutter/test/rendering/sliver_persistent_header_test.dart
@@ -43,8 +43,8 @@ void main() {
 }
 
 class TestRenderSliverFloatingPersistentHeader extends RenderSliverFloatingPersistentHeader {
-  TestRenderSliverFloatingPersistentHeader({required RenderBox child})
-    : super(child: child, vsync: null, showOnScreenConfiguration: null);
+  TestRenderSliverFloatingPersistentHeader({required RenderBox super.child})
+    : super(vsync: null, showOnScreenConfiguration: null);
 
   @override
   double get maxExtent => 200;
@@ -55,8 +55,8 @@ class TestRenderSliverFloatingPersistentHeader extends RenderSliverFloatingPersi
 
 class TestRenderSliverFloatingPinnedPersistentHeader
     extends RenderSliverFloatingPinnedPersistentHeader {
-  TestRenderSliverFloatingPinnedPersistentHeader({required RenderBox child})
-    : super(child: child, vsync: null, showOnScreenConfiguration: null);
+  TestRenderSliverFloatingPinnedPersistentHeader({required RenderBox super.child})
+    : super(vsync: null, showOnScreenConfiguration: null);
 
   @override
   double get maxExtent => 200;

--- a/packages/flutter/test/widgets/actions_test.dart
+++ b/packages/flutter/test/widgets/actions_test.dart
@@ -1899,7 +1899,7 @@ class ThirdTestIntent extends SecondTestIntent {
 }
 
 class TestAction extends CallbackAction<TestIntent> {
-  TestAction({required OnInvokeCallback onInvoke}) : super(onInvoke: onInvoke);
+  TestAction({required OnInvokeCallback super.onInvoke});
 
   @override
   bool isEnabled(TestIntent intent) => enabled;

--- a/packages/flutter/test/widgets/global_keys_moving_test.dart
+++ b/packages/flutter/test/widgets/global_keys_moving_test.dart
@@ -16,7 +16,7 @@ class Item {
 List<Item> items = <Item>[Item(), Item()];
 
 class StatefulLeaf extends StatefulWidget {
-  const StatefulLeaf({GlobalKey? key}) : super(key: key);
+  const StatefulLeaf({GlobalKey? super.key});
 
   @override
   StatefulLeafState createState() => StatefulLeafState();

--- a/packages/flutter/test/widgets/page_forward_transitions_test.dart
+++ b/packages/flutter/test/widgets/page_forward_transitions_test.dart
@@ -29,8 +29,7 @@ class TestTransition extends AnimatedWidget {
 }
 
 class TestRoute<T> extends PageRoute<T> {
-  TestRoute({required this.child, required RouteSettings settings, this.barrierColor})
-    : super(settings: settings);
+  TestRoute({required this.child, required RouteSettings super.settings, this.barrierColor});
 
   final Widget child;
 

--- a/packages/flutter/test/widgets/two_dimensional_utils.dart
+++ b/packages/flutter/test/widgets/two_dimensional_utils.dart
@@ -77,7 +77,7 @@ class SimpleBuilderTableView extends TwoDimensionalScrollView {
     super.mainAxis = Axis.vertical,
     super.verticalDetails = const ScrollableDetails.vertical(),
     super.horizontalDetails = const ScrollableDetails.horizontal(),
-    required TwoDimensionalChildBuilderDelegate delegate,
+    required TwoDimensionalChildBuilderDelegate super.delegate,
     super.cacheExtent,
     super.cacheExtentStyle,
     super.diagonalDragBehavior = DiagonalDragBehavior.none,
@@ -89,7 +89,7 @@ class SimpleBuilderTableView extends TwoDimensionalScrollView {
     this.forgetToLayoutChild = false,
     this.setLayoutOffset = true,
     super.hitTestBehavior,
-  }) : super(delegate: delegate);
+  });
 
   // Piped through for testing in RenderTwoDimensionalViewport
   final bool useCacheExtent;
@@ -128,7 +128,7 @@ class SimpleBuilderTableViewport extends TwoDimensionalViewport {
     required super.verticalAxisDirection,
     required super.horizontalOffset,
     required super.horizontalAxisDirection,
-    required TwoDimensionalChildBuilderDelegate delegate,
+    required TwoDimensionalChildBuilderDelegate super.delegate,
     required super.mainAxis,
     super.cacheExtent,
     super.cacheExtentStyle,
@@ -137,7 +137,7 @@ class SimpleBuilderTableViewport extends TwoDimensionalViewport {
     this.applyDimensions = true,
     this.forgetToLayoutChild = false,
     this.setLayoutOffset = true,
-  }) : super(delegate: delegate);
+  });
 
   // Piped through for testing in RenderTwoDimensionalViewport
   final bool useCacheExtent;
@@ -186,7 +186,7 @@ class RenderSimpleBuilderTableViewport extends RenderTwoDimensionalViewport {
     required super.horizontalAxisDirection,
     required super.verticalOffset,
     required super.verticalAxisDirection,
-    required TwoDimensionalChildBuilderDelegate delegate,
+    required TwoDimensionalChildBuilderDelegate super.delegate,
     required super.mainAxis,
     required super.childManager,
     super.cacheExtent,
@@ -196,7 +196,7 @@ class RenderSimpleBuilderTableViewport extends RenderTwoDimensionalViewport {
     this.setLayoutOffset = true,
     this.useCacheExtent = false,
     this.forgetToLayoutChild = false,
-  }) : super(delegate: delegate);
+  });
 
   // These are to test conditions to validate subclass implementations after
   // layoutChildSequence
@@ -378,12 +378,12 @@ class SimpleListTableViewport extends TwoDimensionalViewport {
     required super.verticalAxisDirection,
     required super.horizontalOffset,
     required super.horizontalAxisDirection,
-    required TwoDimensionalChildListDelegate delegate,
+    required TwoDimensionalChildListDelegate super.delegate,
     required super.mainAxis,
     super.cacheExtent,
     super.cacheExtentStyle,
     super.clipBehavior = Clip.hardEdge,
-  }) : super(delegate: delegate);
+  });
 
   @override
   RenderTwoDimensionalViewport createRenderObject(BuildContext context) {
@@ -422,13 +422,13 @@ class RenderSimpleListTableViewport extends RenderTwoDimensionalViewport {
     required super.horizontalAxisDirection,
     required super.verticalOffset,
     required super.verticalAxisDirection,
-    required TwoDimensionalChildListDelegate delegate,
+    required TwoDimensionalChildListDelegate super.delegate,
     required super.mainAxis,
     required super.childManager,
     super.cacheExtent,
     super.cacheExtentStyle,
     super.clipBehavior = Clip.hardEdge,
-  }) : super(delegate: delegate);
+  });
 
   @override
   void layoutChildSequence() {


### PR DESCRIPTION
Work towards https://github.com/dart-lang/sdk/issues/59226

The analyzer will start reporting cases where a super parameter could be used, and the type of the supar parameter is tightened in the subclass constructor. This is still a perfectly valid super parameter use case.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
