### PR TITLE
Update Fuchsia tests to use realm_builder_server as a subpackage

### DIFF
--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_aot_runner/BUILD.gn
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_aot_runner/BUILD.gn
@@ -40,6 +40,7 @@ executable("dart-aot-runner-integration-test-bin") {
 fuchsia_test_archive("dart-aot-runner-integration-test") {
   deps = [ ":dart-aot-runner-integration-test-bin" ]
   subpackages = [
+    "${fuchsia_sdk}/packages/realm_builder_server",
     "../dart_echo_server:aot_echo_package",
     "//flutter/shell/platform/fuchsia/dart_runner:dart_aot_runner",
   ]

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_aot_runner/meta/dart-aot-runner-integration-test.cml
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_aot_runner/meta/dart-aot-runner-integration-test.cml
@@ -5,7 +5,7 @@
 {
     include: [
         "sys/testing/gtest_runner.shard.cml",
-        "sys/component/realm_builder_absolute.shard.cml",
+        "sys/component/realm_builder_subpackage.shard.cml",
 
         // This test needs both the vulkan facet and the hermetic-tier-2 facet,
         // so we are forced to make it a system test.
@@ -40,12 +40,4 @@
             to: "#realm_builder",
         },
     ],
-    // TODO(https://fxbug.dev/114584): Figure out how to bring these in as deps (if possible oot).
-    facets: {
-        "fuchsia.test": {
-            "deprecated-allowed-packages": [
-                "test_manager"
-            ],
-        },
-    },
 }

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_jit_runner/BUILD.gn
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_jit_runner/BUILD.gn
@@ -40,6 +40,7 @@ executable("dart-jit-runner-integration-test-bin") {
 fuchsia_test_archive("dart-jit-runner-integration-test") {
   deps = [ ":dart-jit-runner-integration-test-bin" ]
   subpackages = [
+    "${fuchsia_sdk}/packages/realm_builder_server",
     "../dart_echo_server:jit_echo_package",
     "//flutter/shell/platform/fuchsia/dart_runner:dart_jit_runner",
   ]

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_jit_runner/meta/dart-jit-runner-integration-test.cml
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_jit_runner/meta/dart-jit-runner-integration-test.cml
@@ -5,7 +5,7 @@
 {
     include: [
         "sys/testing/gtest_runner.shard.cml",
-        "sys/component/realm_builder_absolute.shard.cml",
+        "sys/component/realm_builder_subpackage.shard.cml",
 
         // This test needs both the vulkan facet and the hermetic-tier-2 facet,
         // so we are forced to make it a system test.
@@ -45,12 +45,4 @@
             to: "#realm_builder",
         },
     ],
-    // TODO(https://fxbug.dev/114584): Figure out how to bring these in as deps (if possible oot).
-    facets: {
-        "fuchsia.test": {
-            "deprecated-allowed-packages": [
-                "test_manager"
-            ],
-        },
-    },
 }

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/embedder/BUILD.gn
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/embedder/BUILD.gn
@@ -52,11 +52,12 @@ executable("flutter-embedder-test-bin") {
 fuchsia_test_archive("flutter-embedder-test") {
   deps = [ ":flutter-embedder-test-bin" ]
   subpackages = [
+    "${fuchsia_sdk}/packages/realm_builder_server",
     "child-view:package",
     "parent-view:package",
-    "//flutter/shell/platform/fuchsia/flutter:flutter_jit_runner",
-    "//flutter/shell/platform/fuchsia/flutter:flutter_jit_product_runner",
-    "//flutter/shell/platform/fuchsia/flutter:flutter_aot_runner",
     "//flutter/shell/platform/fuchsia/flutter:flutter_aot_product_runner",
+    "//flutter/shell/platform/fuchsia/flutter:flutter_aot_runner",
+    "//flutter/shell/platform/fuchsia/flutter:flutter_jit_product_runner",
+    "//flutter/shell/platform/fuchsia/flutter:flutter_jit_runner",
   ]
 }

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/embedder/meta/flutter-embedder-test.cml
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/embedder/meta/flutter-embedder-test.cml
@@ -4,7 +4,7 @@
 {
     include: [
         "sys/testing/gtest_runner.shard.cml",
-        "sys/component/realm_builder_absolute.shard.cml",
+        "sys/component/realm_builder_subpackage.shard.cml",
 
         // This test needs both the vulkan facet and the hermetic-tier-2 facet,
         // so we are forced to make it a system test.
@@ -36,8 +36,7 @@
     facets: {
         "fuchsia.test": {
             "deprecated-allowed-packages": [
-                "flatland-scene-manager-test-ui-stack",
-                "test_manager"
+                "flatland-scene-manager-test-ui-stack"
             ],
         },
     },

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/mouse-input/BUILD.gn
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/mouse-input/BUILD.gn
@@ -55,6 +55,7 @@ executable("mouse-input-test-bin") {
 fuchsia_test_archive("mouse-input-test") {
   deps = [ ":mouse-input-test-bin" ]
   subpackages = [
+    "${fuchsia_sdk}/packages/realm_builder_server",
     "mouse-input-view:package",
     "//flutter/shell/platform/fuchsia/flutter:flutter_jit_runner",
   ]

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/mouse-input/meta/mouse-input-test.cml
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/mouse-input/meta/mouse-input-test.cml
@@ -4,7 +4,7 @@
 {
     include: [
         "sys/testing/gtest_runner.shard.cml",
-        "sys/component/realm_builder_absolute.shard.cml",
+        "sys/component/realm_builder_subpackage.shard.cml",
 
         // This test needs both the vulkan facet and the hermetic-tier-2 facet,
         // so we are forced to make it a system test.
@@ -67,8 +67,7 @@
     facets: {
         "fuchsia.test": {
             "deprecated-allowed-packages": [
-                "flatland-scene-manager-test-ui-stack",
-                "test_manager"
+                "flatland-scene-manager-test-ui-stack"
             ],
         },
     },

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/text-input/BUILD.gn
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/text-input/BUILD.gn
@@ -52,6 +52,7 @@ executable("text-input-test-bin") {
 fuchsia_test_archive("text-input-test") {
   deps = [ ":text-input-test-bin" ]
   subpackages = [
+    "${fuchsia_sdk}/packages/realm_builder_server",
     "text-input-view:package",
     "//flutter/shell/platform/fuchsia/flutter:flutter_jit_runner",
   ]

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/text-input/meta/text-input-test.cml
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/text-input/meta/text-input-test.cml
@@ -4,7 +4,7 @@
 {
     include: [
         "sys/testing/gtest_runner.shard.cml",
-        "sys/component/realm_builder_absolute.shard.cml",
+        "sys/component/realm_builder_subpackage.shard.cml",
 
         // This test needs both the vulkan facet and the hermetic-tier-2 facet,
         // so we are forced to make it a system test.
@@ -68,8 +68,7 @@
     facets: {
         "fuchsia.test": {
             "deprecated-allowed-packages": [
-                "flatland-scene-manager-test-ui-stack",
-                "test_manager"
+                "flatland-scene-manager-test-ui-stack"
             ],
         },
     },

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/touch-input/BUILD.gn
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/touch-input/BUILD.gn
@@ -55,6 +55,7 @@ executable("touch-input-test-bin") {
 fuchsia_test_archive("touch-input-test") {
   deps = [ ":touch-input-test-bin" ]
   subpackages = [
+    "${fuchsia_sdk}/packages/realm_builder_server",
     "embedding-flutter-view:package",
     "touch-input-view:package",
     "//flutter/shell/platform/fuchsia/flutter:flutter_jit_runner",

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/touch-input/meta/touch-input-test.cml
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/touch-input/meta/touch-input-test.cml
@@ -4,7 +4,7 @@
 {
     include: [
         "sys/testing/gtest_runner.shard.cml",
-        "sys/component/realm_builder_absolute.shard.cml",
+        "sys/component/realm_builder_subpackage.shard.cml",
 
         // This test needs both the vulkan facet and the hermetic-tier-2 facet,
         // so we are forced to make it a system test.
@@ -59,8 +59,7 @@
     facets: {
         "fuchsia.test": {
             "deprecated-allowed-packages": [
-                "flatland-scene-manager-test-ui-stack",
-                "test_manager"
+                "flatland-scene-manager-test-ui-stack"
             ],
         },
     },

--- a/engine/src/flutter/testing/fuchsia/meta/test_suite.cml
+++ b/engine/src/flutter/testing/fuchsia/meta/test_suite.cml
@@ -1,6 +1,6 @@
 {
     include: [
-         "sys/component/realm_builder_absolute.shard.cml",
+         "sys/component/realm_builder_subpackage.shard.cml",
 
         // TODO(https://fxbug.dev/404543928): Remove this shard usage when possible
         // and replace with explicit routes.


### PR DESCRIPTION
Using the realm builder server as a subpackage allows for more hermetic packaging and is what is the recommended approach in the Fuchsia open source project.