### PR TITLE
Update Fuchsia tests to subpackage their child components

### DIFF
--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_aot_runner/BUILD.gn
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_aot_runner/BUILD.gn
@@ -30,7 +30,6 @@ executable("dart-aot-runner-integration-test-bin") {
     "${fuchsia_sdk}/pkg/fidl_cpp",
     "${fuchsia_sdk}/pkg/sys_component_cpp_testing",
     "${fuchsia_sdk}/pkg/zx",
-    "../dart_echo_server:aot_echo_package",
     "//flutter/fml",
     "//flutter/shell/platform/fuchsia/dart_runner/fidl:dart_test",
     "//flutter/third_party/googletest:gtest",
@@ -40,6 +39,8 @@ executable("dart-aot-runner-integration-test-bin") {
 
 fuchsia_test_archive("dart-aot-runner-integration-test") {
   deps = [ ":dart-aot-runner-integration-test-bin" ]
-  subpackages =
-      [ "//flutter/shell/platform/fuchsia/dart_runner:dart_aot_runner" ]
+  subpackages = [
+    "../dart_echo_server:aot_echo_package",
+    "//flutter/shell/platform/fuchsia/dart_runner:dart_aot_runner",
+  ]
 }

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_aot_runner/README.md
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_aot_runner/README.md
@@ -21,8 +21,6 @@ ninja -C $ENGINE_DIR/out/fuchsia_profile_x64 flutter/shell/platform/fuchsia fuch
 #### Publish files to PM
 ```
 $FUCHSIA_DIR/.jiri_root/bin/ffx repository publish $FUCHSIA_DIR/$(cat $FUCHSIA_DIR/.fx-build-dir)/amber-files --package-archive $ENGINE_DIR/out/fuchsia_profile_x64/dart-aot-runner-integration-test-0.far
-
-$FUCHSIA_DIR/.jiri_root/bin/ffx repository publish $FUCHSIA_DIR/$(cat $FUCHSIA_DIR/.fx-build-dir)/amber-files --package-archive $ENGINE_DIR/out/fuchsia_profile_x64/gen/flutter/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_echo_server/dart_aot_echo_server/dart_aot_echo_server.far
 ```
 
 #### Run test

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_aot_runner/dart-aot-runner-integration-test.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_aot_runner/dart-aot-runner-integration-test.cc
@@ -34,8 +34,7 @@ constexpr auto kDartAotRunnerUrl = "dart_aot_runner#meta/dart_aot_runner.cm";
 constexpr auto kDartAotEchoServer = "dart_aot_echo_server";
 constexpr auto kDartAotEchoServerRef = ChildRef{kDartAotEchoServer};
 constexpr auto kDartAotEchoServerUrl =
-    "fuchsia-pkg://fuchsia.com/dart_aot_echo_server#meta/"
-    "dart_aot_echo_server.cm";
+    "dart_aot_echo_server#meta/dart_aot_echo_server.cm";
 
 class RealmBuilderTest : public ::loop_fixture::RealLoop,
                          public ::testing::Test {

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_aot_runner/meta/dart-aot-runner-integration-test.cml
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_aot_runner/meta/dart-aot-runner-integration-test.cml
@@ -44,8 +44,7 @@
     facets: {
         "fuchsia.test": {
             "deprecated-allowed-packages": [
-                "dart_aot_echo_server",
-                "test_manager",
+                "test_manager"
             ],
         },
     },

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_jit_runner/BUILD.gn
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_jit_runner/BUILD.gn
@@ -30,7 +30,6 @@ executable("dart-jit-runner-integration-test-bin") {
     "${fuchsia_sdk}/pkg/fidl_cpp",
     "${fuchsia_sdk}/pkg/sys_component_cpp_testing",
     "${fuchsia_sdk}/pkg/zx",
-    "../dart_echo_server:jit_echo_package",
     "//flutter/fml",
     "//flutter/shell/platform/fuchsia/dart_runner/fidl:dart_test",
     "//flutter/third_party/googletest:gtest",
@@ -40,6 +39,8 @@ executable("dart-jit-runner-integration-test-bin") {
 
 fuchsia_test_archive("dart-jit-runner-integration-test") {
   deps = [ ":dart-jit-runner-integration-test-bin" ]
-  subpackages =
-      [ "//flutter/shell/platform/fuchsia/dart_runner:dart_jit_runner" ]
+  subpackages = [
+    "../dart_echo_server:jit_echo_package",
+    "//flutter/shell/platform/fuchsia/dart_runner:dart_jit_runner",
+  ]
 }

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_jit_runner/README.md
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_jit_runner/README.md
@@ -21,8 +21,6 @@ ninja -C $ENGINE_DIR/out/fuchsia_debug_x64 flutter/shell/platform/fuchsia fuchsi
 #### Publish files to PM
 ```
 $FUCHSIA_DIR/.jiri_root/bin/ffx repository publish $FUCHSIA_DIR/$(cat $FUCHSIA_DIR/.fx-build-dir)/amber-files --package-archive $ENGINE_DIR/out/fuchsia_debug_x64/dart-jit-runner-integration-test-0.far
-
-$FUCHSIA_DIR/.jiri_root/bin/ffx repository publish $FUCHSIA_DIR/$(cat $FUCHSIA_DIR/.fx-build-dir)/amber-files --package-archive $ENGINE_DIR/out/fuchsia_debug_x64/gen/flutter/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_echo_server/dart_jit_echo_server/dart_jit_echo_server.far
 ```
 
 #### Run test

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_jit_runner/dart-jit-runner-integration-test.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_jit_runner/dart-jit-runner-integration-test.cc
@@ -34,8 +34,7 @@ constexpr auto kDartJitRunnerUrl = "dart_jit_runner#meta/dart_jit_runner.cm";
 constexpr auto kDartJitEchoServer = "dart_jit_echo_server";
 constexpr auto kDartJitEchoServerRef = ChildRef{kDartJitEchoServer};
 constexpr auto kDartJitEchoServerUrl =
-    "fuchsia-pkg://fuchsia.com/dart_jit_echo_server#meta/"
-    "dart_jit_echo_server.cm";
+    "dart_jit_echo_server#meta/dart_jit_echo_server.cm";
 
 class RealmBuilderTest : public ::loop_fixture::RealLoop,
                          public ::testing::Test {

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_jit_runner/meta/dart-jit-runner-integration-test.cml
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_jit_runner/meta/dart-jit-runner-integration-test.cml
@@ -49,7 +49,6 @@
     facets: {
         "fuchsia.test": {
             "deprecated-allowed-packages": [
-                "dart_jit_echo_server",
                 "test_manager"
             ],
         },

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/embedder/BUILD.gn
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/embedder/BUILD.gn
@@ -50,12 +50,10 @@ executable("flutter-embedder-test-bin") {
 }
 
 fuchsia_test_archive("flutter-embedder-test") {
-  deps = [
-    ":flutter-embedder-test-bin",
+  deps = [ ":flutter-embedder-test-bin" ]
+  subpackages = [
     "child-view:package",
     "parent-view:package",
-  ]
-  subpackages = [
     "//flutter/shell/platform/fuchsia/flutter:flutter_jit_runner",
     "//flutter/shell/platform/fuchsia/flutter:flutter_jit_product_runner",
     "//flutter/shell/platform/fuchsia/flutter:flutter_aot_runner",

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/embedder/flutter-embedder-test.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/embedder/flutter-embedder-test.cc
@@ -59,10 +59,8 @@ constexpr auto kFlutterAotRunnerUrl =
     "flutter_aot_runner#meta/flutter_aot_runner.cm";
 constexpr auto kFlutterAotProductRunnerUrl =
     "flutter_aot_product_runner#meta/flutter_aot_product_runner.cm";
-constexpr char kChildViewUrl[] =
-    "fuchsia-pkg://fuchsia.com/child-view#meta/child-view.cm";
-constexpr char kParentViewUrl[] =
-    "fuchsia-pkg://fuchsia.com/parent-view#meta/parent-view.cm";
+constexpr char kChildViewUrl[] = "child-view#meta/child-view.cm";
+constexpr char kParentViewUrl[] = "parent-view#meta/parent-view.cm";
 static constexpr auto kTestUiStackUrl =
     "fuchsia-pkg://fuchsia.com/flatland-scene-manager-test-ui-stack#meta/"
     "test-ui-stack.cm";

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/embedder/meta/flutter-embedder-test.cml
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/embedder/meta/flutter-embedder-test.cml
@@ -36,11 +36,8 @@
     facets: {
         "fuchsia.test": {
             "deprecated-allowed-packages": [
-                "child-view",
                 "flatland-scene-manager-test-ui-stack",
-                "parent-view",
-                "test-ui-stack",
-                "test_manager",
+                "test_manager"
             ],
         },
     },

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/mouse-input/BUILD.gn
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/mouse-input/BUILD.gn
@@ -45,7 +45,6 @@ executable("mouse-input-test-bin") {
     "${fuchsia_sdk}/pkg/fidl_cpp",
     "${fuchsia_sdk}/pkg/sys_component_cpp_testing",
     "${fuchsia_sdk}/pkg/zx",
-    "mouse-input-view:package",
     "//flutter/fml",
     "//flutter/shell/platform/fuchsia/flutter/tests/integration/utils:portable_ui_test",
     "//flutter/third_party/googletest:gtest",
@@ -55,6 +54,8 @@ executable("mouse-input-test-bin") {
 
 fuchsia_test_archive("mouse-input-test") {
   deps = [ ":mouse-input-test-bin" ]
-  subpackages =
-      [ "//flutter/shell/platform/fuchsia/flutter:flutter_jit_runner" ]
+  subpackages = [
+    "mouse-input-view:package",
+    "//flutter/shell/platform/fuchsia/flutter:flutter_jit_runner",
+  ]
 }

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/mouse-input/meta/mouse-input-test.cml
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/mouse-input/meta/mouse-input-test.cml
@@ -67,12 +67,8 @@
     facets: {
         "fuchsia.test": {
             "deprecated-allowed-packages": [
-                "child-view",
-                "cursor",
                 "flatland-scene-manager-test-ui-stack",
-                "mouse-input-view",
-                "test_manager",
-                "test-ui-stack",
+                "test_manager"
             ],
         },
     },

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/mouse-input/mouse-input-test.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/mouse-input/mouse-input-test.cc
@@ -75,8 +75,7 @@ constexpr auto kMouseInputListener = "mouse_input_listener";
 constexpr auto kMouseInputListenerRef = ChildRef{kMouseInputListener};
 constexpr auto kMouseInputView = "mouse-input-view";
 constexpr auto kMouseInputViewRef = ChildRef{kMouseInputView};
-constexpr auto kMouseInputViewUrl =
-    "fuchsia-pkg://fuchsia.com/mouse-input-view#meta/mouse-input-view.cm";
+constexpr auto kMouseInputViewUrl = "mouse-input-view#meta/mouse-input-view.cm";
 
 struct Position {
   double x = 0.0;

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/text-input/BUILD.gn
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/text-input/BUILD.gn
@@ -41,7 +41,6 @@ executable("text-input-test-bin") {
     "${fuchsia_sdk}/pkg/fidl_cpp",
     "${fuchsia_sdk}/pkg/sys_component_cpp_testing",
     "${fuchsia_sdk}/pkg/zx",
-    "text-input-view:package",
     "//flutter/fml",
     "//flutter/shell/platform/fuchsia/flutter/tests/integration/utils:check_view",
     "//flutter/shell/platform/fuchsia/flutter/tests/integration/utils:portable_ui_test",
@@ -52,6 +51,8 @@ executable("text-input-test-bin") {
 
 fuchsia_test_archive("text-input-test") {
   deps = [ ":text-input-test-bin" ]
-  subpackages =
-      [ "//flutter/shell/platform/fuchsia/flutter:flutter_jit_runner" ]
+  subpackages = [
+    "text-input-view:package",
+    "//flutter/shell/platform/fuchsia/flutter:flutter_jit_runner",
+  ]
 }

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/text-input/meta/text-input-test.cml
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/text-input/meta/text-input-test.cml
@@ -68,11 +68,8 @@
     facets: {
         "fuchsia.test": {
             "deprecated-allowed-packages": [
-                "cursor",
                 "flatland-scene-manager-test-ui-stack",
-                "test-ui-stack",
-                "test_manager",
-                "text-input-view",
+                "test_manager"
             ],
         },
     },

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/text-input/text-input-test.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/text-input/text-input-test.cc
@@ -60,7 +60,7 @@ constexpr auto kKeyboardInputListenerRef = ChildRef{kKeyboardInputListener};
 constexpr auto kTextInputView = "text-input-view";
 constexpr auto kTextInputViewRef = ChildRef{kTextInputView};
 static constexpr auto kTextInputViewUrl =
-    "fuchsia-pkg://fuchsia.com/text-input-view#meta/text-input-view.cm";
+    "text-input-view#meta/text-input-view.cm";
 
 constexpr auto kTestUIStackUrl =
     "fuchsia-pkg://fuchsia.com/flatland-scene-manager-test-ui-stack#meta/"

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/touch-input/BUILD.gn
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/touch-input/BUILD.gn
@@ -45,8 +45,6 @@ executable("touch-input-test-bin") {
     "${fuchsia_sdk}/pkg/fidl_cpp",
     "${fuchsia_sdk}/pkg/sys_component_cpp_testing",
     "${fuchsia_sdk}/pkg/zx",
-    "embedding-flutter-view:package",
-    "touch-input-view:package",
     "//flutter/fml",
     "//flutter/shell/platform/fuchsia/flutter/tests/integration/utils:portable_ui_test",
     "//flutter/third_party/googletest:gtest",
@@ -56,6 +54,9 @@ executable("touch-input-test-bin") {
 
 fuchsia_test_archive("touch-input-test") {
   deps = [ ":touch-input-test-bin" ]
-  subpackages =
-      [ "//flutter/shell/platform/fuchsia/flutter:flutter_jit_runner" ]
+  subpackages = [
+    "embedding-flutter-view:package",
+    "touch-input-view:package",
+    "//flutter/shell/platform/fuchsia/flutter:flutter_jit_runner",
+  ]
 }

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/touch-input/meta/touch-input-test.cml
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/touch-input/meta/touch-input-test.cml
@@ -59,10 +59,8 @@
     facets: {
         "fuchsia.test": {
             "deprecated-allowed-packages": [
-                "embedding-flutter-view",
                 "flatland-scene-manager-test-ui-stack",
-                "test_manager",
-                "touch-input-view",
+                "test_manager"
             ],
         },
     },

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/touch-input/touch-input-test.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/touch-input/touch-input-test.cc
@@ -132,13 +132,11 @@ constexpr auto kMockTouchInputListenerRef = ChildRef{kMockTouchInputListener};
 
 constexpr auto kTouchInputView = "touch-input-view";
 constexpr auto kTouchInputViewRef = ChildRef{kTouchInputView};
-constexpr auto kTouchInputViewUrl =
-    "fuchsia-pkg://fuchsia.com/touch-input-view#meta/touch-input-view.cm";
+constexpr auto kTouchInputViewUrl = "touch-input-view#meta/touch-input-view.cm";
 constexpr auto kEmbeddingFlutterView = "embedding-flutter-view";
 constexpr auto kEmbeddingFlutterViewRef = ChildRef{kEmbeddingFlutterView};
 constexpr auto kEmbeddingFlutterViewUrl =
-    "fuchsia-pkg://fuchsia.com/embedding-flutter-view#meta/"
-    "embedding-flutter-view.cm";
+    "embedding-flutter-view#meta/embedding-flutter-view.cm";
 
 bool CompareDouble(double f0, double f1, double epsilon) {
   return std::abs(f0 - f1) <= epsilon;

--- a/engine/src/flutter/testing/fuchsia/test_suites.yaml
+++ b/engine/src/flutter/testing/fuchsia/test_suites.yaml
@@ -14,17 +14,13 @@
 - test_command: test run fuchsia-pkg://fuchsia.com/common_cpp_unittests#meta/common_cpp_unittests.cm
   package: common_cpp_unittests-0.far
 - test_command: test run fuchsia-pkg://fuchsia.com/dart-aot-runner-integration-test#meta/dart-aot-runner-integration-test.cm
-  packages:
-    - dart-aot-runner-integration-test-0.far
-    - gen/flutter/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_echo_server/dart_aot_echo_server/dart_aot_echo_server.far
+  package: dart-aot-runner-integration-test-0.far
   emulator_arch:
     - 'x64'
     - 'arm64'
   variant: profile
 - test_command: test run fuchsia-pkg://fuchsia.com/dart-jit-runner-integration-test#meta/dart-jit-runner-integration-test.cm
-  packages:
-    - dart-jit-runner-integration-test-0.far
-    - gen/flutter/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_echo_server/dart_jit_echo_server/dart_jit_echo_server.far
+  package: dart-jit-runner-integration-test-0.far
   emulator_arch:
     - 'x64'
     - 'arm64'
@@ -51,10 +47,7 @@
 - test_command: test run fuchsia-pkg://fuchsia.com/flow_tests#meta/flow_tests.cm
   package: flow_tests-0.far
 - test_command: test run fuchsia-pkg://fuchsia.com/flutter-embedder-test#meta/flutter-embedder-test.cm
-  packages:
-    - flutter-embedder-test-0.far
-    - gen/flutter/shell/platform/fuchsia/flutter/tests/integration/embedder/child-view/child-view/child-view.far
-    - gen/flutter/shell/platform/fuchsia/flutter/tests/integration/embedder/parent-view/parent-view/parent-view.far
+  package: flutter-embedder-test-0.far
   variant: debug_x64
 - test_command: test run fuchsia-pkg://fuchsia.com/flutter_runner_tests#meta/flutter_runner_tests.cm
   package: flutter_runner_tests-0.far
@@ -65,9 +58,7 @@
 - test_command: test run fuchsia-pkg://fuchsia.com/fml_tests#meta/fml_tests.cm
   package: fml_tests-0.far
 - test_command: test run fuchsia-pkg://fuchsia.com/mouse-input-test#meta/mouse-input-test.cm
-  packages:
-    - mouse-input-test-0.far
-    - gen/flutter/shell/platform/fuchsia/flutter/tests/integration/mouse-input/mouse-input-view/mouse-input-view/mouse-input-view.far
+  package: mouse-input-test-0.far
 - test_command: test run fuchsia-pkg://fuchsia.com/no_dart_plugin_registrant_unittests#meta/no_dart_plugin_registrant_unittests.cm
   package: no_dart_plugin_registrant_unittests-0.far
 - test_command: test run fuchsia-pkg://fuchsia.com/runtime_tests#meta/runtime_tests.cm
@@ -80,19 +71,14 @@
 - test_command: test run fuchsia-pkg://fuchsia.com/testing_unittests#meta/testing_unittests.cm
   package: testing_unittests-0.far
 - test_command: test run fuchsia-pkg://fuchsia.com/text-input-test#meta/text-input-test.cm
-  packages:
-    - text-input-test-0.far
-    - gen/flutter/shell/platform/fuchsia/flutter/tests/integration/text-input/text-input-view/text-input-view/text-input-view.far
+  package: text-input-test-0.far
   variant: debug_x64
 - test_command: test run fuchsia-pkg://fuchsia.com/tonic_unittests#meta/tonic_unittests.cm
   disabled: Dart_LoadELF isn't implemented on Fuchsia
   package: tonic_unittests-0.far
   variant: debug
 - test_command: test run fuchsia-pkg://fuchsia.com/touch-input-test#meta/touch-input-test.cm
-  packages:
-    - touch-input-test-0.far
-    - gen/flutter/shell/platform/fuchsia/flutter/tests/integration/touch-input/touch-input-view/touch-input-view/touch-input-view.far
-    - gen/flutter/shell/platform/fuchsia/flutter/tests/integration/touch-input/embedding-flutter-view/embedding-flutter-view/embedding-flutter-view.far
+  package: touch-input-test-0.far
   variant: debug_x64
 - test_command: test run fuchsia-pkg://fuchsia.com/txt_tests#meta/txt_tests.cm -- --gtest_filter=-ParagraphTest.*
   package: txt_tests-0.far

--- a/engine/src/flutter/tools/fuchsia/devshell/run_integration_test.sh
+++ b/engine/src/flutter/tools/fuchsia/devshell/run_integration_test.sh
@@ -49,16 +49,16 @@ shift # past argument
 test_packages=
 case $test_name in
   embedder)
-    test_packages=("flutter-embedder-test-0.far" "parent-view.far" "child-view.far")
+    test_packages=("flutter-embedder-test-0.far")
     ;;
   text-input)
-    test_packages=("text-input-test-0.far" "text-input-view.far")
+    test_packages=("text-input-test-0.far")
     ;;
   touch-input)
-    test_packages=("touch-input-test-0.far" "touch-input-view.far" "embedding-flutter-view.far")
+    test_packages=("touch-input-test-0.far")
     ;;
   mouse-input)
-    test_packages=("mouse-input-test-0.far" "mouse-input-view.far")
+    test_packages=("mouse-input-test-0.far")
     ;;
   *)
     engine-error "Unknown test name $test_name. You may need to add it to $0"


### PR DESCRIPTION
For Fuchsia tests which use child components from other packages, this commit switches those to being subpackages. This allows the test to be fully contained with a single .far package, which simplifies test execution and eliminates the need for packages to be published to the fuchsia.com namespace.