### PR TITLE
[widgets/raw_menu_anchor.dart] Call onCloseRequested on closed menus

### DIFF
--- a/packages/flutter/lib/src/widgets/raw_menu_anchor.dart
+++ b/packages/flutter/lib/src/widgets/raw_menu_anchor.dart
@@ -313,8 +313,8 @@ class RawMenuAnchor extends StatefulWidget {
   /// This callback can be used to add a delay or a closing animation before the
   /// menu is hidden.
   ///
-  /// This callback is triggered every time [MenuController.close] is called
-  /// while this menu is open.
+  /// This callback is triggered every time [MenuController.close] is called,
+  /// even when the menu overlay is already hidden.
   ///
   /// This callback is also triggered when a sibling [RawMenuAnchor] is opened
   /// while this menu is open. In this case, the callback can be used to add a
@@ -797,10 +797,6 @@ class _RawMenuAnchorState extends State<RawMenuAnchor> with _RawMenuAnchorBaseMi
 
   @override
   void handleCloseRequest() {
-    if (!isOpen) {
-      return;
-    }
-
     // Changes in MediaQuery.sizeOf(context) cause RawMenuAnchor to close during
     // didChangeDependencies. When this happens, calling setState during the
     // closing sequence (handleCloseRequest -> onCloseRequested -> hideOverlay)

--- a/packages/flutter/lib/src/widgets/raw_menu_anchor.dart
+++ b/packages/flutter/lib/src/widgets/raw_menu_anchor.dart
@@ -316,13 +316,13 @@ class RawMenuAnchor extends StatefulWidget {
   /// This callback is triggered every time [MenuController.close] is called,
   /// even when the menu overlay is already hidden.
   ///
-  /// This callback is also triggered when a sibling [RawMenuAnchor] is opened
-  /// while this menu is open. In this case, the callback can be used to add a
-  /// delay or a closing animation while the sibling menu opens. When
-  /// implementing this behavior, consider disabling interactions so that the
-  /// closing menu does not interfere with the opening sibling menu. Also
-  /// consider disabling semantics, focus, and hit testing for the closing menu
-  /// for the duration of the closing animation.
+  /// This callback is also triggered when a sibling [RawMenuAnchor] is opened.
+  /// In this case, the callback can be used to add a delay or a closing
+  /// animation while the sibling menu opens. When implementing this behavior,
+  /// consider disabling interactions so that the closing menu does not
+  /// interfere with the opening sibling menu. Also consider disabling
+  /// semantics, focus, and hit testing for the closing menu for the duration of
+  /// the closing animation.
   ///
   /// Pending timers or animations started in a previous call to
   /// [onCloseRequested] should be canceled when this callback is triggered to

--- a/packages/flutter/test/widgets/raw_menu_anchor_test.dart
+++ b/packages/flutter/test/widgets/raw_menu_anchor_test.dart
@@ -2933,7 +2933,7 @@ void main() {
       await tester.pump();
 
       expect(find.text(Tag.a.a.a.a.text), findsOneWidget);
-      expect(closeRequests, <Tag>[]);
+      expect(closeRequests, <Tag>[Tag.a.a, Tag.a.a.a]);
 
       closeRequests.clear();
 


### PR DESCRIPTION
Small breaking change to https://github.com/flutter/flutter/pull/182357. In https://github.com/flutter/flutter/pull/182357, I added a line to prevent `onCloseRequested` from being called on closed menus. I now remember the original design was actually intentional, because it makes synchronizing delays between sibling menu anchors trivial.

Fixes https://github.com/flutter/flutter/issues/186379

To demonstrate: 

```dart

RawMenuAnchor(
 onOpenRequested: (position, showOverlay) {
    final parentController = MenuController.maybeOf(context)!;

    // This fix makes it so that calling closeChildren on a parent menu controller immediately 
    // calls onCloseRequested on all sibling RawMenuAnchors, allowing any pending 
    // _openTimers on siblings to be canceled prior to those siblings calling showOverlay.
    parentController.closeChildren();

    _openTimer = Timer(const Duration(milliseconds: 500), () {
      _openTimer = null;
      showOverlay();
    });
  },

onCloseRequested: (hideOverlay) {
  _openTimer?.cancel();
  _openTimer = null;
},
// ...
)
```

Considering this behavior was already tested, I modified the original test to reflect the changing behavior.

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

Since this is a breaking change to a breaking change that hasn't landed in stable, should I amend the original breaking change doc, or is a new doc required?

@dkwingsmt @chunhtai 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
