### PR TITLE
engine: explain why each candidate build was skipped in Flutter web loader

### DIFF
--- a/engine/src/flutter/lib/web_ui/flutter_js/src/loader.js
+++ b/engine/src/flutter/lib/web_ui/flutter_js/src/loader.js
@@ -80,27 +80,76 @@ export class FlutterLoader {
     }
 
     const enableWasm = config.wasmAllowList?.[browserEnvironment.browserEngine] ?? defaultWasmSupport[browserEnvironment.browserEngine];
-    const rendererIsCompatible = (renderer) => {
+
+    /**
+     * Returns null if [renderer] is compatible, or a human-readable string
+     * explaining why it isn't.
+     */
+    const rendererIncompatibilityReason = (renderer) => {
       switch (renderer) {
         case "skwasm":
-          return supportsSkwasm && enableWasm;
+          if (!supportsSkwasm) {
+            return "Skwasm requires both WasmGC and WebGL; this browser does not provide both.";
+          }
+          if (!enableWasm) {
+            return `Skwasm is disabled by the loader's WASM allowlist for browser engine "${browserEnvironment.browserEngine}".`;
+          }
+          return null;
         default:
-          return true;
+          return null;
       }
-    }
+    };
 
-    const buildIsCompatible = (build) => {
+    /**
+     * Returns null if [build] is compatible, or a human-readable string
+     * explaining why it isn't. Used both to filter candidate builds and to
+     * log a useful explanation when the loader has to fall back.
+     */
+    const buildIncompatibilityReason = (build) => {
       if (build.compileTarget === "dart2wasm" && !supportsDart2Wasm) {
-        return false;
+        return "dart2wasm requires WasmGC support; this browser does not implement it yet.";
       }
       if (config.renderer && config.renderer != build.renderer) {
-        return false;
+        return `The application is configured to use the "${config.renderer}" renderer; this build targets "${build.renderer}".`;
       }
-      return rendererIsCompatible(build.renderer);
+      return rendererIncompatibilityReason(build.renderer);
     };
-    const build = buildConfig.builds.find(buildIsCompatible);
+
+    let build;
+    const skippedBuilds = [];
+    for (const candidate of buildConfig.builds) {
+      const reason = buildIncompatibilityReason(candidate);
+      if (reason === null) {
+        build = candidate;
+        break;
+      }
+      skippedBuilds.push({ candidate, reason });
+    }
+
     if (!build) {
+      // Surface every skipped build's reason so a user with a "no compatible
+      // build" failure can see exactly which constraint blocked each.
+      for (const skipped of skippedBuilds) {
+        console.warn(
+          `Flutter Web: build ${JSON.stringify(skipped.candidate)} was rejected: ${skipped.reason}`
+        );
+      }
       throw "FlutterLoader could not find a build compatible with configuration and environment.";
+    }
+
+    // If we had to skip preferred builds before finding a compatible one,
+    // log a single info-level explanation so developers understand why
+    // their app silently fell back (e.g. wasm -> js on an older browser).
+    // See https://github.com/flutter/flutter/issues/143603.
+    if (skippedBuilds.length > 0) {
+      const skippedSummary = skippedBuilds
+        .map(({ candidate, reason }) =>
+          `  - ${candidate.compileTarget}/${candidate.renderer}: ${reason}`)
+        .join("\n");
+      console.info(
+        `Flutter Web: using ${build.compileTarget} with the ${build.renderer} ` +
+        `renderer. Earlier candidates were skipped:\n${skippedSummary}`
+      );
     }
 
     const deps = {};


### PR DESCRIPTION
## Description

When the Flutter web loader picks a build for the current browser, it walks `buildConfig.builds` and takes the first one whose `compileTarget`, `renderer`, and WASM-allowlist constraints all match. Today, builds that fail those checks are silently filtered out, so:

* If every build is rejected, the user sees the generic *"FlutterLoader could not find a build compatible..."* error and has no way to tell which constraint blocked which build.
* If a preferred build (e.g. `dart2wasm` + `skwasm`) is rejected and the loader silently falls back to a less-preferred build (e.g. `dart2js` + `canvaskit`), the user has no way to tell that a fallback even happened, much less why.

This was suggested by @yjbanov in https://github.com/flutter/flutter/issues/143603#issuecomment-1996739832 and is the fallback-side complement to the COOP/COEP load-failure warning in #142822.

## What changed

`loader.js`'s `buildIsCompatible` was a `bool`-returning predicate. Refactored to `buildIncompatibilityReason` that returns either `null` (compatible) or a short human-readable string. The selection loop captures the reason for each skipped candidate, then:

* If no compatible build is found, prints a `console.warn` per skipped build before throwing the existing error.
* If at least one preferred build was skipped before settling on a later one, prints a single `console.info` summarizing the fallback path.

Sample output a developer would see when running on a browser without WasmGC:

```
[info] Flutter Web: using dart2js with the canvaskit renderer. Earlier candidates were skipped:
  - dart2wasm/skwasm: dart2wasm requires WasmGC support; this browser does not implement it yet.
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide].
- [x] I read the [Tree Hygiene] page.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] No behavioral change beyond the new diagnostic logging — the build selection algorithm picks the same build it picked before.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/