### PR TITLE
[Android] Add avdmanager functionality validation to flutter doctor

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -195,6 +195,7 @@ class AndroidValidator extends DoctorValidator {
   @override
   Future<ValidationResult> validateImpl() async {
     final messages = <ValidationMessage>[];
+    String? sdkVersionText;
     final AndroidSdk? androidSdk = _androidSdk;
     if (androidSdk == null) {
       // No Android SDK found.
@@ -234,13 +235,41 @@ class AndroidValidator extends DoctorValidator {
       return ValidationResult(ValidationType.missing, messages);
     }
 
+    if (androidSdk.avdManagerPath != null) {
+      _task = 'Validating avdmanager is functional';
+      final processUtils = ProcessUtils(processManager: _processManager, logger: _logger);
+      try {
+        final RunResult result = await processUtils.run(<String>[
+          androidSdk.avdManagerPath!,
+          'list',
+        ], environment: _java?.environment);
+        if (result.exitCode != 0) {
+          messages.add(
+            ValidationMessage.error(
+              'avdmanager is not functional. Running avdmanager failed with exit code ${result.exitCode}:\n'
+              '${result.stderr}\n'
+              'This usually indicates that the Java Development Kit (JDK) is not installed or is misconfigured.',
+            ),
+          );
+          return ValidationResult(ValidationType.partial, messages, statusInfo: sdkVersionText);
+        }
+      } on Exception catch (error) {
+        messages.add(
+          ValidationMessage.error(
+            'avdmanager is not functional. Failed to run avdmanager:\n'
+            '$error',
+          ),
+        );
+        return ValidationResult(ValidationType.partial, messages, statusInfo: sdkVersionText);
+      }
+    }
+
     _task = 'Validating Android SDK licenses';
     if (androidSdk.licensesAvailable && !androidSdk.platformToolsAvailable) {
       messages.add(ValidationMessage.hint(_userMessages.androidSdkLicenseOnly(kAndroidHome)));
       return ValidationResult(ValidationType.partial, messages);
     }
 
-    String? sdkVersionText;
     final AndroidSdkVersion? androidSdkLatestVersion = androidSdk.latestVersion;
     if (androidSdkLatestVersion != null) {
       if (androidSdkLatestVersion.sdkLevel < gradle_utils.compileSdkVersionInt ||

--- a/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
@@ -599,6 +599,73 @@ Review licenses that have not been accepted (y/N)?
     );
   });
 
+  testUsingContext('avdmanager is functional', () async {
+    sdk
+      ..licensesAvailable = true
+      ..platformToolsAvailable = true
+      ..cmdlineToolsAvailable = true
+      ..avdManagerPath = '/foo/bar/avdmanager'
+      ..directory = fileSystem.directory('/foo/bar')
+      ..emulatorPath = 'path/to/emulator';
+
+    processManager.addCommand(const FakeCommand(command: <String>['/foo/bar/avdmanager', 'list']));
+
+    final androidValidator = AndroidValidator(
+      java: FakeJava(),
+      androidSdk: sdk,
+      logger: logger,
+      platform: FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
+      userMessages: UserMessages(),
+      processManager: processManager,
+    );
+
+    final ValidationResult validationResult = await androidValidator.validate();
+    expect(validationResult.type, ValidationType.success);
+    expect(processManager, hasNoRemainingExpectations);
+  });
+
+  testUsingContext('avdmanager is not functional due to missing Java', () async {
+    sdk
+      ..licensesAvailable = true
+      ..platformToolsAvailable = true
+      ..cmdlineToolsAvailable = true
+      ..avdManagerPath = '/foo/bar/avdmanager'
+      ..directory = fileSystem.directory('/foo/bar')
+      ..emulatorPath = 'path/to/emulator';
+
+    processManager.addCommand(
+      const FakeCommand(
+        command: <String>['/foo/bar/avdmanager', 'list'],
+        exitCode: 1,
+        stderr: 'No Java runtime present, requesting install.',
+      ),
+    );
+
+    final androidValidator = AndroidValidator(
+      java: FakeJava(),
+      androidSdk: sdk,
+      logger: logger,
+      platform: FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
+      userMessages: UserMessages(),
+      processManager: processManager,
+    );
+
+    final ValidationResult validationResult = await androidValidator.validate();
+    expect(validationResult.type, ValidationType.partial);
+
+    final ValidationMessage errorMessage = validationResult.messages.firstWhere(
+      (ValidationMessage message) => message.type == ValidationMessageType.error,
+    );
+    expect(
+      errorMessage.message,
+      contains(
+        'avdmanager is not functional. Running avdmanager failed with exit code 1:\n'
+        'No Java runtime present, requesting install.',
+      ),
+    );
+    expect(processManager, hasNoRemainingExpectations);
+  });
+
   // Warning test not available when minimum and error are aligned.
   testUsingContext('detects minimum required java version', () async {
     // Test with older version of JDK
@@ -863,6 +930,9 @@ class FakeAndroidSdk extends Fake implements AndroidSdk {
 
   @override
   String? sdkManagerVersion;
+
+  @override
+  String? avdManagerPath;
 
   @override
   String? adbPath;


### PR DESCRIPTION
On macOS and Linux, Android SDK's avdmanager shell script can fail to run if the Java Development Kit is missing or misconfigured (often throwing "No Java runtime present"). Previously, flutter doctor did not detect this condition, leading to silent or cryptic failures (such as "No device definitions are available" or "Cannot find executable for null" errors during emulator creation).

Modified AndroidValidator.validateImpl in android_workflow.dart to:
- Verify that avdmanager can be successfully executed with the resolved Java environment after confirming that cmdline-tools are available.
- Run avdmanager list and report a clear partial validation error showing the runtime failure if the execution fails or exits with a non-zero code.

Added a new avdManagerPath field to FakeAndroidSdk to prevent test breakage. Added two new unit tests in android_workflow_test.dart to verify that:
- flutter doctor succeeds when avdmanager is functional.
- flutter doctor reports a clear validation error when avdmanager fails to run due to Java issues.

Verified that all tests pass and formatting/analysis are clean.

Fixes: #57483

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.