### PR TITLE
Fix `pub get` resolving wrong path in pub workspaces

### DIFF
--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -272,7 +272,14 @@ class _DefaultPub implements Pub {
       switch (jsonDecode(workspaceRefFile.readAsStringSync())) {
         case {'workspaceRoot': final String workspaceRoot}:
           packageConfigFile = _fileSystem.file(
-            _fileSystem.path.join(workspaceRefFile.parent.path, workspaceRoot),
+            _fileSystem.path.normalize(
+              _fileSystem.path.join(
+                workspaceRefFile.parent.path,
+                workspaceRoot,
+                '.dart_tool',
+                'package_config.json',
+              ),
+            ),
           );
         default:
           // The workspace_ref.json file was malformed. Attempt to load the

--- a/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
@@ -290,6 +290,50 @@ void main() {
   });
 
   testUsingContext(
+    'checkUpToDate skips pub get for a workspace sub-package when the workspace_ref '
+    'points to the workspace root directory',
+    () async {
+      final processManager = FakeProcessManager.empty();
+      final logger = BufferLogger.test();
+      final fileSystem = MemoryFileSystem.test();
+
+      // Sub-package pubspec.yaml is created first so its mtime is older than
+      // the workspace-level pubspec.lock and package_config.json (the skip
+      // check requires pubspec.yaml mtime < lock and < package_config).
+      fileSystem.file('pkg/pubspec.yaml').createSync(recursive: true);
+      fileSystem.file('pkg/.dart_tool/pub/workspace_ref.json')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('{"workspaceRoot": "../../.."}');
+
+      // Workspace root files (created later → newer mtime).
+      fileSystem.file('pubspec.lock').createSync();
+      fileSystem.file('.dart_tool/package_config.json').createSync(recursive: true);
+      fileSystem.file('.dart_tool/version').writeAsStringSync('a');
+      fileSystem.file('bin/cache/flutter.version.json')
+        ..createSync(recursive: true)
+        ..writeAsStringSync(_generateFlutterVersionJson('a'));
+
+      final pub = Pub.test(
+        fileSystem: fileSystem,
+        logger: logger,
+        processManager: processManager,
+        platform: FakePlatform(),
+        botDetector: const FakeBotDetector(false),
+        stdio: FakeStdio(),
+      );
+
+      await pub.get(
+        project: FlutterProject.fromDirectoryTest(fileSystem.directory('pkg')),
+        context: PubContext.pubGet,
+        checkUpToDate: true,
+      );
+
+      expect(logger.traceText, contains('Skipping pub get: version match.'));
+      expect(processManager, hasNoRemainingExpectations);
+    },
+  );
+
+  testUsingContext(
     'checkUpToDate does not skip pub get if the package config is newer than the pubspec '
     'but the current framework version is not the same as the last version',
     () async {


### PR DESCRIPTION
Stumbled upon this while working on #69429 (make `flutter test` faster). Not sure if I should create a separate ticket first.

TLDR: `pub get` should short-circuit if cached but doesn't. This change fixes it.

My understanding of what happened:
#150850 added support for pub workspaces and added a short-circuit to `pub get` based on the workspace root. However, the path resolution logic was broken and no test was added for that logic. #169556 then turned Flutter into a pub workspace which started using the code path and doing a full `pub get` on every invocation.

Fixing this shaves ~300ms off of every `flutter` invocation in the Flutter repo if the cache is warm.



<details><summary>`flutter test` benchmark before:</summary>
<p>

```
=== Matrix Benchmark (round-robin) ===
Flutter root:    /home/felipe/Projects/flutter
Commit:          f74781f6213447540225edae307acb48bbaaaf34
                 Fix SelectableText crash with inline lambda contextMenuBuilder (#184990)
Working tree:    clean
Suite:           foundation  (32 files)
Concurrencies:   4 8 12
Runs per config: 5

>>> Pinning CPU clock to 3000 MHz (amd-pstate=passive, boost=0, governor=performance)

>>> Warmup (discarded)
    -j 8: 5294ms
    [diag after warmup        ] cpu= 2980 MHz  temp=52°C  mem=104369MB  load=1.92  /tmp_dirs=1  dill=45MB

>>> Round 1/5
    [diag before round 1      ] cpu= 2968 MHz  temp=52°C  mem=104368MB  load=1.92  /tmp_dirs=1  dill=45MB
    -j 4: 7553ms
    -j 8: 5288ms
    -j 12: 4451ms
    [diag after round 1       ] cpu= 2971 MHz  temp=54°C  mem=104589MB  load=3.41  /tmp_dirs=1  dill=45MB
>>> Round 2/5
    [diag before round 2      ] cpu= 2975 MHz  temp=54°C  mem=104589MB  load=3.41  /tmp_dirs=1  dill=45MB
    -j 4: 8161ms
    -j 8: 5332ms
    -j 12: 4598ms
    [diag after round 2       ] cpu= 2969 MHz  temp=57°C  mem=103829MB  load=3.46  /tmp_dirs=1  dill=45MB
>>> Round 3/5
    [diag before round 3      ] cpu= 2972 MHz  temp=57°C  mem=103829MB  load=3.46  /tmp_dirs=1  dill=45MB
    -j 4: 7448ms
    -j 8: 5151ms
    -j 12: 5174ms
    [diag after round 3       ] cpu= 2979 MHz  temp=58°C  mem=104768MB  load=4.47  /tmp_dirs=1  dill=45MB
>>> Round 4/5
    [diag before round 4      ] cpu= 2978 MHz  temp=58°C  mem=104767MB  load=4.47  /tmp_dirs=1  dill=45MB
    -j 4: 7377ms
    -j 8: 5355ms
    -j 12: 6392ms
    [diag after round 4       ] cpu= 2983 MHz  temp=59°C  mem=104661MB  load=3.67  /tmp_dirs=1  dill=45MB
>>> Round 5/5
    [diag before round 5      ] cpu= 2975 MHz  temp=59°C  mem=104660MB  load=3.67  /tmp_dirs=1  dill=45MB
    -j 4: 7536ms
    -j 8: 5618ms
    -j 12: 6207ms
    [diag after round 5       ] cpu= 2968 MHz  temp=60°C  mem=104251MB  load=3.08  /tmp_dirs=1  dill=45MB

===========================================================

  COMPARISON  |  Suite: foundation  |  Files: 32  |  Tests: 220

                                                j4                j8               j12
  ------------------------------------------------------------------------------------
  Total wall clock                 7615ms (+/-313)   5349ms (+/-170)   5364ms (+/-898)
    Tool startup                      629ms (+/-9)     645ms (+/-12)     642ms (+/-24)
    Test runner                    6986ms (+/-309)   4704ms (+/-169)   4722ms (+/-912)
      Compile (wall)                2442ms (+/-47)    2586ms (+/-60)    2564ms (+/-32)
      Compile (CPU)                 2442ms (+/-47)    2586ms (+/-60)    2564ms (+/-32)
      Run (wall)                   5767ms (+/-295)   3493ms (+/-175)   3485ms (+/-958)
      Run (CPU)                  19343ms (+/-1084)  20304ms (+/-542) 26481ms (+/-7656)
    Time to first test              1445ms (+/-32)    1452ms (+/-14)    1459ms (+/-32)

  First compile                      852ms (+/-34)     836ms (+/-18)     834ms (+/-25)
  Subsequent compiles (avg)            52ms (+/-1)       58ms (+/-2)       57ms (+/-1)

  Per-test mean                        12ms (+/-0)       13ms (+/-1)       13ms (+/-1)
  Per-test median                       3ms (+/-0)               3ms               3ms


>>> Restoring CPU settings
```

</p>
</details> 

<details><summary>`flutter test` benchmark after:</summary>
<p>

```
=== Matrix Benchmark (round-robin) ===
Flutter root:    /home/felipe/Projects/flutter
Commit:          f74781f6213447540225edae307acb48bbaaaf34
                 Fix SelectableText crash with inline lambda contextMenuBuilder (#184990)
Working tree:    DIRTY
Suite:           foundation  (32 files)
Concurrencies:   4 8 12
Runs per config: 5

Uncommitted changes:
   M packages/flutter_tools/lib/src/dart/pub.dart
   M packages/flutter_tools/test/general.shard/dart/pub_get_test.dart

>>> Pinning CPU clock to 3000 MHz (amd-pstate=passive, boost=0, governor=performance)

>>> Warmup (discarded)
    -j 8: 4861ms
    [diag after warmup        ] cpu= 2980 MHz  temp=50°C  mem=104431MB  load=1.36  /tmp_dirs=1  dill=45MB

>>> Round 1/5
    [diag before round 1      ] cpu= 2980 MHz  temp=50°C  mem=104431MB  load=1.36  /tmp_dirs=1  dill=45MB
    -j 4: 7300ms
    -j 8: 4896ms
    -j 12: 4046ms
    [diag after round 1       ] cpu= 2978 MHz  temp=53°C  mem=103895MB  load=2.82  /tmp_dirs=1  dill=45MB
>>> Round 2/5
    [diag before round 2      ] cpu= 2969 MHz  temp=53°C  mem=103894MB  load=2.82  /tmp_dirs=1  dill=45MB
    -j 4: 7116ms
    -j 8: 4792ms
    -j 12: 4051ms
    [diag after round 2       ] cpu= 2988 MHz  temp=55°C  mem=104153MB  load=2.76  /tmp_dirs=1  dill=45MB
>>> Round 3/5
    [diag before round 3      ] cpu= 2974 MHz  temp=55°C  mem=104153MB  load=2.76  /tmp_dirs=1  dill=45MB
    -j 4: 7435ms
    -j 8: 5104ms
    -j 12: 4596ms
    [diag after round 3       ] cpu= 2968 MHz  temp=57°C  mem=103800MB  load=4.93  /tmp_dirs=1  dill=45MB
>>> Round 4/5
    [diag before round 4      ] cpu= 2964 MHz  temp=57°C  mem=103800MB  load=4.93  /tmp_dirs=1  dill=45MB
    -j 4: 7161ms
    -j 8: 5204ms
    -j 12: 6212ms
    [diag after round 4       ] cpu= 2975 MHz  temp=58°C  mem=103854MB  load=5.50  /tmp_dirs=1  dill=45MB
>>> Round 5/5
    [diag before round 5      ] cpu= 2973 MHz  temp=58°C  mem=103854MB  load=5.50  /tmp_dirs=1  dill=45MB
    -j 4: 7335ms
    -j 8: 5108ms
    -j 12: 6126ms
    [diag after round 5       ] cpu= 2977 MHz  temp=60°C  mem=103924MB  load=5.85  /tmp_dirs=1  dill=45MB

===========================================================

  COMPARISON  |  Suite: foundation  |  Files: 32  |  Tests: 220

                                                j4                j8               j12
  ------------------------------------------------------------------------------------
  Total wall clock                 7269ms (+/-130)   5021ms (+/-170)  5006ms (+/-1085)
    Tool startup                      312ms (+/-5)     324ms (+/-10)      318ms (+/-7)
    Test runner                    6957ms (+/-129)   4697ms (+/-165)  4688ms (+/-1080)
      Compile (wall)                2454ms (+/-30)    2547ms (+/-55)    2608ms (+/-40)
      Compile (CPU)                 2454ms (+/-30)    2547ms (+/-55)    2608ms (+/-40)
      Run (wall)                   5773ms (+/-110)   3471ms (+/-147)  3467ms (+/-1083)
      Run (CPU)                   19253ms (+/-321)  20282ms (+/-800) 26715ms (+/-8723)
    Time to first test              1415ms (+/-23)    1478ms (+/-44)    1486ms (+/-13)

  First compile                      821ms (+/-25)     852ms (+/-33)     861ms (+/-13)
  Subsequent compiles (avg)            54ms (+/-1)       56ms (+/-1)       58ms (+/-1)

  Per-test mean                        13ms (+/-0)       13ms (+/-0)       13ms (+/-0)
  Per-test median                              3ms               3ms               3ms


>>> Restoring CPU settings
```

</p>
</details> 


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

