### PR TITLE
[web] Use heap allocation for buffers that would consume too much space on the Wasm stack

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_memory.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_memory.dart
@@ -8,6 +8,7 @@ library skwasm_impl;
 import 'dart:async';
 import 'dart:convert';
 import 'dart:ffi';
+import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:ui/ui.dart' as ui;
@@ -26,7 +27,37 @@ external StackPointer stackSave();
 @Native<Void Function(StackPointer)>(symbol: '_emscripten_stack_restore', isLeaf: true)
 external void stackRestore(StackPointer pointer);
 
+@Native<Size Function()>(symbol: 'emscripten_stack_get_free', isLeaf: true)
+external int stackGetFree();
+
+@Native<Pointer<Void> Function(Size)>(symbol: 'emscripten_builtin_malloc', isLeaf: true)
+external Pointer<Void> heapAlloc(int length);
+
+@Native<Void Function(Pointer<Void>)>(symbol: 'emscripten_builtin_free', isLeaf: true)
+external void heapFree(Pointer<Void> ptr);
+
 class StackScope {
+  final List<Pointer<Void>> _heapPointers = <Pointer<Void>>[];
+
+  Pointer<Void> allocate(int length) {
+    // Use heap allocation for buffers that would consume too much stack space.
+    final int heapThreshold = math.min(4096, stackGetFree() ~/ 2);
+    if (length > heapThreshold) {
+      final Pointer<Void> ptr = heapAlloc(length);
+      _heapPointers.add(ptr);
+      return ptr;
+    }
+    return stackAlloc(length).cast<Void>();
+  }
+
+  void freeHeap() {
+    // ignore: prefer_foreach
+    for (final Pointer<Void> ptr in _heapPointers) {
+      heapFree(ptr);
+    }
+    _heapPointers.clear();
+  }
+
   Pointer<Int8> convertStringToNative(String string) {
     final Uint8List encoded = utf8.encode(string);
     final Pointer<Int8> pointer = allocInt8Array(encoded.length + 1);
@@ -195,43 +226,44 @@ class StackScope {
 
   Pointer<Bool> allocBoolArray(int count) {
     final int length = count * sizeOf<Bool>();
-    return stackAlloc(length).cast<Bool>();
+    return allocate(length).cast<Bool>();
   }
 
   Pointer<Int8> allocInt8Array(int count) {
     final int length = count * sizeOf<Int8>();
-    return stackAlloc(length).cast<Int8>();
+    return allocate(length).cast<Int8>();
   }
 
   Pointer<Uint16> allocUint16Array(int count) {
     final int length = count * sizeOf<Uint16>();
-    return stackAlloc(length).cast<Uint16>();
+    return allocate(length).cast<Uint16>();
   }
 
   Pointer<Int32> allocInt32Array(int count) {
     final int length = count * sizeOf<Int32>();
-    return stackAlloc(length).cast<Int32>();
+    return allocate(length).cast<Int32>();
   }
 
   Pointer<Uint32> allocUint32Array(int count) {
     final int length = count * sizeOf<Uint32>();
-    return stackAlloc(length).cast<Uint32>();
+    return allocate(length).cast<Uint32>();
   }
 
   Pointer<Float> allocFloatArray(int count) {
     final int length = count * sizeOf<Float>();
-    return stackAlloc(length).cast<Float>();
+    return allocate(length).cast<Float>();
   }
 
   Pointer<Pointer<Void>> allocPointerArray(int count) {
     final int length = count * sizeOf<Pointer<Void>>();
-    return stackAlloc(length).cast<Pointer<Void>>();
+    return allocate(length).cast<Pointer<Void>>();
   }
 }
 
 T withStackScope<T>(T Function(StackScope scope) f) {
   final StackPointer stack = stackSave();
-  final T result = f(StackScope());
+  final scope = StackScope();
+  final T result = f(scope);
   assert(
     result is! Future,
     'withStackScope() closure returned a Future. '
@@ -239,6 +271,7 @@ T withStackScope<T>(T Function(StackScope scope) f) {
     'use async/await, because the stack is restored immediately after the '
     'closure returns.',
   );
+  scope.freeHeap();
   stackRestore(stack);
   return result;
 }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_memory.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_memory.dart
@@ -37,23 +37,29 @@ external Pointer<Void> heapAlloc(int length);
 external void heapFree(Pointer<Void> ptr);
 
 class StackScope {
-  final List<Pointer<Void>> _heapPointers = <Pointer<Void>>[];
+  List<Pointer<Void>>? _heapPointers;
 
   Pointer<Void> _allocate(int length) {
     // Use heap allocation for buffers that would consume too much stack space.
     final int heapThreshold = math.min(4096, stackGetFree() ~/ 2);
     if (length > heapThreshold) {
       final Pointer<Void> ptr = heapAlloc(length);
-      _heapPointers.add(ptr);
+      _heapPointers ??= <Pointer<Void>>[];
+      _heapPointers!.add(ptr);
       return ptr;
     }
     return stackAlloc(length).cast<Void>();
   }
 
   void _freeHeap() {
-    // ignore: prefer_foreach
-    for (final Pointer<Void> ptr in _heapPointers) {
-      heapFree(ptr);
+    if (_heapPointers != null) {
+      // Iterable.forEach is not usable here because tear-offs are disallowed
+      // for external functions like heapFree.
+      // ignore: prefer_foreach
+      for (final Pointer<Void> ptr in _heapPointers!) {
+        heapFree(ptr);
+      }
+      _heapPointers = null;
     }
   }
 

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_memory.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_memory.dart
@@ -39,7 +39,7 @@ external void heapFree(Pointer<Void> ptr);
 class StackScope {
   final List<Pointer<Void>> _heapPointers = <Pointer<Void>>[];
 
-  Pointer<Void> allocate(int length) {
+  Pointer<Void> _allocate(int length) {
     // Use heap allocation for buffers that would consume too much stack space.
     final int heapThreshold = math.min(4096, stackGetFree() ~/ 2);
     if (length > heapThreshold) {
@@ -50,12 +50,11 @@ class StackScope {
     return stackAlloc(length).cast<Void>();
   }
 
-  void freeHeap() {
+  void _freeHeap() {
     // ignore: prefer_foreach
     for (final Pointer<Void> ptr in _heapPointers) {
       heapFree(ptr);
     }
-    _heapPointers.clear();
   }
 
   Pointer<Int8> convertStringToNative(String string) {
@@ -226,44 +225,49 @@ class StackScope {
 
   Pointer<Bool> allocBoolArray(int count) {
     final int length = count * sizeOf<Bool>();
-    return allocate(length).cast<Bool>();
+    return _allocate(length).cast<Bool>();
   }
 
   Pointer<Int8> allocInt8Array(int count) {
     final int length = count * sizeOf<Int8>();
-    return allocate(length).cast<Int8>();
+    return _allocate(length).cast<Int8>();
   }
 
   Pointer<Uint16> allocUint16Array(int count) {
     final int length = count * sizeOf<Uint16>();
-    return allocate(length).cast<Uint16>();
+    return _allocate(length).cast<Uint16>();
   }
 
   Pointer<Int32> allocInt32Array(int count) {
     final int length = count * sizeOf<Int32>();
-    return allocate(length).cast<Int32>();
+    return _allocate(length).cast<Int32>();
   }
 
   Pointer<Uint32> allocUint32Array(int count) {
     final int length = count * sizeOf<Uint32>();
-    return allocate(length).cast<Uint32>();
+    return _allocate(length).cast<Uint32>();
   }
 
   Pointer<Float> allocFloatArray(int count) {
     final int length = count * sizeOf<Float>();
-    return allocate(length).cast<Float>();
+    return _allocate(length).cast<Float>();
   }
 
   Pointer<Pointer<Void>> allocPointerArray(int count) {
     final int length = count * sizeOf<Pointer<Void>>();
-    return allocate(length).cast<Pointer<Void>>();
+    return _allocate(length).cast<Pointer<Void>>();
   }
 }
 
 T withStackScope<T>(T Function(StackScope scope) f) {
   final StackPointer stack = stackSave();
   final scope = StackScope();
-  final T result = f(scope);
+  late final T result;
+  try {
+    result = f(scope);
+  } finally {
+    scope._freeHeap();
+  }
   assert(
     result is! Future,
     'withStackScope() closure returned a Future. '
@@ -271,7 +275,6 @@ T withStackScope<T>(T Function(StackScope scope) f) {
     'use async/await, because the stack is restored immediately after the '
     'closure returns.',
   );
-  scope.freeHeap();
   stackRestore(stack);
   return result;
 }

--- a/engine/src/flutter/lib/web_ui/test/ui/path_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/ui/path_test.dart
@@ -256,4 +256,17 @@ Future<void> testMain() async {
     p.relativeLineTo(-50, 50);
     expect(p.getBounds(), equals(const Rect.fromLTRB(50.0, 50.0, 150.0, 100.0)));
   });
+
+  test('path containing polygon with thousands of points', () {
+    // Check that addPolygon works with a large point list that exceeds the
+    // capacity of the Wasm stack.
+    const pointCount = 10000;
+    final points = List<Offset>.generate(pointCount + 1, (i) => Offset(i.toDouble(), i.toDouble()));
+    final p = Path();
+    p.addPolygon(points, false);
+    expect(
+      p.getBounds(),
+      equals(Rect.fromLTRB(0, 0, pointCount.toDouble(), pointCount.toDouble())),
+    );
+  });
 }

--- a/engine/src/flutter/skwasm/BUILD.gn
+++ b/engine/src/flutter/skwasm/BUILD.gn
@@ -51,7 +51,7 @@ template("skwasm_variant") {
       "-sALLOW_MEMORY_GROWTH",
       "-sALLOW_TABLE_GROWTH",
       "-lexports.js",
-      "-sEXPORTED_FUNCTIONS=[stackAlloc]",
+      "-sEXPORTED_FUNCTIONS=[stackAlloc,_emscripten_stack_get_free,_emscripten_builtin_malloc,_emscripten_builtin_free]",
       "-sEXPORTED_RUNTIME_METHODS=[addFunction,wasmExports,wasmMemory,stackAlloc]",
       "-sINCOMING_MODULE_JS_API=[instantiateWasm,locateFile,noExitRuntime,mainScriptUrlOrBlob,wasmMemory,wasm,skwasmSingleThreaded]",
       "-sUSE_ES6_IMPORT_META=0",


### PR DESCRIPTION
Some Skwasm APIs use a StackScope to allocate buffers whose size depends on the input given to the API.  These buffers may exceed the default Emscripten stack size (64kb).

This PR calls Emscripten's malloc for buffers that are larger than a size limit or that consume a high percentage of the remaining stack space.  The heap buffers will be freed when the StackScope exits.

See discussion at https://github.com/flutter/flutter/pull/185997

Fixes https://github.com/flutter/flutter/issues/185995
Fixes https://github.com/flutter/flutter/issues/182616