### PR TITLE
Clarify BackdropFilter does not affect native platform views

### DIFF
--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -492,6 +492,10 @@ class BackdropGroup extends InheritedWidget {
 /// widget's clip. If there's no clip, the filter will be applied to the full
 /// screen.
 ///
+/// This widget only filters content rendered by Flutter. It does not affect
+/// native platform views (like Android views or iOS views) because those views
+/// are rendered by the platform itself, not by Flutter's engine.
+///
 /// The results of the filter will be blended back into the background using
 /// the [blendMode] parameter.
 /// {@template flutter.widgets.BackdropFilter.blendMode}


### PR DESCRIPTION
Update dart documentation to clarify filtering rules only affect Flutter views.

Fixes: #132089

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.