### PR TITLE
Update semantics accessibility block to also block keyboard focusability

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -5917,6 +5917,11 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
         config.locale = localeForChildren;
       });
     }
+    if (accessibilityFocusBlockType != AccessibilityFocusBlockType.none) {
+      configProvider.updateConfig((SemanticsConfiguration config) {
+        config.isFocused = null;
+      });
+    }
   }
 
   List<_RenderObjectSemantics> _getNonBlockedChildren() {

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -115,10 +115,14 @@ typedef SemanticsUpdateCallback = void Function(SemanticsUpdate update);
 typedef ChildSemanticsConfigurationsDelegate =
     ChildSemanticsConfigurationsResult Function(List<SemanticsConfiguration>);
 
-/// Controls how accessibility and keyboard focus are blocked.
+/// Controls how accessibility focus is blocked.
 ///
-/// This is typically used to prevent screen readers and keyboard focus
-/// from focusing on parts of the UI.
+/// This is typically used to prevent screen readers from focusing on parts
+/// of the UI.
+///
+/// Setting this property also blocks the reporting of keyboard focusability
+/// for the semantics node, but it does not affect the actual keyboard focus
+/// handled by [FocusNode].
 enum AccessibilityFocusBlockType {
   /// Accessibility focus is **not blocked**.
   none,
@@ -3950,10 +3954,6 @@ class SemanticsNode with DiagnosticableTreeMixin {
 
         return true;
       });
-    }
-
-    if (flags.isAccessibilityFocusBlocked) {
-      flags = flags.copyWith(isFocused: Tristate.none);
     }
 
     return SemanticsData(

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -115,9 +115,9 @@ typedef SemanticsUpdateCallback = void Function(SemanticsUpdate update);
 typedef ChildSemanticsConfigurationsDelegate =
     ChildSemanticsConfigurationsResult Function(List<SemanticsConfiguration>);
 
-/// Controls how accessibility focus is blocked.
+/// Controls how accessibility and keyboard focus are blocked.
 ///
-/// This is typically used to prevent screen readers
+/// This is typically used to prevent screen readers and keyboard focus
 /// from focusing on parts of the UI.
 enum AccessibilityFocusBlockType {
   /// Accessibility focus is **not blocked**.
@@ -3950,6 +3950,10 @@ class SemanticsNode with DiagnosticableTreeMixin {
 
         return true;
       });
+    }
+
+    if (flags.isAccessibilityFocusBlocked) {
+      flags = flags.copyWith(isFocused: Tristate.none);
     }
 
     return SemanticsData(

--- a/packages/flutter/test/widgets/semantics_test.dart
+++ b/packages/flutter/test/widgets/semantics_test.dart
@@ -1146,9 +1146,9 @@ void main() {
     semantics.dispose();
   });
 
-  testWidgets('semantics node cant be keyboard focusable but accessibility unfocusable', (
-    WidgetTester tester,
-  ) async {
+  testWidgets('accessibilityBlockType also blocks keyboard focus', (WidgetTester tester) async {
+    final semantics = SemanticsTester(tester);
+
     await tester.pumpWidget(
       Semantics(
         container: true,
@@ -1160,13 +1160,26 @@ void main() {
         child: const SizedBox(width: 10, height: 10),
       ),
     );
-    final Object? exception = tester.takeException();
-    expect(exception, isFlutterError);
-    final error = exception! as FlutterError;
+
     expect(
-      error.message,
-      startsWith('A node that is keyboard focusable cannot be set to accessibility unfocusable'),
+      semantics,
+      hasSemantics(
+        TestSemantics.root(
+          children: <TestSemantics>[
+            TestSemantics(
+              id: 1,
+              flags: SemanticsFlags(isAccessibilityFocusBlocked: true),
+              actions: <SemanticsAction>[SemanticsAction.customAction],
+            ),
+          ],
+        ),
+        ignoreTransform: true,
+        ignoreRect: true,
+        ignoreId: true,
+      ),
     );
+
+    semantics.dispose();
   });
 
   testWidgets('Increased/decreased values are annotated', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/semantics_test.dart
+++ b/packages/flutter/test/widgets/semantics_test.dart
@@ -1147,8 +1147,6 @@ void main() {
   });
 
   testWidgets('accessibilityBlockType also blocks keyboard focus', (WidgetTester tester) async {
-    final semantics = SemanticsTester(tester);
-
     await tester.pumpWidget(
       Semantics(
         container: true,
@@ -1161,25 +1159,9 @@ void main() {
       ),
     );
 
-    expect(
-      semantics,
-      hasSemantics(
-        TestSemantics.root(
-          children: <TestSemantics>[
-            TestSemantics(
-              id: 1,
-              flags: SemanticsFlags(isAccessibilityFocusBlocked: true),
-              actions: <SemanticsAction>[SemanticsAction.customAction],
-            ),
-          ],
-        ),
-        ignoreTransform: true,
-        ignoreRect: true,
-        ignoreId: true,
-      ),
-    );
-
-    semantics.dispose();
+    final SemanticsNode node = tester.getSemantics(find.byType(Semantics));
+    expect(node.getSemanticsData().flagsCollection.isAccessibilityFocusBlocked, true);
+    expect(node.getSemanticsData().flagsCollection.isFocused, Tristate.none);
   });
 
   testWidgets('Increased/decreased values are annotated', (WidgetTester tester) async {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

as title, otherwise blocksubTree won't be useful

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
