### PR TITLE
[Android] Propagate --enable-flutter-gpu Intent extra to engine args

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/FlutterShellArgs.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/FlutterShellArgs.java
@@ -57,6 +57,12 @@ public class FlutterShellArgs {
   public static final String ARG_KEY_TOGGLE_IMPELLER = "enable-impeller";
   public static final String ARG_ENABLE_IMPELLER = "--enable-impeller=true";
   public static final String ARG_DISABLE_IMPELLER = "--enable-impeller=false";
+  /** Intent extra key that opts the engine into the Flutter GPU API. */
+  public static final String ARG_KEY_ENABLE_FLUTTER_GPU = "enable-flutter-gpu";
+
+  /** Engine shell argument emitted when {@link #ARG_KEY_ENABLE_FLUTTER_GPU} is set. */
+  public static final String ARG_ENABLE_FLUTTER_GPU = "--enable-flutter-gpu";
+
   public static final String ARG_KEY_ENABLE_VULKAN_VALIDATION = "enable-vulkan-validation";
   public static final String ARG_ENABLE_VULKAN_VALIDATION = "--enable-vulkan-validation";
   public static final String ARG_KEY_ENABLE_HCPP_AND_SURFACE_CONTROL =
@@ -142,6 +148,9 @@ public class FlutterShellArgs {
       } else {
         args.add(ARG_DISABLE_IMPELLER);
       }
+    }
+    if (intent.getBooleanExtra(ARG_KEY_ENABLE_FLUTTER_GPU, false)) {
+      args.add(ARG_ENABLE_FLUTTER_GPU);
     }
     if (intent.getBooleanExtra(ARG_KEY_ENABLE_VULKAN_VALIDATION, false)) {
       args.add(ARG_ENABLE_VULKAN_VALIDATION);

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterShellArgsTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterShellArgsTest.java
@@ -35,4 +35,28 @@ public class FlutterShellArgsTest {
     assertTrue(argValues.contains("--dart-flags=--observe --no-hot --no-pub"));
     assertTrue(argValues.contains("--trace-skia-allowlist=skia.a,skia.b"));
   }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void itPropagatesEnableFlutterGpuFromIntent() {
+    Intent intent = new Intent();
+    intent.putExtra(FlutterShellArgs.ARG_KEY_ENABLE_FLUTTER_GPU, true);
+
+    FlutterShellArgs args = FlutterShellArgs.fromIntent(intent);
+    HashSet<String> argValues = new HashSet<String>(Arrays.asList(args.toArray()));
+
+    assertEquals(1, argValues.size());
+    assertTrue(argValues.contains(FlutterShellArgs.ARG_ENABLE_FLUTTER_GPU));
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void itDoesNotPropagateEnableFlutterGpuWhenAbsent() {
+    Intent intent = new Intent();
+
+    FlutterShellArgs args = FlutterShellArgs.fromIntent(intent);
+    HashSet<String> argValues = new HashSet<String>(Arrays.asList(args.toArray()));
+
+    assertEquals(0, argValues.size());
+  }
 }


### PR DESCRIPTION
Fixes flutter/flutter#186297. `flutter run --enable-flutter-gpu` now opts the app into Flutter GPU on Android, matching the documented behavior on iOS and macOS.

The flutter tool already sends `--ez enable-flutter-gpu true` as an Intent boolean extra to the launched activity (`packages/flutter_tools/lib/src/android/android_device.dart:668`), the same way it ships `enable-impeller`, `enable-vulkan-validation`, `enable-hcpp-and-surface-control`, etc. `FlutterActivity.getFlutterShellArgs()` calls `FlutterShellArgs.fromIntent(getIntent())` to convert those extras into engine arguments, but `fromIntent` is a hardcoded list of intent-key to engine-arg conversions, and the `enable-flutter-gpu` case was never added. So the extra was silently dropped on the floor, no `--enable-flutter-gpu` ever reached `FlutterLoader.ensureInitializationComplete`, and `settings.enable_flutter_gpu` stayed `false`. The runtime check in `lib/gpu/context.cc` then threw the manifest-required exception, even though its own error message explicitly says the CLI flag is one of the valid opt-ins.

This PR adds two new constants and one new branch in `FlutterShellArgs.fromIntent`:

```java
public static final String ARG_KEY_ENABLE_FLUTTER_GPU = "enable-flutter-gpu";
public static final String ARG_ENABLE_FLUTTER_GPU = "--enable-flutter-gpu";

// In fromIntent, alongside the other boolean extras:
if (intent.getBooleanExtra(ARG_KEY_ENABLE_FLUTTER_GPU, false)) {
  args.add(ARG_ENABLE_FLUTTER_GPU);
}
```

Plus two unit tests covering the present-and-absent cases.

`FlutterShellArgs` is marked deprecated in favor of `FlutterEngineFlags` (per the pending intent-deprecation work in #180686). The fix is kept in `FlutterShellArgs` because (1) `FlutterShellArgs.fromIntent` is still the operative path for converting tool-side Intent extras into engine args, and (2) `FlutterEngineFlags.getFlagFromIntentKey` is currently only used to log a deprecation warning, not to actually convert the extras. When #180686 lands and the conversion moves entirely to `FlutterEngineFlags`, this hardcoded entry will go away with the rest of `FlutterShellArgs`.

`FlutterShellArgsTest.itPropagatesEnableFlutterGpuFromIntent` and `itDoesNotPropagateEnableFlutterGpuWhenAbsent` lock in the behavior at the unit level. Manually verified on a Pixel 10 Pro (Android 16, Vulkan/Impeller) with a flutter_scene-based app: with this patch applied, `flutter run --enable-flutter-gpu --enable-impeller` no longer throws "Flutter GPU must be enabled via the Flutter GPU manifest setting", and the `gpu.gpuContext` access proceeds normally.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md