### PR TITLE
[flutter_tools] Honor --flavor for ios-framework builds

### DIFF
--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -375,6 +375,7 @@ class BuildInfo {
       kFileSystemScheme: ?fileSystemScheme,
       kBuildName: ?buildName,
       kBuildNumber: ?buildNumber,
+      kFlavor: ?flavor,
       if (useLocalCanvasKit) kUseLocalCanvasKitFlag: useLocalCanvasKit.toString(),
     };
   }

--- a/packages/flutter_tools/test/general.shard/build_info_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_info_test.dart
@@ -224,7 +224,7 @@ void main() {
   testWithoutContext('toBuildSystemEnvironment encoding of standard values', () {
     const buildInfo = BuildInfo(
       BuildMode.debug,
-      '',
+      'strawberry',
       treeShakeIcons: true,
       trackWidgetCreation: true,
       dartDefines: <String>['foo=2', 'bar=2'],
@@ -256,7 +256,19 @@ void main() {
       'FileSystemScheme': 'scheme',
       'BuildName': '122',
       'BuildNumber': '22',
+      'Flavor': 'strawberry',
     });
+  });
+
+  testWithoutContext('toBuildSystemEnvironment omits Flavor when flavor is null', () {
+    const buildInfo = BuildInfo(
+      BuildMode.release,
+      null,
+      treeShakeIcons: false,
+      packageConfigPath: '.dart_tool/package_config.json',
+    );
+
+    expect(buildInfo.toBuildSystemEnvironment().containsKey('Flavor'), isFalse);
   });
 
   testWithoutContext('toEnvironmentConfig encoding of standard values', () {


### PR DESCRIPTION
## Summary

`flutter build ios-framework --flavor X` was silently dropping `--flavor` before the asset bundling step ran, so flavor-conditional assets declared in `pubspec.yaml` were missing from the produced `App.xcframework`.

`BuildIOSFrameworkCommand._produceAppFramework` builds its `Environment` directly from `BuildInfo.toBuildSystemEnvironment()`, which was missing the `kFlavor` entry. This adds it, so the flavor reaches `CopyAssets` for that path — matching the propagation that already worked for Xcode-driven builds (`toEnvironmentConfig` includes `FLAVOR` for the Xcode shell phase) and Gradle-driven builds (the gradle plugin passes `-dFlavor=$it` to `flutter assemble` via `BaseFlutterTaskHelper`).

End-to-end reproduction (verified on `Flutter 3.41.8 stable`): https://github.com/eseidel/flavor_bundle_repro

`BundleBuilder`, `BuildMacOSFrameworkCommand`, and `BuildWebCommand` also call `toBuildSystemEnvironment()`. They don't expose `--flavor` to users today, so the gap isn't reachable through them — fixing it at this layer covers them automatically if `--flavor` is ever added.

Fixes #186220.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[relevant style guides]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/