### PR TITLE
fix(web): Fixes CSS override detection when the browser has a default font size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,4 @@ app.*.symbols
 # AI related
 .agents/rules/personal-*
 .agents/skills/personal-*
+/.agent-shell/

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -1092,7 +1092,8 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
     // The factor that we expect for line-height if no override is present.
     // This factor is constant regardless of browser zoom because both
     // lineHeight and fontSize scale proportionally.
-    final double defaultLineHeightFactor = spacingDefault / (typographyMeasurementElementFontSize / findBrowserTextScaleFactor());
+    final double defaultLineHeightFactor =
+        spacingDefault / (typographyMeasurementElementFontSize / findBrowserTextScaleFactor());
 
     _typographySettingsObserver = createDomResizeObserver((
       List<DomResizeObserverEntry> entries,
@@ -1111,8 +1112,9 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
         if (value == null) {
           return true;
         }
-        return (value - defaultValue).abs() < 1e-4 ||
-               (value - defaultValue * computedTextScaleFactor).abs() < 1e-4;
+        return (value - defaultValue).abs() < _typographyPrecisionErrorTolerance ||
+            (value - defaultValue * computedTextScaleFactor).abs() <
+                _typographyPrecisionErrorTolerance;
       }
 
       // We only consider it an override if the line-height factor deviates from
@@ -1148,7 +1150,9 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
 
       computedTextScaleFactorChanged = _updateTextScaleFactor(computedTextScaleFactor);
       computedLineHeightScaleFactorChanged = _updateLineHeightScaleFactorOverride(
-        (computedLineHeightScaleFactor != null && (computedLineHeightScaleFactor - defaultLineHeightFactor).abs() < 1e-4)
+        (computedLineHeightScaleFactor != null &&
+                (computedLineHeightScaleFactor - defaultLineHeightFactor).abs() <
+                    _typographyPrecisionErrorTolerance)
             ? null
             : computedLineHeightScaleFactor,
       );
@@ -1794,6 +1798,7 @@ void invoke3<A1, A2, A3>(
 }
 
 const double _defaultRootFontSize = 16.0;
+const double _typographyPrecisionErrorTolerance = 1e-4;
 
 /// Finds the text scale factor of the browser by looking at the computed style
 /// of the browser's <html> element.

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -1064,7 +1064,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
     _typographyMeasurementElement!.text = 'flutter typography measurement';
     // The element should be hidden from screen readers.
     _typographyMeasurementElement!.setAttribute('aria-hidden', 'true');
-    const spacingDefault = 9999.0;
+    const spacingDefault = 100.0;
     _typographyMeasurementElement!.style
       // The element should be positioned off-screen above
       // the window and not visible.
@@ -1084,9 +1084,16 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
       ..wordSpacing = '${spacingDefault}px'
       ..margin = '0px 0px ${spacingDefault}px 0px';
     domDocument.body!.append(_typographyMeasurementElement!);
+
+    // Measure baseline font size to calculate the default line-height factor.
     final double typographyMeasurementElementFontSize =
         parseFontSize(_typographyMeasurementElement!)?.toDouble() ?? _defaultRootFontSize;
-    final double defaultLineHeightFactor = spacingDefault / typographyMeasurementElementFontSize;
+
+    // The factor that we expect for line-height if no override is present.
+    // This factor is constant regardless of browser zoom because both
+    // lineHeight and fontSize scale proportionally.
+    final double defaultLineHeightFactor = spacingDefault / (typographyMeasurementElementFontSize / findBrowserTextScaleFactor());
+
     _typographySettingsObserver = createDomResizeObserver((
       List<DomResizeObserverEntry> entries,
       DomResizeObserver observer,
@@ -1097,9 +1104,24 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
         'line-height',
       )?.toDouble();
       final double? fontSize = parseFontSize(_typographyMeasurementElement!)?.toDouble();
+
+      // A property is considered "default" (not overridden) if it matches either
+      // the specified value or the zoomed specified value.
+      bool isDefault(double? value, double defaultValue) {
+        if (value == null) {
+          return true;
+        }
+        return (value - defaultValue).abs() < 1e-4 ||
+               (value - defaultValue * computedTextScaleFactor).abs() < 1e-4;
+      }
+
+      // We only consider it an override if the line-height factor deviates from
+      // our baseline. Both lineHeight and fontSize scale with browser zoom,
+      // so their ratio should remain equal to defaultLineHeightFactor unless
+      // an external CSS rule overrides it.
       final double? computedLineHeightScaleFactor =
-          fontSize != null && lineHeight != null && lineHeight != spacingDefault
-          ? lineHeight / fontSize
+          (fontSize != null && !isDefault(lineHeight, spacingDefault))
+          ? lineHeight! / fontSize
           : null;
       final double? computedWordSpacing = parseNumericStyleProperty(
         _typographyMeasurementElement!,
@@ -1126,18 +1148,18 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
 
       computedTextScaleFactorChanged = _updateTextScaleFactor(computedTextScaleFactor);
       computedLineHeightScaleFactorChanged = _updateLineHeightScaleFactorOverride(
-        computedLineHeightScaleFactor == defaultLineHeightFactor
+        (computedLineHeightScaleFactor != null && (computedLineHeightScaleFactor - defaultLineHeightFactor).abs() < 1e-4)
             ? null
             : computedLineHeightScaleFactor,
       );
       computedLetterSpacingChanged = _updateLetterSpacingOverride(
-        computedLetterSpacing == spacingDefault ? null : computedLetterSpacing,
+        isDefault(computedLetterSpacing, spacingDefault) ? null : computedLetterSpacing,
       );
       computedWordSpacingChanged = _updateWordSpacingOverride(
-        computedWordSpacing == spacingDefault ? null : computedWordSpacing,
+        isDefault(computedWordSpacing, spacingDefault) ? null : computedWordSpacing,
       );
       computedParagraphSpacingChanged = _updateParagraphSpacingOverride(
-        computedParagraphSpacing == spacingDefault ? null : computedParagraphSpacing,
+        isDefault(computedParagraphSpacing, spacingDefault) ? null : computedParagraphSpacing,
       );
 
       final bool metricsChanged =

--- a/engine/src/flutter/lib/web_ui/test/engine/platform_dispatcher/platform_dispatcher_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/platform_dispatcher/platform_dispatcher_test.dart
@@ -428,6 +428,32 @@ void testMain() {
       expect(ui.PlatformDispatcher.instance.lineHeightScaleFactorOverride, null);
     });
 
+    test('does not detect override when initialized with browser zoom', () async {
+      final DomElement root = domDocument.documentElement!;
+      final DomElement style = createDomHTMLStyleElement(null);
+
+      // Simulate a browser zoom of 1.25x (20px / 16px) by forcing a global font-size.
+      style.text = '*{ font-size: 20px !important; }';
+      root.append(style);
+
+      try {
+        // Create a new dispatcher while the zoom is active.
+        final EnginePlatformDispatcher testDispatcher = EnginePlatformDispatcher();
+
+        // It should have textScaleFactor of 1.25.
+        expect(testDispatcher.textScaleFactor, 1.25);
+
+        // It should NOT have a line-height override because we measured the
+        // baseline while the zoom was already active.
+        expect(testDispatcher.lineHeightScaleFactorOverride, null);
+
+        // Clean up the test dispatcher to stop its observer and remove its element.
+        testDispatcher.dispose();
+      } finally {
+        style.remove();
+      }
+    });
+
     test('disposes all its views', () {
       final view1 = EngineFlutterView(dispatcher, createDomHTMLDivElement());
       final view2 = EngineFlutterView(dispatcher, createDomHTMLDivElement());

--- a/engine/src/flutter/lib/web_ui/test/engine/platform_dispatcher/platform_dispatcher_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/platform_dispatcher/platform_dispatcher_test.dart
@@ -428,7 +428,7 @@ void testMain() {
       expect(ui.PlatformDispatcher.instance.lineHeightScaleFactorOverride, null);
     });
 
-    test('does not detect override when initialized with browser zoom', () async {
+    test('does not detect override when initialized with browser zoom', () {
       final DomElement root = domDocument.documentElement!;
       final DomElement style = createDomHTMLStyleElement(null);
 
@@ -438,7 +438,7 @@ void testMain() {
 
       try {
         // Create a new dispatcher while the zoom is active.
-        final EnginePlatformDispatcher testDispatcher = EnginePlatformDispatcher();
+        final testDispatcher = EnginePlatformDispatcher();
 
         // It should have textScaleFactor of 1.25.
         expect(testDispatcher.textScaleFactor, 1.25);


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

We detect CSS overrides by creating a "sentinel" Typography
Measurement Element with arbitrary style attributes. We can then
detect if there have been any CSS overrides by measuring the sentinel
element and seeing if the measured values are different from the ones
that we explicitly set.

However, there was a bug when the default font-size was overridden in
the global CSS (for example if you set "Never use font sizes smaller
than:" in Safari settings). If the default font-size was overridden,
then we would also mistakenly detect that the default line height
factor was overridden as well, because the measured line height scaled
with the overridden font-size.

Because we thought the line height was different, we then measured the
line height factor by dividing the measured line height by the
measured font size, which resulted in a huge line height factor
because we set the line height to 9999px on the sentinel element. This
caused very strange rendering artifacts.

This fixes the detection by fixing the line height override logic to
account for zooming caused by the font-size being scaled.

Fixes #185931

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md