### PR TITLE
[ImpellerC] Write a depfile when --shader-bundle is in use

### DIFF
--- a/engine/src/flutter/impeller/compiler/shader_bundle.cc
+++ b/engine/src/flutter/impeller/compiler/shader_bundle.cc
@@ -3,6 +3,12 @@
 // found in the LICENSE file.
 
 #include "impeller/compiler/shader_bundle.h"
+
+#include <filesystem>
+#include <sstream>
+
+#include "flutter/fml/file.h"
+#include "flutter/fml/mapping.h"
 #include "impeller/compiler/compiler.h"
 #include "impeller/compiler/reflector.h"
 #include "impeller/compiler/source_options.h"
@@ -85,7 +91,8 @@ static std::unique_ptr<fb::shaderbundle::BackendShaderT>
 GenerateShaderBackendFB(TargetPlatform target_platform,
                         SourceOptions& options,
                         const std::string& shader_name,
-                        const ShaderConfig& shader_config) {
+                        const ShaderConfig& shader_config,
+                        std::set<std::string>* out_dependencies) {
   auto result = std::make_unique<fb::shaderbundle::BackendShaderT>();
 
   std::shared_ptr<fml::FileMapping> source_file_mapping =
@@ -118,6 +125,17 @@ GenerateShaderBackendFB(TargetPlatform target_platform,
     return nullptr;
   }
 
+  // Record dependencies so the caller can emit a depfile. The shader's
+  // source file plus every transitive `#include` that contributed to
+  // the compilation. The same source is compiled across multiple
+  // target platforms; the std::set dedupes naturally.
+  if (out_dependencies) {
+    out_dependencies->insert(shader_config.source_file_name);
+    for (const auto& included : compiler.GetIncludedFileNames()) {
+      out_dependencies->insert(included);
+    }
+  }
+
   auto reflector = compiler.GetReflector();
   if (reflector == nullptr) {
     std::cerr << "Could not create reflector for bundled shader \""
@@ -145,31 +163,37 @@ GenerateShaderBackendFB(TargetPlatform target_platform,
 static std::unique_ptr<fb::shaderbundle::ShaderT> GenerateShaderFB(
     SourceOptions options,
     const std::string& shader_name,
-    const ShaderConfig& shader_config) {
+    const ShaderConfig& shader_config,
+    std::set<std::string>* out_dependencies) {
   auto result = std::make_unique<fb::shaderbundle::ShaderT>();
   result->name = shader_name;
-  result->metal_ios = GenerateShaderBackendFB(
-      TargetPlatform::kMetalIOS, options, shader_name, shader_config);
+  result->metal_ios =
+      GenerateShaderBackendFB(TargetPlatform::kMetalIOS, options, shader_name,
+                              shader_config, out_dependencies);
   if (!result->metal_ios) {
     return nullptr;
   }
-  result->metal_desktop = GenerateShaderBackendFB(
-      TargetPlatform::kMetalDesktop, options, shader_name, shader_config);
+  result->metal_desktop =
+      GenerateShaderBackendFB(TargetPlatform::kMetalDesktop, options,
+                              shader_name, shader_config, out_dependencies);
   if (!result->metal_desktop) {
     return nullptr;
   }
-  result->opengl_es = GenerateShaderBackendFB(
-      TargetPlatform::kOpenGLES, options, shader_name, shader_config);
+  result->opengl_es =
+      GenerateShaderBackendFB(TargetPlatform::kOpenGLES, options, shader_name,
+                              shader_config, out_dependencies);
   if (!result->opengl_es) {
     return nullptr;
   }
-  result->opengl_desktop = GenerateShaderBackendFB(
-      TargetPlatform::kOpenGLDesktop, options, shader_name, shader_config);
+  result->opengl_desktop =
+      GenerateShaderBackendFB(TargetPlatform::kOpenGLDesktop, options,
+                              shader_name, shader_config, out_dependencies);
   if (!result->opengl_desktop) {
     return nullptr;
   }
-  result->vulkan = GenerateShaderBackendFB(TargetPlatform::kVulkan, options,
-                                           shader_name, shader_config);
+  result->vulkan =
+      GenerateShaderBackendFB(TargetPlatform::kVulkan, options, shader_name,
+                              shader_config, out_dependencies);
   if (!result->vulkan) {
     return nullptr;
   }
@@ -178,7 +202,8 @@ static std::unique_ptr<fb::shaderbundle::ShaderT> GenerateShaderFB(
 
 std::optional<fb::shaderbundle::ShaderBundleT> GenerateShaderBundleFlatbuffer(
     const std::string& bundle_config_json,
-    const SourceOptions& options) {
+    const SourceOptions& options,
+    std::set<std::string>* out_dependencies) {
   // --------------------------------------------------------------------------
   /// 1. Parse the bundle configuration.
   ///
@@ -199,7 +224,7 @@ std::optional<fb::shaderbundle::ShaderBundleT> GenerateShaderBundleFlatbuffer(
 
   for (const auto& [shader_name, shader_config] : bundle_config.value()) {
     std::unique_ptr<fb::shaderbundle::ShaderT> shader =
-        GenerateShaderFB(options, shader_name, shader_config);
+        GenerateShaderFB(options, shader_name, shader_config, out_dependencies);
     if (!shader) {
       return std::nullopt;
     }
@@ -209,13 +234,54 @@ std::optional<fb::shaderbundle::ShaderBundleT> GenerateShaderBundleFlatbuffer(
   return shader_bundle;
 }
 
+/// Write a Ninja-style depfile listing every source file (including
+/// `#include`d headers) that contributed to the shader bundle at
+/// `target`.
+///
+/// Format mirrors `Compiler::CreateDepfileContents` for single-shader
+/// compiles: `<target>: <dep1> <dep2> ... <depN>\n`.
+/// See
+/// https://github.com/ninja-build/ninja/blob/master/src/depfile_parser.cc#L28
+static bool OutputBundleDepfile(const Switches& switches,
+                                const std::string& target,
+                                const std::set<std::string>& dependencies) {
+  auto depfile_path = std::filesystem::absolute(
+      std::filesystem::current_path() / switches.depfile_path);
+
+  std::stringstream stream;
+  stream << target << ":";
+  for (const auto& dep : dependencies) {
+    stream << " " << dep;
+  }
+  stream << "\n";
+  const auto contents = std::make_shared<std::string>(stream.str());
+  const fml::NonOwnedMapping mapping(
+      reinterpret_cast<const uint8_t*>(contents->data()), contents->size(),
+      [contents](auto, auto) {});
+
+  if (!fml::WriteAtomically(*switches.working_directory,
+                            Utf8FromPath(depfile_path).c_str(), mapping)) {
+    std::cerr << "Could not write depfile to " << switches.depfile_path
+              << std::endl;
+    return false;
+  }
+  return true;
+}
+
 bool GenerateShaderBundle(Switches& switches) {
   // --------------------------------------------------------------------------
   /// 1. Parse the shader bundle and generate the flatbuffer result.
   ///
+  /// Collect dependencies along the way so a depfile can be emitted
+  /// after the bundle is written. The same source file is compiled
+  /// across multiple target platforms; the std::set dedupes naturally.
+  ///
 
+  std::set<std::string> dependencies;
+  const bool want_depfile = !switches.depfile_path.empty();
   auto shader_bundle = GenerateShaderBundleFlatbuffer(
-      switches.shader_bundle, switches.CreateSourceOptions());
+      switches.shader_bundle, switches.CreateSourceOptions(),
+      want_depfile ? &dependencies : nullptr);
   if (!shader_bundle.has_value()) {
     // Specific error messages are already handled by
     // GenerateShaderBundleFlatbuffer.
@@ -249,6 +315,20 @@ bool GenerateShaderBundle(Switches& switches) {
   // be 0644.
   if (!SetPermissiveAccess(sl_file_name)) {
     return false;
+  }
+
+  // --------------------------------------------------------------------------
+  /// 3. Output a depfile if one was requested.
+  ///
+  /// Lets build systems (notably Dart's `hooks` framework, which
+  /// `flutter_gpu_shaders`' `buildShaderBundleJson` consumer goes
+  /// through) rerun the bundle build when any contributing source file
+  /// or `#include`d header changes.
+
+  if (want_depfile) {
+    if (!OutputBundleDepfile(switches, sl_file_name.string(), dependencies)) {
+      return false;
+    }
   }
 
   return true;

--- a/engine/src/flutter/impeller/compiler/shader_bundle.cc
+++ b/engine/src/flutter/impeller/compiler/shader_bundle.cc
@@ -245,9 +245,6 @@ std::optional<fb::shaderbundle::ShaderBundleT> GenerateShaderBundleFlatbuffer(
 static bool OutputBundleDepfile(const Switches& switches,
                                 const std::string& target,
                                 const std::set<std::string>& dependencies) {
-  auto depfile_path = std::filesystem::absolute(
-      std::filesystem::current_path() / switches.depfile_path);
-
   std::stringstream stream;
   stream << target << ":";
   for (const auto& dep : dependencies) {
@@ -259,8 +256,13 @@ static bool OutputBundleDepfile(const Switches& switches,
       reinterpret_cast<const uint8_t*>(contents->data()), contents->size(),
       [contents](auto, auto) {});
 
+  // Pass the relative path straight through; fml::WriteAtomically
+  // resolves it against switches.working_directory (a directory fd
+  // representing the build system's intended working dir, which may
+  // differ from std::filesystem::current_path()).
   if (!fml::WriteAtomically(*switches.working_directory,
-                            Utf8FromPath(depfile_path).c_str(), mapping)) {
+                            Utf8FromPath(switches.depfile_path).c_str(),
+                            mapping)) {
     std::cerr << "Could not write depfile to " << switches.depfile_path
               << std::endl;
     return false;
@@ -326,7 +328,8 @@ bool GenerateShaderBundle(Switches& switches) {
   /// or `#include`d header changes.
 
   if (want_depfile) {
-    if (!OutputBundleDepfile(switches, sl_file_name.string(), dependencies)) {
+    if (!OutputBundleDepfile(switches, Utf8FromPath(sl_file_name),
+                             dependencies)) {
       return false;
     }
   }

--- a/engine/src/flutter/impeller/compiler/shader_bundle.h
+++ b/engine/src/flutter/impeller/compiler/shader_bundle.h
@@ -5,6 +5,8 @@
 #ifndef FLUTTER_IMPELLER_COMPILER_SHADER_BUNDLE_H_
 #define FLUTTER_IMPELLER_COMPILER_SHADER_BUNDLE_H_
 
+#include <set>
+
 #include "impeller/compiler/source_options.h"
 #include "impeller/compiler/switches.h"
 #include "impeller/shader_bundle/shader_bundle_flatbuffers.h"
@@ -25,9 +27,16 @@ std::optional<ShaderBundleConfig> ParseShaderBundleConfig(
 ///
 /// @note   Exposed only for testing purposes. Use `GenerateShaderBundle`
 ///         directly.
+///
+/// @param  out_dependencies  Optional. When non-null, populated with the
+///                           set of source files (including transitive
+///                           `#include`s) that contributed to the
+///                           generated bundle. Used by `GenerateShaderBundle`
+///                           to emit a depfile when `--depfile` is set.
 std::optional<fb::shaderbundle::ShaderBundleT> GenerateShaderBundleFlatbuffer(
     const std::string& bundle_config_json,
-    const SourceOptions& options);
+    const SourceOptions& options,
+    std::set<std::string>* out_dependencies = nullptr);
 
 /// @brief  Parses the JSON shader bundle configuration and invokes the
 ///         compiler multiple times to produce a shader bundle flatbuffer, which

--- a/engine/src/flutter/impeller/compiler/shader_bundle_unittests.cc
+++ b/engine/src/flutter/impeller/compiler/shader_bundle_unittests.cc
@@ -219,6 +219,57 @@ TEST(ShaderBundleTest, GenerateShaderBundleFlatbufferProducesCorrectResult) {
   ASSERT_EQ(fragment->metal_desktop->inputs.size(), 0u);
 }
 
+TEST(ShaderBundleTest,
+     GenerateShaderBundleFlatbufferReportsSourceFilesAsDependencies) {
+  std::string fixtures_path = flutter::testing::GetFixturesPath();
+  const std::string fragment_path = fixtures_path + "/flutter_gpu_unlit.frag";
+  const std::string vertex_path = fixtures_path + "/flutter_gpu_unlit.vert";
+  std::string config =
+      "{\"UnlitFragment\": {\"type\": \"fragment\", \"file\":\"" +
+      fragment_path +
+      "\"}, \"UnlitVertex\": {\"type\": \"vertex\", \"file\": \"" +
+      vertex_path + "\"}}";
+
+  SourceOptions options;
+  options.target_platform = TargetPlatform::kRuntimeStageMetal;
+  options.source_language = SourceLanguage::kGLSL;
+
+  std::set<std::string> dependencies;
+  std::optional<fb::shaderbundle::ShaderBundleT> bundle =
+      GenerateShaderBundleFlatbuffer(config, options, &dependencies);
+  ASSERT_TRUE(bundle.has_value());
+
+  // Every primary source file referenced by the bundle config should
+  // appear in the dependency set, deduplicated across the multiple
+  // target-platform compiles of each shader. The fixtures used here
+  // don't contain `#include` directives, so the dependency set
+  // contains exactly the two source files.
+  EXPECT_NE(dependencies.find(fragment_path), dependencies.end());
+  EXPECT_NE(dependencies.find(vertex_path), dependencies.end());
+}
+
+TEST(ShaderBundleTest,
+     GenerateShaderBundleFlatbufferIgnoresNullDependencyCollector) {
+  // Passing nullptr as the dependency collector is supported and is
+  // the default behaviour for callers that don't need a depfile.
+  std::string fixtures_path = flutter::testing::GetFixturesPath();
+  std::string config =
+      "{\"UnlitFragment\": {\"type\": \"fragment\", \"file\": \"" +
+      fixtures_path +
+      "/flutter_gpu_unlit.frag\"}, \"UnlitVertex\": {\"type\": \"vertex\", "
+      "\"file\": \"" +
+      fixtures_path + "/flutter_gpu_unlit.vert\"}}";
+
+  SourceOptions options;
+  options.target_platform = TargetPlatform::kRuntimeStageMetal;
+  options.source_language = SourceLanguage::kGLSL;
+
+  std::optional<fb::shaderbundle::ShaderBundleT> bundle =
+      GenerateShaderBundleFlatbuffer(config, options, /*out_dependencies=*/
+                                     nullptr);
+  ASSERT_TRUE(bundle.has_value());
+}
+
 TEST(ShaderBundleTest, DeriveShaderFloatTypeFromDimensions) {
   // Non-float types always map to nullopt.
   EXPECT_EQ(DeriveShaderFloatType(ShaderType::kSignedInt, 1, 1), std::nullopt);


### PR DESCRIPTION
Fixes flutter/flutter#186340

When `impellerc` is invoked with both `--depfile=<path>` and `--shader-bundle=<json>`, the depfile is silently dropped. `impellerc_main.cc` takes an early return into `GenerateShaderBundle(switches)` when `--shader-bundle` is set, and the depfile-writing branch only runs on the non-bundle path. Build systems consuming impellerc for shader bundles (notably Dart's `hooks` framework, which `flutter_gpu_shaders`'s `buildShaderBundleJson` goes through) have no way to discover which source files and transitive `#include` headers contributed to the produced bundle, and therefore cannot rerun the bundle build when any input changes. The user-visible effect is that editing a `.frag` referenced by a shader bundle manifest does not invalidate the cached bundle output until `flutter clean` is run, which makes shader iteration painful and confuses new users.

This change threads an optional `std::set<std::string>* out_dependencies` parameter through `GenerateShaderBundleFlatbuffer`, `GenerateShaderFB`, and `GenerateShaderBackendFB`. Each `Compiler` instance reports its `GetIncludedFileNames()` plus the primary shader source file into the set, which dedupes naturally across the five target-platform compiles per shader. After successful bundle generation, `GenerateShaderBundle` emits a Ninja-style depfile when `--depfile` is set, mirroring the format produced by `Compiler::CreateDepfileContents` on the single-shader compile path.

Manually verified end to end against a real bundle whose only shader transitively `#include`s a header: the resulting depfile lists both files. The new unit tests cover both the explicit-collector path (set contains the primary source files) and the null-collector path (callers that don't pass a set get exactly today's behaviour). Existing shader-bundle unit tests continue to pass unchanged.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md