### PR TITLE
Add more 0x0 size tests part10

### DIFF
--- a/packages/flutter/test/widgets/align_test.dart
+++ b/packages/flutter/test/widgets/align_test.dart
@@ -115,4 +115,16 @@ void main() {
     final RenderBox box = tester.renderObject<RenderBox>(find.byType(Align));
     expect(box.size.height, equals(50.0));
   });
+
+  testWidgets('Align does not crash at zero area', (WidgetTester tester) async {
+    tester.view.physicalSize = Size.zero;
+    addTearDown(tester.view.reset);
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(child: Align(child: Placeholder())),
+      ),
+    );
+    expect(tester.getSize(find.byType(Align)), Size.zero);
+  });
 }

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -1812,6 +1812,20 @@ void main() {
     expect(aPos.dy, 0.0);
     expect(bPos.dy, 0.0);
   });
+
+  testWidgets('Padding does not crash at zero area', (WidgetTester tester) async {
+    tester.view.physicalSize = Size.zero;
+    addTearDown(tester.view.reset);
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: Padding(padding: EdgeInsets.all(5), child: Placeholder()),
+        ),
+      ),
+    );
+    expect(tester.getSize(find.byType(Padding)), Size.zero);
+  });
 }
 
 HitsRenderBox hits(RenderBox renderBox) => HitsRenderBox(renderBox);

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -325,6 +325,19 @@ void main() {
         ),
       );
     });
+
+    testWidgets('FractionalTranslation does not crash at zero area', (WidgetTester tester) async {
+      tester.view.physicalSize = Size.zero;
+      const offset = Offset(0.4, 0.4);
+      addTearDown(tester.view.reset);
+      await tester.pumpWidget(
+        const Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(child: FractionalTranslation(translation: offset)),
+        ),
+      );
+      expect(tester.getSize(find.byType(FractionalTranslation)), Size.zero);
+    });
   });
 
   group('Semantics', () {

--- a/packages/flutter/test/widgets/center_test.dart
+++ b/packages/flutter/test/widgets/center_test.dart
@@ -14,4 +14,16 @@ void main() {
       ),
     );
   });
+
+  testWidgets('Center does not crash at zero area', (WidgetTester tester) async {
+    tester.view.physicalSize = Size.zero;
+    addTearDown(tester.view.reset);
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(child: Placeholder()),
+      ),
+    );
+    expect(tester.getSize(find.byType(Center)), Size.zero);
+  });
 }

--- a/packages/flutter/test/widgets/composited_transform_test.dart
+++ b/packages/flutter/test/widgets/composited_transform_test.dart
@@ -397,6 +397,27 @@ void main() {
       );
     },
   );
+
+  testWidgets('CompositedTransformTarget & CompositedTransformFollower do not crash at zero area', (
+    WidgetTester tester,
+  ) async {
+    tester.view.physicalSize = Size.zero;
+    addTearDown(tester.view.reset);
+    final link = LayerLink();
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: CompositedTransformTarget(
+            link: link,
+            child: CompositedTransformFollower(link: link),
+          ),
+        ),
+      ),
+    );
+    expect(tester.getSize(find.byType(CompositedTransformTarget)), Size.zero);
+    expect(tester.getSize(find.byType(CompositedTransformFollower)), Size.zero);
+  });
 }
 
 class _CustomWidget extends SingleChildRenderObjectWidget {

--- a/packages/flutter/test/widgets/custom_multi_child_layout_test.dart
+++ b/packages/flutter/test/widgets/custom_multi_child_layout_test.dart
@@ -431,4 +431,18 @@ void main() {
       );
     });
   });
+
+  testWidgets('CustomMultiChildLayout does not crash at zero area', (WidgetTester tester) async {
+    tester.view.physicalSize = Size.zero;
+    final size = ValueNotifier<Size>(const Size(100, 200));
+    addTearDown(tester.view.reset);
+    addTearDown(size.dispose);
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(child: CustomMultiChildLayout(delegate: NotifierLayoutDelegate(size))),
+      ),
+    );
+    expect(tester.getSize(find.byType(CustomMultiChildLayout)), Size.zero);
+  });
 }

--- a/packages/flutter/test/widgets/custom_single_child_layout_test.dart
+++ b/packages/flutter/test/widgets/custom_single_child_layout_test.dart
@@ -168,4 +168,18 @@ void main() {
     box = tester.renderObject(find.byType(CustomSingleChildLayout));
     expect(box.size, equals(const Size(150.0, 240.0)));
   });
+
+  testWidgets('CustomSingleChildLayout does not crash at zero area', (WidgetTester tester) async {
+    tester.view.physicalSize = Size.zero;
+    final size = ValueNotifier<Size>(const Size(100, 200));
+    addTearDown(tester.view.reset);
+    addTearDown(size.dispose);
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(child: CustomSingleChildLayout(delegate: NotifierLayoutDelegate(size))),
+      ),
+    );
+    expect(tester.getSize(find.byType(CustomSingleChildLayout)), Size.zero);
+  });
 }

--- a/packages/flutter/test/widgets/fitted_box_test.dart
+++ b/packages/flutter/test/widgets/fitted_box_test.dart
@@ -555,6 +555,18 @@ void main() {
     );
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets('FittedBox does not crash at zero area', (WidgetTester tester) async {
+    tester.view.physicalSize = Size.zero;
+    addTearDown(tester.view.reset);
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(child: FittedBox(child: Placeholder())),
+      ),
+    );
+    expect(tester.getSize(find.byType(FittedBox)), Size.zero);
+  });
 }
 
 List<Type> getLayers() {

--- a/packages/flutter/test/widgets/rotated_box_test.dart
+++ b/packages/flutter/test/widgets/rotated_box_test.dart
@@ -49,4 +49,16 @@ void main() {
     expect(log, equals(<String>['right']));
     log.clear();
   });
+
+  testWidgets('RotatedBox does not crash at zero area', (WidgetTester tester) async {
+    tester.view.physicalSize = Size.zero;
+    addTearDown(tester.view.reset);
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(child: RotatedBox(quarterTurns: 1)),
+      ),
+    );
+    expect(tester.getSize(find.byType(RotatedBox)), Size.zero);
+  });
 }

--- a/packages/flutter/test/widgets/sized_box_test.dart
+++ b/packages/flutter/test/widgets/sized_box_test.dart
@@ -123,4 +123,16 @@ void main() {
       BoxConstraints.tight(const Size.square(100)),
     );
   });
+
+  testWidgets('SizedBox does not crash at zero area', (WidgetTester tester) async {
+    tester.view.physicalSize = Size.zero;
+    addTearDown(tester.view.reset);
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(child: SizedBox(child: Placeholder())),
+      ),
+    );
+    expect(tester.getSize(find.byType(SizedBox)), Size.zero);
+  });
 }


### PR DESCRIPTION
This is my attempt to handle https://github.com/flutter/flutter/issues/6537 for the following widgets:
SizedBox
CustomMultiChildLayout
CustomSingleChildLayout
Center
Align
Padding
RotatedBox
FractionalTranslation
FittedBox
CompositedTransformTarget
CompositedTransformFollower