### PR TITLE
[Cupertino] More consistent of rendering of CupertinoActivityIndicator

### DIFF
--- a/packages/flutter/lib/src/cupertino/activity_indicator.dart
+++ b/packages/flutter/lib/src/cupertino/activity_indicator.dart
@@ -172,17 +172,22 @@ class _CupertinoActivityIndicatorPainter extends CustomPainter {
     final int tickCount = _kAlphaValues.length;
 
     canvas.save();
-    canvas.translate(size.width / 2.0, size.height / 2.0);
+    canvas.translate(
+      (size.width / 2.0).roundToDouble(),
+      (size.height / 2.0).roundToDouble(),
+    );
 
     final int activeTick = (tickCount * position.value).floor();
 
     for (var i = 0; i < tickCount * progress; ++i) {
       final int t = (i - activeTick) % tickCount;
+      canvas.save();
+      canvas.rotate(i * _kTwoPI / tickCount);
       paint.color = activeColor.withAlpha(
         progress < 1 ? _partiallyRevealedAlpha : _kAlphaValues[t],
       );
       canvas.drawRRect(tickFundamentalShape, paint);
-      canvas.rotate(_kTwoPI / tickCount);
+      canvas.restore();
     }
 
     canvas.restore();

--- a/packages/flutter/lib/src/cupertino/activity_indicator.dart
+++ b/packages/flutter/lib/src/cupertino/activity_indicator.dart
@@ -172,10 +172,7 @@ class _CupertinoActivityIndicatorPainter extends CustomPainter {
     final int tickCount = _kAlphaValues.length;
 
     canvas.save();
-    canvas.translate(
-      (size.width / 2.0).roundToDouble(),
-      (size.height / 2.0).roundToDouble(),
-    );
+    canvas.translate((size.width / 2.0).roundToDouble(), (size.height / 2.0).roundToDouble());
 
     final int activeTick = (tickCount * position.value).floor();
     final int totalTicks = (tickCount * progress).ceil();

--- a/packages/flutter/lib/src/cupertino/activity_indicator.dart
+++ b/packages/flutter/lib/src/cupertino/activity_indicator.dart
@@ -178,11 +178,13 @@ class _CupertinoActivityIndicatorPainter extends CustomPainter {
     );
 
     final int activeTick = (tickCount * position.value).floor();
+    final int totalTicks = (tickCount * progress).ceil();
+    final double tickRotation = _kTwoPI / tickCount;
 
-    for (var i = 0; i < tickCount * progress; ++i) {
+    for (var i = 0; i < totalTicks; ++i) {
       final int t = (i - activeTick) % tickCount;
       canvas.save();
-      canvas.rotate(i * _kTwoPI / tickCount);
+      canvas.rotate(i * tickRotation);
       paint.color = activeColor.withAlpha(
         progress < 1 ? _partiallyRevealedAlpha : _kAlphaValues[t],
       );


### PR DESCRIPTION
Golden tests for CupertinoActivityIndicator have been fairly flaky. See example failure here:
https://ci.chromium.org/ui/p/flutter/builders/prod/Mac%20framework_tests_libraries/28008/overview

```
Failing tests:
/Volumes/Work/s/w/ir/x/w/flutter/packages/flutter/test/cupertino/activity_indicator_test.dart: Activity indicator 0% in progress
/Volumes/Work/s/w/ir/x/w/flutter/packages/flutter/test/cupertino/activity_indicator_test.dart: Activity indicator 100% in progress
/Volumes/Work/s/w/ir/x/w/flutter/packages/flutter/test/cupertino/activity_indicator_test.dart: Activity indicator 30% in progress
/Volumes/Work/s/w/ir/x/w/flutter/packages/flutter/test/cupertino/activity_indicator_test.dart: Activity indicator dark mode
```

The previous implementation has two issues that can result in inconsistent rendering:

* Because we don't snap the centre of the indicator to a pixel boundary, we can end up with inconsistent antialiasing in Skia/Impeller drawing. We now snap to a pixel boundary which avoids introducing error due to floating point differences in the centre point between runs.
* Any floating point error in roration accumulates over time, since we build each rotation on the previous one. We now apply the cumulative rotation starting from the base co-ordinate system on each frame by applying canvas.save() and canvas.restore() so our rotation is the result of a single calculation rather than additional calculation with additional fp error on each rotation. The cost of save/restore are a single push/pop of a 4x4 matrix onto/off the stack, which is negligible.

No test changes because this is covered by existing tests; it just reduces flakiness.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
