### PR TITLE
Dispose TextEditingController in IndexedStack example

### DIFF
--- a/examples/api/lib/widgets/basic/indexed_stack.0.dart
+++ b/examples/api/lib/widgets/basic/indexed_stack.0.dart
@@ -35,6 +35,12 @@ class _IndexedStackExampleState extends State<IndexedStackExample> {
   final TextEditingController fieldText = TextEditingController();
 
   @override
+  void dispose() {
+    fieldText.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Column(
       mainAxisAlignment: .center,


### PR DESCRIPTION
## Description

The `_IndexedStackExampleState` class in the `IndexedStack` API example creates a `TextEditingController` but never disposes it, causing a resource leak.

Added a `dispose()` override that calls `fieldText.dispose()` before `super.dispose()`.

```dart
@override
void dispose() {
  fieldText.dispose();
  super.dispose();
}
```

Fixes #186324

## Tests

Existing tests in `examples/api/test/widgets/basic/indexed_stack.0_test.dart` cover the example. No new tests needed for a dispose fix.