### PR TITLE
[Flutter GPU] Allow customizing the vertex layout on a RenderPipeline

### DIFF
--- a/engine/src/flutter/lib/gpu/BUILD.gn
+++ b/engine/src/flutter/lib/gpu/BUILD.gn
@@ -61,6 +61,9 @@ source_set("gpu") {
     "//flutter/impeller/shader_bundle:shader_bundle_flatbuffers",
     "//flutter/lib/ui",
     "//flutter/third_party/tonic",
+    "//third_party/abseil-cpp/absl/status",
+    "//third_party/abseil-cpp/absl/status:statusor",
+    "//third_party/abseil-cpp/absl/strings",
   ]
 
   if (impeller_supports_rendering) {

--- a/engine/src/flutter/lib/gpu/lib/gpu.dart
+++ b/engine/src/flutter/lib/gpu/lib/gpu.dart
@@ -37,3 +37,4 @@ part 'src/render_pass.dart';
 part 'src/render_pipeline.dart';
 part 'src/shader.dart';
 part 'src/shader_library.dart';
+part 'src/vertex_layout.dart';

--- a/engine/src/flutter/lib/gpu/lib/src/buffer.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/buffer.dart
@@ -59,12 +59,14 @@ base class DeviceBuffer extends NativeFieldWrapperClass1 {
     int offsetInBytes,
     int lengthInBytes,
     int vertexCount,
+    int slot,
   ) {
     renderPass._bindVertexBufferDevice(
       this,
       offsetInBytes,
       lengthInBytes,
       vertexCount,
+      slot,
     );
   }
 

--- a/engine/src/flutter/lib/gpu/lib/src/context.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/context.dart
@@ -157,9 +157,15 @@ base class GpuContext extends NativeFieldWrapperClass1 {
 
   RenderPipeline createRenderPipeline(
     Shader vertexShader,
-    Shader fragmentShader,
-  ) {
-    return RenderPipeline._(this, vertexShader, fragmentShader);
+    Shader fragmentShader, {
+    VertexLayout? vertexLayout,
+  }) {
+    return RenderPipeline._(
+      this,
+      vertexShader,
+      fragmentShader,
+      vertexLayout: vertexLayout,
+    );
   }
 
   /// Associates the default Impeller context with this Context.

--- a/engine/src/flutter/lib/gpu/lib/src/render_pass.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/render_pass.dart
@@ -224,6 +224,22 @@ base class RenderTarget {
 }
 
 base class RenderPass extends NativeFieldWrapperClass1 {
+  /// The maximum number of vertex buffer slots that can be bound to a single
+  /// draw. Matches `flutter::gpu::RenderPass::kMaxVertexBufferSlots` on the
+  /// native side, which in turn matches `impeller::kMaxVertexBuffers`; keep
+  /// them in sync.
+  static const int _kMaxVertexBufferSlots = 16;
+
+  /// Bitmask of slots that have been bound via [bindVertexBuffer] since the
+  /// most recent [clearBindings] (or since this RenderPass was created).
+  /// Bit `i` is set when slot `i` has been bound.
+  int _boundVertexSlotsMask = 0;
+
+  /// Highest slot index that has been bound, or -1 if no slot has been
+  /// bound. Tracked so [draw] can detect sparse bindings without scanning
+  /// the entire bitmask.
+  int _maxBoundVertexSlot = -1;
+
   /// Creates a new RenderPass.
   RenderPass._(
     GpuContext gpuContext,
@@ -281,20 +297,26 @@ base class RenderPass extends NativeFieldWrapperClass1 {
 
   /// Binds [bufferView] as the vertex buffer at the given [slot].
   ///
-  /// [slot] selects which vertex-buffer binding the data should appear at,
-  /// matching the corresponding `VertexBufferLayout.binding` declared on
-  /// the active pipeline's `VertexLayout`. The default of 0 matches the
-  /// default layout declared by a shader bundle, which is what every
-  /// single-buffer call site expects. To bind multiple structure-of-arrays
-  /// vertex buffers, call this method once per slot with the same
-  /// [vertexCount]; the [vertexCount] only takes effect when no index
-  /// buffer is bound and is ignored on subsequent slots, so the values
-  /// supplied to later calls must match the first.
-  /// The maximum number of vertex buffer slots that can be bound to a single
-  /// draw. Matches `flutter::gpu::RenderPass::kMaxVertexBufferSlots` on the
-  /// native side; keep them in sync.
-  static const int _kMaxVertexBufferSlots = 16;
-
+  /// [slot] selects which vertex-buffer binding the data appears at,
+  /// matching the corresponding `VertexBuffer` declared on the active
+  /// pipeline's `VertexLayout`. The default of 0 matches the default
+  /// layout declared by a shader bundle, which is what every single-buffer
+  /// call site expects. To bind multiple structure-of-arrays vertex
+  /// buffers, call this method once per slot. The [vertexCount] takes
+  /// effect only when no index buffer is bound, and is read from the
+  /// binding at slot 0, so values supplied at higher slots are ignored.
+  ///
+  /// Sparse bindings are not supported. Every slot in `[0, highestBound]`
+  /// must have been bound before [draw] is called, otherwise [draw] throws
+  /// a [StateError] naming the unbound slots. Slots can be bound in any
+  /// order.
+  ///
+  /// [slot] must be in `[0, 16)` (Impeller's HAL caps vertex buffer
+  /// bindings at 16). On the OpenGL ES backend, the per-pipeline limit on
+  /// the *total attribute count* across all bound buffers is whatever the
+  /// device reports for `GL_MAX_VERTEX_ATTRIBS` (minimum 8 on GL ES 2.0,
+  /// minimum 16 on GL ES 3.0+), and is enforced by the driver rather than
+  /// by this method.
   void bindVertexBuffer(
     BufferView bufferView,
     int vertexCount, {
@@ -308,6 +330,10 @@ base class RenderPass extends NativeFieldWrapperClass1 {
         'slot',
         'bindVertexBuffer slot must be in [0, $_kMaxVertexBufferSlots)',
       );
+    }
+    _boundVertexSlotsMask |= 1 << slot;
+    if (slot > _maxBoundVertexSlot) {
+      _maxBoundVertexSlot = slot;
     }
     bufferView.buffer._bindAsVertexBuffer(
       this,
@@ -379,6 +405,8 @@ base class RenderPass extends NativeFieldWrapperClass1 {
 
   void clearBindings() {
     _clearBindings();
+    _boundVertexSlotsMask = 0;
+    _maxBoundVertexSlot = -1;
   }
 
   void setColorBlendEnable(bool enable, {int colorAttachmentIndex = 0}) {
@@ -478,6 +506,20 @@ base class RenderPass extends NativeFieldWrapperClass1 {
   }
 
   void draw() {
+    if (_maxBoundVertexSlot >= 0) {
+      final int expectedMask = (1 << (_maxBoundVertexSlot + 1)) - 1;
+      if (_boundVertexSlotsMask != expectedMask) {
+        final List<int> missing = <int>[
+          for (int i = 0; i <= _maxBoundVertexSlot; i++)
+            if ((_boundVertexSlotsMask & (1 << i)) == 0) i,
+        ];
+        throw StateError(
+          'draw() called with sparse vertex buffer bindings: slot(s) '
+          '${missing.join(', ')} were not bound but slot $_maxBoundVertexSlot '
+          'was. Bind every slot in [0, $_maxBoundVertexSlot] before drawing.',
+        );
+      }
+    }
     if (!_draw()) {
       throw Exception("Failed to append draw");
     }

--- a/engine/src/flutter/lib/gpu/lib/src/render_pass.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/render_pass.dart
@@ -279,12 +279,42 @@ base class RenderPass extends NativeFieldWrapperClass1 {
     _bindPipeline(pipeline);
   }
 
-  void bindVertexBuffer(BufferView bufferView, int vertexCount) {
+  /// Binds [bufferView] as the vertex buffer at the given [slot].
+  ///
+  /// [slot] selects which vertex-buffer binding the data should appear at,
+  /// matching the corresponding `VertexBufferLayout.binding` declared on
+  /// the active pipeline's `VertexLayout`. The default of 0 matches the
+  /// default layout declared by a shader bundle, which is what every
+  /// single-buffer call site expects. To bind multiple structure-of-arrays
+  /// vertex buffers, call this method once per slot with the same
+  /// [vertexCount]; the [vertexCount] only takes effect when no index
+  /// buffer is bound and is ignored on subsequent slots, so the values
+  /// supplied to later calls must match the first.
+  /// The maximum number of vertex buffer slots that can be bound to a single
+  /// draw. Matches `flutter::gpu::RenderPass::kMaxVertexBufferSlots` on the
+  /// native side; keep them in sync.
+  static const int _kMaxVertexBufferSlots = 16;
+
+  void bindVertexBuffer(
+    BufferView bufferView,
+    int vertexCount, {
+    int slot = 0,
+  }) {
+    if (slot < 0 || slot >= _kMaxVertexBufferSlots) {
+      throw RangeError.range(
+        slot,
+        0,
+        _kMaxVertexBufferSlots - 1,
+        'slot',
+        'bindVertexBuffer slot must be in [0, $_kMaxVertexBufferSlots)',
+      );
+    }
     bufferView.buffer._bindAsVertexBuffer(
       this,
       bufferView.offsetInBytes,
       bufferView.lengthInBytes,
       vertexCount,
+      slot,
     );
   }
 
@@ -519,7 +549,7 @@ base class RenderPass extends NativeFieldWrapperClass1 {
   )
   external void _bindPipeline(RenderPipeline pipeline);
 
-  @Native<Void Function(Pointer<Void>, Pointer<Void>, Int, Int, Int)>(
+  @Native<Void Function(Pointer<Void>, Pointer<Void>, Int, Int, Int, Int)>(
     symbol: 'InternalFlutterGpu_RenderPass_BindVertexBufferDevice',
   )
   external void _bindVertexBufferDevice(
@@ -527,6 +557,7 @@ base class RenderPass extends NativeFieldWrapperClass1 {
     int offsetInBytes,
     int lengthInBytes,
     int vertexCount,
+    int slot,
   );
 
   @Native<Void Function(Pointer<Void>, Pointer<Void>, Int, Int, Int, Int)>(

--- a/engine/src/flutter/lib/gpu/lib/src/render_pipeline.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/render_pipeline.dart
@@ -8,13 +8,28 @@ part of flutter_gpu;
 
 base class RenderPipeline extends NativeFieldWrapperClass1 {
   /// Creates a new RenderPipeline.
+  ///
+  /// If [vertexLayout] is null, the default interleaved layout declared by
+  /// the bound vertex shader's shader bundle is used. Supply a layout to
+  /// override the default, e.g. to bind multiple structure-of-arrays vertex
+  /// buffers or to reorder attributes.
   RenderPipeline._(
     GpuContext gpuContext,
     Shader vertexShader,
-    Shader fragmentShader,
-  ) : vertexShader = vertexShader,
-      fragmentShader = fragmentShader {
-    String? error = _initialize(gpuContext, vertexShader, fragmentShader);
+    Shader fragmentShader, {
+    VertexLayout? vertexLayout,
+  }) : vertexShader = vertexShader,
+       fragmentShader = fragmentShader {
+    final (ByteData?, ByteData?) packed = vertexLayout == null
+        ? (null, null)
+        : _packVertexLayout(vertexLayout);
+    String? error = _initialize(
+      gpuContext,
+      vertexShader,
+      fragmentShader,
+      packed.$1,
+      packed.$2,
+    );
     if (error != null) {
       throw Exception(error);
     }
@@ -23,13 +38,46 @@ base class RenderPipeline extends NativeFieldWrapperClass1 {
   final Shader vertexShader;
   final Shader fragmentShader;
 
+  /// Packs a [VertexLayout] into the two `Int32List` ByteData buffers expected
+  /// by the C++ side: `[binding, stride]` per buffer entry, and
+  /// `[location, bufferBinding, offset, formatIndex]` per attribute entry.
+  static (ByteData, ByteData) _packVertexLayout(VertexLayout layout) {
+    final Int32List buffersData = Int32List(2 * layout.buffers.length);
+    for (int i = 0; i < layout.buffers.length; i++) {
+      final VertexBufferLayout buf = layout.buffers[i];
+      buffersData[i * 2 + 0] = buf.binding;
+      buffersData[i * 2 + 1] = buf.strideInBytes;
+    }
+    final Int32List attributesData = Int32List(4 * layout.attributes.length);
+    for (int i = 0; i < layout.attributes.length; i++) {
+      final VertexAttribute attr = layout.attributes[i];
+      attributesData[i * 4 + 0] = attr.location;
+      attributesData[i * 4 + 1] = attr.bufferBinding;
+      attributesData[i * 4 + 2] = attr.offsetInBytes;
+      attributesData[i * 4 + 3] = attr.format.index;
+    }
+    return (
+      buffersData.buffer.asByteData(),
+      attributesData.buffer.asByteData(),
+    );
+  }
+
   /// Wrap with native counterpart.
-  @Native<Handle Function(Handle, Pointer<Void>, Pointer<Void>, Pointer<Void>)>(
-    symbol: 'InternalFlutterGpu_RenderPipeline_Initialize',
-  )
+  @Native<
+    Handle Function(
+      Handle,
+      Pointer<Void>,
+      Pointer<Void>,
+      Pointer<Void>,
+      Handle,
+      Handle,
+    )
+  >(symbol: 'InternalFlutterGpu_RenderPipeline_Initialize')
   external String? _initialize(
     GpuContext gpuContext,
     Shader vertexShader,
     Shader fragmentShader,
+    ByteData? bufferLayoutsData,
+    ByteData? attributesData,
   );
 }

--- a/engine/src/flutter/lib/gpu/lib/src/render_pipeline.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/render_pipeline.dart
@@ -20,8 +20,8 @@ base class RenderPipeline extends NativeFieldWrapperClass1 {
     VertexLayout? vertexLayout,
   }) : vertexShader = vertexShader,
        fragmentShader = fragmentShader {
-    final (ByteData?, ByteData?) packed = vertexLayout == null
-        ? (null, null)
+    final (ByteData?, ByteData?, ByteData?) packed = vertexLayout == null
+        ? (null, null, null)
         : _packVertexLayout(vertexLayout);
     String? error = _initialize(
       gpuContext,
@@ -29,6 +29,7 @@ base class RenderPipeline extends NativeFieldWrapperClass1 {
       fragmentShader,
       packed.$1,
       packed.$2,
+      packed.$3,
     );
     if (error != null) {
       throw Exception(error);
@@ -38,27 +39,56 @@ base class RenderPipeline extends NativeFieldWrapperClass1 {
   final Shader vertexShader;
   final Shader fragmentShader;
 
-  /// Packs a [VertexLayout] into the two `Int32List` ByteData buffers expected
-  /// by the C++ side: `[binding, stride]` per buffer entry, and
-  /// `[location, bufferBinding, offset, formatIndex]` per attribute entry.
-  static (ByteData, ByteData) _packVertexLayout(VertexLayout layout) {
+  /// Packs a [VertexLayout] into the three ByteData buffers expected by the
+  /// C++ side:
+  ///
+  /// * `bufferLayouts` (`Int32List`): `[binding, stride]` per buffer entry.
+  /// * `attributes` (`Int32List`): `[bufferBinding, offset, formatIndex,
+  ///   nameByteLength]` per attribute entry.
+  /// * `attributeNames`: concatenated UTF-8 bytes of every attribute name,
+  ///   walked in parallel with `attributes` using the per-entry name length.
+  ///
+  /// Attribute names are ASCII GLSL identifiers, so encoding them as UTF-8
+  /// byte sequences via `codeUnits` is sufficient without a separate
+  /// dependency on `dart:convert`.
+  static (ByteData, ByteData, ByteData) _packVertexLayout(VertexLayout layout) {
     final Int32List buffersData = Int32List(2 * layout.buffers.length);
     for (int i = 0; i < layout.buffers.length; i++) {
       final VertexBufferLayout buf = layout.buffers[i];
       buffersData[i * 2 + 0] = buf.binding;
       buffersData[i * 2 + 1] = buf.strideInBytes;
     }
+
+    // First pass: encode each name to bytes and compute the total length.
+    final List<Uint8List> nameBytes = <Uint8List>[];
+    int totalNameBytes = 0;
+    for (int i = 0; i < layout.attributes.length; i++) {
+      final Uint8List bytes = Uint8List.fromList(
+        layout.attributes[i].name.codeUnits,
+      );
+      nameBytes.add(bytes);
+      totalNameBytes += bytes.length;
+    }
+
+    // Second pass: pack the attribute integer table and the names blob.
     final Int32List attributesData = Int32List(4 * layout.attributes.length);
+    final Uint8List namesData = Uint8List(totalNameBytes);
+    int nameCursor = 0;
     for (int i = 0; i < layout.attributes.length; i++) {
       final VertexAttribute attr = layout.attributes[i];
-      attributesData[i * 4 + 0] = attr.location;
-      attributesData[i * 4 + 1] = attr.bufferBinding;
-      attributesData[i * 4 + 2] = attr.offsetInBytes;
-      attributesData[i * 4 + 3] = attr.format.index;
+      final Uint8List bytes = nameBytes[i];
+      attributesData[i * 4 + 0] = attr.bufferBinding;
+      attributesData[i * 4 + 1] = attr.offsetInBytes;
+      attributesData[i * 4 + 2] = attr.format.index;
+      attributesData[i * 4 + 3] = bytes.length;
+      namesData.setRange(nameCursor, nameCursor + bytes.length, bytes);
+      nameCursor += bytes.length;
     }
+
     return (
       buffersData.buffer.asByteData(),
       attributesData.buffer.asByteData(),
+      namesData.buffer.asByteData(),
     );
   }
 
@@ -71,6 +101,7 @@ base class RenderPipeline extends NativeFieldWrapperClass1 {
       Pointer<Void>,
       Handle,
       Handle,
+      Handle,
     )
   >(symbol: 'InternalFlutterGpu_RenderPipeline_Initialize')
   external String? _initialize(
@@ -79,5 +110,6 @@ base class RenderPipeline extends NativeFieldWrapperClass1 {
     Shader fragmentShader,
     ByteData? bufferLayoutsData,
     ByteData? attributesData,
+    ByteData? attributeNamesData,
   );
 }

--- a/engine/src/flutter/lib/gpu/lib/src/render_pipeline.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/render_pipeline.dart
@@ -42,9 +42,12 @@ base class RenderPipeline extends NativeFieldWrapperClass1 {
   /// Packs a [VertexLayout] into the three ByteData buffers expected by the
   /// C++ side:
   ///
-  /// * `bufferLayouts` (`Int32List`): `[binding, stride]` per buffer entry.
-  /// * `attributes` (`Int32List`): `[bufferBinding, offset, formatIndex,
-  ///   nameByteLength]` per attribute entry.
+  /// * `bufferLayouts` (`Int32List`): `[strideInBytes, attributeCount]` per
+  ///   buffer entry. The buffer's binding slot is implicit in its position.
+  /// * `attributes` (`Int32List`): `[offsetInBytes, formatIndex,
+  ///   nameByteLength]` per attribute entry, flattened across buffers in
+  ///   buffer-list order. Each buffer's `attributeCount` row tells the C++
+  ///   side how many attribute rows belong to it.
   /// * `attributeNames`: concatenated UTF-8 bytes of every attribute name,
   ///   walked in parallel with `attributes` using the per-entry name length.
   ///
@@ -52,37 +55,48 @@ base class RenderPipeline extends NativeFieldWrapperClass1 {
   /// byte sequences via `codeUnits` is sufficient without a separate
   /// dependency on `dart:convert`.
   static (ByteData, ByteData, ByteData) _packVertexLayout(VertexLayout layout) {
-    final Int32List buffersData = Int32List(2 * layout.buffers.length);
+    int totalAttributeCount = 0;
     for (int i = 0; i < layout.buffers.length; i++) {
-      final VertexBufferLayout buf = layout.buffers[i];
-      buffersData[i * 2 + 0] = buf.binding;
-      buffersData[i * 2 + 1] = buf.strideInBytes;
+      totalAttributeCount += layout.buffers[i].attributes.length;
     }
 
-    // First pass: encode each name to bytes and compute the total length.
+    final Int32List buffersData = Int32List(2 * layout.buffers.length);
+    for (int i = 0; i < layout.buffers.length; i++) {
+      final VertexBuffer buf = layout.buffers[i];
+      buffersData[i * 2 + 0] = buf.strideInBytes;
+      buffersData[i * 2 + 1] = buf.attributes.length;
+    }
+
+    // First pass: encode each name to bytes and compute the total length,
+    // walking attributes in buffer-list order.
     final List<Uint8List> nameBytes = <Uint8List>[];
     int totalNameBytes = 0;
-    for (int i = 0; i < layout.attributes.length; i++) {
-      final Uint8List bytes = Uint8List.fromList(
-        layout.attributes[i].name.codeUnits,
-      );
-      nameBytes.add(bytes);
-      totalNameBytes += bytes.length;
+    for (int b = 0; b < layout.buffers.length; b++) {
+      final List<VertexAttribute> attrs = layout.buffers[b].attributes;
+      for (int a = 0; a < attrs.length; a++) {
+        final Uint8List bytes = Uint8List.fromList(attrs[a].name.codeUnits);
+        nameBytes.add(bytes);
+        totalNameBytes += bytes.length;
+      }
     }
 
     // Second pass: pack the attribute integer table and the names blob.
-    final Int32List attributesData = Int32List(4 * layout.attributes.length);
+    final Int32List attributesData = Int32List(3 * totalAttributeCount);
     final Uint8List namesData = Uint8List(totalNameBytes);
+    int attrIndex = 0;
     int nameCursor = 0;
-    for (int i = 0; i < layout.attributes.length; i++) {
-      final VertexAttribute attr = layout.attributes[i];
-      final Uint8List bytes = nameBytes[i];
-      attributesData[i * 4 + 0] = attr.bufferBinding;
-      attributesData[i * 4 + 1] = attr.offsetInBytes;
-      attributesData[i * 4 + 2] = attr.format.index;
-      attributesData[i * 4 + 3] = bytes.length;
-      namesData.setRange(nameCursor, nameCursor + bytes.length, bytes);
-      nameCursor += bytes.length;
+    for (int b = 0; b < layout.buffers.length; b++) {
+      final List<VertexAttribute> attrs = layout.buffers[b].attributes;
+      for (int a = 0; a < attrs.length; a++) {
+        final VertexAttribute attr = attrs[a];
+        final Uint8List bytes = nameBytes[attrIndex];
+        attributesData[attrIndex * 3 + 0] = attr.offsetInBytes;
+        attributesData[attrIndex * 3 + 1] = attr.format.index;
+        attributesData[attrIndex * 3 + 2] = bytes.length;
+        namesData.setRange(nameCursor, nameCursor + bytes.length, bytes);
+        nameCursor += bytes.length;
+        attrIndex++;
+      }
     }
 
     return (

--- a/engine/src/flutter/lib/gpu/lib/src/vertex_layout.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/vertex_layout.dart
@@ -76,6 +76,9 @@ enum VertexFormat {
 /// byte ranges (i.e. `[offsetInBytes, offsetInBytes + format.bytesPerElement)`
 /// ranges must be disjoint across the buffer's attributes).
 final class VertexAttribute {
+  /// Creates a vertex attribute description bound to the shader-side input
+  /// named [name], reading its data in the given [format] starting at byte
+  /// [offsetInBytes] into each element of the owning vertex buffer.
   const VertexAttribute({
     required this.name,
     required this.format,
@@ -114,6 +117,9 @@ final class VertexAttribute {
 // TODO(https://github.com/flutter/flutter/issues/186308): Allow sparse
 // vertex buffer binding slots.
 final class VertexBuffer {
+  /// Creates a vertex buffer slot description with the given per-element
+  /// [strideInBytes] and the list of [attributes] that the vertex shader
+  /// reads from this buffer.
   const VertexBuffer({required this.strideInBytes, required this.attributes});
 
   /// Byte distance from the start of one element to the start of the next
@@ -137,6 +143,7 @@ final class VertexBuffer {
 /// consume a structure-of-arrays mesh without converting to interleaved
 /// form on the CPU).
 final class VertexLayout {
+  /// Creates a vertex input layout that reads from the given [buffers].
   const VertexLayout({required this.buffers});
 
   /// Vertex buffer slots this layout uses. Each buffer's position in this

--- a/engine/src/flutter/lib/gpu/lib/src/vertex_layout.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/vertex_layout.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// ignore_for_file: public_member_api_docs
-
 part of flutter_gpu;
 
 /// The format of a single vertex attribute.
@@ -17,19 +15,40 @@ part of flutter_gpu;
 // TODO(https://github.com/flutter/flutter/issues/186309): Add normalized,
 // packed, half-float, BGRA-swizzled, and 64-bit vertex attribute formats.
 enum VertexFormat {
+  /// One 32-bit float (4 bytes).
   float32(bytesPerElement: 4, componentCount: 1),
+
+  /// Two 32-bit floats (8 bytes).
   float32x2(bytesPerElement: 8, componentCount: 2),
+
+  /// Three 32-bit floats (12 bytes).
   float32x3(bytesPerElement: 12, componentCount: 3),
+
+  /// Four 32-bit floats (16 bytes).
   float32x4(bytesPerElement: 16, componentCount: 4),
 
+  /// One 32-bit unsigned integer (4 bytes).
   uint32(bytesPerElement: 4, componentCount: 1),
+
+  /// Two 32-bit unsigned integers (8 bytes).
   uint32x2(bytesPerElement: 8, componentCount: 2),
+
+  /// Three 32-bit unsigned integers (12 bytes).
   uint32x3(bytesPerElement: 12, componentCount: 3),
+
+  /// Four 32-bit unsigned integers (16 bytes).
   uint32x4(bytesPerElement: 16, componentCount: 4),
 
+  /// One 32-bit signed integer (4 bytes).
   sint32(bytesPerElement: 4, componentCount: 1),
+
+  /// Two 32-bit signed integers (8 bytes).
   sint32x2(bytesPerElement: 8, componentCount: 2),
+
+  /// Three 32-bit signed integers (12 bytes).
   sint32x3(bytesPerElement: 12, componentCount: 3),
+
+  /// Four 32-bit signed integers (16 bytes).
   sint32x4(bytesPerElement: 16, componentCount: 4);
 
   const VertexFormat({
@@ -97,7 +116,12 @@ final class VertexAttribute {
 final class VertexBuffer {
   const VertexBuffer({required this.strideInBytes, required this.attributes});
 
-  /// Byte distance between consecutive elements in this vertex buffer.
+  /// Byte distance from the start of one element to the start of the next
+  /// element in this vertex buffer (not the gap between an element's end and
+  /// the next element's start). Equivalent to the size of a single vertex
+  /// element plus any trailing padding before the next element begins. For a
+  /// tightly packed structure-of-arrays buffer carrying a single attribute,
+  /// this is the same as `attributes[0].format.bytesPerElement`.
   final int strideInBytes;
 
   /// Attributes read from this vertex buffer by the vertex shader.

--- a/engine/src/flutter/lib/gpu/lib/src/vertex_layout.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/vertex_layout.dart
@@ -1,0 +1,123 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// ignore_for_file: public_member_api_docs
+
+part of flutter_gpu;
+
+/// The format of a single vertex attribute.
+///
+/// Each value names a component count, scalar type, and bit width. The enum
+/// currently covers the 32-bit-per-component scalar types (float, signed
+/// integer, unsigned integer) in 1, 2, 3, and 4 component widths. Normalized
+/// integer, packed, half-float, BGRA-swizzled, and 64-bit attribute formats
+/// will be added in a future release; new values are purely additive and
+/// won't affect callers using existing values.
+// TODO(https://github.com/flutter/flutter/issues/186309): Add normalized,
+// packed, half-float, BGRA-swizzled, and 64-bit vertex attribute formats.
+enum VertexFormat {
+  float32(bytesPerElement: 4, componentCount: 1),
+  float32x2(bytesPerElement: 8, componentCount: 2),
+  float32x3(bytesPerElement: 12, componentCount: 3),
+  float32x4(bytesPerElement: 16, componentCount: 4),
+
+  uint32(bytesPerElement: 4, componentCount: 1),
+  uint32x2(bytesPerElement: 8, componentCount: 2),
+  uint32x3(bytesPerElement: 12, componentCount: 3),
+  uint32x4(bytesPerElement: 16, componentCount: 4),
+
+  sint32(bytesPerElement: 4, componentCount: 1),
+  sint32x2(bytesPerElement: 8, componentCount: 2),
+  sint32x3(bytesPerElement: 12, componentCount: 3),
+  sint32x4(bytesPerElement: 16, componentCount: 4);
+
+  const VertexFormat({
+    required this.bytesPerElement,
+    required this.componentCount,
+  });
+
+  /// Total size in bytes of a single attribute element of this format.
+  final int bytesPerElement;
+
+  /// Number of scalar components in a single attribute element.
+  final int componentCount;
+}
+
+/// Describes a single vertex attribute: which shader location it feeds, which
+/// vertex buffer slot it reads from, the byte offset within that buffer's
+/// element, and its format.
+final class VertexAttribute {
+  const VertexAttribute({
+    required this.location,
+    required this.bufferBinding,
+    required this.offsetInBytes,
+    required this.format,
+  });
+
+  /// Shader-side input location, matching the `@location(N)` (WGSL) /
+  /// `layout(location = N)` (GLSL) decoration on the vertex shader's input.
+  final int location;
+
+  /// Vertex buffer slot that this attribute reads from. Must reference a
+  /// [VertexBufferLayout.binding] present in the same [VertexLayout].
+  final int bufferBinding;
+
+  /// Byte offset of this attribute from the start of each element in the
+  /// referenced vertex buffer. Must satisfy
+  /// `offsetInBytes + format.bytesPerElement <= layout.strideInBytes`.
+  final int offsetInBytes;
+
+  /// Format of each attribute element.
+  final VertexFormat format;
+}
+
+/// Describes one vertex buffer slot: its binding index and per-element stride.
+///
+/// Step mode (vertex vs instance) and instance step rate are not yet
+/// configurable; every binding currently advances per vertex. Both options
+/// will be added later as named parameters with sensible defaults, and the
+/// addition will be a non-breaking change for existing call sites.
+///
+/// The [binding] indices used across a [VertexLayout] must be densely
+/// packed starting from 0 (i.e. `0, 1, 2, ...`), and every binding
+/// declared in the layout must have a buffer bound via
+/// [RenderPass.bindVertexBuffer] before drawing. Sparse binding indices
+/// are not currently supported.
+// TODO(https://github.com/flutter/flutter/issues/186307): Allow specifying
+// vertex step mode and instance step rate.
+// TODO(https://github.com/flutter/flutter/issues/186308): Allow sparse
+// vertex buffer binding indices.
+final class VertexBufferLayout {
+  const VertexBufferLayout({
+    required this.binding,
+    required this.strideInBytes,
+  });
+
+  /// Binding index for this vertex buffer slot.
+  final int binding;
+
+  /// Byte distance between consecutive elements in this vertex buffer.
+  final int strideInBytes;
+}
+
+/// A complete vertex input layout: zero or more vertex buffer slots and the
+/// attributes that read from them.
+///
+/// Pass an instance of this class to `GpuContext.createRenderPipeline` to
+/// override the default interleaved layout that the shader bundle declares
+/// (e.g. to bind position and color attributes from separate buffers, or to
+/// consume a structure-of-arrays mesh without converting to interleaved
+/// form on the CPU).
+final class VertexLayout {
+  const VertexLayout({required this.buffers, required this.attributes});
+
+  /// Vertex buffer slots this layout uses. Each entry's [VertexBufferLayout
+  /// .binding] must be referenced by at least one [VertexAttribute].
+  final List<VertexBufferLayout> buffers;
+
+  /// Attributes consumed by the vertex shader. Each [VertexAttribute
+  /// .bufferBinding] must reference a [VertexBufferLayout.binding] present
+  /// in [buffers].
+  final List<VertexAttribute> attributes;
+}

--- a/engine/src/flutter/lib/gpu/lib/src/vertex_layout.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/vertex_layout.dart
@@ -45,69 +45,67 @@ enum VertexFormat {
 }
 
 /// Describes a single vertex attribute: which shader input it feeds (by name),
-/// which vertex buffer slot it reads from, the byte offset within that
-/// buffer's element, and its format.
+/// its byte offset within the owning vertex buffer's element, and its format.
 ///
 /// The [name] must exactly match an `in` (or equivalent stage input)
 /// declaration in the bound vertex shader. Looking the attribute up by name
 /// (rather than by raw location index) keeps Dart-side layouts robust to
 /// shader source edits, mirroring how uniform bindings are resolved by name
 /// via `Shader.getUniformSlot`.
+///
+/// Two attributes within the same [VertexBuffer] must not occupy overlapping
+/// byte ranges (i.e. `[offsetInBytes, offsetInBytes + format.bytesPerElement)`
+/// ranges must be disjoint across the buffer's attributes).
 final class VertexAttribute {
   const VertexAttribute({
     required this.name,
-    required this.bufferBinding,
-    required this.offsetInBytes,
     required this.format,
+    this.offsetInBytes = 0,
   });
 
   /// Name of the shader-side input this attribute feeds (e.g. `position`).
   final String name;
 
-  /// Vertex buffer slot that this attribute reads from. Must reference a
-  /// [VertexBufferLayout.binding] present in the same [VertexLayout].
-  final int bufferBinding;
-
-  /// Byte offset of this attribute from the start of each element in the
-  /// referenced vertex buffer. Must satisfy
-  /// `offsetInBytes + format.bytesPerElement <= layout.strideInBytes`.
-  final int offsetInBytes;
-
   /// Format of each attribute element.
   final VertexFormat format;
+
+  /// Byte offset of this attribute from the start of each element in the
+  /// owning vertex buffer. Must satisfy
+  /// `offsetInBytes + format.bytesPerElement <= VertexBuffer.strideInBytes`.
+  ///
+  /// Defaults to 0, which is the common case for a structure-of-arrays
+  /// layout where each buffer holds exactly one attribute.
+  final int offsetInBytes;
 }
 
-/// Describes one vertex buffer slot: its binding index and per-element stride.
+/// Describes one vertex buffer slot: its per-element stride and the
+/// attributes that are read from it.
+///
+/// A buffer's position in [VertexLayout.buffers] determines the binding
+/// slot it is bound to via [RenderPass.bindVertexBuffer]; the first buffer
+/// is slot 0, the second is slot 1, and so on. Sparse binding slots are
+/// not currently supported.
 ///
 /// Step mode (vertex vs instance) and instance step rate are not yet
-/// configurable; every binding currently advances per vertex. Both options
+/// configurable; every buffer currently advances per vertex. Both options
 /// will be added later as named parameters with sensible defaults, and the
 /// addition will be a non-breaking change for existing call sites.
-///
-/// The [binding] indices used across a [VertexLayout] must be densely
-/// packed starting from 0 (i.e. `0, 1, 2, ...`), and every binding
-/// declared in the layout must have a buffer bound via
-/// [RenderPass.bindVertexBuffer] before drawing. Sparse binding indices
-/// are not currently supported.
 // TODO(https://github.com/flutter/flutter/issues/186307): Allow specifying
 // vertex step mode and instance step rate.
 // TODO(https://github.com/flutter/flutter/issues/186308): Allow sparse
-// vertex buffer binding indices.
-final class VertexBufferLayout {
-  const VertexBufferLayout({
-    required this.binding,
-    required this.strideInBytes,
-  });
-
-  /// Binding index for this vertex buffer slot.
-  final int binding;
+// vertex buffer binding slots.
+final class VertexBuffer {
+  const VertexBuffer({required this.strideInBytes, required this.attributes});
 
   /// Byte distance between consecutive elements in this vertex buffer.
   final int strideInBytes;
+
+  /// Attributes read from this vertex buffer by the vertex shader.
+  final List<VertexAttribute> attributes;
 }
 
 /// A complete vertex input layout: zero or more vertex buffer slots and the
-/// attributes that read from them.
+/// attributes that read from each one.
 ///
 /// Pass an instance of this class to `GpuContext.createRenderPipeline` to
 /// override the default interleaved layout that the shader bundle declares
@@ -115,14 +113,10 @@ final class VertexBufferLayout {
 /// consume a structure-of-arrays mesh without converting to interleaved
 /// form on the CPU).
 final class VertexLayout {
-  const VertexLayout({required this.buffers, required this.attributes});
+  const VertexLayout({required this.buffers});
 
-  /// Vertex buffer slots this layout uses. Each entry's [VertexBufferLayout
-  /// .binding] must be referenced by at least one [VertexAttribute].
-  final List<VertexBufferLayout> buffers;
-
-  /// Attributes consumed by the vertex shader. Each [VertexAttribute
-  /// .bufferBinding] must reference a [VertexBufferLayout.binding] present
-  /// in [buffers].
-  final List<VertexAttribute> attributes;
+  /// Vertex buffer slots this layout uses. Each buffer's position in this
+  /// list determines the binding slot it must be bound to via
+  /// [RenderPass.bindVertexBuffer] before drawing.
+  final List<VertexBuffer> buffers;
 }

--- a/engine/src/flutter/lib/gpu/lib/src/vertex_layout.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/vertex_layout.dart
@@ -44,20 +44,25 @@ enum VertexFormat {
   final int componentCount;
 }
 
-/// Describes a single vertex attribute: which shader location it feeds, which
-/// vertex buffer slot it reads from, the byte offset within that buffer's
-/// element, and its format.
+/// Describes a single vertex attribute: which shader input it feeds (by name),
+/// which vertex buffer slot it reads from, the byte offset within that
+/// buffer's element, and its format.
+///
+/// The [name] must exactly match an `in` (or equivalent stage input)
+/// declaration in the bound vertex shader. Looking the attribute up by name
+/// (rather than by raw location index) keeps Dart-side layouts robust to
+/// shader source edits, mirroring how uniform bindings are resolved by name
+/// via `Shader.getUniformSlot`.
 final class VertexAttribute {
   const VertexAttribute({
-    required this.location,
+    required this.name,
     required this.bufferBinding,
     required this.offsetInBytes,
     required this.format,
   });
 
-  /// Shader-side input location, matching the `@location(N)` (WGSL) /
-  /// `layout(location = N)` (GLSL) decoration on the vertex shader's input.
-  final int location;
+  /// Name of the shader-side input this attribute feeds (e.g. `position`).
+  final String name;
 
   /// Vertex buffer slot that this attribute reads from. Must reference a
   /// [VertexBufferLayout.binding] present in the same [VertexLayout].

--- a/engine/src/flutter/lib/gpu/render_pass.cc
+++ b/engine/src/flutter/lib/gpu/render_pass.cc
@@ -346,15 +346,18 @@ static void BindVertexBuffer(
     wrapper->vertex_buffer_count = static_cast<size_t>(slot) + 1;
   }
 
-  // If the index type is set, then the `vertex_count` becomes the index
-  // count... So don't overwrite the count if it's already been set when binding
-  // the index buffer.
+  // `vertex_count` is only meaningful for slot 0: the Dart-side docstring
+  // for `bindVertexBuffer` states that for slots > 0 the value is ignored
+  // (the slot-0 binding determines the draw range). When the index type is
+  // set, `vertex_count` would become the index count and is already set by
+  // the index-buffer binding path, so we only assign it here if no index
+  // buffer has been bound.
   // TODO(bdero): Consider just doing a more traditional API with
   //              draw(vertexCount) and drawIndexed(indexCount). This is fine,
   //              but overall it would be a bit more explicit and we wouldn't
   //              have to document this behavior where the presence of the index
   //              buffer always takes precedent.
-  if (!wrapper->has_index_buffer) {
+  if (slot == 0 && !wrapper->has_index_buffer) {
     wrapper->element_count = vertex_count;
   }
 }

--- a/engine/src/flutter/lib/gpu/render_pass.cc
+++ b/engine/src/flutter/lib/gpu/render_pass.cc
@@ -94,7 +94,10 @@ void RenderPass::ClearBindings() {
   vertex_texture_bindings.clear();
   fragment_uniform_bindings.clear();
   fragment_texture_bindings.clear();
-  vertex_buffer = {};
+  for (auto& buffer : vertex_buffers) {
+    buffer = {};
+  }
+  vertex_buffer_count = 0;
   index_buffer = {};
   index_buffer_type = impeller::IndexType::kNone;
   element_count = 0;
@@ -213,7 +216,7 @@ bool RenderPass::Draw() {
         texture.texture.resource, texture.sampler);
   }
 
-  render_pass_->SetVertexBuffer(vertex_buffer);
+  render_pass_->SetVertexBuffer(vertex_buffers.data(), vertex_buffer_count);
   render_pass_->SetIndexBuffer(index_buffer, index_buffer_type);
   render_pass_->SetElementCount(element_count);
 
@@ -331,9 +334,17 @@ static void BindVertexBuffer(
     const std::shared_ptr<const impeller::DeviceBuffer>& buffer,
     int offset_in_bytes,
     int length_in_bytes,
-    int vertex_count) {
-  wrapper->vertex_buffer = impeller::BufferView(
+    int vertex_count,
+    int slot) {
+  if (slot < 0 || static_cast<size_t>(slot) >=
+                      flutter::gpu::RenderPass::kMaxVertexBufferSlots) {
+    return;
+  }
+  wrapper->vertex_buffers[slot] = impeller::BufferView(
       buffer, impeller::Range(offset_in_bytes, length_in_bytes));
+  if (static_cast<size_t>(slot) >= wrapper->vertex_buffer_count) {
+    wrapper->vertex_buffer_count = static_cast<size_t>(slot) + 1;
+  }
 
   // If the index type is set, then the `vertex_count` becomes the index
   // count... So don't overwrite the count if it's already been set when binding
@@ -353,9 +364,10 @@ void InternalFlutterGpu_RenderPass_BindVertexBufferDevice(
     flutter::gpu::DeviceBuffer* device_buffer,
     int offset_in_bytes,
     int length_in_bytes,
-    int vertex_count) {
+    int vertex_count,
+    int slot) {
   BindVertexBuffer(wrapper, device_buffer->GetBuffer(), offset_in_bytes,
-                   length_in_bytes, vertex_count);
+                   length_in_bytes, vertex_count, slot);
 }
 
 static void BindIndexBuffer(

--- a/engine/src/flutter/lib/gpu/render_pass.h
+++ b/engine/src/flutter/lib/gpu/render_pass.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_LIB_GPU_RENDER_PASS_H_
 #define FLUTTER_LIB_GPU_RENDER_PASS_H_
 
+#include <array>
 #include <cstdint>
 #include <map>
 #include <memory>
@@ -74,7 +75,13 @@ class RenderPass : public RefCountedDartWrappable<RenderPass> {
   BufferUniformMap fragment_uniform_bindings;
   TextureUniformMap fragment_texture_bindings;
 
-  impeller::BufferView vertex_buffer;
+  // Vertex buffers indexed by binding slot. Impeller's RenderPass accepts up
+  // to 16 vertex buffers per draw call; index `i` corresponds to the binding
+  // declared at slot `i` in the active VertexLayout.
+  static constexpr size_t kMaxVertexBufferSlots = 16;
+  std::array<impeller::BufferView, kMaxVertexBufferSlots> vertex_buffers;
+  // Highest slot index that has been bound on this pass (plus one).
+  size_t vertex_buffer_count = 0;
   impeller::BufferView index_buffer;
   impeller::IndexType index_buffer_type = impeller::IndexType::kNone;
   size_t element_count = 0;
@@ -163,7 +170,8 @@ extern void InternalFlutterGpu_RenderPass_BindVertexBufferDevice(
     flutter::gpu::DeviceBuffer* device_buffer,
     int offset_in_bytes,
     int length_in_bytes,
-    int vertex_count);
+    int vertex_count,
+    int slot);
 
 FLUTTER_GPU_EXPORT
 extern void InternalFlutterGpu_RenderPass_BindIndexBufferDevice(

--- a/engine/src/flutter/lib/gpu/render_pass.h
+++ b/engine/src/flutter/lib/gpu/render_pass.h
@@ -75,9 +75,13 @@ class RenderPass : public RefCountedDartWrappable<RenderPass> {
   BufferUniformMap fragment_uniform_bindings;
   TextureUniformMap fragment_texture_bindings;
 
-  // Vertex buffers indexed by binding slot. Impeller's RenderPass accepts up
-  // to 16 vertex buffers per draw call; index `i` corresponds to the binding
-  // declared at slot `i` in the active VertexLayout.
+  // Vertex buffers indexed by binding slot. Mirrors
+  // `impeller::kMaxVertexBuffers`; Impeller's HAL caps vertex buffer
+  // bindings at 16 per draw, and index `i` here corresponds to the binding
+  // declared at slot `i` in the active VertexLayout. On the OpenGL ES
+  // backend the per-pipeline limit on the *total attribute count* across
+  // all bound buffers is `GL_MAX_VERTEX_ATTRIBS` (spec minimum 8 on GLES
+  // 2.0, 16 on GLES 3.0+), enforced by the driver.
   static constexpr size_t kMaxVertexBufferSlots = 16;
   std::array<impeller::BufferView, kMaxVertexBufferSlots> vertex_buffers;
   // Highest slot index that has been bound on this pass (plus one).

--- a/engine/src/flutter/lib/gpu/render_pipeline.cc
+++ b/engine/src/flutter/lib/gpu/render_pipeline.cc
@@ -6,7 +6,9 @@
 
 #include <array>
 #include <cstdint>
+#include <cstring>
 #include <sstream>
+#include <string_view>
 
 #include "flutter/lib/gpu/shader.h"
 #include "impeller/core/shader_types.h"
@@ -77,7 +79,9 @@ constexpr std::array<VertexFormatInfo, 12> kVertexFormatTable = {{
 constexpr size_t kBufferLayoutInts = 2;
 
 // Width of each "row" in the packed `attributes` ByteData passed from Dart:
-// `[location, bufferBinding, offset, formatIndex]`.
+// `[bufferBinding, offset, formatIndex, nameByteLength]`. The attribute name
+// itself lives in a parallel `attribute_names` byte blob walked sequentially
+// using the per-row `nameByteLength`.
 constexpr size_t kAttributeInts = 4;
 
 // Builds an `impeller::VertexDescriptor` from the user-supplied buffer
@@ -90,6 +94,8 @@ std::string BuildCustomVertexDescriptor(
     size_t buffer_layout_count,
     const int32_t* attributes,
     size_t attribute_count,
+    const char* attribute_names,
+    size_t attribute_names_byte_length,
     impeller::VertexDescriptor& out) {
   // Build the per-binding stride table. Bindings must be densely packed
   // `{0, 1, ..., buffer_layout_count - 1}` because Impeller's
@@ -126,39 +132,46 @@ std::string BuildCustomVertexDescriptor(
         {static_cast<size_t>(stride), static_cast<size_t>(binding)});
   }
 
-  // Build per-attribute IOSlots, looking up shader reflection by location
-  // for the metadata we don't carry on the Dart side.
+  // Build per-attribute IOSlots, looking up shader reflection by name for
+  // the metadata we don't carry on the Dart side. Name-keyed lookup mirrors
+  // the existing uniform binding API and keeps Dart layouts robust to
+  // shader source edits (e.g. reordering `in` declarations).
   const auto& shader_inputs = vertex_shader.GetStageInputs();
   std::vector<impeller::ShaderStageIOSlot> stage_inputs;
   stage_inputs.reserve(attribute_count);
+  size_t name_cursor = 0;
   for (size_t i = 0; i < attribute_count; ++i) {
-    const int32_t location = attributes[i * kAttributeInts + 0];
-    const int32_t buffer_binding = attributes[i * kAttributeInts + 1];
-    const int32_t offset = attributes[i * kAttributeInts + 2];
-    const int32_t format_index = attributes[i * kAttributeInts + 3];
+    const int32_t buffer_binding = attributes[i * kAttributeInts + 0];
+    const int32_t offset = attributes[i * kAttributeInts + 1];
+    const int32_t format_index = attributes[i * kAttributeInts + 2];
+    const int32_t name_byte_length = attributes[i * kAttributeInts + 3];
 
-    if (location < 0) {
-      std::ostringstream s;
-      s << "VertexAttribute.location must be non-negative (got " << location
-        << ").";
-      return s.str();
+    if (name_byte_length <= 0 ||
+        name_cursor + static_cast<size_t>(name_byte_length) >
+            attribute_names_byte_length) {
+      return "Internal error: attribute name overruns the packed names blob.";
     }
+    const std::string_view name(attribute_names + name_cursor,
+                                static_cast<size_t>(name_byte_length));
+    name_cursor += static_cast<size_t>(name_byte_length);
+
     if (buffer_binding < 0) {
       std::ostringstream s;
-      s << "VertexAttribute.bufferBinding must be non-negative (got "
-        << buffer_binding << ").";
+      s << "VertexAttribute '" << name
+        << "' bufferBinding must be non-negative (got " << buffer_binding
+        << ").";
       return s.str();
     }
     if (offset < 0) {
       std::ostringstream s;
-      s << "VertexAttribute.offsetInBytes must be non-negative (got " << offset
-        << ").";
+      s << "VertexAttribute '" << name
+        << "' offsetInBytes must be non-negative (got " << offset << ").";
       return s.str();
     }
     if (format_index < 0 ||
         static_cast<size_t>(format_index) >= kVertexFormatTable.size()) {
       std::ostringstream s;
-      s << "VertexAttribute.format index " << format_index
+      s << "VertexAttribute '" << name << "' format index " << format_index
         << " is out of range.";
       return s.str();
     }
@@ -174,35 +187,39 @@ std::string BuildCustomVertexDescriptor(
     }
     if (matching_layout == nullptr) {
       std::ostringstream s;
-      s << "VertexAttribute at location " << location
-        << " references bufferBinding " << buffer_binding
-        << " which is not declared in VertexLayout.buffers.";
+      s << "VertexAttribute '" << name << "' references bufferBinding "
+        << buffer_binding << " which is not declared in VertexLayout.buffers.";
       return s.str();
     }
     if (static_cast<size_t>(offset) + format.bytes_per_element >
         matching_layout->stride) {
       std::ostringstream s;
-      s << "VertexAttribute at location " << location << " (offset " << offset
-        << " + " << format.bytes_per_element << " bytes) overruns stride of "
+      s << "VertexAttribute '" << name << "' (offset " << offset << " + "
+        << format.bytes_per_element << " bytes) overruns stride of "
         << matching_layout->stride << " on bufferBinding " << buffer_binding
         << ".";
       return s.str();
     }
 
-    // Find the matching shader input by location to validate format and to
-    // copy the metadata we don't carry on the Dart side (name, set, columns,
-    // relaxed_precision).
+    // Find the matching shader input by name to validate format and to copy
+    // the (location, set, columns, relaxed_precision) metadata we don't
+    // carry on the Dart side. The Shader's IOSlot names point into the
+    // shader bundle flatbuffer, which the Shader keeps alive via its code
+    // mapping; the impellerc-generated builds use static string literals.
+    // Either way, strcmp against a NUL-terminated needle is safe.
     const impeller::ShaderStageIOSlot* shader_slot = nullptr;
+    const std::string name_owned(name);
     for (const auto& slot : shader_inputs) {
-      if (slot.location == static_cast<size_t>(location)) {
+      if (slot.name != nullptr &&
+          std::strcmp(slot.name, name_owned.c_str()) == 0) {
         shader_slot = &slot;
         break;
       }
     }
     if (shader_slot == nullptr) {
       std::ostringstream s;
-      s << "VertexAttribute.location " << location
-        << " does not match any input declared by the bound vertex shader.";
+      s << "VertexAttribute name '" << name
+        << "' does not match any input declared by the bound vertex shader.";
       return s.str();
     }
     // Match the shader's scalar type class (float vs signed int vs unsigned
@@ -220,8 +237,8 @@ std::string BuildCustomVertexDescriptor(
     if (shader_slot->type != format.type ||
         shader_slot->bit_width != format.bit_width) {
       std::ostringstream s;
-      s << "VertexAttribute at location " << location
-        << " format does not match the vertex shader's declared input type.";
+      s << "VertexAttribute '" << name
+        << "' format does not match the vertex shader's declared input type.";
       return s.str();
     }
 
@@ -229,6 +246,10 @@ std::string BuildCustomVertexDescriptor(
     built.binding = static_cast<size_t>(buffer_binding);
     built.offset = static_cast<size_t>(offset);
     stage_inputs.push_back(built);
+  }
+
+  if (name_cursor != attribute_names_byte_length) {
+    return "Internal error: attribute names blob has trailing bytes.";
   }
 
   out.SetStageInputs(stage_inputs, stage_layouts);
@@ -250,7 +271,8 @@ Dart_Handle InternalFlutterGpu_RenderPipeline_Initialize(
     flutter::gpu::Shader* vertex_shader,
     flutter::gpu::Shader* fragment_shader,
     Dart_Handle buffer_layouts_handle,
-    Dart_Handle attributes_handle) {
+    Dart_Handle attributes_handle,
+    Dart_Handle attribute_names_handle) {
   // Lazily register the shaders synchronously if they haven't been already.
   vertex_shader->RegisterSync(*gpu_context);
   fragment_shader->RegisterSync(*gpu_context);
@@ -259,10 +281,12 @@ Dart_Handle InternalFlutterGpu_RenderPipeline_Initialize(
 
   const bool buffer_layouts_provided = !Dart_IsNull(buffer_layouts_handle);
   const bool attributes_provided = !Dart_IsNull(attributes_handle);
-  if (buffer_layouts_provided != attributes_provided) {
+  const bool attribute_names_provided = !Dart_IsNull(attribute_names_handle);
+  if (buffer_layouts_provided != attributes_provided ||
+      attributes_provided != attribute_names_provided) {
     return tonic::ToDart(
-        "VertexLayout requires both buffer layouts and attributes to be "
-        "provided together.");
+        "VertexLayout requires buffer layouts, attributes, and attribute "
+        "names to be provided together.");
   }
 
   if (buffer_layouts_provided) {
@@ -275,10 +299,12 @@ Dart_Handle InternalFlutterGpu_RenderPipeline_Initialize(
     // and returned only after the typed-data handles go out of scope.
     std::vector<int32_t> buffer_layouts_ints;
     std::vector<int32_t> attribute_ints;
+    std::vector<char> attribute_names_bytes;
     std::string copy_error;
     {
       tonic::DartByteData buffer_layouts_data(buffer_layouts_handle);
       tonic::DartByteData attributes_data(attributes_handle);
+      tonic::DartByteData attribute_names_data(attribute_names_handle);
       if (buffer_layouts_data.length_in_bytes() %
               (flutter::gpu::kBufferLayoutInts * sizeof(int32_t)) !=
           0) {
@@ -293,6 +319,8 @@ Dart_Handle InternalFlutterGpu_RenderPipeline_Initialize(
             static_cast<const int32_t*>(buffer_layouts_data.data());
         const auto* attributes_src =
             static_cast<const int32_t*>(attributes_data.data());
+        const auto* names_src =
+            static_cast<const char*>(attribute_names_data.data());
         buffer_layouts_ints.assign(
             buffer_layouts_src,
             buffer_layouts_src +
@@ -300,6 +328,8 @@ Dart_Handle InternalFlutterGpu_RenderPipeline_Initialize(
         attribute_ints.assign(
             attributes_src, attributes_src + attributes_data.length_in_bytes() /
                                                  sizeof(int32_t));
+        attribute_names_bytes.assign(
+            names_src, names_src + attribute_names_data.length_in_bytes());
       }
     }
     if (!copy_error.empty()) {
@@ -314,7 +344,8 @@ Dart_Handle InternalFlutterGpu_RenderPipeline_Initialize(
     auto descriptor = std::make_shared<impeller::VertexDescriptor>();
     std::string error = flutter::gpu::BuildCustomVertexDescriptor(
         *vertex_shader, buffer_layouts_ints.data(), buffer_layout_count,
-        attribute_ints.data(), attribute_count, *descriptor);
+        attribute_ints.data(), attribute_count, attribute_names_bytes.data(),
+        attribute_names_bytes.size(), *descriptor);
     if (!error.empty()) {
       return tonic::ToDart(error);
     }

--- a/engine/src/flutter/lib/gpu/render_pipeline.cc
+++ b/engine/src/flutter/lib/gpu/render_pipeline.cc
@@ -4,8 +4,15 @@
 
 #include "flutter/lib/gpu/render_pipeline.h"
 
+#include <array>
+#include <cstdint>
+#include <sstream>
+
 #include "flutter/lib/gpu/shader.h"
+#include "impeller/core/shader_types.h"
 #include "impeller/renderer/pipeline_descriptor.h"
+#include "impeller/renderer/vertex_descriptor.h"
+#include "third_party/tonic/typed_data/dart_byte_data.h"
 
 namespace flutter {
 namespace gpu {
@@ -14,27 +21,221 @@ IMPLEMENT_WRAPPERTYPEINFO(flutter_gpu, RenderPipeline);
 
 RenderPipeline::RenderPipeline(
     fml::RefPtr<flutter::gpu::Shader> vertex_shader,
-    fml::RefPtr<flutter::gpu::Shader> fragment_shader)
+    fml::RefPtr<flutter::gpu::Shader> fragment_shader,
+    std::shared_ptr<impeller::VertexDescriptor> vertex_descriptor)
     : vertex_shader_(std::move(vertex_shader)),
-      fragment_shader_(std::move(fragment_shader)) {}
+      fragment_shader_(std::move(fragment_shader)),
+      vertex_descriptor_(std::move(vertex_descriptor)) {}
 
 void RenderPipeline::BindToPipelineDescriptor(
     impeller::ShaderLibrary& library,
     impeller::PipelineDescriptor& desc) {
-  auto vertex_descriptor = vertex_shader_->CreateVertexDescriptor();
-  vertex_descriptor->RegisterDescriptorSetLayouts(
+  vertex_descriptor_->RegisterDescriptorSetLayouts(
       vertex_shader_->GetDescriptorSetLayouts().data(),
       vertex_shader_->GetDescriptorSetLayouts().size());
-  vertex_descriptor->RegisterDescriptorSetLayouts(
+  vertex_descriptor_->RegisterDescriptorSetLayouts(
       fragment_shader_->GetDescriptorSetLayouts().data(),
       fragment_shader_->GetDescriptorSetLayouts().size());
-  desc.SetVertexDescriptor(vertex_descriptor);
+  desc.SetVertexDescriptor(vertex_descriptor_);
 
   desc.AddStageEntrypoint(vertex_shader_->GetFunctionFromLibrary(library));
   desc.AddStageEntrypoint(fragment_shader_->GetFunctionFromLibrary(library));
 }
 
 RenderPipeline::~RenderPipeline() = default;
+
+namespace {
+
+// Translation table from the Dart-side `VertexFormat` enum (encoded as the
+// enum index) to the `(ShaderType, bit_width, vec_size, bytes_per_element)`
+// tuple Impeller's HAL stores in `ShaderStageIOSlot`. The order MUST stay
+// in sync with `lib/src/vertex_layout.dart`.
+struct VertexFormatInfo {
+  impeller::ShaderType type;
+  size_t bit_width;
+  size_t vec_size;
+  size_t bytes_per_element;
+};
+
+constexpr std::array<VertexFormatInfo, 12> kVertexFormatTable = {{
+    {impeller::ShaderType::kFloat, 32, 1, 4},         // float32
+    {impeller::ShaderType::kFloat, 32, 2, 8},         // float32x2
+    {impeller::ShaderType::kFloat, 32, 3, 12},        // float32x3
+    {impeller::ShaderType::kFloat, 32, 4, 16},        // float32x4
+    {impeller::ShaderType::kUnsignedInt, 32, 1, 4},   // uint32
+    {impeller::ShaderType::kUnsignedInt, 32, 2, 8},   // uint32x2
+    {impeller::ShaderType::kUnsignedInt, 32, 3, 12},  // uint32x3
+    {impeller::ShaderType::kUnsignedInt, 32, 4, 16},  // uint32x4
+    {impeller::ShaderType::kSignedInt, 32, 1, 4},     // sint32
+    {impeller::ShaderType::kSignedInt, 32, 2, 8},     // sint32x2
+    {impeller::ShaderType::kSignedInt, 32, 3, 12},    // sint32x3
+    {impeller::ShaderType::kSignedInt, 32, 4, 16},    // sint32x4
+}};
+
+// Width of each "row" in the packed `bufferLayouts` ByteData passed from
+// Dart: `[binding, stride]`.
+constexpr size_t kBufferLayoutInts = 2;
+
+// Width of each "row" in the packed `attributes` ByteData passed from Dart:
+// `[location, bufferBinding, offset, formatIndex]`.
+constexpr size_t kAttributeInts = 4;
+
+// Builds an `impeller::VertexDescriptor` from the user-supplied buffer
+// layout and attribute arrays, validating each entry against the vertex
+// shader's reflection metadata. On validation failure, returns a non-empty
+// string describing the first problem found.
+std::string BuildCustomVertexDescriptor(
+    const flutter::gpu::Shader& vertex_shader,
+    const int32_t* buffer_layouts,
+    size_t buffer_layout_count,
+    const int32_t* attributes,
+    size_t attribute_count,
+    impeller::VertexDescriptor& out) {
+  // Build the per-binding stride table. Bindings must be densely packed
+  // `{0, 1, ..., buffer_layout_count - 1}` because Impeller's
+  // RenderPass::SetVertexBuffer rejects sparse bindings; the HAL would need
+  // a `firstBinding`-style entry point before this restriction can be lifted.
+  // TODO(https://github.com/flutter/flutter/issues/186308): Allow sparse
+  // vertex buffer binding indices.
+  std::vector<impeller::ShaderStageBufferLayout> stage_layouts;
+  stage_layouts.reserve(buffer_layout_count);
+  std::vector<bool> binding_seen(buffer_layout_count, false);
+  for (size_t i = 0; i < buffer_layout_count; ++i) {
+    const int32_t binding = buffer_layouts[i * kBufferLayoutInts + 0];
+    const int32_t stride = buffer_layouts[i * kBufferLayoutInts + 1];
+    if (binding < 0 || static_cast<size_t>(binding) >= buffer_layout_count) {
+      std::ostringstream s;
+      s << "VertexBufferLayout.binding must be in [0, " << buffer_layout_count
+        << ") (got " << binding
+        << "); binding indices must be densely packed starting from 0.";
+      return s.str();
+    }
+    if (binding_seen[binding]) {
+      std::ostringstream s;
+      s << "VertexBufferLayout.binding " << binding << " was declared twice.";
+      return s.str();
+    }
+    binding_seen[binding] = true;
+    if (stride <= 0) {
+      std::ostringstream s;
+      s << "VertexBufferLayout.strideInBytes must be positive (got " << stride
+        << ").";
+      return s.str();
+    }
+    stage_layouts.push_back(
+        {static_cast<size_t>(stride), static_cast<size_t>(binding)});
+  }
+
+  // Build per-attribute IOSlots, looking up shader reflection by location
+  // for the metadata we don't carry on the Dart side.
+  const auto& shader_inputs = vertex_shader.GetStageInputs();
+  std::vector<impeller::ShaderStageIOSlot> stage_inputs;
+  stage_inputs.reserve(attribute_count);
+  for (size_t i = 0; i < attribute_count; ++i) {
+    const int32_t location = attributes[i * kAttributeInts + 0];
+    const int32_t buffer_binding = attributes[i * kAttributeInts + 1];
+    const int32_t offset = attributes[i * kAttributeInts + 2];
+    const int32_t format_index = attributes[i * kAttributeInts + 3];
+
+    if (location < 0) {
+      std::ostringstream s;
+      s << "VertexAttribute.location must be non-negative (got " << location
+        << ").";
+      return s.str();
+    }
+    if (buffer_binding < 0) {
+      std::ostringstream s;
+      s << "VertexAttribute.bufferBinding must be non-negative (got "
+        << buffer_binding << ").";
+      return s.str();
+    }
+    if (offset < 0) {
+      std::ostringstream s;
+      s << "VertexAttribute.offsetInBytes must be non-negative (got " << offset
+        << ").";
+      return s.str();
+    }
+    if (format_index < 0 ||
+        static_cast<size_t>(format_index) >= kVertexFormatTable.size()) {
+      std::ostringstream s;
+      s << "VertexAttribute.format index " << format_index
+        << " is out of range.";
+      return s.str();
+    }
+    const VertexFormatInfo& format = kVertexFormatTable[format_index];
+
+    // Find the matching layout (for stride bounds checking).
+    const impeller::ShaderStageBufferLayout* matching_layout = nullptr;
+    for (const auto& layout : stage_layouts) {
+      if (layout.binding == static_cast<size_t>(buffer_binding)) {
+        matching_layout = &layout;
+        break;
+      }
+    }
+    if (matching_layout == nullptr) {
+      std::ostringstream s;
+      s << "VertexAttribute at location " << location
+        << " references bufferBinding " << buffer_binding
+        << " which is not declared in VertexLayout.buffers.";
+      return s.str();
+    }
+    if (static_cast<size_t>(offset) + format.bytes_per_element >
+        matching_layout->stride) {
+      std::ostringstream s;
+      s << "VertexAttribute at location " << location << " (offset " << offset
+        << " + " << format.bytes_per_element << " bytes) overruns stride of "
+        << matching_layout->stride << " on bufferBinding " << buffer_binding
+        << ".";
+      return s.str();
+    }
+
+    // Find the matching shader input by location to validate format and to
+    // copy the metadata we don't carry on the Dart side (name, set, columns,
+    // relaxed_precision).
+    const impeller::ShaderStageIOSlot* shader_slot = nullptr;
+    for (const auto& slot : shader_inputs) {
+      if (slot.location == static_cast<size_t>(location)) {
+        shader_slot = &slot;
+        break;
+      }
+    }
+    if (shader_slot == nullptr) {
+      std::ostringstream s;
+      s << "VertexAttribute.location " << location
+        << " does not match any input declared by the bound vertex shader.";
+      return s.str();
+    }
+    // Match the shader's scalar type class (float vs signed int vs unsigned
+    // int). Mirroring WebGPU, Vulkan, and Metal, component-count mismatches
+    // are NOT errors: the shader receives default substitution (missing
+    // components default to (0, 0, 0, 1)) when the buffer supplies fewer
+    // components than declared, and reads only the leading components when
+    // the buffer supplies more. The shipped enum only contains 32-bit
+    // formats, so checking `type` alone is sufficient until 8/16-bit
+    // formats are added.
+    // TODO(https://github.com/flutter/flutter/issues/186309): Add
+    // normalized, packed, half-float, BGRA-swizzled, and 64-bit vertex
+    // attribute formats; the format check will need to also verify
+    // `bit_width` once those land.
+    if (shader_slot->type != format.type ||
+        shader_slot->bit_width != format.bit_width) {
+      std::ostringstream s;
+      s << "VertexAttribute at location " << location
+        << " format does not match the vertex shader's declared input type.";
+      return s.str();
+    }
+
+    impeller::ShaderStageIOSlot built = *shader_slot;
+    built.binding = static_cast<size_t>(buffer_binding);
+    built.offset = static_cast<size_t>(offset);
+    stage_inputs.push_back(built);
+  }
+
+  out.SetStageInputs(stage_inputs, stage_layouts);
+  return {};
+}
+
+}  // namespace
 
 }  // namespace gpu
 }  // namespace flutter
@@ -47,14 +248,85 @@ Dart_Handle InternalFlutterGpu_RenderPipeline_Initialize(
     Dart_Handle wrapper,
     flutter::gpu::Context* gpu_context,
     flutter::gpu::Shader* vertex_shader,
-    flutter::gpu::Shader* fragment_shader) {
+    flutter::gpu::Shader* fragment_shader,
+    Dart_Handle buffer_layouts_handle,
+    Dart_Handle attributes_handle) {
   // Lazily register the shaders synchronously if they haven't been already.
   vertex_shader->RegisterSync(*gpu_context);
   fragment_shader->RegisterSync(*gpu_context);
 
+  std::shared_ptr<impeller::VertexDescriptor> vertex_descriptor;
+
+  const bool buffer_layouts_provided = !Dart_IsNull(buffer_layouts_handle);
+  const bool attributes_provided = !Dart_IsNull(attributes_handle);
+  if (buffer_layouts_provided != attributes_provided) {
+    return tonic::ToDart(
+        "VertexLayout requires both buffer layouts and attributes to be "
+        "provided together.");
+  }
+
+  if (buffer_layouts_provided) {
+    // Copy the packed Dart-side ByteData buffers into local vectors so the
+    // tonic::DartByteData typed-data handles are released before we make any
+    // call back into the Dart VM (e.g. tonic::ToDart for an error string).
+    // Holding a typed-data handle while calling into the VM raises
+    // "Callbacks into the Dart VM are currently prohibited." Errors raised
+    // inside the inner scope must therefore be deferred to a local string
+    // and returned only after the typed-data handles go out of scope.
+    std::vector<int32_t> buffer_layouts_ints;
+    std::vector<int32_t> attribute_ints;
+    std::string copy_error;
+    {
+      tonic::DartByteData buffer_layouts_data(buffer_layouts_handle);
+      tonic::DartByteData attributes_data(attributes_handle);
+      if (buffer_layouts_data.length_in_bytes() %
+              (flutter::gpu::kBufferLayoutInts * sizeof(int32_t)) !=
+          0) {
+        copy_error =
+            "Internal error: buffer layouts ByteData has invalid length.";
+      } else if (attributes_data.length_in_bytes() %
+                     (flutter::gpu::kAttributeInts * sizeof(int32_t)) !=
+                 0) {
+        copy_error = "Internal error: attributes ByteData has invalid length.";
+      } else {
+        const auto* buffer_layouts_src =
+            static_cast<const int32_t*>(buffer_layouts_data.data());
+        const auto* attributes_src =
+            static_cast<const int32_t*>(attributes_data.data());
+        buffer_layouts_ints.assign(
+            buffer_layouts_src,
+            buffer_layouts_src +
+                buffer_layouts_data.length_in_bytes() / sizeof(int32_t));
+        attribute_ints.assign(
+            attributes_src, attributes_src + attributes_data.length_in_bytes() /
+                                                 sizeof(int32_t));
+      }
+    }
+    if (!copy_error.empty()) {
+      return tonic::ToDart(copy_error);
+    }
+
+    const size_t buffer_layout_count =
+        buffer_layouts_ints.size() / flutter::gpu::kBufferLayoutInts;
+    const size_t attribute_count =
+        attribute_ints.size() / flutter::gpu::kAttributeInts;
+
+    auto descriptor = std::make_shared<impeller::VertexDescriptor>();
+    std::string error = flutter::gpu::BuildCustomVertexDescriptor(
+        *vertex_shader, buffer_layouts_ints.data(), buffer_layout_count,
+        attribute_ints.data(), attribute_count, *descriptor);
+    if (!error.empty()) {
+      return tonic::ToDart(error);
+    }
+    vertex_descriptor = std::move(descriptor);
+  } else {
+    vertex_descriptor = vertex_shader->CreateVertexDescriptor();
+  }
+
   auto res = fml::MakeRefCounted<flutter::gpu::RenderPipeline>(
-      fml::RefPtr<flutter::gpu::Shader>(vertex_shader),  //
-      fml::RefPtr<flutter::gpu::Shader>(fragment_shader));
+      fml::RefPtr<flutter::gpu::Shader>(vertex_shader),    //
+      fml::RefPtr<flutter::gpu::Shader>(fragment_shader),  //
+      std::move(vertex_descriptor));
   res->AssociateWithDartWrapper(wrapper);
 
   return Dart_Null();

--- a/engine/src/flutter/lib/gpu/render_pipeline.cc
+++ b/engine/src/flutter/lib/gpu/render_pipeline.cc
@@ -7,13 +7,16 @@
 #include <array>
 #include <cstdint>
 #include <cstring>
-#include <sstream>
+#include <span>
 #include <string_view>
 
 #include "flutter/lib/gpu/shader.h"
 #include "impeller/core/shader_types.h"
 #include "impeller/renderer/pipeline_descriptor.h"
 #include "impeller/renderer/vertex_descriptor.h"
+#include "third_party/abseil-cpp/absl/status/status.h"
+#include "third_party/abseil-cpp/absl/status/statusor.h"
+#include "third_party/abseil-cpp/absl/strings/str_cat.h"
 #include "third_party/tonic/typed_data/dart_byte_data.h"
 
 namespace flutter {
@@ -27,17 +30,22 @@ RenderPipeline::RenderPipeline(
     std::shared_ptr<impeller::VertexDescriptor> vertex_descriptor)
     : vertex_shader_(std::move(vertex_shader)),
       fragment_shader_(std::move(fragment_shader)),
-      vertex_descriptor_(std::move(vertex_descriptor)) {}
-
-void RenderPipeline::BindToPipelineDescriptor(
-    impeller::ShaderLibrary& library,
-    impeller::PipelineDescriptor& desc) {
+      vertex_descriptor_(std::move(vertex_descriptor)) {
+  // Register the descriptor set layouts contributed by each shader exactly
+  // once, here at construction. Doing this in BindToPipelineDescriptor (as
+  // earlier revisions did) would append the same layouts on every bind
+  // since `RegisterDescriptorSetLayouts` accumulates rather than replaces.
   vertex_descriptor_->RegisterDescriptorSetLayouts(
       vertex_shader_->GetDescriptorSetLayouts().data(),
       vertex_shader_->GetDescriptorSetLayouts().size());
   vertex_descriptor_->RegisterDescriptorSetLayouts(
       fragment_shader_->GetDescriptorSetLayouts().data(),
       fragment_shader_->GetDescriptorSetLayouts().size());
+}
+
+void RenderPipeline::BindToPipelineDescriptor(
+    impeller::ShaderLibrary& library,
+    impeller::PipelineDescriptor& desc) {
   desc.SetVertexDescriptor(vertex_descriptor_);
 
   desc.AddStageEntrypoint(vertex_shader_->GetFunctionFromLibrary(library));
@@ -89,8 +97,8 @@ constexpr size_t kAttributeInts = 3;
 
 // Builds an `impeller::VertexDescriptor` from the user-supplied buffer
 // layout and attribute arrays, validating each entry against the vertex
-// shader's reflection metadata. On validation failure, returns a non-empty
-// string describing the first problem found.
+// shader's reflection metadata. On validation failure, returns a non-OK
+// status whose message describes the first problem found.
 //
 // Binding slots are implicit in buffer-list position. Buffer N (0-indexed)
 // is bound at binding slot N. This makes sparse bindings impossible to
@@ -99,15 +107,13 @@ constexpr size_t kAttributeInts = 3;
 // `firstBinding`-style entry point added to the HAL.
 // TODO(https://github.com/flutter/flutter/issues/186308): Allow sparse
 // vertex buffer binding slots.
-std::string BuildCustomVertexDescriptor(
-    const flutter::gpu::Shader& vertex_shader,
-    const int32_t* buffer_layouts,
-    size_t buffer_layout_count,
-    const int32_t* attributes,
-    size_t attribute_count,
-    const char* attribute_names,
-    size_t attribute_names_byte_length,
-    impeller::VertexDescriptor& out) {
+absl::StatusOr<std::shared_ptr<impeller::VertexDescriptor>>
+BuildCustomVertexDescriptor(const flutter::gpu::Shader& vertex_shader,
+                            std::span<const int32_t> buffer_layouts,
+                            std::span<const int32_t> attributes,
+                            std::span<const char> attribute_names) {
+  const size_t buffer_layout_count = buffer_layouts.size() / kBufferLayoutInts;
+  const size_t attribute_count = attributes.size() / kAttributeInts;
   const auto& shader_inputs = vertex_shader.GetStageInputs();
 
   std::vector<impeller::ShaderStageBufferLayout> stage_layouts;
@@ -123,16 +129,16 @@ std::string BuildCustomVertexDescriptor(
     const int32_t attr_count_in_buffer =
         buffer_layouts[buffer_index * kBufferLayoutInts + 1];
     if (stride <= 0) {
-      std::ostringstream s;
-      s << "VertexBuffer.strideInBytes must be positive (got " << stride
-        << ") on buffer at index " << buffer_index << ".";
-      return s.str();
+      return absl::InvalidArgumentError(
+          absl::StrCat("VertexBuffer.strideInBytes must be positive (got ",
+                       stride, ") on buffer at index ", buffer_index, "."));
     }
     if (attr_count_in_buffer < 0 ||
         attr_cursor + static_cast<size_t>(attr_count_in_buffer) >
             attribute_count) {
-      return "Internal error: attribute count overruns the packed attributes "
-             "blob.";
+      return absl::InvalidArgumentError(
+          "Internal error: attribute count overruns the packed attributes "
+          "blob.");
     }
     stage_layouts.push_back({static_cast<size_t>(stride), buffer_index});
 
@@ -155,36 +161,33 @@ std::string BuildCustomVertexDescriptor(
 
       if (name_byte_length <= 0 ||
           name_cursor + static_cast<size_t>(name_byte_length) >
-              attribute_names_byte_length) {
-        return "Internal error: attribute name overruns the packed names "
-               "blob.";
+              attribute_names.size()) {
+        return absl::InvalidArgumentError(
+            "Internal error: attribute name overruns the packed names blob.");
       }
-      const std::string_view name(attribute_names + name_cursor,
+      const std::string_view name(attribute_names.data() + name_cursor,
                                   static_cast<size_t>(name_byte_length));
       name_cursor += static_cast<size_t>(name_byte_length);
 
       if (offset < 0) {
-        std::ostringstream s;
-        s << "VertexAttribute '" << name
-          << "' offsetInBytes must be non-negative (got " << offset << ").";
-        return s.str();
+        return absl::InvalidArgumentError(absl::StrCat(
+            "VertexAttribute '", name,
+            "' offsetInBytes must be non-negative (got ", offset, ")."));
       }
       if (format_index < 0 ||
           static_cast<size_t>(format_index) >= kVertexFormatTable.size()) {
-        std::ostringstream s;
-        s << "VertexAttribute '" << name << "' format index " << format_index
-          << " is out of range.";
-        return s.str();
+        return absl::InvalidArgumentError(
+            absl::StrCat("VertexAttribute '", name, "' format index ",
+                         format_index, " is out of range."));
       }
       const VertexFormatInfo& format = kVertexFormatTable[format_index];
 
       if (static_cast<size_t>(offset) + format.bytes_per_element >
           static_cast<size_t>(stride)) {
-        std::ostringstream s;
-        s << "VertexAttribute '" << name << "' (offset " << offset << " + "
-          << format.bytes_per_element << " bytes) overruns stride of " << stride
-          << " on buffer at index " << buffer_index << ".";
-        return s.str();
+        return absl::InvalidArgumentError(absl::StrCat(
+            "VertexAttribute '", name, "' (offset ", offset, " + ",
+            format.bytes_per_element, " bytes) overruns stride of ", stride,
+            " on buffer at index ", buffer_index, "."));
       }
 
       // Detect overlap against earlier attributes in this buffer before
@@ -195,12 +198,11 @@ std::string BuildCustomVertexDescriptor(
       const std::string name_owned(name);
       for (const auto& other : ranges_in_buffer) {
         if (begin < other.end && other.begin < end) {
-          std::ostringstream s;
-          s << "VertexAttribute '" << name << "' (bytes [" << begin << ", "
-            << end << ")) overlaps VertexAttribute '" << other.name
-            << "' (bytes [" << other.begin << ", " << other.end
-            << ")) on buffer at index " << buffer_index << ".";
-          return s.str();
+          return absl::InvalidArgumentError(
+              absl::StrCat("VertexAttribute '", name, "' (bytes [", begin, ", ",
+                           end, ")) overlaps VertexAttribute '", other.name,
+                           "' (bytes [", other.begin, ", ", other.end,
+                           ")) on buffer at index ", buffer_index, "."));
         }
       }
       ranges_in_buffer.push_back({name_owned, begin, end});
@@ -221,11 +223,10 @@ std::string BuildCustomVertexDescriptor(
         }
       }
       if (shader_slot == nullptr) {
-        std::ostringstream s;
-        s << "VertexAttribute name '" << name
-          << "' does not match any input declared by the bound vertex "
-             "shader.";
-        return s.str();
+        return absl::InvalidArgumentError(absl::StrCat(
+            "VertexAttribute name '", name,
+            "' does not match any input declared by the bound vertex "
+            "shader."));
       }
       // Match the shader's scalar type class (float vs signed int vs
       // unsigned int). Mirroring WebGPU, Vulkan, and Metal, component-count
@@ -241,11 +242,10 @@ std::string BuildCustomVertexDescriptor(
       // `bit_width` once those land.
       if (shader_slot->type != format.type ||
           shader_slot->bit_width != format.bit_width) {
-        std::ostringstream s;
-        s << "VertexAttribute '" << name
-          << "' format does not match the vertex shader's declared input "
-             "type.";
-        return s.str();
+        return absl::InvalidArgumentError(absl::StrCat(
+            "VertexAttribute '", name,
+            "' format does not match the vertex shader's declared input "
+            "type."));
       }
 
       impeller::ShaderStageIOSlot built = *shader_slot;
@@ -256,15 +256,18 @@ std::string BuildCustomVertexDescriptor(
   }
 
   if (attr_cursor != attribute_count) {
-    return "Internal error: attributes blob has trailing rows not consumed "
-           "by any buffer.";
+    return absl::InvalidArgumentError(
+        "Internal error: attributes blob has trailing rows not consumed "
+        "by any buffer.");
   }
-  if (name_cursor != attribute_names_byte_length) {
-    return "Internal error: attribute names blob has trailing bytes.";
+  if (name_cursor != attribute_names.size()) {
+    return absl::InvalidArgumentError(
+        "Internal error: attribute names blob has trailing bytes.");
   }
 
-  out.SetStageInputs(stage_inputs, stage_layouts);
-  return {};
+  auto descriptor = std::make_shared<impeller::VertexDescriptor>();
+  descriptor->SetStageInputs(stage_inputs, stage_layouts);
+  return descriptor;
 }
 
 }  // namespace
@@ -347,20 +350,19 @@ Dart_Handle InternalFlutterGpu_RenderPipeline_Initialize(
       return tonic::ToDart(copy_error);
     }
 
-    const size_t buffer_layout_count =
-        buffer_layouts_ints.size() / flutter::gpu::kBufferLayoutInts;
-    const size_t attribute_count =
-        attribute_ints.size() / flutter::gpu::kAttributeInts;
-
-    auto descriptor = std::make_shared<impeller::VertexDescriptor>();
-    std::string error = flutter::gpu::BuildCustomVertexDescriptor(
-        *vertex_shader, buffer_layouts_ints.data(), buffer_layout_count,
-        attribute_ints.data(), attribute_count, attribute_names_bytes.data(),
-        attribute_names_bytes.size(), *descriptor);
-    if (!error.empty()) {
-      return tonic::ToDart(error);
+    absl::StatusOr<std::shared_ptr<impeller::VertexDescriptor>> built =
+        flutter::gpu::BuildCustomVertexDescriptor(
+            *vertex_shader,
+            std::span<const int32_t>(buffer_layouts_ints.data(),
+                                     buffer_layouts_ints.size()),
+            std::span<const int32_t>(attribute_ints.data(),
+                                     attribute_ints.size()),
+            std::span<const char>(attribute_names_bytes.data(),
+                                  attribute_names_bytes.size()));
+    if (!built.ok()) {
+      return tonic::ToDart(std::string(built.status().message()));
     }
-    vertex_descriptor = std::move(descriptor);
+    vertex_descriptor = *std::move(built);
   } else {
     vertex_descriptor = vertex_shader->CreateVertexDescriptor();
   }

--- a/engine/src/flutter/lib/gpu/render_pipeline.cc
+++ b/engine/src/flutter/lib/gpu/render_pipeline.cc
@@ -75,19 +75,30 @@ constexpr std::array<VertexFormatInfo, 12> kVertexFormatTable = {{
 }};
 
 // Width of each "row" in the packed `bufferLayouts` ByteData passed from
-// Dart: `[binding, stride]`.
+// Dart: `[strideInBytes, attributeCount]`. Each buffer's binding slot is
+// implicit in its position in the array (the first buffer is slot 0, etc.).
 constexpr size_t kBufferLayoutInts = 2;
 
 // Width of each "row" in the packed `attributes` ByteData passed from Dart:
-// `[bufferBinding, offset, formatIndex, nameByteLength]`. The attribute name
-// itself lives in a parallel `attribute_names` byte blob walked sequentially
-// using the per-row `nameByteLength`.
-constexpr size_t kAttributeInts = 4;
+// `[offsetInBytes, formatIndex, nameByteLength]`. Attribute rows are
+// flattened across buffers in buffer-list order; each buffer's
+// `attributeCount` indicates how many attribute rows belong to it. The
+// attribute name itself lives in a parallel `attribute_names` byte blob
+// walked sequentially using the per-row `nameByteLength`.
+constexpr size_t kAttributeInts = 3;
 
 // Builds an `impeller::VertexDescriptor` from the user-supplied buffer
 // layout and attribute arrays, validating each entry against the vertex
 // shader's reflection metadata. On validation failure, returns a non-empty
 // string describing the first problem found.
+//
+// Binding slots are implicit in buffer-list position. Buffer N (0-indexed)
+// is bound at binding slot N. This makes sparse bindings impossible to
+// express by construction; Impeller's RenderPass::SetVertexBuffer also
+// rejects sparse bindings, and lifting that restriction would need a
+// `firstBinding`-style entry point added to the HAL.
+// TODO(https://github.com/flutter/flutter/issues/186308): Allow sparse
+// vertex buffer binding slots.
 std::string BuildCustomVertexDescriptor(
     const flutter::gpu::Shader& vertex_shader,
     const int32_t* buffer_layouts,
@@ -97,157 +108,157 @@ std::string BuildCustomVertexDescriptor(
     const char* attribute_names,
     size_t attribute_names_byte_length,
     impeller::VertexDescriptor& out) {
-  // Build the per-binding stride table. Bindings must be densely packed
-  // `{0, 1, ..., buffer_layout_count - 1}` because Impeller's
-  // RenderPass::SetVertexBuffer rejects sparse bindings; the HAL would need
-  // a `firstBinding`-style entry point before this restriction can be lifted.
-  // TODO(https://github.com/flutter/flutter/issues/186308): Allow sparse
-  // vertex buffer binding indices.
+  const auto& shader_inputs = vertex_shader.GetStageInputs();
+
   std::vector<impeller::ShaderStageBufferLayout> stage_layouts;
   stage_layouts.reserve(buffer_layout_count);
-  std::vector<bool> binding_seen(buffer_layout_count, false);
-  for (size_t i = 0; i < buffer_layout_count; ++i) {
-    const int32_t binding = buffer_layouts[i * kBufferLayoutInts + 0];
-    const int32_t stride = buffer_layouts[i * kBufferLayoutInts + 1];
-    if (binding < 0 || static_cast<size_t>(binding) >= buffer_layout_count) {
-      std::ostringstream s;
-      s << "VertexBufferLayout.binding must be in [0, " << buffer_layout_count
-        << ") (got " << binding
-        << "); binding indices must be densely packed starting from 0.";
-      return s.str();
-    }
-    if (binding_seen[binding]) {
-      std::ostringstream s;
-      s << "VertexBufferLayout.binding " << binding << " was declared twice.";
-      return s.str();
-    }
-    binding_seen[binding] = true;
-    if (stride <= 0) {
-      std::ostringstream s;
-      s << "VertexBufferLayout.strideInBytes must be positive (got " << stride
-        << ").";
-      return s.str();
-    }
-    stage_layouts.push_back(
-        {static_cast<size_t>(stride), static_cast<size_t>(binding)});
-  }
-
-  // Build per-attribute IOSlots, looking up shader reflection by name for
-  // the metadata we don't carry on the Dart side. Name-keyed lookup mirrors
-  // the existing uniform binding API and keeps Dart layouts robust to
-  // shader source edits (e.g. reordering `in` declarations).
-  const auto& shader_inputs = vertex_shader.GetStageInputs();
   std::vector<impeller::ShaderStageIOSlot> stage_inputs;
   stage_inputs.reserve(attribute_count);
+
+  size_t attr_cursor = 0;
   size_t name_cursor = 0;
-  for (size_t i = 0; i < attribute_count; ++i) {
-    const int32_t buffer_binding = attributes[i * kAttributeInts + 0];
-    const int32_t offset = attributes[i * kAttributeInts + 1];
-    const int32_t format_index = attributes[i * kAttributeInts + 2];
-    const int32_t name_byte_length = attributes[i * kAttributeInts + 3];
-
-    if (name_byte_length <= 0 ||
-        name_cursor + static_cast<size_t>(name_byte_length) >
-            attribute_names_byte_length) {
-      return "Internal error: attribute name overruns the packed names blob.";
-    }
-    const std::string_view name(attribute_names + name_cursor,
-                                static_cast<size_t>(name_byte_length));
-    name_cursor += static_cast<size_t>(name_byte_length);
-
-    if (buffer_binding < 0) {
+  for (size_t buffer_index = 0; buffer_index < buffer_layout_count;
+       ++buffer_index) {
+    const int32_t stride = buffer_layouts[buffer_index * kBufferLayoutInts + 0];
+    const int32_t attr_count_in_buffer =
+        buffer_layouts[buffer_index * kBufferLayoutInts + 1];
+    if (stride <= 0) {
       std::ostringstream s;
-      s << "VertexAttribute '" << name
-        << "' bufferBinding must be non-negative (got " << buffer_binding
-        << ").";
+      s << "VertexBuffer.strideInBytes must be positive (got " << stride
+        << ") on buffer at index " << buffer_index << ".";
       return s.str();
     }
-    if (offset < 0) {
-      std::ostringstream s;
-      s << "VertexAttribute '" << name
-        << "' offsetInBytes must be non-negative (got " << offset << ").";
-      return s.str();
+    if (attr_count_in_buffer < 0 ||
+        attr_cursor + static_cast<size_t>(attr_count_in_buffer) >
+            attribute_count) {
+      return "Internal error: attribute count overruns the packed attributes "
+             "blob.";
     }
-    if (format_index < 0 ||
-        static_cast<size_t>(format_index) >= kVertexFormatTable.size()) {
-      std::ostringstream s;
-      s << "VertexAttribute '" << name << "' format index " << format_index
-        << " is out of range.";
-      return s.str();
-    }
-    const VertexFormatInfo& format = kVertexFormatTable[format_index];
+    stage_layouts.push_back({static_cast<size_t>(stride), buffer_index});
 
-    // Find the matching layout (for stride bounds checking).
-    const impeller::ShaderStageBufferLayout* matching_layout = nullptr;
-    for (const auto& layout : stage_layouts) {
-      if (layout.binding == static_cast<size_t>(buffer_binding)) {
-        matching_layout = &layout;
-        break;
+    // Track each attribute's byte range within this buffer so we can
+    // detect overlaps after building them all.
+    struct AttrRange {
+      std::string name;
+      size_t begin;
+      size_t end;
+    };
+    std::vector<AttrRange> ranges_in_buffer;
+    ranges_in_buffer.reserve(attr_count_in_buffer);
+
+    for (size_t a = 0; a < static_cast<size_t>(attr_count_in_buffer); ++a) {
+      const int32_t offset = attributes[attr_cursor * kAttributeInts + 0];
+      const int32_t format_index = attributes[attr_cursor * kAttributeInts + 1];
+      const int32_t name_byte_length =
+          attributes[attr_cursor * kAttributeInts + 2];
+      ++attr_cursor;
+
+      if (name_byte_length <= 0 ||
+          name_cursor + static_cast<size_t>(name_byte_length) >
+              attribute_names_byte_length) {
+        return "Internal error: attribute name overruns the packed names "
+               "blob.";
       }
-    }
-    if (matching_layout == nullptr) {
-      std::ostringstream s;
-      s << "VertexAttribute '" << name << "' references bufferBinding "
-        << buffer_binding << " which is not declared in VertexLayout.buffers.";
-      return s.str();
-    }
-    if (static_cast<size_t>(offset) + format.bytes_per_element >
-        matching_layout->stride) {
-      std::ostringstream s;
-      s << "VertexAttribute '" << name << "' (offset " << offset << " + "
-        << format.bytes_per_element << " bytes) overruns stride of "
-        << matching_layout->stride << " on bufferBinding " << buffer_binding
-        << ".";
-      return s.str();
-    }
+      const std::string_view name(attribute_names + name_cursor,
+                                  static_cast<size_t>(name_byte_length));
+      name_cursor += static_cast<size_t>(name_byte_length);
 
-    // Find the matching shader input by name to validate format and to copy
-    // the (location, set, columns, relaxed_precision) metadata we don't
-    // carry on the Dart side. The Shader's IOSlot names point into the
-    // shader bundle flatbuffer, which the Shader keeps alive via its code
-    // mapping; the impellerc-generated builds use static string literals.
-    // Either way, strcmp against a NUL-terminated needle is safe.
-    const impeller::ShaderStageIOSlot* shader_slot = nullptr;
-    const std::string name_owned(name);
-    for (const auto& slot : shader_inputs) {
-      if (slot.name != nullptr &&
-          std::strcmp(slot.name, name_owned.c_str()) == 0) {
-        shader_slot = &slot;
-        break;
+      if (offset < 0) {
+        std::ostringstream s;
+        s << "VertexAttribute '" << name
+          << "' offsetInBytes must be non-negative (got " << offset << ").";
+        return s.str();
       }
-    }
-    if (shader_slot == nullptr) {
-      std::ostringstream s;
-      s << "VertexAttribute name '" << name
-        << "' does not match any input declared by the bound vertex shader.";
-      return s.str();
-    }
-    // Match the shader's scalar type class (float vs signed int vs unsigned
-    // int). Mirroring WebGPU, Vulkan, and Metal, component-count mismatches
-    // are NOT errors: the shader receives default substitution (missing
-    // components default to (0, 0, 0, 1)) when the buffer supplies fewer
-    // components than declared, and reads only the leading components when
-    // the buffer supplies more. The shipped enum only contains 32-bit
-    // formats, so checking `type` alone is sufficient until 8/16-bit
-    // formats are added.
-    // TODO(https://github.com/flutter/flutter/issues/186309): Add
-    // normalized, packed, half-float, BGRA-swizzled, and 64-bit vertex
-    // attribute formats; the format check will need to also verify
-    // `bit_width` once those land.
-    if (shader_slot->type != format.type ||
-        shader_slot->bit_width != format.bit_width) {
-      std::ostringstream s;
-      s << "VertexAttribute '" << name
-        << "' format does not match the vertex shader's declared input type.";
-      return s.str();
-    }
+      if (format_index < 0 ||
+          static_cast<size_t>(format_index) >= kVertexFormatTable.size()) {
+        std::ostringstream s;
+        s << "VertexAttribute '" << name << "' format index " << format_index
+          << " is out of range.";
+        return s.str();
+      }
+      const VertexFormatInfo& format = kVertexFormatTable[format_index];
 
-    impeller::ShaderStageIOSlot built = *shader_slot;
-    built.binding = static_cast<size_t>(buffer_binding);
-    built.offset = static_cast<size_t>(offset);
-    stage_inputs.push_back(built);
+      if (static_cast<size_t>(offset) + format.bytes_per_element >
+          static_cast<size_t>(stride)) {
+        std::ostringstream s;
+        s << "VertexAttribute '" << name << "' (offset " << offset << " + "
+          << format.bytes_per_element << " bytes) overruns stride of " << stride
+          << " on buffer at index " << buffer_index << ".";
+        return s.str();
+      }
+
+      // Detect overlap against earlier attributes in this buffer before
+      // doing any shader-side lookups, so the overlap diagnostic isn't
+      // shadowed by a less informative name-mismatch error.
+      const size_t begin = static_cast<size_t>(offset);
+      const size_t end = begin + format.bytes_per_element;
+      const std::string name_owned(name);
+      for (const auto& other : ranges_in_buffer) {
+        if (begin < other.end && other.begin < end) {
+          std::ostringstream s;
+          s << "VertexAttribute '" << name << "' (bytes [" << begin << ", "
+            << end << ")) overlaps VertexAttribute '" << other.name
+            << "' (bytes [" << other.begin << ", " << other.end
+            << ")) on buffer at index " << buffer_index << ".";
+          return s.str();
+        }
+      }
+      ranges_in_buffer.push_back({name_owned, begin, end});
+
+      // Find the matching shader input by name to validate format and to
+      // copy the (location, set, columns, relaxed_precision) metadata we
+      // don't carry on the Dart side. The Shader's IOSlot names point into
+      // the shader bundle flatbuffer, which the Shader keeps alive via its
+      // code mapping; the impellerc-generated builds use static string
+      // literals. Either way, strcmp against a NUL-terminated needle is
+      // safe.
+      const impeller::ShaderStageIOSlot* shader_slot = nullptr;
+      for (const auto& slot : shader_inputs) {
+        if (slot.name != nullptr &&
+            std::strcmp(slot.name, name_owned.c_str()) == 0) {
+          shader_slot = &slot;
+          break;
+        }
+      }
+      if (shader_slot == nullptr) {
+        std::ostringstream s;
+        s << "VertexAttribute name '" << name
+          << "' does not match any input declared by the bound vertex "
+             "shader.";
+        return s.str();
+      }
+      // Match the shader's scalar type class (float vs signed int vs
+      // unsigned int). Mirroring WebGPU, Vulkan, and Metal, component-count
+      // mismatches are NOT errors: the shader receives default substitution
+      // (missing components default to (0, 0, 0, 1)) when the buffer
+      // supplies fewer components than declared, and reads only the leading
+      // components when the buffer supplies more. The shipped enum only
+      // contains 32-bit formats, so checking `type` alone is sufficient
+      // until 8/16-bit formats are added.
+      // TODO(https://github.com/flutter/flutter/issues/186309): Add
+      // normalized, packed, half-float, BGRA-swizzled, and 64-bit vertex
+      // attribute formats; the format check will need to also verify
+      // `bit_width` once those land.
+      if (shader_slot->type != format.type ||
+          shader_slot->bit_width != format.bit_width) {
+        std::ostringstream s;
+        s << "VertexAttribute '" << name
+          << "' format does not match the vertex shader's declared input "
+             "type.";
+        return s.str();
+      }
+
+      impeller::ShaderStageIOSlot built = *shader_slot;
+      built.binding = buffer_index;
+      built.offset = static_cast<size_t>(offset);
+      stage_inputs.push_back(built);
+    }
   }
 
+  if (attr_cursor != attribute_count) {
+    return "Internal error: attributes blob has trailing rows not consumed "
+           "by any buffer.";
+  }
   if (name_cursor != attribute_names_byte_length) {
     return "Internal error: attribute names blob has trailing bytes.";
   }

--- a/engine/src/flutter/lib/gpu/render_pipeline.h
+++ b/engine/src/flutter/lib/gpu/render_pipeline.h
@@ -5,11 +5,14 @@
 #ifndef FLUTTER_LIB_GPU_RENDER_PIPELINE_H_
 #define FLUTTER_LIB_GPU_RENDER_PIPELINE_H_
 
+#include <memory>
+
 #include "flutter/lib/gpu/context.h"
 #include "flutter/lib/gpu/export.h"
 #include "flutter/lib/gpu/shader.h"
 #include "flutter/lib/ui/dart_wrapper.h"
 #include "impeller/renderer/pipeline_descriptor.h"
+#include "impeller/renderer/vertex_descriptor.h"
 
 namespace flutter {
 namespace gpu {
@@ -20,7 +23,8 @@ class RenderPipeline : public RefCountedDartWrappable<RenderPipeline> {
 
  public:
   RenderPipeline(fml::RefPtr<flutter::gpu::Shader> vertex_shader,
-                 fml::RefPtr<flutter::gpu::Shader> fragment_shader);
+                 fml::RefPtr<flutter::gpu::Shader> fragment_shader,
+                 std::shared_ptr<impeller::VertexDescriptor> vertex_descriptor);
 
   ~RenderPipeline() override;
 
@@ -30,6 +34,11 @@ class RenderPipeline : public RefCountedDartWrappable<RenderPipeline> {
  private:
   fml::RefPtr<flutter::gpu::Shader> vertex_shader_;
   fml::RefPtr<flutter::gpu::Shader> fragment_shader_;
+  // Vertex descriptor used at pipeline-build time. When the caller passes
+  // a custom `VertexLayout` to `GpuContext.createRenderPipeline`, this is
+  // built from that layout against the vertex shader's reflection metadata.
+  // Otherwise it is the impellerc-generated default for the vertex shader.
+  std::shared_ptr<impeller::VertexDescriptor> vertex_descriptor_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(RenderPipeline);
 };
@@ -48,7 +57,9 @@ extern Dart_Handle InternalFlutterGpu_RenderPipeline_Initialize(
     Dart_Handle wrapper,
     flutter::gpu::Context* gpu_context,
     flutter::gpu::Shader* vertex_shader,
-    flutter::gpu::Shader* fragment_shader);
+    flutter::gpu::Shader* fragment_shader,
+    Dart_Handle buffer_layouts_handle,
+    Dart_Handle attributes_handle);
 
 }  // extern "C"
 

--- a/engine/src/flutter/lib/gpu/render_pipeline.h
+++ b/engine/src/flutter/lib/gpu/render_pipeline.h
@@ -38,6 +38,12 @@ class RenderPipeline : public RefCountedDartWrappable<RenderPipeline> {
   // a custom `VertexLayout` to `GpuContext.createRenderPipeline`, this is
   // built from that layout against the vertex shader's reflection metadata.
   // Otherwise it is the impellerc-generated default for the vertex shader.
+  //
+  // Shared rather than unique because `impeller::PipelineDescriptor::
+  // SetVertexDescriptor` stores its argument as `shared_ptr<VertexDescriptor>`
+  // and `impeller::VertexDescriptor` is non-copyable; we have to keep a
+  // reference here so the descriptor remains valid across the many
+  // `BindToPipelineDescriptor` calls a single pipeline may participate in.
   std::shared_ptr<impeller::VertexDescriptor> vertex_descriptor_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(RenderPipeline);

--- a/engine/src/flutter/lib/gpu/render_pipeline.h
+++ b/engine/src/flutter/lib/gpu/render_pipeline.h
@@ -59,7 +59,8 @@ extern Dart_Handle InternalFlutterGpu_RenderPipeline_Initialize(
     flutter::gpu::Shader* vertex_shader,
     flutter::gpu::Shader* fragment_shader,
     Dart_Handle buffer_layouts_handle,
-    Dart_Handle attributes_handle);
+    Dart_Handle attributes_handle,
+    Dart_Handle attribute_names_handle);
 
 }  // extern "C"
 

--- a/engine/src/flutter/lib/gpu/shader.cc
+++ b/engine/src/flutter/lib/gpu/shader.cc
@@ -93,6 +93,15 @@ std::shared_ptr<impeller::VertexDescriptor> Shader::CreateVertexDescriptor()
   return vertex_descriptor;
 }
 
+const std::vector<impeller::ShaderStageIOSlot>& Shader::GetStageInputs() const {
+  return inputs_;
+}
+
+const std::vector<impeller::ShaderStageBufferLayout>&
+Shader::GetStageBufferLayouts() const {
+  return layouts_;
+}
+
 impeller::ShaderStage Shader::GetShaderStage() const {
   return stage_;
 }

--- a/engine/src/flutter/lib/gpu/shader.h
+++ b/engine/src/flutter/lib/gpu/shader.h
@@ -60,6 +60,11 @@ class Shader : public RefCountedDartWrappable<Shader> {
 
   std::shared_ptr<impeller::VertexDescriptor> CreateVertexDescriptor() const;
 
+  const std::vector<impeller::ShaderStageIOSlot>& GetStageInputs() const;
+
+  const std::vector<impeller::ShaderStageBufferLayout>& GetStageBufferLayouts()
+      const;
+
   const std::vector<impeller::DescriptorSetLayout>& GetDescriptorSetLayouts()
       const;
 

--- a/engine/src/flutter/testing/dart/gpu_test.dart
+++ b/engine/src/flutter/testing/dart/gpu_test.dart
@@ -575,6 +575,188 @@ void main() async {
     await comparer.addGoldenImage(image, 'flutter_gpu_test_triangle.png');
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 
+  // A custom VertexLayout that matches the impellerc-generated default for the
+  // UnlitVertex shader (one binding 0, vec2 position at location 0, offset 0)
+  // should produce identical pipeline behavior. This pins the shape of the
+  // VertexLayout/VertexAttribute/VertexBufferLayout/VertexFormat API and the
+  // FFI plumbing through createRenderPipeline.
+  test('Can render triangle with explicit VertexLayout', () async {
+    final RenderPassState state = createSimpleRenderPass();
+
+    final gpu.ShaderLibrary library = gpu.ShaderLibrary.fromAsset('test.shaderbundle')!;
+    final gpu.RenderPipeline pipeline = gpu.gpuContext.createRenderPipeline(
+      library['UnlitVertex']!,
+      library['UnlitFragment']!,
+      vertexLayout: const gpu.VertexLayout(
+        buffers: <gpu.VertexBufferLayout>[gpu.VertexBufferLayout(binding: 0, strideInBytes: 8)],
+        attributes: <gpu.VertexAttribute>[
+          gpu.VertexAttribute(
+            location: 0,
+            bufferBinding: 0,
+            offsetInBytes: 0,
+            format: gpu.VertexFormat.float32x2,
+          ),
+        ],
+      ),
+    );
+    state.renderPass.bindPipeline(pipeline);
+
+    final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
+    final gpu.BufferView vertices = transients.emplace(
+      float32(<double>[-0.5, 0.5, 0.0, -0.5, 0.5, 0.5]),
+    );
+    final gpu.BufferView vertInfo = transients.emplace(unlitUBO(Matrix4.identity(), Colors.lime));
+    state.renderPass.bindVertexBuffer(vertices, 3);
+    state.renderPass.bindUniform(pipeline.vertexShader.getUniformSlot('VertInfo'), vertInfo);
+    state.renderPass.draw();
+    state.commandBuffer.submit();
+
+    final ui.Image image = state.renderTexture.asImage();
+    await comparer.addGoldenImage(image, 'flutter_gpu_test_triangle.png');
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  test(
+    'createRenderPipeline rejects VertexLayout with wrong attribute format',
+    () async {
+      final gpu.ShaderLibrary library = gpu.ShaderLibrary.fromAsset('test.shaderbundle')!;
+      try {
+        gpu.gpuContext.createRenderPipeline(
+          library['UnlitVertex']!,
+          library['UnlitFragment']!,
+          vertexLayout: const gpu.VertexLayout(
+            buffers: <gpu.VertexBufferLayout>[gpu.VertexBufferLayout(binding: 0, strideInBytes: 8)],
+            attributes: <gpu.VertexAttribute>[
+              // UnlitVertex declares a float `vec2 position` at location 0,
+              // so binding a uint32x2 (different scalar type class) here must
+              // throw. Component-count mismatches are NOT errors: a buffer
+              // can supply more or fewer components than the shader reads,
+              // matching WebGPU / Vulkan / Metal default-substitution rules.
+              gpu.VertexAttribute(
+                location: 0,
+                bufferBinding: 0,
+                offsetInBytes: 0,
+                format: gpu.VertexFormat.uint32x2,
+              ),
+            ],
+          ),
+        );
+        fail('Expected exception for mismatched VertexFormat scalar type.');
+      } catch (e) {
+        expect(
+          e.toString(),
+          contains("format does not match the vertex shader's declared input type"),
+        );
+      }
+    },
+    skip: !(impellerEnabled && flutterGpuEnabled),
+  );
+
+  test(
+    'createRenderPipeline rejects VertexAttribute that overruns stride',
+    () async {
+      final gpu.ShaderLibrary library = gpu.ShaderLibrary.fromAsset('test.shaderbundle')!;
+      try {
+        gpu.gpuContext.createRenderPipeline(
+          library['UnlitVertex']!,
+          library['UnlitFragment']!,
+          vertexLayout: const gpu.VertexLayout(
+            buffers: <gpu.VertexBufferLayout>[gpu.VertexBufferLayout(binding: 0, strideInBytes: 8)],
+            attributes: <gpu.VertexAttribute>[
+              // float32x2 (8 bytes) at offset 4 with stride 8 overruns by 4.
+              gpu.VertexAttribute(
+                location: 0,
+                bufferBinding: 0,
+                offsetInBytes: 4,
+                format: gpu.VertexFormat.float32x2,
+              ),
+            ],
+          ),
+        );
+        fail('Expected exception for offset+format overruning stride.');
+      } catch (e) {
+        expect(e.toString(), contains('overruns stride'));
+      }
+    },
+    skip: !(impellerEnabled && flutterGpuEnabled),
+  );
+
+  test(
+    'createRenderPipeline rejects VertexAttribute with unknown bufferBinding',
+    () async {
+      final gpu.ShaderLibrary library = gpu.ShaderLibrary.fromAsset('test.shaderbundle')!;
+      try {
+        gpu.gpuContext.createRenderPipeline(
+          library['UnlitVertex']!,
+          library['UnlitFragment']!,
+          vertexLayout: const gpu.VertexLayout(
+            buffers: <gpu.VertexBufferLayout>[gpu.VertexBufferLayout(binding: 0, strideInBytes: 8)],
+            attributes: <gpu.VertexAttribute>[
+              gpu.VertexAttribute(
+                location: 0,
+                bufferBinding: 7, // not declared in `buffers`
+                offsetInBytes: 0,
+                format: gpu.VertexFormat.float32x2,
+              ),
+            ],
+          ),
+        );
+        fail('Expected exception for unknown bufferBinding.');
+      } catch (e) {
+        expect(e.toString(), contains('not declared in VertexLayout.buffers'));
+      }
+    },
+    skip: !(impellerEnabled && flutterGpuEnabled),
+  );
+
+  test(
+    'bindVertexBuffer throws RangeError for out-of-range slot',
+    () async {
+      final RenderPassState state = createSimpleRenderPass();
+      final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
+      state.renderPass.bindPipeline(pipeline);
+
+      final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
+      final gpu.BufferView vertices = transients.emplace(
+        float32(<double>[-0.5, 0.5, 0.0, -0.5, 0.5, 0.5]),
+      );
+
+      expect(() => state.renderPass.bindVertexBuffer(vertices, 3, slot: -1), throwsRangeError);
+      expect(() => state.renderPass.bindVertexBuffer(vertices, 3, slot: 16), throwsRangeError);
+    },
+    skip: !(impellerEnabled && flutterGpuEnabled),
+  );
+
+  test(
+    'createRenderPipeline rejects VertexAttribute with unknown location',
+    () async {
+      final gpu.ShaderLibrary library = gpu.ShaderLibrary.fromAsset('test.shaderbundle')!;
+      try {
+        gpu.gpuContext.createRenderPipeline(
+          library['UnlitVertex']!,
+          library['UnlitFragment']!,
+          vertexLayout: const gpu.VertexLayout(
+            buffers: <gpu.VertexBufferLayout>[gpu.VertexBufferLayout(binding: 0, strideInBytes: 8)],
+            attributes: <gpu.VertexAttribute>[
+              gpu.VertexAttribute(
+                location: 5, // UnlitVertex only declares location 0
+                bufferBinding: 0,
+                offsetInBytes: 0,
+                format: gpu.VertexFormat.float32x2,
+              ),
+            ],
+          ),
+        );
+        fail('Expected exception for unknown location.');
+      } catch (e) {
+        expect(
+          e.toString(),
+          contains('does not match any input declared by the bound vertex shader'),
+        );
+      }
+    },
+    skip: !(impellerEnabled && flutterGpuEnabled),
+  );
+
   // Renders a green triangle pointing downwards using polygon mode line.
   test('Can render triangle with polygon mode line.', () async {
     final RenderPassState state = createSimpleRenderPass();

--- a/engine/src/flutter/testing/dart/gpu_test.dart
+++ b/engine/src/flutter/testing/dart/gpu_test.dart
@@ -591,7 +591,7 @@ void main() async {
         buffers: <gpu.VertexBufferLayout>[gpu.VertexBufferLayout(binding: 0, strideInBytes: 8)],
         attributes: <gpu.VertexAttribute>[
           gpu.VertexAttribute(
-            location: 0,
+            name: 'position',
             bufferBinding: 0,
             offsetInBytes: 0,
             format: gpu.VertexFormat.float32x2,
@@ -626,13 +626,14 @@ void main() async {
           vertexLayout: const gpu.VertexLayout(
             buffers: <gpu.VertexBufferLayout>[gpu.VertexBufferLayout(binding: 0, strideInBytes: 8)],
             attributes: <gpu.VertexAttribute>[
-              // UnlitVertex declares a float `vec2 position` at location 0,
-              // so binding a uint32x2 (different scalar type class) here must
-              // throw. Component-count mismatches are NOT errors: a buffer
-              // can supply more or fewer components than the shader reads,
-              // matching WebGPU / Vulkan / Metal default-substitution rules.
+              // UnlitVertex declares a float `vec2 position`, so binding a
+              // uint32x2 (different scalar type class) here must throw.
+              // Component-count mismatches are NOT errors: a buffer can
+              // supply more or fewer components than the shader reads,
+              // matching the default-substitution rules every modern HAL
+              // uses.
               gpu.VertexAttribute(
-                location: 0,
+                name: 'position',
                 bufferBinding: 0,
                 offsetInBytes: 0,
                 format: gpu.VertexFormat.uint32x2,
@@ -664,7 +665,7 @@ void main() async {
             attributes: <gpu.VertexAttribute>[
               // float32x2 (8 bytes) at offset 4 with stride 8 overruns by 4.
               gpu.VertexAttribute(
-                location: 0,
+                name: 'position',
                 bufferBinding: 0,
                 offsetInBytes: 4,
                 format: gpu.VertexFormat.float32x2,
@@ -692,7 +693,7 @@ void main() async {
             buffers: <gpu.VertexBufferLayout>[gpu.VertexBufferLayout(binding: 0, strideInBytes: 8)],
             attributes: <gpu.VertexAttribute>[
               gpu.VertexAttribute(
-                location: 0,
+                name: 'position',
                 bufferBinding: 7, // not declared in `buffers`
                 offsetInBytes: 0,
                 format: gpu.VertexFormat.float32x2,
@@ -727,7 +728,7 @@ void main() async {
   );
 
   test(
-    'createRenderPipeline rejects VertexAttribute with unknown location',
+    'createRenderPipeline rejects VertexAttribute with unknown name',
     () async {
       final gpu.ShaderLibrary library = gpu.ShaderLibrary.fromAsset('test.shaderbundle')!;
       try {
@@ -738,7 +739,7 @@ void main() async {
             buffers: <gpu.VertexBufferLayout>[gpu.VertexBufferLayout(binding: 0, strideInBytes: 8)],
             attributes: <gpu.VertexAttribute>[
               gpu.VertexAttribute(
-                location: 5, // UnlitVertex only declares location 0
+                name: 'nonexistent_attribute',
                 bufferBinding: 0,
                 offsetInBytes: 0,
                 format: gpu.VertexFormat.float32x2,
@@ -746,7 +747,7 @@ void main() async {
             ],
           ),
         );
-        fail('Expected exception for unknown location.');
+        fail('Expected exception for unknown attribute name.');
       } catch (e) {
         expect(
           e.toString(),

--- a/engine/src/flutter/testing/dart/gpu_test.dart
+++ b/engine/src/flutter/testing/dart/gpu_test.dart
@@ -575,11 +575,11 @@ void main() async {
     await comparer.addGoldenImage(image, 'flutter_gpu_test_triangle.png');
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 
-  // A custom VertexLayout that matches the impellerc-generated default for the
-  // UnlitVertex shader (one binding 0, vec2 position at location 0, offset 0)
+  // A custom VertexLayout that matches the shader bundle's default for the
+  // UnlitVertex shader (one buffer at slot 0, vec2 position at offset 0)
   // should produce identical pipeline behavior. This pins the shape of the
-  // VertexLayout/VertexAttribute/VertexBufferLayout/VertexFormat API and the
-  // FFI plumbing through createRenderPipeline.
+  // VertexLayout/VertexBuffer/VertexAttribute/VertexFormat API and the FFI
+  // plumbing through createRenderPipeline.
   test('Can render triangle with explicit VertexLayout', () async {
     final RenderPassState state = createSimpleRenderPass();
 
@@ -588,13 +588,12 @@ void main() async {
       library['UnlitVertex']!,
       library['UnlitFragment']!,
       vertexLayout: const gpu.VertexLayout(
-        buffers: <gpu.VertexBufferLayout>[gpu.VertexBufferLayout(binding: 0, strideInBytes: 8)],
-        attributes: <gpu.VertexAttribute>[
-          gpu.VertexAttribute(
-            name: 'position',
-            bufferBinding: 0,
-            offsetInBytes: 0,
-            format: gpu.VertexFormat.float32x2,
+        buffers: <gpu.VertexBuffer>[
+          gpu.VertexBuffer(
+            strideInBytes: 8,
+            attributes: <gpu.VertexAttribute>[
+              gpu.VertexAttribute(name: 'position', format: gpu.VertexFormat.float32x2),
+            ],
           ),
         ],
       ),
@@ -624,19 +623,18 @@ void main() async {
           library['UnlitVertex']!,
           library['UnlitFragment']!,
           vertexLayout: const gpu.VertexLayout(
-            buffers: <gpu.VertexBufferLayout>[gpu.VertexBufferLayout(binding: 0, strideInBytes: 8)],
-            attributes: <gpu.VertexAttribute>[
-              // UnlitVertex declares a float `vec2 position`, so binding a
-              // uint32x2 (different scalar type class) here must throw.
-              // Component-count mismatches are NOT errors: a buffer can
-              // supply more or fewer components than the shader reads,
-              // matching the default-substitution rules every modern HAL
-              // uses.
-              gpu.VertexAttribute(
-                name: 'position',
-                bufferBinding: 0,
-                offsetInBytes: 0,
-                format: gpu.VertexFormat.uint32x2,
+            buffers: <gpu.VertexBuffer>[
+              gpu.VertexBuffer(
+                strideInBytes: 8,
+                attributes: <gpu.VertexAttribute>[
+                  // UnlitVertex declares a float `vec2 position`, so binding
+                  // a uint32x2 (different scalar type class) here must throw.
+                  // Component-count mismatches are NOT errors: a buffer can
+                  // supply more or fewer components than the shader reads,
+                  // matching the default-substitution rules every modern HAL
+                  // uses.
+                  gpu.VertexAttribute(name: 'position', format: gpu.VertexFormat.uint32x2),
+                ],
               ),
             ],
           ),
@@ -661,14 +659,17 @@ void main() async {
           library['UnlitVertex']!,
           library['UnlitFragment']!,
           vertexLayout: const gpu.VertexLayout(
-            buffers: <gpu.VertexBufferLayout>[gpu.VertexBufferLayout(binding: 0, strideInBytes: 8)],
-            attributes: <gpu.VertexAttribute>[
-              // float32x2 (8 bytes) at offset 4 with stride 8 overruns by 4.
-              gpu.VertexAttribute(
-                name: 'position',
-                bufferBinding: 0,
-                offsetInBytes: 4,
-                format: gpu.VertexFormat.float32x2,
+            buffers: <gpu.VertexBuffer>[
+              gpu.VertexBuffer(
+                strideInBytes: 8,
+                attributes: <gpu.VertexAttribute>[
+                  // float32x2 (8 bytes) at offset 4 with stride 8 overruns by 4.
+                  gpu.VertexAttribute(
+                    name: 'position',
+                    offsetInBytes: 4,
+                    format: gpu.VertexFormat.float32x2,
+                  ),
+                ],
               ),
             ],
           ),
@@ -682,7 +683,7 @@ void main() async {
   );
 
   test(
-    'createRenderPipeline rejects VertexAttribute with unknown bufferBinding',
+    'createRenderPipeline rejects VertexLayout with overlapping attributes',
     () async {
       final gpu.ShaderLibrary library = gpu.ShaderLibrary.fromAsset('test.shaderbundle')!;
       try {
@@ -690,20 +691,26 @@ void main() async {
           library['UnlitVertex']!,
           library['UnlitFragment']!,
           vertexLayout: const gpu.VertexLayout(
-            buffers: <gpu.VertexBufferLayout>[gpu.VertexBufferLayout(binding: 0, strideInBytes: 8)],
-            attributes: <gpu.VertexAttribute>[
-              gpu.VertexAttribute(
-                name: 'position',
-                bufferBinding: 7, // not declared in `buffers`
-                offsetInBytes: 0,
-                format: gpu.VertexFormat.float32x2,
+            buffers: <gpu.VertexBuffer>[
+              gpu.VertexBuffer(
+                strideInBytes: 8,
+                attributes: <gpu.VertexAttribute>[
+                  // Two attributes both occupying bytes [0, 8) in the same
+                  // buffer. The second one isn't a real shader input, but
+                  // the overlap check fires before the name check.
+                  gpu.VertexAttribute(name: 'position', format: gpu.VertexFormat.float32x2),
+                  gpu.VertexAttribute(name: 'aliased', format: gpu.VertexFormat.float32x2),
+                ],
               ),
             ],
           ),
         );
-        fail('Expected exception for unknown bufferBinding.');
+        fail('Expected exception for overlapping VertexAttributes.');
       } catch (e) {
-        expect(e.toString(), contains('not declared in VertexLayout.buffers'));
+        final String msg = e.toString();
+        expect(msg, contains('overlaps'));
+        expect(msg, contains("'position'"));
+        expect(msg, contains("'aliased'"));
       }
     },
     skip: !(impellerEnabled && flutterGpuEnabled),
@@ -736,13 +743,15 @@ void main() async {
           library['UnlitVertex']!,
           library['UnlitFragment']!,
           vertexLayout: const gpu.VertexLayout(
-            buffers: <gpu.VertexBufferLayout>[gpu.VertexBufferLayout(binding: 0, strideInBytes: 8)],
-            attributes: <gpu.VertexAttribute>[
-              gpu.VertexAttribute(
-                name: 'nonexistent_attribute',
-                bufferBinding: 0,
-                offsetInBytes: 0,
-                format: gpu.VertexFormat.float32x2,
+            buffers: <gpu.VertexBuffer>[
+              gpu.VertexBuffer(
+                strideInBytes: 8,
+                attributes: <gpu.VertexAttribute>[
+                  gpu.VertexAttribute(
+                    name: 'nonexistent_attribute',
+                    format: gpu.VertexFormat.float32x2,
+                  ),
+                ],
               ),
             ],
           ),

--- a/engine/src/flutter/testing/dart/gpu_test.dart
+++ b/engine/src/flutter/testing/dart/gpu_test.dart
@@ -707,7 +707,7 @@ void main() async {
         );
         fail('Expected exception for overlapping VertexAttributes.');
       } catch (e) {
-        final String msg = e.toString();
+        final msg = e.toString();
         expect(msg, contains('overlaps'));
         expect(msg, contains("'position'"));
         expect(msg, contains("'aliased'"));

--- a/engine/src/flutter/testing/dart/gpu_test.dart
+++ b/engine/src/flutter/testing/dart/gpu_test.dart
@@ -288,23 +288,27 @@ void main() async {
     expect(success, false);
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 
-  test('DeviceBuffer.overwrite throws for negative destination offset', () async {
-    final gpu.DeviceBuffer deviceBuffer = gpu.gpuContext.createDeviceBuffer(
-      gpu.StorageMode.hostVisible,
-      4,
-    );
-
-    try {
-      deviceBuffer.overwrite(
-        Int8List.fromList(<int>[0, 1, 2, 3]).buffer.asByteData(),
-        destinationOffsetInBytes: -1,
+  test(
+    'DeviceBuffer.overwrite throws for negative destination offset',
+    () async {
+      final gpu.DeviceBuffer deviceBuffer = gpu.gpuContext.createDeviceBuffer(
+        gpu.StorageMode.hostVisible,
+        4,
       );
-      deviceBuffer.flush();
-      fail('Exception not thrown for negative destination offset.');
-    } catch (e) {
-      expect(e.toString(), contains('destinationOffsetInBytes must be positive'));
-    }
-  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+      try {
+        deviceBuffer.overwrite(
+          Int8List.fromList(<int>[0, 1, 2, 3]).buffer.asByteData(),
+          destinationOffsetInBytes: -1,
+        );
+        deviceBuffer.flush();
+        fail('Exception not thrown for negative destination offset.');
+      } catch (e) {
+        expect(e.toString(), contains('destinationOffsetInBytes must be positive'));
+      }
+    },
+    skip: !(impellerEnabled && flutterGpuEnabled),
+  );
 
   test('GpuContext.createTexture', () async {
     final gpu.Texture texture = gpu.gpuContext.createTexture(gpu.StorageMode.hostVisible, 100, 100);
@@ -399,102 +403,122 @@ void main() async {
     }
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 
-  test('RenderPass.setStencilReference doesnt throw for valid values', () async {
-    final RenderPassState state = createSimpleRenderPass();
+  test(
+    'RenderPass.setStencilReference doesnt throw for valid values',
+    () async {
+      final RenderPassState state = createSimpleRenderPass();
 
-    state.renderPass.setStencilReference(0);
-    state.renderPass.setStencilReference(2 << 30);
-  }, skip: !(impellerEnabled && flutterGpuEnabled));
+      state.renderPass.setStencilReference(0);
+      state.renderPass.setStencilReference(2 << 30);
+    },
+    skip: !(impellerEnabled && flutterGpuEnabled),
+  );
 
-  test('RenderPass.setStencilReference throws for invalid values', () async {
-    final RenderPassState state = createSimpleRenderPass();
+  test(
+    'RenderPass.setStencilReference throws for invalid values',
+    () async {
+      final RenderPassState state = createSimpleRenderPass();
 
-    try {
-      state.renderPass.setStencilReference(-1);
-      fail('Exception not thrown for out of bounds stencil reference.');
-    } catch (e) {
-      expect(e.toString(), contains('The stencil reference value must be in the range'));
-    }
+      try {
+        state.renderPass.setStencilReference(-1);
+        fail('Exception not thrown for out of bounds stencil reference.');
+      } catch (e) {
+        expect(e.toString(), contains('The stencil reference value must be in the range'));
+      }
 
-    try {
-      state.renderPass.setStencilReference(2 << 31);
-      fail('Exception not thrown for out of bounds stencil reference.');
-    } catch (e) {
-      expect(e.toString(), contains('The stencil reference value must be in the range'));
-    }
-  }, skip: !(impellerEnabled && flutterGpuEnabled));
+      try {
+        state.renderPass.setStencilReference(2 << 31);
+        fail('Exception not thrown for out of bounds stencil reference.');
+      } catch (e) {
+        expect(e.toString(), contains('The stencil reference value must be in the range'));
+      }
+    },
+    skip: !(impellerEnabled && flutterGpuEnabled),
+  );
 
-  test('RenderPass.setStencilConfig doesnt throw for valid values', () async {
-    final RenderPassState state = createSimpleRenderPass();
+  test(
+    'RenderPass.setStencilConfig doesnt throw for valid values',
+    () async {
+      final RenderPassState state = createSimpleRenderPass();
 
-    state.renderPass.setStencilConfig(gpu.StencilConfig());
-    state.renderPass.setStencilConfig(
-      gpu.StencilConfig(
-        compareFunction: gpu.CompareFunction.notEqual,
-        depthFailureOperation: gpu.StencilOperation.decrementWrap,
-        depthStencilPassOperation: gpu.StencilOperation.incrementWrap,
-        stencilFailureOperation: gpu.StencilOperation.invert,
-        readMask: 0,
-        writeMask: 0,
-      ),
-      targetFace: gpu.StencilFace.back,
-    );
-  }, skip: !(impellerEnabled && flutterGpuEnabled));
-
-  test('RenderPass.setStencilConfig throws for invalid masks', () async {
-    final RenderPassState state = createSimpleRenderPass();
-
-    try {
-      state.renderPass.setStencilConfig(gpu.StencilConfig(readMask: -1));
-      fail('Exception not thrown for invalid stencil read mask.');
-    } catch (e) {
-      expect(e.toString(), contains('The stencil read mask must be in the range'));
-    }
-    try {
-      state.renderPass.setStencilConfig(gpu.StencilConfig(readMask: 0xFFFFFFFF + 1));
-      fail('Exception not thrown for invalid stencil read mask.');
-    } catch (e) {
-      expect(e.toString(), contains('The stencil read mask must be in the range'));
-    }
-
-    try {
-      state.renderPass.setStencilConfig(gpu.StencilConfig(writeMask: -1));
-      fail('Exception not thrown for invalid stencil write mask.');
-    } catch (e) {
-      expect(e.toString(), contains('The stencil write mask must be in the range'));
-    }
-    try {
-      state.renderPass.setStencilConfig(gpu.StencilConfig(writeMask: 0xFFFFFFFF + 1));
-      fail('Exception not thrown for invalid stencil write mask.');
-    } catch (e) {
-      expect(e.toString(), contains('The stencil write mask must be in the range'));
-    }
-  }, skip: !(impellerEnabled && flutterGpuEnabled));
-
-  test('RenderPass.bindTexture throws for deviceTransient Textures', () async {
-    final RenderPassState state = createSimpleRenderPass();
-
-    final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
-    // Although this is a non-texture uniform slot, it'll work fine for the
-    // purposes of testing this error.
-    final gpu.UniformSlot vertInfo = pipeline.vertexShader.getUniformSlot('VertInfo');
-
-    final gpu.Texture texture = gpu.gpuContext.createTexture(
-      gpu.StorageMode.deviceTransient,
-      100,
-      100,
-    );
-
-    try {
-      state.renderPass.bindTexture(vertInfo, texture);
-      fail('Exception not thrown when binding a transient texture.');
-    } catch (e) {
-      expect(
-        e.toString(),
-        contains('Textures with StorageMode.deviceTransient cannot be bound to a RenderPass'),
+      state.renderPass.setStencilConfig(gpu.StencilConfig());
+      state.renderPass.setStencilConfig(
+        gpu.StencilConfig(
+          compareFunction: gpu.CompareFunction.notEqual,
+          depthFailureOperation: gpu.StencilOperation.decrementWrap,
+          depthStencilPassOperation: gpu.StencilOperation.incrementWrap,
+          stencilFailureOperation: gpu.StencilOperation.invert,
+          readMask: 0,
+          writeMask: 0,
+        ),
+        targetFace: gpu.StencilFace.back,
       );
-    }
-  }, skip: !(impellerEnabled && flutterGpuEnabled));
+    },
+    skip: !(impellerEnabled && flutterGpuEnabled),
+  );
+
+  test(
+    'RenderPass.setStencilConfig throws for invalid masks',
+    () async {
+      final RenderPassState state = createSimpleRenderPass();
+
+      try {
+        state.renderPass.setStencilConfig(gpu.StencilConfig(readMask: -1));
+        fail('Exception not thrown for invalid stencil read mask.');
+      } catch (e) {
+        expect(e.toString(), contains('The stencil read mask must be in the range'));
+      }
+      try {
+        state.renderPass.setStencilConfig(gpu.StencilConfig(readMask: 0xFFFFFFFF + 1));
+        fail('Exception not thrown for invalid stencil read mask.');
+      } catch (e) {
+        expect(e.toString(), contains('The stencil read mask must be in the range'));
+      }
+
+      try {
+        state.renderPass.setStencilConfig(gpu.StencilConfig(writeMask: -1));
+        fail('Exception not thrown for invalid stencil write mask.');
+      } catch (e) {
+        expect(e.toString(), contains('The stencil write mask must be in the range'));
+      }
+      try {
+        state.renderPass.setStencilConfig(gpu.StencilConfig(writeMask: 0xFFFFFFFF + 1));
+        fail('Exception not thrown for invalid stencil write mask.');
+      } catch (e) {
+        expect(e.toString(), contains('The stencil write mask must be in the range'));
+      }
+    },
+    skip: !(impellerEnabled && flutterGpuEnabled),
+  );
+
+  test(
+    'RenderPass.bindTexture throws for deviceTransient Textures',
+    () async {
+      final RenderPassState state = createSimpleRenderPass();
+
+      final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
+      // Although this is a non-texture uniform slot, it'll work fine for the
+      // purposes of testing this error.
+      final gpu.UniformSlot vertInfo = pipeline.vertexShader.getUniformSlot('VertInfo');
+
+      final gpu.Texture texture = gpu.gpuContext.createTexture(
+        gpu.StorageMode.deviceTransient,
+        100,
+        100,
+      );
+
+      try {
+        state.renderPass.bindTexture(vertInfo, texture);
+        fail('Exception not thrown when binding a transient texture.');
+      } catch (e) {
+        expect(
+          e.toString(),
+          contains('Textures with StorageMode.deviceTransient cannot be bound to a RenderPass'),
+        );
+      }
+    },
+    skip: !(impellerEnabled && flutterGpuEnabled),
+  );
 
   // Performs no draw calls. Just clears the render target to a solid green color.
   test('Can render clear color', () async {
@@ -590,164 +614,188 @@ void main() async {
     await comparer.addGoldenImage(image, 'flutter_gpu_test_triangle.png');
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 
-  test('createRenderPipeline rejects VertexLayout with wrong attribute format', () async {
-    final gpu.ShaderLibrary library = gpu.ShaderLibrary.fromAsset('test.shaderbundle')!;
-    try {
-      gpu.gpuContext.createRenderPipeline(
-        library['UnlitVertex']!,
-        library['UnlitFragment']!,
-        vertexLayout: const gpu.VertexLayout(
-          buffers: <gpu.VertexBuffer>[
-            gpu.VertexBuffer(
-              strideInBytes: 8,
-              attributes: <gpu.VertexAttribute>[
-                // UnlitVertex declares a float `vec2 position`, so binding
-                // a uint32x2 (different scalar type class) here must throw.
-                // Component-count mismatches are NOT errors: a buffer can
-                // supply more or fewer components than the shader reads,
-                // matching the default-substitution rules every modern HAL
-                // uses.
-                gpu.VertexAttribute(name: 'position', format: gpu.VertexFormat.uint32x2),
-              ],
-            ),
-          ],
-        ),
+  test(
+    'createRenderPipeline rejects VertexLayout with wrong attribute format',
+    () async {
+      final gpu.ShaderLibrary library = gpu.ShaderLibrary.fromAsset('test.shaderbundle')!;
+      try {
+        gpu.gpuContext.createRenderPipeline(
+          library['UnlitVertex']!,
+          library['UnlitFragment']!,
+          vertexLayout: const gpu.VertexLayout(
+            buffers: <gpu.VertexBuffer>[
+              gpu.VertexBuffer(
+                strideInBytes: 8,
+                attributes: <gpu.VertexAttribute>[
+                  // UnlitVertex declares a float `vec2 position`, so binding
+                  // a uint32x2 (different scalar type class) here must throw.
+                  // Component-count mismatches are NOT errors: a buffer can
+                  // supply more or fewer components than the shader reads,
+                  // matching the default-substitution rules every modern HAL
+                  // uses.
+                  gpu.VertexAttribute(name: 'position', format: gpu.VertexFormat.uint32x2),
+                ],
+              ),
+            ],
+          ),
+        );
+        fail('Expected exception for mismatched VertexFormat scalar type.');
+      } catch (e) {
+        expect(
+          e.toString(),
+          contains("format does not match the vertex shader's declared input type"),
+        );
+      }
+    },
+    skip: !(impellerEnabled && flutterGpuEnabled),
+  );
+
+  test(
+    'createRenderPipeline rejects VertexAttribute that overruns stride',
+    () async {
+      final gpu.ShaderLibrary library = gpu.ShaderLibrary.fromAsset('test.shaderbundle')!;
+      try {
+        gpu.gpuContext.createRenderPipeline(
+          library['UnlitVertex']!,
+          library['UnlitFragment']!,
+          vertexLayout: const gpu.VertexLayout(
+            buffers: <gpu.VertexBuffer>[
+              gpu.VertexBuffer(
+                strideInBytes: 8,
+                attributes: <gpu.VertexAttribute>[
+                  // float32x2 (8 bytes) at offset 4 with stride 8 overruns by 4.
+                  gpu.VertexAttribute(
+                    name: 'position',
+                    offsetInBytes: 4,
+                    format: gpu.VertexFormat.float32x2,
+                  ),
+                ],
+              ),
+            ],
+          ),
+        );
+        fail('Expected exception for offset+format overruning stride.');
+      } catch (e) {
+        expect(e.toString(), contains('overruns stride'));
+      }
+    },
+    skip: !(impellerEnabled && flutterGpuEnabled),
+  );
+
+  test(
+    'createRenderPipeline rejects VertexLayout with overlapping attributes',
+    () async {
+      final gpu.ShaderLibrary library = gpu.ShaderLibrary.fromAsset('test.shaderbundle')!;
+      try {
+        gpu.gpuContext.createRenderPipeline(
+          library['UnlitVertex']!,
+          library['UnlitFragment']!,
+          vertexLayout: const gpu.VertexLayout(
+            buffers: <gpu.VertexBuffer>[
+              gpu.VertexBuffer(
+                strideInBytes: 8,
+                attributes: <gpu.VertexAttribute>[
+                  // Two attributes both occupying bytes [0, 8) in the same
+                  // buffer. The second one isn't a real shader input, but
+                  // the overlap check fires before the name check.
+                  gpu.VertexAttribute(name: 'position', format: gpu.VertexFormat.float32x2),
+                  gpu.VertexAttribute(name: 'aliased', format: gpu.VertexFormat.float32x2),
+                ],
+              ),
+            ],
+          ),
+        );
+        fail('Expected exception for overlapping VertexAttributes.');
+      } catch (e) {
+        final msg = e.toString();
+        expect(msg, contains('overlaps'));
+        expect(msg, contains("'position'"));
+        expect(msg, contains("'aliased'"));
+      }
+    },
+    skip: !(impellerEnabled && flutterGpuEnabled),
+  );
+
+  test(
+    'bindVertexBuffer throws RangeError for out-of-range slot',
+    () async {
+      final RenderPassState state = createSimpleRenderPass();
+      final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
+      state.renderPass.bindPipeline(pipeline);
+
+      final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
+      final gpu.BufferView vertices = transients.emplace(
+        float32(<double>[-0.5, 0.5, 0.0, -0.5, 0.5, 0.5]),
       );
-      fail('Expected exception for mismatched VertexFormat scalar type.');
-    } catch (e) {
+
+      expect(() => state.renderPass.bindVertexBuffer(vertices, 3, slot: -1), throwsRangeError);
+      expect(() => state.renderPass.bindVertexBuffer(vertices, 3, slot: 16), throwsRangeError);
+    },
+    skip: !(impellerEnabled && flutterGpuEnabled),
+  );
+
+  test(
+    'draw throws StateError on sparse vertex buffer bindings',
+    () async {
+      final RenderPassState state = createSimpleRenderPass();
+      final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
+      state.renderPass.bindPipeline(pipeline);
+
+      final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
+      final gpu.BufferView vertices = transients.emplace(
+        float32(<double>[-0.5, 0.5, 0.0, -0.5, 0.5, 0.5]),
+      );
+
+      // Bind only slot 1 (skipping slot 0). draw() must surface a clear
+      // error rather than letting the underlying HAL validation fail
+      // silently or render with an empty slot.
+      state.renderPass.bindVertexBuffer(vertices, 3, slot: 1);
       expect(
-        e.toString(),
-        contains("format does not match the vertex shader's declared input type"),
-      );
-    }
-  }, skip: !(impellerEnabled && flutterGpuEnabled));
-
-  test('createRenderPipeline rejects VertexAttribute that overruns stride', () async {
-    final gpu.ShaderLibrary library = gpu.ShaderLibrary.fromAsset('test.shaderbundle')!;
-    try {
-      gpu.gpuContext.createRenderPipeline(
-        library['UnlitVertex']!,
-        library['UnlitFragment']!,
-        vertexLayout: const gpu.VertexLayout(
-          buffers: <gpu.VertexBuffer>[
-            gpu.VertexBuffer(
-              strideInBytes: 8,
-              attributes: <gpu.VertexAttribute>[
-                // float32x2 (8 bytes) at offset 4 with stride 8 overruns by 4.
-                gpu.VertexAttribute(
-                  name: 'position',
-                  offsetInBytes: 4,
-                  format: gpu.VertexFormat.float32x2,
-                ),
-              ],
-            ),
-          ],
+        () => state.renderPass.draw(),
+        throwsA(
+          isA<StateError>().having(
+            (StateError e) => e.message,
+            'message',
+            allOf(contains('sparse'), contains('slot(s) 0')),
+          ),
         ),
       );
-      fail('Expected exception for offset+format overruning stride.');
-    } catch (e) {
-      expect(e.toString(), contains('overruns stride'));
-    }
-  }, skip: !(impellerEnabled && flutterGpuEnabled));
+    },
+    skip: !(impellerEnabled && flutterGpuEnabled),
+  );
 
-  test('createRenderPipeline rejects VertexLayout with overlapping attributes', () async {
-    final gpu.ShaderLibrary library = gpu.ShaderLibrary.fromAsset('test.shaderbundle')!;
-    try {
-      gpu.gpuContext.createRenderPipeline(
-        library['UnlitVertex']!,
-        library['UnlitFragment']!,
-        vertexLayout: const gpu.VertexLayout(
-          buffers: <gpu.VertexBuffer>[
-            gpu.VertexBuffer(
-              strideInBytes: 8,
-              attributes: <gpu.VertexAttribute>[
-                // Two attributes both occupying bytes [0, 8) in the same
-                // buffer. The second one isn't a real shader input, but
-                // the overlap check fires before the name check.
-                gpu.VertexAttribute(name: 'position', format: gpu.VertexFormat.float32x2),
-                gpu.VertexAttribute(name: 'aliased', format: gpu.VertexFormat.float32x2),
-              ],
-            ),
-          ],
-        ),
-      );
-      fail('Expected exception for overlapping VertexAttributes.');
-    } catch (e) {
-      final msg = e.toString();
-      expect(msg, contains('overlaps'));
-      expect(msg, contains("'position'"));
-      expect(msg, contains("'aliased'"));
-    }
-  }, skip: !(impellerEnabled && flutterGpuEnabled));
-
-  test('bindVertexBuffer throws RangeError for out-of-range slot', () async {
-    final RenderPassState state = createSimpleRenderPass();
-    final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
-    state.renderPass.bindPipeline(pipeline);
-
-    final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
-    final gpu.BufferView vertices = transients.emplace(
-      float32(<double>[-0.5, 0.5, 0.0, -0.5, 0.5, 0.5]),
-    );
-
-    expect(() => state.renderPass.bindVertexBuffer(vertices, 3, slot: -1), throwsRangeError);
-    expect(() => state.renderPass.bindVertexBuffer(vertices, 3, slot: 16), throwsRangeError);
-  }, skip: !(impellerEnabled && flutterGpuEnabled));
-
-  test('draw throws StateError on sparse vertex buffer bindings', () async {
-    final RenderPassState state = createSimpleRenderPass();
-    final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
-    state.renderPass.bindPipeline(pipeline);
-
-    final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
-    final gpu.BufferView vertices = transients.emplace(
-      float32(<double>[-0.5, 0.5, 0.0, -0.5, 0.5, 0.5]),
-    );
-
-    // Bind only slot 1 (skipping slot 0). draw() must surface a clear
-    // error rather than letting the underlying HAL validation fail
-    // silently or render with an empty slot.
-    state.renderPass.bindVertexBuffer(vertices, 3, slot: 1);
-    expect(
-      () => state.renderPass.draw(),
-      throwsA(
-        isA<StateError>().having(
-          (StateError e) => e.message,
-          'message',
-          allOf(contains('sparse'), contains('slot(s) 0')),
-        ),
-      ),
-    );
-  }, skip: !(impellerEnabled && flutterGpuEnabled));
-
-  test('createRenderPipeline rejects VertexAttribute with unknown name', () async {
-    final gpu.ShaderLibrary library = gpu.ShaderLibrary.fromAsset('test.shaderbundle')!;
-    try {
-      gpu.gpuContext.createRenderPipeline(
-        library['UnlitVertex']!,
-        library['UnlitFragment']!,
-        vertexLayout: const gpu.VertexLayout(
-          buffers: <gpu.VertexBuffer>[
-            gpu.VertexBuffer(
-              strideInBytes: 8,
-              attributes: <gpu.VertexAttribute>[
-                gpu.VertexAttribute(
-                  name: 'nonexistent_attribute',
-                  format: gpu.VertexFormat.float32x2,
-                ),
-              ],
-            ),
-          ],
-        ),
-      );
-      fail('Expected exception for unknown attribute name.');
-    } catch (e) {
-      expect(
-        e.toString(),
-        contains('does not match any input declared by the bound vertex shader'),
-      );
-    }
-  }, skip: !(impellerEnabled && flutterGpuEnabled));
+  test(
+    'createRenderPipeline rejects VertexAttribute with unknown name',
+    () async {
+      final gpu.ShaderLibrary library = gpu.ShaderLibrary.fromAsset('test.shaderbundle')!;
+      try {
+        gpu.gpuContext.createRenderPipeline(
+          library['UnlitVertex']!,
+          library['UnlitFragment']!,
+          vertexLayout: const gpu.VertexLayout(
+            buffers: <gpu.VertexBuffer>[
+              gpu.VertexBuffer(
+                strideInBytes: 8,
+                attributes: <gpu.VertexAttribute>[
+                  gpu.VertexAttribute(
+                    name: 'nonexistent_attribute',
+                    format: gpu.VertexFormat.float32x2,
+                  ),
+                ],
+              ),
+            ],
+          ),
+        );
+        fail('Expected exception for unknown attribute name.');
+      } catch (e) {
+        expect(
+          e.toString(),
+          contains('does not match any input declared by the bound vertex shader'),
+        );
+      }
+    },
+    skip: !(impellerEnabled && flutterGpuEnabled),
+  );
 
   // Renders a green triangle pointing downwards using polygon mode line.
   test('Can render triangle with polygon mode line.', () async {
@@ -793,30 +841,38 @@ void main() async {
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   // Renders a green triangle pointing downwards, with 4xMSAA.
-  test('Can render triangle with MSAA', () async {
-    final RenderPassState state = createSimpleRenderPassWithMSAA();
-    drawTriangle(state, Colors.lime);
-    state.commandBuffer.submit();
-
-    final ui.Image image = state.renderTexture.asImage();
-    await comparer.addGoldenImage(image, 'flutter_gpu_test_triangle_msaa.png');
-  }, skip: !(impellerEnabled && flutterGpuEnabled && gpu.gpuContext.doesSupportOffscreenMSAA));
-
-  test('Rendering with MSAA throws exception when offscreen MSAA is not supported', () async {
-    try {
+  test(
+    'Can render triangle with MSAA',
+    () async {
       final RenderPassState state = createSimpleRenderPassWithMSAA();
       drawTriangle(state, Colors.lime);
       state.commandBuffer.submit();
-      fail('Exception not thrown when offscreen MSAA is not supported.');
-    } catch (e) {
-      expect(
-        e.toString(),
-        contains(
-          'The backend does not support multisample anti-aliasing for offscreen color and stencil attachments',
-        ),
-      );
-    }
-  }, skip: !(impellerEnabled && flutterGpuEnabled && !gpu.gpuContext.doesSupportOffscreenMSAA));
+
+      final ui.Image image = state.renderTexture.asImage();
+      await comparer.addGoldenImage(image, 'flutter_gpu_test_triangle_msaa.png');
+    },
+    skip: !(impellerEnabled && flutterGpuEnabled && gpu.gpuContext.doesSupportOffscreenMSAA),
+  );
+
+  test(
+    'Rendering with MSAA throws exception when offscreen MSAA is not supported',
+    () async {
+      try {
+        final RenderPassState state = createSimpleRenderPassWithMSAA();
+        drawTriangle(state, Colors.lime);
+        state.commandBuffer.submit();
+        fail('Exception not thrown when offscreen MSAA is not supported.');
+      } catch (e) {
+        expect(
+          e.toString(),
+          contains(
+            'The backend does not support multisample anti-aliasing for offscreen color and stencil attachments',
+          ),
+        );
+      }
+    },
+    skip: !(impellerEnabled && flutterGpuEnabled && !gpu.gpuContext.doesSupportOffscreenMSAA),
+  );
 
   // Renders a hollow green triangle pointing downwards.
   test('Can render hollowed out triangle using stencil ops', () async {
@@ -946,43 +1002,62 @@ void main() async {
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   // Renders a hexagon using line strip primitive type.
-  test('Can render hollow hexagon using line strip primitive type', () async {
-    final RenderPassState state = createSimpleRenderPass();
+  test(
+    'Can render hollow hexagon using line strip primitive type',
+    () async {
+      final RenderPassState state = createSimpleRenderPass();
 
-    final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
-    state.renderPass.bindPipeline(pipeline);
+      final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
+      state.renderPass.bindPipeline(pipeline);
 
-    // Configure blending with defaults (just to test the bindings).
-    state.renderPass.setColorBlendEnable(true);
-    state.renderPass.setColorBlendEquation(gpu.ColorBlendEquation());
+      // Configure blending with defaults (just to test the bindings).
+      state.renderPass.setColorBlendEnable(true);
+      state.renderPass.setColorBlendEquation(gpu.ColorBlendEquation());
 
-    // Set primitive type
-    state.renderPass.setPrimitiveType(gpu.PrimitiveType.lineStrip);
+      // Set primitive type
+      state.renderPass.setPrimitiveType(gpu.PrimitiveType.lineStrip);
 
-    final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
-    final gpu.BufferView vertices = transients.emplace(
-      float32(<double>[1.0, 0.0, 0.5, 0.8, -0.5, 0.8, -1.0, 0.0, -0.5, -0.8, 0.5, -0.8, 1.0, 0.0]),
-    );
-    final gpu.BufferView vertInfoData = transients.emplace(
-      float32(<double>[
-        1, 0, 0, 0, // mvp
-        0, 1, 0, 0, // mvp
-        0, 0, 1, 0, // mvp
-        0, 0, 0, 1, // mvp
-        0, 1, 0, 1, // color
-      ]),
-    );
-    state.renderPass.bindVertexBuffer(vertices, 7);
+      final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
+      final gpu.BufferView vertices = transients.emplace(
+        float32(<double>[
+          1.0,
+          0.0,
+          0.5,
+          0.8,
+          -0.5,
+          0.8,
+          -1.0,
+          0.0,
+          -0.5,
+          -0.8,
+          0.5,
+          -0.8,
+          1.0,
+          0.0,
+        ]),
+      );
+      final gpu.BufferView vertInfoData = transients.emplace(
+        float32(<double>[
+          1, 0, 0, 0, // mvp
+          0, 1, 0, 0, // mvp
+          0, 0, 1, 0, // mvp
+          0, 0, 0, 1, // mvp
+          0, 1, 0, 1, // color
+        ]),
+      );
+      state.renderPass.bindVertexBuffer(vertices, 7);
 
-    final gpu.UniformSlot vertInfo = pipeline.vertexShader.getUniformSlot('VertInfo');
-    state.renderPass.bindUniform(vertInfo, vertInfoData);
-    state.renderPass.draw();
+      final gpu.UniformSlot vertInfo = pipeline.vertexShader.getUniformSlot('VertInfo');
+      state.renderPass.bindUniform(vertInfo, vertInfoData);
+      state.renderPass.draw();
 
-    state.commandBuffer.submit();
+      state.commandBuffer.submit();
 
-    final ui.Image image = state.renderTexture.asImage();
-    await comparer.addGoldenImage(image, 'flutter_gpu_test_hexgon_line_strip.png');
-  }, skip: !(impellerEnabled && flutterGpuEnabled));
+      final ui.Image image = state.renderTexture.asImage();
+      await comparer.addGoldenImage(image, 'flutter_gpu_test_hexgon_line_strip.png');
+    },
+    skip: !(impellerEnabled && flutterGpuEnabled),
+  );
 
   // Renders the middle part triangle using scissor.
   test('Can render portion of the triangle using scissor', () async {
@@ -1026,12 +1101,16 @@ void main() async {
     await comparer.addGoldenImage(image, 'flutter_gpu_test_scissor.png');
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 
-  test('RenderPass.setScissor doesnt throw for valid values', () async {
-    final RenderPassState state = createSimpleRenderPass();
+  test(
+    'RenderPass.setScissor doesnt throw for valid values',
+    () async {
+      final RenderPassState state = createSimpleRenderPass();
 
-    state.renderPass.setScissor(gpu.Scissor(x: 25, width: 50, height: 100));
-    state.renderPass.setScissor(gpu.Scissor(width: 50, height: 100));
-  }, skip: !(impellerEnabled && flutterGpuEnabled));
+      state.renderPass.setScissor(gpu.Scissor(x: 25, width: 50, height: 100));
+      state.renderPass.setScissor(gpu.Scissor(width: 50, height: 100));
+    },
+    skip: !(impellerEnabled && flutterGpuEnabled),
+  );
 
   test('RenderPass.setScissor throws for invalid values', () async {
     final RenderPassState state = createSimpleRenderPass();
@@ -1051,12 +1130,16 @@ void main() async {
     }
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 
-  test('RenderPass.setViewport doesnt throw for valid values', () async {
-    final RenderPassState state = createSimpleRenderPass();
+  test(
+    'RenderPass.setViewport doesnt throw for valid values',
+    () async {
+      final RenderPassState state = createSimpleRenderPass();
 
-    state.renderPass.setViewport(gpu.Viewport(x: 25, width: 50, height: 100));
-    state.renderPass.setViewport(gpu.Viewport(width: 50, height: 100));
-  }, skip: !(impellerEnabled && flutterGpuEnabled));
+      state.renderPass.setViewport(gpu.Viewport(x: 25, width: 50, height: 100));
+      state.renderPass.setViewport(gpu.Viewport(width: 50, height: 100));
+    },
+    skip: !(impellerEnabled && flutterGpuEnabled),
+  );
 
   test('RenderPass.setViewport throws for invalid values', () async {
     final RenderPassState state = createSimpleRenderPass();

--- a/engine/src/flutter/testing/dart/gpu_test.dart
+++ b/engine/src/flutter/testing/dart/gpu_test.dart
@@ -288,27 +288,23 @@ void main() async {
     expect(success, false);
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 
-  test(
-    'DeviceBuffer.overwrite throws for negative destination offset',
-    () async {
-      final gpu.DeviceBuffer deviceBuffer = gpu.gpuContext.createDeviceBuffer(
-        gpu.StorageMode.hostVisible,
-        4,
-      );
+  test('DeviceBuffer.overwrite throws for negative destination offset', () async {
+    final gpu.DeviceBuffer deviceBuffer = gpu.gpuContext.createDeviceBuffer(
+      gpu.StorageMode.hostVisible,
+      4,
+    );
 
-      try {
-        deviceBuffer.overwrite(
-          Int8List.fromList(<int>[0, 1, 2, 3]).buffer.asByteData(),
-          destinationOffsetInBytes: -1,
-        );
-        deviceBuffer.flush();
-        fail('Exception not thrown for negative destination offset.');
-      } catch (e) {
-        expect(e.toString(), contains('destinationOffsetInBytes must be positive'));
-      }
-    },
-    skip: !(impellerEnabled && flutterGpuEnabled),
-  );
+    try {
+      deviceBuffer.overwrite(
+        Int8List.fromList(<int>[0, 1, 2, 3]).buffer.asByteData(),
+        destinationOffsetInBytes: -1,
+      );
+      deviceBuffer.flush();
+      fail('Exception not thrown for negative destination offset.');
+    } catch (e) {
+      expect(e.toString(), contains('destinationOffsetInBytes must be positive'));
+    }
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   test('GpuContext.createTexture', () async {
     final gpu.Texture texture = gpu.gpuContext.createTexture(gpu.StorageMode.hostVisible, 100, 100);
@@ -403,122 +399,102 @@ void main() async {
     }
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 
-  test(
-    'RenderPass.setStencilReference doesnt throw for valid values',
-    () async {
-      final RenderPassState state = createSimpleRenderPass();
+  test('RenderPass.setStencilReference doesnt throw for valid values', () async {
+    final RenderPassState state = createSimpleRenderPass();
 
-      state.renderPass.setStencilReference(0);
-      state.renderPass.setStencilReference(2 << 30);
-    },
-    skip: !(impellerEnabled && flutterGpuEnabled),
-  );
+    state.renderPass.setStencilReference(0);
+    state.renderPass.setStencilReference(2 << 30);
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
 
-  test(
-    'RenderPass.setStencilReference throws for invalid values',
-    () async {
-      final RenderPassState state = createSimpleRenderPass();
+  test('RenderPass.setStencilReference throws for invalid values', () async {
+    final RenderPassState state = createSimpleRenderPass();
 
-      try {
-        state.renderPass.setStencilReference(-1);
-        fail('Exception not thrown for out of bounds stencil reference.');
-      } catch (e) {
-        expect(e.toString(), contains('The stencil reference value must be in the range'));
-      }
+    try {
+      state.renderPass.setStencilReference(-1);
+      fail('Exception not thrown for out of bounds stencil reference.');
+    } catch (e) {
+      expect(e.toString(), contains('The stencil reference value must be in the range'));
+    }
 
-      try {
-        state.renderPass.setStencilReference(2 << 31);
-        fail('Exception not thrown for out of bounds stencil reference.');
-      } catch (e) {
-        expect(e.toString(), contains('The stencil reference value must be in the range'));
-      }
-    },
-    skip: !(impellerEnabled && flutterGpuEnabled),
-  );
+    try {
+      state.renderPass.setStencilReference(2 << 31);
+      fail('Exception not thrown for out of bounds stencil reference.');
+    } catch (e) {
+      expect(e.toString(), contains('The stencil reference value must be in the range'));
+    }
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
 
-  test(
-    'RenderPass.setStencilConfig doesnt throw for valid values',
-    () async {
-      final RenderPassState state = createSimpleRenderPass();
+  test('RenderPass.setStencilConfig doesnt throw for valid values', () async {
+    final RenderPassState state = createSimpleRenderPass();
 
-      state.renderPass.setStencilConfig(gpu.StencilConfig());
-      state.renderPass.setStencilConfig(
-        gpu.StencilConfig(
-          compareFunction: gpu.CompareFunction.notEqual,
-          depthFailureOperation: gpu.StencilOperation.decrementWrap,
-          depthStencilPassOperation: gpu.StencilOperation.incrementWrap,
-          stencilFailureOperation: gpu.StencilOperation.invert,
-          readMask: 0,
-          writeMask: 0,
-        ),
-        targetFace: gpu.StencilFace.back,
+    state.renderPass.setStencilConfig(gpu.StencilConfig());
+    state.renderPass.setStencilConfig(
+      gpu.StencilConfig(
+        compareFunction: gpu.CompareFunction.notEqual,
+        depthFailureOperation: gpu.StencilOperation.decrementWrap,
+        depthStencilPassOperation: gpu.StencilOperation.incrementWrap,
+        stencilFailureOperation: gpu.StencilOperation.invert,
+        readMask: 0,
+        writeMask: 0,
+      ),
+      targetFace: gpu.StencilFace.back,
+    );
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  test('RenderPass.setStencilConfig throws for invalid masks', () async {
+    final RenderPassState state = createSimpleRenderPass();
+
+    try {
+      state.renderPass.setStencilConfig(gpu.StencilConfig(readMask: -1));
+      fail('Exception not thrown for invalid stencil read mask.');
+    } catch (e) {
+      expect(e.toString(), contains('The stencil read mask must be in the range'));
+    }
+    try {
+      state.renderPass.setStencilConfig(gpu.StencilConfig(readMask: 0xFFFFFFFF + 1));
+      fail('Exception not thrown for invalid stencil read mask.');
+    } catch (e) {
+      expect(e.toString(), contains('The stencil read mask must be in the range'));
+    }
+
+    try {
+      state.renderPass.setStencilConfig(gpu.StencilConfig(writeMask: -1));
+      fail('Exception not thrown for invalid stencil write mask.');
+    } catch (e) {
+      expect(e.toString(), contains('The stencil write mask must be in the range'));
+    }
+    try {
+      state.renderPass.setStencilConfig(gpu.StencilConfig(writeMask: 0xFFFFFFFF + 1));
+      fail('Exception not thrown for invalid stencil write mask.');
+    } catch (e) {
+      expect(e.toString(), contains('The stencil write mask must be in the range'));
+    }
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  test('RenderPass.bindTexture throws for deviceTransient Textures', () async {
+    final RenderPassState state = createSimpleRenderPass();
+
+    final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
+    // Although this is a non-texture uniform slot, it'll work fine for the
+    // purposes of testing this error.
+    final gpu.UniformSlot vertInfo = pipeline.vertexShader.getUniformSlot('VertInfo');
+
+    final gpu.Texture texture = gpu.gpuContext.createTexture(
+      gpu.StorageMode.deviceTransient,
+      100,
+      100,
+    );
+
+    try {
+      state.renderPass.bindTexture(vertInfo, texture);
+      fail('Exception not thrown when binding a transient texture.');
+    } catch (e) {
+      expect(
+        e.toString(),
+        contains('Textures with StorageMode.deviceTransient cannot be bound to a RenderPass'),
       );
-    },
-    skip: !(impellerEnabled && flutterGpuEnabled),
-  );
-
-  test(
-    'RenderPass.setStencilConfig throws for invalid masks',
-    () async {
-      final RenderPassState state = createSimpleRenderPass();
-
-      try {
-        state.renderPass.setStencilConfig(gpu.StencilConfig(readMask: -1));
-        fail('Exception not thrown for invalid stencil read mask.');
-      } catch (e) {
-        expect(e.toString(), contains('The stencil read mask must be in the range'));
-      }
-      try {
-        state.renderPass.setStencilConfig(gpu.StencilConfig(readMask: 0xFFFFFFFF + 1));
-        fail('Exception not thrown for invalid stencil read mask.');
-      } catch (e) {
-        expect(e.toString(), contains('The stencil read mask must be in the range'));
-      }
-
-      try {
-        state.renderPass.setStencilConfig(gpu.StencilConfig(writeMask: -1));
-        fail('Exception not thrown for invalid stencil write mask.');
-      } catch (e) {
-        expect(e.toString(), contains('The stencil write mask must be in the range'));
-      }
-      try {
-        state.renderPass.setStencilConfig(gpu.StencilConfig(writeMask: 0xFFFFFFFF + 1));
-        fail('Exception not thrown for invalid stencil write mask.');
-      } catch (e) {
-        expect(e.toString(), contains('The stencil write mask must be in the range'));
-      }
-    },
-    skip: !(impellerEnabled && flutterGpuEnabled),
-  );
-
-  test(
-    'RenderPass.bindTexture throws for deviceTransient Textures',
-    () async {
-      final RenderPassState state = createSimpleRenderPass();
-
-      final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
-      // Although this is a non-texture uniform slot, it'll work fine for the
-      // purposes of testing this error.
-      final gpu.UniformSlot vertInfo = pipeline.vertexShader.getUniformSlot('VertInfo');
-
-      final gpu.Texture texture = gpu.gpuContext.createTexture(
-        gpu.StorageMode.deviceTransient,
-        100,
-        100,
-      );
-
-      try {
-        state.renderPass.bindTexture(vertInfo, texture);
-        fail('Exception not thrown when binding a transient texture.');
-      } catch (e) {
-        expect(
-          e.toString(),
-          contains('Textures with StorageMode.deviceTransient cannot be bound to a RenderPass'),
-        );
-      }
-    },
-    skip: !(impellerEnabled && flutterGpuEnabled),
-  );
+    }
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   // Performs no draw calls. Just clears the render target to a solid green color.
   test('Can render clear color', () async {
@@ -614,158 +590,164 @@ void main() async {
     await comparer.addGoldenImage(image, 'flutter_gpu_test_triangle.png');
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 
-  test(
-    'createRenderPipeline rejects VertexLayout with wrong attribute format',
-    () async {
-      final gpu.ShaderLibrary library = gpu.ShaderLibrary.fromAsset('test.shaderbundle')!;
-      try {
-        gpu.gpuContext.createRenderPipeline(
-          library['UnlitVertex']!,
-          library['UnlitFragment']!,
-          vertexLayout: const gpu.VertexLayout(
-            buffers: <gpu.VertexBuffer>[
-              gpu.VertexBuffer(
-                strideInBytes: 8,
-                attributes: <gpu.VertexAttribute>[
-                  // UnlitVertex declares a float `vec2 position`, so binding
-                  // a uint32x2 (different scalar type class) here must throw.
-                  // Component-count mismatches are NOT errors: a buffer can
-                  // supply more or fewer components than the shader reads,
-                  // matching the default-substitution rules every modern HAL
-                  // uses.
-                  gpu.VertexAttribute(name: 'position', format: gpu.VertexFormat.uint32x2),
-                ],
-              ),
-            ],
-          ),
-        );
-        fail('Expected exception for mismatched VertexFormat scalar type.');
-      } catch (e) {
-        expect(
-          e.toString(),
-          contains("format does not match the vertex shader's declared input type"),
-        );
-      }
-    },
-    skip: !(impellerEnabled && flutterGpuEnabled),
-  );
-
-  test(
-    'createRenderPipeline rejects VertexAttribute that overruns stride',
-    () async {
-      final gpu.ShaderLibrary library = gpu.ShaderLibrary.fromAsset('test.shaderbundle')!;
-      try {
-        gpu.gpuContext.createRenderPipeline(
-          library['UnlitVertex']!,
-          library['UnlitFragment']!,
-          vertexLayout: const gpu.VertexLayout(
-            buffers: <gpu.VertexBuffer>[
-              gpu.VertexBuffer(
-                strideInBytes: 8,
-                attributes: <gpu.VertexAttribute>[
-                  // float32x2 (8 bytes) at offset 4 with stride 8 overruns by 4.
-                  gpu.VertexAttribute(
-                    name: 'position',
-                    offsetInBytes: 4,
-                    format: gpu.VertexFormat.float32x2,
-                  ),
-                ],
-              ),
-            ],
-          ),
-        );
-        fail('Expected exception for offset+format overruning stride.');
-      } catch (e) {
-        expect(e.toString(), contains('overruns stride'));
-      }
-    },
-    skip: !(impellerEnabled && flutterGpuEnabled),
-  );
-
-  test(
-    'createRenderPipeline rejects VertexLayout with overlapping attributes',
-    () async {
-      final gpu.ShaderLibrary library = gpu.ShaderLibrary.fromAsset('test.shaderbundle')!;
-      try {
-        gpu.gpuContext.createRenderPipeline(
-          library['UnlitVertex']!,
-          library['UnlitFragment']!,
-          vertexLayout: const gpu.VertexLayout(
-            buffers: <gpu.VertexBuffer>[
-              gpu.VertexBuffer(
-                strideInBytes: 8,
-                attributes: <gpu.VertexAttribute>[
-                  // Two attributes both occupying bytes [0, 8) in the same
-                  // buffer. The second one isn't a real shader input, but
-                  // the overlap check fires before the name check.
-                  gpu.VertexAttribute(name: 'position', format: gpu.VertexFormat.float32x2),
-                  gpu.VertexAttribute(name: 'aliased', format: gpu.VertexFormat.float32x2),
-                ],
-              ),
-            ],
-          ),
-        );
-        fail('Expected exception for overlapping VertexAttributes.');
-      } catch (e) {
-        final msg = e.toString();
-        expect(msg, contains('overlaps'));
-        expect(msg, contains("'position'"));
-        expect(msg, contains("'aliased'"));
-      }
-    },
-    skip: !(impellerEnabled && flutterGpuEnabled),
-  );
-
-  test(
-    'bindVertexBuffer throws RangeError for out-of-range slot',
-    () async {
-      final RenderPassState state = createSimpleRenderPass();
-      final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
-      state.renderPass.bindPipeline(pipeline);
-
-      final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
-      final gpu.BufferView vertices = transients.emplace(
-        float32(<double>[-0.5, 0.5, 0.0, -0.5, 0.5, 0.5]),
+  test('createRenderPipeline rejects VertexLayout with wrong attribute format', () async {
+    final gpu.ShaderLibrary library = gpu.ShaderLibrary.fromAsset('test.shaderbundle')!;
+    try {
+      gpu.gpuContext.createRenderPipeline(
+        library['UnlitVertex']!,
+        library['UnlitFragment']!,
+        vertexLayout: const gpu.VertexLayout(
+          buffers: <gpu.VertexBuffer>[
+            gpu.VertexBuffer(
+              strideInBytes: 8,
+              attributes: <gpu.VertexAttribute>[
+                // UnlitVertex declares a float `vec2 position`, so binding
+                // a uint32x2 (different scalar type class) here must throw.
+                // Component-count mismatches are NOT errors: a buffer can
+                // supply more or fewer components than the shader reads,
+                // matching the default-substitution rules every modern HAL
+                // uses.
+                gpu.VertexAttribute(name: 'position', format: gpu.VertexFormat.uint32x2),
+              ],
+            ),
+          ],
+        ),
       );
+      fail('Expected exception for mismatched VertexFormat scalar type.');
+    } catch (e) {
+      expect(
+        e.toString(),
+        contains("format does not match the vertex shader's declared input type"),
+      );
+    }
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
 
-      expect(() => state.renderPass.bindVertexBuffer(vertices, 3, slot: -1), throwsRangeError);
-      expect(() => state.renderPass.bindVertexBuffer(vertices, 3, slot: 16), throwsRangeError);
-    },
-    skip: !(impellerEnabled && flutterGpuEnabled),
-  );
+  test('createRenderPipeline rejects VertexAttribute that overruns stride', () async {
+    final gpu.ShaderLibrary library = gpu.ShaderLibrary.fromAsset('test.shaderbundle')!;
+    try {
+      gpu.gpuContext.createRenderPipeline(
+        library['UnlitVertex']!,
+        library['UnlitFragment']!,
+        vertexLayout: const gpu.VertexLayout(
+          buffers: <gpu.VertexBuffer>[
+            gpu.VertexBuffer(
+              strideInBytes: 8,
+              attributes: <gpu.VertexAttribute>[
+                // float32x2 (8 bytes) at offset 4 with stride 8 overruns by 4.
+                gpu.VertexAttribute(
+                  name: 'position',
+                  offsetInBytes: 4,
+                  format: gpu.VertexFormat.float32x2,
+                ),
+              ],
+            ),
+          ],
+        ),
+      );
+      fail('Expected exception for offset+format overruning stride.');
+    } catch (e) {
+      expect(e.toString(), contains('overruns stride'));
+    }
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
 
-  test(
-    'createRenderPipeline rejects VertexAttribute with unknown name',
-    () async {
-      final gpu.ShaderLibrary library = gpu.ShaderLibrary.fromAsset('test.shaderbundle')!;
-      try {
-        gpu.gpuContext.createRenderPipeline(
-          library['UnlitVertex']!,
-          library['UnlitFragment']!,
-          vertexLayout: const gpu.VertexLayout(
-            buffers: <gpu.VertexBuffer>[
-              gpu.VertexBuffer(
-                strideInBytes: 8,
-                attributes: <gpu.VertexAttribute>[
-                  gpu.VertexAttribute(
-                    name: 'nonexistent_attribute',
-                    format: gpu.VertexFormat.float32x2,
-                  ),
-                ],
-              ),
-            ],
-          ),
-        );
-        fail('Expected exception for unknown attribute name.');
-      } catch (e) {
-        expect(
-          e.toString(),
-          contains('does not match any input declared by the bound vertex shader'),
-        );
-      }
-    },
-    skip: !(impellerEnabled && flutterGpuEnabled),
-  );
+  test('createRenderPipeline rejects VertexLayout with overlapping attributes', () async {
+    final gpu.ShaderLibrary library = gpu.ShaderLibrary.fromAsset('test.shaderbundle')!;
+    try {
+      gpu.gpuContext.createRenderPipeline(
+        library['UnlitVertex']!,
+        library['UnlitFragment']!,
+        vertexLayout: const gpu.VertexLayout(
+          buffers: <gpu.VertexBuffer>[
+            gpu.VertexBuffer(
+              strideInBytes: 8,
+              attributes: <gpu.VertexAttribute>[
+                // Two attributes both occupying bytes [0, 8) in the same
+                // buffer. The second one isn't a real shader input, but
+                // the overlap check fires before the name check.
+                gpu.VertexAttribute(name: 'position', format: gpu.VertexFormat.float32x2),
+                gpu.VertexAttribute(name: 'aliased', format: gpu.VertexFormat.float32x2),
+              ],
+            ),
+          ],
+        ),
+      );
+      fail('Expected exception for overlapping VertexAttributes.');
+    } catch (e) {
+      final msg = e.toString();
+      expect(msg, contains('overlaps'));
+      expect(msg, contains("'position'"));
+      expect(msg, contains("'aliased'"));
+    }
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  test('bindVertexBuffer throws RangeError for out-of-range slot', () async {
+    final RenderPassState state = createSimpleRenderPass();
+    final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
+    state.renderPass.bindPipeline(pipeline);
+
+    final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
+    final gpu.BufferView vertices = transients.emplace(
+      float32(<double>[-0.5, 0.5, 0.0, -0.5, 0.5, 0.5]),
+    );
+
+    expect(() => state.renderPass.bindVertexBuffer(vertices, 3, slot: -1), throwsRangeError);
+    expect(() => state.renderPass.bindVertexBuffer(vertices, 3, slot: 16), throwsRangeError);
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  test('draw throws StateError on sparse vertex buffer bindings', () async {
+    final RenderPassState state = createSimpleRenderPass();
+    final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
+    state.renderPass.bindPipeline(pipeline);
+
+    final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
+    final gpu.BufferView vertices = transients.emplace(
+      float32(<double>[-0.5, 0.5, 0.0, -0.5, 0.5, 0.5]),
+    );
+
+    // Bind only slot 1 (skipping slot 0). draw() must surface a clear
+    // error rather than letting the underlying HAL validation fail
+    // silently or render with an empty slot.
+    state.renderPass.bindVertexBuffer(vertices, 3, slot: 1);
+    expect(
+      () => state.renderPass.draw(),
+      throwsA(
+        isA<StateError>().having(
+          (StateError e) => e.message,
+          'message',
+          allOf(contains('sparse'), contains('slot(s) 0')),
+        ),
+      ),
+    );
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  test('createRenderPipeline rejects VertexAttribute with unknown name', () async {
+    final gpu.ShaderLibrary library = gpu.ShaderLibrary.fromAsset('test.shaderbundle')!;
+    try {
+      gpu.gpuContext.createRenderPipeline(
+        library['UnlitVertex']!,
+        library['UnlitFragment']!,
+        vertexLayout: const gpu.VertexLayout(
+          buffers: <gpu.VertexBuffer>[
+            gpu.VertexBuffer(
+              strideInBytes: 8,
+              attributes: <gpu.VertexAttribute>[
+                gpu.VertexAttribute(
+                  name: 'nonexistent_attribute',
+                  format: gpu.VertexFormat.float32x2,
+                ),
+              ],
+            ),
+          ],
+        ),
+      );
+      fail('Expected exception for unknown attribute name.');
+    } catch (e) {
+      expect(
+        e.toString(),
+        contains('does not match any input declared by the bound vertex shader'),
+      );
+    }
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   // Renders a green triangle pointing downwards using polygon mode line.
   test('Can render triangle with polygon mode line.', () async {
@@ -811,38 +793,30 @@ void main() async {
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   // Renders a green triangle pointing downwards, with 4xMSAA.
-  test(
-    'Can render triangle with MSAA',
-    () async {
+  test('Can render triangle with MSAA', () async {
+    final RenderPassState state = createSimpleRenderPassWithMSAA();
+    drawTriangle(state, Colors.lime);
+    state.commandBuffer.submit();
+
+    final ui.Image image = state.renderTexture.asImage();
+    await comparer.addGoldenImage(image, 'flutter_gpu_test_triangle_msaa.png');
+  }, skip: !(impellerEnabled && flutterGpuEnabled && gpu.gpuContext.doesSupportOffscreenMSAA));
+
+  test('Rendering with MSAA throws exception when offscreen MSAA is not supported', () async {
+    try {
       final RenderPassState state = createSimpleRenderPassWithMSAA();
       drawTriangle(state, Colors.lime);
       state.commandBuffer.submit();
-
-      final ui.Image image = state.renderTexture.asImage();
-      await comparer.addGoldenImage(image, 'flutter_gpu_test_triangle_msaa.png');
-    },
-    skip: !(impellerEnabled && flutterGpuEnabled && gpu.gpuContext.doesSupportOffscreenMSAA),
-  );
-
-  test(
-    'Rendering with MSAA throws exception when offscreen MSAA is not supported',
-    () async {
-      try {
-        final RenderPassState state = createSimpleRenderPassWithMSAA();
-        drawTriangle(state, Colors.lime);
-        state.commandBuffer.submit();
-        fail('Exception not thrown when offscreen MSAA is not supported.');
-      } catch (e) {
-        expect(
-          e.toString(),
-          contains(
-            'The backend does not support multisample anti-aliasing for offscreen color and stencil attachments',
-          ),
-        );
-      }
-    },
-    skip: !(impellerEnabled && flutterGpuEnabled && !gpu.gpuContext.doesSupportOffscreenMSAA),
-  );
+      fail('Exception not thrown when offscreen MSAA is not supported.');
+    } catch (e) {
+      expect(
+        e.toString(),
+        contains(
+          'The backend does not support multisample anti-aliasing for offscreen color and stencil attachments',
+        ),
+      );
+    }
+  }, skip: !(impellerEnabled && flutterGpuEnabled && !gpu.gpuContext.doesSupportOffscreenMSAA));
 
   // Renders a hollow green triangle pointing downwards.
   test('Can render hollowed out triangle using stencil ops', () async {
@@ -972,62 +946,43 @@ void main() async {
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   // Renders a hexagon using line strip primitive type.
-  test(
-    'Can render hollow hexagon using line strip primitive type',
-    () async {
-      final RenderPassState state = createSimpleRenderPass();
+  test('Can render hollow hexagon using line strip primitive type', () async {
+    final RenderPassState state = createSimpleRenderPass();
 
-      final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
-      state.renderPass.bindPipeline(pipeline);
+    final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
+    state.renderPass.bindPipeline(pipeline);
 
-      // Configure blending with defaults (just to test the bindings).
-      state.renderPass.setColorBlendEnable(true);
-      state.renderPass.setColorBlendEquation(gpu.ColorBlendEquation());
+    // Configure blending with defaults (just to test the bindings).
+    state.renderPass.setColorBlendEnable(true);
+    state.renderPass.setColorBlendEquation(gpu.ColorBlendEquation());
 
-      // Set primitive type
-      state.renderPass.setPrimitiveType(gpu.PrimitiveType.lineStrip);
+    // Set primitive type
+    state.renderPass.setPrimitiveType(gpu.PrimitiveType.lineStrip);
 
-      final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
-      final gpu.BufferView vertices = transients.emplace(
-        float32(<double>[
-          1.0,
-          0.0,
-          0.5,
-          0.8,
-          -0.5,
-          0.8,
-          -1.0,
-          0.0,
-          -0.5,
-          -0.8,
-          0.5,
-          -0.8,
-          1.0,
-          0.0,
-        ]),
-      );
-      final gpu.BufferView vertInfoData = transients.emplace(
-        float32(<double>[
-          1, 0, 0, 0, // mvp
-          0, 1, 0, 0, // mvp
-          0, 0, 1, 0, // mvp
-          0, 0, 0, 1, // mvp
-          0, 1, 0, 1, // color
-        ]),
-      );
-      state.renderPass.bindVertexBuffer(vertices, 7);
+    final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
+    final gpu.BufferView vertices = transients.emplace(
+      float32(<double>[1.0, 0.0, 0.5, 0.8, -0.5, 0.8, -1.0, 0.0, -0.5, -0.8, 0.5, -0.8, 1.0, 0.0]),
+    );
+    final gpu.BufferView vertInfoData = transients.emplace(
+      float32(<double>[
+        1, 0, 0, 0, // mvp
+        0, 1, 0, 0, // mvp
+        0, 0, 1, 0, // mvp
+        0, 0, 0, 1, // mvp
+        0, 1, 0, 1, // color
+      ]),
+    );
+    state.renderPass.bindVertexBuffer(vertices, 7);
 
-      final gpu.UniformSlot vertInfo = pipeline.vertexShader.getUniformSlot('VertInfo');
-      state.renderPass.bindUniform(vertInfo, vertInfoData);
-      state.renderPass.draw();
+    final gpu.UniformSlot vertInfo = pipeline.vertexShader.getUniformSlot('VertInfo');
+    state.renderPass.bindUniform(vertInfo, vertInfoData);
+    state.renderPass.draw();
 
-      state.commandBuffer.submit();
+    state.commandBuffer.submit();
 
-      final ui.Image image = state.renderTexture.asImage();
-      await comparer.addGoldenImage(image, 'flutter_gpu_test_hexgon_line_strip.png');
-    },
-    skip: !(impellerEnabled && flutterGpuEnabled),
-  );
+    final ui.Image image = state.renderTexture.asImage();
+    await comparer.addGoldenImage(image, 'flutter_gpu_test_hexgon_line_strip.png');
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   // Renders the middle part triangle using scissor.
   test('Can render portion of the triangle using scissor', () async {
@@ -1071,16 +1026,12 @@ void main() async {
     await comparer.addGoldenImage(image, 'flutter_gpu_test_scissor.png');
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 
-  test(
-    'RenderPass.setScissor doesnt throw for valid values',
-    () async {
-      final RenderPassState state = createSimpleRenderPass();
+  test('RenderPass.setScissor doesnt throw for valid values', () async {
+    final RenderPassState state = createSimpleRenderPass();
 
-      state.renderPass.setScissor(gpu.Scissor(x: 25, width: 50, height: 100));
-      state.renderPass.setScissor(gpu.Scissor(width: 50, height: 100));
-    },
-    skip: !(impellerEnabled && flutterGpuEnabled),
-  );
+    state.renderPass.setScissor(gpu.Scissor(x: 25, width: 50, height: 100));
+    state.renderPass.setScissor(gpu.Scissor(width: 50, height: 100));
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   test('RenderPass.setScissor throws for invalid values', () async {
     final RenderPassState state = createSimpleRenderPass();
@@ -1100,16 +1051,12 @@ void main() async {
     }
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 
-  test(
-    'RenderPass.setViewport doesnt throw for valid values',
-    () async {
-      final RenderPassState state = createSimpleRenderPass();
+  test('RenderPass.setViewport doesnt throw for valid values', () async {
+    final RenderPassState state = createSimpleRenderPass();
 
-      state.renderPass.setViewport(gpu.Viewport(x: 25, width: 50, height: 100));
-      state.renderPass.setViewport(gpu.Viewport(width: 50, height: 100));
-    },
-    skip: !(impellerEnabled && flutterGpuEnabled),
-  );
+    state.renderPass.setViewport(gpu.Viewport(x: 25, width: 50, height: 100));
+    state.renderPass.setViewport(gpu.Viewport(width: 50, height: 100));
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   test('RenderPass.setViewport throws for invalid values', () async {
     final RenderPassState state = createSimpleRenderPass();


### PR DESCRIPTION
Adds an explicit `VertexLayout` value type that the caller can pass to `GpuContext.createRenderPipeline` to override the default interleaved layout declared by the bound vertex shader's shader bundle, plus a `slot:` parameter on `RenderPass.bindVertexBuffer` so multiple vertex buffers can be bound to a single draw. This unblocks structure-of-arrays mesh loading (positions in one buffer, normals + UVs in another, etc.) and lets a renderer reorder attributes from the impellerc-generated default.

The shipped scope intentionally pins only what's expressible against today's HAL without backing the API into a corner. The deferred capabilities (instancing, sparse bindings, normalized / packed / half-float / BGRA / 64-bit formats) are tracked at #186307, #186308, and #186309, with TODO comments at the relevant call sites pointing at each tracking issue.

### Dart surface

```dart
enum VertexFormat {
  float32, float32x2, float32x3, float32x4,
  uint32,  uint32x2,  uint32x3,  uint32x4,
  sint32,  sint32x2,  sint32x3,  sint32x4,
}

class VertexAttribute {
  String name;
  VertexFormat format;
  int offsetInBytes; // defaults to 0
}

class VertexBuffer {
  int strideInBytes;
  List<VertexAttribute> attributes;
}

class VertexLayout {
  List<VertexBuffer> buffers;
}

GpuContext.createRenderPipeline(vertex, fragment, {VertexLayout? vertexLayout});
RenderPass.bindVertexBuffer(BufferView, int vertexCount, {int slot = 0});
```

If `vertexLayout` is `null`, the default for the bound vertex shader is used (today's behavior). The new `slot:` parameter defaults to `0`, so all existing single-buffer call sites compile unchanged.

Attributes nest under the `VertexBuffer` they read from; each buffer's position in `VertexLayout.buffers` determines the binding slot it must be bound to via `RenderPass.bindVertexBuffer` (the first buffer is slot 0, the second is slot 1, and so on). `offsetInBytes` defaults to 0 so the common structure-of-arrays case (one attribute per buffer at the start of each element) doesn't need to spell it out.

Attributes are keyed by the shader-side input `name` rather than a raw integer location, mirroring how uniform bindings are resolved via `Shader.getUniformSlot('VertInfo')`. This keeps the Dart layout robust to shader edits that reorder `in` declarations (the underlying location, which is what every backend ultimately consumes, is read from the shader's reflection at pipeline build time).

### Example: structure-of-arrays glTF mesh

Most glTF mesh primitives store each vertex attribute (POSITION, NORMAL, TEXCOORD_0, ...) in its own accessor, often inside its own buffer view. Without a configurable vertex layout, callers were forced to interleave those attributes on the CPU before upload. With this change, each attribute can keep its own buffer and bind at its own slot.

Given a vertex shader that declares three named inputs:

```glsl
in vec3 position;
in vec3 normal;
in vec2 texcoord;
```

A renderer can describe the SoA layout once at pipeline creation and then bind one buffer per slot per draw:

```dart
import 'package:flutter_gpu/gpu.dart' as gpu;

final pipeline = gpu.gpuContext.createRenderPipeline(
  vertexShader,
  fragmentShader,
  vertexLayout: const gpu.VertexLayout(
    buffers: <gpu.VertexBuffer>[
      gpu.VertexBuffer(
        strideInBytes: 12,
        attributes: <gpu.VertexAttribute>[
          gpu.VertexAttribute(name: 'position', format: gpu.VertexFormat.float32x3),
        ],
      ),
      gpu.VertexBuffer(
        strideInBytes: 12,
        attributes: <gpu.VertexAttribute>[
          gpu.VertexAttribute(name: 'normal', format: gpu.VertexFormat.float32x3),
        ],
      ),
      gpu.VertexBuffer(
        strideInBytes: 8,
        attributes: <gpu.VertexAttribute>[
          gpu.VertexAttribute(name: 'texcoord', format: gpu.VertexFormat.float32x2),
        ],
      ),
    ],
  ),
);

// Per draw call: bind one buffer per slot.
renderPass.bindPipeline(pipeline);
renderPass.bindVertexBuffer(positionsView, vertexCount, slot: 0);
renderPass.bindVertexBuffer(normalsView,   vertexCount, slot: 1);
renderPass.bindVertexBuffer(texcoordsView, vertexCount, slot: 2);
renderPass.draw();
```

Interleaved layouts work too: declare one `VertexBuffer` whose `strideInBytes` covers the whole vertex, list every attribute under it, and give each attribute past the first an explicit `offsetInBytes` into the element:

```dart
vertexLayout: const gpu.VertexLayout(
  buffers: <gpu.VertexBuffer>[
    gpu.VertexBuffer(
      strideInBytes: 32,
      attributes: <gpu.VertexAttribute>[
        gpu.VertexAttribute(name: 'position', format: gpu.VertexFormat.float32x3),
        gpu.VertexAttribute(
          name: 'normal',
          format: gpu.VertexFormat.float32x3,
          offsetInBytes: 12,
        ),
        gpu.VertexAttribute(
          name: 'texcoord',
          format: gpu.VertexFormat.float32x2,
          offsetInBytes: 24,
        ),
      ],
    ),
  ],
),
```

This is also how a caller would override the impellerc-generated default to skip an unused attribute or reorder the components.

### Validation

`createRenderPipeline` throws a Dart exception when:

- A `VertexAttribute.format` doesn't match the bound vertex shader's declared scalar type class (float vs signed int vs unsigned int). Component-count mismatches are NOT errors, mirroring the default-substitution rules every modern HAL uses ((0, 0, 0, 1) fill).
- An attribute's `offsetInBytes + format.bytesPerElement` overruns the owning `VertexBuffer`'s stride.
- Two attributes within the same `VertexBuffer` occupy overlapping byte ranges (i.e. `[offsetInBytes, offsetInBytes + format.bytesPerElement)` ranges that intersect).
- An attribute's `name` doesn't match any vertex shader input declaration.

`RenderPass.bindVertexBuffer` throws `RangeError` if `slot` is outside `[0, 16)`.

### C++ plumbing

- `Shader::GetStageInputs()` exposes the impellerc-reflected attribute metadata so the pipeline initializer can resolve user attribute names to `(location, set, columns, relaxed_precision)` and validate user formats against the shader's declared scalar type.
- `RenderPipeline` stores its own `impeller::VertexDescriptor`, built from the user layout when supplied or fetched from the shader's reflection otherwise.
- `RenderPass` upgrades `vertex_buffer` to a `std::array<BufferView, 16>` indexed by binding slot, tracks the highest bound slot, and forwards the whole array to `impeller::RenderPass::SetVertexBuffer(BufferView*, count)`.

The packed `(buffer layouts, attributes, attribute names)` data is passed via FFI as three `ByteData` handles and copied out of the typed-data handles before any callback into the Dart VM (else `Dart_TypedDataAcquireData` would forbid the callback). With nested attributes, `bufferLayouts` rows shrink to `[strideInBytes, attributeCount]` and `attributes` rows shrink to `[offsetInBytes, formatIndex, nameByteLength]`; binding slots are implicit in each buffer's position, and the C++ side walks attribute rows by consuming each buffer's `attributeCount` in order. Attribute names are encoded as concatenated UTF-8 bytes walked in parallel with the attributes integer table using each entry's `nameByteLength`.

### Tests

Adds six `gpu_test.dart` tests covering an explicit-layout-matching-default render, a slot-range check, and four `createRenderPipeline` validation paths (wrong format, overrun stride, overlapping attributes within a buffer, unknown attribute name). All pass on `flutter_tester_opengles` (SwANGLE) and `flutter_tester` (Metal) locally.

Fixes #145013.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
