### PR TITLE
Increase the run time of text field integration tests to 10 seconds

### DIFF
--- a/dev/benchmarks/macrobenchmarks/test/fullscreen_textfield_perf_e2e.dart
+++ b/dev/benchmarks/macrobenchmarks/test/fullscreen_textfield_perf_e2e.dart
@@ -16,7 +16,7 @@ void main() {
     body: (WidgetController controller) async {
       final Finder textfield = find.byKey(const ValueKey<String>('fullscreen-textfield'));
       await controller.tap(textfield);
-      await Future<void>.delayed(const Duration(milliseconds: 10000));
+      await Future<void>.delayed(const Duration(seconds: 10));
     },
   );
 }

--- a/dev/benchmarks/macrobenchmarks/test/fullscreen_textfield_perf_e2e.dart
+++ b/dev/benchmarks/macrobenchmarks/test/fullscreen_textfield_perf_e2e.dart
@@ -16,7 +16,7 @@ void main() {
     body: (WidgetController controller) async {
       final Finder textfield = find.byKey(const ValueKey<String>('fullscreen-textfield'));
       await controller.tap(textfield);
-      await Future<void>.delayed(const Duration(milliseconds: 5000));
+      await Future<void>.delayed(const Duration(milliseconds: 10000));
     },
   );
 }

--- a/dev/benchmarks/macrobenchmarks/test/textfield_perf_e2e.dart
+++ b/dev/benchmarks/macrobenchmarks/test/textfield_perf_e2e.dart
@@ -17,7 +17,7 @@ void main() {
       final Finder textfield = find.byKey(const ValueKey<String>('basic-textfield'));
       await controller.tap(textfield);
       // Caret should be cached, so repeated blinking should not require recompute.
-      await Future<void>.delayed(const Duration(milliseconds: 10000));
+      await Future<void>.delayed(const Duration(seconds: 10));
     },
   );
 }

--- a/dev/benchmarks/macrobenchmarks/test/textfield_perf_e2e.dart
+++ b/dev/benchmarks/macrobenchmarks/test/textfield_perf_e2e.dart
@@ -17,7 +17,7 @@ void main() {
       final Finder textfield = find.byKey(const ValueKey<String>('basic-textfield'));
       await controller.tap(textfield);
       // Caret should be cached, so repeated blinking should not require recompute.
-      await Future<void>.delayed(const Duration(milliseconds: 5000));
+      await Future<void>.delayed(const Duration(milliseconds: 10000));
     },
   );
 }

--- a/dev/benchmarks/macrobenchmarks/test_driver/fullscreen_textfield_perf_test.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/fullscreen_textfield_perf_test.dart
@@ -16,7 +16,7 @@ void main() {
       final SerializableFinder textfield = find.byValueKey('fullscreen-textfield');
       // ignore: unawaited_futures
       driver.tap(textfield);
-      await Future<void>.delayed(const Duration(milliseconds: 5000));
+      await Future<void>.delayed(const Duration(milliseconds: 10000));
     },
   );
 }

--- a/dev/benchmarks/macrobenchmarks/test_driver/fullscreen_textfield_perf_test.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/fullscreen_textfield_perf_test.dart
@@ -16,7 +16,7 @@ void main() {
       final SerializableFinder textfield = find.byValueKey('fullscreen-textfield');
       // ignore: unawaited_futures
       driver.tap(textfield);
-      await Future<void>.delayed(const Duration(milliseconds: 10000));
+      await Future<void>.delayed(const Duration(seconds: 10));
     },
   );
 }

--- a/dev/benchmarks/macrobenchmarks/test_driver/textfield_perf_test.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/textfield_perf_test.dart
@@ -17,7 +17,7 @@ void main() {
       // ignore: unawaited_futures
       driver.tap(textfield);
       // Caret should be cached, so repeated blinking should not require recompute.
-      await Future<void>.delayed(const Duration(milliseconds: 5000));
+      await Future<void>.delayed(const Duration(milliseconds: 10000));
     },
   );
 }

--- a/dev/benchmarks/macrobenchmarks/test_driver/textfield_perf_test.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/textfield_perf_test.dart
@@ -17,7 +17,7 @@ void main() {
       // ignore: unawaited_futures
       driver.tap(textfield);
       // Caret should be cached, so repeated blinking should not require recompute.
-      await Future<void>.delayed(const Duration(milliseconds: 10000));
+      await Future<void>.delayed(const Duration(seconds: 10));
     },
   );
 }


### PR DESCRIPTION
These tests have been flaky because they sometimes end before generating the number of frames expected by the performance test framework.

See https://github.com/flutter/flutter/issues/185734