### PR TITLE
Adds device metrics override

### DIFF
--- a/packages/flutter/lib/src/foundation/binding.dart
+++ b/packages/flutter/lib/src/foundation/binding.dart
@@ -609,21 +609,21 @@ abstract class BindingBase {
         name: FoundationServiceExtensions.brightnessOverride.name,
         callback: (Map<String, String> parameters) async {
           if (parameters.containsKey('value')) {
-            debugDeviceMetricsOverrides.brightness = switch (parameters['value']) {
+            debugPlatformOverrides.platformBrightness = switch (parameters['value']) {
               'Brightness.light' => ui.Brightness.light,
               'Brightness.dark' => ui.Brightness.dark,
               _ => null,
             };
             _postExtensionStateChangedEvent(
               FoundationServiceExtensions.brightnessOverride.name,
-              (debugDeviceMetricsOverrides.brightness ?? platformDispatcher.platformBrightness)
+              (debugPlatformOverrides.platformBrightness ?? platformDispatcher.platformBrightness)
                   .toString(),
             );
             await reassembleApplication();
           }
           return <String, dynamic>{
             'value':
-                (debugDeviceMetricsOverrides.brightness ?? platformDispatcher.platformBrightness)
+                (debugPlatformOverrides.platformBrightness ?? platformDispatcher.platformBrightness)
                     .toString(),
           };
         },

--- a/packages/flutter/lib/src/foundation/binding.dart
+++ b/packages/flutter/lib/src/foundation/binding.dart
@@ -609,19 +609,22 @@ abstract class BindingBase {
         name: FoundationServiceExtensions.brightnessOverride.name,
         callback: (Map<String, String> parameters) async {
           if (parameters.containsKey('value')) {
-            debugBrightnessOverride = switch (parameters['value']) {
+            debugDeviceMetricsOverrides.brightness = switch (parameters['value']) {
               'Brightness.light' => ui.Brightness.light,
               'Brightness.dark' => ui.Brightness.dark,
               _ => null,
             };
             _postExtensionStateChangedEvent(
               FoundationServiceExtensions.brightnessOverride.name,
-              (debugBrightnessOverride ?? platformDispatcher.platformBrightness).toString(),
+              (debugDeviceMetricsOverrides.brightness ?? platformDispatcher.platformBrightness)
+                  .toString(),
             );
             await reassembleApplication();
           }
           return <String, dynamic>{
-            'value': (debugBrightnessOverride ?? platformDispatcher.platformBrightness).toString(),
+            'value':
+                (debugDeviceMetricsOverrides.brightness ?? platformDispatcher.platformBrightness)
+                    .toString(),
           };
         },
       );

--- a/packages/flutter/lib/src/foundation/debug.dart
+++ b/packages/flutter/lib/src/foundation/debug.dart
@@ -41,7 +41,7 @@ bool debugAssertAllFoundationVarsUnset(
     if (debugPrint != debugPrintOverride ||
         debugDefaultTargetPlatformOverride != null ||
         debugDoublePrecision != null ||
-        !debugDeviceMetricsOverrides.isEmpty) {
+        !debugPlatformOverrides.isEmpty) {
       throw FlutterError(reason);
     }
     return true;
@@ -119,50 +119,49 @@ String debugFormatDouble(double? value) {
   return value.toStringAsFixed(1);
 }
 
-/// A class that holds overrides for device metrics in debug mode.
+/// A class that holds overrides for platform metrics in debug mode.
 ///
-/// This is used to customize or simulate specific device profiles during development
+/// This is used to customize or simulate specific platform profiles during development
 /// and testing.
-class DebugDeviceMetricsOverrides {
-  /// Creates a [DebugDeviceMetricsOverrides] configuration.
-  DebugDeviceMetricsOverrides();
+class DebugPlatformOverrides {
+  DebugPlatformOverrides._();
 
   /// The [Brightness] to override the platform brightness with.
-  ui.Brightness? brightness;
+  ui.Brightness? platformBrightness;
 
   /// Whether all fields of this override configuration are null.
-  bool get isEmpty => brightness == null;
+  bool get isEmpty => platformBrightness == null;
 }
 
-/// The active configuration of device metrics overrides.
+/// The active configuration of platform overrides.
 ///
-/// In debug mode, this can be set to customize or simulate specific device
+/// In debug mode, this can be set to customize or simulate specific platform
 /// metrics (such as platform brightness).
 ///
 /// This has no effect in release builds.
-final DebugDeviceMetricsOverrides debugDeviceMetricsOverrides = DebugDeviceMetricsOverrides();
+final DebugPlatformOverrides debugPlatformOverrides = DebugPlatformOverrides._();
 
 /// A setting that can be used to override the platform [Brightness] exposed
 /// from [BindingBase.platformDispatcher].
 ///
-/// This is a deprecated wrapper around [debugDeviceMetricsOverrides]. Use
-/// [debugDeviceMetricsOverrides] instead.
+/// This is a deprecated wrapper around [debugPlatformOverrides]. Use
+/// [debugPlatformOverrides] instead.
 ///
 /// See also:
 ///
 ///  * [WidgetsApp], which uses the [debugBrightnessOverride] setting in debug mode
 ///    to construct a [MediaQueryData].
 @Deprecated(
-  'Use debugDeviceMetricsOverrides.brightness instead. '
+  'Use debugPlatformOverrides.platformBrightness instead. '
   'This feature was deprecated after v3.33.0-0.0.pre.',
 )
-ui.Brightness? get debugBrightnessOverride => debugDeviceMetricsOverrides.brightness;
+ui.Brightness? get debugBrightnessOverride => debugPlatformOverrides.platformBrightness;
 @Deprecated(
-  'Use debugDeviceMetricsOverrides.brightness instead. '
+  'Use debugPlatformOverrides.platformBrightness instead. '
   'This feature was deprecated after v3.33.0-0.0.pre.',
 )
 set debugBrightnessOverride(ui.Brightness? value) {
-  debugDeviceMetricsOverrides.brightness = value;
+  debugPlatformOverrides.platformBrightness = value;
 }
 
 /// The address for the active DevTools server used for debugging this

--- a/packages/flutter/lib/src/foundation/debug.dart
+++ b/packages/flutter/lib/src/foundation/debug.dart
@@ -41,7 +41,7 @@ bool debugAssertAllFoundationVarsUnset(
     if (debugPrint != debugPrintOverride ||
         debugDefaultTargetPlatformOverride != null ||
         debugDoublePrecision != null ||
-        debugBrightnessOverride != null) {
+        !debugDeviceMetricsOverrides.isEmpty) {
       throw FlutterError(reason);
     }
     return true;
@@ -119,14 +119,51 @@ String debugFormatDouble(double? value) {
   return value.toStringAsFixed(1);
 }
 
+/// A class that holds overrides for device metrics in debug mode.
+///
+/// This is used to customize or simulate specific device profiles during development
+/// and testing.
+class DebugDeviceMetricsOverrides {
+  /// Creates a [DebugDeviceMetricsOverrides] configuration.
+  DebugDeviceMetricsOverrides();
+
+  /// The [Brightness] to override the platform brightness with.
+  ui.Brightness? brightness;
+
+  /// Whether all fields of this override configuration are null.
+  bool get isEmpty => brightness == null;
+}
+
+/// The active configuration of device metrics overrides.
+///
+/// In debug mode, this can be set to customize or simulate specific device
+/// metrics (such as platform brightness).
+///
+/// This has no effect in release builds.
+final DebugDeviceMetricsOverrides debugDeviceMetricsOverrides = DebugDeviceMetricsOverrides();
+
 /// A setting that can be used to override the platform [Brightness] exposed
 /// from [BindingBase.platformDispatcher].
+///
+/// This is a deprecated wrapper around [debugDeviceMetricsOverrides]. Use
+/// [debugDeviceMetricsOverrides] instead.
 ///
 /// See also:
 ///
 ///  * [WidgetsApp], which uses the [debugBrightnessOverride] setting in debug mode
 ///    to construct a [MediaQueryData].
-ui.Brightness? debugBrightnessOverride;
+@Deprecated(
+  'Use debugDeviceMetricsOverrides.brightness instead. '
+  'This feature was deprecated after v3.33.0-0.0.pre.',
+)
+ui.Brightness? get debugBrightnessOverride => debugDeviceMetricsOverrides.brightness;
+@Deprecated(
+  'Use debugDeviceMetricsOverrides.brightness instead. '
+  'This feature was deprecated after v3.33.0-0.0.pre.',
+)
+set debugBrightnessOverride(ui.Brightness? value) {
+  debugDeviceMetricsOverrides.brightness = value;
+}
 
 /// The address for the active DevTools server used for debugging this
 /// application.

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -2377,13 +2377,13 @@ class _MediaQueryFromViewState extends State<_MediaQueryFromView> with WidgetsBi
   Widget build(BuildContext context) {
     MediaQueryData effectiveData = _data!;
     // If we get our platformBrightness from the PlatformDispatcher (i.e. we have no parentData) replace it
-    // with the debugDeviceMetricsOverrides.brightness in non-release mode.
+    // with the debugPlatformOverrides.platformBrightness in non-release mode.
     if (!kReleaseMode &&
         _parentData == null &&
-        debugDeviceMetricsOverrides.brightness != null &&
-        effectiveData.platformBrightness != debugDeviceMetricsOverrides.brightness) {
+        debugPlatformOverrides.platformBrightness != null &&
+        effectiveData.platformBrightness != debugPlatformOverrides.platformBrightness) {
       effectiveData = effectiveData.copyWith(
-        platformBrightness: debugDeviceMetricsOverrides.brightness,
+        platformBrightness: debugPlatformOverrides.platformBrightness,
       );
     }
     return MediaQuery(data: effectiveData, child: widget.child);

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -2377,11 +2377,14 @@ class _MediaQueryFromViewState extends State<_MediaQueryFromView> with WidgetsBi
   Widget build(BuildContext context) {
     MediaQueryData effectiveData = _data!;
     // If we get our platformBrightness from the PlatformDispatcher (i.e. we have no parentData) replace it
-    // with the debugBrightnessOverride in non-release mode.
+    // with the debugDeviceMetricsOverrides.brightness in non-release mode.
     if (!kReleaseMode &&
         _parentData == null &&
-        effectiveData.platformBrightness != debugBrightnessOverride) {
-      effectiveData = effectiveData.copyWith(platformBrightness: debugBrightnessOverride);
+        debugDeviceMetricsOverrides.brightness != null &&
+        effectiveData.platformBrightness != debugDeviceMetricsOverrides.brightness) {
+      effectiveData = effectiveData.copyWith(
+        platformBrightness: debugDeviceMetricsOverrides.brightness,
+      );
     }
     return MediaQuery(data: effectiveData, child: widget.child);
   }

--- a/packages/flutter/test/foundation/debug_test.dart
+++ b/packages/flutter/test/foundation/debug_test.dart
@@ -101,44 +101,44 @@ void main() {
     });
   });
 
-  group('DebugDeviceMetricsOverrides', () {
+  group('DebugPlatformOverrides', () {
     tearDown(() {
-      debugDeviceMetricsOverrides.brightness = null;
+      debugPlatformOverrides.platformBrightness = null;
     });
 
     test('defaults to null', () {
-      expect(debugDeviceMetricsOverrides.brightness, isNull);
+      expect(debugPlatformOverrides.platformBrightness, isNull);
       expect(debugBrightnessOverride, isNull);
     });
 
-    test('setting debugBrightnessOverride affects debugDeviceMetricsOverrides.brightness', () {
+    test('setting debugBrightnessOverride affects debugPlatformOverrides.platformBrightness', () {
       debugBrightnessOverride = Brightness.dark;
-      expect(debugDeviceMetricsOverrides.brightness, Brightness.dark);
+      expect(debugPlatformOverrides.platformBrightness, Brightness.dark);
       expect(debugBrightnessOverride, Brightness.dark);
     });
 
-    test('setting debugDeviceMetricsOverrides.brightness affects debugBrightnessOverride', () {
-      debugDeviceMetricsOverrides.brightness = Brightness.light;
+    test('setting debugPlatformOverrides.platformBrightness affects debugBrightnessOverride', () {
+      debugPlatformOverrides.platformBrightness = Brightness.light;
       expect(debugBrightnessOverride, Brightness.light);
     });
 
     test('isEmpty behaves correctly', () {
-      expect(debugDeviceMetricsOverrides.isEmpty, isTrue);
+      expect(debugPlatformOverrides.isEmpty, isTrue);
 
-      debugDeviceMetricsOverrides.brightness = Brightness.dark;
-      expect(debugDeviceMetricsOverrides.isEmpty, isFalse);
+      debugPlatformOverrides.platformBrightness = Brightness.dark;
+      expect(debugPlatformOverrides.isEmpty, isFalse);
 
-      debugDeviceMetricsOverrides.brightness = null;
-      expect(debugDeviceMetricsOverrides.isEmpty, isTrue);
+      debugPlatformOverrides.platformBrightness = null;
+      expect(debugPlatformOverrides.isEmpty, isTrue);
     });
 
-    test('debugAssertAllFoundationVarsUnset detects non-empty debugDeviceMetricsOverrides', () {
+    test('debugAssertAllFoundationVarsUnset detects non-empty debugPlatformOverrides', () {
       expect(() => debugAssertAllFoundationVarsUnset('reason'), returnsNormally);
 
-      debugDeviceMetricsOverrides.brightness = Brightness.dark;
+      debugPlatformOverrides.platformBrightness = Brightness.dark;
       expect(() => debugAssertAllFoundationVarsUnset('reason'), throwsA(isA<FlutterError>()));
 
-      debugDeviceMetricsOverrides.brightness = null;
+      debugPlatformOverrides.platformBrightness = null;
       expect(() => debugAssertAllFoundationVarsUnset('reason'), returnsNormally);
     });
   });

--- a/packages/flutter/test/foundation/debug_test.dart
+++ b/packages/flutter/test/foundation/debug_test.dart
@@ -100,4 +100,46 @@ void main() {
       }
     });
   });
+
+  group('DebugDeviceMetricsOverrides', () {
+    tearDown(() {
+      debugDeviceMetricsOverrides.brightness = null;
+    });
+
+    test('defaults to null', () {
+      expect(debugDeviceMetricsOverrides.brightness, isNull);
+      expect(debugBrightnessOverride, isNull);
+    });
+
+    test('setting debugBrightnessOverride affects debugDeviceMetricsOverrides.brightness', () {
+      debugBrightnessOverride = Brightness.dark;
+      expect(debugDeviceMetricsOverrides.brightness, Brightness.dark);
+      expect(debugBrightnessOverride, Brightness.dark);
+    });
+
+    test('setting debugDeviceMetricsOverrides.brightness affects debugBrightnessOverride', () {
+      debugDeviceMetricsOverrides.brightness = Brightness.light;
+      expect(debugBrightnessOverride, Brightness.light);
+    });
+
+    test('isEmpty behaves correctly', () {
+      expect(debugDeviceMetricsOverrides.isEmpty, isTrue);
+
+      debugDeviceMetricsOverrides.brightness = Brightness.dark;
+      expect(debugDeviceMetricsOverrides.isEmpty, isFalse);
+
+      debugDeviceMetricsOverrides.brightness = null;
+      expect(debugDeviceMetricsOverrides.isEmpty, isTrue);
+    });
+
+    test('debugAssertAllFoundationVarsUnset detects non-empty debugDeviceMetricsOverrides', () {
+      expect(() => debugAssertAllFoundationVarsUnset('reason'), returnsNormally);
+
+      debugDeviceMetricsOverrides.brightness = Brightness.dark;
+      expect(() => debugAssertAllFoundationVarsUnset('reason'), throwsA(isA<FlutterError>()));
+
+      debugDeviceMetricsOverrides.brightness = null;
+      expect(() => debugAssertAllFoundationVarsUnset('reason'), returnsNormally);
+    });
+  });
 }

--- a/packages/flutter_tools/lib/src/base/command_help.dart
+++ b/packages/flutter_tools/lib/src/base/command_help.dart
@@ -76,7 +76,7 @@ class CommandHelp {
   late final CommandHelpOption b = _makeOption(
     'b',
     'Toggle platform brightness (dark and light mode).',
-    'debugBrightnessOverride',
+    'debugDeviceMetricsOverrides',
   );
 
   late final CommandHelpOption c = _makeOption('c', 'Clear the screen');

--- a/packages/flutter_tools/lib/src/base/command_help.dart
+++ b/packages/flutter_tools/lib/src/base/command_help.dart
@@ -76,7 +76,7 @@ class CommandHelp {
   late final CommandHelpOption b = _makeOption(
     'b',
     'Toggle platform brightness (dark and light mode).',
-    'debugDeviceMetricsOverrides',
+    'debugPlatformOverrides',
   );
 
   late final CommandHelpOption c = _makeOption('c', 'Clear the screen');

--- a/packages/flutter_tools/test/general.shard/base/command_help_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/command_help_test.dart
@@ -122,7 +122,7 @@ void main() {
         expect(commandHelp.S.toString(), contains('\x1B[90m(debugDumpSemantics)\x1B[39m'));
         expect(commandHelp.U.toString(), contains('\x1B[90m(debugDumpSemantics)\x1B[39m'));
         expect(commandHelp.a.toString(), contains('\x1B[90m(debugProfileWidgetBuilds)\x1B[39m'));
-        expect(commandHelp.b.toString(), contains('\x1B[90m(debugBrightnessOverride)\x1B[39m'));
+        expect(commandHelp.b.toString(), contains('\x1B[90m(debugDeviceMetricsOverrides)\x1B[39m'));
         expect(commandHelp.f.toString(), contains('\x1B[90m(debugDumpFocusTree)\x1B[39m'));
         expect(
           commandHelp.i.toString(),
@@ -222,7 +222,7 @@ void main() {
         expect(
           commandHelp.b.toString(),
           equals(
-            '\x1B[1mb\x1B[22m Toggle platform brightness (dark and light mode).        \x1B[90m(debugBrightnessOverride)\x1B[39m\x1B[22m',
+            '\x1B[1mb\x1B[22m Toggle platform brightness (dark and light mode).    \x1B[90m(debugDeviceMetricsOverrides)\x1B[39m\x1B[22m',
           ),
         );
         expect(commandHelp.c.toString(), equals('\x1B[1mc\x1B[22m Clear the screen'));
@@ -332,7 +332,7 @@ void main() {
         expect(
           commandHelp.b.toString(),
           equals(
-            'b Toggle platform brightness (dark and light mode).        (debugBrightnessOverride)',
+            'b Toggle platform brightness (dark and light mode).    (debugDeviceMetricsOverrides)',
           ),
         );
         expect(commandHelp.c.toString(), equals('c Clear the screen'));

--- a/packages/flutter_tools/test/general.shard/base/command_help_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/command_help_test.dart
@@ -122,7 +122,7 @@ void main() {
         expect(commandHelp.S.toString(), contains('\x1B[90m(debugDumpSemantics)\x1B[39m'));
         expect(commandHelp.U.toString(), contains('\x1B[90m(debugDumpSemantics)\x1B[39m'));
         expect(commandHelp.a.toString(), contains('\x1B[90m(debugProfileWidgetBuilds)\x1B[39m'));
-        expect(commandHelp.b.toString(), contains('\x1B[90m(debugDeviceMetricsOverrides)\x1B[39m'));
+        expect(commandHelp.b.toString(), contains('\x1B[90m(debugPlatformOverrides)\x1B[39m'));
         expect(commandHelp.f.toString(), contains('\x1B[90m(debugDumpFocusTree)\x1B[39m'));
         expect(
           commandHelp.i.toString(),
@@ -222,7 +222,7 @@ void main() {
         expect(
           commandHelp.b.toString(),
           equals(
-            '\x1B[1mb\x1B[22m Toggle platform brightness (dark and light mode).    \x1B[90m(debugDeviceMetricsOverrides)\x1B[39m\x1B[22m',
+            '\x1B[1mb\x1B[22m Toggle platform brightness (dark and light mode).         \x1B[90m(debugPlatformOverrides)\x1B[39m\x1B[22m',
           ),
         );
         expect(commandHelp.c.toString(), equals('\x1B[1mc\x1B[22m Clear the screen'));
@@ -332,7 +332,7 @@ void main() {
         expect(
           commandHelp.b.toString(),
           equals(
-            'b Toggle platform brightness (dark and light mode).    (debugDeviceMetricsOverrides)',
+            'b Toggle platform brightness (dark and light mode).         (debugPlatformOverrides)',
           ),
         );
         expect(commandHelp.c.toString(), equals('c Clear the screen'));

--- a/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
+++ b/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
@@ -445,7 +445,7 @@ void main() {
         'p Toggle the display of construction lines.                                  (debugPaintSizeEnabled)',
         'I Toggle oversized image inversion.                                     (debugInvertOversizedImages)',
         'o Simulate different operating systems.                                      (defaultTargetPlatform)',
-        'b Toggle platform brightness (dark and light mode).                    (debugDeviceMetricsOverrides)',
+        'b Toggle platform brightness (dark and light mode).                         (debugPlatformOverrides)',
         'P Toggle performance overlay.                                    (WidgetsApp.showPerformanceOverlay)',
         'a Toggle timeline events for all widget build methods.                    (debugProfileWidgetBuilds)',
         'g Run source code generators.',

--- a/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
+++ b/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
@@ -445,7 +445,7 @@ void main() {
         'p Toggle the display of construction lines.                                  (debugPaintSizeEnabled)',
         'I Toggle oversized image inversion.                                     (debugInvertOversizedImages)',
         'o Simulate different operating systems.                                      (defaultTargetPlatform)',
-        'b Toggle platform brightness (dark and light mode).                        (debugBrightnessOverride)',
+        'b Toggle platform brightness (dark and light mode).                    (debugDeviceMetricsOverrides)',
         'P Toggle performance overlay.                                    (WidgetsApp.showPerformanceOverlay)',
         'a Toggle timeline events for all widget build methods.                    (debugProfileWidgetBuilds)',
         'g Run source code generators.',


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

based on flutter.dev/go/view-metrics-overrides, but since we only have device wise override for now (platform brightness) I only created an top level object to encapsulate it.

When we start to add size and padding override, then we can add the view id to override map in that class.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
