### PR TITLE
docs: fix doubled-word typos in comments

### DIFF
--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -1244,7 +1244,7 @@ class SelectionOverlay {
   //
   // On Apple and web platforms only one selection handle can be dragged
   // at a time, so when the end handle is being dragged on these platforms
-  // the the start handle cannot be dragged.
+  // the start handle cannot be dragged.
   bool get _canDragStartHandle =>
       !_isDraggingEndHandle ||
       (defaultTargetPlatform != TargetPlatform.iOS &&
@@ -1365,7 +1365,7 @@ class SelectionOverlay {
   //
   // On Apple and web platforms only one selection handle can be dragged
   // at a time, so when the start handle is being dragged on these platforms
-  // the the end handle cannot be dragged.
+  // the end handle cannot be dragged.
   bool get _canDragEndHandle =>
       !_isDraggingStartHandle ||
       (defaultTargetPlatform != TargetPlatform.iOS &&

--- a/packages/flutter_tools/lib/src/ios/lldb.dart
+++ b/packages/flutter_tools/lib/src/ios/lldb.dart
@@ -343,7 +343,7 @@ class _LLDBLogPatternCompleter {
   }
 }
 
-/// A container class for associating a [Process] that is is running LLDB with
+/// A container class for associating a [Process] that is running LLDB with
 /// the iOS device process of an application.
 class _LLDBProcess {
   _LLDBProcess({required Process process, required this.appProcessId, required Logger logger})

--- a/packages/flutter_tools/test/host_cross_arch.shard/ios_content_validation_test.dart
+++ b/packages/flutter_tools/test/host_cross_arch.shard/ios_content_validation_test.dart
@@ -122,7 +122,7 @@ void main() {
             outputRunnerBinaryDebugDylib = outputApp.childFile('Runner.debug.dylib');
 
             // Exists only if the plugin is built as a dynamic framework.
-            // This is is the default for CocoaPods but not Swift Package Manager.
+            // This is the default for CocoaPods but not Swift Package Manager.
             outputPluginFrameworkBinary = frameworkDirectory
                 .childDirectory('hello.framework')
                 .childFile('hello');


### PR DESCRIPTION
## Summary

Removes accidentally repeated words ("the the", "is is") in dartdoc and inline comments across lutter and lutter_tools. Comment-only follow-up to #186319.

No code, public API, or behavior is touched. The fix is mechanical and was verified by re-grepping the modified files.

## Changes

- `packages/flutter/lib/src/widgets/text_selection.dart`: `the the start handle` -> `the start handle`; `the the end handle` -> `the end handle`
- `packages/flutter_tools/lib/src/ios/lldb.dart`: dartdoc on `_LLDBProcess` — `[Process] that is is running LLDB` -> `[Process] that is running LLDB`
- `packages/flutter_tools/test/host_cross_arch.shard/ios_content_validation_test.dart`: `This is is the default for CocoaPods` -> `This is the default for CocoaPods`

## Tests

No tests added. This is a comment-only change with no executable lines touched. Verified locally by grepping the touched files for residual `the the` / `is is` / `to to` / similar doubled tokens — none remain.

## Notes for maintainers

- Pre-launch checklist read; no engineering doc rewrite needed (docs-only).
- No Material or Cupertino source paths are modified, so the active code freeze is not impacted.
- Authored by a human (Nicoreia) with AI tooling assistance, in line with Flutter's AI contribution policy: scope is small, mechanical, and reviewable; no generated logic.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page and followed its process for submitting this PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
