### PR TITLE
Remove no-shuffle tag from dropdown_test.dart

### DIFF
--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -4161,36 +4161,34 @@ void main() {
     );
   });
 
-  testWidgets(
-    'Conflicting scrollbars are not applied by ScrollBehavior to Dropdown',
-    (WidgetTester tester) async {
-      // Regression test for https://github.com/flutter/flutter/issues/83819
-      // Open the dropdown menu
-      final Key buttonKey = UniqueKey();
-      await tester.pumpWidget(
-        buildFrame(
-          buttonKey: buttonKey,
-          initialValue: null, // nothing selected
-          items: List<String>.generate(100, (int index) => index.toString()),
-          onChanged: onChanged,
-        ),
-      );
-      await tester.tap(find.byKey(buttonKey));
-      await tester.pump();
-      await tester.pumpAndSettle(); // finish the menu animation
+  testWidgets('Conflicting scrollbars are not applied by ScrollBehavior to Dropdown', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/83819
+    // Open the dropdown menu
+    final Key buttonKey = UniqueKey();
+    await tester.pumpWidget(
+      buildFrame(
+        buttonKey: buttonKey,
+        initialValue: null, // nothing selected
+        items: List<String>.generate(100, (int index) => index.toString()),
+        onChanged: onChanged,
+      ),
+    );
+    await tester.tap(find.byKey(buttonKey));
+    await tester.pump();
+    await tester.pumpAndSettle(); // finish the menu animation
 
-      // The inherited ScrollBehavior should not apply Scrollbars since they are
-      // already built in to the widget. For iOS platform, ScrollBar directly returns
-      // CupertinoScrollbar
-      expect(
-        find.byType(CupertinoScrollbar),
-        debugDefaultTargetPlatformOverride == TargetPlatform.iOS ? findsOneWidget : findsNothing,
-      );
-      expect(find.byType(Scrollbar), findsOneWidget);
-      expect(find.byType(RawScrollbar), findsNothing);
-    },
-    variant: TargetPlatformVariant.all(),
-  );
+    // The inherited ScrollBehavior should not apply Scrollbars since they are
+    // already built in to the widget. For iOS platform, ScrollBar directly returns
+    // CupertinoScrollbar
+    expect(
+      find.byType(CupertinoScrollbar),
+      debugDefaultTargetPlatformOverride == TargetPlatform.iOS ? findsOneWidget : findsNothing,
+    );
+    expect(find.byType(Scrollbar), findsOneWidget);
+    expect(find.byType(RawScrollbar), findsNothing);
+  }, variant: TargetPlatformVariant.all());
 
   testWidgets('borderRadius property works properly', (WidgetTester tester) async {
     const radius = 20.0;

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -2,15 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// no-shuffle:
-//   //TODO(gspencergoog): Remove this tag once this test's state leaks/test
-//   dependencies have been fixed.
-//   https://github.com/flutter/flutter/issues/85160
-//   Fails with "flutter test --test-randomize-ordering-seed=456"
 // reduced-test-set:
 //   This file is run as part of a reduced test set in CI on Mac and Windows
 //   machines.
-@Tags(<String>['reduced-test-set', 'no-shuffle'])
+@Tags(<String>['reduced-test-set'])
 library;
 
 import 'dart:math' as math;


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/85160

It seems, the tests were already fixed, when I run with the seed `456` or `1408669812`

```
flutter test test/material/dropdown_test.dart --test-randomize-ordering-seed=1408669812   
Building flutter tool...
Resolving dependencies... (1.0s)
Downloading packages... 
Got dependencies.
Resolving dependencies in `/Users/valentinvignal/Projects/flutter`... 
Downloading packages... 
  _fe_analyzer_shared 95.0.0 (100.0.0 available)
  adaptive_breakpoints 0.1.7 (discontinued)
  analyzer 10.1.0 (13.0.0 available)
  archive 3.6.1 (4.0.9 available)
  cli_util 0.4.2 (0.5.1 available)
  dart_style 3.1.7 (3.1.9 available)
  device_info 2.0.3 (discontinued replaced by device_info_plus)
  devtools_shared 12.1.0 (13.0.1 available)
  gcloud 0.8.19 (0.9.0 available)
  google_fonts 6.3.3 (8.1.0 available)
  googleapis 14.0.0 (16.0.0 available)
  googleapis_auth 2.3.0 (2.3.1 available)
  isolate 2.1.1 (discontinued)
  js 0.7.2 (discontinued)
  native_toolchain_c 0.17.6 (0.18.0 available)
  pedantic 1.11.1 (discontinued replaced by lints)
  video_player_avfoundation 2.9.5 (2.9.6 available)
  xml 6.6.1 (7.0.1 available)
Got dependencies in `/Users/valentinvignal/Projects/flutter`!
5 packages are discontinued.
13 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
Shuffling test order with --test-randomize-ordering-seed=1408669812
00:32 +123: All tests passed!       
```



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
