### PR TITLE
Reduce CanvasKit memory use on Safari

### DIFF
--- a/engine/src/flutter/lib/web_ui/README.md
+++ b/engine/src/flutter/lib/web_ui/README.md
@@ -277,6 +277,9 @@ The Flutter Web engine's sources are in `localhost:<port>` > `lib` > `_engine` >
 `engine`. You can set breakpoints in Dart source files and use the Chrome
 debugger to inspect variables' values.
 
+For Safari-specific CanvasKit memory behavior, see
+[Safari CanvasKit memory][10].
+
 ## Building CanvasKit and Skwasm
 
 To build CanvasKit and/or Skwasm locally, you must first set up your gclient config to
@@ -329,3 +332,4 @@ Note: The provided Dart SDK is used to run the `felt` tool itself, and to compil
 [7]: https://developer.chrome.com/docs/devtools
 [8]: https://developer.chrome.com/docs/devtools/sources
 [9]: https://github.com/flutter/flutter/blob/main/docs/engine/contributing/Setting-up-the-Engine-development-environment.md#additional-steps-for-web-engine
+[10]: docs/SAFARI_CANVASKIT_MEMORY.md

--- a/engine/src/flutter/lib/web_ui/docs/SAFARI_CANVASKIT_MEMORY.md
+++ b/engine/src/flutter/lib/web_ui/docs/SAFARI_CANVASKIT_MEMORY.md
@@ -1,0 +1,25 @@
+# Safari CanvasKit memory
+
+Flutter Web uses CanvasKit to render Flutter pictures into one or more canvas
+surfaces. Safari's WebGL and canvas memory can remain resident longer than in
+Chromium-based browsers, so a CanvasKit app that is stable in Chrome can have a
+much higher physical footprint in Safari.
+
+The web engine applies Safari-specific CanvasKit defaults to reduce this
+footprint:
+
+* `canvasKitForceCpuOnly` defaults to `true` in Safari. An app can still opt out
+  by setting `canvasKitForceCpuOnly` in `window.flutterConfiguration` or by
+  compiling with `FLUTTER_WEB_CANVASKIT_FORCE_CPU_ONLY=false`.
+* `canvasKitMaximumSurfaces` defaults to `2` in Safari. A single surface can
+  merge Flutter overlays with platform-view underlays, which can make platform
+  views such as Google Maps disappear behind Flutter content. Two surfaces keep
+  the underlay and overlay paths separate while reducing retained canvas state.
+* The Safari CanvasKit rasterizer caps Skia's resource cache so GPU-backed
+  resources are not allowed to grow to the same size as other browsers.
+
+When changing these defaults, validate both memory and platform-view
+composition. A useful regression test is a release-mode CanvasKit app that
+places Flutter content above a platform view, idles for at least 60 seconds, and
+checks that the platform view remains visible while Safari WebContent memory
+stays below the expected limit.

--- a/engine/src/flutter/lib/web_ui/docs/SAFARI_CANVASKIT_MEMORY.md
+++ b/engine/src/flutter/lib/web_ui/docs/SAFARI_CANVASKIT_MEMORY.md
@@ -20,6 +20,6 @@ footprint:
 
 When changing these defaults, validate both memory and platform-view
 composition. A useful regression test is a release-mode CanvasKit app that
-places Flutter content above a platform view, idles for at least 60 seconds, and
-checks that the platform view remains visible while Safari WebContent memory
+places Flutter content above a platform view, waits for Safari WebContent memory
+to stabilize, and checks that the platform view remains visible while memory
 stays below the expected limit.

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
@@ -7,6 +7,7 @@ import 'dart:js_interop';
 import 'dart:math' as math;
 import 'dart:typed_data';
 
+import 'package:meta/meta.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui;
 import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
@@ -17,6 +18,9 @@ bool get isExperimentalWebParagraph =>
 class CanvasKitRenderer extends Renderer {
   static CanvasKitRenderer get instance => _instance;
   static late CanvasKitRenderer _instance;
+
+  @visibleForTesting
+  static const int safariResourceCacheMaxBytes = 24 * 1024 * 1024;
 
   Future<void>? _initialized;
 
@@ -34,14 +38,22 @@ class CanvasKitRenderer extends Renderer {
   FlutterFontCollection get fontCollection => _fontCollection;
 
   static Rasterizer _createRasterizer() {
-    if (configuration.canvasKitForceMultiSurfaceRasterizer || isSafari || isFirefox) {
-      return MultiSurfaceRasterizer(
+    final Rasterizer rasterizer;
+    final bool useMultiSurfaceRasterizer =
+        configuration.canvasKitForceMultiSurfaceRasterizer || isFirefox || isSafari;
+    if (useMultiSurfaceRasterizer) {
+      rasterizer = MultiSurfaceRasterizer(
         (OnscreenCanvasProvider canvasProvider) => CkOnscreenSurface(canvasProvider),
       );
+    } else {
+      rasterizer = OffscreenCanvasRasterizer(
+        (OffscreenCanvasProvider canvasProvider) => CkOffscreenSurface(canvasProvider),
+      );
     }
-    return OffscreenCanvasRasterizer(
-      (OffscreenCanvasProvider canvasProvider) => CkOffscreenSurface(canvasProvider),
-    );
+    if (isSafari) {
+      rasterizer.setResourceCacheMaxBytes(safariResourceCacheMaxBytes);
+    }
+    return rasterizer;
   }
 
   @override

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
@@ -7,7 +7,6 @@ import 'dart:js_interop';
 import 'dart:math' as math;
 import 'dart:typed_data';
 
-import 'package:meta/meta.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui;
 import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
@@ -19,8 +18,7 @@ class CanvasKitRenderer extends Renderer {
   static CanvasKitRenderer get instance => _instance;
   static late CanvasKitRenderer _instance;
 
-  @visibleForTesting
-  static const int safariResourceCacheMaxBytes = 24 * 1024 * 1024;
+  static const int _safariResourceCacheMaxBytes = 24 * 1024 * 1024;
 
   Future<void>? _initialized;
 
@@ -51,7 +49,7 @@ class CanvasKitRenderer extends Renderer {
       );
     }
     if (isSafari) {
-      rasterizer.setResourceCacheMaxBytes(safariResourceCacheMaxBytes);
+      rasterizer.setResourceCacheMaxBytes(_safariResourceCacheMaxBytes);
     }
     return rasterizer;
   }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/surface.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/surface.dart
@@ -226,6 +226,8 @@ abstract class CkSurface extends Surface {
     _skSurface = null;
   }
 
+  void release() {}
+
   @override
   void setSkiaResourceCacheMaxBytes(int bytes) {
     _grContext?.setResourceCacheLimitBytes(bytes.toDouble());

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/compositing/display_canvas_factory.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/compositing/display_canvas_factory.dart
@@ -97,6 +97,7 @@ class DisplayCanvasFactory<T extends DisplayCanvas> {
       'was not created by this factory',
     );
     canvas.hostElement.remove();
+    canvas.release();
     _liveCanvases.remove(canvas);
     _cache.add(canvas);
   }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/compositing/rasterizer.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/compositing/rasterizer.dart
@@ -164,6 +164,9 @@ abstract class DisplayCanvas {
   /// Initialize the overlay.
   void initialize();
 
+  /// Releases transient resources while keeping this canvas reusable.
+  void release() {}
+
   /// Disposes this overlay.
   void dispose();
 }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/compositing/render_canvas.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/compositing/render_canvas.dart
@@ -47,6 +47,7 @@ class RenderCanvas extends DisplayCanvas {
   final DomHTMLCanvasElement canvasElement = createDomCanvasElement();
   int _pixelWidth = 0;
   int _pixelHeight = 0;
+  bool _hasTransferredBitmap = false;
 
   late final DomImageBitmapRenderingContext renderContext = canvasElement.contextBitmapRenderer;
 
@@ -73,6 +74,7 @@ class RenderCanvas extends DisplayCanvas {
   void render(DomImageBitmap bitmap) {
     _ensureSize(BitmapSize(bitmap.width, bitmap.height));
     renderContext.transferFromImageBitmap(bitmap);
+    _hasTransferredBitmap = true;
   }
 
   void renderWithNoBitmapSupport(
@@ -127,7 +129,21 @@ class RenderCanvas extends DisplayCanvas {
   }
 
   @override
+  void release() {
+    if (!_hasTransferredBitmap) {
+      return;
+    }
+    renderContext.transferFromImageBitmap(null);
+    _hasTransferredBitmap = false;
+  }
+
+  @override
   void dispose() {
-    // No extra cleanup needed.
+    release();
+    _pixelWidth = 0;
+    _pixelHeight = 0;
+    canvasElement.width = 0;
+    canvasElement.height = 0;
+    _updateLogicalHtmlCanvasSize();
   }
 }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/compositing/surface.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/compositing/surface.dart
@@ -43,6 +43,9 @@ abstract class SurfaceProvider<C extends Surface, D extends CanvasProvider> {
 
   int? _resourceCacheMaxBytes;
 
+  @visibleForTesting
+  int? get debugResourceCacheMaxBytes => _resourceCacheMaxBytes;
+
   void setSkiaResourceCacheMaxBytes(int bytes) {
     _resourceCacheMaxBytes = bytes;
     for (final C surface in _createdSurfaces) {

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/compositing/surface.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/compositing/surface.dart
@@ -43,7 +43,7 @@ abstract class SurfaceProvider<C extends Surface, D extends CanvasProvider> {
 
   int? _resourceCacheMaxBytes;
 
-  @visibleForTesting
+  /// The configured Skia resource cache limit, if one has been set.
   int? get debugResourceCacheMaxBytes => _resourceCacheMaxBytes;
 
   void setSkiaResourceCacheMaxBytes(int bytes) {

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/configuration.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/configuration.dart
@@ -47,6 +47,7 @@ library configuration;
 import 'dart:js_interop';
 
 import 'package:meta/meta.dart';
+import 'browser_detection.dart';
 import 'dom.dart';
 
 enum CanvasKitVariant {
@@ -288,10 +289,25 @@ class FlutterConfiguration {
   ///
   /// This is mainly used for testing or for apps that want to ensure they
   /// run on devices which don't support WebGL.
-  bool get canvasKitForceCpuOnly =>
-      _configuration?.canvasKitForceCpuOnly ?? _defaultCanvasKitForceCpuOnly;
+  bool get canvasKitForceCpuOnly {
+    final bool? configured = _configuration?.canvasKitForceCpuOnly;
+    if (configured != null) {
+      return configured;
+    }
+    if (_hasDefaultCanvasKitForceCpuOnly) {
+      return _defaultCanvasKitForceCpuOnly;
+    }
+    return isSafari;
+  }
+
+  static const String _canvasKitForceCpuOnlyEnvironment = 'FLUTTER_WEB_CANVASKIT_FORCE_CPU_ONLY';
+
+  static const bool _hasDefaultCanvasKitForceCpuOnly = bool.hasEnvironment(
+    _canvasKitForceCpuOnlyEnvironment,
+  );
+
   static const bool _defaultCanvasKitForceCpuOnly = bool.fromEnvironment(
-    'FLUTTER_WEB_CANVASKIT_FORCE_CPU_ONLY',
+    _canvasKitForceCpuOnlyEnvironment,
   );
 
   bool get canvasKitForceMultiSurfaceRasterizer =>
@@ -301,11 +317,23 @@ class FlutterConfiguration {
     'FLUTTER_WEB_CANVASKIT_FORCE_MULTI_SURFACE_RASTERIZER',
   );
 
+  /// The default maximum number of canvases to use when rendering in CanvasKit.
+  @visibleForTesting
+  static const int defaultCanvasKitMaximumSurfaces = 8;
+
+  /// Safari needs at least two surfaces to keep platform-view underlays and
+  /// Flutter overlays separate, but more surfaces retain additional GPU state.
+  @visibleForTesting
+  static const int safariDefaultCanvasKitMaximumSurfaces = 2;
+
   /// The maximum number of canvases to use when rendering in CanvasKit.
   ///
   /// Limits the amount of overlays that can be created.
   int get canvasKitMaximumSurfaces {
-    final int maxSurfaces = _configuration?.canvasKitMaximumSurfaces?.toInt() ?? 8;
+    final int defaultMaxSurfaces = isSafari
+        ? safariDefaultCanvasKitMaximumSurfaces
+        : defaultCanvasKitMaximumSurfaces;
+    final int maxSurfaces = _configuration?.canvasKitMaximumSurfaces?.toInt() ?? defaultMaxSurfaces;
     if (maxSurfaces < 1) {
       return 1;
     }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/configuration.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/configuration.dart
@@ -318,21 +318,19 @@ class FlutterConfiguration {
   );
 
   /// The default maximum number of canvases to use when rendering in CanvasKit.
-  @visibleForTesting
-  static const int defaultCanvasKitMaximumSurfaces = 8;
+  static const int _defaultCanvasKitMaximumSurfaces = 8;
 
   /// Safari needs at least two surfaces to keep platform-view underlays and
   /// Flutter overlays separate, but more surfaces retain additional GPU state.
-  @visibleForTesting
-  static const int safariDefaultCanvasKitMaximumSurfaces = 2;
+  static const int _safariDefaultCanvasKitMaximumSurfaces = 2;
 
   /// The maximum number of canvases to use when rendering in CanvasKit.
   ///
   /// Limits the amount of overlays that can be created.
   int get canvasKitMaximumSurfaces {
     final int defaultMaxSurfaces = isSafari
-        ? safariDefaultCanvasKitMaximumSurfaces
-        : defaultCanvasKitMaximumSurfaces;
+        ? _safariDefaultCanvasKitMaximumSurfaces
+        : _defaultCanvasKitMaximumSurfaces;
     final int maxSurfaces = _configuration?.canvasKitMaximumSurfaces?.toInt() ?? defaultMaxSurfaces;
     if (maxSurfaces < 1) {
       return 1;

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
@@ -176,6 +176,7 @@ class PlatformViewManager {
   /// never been rendered before.
   void clearPlatformView(int viewId) {
     // Remove from our cache, and then from the DOM...
+    _viewIdToType.remove(viewId);
     _contents.remove(viewId)?.remove();
   }
 

--- a/engine/src/flutter/lib/web_ui/test/canvaskit/rasterizer_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/canvaskit/rasterizer_test.dart
@@ -7,6 +7,7 @@ import 'dart:js_interop';
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 import 'common.dart';
 
@@ -16,16 +17,38 @@ void main() {
 
 void testMain() {
   setUpCanvasKitTest(withImplicitView: true);
-  test(
-    'defaults to OffscreenCanvasRasterizer on Chrome and MultiSurfaceRasterizer on Firefox and Safari',
-    () {
-      if (isChromium) {
-        expect(CanvasKitRenderer.instance.rasterizer, isA<OffscreenCanvasRasterizer>());
-      } else {
-        expect(CanvasKitRenderer.instance.rasterizer, isA<MultiSurfaceRasterizer>());
-      }
-    },
-  );
+
+  tearDown(() {
+    ui_web.browser.debugBrowserEngineOverride = null;
+    ui_web.browser.debugOperatingSystemOverride = null;
+    CanvasKitRenderer.instance.debugResetRasterizer();
+  });
+
+  test('defaults to OffscreenCanvasRasterizer on Chrome and MultiSurfaceRasterizer on Firefox', () {
+    if (isChromium) {
+      expect(CanvasKitRenderer.instance.rasterizer, isA<OffscreenCanvasRasterizer>());
+    } else {
+      expect(CanvasKitRenderer.instance.rasterizer, isA<MultiSurfaceRasterizer>());
+    }
+  });
+
+  test('defaults to MultiSurfaceRasterizer on desktop Safari', () {
+    ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.webkit;
+    ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.macOs;
+
+    CanvasKitRenderer.instance.debugResetRasterizer();
+
+    expect(CanvasKitRenderer.instance.rasterizer, isA<MultiSurfaceRasterizer>());
+  });
+
+  test('defaults to MultiSurfaceRasterizer on iOS Safari', () {
+    ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.webkit;
+    ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.iOs;
+
+    CanvasKitRenderer.instance.debugResetRasterizer();
+
+    expect(CanvasKitRenderer.instance.rasterizer, isA<MultiSurfaceRasterizer>());
+  });
 
   test('can be configured to always use MultiSurfaceRasterizer', () {
     debugOverrideJsConfiguration(

--- a/engine/src/flutter/lib/web_ui/test/canvaskit/rasterizer_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/canvaskit/rasterizer_test.dart
@@ -18,12 +18,6 @@ void main() {
 void testMain() {
   setUpCanvasKitTest(withImplicitView: true);
 
-  tearDown(() {
-    ui_web.browser.debugBrowserEngineOverride = null;
-    ui_web.browser.debugOperatingSystemOverride = null;
-    CanvasKitRenderer.instance.debugResetRasterizer();
-  });
-
   test('defaults to OffscreenCanvasRasterizer on Chrome and MultiSurfaceRasterizer on Firefox', () {
     if (isChromium) {
       expect(CanvasKitRenderer.instance.rasterizer, isA<OffscreenCanvasRasterizer>());
@@ -33,21 +27,33 @@ void testMain() {
   });
 
   test('defaults to MultiSurfaceRasterizer on desktop Safari', () {
-    ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.webkit;
-    ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.macOs;
+    try {
+      ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.webkit;
+      ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.macOs;
 
-    CanvasKitRenderer.instance.debugResetRasterizer();
+      CanvasKitRenderer.instance.debugResetRasterizer();
 
-    expect(CanvasKitRenderer.instance.rasterizer, isA<MultiSurfaceRasterizer>());
+      expect(CanvasKitRenderer.instance.rasterizer, isA<MultiSurfaceRasterizer>());
+    } finally {
+      ui_web.browser.debugBrowserEngineOverride = null;
+      ui_web.browser.debugOperatingSystemOverride = null;
+      CanvasKitRenderer.instance.debugResetRasterizer();
+    }
   });
 
   test('defaults to MultiSurfaceRasterizer on iOS Safari', () {
-    ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.webkit;
-    ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.iOs;
+    try {
+      ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.webkit;
+      ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.iOs;
 
-    CanvasKitRenderer.instance.debugResetRasterizer();
+      CanvasKitRenderer.instance.debugResetRasterizer();
 
-    expect(CanvasKitRenderer.instance.rasterizer, isA<MultiSurfaceRasterizer>());
+      expect(CanvasKitRenderer.instance.rasterizer, isA<MultiSurfaceRasterizer>());
+    } finally {
+      ui_web.browser.debugBrowserEngineOverride = null;
+      ui_web.browser.debugOperatingSystemOverride = null;
+      CanvasKitRenderer.instance.debugResetRasterizer();
+    }
   });
 
   test('can be configured to always use MultiSurfaceRasterizer', () {

--- a/engine/src/flutter/lib/web_ui/test/canvaskit/renderer_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/canvaskit/renderer_test.dart
@@ -84,8 +84,6 @@ void testMain() {
     setUpCanvasKitTest();
 
     tearDown(() {
-      ui_web.browser.debugBrowserEngineOverride = null;
-      ui_web.browser.debugOperatingSystemOverride = null;
       CanvasKitRenderer.instance.debugResetRasterizer();
     });
 
@@ -204,41 +202,55 @@ void testMain() {
     );
 
     test('uses MultiSurfaceRasterizer and caps Skia resource cache on desktop Safari', () {
-      ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.webkit;
-      ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.macOs;
+      try {
+        ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.webkit;
+        ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.macOs;
 
-      CanvasKitRenderer.instance.debugResetRasterizer();
+        CanvasKitRenderer.instance.debugResetRasterizer();
 
-      expect(CanvasKitRenderer.instance.rasterizer, isA<MultiSurfaceRasterizer>());
-      expect(
-        CanvasKitRenderer.instance.rasterizer.surfaceProvider.debugResourceCacheMaxBytes,
-        CanvasKitRenderer.safariResourceCacheMaxBytes,
-      );
+        expect(CanvasKitRenderer.instance.rasterizer, isA<MultiSurfaceRasterizer>());
+        expect(
+          CanvasKitRenderer.instance.rasterizer.surfaceProvider.debugResourceCacheMaxBytes,
+          24 * 1024 * 1024,
+        );
+      } finally {
+        ui_web.browser.debugBrowserEngineOverride = null;
+        ui_web.browser.debugOperatingSystemOverride = null;
+      }
     });
 
     test('uses MultiSurfaceRasterizer and caps Skia resource cache on iOS Safari', () {
-      ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.webkit;
-      ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.iOs;
+      try {
+        ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.webkit;
+        ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.iOs;
 
-      CanvasKitRenderer.instance.debugResetRasterizer();
+        CanvasKitRenderer.instance.debugResetRasterizer();
 
-      expect(CanvasKitRenderer.instance.rasterizer, isA<MultiSurfaceRasterizer>());
-      expect(
-        CanvasKitRenderer.instance.rasterizer.surfaceProvider.debugResourceCacheMaxBytes,
-        CanvasKitRenderer.safariResourceCacheMaxBytes,
-      );
+        expect(CanvasKitRenderer.instance.rasterizer, isA<MultiSurfaceRasterizer>());
+        expect(
+          CanvasKitRenderer.instance.rasterizer.surfaceProvider.debugResourceCacheMaxBytes,
+          24 * 1024 * 1024,
+        );
+      } finally {
+        ui_web.browser.debugBrowserEngineOverride = null;
+        ui_web.browser.debugOperatingSystemOverride = null;
+      }
     });
 
     test('does not cap Skia resource cache on Chromium', () {
-      ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.blink;
+      try {
+        ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.blink;
 
-      CanvasKitRenderer.instance.debugResetRasterizer();
+        CanvasKitRenderer.instance.debugResetRasterizer();
 
-      expect(CanvasKitRenderer.instance.rasterizer, isA<OffscreenCanvasRasterizer>());
-      expect(
-        CanvasKitRenderer.instance.rasterizer.surfaceProvider.debugResourceCacheMaxBytes,
-        isNull,
-      );
+        expect(CanvasKitRenderer.instance.rasterizer, isA<OffscreenCanvasRasterizer>());
+        expect(
+          CanvasKitRenderer.instance.rasterizer.surfaceProvider.debugResourceCacheMaxBytes,
+          isNull,
+        );
+      } finally {
+        ui_web.browser.debugBrowserEngineOverride = null;
+      }
     });
 
     test('can be configured to always use MultiSurfaceRasterizer', () {

--- a/engine/src/flutter/lib/web_ui/test/canvaskit/renderer_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/canvaskit/renderer_test.dart
@@ -9,6 +9,7 @@ import 'package:test/test.dart';
 
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 import 'common.dart';
 
@@ -83,6 +84,8 @@ void testMain() {
     setUpCanvasKitTest();
 
     tearDown(() {
+      ui_web.browser.debugBrowserEngineOverride = null;
+      ui_web.browser.debugOperatingSystemOverride = null;
       CanvasKitRenderer.instance.debugResetRasterizer();
     });
 
@@ -190,7 +193,7 @@ void testMain() {
     });
 
     test(
-      'defaults to OffscreenCanvasRasterizer on Chrome and MultiSurfaceRasterizer on Firefox and Safari',
+      'defaults to OffscreenCanvasRasterizer on Chrome and MultiSurfaceRasterizer on Firefox',
       () {
         if (isChromium) {
           expect(CanvasKitRenderer.instance.rasterizer, isA<OffscreenCanvasRasterizer>());
@@ -199,6 +202,44 @@ void testMain() {
         }
       },
     );
+
+    test('uses MultiSurfaceRasterizer and caps Skia resource cache on desktop Safari', () {
+      ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.webkit;
+      ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.macOs;
+
+      CanvasKitRenderer.instance.debugResetRasterizer();
+
+      expect(CanvasKitRenderer.instance.rasterizer, isA<MultiSurfaceRasterizer>());
+      expect(
+        CanvasKitRenderer.instance.rasterizer.surfaceProvider.debugResourceCacheMaxBytes,
+        CanvasKitRenderer.safariResourceCacheMaxBytes,
+      );
+    });
+
+    test('uses MultiSurfaceRasterizer and caps Skia resource cache on iOS Safari', () {
+      ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.webkit;
+      ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.iOs;
+
+      CanvasKitRenderer.instance.debugResetRasterizer();
+
+      expect(CanvasKitRenderer.instance.rasterizer, isA<MultiSurfaceRasterizer>());
+      expect(
+        CanvasKitRenderer.instance.rasterizer.surfaceProvider.debugResourceCacheMaxBytes,
+        CanvasKitRenderer.safariResourceCacheMaxBytes,
+      );
+    });
+
+    test('does not cap Skia resource cache on Chromium', () {
+      ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.blink;
+
+      CanvasKitRenderer.instance.debugResetRasterizer();
+
+      expect(CanvasKitRenderer.instance.rasterizer, isA<OffscreenCanvasRasterizer>());
+      expect(
+        CanvasKitRenderer.instance.rasterizer.surfaceProvider.debugResourceCacheMaxBytes,
+        isNull,
+      );
+    });
 
     test('can be configured to always use MultiSurfaceRasterizer', () {
       debugOverrideJsConfiguration(

--- a/engine/src/flutter/lib/web_ui/test/engine/compositing/display_canvas_factory_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/compositing/display_canvas_factory_test.dart
@@ -13,6 +13,8 @@ void main() {
 }
 
 class DummyDisplayCanvas extends DisplayCanvas {
+  int releaseCount = 0;
+
   @override
   void dispose() {}
 
@@ -23,6 +25,11 @@ class DummyDisplayCanvas extends DisplayCanvas {
 
   @override
   void initialize() {}
+
+  @override
+  void release() {
+    releaseCount += 1;
+  }
 
   @override
   bool get isConnected => throw UnimplementedError();
@@ -62,6 +69,17 @@ void testMain() {
       // just created.
       final DisplayCanvas newCanvas = factory.getCanvas();
       expect(newCanvas, equals(canvas));
+    });
+
+    test('releaseCanvas releases transient resources before caching the canvas', () {
+      final factory = DisplayCanvasFactory<DummyDisplayCanvas>(
+        createCanvas: () => DummyDisplayCanvas(),
+      );
+
+      final DummyDisplayCanvas canvas = factory.getCanvas();
+      factory.releaseCanvas(canvas);
+
+      expect(canvas.releaseCount, 1);
     });
 
     test('isLive', () {

--- a/engine/src/flutter/lib/web_ui/test/engine/compositing/render_canvas_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/compositing/render_canvas_test.dart
@@ -59,6 +59,26 @@ void testMain() {
       expect(canvas.canvasElement.style.height, '32px');
     });
 
+    test('releases transferred bitmap resources while remaining reusable', () async {
+      final canvas = RenderCanvas();
+      canvas.render(await newBitmap(10, 16));
+
+      expect(canvas.canvasElement.width, 10);
+      expect(canvas.canvasElement.height, 16);
+
+      canvas.release();
+      expect(canvas.canvasElement.width, 10);
+      expect(canvas.canvasElement.height, 16);
+
+      canvas.render(await newBitmap(20, 24));
+      expect(canvas.canvasElement.width, 20);
+      expect(canvas.canvasElement.height, 24);
+
+      canvas.dispose();
+      expect(canvas.canvasElement.width, 0);
+      expect(canvas.canvasElement.height, 0);
+    });
+
     test('rounds physical size to nearest integer size', () async {
       final EngineFlutterWindow implicitView = EnginePlatformDispatcher.instance.implicitView!;
       implicitView.debugPhysicalSizeOverride = const ui.Size(199.999999, 200.000001);

--- a/engine/src/flutter/lib/web_ui/test/engine/configuration_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/configuration_test.dart
@@ -10,6 +10,7 @@ import 'dart:js_interop';
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 import '../common/matchers.dart';
 
@@ -78,8 +79,42 @@ void testMain() {
       defaultConfig.setUserConfiguration(<String, Object?>{}.jsify()! as JsFlutterConfiguration);
     });
 
+    tearDown(() {
+      ui_web.browser.debugBrowserEngineOverride = null;
+    });
+
     test('canvasKitVariant', () {
       expect(defaultConfig.canvasKitVariant, CanvasKitVariant.auto);
+    });
+
+    test('canvasKitMaximumSurfaces defaults to 8 outside Safari', () {
+      ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.blink;
+
+      expect(
+        defaultConfig.canvasKitMaximumSurfaces,
+        FlutterConfiguration.defaultCanvasKitMaximumSurfaces,
+      );
+    });
+
+    test('canvasKitMaximumSurfaces defaults to 2 on Safari', () {
+      ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.webkit;
+
+      expect(
+        defaultConfig.canvasKitMaximumSurfaces,
+        FlutterConfiguration.safariDefaultCanvasKitMaximumSurfaces,
+      );
+    });
+
+    test('canvasKitForceCpuOnly defaults to false outside Safari', () {
+      ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.blink;
+
+      expect(defaultConfig.canvasKitForceCpuOnly, isFalse);
+    });
+
+    test('canvasKitForceCpuOnly defaults to true on Safari', () {
+      ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.webkit;
+
+      expect(defaultConfig.canvasKitForceCpuOnly, isTrue);
     });
 
     test('multiViewEnabled', () {
@@ -130,6 +165,28 @@ void testMain() {
         <String, Object?>{'multiViewEnabled': true}.jsify()! as JsFlutterConfiguration,
       );
       expect(config.multiViewEnabled, isTrue);
+    });
+
+    test('canvasKitMaximumSurfaces override is preserved on Safari', () {
+      ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.webkit;
+
+      final config = FlutterConfiguration();
+      config.setUserConfiguration(
+        <String, Object?>{'canvasKitMaximumSurfaces': 4}.jsify()! as JsFlutterConfiguration,
+      );
+
+      expect(config.canvasKitMaximumSurfaces, 4);
+    });
+
+    test('canvasKitForceCpuOnly override is preserved on Safari', () {
+      ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.webkit;
+
+      final config = FlutterConfiguration();
+      config.setUserConfiguration(
+        <String, Object?>{'canvasKitForceCpuOnly': false}.jsify()! as JsFlutterConfiguration,
+      );
+
+      expect(config.canvasKitForceCpuOnly, isFalse);
     });
   });
 }

--- a/engine/src/flutter/lib/web_ui/test/engine/configuration_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/configuration_test.dart
@@ -79,42 +79,48 @@ void testMain() {
       defaultConfig.setUserConfiguration(<String, Object?>{}.jsify()! as JsFlutterConfiguration);
     });
 
-    tearDown(() {
-      ui_web.browser.debugBrowserEngineOverride = null;
-    });
-
     test('canvasKitVariant', () {
       expect(defaultConfig.canvasKitVariant, CanvasKitVariant.auto);
     });
 
     test('canvasKitMaximumSurfaces defaults to 8 outside Safari', () {
-      ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.blink;
+      try {
+        ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.blink;
 
-      expect(
-        defaultConfig.canvasKitMaximumSurfaces,
-        FlutterConfiguration.defaultCanvasKitMaximumSurfaces,
-      );
+        expect(defaultConfig.canvasKitMaximumSurfaces, 8);
+      } finally {
+        ui_web.browser.debugBrowserEngineOverride = null;
+      }
     });
 
     test('canvasKitMaximumSurfaces defaults to 2 on Safari', () {
-      ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.webkit;
+      try {
+        ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.webkit;
 
-      expect(
-        defaultConfig.canvasKitMaximumSurfaces,
-        FlutterConfiguration.safariDefaultCanvasKitMaximumSurfaces,
-      );
+        expect(defaultConfig.canvasKitMaximumSurfaces, 2);
+      } finally {
+        ui_web.browser.debugBrowserEngineOverride = null;
+      }
     });
 
     test('canvasKitForceCpuOnly defaults to false outside Safari', () {
-      ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.blink;
+      try {
+        ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.blink;
 
-      expect(defaultConfig.canvasKitForceCpuOnly, isFalse);
+        expect(defaultConfig.canvasKitForceCpuOnly, isFalse);
+      } finally {
+        ui_web.browser.debugBrowserEngineOverride = null;
+      }
     });
 
     test('canvasKitForceCpuOnly defaults to true on Safari', () {
-      ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.webkit;
+      try {
+        ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.webkit;
 
-      expect(defaultConfig.canvasKitForceCpuOnly, isTrue);
+        expect(defaultConfig.canvasKitForceCpuOnly, isTrue);
+      } finally {
+        ui_web.browser.debugBrowserEngineOverride = null;
+      }
     });
 
     test('multiViewEnabled', () {
@@ -168,25 +174,33 @@ void testMain() {
     });
 
     test('canvasKitMaximumSurfaces override is preserved on Safari', () {
-      ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.webkit;
+      try {
+        ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.webkit;
 
-      final config = FlutterConfiguration();
-      config.setUserConfiguration(
-        <String, Object?>{'canvasKitMaximumSurfaces': 4}.jsify()! as JsFlutterConfiguration,
-      );
+        final config = FlutterConfiguration();
+        config.setUserConfiguration(
+          <String, Object?>{'canvasKitMaximumSurfaces': 4}.jsify()! as JsFlutterConfiguration,
+        );
 
-      expect(config.canvasKitMaximumSurfaces, 4);
+        expect(config.canvasKitMaximumSurfaces, 4);
+      } finally {
+        ui_web.browser.debugBrowserEngineOverride = null;
+      }
     });
 
     test('canvasKitForceCpuOnly override is preserved on Safari', () {
-      ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.webkit;
+      try {
+        ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.webkit;
 
-      final config = FlutterConfiguration();
-      config.setUserConfiguration(
-        <String, Object?>{'canvasKitForceCpuOnly': false}.jsify()! as JsFlutterConfiguration,
-      );
+        final config = FlutterConfiguration();
+        config.setUserConfiguration(
+          <String, Object?>{'canvasKitForceCpuOnly': false}.jsify()! as JsFlutterConfiguration,
+        );
 
-      expect(config.canvasKitForceCpuOnly, isFalse);
+        expect(config.canvasKitForceCpuOnly, isFalse);
+      } finally {
+        ui_web.browser.debugBrowserEngineOverride = null;
+      }
     });
   });
 }

--- a/engine/src/flutter/lib/web_ui/test/engine/platform_views/content_manager_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/platform_views/content_manager_test.dart
@@ -60,6 +60,21 @@ void testMain() {
         expect(contentManager.knowsViewId(viewId), isFalse);
         expect(view.parentNode, isNull);
       });
+
+      test('forgets visibility metadata after clearing viewIds', () {
+        contentManager.renderContent(
+          ui_web.PlatformViewRegistry.defaultInvisibleViewType,
+          viewId,
+          <dynamic, dynamic>{'tagName': 'script'},
+        );
+
+        expect(contentManager.isInvisible(viewId), isTrue);
+
+        contentManager.clearPlatformView(viewId);
+
+        expect(contentManager.knowsViewId(viewId), isFalse);
+        expect(contentManager.isInvisible(viewId), isFalse);
+      });
     });
 
     group('registerFactory', () {

--- a/engine/src/flutter/lib/web_ui/test/engine/platform_views/content_manager_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/platform_views/content_manager_test.dart
@@ -65,7 +65,7 @@ void testMain() {
         contentManager.renderContent(
           ui_web.PlatformViewRegistry.defaultInvisibleViewType,
           viewId,
-          <dynamic, dynamic>{'tagName': 'script'},
+          <String, String>{'tagName': 'script'},
         );
 
         expect(contentManager.isInvisible(viewId), isTrue);

--- a/packages/flutter/lib/src/widgets/_html_element_view_web.dart
+++ b/packages/flutter/lib/src/widgets/_html_element_view_web.dart
@@ -58,7 +58,10 @@ extension HtmlElementViewImpl on HtmlElementView {
   /// Creates the controller and kicks off its initialization.
   _HtmlElementViewController _createController(PlatformViewCreationParams params) {
     final controller = _HtmlElementViewController(params.id, viewType, creationParams);
-    controller._initialize().then((_) {
+    controller._initialize().then((bool shouldNotifyCreated) {
+      if (!shouldNotifyCreated) {
+        return;
+      }
       params.onPlatformViewCreated(params.id);
       onPlatformViewCreated?.call(params.id);
     });
@@ -91,11 +94,18 @@ class _HtmlElementViewController extends PlatformViewController {
   final dynamic creationParams;
 
   bool _initialized = false;
+  bool _disposed = false;
+  bool _disposeSent = false;
 
-  Future<void> _initialize() async {
+  Future<bool> _initialize() async {
     final args = <String, dynamic>{'id': viewId, 'viewType': viewType, 'params': creationParams};
     await SystemChannels.platform_views.invokeMethod<void>('create', args);
     _initialized = true;
+    if (_disposed) {
+      await _disposePlatformView();
+      return false;
+    }
+    return true;
   }
 
   @override
@@ -112,8 +122,17 @@ class _HtmlElementViewController extends PlatformViewController {
 
   @override
   Future<void> dispose() async {
+    _disposed = true;
     if (_initialized) {
-      await SystemChannels.platform_views.invokeMethod<void>('dispose', viewId);
+      await _disposePlatformView();
     }
+  }
+
+  Future<void> _disposePlatformView() async {
+    if (_disposeSent) {
+      return;
+    }
+    _disposeSent = true;
+    await SystemChannels.platform_views.invokeMethod<void>('dispose', viewId);
   }
 }

--- a/packages/flutter/test/widgets/html_element_view_test.dart
+++ b/packages/flutter/test/widgets/html_element_view_test.dart
@@ -208,6 +208,51 @@ void main() {
       expect(fakePlatformViewRegistry.views, isEmpty);
     });
 
+    testWidgets('Dispose HTML view when create completes after widget disposal', (
+      WidgetTester tester,
+    ) async {
+      final createCompleter = Completer<void>();
+      final methodCalls = <String>[];
+      var didCallOnPlatformViewCreated = false;
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform_views,
+        (MethodCall call) {
+          methodCalls.add(call.method);
+          return switch (call.method) {
+            'create' => createCompleter.future,
+            'dispose' => Future<void>.value(),
+            _ => Future<void>.value(),
+          };
+        },
+      );
+
+      await tester.pumpWidget(
+        Center(
+          child: SizedBox(
+            width: 200.0,
+            height: 100.0,
+            child: HtmlElementView(
+              viewType: 'webview',
+              onPlatformViewCreated: (_) {
+                didCallOnPlatformViewCreated = true;
+              },
+            ),
+          ),
+        ),
+      );
+      expect(methodCalls, <String>['create']);
+
+      await tester.pumpWidget(const Center(child: SizedBox(width: 200.0, height: 100.0)));
+      expect(methodCalls, <String>['create']);
+
+      createCompleter.complete();
+      await tester.pump();
+
+      expect(methodCalls, <String>['create', 'dispose']);
+      expect(didCallOnPlatformViewCreated, isFalse);
+    });
+
     testWidgets('HTML view survives widget tree change', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       fakePlatformViewRegistry.registerViewFactory('webview', _mockViewFactory);


### PR DESCRIPTION
Reduces Safari's CanvasKit memory footprint for Flutter web apps while preserving platform-view composition.

Safari can retain a much higher physical footprint than Chrome for CanvasKit apps. In a production-style Flutter web flow with a Google Maps platform view, the baseline Safari WebContent footprint was `639.0M / 652.8M` after 60 seconds idle, while Chrome stayed around `48.8M / 52.5M` JS heap. This PR applies Safari-specific CanvasKit defaults, caps Safari's Skia resource cache, tightens web platform-view cleanup, and fixes an `HtmlElementView` create/dispose race.

Validation from the same flow after the change:

* Final Safari run through the normal `bin/flutter` web SDK cache: `373.0M / 451.8M` after 60 seconds idle, with the map visible.
* Three cached Safari repeats: `383.87M / 443.63M` mean after 60 seconds idle, with the map visible in all runs.
* Chrome guard through the normal SDK cache: `48.9M / 52.3M` after 60 seconds idle, matching the baseline.

Fixes flutter/flutter#93404

No `flutter/tests` migration is needed; this changes Flutter web engine and framework behavior without a breaking API change.

## Release / cherry-pick information

### Issue Link:

https://github.com/flutter/flutter/issues/93404

### Impact Description:

Safari web apps using CanvasKit can use several hundred MB more memory than Chrome and may slow or crash. Apps using platform views, such as Google Maps, also need the Safari memory reduction to preserve underlay/overlay composition so the platform view remains visible.

### Changelog Description:

[flutter/93404] When running CanvasKit Flutter web apps on Safari, reduce memory footprint with Safari-specific CanvasKit defaults while preserving platform-view composition.

### Workaround:

Apps can manually set `canvasKitForceCpuOnly: true` and `canvasKitMaximumSurfaces: 2`, but this PR makes Safari defaults safer without requiring each app to configure them.

### Risk:

  - [ ] Low
  - [x] Medium
  - [ ] High

### Test Coverage:

  - [x] Yes
  - [ ] No

### Validation Steps:

* `dart format engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/renderer.dart engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/surface.dart engine/src/flutter/lib/web_ui/lib/src/engine/compositing/rasterizer.dart engine/src/flutter/lib/web_ui/lib/src/engine/compositing/render_canvas.dart engine/src/flutter/lib/web_ui/lib/src/engine/compositing/surface.dart engine/src/flutter/lib/web_ui/lib/src/engine/configuration.dart engine/src/flutter/lib/web_ui/lib/src/engine/platform_views/content_manager.dart engine/src/flutter/lib/web_ui/test/canvaskit/rasterizer_test.dart engine/src/flutter/lib/web_ui/test/canvaskit/renderer_test.dart engine/src/flutter/lib/web_ui/test/engine/compositing/render_canvas_test.dart engine/src/flutter/lib/web_ui/test/engine/configuration_test.dart engine/src/flutter/lib/web_ui/test/engine/platform_views/content_manager_test.dart packages/flutter/lib/src/widgets/_html_element_view_web.dart packages/flutter/test/widgets/html_element_view_test.dart`
* `felt test --browser=chrome --renderer=canvaskit --suite=chrome-dart2js-canvaskit-engine --fail-early`
* `felt test --browser=chrome --renderer=canvaskit --suite=chrome-dart2js-canvaskit-canvaskit --fail-early`
* `flutter test --platform chrome test/widgets/html_element_view_test.dart`
* `git diff --check`
* Manual Safari memory profile of the Rider web flow: home, trip options, and 60 seconds idle, including platform-view visibility checks.
* Chrome memory profile of the same flow as a regression guard.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

This is a draft until the submitter has completed human review of the AI-assisted changes and signed the CLA.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
