### PR TITLE
tool: build both Wasm and JS targets for `flutter run --wasm`

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:dds/dds.dart';
 import 'package:dwds/dwds.dart';
+import 'package:meta/meta.dart';
 import 'package:package_config/package_config.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 import 'package:vm_service/vm_service.dart' as vmservice;
@@ -416,6 +417,9 @@ class ResidentWebRunner extends ResidentRunner {
   /// Without `--wasm`, only a single JS config is returned.
   ///
   /// See https://github.com/flutter/flutter/issues/172006.
+  @visibleForTesting
+  List<WebCompilerConfig> get debugCompilerConfigs => _compilerConfigs;
+
   List<WebCompilerConfig> get _compilerConfigs {
     if (debuggingOptions.webUseWasm) {
       return <WebCompilerConfig>[

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -349,7 +349,7 @@ class ResidentWebRunner extends ResidentRunner {
             target,
             debuggingOptions.buildInfo,
             ServiceWorkerStrategy.none,
-            compilerConfigs: <WebCompilerConfig>[_compilerConfig],
+            compilerConfigs: _compilerConfigs,
           );
         }
         final webDevFS = flutterDevice!.devFS! as WebDevFS;
@@ -406,18 +406,37 @@ class ResidentWebRunner extends ResidentRunner {
     }
   }
 
-  WebCompilerConfig get _compilerConfig {
+  /// Compiler configurations to build for `flutter run`.
+  ///
+  /// When `--wasm` is set, this returns both a Wasm and a JS configuration so
+  /// the Flutter web loader can fall back to JS at runtime on browsers that
+  /// don't support WasmGC. This matches `flutter build web --wasm`, which
+  /// already builds both variants for the same reason.
+  ///
+  /// Without `--wasm`, only a single JS config is returned.
+  ///
+  /// See https://github.com/flutter/flutter/issues/172006.
+  List<WebCompilerConfig> get _compilerConfigs {
     if (debuggingOptions.webUseWasm) {
-      return WasmCompilerConfig(
-        optimizationLevel: 0,
-        stripWasm: false,
-        renderer: debuggingOptions.webRenderer,
-      );
+      return <WebCompilerConfig>[
+        WasmCompilerConfig(
+          optimizationLevel: 0,
+          stripWasm: false,
+          renderer: debuggingOptions.webRenderer,
+        ),
+        // JS fallback for browsers that don't support WasmGC.
+        JsCompilerConfig.run(
+          nativeNullAssertions: debuggingOptions.nativeNullAssertions,
+          renderer: debuggingOptions.webRenderer,
+        ),
+      ];
     }
-    return JsCompilerConfig.run(
-      nativeNullAssertions: debuggingOptions.nativeNullAssertions,
-      renderer: debuggingOptions.webRenderer,
-    );
+    return <WebCompilerConfig>[
+      JsCompilerConfig.run(
+        nativeNullAssertions: debuggingOptions.nativeNullAssertions,
+        renderer: debuggingOptions.webRenderer,
+      ),
+    ];
   }
 
   /// Handles the no clients available scenario gracefully.
@@ -502,7 +521,7 @@ class ResidentWebRunner extends ResidentRunner {
           target,
           debuggingOptions.buildInfo,
           ServiceWorkerStrategy.none,
-          compilerConfigs: <WebCompilerConfig>[_compilerConfig],
+          compilerConfigs: _compilerConfigs,
         );
       } on ToolExit {
         return OperationResult(1, 'Failed to recompile application.');

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -27,6 +27,7 @@ import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/isolated/devfs_web.dart';
 import 'package:flutter_tools/src/isolated/resident_web_runner.dart';
+import 'package:flutter_tools/src/web/compiler_config.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/resident_runner.dart';
 import 'package:flutter_tools/src/vmservice.dart';
@@ -1022,6 +1023,62 @@ name: my_app
     overrides: <Type, Generator>{
       Analytics: () => fakeAnalytics,
       BuildSystem: () => TestBuildSystem.all(BuildResult(success: true)),
+      FileSystem: () => fileSystem,
+      ProcessManager: () => processManager,
+      Pub: ThrowingPub.new,
+    },
+  );
+
+  // Regression tests for https://github.com/flutter/flutter/issues/172006:
+  // `flutter run --wasm` must produce both a Wasm and a JS compiler config so
+  // the runtime web loader can fall back to JS on browsers that don't support
+  // WasmGC. Without `--wasm`, only a JS config is produced.
+  testUsingContext(
+    '--wasm produces both Wasm and JS compiler configs for runtime fallback',
+    () async {
+      final ResidentWebRunner residentWebRunner =
+          setUpResidentRunner(
+            flutterDevice,
+            debuggingOptions: DebuggingOptions.enabled(
+              const BuildInfo(
+                BuildMode.debug,
+                null,
+                trackWidgetCreation: true,
+                treeShakeIcons: false,
+                packageConfigPath: '.dart_tool/package_config.json',
+              ),
+              webUseWasm: true,
+            ),
+          )
+              as ResidentWebRunner;
+
+      final List<WebCompilerConfig> configs = residentWebRunner.debugCompilerConfigs;
+
+      expect(configs, hasLength(2));
+      expect(
+        configs.map((WebCompilerConfig c) => c.compileTarget),
+        containsAll(<CompileTarget>[CompileTarget.wasm, CompileTarget.js]),
+      );
+    },
+    overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      ProcessManager: () => processManager,
+      Pub: ThrowingPub.new,
+    },
+  );
+
+  testUsingContext(
+    'no --wasm produces only a JS compiler config',
+    () async {
+      final ResidentWebRunner residentWebRunner =
+          setUpResidentRunner(flutterDevice) as ResidentWebRunner;
+
+      final List<WebCompilerConfig> configs = residentWebRunner.debugCompilerConfigs;
+
+      expect(configs, hasLength(1));
+      expect(configs.single, isA<JsCompilerConfig>());
+    },
+    overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
       Pub: ThrowingPub.new,


### PR DESCRIPTION
## Description

Fixes #172006.

`flutter build web --wasm` already produces both a Wasm and a JS build of the app, so the [Flutter web loader](https://github.com/flutter/flutter/blob/master/engine/src/flutter/lib/web_ui/flutter_js/src/loader.js#L92) can fall back to JS at runtime on browsers that don't support WasmGC. `flutter run --wasm` only produces the Wasm build, so attempting to run on a non-WasmGC browser (e.g. iOS Safari connected via remote debugging) fails with:

```
FlutterLoader could not find a build compatible with configuration and environment.
```

This PR brings the `flutter run --wasm` path in line with `flutter build web --wasm` by returning a list of compiler configurations (Wasm + JS when `--wasm` is set, JS-only otherwise) from `ResidentWebRunner._compilerConfigs` and passing it through to `WebBuilder.buildWeb` at both invocation sites.

### Repro (from the original issue)

```bash
flutter create test_app --platform web
cd test_app
flutter run -d chrome --wasm --web-hostname 0.0.0.0
# Then connect a browser without WasmGC support (iOS Safari, older browsers, etc.)
# Before this PR: "FlutterLoader could not find a build compatible..."
# After  this PR: app loads via the JS fallback build
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide].
- [x] I read the [Tree Hygiene] page.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] All existing and new tests are passing locally (50/50 in `resident_web_runner_test.dart`).

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/