### PR TITLE
[a11y assessment app] Update menu filter to support multi-tag selection

### DIFF
--- a/dev/a11y_assessments/lib/main.dart
+++ b/dev/a11y_assessments/lib/main.dart
@@ -117,7 +117,7 @@ class HomePageState extends State<HomePage> {
   @override
   Widget build(BuildContext context) {
     final List<UseCase> effectiveUseCases = useCases.where((UseCase useCase) {
-      return _selectedTags.isEmpty || _selectedTags.every((Tag tag) => useCase.tags.contains(tag));
+      return _selectedTags.isEmpty || _selectedTags.any((Tag tag) => useCase.tags.contains(tag));
     }).toList();
 
     return Scaffold(

--- a/dev/a11y_assessments/test/home_page_test.dart
+++ b/dev/a11y_assessments/test/home_page_test.dart
@@ -426,4 +426,30 @@ void main() {
     await tester.pumpAndSettle();
     expect(findHeadingLevelOnes, findsOne);
   });
+
+  testWidgets('Filter shows items from both batches when both are selected', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const App());
+    await tester.pumpAndSettle();
+
+    // Initially, only batch2 is selected by default.
+    // Verify a batch2 item is visible.
+    expect(find.text('AboutListTile'), findsOneWidget);
+    // Verify a batch1 item is not visible.
+    expect(find.text('CheckBoxListTile'), findsNothing);
+
+    // Open the filter menu.
+    await tester.tap(find.byTooltip('Filter by tags'));
+    await tester.pumpAndSettle();
+
+    // Select batch1.
+    await tester.tap(find.text('batch1'));
+    await tester.pumpAndSettle();
+
+    // Now both batch1 and batch2 should be selected.
+    // Verify both items are visible.
+    expect(find.text('AboutListTile'), findsOneWidget);
+    expect(find.text('CheckBoxListTile'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
