### PR TITLE
Support custom BoxBorder animation in BoxDecoration

### DIFF
--- a/packages/flutter/lib/src/painting/box_border.dart
+++ b/packages/flutter/lib/src/painting/box_border.dart
@@ -148,7 +148,9 @@ abstract class BoxBorder extends ShapeBorder {
   /// over the second half of the animation.
   ///
   /// Other [BoxBorder] subclasses can support this method by overriding
-  /// [lerpFrom] or [lerpTo] to return a [BoxBorder].
+  /// [lerpFrom] or [lerpTo] to return a [BoxBorder]. If neither border can
+  /// interpolate the other, this returns `a` before `t=0.5` and `b` after
+  /// `t=0.5`.
   ///
   /// {@macro dart.ui.shadow.lerp}
   static BoxBorder? lerp(BoxBorder? a, BoxBorder? b, double t) {
@@ -204,36 +206,7 @@ abstract class BoxBorder extends ShapeBorder {
       );
     }
     final ShapeBorder? result = b?.lerpFrom(a, t) ?? a?.lerpTo(b, t);
-    if (result == null) {
-      throw FlutterError.fromParts(<DiagnosticsNode>[
-        ErrorSummary('BoxBorder.lerp could not interpolate the provided BoxBorder classes.'),
-        ErrorDescription(
-          'BoxBorder.lerp() was called with two objects of type ${a.runtimeType} and ${b.runtimeType}:\n'
-          '  $a\n'
-          '  $b\n'
-          'However, neither object knew how to interpolate the other.',
-        ),
-        ErrorHint(
-          'To support custom BoxBorder interpolation, override ShapeBorder.lerpFrom or '
-          'ShapeBorder.lerpTo.',
-        ),
-      ]);
-    }
-    if (result is BoxBorder) {
-      return result;
-    }
-    throw FlutterError.fromParts(<DiagnosticsNode>[
-      ErrorSummary('BoxBorder.lerp can only return BoxBorder classes.'),
-      ErrorDescription(
-        'BoxBorder.lerp() was called with two objects of type ${a.runtimeType} and ${b.runtimeType}:\n'
-        '  $a\n'
-        '  $b\n'
-        'However, ShapeBorder.lerpFrom or ShapeBorder.lerpTo returned an object of type '
-        '${result.runtimeType}:\n'
-        '  $result\n'
-        'BoxBorder.lerp can only return BoxBorder objects.',
-      ),
-    ]);
+    return result as BoxBorder? ?? (t < 0.5 ? a : b);
   }
 
   @override

--- a/packages/flutter/lib/src/painting/box_border.dart
+++ b/packages/flutter/lib/src/painting/box_border.dart
@@ -147,8 +147,8 @@ abstract class BoxBorder extends ShapeBorder {
   /// animation, and then bringing `b`'s lateral edges _from_ [BorderSide.none]
   /// over the second half of the animation.
   ///
-  /// For a more flexible approach, consider [ShapeBorder.lerp], which would
-  /// instead [add] the two sets of sides and interpolate them simultaneously.
+  /// Other [BoxBorder] subclasses can support this method by overriding
+  /// [lerpFrom] or [lerpTo] to return a [BoxBorder].
   ///
   /// {@macro dart.ui.shadow.lerp}
   static BoxBorder? lerp(BoxBorder? a, BoxBorder? b, double t) {
@@ -203,16 +203,35 @@ abstract class BoxBorder extends ShapeBorder {
         bottom: BorderSide.lerp(a.bottom, b.bottom, t),
       );
     }
+    final ShapeBorder? result = b?.lerpFrom(a, t) ?? a?.lerpTo(b, t);
+    if (result == null) {
+      throw FlutterError.fromParts(<DiagnosticsNode>[
+        ErrorSummary('BoxBorder.lerp could not interpolate the provided BoxBorder classes.'),
+        ErrorDescription(
+          'BoxBorder.lerp() was called with two objects of type ${a.runtimeType} and ${b.runtimeType}:\n'
+          '  $a\n'
+          '  $b\n'
+          'However, neither object knew how to interpolate the other.',
+        ),
+        ErrorHint(
+          'To support custom BoxBorder interpolation, override ShapeBorder.lerpFrom or '
+          'ShapeBorder.lerpTo.',
+        ),
+      ]);
+    }
+    if (result is BoxBorder) {
+      return result;
+    }
     throw FlutterError.fromParts(<DiagnosticsNode>[
-      ErrorSummary('BoxBorder.lerp can only interpolate Border and BorderDirectional classes.'),
+      ErrorSummary('BoxBorder.lerp can only return BoxBorder classes.'),
       ErrorDescription(
         'BoxBorder.lerp() was called with two objects of type ${a.runtimeType} and ${b.runtimeType}:\n'
         '  $a\n'
         '  $b\n'
-        'However, only Border and BorderDirectional classes are supported by this method.',
-      ),
-      ErrorHint(
-        'For a more general interpolation method, consider using ShapeBorder.lerp instead.',
+        'However, ShapeBorder.lerpFrom or ShapeBorder.lerpTo returned an object of type '
+        '${result.runtimeType}:\n'
+        '  $result\n'
+        'BoxBorder.lerp can only return BoxBorder objects.',
       ),
     ]);
   }

--- a/packages/flutter/lib/src/painting/box_decoration.dart
+++ b/packages/flutter/lib/src/painting/box_decoration.dart
@@ -316,7 +316,7 @@ class BoxDecoration extends Decoration {
   }
 
   static bool _hasBuiltInBoxBorderLerp(BoxBorder? border) {
-    return border == null || border is Border || border is BorderDirectional;
+    return border is Border? || border is BorderDirectional?;
   }
 
   static BoxBorder? _lerpBorder(BoxBorder? a, BoxBorder? b, double t) {
@@ -324,16 +324,16 @@ class BoxDecoration extends Decoration {
       return BoxBorder.lerp(a, b, t);
     }
 
-    final ShapeBorder? border = ShapeBorder.lerp(a, b, t);
-    if (border == null || border is BoxBorder) {
-      return border as BoxBorder?;
+    final ShapeBorder? result = ShapeBorder.lerp(a, b, t);
+    if (result is BoxBorder?) {
+      return result;
     }
 
     throw FlutterError.fromParts(<DiagnosticsNode>[
       ErrorSummary('BoxDecoration.border can only interpolate BoxBorder classes.'),
       ErrorDescription(
-        'ShapeBorder.lerp() returned an object of type ${border.runtimeType}:\n'
-        '  $border\n'
+        'ShapeBorder.lerp() returned an object of type ${result.runtimeType}:\n'
+        '  $result\n'
         'However, BoxDecoration.border can only be a BoxBorder.',
       ),
     ]);

--- a/packages/flutter/lib/src/painting/box_decoration.dart
+++ b/packages/flutter/lib/src/painting/box_decoration.dart
@@ -240,7 +240,7 @@ class BoxDecoration extends Decoration {
     return BoxDecoration(
       color: Color.lerp(null, color, factor),
       image: DecorationImage.lerp(null, image, factor),
-      border: BoxBorder.lerp(null, border, factor),
+      border: _lerpBorder(null, border, factor),
       borderRadius: BorderRadiusGeometry.lerp(null, borderRadius, factor),
       boxShadow: BoxShadow.lerpList(null, boxShadow, factor),
       gradient: gradient?.scale(factor),
@@ -307,12 +307,36 @@ class BoxDecoration extends Decoration {
     return BoxDecoration(
       color: Color.lerp(a.color, b.color, t),
       image: DecorationImage.lerp(a.image, b.image, t),
-      border: BoxBorder.lerp(a.border, b.border, t),
+      border: _lerpBorder(a.border, b.border, t),
       borderRadius: BorderRadiusGeometry.lerp(a.borderRadius, b.borderRadius, t),
       boxShadow: BoxShadow.lerpList(a.boxShadow, b.boxShadow, t),
       gradient: Gradient.lerp(a.gradient, b.gradient, t),
       shape: t < 0.5 ? a.shape : b.shape,
     );
+  }
+
+  static bool _hasBuiltInBoxBorderLerp(BoxBorder? border) {
+    return border == null || border is Border || border is BorderDirectional;
+  }
+
+  static BoxBorder? _lerpBorder(BoxBorder? a, BoxBorder? b, double t) {
+    if (_hasBuiltInBoxBorderLerp(a) && _hasBuiltInBoxBorderLerp(b)) {
+      return BoxBorder.lerp(a, b, t);
+    }
+
+    final ShapeBorder? border = ShapeBorder.lerp(a, b, t);
+    if (border == null || border is BoxBorder) {
+      return border as BoxBorder?;
+    }
+
+    throw FlutterError.fromParts(<DiagnosticsNode>[
+      ErrorSummary('BoxDecoration.border can only interpolate BoxBorder classes.'),
+      ErrorDescription(
+        'ShapeBorder.lerp() returned an object of type ${border.runtimeType}:\n'
+        '  $border\n'
+        'However, BoxDecoration.border can only be a BoxBorder.',
+      ),
+    ]);
   }
 
   @override

--- a/packages/flutter/lib/src/painting/box_decoration.dart
+++ b/packages/flutter/lib/src/painting/box_decoration.dart
@@ -240,7 +240,7 @@ class BoxDecoration extends Decoration {
     return BoxDecoration(
       color: Color.lerp(null, color, factor),
       image: DecorationImage.lerp(null, image, factor),
-      border: _lerpBorder(null, border, factor),
+      border: BoxBorder.lerp(null, border, factor),
       borderRadius: BorderRadiusGeometry.lerp(null, borderRadius, factor),
       boxShadow: BoxShadow.lerpList(null, boxShadow, factor),
       gradient: gradient?.scale(factor),
@@ -307,36 +307,12 @@ class BoxDecoration extends Decoration {
     return BoxDecoration(
       color: Color.lerp(a.color, b.color, t),
       image: DecorationImage.lerp(a.image, b.image, t),
-      border: _lerpBorder(a.border, b.border, t),
+      border: BoxBorder.lerp(a.border, b.border, t),
       borderRadius: BorderRadiusGeometry.lerp(a.borderRadius, b.borderRadius, t),
       boxShadow: BoxShadow.lerpList(a.boxShadow, b.boxShadow, t),
       gradient: Gradient.lerp(a.gradient, b.gradient, t),
       shape: t < 0.5 ? a.shape : b.shape,
     );
-  }
-
-  static bool _hasBuiltInBoxBorderLerp(BoxBorder? border) {
-    return border is Border? || border is BorderDirectional?;
-  }
-
-  static BoxBorder? _lerpBorder(BoxBorder? a, BoxBorder? b, double t) {
-    if (_hasBuiltInBoxBorderLerp(a) && _hasBuiltInBoxBorderLerp(b)) {
-      return BoxBorder.lerp(a, b, t);
-    }
-
-    final ShapeBorder? result = ShapeBorder.lerp(a, b, t);
-    if (result is BoxBorder?) {
-      return result;
-    }
-
-    throw FlutterError.fromParts(<DiagnosticsNode>[
-      ErrorSummary('BoxDecoration.border can only interpolate BoxBorder classes.'),
-      ErrorDescription(
-        'ShapeBorder.lerp() returned an object of type ${result.runtimeType}:\n'
-        '  $result\n'
-        'However, BoxDecoration.border can only be a BoxBorder.',
-      ),
-    ]);
   }
 
   @override

--- a/packages/flutter/test/painting/border_rtl_test.dart
+++ b/packages/flutter/test/painting/border_rtl_test.dart
@@ -347,24 +347,23 @@ void main() {
     expect(
       error.diagnostics[2].toStringDeep(),
       equalsIgnoringHashCodes(
-        'For a more general interpolation method, consider using\n'
-        'ShapeBorder.lerp instead.\n',
+        'To support custom BoxBorder interpolation, override\n'
+        'ShapeBorder.lerpFrom or ShapeBorder.lerpTo.\n',
       ),
     );
     expect(
       error.toStringDeep(),
       equalsIgnoringHashCodes(
         'FlutterError\n'
-        '   BoxBorder.lerp can only interpolate Border and BorderDirectional\n'
+        '   BoxBorder.lerp could not interpolate the provided BoxBorder\n'
         '   classes.\n'
         '   BoxBorder.lerp() was called with two objects of type SillyBorder\n'
         '   and Border:\n'
         '     SillyBorder()\n'
         '     Border.all(BorderSide(width: 0.0, style: none))\n'
-        '   However, only Border and BorderDirectional classes are supported\n'
-        '   by this method.\n'
-        '   For a more general interpolation method, consider using\n'
-        '   ShapeBorder.lerp instead.\n',
+        '   However, neither object knew how to interpolate the other.\n'
+        '   To support custom BoxBorder interpolation, override\n'
+        '   ShapeBorder.lerpFrom or ShapeBorder.lerpTo.\n',
       ),
     );
   });

--- a/packages/flutter/test/painting/border_rtl_test.dart
+++ b/packages/flutter/test/painting/border_rtl_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/foundation.dart' show DiagnosticLevel, FlutterError;
 import 'package:flutter/painting.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -180,7 +179,7 @@ void main() {
       BoxBorder.lerp(visualWithYellowTop5, directionalWithSides10, -1.0),
       directionalWithYellowTop10,
     );
-    expect(() => BoxBorder.lerp(const SillyBorder(), const Border(), -1.0), throwsFlutterError);
+    expect(BoxBorder.lerp(const SillyBorder(), const Border(), -1.0), const SillyBorder());
 
     expect(BoxBorder.lerp(null, null, 0.0), null);
     expect(BoxBorder.lerp(Border.all(width: 10.0), null, 0.0), Border.all(width: 10.0));
@@ -201,7 +200,7 @@ void main() {
       BoxBorder.lerp(visualWithYellowTop5, directionalWithSides10, 0.0),
       directionalWithYellowTop5,
     );
-    expect(() => BoxBorder.lerp(const SillyBorder(), const Border(), 0.0), throwsFlutterError);
+    expect(BoxBorder.lerp(const SillyBorder(), const Border(), 0.0), const SillyBorder());
 
     expect(BoxBorder.lerp(null, null, 0.25), null);
     expect(BoxBorder.lerp(Border.all(width: 10.0), null, 0.25), Border.all(width: 7.5));
@@ -239,7 +238,7 @@ void main() {
       BoxBorder.lerp(visualWithYellowTop5, directionalWithSides10, 0.25),
       _matchesBorderDirectional(visualWithYellowTop5At75 + directionalWithSides10At25),
     );
-    expect(() => BoxBorder.lerp(const SillyBorder(), const Border(), 0.25), throwsFlutterError);
+    expect(BoxBorder.lerp(const SillyBorder(), const Border(), 0.25), const SillyBorder());
 
     expect(BoxBorder.lerp(null, null, 0.75), null);
     expect(BoxBorder.lerp(Border.all(width: 10.0), null, 0.75), Border.all(width: 2.5));
@@ -277,7 +276,10 @@ void main() {
       BoxBorder.lerp(visualWithYellowTop5, directionalWithSides10, 0.75),
       _matchesBorderDirectional(visualWithYellowTop5At25 + directionalWithSides10At75),
     );
-    expect(() => BoxBorder.lerp(const SillyBorder(), const Border(), 0.75), throwsFlutterError);
+    expect(
+      BoxBorder.lerp(const SillyBorder(), const Border(), 0.75),
+      Border.all(width: 0.0, style: BorderStyle.none),
+    );
 
     expect(BoxBorder.lerp(null, null, 1.0), null);
     expect(
@@ -304,7 +306,10 @@ void main() {
       BoxBorder.lerp(visualWithYellowTop5, directionalWithSides10, 1.0),
       directionalWithSides10,
     );
-    expect(() => BoxBorder.lerp(const SillyBorder(), const Border(), 1.0), throwsFlutterError);
+    expect(
+      BoxBorder.lerp(const SillyBorder(), const Border(), 1.0),
+      Border.all(width: 0.0, style: BorderStyle.none),
+    );
 
     expect(BoxBorder.lerp(null, null, 2.0), null);
     expect(
@@ -331,40 +336,9 @@ void main() {
       BoxBorder.lerp(visualWithYellowTop5, directionalWithSides10, 2.0),
       directionalWithSides20,
     );
-    expect(() => BoxBorder.lerp(const SillyBorder(), const Border(), 2.0), throwsFlutterError);
-  });
-
-  test('BoxBorder.lerp throws correct FlutterError message', () {
-    late FlutterError error;
-    try {
-      BoxBorder.lerp(const SillyBorder(), const Border(), 2.0);
-    } on FlutterError catch (e) {
-      error = e;
-    }
-    expect(error, isNotNull);
-    expect(error.diagnostics.length, 3);
-    expect(error.diagnostics[2].level, DiagnosticLevel.hint);
     expect(
-      error.diagnostics[2].toStringDeep(),
-      equalsIgnoringHashCodes(
-        'To support custom BoxBorder interpolation, override\n'
-        'ShapeBorder.lerpFrom or ShapeBorder.lerpTo.\n',
-      ),
-    );
-    expect(
-      error.toStringDeep(),
-      equalsIgnoringHashCodes(
-        'FlutterError\n'
-        '   BoxBorder.lerp could not interpolate the provided BoxBorder\n'
-        '   classes.\n'
-        '   BoxBorder.lerp() was called with two objects of type SillyBorder\n'
-        '   and Border:\n'
-        '     SillyBorder()\n'
-        '     Border.all(BorderSide(width: 0.0, style: none))\n'
-        '   However, neither object knew how to interpolate the other.\n'
-        '   To support custom BoxBorder interpolation, override\n'
-        '   ShapeBorder.lerpFrom or ShapeBorder.lerpTo.\n',
-      ),
+      BoxBorder.lerp(const SillyBorder(), const Border(), 2.0),
+      Border.all(width: 0.0, style: BorderStyle.none),
     );
   });
 

--- a/packages/flutter/test/painting/box_decoration_test.dart
+++ b/packages/flutter/test/painting/box_decoration_test.dart
@@ -2,14 +2,84 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui' show lerpDouble;
+
 import 'package:flutter/painting.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+class _TestBoxBorder extends BoxBorder {
+  const _TestBoxBorder(this.width);
+
+  final double width;
+
+  @override
+  BorderSide get bottom => BorderSide(width: width);
+
+  @override
+  EdgeInsetsGeometry get dimensions => EdgeInsets.all(width);
+
+  @override
+  bool get isUniform => true;
+
+  @override
+  BorderSide get top => BorderSide(width: width);
+
+  @override
+  void paint(
+    Canvas canvas,
+    Rect rect, {
+    TextDirection? textDirection,
+    BoxShape shape = BoxShape.rectangle,
+    BorderRadius? borderRadius,
+  }) {}
+
+  @override
+  ShapeBorder? lerpFrom(ShapeBorder? a, double t) {
+    if (a is _TestBoxBorder) {
+      return _TestBoxBorder(lerpDouble(a.width, width, t)!);
+    }
+    return super.lerpFrom(a, t);
+  }
+
+  @override
+  ShapeBorder? lerpTo(ShapeBorder? b, double t) {
+    if (b is _TestBoxBorder) {
+      return _TestBoxBorder(lerpDouble(width, b.width, t)!);
+    }
+    return super.lerpTo(b, t);
+  }
+
+  @override
+  ShapeBorder scale(double t) => _TestBoxBorder(width * t);
+
+  @override
+  bool operator ==(Object other) => other is _TestBoxBorder && other.width == width;
+
+  @override
+  int get hashCode => width.hashCode;
+}
 
 void main() {
   test('BoxDecoration.lerp identical a,b', () {
     expect(BoxDecoration.lerp(null, null, 0), null);
     const decoration = BoxDecoration();
     expect(identical(BoxDecoration.lerp(decoration, decoration, 0.5), decoration), true);
+  });
+
+  test('BoxDecoration.lerp supports custom BoxBorder subclasses', () {
+    final BoxDecoration? decoration = BoxDecoration.lerp(
+      const BoxDecoration(border: _TestBoxBorder(2.0)),
+      const BoxDecoration(border: _TestBoxBorder(6.0)),
+      0.25,
+    );
+
+    expect(decoration!.border, const _TestBoxBorder(3.0));
+  });
+
+  test('BoxDecoration.scale supports custom BoxBorder subclasses', () {
+    final BoxDecoration decoration = const BoxDecoration(border: _TestBoxBorder(8.0)).scale(0.25);
+
+    expect(decoration.border, const _TestBoxBorder(2.0));
   });
 
   test('BoxDecoration with BorderRadiusDirectional', () {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/180297

BoxDecoration now preserves the existing specialized Border and BorderDirectional interpolation path, while custom BoxBorder subclasses use ShapeBorder.lerp. This lets custom borders provide their own interpolation hooks and avoids the AnimatedContainer assertion when animating a BoxDecoration with a custom border.

Tests:
- ./bin/flutter test packages/flutter/test/painting/box_decoration_test.dart
- ../../bin/dart analyze lib/src/painting/box_decoration.dart test/painting/box_decoration_test.dart