### PR TITLE
Fix TestSemantics typo bugs in semantics_tester (widgets and material)

### DIFF
--- a/packages/flutter/test/material/semantics_tester.dart
+++ b/packages/flutter/test/material/semantics_tester.dart
@@ -508,7 +508,7 @@ class TestSemantics {
       );
     }
 
-    if (controlsNodes != controlsNodes && !setEquals(controlsNodes, node.controlsNodes)) {
+    if (controlsNodes != null && !setEquals(controlsNodes, node.controlsNodes)) {
       return fail(
         'expected node id $id to controls nodes $controlsNodes but found controlling nodes ${node.controlsNodes}',
       );
@@ -716,7 +716,7 @@ class SemanticsTester {
           (second[i] is! LocaleStringAttribute ||
               second[i].range != first[i].range ||
               (second[i] as LocaleStringAttribute).locale !=
-                  (second[i] as LocaleStringAttribute).locale)) {
+                  (first[i] as LocaleStringAttribute).locale)) {
         return false;
       }
     }
@@ -1180,8 +1180,9 @@ class _IncludesNodeWith extends Matcher {
              scrollExtentMin != null ||
              maxValueLength != null ||
              currentValueLength != null ||
-             inputType != null,
-         minValue != null || maxValue != null,
+             inputType != null ||
+             minValue != null ||
+             maxValue != null,
        );
   final AttributedString? attributedLabel;
   final AttributedString? attributedValue;

--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -508,7 +508,7 @@ class TestSemantics {
       );
     }
 
-    if (controlsNodes != controlsNodes && !setEquals(controlsNodes, node.controlsNodes)) {
+    if (controlsNodes != null && !setEquals(controlsNodes, node.controlsNodes)) {
       return fail(
         'expected node id $id to controls nodes $controlsNodes but found controlling nodes ${node.controlsNodes}',
       );
@@ -716,7 +716,7 @@ class SemanticsTester {
           (second[i] is! LocaleStringAttribute ||
               second[i].range != first[i].range ||
               (second[i] as LocaleStringAttribute).locale !=
-                  (second[i] as LocaleStringAttribute).locale)) {
+                  (first[i] as LocaleStringAttribute).locale)) {
         return false;
       }
     }
@@ -1180,8 +1180,9 @@ class _IncludesNodeWith extends Matcher {
              scrollExtentMin != null ||
              maxValueLength != null ||
              currentValueLength != null ||
-             inputType != null,
-         minValue != null || maxValue != null,
+             inputType != null ||
+             minValue != null ||
+             maxValue != null,
        );
   final AttributedString? attributedLabel;
   final AttributedString? attributedValue;


### PR DESCRIPTION
## Description

Fixes three latent bugs in `TestSemantics` identified in #185900. The same bugs existed in both `test/widgets/semantics_tester.dart` and `test/material/semantics_tester.dart` (the material copy was introduced in #185736).

### Bug 1 — `controlsNodes` self-comparison (line 511)

```dart
// Before (always false — setEquals never runs)
if (controlsNodes != controlsNodes && !setEquals(controlsNodes, node.controlsNodes)) {

// After
if (controlsNodes != null && !setEquals(controlsNodes, node.controlsNodes)) {
```

### Bug 2 — Locale compared to itself (line 718–719)

```dart
// Before (compares second[i] to second[i] — always equal)
(second[i] as LocaleStringAttribute).locale !=
    (second[i] as LocaleStringAttribute).locale

// After
(second[i] as LocaleStringAttribute).locale !=
    (first[i] as LocaleStringAttribute).locale
```

### Bug 3 — Stray comma turns condition into assert message (line 1183–1184)

```dart
// Before — comma ends the assert condition; minValue/maxValue check
// becomes the optional message argument and is never evaluated
inputType != null,
minValue != null || maxValue != null,

// After — all conditions are part of the assert condition
inputType != null ||
minValue != null ||
maxValue != null,
```

## Tests

No new tests added — the fixes are corrections to existing test infrastructure (`semantics_tester.dart` is itself a test helper). The changes make previously dead code paths actually execute.

Fixes #185900