### PR TITLE
Fix Windows Korean IME caret position during composition

### DIFF
--- a/engine/src/flutter/shell/platform/windows/flutter_window.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_window.cc
@@ -33,6 +33,23 @@ static const int kLinesPerScrollWindowsDefault = 3;
 
 static constexpr int32_t kDefaultPointerDeviceId = 0;
 
+static int GetCursorPositionForComposition(const TextInputManager& manager,
+                                           LPARAM lparam,
+                                           size_t text_length) {
+  if (!(lparam & GCS_CURSORPOS)) {
+    // Some IMEs update the composition string without reporting an explicit
+    // cursor position. In that case, keep the framework caret at the end of
+    // the latest composition text.
+    return static_cast<int>(text_length);
+  }
+
+  long position = manager.GetComposingCursorPosition();
+  if (position < 0 || static_cast<size_t>(position) > text_length) {
+    return static_cast<int>(text_length);
+  }
+  return static_cast<int>(position);
+}
+
 // This method is only valid during a window message related to mouse/touch
 // input.
 // See
@@ -885,19 +902,21 @@ void FlutterWindow::OnImeComposition(UINT const message,
   if (lparam & GCS_RESULTSTR) {
     // Commit but don't end composing.
     // Read the committed composing string.
-    long pos = text_input_manager_->GetComposingCursorPosition();
     std::optional<std::u16string> text = text_input_manager_->GetResultString();
     if (text) {
+      int pos = GetCursorPositionForComposition(*text_input_manager_, lparam,
+                                                text->length());
       OnComposeChange(text.value(), pos);
       OnComposeCommit();
     }
   }
   if (lparam & GCS_COMPSTR) {
     // Read the in-progress composing string.
-    long pos = text_input_manager_->GetComposingCursorPosition();
     std::optional<std::u16string> text =
         text_input_manager_->GetComposingString();
     if (text) {
+      int pos = GetCursorPositionForComposition(*text_input_manager_, lparam,
+                                                text->length());
       OnComposeChange(text.value(), pos);
     }
   }

--- a/engine/src/flutter/shell/platform/windows/flutter_window.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_window.cc
@@ -43,7 +43,7 @@ static int GetCursorPositionForComposition(const TextInputManager& manager,
     return static_cast<int>(text_length);
   }
 
-  long position = manager.GetComposingCursorPosition();
+  int position = static_cast<int>(manager.GetComposingCursorPosition());
   if (position < 0 || static_cast<size_t>(position) > text_length) {
     return static_cast<int>(text_length);
   }

--- a/engine/src/flutter/shell/platform/windows/window_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/window_unittests.cc
@@ -54,10 +54,9 @@ TEST(MockWindow, OnImeCompositionCompose) {
   EXPECT_CALL(*text_input_manager, GetResultString())
       .WillRepeatedly(
           Return(std::optional<std::u16string>(std::u16string(u"`}"))));
-  EXPECT_CALL(*text_input_manager, GetComposingCursorPosition())
-      .WillRepeatedly(Return((int)0));
+  EXPECT_CALL(*text_input_manager, GetComposingCursorPosition()).Times(0);
 
-  EXPECT_CALL(window, OnComposeChange(std::u16string(u"nihao"), 0)).Times(1);
+  EXPECT_CALL(window, OnComposeChange(std::u16string(u"nihao"), 5)).Times(1);
   EXPECT_CALL(window, OnComposeChange(std::u16string(u"`}"), 0)).Times(0);
   EXPECT_CALL(window, OnComposeCommit()).Times(0);
   ON_CALL(window, OnImeComposition)
@@ -65,6 +64,27 @@ TEST(MockWindow, OnImeCompositionCompose) {
   EXPECT_CALL(window, OnImeComposition(_, _, _)).Times(1);
 
   // Send an IME_COMPOSITION event that contains just the composition string.
+  window.InjectWindowMessage(WM_IME_COMPOSITION, 0, GCS_COMPSTR);
+}
+
+// Regression test for https://github.com/flutter/flutter/issues/140739.
+TEST(MockWindow, OnImeCompositionDefaultsKoreanCursorToCompositionEnd) {
+  auto windows_proc_table = std::make_unique<MockWindowsProcTable>();
+  auto* text_input_manager = new MockTextInputManager();
+  std::unique_ptr<TextInputManager> text_input_manager_ptr(text_input_manager);
+  MockWindow window(std::move(windows_proc_table),
+                    std::move(text_input_manager_ptr));
+  EXPECT_CALL(*text_input_manager, GetComposingString())
+      .WillRepeatedly(
+          Return(std::optional<std::u16string>(std::u16string(u"다"))));
+  EXPECT_CALL(*text_input_manager, GetComposingCursorPosition()).Times(0);
+
+  EXPECT_CALL(window, OnComposeChange(std::u16string(u"다"), 1)).Times(1);
+  EXPECT_CALL(window, OnComposeCommit()).Times(0);
+  ON_CALL(window, OnImeComposition)
+      .WillByDefault(Invoke(&window, &MockWindow::CallOnImeComposition));
+  EXPECT_CALL(window, OnImeComposition(_, _, _)).Times(1);
+
   window.InjectWindowMessage(WM_IME_COMPOSITION, 0, GCS_COMPSTR);
 }
 
@@ -80,11 +100,10 @@ TEST(MockWindow, OnImeCompositionResult) {
   EXPECT_CALL(*text_input_manager, GetResultString())
       .WillRepeatedly(
           Return(std::optional<std::u16string>(std::u16string(u"`}"))));
-  EXPECT_CALL(*text_input_manager, GetComposingCursorPosition())
-      .WillRepeatedly(Return((int)0));
+  EXPECT_CALL(*text_input_manager, GetComposingCursorPosition()).Times(0);
 
   EXPECT_CALL(window, OnComposeChange(std::u16string(u"nihao"), 0)).Times(0);
-  EXPECT_CALL(window, OnComposeChange(std::u16string(u"`}"), 0)).Times(1);
+  EXPECT_CALL(window, OnComposeChange(std::u16string(u"`}"), 2)).Times(1);
   EXPECT_CALL(window, OnComposeCommit()).Times(1);
   ON_CALL(window, OnImeComposition)
       .WillByDefault(Invoke(&window, &MockWindow::CallOnImeComposition));
@@ -114,13 +133,12 @@ TEST(MockWindow, OnImeCompositionResultAndCompose) {
   }
   {
     InSequence dummy;
-    EXPECT_CALL(window, OnComposeChange(std::u16string(u"今日"), 0)).Times(1);
+    EXPECT_CALL(window, OnComposeChange(std::u16string(u"今日"), 2)).Times(1);
     EXPECT_CALL(window, OnComposeCommit()).Times(1);
-    EXPECT_CALL(window, OnComposeChange(std::u16string(u"は"), 0)).Times(1);
+    EXPECT_CALL(window, OnComposeChange(std::u16string(u"は"), 1)).Times(1);
   }
 
-  EXPECT_CALL(*text_input_manager, GetComposingCursorPosition())
-      .WillRepeatedly(Return((int)0));
+  EXPECT_CALL(*text_input_manager, GetComposingCursorPosition()).Times(0);
 
   ON_CALL(window, OnImeComposition)
       .WillByDefault(Invoke(&window, &MockWindow::CallOnImeComposition));
@@ -130,6 +148,50 @@ TEST(MockWindow, OnImeCompositionResultAndCompose) {
   // composition string.
   window.InjectWindowMessage(WM_IME_COMPOSITION, 0,
                              GCS_COMPSTR | GCS_RESULTSTR);
+}
+
+TEST(MockWindow, OnImeCompositionUsesCursorPositionWhenProvided) {
+  auto windows_proc_table = std::make_unique<MockWindowsProcTable>();
+  auto* text_input_manager = new MockTextInputManager();
+  std::unique_ptr<TextInputManager> text_input_manager_ptr(text_input_manager);
+  MockWindow window(std::move(windows_proc_table),
+                    std::move(text_input_manager_ptr));
+  EXPECT_CALL(*text_input_manager, GetComposingString())
+      .WillRepeatedly(
+          Return(std::optional<std::u16string>(std::u16string(u"nihao"))));
+  EXPECT_CALL(*text_input_manager, GetComposingCursorPosition())
+      .WillOnce(Return(2));
+
+  EXPECT_CALL(window, OnComposeChange(std::u16string(u"nihao"), 2)).Times(1);
+  EXPECT_CALL(window, OnComposeCommit()).Times(0);
+  ON_CALL(window, OnImeComposition)
+      .WillByDefault(Invoke(&window, &MockWindow::CallOnImeComposition));
+  EXPECT_CALL(window, OnImeComposition(_, _, _)).Times(1);
+
+  window.InjectWindowMessage(WM_IME_COMPOSITION, 0,
+                             GCS_COMPSTR | GCS_CURSORPOS);
+}
+
+TEST(MockWindow, OnImeCompositionFallsBackToTextEndForInvalidCursorPosition) {
+  auto windows_proc_table = std::make_unique<MockWindowsProcTable>();
+  auto* text_input_manager = new MockTextInputManager();
+  std::unique_ptr<TextInputManager> text_input_manager_ptr(text_input_manager);
+  MockWindow window(std::move(windows_proc_table),
+                    std::move(text_input_manager_ptr));
+  EXPECT_CALL(*text_input_manager, GetComposingString())
+      .WillRepeatedly(
+          Return(std::optional<std::u16string>(std::u16string(u"nihao"))));
+  EXPECT_CALL(*text_input_manager, GetComposingCursorPosition())
+      .WillOnce(Return(-1));
+
+  EXPECT_CALL(window, OnComposeChange(std::u16string(u"nihao"), 5)).Times(1);
+  EXPECT_CALL(window, OnComposeCommit()).Times(0);
+  ON_CALL(window, OnImeComposition)
+      .WillByDefault(Invoke(&window, &MockWindow::CallOnImeComposition));
+  EXPECT_CALL(window, OnImeComposition(_, _, _)).Times(1);
+
+  window.InjectWindowMessage(WM_IME_COMPOSITION, 0,
+                             GCS_COMPSTR | GCS_CURSORPOS);
 }
 
 TEST(MockWindow, OnImeCompositionClearChange) {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/140739

## Summary

This fixes a Windows Korean IME caret positioning issue where the caret could appear before the active composing syllable while entering Korean text.

The Windows embedder previously queried the IME composing cursor position for every `WM_IME_COMPOSITION` update. However, Microsoft Korean IME can send composition updates with `GCS_COMPSTR` or `GCS_RESULTSTR` without the `GCS_CURSORPOS` flag. In that case, the cursor position is not explicitly part of the message, so querying it can produce a missing or stale cursor value. That stale value can then be converted into Flutter's text selection and place the visual caret before the end of the active composing range.

## Recordings

Before this fix, the caret can appear before the active Korean composing syllable:

![Before fix: Windows Korean IME caret appears before the active composing syllable](https://raw.githubusercontent.com/CHOIgoung/flutter/pr-assets-ime-caret-20260512-010049/windows-korean-ime-caret-before-fix.gif)

After this fix, the caret stays at the end of the active composing syllable:

![After fix: Windows Korean IME caret stays at the composition end](https://raw.githubusercontent.com/CHOIgoung/flutter/pr-assets-ime-caret-20260512-010049/windows-korean-ime-caret-position.gif)

## Root Cause

For Korean input such as `가나달`, the engine receives `WM_IME_COMPOSITION` updates for the active syllable. Local runtime logging showed that Microsoft Korean IME sends composition text updates without `GCS_CURSORPOS`:

```text
[IME] OnImeComposition message=271, wparam=45796, lparam=24600, has_result=0, has_comp=1, has_cursor=0
[IME] GCS_CURSORPOS absent; fallback_cursor_pos=1
[IME] composing text="다", text_length=1, compose_change_cursor_pos=1
[IME] ComposeChangeHook input_text="다", input_length=1, cursor_pos=1, before_text="가나", before_selection=(2, 2), before_composing=(2, 2), after_text="가나다", after_selection=(3, 3), after_composing=(2, 3)
[IME] SendStateUpdate text="가나다", selection=(3, 3), composing=(2, 3)

[IME] OnImeComposition message=271, wparam=45804, lparam=24600, has_result=0, has_comp=1, has_cursor=0
[IME] GCS_CURSORPOS absent; fallback_cursor_pos=1
[IME] composing text="달", text_length=1, compose_change_cursor_pos=1
[IME] ComposeChangeHook input_text="달", input_length=1, cursor_pos=1, before_text="가나다", before_selection=(3, 3), before_composing=(2, 3), after_text="가나달", after_selection=(3, 3), after_composing=(2, 3)
[IME] SendStateUpdate text="가나달", selection=(3, 3), composing=(2, 3)
```

In the problematic path, `has_comp=1` but `has_cursor=0`. The composing text is present, but the IME did not provide an explicit composing cursor position.

## Fix

This change makes the Windows embedder read the IME composing cursor only when `GCS_CURSORPOS` is present in `lParam`.

When `GCS_CURSORPOS` is absent, the embedder falls back to the end of the current composition text. If `GCS_CURSORPOS` is present but returns an out-of-range value, it also falls back to the composition end.

This keeps explicit IME cursor positions working for IMEs that provide them, while avoiding stale or missing cursor values for Korean composition updates.

## Validation

- Added regression coverage for Korean composition updates without `GCS_CURSORPOS`.
- Added coverage that explicit `GCS_CURSORPOS` is still used when present.
- Added coverage that out-of-range cursor positions fall back to the composition end.
- Ran:

```text
flutter_windows_unittests.exe --gtest_filter=MockWindow.OnImeComposition*
```

Result:

```text
[==========] Running 7 tests from 1 test suite.
[  PASSED  ] 7 tests.
```

- Manually verified Korean IME input for `가나달` with a local diagnostic build. The final editing state showed the caret at the end of the composing range:

```text
text="가나달", selection=(3, 3), composing=(2, 3)
```
