### PR TITLE
Add ScrollIntent support to Slider widget for gamepad/hardware input

### DIFF
--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -696,6 +696,7 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
     positionController.value = _convert(widget.value);
     _actionMap = <Type, Action<Intent>>{
       _AdjustSliderIntent: CallbackAction<_AdjustSliderIntent>(onInvoke: _actionHandler),
+      ScrollIntent: CallbackAction<ScrollIntent>(onInvoke: _handleScrollIntent),
     };
     if (widget.focusNode == null) {
       // Only create a new node if the widget doesn't have one.
@@ -712,6 +713,27 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
     positionController.dispose();
     _focusNode?.dispose();
     super.dispose();
+  }
+
+  void _handleScrollIntent(ScrollIntent intent) {
+    if (!_enabled) {
+      return;
+    }
+
+    final TextDirection directionality = Directionality.of(_renderObjectKey.currentContext!);
+
+    // Determine if we should increase or decrease based on scroll direction
+    // For horizontal scrolling: right increases (LTR) or left increases (RTL)
+    // For vertical scrolling: up increases, down decreases
+    final bool shouldIncrease = switch (intent.direction) {
+      AxisDirection.right => directionality == TextDirection.ltr,
+      AxisDirection.left => directionality == TextDirection.rtl,
+      AxisDirection.up => true,
+      AxisDirection.down => false,
+    };
+
+    final slider = _renderObjectKey.currentContext!.findRenderObject()! as _RenderSlider;
+    return shouldIncrease ? slider.increaseAction() : slider.decreaseAction();
   }
 
   void _handleChanged(double value) {

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -715,27 +715,6 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
     super.dispose();
   }
 
-  void _handleScrollIntent(ScrollIntent intent) {
-    if (!_enabled) {
-      return;
-    }
-
-    final TextDirection directionality = Directionality.of(_renderObjectKey.currentContext!);
-
-    // Determine if we should increase or decrease based on scroll direction
-    // For horizontal scrolling: right increases (LTR) or left increases (RTL)
-    // For vertical scrolling: up increases, down decreases
-    final bool shouldIncrease = switch (intent.direction) {
-      AxisDirection.right => directionality == TextDirection.ltr,
-      AxisDirection.left => directionality == TextDirection.rtl,
-      AxisDirection.up => true,
-      AxisDirection.down => false,
-    };
-
-    final slider = _renderObjectKey.currentContext!.findRenderObject()! as _RenderSlider;
-    return shouldIncrease ? slider.increaseAction() : slider.decreaseAction();
-  }
-
   void _handleChanged(double value) {
     assert(widget.onChanged != null);
     final double lerpValue = _lerp(value);
@@ -763,17 +742,36 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
   }
 
   void _actionHandler(_AdjustSliderIntent intent) {
-    final TextDirection directionality = Directionality.of(_renderObjectKey.currentContext!);
-    final bool shouldIncrease = switch (intent.type) {
-      _SliderAdjustmentType.up => true,
-      _SliderAdjustmentType.down => false,
-      _SliderAdjustmentType.left => directionality == TextDirection.rtl,
-      _SliderAdjustmentType.right => directionality == TextDirection.ltr,
-    };
+    _handleDirectionalInput(
+      shouldIncrease: switch (intent.type) {
+        _SliderAdjustmentType.up => true,
+        _SliderAdjustmentType.down => false,
+        _SliderAdjustmentType.left => _isRtl,
+        _SliderAdjustmentType.right => !_isRtl,
+      },
+    );
+  }
 
+  void _handleScrollIntent(ScrollIntent intent) {
+    if (!_enabled) {
+      return;
+    }
+    _handleDirectionalInput(
+      shouldIncrease: switch (intent.direction) {
+        AxisDirection.right => !_isRtl,
+        AxisDirection.left => _isRtl,
+        AxisDirection.up => true,
+        AxisDirection.down => false,
+      },
+    );
+  }
+
+  void _handleDirectionalInput({required bool shouldIncrease}) {
     final slider = _renderObjectKey.currentContext!.findRenderObject()! as _RenderSlider;
     return shouldIncrease ? slider.increaseAction() : slider.decreaseAction();
   }
+
+  bool get _isRtl => Directionality.of(_renderObjectKey.currentContext!) == TextDirection.rtl;
 
   bool _focused = false;
   void _handleFocusHighlightChanged(bool focused) {

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -40,6 +40,32 @@ import 'theme.dart';
 /// value indicator in a [RenderBox] that appears in the [Overlay].
 typedef PaintValueIndicator = void Function(PaintingContext context, Offset offset);
 
+/// Signature for a function that calculates the increment for scroll inputs.
+typedef SliderScrollIncrementCalculator = double Function(SliderScrollIncrementDetails details);
+
+/// Details passed to [SliderScrollIncrementCalculator].
+class SliderScrollIncrementDetails {
+  /// Creates a [SliderScrollIncrementDetails].
+  const SliderScrollIncrementDetails({required this.type, required this.semanticActionUnit});
+
+  /// The type of scroll increment (line or page).
+  final SliderScrollIncrementType type;
+
+  /// The semantic action unit for this slider.
+  /// For discrete sliders: 1.0 / divisions
+  /// For continuous sliders: platform-dependent (0.05 or 0.1)
+  final double semanticActionUnit;
+}
+
+/// Types of scroll increments.
+enum SliderScrollIncrementType {
+  /// Small increment (e.g., mouse wheel scroll).
+  line,
+
+  /// Large increment (e.g., Page Up/Down).
+  page,
+}
+
 enum _SliderType { material, adaptive }
 
 /// Possible ways for a user to interact with a [Slider].
@@ -190,6 +216,7 @@ class Slider extends StatefulWidget {
     this.allowedInteraction,
     this.padding,
     this.showValueIndicator,
+    this.scrollIncrementCalculator,
     @Deprecated(
       'Set this flag to false to opt into the 2024 slider appearance. Defaults to true. '
       'In the future, this flag will default to false. Use SliderThemeData to customize individual properties. '
@@ -242,6 +269,7 @@ class Slider extends StatefulWidget {
     this.autofocus = false,
     this.allowedInteraction,
     this.showValueIndicator,
+    this.scrollIncrementCalculator,
     @Deprecated(
       'Set this flag to false to opt into the 2024 slider appearance. Defaults to true. '
       'In the future, this flag will default to false. Use SliderThemeData to customize individual properties. '
@@ -577,6 +605,28 @@ class Slider extends StatefulWidget {
   /// null, defaults to [ShowValueIndicator.onlyForDiscrete].
   final ShowValueIndicator? showValueIndicator;
 
+  /// Calculates the increment amount for scroll inputs.
+  ///
+  /// If null, a default calculator is used that handles both
+  /// [SliderScrollIncrementType.line] and [SliderScrollIncrementType.page].
+  ///
+  /// The calculator receives a [SliderScrollIncrementDetails] object containing:
+  /// - [SliderScrollIncrementDetails.type]: Whether this is a line or page scroll
+  /// - [SliderScrollIncrementDetails.semanticActionUnit]: The base increment unit
+  ///
+  /// For example, to use 5x the increment for page scrolls:
+  /// ```dart
+  /// Slider(
+  ///   scrollIncrementCalculator: (details) {
+  ///     if (details.type == SliderScrollIncrementType.page) {
+  ///       return details.semanticActionUnit * 5;
+  ///     }
+  ///     return details.semanticActionUnit;
+  ///   },
+  /// )
+  /// ```
+  final SliderScrollIncrementCalculator? scrollIncrementCalculator;
+
   /// When true, the [Slider] will use the 2023 Material Design 3 appearance.
   /// Defaults to true.
   ///
@@ -621,6 +671,12 @@ class Slider extends StatefulWidget {
     );
     properties.add(ObjectFlagProperty<FocusNode>.has('focusNode', focusNode));
     properties.add(FlagProperty('autofocus', value: autofocus, ifTrue: 'autofocus'));
+    properties.add(
+      ObjectFlagProperty<SliderScrollIncrementCalculator>.has(
+        'scrollIncrementCalculator',
+        scrollIncrementCalculator,
+      ),
+    );
   }
 }
 
@@ -753,14 +809,43 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
   }
 
   void _handleScrollIntent(ScrollIntent intent) {
-    _handleDirectionalInput(
+    final double increment = _calculateScrollIncrement(intent.type);
+
+    if (increment == 0) {
+      return;
+    }
+
+    _handleDirectionalInputWithIncrement(
       shouldIncrease: switch (intent.direction) {
         AxisDirection.right => !_isRtl,
         AxisDirection.left => _isRtl,
         AxisDirection.up => true,
         AxisDirection.down => false,
       },
+      increment: increment,
     );
+  }
+
+  double _calculateScrollIncrement(ScrollIncrementType scrollIncrementType) {
+    final SliderScrollIncrementCalculator calculator =
+        widget.scrollIncrementCalculator ?? _defaultScrollIncrementCalculator;
+
+    return calculator(
+      SliderScrollIncrementDetails(
+        type: switch (scrollIncrementType) {
+          ScrollIncrementType.line => SliderScrollIncrementType.line,
+          ScrollIncrementType.page => SliderScrollIncrementType.page,
+        },
+        semanticActionUnit: _semanticActionUnit,
+      ),
+    );
+  }
+
+  static double _defaultScrollIncrementCalculator(SliderScrollIncrementDetails details) {
+    return switch (details.type) {
+      SliderScrollIncrementType.line => details.semanticActionUnit,
+      SliderScrollIncrementType.page => details.semanticActionUnit * 5,
+    };
   }
 
   void _handleDirectionalInput({required bool shouldIncrease}) {
@@ -769,6 +854,26 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
       slider.increaseAction();
     } else {
       slider.decreaseAction();
+    }
+  }
+
+  void _handleDirectionalInputWithIncrement({
+    required bool shouldIncrease,
+    required double increment,
+  }) {
+    if (!_enabled) {
+      return;
+    }
+
+    final slider = _renderObjectKey.currentContext!.findRenderObject()! as _RenderSlider;
+    final double newValue = shouldIncrease
+        ? clampDouble(slider.value + increment, 0.0, 1.0)
+        : clampDouble(slider.value - increment, 0.0, 1.0);
+
+    if (slider.onChanged != null) {
+      slider.onChangeStart?.call(_lerp(slider.value));
+      slider.onChanged!(_lerp(newValue));
+      slider.onChangeEnd?.call(_lerp(newValue));
     }
   }
 
@@ -821,6 +926,11 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
     assert(value <= widget.max);
     assert(value >= widget.min);
     return widget.max > widget.min ? (value - widget.min) / (widget.max - widget.min) : 0.0;
+  }
+
+  double get _semanticActionUnit {
+    final slider = _renderObjectKey.currentContext!.findRenderObject()! as _RenderSlider;
+    return slider._semanticActionUnit;
   }
 
   @override

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -619,14 +619,13 @@ class Slider extends StatefulWidget {
   /// The calculator receives a [SliderScrollIncrementDetails] object containing:
   /// - [SliderScrollIncrementDetails.type]: Whether this is a line or page scroll
   /// - [SliderScrollIncrementDetails.semanticActionUnit]: The base increment unit
-  /// Calculates the increment amount for scroll inputs.
   ///
   /// This calculator determines how much the slider value changes when a
   /// [ScrollIntent] is received.
   ///
   /// This property triggers exclusively when the widget intercepts a [ScrollIntent]
-  /// (such as from mouse wheel scrolls or gamepad axis movements). It does not 
-  /// apply to traditional directional navigation, regular touch drags, or direct 
+  /// (such as from mouse wheel scrolls or gamepad axis movements). It does not
+  /// apply to traditional directional navigation, regular touch drags, or direct
   /// track clicks.
   ///
   /// The function receives a [SliderScrollIncrementDetails] object. The
@@ -635,13 +634,17 @@ class Slider extends StatefulWidget {
   ///
   /// If this property is null, a default calculator is used. The default
   /// behavior returns `semanticActionUnit` for line scrolls and
-  /// `semanticActionUnit * 5` for page scrolls.
-  /// For example, to use 5x the increment for page scrolls:
+  /// `semanticActionUnit * 5` for page scrolls. The 5x multiplier is a
+  /// heuristic to make page jumps significantly larger than line scrolls
+  /// on the slider track, analogous to how [Scrollable] uses 80% of the
+  /// viewport for page scrolls versus a fixed 50px for line scrolls.
+  ///
+  /// For example, to use 10x the increment for page scrolls:
   /// ```dart
   /// Slider(
   ///   scrollIncrementCalculator: (details) {
   ///     if (details.type == SliderScrollIncrementType.page) {
-  ///       return details.semanticActionUnit * 5;
+  ///       return details.semanticActionUnit * 10;
   ///     }
   ///     return details.semanticActionUnit;
   ///   },
@@ -866,6 +869,9 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
     );
   }
 
+  // The default page multiplier of 5 is a heuristic: page scrolls should be
+  // noticeably larger than line scrolls on the slider track, similar to how
+  // Scrollable defaults to 80% viewport for page vs 50px for line.
   static double _defaultScrollIncrementCalculator(SliderScrollIncrementDetails details) {
     return switch (details.type) {
       SliderScrollIncrementType.line => details.semanticActionUnit,

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -695,7 +695,7 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
     enableController.value = widget.onChanged != null ? 1.0 : 0.0;
     positionController.value = _convert(widget.value);
     _actionMap = <Type, Action<Intent>>{
-      _AdjustSliderIntent: CallbackAction<_AdjustSliderIntent>(onInvoke: _actionHandler),
+      _AdjustSliderIntent: CallbackAction<_AdjustSliderIntent>(onInvoke: _handleAdjustSliderIntent),
       ScrollIntent: CallbackAction<ScrollIntent>(onInvoke: _handleScrollIntent),
     };
     if (widget.focusNode == null) {
@@ -741,7 +741,7 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
     widget.onChangeEnd?.call(_lerp(value));
   }
 
-  void _actionHandler(_AdjustSliderIntent intent) {
+  void _handleAdjustSliderIntent(_AdjustSliderIntent intent) {
     _handleDirectionalInput(
       shouldIncrease: switch (intent.type) {
         _SliderAdjustmentType.up => true,
@@ -753,9 +753,6 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
   }
 
   void _handleScrollIntent(ScrollIntent intent) {
-    if (!_enabled) {
-      return;
-    }
     _handleDirectionalInput(
       shouldIncrease: switch (intent.direction) {
         AxisDirection.right => !_isRtl,
@@ -768,7 +765,11 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
 
   void _handleDirectionalInput({required bool shouldIncrease}) {
     final slider = _renderObjectKey.currentContext!.findRenderObject()! as _RenderSlider;
-    return shouldIncrease ? slider.increaseAction() : slider.decreaseAction();
+    if (shouldIncrease) {
+      slider.increaseAction();
+    } else {
+      slider.decreaseAction();
+    }
   }
 
   bool get _isRtl => Directionality.of(_renderObjectKey.currentContext!) == TextDirection.rtl;

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -870,8 +870,7 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
   }
 
   // The default page multiplier of 5 is a heuristic: page scrolls should be
-  // noticeably larger than line scrolls on the slider track, similar to how
-  // Scrollable defaults to 80% viewport for page vs 50px for line.
+  // noticeably larger than line scrolls on the slider track.
   static double _defaultScrollIncrementCalculator(SliderScrollIncrementDetails details) {
     return switch (details.type) {
       SliderScrollIncrementType.line => details.semanticActionUnit,

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -619,7 +619,23 @@ class Slider extends StatefulWidget {
   /// The calculator receives a [SliderScrollIncrementDetails] object containing:
   /// - [SliderScrollIncrementDetails.type]: Whether this is a line or page scroll
   /// - [SliderScrollIncrementDetails.semanticActionUnit]: The base increment unit
+  /// Calculates the increment amount for scroll inputs.
   ///
+  /// This calculator determines how much the slider value changes when a
+  /// [ScrollIntent] is received.
+  ///
+  /// This property triggers exclusively when the widget intercepts a [ScrollIntent]
+  /// (such as from mouse wheel scrolls or gamepad axis movements). It does not 
+  /// apply to traditional directional navigation, regular touch drags, or direct 
+  /// track clicks.
+  ///
+  /// The function receives a [SliderScrollIncrementDetails] object. The
+  /// returned [double] value represents the actual change applied to the slider
+  /// value, which ranges from 0.0 to 1.0.
+  ///
+  /// If this property is null, a default calculator is used. The default
+  /// behavior returns `semanticActionUnit` for line scrolls and
+  /// `semanticActionUnit * 5` for page scrolls.
   /// For example, to use 5x the increment for page scrolls:
   /// ```dart
   /// Slider(

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -51,9 +51,15 @@ class SliderScrollIncrementDetails {
   /// The type of scroll increment (line or page).
   final SliderScrollIncrementType type;
 
-  /// The semantic action unit for this slider.
-  /// For discrete sliders: 1.0 / divisions
-  /// For continuous sliders: platform-dependent (0.05 or 0.1)
+  /// The amount by which the slider value changes during a semantic adjustment.
+  ///
+  /// This value represents the standard increment or decrement applied to the
+  /// slider when an accessibility service (like TalkBack or VoiceOver) requests
+  /// a change. It serves as a baseline configuration or reference point that
+  /// custom calculators can use to determine final scroll increments.
+  ///
+  /// For discrete sliders, this is calculated as `1.0 / divisions`.
+  /// For continuous sliders, it defaults to a platform-dependent value: 0.1 for iOS or macOS, and 0.05 otherwise.
   final double semanticActionUnit;
 }
 

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -797,7 +797,7 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
     widget.onChangeEnd?.call(_lerp(value));
   }
 
-  void _handleAdjustSliderIntent(_AdjustSliderIntent intent) {
+  Object _handleAdjustSliderIntent(_AdjustSliderIntent intent) {
     _handleDirectionalInput(
       shouldIncrease: switch (intent.type) {
         _SliderAdjustmentType.up => true,
@@ -806,13 +806,14 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
         _SliderAdjustmentType.right => !_isRtl,
       },
     );
+    return true;
   }
 
-  void _handleScrollIntent(ScrollIntent intent) {
+  Object _handleScrollIntent(ScrollIntent intent) {
     final double increment = _calculateScrollIncrement(intent.type);
 
     if (increment == 0) {
-      return;
+      return false;
     }
 
     _handleDirectionalInputWithIncrement(
@@ -824,6 +825,8 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
       },
       increment: increment,
     );
+
+    return true;
   }
 
   double _calculateScrollIncrement(ScrollIncrementType scrollIncrementType) {
@@ -849,6 +852,9 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
   }
 
   void _handleDirectionalInput({required bool shouldIncrease}) {
+    if (!_enabled) {
+      return;
+    }
     final slider = _renderObjectKey.currentContext!.findRenderObject()! as _RenderSlider;
     if (shouldIncrease) {
       slider.increaseAction();

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -872,13 +872,17 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
     }
 
     final slider = _renderObjectKey.currentContext!.findRenderObject()! as _RenderSlider;
-    final double newValue = shouldIncrease
-        ? clampDouble(slider.value + increment, 0.0, 1.0)
-        : clampDouble(slider.value - increment, 0.0, 1.0);
+
+    double newValue = shouldIncrease ? slider.value + increment : slider.value - increment;
+    newValue = clampDouble(newValue, 0.0, 1.0);
+
+    if (slider.isDiscrete) {
+      newValue = (newValue * slider.divisions!).round() / slider.divisions!;
+    }
 
     if (slider.onChanged != null) {
       slider.onChangeStart?.call(_lerp(slider.value));
-      slider.onChanged!(_lerp(newValue));
+      slider.onChanged!(newValue);
       slider.onChangeEnd?.call(_lerp(newValue));
     }
   }

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -636,8 +636,7 @@ class Slider extends StatefulWidget {
   /// behavior returns `semanticActionUnit` for line scrolls and
   /// `semanticActionUnit * 5` for page scrolls. The 5x multiplier is a
   /// heuristic to make page jumps significantly larger than line scrolls
-  /// on the slider track, analogous to how [Scrollable] uses 80% of the
-  /// viewport for page scrolls versus a fixed 50px for line scrolls.
+  /// on the slider track.
   ///
   /// For example, to use 10x the increment for page scrolls:
   /// ```dart

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -48,7 +48,7 @@ class SliderScrollIncrementDetails {
   /// Creates a [SliderScrollIncrementDetails].
   const SliderScrollIncrementDetails({required this.type, required this.semanticActionUnit});
 
-  /// The type of scroll increment (line or page).
+  /// The type of scroll increment (line or page) of the [ScrollIntent].
   final SliderScrollIncrementType type;
 
   /// The amount by which the slider value changes during a semantic adjustment.

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -49,7 +49,7 @@ class SliderScrollIncrementDetails {
   const SliderScrollIncrementDetails({required this.type, required this.semanticActionUnit});
 
   /// The type of scroll increment (line or page) of the [ScrollIntent].
-  final SliderScrollIncrementType type;
+  final ScrollIncrementType type;
 
   /// The amount by which the slider value changes during a semantic adjustment.
   ///
@@ -61,15 +61,6 @@ class SliderScrollIncrementDetails {
   /// For discrete sliders, this is calculated as `1.0 / divisions`.
   /// For continuous sliders, it defaults to a platform-dependent value: 0.1 for iOS or macOS, and 0.05 otherwise.
   final double semanticActionUnit;
-}
-
-/// Types of scroll increments.
-enum SliderScrollIncrementType {
-  /// Small increment (e.g., mouse wheel scroll).
-  line,
-
-  /// Large increment (e.g., Page Up/Down).
-  page,
 }
 
 enum _SliderType { material, adaptive }
@@ -614,7 +605,7 @@ class Slider extends StatefulWidget {
   /// Calculates the increment amount for scroll inputs.
   ///
   /// If null, a default calculator is used that handles both
-  /// [SliderScrollIncrementType.line] and [SliderScrollIncrementType.page].
+  /// [ScrollIncrementType.line] and [ScrollIncrementType.page].
   ///
   /// The calculator receives a [SliderScrollIncrementDetails] object containing:
   /// - [SliderScrollIncrementDetails.type]: Whether this is a line or page scroll
@@ -642,7 +633,7 @@ class Slider extends StatefulWidget {
   /// ```dart
   /// Slider(
   ///   scrollIncrementCalculator: (details) {
-  ///     if (details.type == SliderScrollIncrementType.page) {
+  ///     if (details.type == ScrollIncrementType.page) {
   ///       return details.semanticActionUnit * 10;
   ///     }
   ///     return details.semanticActionUnit;
@@ -858,13 +849,7 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
         widget.scrollIncrementCalculator ?? _defaultScrollIncrementCalculator;
 
     return calculator(
-      SliderScrollIncrementDetails(
-        type: switch (scrollIncrementType) {
-          ScrollIncrementType.line => SliderScrollIncrementType.line,
-          ScrollIncrementType.page => SliderScrollIncrementType.page,
-        },
-        semanticActionUnit: _semanticActionUnit,
-      ),
+      SliderScrollIncrementDetails(type: scrollIncrementType, semanticActionUnit: _semanticActionUnit),
     );
   }
 
@@ -872,8 +857,8 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
   // noticeably larger than line scrolls on the slider track.
   static double _defaultScrollIncrementCalculator(SliderScrollIncrementDetails details) {
     return switch (details.type) {
-      SliderScrollIncrementType.line => details.semanticActionUnit,
-      SliderScrollIncrementType.page => details.semanticActionUnit * 5,
+      ScrollIncrementType.line => details.semanticActionUnit,
+      ScrollIncrementType.page => details.semanticActionUnit * 5,
     };
   }
 

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -5679,6 +5679,113 @@ void main() {
     );
     expect(tester.getSize(find.byType(Slider)), Size.zero);
   });
+
+  group('ScrollIntent support', () {
+    testWidgets('Slider can be incremented and decremented by keyboard shortcuts - LTR', (
+      WidgetTester tester,
+    ) async {
+      tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
+      var currentValue = 0.5;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Center(
+              child: StatefulBuilder(
+                builder: (BuildContext context, StateSetter setState) {
+                  return Slider(
+                    value: currentValue,
+                    onChangeStart: (double newValue) {
+                      setState(() {});
+                    },
+                    onChanged: (double newValue) {
+                      setState(() {
+                        currentValue = newValue;
+                      });
+                    },
+                    onChangeEnd: (double newValue) {
+                      setState(() {});
+                    },
+                    autofocus: true,
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Test right arrow
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pumpAndSettle();
+      expect(currentValue, greaterThan(0.5));
+
+      // Test left arrow
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pumpAndSettle();
+      expect(currentValue, 0.5);
+
+      // Test up arrow
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pumpAndSettle();
+      expect(currentValue, greaterThan(0.5));
+
+      // Test down arrow
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pumpAndSettle();
+      expect(currentValue, 0.5);
+    });
+
+    testWidgets('Slider can be incremented and decremented by keyboard shortcuts - RTL', (
+      WidgetTester tester,
+    ) async {
+      tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
+      var currentValue = 0.5;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Center(
+              child: StatefulBuilder(
+                builder: (BuildContext context, StateSetter setState) {
+                  return Directionality(
+                    textDirection: TextDirection.rtl,
+                    child: Slider(
+                      value: currentValue,
+                      onChangeStart: (double newValue) {
+                        setState(() {});
+                      },
+                      onChanged: (double newValue) {
+                        setState(() {
+                          currentValue = newValue;
+                        });
+                      },
+                      onChangeEnd: (double newValue) {
+                        setState(() {});
+                      },
+                      autofocus: true,
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // In RTL, right should decrease
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pumpAndSettle();
+      expect(currentValue, lessThan(0.5));
+
+      // In RTL, left should increase
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pumpAndSettle();
+      expect(currentValue, 0.5);
+    });
+  });
 }
 
 // A slider value indicator that's a circle with a fixed size and

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -5679,209 +5679,250 @@ void main() {
     );
     expect(tester.getSize(find.byType(Slider)), Size.zero);
   });
-  group('ScrollIntent support', () {
-    testWidgets('ScrollIntent increases slider value with line increment', (
-      WidgetTester tester,
-    ) async {
-      var value = 0.5;
-      var calculatorCallCount = 0;
+  group('ScrollIntent support - Production Quality Tests', () {
+    const discreteSliderDivisions = 10;
+    const double discreteSliderLineIncrement = 1.0 / discreteSliderDivisions;
+    const pageIncrementMultiplier = 5.0;
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Material(
-            child: Center(
-              child: StatefulBuilder(
-                builder: (BuildContext context, StateSetter setState) {
-                  return Slider(
-                    key: const Key('slider'),
-                    value: value,
-                    divisions: 10,
-                    scrollIncrementCalculator: (SliderScrollIncrementDetails details) {
-                      calculatorCallCount++;
-                      // For line type, return the semantic action unit (1/divisions = 0.1)
-                      // For page type, return 5x the semantic action unit
-                      return switch (details.type) {
-                        SliderScrollIncrementType.line => details.semanticActionUnit,
-                        SliderScrollIncrementType.page => details.semanticActionUnit * 5,
-                      };
-                    },
-                    onChanged: (double newValue) {
-                      setState(() {
-                        value = newValue;
-                      });
-                    },
-                    autofocus: true,
-                  );
-                },
-              ),
+    Widget buildTestSlider({
+      required double initialValue,
+      required ValueChanged<double> onChanged,
+      int? divisions,
+      SliderScrollIncrementCalculator? scrollIncrementCalculator,
+    }) {
+      return MaterialApp(
+        home: Material(
+          child: Center(
+            child: Slider(
+              value: initialValue,
+              divisions: divisions,
+              scrollIncrementCalculator: scrollIncrementCalculator,
+              onChanged: onChanged,
+              autofocus: true,
             ),
           ),
         ),
       );
+    }
+
+    testWidgets('Calculator is invoked when ScrollIntent is received', (WidgetTester tester) async {
+      var calculatorInvokeCount = 0;
+      var value = 0.5;
+
+      await tester.pumpWidget(
+        buildTestSlider(
+          initialValue: value,
+          divisions: discreteSliderDivisions,
+          scrollIncrementCalculator: (SliderScrollIncrementDetails details) {
+            calculatorInvokeCount++;
+            return details.semanticActionUnit;
+          },
+          onChanged: (double newValue) {
+            value = newValue;
+          },
+        ),
+      );
       await tester.pumpAndSettle();
 
-      expect(value, equals(0.5));
-      expect(calculatorCallCount, equals(0));
+      expect(
+        calculatorInvokeCount,
+        equals(0),
+        reason: 'Calculator should not be called during build',
+      );
 
-      final FocusNode? primaryFocus = FocusManager.instance.primaryFocus;
-      expect(primaryFocus?.context, isNotNull);
+      final FocusNode? focusNode = FocusManager.instance.primaryFocus;
+      expect(focusNode?.context, isNotNull, reason: 'Slider should have focus');
 
-      // Invoke ScrollIntent with right direction (should increase value)
       Actions.maybeInvoke<ScrollIntent>(
-        primaryFocus!.context!,
+        focusNode!.context!,
         const ScrollIntent(direction: AxisDirection.right),
       );
-
       await tester.pumpAndSettle();
 
-      // Verify the value increased
-      expect(value, greaterThan(0.5));
-      // Calculator should have been called once
-      expect(calculatorCallCount, equals(1));
+      expect(
+        calculatorInvokeCount,
+        equals(1),
+        reason: 'Calculator should be invoked once per ScrollIntent',
+      );
     });
 
-    testWidgets('ScrollIntent decreases slider value when going left', (WidgetTester tester) async {
+    testWidgets('Calculator receives correct increment type (line vs page)', (
+      WidgetTester tester,
+    ) async {
+      final receivedTypes = <SliderScrollIncrementType>[];
       var value = 0.5;
 
       await tester.pumpWidget(
-        MaterialApp(
-          home: Material(
-            child: Center(
-              child: StatefulBuilder(
-                builder: (BuildContext context, StateSetter setState) {
-                  return Slider(
-                    key: const Key('slider'),
-                    value: value,
-                    divisions: 10,
-                    onChanged: (double newValue) {
-                      setState(() {
-                        value = newValue;
-                      });
-                    },
-                    autofocus: true,
-                  );
-                },
-              ),
-            ),
-          ),
+        buildTestSlider(
+          initialValue: value,
+          divisions: discreteSliderDivisions,
+          scrollIncrementCalculator: (SliderScrollIncrementDetails details) {
+            receivedTypes.add(details.type);
+            return details.semanticActionUnit;
+          },
+          onChanged: (double newValue) {
+            value = newValue;
+          },
         ),
       );
       await tester.pumpAndSettle();
 
-      expect(value, equals(0.5));
+      final FocusNode? focusNode = FocusManager.instance.primaryFocus;
+      expect(focusNode?.context, isNotNull);
 
-      final FocusNode? primaryFocus = FocusManager.instance.primaryFocus;
-      expect(primaryFocus?.context, isNotNull);
-
-      // Invoke ScrollIntent with left direction (should decrease value)
       Actions.maybeInvoke<ScrollIntent>(
-        primaryFocus!.context!,
-        const ScrollIntent(direction: AxisDirection.left),
-      );
-
-      await tester.pumpAndSettle();
-
-      // Verify the value decreased
-      expect(value, lessThan(0.5));
-    });
-
-    testWidgets('ScrollIntent with page increment moves by 5x the line increment', (
-      WidgetTester tester,
-    ) async {
-      var value = 0.0;
-
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Material(
-            child: Center(
-              child: StatefulBuilder(
-                builder: (BuildContext context, StateSetter setState) {
-                  return Slider(
-                    key: const Key('slider'),
-                    value: value,
-                    min: 0.0,
-                    max: 1.0,
-                    divisions: 10,
-                    onChanged: (double newValue) {
-                      setState(() {
-                        value = newValue;
-                      });
-                    },
-                    autofocus: true,
-                  );
-                },
-              ),
-            ),
-          ),
-        ),
+        focusNode!.context!,
+        const ScrollIntent(direction: AxisDirection.right),
       );
       await tester.pumpAndSettle();
 
-      expect(value, equals(0.0));
+      expect(
+        receivedTypes.last,
+        SliderScrollIncrementType.line,
+        reason: 'Calculator should receive line type when ScrollIncrementType.line is used',
+      );
 
-      final FocusNode? primaryFocus = FocusManager.instance.primaryFocus;
-      expect(primaryFocus?.context, isNotNull);
-
-      // Invoke ScrollIntent with page type (should move by 5 * 0.1 = 0.5)
       Actions.maybeInvoke<ScrollIntent>(
-        primaryFocus!.context!,
+        focusNode.context!,
         const ScrollIntent(direction: AxisDirection.right, type: ScrollIncrementType.page),
       );
-
       await tester.pumpAndSettle();
 
-      // Should increase by approximately 0.5 (5 * 0.1)
-      expect(value, moreOrLessEquals(0.5, epsilon: 0.01));
+      expect(
+        receivedTypes.last,
+        SliderScrollIncrementType.page,
+        reason: 'Calculator should receive page type when ScrollIncrementType.page is used',
+      );
     });
 
-    testWidgets('ScrollIntent with continuous slider uses default increment', (
+    testWidgets('Calculator receives semanticActionUnit based on slider configuration', (
+      WidgetTester tester,
+    ) async {
+      final receivedUnits = <double>[];
+      var value = 0.0;
+
+      await tester.pumpWidget(
+        buildTestSlider(
+          initialValue: value,
+          divisions: discreteSliderDivisions,
+          scrollIncrementCalculator: (SliderScrollIncrementDetails details) {
+            receivedUnits.add(details.semanticActionUnit);
+            return details.semanticActionUnit;
+          },
+          onChanged: (double newValue) {
+            value = newValue;
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final FocusNode? focusNode = FocusManager.instance.primaryFocus;
+      expect(focusNode?.context, isNotNull);
+
+      Actions.maybeInvoke<ScrollIntent>(
+        focusNode!.context!,
+        const ScrollIntent(direction: AxisDirection.right),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        receivedUnits.last,
+        moreOrLessEquals(discreteSliderLineIncrement, epsilon: 0.001),
+        reason: 'semanticActionUnit should be 1.0 / divisions for discrete slider',
+      );
+    });
+
+    testWidgets('Slider value changes by the amount returned by calculator', (
+      WidgetTester tester,
+    ) async {
+      const customLineIncrement = 0.15;
+      var value = 0.0;
+
+      await tester.pumpWidget(
+        buildTestSlider(
+          initialValue: value,
+          scrollIncrementCalculator: (SliderScrollIncrementDetails details) {
+            return customLineIncrement;
+          },
+          onChanged: (double newValue) {
+            value = newValue;
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final initialValue = value;
+      final FocusNode? focusNode = FocusManager.instance.primaryFocus;
+      expect(focusNode?.context, isNotNull);
+
+      Actions.maybeInvoke<ScrollIntent>(
+        focusNode!.context!,
+        const ScrollIntent(direction: AxisDirection.right),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        value,
+        moreOrLessEquals(initialValue + customLineIncrement, epsilon: 0.001),
+        reason: 'Slider value should increase by calculator return value ($customLineIncrement)',
+      );
+    });
+
+    testWidgets('Default calculator applies 5x multiplier for page increments', (
       WidgetTester tester,
     ) async {
       var value = 0.0;
 
       await tester.pumpWidget(
-        MaterialApp(
-          home: Material(
-            child: Center(
-              child: StatefulBuilder(
-                builder: (BuildContext context, StateSetter setState) {
-                  return Slider(
-                    key: const Key('slider'),
-                    value: value,
-                    // No divisions - continuous slider
-                    onChanged: (double newValue) {
-                      setState(() {
-                        value = newValue;
-                      });
-                    },
-                    autofocus: true,
-                  );
-                },
-              ),
-            ),
-          ),
+        buildTestSlider(
+          initialValue: value,
+          divisions: discreteSliderDivisions,
+          onChanged: (double newValue) {
+            value = newValue;
+          },
         ),
       );
       await tester.pumpAndSettle();
 
-      expect(value, equals(0.0));
+      final FocusNode? focusNode = FocusManager.instance.primaryFocus;
+      expect(focusNode?.context, isNotNull);
 
-      final FocusNode? primaryFocus = FocusManager.instance.primaryFocus;
-      expect(primaryFocus?.context, isNotNull);
-
-      // Invoke ScrollIntent - should use default 0.05 increment for continuous sliders
       Actions.maybeInvoke<ScrollIntent>(
-        primaryFocus!.context!,
+        focusNode!.context!,
         const ScrollIntent(direction: AxisDirection.right),
       );
+      await tester.pumpAndSettle();
+      final afterLineIncrement = value;
 
+      await tester.pumpWidget(
+        buildTestSlider(
+          initialValue: value,
+          divisions: discreteSliderDivisions,
+          onChanged: (double newValue) {
+            value = newValue;
+          },
+        ),
+      );
       await tester.pumpAndSettle();
 
-      // Should increase by approximately 0.05
-      expect(value, moreOrLessEquals(0.05, epsilon: 0.01));
+      Actions.maybeInvoke<ScrollIntent>(
+        focusNode.context!,
+        const ScrollIntent(direction: AxisDirection.right, type: ScrollIncrementType.page),
+      );
+      await tester.pumpAndSettle();
+
+      final double pageIncrement = value - afterLineIncrement;
+      final lineIncrement = afterLineIncrement;
+
+      expect(
+        pageIncrement,
+        moreOrLessEquals(lineIncrement * pageIncrementMultiplier, epsilon: 0.001),
+        reason:
+            'Default calculator should apply ${pageIncrementMultiplier}x multiplier for page increments',
+      );
     });
 
-    testWidgets('ScrollIntent respects RTL layout', (WidgetTester tester) async {
+    testWidgets('ScrollIntent respects text direction (RTL)', (WidgetTester tester) async {
       var value = 0.5;
 
       await tester.pumpWidget(
@@ -5890,22 +5931,13 @@ void main() {
             textDirection: TextDirection.rtl,
             child: Material(
               child: Center(
-                child: StatefulBuilder(
-                  builder: (BuildContext context, StateSetter setState) {
-                    return Slider(
-                      key: const Key('slider'),
-                      value: value,
-                      min: 0.0,
-                      max: 1.0,
-                      divisions: 10,
-                      onChanged: (double newValue) {
-                        setState(() {
-                          value = newValue;
-                        });
-                      },
-                      autofocus: true,
-                    );
+                child: Slider(
+                  value: value,
+                  divisions: discreteSliderDivisions,
+                  onChanged: (double newValue) {
+                    value = newValue;
                   },
+                  autofocus: true,
                 ),
               ),
             ),
@@ -5914,41 +5946,127 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(value, equals(0.5));
+      final FocusNode? focusNode = FocusManager.instance.primaryFocus;
+      expect(focusNode?.context, isNotNull);
 
-      final FocusNode? primaryFocus = FocusManager.instance.primaryFocus;
-      expect(primaryFocus?.context, isNotNull);
-
-      // In RTL, right direction should decrease the value
       Actions.maybeInvoke<ScrollIntent>(
-        primaryFocus!.context!,
+        focusNode!.context!,
         const ScrollIntent(direction: AxisDirection.right),
       );
-
       await tester.pumpAndSettle();
 
-      // In RTL mode, right should decrease
-      expect(value, lessThan(0.5));
+      expect(value, lessThan(0.5), reason: 'In RTL layout, right direction should decrease value');
     });
 
-    testWidgets('ScrollIntent is ignored when slider is disabled', (WidgetTester tester) async {
-      const value = 0.5;
+    testWidgets('All scroll directions are handled correctly', (WidgetTester tester) async {
+      final List<(AxisDirection, bool, String)> directions = [
+        (AxisDirection.right, true, 'right should increase'),
+        (AxisDirection.left, false, 'left should decrease'),
+        (AxisDirection.up, true, 'up should increase'),
+        (AxisDirection.down, false, 'down should decrease'),
+      ];
+
+      for (final (direction, shouldIncrease, description) in directions) {
+        var value = 0.5;
+
+        await tester.pumpWidget(
+          buildTestSlider(
+            initialValue: value,
+            divisions: discreteSliderDivisions,
+            onChanged: (double newValue) {
+              value = newValue;
+            },
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final FocusNode? focusNode = FocusManager.instance.primaryFocus;
+        expect(focusNode?.context, isNotNull);
+
+        Actions.maybeInvoke<ScrollIntent>(focusNode!.context!, ScrollIntent(direction: direction));
+        await tester.pumpAndSettle();
+
+        if (shouldIncrease) {
+          expect(value, greaterThan(0.5), reason: description);
+        } else {
+          expect(value, lessThan(0.5), reason: description);
+        }
+      }
+    });
+
+    testWidgets('Continuous slider works with ScrollIntent', (WidgetTester tester) async {
+      var value = 0.0;
+
+      await tester.pumpWidget(
+        buildTestSlider(
+          initialValue: value,
+          onChanged: (double newValue) {
+            value = newValue;
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final FocusNode? focusNode = FocusManager.instance.primaryFocus;
+      expect(focusNode?.context, isNotNull);
+
+      Actions.maybeInvoke<ScrollIntent>(
+        focusNode!.context!,
+        const ScrollIntent(direction: AxisDirection.right),
+      );
+      await tester.pumpAndSettle();
+
+      expect(value, greaterThan(0.0), reason: 'Continuous slider should update');
+    });
+
+    testWidgets('ScrollIntent respects min/max boundaries', (WidgetTester tester) async {
+      var value = 0.95;
+
+      await tester.pumpWidget(
+        buildTestSlider(
+          initialValue: value,
+          divisions: discreteSliderDivisions,
+          onChanged: (double newValue) {
+            value = newValue;
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final FocusNode? focusNode = FocusManager.instance.primaryFocus;
+      expect(focusNode?.context, isNotNull);
+
+      Actions.maybeInvoke<ScrollIntent>(
+        focusNode!.context!,
+        const ScrollIntent(direction: AxisDirection.right, type: ScrollIncrementType.page),
+      );
+      await tester.pumpAndSettle();
+
+      expect(value, lessThanOrEqualTo(1.0), reason: 'Should not exceed max value');
+    });
+
+    testWidgets('ScrollIntent triggers onChangeStart and onChangeEnd', (WidgetTester tester) async {
+      var startCalled = false;
+      var endCalled = false;
+      var value = 0.5;
 
       await tester.pumpWidget(
         MaterialApp(
           home: Material(
             child: Center(
-              child: StatefulBuilder(
-                builder: (BuildContext context, StateSetter setState) {
-                  return const Slider(
-                    key: Key('slider'),
-                    value: value,
-                    divisions: 10,
-                    // Disabled slider (onChanged is null)
-                    onChanged: null,
-                    autofocus: true,
-                  );
+              child: Slider(
+                value: value,
+                divisions: discreteSliderDivisions,
+                onChangeStart: (double newValue) {
+                  startCalled = true;
                 },
+                onChangeEnd: (double newValue) {
+                  endCalled = true;
+                },
+                onChanged: (double newValue) {
+                  value = newValue;
+                },
+                autofocus: true,
               ),
             ),
           ),
@@ -5956,23 +6074,17 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(value, equals(0.5));
+      final FocusNode? focusNode = FocusManager.instance.primaryFocus;
+      expect(focusNode?.context, isNotNull);
 
-      final FocusNode? primaryFocus = FocusManager.instance.primaryFocus;
-      expect(primaryFocus?.context, isNotNull);
-
-      // Try to invoke ScrollIntent on disabled slider
-      final Object? result = Actions.maybeInvoke<ScrollIntent>(
-        primaryFocus!.context!,
+      Actions.maybeInvoke<ScrollIntent>(
+        focusNode!.context!,
         const ScrollIntent(direction: AxisDirection.right),
       );
-
       await tester.pumpAndSettle();
 
-      // Value should not change
-      expect(value, equals(0.5));
-      // Action should be ignored (returns null or false)
-      expect(result, isNull);
+      expect(startCalled, isTrue, reason: 'onChangeStart should be called');
+      expect(endCalled, isTrue, reason: 'onChangeEnd should be called');
     });
   });
 }

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -5679,13 +5679,12 @@ void main() {
     );
     expect(tester.getSize(find.byType(Slider)), Size.zero);
   });
-
   group('ScrollIntent support', () {
-    testWidgets('Slider can be incremented and decremented by keyboard shortcuts - LTR', (
+    testWidgets('ScrollIntent increases slider value with line increment', (
       WidgetTester tester,
     ) async {
-      tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
-      var currentValue = 0.5;
+      var value = 0.5;
+      var calculatorCallCount = 0;
 
       await tester.pumpWidget(
         MaterialApp(
@@ -5694,17 +5693,22 @@ void main() {
               child: StatefulBuilder(
                 builder: (BuildContext context, StateSetter setState) {
                   return Slider(
-                    value: currentValue,
-                    onChangeStart: (double newValue) {
-                      setState(() {});
+                    key: const Key('slider'),
+                    value: value,
+                    divisions: 10,
+                    scrollIncrementCalculator: (SliderScrollIncrementDetails details) {
+                      calculatorCallCount++;
+                      // For line type, return the semantic action unit (1/divisions = 0.1)
+                      // For page type, return 5x the semantic action unit
+                      return switch (details.type) {
+                        SliderScrollIncrementType.line => details.semanticActionUnit,
+                        SliderScrollIncrementType.page => details.semanticActionUnit * 5,
+                      };
                     },
                     onChanged: (double newValue) {
                       setState(() {
-                        currentValue = newValue;
+                        value = newValue;
                       });
-                    },
-                    onChangeEnd: (double newValue) {
-                      setState(() {});
                     },
                     autofocus: true,
                   );
@@ -5716,32 +5720,28 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      // Test right arrow
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
-      await tester.pumpAndSettle();
-      expect(currentValue, greaterThan(0.5));
+      expect(value, equals(0.5));
+      expect(calculatorCallCount, equals(0));
 
-      // Test left arrow
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
-      await tester.pumpAndSettle();
-      expect(currentValue, 0.5);
+      final FocusNode? primaryFocus = FocusManager.instance.primaryFocus;
+      expect(primaryFocus?.context, isNotNull);
 
-      // Test up arrow
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
-      await tester.pumpAndSettle();
-      expect(currentValue, greaterThan(0.5));
+      // Invoke ScrollIntent with right direction (should increase value)
+      Actions.maybeInvoke<ScrollIntent>(
+        primaryFocus!.context!,
+        const ScrollIntent(direction: AxisDirection.right),
+      );
 
-      // Test down arrow
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
       await tester.pumpAndSettle();
-      expect(currentValue, 0.5);
+
+      // Verify the value increased
+      expect(value, greaterThan(0.5));
+      // Calculator should have been called once
+      expect(calculatorCallCount, equals(1));
     });
 
-    testWidgets('Slider can be incremented and decremented by keyboard shortcuts - RTL', (
-      WidgetTester tester,
-    ) async {
-      tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
-      var currentValue = 0.5;
+    testWidgets('ScrollIntent decreases slider value when going left', (WidgetTester tester) async {
+      var value = 0.5;
 
       await tester.pumpWidget(
         MaterialApp(
@@ -5749,23 +5749,16 @@ void main() {
             child: Center(
               child: StatefulBuilder(
                 builder: (BuildContext context, StateSetter setState) {
-                  return Directionality(
-                    textDirection: TextDirection.rtl,
-                    child: Slider(
-                      value: currentValue,
-                      onChangeStart: (double newValue) {
-                        setState(() {});
-                      },
-                      onChanged: (double newValue) {
-                        setState(() {
-                          currentValue = newValue;
-                        });
-                      },
-                      onChangeEnd: (double newValue) {
-                        setState(() {});
-                      },
-                      autofocus: true,
-                    ),
+                  return Slider(
+                    key: const Key('slider'),
+                    value: value,
+                    divisions: 10,
+                    onChanged: (double newValue) {
+                      setState(() {
+                        value = newValue;
+                      });
+                    },
+                    autofocus: true,
                   );
                 },
               ),
@@ -5775,15 +5768,211 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      // In RTL, right should decrease
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
-      await tester.pumpAndSettle();
-      expect(currentValue, lessThan(0.5));
+      expect(value, equals(0.5));
 
-      // In RTL, left should increase
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      final FocusNode? primaryFocus = FocusManager.instance.primaryFocus;
+      expect(primaryFocus?.context, isNotNull);
+
+      // Invoke ScrollIntent with left direction (should decrease value)
+      Actions.maybeInvoke<ScrollIntent>(
+        primaryFocus!.context!,
+        const ScrollIntent(direction: AxisDirection.left),
+      );
+
       await tester.pumpAndSettle();
-      expect(currentValue, 0.5);
+
+      // Verify the value decreased
+      expect(value, lessThan(0.5));
+    });
+
+    testWidgets('ScrollIntent with page increment moves by 5x the line increment', (
+      WidgetTester tester,
+    ) async {
+      var value = 0.0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Center(
+              child: StatefulBuilder(
+                builder: (BuildContext context, StateSetter setState) {
+                  return Slider(
+                    key: const Key('slider'),
+                    value: value,
+                    min: 0.0,
+                    max: 1.0,
+                    divisions: 10,
+                    onChanged: (double newValue) {
+                      setState(() {
+                        value = newValue;
+                      });
+                    },
+                    autofocus: true,
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(value, equals(0.0));
+
+      final FocusNode? primaryFocus = FocusManager.instance.primaryFocus;
+      expect(primaryFocus?.context, isNotNull);
+
+      // Invoke ScrollIntent with page type (should move by 5 * 0.1 = 0.5)
+      Actions.maybeInvoke<ScrollIntent>(
+        primaryFocus!.context!,
+        const ScrollIntent(direction: AxisDirection.right, type: ScrollIncrementType.page),
+      );
+
+      await tester.pumpAndSettle();
+
+      // Should increase by approximately 0.5 (5 * 0.1)
+      expect(value, moreOrLessEquals(0.5, epsilon: 0.01));
+    });
+
+    testWidgets('ScrollIntent with continuous slider uses default increment', (
+      WidgetTester tester,
+    ) async {
+      var value = 0.0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Center(
+              child: StatefulBuilder(
+                builder: (BuildContext context, StateSetter setState) {
+                  return Slider(
+                    key: const Key('slider'),
+                    value: value,
+                    // No divisions - continuous slider
+                    onChanged: (double newValue) {
+                      setState(() {
+                        value = newValue;
+                      });
+                    },
+                    autofocus: true,
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(value, equals(0.0));
+
+      final FocusNode? primaryFocus = FocusManager.instance.primaryFocus;
+      expect(primaryFocus?.context, isNotNull);
+
+      // Invoke ScrollIntent - should use default 0.05 increment for continuous sliders
+      Actions.maybeInvoke<ScrollIntent>(
+        primaryFocus!.context!,
+        const ScrollIntent(direction: AxisDirection.right),
+      );
+
+      await tester.pumpAndSettle();
+
+      // Should increase by approximately 0.05
+      expect(value, moreOrLessEquals(0.05, epsilon: 0.01));
+    });
+
+    testWidgets('ScrollIntent respects RTL layout', (WidgetTester tester) async {
+      var value = 0.5;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Directionality(
+            textDirection: TextDirection.rtl,
+            child: Material(
+              child: Center(
+                child: StatefulBuilder(
+                  builder: (BuildContext context, StateSetter setState) {
+                    return Slider(
+                      key: const Key('slider'),
+                      value: value,
+                      min: 0.0,
+                      max: 1.0,
+                      divisions: 10,
+                      onChanged: (double newValue) {
+                        setState(() {
+                          value = newValue;
+                        });
+                      },
+                      autofocus: true,
+                    );
+                  },
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(value, equals(0.5));
+
+      final FocusNode? primaryFocus = FocusManager.instance.primaryFocus;
+      expect(primaryFocus?.context, isNotNull);
+
+      // In RTL, right direction should decrease the value
+      Actions.maybeInvoke<ScrollIntent>(
+        primaryFocus!.context!,
+        const ScrollIntent(direction: AxisDirection.right),
+      );
+
+      await tester.pumpAndSettle();
+
+      // In RTL mode, right should decrease
+      expect(value, lessThan(0.5));
+    });
+
+    testWidgets('ScrollIntent is ignored when slider is disabled', (WidgetTester tester) async {
+      const value = 0.5;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Center(
+              child: StatefulBuilder(
+                builder: (BuildContext context, StateSetter setState) {
+                  return const Slider(
+                    key: Key('slider'),
+                    value: value,
+                    divisions: 10,
+                    // Disabled slider (onChanged is null)
+                    onChanged: null,
+                    autofocus: true,
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(value, equals(0.5));
+
+      final FocusNode? primaryFocus = FocusManager.instance.primaryFocus;
+      expect(primaryFocus?.context, isNotNull);
+
+      // Try to invoke ScrollIntent on disabled slider
+      final Object? result = Actions.maybeInvoke<ScrollIntent>(
+        primaryFocus!.context!,
+        const ScrollIntent(direction: AxisDirection.right),
+      );
+
+      await tester.pumpAndSettle();
+
+      // Value should not change
+      expect(value, equals(0.5));
+      // Action should be ignored (returns null or false)
+      expect(result, isNull);
     });
   });
 }

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -5749,7 +5749,7 @@ void main() {
     testWidgets('Calculator receives correct increment type (line vs page)', (
       WidgetTester tester,
     ) async {
-      final receivedTypes = <SliderScrollIncrementType>[];
+      final receivedTypes = <ScrollIncrementType>[];
       var value = 0.5;
 
       await tester.pumpWidget(
@@ -5778,7 +5778,7 @@ void main() {
 
       expect(
         receivedTypes.last,
-        SliderScrollIncrementType.line,
+        ScrollIncrementType.line,
         reason: 'Calculator should receive line type when ScrollIncrementType.line is used',
       );
 
@@ -5790,7 +5790,7 @@ void main() {
 
       expect(
         receivedTypes.last,
-        SliderScrollIncrementType.page,
+        ScrollIncrementType.page,
         reason: 'Calculator should receive page type when ScrollIncrementType.page is used',
       );
     });


### PR DESCRIPTION
This PR adds support for `ScrollIntent` to the `Slider` widget, enabling gamepad and hardware scroll input to adjust slider values. This addresses the feature request in #185652.


### Related Issues

Fixes #185652


### Example Usage

```dart

Actions.maybeInvoke(
  context,
  ScrollIntent(direction: AxisDirection.right),
);

```


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.