### PR TITLE
Time picker error in locales that do not use Latin digits

### DIFF
--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -1753,8 +1753,7 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
   late final RestorableTimeOfDay _selectedTime = RestorableTimeOfDay(widget.initialSelectedTime);
   final RestorableBool hourHasError = RestorableBool(false);
   final RestorableBool minuteHasError = RestorableBool(false);
-  Map<String, int>? _cachedHours;
-  Map<String, int>? _cachedMinutes;
+  Map<String, int>? _cachedNumbers;
   Locale? _cachedLocale;
 
   @override
@@ -1762,8 +1761,7 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
     super.didChangeDependencies();
     final Locale locale = Localizations.localeOf(context);
     if (_cachedLocale != locale) {
-      _cachedHours = null;
-      _cachedMinutes = null;
+      _cachedNumbers = null;
       _cachedLocale = locale;
     }
   }
@@ -1791,7 +1789,7 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
       return null;
     }
 
-    int? newHour = _tryParseLocalizedHour(value);
+    int? newHour = _tryParseLocalizedNumber(value);
     if (newHour == null) {
       return null;
     }
@@ -1817,7 +1815,7 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
       return null;
     }
 
-    final int? newMinute = _tryParseLocalizedMinute(value);
+    final int? newMinute = _tryParseLocalizedNumber(value);
     if (newMinute == null) {
       return null;
     }
@@ -1828,40 +1826,34 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
     return null;
   }
 
-  int? _tryParseLocalizedHour(String hour) {
-    final int? parsedHour = int.tryParse(hour);
-    if (parsedHour != null) {
-      return parsedHour;
+  int? _tryParseLocalizedNumber(String number) {
+    final int? parsedNumber = int.tryParse(number);
+    if (parsedNumber != null) {
+      return parsedNumber;
     }
 
-    final MaterialLocalizations localizations = MaterialLocalizations.of(
-      context,
-    );
+    _cachedNumbers ??= _generateLocalizedNumbers();
 
-    _cachedHours ??= <String, int>{
-      for (int i = 0; i < 24; i++)
-        localizations.formatHour(TimeOfDay(hour: i, minute: 0)): i,
-    };
-
-    return _cachedHours![hour];
+    return _cachedNumbers![number];
   }
 
-  int? _tryParseLocalizedMinute(String minute) {
-    final int? parsedMinute = int.tryParse(minute);
-    if (parsedMinute != null) {
-      return parsedMinute;
-    }
-
+  Map<String, int> _generateLocalizedNumbers() {
     final MaterialLocalizations localizations = MaterialLocalizations.of(
       context,
     );
 
-    _cachedMinutes ??= <String, int>{
-      for (int i = 0; i < 60; i++)
-        localizations.formatMinute(TimeOfDay(hour: 0, minute: i)): i,
+    // Supports 0, 1, 2, ..., 59.
+    final numbers = <String, int>{
+      for (int i = 0; i < 60; i++) localizations.formatDecimal(i): i,
     };
 
-    return _cachedMinutes![minute];
+    // Support 00, 01, 02, ..., 09.
+    final String zero = localizations.formatDecimal(0);
+    for (var i = 0; i < 10; i++) {
+      numbers[zero + localizations.formatDecimal(i)] = i;
+    }
+
+    return numbers;
   }
 
   void _handleHourSavedSubmitted(String? value) {
@@ -1885,7 +1877,7 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
     final int? newMinute = _parseMinute(value);
     if (newMinute != null) {
       _selectedTime.value = TimeOfDay(
-        hour: _selectedTime.value.hour,
+        hour: _selectedTime.value.hour, 
         minute: newMinute,
       );
       _TimePickerModel.setSelectedTime(context, _selectedTime.value);

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -1842,7 +1842,7 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
   Map<String, int> _generateLocalizedNumbers() {
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
 
-    // Supports 0, 1, 2, ..., 59.
+    // Supports 0 - 59.
     final numbers = <String, int>{
       for (int i = 0; i < 60; i++) localizations.formatDecimal(i): i,
     };

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -1834,26 +1834,28 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
 
     _cachedNumbers ??= _generateLocalizedNumbers();
 
-    return _cachedNumbers![number];
+    final String trimmedNumber = _removeLeadingZeros(number);
+
+    return _cachedNumbers![trimmedNumber];
   }
 
   Map<String, int> _generateLocalizedNumbers() {
-    final MaterialLocalizations localizations = MaterialLocalizations.of(
-      context,
-    );
+    final MaterialLocalizations localizations = MaterialLocalizations.of(context);
 
     // Supports 0, 1, 2, ..., 59.
     final numbers = <String, int>{
       for (int i = 0; i < 60; i++) localizations.formatDecimal(i): i,
     };
 
-    // Support 00, 01, 02, ..., 09.
-    final String zero = localizations.formatDecimal(0);
-    for (var i = 0; i < 10; i++) {
-      numbers[zero + localizations.formatDecimal(i)] = i;
-    }
-
     return numbers;
+  }
+
+  String _removeLeadingZeros(String value) {
+    final String localizedZero = MaterialLocalizations.of(context).formatDecimal(0);
+    while (value.startsWith(localizedZero) && value.length > 1) {
+      value = value.substring(localizedZero.length);
+    }
+    return value;
   }
 
   void _handleHourSavedSubmitted(String? value) {
@@ -1876,10 +1878,7 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
   void _handleMinuteSavedSubmitted(String? value) {
     final int? newMinute = _parseMinute(value);
     if (newMinute != null) {
-      _selectedTime.value = TimeOfDay(
-        hour: _selectedTime.value.hour, 
-        minute: newMinute,
-      );
+      _selectedTime.value = TimeOfDay(hour: _selectedTime.value.hour, minute: newMinute);
       _TimePickerModel.setSelectedTime(context, _selectedTime.value);
       FocusScope.of(context).unfocus();
     }

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -1753,6 +1753,18 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
   late final RestorableTimeOfDay _selectedTime = RestorableTimeOfDay(widget.initialSelectedTime);
   final RestorableBool hourHasError = RestorableBool(false);
   final RestorableBool minuteHasError = RestorableBool(false);
+  Map<String, int>? cachedNumbers;
+  Locale? _cachedLocale;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final Locale locale = Localizations.localeOf(context);
+    if (_cachedLocale != locale) {
+      cachedNumbers = null;
+      _cachedLocale = locale;
+    }
+  }
 
   @override
   void dispose() {
@@ -1777,7 +1789,7 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
       return null;
     }
 
-    int? newHour = int.tryParse(value);
+    int? newHour = _tryParseLocalizedNumber(value);
     if (newHour == null) {
       return null;
     }
@@ -1803,7 +1815,7 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
       return null;
     }
 
-    final int? newMinute = int.tryParse(value);
+    final int? newMinute = _tryParseLocalizedNumber(value);
     if (newMinute == null) {
       return null;
     }
@@ -1812,6 +1824,33 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
       return newMinute;
     }
     return null;
+  }
+
+  int? _tryParseLocalizedNumber(String number) {
+    final int? parsedNumber = int.tryParse(number);
+    if (parsedNumber != null) {
+      return parsedNumber;
+    }
+
+    cachedNumbers ??= _generateLocalizedNumbers();
+
+    return cachedNumbers![number];
+  }
+
+  Map<String, int> _generateLocalizedNumbers() {
+    // Supports 0, 1, 2, ..., 59.
+    final Map<String, int> numbers = {
+      for (var i = 0; i < 60; i++)
+        MaterialLocalizations.of(context).formatDecimal(i): i,
+    };
+
+    // Support 00, 01, 02, ..., 09.
+    final String zero = numbers.keys.first;
+    for (var i = 0; i < 10; i++) {
+      numbers[zero + numbers.keys.elementAt(i)] = i;
+    }
+
+    return numbers;
   }
 
   void _handleHourSavedSubmitted(String? value) {
@@ -1834,7 +1873,10 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
   void _handleMinuteSavedSubmitted(String? value) {
     final int? newMinute = _parseMinute(value);
     if (newMinute != null) {
-      _selectedTime.value = TimeOfDay(hour: _selectedTime.value.hour, minute: int.parse(value!));
+      _selectedTime.value = TimeOfDay(
+        hour: _selectedTime.value.hour, 
+        minute: _tryParseLocalizedNumber(value!)!,
+      );
       _TimePickerModel.setSelectedTime(context, _selectedTime.value);
       FocusScope.of(context).unfocus();
     }

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -1753,7 +1753,7 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
   late final RestorableTimeOfDay _selectedTime = RestorableTimeOfDay(widget.initialSelectedTime);
   final RestorableBool hourHasError = RestorableBool(false);
   final RestorableBool minuteHasError = RestorableBool(false);
-  Map<String, int>? cachedNumbers;
+  Map<String, int>? _cachedNumbers;
   Locale? _cachedLocale;
 
   @override
@@ -1761,7 +1761,7 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
     super.didChangeDependencies();
     final Locale locale = Localizations.localeOf(context);
     if (_cachedLocale != locale) {
-      cachedNumbers = null;
+      _cachedNumbers = null;
       _cachedLocale = locale;
     }
   }
@@ -1832,22 +1832,25 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
       return parsedNumber;
     }
 
-    cachedNumbers ??= _generateLocalizedNumbers();
+    _cachedNumbers ??= _generateLocalizedNumbers();
 
-    return cachedNumbers![number];
+    return _cachedNumbers![number];
   }
 
   Map<String, int> _generateLocalizedNumbers() {
+    final MaterialLocalizations localizations = MaterialLocalizations.of(
+      context,
+    );
+
     // Supports 0, 1, 2, ..., 59.
-    final Map<String, int> numbers = {
-      for (var i = 0; i < 60; i++)
-        MaterialLocalizations.of(context).formatDecimal(i): i,
+    final numbers = <String, int>{
+      for (int i = 0; i < 60; i++) localizations.formatDecimal(i): i,
     };
 
     // Support 00, 01, 02, ..., 09.
-    final String zero = numbers.keys.first;
+    final String zero = localizations.formatDecimal(0);
     for (var i = 0; i < 10; i++) {
-      numbers[zero + numbers.keys.elementAt(i)] = i;
+      numbers[zero + localizations.formatDecimal(i)] = i;
     }
 
     return numbers;
@@ -1875,7 +1878,7 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
     if (newMinute != null) {
       _selectedTime.value = TimeOfDay(
         hour: _selectedTime.value.hour, 
-        minute: _tryParseLocalizedNumber(value!)!,
+        minute: newMinute,
       );
       _TimePickerModel.setSelectedTime(context, _selectedTime.value);
       FocusScope.of(context).unfocus();

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -1843,9 +1843,7 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
 
     // Supports 0 - 59.
-    final numbers = <String, int>{
-      for (int i = 0; i < 60; i++) localizations.formatDecimal(i): i,
-    };
+    final numbers = <String, int>{for (int i = 0; i < 60; i++) localizations.formatDecimal(i): i};
 
     return numbers;
   }

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -1852,7 +1852,7 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
 
   String _removeLeadingZeros(String value) {
     final String localizedZero = MaterialLocalizations.of(context).formatDecimal(0);
-    while (value.startsWith(localizedZero) && value.length > 1) {
+    while (value.startsWith(localizedZero) && value.length > localizedZero.length) {
       value = value.substring(localizedZero.length);
     }
     return value;

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -1753,7 +1753,8 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
   late final RestorableTimeOfDay _selectedTime = RestorableTimeOfDay(widget.initialSelectedTime);
   final RestorableBool hourHasError = RestorableBool(false);
   final RestorableBool minuteHasError = RestorableBool(false);
-  Map<String, int>? _cachedNumbers;
+  Map<String, int>? _cachedHours;
+  Map<String, int>? _cachedMinutes;
   Locale? _cachedLocale;
 
   @override
@@ -1761,7 +1762,8 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
     super.didChangeDependencies();
     final Locale locale = Localizations.localeOf(context);
     if (_cachedLocale != locale) {
-      _cachedNumbers = null;
+      _cachedHours = null;
+      _cachedMinutes = null;
       _cachedLocale = locale;
     }
   }
@@ -1789,7 +1791,7 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
       return null;
     }
 
-    int? newHour = _tryParseLocalizedNumber(value);
+    int? newHour = _tryParseLocalizedHour(value);
     if (newHour == null) {
       return null;
     }
@@ -1815,7 +1817,7 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
       return null;
     }
 
-    final int? newMinute = _tryParseLocalizedNumber(value);
+    final int? newMinute = _tryParseLocalizedMinute(value);
     if (newMinute == null) {
       return null;
     }
@@ -1826,34 +1828,40 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
     return null;
   }
 
-  int? _tryParseLocalizedNumber(String number) {
-    final int? parsedNumber = int.tryParse(number);
-    if (parsedNumber != null) {
-      return parsedNumber;
+  int? _tryParseLocalizedHour(String hour) {
+    final int? parsedHour = int.tryParse(hour);
+    if (parsedHour != null) {
+      return parsedHour;
     }
 
-    _cachedNumbers ??= _generateLocalizedNumbers();
-
-    return _cachedNumbers![number];
-  }
-
-  Map<String, int> _generateLocalizedNumbers() {
     final MaterialLocalizations localizations = MaterialLocalizations.of(
       context,
     );
 
-    // Supports 0, 1, 2, ..., 59.
-    final numbers = <String, int>{
-      for (int i = 0; i < 60; i++) localizations.formatDecimal(i): i,
+    _cachedHours ??= <String, int>{
+      for (int i = 0; i < 24; i++)
+        localizations.formatHour(TimeOfDay(hour: i, minute: 0)): i,
     };
 
-    // Support 00, 01, 02, ..., 09.
-    final String zero = localizations.formatDecimal(0);
-    for (var i = 0; i < 10; i++) {
-      numbers[zero + localizations.formatDecimal(i)] = i;
+    return _cachedHours![hour];
+  }
+
+  int? _tryParseLocalizedMinute(String minute) {
+    final int? parsedMinute = int.tryParse(minute);
+    if (parsedMinute != null) {
+      return parsedMinute;
     }
 
-    return numbers;
+    final MaterialLocalizations localizations = MaterialLocalizations.of(
+      context,
+    );
+
+    _cachedMinutes ??= <String, int>{
+      for (int i = 0; i < 60; i++)
+        localizations.formatMinute(TimeOfDay(hour: 0, minute: i)): i,
+    };
+
+    return _cachedMinutes![minute];
   }
 
   void _handleHourSavedSubmitted(String? value) {
@@ -1877,7 +1885,7 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
     final int? newMinute = _parseMinute(value);
     if (newMinute != null) {
       _selectedTime.value = TimeOfDay(
-        hour: _selectedTime.value.hour, 
+        hour: _selectedTime.value.hour,
         minute: newMinute,
       );
       _TimePickerModel.setSelectedTime(context, _selectedTime.value);

--- a/packages/flutter/test/material/time_picker_test.dart
+++ b/packages/flutter/test/material/time_picker_test.dart
@@ -2107,6 +2107,9 @@ void main() {
           Locale('my'),
           Locale('th'),
           Locale('ne'),
+          Locale('fr'),
+          Locale('de'),
+          Locale('pt')
         ];
 
         Future<void> verifyLocale(Locale locale) async {

--- a/packages/flutter/test/material/time_picker_test.dart
+++ b/packages/flutter/test/material/time_picker_test.dart
@@ -2096,6 +2096,58 @@ void main() {
         expect(result, equals(const TimeOfDay(hour: 9, minute: 12)));
       });
 
+      testWidgets('parses localized digits in input fields (Farsi)', (
+        WidgetTester tester,
+      ) async {
+        TimeOfDay? result;
+
+        // Build launcher with Farsi locale so that localized digits are used.
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: const <LocalizationsDelegate<dynamic>>[
+              GlobalMaterialLocalizations.delegate,
+              GlobalWidgetsLocalizations.delegate,
+              GlobalCupertinoLocalizations.delegate,
+            ],
+            supportedLocales: const <Locale>[Locale('en'), Locale('fa', 'IR')],
+            restorationScopeId: 'app',
+            locale: const Locale('fa', 'IR'),
+            theme: ThemeData(useMaterial3: materialType == MaterialType.material3),
+            home: _TimePickerLauncher(
+              onChanged: (TimeOfDay? time) {
+                result = time;
+              },
+              emptyInitialInput: false,
+            ),
+          ),
+        );
+
+        // Open the picker.
+        await tester.tap(find.text('X'));
+        await tester.pumpAndSettle();
+
+        // Switch to input mode and read the text fields.
+        await tester.tap(find.byIcon(Icons.keyboard_outlined));
+        await tester.pumpAndSettle();
+
+        final TextField hourField = tester.widget(find.byType(TextField).first);
+        final TextField minuteField = tester.widget(find.byType(TextField).last);
+
+        final String hourText = hourField.controller?.text ?? '';
+        final String minuteText = minuteField.controller?.text ?? '';
+
+        final BuildContext context = tester.element(find.byType(TextField).first);
+
+        final String localizedSeven = MaterialLocalizations.of(context).formatDecimal(7);
+        expect(hourText, equals(localizedSeven));
+        final String localizedZero = MaterialLocalizations.of(context).formatDecimal(0);
+        expect(minuteText, equals('$localizedZero$localizedZero'));
+
+        await finishPicker(tester);
+
+        expect(result, equals(const TimeOfDay(hour: 7, minute: 0)));
+      });
+
       testWidgets('Toggle to dial mode keeps selected time', (WidgetTester tester) async {
         late TimeOfDay result;
         await startPicker(

--- a/packages/flutter/test/material/time_picker_test.dart
+++ b/packages/flutter/test/material/time_picker_test.dart
@@ -674,23 +674,21 @@ void main() {
         expect(find.text('Cancel'), findsOneWidget);
       });
 
-      testWidgets(
-        'Material3 - large actions label should not overflow in input mode',
-        (WidgetTester tester) async {
-          await startPicker(
-            tester,
-            (TimeOfDay? time) {},
-            entryMode: TimePickerEntryMode.input,
-            materialType: MaterialType.material3,
-            cancelText: 'Very very very long cancel text',
-            confirmText: 'Very very very long confirm text',
-          );
+      testWidgets('Material3 - large actions label should not overflow in input mode', (
+        WidgetTester tester,
+      ) async {
+        await startPicker(
+          tester,
+          (TimeOfDay? time) {},
+          entryMode: TimePickerEntryMode.input,
+          materialType: MaterialType.material3,
+          cancelText: 'Very very very long cancel text',
+          confirmText: 'Very very very long confirm text',
+        );
 
-          // Verify that no overflow errors occur.
-          expect(tester.takeException(), isNull);
-        },
-        variant: TargetPlatformVariant.mobile(),
-      );
+        // Verify that no overflow errors occur.
+        expect(tester.takeException(), isNull);
+      }, variant: TargetPlatformVariant.mobile());
 
       testWidgets('respects MediaQueryData.alwaysUse24HourFormat == false', (
         WidgetTester tester,
@@ -2096,9 +2094,7 @@ void main() {
         expect(result, equals(const TimeOfDay(hour: 9, minute: 12)));
       });
 
-      testWidgets('parses localized digits in input fields', (
-        WidgetTester tester,
-      ) async {
+      testWidgets('parses localized digits in input fields', (WidgetTester tester) async {
         const localizedDigitLocales = <Locale>[
           Locale('en'),
           Locale('ar'),
@@ -2109,7 +2105,7 @@ void main() {
           Locale('ne'),
           Locale('fr'),
           Locale('de'),
-          Locale('pt')
+          Locale('pt'),
         ];
 
         Future<void> verifyLocale(Locale locale) async {
@@ -2125,9 +2121,7 @@ void main() {
               supportedLocales: <Locale>[const Locale('en'), locale],
               restorationScopeId: 'app',
               locale: locale,
-              theme: ThemeData(
-                useMaterial3: materialType == MaterialType.material3,
-              ),
+              theme: ThemeData(useMaterial3: materialType == MaterialType.material3),
               home: _TimePickerLauncher(
                 onChanged: (TimeOfDay? time) {
                   result = time;
@@ -2667,57 +2661,52 @@ void main() {
     },
   );
 
-  testWidgets(
-    'AM/PM buttons have correct selected/checked semantics for platform variant',
-    (WidgetTester tester) async {
-      // Regression test for https://github.com/flutter/flutter/issues/173302
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Builder(
-            builder: (BuildContext context) {
-              return TextButton(
-                onPressed: () {
-                  showTimePicker(
-                    context: context,
-                    initialTime: const TimeOfDay(hour: 14, minute: 0),
-                  );
-                },
-                child: const Text('Open Picker'),
-              );
-            },
-          ),
+  testWidgets('AM/PM buttons have correct selected/checked semantics for platform variant', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/173302
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (BuildContext context) {
+            return TextButton(
+              onPressed: () {
+                showTimePicker(context: context, initialTime: const TimeOfDay(hour: 14, minute: 0));
+              },
+              child: const Text('Open Picker'),
+            );
+          },
         ),
-      );
+      ),
+    );
 
-      await tester.tap(find.text('Open Picker'));
-      await tester.pumpAndSettle();
+    await tester.tap(find.text('Open Picker'));
+    await tester.pumpAndSettle();
 
-      final Finder pmButtonSemantics = find.ancestor(
-        of: find.widgetWithText(InkWell, 'PM'),
-        matching: find.byWidgetPredicate(
-          (Widget widget) => widget is Semantics && (widget.properties.button ?? false),
-        ),
-      );
+    final Finder pmButtonSemantics = find.ancestor(
+      of: find.widgetWithText(InkWell, 'PM'),
+      matching: find.byWidgetPredicate(
+        (Widget widget) => widget is Semantics && (widget.properties.button ?? false),
+      ),
+    );
 
-      final Finder amButtonSemantics = find.ancestor(
-        of: find.widgetWithText(InkWell, 'AM'),
-        matching: find.byWidgetPredicate(
-          (Widget widget) => widget is Semantics && (widget.properties.button ?? false),
-        ),
-      );
+    final Finder amButtonSemantics = find.ancestor(
+      of: find.widgetWithText(InkWell, 'AM'),
+      matching: find.byWidgetPredicate(
+        (Widget widget) => widget is Semantics && (widget.properties.button ?? false),
+      ),
+    );
 
-      bool? getPlatformSemanticProperty(Semantics semantics) {
-        return switch (defaultTargetPlatform) {
-          TargetPlatform.iOS => semantics.properties.selected,
-          _ => semantics.properties.checked,
-        };
-      }
+    bool? getPlatformSemanticProperty(Semantics semantics) {
+      return switch (defaultTargetPlatform) {
+        TargetPlatform.iOS => semantics.properties.selected,
+        _ => semantics.properties.checked,
+      };
+    }
 
-      expect(getPlatformSemanticProperty(tester.widget<Semantics>(pmButtonSemantics)), isTrue);
-      expect(getPlatformSemanticProperty(tester.widget<Semantics>(amButtonSemantics)), isFalse);
-    },
-    variant: TargetPlatformVariant.all(),
-  );
+    expect(getPlatformSemanticProperty(tester.widget<Semantics>(pmButtonSemantics)), isTrue);
+    expect(getPlatformSemanticProperty(tester.widget<Semantics>(amButtonSemantics)), isFalse);
+  }, variant: TargetPlatformVariant.all());
 
   testWidgets('TimePickerDialog does not crash at zero area', (WidgetTester tester) async {
     await tester.pumpWidget(

--- a/packages/flutter/test/material/time_picker_test.dart
+++ b/packages/flutter/test/material/time_picker_test.dart
@@ -2096,56 +2096,75 @@ void main() {
         expect(result, equals(const TimeOfDay(hour: 9, minute: 12)));
       });
 
-      testWidgets('parses localized digits in input fields (Farsi)', (
+      testWidgets('parses localized digits in input fields', (
         WidgetTester tester,
       ) async {
-        TimeOfDay? result;
+        const localizedDigitLocales = <Locale>[
+          Locale('en'),
+          Locale('ar'),
+          Locale('fa'),
+          Locale('bn'),
+          Locale('my'),
+          Locale('th'),
+          Locale('ne'),
+        ];
 
-        // Build launcher with Farsi locale so that localized digits are used.
-        await tester.pumpWidget(
-          MaterialApp(
-            localizationsDelegates: const <LocalizationsDelegate<dynamic>>[
-              GlobalMaterialLocalizations.delegate,
-              GlobalWidgetsLocalizations.delegate,
-              GlobalCupertinoLocalizations.delegate,
-            ],
-            supportedLocales: const <Locale>[Locale('en'), Locale('fa', 'IR')],
-            restorationScopeId: 'app',
-            locale: const Locale('fa', 'IR'),
-            theme: ThemeData(useMaterial3: materialType == MaterialType.material3),
-            home: _TimePickerLauncher(
-              onChanged: (TimeOfDay? time) {
-                result = time;
-              },
-              emptyInitialInput: false,
+        Future<void> verifyLocale(Locale locale) async {
+          TimeOfDay? result;
+
+          await tester.pumpWidget(
+            MaterialApp(
+              localizationsDelegates: const <LocalizationsDelegate<dynamic>>[
+                GlobalMaterialLocalizations.delegate,
+                GlobalWidgetsLocalizations.delegate,
+                GlobalCupertinoLocalizations.delegate,
+              ],
+              supportedLocales: <Locale>[const Locale('en'), locale],
+              restorationScopeId: 'app',
+              locale: locale,
+              theme: ThemeData(
+                useMaterial3: materialType == MaterialType.material3,
+              ),
+              home: _TimePickerLauncher(
+                onChanged: (TimeOfDay? time) {
+                  result = time;
+                },
+                emptyInitialInput: false,
+              ),
             ),
-          ),
-        );
+          );
 
-        // Open the picker.
-        await tester.tap(find.text('X'));
-        await tester.pumpAndSettle();
+          // Open the picker.
+          await tester.tap(find.text('X'));
+          await tester.pumpAndSettle();
 
-        // Switch to input mode and read the text fields.
-        await tester.tap(find.byIcon(Icons.keyboard_outlined));
-        await tester.pumpAndSettle();
+          // Switch to input mode and read the text fields.
+          await tester.tap(find.byIcon(Icons.keyboard_outlined));
+          await tester.pumpAndSettle();
 
-        final TextField hourField = tester.widget(find.byType(TextField).first);
-        final TextField minuteField = tester.widget(find.byType(TextField).last);
+          final TextField hourField = tester.widget(find.byType(TextField).first);
+          final TextField minuteField = tester.widget(find.byType(TextField).last);
 
-        final String hourText = hourField.controller?.text ?? '';
-        final String minuteText = minuteField.controller?.text ?? '';
+          final String hourText = hourField.controller?.text ?? '';
+          final String minuteText = minuteField.controller?.text ?? '';
 
-        final BuildContext context = tester.element(find.byType(TextField).first);
+          final BuildContext context = tester.element(find.byType(TextField).first);
 
-        final String localizedSeven = MaterialLocalizations.of(context).formatDecimal(7);
-        expect(hourText, equals(localizedSeven));
-        final String localizedZero = MaterialLocalizations.of(context).formatDecimal(0);
-        expect(minuteText, equals('$localizedZero$localizedZero'));
+          const timeOfDay = TimeOfDay(hour: 7, minute: 0);
+          final MaterialLocalizations localizations = MaterialLocalizations.of(context);
+          final String localizedHour = localizations.formatHour(timeOfDay);
+          expect(hourText, equals(localizedHour));
+          final String localizedMinute = localizations.formatMinute(timeOfDay);
+          expect(minuteText, equals(localizedMinute));
 
-        await finishPicker(tester);
+          await finishPicker(tester);
 
-        expect(result, equals(const TimeOfDay(hour: 7, minute: 0)));
+          expect(result, equals(timeOfDay));
+        }
+
+        for (final locale in localizedDigitLocales) {
+          await verifyLocale(locale);
+        }
       });
 
       testWidgets('Toggle to dial mode keeps selected time', (WidgetTester tester) async {


### PR DESCRIPTION
The time picker currently uses `int.parse` and `int.tryParse` to parse the entered number. However, in some locales, numbers are not represented using Latin digits, which causes the parsing to fail. In this implementation, I use `MaterialLocalizations` to parse the number directly, ensuring that it works correctly for all locales.

Fixes #85527

A test has been added to ensure that the new implementation works as expected and does not cause any breaking changes.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.