### PR TITLE
[material] Reduce flakiness in ink_paint_test

### DIFF
--- a/packages/flutter/test/material/ink_paint_test.dart
+++ b/packages/flutter/test/material/ink_paint_test.dart
@@ -90,6 +90,7 @@ void main() {
   });
 
   testWidgets('Material3 - InkWell widget renders an ink splash', (WidgetTester tester) async {
+    await _warmUpShader(tester, InkSparkle.splashFactory);
     const inkWellKey = Key('InkWell');
     const splashColor = Color(0xAA0000FF);
     const borderRadius = BorderRadius.all(Radius.circular(6.0));
@@ -326,6 +327,7 @@ void main() {
   });
 
   testWidgets('Material3 - Does the Ink widget render anything', (WidgetTester tester) async {
+    await _warmUpShader(tester, InkSparkle.splashFactory);
     const inkWellKey = Key('InkWell');
     await tester.pumpWidget(
       MaterialApp(
@@ -717,6 +719,7 @@ void main() {
   testWidgets('Material3 - Custom rectCallback renders an ink splash from its center', (
     WidgetTester tester,
   ) async {
+    await _warmUpShader(tester, InkSparkle.splashFactory);
     const inkWResponseKey = Key('InkResponse');
     const splashColor = Color(0xff00ff00);
 
@@ -822,4 +825,43 @@ class _InkRippleFactory extends InteractiveInkFeatureFactory {
       textDirection: textDirection,
     );
   }
+}
+
+/// The set of [InteractiveInkFeatureFactory]s whose shaders have been warmed up
+/// in this test run.
+final Set<InteractiveInkFeatureFactory> _warmedUpFactories = <InteractiveInkFeatureFactory>{};
+
+/// Warms up fragment shaders for a given [splashFactory] before running golden
+/// tests.
+///
+/// Because fragment shaders are compiled asynchronously on the engine's
+/// background thread, compiling them is a real-world task that does not respect
+/// the virtual clock. We use [WidgetTester.runAsync] to yield to the real-world
+/// event loop, allowing the compilation to finish before taking a golden
+/// screenshot.
+Future<void> _warmUpShader(WidgetTester tester, InteractiveInkFeatureFactory splashFactory) async {
+  if (_warmedUpFactories.contains(splashFactory)) {
+    return;
+  }
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Material(
+        child: Center(
+          child: InkWell(splashFactory: splashFactory, onTap: () {}),
+        ),
+      ),
+    ),
+  );
+  await tester.tap(find.byType(InkWell));
+
+  // Trigger the ink splash animation.
+  await tester.pump();
+
+  // Yield to the real-world event loop to allow asynchronous shader compilation
+  // to complete.
+  await tester.runAsync(() async {
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+  });
+  await tester.pumpAndSettle();
+  _warmedUpFactories.add(splashFactory);
 }

--- a/packages/flutter/test/material/ink_paint_test.dart
+++ b/packages/flutter/test/material/ink_paint_test.dart
@@ -7,7 +7,6 @@
 @Tags(<String>['reduced-test-set'])
 library;
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -120,7 +119,20 @@ void main() {
     await tester.pump(const Duration(milliseconds: 200)); // wait for splash to be well under way
 
     final box = Material.of(tester.element(find.byType(InkWell))) as RenderBox;
-    if (kIsWeb) {
+    final isSparkle =
+        Theme.of(tester.element(find.byType(InkWell))).splashFactory == InkSparkle.splashFactory;
+    if (isSparkle) {
+      expect(
+        box,
+        paints
+          ..translate(x: 0.0, y: 0.0)
+          ..save()
+          ..translate(x: 300.0, y: 270.0)
+          ..clipRRect(rrect: RRect.fromLTRBR(0.0, 0.0, 200.0, 60.0, const Radius.circular(6.0)))
+          ..rect(rect: const Rect.fromLTRB(0.0, 0.0, 200, 60))
+          ..restore(),
+      );
+    } else {
       expect(
         box,
         paints
@@ -131,17 +143,6 @@ void main() {
           ..translate(x: 300.0, y: 270.0)
           ..clipRRect(rrect: RRect.fromLTRBR(0.0, 0.0, 200.0, 60.0, const Radius.circular(6.0)))
           ..circle()
-          ..restore(),
-      );
-    } else {
-      expect(
-        box,
-        paints
-          ..translate(x: 0.0, y: 0.0)
-          ..save()
-          ..translate(x: 300.0, y: 270.0)
-          ..clipRRect(rrect: RRect.fromLTRBR(0.0, 0.0, 200.0, 60.0, const Radius.circular(6.0)))
-          ..rect(rect: const Rect.fromLTRB(0.0, 0.0, 200, 60))
           ..restore(),
       );
     }
@@ -831,6 +832,17 @@ class _InkRippleFactory extends InteractiveInkFeatureFactory {
 /// in this test run.
 final Set<InteractiveInkFeatureFactory> _warmedUpFactories = <InteractiveInkFeatureFactory>{};
 
+/// The real-world delay duration used to yield execution to the engine for
+/// asynchronous shader compilation.
+///
+/// Shaders are compiled asynchronously on a background thread in the engine,
+/// which operates outside the control of the virtualized [WidgetTester] clock.
+/// Since the engine/framework have no mechanism exposing [Future] that
+/// completes when a fragment program finishes compiling, we use a relatively
+/// large real-world delay to ensure compilation completes even under heavy
+/// load on CI.
+const Duration _kShaderWarmUpDelay = Duration(milliseconds: 200);
+
 /// Warms up fragment shaders for a given [splashFactory] before running golden
 /// tests.
 ///
@@ -860,7 +872,7 @@ Future<void> _warmUpShader(WidgetTester tester, InteractiveInkFeatureFactory spl
   // Yield to the real-world event loop to allow asynchronous shader compilation
   // to complete.
   await tester.runAsync(() async {
-    await Future<void>.delayed(const Duration(milliseconds: 50));
+    await Future<void>.delayed(_kShaderWarmUpDelay);
   });
   await tester.pumpAndSettle();
   _warmedUpFactories.add(splashFactory);


### PR DESCRIPTION
Material 3 InkSparkle-related golden tests in were flaky because `InkSparkle` compiles its fragment shader asynchronously on first use. Running real async work (like compiling a shader) involves actual async work which violates `testWidgets`'s contract, since it's reliant on a `FakeAsync` environment. Because the tests immediately tap the ink well and capture a screenshot without warming up the shader, the sparkles are sometimes missed in the rendered frame if the compile takes longer than the virtual clock ticks.

I've tried to resolve this by adding a `_warmUpShader` helper that pumps a dummy `InkWell` and taps it to trigger and await shader compilation as a warmup before the real tests execute. The splashes should render deterministically on all runs after the shader compile has happened.

Since Skwasm supports custom shaders, rather than statically checking `kIsWeb`, we also use standard tests rather than falling back on the web fallback `circle` assertions.

Example test failure:
https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8682404453729358625/+/u/run_test.dart_for_web_skwasm_tests_shard_and_subshard_1_last/stdout

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
