### PR TITLE
engine: warn on WASM load failure when not crossOriginIsolated

### DIFF
--- a/engine/src/flutter/lib/web_ui/flutter_js/src/entrypoint_loader.js
+++ b/engine/src/flutter/lib/web_ui/flutter_js/src/entrypoint_loader.js
@@ -160,39 +160,69 @@ export class FlutterEntrypointLoader {
       if (this._ttPolicy != null) {
         jsSupportRuntimeUri = this._ttPolicy.createScriptURL(jsSupportRuntimeUri);
       }
-      const jsSupportRuntime = await import(jsSupportRuntimeUri);
+      try {
+        const jsSupportRuntime = await import(jsSupportRuntimeUri);
 
-      const compiledDartAppPromise = jsSupportRuntime.compileStreaming(fetch(moduleUri));
+        const compiledDartAppPromise = jsSupportRuntime.compileStreaming(fetch(moduleUri));
 
-      let importsPromise;
-      if (build.renderer === "skwasm") {
-        importsPromise = (async () => {
-          const skwasmInstance = await deps.skwasm;
-          window._flutter_skwasmInstance = skwasmInstance;
-          return {
-            skwasm: skwasmInstance.wasmExports,
-            skwasmWrapper: skwasmInstance,
-            ffi: {
-              memory: skwasmInstance.wasmMemory,
-            },
-          };
-        })();
-      } else {
-        importsPromise = Promise.resolve({});
-      }
-      const compiledDartApp = await compiledDartAppPromise;
-      const dartApp = await compiledDartApp.instantiate(await importsPromise, {
-        loadDynamicModule: async (wasmUri, mjsUri) => {
-          const wasmBytes = fetch(resolveUrlWithSegments(entrypointBaseUrl, wasmUri));
-          let mjsRuntimeUri = resolveUrlWithSegments(entrypointBaseUrl, mjsUri);
-          if (this._ttPolicy != null) {
-            mjsRuntimeUri = this._ttPolicy.createScriptURL(mjsRuntimeUri);
-          }
-          const mjsModule = import(mjsRuntimeUri);
-          return [await wasmBytes, await mjsModule];
+        let importsPromise;
+        if (build.renderer === "skwasm") {
+          importsPromise = (async () => {
+            const skwasmInstance = await deps.skwasm;
+            window._flutter_skwasmInstance = skwasmInstance;
+            return {
+              skwasm: skwasmInstance.wasmExports,
+              skwasmWrapper: skwasmInstance,
+              ffi: {
+                memory: skwasmInstance.wasmMemory,
+              },
+            };
+          })();
+        } else {
+          importsPromise = Promise.resolve({});
         }
-      });
-      await dartApp.invokeMain();
+        const compiledDartApp = await compiledDartAppPromise;
+        const dartApp = await compiledDartApp.instantiate(await importsPromise, {
+          loadDynamicModule: async (wasmUri, mjsUri) => {
+            const wasmBytes = fetch(resolveUrlWithSegments(entrypointBaseUrl, wasmUri));
+            let mjsRuntimeUri = resolveUrlWithSegments(entrypointBaseUrl, mjsUri);
+            if (this._ttPolicy != null) {
+              mjsRuntimeUri = this._ttPolicy.createScriptURL(mjsRuntimeUri);
+            }
+            const mjsModule = import(mjsRuntimeUri);
+            return [await wasmBytes, await mjsModule];
+          }
+        });
+        await dartApp.invokeMain();
+      } catch (error) {
+        // A common WASM-load failure mode is that the hosting page is not
+        // crossOriginIsolated. WASM features such as SharedArrayBuffer and
+        // shared-memory threading require the page to opt into cross-origin
+        // isolation via the Cross-Origin-Opener-Policy and
+        // Cross-Origin-Embedder-Policy HTTP response headers.
+        //
+        // Without those headers, the underlying WebAssembly error is often
+        // a low-level message ("SharedArrayBuffer is not defined", "shared
+        // memory not enabled", etc.) that doesn't point the developer to
+        // the actual configuration problem. Detect the case and emit a
+        // single actionable warning before re-throwing the original error.
+        //
+        // See https://github.com/flutter/flutter/issues/142822
+        if (typeof window !== "undefined" && window.crossOriginIsolated === false) {
+          console.warn(
+            "Flutter Web (WASM) failed to load and the hosting page is not " +
+            "cross-origin isolated. Some WASM features (SharedArrayBuffer, " +
+            "shared-memory threading) require cross-origin isolation, which " +
+            "the server enables by sending these HTTP response headers:\n" +
+            "  Cross-Origin-Opener-Policy: same-origin\n" +
+            "  Cross-Origin-Embedder-Policy: require-corp\n" +
+            "If you can't change these headers, build with the JavaScript " +
+            "compile target instead of dart2wasm. " +
+            "See https://web.dev/articles/coop-coep for details."
+          );
+        }
+        throw error;
+      }
     }
   }
 


### PR DESCRIPTION
## Description

Fixes #142822.

When a Flutter WASM web app fails to load because the hosting page is not cross-origin isolated (i.e. the server isn't sending COOP/COEP HTTP headers), the underlying WebAssembly / SharedArrayBuffer errors that surface in the browser console are obscure and don't point the developer at the real problem. Examples of what users currently see:

* `ReferenceError: SharedArrayBuffer is not defined`
* `RuntimeError: WebAssembly.instantiate(): shared memory not enabled`
* `TypeError: Failed to execute 'compileStreaming' on 'WebAssembly'`

This PR wraps the WASM entrypoint load in `_loadWasmEntrypoint` in a try/catch. On failure, it checks `window.crossOriginIsolated === false`. When that's the case, it emits a single `console.warn` that:

* Names the two missing HTTP headers (`Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp`).
* Suggests building with the JavaScript compile target instead of `dart2wasm` if the developer can't change the server headers.
* Links to the canonical [web.dev COOP/COEP guide](https://web.dev/articles/coop-coep).

The original error is re-thrown, so the existing failure path is unchanged — this is purely additive diagnostic output.

## Pre-launch Checklist

- [x] I read the [Contributor Guide].
- [x] I read the [Tree Hygiene] page.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] No new code paths are added — only a try/catch around an existing load with a heuristic warning.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/