### PR TITLE
Fix AnimatedList.separated assert when removing last item mid-removal…

### DIFF
--- a/packages/flutter/lib/src/widgets/animated_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/animated_scroll_view.dart
@@ -749,10 +749,14 @@ abstract class _AnimatedScrollViewState<T extends _AnimatedScrollView> extends S
       _sliverAnimatedMultiBoxKey.currentState!.removeItem(index, builder, duration: duration);
     } else {
       final int itemIndex = _computeItemIndex(index);
+      // Children animating out from earlier removeItem calls still count
+      // towards [_itemsCount], so subtract them to recognize the new tail
+      // of the visible list while a previous removal is still in flight.
+      final int visibleItemsCount = _itemsCount - _outgoingItemsCount;
       // Remove the item
       _sliverAnimatedMultiBoxKey.currentState!.removeItem(itemIndex, builder, duration: duration);
-      if (_itemsCount > 1) {
-        if (itemIndex == _itemsCount - 1) {
+      if (visibleItemsCount > 1) {
+        if (itemIndex == visibleItemsCount - 1) {
           // The item was removed from the end of the list, so the separator to remove is the one at `last index` - 1.
           _sliverAnimatedMultiBoxKey.currentState!.removeItem(
             itemIndex - 1,
@@ -815,6 +819,8 @@ abstract class _AnimatedScrollViewState<T extends _AnimatedScrollView> extends S
   }
 
   int get _itemsCount => _sliverAnimatedMultiBoxKey.currentState!._itemsCount;
+
+  int get _outgoingItemsCount => _sliverAnimatedMultiBoxKey.currentState!._outgoingItems.length;
 
   // Helper method to compute the index for the item to insert or remove considering the separators in between.
   int _computeItemIndex(int index) {

--- a/packages/flutter/test/widgets/animated_list_test.dart
+++ b/packages/flutter/test/widgets/animated_list_test.dart
@@ -1204,6 +1204,81 @@ void main() {
     expect(itemsSeparatorsTexts[2].data, 'item 1');
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/186361
+  testWidgets(
+    'AnimatedList.separated can remove the last item while another item is still animating out',
+    (WidgetTester tester) async {
+      Widget itemBuilder(BuildContext context, int index, Animation<double> animation) {
+        return SizedBox(height: 100.0, child: Center(child: Text('item $index')));
+      }
+
+      Widget separatorBuilder(BuildContext context, int index, Animation<double> animation) {
+        return SizedBox(height: 10.0, child: Center(child: Text('separator $index')));
+      }
+
+      Widget removedSeparatorBuilder(BuildContext context, int index, Animation<double> animation) {
+        return SizedBox(height: 10.0, child: Center(child: Text('removing separator $index')));
+      }
+
+      AnimatedRemovedItemBuilder removedItemBuilder(int index) {
+        return (BuildContext context, Animation<double> animation) {
+          return SizedBox(height: 100.0, child: Center(child: Text('removing item $index')));
+        };
+      }
+
+      final listKey = GlobalKey<AnimatedListState>();
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: AnimatedList.separated(
+            key: listKey,
+            initialItemCount: 3,
+            itemBuilder: itemBuilder,
+            separatorBuilder: separatorBuilder,
+            removedSeparatorBuilder: removedSeparatorBuilder,
+          ),
+        ),
+      );
+
+      // Start removing a non-last item (index 0) with a long animation.
+      listKey.currentState!.removeItem(
+        0,
+        removedItemBuilder(0),
+        duration: const Duration(seconds: 10),
+      );
+      await tester.pump(const Duration(milliseconds: 50));
+
+      // While the first removal is still animating, remove the new last item.
+      // Before the fix this triggered an "itemIndex >= 0 && itemIndex < _itemsCount"
+      // assertion inside _SliverAnimatedMultiBoxAdaptorState.removeItem.
+      listKey.currentState!.removeItem(
+        1,
+        removedItemBuilder(2),
+        duration: const Duration(milliseconds: 100),
+      );
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('removing item 0'), findsOneWidget);
+      expect(find.text('removing item 2'), findsOneWidget);
+      // The surviving item is the originally-middle item. The itemBuilder
+      // rebuilds with its current user-facing index, which is 0 now.
+      expect(find.text('item 0'), findsOneWidget);
+      expect(find.text('item 1'), findsNothing);
+      expect(find.text('item 2'), findsNothing);
+
+      await tester.pumpAndSettle();
+
+      // All removal animations finished and the surviving item is alone.
+      expect(find.text('removing item 0'), findsNothing);
+      expect(find.text('removing item 2'), findsNothing);
+      expect(find.text('item 0'), findsOneWidget);
+      expect(find.text('item 1'), findsNothing);
+      expect(find.text('item 2'), findsNothing);
+    },
+  );
+
   testWidgets('AnimatedList does not crash at zero area', (WidgetTester tester) async {
     tester.view.physicalSize = Size.zero;
     final controller = ScrollController();


### PR DESCRIPTION
## Summary

`AnimatedList.separated.removeItem` used the sliver's total child count (`_itemsCount`) to decide whether the just-removed item was the last item in the list. That count still includes children animating out from earlier `removeItem` calls, so while a previous removal was in flight the new tail of the visible list was misclassified as a middle item. The separator removal then targeted the wrong index, and once the item being removed was added to `_outgoingItems` the next `_indexToItemIndex` lookup ran past `_itemsCount` and tripped the `itemIndex >= 0 && itemIndex < _itemsCount` assertion inside `_SliverAnimatedMultiBoxAdaptorState.removeItem`.

The fix captures `_itemsCount - _outgoingItems.length` before mutating the sliver and uses that visible count for both the "are there enough items to have a separator?" and "is this the new last item?" checks. When no removal is in flight `_outgoingItems` is empty and behavior is unchanged, so existing `.separated` coverage and the `removeAllItems` regression test from #176452 continue to pass.

## Related issues

Fixes #186361.

Related prior fix for the non-separated `removeAllItems` variant: #176452 (issue #176362).

## Test plan

- [x] Added a regression test in `packages/flutter/test/widgets/animated_list_test.dart` that reproduces the assertion on master and passes with this change: starts a 10s removal on a non-last item, pumps part of the animation, then removes the new last item, and asserts no exception is thrown.
- [x] `flutter test packages/flutter/test/widgets/animated_list_test.dart packages/flutter/test/widgets/animated_grid_test.dart` — 34 tests pass, including the existing comprehensive `AnimatedList.separated` test and the `removeAllItems` regression test from #176452.
- [x] `dart analyze` on the touched files: no issues.
- [x] Manually verified with the reproducer from the issue: before the fix the assertion fires in the debug console; after the fix the second removal animates out cleanly.

## AI disclosure

Written with assistance from Claude Code (Anthropic). I reviewed every change, ran the tests, and verified the fix manually before submitting.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md