### PR TITLE
[bots] Fix dart-analysis flake by pub getting standalone packages in the validation itself

### DIFF
--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -311,6 +311,7 @@ List<Validation> _getValidations({
     ),
     Validation('package-allowlist', 'Package Allowlist...', () => _checkConsumerDependencies()),
     Validation('dart-analysis', 'Dart analysis...', () async {
+      await _ensureStandalonePackagesArePubGot();
       final CommandResult result = await _runFlutterAnalyze(
         flutterRoot,
         options: <String>['--flutter-repo', ...passthroughArguments],
@@ -331,15 +332,14 @@ List<Validation> _getValidations({
       () => _verifyPrivateLints(flutterRoot, getDartAnalyzeResult()),
     ),
     Validation('executable-allowlist', 'Executable allowlist...', () => _checkForNewExecutables()),
-    Validation(
-      'dart-analysis-watch',
-      'Dart analysis (with --watch)...',
-      () => _runFlutterAnalyze(
+    Validation('dart-analysis-watch', 'Dart analysis (with --watch)...', () async {
+      await _ensureStandalonePackagesArePubGot();
+      await _runFlutterAnalyze(
         flutterRoot,
         failureMessage: 'Dart analyzer failed when --watch was used.',
         options: <String>['--flutter-repo', '--watch', '--benchmark', ...passthroughArguments],
-      ),
-    ),
+      );
+    }),
     Validation(
       'snippets',
       'Snippet code...',
@@ -2763,6 +2763,33 @@ Future<CommandResult> _runFlutterAnalyze(
     workingDirectory: workingDirectory,
     failureMessage: failureMessage,
   );
+}
+
+/// Packages whose `pubspec.yaml` is intentionally outside the workspace.
+/// `flutter analyze --flutter-repo` walks them along with the workspace
+/// packages, so they need their own `.dart_tool/package_config.json` to
+/// be analyzable.
+///
+/// `flutter update-packages` (run as the `update-packages` validation in
+/// this same shard) already pub gets these. We pin the pub get here too
+/// so that the analyze validation is self-contained, which keeps it
+/// passing if any state was wiped between validations or if a future
+/// refactor changes the validation order.
+const List<List<String>> _standalonePackagesOutsideWorkspace = <List<String>>[
+  <String>['dev', 'integration_tests', 'hook_user_defines'],
+];
+
+Future<void> _ensureStandalonePackagesArePubGot() async {
+  for (final List<String> segments in _standalonePackagesOutsideWorkspace) {
+    final String packageDir = path.joinAll(<String>[flutterRoot, ...segments]);
+    await runCommand(
+      flutter,
+      const <String>['pub', 'get'],
+      workingDirectory: packageDir,
+      failureMessage:
+          'Failed to "flutter pub get" the standalone (non-workspace) package at $packageDir.',
+    );
+  }
 }
 
 // These files legitimately require executable permissions


### PR DESCRIPTION
This is a flake fix for the `dart-analysis` step on the `Linux analyze` shard. Noticed the flake on https://github.com/flutter/flutter/pull/186300, an unrelated PR that failed there with:

```
error - Target of URI doesn't exist: 'package:hook_user_defines/hook_user_defines.dart' (dev/integration_tests/hook_user_defines/test/hook_user_defines_test.dart:5:8)
error - The function 'sum' isn't defined (dev/integration_tests/hook_user_defines/test/hook_user_defines_test.dart:11:12)
```

`flutter analyze --flutter-repo` walks every package in the repo, including ones whose `pubspec.yaml` is intentionally outside the workspace. Currently that's just `dev/integration_tests/hook_user_defines/`, which needs its own `.dart_tool/package_config.json` to resolve `package:hook_user_defines/hook_user_defines.dart` and the `sum` function its test imports.

`flutter update-packages` (run as the `update-packages` validation earlier in the same shard) unconditionally pub gets that standalone package at `packages/flutter_tools/lib/src/commands/update_packages.dart:234`. The shard validations run sequentially (`dev/bots/analyze.dart:193-202`), so under normal conditions analyze succeeds. The fact that `update-packages` succeeded but `dart-analysis` then saw the missing import points at infrastructure (filesystem state not visible across processes, intermediate state wiped, etc.) rather than logic.

This PR adds a small private helper, `_ensureStandalonePackagesArePubGot`, driven by a `_standalonePackagesOutsideWorkspace` constant, and calls it at the start of both the `dart-analysis` and `dart-analysis-watch` validations before invoking `_runFlutterAnalyze`. The second pub get is fast on a populated lockfile, and the analyze validations no longer depend on the success of any earlier validation. `flutter update-packages` keeps doing what it always did. Future additions to the standalone-packages list need a single line of source.

The fix could alternatively live in `flutter analyze --flutter-repo` itself, but the flake is shard-scoped and `flutter analyze` should keep behaving the way users invoke it from outside CI. Putting the workaround in the validation keeps the fix narrow and easy to remove later if root-cause work eliminates the underlying flake.

This PR does not have a dedicated issue: no separate issue was filed for the flake; the evidence and analysis live on flutter/flutter#186300. Verified locally by deleting `dev/integration_tests/hook_user_defines/.dart_tool/` to simulate the flake and running `dart --enable-asserts dev/bots/analyze.dart --only=dart-analysis`. Without this change the validation fails with the same two errors observed on CI; with this change the helper pub gets the standalone package first and analyze succeeds (`No issues found!`).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt]. The change is in the bots shard and exercises an existing validation path; verified by simulating the flake locally as described above.
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md