### PR TITLE
Pass XcodeBasedProject instead of String to functions in XcodeProjectInterpreter

### DIFF
--- a/packages/flutter_tools/lib/src/commands/clean.dart
+++ b/packages/flutter_tools/lib/src/commands/clean.dart
@@ -104,7 +104,7 @@ class CleanCommand extends FlutterCommand {
     try {
       final XcodeProjectInterpreter xcodeProjectInterpreter = globals.xcodeProjectInterpreter!;
       final XcodeProjectInfo projectInfo = (await xcodeProjectInterpreter.getInfo(
-        xcodeWorkspace.parent.path,
+        xcodeProject,
         buildDirectory: globals.fs.directory(xcodeProject.darwinPlatform.buildDirectory()),
       ))!;
       if (argResults?.wasParsed('scheme') ?? false) {
@@ -116,6 +116,7 @@ class CleanCommand extends FlutterCommand {
           throwToolExit('Scheme "$scheme" not found in ${projectInfo.schemes}');
         }
         await xcodeProjectInterpreter.cleanWorkspace(
+          xcodeProject,
           xcodeWorkspace.path,
           scheme,
           verbose: _verbose,
@@ -124,6 +125,7 @@ class CleanCommand extends FlutterCommand {
       } else {
         for (final String scheme in projectInfo.schemes) {
           await xcodeProjectInterpreter.cleanWorkspace(
+            xcodeProject,
             xcodeWorkspace.path,
             scheme,
             verbose: _verbose,

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -307,7 +307,7 @@ Future<XcodeBuildResult> buildXcodeProject({
 
   final List<String> xcodebuildCommandArgs = await globals.xcode!
       .fetchDependenciesAndGenerateXcodebuildArgs(
-        app.project.hostAppRoot.path,
+        app.project,
         globals.fs.directory(buildDirectoryPath),
         skipPackageUpdatesAndValidation: false,
       );

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -22,6 +22,7 @@ import '../base/version.dart';
 import '../build_info.dart';
 import '../convert.dart';
 import '../reporting/reporting.dart';
+import '../xcode_project.dart';
 
 final _settingExpr = RegExp(r'(\w+)\s*=\s*(.*)$');
 final _varExpr = RegExp(r'\$\(([^)]*)\)');
@@ -186,14 +187,14 @@ class XcodeProjectInterpreter {
   /// Using this method when running `xcodebuild` commands ensures that `xcrun` is used properly
   /// and that the Swift package cache is properly configured.
   Future<List<String>> fetchDependenciesAndGenerateXcodebuildArgs(
-    String projectPath,
+    XcodeBasedProject xcodeProject,
     Directory buildDirectory, {
     bool skipPackageUpdatesAndValidation = true,
   }) async {
     // All `xcodebuild` project commands will download and resolve Swift packages.
     // We should always prefetch Swift packages before running any `xcodebuild` project command
     // to control the output.
-    await prefetchSwiftPackages(projectPath, buildDirectory: buildDirectory, quiet: false);
+    await prefetchSwiftPackages(xcodeProject, buildDirectory: buildDirectory, quiet: false);
 
     return _xcodebuildProjectCommandArguments(
       buildDirectory,
@@ -234,7 +235,7 @@ class XcodeProjectInterpreter {
   /// If [XcodeProjectBuildContext.scheme] is `null`, `xcodebuild` will
   /// return build settings for the first discovered target (by default this is Runner).
   Future<Map<String, String>> getBuildSettings(
-    String projectPath, {
+    XcodeBasedProject xcodeProject, {
     required XcodeProjectBuildContext buildContext,
     Duration timeout = const Duration(minutes: 1),
   }) async {
@@ -249,9 +250,10 @@ class XcodeProjectInterpreter {
       XcodeSdk.WatchOS || XcodeSdk.WatchSimulator => getIosBuildDirectory(),
     };
     final List<String> xcodebuildCommandArgs = await fetchDependenciesAndGenerateXcodebuildArgs(
-      projectPath,
+      xcodeProject,
       _fileSystem.directory(buildDir),
     );
+    final String projectPath = xcodeProject.xcodeProject.path;
     final showBuildSettingsCommand = <String>[
       ...xcodebuildCommandArgs,
       '-project',
@@ -362,6 +364,7 @@ class XcodeProjectInterpreter {
   }
 
   Future<void> cleanWorkspace(
+    XcodeBasedProject xcodeProject,
     String workspacePath,
     String scheme, {
     required Directory buildDirectory,
@@ -369,7 +372,7 @@ class XcodeProjectInterpreter {
   }) async {
     final String projectPath = _fileSystem.currentDirectory.path;
     final List<String> xcodebuildCommandArgs = await fetchDependenciesAndGenerateXcodebuildArgs(
-      projectPath,
+      xcodeProject,
       buildDirectory,
     );
     await _processUtils.run(<String>[
@@ -402,11 +405,12 @@ class XcodeProjectInterpreter {
   /// If [quiet] is false, it will print a spinner while the command is running and print logs of
   /// what Swift packages are being fetched.
   Future<void> prefetchSwiftPackages(
-    String projectPath, {
+    XcodeBasedProject xcodeProject, {
     required Directory buildDirectory,
     bool quiet = true,
     bool waitForCompletion = true,
   }) async {
+    final String projectPath = xcodeProject.hostAppRoot.path;
     Status? status;
     try {
       final command = <String>[
@@ -497,7 +501,7 @@ class XcodeProjectInterpreter {
   }
 
   Future<XcodeProjectInfo?> getInfo(
-    String projectPath, {
+    XcodeBasedProject xcodeProject, {
     String? projectFilename,
     required Directory buildDirectory,
   }) async {
@@ -509,7 +513,7 @@ class XcodeProjectInterpreter {
     const corruptedProjectExitCode = 74;
     bool allowedFailures(int c) => c == missingProjectExitCode || c == corruptedProjectExitCode;
     final List<String> xcodebuildCommandArgs = await fetchDependenciesAndGenerateXcodebuildArgs(
-      projectPath,
+      xcodeProject,
       buildDirectory,
     );
     final RunResult result = await _processUtils.run(
@@ -520,7 +524,7 @@ class XcodeProjectInterpreter {
       ],
       throwOnError: true,
       allowedFailures: allowedFailures,
-      workingDirectory: projectPath,
+      workingDirectory: xcodeProject.hostAppRoot.path,
     );
     if (allowedFailures(result.exitCode)) {
       // User configuration error, tool exit instead of crashing.

--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -125,7 +125,7 @@ Future<void> buildMacOS({
   // regardless of the project name so long as there is exactly one project.
   final String? xcodeProjectName = xcodeProject.existsSync() ? xcodeProject.basename : null;
   final XcodeProjectInfo? projectInfo = await globals.xcodeProjectInterpreter?.getInfo(
-    xcodeProject.parent.path,
+    flutterProject.macos,
     projectFilename: xcodeProjectName,
     buildDirectory: flutterBuildDir,
   );
@@ -217,7 +217,7 @@ Future<void> buildMacOS({
   try {
     final List<String> xcodebuildCommandArgs = await globals.xcode!
         .fetchDependenciesAndGenerateXcodebuildArgs(
-          flutterProject.macos.hostAppRoot.path,
+          flutterProject.macos,
           globals.fs.directory(buildDirectoryPath),
           skipPackageUpdatesAndValidation: false,
         );

--- a/packages/flutter_tools/lib/src/macos/darwin_dependency_management.dart
+++ b/packages/flutter_tools/lib/src/macos/darwin_dependency_management.dart
@@ -78,7 +78,7 @@ class DarwinDependencyManagement {
 
       // Start the SwiftPM dependency resolution in the background.
       await _xcodeProjectInterpreter?.prefetchSwiftPackages(
-        xcodeProject.hostAppRoot.path,
+        xcodeProject,
         waitForCompletion: false,
         buildDirectory: _fileSystem.directory(
           platform.buildDirectory(config: _config, fileSystem: _fileSystem),

--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -19,6 +19,7 @@ import '../base/version.dart';
 import '../build_info.dart';
 import '../cache.dart';
 import '../ios/xcodeproj.dart';
+import '../xcode_project.dart';
 
 Version get xcodeRequiredVersion => Version(15, null, null);
 
@@ -232,11 +233,11 @@ class Xcode {
   List<String> xcrunCommand() => _xcodeProjectInterpreter.xcrunCommand();
 
   Future<List<String>> fetchDependenciesAndGenerateXcodebuildArgs(
-    String projectPath,
+    XcodeBasedProject xcodeProject,
     Directory buildDirectory, {
     bool skipPackageUpdatesAndValidation = true,
   }) async => _xcodeProjectInterpreter.fetchDependenciesAndGenerateXcodebuildArgs(
-    projectPath,
+    xcodeProject,
     buildDirectory,
     skipPackageUpdatesAndValidation: skipPackageUpdatesAndValidation,
   );

--- a/packages/flutter_tools/lib/src/migrations/swift_package_manager_integration_migration.dart
+++ b/packages/flutter_tools/lib/src/migrations/swift_package_manager_integration_migration.dart
@@ -229,7 +229,7 @@ class SwiftPackageManagerIntegrationMigration extends ProjectMigrator {
 
       // Get the project info to make sure it compiles with xcodebuild
       await _xcodeProjectInterpreter.getInfo(
-        _xcodeProject.hostAppRoot.path,
+        _xcodeProject,
         buildDirectory: _fileSystem.directory(
           _platform.buildDirectory(config: _config, fileSystem: _fileSystem),
         ),

--- a/packages/flutter_tools/lib/src/xcode_project.dart
+++ b/packages/flutter_tools/lib/src/xcode_project.dart
@@ -240,7 +240,7 @@ abstract class XcodeBasedProject extends FlutterProjectPlatform {
       return null;
     }
     return _projectInfo ??= await xcodeProjectInterpreter.getInfo(
-      hostAppRoot.path,
+      this,
       buildDirectory: globals.fs.directory(darwinPlatform.buildDirectory()),
     );
   }
@@ -339,7 +339,7 @@ abstract class XcodeBasedProject extends FlutterProjectPlatform {
     }
 
     final Map<String, String> buildSettings = await xcodeProjectInterpreter.getBuildSettings(
-      xcodeProject.path,
+      this,
       buildContext: buildContext,
     );
     if (buildSettings.isNotEmpty) {

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ios_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ios_test.dart
@@ -42,7 +42,7 @@ class FakeXcodeProjectInterpreterWithBuildSettings extends FakeXcodeProjectInter
 
   @override
   Future<Map<String, String>> getBuildSettings(
-    String projectPath, {
+    XcodeBasedProject xcodeProject, {
     XcodeProjectBuildContext? buildContext,
     Duration timeout = const Duration(minutes: 1),
   }) async {

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
@@ -18,6 +18,7 @@ import 'package:flutter_tools/src/commands/build_ios.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/ios/plist_parser.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
+import 'package:flutter_tools/src/project.dart';
 import 'package:test/fake.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 
@@ -40,7 +41,7 @@ class FakeXcodeProjectInterpreterWithBuildSettings extends FakeXcodeProjectInter
   Map<String, String> get overrides => _overrides;
   @override
   Future<Map<String, String>> getBuildSettings(
-    String projectPath, {
+    XcodeBasedProject xcodeProject, {
     XcodeProjectBuildContext? buildContext,
     Duration timeout = const Duration(minutes: 1),
   }) async {

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
@@ -35,7 +35,7 @@ import '../../src/throwing_pub.dart';
 class FakeXcodeProjectInterpreterWithProfile extends FakeXcodeProjectInterpreter {
   @override
   Future<XcodeProjectInfo> getInfo(
-    String projectPath, {
+    XcodeBasedProject xcodeProject, {
     String? projectFilename,
     required Directory buildDirectory,
   }) async {
@@ -52,7 +52,7 @@ class FakeXcodeProjectInterpreterWithBuildSettings extends FakeXcodeProjectInter
 
   @override
   Future<XcodeProjectInfo> getInfo(
-    String projectPath, {
+    XcodeBasedProject xcodeProject, {
     String? projectFilename,
     required Directory buildDirectory,
   }) async {
@@ -63,7 +63,7 @@ class FakeXcodeProjectInterpreterWithBuildSettings extends FakeXcodeProjectInter
 
   @override
   Future<Map<String, String>> getBuildSettings(
-    String projectPath, {
+    XcodeBasedProject xcodeProject, {
     XcodeProjectBuildContext? buildContext,
     Duration timeout = const Duration(minutes: 1),
   }) async {
@@ -825,42 +825,38 @@ STDERR STUFF
     },
   );
 
-  testUsingContext(
-    'Refuses to build for macOS when feature is disabled',
-    () {
-      final CommandRunner<void> runner = createTestCommandRunner(
-        BuildCommand(
-          androidSdk: FakeAndroidSdk(),
-          buildSystem: TestBuildSystem.all(BuildResult(success: true)),
-          fileSystem: fileSystem,
-          logger: logger,
-          osUtils: FakeOperatingSystemUtils(),
-          config: FakeConfig(),
-          platform: FakePlatform(),
-          fileSystemUtils: FakeFileSystemUtils(),
-          terminal: FakeTerminal(),
-          plistParser: FakePlistParser(),
-          processUtils: FakeProcessUtils(),
-          processManager: FakeProcessManager.any(),
-          templateRenderer: FakeTemplateRenderer(),
-          xcode: FakeXcode(),
-          artifacts: FakeArtifacts(),
-          cache: FakeCache(),
-          flutterVersion: FakeFlutterVersion(),
-        ),
-      );
+  testUsingContext('Refuses to build for macOS when feature is disabled', () {
+    final CommandRunner<void> runner = createTestCommandRunner(
+      BuildCommand(
+        androidSdk: FakeAndroidSdk(),
+        buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+        fileSystem: fileSystem,
+        logger: logger,
+        osUtils: FakeOperatingSystemUtils(),
+        config: FakeConfig(),
+        platform: FakePlatform(),
+        fileSystemUtils: FakeFileSystemUtils(),
+        terminal: FakeTerminal(),
+        plistParser: FakePlistParser(),
+        processUtils: FakeProcessUtils(),
+        processManager: FakeProcessManager.any(),
+        templateRenderer: FakeTemplateRenderer(),
+        xcode: FakeXcode(),
+        artifacts: FakeArtifacts(),
+        cache: FakeCache(),
+        flutterVersion: FakeFlutterVersion(),
+      ),
+    );
 
-      final bool supported = BuildMacosCommand(
-        logger: BufferLogger.test(),
-        verboseHelp: false,
-      ).supported;
-      expect(
-        () => runner.run(<String>['build', 'macos', '--no-pub']),
-        supported ? throwsToolExit() : throwsA(isA<UsageException>()),
-      );
-    },
-    overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()},
-  );
+    final bool supported = BuildMacosCommand(
+      logger: BufferLogger.test(),
+      verboseHelp: false,
+    ).supported;
+    expect(
+      () => runner.run(<String>['build', 'macos', '--no-pub']),
+      supported ? throwsToolExit() : throwsA(isA<UsageException>()),
+    );
+  }, overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()});
 
   testUsingContext(
     'hidden when not enabled on macOS host',

--- a/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
@@ -354,39 +354,35 @@ void main() {
         },
       );
 
-      testUsingContext(
-        '$CleanCommand handles missing delete permissions',
-        () async {
-          final handler = FileExceptionHandler();
+      testUsingContext('$CleanCommand handles missing delete permissions', () async {
+        final handler = FileExceptionHandler();
 
-          // Ensures we handle ErrorHandlingFileSystem appropriately in prod.
-          // See https://github.com/flutter/flutter/issues/108978.
-          final FileSystem fileSystem = ErrorHandlingFileSystem(
-            delegate: MemoryFileSystem.test(opHandle: handler.opHandle),
-            platform: windowsPlatform,
-          );
-          final File throwingFile = fileSystem.file('bad')..createSync();
-          handler.addError(
-            throwingFile,
-            FileSystemOp.delete,
-            const FileSystemException('OS error: Access Denied'),
-          );
+        // Ensures we handle ErrorHandlingFileSystem appropriately in prod.
+        // See https://github.com/flutter/flutter/issues/108978.
+        final FileSystem fileSystem = ErrorHandlingFileSystem(
+          delegate: MemoryFileSystem.test(opHandle: handler.opHandle),
+          platform: windowsPlatform,
+        );
+        final File throwingFile = fileSystem.file('bad')..createSync();
+        handler.addError(
+          throwingFile,
+          FileSystemOp.delete,
+          const FileSystemException('OS error: Access Denied'),
+        );
 
-          xcodeProjectInterpreter.isInstalled = false;
+        xcodeProjectInterpreter.isInstalled = false;
 
-          final command = CleanCommand();
-          command.deleteFile(throwingFile);
+        final command = CleanCommand();
+        command.deleteFile(throwingFile);
 
-          expect(
-            testLogger.errorText,
-            contains(
-              'Failed to remove bad. A program may still be using a file in the directory or the directory itself',
-            ),
-          );
-          expect(throwingFile, exists);
-        },
-        overrides: <Type, Generator>{Platform: () => windowsPlatform, Xcode: () => xcode},
-      );
+        expect(
+          testLogger.errorText,
+          contains(
+            'Failed to remove bad. A program may still be using a file in the directory or the directory itself',
+          ),
+        );
+        expect(throwingFile, exists);
+      }, overrides: <Type, Generator>{Platform: () => windowsPlatform, Xcode: () => xcode});
     });
   });
 }
@@ -434,7 +430,7 @@ class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterprete
 
   @override
   Future<XcodeProjectInfo> getInfo(
-    String projectPath, {
+    XcodeBasedProject xcodeProject, {
     String? projectFilename,
     required Directory buildDirectory,
   }) async {
@@ -448,6 +444,7 @@ class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterprete
 
   @override
   Future<void> cleanWorkspace(
+    XcodeBasedProject xcodeProject,
     String workspacePath,
     String scheme, {
     required Directory buildDirectory,

--- a/packages/flutter_tools/test/general.shard/build_system/targets/common_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/common_test.dart
@@ -16,6 +16,7 @@ import 'package:flutter_tools/src/compile.dart';
 import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
+import 'package:flutter_tools/src/project.dart';
 import 'package:test/fake.dart';
 
 import '../../../src/common.dart';
@@ -72,110 +73,98 @@ void main() {
     iosEnvironment.buildDir.createSync(recursive: true);
   });
 
-  testUsingContext(
-    'KernelSnapshot throws error if missing build mode',
-    () async {
-      androidEnvironment.defines.remove(kBuildMode);
-      expect(
-        const KernelSnapshot().build(androidEnvironment),
-        throwsA(isA<MissingDefineException>()),
-      );
-    },
-    overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()},
-  );
+  testUsingContext('KernelSnapshot throws error if missing build mode', () async {
+    androidEnvironment.defines.remove(kBuildMode);
+    expect(
+      const KernelSnapshot().build(androidEnvironment),
+      throwsA(isA<MissingDefineException>()),
+    );
+  }, overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()});
 
-  testUsingContext(
-    'KernelSnapshot handles null result from kernel compilation',
-    () async {
-      fileSystem.file('.dart_tool/package_config.json')
-        ..createSync(recursive: true)
-        ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
-      final String build = androidEnvironment.buildDir.path;
-      final String flutterPatchedSdkPath = artifacts.getArtifactPath(
-        Artifact.flutterPatchedSdkPath,
-        platform: TargetPlatform.android_arm,
-        mode: BuildMode.profile,
-      );
-      processManager.addCommands(<FakeCommand>[
-        FakeCommand(
-          command: <String>[
-            artifacts.getArtifactPath(Artifact.engineDartAotRuntime),
-            artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
-            '--sdk-root',
-            '$flutterPatchedSdkPath/',
-            '--target=flutter',
-            '--no-print-incremental-dependencies',
-            ...buildModeOptions(BuildMode.profile, <String>[]),
-            '--track-widget-creation',
-            '--aot',
-            '--tfa',
-            '--target-os',
-            'android',
-            '--packages',
-            '/.dart_tool/package_config.json',
-            '--output-dill',
-            '$build/app.dill',
-            '--depfile',
-            '$build/kernel_snapshot_program.d',
-            '--verbosity=error',
-            'file:///lib/main.dart',
-          ],
-          exitCode: 1,
-        ),
-      ]);
+  testUsingContext('KernelSnapshot handles null result from kernel compilation', () async {
+    fileSystem.file('.dart_tool/package_config.json')
+      ..createSync(recursive: true)
+      ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
+    final String build = androidEnvironment.buildDir.path;
+    final String flutterPatchedSdkPath = artifacts.getArtifactPath(
+      Artifact.flutterPatchedSdkPath,
+      platform: TargetPlatform.android_arm,
+      mode: BuildMode.profile,
+    );
+    processManager.addCommands(<FakeCommand>[
+      FakeCommand(
+        command: <String>[
+          artifacts.getArtifactPath(Artifact.engineDartAotRuntime),
+          artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
+          '--sdk-root',
+          '$flutterPatchedSdkPath/',
+          '--target=flutter',
+          '--no-print-incremental-dependencies',
+          ...buildModeOptions(BuildMode.profile, <String>[]),
+          '--track-widget-creation',
+          '--aot',
+          '--tfa',
+          '--target-os',
+          'android',
+          '--packages',
+          '/.dart_tool/package_config.json',
+          '--output-dill',
+          '$build/app.dill',
+          '--depfile',
+          '$build/kernel_snapshot_program.d',
+          '--verbosity=error',
+          'file:///lib/main.dart',
+        ],
+        exitCode: 1,
+      ),
+    ]);
 
-      await expectLater(() => const KernelSnapshot().build(androidEnvironment), throwsException);
-      expect(processManager, hasNoRemainingExpectations);
-    },
-    overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()},
-  );
+    await expectLater(() => const KernelSnapshot().build(androidEnvironment), throwsException);
+    expect(processManager, hasNoRemainingExpectations);
+  }, overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()});
 
-  testUsingContext(
-    'KernelSnapshot does use track widget creation on profile builds',
-    () async {
-      fileSystem.file('.dart_tool/package_config.json')
-        ..createSync(recursive: true)
-        ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
-      final String build = androidEnvironment.buildDir.path;
-      final String flutterPatchedSdkPath = artifacts.getArtifactPath(
-        Artifact.flutterPatchedSdkPath,
-        platform: TargetPlatform.android_arm,
-        mode: BuildMode.profile,
-      );
-      processManager.addCommands(<FakeCommand>[
-        FakeCommand(
-          command: <String>[
-            artifacts.getArtifactPath(Artifact.engineDartAotRuntime),
-            artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
-            '--sdk-root',
-            '$flutterPatchedSdkPath/',
-            '--target=flutter',
-            '--no-print-incremental-dependencies',
-            ...buildModeOptions(BuildMode.profile, <String>[]),
-            '--track-widget-creation',
-            '--aot',
-            '--tfa',
-            '--target-os',
-            'android',
-            '--packages',
-            '/.dart_tool/package_config.json',
-            '--output-dill',
-            '$build/app.dill',
-            '--depfile',
-            '$build/kernel_snapshot_program.d',
-            '--verbosity=error',
-            'file:///lib/main.dart',
-          ],
-          stdout: 'result $kBoundaryKey\n$kBoundaryKey\n$kBoundaryKey $build/app.dill 0\n',
-        ),
-      ]);
+  testUsingContext('KernelSnapshot does use track widget creation on profile builds', () async {
+    fileSystem.file('.dart_tool/package_config.json')
+      ..createSync(recursive: true)
+      ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
+    final String build = androidEnvironment.buildDir.path;
+    final String flutterPatchedSdkPath = artifacts.getArtifactPath(
+      Artifact.flutterPatchedSdkPath,
+      platform: TargetPlatform.android_arm,
+      mode: BuildMode.profile,
+    );
+    processManager.addCommands(<FakeCommand>[
+      FakeCommand(
+        command: <String>[
+          artifacts.getArtifactPath(Artifact.engineDartAotRuntime),
+          artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
+          '--sdk-root',
+          '$flutterPatchedSdkPath/',
+          '--target=flutter',
+          '--no-print-incremental-dependencies',
+          ...buildModeOptions(BuildMode.profile, <String>[]),
+          '--track-widget-creation',
+          '--aot',
+          '--tfa',
+          '--target-os',
+          'android',
+          '--packages',
+          '/.dart_tool/package_config.json',
+          '--output-dill',
+          '$build/app.dill',
+          '--depfile',
+          '$build/kernel_snapshot_program.d',
+          '--verbosity=error',
+          'file:///lib/main.dart',
+        ],
+        stdout: 'result $kBoundaryKey\n$kBoundaryKey\n$kBoundaryKey $build/app.dill 0\n',
+      ),
+    ]);
 
-      await const KernelSnapshot().build(androidEnvironment);
+    await const KernelSnapshot().build(androidEnvironment);
 
-      expect(processManager, hasNoRemainingExpectations);
-    },
-    overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()},
-  );
+    expect(processManager, hasNoRemainingExpectations);
+  }, overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()});
 
   testUsingContext(
     'KernelSnapshot correctly handles an empty string in ExtraFrontEndOptions',
@@ -224,157 +213,145 @@ void main() {
     overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()},
   );
 
-  testUsingContext(
-    'KernelSnapshot correctly forwards FrontendServerStarterPath',
-    () async {
-      fileSystem.file('.dart_tool/package_config.json')
-        ..createSync(recursive: true)
-        ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
-      final String build = androidEnvironment.buildDir.path;
-      final String flutterPatchedSdkPath = artifacts.getArtifactPath(
-        Artifact.flutterPatchedSdkPath,
-        platform: TargetPlatform.android_arm,
-        mode: BuildMode.profile,
-      );
-      processManager.addCommands(<FakeCommand>[
-        FakeCommand(
-          command: <String>[
-            artifacts.getArtifactPath(Artifact.engineDartBinary),
-            'path/to/frontend_server_starter.dart',
-            '--sdk-root',
-            '$flutterPatchedSdkPath/',
-            '--target=flutter',
-            '--no-print-incremental-dependencies',
-            ...buildModeOptions(BuildMode.profile, <String>[]),
-            '--track-widget-creation',
-            '--aot',
-            '--tfa',
-            '--target-os',
-            'android',
-            '--packages',
-            '/.dart_tool/package_config.json',
-            '--output-dill',
-            '$build/app.dill',
-            '--depfile',
-            '$build/kernel_snapshot_program.d',
-            '--verbosity=error',
-            'file:///lib/main.dart',
-          ],
-          stdout: 'result $kBoundaryKey\n$kBoundaryKey\n$kBoundaryKey $build/app.dill 0\n',
-        ),
-      ]);
+  testUsingContext('KernelSnapshot correctly forwards FrontendServerStarterPath', () async {
+    fileSystem.file('.dart_tool/package_config.json')
+      ..createSync(recursive: true)
+      ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
+    final String build = androidEnvironment.buildDir.path;
+    final String flutterPatchedSdkPath = artifacts.getArtifactPath(
+      Artifact.flutterPatchedSdkPath,
+      platform: TargetPlatform.android_arm,
+      mode: BuildMode.profile,
+    );
+    processManager.addCommands(<FakeCommand>[
+      FakeCommand(
+        command: <String>[
+          artifacts.getArtifactPath(Artifact.engineDartBinary),
+          'path/to/frontend_server_starter.dart',
+          '--sdk-root',
+          '$flutterPatchedSdkPath/',
+          '--target=flutter',
+          '--no-print-incremental-dependencies',
+          ...buildModeOptions(BuildMode.profile, <String>[]),
+          '--track-widget-creation',
+          '--aot',
+          '--tfa',
+          '--target-os',
+          'android',
+          '--packages',
+          '/.dart_tool/package_config.json',
+          '--output-dill',
+          '$build/app.dill',
+          '--depfile',
+          '$build/kernel_snapshot_program.d',
+          '--verbosity=error',
+          'file:///lib/main.dart',
+        ],
+        stdout: 'result $kBoundaryKey\n$kBoundaryKey\n$kBoundaryKey $build/app.dill 0\n',
+      ),
+    ]);
 
-      await const KernelSnapshot().build(
-        androidEnvironment
-          ..defines[kFrontendServerStarterPath] = 'path/to/frontend_server_starter.dart',
-      );
+    await const KernelSnapshot().build(
+      androidEnvironment
+        ..defines[kFrontendServerStarterPath] = 'path/to/frontend_server_starter.dart',
+    );
 
-      expect(processManager, hasNoRemainingExpectations);
-    },
-    overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()},
-  );
+    expect(processManager, hasNoRemainingExpectations);
+  }, overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()});
 
-  testUsingContext(
-    'KernelSnapshot correctly forwards ExtraFrontEndOptions',
-    () async {
-      fileSystem.file('.dart_tool/package_config.json')
-        ..createSync(recursive: true)
-        ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
-      final String build = androidEnvironment.buildDir.path;
-      final String flutterPatchedSdkPath = artifacts.getArtifactPath(
-        Artifact.flutterPatchedSdkPath,
-        platform: TargetPlatform.android_arm,
-        mode: BuildMode.profile,
-      );
-      processManager.addCommands(<FakeCommand>[
-        FakeCommand(
-          command: <String>[
-            artifacts.getArtifactPath(Artifact.engineDartAotRuntime),
-            artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
-            '--sdk-root',
-            '$flutterPatchedSdkPath/',
-            '--target=flutter',
-            '--no-print-incremental-dependencies',
-            ...buildModeOptions(BuildMode.profile, <String>[]),
-            '--track-widget-creation',
-            '--aot',
-            '--tfa',
-            '--target-os',
-            'android',
-            '--packages',
-            '/.dart_tool/package_config.json',
-            '--output-dill',
-            '$build/app.dill',
-            '--depfile',
-            '$build/kernel_snapshot_program.d',
-            '--verbosity=error',
-            'foo',
-            'bar',
-            'file:///lib/main.dart',
-          ],
-          stdout: 'result $kBoundaryKey\n$kBoundaryKey\n$kBoundaryKey $build/app.dill 0\n',
-        ),
-      ]);
+  testUsingContext('KernelSnapshot correctly forwards ExtraFrontEndOptions', () async {
+    fileSystem.file('.dart_tool/package_config.json')
+      ..createSync(recursive: true)
+      ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
+    final String build = androidEnvironment.buildDir.path;
+    final String flutterPatchedSdkPath = artifacts.getArtifactPath(
+      Artifact.flutterPatchedSdkPath,
+      platform: TargetPlatform.android_arm,
+      mode: BuildMode.profile,
+    );
+    processManager.addCommands(<FakeCommand>[
+      FakeCommand(
+        command: <String>[
+          artifacts.getArtifactPath(Artifact.engineDartAotRuntime),
+          artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
+          '--sdk-root',
+          '$flutterPatchedSdkPath/',
+          '--target=flutter',
+          '--no-print-incremental-dependencies',
+          ...buildModeOptions(BuildMode.profile, <String>[]),
+          '--track-widget-creation',
+          '--aot',
+          '--tfa',
+          '--target-os',
+          'android',
+          '--packages',
+          '/.dart_tool/package_config.json',
+          '--output-dill',
+          '$build/app.dill',
+          '--depfile',
+          '$build/kernel_snapshot_program.d',
+          '--verbosity=error',
+          'foo',
+          'bar',
+          'file:///lib/main.dart',
+        ],
+        stdout: 'result $kBoundaryKey\n$kBoundaryKey\n$kBoundaryKey $build/app.dill 0\n',
+      ),
+    ]);
 
-      await const KernelSnapshot().build(
-        androidEnvironment..defines[kExtraFrontEndOptions] = 'foo,bar',
-      );
+    await const KernelSnapshot().build(
+      androidEnvironment..defines[kExtraFrontEndOptions] = 'foo,bar',
+    );
 
-      expect(processManager, hasNoRemainingExpectations);
-    },
-    overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()},
-  );
+    expect(processManager, hasNoRemainingExpectations);
+  }, overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()});
 
-  testUsingContext(
-    'KernelSnapshot can disable track-widget-creation on debug builds',
-    () async {
-      fileSystem.file('.dart_tool/package_config.json')
-        ..createSync(recursive: true)
-        ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
+  testUsingContext('KernelSnapshot can disable track-widget-creation on debug builds', () async {
+    fileSystem.file('.dart_tool/package_config.json')
+      ..createSync(recursive: true)
+      ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
 
-      final String build = androidEnvironment.buildDir.path;
-      final String flutterPatchedSdkPath = artifacts.getArtifactPath(
-        Artifact.flutterPatchedSdkPath,
-        platform: TargetPlatform.android_arm,
-        mode: BuildMode.debug,
-      );
-      processManager.addCommands(<FakeCommand>[
-        FakeCommand(
-          command: <String>[
-            artifacts.getArtifactPath(Artifact.engineDartAotRuntime),
-            artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
-            '--sdk-root',
-            '$flutterPatchedSdkPath/',
-            '--target=flutter',
-            '--no-print-incremental-dependencies',
-            ...buildModeOptions(BuildMode.debug, <String>[]),
-            '--no-link-platform',
-            '--packages',
-            '/.dart_tool/package_config.json',
-            '--output-dill',
-            '$build/app.dill',
-            '--depfile',
-            '$build/kernel_snapshot_program.d',
-            '--incremental',
-            '--initialize-from-dill',
-            '$build/app.dill',
-            '--verbosity=error',
-            'file:///lib/main.dart',
-          ],
-          stdout: 'result $kBoundaryKey\n$kBoundaryKey\n$kBoundaryKey $build/app.dill 0\n',
-        ),
-      ]);
+    final String build = androidEnvironment.buildDir.path;
+    final String flutterPatchedSdkPath = artifacts.getArtifactPath(
+      Artifact.flutterPatchedSdkPath,
+      platform: TargetPlatform.android_arm,
+      mode: BuildMode.debug,
+    );
+    processManager.addCommands(<FakeCommand>[
+      FakeCommand(
+        command: <String>[
+          artifacts.getArtifactPath(Artifact.engineDartAotRuntime),
+          artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
+          '--sdk-root',
+          '$flutterPatchedSdkPath/',
+          '--target=flutter',
+          '--no-print-incremental-dependencies',
+          ...buildModeOptions(BuildMode.debug, <String>[]),
+          '--no-link-platform',
+          '--packages',
+          '/.dart_tool/package_config.json',
+          '--output-dill',
+          '$build/app.dill',
+          '--depfile',
+          '$build/kernel_snapshot_program.d',
+          '--incremental',
+          '--initialize-from-dill',
+          '$build/app.dill',
+          '--verbosity=error',
+          'file:///lib/main.dart',
+        ],
+        stdout: 'result $kBoundaryKey\n$kBoundaryKey\n$kBoundaryKey $build/app.dill 0\n',
+      ),
+    ]);
 
-      await const KernelSnapshot().build(
-        androidEnvironment
-          ..defines[kBuildMode] = BuildMode.debug.cliName
-          ..defines[kTrackWidgetCreation] = 'false',
-      );
+    await const KernelSnapshot().build(
+      androidEnvironment
+        ..defines[kBuildMode] = BuildMode.debug.cliName
+        ..defines[kTrackWidgetCreation] = 'false',
+    );
 
-      expect(processManager, hasNoRemainingExpectations);
-    },
-    overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()},
-  );
+    expect(processManager, hasNoRemainingExpectations);
+  }, overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()});
 
   testUsingContext(
     'KernelSnapshot forces platform linking on debug for darwin target platforms',
@@ -639,64 +616,60 @@ void main() {
     },
   );
 
-  testUsingContext(
-    'KernelSnapshot does use track widget creation on debug builds',
-    () async {
-      fileSystem.file('.dart_tool/package_config.json')
-        ..createSync(recursive: true)
-        ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
-      final testEnvironment = Environment.test(
-        fileSystem.currentDirectory,
-        defines: <String, String>{
-          kBuildMode: BuildMode.debug.cliName,
-          kTargetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
-        },
-        processManager: processManager,
-        artifacts: artifacts,
-        fileSystem: fileSystem,
-        logger: logger,
-      );
-      final String build = testEnvironment.buildDir.path;
-      final String flutterPatchedSdkPath = artifacts.getArtifactPath(
-        Artifact.flutterPatchedSdkPath,
-        platform: TargetPlatform.android_arm,
-        mode: BuildMode.debug,
-      );
-      processManager.addCommands(<FakeCommand>[
-        FakeCommand(
-          command: <String>[
-            artifacts.getArtifactPath(Artifact.engineDartAotRuntime),
-            artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
-            '--sdk-root',
-            '$flutterPatchedSdkPath/',
-            '--target=flutter',
-            '--no-print-incremental-dependencies',
-            ...buildModeOptions(BuildMode.debug, <String>[]),
-            '--track-widget-creation',
-            '--no-link-platform',
-            '--packages',
-            '/.dart_tool/package_config.json',
-            '--output-dill',
-            '$build/app.dill',
-            '--depfile',
-            '$build/kernel_snapshot_program.d',
-            '--incremental',
-            '--initialize-from-dill',
-            '$build/app.dill',
-            '--verbosity=error',
-            'file:///lib/main.dart',
-          ],
-          stdout:
-              'result $kBoundaryKey\n$kBoundaryKey\n$kBoundaryKey /build/653e11a8e6908714056a57cd6b4f602a/app.dill 0\n',
-        ),
-      ]);
+  testUsingContext('KernelSnapshot does use track widget creation on debug builds', () async {
+    fileSystem.file('.dart_tool/package_config.json')
+      ..createSync(recursive: true)
+      ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
+    final testEnvironment = Environment.test(
+      fileSystem.currentDirectory,
+      defines: <String, String>{
+        kBuildMode: BuildMode.debug.cliName,
+        kTargetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
+      },
+      processManager: processManager,
+      artifacts: artifacts,
+      fileSystem: fileSystem,
+      logger: logger,
+    );
+    final String build = testEnvironment.buildDir.path;
+    final String flutterPatchedSdkPath = artifacts.getArtifactPath(
+      Artifact.flutterPatchedSdkPath,
+      platform: TargetPlatform.android_arm,
+      mode: BuildMode.debug,
+    );
+    processManager.addCommands(<FakeCommand>[
+      FakeCommand(
+        command: <String>[
+          artifacts.getArtifactPath(Artifact.engineDartAotRuntime),
+          artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
+          '--sdk-root',
+          '$flutterPatchedSdkPath/',
+          '--target=flutter',
+          '--no-print-incremental-dependencies',
+          ...buildModeOptions(BuildMode.debug, <String>[]),
+          '--track-widget-creation',
+          '--no-link-platform',
+          '--packages',
+          '/.dart_tool/package_config.json',
+          '--output-dill',
+          '$build/app.dill',
+          '--depfile',
+          '$build/kernel_snapshot_program.d',
+          '--incremental',
+          '--initialize-from-dill',
+          '$build/app.dill',
+          '--verbosity=error',
+          'file:///lib/main.dart',
+        ],
+        stdout:
+            'result $kBoundaryKey\n$kBoundaryKey\n$kBoundaryKey /build/653e11a8e6908714056a57cd6b4f602a/app.dill 0\n',
+      ),
+    ]);
 
-      await const KernelSnapshot().build(testEnvironment);
+    await const KernelSnapshot().build(testEnvironment);
 
-      expect(processManager, hasNoRemainingExpectations);
-    },
-    overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()},
-  );
+    expect(processManager, hasNoRemainingExpectations);
+  }, overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()});
 
   testUsingContext('AotElfProfile Produces correct output directory', () async {
     final String build = androidEnvironment.buildDir.path;
@@ -926,7 +899,7 @@ class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterprete
 
   @override
   Future<XcodeProjectInfo?> getInfo(
-    String projectPath, {
+    XcodeBasedProject xcodeProject, {
     required Directory buildDirectory,
     String? projectFilename,
   }) async {

--- a/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
@@ -17,6 +17,7 @@ import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/build_system/targets/ios.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
+import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:test/fake.dart';
 import 'package:unified_analytics/unified_analytics.dart';
@@ -1622,7 +1623,7 @@ class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterprete
 
   @override
   Future<XcodeProjectInfo?> getInfo(
-    String projectPath, {
+    XcodeBasedProject xcodeProject, {
     required Directory buildDirectory,
     String? projectFilename,
   }) async {

--- a/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/build_system/targets/macos.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
+import 'package:flutter_tools/src/project.dart';
 import 'package:test/fake.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 
@@ -954,7 +955,7 @@ class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterprete
 
   @override
   Future<XcodeProjectInfo?> getInfo(
-    String projectPath, {
+    XcodeBasedProject xcodeProject, {
     required Directory buildDirectory,
     String? projectFilename,
   }) async {

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
@@ -1537,7 +1537,7 @@ class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterprete
 
   @override
   Future<List<String>> fetchDependenciesAndGenerateXcodebuildArgs(
-    String projectPath,
+    XcodeBasedProject xcodeProject,
     Directory buildDirectory, {
     bool skipPackageUpdatesAndValidation = true,
   }) async {
@@ -1546,14 +1546,14 @@ class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterprete
 
   @override
   Future<XcodeProjectInfo?> getInfo(
-    String projectPath, {
+    XcodeBasedProject xcodeProject, {
     String? projectFilename,
     required Directory buildDirectory,
   }) async => projectInfo;
 
   @override
   Future<Map<String, String>> getBuildSettings(
-    String projectPath, {
+    XcodeBasedProject xcodeProject, {
     required XcodeProjectBuildContext buildContext,
     Duration timeout = const Duration(minutes: 1),
   }) async => buildSettings;

--- a/packages/flutter_tools/test/general.shard/ios/mac_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/mac_test.dart
@@ -1321,7 +1321,7 @@ class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterprete
 
   @override
   Future<XcodeProjectInfo?> getInfo(
-    String projectPath, {
+    XcodeBasedProject xcodeProject, {
     String? projectFilename,
     required Directory buildDirectory,
   }) async {
@@ -1335,7 +1335,7 @@ class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterprete
 
   @override
   Future<List<String>> fetchDependenciesAndGenerateXcodebuildArgs(
-    String projectPath,
+    XcodeBasedProject xcodeProject,
     Directory buildDirectory, {
     bool skipPackageUpdatesAndValidation = true,
   }) async {

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -17,6 +17,7 @@ import 'package:flutter_tools/src/ios/xcode_build_settings.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
 import 'package:flutter_tools/src/macos/xcode.dart';
 import 'package:flutter_tools/src/project.dart';
+import 'package:test/fake.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 
 import '../../src/common.dart';
@@ -306,7 +307,7 @@ void main() {
 
       expect(
         await xcodeProjectInterpreter.getBuildSettings(
-          '',
+          FakeXcodeBasedProject('', fileSystem),
           buildContext: const XcodeProjectBuildContext(deviceId: '123', scheme: 'Free'),
         ),
         const <String, String>{},
@@ -353,7 +354,7 @@ void main() {
 
       expect(
         await xcodeProjectInterpreter.getBuildSettings(
-          '',
+          FakeXcodeBasedProject('', fileSystem),
           buildContext: const XcodeProjectBuildContext(sdk: XcodeSdk.IPhoneSimulator),
         ),
         const <String, String>{},
@@ -398,7 +399,7 @@ void main() {
 
       expect(
         await xcodeProjectInterpreter.getBuildSettings(
-          '',
+          FakeXcodeBasedProject('', fileSystem),
           buildContext: const XcodeProjectBuildContext(),
         ),
         const <String, String>{},
@@ -447,7 +448,7 @@ void main() {
       ]);
       expect(
         await xcodeProjectInterpreter.getBuildSettings(
-          '',
+          FakeXcodeBasedProject('', fileSystem),
           buildContext: const XcodeProjectBuildContext(scheme: 'Free'),
         ),
         const <String, String>{},
@@ -492,7 +493,7 @@ void main() {
 
       expect(
         await xcodeProjectInterpreter.getBuildSettings(
-          '',
+          FakeXcodeBasedProject('', fileSystem),
           buildContext: const XcodeProjectBuildContext(sdk: XcodeSdk.WatchOS),
         ),
         const <String, String>{},
@@ -537,7 +538,7 @@ void main() {
 
       expect(
         await xcodeProjectInterpreter.getBuildSettings(
-          '',
+          FakeXcodeBasedProject('', fileSystem),
           buildContext: const XcodeProjectBuildContext(sdk: XcodeSdk.WatchSimulator),
         ),
         const <String, String>{},
@@ -598,7 +599,7 @@ void main() {
 
       expect(
         await xcodeProjectInterpreter.getBuildSettings(
-          '',
+          FakeXcodeBasedProject('', fileSystem),
           buildContext: const XcodeProjectBuildContext(sdk: XcodeSdk.MacOSX),
         ),
         const <String, String>{},
@@ -645,6 +646,7 @@ void main() {
     ]);
 
     await xcodeProjectInterpreter.cleanWorkspace(
+      FakeXcodeBasedProject('', fileSystem),
       'workspace_path',
       'Free',
       buildDirectory: buildDirectory,
@@ -685,7 +687,10 @@ void main() {
       );
 
       expect(
-        await xcodeProjectInterpreter.getInfo(workingDirectory, buildDirectory: buildDirectory),
+        await xcodeProjectInterpreter.getInfo(
+          FakeXcodeBasedProject(workingDirectory, fileSystem),
+          buildDirectory: buildDirectory,
+        ),
         isNotNull,
       );
       expect(fakeProcessManager, hasNoRemainingExpectations);
@@ -729,7 +734,10 @@ void main() {
       );
 
       await expectLater(
-        () => xcodeProjectInterpreter.getInfo(workingDirectory, buildDirectory: buildDirectory),
+        () => xcodeProjectInterpreter.getInfo(
+          FakeXcodeBasedProject(workingDirectory, fileSystem),
+          buildDirectory: buildDirectory,
+        ),
         throwsToolExit(message: stderr),
       );
       expect(fakeProcessManager, hasNoRemainingExpectations);
@@ -773,7 +781,10 @@ void main() {
       );
 
       await expectLater(
-        () => xcodeProjectInterpreter.getInfo(workingDirectory, buildDirectory: buildDirectory),
+        () => xcodeProjectInterpreter.getInfo(
+          FakeXcodeBasedProject(workingDirectory, fileSystem),
+          buildDirectory: buildDirectory,
+        ),
         throwsToolExit(message: stderr),
       );
       expect(fakeProcessManager, hasNoRemainingExpectations);
@@ -2550,7 +2561,7 @@ Resolved source packages:
         analytics: const NoOpAnalytics(),
       );
       await xcodeProjectInterpreter.prefetchSwiftPackages(
-        projectPath,
+        FakeXcodeBasedProject(projectPath, fs),
         buildDirectory: buildDirectory,
         quiet: false,
       );
@@ -2608,7 +2619,7 @@ Xcode is fetching Swift Package Manager dependencies. This may take several minu
       analytics: const NoOpAnalytics(),
     );
     await xcodeProjectInterpreter.prefetchSwiftPackages(
-      projectPath,
+      FakeXcodeBasedProject(projectPath, fs),
       buildDirectory: buildDirectory,
       quiet: false,
     );
@@ -2656,7 +2667,7 @@ Xcode is fetching Swift Package Manager dependencies. This may take several minu
         analytics: const NoOpAnalytics(),
       );
       await xcodeProjectInterpreter.prefetchSwiftPackages(
-        projectPath,
+        FakeXcodeBasedProject(projectPath, fs),
         buildDirectory: buildDirectory,
         quiet: false,
       );
@@ -2705,14 +2716,14 @@ Xcode is fetching Swift Package Manager dependencies. This may take several minu
     );
 
     await xcodeProjectInterpreter.prefetchSwiftPackages(
-      projectPath,
+      FakeXcodeBasedProject(projectPath, fs),
       buildDirectory: buildDirectory,
       quiet: false,
     );
     expect(fakeProcessManager, hasNoRemainingExpectations);
 
     await xcodeProjectInterpreter.prefetchSwiftPackages(
-      projectPath,
+      FakeXcodeBasedProject(projectPath, fs),
       buildDirectory: buildDirectory,
       quiet: false,
     );
@@ -2781,7 +2792,7 @@ Resolved source packages:
       analytics: const NoOpAnalytics(),
     );
     await xcodeProjectInterpreter.prefetchSwiftPackages(
-      projectPath,
+      FakeXcodeBasedProject(projectPath, fs),
       buildDirectory: buildDirectory,
     );
     expect(fakeProcessManager, hasNoRemainingExpectations);
@@ -2855,7 +2866,7 @@ Resolved source packages:
         analytics: const NoOpAnalytics(),
       );
       await xcodeProjectInterpreter.prefetchSwiftPackages(
-        projectPath,
+        FakeXcodeBasedProject(projectPath, fs),
         buildDirectory: buildDirectory,
         waitForCompletion: false,
       );
@@ -2907,7 +2918,7 @@ Resolved source packages:
     );
     await expectLater(
       xcodeProjectInterpreter.prefetchSwiftPackages(
-        projectPath,
+        FakeXcodeBasedProject(projectPath, fs),
         buildDirectory: buildDirectory,
         quiet: false,
       ),
@@ -2930,4 +2941,18 @@ Resolved source packages:
       '/build/ios/SourcePackages',
     );
   });
+}
+
+class FakeXcodeBasedProject extends Fake implements XcodeBasedProject {
+  FakeXcodeBasedProject(this.path, [FileSystem? fileSystem])
+    : fs = fileSystem ?? MemoryFileSystem.test();
+
+  final String path;
+  final FileSystem fs;
+
+  @override
+  Directory get hostAppRoot => fs.directory(path);
+
+  @override
+  Directory get xcodeProject => fs.directory(path);
 }

--- a/packages/flutter_tools/test/general.shard/macos/darwin_dependency_management_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/darwin_dependency_management_test.dart
@@ -1555,7 +1555,7 @@ class FakePluginPlatform extends Fake implements PluginPlatform {}
 class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterpreter {
   @override
   Future<void> prefetchSwiftPackages(
-    String projectPath, {
+    XcodeBasedProject xcodeProject, {
     required Directory buildDirectory,
     bool quiet = true,
     bool waitForCompletion = true,

--- a/packages/flutter_tools/test/general.shard/migrations/swift_package_manager_integration_migration_test.dart
+++ b/packages/flutter_tools/test/general.shard/migrations/swift_package_manager_integration_migration_test.dart
@@ -4519,7 +4519,7 @@ class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterprete
 
   @override
   Future<XcodeProjectInfo?> getInfo(
-    String projectPath, {
+    XcodeBasedProject xcodeProject, {
     String? projectFilename,
     required Directory buildDirectory,
   }) async {

--- a/packages/flutter_tools/test/general.shard/project_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_test.dart
@@ -2639,7 +2639,7 @@ class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterprete
 
   @override
   Future<Map<String, String>> getBuildSettings(
-    String projectPath, {
+    XcodeBasedProject xcodeProject, {
     XcodeProjectBuildContext? buildContext,
     Duration timeout = const Duration(minutes: 1),
   }) async {
@@ -2651,7 +2651,7 @@ class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterprete
 
   @override
   Future<XcodeProjectInfo> getInfo(
-    String projectPath, {
+    XcodeBasedProject xcodeProject, {
     String? projectFilename,
     required Directory buildDirectory,
   }) async {

--- a/packages/flutter_tools/test/general.shard/xcode_project_test.dart
+++ b/packages/flutter_tools/test/general.shard/xcode_project_test.dart
@@ -111,16 +111,12 @@ void main() {
     });
 
     group('projectInfo', () {
-      testUsingContext(
-        'is null if XcodeProjectInterpreter is null',
-        () async {
-          final fs = MemoryFileSystem.test();
-          final project = IosProject.fromFlutter(FakeFlutterProject(fileSystem: fs));
-          project.xcodeProject.createSync(recursive: true);
-          expect(await project.projectInfo(), isNull);
-        },
-        overrides: <Type, Generator>{XcodeProjectInterpreter: () => null},
-      );
+      testUsingContext('is null if XcodeProjectInterpreter is null', () async {
+        final fs = MemoryFileSystem.test();
+        final project = IosProject.fromFlutter(FakeFlutterProject(fileSystem: fs));
+        project.xcodeProject.createSync(recursive: true);
+        expect(await project.projectInfo(), isNull);
+      }, overrides: <Type, Generator>{XcodeProjectInterpreter: () => null});
 
       testUsingContext(
         'is null if XcodeProjectInterpreter is not installed',
@@ -157,28 +153,20 @@ void main() {
       );
     });
 
-    testUsingContext(
-      'schemeForBuildInfo succeeds',
-      () async {
-        final fs = MemoryFileSystem.test();
-        final project = IosProject.fromFlutter(FakeFlutterProject(fileSystem: fs));
-        project.xcodeProject.createSync(recursive: true);
-        const BuildInfo buildInfo = BuildInfo.debug;
-        expect(await project.schemeForBuildInfo(buildInfo), 'Runner');
-      },
-      overrides: <Type, Generator>{XcodeProjectInterpreter: () => FakeXcodeProjectInterpreter()},
-    );
+    testUsingContext('schemeForBuildInfo succeeds', () async {
+      final fs = MemoryFileSystem.test();
+      final project = IosProject.fromFlutter(FakeFlutterProject(fileSystem: fs));
+      project.xcodeProject.createSync(recursive: true);
+      const BuildInfo buildInfo = BuildInfo.debug;
+      expect(await project.schemeForBuildInfo(buildInfo), 'Runner');
+    }, overrides: <Type, Generator>{XcodeProjectInterpreter: () => FakeXcodeProjectInterpreter()});
 
-    testUsingContext(
-      'schemeForBuildInfo returns null if unable to find project',
-      () async {
-        final fs = MemoryFileSystem.test();
-        final project = IosProject.fromFlutter(FakeFlutterProject(fileSystem: fs));
-        const BuildInfo buildInfo = BuildInfo.debug;
-        expect(await project.schemeForBuildInfo(buildInfo), isNull);
-      },
-      overrides: <Type, Generator>{XcodeProjectInterpreter: () => FakeXcodeProjectInterpreter()},
-    );
+    testUsingContext('schemeForBuildInfo returns null if unable to find project', () async {
+      final fs = MemoryFileSystem.test();
+      final project = IosProject.fromFlutter(FakeFlutterProject(fileSystem: fs));
+      const BuildInfo buildInfo = BuildInfo.debug;
+      expect(await project.schemeForBuildInfo(buildInfo), isNull);
+    }, overrides: <Type, Generator>{XcodeProjectInterpreter: () => FakeXcodeProjectInterpreter()});
 
     testUsingContext(
       'schemeForBuildInfo succeeds with flavor',
@@ -399,53 +387,42 @@ void main() {
 
     group('ensureReadyForPlatformSpecificTooling', () {
       group('lldb files are generated', () {
-        testUsingContext(
-          'when they are missing',
-          () async {
-            final fs = MemoryFileSystem.test();
-            final Directory projectDirectory = fs.directory('path');
-            projectDirectory.childDirectory('ios').createSync(recursive: true);
-            final FlutterManifest manifest = FakeFlutterManifest();
-            final flutterProject = FlutterProject(projectDirectory, manifest, manifest);
-            final project = IosProject.fromFlutter(flutterProject);
-            expect(project.lldbInitFile, isNot(exists));
-            expect(project.lldbHelperPythonFile, isNot(exists));
+        testUsingContext('when they are missing', () async {
+          final fs = MemoryFileSystem.test();
+          final Directory projectDirectory = fs.directory('path');
+          projectDirectory.childDirectory('ios').createSync(recursive: true);
+          final FlutterManifest manifest = FakeFlutterManifest();
+          final flutterProject = FlutterProject(projectDirectory, manifest, manifest);
+          final project = IosProject.fromFlutter(flutterProject);
+          expect(project.lldbInitFile, isNot(exists));
+          expect(project.lldbHelperPythonFile, isNot(exists));
 
-            await project.ensureReadyForPlatformSpecificTooling();
+          await project.ensureReadyForPlatformSpecificTooling();
 
-            expect(project.lldbInitFile, exists);
-            expect(project.lldbHelperPythonFile, exists);
-          },
-          overrides: <Type, Generator>{Cache: () => FakeCache(olderThanToolsStamp: true)},
-        );
+          expect(project.lldbInitFile, exists);
+          expect(project.lldbHelperPythonFile, exists);
+        }, overrides: <Type, Generator>{Cache: () => FakeCache(olderThanToolsStamp: true)});
 
-        testUsingContext(
-          'when they are older than tool',
-          () async {
-            final fs = MemoryFileSystem.test();
-            final Directory projectDirectory = fs.directory('path');
-            projectDirectory.childDirectory('ios').createSync(recursive: true);
-            final FlutterManifest manifest = FakeFlutterManifest();
-            final flutterProject = FlutterProject(projectDirectory, manifest, manifest);
-            final project = IosProject.fromFlutter(flutterProject);
-            project.lldbInitFile.createSync(recursive: true);
-            project.lldbInitFile.writeAsStringSync('old');
-            project.lldbHelperPythonFile.createSync(recursive: true);
-            project.lldbHelperPythonFile.writeAsStringSync('old');
+        testUsingContext('when they are older than tool', () async {
+          final fs = MemoryFileSystem.test();
+          final Directory projectDirectory = fs.directory('path');
+          projectDirectory.childDirectory('ios').createSync(recursive: true);
+          final FlutterManifest manifest = FakeFlutterManifest();
+          final flutterProject = FlutterProject(projectDirectory, manifest, manifest);
+          final project = IosProject.fromFlutter(flutterProject);
+          project.lldbInitFile.createSync(recursive: true);
+          project.lldbInitFile.writeAsStringSync('old');
+          project.lldbHelperPythonFile.createSync(recursive: true);
+          project.lldbHelperPythonFile.writeAsStringSync('old');
 
-            await project.ensureReadyForPlatformSpecificTooling();
+          await project.ensureReadyForPlatformSpecificTooling();
 
-            expect(
-              project.lldbInitFile.readAsStringSync(),
-              contains('Generated file, do not edit.'),
-            );
-            expect(
-              project.lldbHelperPythonFile.readAsStringSync(),
-              contains('Generated file, do not edit.'),
-            );
-          },
-          overrides: <Type, Generator>{Cache: () => FakeCache(olderThanToolsStamp: true)},
-        );
+          expect(project.lldbInitFile.readAsStringSync(), contains('Generated file, do not edit.'));
+          expect(
+            project.lldbHelperPythonFile.readAsStringSync(),
+            contains('Generated file, do not edit.'),
+          );
+        }, overrides: <Type, Generator>{Cache: () => FakeCache(olderThanToolsStamp: true)});
       });
     });
   });
@@ -618,7 +595,7 @@ class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterprete
 
   @override
   Future<XcodeProjectInfo?> getInfo(
-    String projectPath, {
+    XcodeBasedProject xcodeProject, {
     String? projectFilename,
     required Directory buildDirectory,
   }) async {

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -367,7 +367,7 @@ class FakeXcodeProjectInterpreter implements XcodeProjectInterpreter {
 
   @override
   Future<Map<String, String>> getBuildSettings(
-    String projectPath, {
+    XcodeBasedProject xcodeProject, {
     XcodeProjectBuildContext? buildContext,
     Duration timeout = const Duration(minutes: 1),
   }) async {
@@ -384,6 +384,7 @@ class FakeXcodeProjectInterpreter implements XcodeProjectInterpreter {
 
   @override
   Future<void> cleanWorkspace(
+    XcodeBasedProject xcodeProject,
     String workspacePath,
     String scheme, {
     required Directory buildDirectory,
@@ -392,7 +393,7 @@ class FakeXcodeProjectInterpreter implements XcodeProjectInterpreter {
 
   @override
   Future<XcodeProjectInfo> getInfo(
-    String projectPath, {
+    XcodeBasedProject xcodeProject, {
     String? projectFilename,
     required Directory buildDirectory,
   }) async {
@@ -406,7 +407,7 @@ class FakeXcodeProjectInterpreter implements XcodeProjectInterpreter {
 
   @override
   Future<void> prefetchSwiftPackages(
-    String projectPath, {
+    XcodeBasedProject xcodeProject, {
     required Directory buildDirectory,
     bool quiet = true,
     bool waitForCompletion = true,
@@ -414,7 +415,7 @@ class FakeXcodeProjectInterpreter implements XcodeProjectInterpreter {
 
   @override
   Future<List<String>> fetchDependenciesAndGenerateXcodebuildArgs(
-    String projectPath,
+    XcodeBasedProject xcodeProject,
     Directory buildDirectory, {
     bool skipPackageUpdatesAndValidation = true,
   }) async {


### PR DESCRIPTION
Pass `XcodeBasedProject` instead of the project path string.

This will enable us to be able to get more information about the project (other than just the project path) from places in `xcodeproj.dart`. Needed for https://github.com/flutter/flutter/pull/185218, https://github.com/flutter/flutter/pull/186006/changes#r3191012567

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
