### PR TITLE
[tools] Pass IMPELLERC and LIBTESSELLATOR env vars to build hooks

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
@@ -388,6 +388,8 @@ Future<FlutterNativeAssetsBuildRunner> createFlutterNativeAssetsBuildRunner(
     environment.logger,
     runPackageName,
     includeDevDependencies: includeDevDependencies,
+    artifacts: environment.artifacts,
+    platform: environment.platform,
     pubspecPath,
   );
 }

--- a/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
@@ -9,8 +9,10 @@ import 'package:data_assets/data_assets.dart';
 import 'package:hooks/hooks.dart';
 import 'package:hooks_runner/hooks_runner.dart';
 import 'package:logging/logging.dart' as logging;
+import 'package:meta/meta.dart';
 import 'package:package_config/package_config_types.dart';
 
+import '../../artifacts.dart';
 import '../../base/common.dart';
 import '../../base/file_system.dart';
 import '../../base/logger.dart';
@@ -419,6 +421,47 @@ abstract interface class FlutterNativeAssetsBuildRunner {
 }
 
 /// Uses `package:hooks_runner` for its implementation.
+/// Builds the environment passed to build hook subprocesses.
+///
+/// Starts from the parent process environment, filtered through
+/// [NativeAssetsBuildRunner.includeHookEnvironmentVariable] (the same
+/// allowlist the package would compute by default), and then injects
+/// well-known host-tool paths so hooks don't have to re-implement
+/// flutter_tools' own artifact resolution.
+///
+/// Currently exposes:
+///
+///   * `IMPELLERC`: absolute path to the host-side `impellerc` binary.
+///   * `LIBTESSELLATOR`: absolute path to the host-side
+///     `libtessellator` shared library.
+///
+/// When `--local-engine` is in effect [artifacts] resolves to
+/// `CachedLocalEngineArtifacts`, which prefers the local-engine
+/// binaries with a fall-through to the SDK cache. Hooks that read these
+/// env vars therefore get the correct host tools whether or not
+/// `--local-engine` is set, with no per-package logic required.
+@visibleForTesting
+Map<String, String> buildHookEnvironment({
+  required Artifacts artifacts,
+  required Platform platform,
+}) {
+  final env = <String, String>{
+    for (final entry in platform.environment.entries)
+      if (NativeAssetsBuildRunner.includeHookEnvironmentVariable(
+        entry.key.toUpperCase(),
+      ))
+        entry.key: entry.value,
+  };
+  // Resolve to absolute paths so hooks that change their working
+  // directory before invoking these tools still find them.
+  env['IMPELLERC'] = artifacts.getHostArtifact(HostArtifact.impellerc).absolute.path;
+  env['LIBTESSELLATOR'] = artifacts
+      .getHostArtifact(HostArtifact.libtessellator)
+      .absolute
+      .path;
+  return env;
+}
+
 class FlutterNativeAssetsBuildRunnerImpl implements FlutterNativeAssetsBuildRunner {
   FlutterNativeAssetsBuildRunnerImpl(
     this.packageConfigPath,
@@ -428,6 +471,8 @@ class FlutterNativeAssetsBuildRunnerImpl implements FlutterNativeAssetsBuildRunn
     this.runPackageName,
     this.pubspecPath, {
     required this.includeDevDependencies,
+    required this.artifacts,
+    required this.platform,
   });
 
   final String pubspecPath;
@@ -439,6 +484,16 @@ class FlutterNativeAssetsBuildRunnerImpl implements FlutterNativeAssetsBuildRunn
 
   /// Include the dev dependencies of [runPackageName].
   final bool includeDevDependencies;
+
+  /// Used to resolve host-side tools that hooks may need (e.g. `impellerc`).
+  /// When `--local-engine` is in effect this returns the local-engine
+  /// binaries with a fall-through to the SDK cache, so hooks see the same
+  /// versions of host tools that flutter_tools' own build targets do.
+  final Artifacts artifacts;
+
+  /// Provides access to environment variables for filtering through to the
+  /// hook subprocess.
+  final Platform platform;
 
   late final _logger = logging.Logger('')
     ..onRecord.listen((logging.LogRecord record) {
@@ -479,6 +534,7 @@ class FlutterNativeAssetsBuildRunnerImpl implements FlutterNativeAssetsBuildRunn
     fileSystem: fileSystem,
     packageLayout: packageLayout,
     userDefines: UserDefines(workspacePubspec: Uri.file(pubspecPath)),
+    hookEnvironment: buildHookEnvironment(artifacts: artifacts, platform: platform),
   );
 
   @override

--- a/packages/flutter_tools/lib/src/isolated/native_assets/test/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/test/native_assets.dart
@@ -46,6 +46,8 @@ Future<Uri?> testCompilerBuildNativeAssets(BuildInfo buildInfo) async {
     globals.logger,
     runPackageName,
     includeDevDependencies: true,
+    artifacts: globals.artifacts!,
+    platform: globals.platform,
     pubspecPath,
   );
 

--- a/packages/flutter_tools/test/general.shard/isolated/build_system/targets/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/build_system/targets/native_assets_test.dart
@@ -67,23 +67,15 @@ void main() {
     androidEnvironment.buildDir.createSync(recursive: true);
   });
 
-  testUsingContext(
-    'no dependency on KernelSnapshot',
-    () async {
-      const target = BuildHooks();
-      expect(target.dependencies, isNot(isA<KernelSnapshot>()));
-    },
-    overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()},
-  );
+  testUsingContext('no dependency on KernelSnapshot', () async {
+    const target = BuildHooks();
+    expect(target.dependencies, isNot(isA<KernelSnapshot>()));
+  }, overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()});
 
-  testUsingContext(
-    'NativeAssets throws error if missing target platform',
-    () async {
-      iosEnvironment.defines.remove(kTargetPlatform);
-      expect(const BuildHooks().build(iosEnvironment), throwsA(isA<MissingDefineException>()));
-    },
-    overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()},
-  );
+  testUsingContext('NativeAssets throws error if missing target platform', () async {
+    iosEnvironment.defines.remove(kTargetPlatform);
+    expect(const BuildHooks().build(iosEnvironment), throwsA(isA<MissingDefineException>()));
+  }, overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()});
 
   testUsingContext('NativeAssets defaults to ios archs if missing', () async {
     writePackageConfigFiles(directory: iosEnvironment.projectDir, mainLibName: 'my_app');
@@ -424,10 +416,7 @@ void main() {
         artifacts: artifacts,
         platform: FakePlatform(),
       );
-      expect(
-        env['IMPELLERC'],
-        artifacts.getHostArtifact(HostArtifact.impellerc).absolute.path,
-      );
+      expect(env['IMPELLERC'], artifacts.getHostArtifact(HostArtifact.impellerc).absolute.path);
       expect(
         env['LIBTESSELLATOR'],
         artifacts.getHostArtifact(HostArtifact.libtessellator).absolute.path,

--- a/packages/flutter_tools/test/general.shard/isolated/build_system/targets/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/build_system/targets/native_assets_test.dart
@@ -8,6 +8,7 @@ import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/build_system/exceptions.dart';
@@ -399,6 +400,56 @@ void main() {
       },
     );
   }
+
+  group('buildHookEnvironment', () {
+    test('exposes IMPELLERC and LIBTESSELLATOR from cached artifacts', () {
+      final Map<String, String> env = buildHookEnvironment(
+        artifacts: Artifacts.test(),
+        platform: FakePlatform(),
+      );
+      expect(env, contains('IMPELLERC'));
+      expect(env, contains('LIBTESSELLATOR'));
+      expect(env['IMPELLERC'], endsWith('impellerc'));
+    });
+
+    test('values match Artifacts.getHostArtifact(...)', () {
+      // Whatever path the host-artifact resolver produces is the same path
+      // the hook subprocess sees. This is the contract that lets a
+      // --local-engine override flow through to hooks: when
+      // CachedLocalEngineArtifacts overrides getHostArtifact to point at
+      // out/<host>/impellerc with a fall-through to the SDK cache,
+      // buildHookEnvironment publishes that resolved path verbatim.
+      final artifacts = Artifacts.test();
+      final Map<String, String> env = buildHookEnvironment(
+        artifacts: artifacts,
+        platform: FakePlatform(),
+      );
+      expect(
+        env['IMPELLERC'],
+        artifacts.getHostArtifact(HostArtifact.impellerc).absolute.path,
+      );
+      expect(
+        env['LIBTESSELLATOR'],
+        artifacts.getHostArtifact(HostArtifact.libtessellator).absolute.path,
+      );
+    });
+
+    test('preserves filtered parent environment variables', () {
+      final Map<String, String> env = buildHookEnvironment(
+        artifacts: Artifacts.test(),
+        platform: FakePlatform(
+          environment: const <String, String>{
+            'PATH': '/usr/bin',
+            'HOME': '/home/dev',
+            'SOMETHING_ELSE': 'should-be-dropped',
+          },
+        ),
+      );
+      expect(env['PATH'], '/usr/bin');
+      expect(env['HOME'], '/home/dev');
+      expect(env, isNot(contains('SOMETHING_ELSE')));
+    });
+  });
 }
 
 List<String> _resolvedOutputs(Target target, Environment environment) {


### PR DESCRIPTION
Fixes flutter/flutter#186299. When flutter_tools spawns build hooks (the cross-package replacement for `native_assets_cli`), it now publishes `IMPELLERC` and `LIBTESSELLATOR` environment variables resolved through `Artifacts.getHostArtifact(...)`, so build hooks that need host-side tools see the same versions of those tools that flutter_tools' own build targets do.

Build hooks run as separate Dart subprocesses spawned by `hooks_runner`. They don't have access to flutter_tools' in-process `Artifacts` API, so packages that need host tools (the canonical case being `flutter_gpu_shaders`, which compiles `.shaderbundle.json` via `impellerc`) re-implement their own artifact resolution by walking up from the dart binary into `bin/cache/artifacts/engine/<host>/`. That homegrown lookup misses the `--local-engine` override that `CachedLocalEngineArtifacts.getHostArtifact` already wires up for flutter_tools' own targets (the FragmentProgram shader compiler at `build_system/tools/shader_compiler.dart:167` works correctly under `--local-engine` for this exact reason). The downstream symptom is silent version skew: a freshly built local engine paired with a hook that picked up the cached SDK's `impellerc` produces shader bundles in a format the local engine doesn't understand. The user sees an opaque `Unsupported shader bundle format version: 1, expected: 2` at runtime with no pointer back to the artifact mismatch.

`flutter_tools/lib/src/isolated/native_assets/native_assets.dart` adds a `buildHookEnvironment(...)` helper that takes `Artifacts` and `Platform`, replicates the `NativeAssetsBuildRunner` default filter, and adds `IMPELLERC` and `LIBTESSELLATOR` from the `HostArtifact` resolver. `Artifacts` and `Platform` are threaded through `FlutterNativeAssetsBuildRunnerImpl`'s constructor and used to populate `NativeAssetsBuildRunner.hookEnvironment`. `flutter_tools/lib/src/build_system/targets/native_assets.dart` updates `createFlutterNativeAssetsBuildRunner(environment)` to pass `environment.artifacts` and `environment.platform` through to the impl. The pattern matches what desktop builds already do for `LOCAL_ENGINE` and `LOCAL_ENGINE_HOST` env vars (see `lib/src/linux/build_linux.dart:75-76`, `lib/src/windows/build_windows.dart:292-293`).

Hooks that don't read these env vars are unaffected. Hooks that opt in (e.g. by checking `Platform.environment['IMPELLERC']`) get correct behavior under both `--local-engine` and the normal cached engine without any per-package logic. The cache hash for build hook inputs already includes the hook environment, so consumers will see a one-time cache miss on the first run after this lands and stable hits thereafter.

`packages/flutter_tools/test/general.shard/isolated/build_system/targets/native_assets_test.dart` adds three direct tests for `buildHookEnvironment`: verifying `IMPELLERC` and `LIBTESSELLATOR` are present in the produced env; verifying the values match `Artifacts.getHostArtifact(...)` (the contract that propagates the `--local-engine` override to hooks); and verifying the parent-process env is filtered through the same allowlist `NativeAssetsBuildRunner` uses by default. All 14 tests in the file pass, including the original 11.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md