### PR TITLE
Disable spell check for obscured text

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -3507,7 +3507,11 @@ class EditableTextState extends State<EditableText>
         widget.spellCheckConfiguration,
         obscureText: widget.obscureText,
       );
-      if (!spellCheckEnabled) {
+      if (spellCheckEnabled) {
+        if (textEditingValue.text.isNotEmpty) {
+          _performSpellCheck(textEditingValue.text);
+        }
+      } else {
         spellCheckResults = null;
       }
     }
@@ -4633,7 +4637,7 @@ class EditableTextState extends State<EditableText>
       final List<SuggestionSpan>? suggestions = await _spellCheckConfiguration.spellCheckService!
           .fetchSpellCheckSuggestions(localeForSpellChecking!, text);
 
-      if (suggestions == null || !mounted || !spellCheckEnabled || widget.obscureText) {
+      if (suggestions == null || !mounted || !spellCheckEnabled) {
         // The request to fetch spell check suggestions was canceled due to ongoing request,
         // the widget was unmounted, or spell check was disabled before the
         // request completed.

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2051,6 +2051,8 @@ class EditableText extends StatefulWidget {
   /// Specifies the [SpellCheckService] used to spell check text input and the
   /// [TextStyle] used to style text with misspelled words.
   ///
+  /// Spell check is disabled when [obscureText] is true.
+  ///
   /// If the [SpellCheckService] is left null, spell check is disabled by
   /// default unless the [DefaultSpellCheckService] is supported, in which case
   /// it is used. It is currently supported only on Android and iOS.
@@ -3050,18 +3052,21 @@ class EditableTextState extends State<EditableText>
   /// If spell check is enabled, this will try to infer a value for
   /// the [SpellCheckService] if left unspecified.
   static SpellCheckConfiguration _inferSpellCheckConfiguration(
-    SpellCheckConfiguration? configuration,
-  ) {
+    SpellCheckConfiguration? configuration, {
+    required bool obscureText,
+  }) {
     final SpellCheckService? spellCheckService = configuration?.spellCheckService;
     final bool spellCheckAutomaticallyDisabled =
-        configuration == null || configuration == const SpellCheckConfiguration.disabled();
+        obscureText ||
+        configuration == null ||
+        configuration == const SpellCheckConfiguration.disabled();
     final bool spellCheckServiceIsConfigured =
         spellCheckService != null ||
         WidgetsBinding.instance.platformDispatcher.nativeSpellCheckServiceDefined;
     if (spellCheckAutomaticallyDisabled || !spellCheckServiceIsConfigured) {
       // Only enable spell check if a non-disabled configuration is provided
-      // and if that configuration does not specify a spell check service,
-      // a native spell checker must be supported.
+      // for unobscured text and, if that configuration does not specify a
+      // spell check service, a native spell checker must be supported.
       assert(() {
         if (!spellCheckAutomaticallyDisabled && !spellCheckServiceIsConfigured) {
           FlutterError.reportError(
@@ -3284,7 +3289,10 @@ class EditableTextState extends State<EditableText>
     widget.controller.addListener(_didChangeTextEditingValue);
     widget.focusNode.addListener(_handleFocusChanged);
     _cursorVisibilityNotifier.value = widget.showCursor;
-    _spellCheckConfiguration = _inferSpellCheckConfiguration(widget.spellCheckConfiguration);
+    _spellCheckConfiguration = _inferSpellCheckConfiguration(
+      widget.spellCheckConfiguration,
+      obscureText: widget.obscureText,
+    );
     _appLifecycleListener = AppLifecycleListener(onResume: _onResume);
     _initProcessTextActions();
   }
@@ -3490,6 +3498,17 @@ class EditableTextState extends State<EditableText>
           _obscureLatestCharIndex = null;
         }
         _textInputConnection!.updateConfig(_effectiveAutofillClient.textInputConfiguration);
+      }
+    }
+
+    if (oldWidget.spellCheckConfiguration != widget.spellCheckConfiguration ||
+        oldWidget.obscureText != widget.obscureText) {
+      _spellCheckConfiguration = _inferSpellCheckConfiguration(
+        widget.spellCheckConfiguration,
+        obscureText: widget.obscureText,
+      );
+      if (!spellCheckEnabled) {
+        spellCheckResults = null;
       }
     }
 
@@ -4614,9 +4633,10 @@ class EditableTextState extends State<EditableText>
       final List<SuggestionSpan>? suggestions = await _spellCheckConfiguration.spellCheckService!
           .fetchSpellCheckSuggestions(localeForSpellChecking!, text);
 
-      if (suggestions == null || !mounted) {
+      if (suggestions == null || !mounted || !spellCheckEnabled || widget.obscureText) {
         // The request to fetch spell check suggestions was canceled due to ongoing request,
-        // or the widget was unmounted.
+        // the widget was unmounted, or spell check was disabled before the
+        // request completed.
         return;
       }
 

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2051,7 +2051,10 @@ class EditableText extends StatefulWidget {
   /// Specifies the [SpellCheckService] used to spell check text input and the
   /// [TextStyle] used to style text with misspelled words.
   ///
-  /// Spell check is disabled when [obscureText] is true.
+  /// Spell check is disabled for password input, including when [obscureText]
+  /// is true, [keyboardType] is [TextInputType.visiblePassword], or
+  /// [autofillHints] contains [AutofillHints.password] or
+  /// [AutofillHints.newPassword].
   ///
   /// If the [SpellCheckService] is left null, spell check is disabled by
   /// default unless the [DefaultSpellCheckService] is supported, in which case
@@ -3054,10 +3057,16 @@ class EditableTextState extends State<EditableText>
   static SpellCheckConfiguration _inferSpellCheckConfiguration(
     SpellCheckConfiguration? configuration, {
     required bool obscureText,
+    required TextInputType keyboardType,
+    required Iterable<String>? autofillHints,
   }) {
     final SpellCheckService? spellCheckService = configuration?.spellCheckService;
     final bool spellCheckAutomaticallyDisabled =
-        obscureText ||
+        _isPasswordInput(
+          obscureText: obscureText,
+          keyboardType: keyboardType,
+          autofillHints: autofillHints,
+        ) ||
         configuration == null ||
         configuration == const SpellCheckConfiguration.disabled();
     final bool spellCheckServiceIsConfigured =
@@ -3065,7 +3074,7 @@ class EditableTextState extends State<EditableText>
         WidgetsBinding.instance.platformDispatcher.nativeSpellCheckServiceDefined;
     if (spellCheckAutomaticallyDisabled || !spellCheckServiceIsConfigured) {
       // Only enable spell check if a non-disabled configuration is provided
-      // for unobscured text and, if that configuration does not specify a
+      // for non-password text and, if that configuration does not specify a
       // spell check service, a native spell checker must be supported.
       assert(() {
         if (!spellCheckAutomaticallyDisabled && !spellCheckServiceIsConfigured) {
@@ -3091,6 +3100,19 @@ class EditableTextState extends State<EditableText>
     return configuration.copyWith(
       spellCheckService: spellCheckService ?? DefaultSpellCheckService(),
     );
+  }
+
+  static bool _isPasswordInput({
+    required bool obscureText,
+    required TextInputType keyboardType,
+    required Iterable<String>? autofillHints,
+  }) {
+    return obscureText ||
+        keyboardType == TextInputType.visiblePassword ||
+        (autofillHints?.any(
+              (String hint) => hint == AutofillHints.password || hint == AutofillHints.newPassword,
+            ) ??
+            false);
   }
 
   /// Returns the [ContextMenuButtonItem]s for the given [ToolbarOptions].
@@ -3292,6 +3314,8 @@ class EditableTextState extends State<EditableText>
     _spellCheckConfiguration = _inferSpellCheckConfiguration(
       widget.spellCheckConfiguration,
       obscureText: widget.obscureText,
+      keyboardType: widget.keyboardType,
+      autofillHints: widget.autofillHints,
     );
     _appLifecycleListener = AppLifecycleListener(onResume: _onResume);
     _initProcessTextActions();
@@ -3502,10 +3526,17 @@ class EditableTextState extends State<EditableText>
     }
 
     if (oldWidget.spellCheckConfiguration != widget.spellCheckConfiguration ||
-        oldWidget.obscureText != widget.obscureText) {
+        oldWidget.obscureText != widget.obscureText ||
+        oldWidget.keyboardType != widget.keyboardType ||
+        !listEquals<String>(
+          oldWidget.autofillHints?.toList(growable: false),
+          widget.autofillHints?.toList(growable: false),
+        )) {
       _spellCheckConfiguration = _inferSpellCheckConfiguration(
         widget.spellCheckConfiguration,
         obscureText: widget.obscureText,
+        keyboardType: widget.keyboardType,
+        autofillHints: widget.autofillHints,
       );
       if (spellCheckEnabled) {
         if (textEditingValue.text.isNotEmpty) {

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -3074,7 +3074,7 @@ class EditableTextState extends State<EditableText>
         WidgetsBinding.instance.platformDispatcher.nativeSpellCheckServiceDefined;
     if (spellCheckAutomaticallyDisabled || !spellCheckServiceIsConfigured) {
       // Only enable spell check if a non-disabled configuration is provided
-      // for non-password text and, if that configuration does not specify a
+      // for non-password input and, if that configuration does not specify a
       // spell check service, a native spell checker must be supported.
       assert(() {
         if (!spellCheckAutomaticallyDisabled && !spellCheckServiceIsConfigured) {

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -16003,9 +16003,7 @@ void main() {
       expect(state.spellCheckConfiguration, equals(const SpellCheckConfiguration.disabled()));
     });
 
-    testWidgets('Spell check disabled when obscureText changes to true', (
-      WidgetTester tester,
-    ) async {
+    testWidgets('Spell check updates when obscureText changes', (WidgetTester tester) async {
       final fakeSpellCheckService = FakeSpellCheckService();
       controller.text = 'A';
 
@@ -16042,6 +16040,15 @@ void main() {
       expect(state.spellCheckEnabled, isFalse);
       expect(state.spellCheckConfiguration, equals(const SpellCheckConfiguration.disabled()));
       expect(state.spellCheckResults, isNull);
+      expect(fakeSpellCheckService.fetchSpellCheckSuggestionsCallCount, 0);
+
+      await tester.pumpWidget(buildEditableText(obscureText: false));
+      await tester.pump();
+
+      state = tester.state<EditableTextState>(find.byType(EditableText));
+      expect(state.spellCheckEnabled, isTrue);
+      expect(fakeSpellCheckService.fetchSpellCheckSuggestionsCallCount, 1);
+      expect(fakeSpellCheckService.lastSpellCheckText, 'A');
     });
 
     testWidgets(
@@ -19088,7 +19095,17 @@ class _TestScrollController extends ScrollController {
   bool get attached => hasListeners;
 }
 
-class FakeSpellCheckService extends DefaultSpellCheckService {}
+class FakeSpellCheckService extends DefaultSpellCheckService {
+  int fetchSpellCheckSuggestionsCallCount = 0;
+  String? lastSpellCheckText;
+
+  @override
+  Future<List<SuggestionSpan>?> fetchSpellCheckSuggestions(Locale locale, String text) async {
+    fetchSpellCheckSuggestionsCallCount += 1;
+    lastSpellCheckText = text;
+    return const <SuggestionSpan>[];
+  }
+}
 
 class FakeFlutterView extends TestFlutterView {
   FakeFlutterView(TestFlutterView view, {required this.viewId})

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -16003,7 +16003,66 @@ void main() {
       expect(state.spellCheckConfiguration, equals(const SpellCheckConfiguration.disabled()));
     });
 
-    testWidgets('Spell check updates when obscureText changes', (WidgetTester tester) async {
+    testWidgets('Spell check disabled for visible password input type', (
+      WidgetTester tester,
+    ) async {
+      final fakeSpellCheckService = FakeSpellCheckService();
+      controller.text = 'A';
+
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: EditableText(
+            controller: controller,
+            focusNode: focusNode,
+            keyboardType: TextInputType.visiblePassword,
+            style: const TextStyle(),
+            cursorColor: const Color(0xFF0000FF),
+            backgroundCursorColor: const Color(0xFF808080),
+            cursorOpacityAnimates: true,
+            autofillHints: null,
+            spellCheckConfiguration: SpellCheckConfiguration(
+              spellCheckService: fakeSpellCheckService,
+              misspelledTextStyle: const TextStyle(decoration: TextDecoration.underline),
+            ),
+          ),
+        ),
+      );
+
+      final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
+      expect(state.spellCheckEnabled, isFalse);
+      expect(state.spellCheckConfiguration, equals(const SpellCheckConfiguration.disabled()));
+    });
+
+    testWidgets('Spell check disabled for password autofill hints', (WidgetTester tester) async {
+      final fakeSpellCheckService = FakeSpellCheckService();
+      controller.text = 'A';
+
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: EditableText(
+            controller: controller,
+            focusNode: focusNode,
+            style: const TextStyle(),
+            cursorColor: const Color(0xFF0000FF),
+            backgroundCursorColor: const Color(0xFF808080),
+            cursorOpacityAnimates: true,
+            autofillHints: const <String>[AutofillHints.password],
+            spellCheckConfiguration: SpellCheckConfiguration(
+              spellCheckService: fakeSpellCheckService,
+              misspelledTextStyle: const TextStyle(decoration: TextDecoration.underline),
+            ),
+          ),
+        ),
+      );
+
+      final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
+      expect(state.spellCheckEnabled, isFalse);
+      expect(state.spellCheckConfiguration, equals(const SpellCheckConfiguration.disabled()));
+    });
+
+    testWidgets('Spell check updates when non-password obscureText changes', (
+      WidgetTester tester,
+    ) async {
       const suggestionSpans = <SuggestionSpan>[
         SuggestionSpan(TextRange(start: 0, end: 1), <String>['a']),
       ];
@@ -16065,6 +16124,53 @@ void main() {
       expect(fakeSpellCheckService.fetchSpellCheckSuggestionsCallCount, 1);
       expect(fakeSpellCheckService.lastSpellCheckText, 'A');
       expect(state.spellCheckResults, const SpellCheckResults('A', suggestionSpans));
+    });
+
+    testWidgets('Spell check stays disabled for visible password when obscureText changes', (
+      WidgetTester tester,
+    ) async {
+      final fakeSpellCheckService = FakeSpellCheckService();
+      controller.text = 'A';
+      var obscureText = true;
+      late StateSetter setState;
+
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: StatefulBuilder(
+            builder: (BuildContext context, StateSetter localSetState) {
+              setState = localSetState;
+              return EditableText(
+                controller: controller,
+                focusNode: focusNode,
+                keyboardType: TextInputType.visiblePassword,
+                obscureText: obscureText,
+                style: const TextStyle(),
+                cursorColor: const Color(0xFF0000FF),
+                backgroundCursorColor: const Color(0xFF808080),
+                cursorOpacityAnimates: true,
+                autofillHints: null,
+                spellCheckConfiguration: SpellCheckConfiguration(
+                  spellCheckService: fakeSpellCheckService,
+                  misspelledTextStyle: const TextStyle(decoration: TextDecoration.underline),
+                ),
+              );
+            },
+          ),
+        ),
+      );
+
+      EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
+      expect(state.spellCheckEnabled, isFalse);
+
+      setState(() {
+        obscureText = false;
+      });
+      await tester.pump();
+
+      state = tester.state<EditableTextState>(find.byType(EditableText));
+      expect(state.spellCheckEnabled, isFalse);
+      expect(state.spellCheckConfiguration, equals(const SpellCheckConfiguration.disabled()));
+      expect(fakeSpellCheckService.fetchSpellCheckSuggestionsCallCount, 0);
     });
 
     testWidgets(

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -15980,19 +15980,19 @@ void main() {
       controller.text = 'A';
 
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           home: EditableText(
             controller: controller,
             focusNode: focusNode,
             obscureText: true,
             style: const TextStyle(),
-            cursorColor: Colors.blue,
-            backgroundCursorColor: Colors.grey,
+            cursorColor: const Color(0xFF0000FF),
+            backgroundCursorColor: const Color(0xFF808080),
             cursorOpacityAnimates: true,
             autofillHints: null,
             spellCheckConfiguration: SpellCheckConfiguration(
               spellCheckService: fakeSpellCheckService,
-              misspelledTextStyle: TextField.materialMisspelledTextStyle,
+              misspelledTextStyle: const TextStyle(decoration: TextDecoration.underline),
             ),
           ),
         ),
@@ -16004,23 +16004,28 @@ void main() {
     });
 
     testWidgets('Spell check updates when obscureText changes', (WidgetTester tester) async {
-      final fakeSpellCheckService = FakeSpellCheckService();
+      const suggestionSpans = <SuggestionSpan>[
+        SuggestionSpan(TextRange(start: 0, end: 1), <String>['a']),
+      ];
+      final fakeSpellCheckService = FakeSpellCheckService(
+        suggestionSpansByText: const <String, List<SuggestionSpan>?>{'A': suggestionSpans},
+      );
       controller.text = 'A';
 
       Widget buildEditableText({required bool obscureText}) {
-        return MaterialApp(
+        return TestWidgetsApp(
           home: EditableText(
             controller: controller,
             focusNode: focusNode,
             obscureText: obscureText,
             style: const TextStyle(),
-            cursorColor: Colors.blue,
-            backgroundCursorColor: Colors.grey,
+            cursorColor: const Color(0xFF0000FF),
+            backgroundCursorColor: const Color(0xFF808080),
             cursorOpacityAnimates: true,
             autofillHints: null,
             spellCheckConfiguration: SpellCheckConfiguration(
               spellCheckService: fakeSpellCheckService,
-              misspelledTextStyle: TextField.materialMisspelledTextStyle,
+              misspelledTextStyle: const TextStyle(decoration: TextDecoration.underline),
             ),
           ),
         );
@@ -16030,9 +16035,7 @@ void main() {
 
       EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
       expect(state.spellCheckEnabled, isTrue);
-      state.spellCheckResults = const SpellCheckResults('A', <SuggestionSpan>[
-        SuggestionSpan(TextRange(start: 0, end: 1), <String>['a']),
-      ]);
+      state.spellCheckResults = const SpellCheckResults('A', suggestionSpans);
 
       await tester.pumpWidget(buildEditableText(obscureText: true));
 
@@ -16049,6 +16052,7 @@ void main() {
       expect(state.spellCheckEnabled, isTrue);
       expect(fakeSpellCheckService.fetchSpellCheckSuggestionsCallCount, 1);
       expect(fakeSpellCheckService.lastSpellCheckText, 'A');
+      expect(state.spellCheckResults, const SpellCheckResults('A', suggestionSpans));
     });
 
     testWidgets(
@@ -19096,6 +19100,9 @@ class _TestScrollController extends ScrollController {
 }
 
 class FakeSpellCheckService extends DefaultSpellCheckService {
+  FakeSpellCheckService({this.suggestionSpansByText = const <String, List<SuggestionSpan>?>{}});
+
+  final Map<String, List<SuggestionSpan>?> suggestionSpansByText;
   int fetchSpellCheckSuggestionsCallCount = 0;
   String? lastSpellCheckText;
 
@@ -19103,7 +19110,9 @@ class FakeSpellCheckService extends DefaultSpellCheckService {
   Future<List<SuggestionSpan>?> fetchSpellCheckSuggestions(Locale locale, String text) async {
     fetchSpellCheckSuggestionsCallCount += 1;
     lastSpellCheckText = text;
-    return const <SuggestionSpan>[];
+    return suggestionSpansByText.containsKey(text)
+        ? suggestionSpansByText[text]
+        : const <SuggestionSpan>[];
   }
 }
 

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -16011,33 +16011,45 @@ void main() {
         suggestionSpansByText: const <String, List<SuggestionSpan>?>{'A': suggestionSpans},
       );
       controller.text = 'A';
+      var obscureText = false;
+      late StateSetter setState;
 
-      Widget buildEditableText({required bool obscureText}) {
-        return TestWidgetsApp(
-          home: EditableText(
-            controller: controller,
-            focusNode: focusNode,
-            obscureText: obscureText,
-            style: const TextStyle(),
-            cursorColor: const Color(0xFF0000FF),
-            backgroundCursorColor: const Color(0xFF808080),
-            cursorOpacityAnimates: true,
-            autofillHints: null,
-            spellCheckConfiguration: SpellCheckConfiguration(
-              spellCheckService: fakeSpellCheckService,
-              misspelledTextStyle: const TextStyle(decoration: TextDecoration.underline),
-            ),
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: StatefulBuilder(
+            builder: (BuildContext context, StateSetter localSetState) {
+              setState = localSetState;
+              return EditableText(
+                controller: controller,
+                focusNode: focusNode,
+                obscureText: obscureText,
+                style: const TextStyle(),
+                cursorColor: const Color(0xFF0000FF),
+                backgroundCursorColor: const Color(0xFF808080),
+                cursorOpacityAnimates: true,
+                autofillHints: null,
+                spellCheckConfiguration: SpellCheckConfiguration(
+                  spellCheckService: fakeSpellCheckService,
+                  misspelledTextStyle: const TextStyle(decoration: TextDecoration.underline),
+                ),
+              );
+            },
           ),
-        );
-      }
+        ),
+      );
 
-      await tester.pumpWidget(buildEditableText(obscureText: false));
+      void setObscureText(bool value) {
+        setState(() {
+          obscureText = value;
+        });
+      }
 
       EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
       expect(state.spellCheckEnabled, isTrue);
       state.spellCheckResults = const SpellCheckResults('A', suggestionSpans);
 
-      await tester.pumpWidget(buildEditableText(obscureText: true));
+      setObscureText(true);
+      await tester.pump();
 
       state = tester.state<EditableTextState>(find.byType(EditableText));
       expect(state.spellCheckEnabled, isFalse);
@@ -16045,7 +16057,7 @@ void main() {
       expect(state.spellCheckResults, isNull);
       expect(fakeSpellCheckService.fetchSpellCheckSuggestionsCallCount, 0);
 
-      await tester.pumpWidget(buildEditableText(obscureText: false));
+      setObscureText(false);
       await tester.pump();
 
       state = tester.state<EditableTextState>(find.byType(EditableText));

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -15975,6 +15975,75 @@ void main() {
       );
     });
 
+    testWidgets('Spell check disabled when obscureText is true', (WidgetTester tester) async {
+      final fakeSpellCheckService = FakeSpellCheckService();
+      controller.text = 'A';
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: EditableText(
+            controller: controller,
+            focusNode: focusNode,
+            obscureText: true,
+            style: const TextStyle(),
+            cursorColor: Colors.blue,
+            backgroundCursorColor: Colors.grey,
+            cursorOpacityAnimates: true,
+            autofillHints: null,
+            spellCheckConfiguration: SpellCheckConfiguration(
+              spellCheckService: fakeSpellCheckService,
+              misspelledTextStyle: TextField.materialMisspelledTextStyle,
+            ),
+          ),
+        ),
+      );
+
+      final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
+      expect(state.spellCheckEnabled, isFalse);
+      expect(state.spellCheckConfiguration, equals(const SpellCheckConfiguration.disabled()));
+    });
+
+    testWidgets('Spell check disabled when obscureText changes to true', (
+      WidgetTester tester,
+    ) async {
+      final fakeSpellCheckService = FakeSpellCheckService();
+      controller.text = 'A';
+
+      Widget buildEditableText({required bool obscureText}) {
+        return MaterialApp(
+          home: EditableText(
+            controller: controller,
+            focusNode: focusNode,
+            obscureText: obscureText,
+            style: const TextStyle(),
+            cursorColor: Colors.blue,
+            backgroundCursorColor: Colors.grey,
+            cursorOpacityAnimates: true,
+            autofillHints: null,
+            spellCheckConfiguration: SpellCheckConfiguration(
+              spellCheckService: fakeSpellCheckService,
+              misspelledTextStyle: TextField.materialMisspelledTextStyle,
+            ),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(buildEditableText(obscureText: false));
+
+      EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
+      expect(state.spellCheckEnabled, isTrue);
+      state.spellCheckResults = const SpellCheckResults('A', <SuggestionSpan>[
+        SuggestionSpan(TextRange(start: 0, end: 1), <String>['a']),
+      ]);
+
+      await tester.pumpWidget(buildEditableText(obscureText: true));
+
+      state = tester.state<EditableTextState>(find.byType(EditableText));
+      expect(state.spellCheckEnabled, isFalse);
+      expect(state.spellCheckConfiguration, equals(const SpellCheckConfiguration.disabled()));
+      expect(state.spellCheckResults, isNull);
+    });
+
     testWidgets(
       'Spell check disabled when spell check configuration specified but no default spell check service available',
       (WidgetTester tester) async {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/185843

When `EditableText` has `obscureText: true`, spell check should not run or keep previous spell-check results. This makes the inferred spell-check configuration disabled for obscured text, recomputes that configuration when `obscureText` changes, refreshes spell check when obscured text becomes visible again, and ignores async spell-check responses that return after spell check has been disabled.

Tests:
- `../../bin/flutter test test/widgets/editable_text_test.dart --plain-name='Spell check'`
- `../../bin/flutter analyze --no-pub lib/src/widgets/editable_text.dart test/widgets/editable_text_test.dart`
- `git diff --check`