### PR TITLE
[ios] Correct handling for CADisplayLink paused-to-unpaused transitions

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterKeyboardInsetManager.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterKeyboardInsetManager.mm
@@ -273,7 +273,7 @@
   // Set animation begin value and DisplayLink tracking values.
   CGFloat currentInset = delegate.physicalViewInsetBottom;
   self.keyboardAnimationView.frame = CGRectMake(0, currentInset, 0, 0);
-  self.keyboardAnimationStartTime = fml::TimePoint::Now().ToEpochDelta().ToSeconds();
+  self.keyboardAnimationStartTime = fml::TimePoint::Now().ToEpochDelta().ToSecondsF();
   self.originalViewInsetBottom = currentInset;
 
   // Invalidate old vsync client if old animation is not completed.

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterVSyncClient.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterVSyncClient.mm
@@ -14,6 +14,7 @@
 FLUTTER_ASSERT_ARC
 
 NSString* const kCADisableMinimumFrameDurationOnPhoneKey = @"CADisableMinimumFrameDurationOnPhone";
+static const double kDefaultRefreshRate = 60.0;
 
 @implementation FlutterVSyncClient {
   flutter::VsyncWaiter::Callback _callback;
@@ -63,8 +64,8 @@ NSString* const kCADisableMinimumFrameDurationOnPhoneKey = @"CADisableMinimumFra
   if (!_isVariableRefreshRateEnabled) {
     return;
   }
-  double maxFrameRate = fmax(refreshRate, 60);
-  double minFrameRate = fmax(maxFrameRate / 2, 60);
+  double maxFrameRate = fmax(refreshRate, kDefaultRefreshRate);
+  double minFrameRate = fmax(maxFrameRate / 2, kDefaultRefreshRate);
   if (@available(iOS 15.0, *)) {
     _displayLink.preferredFrameRateRange =
         CAFrameRateRangeMake(minFrameRate, maxFrameRate, maxFrameRate);
@@ -89,14 +90,24 @@ NSString* const kCADisableMinimumFrameDurationOnPhoneKey = @"CADisableMinimumFra
   // callback need to be rebased to fml::TimePoint's epoch.
   //
   // According to Apple's docs, before the first frame is delivered, or when the display link is
-  // paused, both timestamp and targetTimestamp properties are 0.0.
-
-  CFTimeInterval delay = CACurrentMediaTime() - link.timestamp;
+  // paused, both timestamp and targetTimestamp properties are 0.0. To guarantee consistent frame
+  // progression, we guard against zero values and fall back to CACurrentMediaTime().
+  CFTimeInterval timestamp = link.timestamp;
+  if (timestamp == 0.0) {
+    timestamp = CACurrentMediaTime();
+  }
+  CFTimeInterval delay = CACurrentMediaTime() - timestamp;
   fml::TimePoint frame_start_time = fml::TimePoint::Now() - fml::TimeDelta::FromSecondsF(delay);
 
-  // frame_target_time is the anticipated presentation time of the next screen refresh. If
-  // frame_target_time is zero, fall back to frame start time.
-  CFTimeInterval duration = link.targetTimestamp - link.timestamp;
+  // targetTimestamp is the anticipated presentation time of the next screen refresh. If
+  // targetTimestamp is zero or less than/equal to timestamp (which also occurs on paused/unpaused
+  // transitions), synthesize a projected target time based on the current refresh rate.
+  CFTimeInterval targetTimestamp = link.targetTimestamp;
+  if (targetTimestamp <= timestamp) {
+    double effectiveRefreshRate = _refreshRate > 0.0 ? _refreshRate : kDefaultRefreshRate;
+    targetTimestamp = timestamp + (1.0 / effectiveRefreshRate);
+  }
+  CFTimeInterval duration = targetTimestamp - timestamp;
   fml::TimePoint frame_target_time = frame_start_time + fml::TimeDelta::FromSecondsF(duration);
 
   [FlutterTracing tracePlatformVsyncWithStartTime:frame_start_time.ToEpochDelta().ToSecondsF()
@@ -112,7 +123,10 @@ NSString* const kCADisableMinimumFrameDurationOnPhoneKey = @"CADisableMinimumFra
   // Round to nearest whole Hz value to ensure we don't introduce frame timing issues due to
   // floating point error. e.g. 59.998, 60.004, 59.995, ... --> 60.000, 60.000, 60.000, ...
   if (duration > 0) {
-    _refreshRate = round(1 / duration);
+    double roundedRefreshRate = round(1.0 / duration);
+    if (roundedRefreshRate > 0.0) {
+      _refreshRate = roundedRefreshRate;
+    }
   }
 
   recorder->RecordVsync(frame_start_time, frame_target_time);

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -621,6 +621,64 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   [engine destroyContext];
 }
 
+- (void)testKeyboardAnimationFirstVsyncCallbackCalculatesSafeInset {
+  FlutterEnginePartialMock* engine = [[FlutterEnginePartialMock alloc] init];
+  [engine runWithEntrypoint:nil];
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
+                                                                                nibName:nil
+                                                                                 bundle:nil];
+  FlutterViewController* viewControllerMock = OCMPartialMock(viewController);
+  OCMStub([viewControllerMock isViewLoaded]).andReturn(YES);
+  [viewControllerMock view];
+  viewController.keyboardInsetManager.delegate =
+      (id<FlutterKeyboardInsetManagerDelegate>)viewControllerMock;
+
+  engine.viewController = viewControllerMock;
+
+  XCTestExpectation* expectation = [self expectationWithDescription:@"metrics updated"];
+  // Stub updateViewportMetricsWithInset: to capture the inset value passed.
+  __block CGFloat capturedInset = -1.0;
+  __block BOOL fulfilled = NO;
+  OCMStub([viewControllerMock updateViewportMetricsWithInset:0])
+      .ignoringNonObjectArgs()
+      .andDo(^(NSInvocation* invocation) {
+        [invocation getArgument:&capturedInset atIndex:2];
+        if (!fulfilled) {
+          fulfilled = YES;
+          // Prevent the instant UIView animation completion block from overriding the captured
+          // vsync inset.
+          [viewController.keyboardInsetManager invalidateKeyboardAnimationVSyncClient];
+          [expectation fulfill];
+        }
+      });
+
+  // Configure keyboard spring animation.
+  CASpringAnimation* springAnimation = [CASpringAnimation animation];
+  springAnimation.mass = 1.0;
+  springAnimation.stiffness = 100.0;
+  springAnimation.damping = 10.0;
+  springAnimation.keyPath = @"position";
+
+  viewController.keyboardInsetManager.targetViewInsetBottom = 300.0;
+
+  // Start the keyboard animation.
+  [viewController.keyboardInsetManager startKeyBoardAnimation:0.25];
+  [viewController.keyboardInsetManager setUpKeyboardSpringAnimationIfNeeded:springAnimation];
+
+  // Simulate the first vsync callback passing the initial CADisplayLink directly.
+  FlutterVSyncClient* client = viewController.keyboardInsetManager.keyboardAnimationVSyncClient;
+  [client onDisplayLink:client.displayLink];
+
+  // Wait for task runner to execute callback on main queue.
+  [self waitForExpectationsWithTimeout:5.0 handler:nil];
+
+  // The captured inset must be a finite, non-NaN, non-negative value (close to start of animation).
+  XCTAssertFalse(isnan(capturedInset));
+  XCTAssertFalse(isinf(capturedInset));
+  XCTAssertGreaterThanOrEqual(capturedInset, 0.0);
+  XCTAssertLessThan(capturedInset, 300.0);
+}
+
 - (void)testKeyboardAnimationWillWaitUIThreadVsync {
   // We need to make sure the new viewport metrics get sent after the
   // begin frame event has processed. And this test is to expect that the callback

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/VSyncClientTest.swift
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/VSyncClientTest.swift
@@ -17,6 +17,69 @@ class VSyncClientTest: XCTestCase {
     super.tearDown()
   }
 
+  /// Verifies that the vsync client safely synthesizes a target timestamp when the display link's
+  /// `targetTimestamp` is invalid (i.e. evaluates to 0.0).
+  ///
+  /// Apple's `CADisplayLink` documentation specifies:
+  /// > "The targetTimestamp value is only valid after the display link has delivered at least one
+  /// > frame. Before the first frame is delivered, or when the display link is paused, the value
+  /// > of targetTimestamp is 0."
+  ///
+  /// Our vsync waiter operates on-demand in a request-and-pause cycle. This means every new frame
+  /// sequence begins (e.g. in response to a gesture) with a paused-to-unpaused transition, causing
+  /// the first callback to receive `targetTimestamp = 0.0`.
+  ///
+  /// Without a fallback, passing `targetTime = 0.0` downstream causes a negative presentation time
+  /// when subtracted from the start time.
+  ///
+  /// This test passes a newly created, paused `CADisplayLink` (whose properties both evaluate to
+  /// 0.0) and asserts that the client intercepts the invalid state and synthesizes a safe, positive
+  /// next-frame target timestamp based on the display's maximum refresh rate.
+  func testRealDisplayLinkVsyncTimestampsCorrect() {
+    var callbackStartTime: CFTimeInterval = -1
+    var callbackTargetTime: CFTimeInterval = -1
+    let vsyncClient = VSyncClient(
+      taskRunner: threadTaskRunner,
+      isVariableRefreshRateEnabled: false,
+      maxRefreshRate: 60.0
+    ) { startTime, targetTime in
+      callbackStartTime = startTime
+      callbackTargetTime = targetTime
+    }!
+    let link = vsyncClient.displayLink
+
+    vsyncClient.onDisplayLink(link)
+
+    // Since the display link is paused and has not delivered a frame yet, both timestamp and
+    // targetTimestamp are 0.0. Verify the client synthesizes a valid target timestamp using the max
+    // refresh rate.
+    XCTAssertGreaterThan(callbackStartTime, 0.0)
+    XCTAssertEqual(callbackTargetTime - callbackStartTime, 1.0 / 60.0, accuracy: 0.0001)
+  }
+
+  func testVsyncClientPreventsZeroRefreshRateDivision() {
+    var callbackStartTime: CFTimeInterval = -1
+    var callbackTargetTime: CFTimeInterval = -1
+    // Initialize with maxRefreshRate = 0.0 to simulate uninitialized/zero max refresh rate.
+    let vsyncClient = VSyncClient(
+      taskRunner: threadTaskRunner,
+      isVariableRefreshRateEnabled: false,
+      maxRefreshRate: 0.0
+    ) { startTime, targetTime in
+      callbackStartTime = startTime
+      callbackTargetTime = targetTime
+    }!
+    let link = vsyncClient.displayLink
+
+    vsyncClient.onDisplayLink(link)
+
+    XCTAssertGreaterThan(callbackStartTime, 0.0)
+    // Should fallback to effectiveRefreshRate of 60.0.
+    XCTAssertEqual(callbackTargetTime - callbackStartTime, 1.0 / 60.0, accuracy: 0.0001)
+    XCTAssertFalse(callbackTargetTime.isNaN)
+    XCTAssertFalse(callbackTargetTime.isInfinite)
+  }
+
   func testSetAllowPauseAfterVsyncCorrect() {
     let vsyncClient = VSyncClient(
       taskRunner: threadTaskRunner,


### PR DESCRIPTION
According to Apple's documentation `CADisplayLink.targetTimestamp` and
`timestamp` properties are only valid after the display link has
delivered at least one frame. Before the first frame is delivered, or
when the isplay link is paused, these values evaluate to `0.0`.

Because our vsync client uses an on-demand request-and-pause cycle to
preserve battery, every new frame sequence begins with a
paused-to-unpaused transition. Previously, receiving `0.0` on the
initial vsync callback resulted in negative or incorrect frame durations
and delay calculations passed downstream to the engine's frame timings
recorder. Due to the way values were rebased relative to
`fml::TimePoint`s, the end result was that the first frame was recorded
with a duration of `0.0` and a target time equal to its start time.

This commit ensures consistent frame progression by setting the start
timestamp to `CACurrentMediaTime()` and synthesizing a frame end time as
frame start + the inverse of the refresh rate. This behaviour is
consistent with equivalent code in the macOS embedder's
`FlutterDisplayLink.mm`.

This also fixes a bug in `FlutterKeyboardInsetManager` wherein the start
time was recorded using `ToSeconds()` (rounded to nearest integer
second) rather than `ToSecondsF()` which records the current timestamp
accurately.

This adds tests for:
* Verify VSyncClient behaviour on the paused-to-unpaused transition.
* Verify VSyncClient defends against 0.0 Hz refresh rate.
* Integration test verifying that the keyboard inset is animated
  correctly on first frame.

Issue: https://github.com/flutter/flutter/issues/112232

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
