### PR TITLE
Optimize compatible `DrawDiffRoundRect` calls to use `DrawRoundRect`

### DIFF
--- a/engine/src/flutter/display_list/display_list_unittests.cc
+++ b/engine/src/flutter/display_list/display_list_unittests.cc
@@ -5105,18 +5105,6 @@ TEST_F(DisplayListTest, DrawDiffRoundRectPromoteToDrawRoundRect) {
   builder.DrawDiffRoundRect(outer_rrect, inner_rrect, paint);
   auto dl = builder.Build();
 
-  bool dl_has_draw_drrect = false;
-  bool dl_has_draw_rrect = false;
-  for (DlIndex i = 0; i < dl->GetRecordCount(); i++) {
-    if (dl->GetOpType(i) == DisplayListOpType::kDrawDiffRoundRect) {
-      dl_has_draw_drrect = true;
-    } else if (dl->GetOpType(i) == DisplayListOpType::kDrawRoundRect) {
-      dl_has_draw_rrect = true;
-    }
-  }
-  EXPECT_FALSE(dl_has_draw_drrect);
-  EXPECT_TRUE(dl_has_draw_rrect);
-
   DlScalar expected_stroke_width = inner_inset;
   DlScalar half_width = expected_stroke_width * 0.5f;
   DlRoundRect expected_round_rect = DlRoundRect::MakeRectRadii(

--- a/engine/src/flutter/display_list/display_list_unittests.cc
+++ b/engine/src/flutter/display_list/display_list_unittests.cc
@@ -5105,6 +5105,18 @@ TEST_F(DisplayListTest, DrawDiffRoundRectPromoteToDrawRoundRect) {
   builder.DrawDiffRoundRect(outer_rrect, inner_rrect, paint);
   auto dl = builder.Build();
 
+  bool dl_has_draw_drrect = false;
+  bool dl_has_draw_rrect = false;
+  for (DlIndex i = 0; i < dl->GetRecordCount(); i++) {
+    if (dl->GetOpType(i) == DisplayListOpType::kDrawDiffRoundRect) {
+      dl_has_draw_drrect = true;
+    } else if (dl->GetOpType(i) == DisplayListOpType::kDrawRoundRect) {
+      dl_has_draw_rrect = true;
+    }
+  }
+  EXPECT_FALSE(dl_has_draw_drrect);
+  EXPECT_TRUE(dl_has_draw_rrect);
+
   DlScalar expected_stroke_width = inner_inset;
   DlScalar half_width = expected_stroke_width * 0.5f;
   DlRoundRect expected_round_rect = DlRoundRect::MakeRectRadii(

--- a/engine/src/flutter/display_list/display_list_unittests.cc
+++ b/engine/src/flutter/display_list/display_list_unittests.cc
@@ -8,7 +8,6 @@
 #include <utility>
 #include <vector>
 
-#include "display_list/geometry/dl_geometry_types.h"
 #include "flutter/display_list/display_list.h"
 #include "flutter/display_list/dl_blend_mode.h"
 #include "flutter/display_list/dl_builder.h"
@@ -5144,17 +5143,23 @@ TEST_F(DisplayListTest, DrawStrokedDiffRoundRectDoesNotPromoteToDrawRoundRect) {
       .bottom_right = DlSize(outer_radii.bottom_right.width - inner_inset)};
   DlRoundRect inner_rrect = DlRoundRect::MakeRectRadii(inner_rect, inner_radii);
 
-  DlPaint paint = DlPaint().setDrawStyle(DlDrawStyle::kFill);
+  DlPaint paint = DlPaint().setDrawStyle(DlDrawStyle::kStroke);
 
   DisplayListBuilder builder;
   builder.DrawDiffRoundRect(outer_rrect, inner_rrect, paint);
   auto dl = builder.Build();
 
-  DisplayListBuilder expected;
-  expected.DrawDiffRoundRect(outer_rrect, inner_rrect, paint);
-  auto expect_dl = expected.Build();
-
-  ASSERT_TRUE(DisplayListsEQ_Verbose(dl, expect_dl));
+  bool dl_has_draw_drrect = false;
+  bool dl_has_draw_rrect = false;
+  for (DlIndex i = 0; i < dl->GetRecordCount(); i++) {
+    if (dl->GetOpType(i) == DisplayListOpType::kDrawDiffRoundRect) {
+      dl_has_draw_drrect = true;
+    } else if (dl->GetOpType(i) == DisplayListOpType::kDrawRoundRect) {
+      dl_has_draw_rrect = true;
+    }
+  }
+  EXPECT_TRUE(dl_has_draw_drrect);
+  EXPECT_FALSE(dl_has_draw_rrect);
 }
 
 // DrawDiffRoundRect with unequal side widths does not have an equivalent
@@ -5185,11 +5190,17 @@ TEST_F(DisplayListTest,
   builder.DrawDiffRoundRect(outer_rrect, inner_rrect, paint);
   auto dl = builder.Build();
 
-  DisplayListBuilder expected;
-  expected.DrawDiffRoundRect(outer_rrect, inner_rrect, paint);
-  auto expect_dl = expected.Build();
-
-  ASSERT_TRUE(DisplayListsEQ_Verbose(dl, expect_dl));
+  bool dl_has_draw_drrect = false;
+  bool dl_has_draw_rrect = false;
+  for (DlIndex i = 0; i < dl->GetRecordCount(); i++) {
+    if (dl->GetOpType(i) == DisplayListOpType::kDrawDiffRoundRect) {
+      dl_has_draw_drrect = true;
+    } else if (dl->GetOpType(i) == DisplayListOpType::kDrawRoundRect) {
+      dl_has_draw_rrect = true;
+    }
+  }
+  EXPECT_TRUE(dl_has_draw_drrect);
+  EXPECT_FALSE(dl_has_draw_rrect);
 }
 
 TEST_F(DisplayListTest, DrawRectPathPromoteToDrawRect) {

--- a/engine/src/flutter/display_list/display_list_unittests.cc
+++ b/engine/src/flutter/display_list/display_list_unittests.cc
@@ -8,6 +8,7 @@
 #include <utility>
 #include <vector>
 
+#include "display_list/geometry/dl_geometry_types.h"
 #include "flutter/display_list/display_list.h"
 #include "flutter/display_list/dl_blend_mode.h"
 #include "flutter/display_list/dl_builder.h"
@@ -5078,6 +5079,114 @@ TEST_F(DisplayListTest, DrawOvalRRectPromoteToDrawOval) {
 
   DisplayListBuilder expected;
   expected.DrawOval(rect, DlPaint());
+  auto expect_dl = expected.Build();
+
+  ASSERT_TRUE(DisplayListsEQ_Verbose(dl, expect_dl));
+}
+
+// DrawDiffRoundRect with an equivalent RoundRect draws the RoundRect.
+TEST_F(DisplayListTest, DrawDiffRoundRectPromoteToDrawRoundRect) {
+  DlRect outer_rect = DlRect::MakeLTRB(10.0f, 10.0f, 110.0f, 110.0f);
+  DlRoundingRadii outer_radii = {DlSize(5.0f), DlSize(10.0f), DlSize(20.0f),
+                                 DlSize(50.0f)};
+  DlRoundRect outer_rrect = DlRoundRect::MakeRectRadii(outer_rect, outer_radii);
+
+  DlScalar inner_inset = 5.0f;
+  DlRect inner_rect = outer_rect.Expand(-inner_inset);
+  DlRoundingRadii inner_radii = {
+      .top_left = DlSize(outer_radii.top_left.width - inner_inset),
+      .top_right = DlSize(outer_radii.top_right.width - inner_inset),
+      .bottom_left = DlSize(outer_radii.bottom_left.width - inner_inset),
+      .bottom_right = DlSize(outer_radii.bottom_right.width - inner_inset)};
+  DlRoundRect inner_rrect = DlRoundRect::MakeRectRadii(inner_rect, inner_radii);
+
+  DlPaint paint = DlPaint().setDrawStyle(DlDrawStyle::kFill);
+
+  DisplayListBuilder builder;
+  builder.DrawDiffRoundRect(outer_rrect, inner_rrect, paint);
+  auto dl = builder.Build();
+
+  DlScalar expected_stroke_width = inner_inset;
+  DlScalar half_width = expected_stroke_width * 0.5f;
+  DlRoundRect expected_round_rect = DlRoundRect::MakeRectRadii(
+      inner_rect.Expand(half_width),
+      {.top_left = DlSize(inner_radii.top_left.width + half_width),
+       .top_right = DlSize(inner_radii.top_right.width + half_width),
+       .bottom_left = DlSize(inner_radii.bottom_left.width + half_width),
+       .bottom_right = DlSize(inner_radii.bottom_right.width + half_width)});
+  DlPaint expected_paint = DlPaint()
+                               .setDrawStyle(DlDrawStyle::kStroke)
+                               .setStrokeWidth(expected_stroke_width);
+
+  DisplayListBuilder expected;
+  expected.DrawRoundRect(expected_round_rect, expected_paint);
+  auto expect_dl = expected.Build();
+
+  ASSERT_TRUE(DisplayListsEQ_Verbose(dl, expect_dl));
+}
+
+// DrawDiffRoundRect with stroked paint does not have an equivalent RoundRect,
+// and draws the DiffRoundRect.
+TEST_F(DisplayListTest, DrawStrokedDiffRoundRectDoesNotPromoteToDrawRoundRect) {
+  // All values match the above
+  // `DrawDiffRoundRectPromoteToDrawRoundRect` test, except with a stroke paint.
+  DlRect outer_rect = DlRect::MakeLTRB(10.0f, 10.0f, 110.0f, 110.0f);
+  DlRoundingRadii outer_radii = {DlSize(5.0f), DlSize(10.0f), DlSize(20.0f),
+                                 DlSize(50.0f)};
+  DlRoundRect outer_rrect = DlRoundRect::MakeRectRadii(outer_rect, outer_radii);
+
+  DlScalar inner_inset = 5.0f;
+  DlRect inner_rect = outer_rect.Expand(-inner_inset);
+  DlRoundingRadii inner_radii = {
+      .top_left = DlSize(outer_radii.top_left.width - inner_inset),
+      .top_right = DlSize(outer_radii.top_right.width - inner_inset),
+      .bottom_left = DlSize(outer_radii.bottom_left.width - inner_inset),
+      .bottom_right = DlSize(outer_radii.bottom_right.width - inner_inset)};
+  DlRoundRect inner_rrect = DlRoundRect::MakeRectRadii(inner_rect, inner_radii);
+
+  DlPaint paint = DlPaint().setDrawStyle(DlDrawStyle::kFill);
+
+  DisplayListBuilder builder;
+  builder.DrawDiffRoundRect(outer_rrect, inner_rrect, paint);
+  auto dl = builder.Build();
+
+  DisplayListBuilder expected;
+  expected.DrawDiffRoundRect(outer_rrect, inner_rrect, paint);
+  auto expect_dl = expected.Build();
+
+  ASSERT_TRUE(DisplayListsEQ_Verbose(dl, expect_dl));
+}
+
+// DrawDiffRoundRect with unequal side widths does not have an equivalent
+// RoundRect, and draws the DiffRoundRect.
+TEST_F(DisplayListTest,
+       DrawDiffRoundRectWithUnequalSidesDoesNotPromoteToDrawRoundRect) {
+  // All values match the above
+  // `DrawDiffRoundRectPromoteToDrawRoundRect` test, except the inner rect is
+  // inset by a different amount vertically and horizontally.
+  DlRect outer_rect = DlRect::MakeLTRB(10.0f, 10.0f, 110.0f, 110.0f);
+  DlRoundingRadii outer_radii = {DlSize(5.0f), DlSize(10.0f), DlSize(20.0f),
+                                 DlSize(50.0f)};
+  DlRoundRect outer_rrect = DlRoundRect::MakeRectRadii(outer_rect, outer_radii);
+
+  DlScalar inner_inset_x = 5.0f;
+  DlScalar inner_inset_y = 4.0f;
+  DlRect inner_rect = outer_rect.Expand(-inner_inset_x, -inner_inset_y);
+  DlRoundingRadii inner_radii = {
+      .top_left = DlSize(outer_radii.top_left.width - inner_inset_x),
+      .top_right = DlSize(outer_radii.top_right.width - inner_inset_x),
+      .bottom_left = DlSize(outer_radii.bottom_left.width - inner_inset_x),
+      .bottom_right = DlSize(outer_radii.bottom_right.width - inner_inset_x)};
+  DlRoundRect inner_rrect = DlRoundRect::MakeRectRadii(inner_rect, inner_radii);
+
+  DlPaint paint = DlPaint().setDrawStyle(DlDrawStyle::kFill);
+
+  DisplayListBuilder builder;
+  builder.DrawDiffRoundRect(outer_rrect, inner_rrect, paint);
+  auto dl = builder.Build();
+
+  DisplayListBuilder expected;
+  expected.DrawDiffRoundRect(outer_rrect, inner_rrect, paint);
   auto expect_dl = expected.Build();
 
   ASSERT_TRUE(DisplayListsEQ_Verbose(dl, expect_dl));

--- a/engine/src/flutter/display_list/display_list_unittests.cc
+++ b/engine/src/flutter/display_list/display_list_unittests.cc
@@ -223,6 +223,16 @@ class DisplayListTestBase : public BaseT {
                            erode_bounds, desc + " LR&TB swapped, erode 2");
   }
 
+  static int CountOps(const sk_sp<DisplayList>& dl, DisplayListOpType op_type) {
+    int count = 0;
+    for (DlIndex i = 0; i < dl->GetRecordCount(); i++) {
+      if (dl->GetOpType(i) == op_type) {
+        count++;
+      }
+    }
+    return count;
+  }
+
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(DisplayListTestBase);
 };
@@ -5105,6 +5115,9 @@ TEST_F(DisplayListTest, DrawDiffRoundRectPromoteToDrawRoundRect) {
   builder.DrawDiffRoundRect(outer_rrect, inner_rrect, paint);
   auto dl = builder.Build();
 
+  EXPECT_EQ(CountOps(dl, DisplayListOpType::kDrawDiffRoundRect), 0);
+  EXPECT_EQ(CountOps(dl, DisplayListOpType::kDrawRoundRect), 1);
+
   DlScalar expected_stroke_width = inner_inset;
   DlScalar half_width = expected_stroke_width * 0.5f;
   DlRoundRect expected_round_rect = DlRoundRect::MakeRectRadii(
@@ -5149,17 +5162,8 @@ TEST_F(DisplayListTest, DrawStrokedDiffRoundRectDoesNotPromoteToDrawRoundRect) {
   builder.DrawDiffRoundRect(outer_rrect, inner_rrect, paint);
   auto dl = builder.Build();
 
-  bool dl_has_draw_drrect = false;
-  bool dl_has_draw_rrect = false;
-  for (DlIndex i = 0; i < dl->GetRecordCount(); i++) {
-    if (dl->GetOpType(i) == DisplayListOpType::kDrawDiffRoundRect) {
-      dl_has_draw_drrect = true;
-    } else if (dl->GetOpType(i) == DisplayListOpType::kDrawRoundRect) {
-      dl_has_draw_rrect = true;
-    }
-  }
-  EXPECT_TRUE(dl_has_draw_drrect);
-  EXPECT_FALSE(dl_has_draw_rrect);
+  EXPECT_EQ(CountOps(dl, DisplayListOpType::kDrawDiffRoundRect), 1);
+  EXPECT_EQ(CountOps(dl, DisplayListOpType::kDrawRoundRect), 0);
 }
 
 // DrawDiffRoundRect with unequal side widths does not have an equivalent
@@ -5190,17 +5194,8 @@ TEST_F(DisplayListTest,
   builder.DrawDiffRoundRect(outer_rrect, inner_rrect, paint);
   auto dl = builder.Build();
 
-  bool dl_has_draw_drrect = false;
-  bool dl_has_draw_rrect = false;
-  for (DlIndex i = 0; i < dl->GetRecordCount(); i++) {
-    if (dl->GetOpType(i) == DisplayListOpType::kDrawDiffRoundRect) {
-      dl_has_draw_drrect = true;
-    } else if (dl->GetOpType(i) == DisplayListOpType::kDrawRoundRect) {
-      dl_has_draw_rrect = true;
-    }
-  }
-  EXPECT_TRUE(dl_has_draw_drrect);
-  EXPECT_FALSE(dl_has_draw_rrect);
+  EXPECT_EQ(CountOps(dl, DisplayListOpType::kDrawDiffRoundRect), 1);
+  EXPECT_EQ(CountOps(dl, DisplayListOpType::kDrawRoundRect), 0);
 }
 
 TEST_F(DisplayListTest, DrawRectPathPromoteToDrawRect) {

--- a/engine/src/flutter/display_list/display_list_unittests.cc
+++ b/engine/src/flutter/display_list/display_list_unittests.cc
@@ -5096,8 +5096,10 @@ TEST_F(DisplayListTest, DrawOvalRRectPromoteToDrawOval) {
 // DrawDiffRoundRect with an equivalent RoundRect draws the RoundRect.
 TEST_F(DisplayListTest, DrawDiffRoundRectPromoteToDrawRoundRect) {
   DlRect outer_rect = DlRect::MakeLTRB(10.0f, 10.0f, 110.0f, 110.0f);
-  DlRoundingRadii outer_radii = {DlSize(5.0f), DlSize(10.0f), DlSize(20.0f),
-                                 DlSize(50.0f)};
+  DlRoundingRadii outer_radii = {.top_left = DlSize(5.0f),
+                                 .top_right = DlSize(10.0f),
+                                 .bottom_left = DlSize(20.0f),
+                                 .bottom_right = DlSize(50.0f)};
   DlRoundRect outer_rrect = DlRoundRect::MakeRectRadii(outer_rect, outer_radii);
 
   DlScalar inner_inset = 5.0f;
@@ -5143,8 +5145,10 @@ TEST_F(DisplayListTest, DrawStrokedDiffRoundRectDoesNotPromoteToDrawRoundRect) {
   // All values match the above
   // `DrawDiffRoundRectPromoteToDrawRoundRect` test, except with a stroke paint.
   DlRect outer_rect = DlRect::MakeLTRB(10.0f, 10.0f, 110.0f, 110.0f);
-  DlRoundingRadii outer_radii = {DlSize(5.0f), DlSize(10.0f), DlSize(20.0f),
-                                 DlSize(50.0f)};
+  DlRoundingRadii outer_radii = {.top_left = DlSize(5.0f),
+                                 .top_right = DlSize(10.0f),
+                                 .bottom_left = DlSize(20.0f),
+                                 .bottom_right = DlSize(50.0f)};
   DlRoundRect outer_rrect = DlRoundRect::MakeRectRadii(outer_rect, outer_radii);
 
   DlScalar inner_inset = 5.0f;
@@ -5174,8 +5178,10 @@ TEST_F(DisplayListTest,
   // `DrawDiffRoundRectPromoteToDrawRoundRect` test, except the inner rect is
   // inset by a different amount vertically and horizontally.
   DlRect outer_rect = DlRect::MakeLTRB(10.0f, 10.0f, 110.0f, 110.0f);
-  DlRoundingRadii outer_radii = {DlSize(5.0f), DlSize(10.0f), DlSize(20.0f),
-                                 DlSize(50.0f)};
+  DlRoundingRadii outer_radii = {.top_left = DlSize(5.0f),
+                                 .top_right = DlSize(10.0f),
+                                 .bottom_left = DlSize(20.0f),
+                                 .bottom_right = DlSize(50.0f)};
   DlRoundRect outer_rrect = DlRoundRect::MakeRectRadii(outer_rect, outer_radii);
 
   DlScalar inner_inset_x = 5.0f;

--- a/engine/src/flutter/display_list/dl_builder.cc
+++ b/engine/src/flutter/display_list/dl_builder.cc
@@ -53,6 +53,14 @@ std::optional<std::pair<DlRoundRect, DlPaint>> DiffRoundRectToRoundRect(
   const DlRect& inner_bounds = inner.GetBounds();
   const DlScalar stroke_width = inner_bounds.GetLeft() - outer_bounds.GetLeft();
 
+  // There are behavior differences between DiffRoundRect and stroked RoundRect
+  // when the calculated stroke width is 0 or negative. It's not clear what the
+  // right behavior is for this case, but we exit here and don't return a
+  // RoundRect to preserve the existing DiffRoundRect behavior.
+  if (stroke_width <= 0) {
+    return std::nullopt;
+  }
+
   // Verify the other sides are inset by the same amount.
   if (!DlScalarNearlyEqual(inner_bounds.GetTop() - outer_bounds.GetTop(),
                            stroke_width) ||

--- a/engine/src/flutter/display_list/dl_builder.cc
+++ b/engine/src/flutter/display_list/dl_builder.cc
@@ -19,6 +19,93 @@
 
 namespace flutter {
 
+namespace {
+
+// Returns a stroked RoundRect that is equivalent to a provided DiffRoundRect,
+// if one exists.
+//
+// A DiffRoundRect has an equivalent stroked RoundRect if all of the following
+// conditions are met:
+// - Its paint style is kFill.
+// - The bounds of its inner RoundRect is equal to the bounds of its outer
+//   RoundRect inset by the same amount on each side. This inset amount is
+//   the stroke width of the equivalent stroked RoundRect.
+// - Its outer and inner RoundRects both have circular corners.
+// - Each corner radius of the inner RoundRect is equal to the corresponding
+//   outer RoundRect corner radius subtracting the stroke width.
+//
+// If all conditions are met, the equivalent stroked RoundRect is created by
+// expanding the inner RoundRect's sides and corner radii by half the stroke
+// width. (Or equivalently by insetting the outer RoundRect's sides and corner
+// radii by half the stroke width.)
+std::optional<std::pair<DlRoundRect, DlPaint>> DiffRoundRectToRoundRect(
+    const DlRoundRect& outer,
+    const DlRoundRect& inner,
+    const DlPaint& paint) {
+  if (paint.getDrawStyle() != DlDrawStyle::kFill) {
+    return std::nullopt;
+  }
+
+  // The stroke width is equal to the inset of the inner bounds from the outer
+  // bounds on each side. Arbitrarily pick the left side to initialize
+  // stroke_width.
+  const DlRect& outer_bounds = outer.GetBounds();
+  const DlRect& inner_bounds = inner.GetBounds();
+  const DlScalar stroke_width = inner_bounds.GetLeft() - outer_bounds.GetLeft();
+
+  // Verify the other sides are inset by the same amount.
+  if (!DlScalarNearlyEqual(inner_bounds.GetTop() - outer_bounds.GetTop(),
+                           stroke_width) ||
+      !DlScalarNearlyEqual(outer_bounds.GetRight() - inner_bounds.GetRight(),
+                           stroke_width) ||
+      !DlScalarNearlyEqual(outer_bounds.GetBottom() - inner_bounds.GetBottom(),
+                           stroke_width)) {
+    return std::nullopt;
+  }
+
+  // Verify the outer and inner RoundRects have circular corners.
+  const DlRoundingRadii& outer_radii = outer.GetRadii();
+  const DlRoundingRadii& inner_radii = inner.GetRadii();
+  if (!outer_radii.AreAllCornersCircular() ||
+      !inner_radii.AreAllCornersCircular()) {
+    return std::nullopt;
+  }
+
+  // Verify the corner radii are consistent with the stroke width.
+  if (!DlScalarNearlyEqual(
+          outer_radii.top_left.width - inner_radii.top_left.width,
+          stroke_width) ||
+      !DlScalarNearlyEqual(
+          outer_radii.top_right.width - inner_radii.top_right.width,
+          stroke_width) ||
+      !DlScalarNearlyEqual(
+          outer_radii.bottom_left.width - inner_radii.bottom_left.width,
+          stroke_width) ||
+      !DlScalarNearlyEqual(
+          outer_radii.bottom_right.width - inner_radii.bottom_right.width,
+          stroke_width)) {
+    return std::nullopt;
+  }
+
+  DlPaint stroke_paint = paint;
+  stroke_paint.setDrawStyle(DlDrawStyle::kStroke);
+  stroke_paint.setStrokeWidth(stroke_width);
+
+  const DlScalar half_stroke_width = stroke_width * 0.5f;
+  const DlRoundRect stroked_rrect = DlRoundRect::MakeRectRadii(
+      inner_bounds.Expand(half_stroke_width),
+      {
+          DlSize(inner_radii.top_left.width + half_stroke_width),
+          DlSize(inner_radii.top_right.width + half_stroke_width),
+          DlSize(inner_radii.bottom_left.width + half_stroke_width),
+          DlSize(inner_radii.bottom_right.width + half_stroke_width),
+      });
+
+  return std::make_pair(stroked_rrect, stroke_paint);
+}
+
+}  // namespace
+
 // CopyV(dst, src,n, src,n, ...) copies any number of typed srcs into dst.
 static void CopyV(void* dst) {}
 
@@ -1254,6 +1341,10 @@ void DisplayListBuilder::drawDiffRoundRect(const DlRoundRect& outer,
 void DisplayListBuilder::DrawDiffRoundRect(const DlRoundRect& outer,
                                            const DlRoundRect& inner,
                                            const DlPaint& paint) {
+  if (auto rrect_and_paint = DiffRoundRectToRoundRect(outer, inner, paint)) {
+    DrawRoundRect(rrect_and_paint->first, rrect_and_paint->second);
+    return;
+  }
   SetAttributesFromPaint(paint, DisplayListOpFlags::kDrawDRRectFlags);
   drawDiffRoundRect(outer, inner);
 }

--- a/engine/src/flutter/impeller/display_list/aiks_dl_basic_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_basic_unittests.cc
@@ -2670,5 +2670,41 @@ TEST_P(AiksTest, CompareAntiAliasAndNonAntiAlias) {
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
+TEST_P(AiksTest, CompareDiffRoundRectAndRoundRect) {
+  DisplayListBuilder builder;
+  builder.DrawColor(DlColor::kBlack(), DlBlendMode::kSrc);
+
+  DlRect outer_rect = DlRect::MakeXYWH(0, 0, 100, 100);
+  DlRoundingRadii outer_radii = {.top_left = DlSize(5.0f),
+                                 .top_right = DlSize(10.0f),
+                                 .bottom_left = DlSize(20.0f),
+                                 .bottom_right = DlSize(50.0f)};
+  DlRoundRect outer_rrect = DlRoundRect::MakeRectRadii(outer_rect, outer_radii);
+
+  DlScalar inner_inset = 5.0f;
+  DlRect inner_rect = outer_rect.Expand(-inner_inset);
+  DlRoundingRadii inner_radii = {
+      .top_left = DlSize(outer_radii.top_left.width - inner_inset),
+      .top_right = DlSize(outer_radii.top_right.width - inner_inset),
+      .bottom_left = DlSize(outer_radii.bottom_left.width - inner_inset),
+      .bottom_right = DlSize(outer_radii.bottom_right.width - inner_inset)};
+  DlRoundRect inner_rrect = DlRoundRect::MakeRectRadii(inner_rect, inner_radii);
+
+  builder.Translate(50, 50);
+
+  // Draw DiffRoundRect.
+  builder.DrawDiffRoundRect(outer_rrect, inner_rrect,
+                            DlPaint().setColor(DlColor::kSkyBlue()));
+
+  // Draw simalated DiffRoundRect by drawing the outer RoundRect and clearing
+  // the inner RoundRect.
+  builder.Translate(200, 0);
+  builder.DrawRoundRect(outer_rrect, DlPaint().setColor(DlColor::kSkyBlue()));
+  builder.DrawRoundRect(inner_rrect,
+                        DlPaint().setBlendMode(DlBlendMode::kClear));
+
+  ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -192,13 +192,6 @@ static std::unique_ptr<EntityPassTarget> CreateRenderTarget(
   );
 }
 
-bool AreCornersCircular(const RoundingRadii& radii) {
-  return ScalarNearlyEqual(radii.top_left.width, radii.top_left.height) &&
-         ScalarNearlyEqual(radii.top_right.width, radii.top_right.height) &&
-         ScalarNearlyEqual(radii.bottom_left.width, radii.bottom_left.height) &&
-         ScalarNearlyEqual(radii.bottom_right.width, radii.bottom_right.height);
-}
-
 }  // namespace
 
 class Canvas::RRectBlurShape : public BlurShape {
@@ -977,7 +970,7 @@ void Canvas::DrawRoundRect(const RoundRect& round_rect, const Paint& paint) {
   const RoundingRadii& radii = round_rect.GetRadii();
 
   if (renderer_.GetContext()->GetFlags().use_sdfs &&
-      IsCompatibleWithSDFRendering(paint) && AreCornersCircular(radii)) {
+      IsCompatibleWithSDFRendering(paint) && radii.AreAllCornersCircular()) {
     auto params = UberSDFParameters::MakeRoundedRect(
         /*color=*/paint.color,
         /*rect=*/round_rect.GetBounds(),

--- a/engine/src/flutter/impeller/geometry/rounding_radii.h
+++ b/engine/src/flutter/impeller/geometry/rounding_radii.h
@@ -60,6 +60,13 @@ struct RoundingRadii {
            ScalarNearlyEqual(top_left.height, bottom_left.height, tolerance);
   }
 
+  constexpr bool AreAllCornersCircular() const {
+    return ScalarNearlyEqual(top_left.width, top_left.height) &&
+           ScalarNearlyEqual(top_right.width, top_right.height) &&
+           ScalarNearlyEqual(bottom_left.width, bottom_left.height) &&
+           ScalarNearlyEqual(bottom_right.width, bottom_right.height);
+  }
+
   /// @brief  Returns a scaled copy of this object, ensuring that the sum of the
   ///         corner radii on each side does not exceed the width or height of
   ///         the given bounds.

--- a/engine/src/flutter/impeller/geometry/rounding_radii_unittests.cc
+++ b/engine/src/flutter/impeller/geometry/rounding_radii_unittests.cc
@@ -16,6 +16,7 @@ TEST(RoudingRadiiTest, RoundingRadiiEmptyDeclaration) {
 
   EXPECT_TRUE(radii.AreAllCornersEmpty());
   EXPECT_TRUE(radii.AreAllCornersSame());
+  EXPECT_TRUE(radii.AreAllCornersCircular());
   EXPECT_TRUE(radii.IsFinite());
   EXPECT_EQ(radii.top_left, Size());
   EXPECT_EQ(radii.top_right, Size());
@@ -36,6 +37,7 @@ TEST(RoudingRadiiTest, RoundingRadiiDefaultConstructor) {
 
   EXPECT_TRUE(radii.AreAllCornersEmpty());
   EXPECT_TRUE(radii.AreAllCornersSame());
+  EXPECT_TRUE(radii.AreAllCornersCircular());
   EXPECT_TRUE(radii.IsFinite());
   EXPECT_EQ(radii.top_left, Size());
   EXPECT_EQ(radii.top_right, Size());
@@ -48,6 +50,7 @@ TEST(RoudingRadiiTest, RoundingRadiiScalarConstructor) {
 
   EXPECT_FALSE(radii.AreAllCornersEmpty());
   EXPECT_TRUE(radii.AreAllCornersSame());
+  EXPECT_TRUE(radii.AreAllCornersCircular());
   EXPECT_TRUE(radii.IsFinite());
   EXPECT_EQ(radii.top_left, Size(5.0f, 5.0f));
   EXPECT_EQ(radii.top_right, Size(5.0f, 5.0f));
@@ -60,6 +63,7 @@ TEST(RoudingRadiiTest, RoundingRadiiEmptyScalarConstructor) {
 
   EXPECT_TRUE(radii.AreAllCornersEmpty());
   EXPECT_TRUE(radii.AreAllCornersSame());
+  EXPECT_TRUE(radii.AreAllCornersCircular());
   EXPECT_TRUE(radii.IsFinite());
   EXPECT_EQ(radii.top_left, Size(-5.0f, -5.0f));
   EXPECT_EQ(radii.top_right, Size(-5.0f, -5.0f));
@@ -72,6 +76,7 @@ TEST(RoudingRadiiTest, RoundingRadiiSizeConstructor) {
 
   EXPECT_FALSE(radii.AreAllCornersEmpty());
   EXPECT_TRUE(radii.AreAllCornersSame());
+  EXPECT_FALSE(radii.AreAllCornersCircular());
   EXPECT_TRUE(radii.IsFinite());
   EXPECT_EQ(radii.top_left, Size(5.0f, 6.0f));
   EXPECT_EQ(radii.top_right, Size(5.0f, 6.0f));
@@ -85,6 +90,7 @@ TEST(RoudingRadiiTest, RoundingRadiiEmptySizeConstructor) {
 
     EXPECT_TRUE(radii.AreAllCornersEmpty());
     EXPECT_TRUE(radii.AreAllCornersSame());
+    EXPECT_FALSE(radii.AreAllCornersCircular());
     EXPECT_TRUE(radii.IsFinite());
     EXPECT_EQ(radii.top_left, Size(-5.0f, 6.0f));
     EXPECT_EQ(radii.top_right, Size(-5.0f, 6.0f));
@@ -97,6 +103,7 @@ TEST(RoudingRadiiTest, RoundingRadiiEmptySizeConstructor) {
 
     EXPECT_TRUE(radii.AreAllCornersEmpty());
     EXPECT_TRUE(radii.AreAllCornersSame());
+    EXPECT_FALSE(radii.AreAllCornersCircular());
     EXPECT_TRUE(radii.IsFinite());
     EXPECT_EQ(radii.top_left, Size(5.0f, -6.0f));
     EXPECT_EQ(radii.top_right, Size(5.0f, -6.0f));
@@ -115,6 +122,7 @@ TEST(RoudingRadiiTest, RoundingRadiiNamedSizesConstructor) {
 
   EXPECT_FALSE(radii.AreAllCornersEmpty());
   EXPECT_FALSE(radii.AreAllCornersSame());
+  EXPECT_FALSE(radii.AreAllCornersCircular());
   EXPECT_TRUE(radii.IsFinite());
   EXPECT_EQ(radii.top_left, Size(5.0f, 5.5f));
   EXPECT_EQ(radii.top_right, Size(6.0f, 6.5f));
@@ -130,6 +138,7 @@ TEST(RoudingRadiiTest, RoundingRadiiPartialNamedSizesConstructor) {
 
     EXPECT_FALSE(radii.AreAllCornersEmpty());
     EXPECT_FALSE(radii.AreAllCornersSame());
+    EXPECT_FALSE(radii.AreAllCornersCircular());
     EXPECT_TRUE(radii.IsFinite());
     EXPECT_EQ(radii.top_left, Size(5.0f, 5.5f));
     EXPECT_EQ(radii.top_right, Size());
@@ -144,6 +153,7 @@ TEST(RoudingRadiiTest, RoundingRadiiPartialNamedSizesConstructor) {
 
     EXPECT_FALSE(radii.AreAllCornersEmpty());
     EXPECT_FALSE(radii.AreAllCornersSame());
+    EXPECT_FALSE(radii.AreAllCornersCircular());
     EXPECT_TRUE(radii.IsFinite());
     EXPECT_EQ(radii.top_left, Size());
     EXPECT_EQ(radii.top_right, Size(6.0f, 6.5f));
@@ -158,6 +168,7 @@ TEST(RoudingRadiiTest, RoundingRadiiPartialNamedSizesConstructor) {
 
     EXPECT_FALSE(radii.AreAllCornersEmpty());
     EXPECT_FALSE(radii.AreAllCornersSame());
+    EXPECT_FALSE(radii.AreAllCornersCircular());
     EXPECT_TRUE(radii.IsFinite());
     EXPECT_EQ(radii.top_left, Size());
     EXPECT_EQ(radii.top_right, Size());
@@ -172,6 +183,7 @@ TEST(RoudingRadiiTest, RoundingRadiiPartialNamedSizesConstructor) {
 
     EXPECT_FALSE(radii.AreAllCornersEmpty());
     EXPECT_FALSE(radii.AreAllCornersSame());
+    EXPECT_FALSE(radii.AreAllCornersCircular());
     EXPECT_TRUE(radii.IsFinite());
     EXPECT_EQ(radii.top_left, Size());
     EXPECT_EQ(radii.top_right, Size());
@@ -191,6 +203,7 @@ TEST(RoudingRadiiTest, RoundingRadiiMultiply) {
 
   EXPECT_FALSE(doubled.AreAllCornersEmpty());
   EXPECT_FALSE(doubled.AreAllCornersSame());
+  EXPECT_FALSE(doubled.AreAllCornersCircular());
   EXPECT_TRUE(doubled.IsFinite());
   EXPECT_EQ(doubled.top_left, Size(10.0f, 11.0f));
   EXPECT_EQ(doubled.top_right, Size(12.0f, 13.0f));


### PR DESCRIPTION
Updates display_list_builder to optimize `DrawDiffRoundRect` calls to draw an equivalent stroked RoundRect using `DrawRoundRect` when possible. See https://github.com/flutter/flutter/issues/185696#issuecomment-4399851139

Fixes https://github.com/flutter/flutter/issues/185696

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
