### PR TITLE
Remove Cupertino semantics tester cross-imports

### DIFF
--- a/packages/flutter/test/cupertino/action_sheet_test.dart
+++ b/packages/flutter/test/cupertino/action_sheet_test.dart
@@ -16,7 +16,7 @@ import 'package:flutter/services.dart';
 
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/semantics_tester.dart';
+import 'semantics_tester.dart';
 
 void main() {
   testWidgets('Overall appearance is correct for the light theme', (WidgetTester tester) async {
@@ -1813,46 +1813,44 @@ void main() {
     semantics.dispose();
   });
 
-  testWidgets(
-    'Conflicting scrollbars are not applied by ScrollBehavior to CupertinoActionSheet',
-    (WidgetTester tester) async {
-      // Regression test for https://github.com/flutter/flutter/issues/83819
-      final actionScrollController = ScrollController();
-      addTearDown(actionScrollController.dispose);
-      await tester.pumpWidget(
-        createAppWithButtonThatLaunchesActionSheet(
-          Builder(
-            builder: (BuildContext context) {
-              return MediaQuery.withClampedTextScaling(
-                minScaleFactor: 3.0,
-                maxScaleFactor: 3.0,
-                child: CupertinoActionSheet(
-                  title: const Text('The title'),
-                  message: const Text('The message.'),
-                  actions: <Widget>[
-                    CupertinoActionSheetAction(child: const Text('One'), onPressed: () {}),
-                    CupertinoActionSheetAction(child: const Text('Two'), onPressed: () {}),
-                  ],
-                  actionScrollController: actionScrollController,
-                ),
-              );
-            },
-          ),
+  testWidgets('Conflicting scrollbars are not applied by ScrollBehavior to CupertinoActionSheet', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/83819
+    final actionScrollController = ScrollController();
+    addTearDown(actionScrollController.dispose);
+    await tester.pumpWidget(
+      createAppWithButtonThatLaunchesActionSheet(
+        Builder(
+          builder: (BuildContext context) {
+            return MediaQuery.withClampedTextScaling(
+              minScaleFactor: 3.0,
+              maxScaleFactor: 3.0,
+              child: CupertinoActionSheet(
+                title: const Text('The title'),
+                message: const Text('The message.'),
+                actions: <Widget>[
+                  CupertinoActionSheetAction(child: const Text('One'), onPressed: () {}),
+                  CupertinoActionSheetAction(child: const Text('Two'), onPressed: () {}),
+                ],
+                actionScrollController: actionScrollController,
+              ),
+            );
+          },
         ),
-      );
+      ),
+    );
 
-      await tester.tap(find.text('Go'));
-      await tester.pump();
+    await tester.tap(find.text('Go'));
+    await tester.pump();
 
-      // The inherited ScrollBehavior should not apply scrollbars since they are
-      // already built in to the widget.
-      expect(find.byType(RawScrollbar), findsNothing);
-      // Built in CupertinoScrollbars should only number 2: one for the actions,
-      // one for the content.
-      expect(find.byType(CupertinoScrollbar), findsNWidgets(2));
-    },
-    variant: TargetPlatformVariant.all(),
-  );
+    // The inherited ScrollBehavior should not apply scrollbars since they are
+    // already built in to the widget.
+    expect(find.byType(RawScrollbar), findsNothing);
+    // Built in CupertinoScrollbars should only number 2: one for the actions,
+    // one for the content.
+    expect(find.byType(CupertinoScrollbar), findsNWidgets(2));
+  }, variant: TargetPlatformVariant.all());
 
   testWidgets('Hovering over Cupertino action sheet action updates cursor to clickable on Web', (
     WidgetTester tester,
@@ -1927,55 +1925,53 @@ void main() {
     expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), customCursor);
   });
 
-  testWidgets(
-    'Action sheets emits haptic vibration on sliding into a button',
-    (WidgetTester tester) async {
-      var vibrationCount = 0;
+  testWidgets('Action sheets emits haptic vibration on sliding into a button', (
+    WidgetTester tester,
+  ) async {
+    var vibrationCount = 0;
 
-      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(SystemChannels.platform, (
-        MethodCall methodCall,
-      ) async {
-        if (methodCall.method == 'HapticFeedback.vibrate') {
-          expect(methodCall.arguments, 'HapticFeedbackType.selectionClick');
-          vibrationCount += 1;
-        }
-        return null;
-      });
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(SystemChannels.platform, (
+      MethodCall methodCall,
+    ) async {
+      if (methodCall.method == 'HapticFeedback.vibrate') {
+        expect(methodCall.arguments, 'HapticFeedbackType.selectionClick');
+        vibrationCount += 1;
+      }
+      return null;
+    });
 
-      await tester.pumpWidget(
-        createAppWithButtonThatLaunchesActionSheet(
-          CupertinoActionSheet(
-            title: const Text('The title'),
-            actions: <Widget>[
-              CupertinoActionSheetAction(child: const Text('One'), onPressed: () {}),
-              CupertinoActionSheetAction(child: const Text('Two'), onPressed: () {}),
-              CupertinoActionSheetAction(child: const Text('Three'), onPressed: () {}),
-            ],
-          ),
+    await tester.pumpWidget(
+      createAppWithButtonThatLaunchesActionSheet(
+        CupertinoActionSheet(
+          title: const Text('The title'),
+          actions: <Widget>[
+            CupertinoActionSheetAction(child: const Text('One'), onPressed: () {}),
+            CupertinoActionSheetAction(child: const Text('Two'), onPressed: () {}),
+            CupertinoActionSheetAction(child: const Text('Three'), onPressed: () {}),
+          ],
         ),
-      );
+      ),
+    );
 
-      await tester.tap(find.text('Go'));
-      await tester.pumpAndSettle();
+    await tester.tap(find.text('Go'));
+    await tester.pumpAndSettle();
 
-      final TestGesture gesture = await tester.startGesture(tester.getCenter(find.text('One')));
-      await tester.pumpAndSettle();
-      // Tapping down on a button should not emit vibration.
-      expect(vibrationCount, 0);
+    final TestGesture gesture = await tester.startGesture(tester.getCenter(find.text('One')));
+    await tester.pumpAndSettle();
+    // Tapping down on a button should not emit vibration.
+    expect(vibrationCount, 0);
 
-      await gesture.moveTo(tester.getCenter(find.text('Two')));
-      await tester.pumpAndSettle();
-      expect(vibrationCount, 1);
+    await gesture.moveTo(tester.getCenter(find.text('Two')));
+    await tester.pumpAndSettle();
+    expect(vibrationCount, 1);
 
-      await gesture.moveTo(tester.getCenter(find.text('Three')));
-      await tester.pumpAndSettle();
-      expect(vibrationCount, 2);
+    await gesture.moveTo(tester.getCenter(find.text('Three')));
+    await tester.pumpAndSettle();
+    expect(vibrationCount, 2);
 
-      await gesture.up();
-      expect(vibrationCount, 2);
-    },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-  );
+    await gesture.up();
+    expect(vibrationCount, 2);
+  }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
   testWidgets(
     'CupertinoActionSheet appearance changes correctly when actions or cancel button is focused',

--- a/packages/flutter/test/cupertino/bottom_tab_bar_test.dart
+++ b/packages/flutter/test/cupertino/bottom_tab_bar_test.dart
@@ -9,7 +9,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../image_data.dart';
-import '../widgets/semantics_tester.dart';
+import 'semantics_tester.dart';
 
 Future<void> pumpWidgetWithBoilerplate(WidgetTester tester, Widget widget) async {
   await tester.pumpWidget(

--- a/packages/flutter/test/cupertino/button_test.dart
+++ b/packages/flutter/test/cupertino/button_test.dart
@@ -10,7 +10,7 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/semantics_tester.dart';
+import 'semantics_tester.dart';
 
 const TextStyle testStyle = TextStyle(fontSize: 10.0, letterSpacing: 0.0);
 

--- a/packages/flutter/test/cupertino/checkbox_test.dart
+++ b/packages/flutter/test/cupertino/checkbox_test.dart
@@ -15,7 +15,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/semantics_tester.dart';
+import 'semantics_tester.dart';
 
 void main() {
   setUp(() {

--- a/packages/flutter/test/cupertino/dialog_test.dart
+++ b/packages/flutter/test/cupertino/dialog_test.dart
@@ -16,7 +16,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/semantics_tester.dart';
+import 'semantics_tester.dart';
 
 void main() {
   testWidgets('Overall appearance is correct for the light theme', (WidgetTester tester) async {
@@ -1821,42 +1821,40 @@ void main() {
     expect(find.byType(CupertinoAlertDialog), findsOneWidget);
   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/33615
 
-  testWidgets(
-    'Conflicting scrollbars are not applied by ScrollBehavior to CupertinoAlertDialog',
-    (WidgetTester tester) async {
-      // Regression test for https://github.com/flutter/flutter/issues/83819
-      final actionScrollController = ScrollController();
-      addTearDown(actionScrollController.dispose);
-      await tester.pumpWidget(
-        createAppWithButtonThatLaunchesDialog(
-          dialogBuilder: (BuildContext context) {
-            return MediaQuery.withNoTextScaling(
-              child: CupertinoAlertDialog(
-                title: const Text('Test Title'),
-                content: const Text('Test Content'),
-                actions: const <Widget>[
-                  CupertinoDialogAction(child: Text('One')),
-                  CupertinoDialogAction(child: Text('Two')),
-                ],
-                actionScrollController: actionScrollController,
-              ),
-            );
-          },
-        ),
-      );
+  testWidgets('Conflicting scrollbars are not applied by ScrollBehavior to CupertinoAlertDialog', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/83819
+    final actionScrollController = ScrollController();
+    addTearDown(actionScrollController.dispose);
+    await tester.pumpWidget(
+      createAppWithButtonThatLaunchesDialog(
+        dialogBuilder: (BuildContext context) {
+          return MediaQuery.withNoTextScaling(
+            child: CupertinoAlertDialog(
+              title: const Text('Test Title'),
+              content: const Text('Test Content'),
+              actions: const <Widget>[
+                CupertinoDialogAction(child: Text('One')),
+                CupertinoDialogAction(child: Text('Two')),
+              ],
+              actionScrollController: actionScrollController,
+            ),
+          );
+        },
+      ),
+    );
 
-      await tester.tap(find.text('Go'));
-      await tester.pump();
+    await tester.tap(find.text('Go'));
+    await tester.pump();
 
-      // The inherited ScrollBehavior should not apply scrollbars since they are
-      // already built in to the widget.
-      expect(find.byType(RawScrollbar), findsNothing);
-      // Built in CupertinoScrollbars should only number 2: one for the actions,
-      // one for the content.
-      expect(find.byType(CupertinoScrollbar), findsNWidgets(2));
-    },
-    variant: TargetPlatformVariant.all(),
-  );
+    // The inherited ScrollBehavior should not apply scrollbars since they are
+    // already built in to the widget.
+    expect(find.byType(RawScrollbar), findsNothing);
+    // Built in CupertinoScrollbars should only number 2: one for the actions,
+    // one for the content.
+    expect(find.byType(CupertinoScrollbar), findsNWidgets(2));
+  }, variant: TargetPlatformVariant.all());
 
   testWidgets('CupertinoAlertDialog scrollbars controllers should be different', (
     WidgetTester tester,

--- a/packages/flutter/test/cupertino/menu_anchor_test.dart
+++ b/packages/flutter/test/cupertino/menu_anchor_test.dart
@@ -13,7 +13,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/semantics_tester.dart';
+import 'semantics_tester.dart';
 
 void main() {
   late MenuController controller;
@@ -4105,12 +4105,11 @@ void main() {
           darkColor: Color.fromRGBO(150, 0, 0, 1),
         );
 
-        const decoration = WidgetStateProperty<BoxDecoration>.fromMap(
-          <WidgetStatesConstraint, BoxDecoration>{
-            WidgetState.dragged: BoxDecoration(color: customSwipedColor),
-            WidgetState.any: BoxDecoration(),
-          },
-        );
+        const decoration =
+            WidgetStateProperty<BoxDecoration>.fromMap(<WidgetStatesConstraint, BoxDecoration>{
+              WidgetState.dragged: BoxDecoration(color: customSwipedColor),
+              WidgetState.any: BoxDecoration(),
+            });
 
         BoxDecoration getItemDecoration(Tag tag) {
           return tester

--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -12,7 +12,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/semantics_tester.dart';
+import 'semantics_tester.dart';
 
 int count = 0;
 

--- a/packages/flutter/test/cupertino/picker_test.dart
+++ b/packages/flutter/test/cupertino/picker_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/semantics_tester.dart';
+import 'semantics_tester.dart';
 
 /// A [CustomPainter] that calls a callback when it paints.
 class TestCallbackPainter extends CustomPainter {
@@ -473,51 +473,49 @@ void main() {
       expect(selectedItems, <int>[2, 1]);
     });
 
-    testWidgets(
-      'does not trigger haptics or sounds when scrolling by tapping on the item',
-      (WidgetTester tester) async {
-        final selectedItems = <int>[];
-        final systemCalls = <MethodCall>[];
+    testWidgets('does not trigger haptics or sounds when scrolling by tapping on the item', (
+      WidgetTester tester,
+    ) async {
+      final selectedItems = <int>[];
+      final systemCalls = <MethodCall>[];
 
-        tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(SystemChannels.platform, (
-          MethodCall methodCall,
-        ) async {
-          systemCalls.add(methodCall);
-          return null;
-        });
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(SystemChannels.platform, (
+        MethodCall methodCall,
+      ) async {
+        systemCalls.add(methodCall);
+        return null;
+      });
 
-        await tester.pumpWidget(
-          Directionality(
-            textDirection: TextDirection.ltr,
-            child: CupertinoPicker(
-              itemExtent: 100.0,
-              onSelectedItemChanged: (int index) {
-                selectedItems.add(index);
-              },
-              children: List<Widget>.generate(100, (int index) {
-                return Center(
-                  child: SizedBox(width: 400.0, height: 100.0, child: Text(index.toString())),
-                );
-              }),
-            ),
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: CupertinoPicker(
+            itemExtent: 100.0,
+            onSelectedItemChanged: (int index) {
+              selectedItems.add(index);
+            },
+            children: List<Widget>.generate(100, (int index) {
+              return Center(
+                child: SizedBox(width: 400.0, height: 100.0, child: Text(index.toString())),
+              );
+            }),
           ),
-        );
+        ),
+      );
 
-        await tester.tap(find.text('2'), warnIfMissed: false); // has an IgnorePointer
-        await tester.pumpAndSettle(const Duration(milliseconds: 10));
+      await tester.tap(find.text('2'), warnIfMissed: false); // has an IgnorePointer
+      await tester.pumpAndSettle(const Duration(milliseconds: 10));
 
-        // Expect that the item changed, but haptics were not triggered.
-        expect(selectedItems, <int>[1, 2]);
-        expect(systemCalls, isEmpty);
+      // Expect that the item changed, but haptics were not triggered.
+      expect(selectedItems, <int>[1, 2]);
+      expect(systemCalls, isEmpty);
 
-        await tester.drag(find.text('2'), const Offset(0.0, -30.0), warnIfMissed: false);
-        await tester.pumpAndSettle(const Duration(milliseconds: 10));
-        // Expect that moving within the item does not trigger haptics after animating scroll.
-        expect(selectedItems, <int>[1, 2]);
-        expect(systemCalls, isEmpty);
-      },
-      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-    );
+      await tester.drag(find.text('2'), const Offset(0.0, -30.0), warnIfMissed: false);
+      await tester.pumpAndSettle(const Duration(milliseconds: 10));
+      // Expect that moving within the item does not trigger haptics after animating scroll.
+      expect(selectedItems, <int>[1, 2]);
+      expect(systemCalls, isEmpty);
+    }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
     testWidgets(
       'do not trigger haptic or sounds on non-iOS devices',

--- a/packages/flutter/test/cupertino/radio_test.dart
+++ b/packages/flutter/test/cupertino/radio_test.dart
@@ -15,7 +15,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/semantics_tester.dart';
+import 'semantics_tester.dart';
 
 void main() {
   testWidgets('Radio control test', (WidgetTester tester) async {

--- a/packages/flutter/test/cupertino/route_test.dart
+++ b/packages/flutter/test/cupertino/route_test.dart
@@ -12,7 +12,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/semantics_tester.dart';
+import 'semantics_tester.dart';
 
 void main() {
   late MockNavigatorObserver navigatorObserver;

--- a/packages/flutter/test/cupertino/segmented_control_test.dart
+++ b/packages/flutter/test/cupertino/segmented_control_test.dart
@@ -16,7 +16,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/semantics_tester.dart';
+import 'semantics_tester.dart';
 
 RenderBox getRenderSegmentedControl(WidgetTester tester) {
   return tester.allRenderObjects.firstWhere((RenderObject currentObject) {

--- a/packages/flutter/test/cupertino/semantics_tester.dart
+++ b/packages/flutter/test/cupertino/semantics_tester.dart
@@ -1,0 +1,1326 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/physics.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+export 'dart:ui' show SemanticsAction, SemanticsFlag, SemanticsFlags;
+export 'package:flutter/rendering.dart' show SemanticsData;
+
+const String _matcherHelp =
+    'Try dumping the semantics with debugDumpSemanticsTree(DebugSemanticsDumpOrder.inverseHitTest) from the package:flutter/rendering.dart library to see what the semantics tree looks like.';
+
+// TODO(justinmc): Remove this per
+// https://github.com/flutter/flutter/issues/184367.
+/// Test semantics data that is compared against real semantics tree.
+///
+/// Useful with [hasSemantics] and [SemanticsTester] to test the contents of the
+/// semantics tree.
+///
+/// This class should be avoided due to a high frequency of breakages caused by
+/// small semantics tree changes. Instead, prefer [SemanticsController.find],
+/// accessible via [WidgetTester.semantics], or the matchers [isSemantics] and
+/// [matchesSemantics].
+@Deprecated(
+  'Use `SemanticsController.find`, `isSemantics`, or `matchesSemantics` instead. '
+  'This feature was deprecated after v3.43.0-0.3.pre.',
+)
+class TestSemantics {
+  /// Creates an object with some test semantics data.
+  ///
+  /// The [id] field is required. The root node has an id of zero. Other nodes
+  /// are given a unique id when they are created, in a predictable fashion, and
+  /// so these values can be hard-coded.
+  ///
+  /// The [rect] field is required and has no default. Convenient values are
+  /// available:
+  ///
+  ///  * [TestSemantics.rootRect]: 2400x1600, the test screen's size in physical
+  ///    pixels, useful for the node with id zero.
+  ///
+  ///  * [TestSemantics.fullScreen] 800x600, the test screen's size in logical
+  ///    pixels, useful for other full-screen widgets.
+  @Deprecated(
+    'Use `SemanticsController.find`, `isSemantics`, or `matchesSemantics` instead. '
+    'This feature was deprecated after v3.43.0-0.3.pre.',
+  )
+  TestSemantics({
+    this.id,
+    this.flags = 0,
+    this.actions = 0,
+    this.label = '',
+    this.value = '',
+    this.tooltip = '',
+    this.headingLevel,
+    this.increasedValue = '',
+    this.decreasedValue = '',
+    this.hint = '',
+    this.textDirection,
+    this.rect,
+    this.transform,
+    this.textSelection,
+    this.children = const <TestSemantics>[],
+    this.scrollIndex,
+    this.scrollChildren,
+    Iterable<SemanticsTag>? tags,
+    this.role = SemanticsRole.none,
+    this.validationResult = SemanticsValidationResult.none,
+    this.inputType = SemanticsInputType.none,
+    this.controlsNodes,
+    this.linkUrl,
+    this.maxValueLength,
+    this.currentValueLength,
+    this.identifier = '',
+    this.traversalParentIdentifier,
+    this.traversalChildIdentifier,
+    this.locale,
+    this.hintOverrides,
+  }) : assert(flags is int || flags is List<SemanticsFlag> || flags is SemanticsFlags),
+       assert(actions is int || actions is List<SemanticsAction>),
+       tags = tags?.toSet() ?? <SemanticsTag>{};
+
+  /// Creates an object with some test semantics data, with the [id] and [rect]
+  /// set to the appropriate values for the root node.
+  @Deprecated(
+    'Use `SemanticsController.find`, `isSemantics`, or `matchesSemantics` instead. '
+    'This feature was deprecated after v3.43.0-0.3.pre.',
+  )
+  TestSemantics.root({
+    this.flags = 0,
+    this.actions = 0,
+    this.label = '',
+    this.value = '',
+    this.increasedValue = '',
+    this.decreasedValue = '',
+    this.hint = '',
+    this.tooltip = '',
+    this.headingLevel,
+    this.textDirection,
+    this.transform,
+    this.textSelection,
+    this.children = const <TestSemantics>[],
+    this.scrollIndex,
+    this.scrollChildren,
+    Iterable<SemanticsTag>? tags,
+    this.role = SemanticsRole.none,
+    this.validationResult = SemanticsValidationResult.none,
+    this.inputType = SemanticsInputType.none,
+    this.controlsNodes,
+    this.linkUrl,
+    this.maxValueLength,
+    this.currentValueLength,
+    this.identifier = '',
+    this.traversalParentIdentifier,
+    this.traversalChildIdentifier,
+    this.locale,
+    this.hintOverrides,
+  }) : id = 0,
+       assert(flags is int || flags is List<SemanticsFlag> || flags is SemanticsFlags),
+       assert(actions is int || actions is List<SemanticsAction>),
+       rect = TestSemantics.rootRect,
+       tags = tags?.toSet() ?? <SemanticsTag>{};
+
+  /// Creates an object with some test semantics data, with the [id] and [rect]
+  /// set to the appropriate values for direct children of the root node.
+  ///
+  /// The [transform] is set to a 3.0 scale (to account for the
+  /// [dart:ui.FlutterView.devicePixelRatio] being 3.0 on the test
+  /// pseudo-device).
+  ///
+  /// The [rect] field is required and has no default. The
+  /// [TestSemantics.fullScreen] property may be useful as a value; it describes
+  /// an 800x600 rectangle, which is the test screen's size in logical pixels.
+  @Deprecated(
+    'Use `SemanticsController.find`, `isSemantics`, or `matchesSemantics` instead. '
+    'This feature was deprecated after v3.43.0-0.3.pre.',
+  )
+  TestSemantics.rootChild({
+    this.id,
+    this.flags = 0,
+    this.actions = 0,
+    this.label = '',
+    this.hint = '',
+    this.value = '',
+    this.tooltip = '',
+    this.headingLevel,
+    this.increasedValue = '',
+    this.decreasedValue = '',
+    this.textDirection,
+    this.rect,
+    Matrix4? transform,
+    this.textSelection,
+    this.children = const <TestSemantics>[],
+    this.scrollIndex,
+    this.scrollChildren,
+    Iterable<SemanticsTag>? tags,
+    this.role = SemanticsRole.none,
+    this.validationResult = SemanticsValidationResult.none,
+    this.inputType = SemanticsInputType.none,
+    this.controlsNodes,
+    this.linkUrl,
+    this.maxValueLength,
+    this.currentValueLength,
+    this.identifier = '',
+    this.traversalParentIdentifier,
+    this.traversalChildIdentifier,
+    this.locale,
+    this.hintOverrides,
+  }) : assert(flags is int || flags is List<SemanticsFlag> || flags is SemanticsFlags),
+       assert(actions is int || actions is List<SemanticsAction>),
+       transform = _applyRootChildScale(transform),
+       tags = tags?.toSet() ?? <SemanticsTag>{};
+
+  /// The unique identifier for this node.
+  ///
+  /// The root node has an id of zero. Other nodes are given a unique id when
+  /// they are created.
+  final int? id;
+
+  /// The SemanticsFlags on this node.
+  ///
+  /// There are three ways to specify this property: as an `int` that encodes the
+  /// flags as a bit field, or as a `List<SemanticsFlag>` that are _on_, or as a `SemanticsFlags`.
+  ///
+  /// Using `SemanticsFlags` is recommended.
+  ///
+  /// The `int` and `List<SemanticsFlag>` types are considered deprecated as they
+  /// have limited bits and only support the first 31 flags.
+  final dynamic flags;
+
+  /// The [SemanticsAction]s set on this node.
+  ///
+  /// There are two ways to specify this property: as an `int` that encodes the
+  /// actions as a bit field, or as a `List<SemanticsAction>`.
+  ///
+  /// Using `List<SemanticsAction>` is recommended due to better readability.
+  ///
+  /// The tester does not check the function corresponding to the action, but
+  /// only its existence.
+  final dynamic actions;
+
+  /// A textual description of this node.
+  final String label;
+
+  /// A textual description for the value of this node.
+  final String value;
+
+  /// What [value] will become after [SemanticsAction.increase] has been
+  /// performed.
+  final String increasedValue;
+
+  /// What [value] will become after [SemanticsAction.decrease] has been
+  /// performed.
+  final String decreasedValue;
+
+  /// A brief textual description of the result of the action that can be
+  /// performed on this node.
+  final String hint;
+
+  /// A textual tooltip of this node.
+  final String tooltip;
+
+  /// The reading direction of the [label].
+  ///
+  /// Even if this is not set, the [hasSemantics] matcher will verify that if a
+  /// label is present on the [SemanticsNode], a [SemanticsNode.textDirection]
+  /// is also set.
+  final TextDirection? textDirection;
+
+  /// The bounding box for this node in its coordinate system.
+  ///
+  /// Convenient values are available:
+  ///
+  ///  * [TestSemantics.rootRect]: 2400x1600, the test screen's size in physical
+  ///    pixels, useful for the node with id zero.
+  ///
+  ///  * [TestSemantics.fullScreen] 800x600, the test screen's size in logical
+  ///    pixels, useful for other full-screen widgets.
+  final Rect? rect;
+
+  /// The test screen's size in physical pixels, typically used as the [rect]
+  /// for the node with id zero.
+  ///
+  /// See also:
+  ///
+  ///  * [TestSemantics.root], which uses this value to describe the root
+  ///    node.
+  static const Rect rootRect = Rect.fromLTWH(0.0, 0.0, 2400.0, 1800.0);
+
+  /// The test screen's size in logical pixels, useful for the [rect] of
+  /// full-screen widgets other than the root node.
+  static const Rect fullScreen = Rect.fromLTWH(0.0, 0.0, 800.0, 600.0);
+
+  /// The transform from this node's coordinate system to its parent's coordinate system.
+  ///
+  /// By default, the transform is null, which represents the identity
+  /// transformation (i.e., that this node has the same coordinate system as its
+  /// parent).
+  final Matrix4? transform;
+
+  /// The index of the first visible semantic node within a scrollable.
+  final int? scrollIndex;
+
+  /// The total number of semantic nodes within a scrollable.
+  final int? scrollChildren;
+
+  /// The expected text selection.
+  final TextSelection? textSelection;
+
+  /// The validation result for this node, if any.
+  ///
+  /// See also:
+  ///
+  ///  * [SemanticsValidationResult], which is the enum listing possible values
+  ///    for this field.
+  final SemanticsValidationResult validationResult;
+
+  /// The expected heading level
+  final int? headingLevel;
+
+  /// The expected role for the node.
+  ///
+  /// Defaults to SemanticsRole.none if not set.
+  final SemanticsRole role;
+
+  /// The expected input type for the node.
+  ///
+  /// Defaults to SemanticsInputType.none if not set.
+  final SemanticsInputType inputType;
+
+  /// The expected nodes that this node controls.
+  ///
+  /// Defaults to an empty set if not set.
+  final Set<String>? controlsNodes;
+
+  /// The expected url for the node.
+  ///
+  /// Defaults to null if not set.
+  final Uri? linkUrl;
+
+  /// The expected max value length for the node.
+  ///
+  /// Defaults to null if not set.
+  final int? maxValueLength;
+
+  /// The expected current value length for the node.
+  ///
+  /// Defaults to null if not set.
+  final int? currentValueLength;
+
+  /// The expected identifier for the node.
+  ///
+  /// Defaults to an empty string if not set.
+  final String identifier;
+
+  /// The expected traversalParentIdentifier for the node.
+  ///
+  /// Defaults to null if not set.
+  final Object? traversalParentIdentifier;
+
+  /// The expected traversalChildIdentifier for the node.
+  ///
+  /// Defaults to null if not set.
+  final Object? traversalChildIdentifier;
+
+  /// The expected locale for the node.
+  ///
+  /// Defaults to null if not set.
+  final Locale? locale;
+
+  /// The expected hint overrides for the node.
+  ///
+  /// Defaults to null if not set.
+  final SemanticsHintOverrides? hintOverrides;
+
+  static Matrix4 _applyRootChildScale(Matrix4? transform) {
+    final result = Matrix4.diagonal3Values(3.0, 3.0, 1.0);
+    if (transform != null) {
+      result.multiply(transform);
+    }
+    return result;
+  }
+
+  /// The children of this node.
+  final List<TestSemantics> children;
+
+  /// The tags of this node.
+  final Set<SemanticsTag> tags;
+
+  bool _matches(
+    SemanticsNode? node,
+    Map<dynamic, dynamic> matchState, {
+    bool ignoreRect = false,
+    bool ignoreTransform = false,
+    bool ignoreId = false,
+    bool ignoreTraversalIdentifier = false,
+    DebugSemanticsDumpOrder childOrder = DebugSemanticsDumpOrder.inverseHitTest,
+  }) {
+    bool fail(String message) {
+      matchState[TestSemantics] = message;
+      return false;
+    }
+
+    if (node == null) {
+      return fail('could not find node with id $id.');
+    }
+    if (!ignoreId && id != node.id) {
+      return fail('expected node id $id but found id ${node.id}.');
+    }
+
+    final SemanticsData nodeData = node.getSemanticsData();
+
+    if (flags is SemanticsFlags) {
+      if (flags != nodeData.flagsCollection) {
+        return fail(
+          'expected node id $id to have flags $flags but found flags ${nodeData.flagsCollection}.',
+        );
+      }
+    }
+    // the bitmask flags only support first 31 flags.
+    else {
+      final int flagsBitmask = flags is int
+          ? flags as int
+          : (flags as List<SemanticsFlag>).fold<int>(
+              0,
+              (int bitmask, SemanticsFlag flag) => bitmask | flag.index,
+            );
+
+      if (flagsBitmask != nodeData.flags) {
+        return fail('expected node id $id to have flags $flags but found flags ${nodeData.flags}.');
+      }
+    }
+
+    final int actionsBitmask = actions is int
+        ? actions as int
+        : (actions as List<SemanticsAction>).fold<int>(
+            0,
+            (int bitmask, SemanticsAction action) => bitmask | action.index,
+          );
+    if (actionsBitmask != nodeData.actions) {
+      return fail(
+        'expected node id $id to have actions $actions but found actions ${nodeData.actions}.',
+      );
+    }
+
+    if (label != nodeData.label) {
+      return fail(
+        'expected node id $id to have label "$label" but found label "${nodeData.label}".',
+      );
+    }
+    if (value != nodeData.value) {
+      return fail(
+        'expected node id $id to have value "$value" but found value "${nodeData.value}".',
+      );
+    }
+    if (increasedValue != nodeData.increasedValue) {
+      return fail(
+        'expected node id $id to have increasedValue "$increasedValue" but found value "${nodeData.increasedValue}".',
+      );
+    }
+    if (decreasedValue != nodeData.decreasedValue) {
+      return fail(
+        'expected node id $id to have decreasedValue "$decreasedValue" but found value "${nodeData.decreasedValue}".',
+      );
+    }
+    if (hint != nodeData.hint) {
+      return fail('expected node id $id to have hint "$hint" but found hint "${nodeData.hint}".');
+    }
+    if (tooltip != nodeData.tooltip) {
+      return fail(
+        'expected node id $id to have tooltip "$tooltip" but found hint "${nodeData.tooltip}".',
+      );
+    }
+    if (textDirection != null && textDirection != nodeData.textDirection) {
+      return fail(
+        'expected node id $id to have textDirection "$textDirection" but found "${nodeData.textDirection}".',
+      );
+    }
+    if ((nodeData.label != '' ||
+            nodeData.value != '' ||
+            nodeData.hint != '' ||
+            node.increasedValue != '' ||
+            node.decreasedValue != '') &&
+        nodeData.textDirection == null) {
+      return fail(
+        'expected node id $id, which has a label, value, or hint, to have a textDirection, but it did not.',
+      );
+    }
+    if (!ignoreRect && rect != nodeData.rect) {
+      return fail('expected node id $id to have rect $rect but found rect ${nodeData.rect}.');
+    }
+    if (!ignoreTransform && transform != nodeData.transform) {
+      return fail(
+        'expected node id $id to have transform $transform but found transform:\n${nodeData.transform}.',
+      );
+    }
+    if (textSelection?.baseOffset != nodeData.textSelection?.baseOffset ||
+        textSelection?.extentOffset != nodeData.textSelection?.extentOffset) {
+      return fail(
+        'expected node id $id to have textSelection [${textSelection?.baseOffset}, ${textSelection?.end}] but found: [${nodeData.textSelection?.baseOffset}, ${nodeData.textSelection?.extentOffset}].',
+      );
+    }
+    if (scrollIndex != null && scrollIndex != nodeData.scrollIndex) {
+      return fail(
+        'expected node id $id to have scrollIndex $scrollIndex but found scrollIndex ${nodeData.scrollIndex}.',
+      );
+    }
+    if (scrollChildren != null && scrollChildren != nodeData.scrollChildCount) {
+      return fail(
+        'expected node id $id to have scrollIndex $scrollChildren but found scrollIndex ${nodeData.scrollChildCount}.',
+      );
+    }
+
+    final int childrenCount;
+    if (childOrder == DebugSemanticsDumpOrder.traversalOrder) {
+      childrenCount = node.mergeAllDescendantsIntoThisNode ? 0 : node.childrenCountInTraversalOrder;
+    } else {
+      childrenCount = node.mergeAllDescendantsIntoThisNode ? 0 : node.childrenCount;
+    }
+
+    if (children.length != childrenCount) {
+      return fail(
+        'expected node id $id to have ${children.length} child${children.length == 1 ? "" : "ren"} but found $childrenCount.',
+      );
+    }
+    if (headingLevel != null && headingLevel != node.headingLevel) {
+      return fail(
+        'expected node id $id to have headingLevel $headingLevel but found headingLevel ${node.headingLevel}',
+      );
+    }
+
+    if (role != node.role) {
+      return fail('expected node id $id to have role $role but found role ${node.role}');
+    }
+
+    if (validationResult != node.validationResult) {
+      return fail(
+        'expected node id $id to have validationResult $validationResult but found validationResult ${node.validationResult}',
+      );
+    }
+    if (inputType != node.inputType) {
+      return fail(
+        'expected node id $id to have input type $inputType but found input type ${node.inputType}',
+      );
+    }
+
+    if (controlsNodes != controlsNodes && !setEquals(controlsNodes, node.controlsNodes)) {
+      return fail(
+        'expected node id $id to controls nodes $controlsNodes but found controlling nodes ${node.controlsNodes}',
+      );
+    }
+
+    if (linkUrl?.toString() != node.linkUrl?.toString()) {
+      return fail(
+        'expected node id $id to have link url $linkUrl but found link url ${node.linkUrl}',
+      );
+    }
+    if (maxValueLength != node.maxValueLength) {
+      return fail(
+        'expected node id $id to have max value length $maxValueLength but found max value length ${node.maxValueLength}',
+      );
+    }
+    if (currentValueLength != node.currentValueLength) {
+      return fail(
+        'expected node id $id to have current value length $currentValueLength but found current value length ${node.currentValueLength}',
+      );
+    }
+    if (!ignoreTraversalIdentifier) {
+      if (traversalChildIdentifier != node.traversalChildIdentifier) {
+        return fail(
+          'expected node id $id to have traversalChildIdentifier $traversalChildIdentifier but found identifier ${node.traversalChildIdentifier}',
+        );
+      }
+      if (traversalParentIdentifier != node.traversalParentIdentifier) {
+        return fail(
+          'expected node id $id to have traversalParentIdentifier $traversalParentIdentifier but found identifier ${node.traversalParentIdentifier}',
+        );
+      }
+    }
+    if (hintOverrides != node.hintOverrides) {
+      return fail(
+        'expected node id $id to have hint overrides $hintOverrides but found hint overrides ${node.hintOverrides}',
+      );
+    }
+    if (locale != null && locale != node.getSemanticsData().locale) {
+      return fail(
+        'expected node id $id to have locale $locale but found locale ${node.getSemanticsData().locale}',
+      );
+    }
+
+    if (children.isEmpty) {
+      return true;
+    }
+    var result = true;
+    final Iterator<TestSemantics> it = children.iterator;
+    for (final SemanticsNode child in node.debugListChildrenInOrder(childOrder)) {
+      it.moveNext();
+      final bool childMatches = it.current._matches(
+        child,
+        matchState,
+        ignoreRect: ignoreRect,
+        ignoreTransform: ignoreTransform,
+        ignoreId: ignoreId,
+        ignoreTraversalIdentifier: ignoreTraversalIdentifier,
+        childOrder: childOrder,
+      );
+      if (!childMatches) {
+        result = false;
+        return false;
+      }
+    }
+    if (it.moveNext()) {
+      return false;
+    }
+    return result;
+  }
+
+  @override
+  String toString([int indentAmount = 0]) {
+    final String indent = '  ' * indentAmount;
+    final buf = StringBuffer();
+    buf.writeln('$indent${objectRuntimeType(this, 'TestSemantics')}(');
+    if (id != null) {
+      buf.writeln('$indent  id: $id,');
+    }
+    if ((flags is int && flags != 0) ||
+        (flags is List<SemanticsFlag> && (flags as List<SemanticsFlag>).isNotEmpty) ||
+        (flags is SemanticsFlags && (flags as SemanticsFlags) != SemanticsFlags.none)) {
+      buf.writeln('$indent  flags: ${SemanticsTester._flagsToSemanticsFlagExpression(flags)},');
+    }
+    if (actions is int && actions != 0 ||
+        actions is List<SemanticsAction> && (actions as List<SemanticsAction>).isNotEmpty) {
+      buf.writeln(
+        '$indent  actions: ${SemanticsTester._actionsToSemanticsActionExpression(actions)},',
+      );
+    }
+    if (label != '') {
+      buf.writeln("$indent  label: '$label',");
+    }
+    if (value != '') {
+      buf.writeln("$indent  value: '$value',");
+    }
+    if (increasedValue != '') {
+      buf.writeln("$indent  increasedValue: '$increasedValue',");
+    }
+    if (decreasedValue != '') {
+      buf.writeln("$indent  decreasedValue: '$decreasedValue',");
+    }
+    if (hint != '') {
+      buf.writeln("$indent  hint: '$hint',");
+    }
+    if (tooltip != '') {
+      buf.writeln("$indent  tooltip: '$tooltip',");
+    }
+    if (textDirection != null) {
+      buf.writeln('$indent  textDirection: $textDirection,');
+    }
+    if (textSelection?.isValid ?? false) {
+      buf.writeln('$indent  textSelection:\n[${textSelection!.start}, ${textSelection!.end}],');
+    }
+    if (scrollIndex != null) {
+      buf.writeln('$indent scrollIndex: $scrollIndex,');
+    }
+    if (rect != null) {
+      buf.writeln('$indent  rect: $rect,');
+    }
+    if (transform != null) {
+      buf.writeln(
+        '$indent  transform:\n${transform.toString().trim().split('\n').map<String>((String line) => '$indent    $line').join('\n')},',
+      );
+    }
+    if (inputType != SemanticsInputType.none) {
+      buf.writeln('$indent  inputType: $inputType,');
+    }
+    if (controlsNodes != null) {
+      buf.writeln('$indent  controlsNodes: $controlsNodes,');
+    }
+    if (linkUrl != null) {
+      buf.writeln('$indent  linkUrl: $linkUrl,');
+    }
+    if (maxValueLength != null) {
+      buf.writeln('$indent  maxValueLength: $maxValueLength,');
+    }
+    if (currentValueLength != null) {
+      buf.writeln('$indent  currentValueLength: $currentValueLength,');
+    }
+    if (identifier.isNotEmpty) {
+      buf.writeln('$indent  identifier: $identifier,');
+    }
+    if (hintOverrides != null) {
+      buf.writeln('$indent  hintOverrides: $hintOverrides,');
+    }
+    buf.writeln('$indent  children: <TestSemantics>[');
+    for (final TestSemantics child in children) {
+      buf.writeln('${child.toString(indentAmount + 2)},');
+    }
+    buf.writeln('$indent  ],');
+    buf.write('$indent)');
+    return buf.toString();
+  }
+}
+
+/// Ensures that the given widget tester has a semantics tree to test.
+///
+/// Useful with [hasSemantics] to test the contents of the semantics tree.
+class SemanticsTester {
+  /// Creates a semantics tester for the given widget tester.
+  ///
+  /// You should call [dispose] at the end of a test that creates a semantics
+  /// tester.
+  SemanticsTester(this.tester) {
+    _semanticsHandle = tester.ensureSemantics();
+
+    // This _extra_ clean-up is needed for the case when a test fails and
+    // therefore fails to call dispose() explicitly. The test is still required
+    // to call dispose() explicitly, because the semanticsOwner check is
+    // performed irrespective of whether the owner was created via
+    // SemanticsTester or directly. When the test succeeds, this tear-down
+    // becomes a no-op.
+    addTearDown(dispose);
+  }
+
+  /// The widget tester that this object is testing the semantics of.
+  final WidgetTester tester;
+  SemanticsHandle? _semanticsHandle;
+
+  /// Release resources held by this semantics tester.
+  ///
+  /// Call this function at the end of any test that uses a semantics tester. It
+  /// is OK to call this function multiple times. If the resources have already
+  /// been released, the subsequent calls have no effect.
+  @mustCallSuper
+  void dispose() {
+    _semanticsHandle?.dispose();
+    _semanticsHandle = null;
+  }
+
+  @override
+  String toString() =>
+      'SemanticsTester for ${tester.binding.pipelineOwner.semanticsOwner?.rootSemanticsNode}';
+
+  bool _stringAttributesEqual(List<StringAttribute> first, List<StringAttribute> second) {
+    if (first.length != second.length) {
+      return false;
+    }
+    for (var i = 0; i < first.length; i++) {
+      if (first[i] is SpellOutStringAttribute &&
+          (second[i] is! SpellOutStringAttribute || second[i].range != first[i].range)) {
+        return false;
+      }
+      if (first[i] is LocaleStringAttribute &&
+          (second[i] is! LocaleStringAttribute ||
+              second[i].range != first[i].range ||
+              (second[i] as LocaleStringAttribute).locale !=
+                  (second[i] as LocaleStringAttribute).locale)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /// Returns all semantics nodes in the current semantics tree whose properties
+  /// match the non-null arguments.
+  ///
+  /// If multiple arguments are non-null, each of the returned nodes must match
+  /// on all of them.
+  ///
+  /// If `ancestor` is not null, only the descendants of it are returned.
+  Iterable<SemanticsNode> nodesWith({
+    AttributedString? attributedLabel,
+    AttributedString? attributedValue,
+    AttributedString? attributedHint,
+    String? label,
+    String? value,
+    String? hint,
+    String? increasedValue,
+    String? decreasedValue,
+    TextDirection? textDirection,
+    List<SemanticsAction>? actions,
+    List<SemanticsFlag>? flags,
+    SemanticsFlags? flagsCollection,
+    Set<SemanticsTag>? tags,
+    double? scrollPosition,
+    double? scrollExtentMax,
+    double? scrollExtentMin,
+    int? currentValueLength,
+    int? maxValueLength,
+    String? maxValue,
+    String? minValue,
+    SemanticsNode? ancestor,
+    SemanticsInputType? inputType,
+  }) {
+    bool checkNode(SemanticsNode node) {
+      if (label != null && node.label != label) {
+        return false;
+      }
+      if (attributedLabel != null &&
+          (attributedLabel.string != node.attributedLabel.string ||
+              !_stringAttributesEqual(
+                attributedLabel.attributes,
+                node.attributedLabel.attributes,
+              ))) {
+        return false;
+      }
+      if (value != null && node.value != value) {
+        return false;
+      }
+      if (attributedValue != null &&
+          (attributedValue.string != node.attributedValue.string ||
+              !_stringAttributesEqual(
+                attributedValue.attributes,
+                node.attributedValue.attributes,
+              ))) {
+        return false;
+      }
+      if (hint != null && node.hint != hint) {
+        return false;
+      }
+      if (increasedValue != null && node.increasedValue != increasedValue) {
+        return false;
+      }
+      if (decreasedValue != null && node.decreasedValue != decreasedValue) {
+        return false;
+      }
+      if (attributedHint != null &&
+          (attributedHint.string != node.attributedHint.string ||
+              !_stringAttributesEqual(attributedHint.attributes, node.attributedHint.attributes))) {
+        return false;
+      }
+      if (textDirection != null && node.textDirection != textDirection) {
+        return false;
+      }
+
+      if (actions != null) {
+        final int expectedActions = actions.fold<int>(
+          0,
+          (int value, SemanticsAction action) => value | action.index,
+        );
+        final int actualActions = node.getSemanticsData().actions;
+        if (expectedActions != actualActions) {
+          return false;
+        }
+      }
+
+      if (flagsCollection != null) {
+        final SemanticsFlags expectedFlags = flagsCollection;
+        final SemanticsFlags actualFlags = node.getSemanticsData().flagsCollection;
+        if (expectedFlags != actualFlags) {
+          return false;
+        }
+      }
+      // `flags` are deprecated and only support the first 31 flags.
+      else if (flags != null) {
+        final int expectedFlags = flags.fold<int>(
+          0,
+          (int value, SemanticsFlag flag) => value | flag.index,
+        );
+        final int actualFlags = node.getSemanticsData().flags;
+        if (expectedFlags != actualFlags) {
+          return false;
+        }
+      }
+      if (tags != null) {
+        final Set<SemanticsTag>? actualTags = node.getSemanticsData().tags;
+        if (!setEquals<SemanticsTag>(actualTags, tags)) {
+          return false;
+        }
+      }
+      if (scrollPosition != null && !nearEqual(node.scrollPosition, scrollPosition, 0.1)) {
+        return false;
+      }
+      if (scrollExtentMax != null && !nearEqual(node.scrollExtentMax, scrollExtentMax, 0.1)) {
+        return false;
+      }
+      if (scrollExtentMin != null && !nearEqual(node.scrollExtentMin, scrollExtentMin, 0.1)) {
+        return false;
+      }
+      if (currentValueLength != null && node.currentValueLength != currentValueLength) {
+        return false;
+      }
+      if (maxValueLength != null && node.maxValueLength != maxValueLength) {
+        return false;
+      }
+      if (inputType != null && node.inputType != inputType) {
+        return false;
+      }
+      if (maxValue != null && node.maxValue != maxValue) {
+        return false;
+      }
+      if (minValue != null && node.minValue != minValue) {
+        return false;
+      }
+      return true;
+    }
+
+    final result = <SemanticsNode>[];
+    bool visit(SemanticsNode node) {
+      if (checkNode(node)) {
+        result.add(node);
+      }
+      node.visitChildren(visit);
+      return true;
+    }
+
+    visit(ancestor ?? tester.binding.pipelineOwner.semanticsOwner!.rootSemanticsNode!);
+
+    return result;
+  }
+
+  /// Generates an expression that creates a [TestSemantics] reflecting the
+  /// current tree of [SemanticsNode]s.
+  ///
+  /// Use this method to generate code for unit tests. It works similar to
+  /// screenshot testing. The very first time you add semantics to a widget you
+  /// verify manually that the widget behaves correctly. You then use this
+  /// method to generate test code for this widget.
+  ///
+  /// Example:
+  ///
+  /// ```dart
+  /// testWidgets('generate code for MyWidget', (WidgetTester tester) async {
+  ///   var semantics = SemanticsTester(tester);
+  ///   await tester.pumpWidget(MyWidget());
+  ///   print(semantics.generateTestSemanticsExpressionForCurrentSemanticsTree());
+  ///   semantics.dispose();
+  /// });
+  /// ```
+  ///
+  /// You can now copy the code printed to the console into a unit test:
+  ///
+  /// ```dart
+  /// testWidgets('generate code for MyWidget', (WidgetTester tester) async {
+  ///   var semantics = SemanticsTester(tester);
+  ///   await tester.pumpWidget(MyWidget());
+  ///   expect(semantics, hasSemantics(
+  ///     // Generated code:
+  ///     TestSemantics(
+  ///       ... properties and child nodes ...
+  ///     ),
+  ///     ignoreRect: true,
+  ///     ignoreTransform: true,
+  ///     ignoreId: true,
+  ///   ));
+  ///   semantics.dispose();
+  /// });
+  /// ```
+  ///
+  /// At this point the unit test should automatically pass because it was
+  /// generated from the actual [SemanticsNode]s. Next time the semantics tree
+  /// changes, the test code may either be updated manually, or regenerated and
+  /// replaced using this method again.
+  ///
+  /// Avoid submitting huge piles of generated test code. This will make test
+  /// code hard to review and it will make it tempting to regenerate test code
+  /// every time and ignore potential regressions. Make sure you do not
+  /// over-test. Prefer breaking your widgets into smaller widgets and test them
+  /// individually.
+  String generateTestSemanticsExpressionForCurrentSemanticsTree(
+    DebugSemanticsDumpOrder childOrder,
+  ) {
+    final SemanticsNode? node = tester.binding.pipelineOwner.semanticsOwner?.rootSemanticsNode;
+    return _generateSemanticsTestForNode(node, 0, childOrder);
+  }
+
+  static String _flagsToSemanticsFlagExpression(dynamic flags) {
+    Iterable<SemanticsFlag> list;
+    if (flags is SemanticsFlags) {
+      return '<SemanticsFlag>[${flags.toStrings().join(', ')}]';
+    } else if (flags is int) {
+      list = SemanticsFlag.values.where((SemanticsFlag flag) => (flag.index & flags) != 0);
+    } else {
+      list = flags as List<SemanticsFlag>;
+    }
+    return '<SemanticsFlag>[${list.join(', ')}]';
+  }
+
+  static String _tagsToSemanticsTagExpression(Set<SemanticsTag> tags) {
+    return '<SemanticsTag>[${tags.map<String>((SemanticsTag tag) => "const SemanticsTag('${tag.name}')").join(', ')}]';
+  }
+
+  static String _actionsToSemanticsActionExpression(dynamic actions) {
+    Iterable<SemanticsAction> list;
+    if (actions is int) {
+      list = SemanticsAction.values.where(
+        (SemanticsAction action) => (action.index & actions) != 0,
+      );
+    } else {
+      list = actions as List<SemanticsAction>;
+    }
+    return '<SemanticsAction>[${list.join(', ')}]';
+  }
+
+  /// Recursively generates [TestSemantics] code for [node] and its children,
+  /// indenting the expression by `indentAmount`.
+  static String _generateSemanticsTestForNode(
+    SemanticsNode? node,
+    int indentAmount,
+    DebugSemanticsDumpOrder childOrder,
+  ) {
+    if (node == null) {
+      return 'null';
+    }
+    final String indent = '  ' * indentAmount;
+    final buf = StringBuffer();
+    final SemanticsData nodeData = node.getSemanticsData();
+    final isRoot = node.id == 0;
+    buf.writeln('TestSemantics${isRoot ? '.root' : ''}(');
+    if (!isRoot) {
+      buf.writeln('  id: ${node.id},');
+    }
+    if (nodeData.tags != null) {
+      buf.writeln('  tags: ${_tagsToSemanticsTagExpression(nodeData.tags!)},');
+    }
+    if (nodeData.flags != 0) {
+      buf.writeln('  flags: ${_flagsToSemanticsFlagExpression(nodeData.flags)},');
+    }
+    if (nodeData.actions != 0) {
+      buf.writeln('  actions: ${_actionsToSemanticsActionExpression(nodeData.actions)},');
+    }
+    if (node.label.isNotEmpty) {
+      // Escape newlines and text directionality control characters.
+      final String escapedLabel = node.label
+          .replaceAll('\n', r'\n')
+          .replaceAll('\u202a', r'\u202a')
+          .replaceAll('\u202c', r'\u202c');
+      buf.writeln("  label: '$escapedLabel',");
+    }
+    if (node.value.isNotEmpty) {
+      buf.writeln("  value: '${node.value}',");
+    }
+    if (node.increasedValue.isNotEmpty) {
+      buf.writeln("  increasedValue: '${node.increasedValue}',");
+    }
+    if (node.decreasedValue.isNotEmpty) {
+      buf.writeln("  decreasedValue: '${node.decreasedValue}',");
+    }
+    if (node.hint.isNotEmpty) {
+      buf.writeln("  hint: '${node.hint}',");
+    }
+    if (node.textDirection != null) {
+      buf.writeln('  textDirection: ${node.textDirection},');
+    }
+    if (node.role != SemanticsRole.none) {
+      buf.writeln('  role: ${node.role},');
+    }
+    if (node.inputType != SemanticsInputType.none) {
+      buf.writeln('  inputType: ${node.inputType},');
+    }
+    if (node.controlsNodes != null) {
+      buf.writeln('  controlsNodes: ${node.controlsNodes},');
+    }
+    if (node.linkUrl != null) {
+      buf.writeln('  linkUrl: ${node.linkUrl},');
+    }
+    if (node.maxValueLength != null) {
+      buf.writeln('  maxValueLength: ${node.maxValueLength},');
+    }
+    if (node.currentValueLength != null) {
+      buf.writeln('  currentValueLength: ${node.currentValueLength},');
+    }
+    if (node.identifier.isNotEmpty) {
+      buf.writeln('  identifier: ${node.identifier},');
+    }
+    if (node.hintOverrides != null) {
+      buf.writeln('  hintOverrides: ${node.hintOverrides},');
+    }
+    if (node.hasChildren) {
+      buf.writeln('  children: <TestSemantics>[');
+      for (final SemanticsNode child in node.debugListChildrenInOrder(childOrder)) {
+        buf
+          ..write(_generateSemanticsTestForNode(child, 2, childOrder))
+          ..writeln(',');
+      }
+      buf.writeln('  ],');
+    }
+
+    buf.write(')');
+    return buf.toString().split('\n').map<String>((String l) => '$indent$l').join('\n');
+  }
+}
+
+class _HasSemantics extends Matcher {
+  const _HasSemantics(
+    this._semantics, {
+    required this.ignoreRect,
+    required this.ignoreTransform,
+    required this.ignoreId,
+    required this.ignoreTraversalIdentifier,
+    required this.childOrder,
+  });
+
+  final TestSemantics _semantics;
+  final bool ignoreRect;
+  final bool ignoreTransform;
+  final bool ignoreId;
+  final bool ignoreTraversalIdentifier;
+  final DebugSemanticsDumpOrder childOrder;
+
+  @override
+  bool matches(covariant SemanticsTester item, Map<dynamic, dynamic> matchState) {
+    final bool doesMatch = _semantics._matches(
+      item.tester.binding.pipelineOwner.semanticsOwner?.rootSemanticsNode,
+      matchState,
+      ignoreTransform: ignoreTransform,
+      ignoreRect: ignoreRect,
+      ignoreId: ignoreId,
+      ignoreTraversalIdentifier: ignoreTraversalIdentifier,
+      childOrder: childOrder,
+    );
+    if (!doesMatch) {
+      matchState['would-match'] = item.generateTestSemanticsExpressionForCurrentSemanticsTree(
+        childOrder,
+      );
+    }
+    if (item.tester.binding.pipelineOwner.semanticsOwner == null) {
+      matchState['additional-notes'] =
+          '(Check that the SemanticsTester has not been disposed early.)';
+    }
+    return doesMatch;
+  }
+
+  @override
+  Description describe(Description description) {
+    return description.add('semantics node matching:\n$_semantics');
+  }
+
+  String _indent(String? text) {
+    return text
+        .toString()
+        .trimRight()
+        .split('\n')
+        .map<String>((String line) => '  $line')
+        .join('\n');
+  }
+
+  @override
+  Description describeMismatch(
+    dynamic item,
+    Description mismatchDescription,
+    Map<dynamic, dynamic> matchState,
+    bool verbose,
+  ) {
+    Description result = mismatchDescription
+        .add('${matchState[TestSemantics]}\n')
+        .add('Current SemanticsNode tree:\n')
+        .add(
+          _indent(
+            RendererBinding.instance.renderView.debugSemantics?.toStringDeep(
+              childOrder: childOrder,
+            ),
+          ),
+        )
+        .add('\n')
+        .add('The semantics tree would have matched the following configuration:\n')
+        .add(_indent(matchState['would-match'] as String));
+    if (matchState.containsKey('additional-notes')) {
+      result = result.add('\n').add(matchState['additional-notes'] as String);
+    }
+    return result;
+  }
+}
+
+/// Asserts that a [SemanticsTester] has a semantics tree that exactly matches the given semantics.
+Matcher hasSemantics(
+  TestSemantics semantics, {
+  bool ignoreRect = false,
+  bool ignoreTransform = false,
+  bool ignoreId = false,
+  bool ignoreTraversalIdentifier = true,
+  DebugSemanticsDumpOrder childOrder = DebugSemanticsDumpOrder.traversalOrder,
+}) {
+  return _HasSemantics(
+    semantics,
+    ignoreRect: ignoreRect,
+    ignoreTransform: ignoreTransform,
+    ignoreId: ignoreId,
+    ignoreTraversalIdentifier: ignoreTraversalIdentifier,
+    childOrder: childOrder,
+  );
+}
+
+class _IncludesNodeWith extends Matcher {
+  const _IncludesNodeWith({
+    this.attributedLabel,
+    this.attributedValue,
+    this.attributedHint,
+    this.label,
+    this.value,
+    this.hint,
+    this.increasedValue,
+    this.decreasedValue,
+    this.textDirection,
+    this.actions,
+    this.flags,
+    this.flagsCollection,
+    this.tags,
+    this.scrollPosition,
+    this.scrollExtentMax,
+    this.scrollExtentMin,
+    this.maxValueLength,
+    this.currentValueLength,
+    this.inputType,
+    this.minValue,
+    this.maxValue,
+  }) : assert(
+         label != null ||
+             value != null ||
+             actions != null ||
+             flags != null ||
+             flagsCollection != null ||
+             tags != null ||
+             increasedValue != null ||
+             decreasedValue != null ||
+             scrollPosition != null ||
+             scrollExtentMax != null ||
+             scrollExtentMin != null ||
+             maxValueLength != null ||
+             currentValueLength != null ||
+             inputType != null,
+         minValue != null || maxValue != null,
+       );
+  final AttributedString? attributedLabel;
+  final AttributedString? attributedValue;
+  final AttributedString? attributedHint;
+  final String? label;
+  final String? value;
+  final String? hint;
+  final String? increasedValue;
+  final String? decreasedValue;
+  final TextDirection? textDirection;
+  final List<SemanticsAction>? actions;
+  final List<SemanticsFlag>? flags;
+  final SemanticsFlags? flagsCollection;
+  final Set<SemanticsTag>? tags;
+  final double? scrollPosition;
+  final double? scrollExtentMax;
+  final double? scrollExtentMin;
+  final int? currentValueLength;
+  final int? maxValueLength;
+  final SemanticsInputType? inputType;
+  final String? minValue;
+  final String? maxValue;
+
+  @override
+  bool matches(covariant SemanticsTester item, Map<dynamic, dynamic> matchState) {
+    return item
+        .nodesWith(
+          attributedLabel: attributedLabel,
+          attributedValue: attributedValue,
+          attributedHint: attributedHint,
+          label: label,
+          value: value,
+          hint: hint,
+          increasedValue: increasedValue,
+          decreasedValue: decreasedValue,
+          textDirection: textDirection,
+          actions: actions,
+          flags: flags,
+          flagsCollection: flagsCollection,
+          tags: tags,
+          scrollPosition: scrollPosition,
+          scrollExtentMax: scrollExtentMax,
+          scrollExtentMin: scrollExtentMin,
+          currentValueLength: currentValueLength,
+          maxValueLength: maxValueLength,
+          inputType: inputType,
+          minValue: minValue,
+          maxValue: maxValue,
+        )
+        .isNotEmpty;
+  }
+
+  @override
+  Description describe(Description description) {
+    return description.add('includes node with $_configAsString');
+  }
+
+  @override
+  Description describeMismatch(
+    dynamic item,
+    Description mismatchDescription,
+    Map<dynamic, dynamic> matchState,
+    bool verbose,
+  ) {
+    return mismatchDescription.add('could not find node with $_configAsString.\n$_matcherHelp');
+  }
+
+  String get _configAsString {
+    final strings = <String>[
+      if (label != null) 'label "$label"',
+      if (value != null) 'value "$value"',
+      if (hint != null) 'hint "$hint"',
+      if (textDirection != null) ' (${textDirection!.name})',
+      if (actions != null) 'actions "${actions!.join(', ')}"',
+      if (flags != null) 'flags "${flags!.join(', ')}"',
+      if (tags != null) 'tags "${tags!.join(', ')}"',
+      if (increasedValue != null) 'increasedValue "$increasedValue"',
+      if (decreasedValue != null) 'decreasedValue "$decreasedValue"',
+      if (scrollPosition != null) 'scrollPosition "$scrollPosition"',
+      if (scrollExtentMax != null) 'scrollExtentMax "$scrollExtentMax"',
+      if (scrollExtentMin != null) 'scrollExtentMin "$scrollExtentMin"',
+      if (currentValueLength != null) 'currentValueLength "$currentValueLength"',
+      if (maxValueLength != null) 'maxValueLength "$maxValueLength"',
+      if (inputType != null) 'inputType $inputType',
+      if (minValue != null) 'minValue "$minValue"',
+      if (maxValue != null) 'maxValue "$maxValue"',
+    ];
+    return strings.join(', ');
+  }
+}
+
+/// Asserts that a node in the semantics tree of [SemanticsTester] has `label`,
+/// `textDirection`, and `actions`.
+///
+/// If null is provided for an argument, it will match against any value.
+Matcher includesNodeWith({
+  String? label,
+  AttributedString? attributedLabel,
+  String? value,
+  AttributedString? attributedValue,
+  String? hint,
+  AttributedString? attributedHint,
+  String? increasedValue,
+  String? decreasedValue,
+  TextDirection? textDirection,
+  List<SemanticsAction>? actions,
+  List<SemanticsFlag>? flags,
+  SemanticsFlags? flagsCollection,
+  Set<SemanticsTag>? tags,
+  double? scrollPosition,
+  double? scrollExtentMax,
+  double? scrollExtentMin,
+  int? maxValueLength,
+  int? currentValueLength,
+  SemanticsInputType? inputType,
+  String? minValue,
+  String? maxValue,
+}) {
+  return _IncludesNodeWith(
+    label: label,
+    attributedLabel: attributedLabel,
+    value: value,
+    attributedValue: attributedValue,
+    hint: hint,
+    attributedHint: attributedHint,
+    textDirection: textDirection,
+    increasedValue: increasedValue,
+    decreasedValue: decreasedValue,
+    actions: actions,
+    flags: flags,
+    flagsCollection: flagsCollection,
+    tags: tags,
+    scrollPosition: scrollPosition,
+    scrollExtentMax: scrollExtentMax,
+    scrollExtentMin: scrollExtentMin,
+    maxValueLength: maxValueLength,
+    currentValueLength: currentValueLength,
+    inputType: inputType,
+    minValue: minValue,
+    maxValue: maxValue,
+  );
+}

--- a/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
+++ b/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
@@ -17,7 +17,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/semantics_tester.dart';
+import 'semantics_tester.dart';
 
 RenderBox getRenderSegmentedControl(WidgetTester tester) {
   return tester.allRenderObjects.firstWhere((RenderObject currentObject) {

--- a/packages/flutter/test/cupertino/switch_test.dart
+++ b/packages/flutter/test/cupertino/switch_test.dart
@@ -17,8 +17,8 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/semantics_tester.dart';
 import 'list_tile_tester.dart';
+import 'semantics_tester.dart';
 
 void main() {
   testWidgets('Switch can toggle on tap', (WidgetTester tester) async {
@@ -89,143 +89,137 @@ void main() {
     expect(value, isTrue);
   });
 
-  testWidgets(
-    'Switch emits light haptic vibration on tap',
-    (WidgetTester tester) async {
-      final Key switchKey = UniqueKey();
-      var value = false;
+  testWidgets('Switch emits light haptic vibration on tap', (WidgetTester tester) async {
+    final Key switchKey = UniqueKey();
+    var value = false;
 
-      final log = <MethodCall>[];
+    final log = <MethodCall>[];
 
-      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(SystemChannels.platform, (
-        MethodCall methodCall,
-      ) async {
-        log.add(methodCall);
-        return null;
-      });
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(SystemChannels.platform, (
+      MethodCall methodCall,
+    ) async {
+      log.add(methodCall);
+      return null;
+    });
 
-      await tester.pumpWidget(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: StatefulBuilder(
-            builder: (BuildContext context, StateSetter setState) {
-              return Center(
-                child: CupertinoSwitch(
-                  key: switchKey,
-                  value: value,
-                  dragStartBehavior: DragStartBehavior.down,
-                  onChanged: (bool newValue) {
-                    setState(() {
-                      value = newValue;
-                    });
-                  },
-                ),
-              );
-            },
-          ),
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return Center(
+              child: CupertinoSwitch(
+                key: switchKey,
+                value: value,
+                dragStartBehavior: DragStartBehavior.down,
+                onChanged: (bool newValue) {
+                  setState(() {
+                    value = newValue;
+                  });
+                },
+              ),
+            );
+          },
         ),
-      );
+      ),
+    );
 
-      await tester.tap(find.byKey(switchKey));
-      await tester.pump();
+    await tester.tap(find.byKey(switchKey));
+    await tester.pump();
 
-      expect(log, hasLength(1));
-      expect(
-        log.single,
-        isMethodCall('HapticFeedback.vibrate', arguments: 'HapticFeedbackType.lightImpact'),
-      );
-    },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-  );
+    expect(log, hasLength(1));
+    expect(
+      log.single,
+      isMethodCall('HapticFeedback.vibrate', arguments: 'HapticFeedbackType.lightImpact'),
+    );
+  }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
-  testWidgets(
-    'Using other widgets that rebuild the switch will not cause vibrations',
-    (WidgetTester tester) async {
-      final Key switchKey = UniqueKey();
-      final Key switchKey2 = UniqueKey();
-      var value = false;
-      var value2 = false;
-      final log = <MethodCall>[];
+  testWidgets('Using other widgets that rebuild the switch will not cause vibrations', (
+    WidgetTester tester,
+  ) async {
+    final Key switchKey = UniqueKey();
+    final Key switchKey2 = UniqueKey();
+    var value = false;
+    var value2 = false;
+    final log = <MethodCall>[];
 
-      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(SystemChannels.platform, (
-        MethodCall methodCall,
-      ) async {
-        log.add(methodCall);
-        return null;
-      });
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(SystemChannels.platform, (
+      MethodCall methodCall,
+    ) async {
+      log.add(methodCall);
+      return null;
+    });
 
-      await tester.pumpWidget(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: StatefulBuilder(
-            builder: (BuildContext context, StateSetter setState) {
-              return Center(
-                child: Column(
-                  children: <Widget>[
-                    CupertinoSwitch(
-                      key: switchKey,
-                      value: value,
-                      onChanged: (bool newValue) {
-                        setState(() {
-                          value = newValue;
-                        });
-                      },
-                    ),
-                    CupertinoSwitch(
-                      key: switchKey2,
-                      value: value2,
-                      onChanged: (bool newValue) {
-                        setState(() {
-                          value2 = newValue;
-                        });
-                      },
-                    ),
-                  ],
-                ),
-              );
-            },
-          ),
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return Center(
+              child: Column(
+                children: <Widget>[
+                  CupertinoSwitch(
+                    key: switchKey,
+                    value: value,
+                    onChanged: (bool newValue) {
+                      setState(() {
+                        value = newValue;
+                      });
+                    },
+                  ),
+                  CupertinoSwitch(
+                    key: switchKey2,
+                    value: value2,
+                    onChanged: (bool newValue) {
+                      setState(() {
+                        value2 = newValue;
+                      });
+                    },
+                  ),
+                ],
+              ),
+            );
+          },
         ),
-      );
+      ),
+    );
 
-      await tester.tap(find.byKey(switchKey));
-      await tester.pump();
+    await tester.tap(find.byKey(switchKey));
+    await tester.pump();
 
-      expect(log, hasLength(1));
-      expect(
-        log[0],
-        isMethodCall('HapticFeedback.vibrate', arguments: 'HapticFeedbackType.lightImpact'),
-      );
+    expect(log, hasLength(1));
+    expect(
+      log[0],
+      isMethodCall('HapticFeedback.vibrate', arguments: 'HapticFeedbackType.lightImpact'),
+    );
 
-      await tester.tap(find.byKey(switchKey2));
-      await tester.pump();
+    await tester.tap(find.byKey(switchKey2));
+    await tester.pump();
 
-      expect(log, hasLength(2));
-      expect(
-        log[1],
-        isMethodCall('HapticFeedback.vibrate', arguments: 'HapticFeedbackType.lightImpact'),
-      );
+    expect(log, hasLength(2));
+    expect(
+      log[1],
+      isMethodCall('HapticFeedback.vibrate', arguments: 'HapticFeedbackType.lightImpact'),
+    );
 
-      await tester.tap(find.byKey(switchKey));
-      await tester.pump();
+    await tester.tap(find.byKey(switchKey));
+    await tester.pump();
 
-      expect(log, hasLength(3));
-      expect(
-        log[2],
-        isMethodCall('HapticFeedback.vibrate', arguments: 'HapticFeedbackType.lightImpact'),
-      );
+    expect(log, hasLength(3));
+    expect(
+      log[2],
+      isMethodCall('HapticFeedback.vibrate', arguments: 'HapticFeedbackType.lightImpact'),
+    );
 
-      await tester.tap(find.byKey(switchKey2));
-      await tester.pump();
+    await tester.tap(find.byKey(switchKey2));
+    await tester.pump();
 
-      expect(log, hasLength(4));
-      expect(
-        log[3],
-        isMethodCall('HapticFeedback.vibrate', arguments: 'HapticFeedbackType.lightImpact'),
-      );
-    },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-  );
+    expect(log, hasLength(4));
+    expect(
+      log[3],
+      isMethodCall('HapticFeedback.vibrate', arguments: 'HapticFeedbackType.lightImpact'),
+    );
+  }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
   testWidgets('Haptic vibration triggers on drag', (WidgetTester tester) async {
     var value = false;
@@ -270,63 +264,61 @@ void main() {
     );
   }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
-  testWidgets(
-    'No haptic vibration triggers from a programmatic value change',
-    (WidgetTester tester) async {
-      final Key switchKey = UniqueKey();
-      var value = false;
+  testWidgets('No haptic vibration triggers from a programmatic value change', (
+    WidgetTester tester,
+  ) async {
+    final Key switchKey = UniqueKey();
+    var value = false;
 
-      final log = <MethodCall>[];
-      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(SystemChannels.platform, (
-        MethodCall methodCall,
-      ) async {
-        log.add(methodCall);
-        return null;
-      });
+    final log = <MethodCall>[];
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(SystemChannels.platform, (
+      MethodCall methodCall,
+    ) async {
+      log.add(methodCall);
+      return null;
+    });
 
-      await tester.pumpWidget(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: StatefulBuilder(
-            builder: (BuildContext context, StateSetter setState) {
-              return Center(
-                child: Column(
-                  children: <Widget>[
-                    CupertinoButton(
-                      child: const Text('Button'),
-                      onPressed: () {
-                        setState(() {
-                          value = !value;
-                        });
-                      },
-                    ),
-                    CupertinoSwitch(
-                      key: switchKey,
-                      value: value,
-                      onChanged: (bool newValue) {
-                        setState(() {
-                          value = newValue;
-                        });
-                      },
-                    ),
-                  ],
-                ),
-              );
-            },
-          ),
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return Center(
+              child: Column(
+                children: <Widget>[
+                  CupertinoButton(
+                    child: const Text('Button'),
+                    onPressed: () {
+                      setState(() {
+                        value = !value;
+                      });
+                    },
+                  ),
+                  CupertinoSwitch(
+                    key: switchKey,
+                    value: value,
+                    onChanged: (bool newValue) {
+                      setState(() {
+                        value = newValue;
+                      });
+                    },
+                  ),
+                ],
+              ),
+            );
+          },
         ),
-      );
+      ),
+    );
 
-      expect(value, isFalse);
+    expect(value, isFalse);
 
-      await tester.tap(find.byType(CupertinoButton));
-      expect(value, isTrue);
-      await tester.pump();
+    await tester.tap(find.byType(CupertinoButton));
+    expect(value, isTrue);
+    await tester.pump();
 
-      expect(log, hasLength(0));
-    },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-  );
+    expect(log, hasLength(0));
+  }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
   testWidgets('Switch can drag (LTR)', (WidgetTester tester) async {
     var value = false;

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -24,10 +24,10 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../widgets/clipboard_utils.dart';
-import '../widgets/semantics_tester.dart';
 import '../widgets/text_selection_toolbar_utils.dart';
 import 'editable_text_utils.dart';
 import 'live_text_utils.dart';
+import 'semantics_tester.dart';
 
 class MockTextSelectionControls extends TextSelectionControls {
   @override
@@ -235,42 +235,40 @@ void main() {
     await Clipboard.setData(const ClipboardData(text: 'Clipboard data'));
   });
 
-  testWidgets(
-    'Live Text button shows and hides correctly when LiveTextStatus changes',
-    (WidgetTester tester) async {
-      final liveTextInputTester = LiveTextInputTester();
-      addTearDown(liveTextInputTester.dispose);
+  testWidgets('Live Text button shows and hides correctly when LiveTextStatus changes', (
+    WidgetTester tester,
+  ) async {
+    final liveTextInputTester = LiveTextInputTester();
+    addTearDown(liveTextInputTester.dispose);
 
-      final controller = TextEditingController(text: '');
-      addTearDown(controller.dispose);
-      const Key key = ValueKey<String>('TextField');
-      final focusNode = FocusNode();
-      addTearDown(focusNode.dispose);
-      final Widget app = CupertinoApp(
-        home: CupertinoPageScaffold(
-          child: Center(
-            child: CupertinoTextField(key: key, controller: controller, focusNode: focusNode),
-          ),
+    final controller = TextEditingController(text: '');
+    addTearDown(controller.dispose);
+    const Key key = ValueKey<String>('TextField');
+    final focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+    final Widget app = CupertinoApp(
+      home: CupertinoPageScaffold(
+        child: Center(
+          child: CupertinoTextField(key: key, controller: controller, focusNode: focusNode),
         ),
-      );
+      ),
+    );
 
-      liveTextInputTester.mockLiveTextInputEnabled = true;
-      await tester.pumpWidget(app);
-      focusNode.requestFocus();
-      await tester.pumpAndSettle();
+    liveTextInputTester.mockLiveTextInputEnabled = true;
+    await tester.pumpWidget(app);
+    focusNode.requestFocus();
+    await tester.pumpAndSettle();
 
-      final Finder textFinder = find.byType(EditableText);
-      await tester.longPress(textFinder);
-      await tester.pumpAndSettle();
-      expect(findLiveTextButton(), kIsWeb ? findsNothing : findsOneWidget);
+    final Finder textFinder = find.byType(EditableText);
+    await tester.longPress(textFinder);
+    await tester.pumpAndSettle();
+    expect(findLiveTextButton(), kIsWeb ? findsNothing : findsOneWidget);
 
-      liveTextInputTester.mockLiveTextInputEnabled = false;
-      await tester.longPress(textFinder);
-      await tester.pumpAndSettle();
-      expect(findLiveTextButton(), findsNothing);
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-  );
+    liveTextInputTester.mockLiveTextInputEnabled = false;
+    await tester.longPress(textFinder);
+    await tester.pumpAndSettle();
+    expect(findLiveTextButton(), findsNothing);
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
 
   testWidgets(
     'Look Up shows up on iOS only',
@@ -533,71 +531,69 @@ void main() {
     );
   });
 
-  testWidgets(
-    'Activates the text field when receives semantics focus on desktops',
-    (WidgetTester tester) async {
-      final semantics = SemanticsTester(tester);
-      final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;
-      final focusNode = FocusNode();
-      addTearDown(focusNode.dispose);
-      await tester.pumpWidget(CupertinoApp(home: CupertinoTextField(focusNode: focusNode)));
-      expect(
-        semantics,
-        hasSemantics(
-          TestSemantics.root(
-            children: <TestSemantics>[
-              TestSemantics(
-                id: 1,
-                textDirection: TextDirection.ltr,
-                children: <TestSemantics>[
-                  TestSemantics(
-                    id: 2,
-                    children: <TestSemantics>[
-                      TestSemantics(
-                        id: 3,
-                        flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
-                        children: <TestSemantics>[
-                          TestSemantics(
-                            id: 4,
-                            inputType: ui.SemanticsInputType.text,
-                            flags: <SemanticsFlag>[
-                              SemanticsFlag.isTextField,
-                              SemanticsFlag.isFocusable,
-                              SemanticsFlag.hasEnabledState,
-                              SemanticsFlag.isEnabled,
-                            ],
-                            actions: <SemanticsAction>[
-                              SemanticsAction.tap,
-                              SemanticsAction.focus,
-                              SemanticsAction.didGainAccessibilityFocus,
-                              SemanticsAction.didLoseAccessibilityFocus,
-                            ],
-                            textDirection: TextDirection.ltr,
-                          ),
-                        ],
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            ],
-          ),
-          ignoreRect: true,
-          ignoreTransform: true,
+  testWidgets('Activates the text field when receives semantics focus on desktops', (
+    WidgetTester tester,
+  ) async {
+    final semantics = SemanticsTester(tester);
+    final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;
+    final focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+    await tester.pumpWidget(CupertinoApp(home: CupertinoTextField(focusNode: focusNode)));
+    expect(
+      semantics,
+      hasSemantics(
+        TestSemantics.root(
+          children: <TestSemantics>[
+            TestSemantics(
+              id: 1,
+              textDirection: TextDirection.ltr,
+              children: <TestSemantics>[
+                TestSemantics(
+                  id: 2,
+                  children: <TestSemantics>[
+                    TestSemantics(
+                      id: 3,
+                      flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
+                      children: <TestSemantics>[
+                        TestSemantics(
+                          id: 4,
+                          inputType: ui.SemanticsInputType.text,
+                          flags: <SemanticsFlag>[
+                            SemanticsFlag.isTextField,
+                            SemanticsFlag.isFocusable,
+                            SemanticsFlag.hasEnabledState,
+                            SemanticsFlag.isEnabled,
+                          ],
+                          actions: <SemanticsAction>[
+                            SemanticsAction.tap,
+                            SemanticsAction.focus,
+                            SemanticsAction.didGainAccessibilityFocus,
+                            SemanticsAction.didLoseAccessibilityFocus,
+                          ],
+                          textDirection: TextDirection.ltr,
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ],
         ),
-      );
+        ignoreRect: true,
+        ignoreTransform: true,
+      ),
+    );
 
-      expect(focusNode.hasFocus, isFalse);
-      semanticsOwner.performAction(4, SemanticsAction.didGainAccessibilityFocus);
-      await tester.pumpAndSettle();
-      expect(focusNode.hasFocus, isTrue);
-      semanticsOwner.performAction(4, SemanticsAction.didLoseAccessibilityFocus);
-      await tester.pumpAndSettle();
-      expect(focusNode.hasFocus, isFalse);
-      semantics.dispose();
-    },
-    variant: TargetPlatformVariant.desktop(),
-  );
+    expect(focusNode.hasFocus, isFalse);
+    semanticsOwner.performAction(4, SemanticsAction.didGainAccessibilityFocus);
+    await tester.pumpAndSettle();
+    expect(focusNode.hasFocus, isTrue);
+    semanticsOwner.performAction(4, SemanticsAction.didLoseAccessibilityFocus);
+    await tester.pumpAndSettle();
+    expect(focusNode.hasFocus, isFalse);
+    semantics.dispose();
+  }, variant: TargetPlatformVariant.desktop());
 
   testWidgets('takes available space horizontally and takes intrinsic space vertically no-strut', (
     WidgetTester tester,
@@ -657,45 +653,41 @@ void main() {
     );
   });
 
-  testWidgets(
-    'selection handles color respects CupertinoTheme',
-    (WidgetTester tester) async {
-      // Regression test for https://github.com/flutter/flutter/issues/74890.
-      const expectedSelectionHandleColor = Color.fromARGB(255, 10, 200, 255);
+  testWidgets('selection handles color respects CupertinoTheme', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/74890.
+    const expectedSelectionHandleColor = Color.fromARGB(255, 10, 200, 255);
 
-      final controller = TextEditingController(text: 'Some text.');
-      addTearDown(controller.dispose);
+    final controller = TextEditingController(text: 'Some text.');
+    addTearDown(controller.dispose);
 
-      await tester.pumpWidget(
-        CupertinoApp(
-          theme: const CupertinoThemeData(selectionHandleColor: CupertinoColors.destructiveRed),
-          home: Center(
-            child: CupertinoTheme(
-              data: const CupertinoThemeData(selectionHandleColor: expectedSelectionHandleColor),
-              child: CupertinoTextField(controller: controller),
-            ),
+    await tester.pumpWidget(
+      CupertinoApp(
+        theme: const CupertinoThemeData(selectionHandleColor: CupertinoColors.destructiveRed),
+        home: Center(
+          child: CupertinoTheme(
+            data: const CupertinoThemeData(selectionHandleColor: expectedSelectionHandleColor),
+            child: CupertinoTextField(controller: controller),
           ),
         ),
-      );
+      ),
+    );
 
-      await tester.tapAt(textOffsetToPosition(tester, 0));
-      await tester.pump();
-      await tester.tapAt(textOffsetToPosition(tester, 0));
-      await tester.pumpAndSettle();
-      final Iterable<RenderBox> boxes = tester.renderObjectList<RenderBox>(
-        find.descendant(
-          of: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_SelectionHandleOverlay'),
-          matching: find.byType(CustomPaint),
-        ),
-      );
-      expect(boxes.length, 2);
+    await tester.tapAt(textOffsetToPosition(tester, 0));
+    await tester.pump();
+    await tester.tapAt(textOffsetToPosition(tester, 0));
+    await tester.pumpAndSettle();
+    final Iterable<RenderBox> boxes = tester.renderObjectList<RenderBox>(
+      find.descendant(
+        of: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_SelectionHandleOverlay'),
+        matching: find.byType(CustomPaint),
+      ),
+    );
+    expect(boxes.length, 2);
 
-      for (final box in boxes) {
-        expect(box, paints..path(color: expectedSelectionHandleColor));
-      }
-    },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-  );
+    for (final box in boxes) {
+      expect(box, paints..path(color: expectedSelectionHandleColor));
+    }
+  }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
   testWidgets('uses DefaultSelectionStyle for selection and cursor colors if provided', (
     WidgetTester tester,
@@ -1931,33 +1923,29 @@ void main() {
     skip: isContextMenuProvidedByPlatform,
   );
 
-  testWidgets(
-    'tap moves cursor to the edge of the word it tapped on',
-    (WidgetTester tester) async {
-      final controller = TextEditingController(text: 'Atwater Peel Sherbrooke Bonaventure');
-      addTearDown(controller.dispose);
-      await tester.pumpWidget(
-        CupertinoApp(
-          home: Center(child: CupertinoTextField(controller: controller)),
-        ),
-      );
+  testWidgets('tap moves cursor to the edge of the word it tapped on', (WidgetTester tester) async {
+    final controller = TextEditingController(text: 'Atwater Peel Sherbrooke Bonaventure');
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(child: CupertinoTextField(controller: controller)),
+      ),
+    );
 
-      final Offset textFieldStart = tester.getTopLeft(find.byType(CupertinoTextField));
+    final Offset textFieldStart = tester.getTopLeft(find.byType(CupertinoTextField));
 
-      await tester.tapAt(textFieldStart + const Offset(50.0, 5.0));
-      await tester.pump();
+    await tester.tapAt(textFieldStart + const Offset(50.0, 5.0));
+    await tester.pump();
 
-      // We moved the cursor.
-      expect(
-        controller.selection,
-        const TextSelection.collapsed(offset: 7, affinity: TextAffinity.upstream),
-      );
+    // We moved the cursor.
+    expect(
+      controller.selection,
+      const TextSelection.collapsed(offset: 7, affinity: TextAffinity.upstream),
+    );
 
-      // But don't trigger the toolbar.
-      expect(find.byType(CupertinoButton), findsNothing);
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-  );
+    // But don't trigger the toolbar.
+    expect(find.byType(CupertinoButton), findsNothing);
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
 
   testWidgets(
     'slow double tap does not trigger double tap',
@@ -1998,155 +1986,149 @@ void main() {
     }),
   );
 
-  testWidgets(
-    'Tapping on a collapsed selection toggles the toolbar',
-    (WidgetTester tester) async {
-      final controller = TextEditingController(
-        text:
-            'Atwater Peel Sherbrooke Bonaventure Angrignon Peel Côte-des-Neigse Atwater Peel Sherbrooke Bonaventure Angrignon Peel Côte-des-Neiges',
-      );
-      addTearDown(controller.dispose);
-      // On iOS/iPadOS, during a tap we select the edge of the word closest to the tap.
-      await tester.pumpWidget(
-        CupertinoApp(
-          home: Center(child: CupertinoTextField(controller: controller, maxLines: 2)),
-        ),
-      );
+  testWidgets('Tapping on a collapsed selection toggles the toolbar', (WidgetTester tester) async {
+    final controller = TextEditingController(
+      text:
+          'Atwater Peel Sherbrooke Bonaventure Angrignon Peel Côte-des-Neigse Atwater Peel Sherbrooke Bonaventure Angrignon Peel Côte-des-Neiges',
+    );
+    addTearDown(controller.dispose);
+    // On iOS/iPadOS, during a tap we select the edge of the word closest to the tap.
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(child: CupertinoTextField(controller: controller, maxLines: 2)),
+      ),
+    );
 
-      final double lineHeight = findRenderEditable(tester).preferredLineHeight;
-      final Offset begPos = textOffsetToPosition(tester, 0);
-      final Offset endPos =
-          textOffsetToPosition(tester, 35) +
-          const Offset(
-            200.0,
-            0.0,
-          ); // Index of 'Bonaventure|' + Offset(200.0,0), which is at the end of the first line.
-      final Offset vPos = textOffsetToPosition(tester, 29); // Index of 'Bonav|enture'.
-      final Offset wPos = textOffsetToPosition(tester, 3); // Index of 'Atw|ater'.
+    final double lineHeight = findRenderEditable(tester).preferredLineHeight;
+    final Offset begPos = textOffsetToPosition(tester, 0);
+    final Offset endPos =
+        textOffsetToPosition(tester, 35) +
+        const Offset(
+          200.0,
+          0.0,
+        ); // Index of 'Bonaventure|' + Offset(200.0,0), which is at the end of the first line.
+    final Offset vPos = textOffsetToPosition(tester, 29); // Index of 'Bonav|enture'.
+    final Offset wPos = textOffsetToPosition(tester, 3); // Index of 'Atw|ater'.
 
-      // This tap just puts the cursor somewhere different than where the double
-      // tap will occur to test that the double tap moves the existing cursor first.
-      await tester.tapAt(wPos);
-      await tester.pump(const Duration(milliseconds: 500));
+    // This tap just puts the cursor somewhere different than where the double
+    // tap will occur to test that the double tap moves the existing cursor first.
+    await tester.tapAt(wPos);
+    await tester.pump(const Duration(milliseconds: 500));
 
-      await tester.tapAt(vPos);
-      await tester.pump(const Duration(milliseconds: 500));
-      // First tap moved the cursor. Here we tap the position where 'v' is located.
-      // On iOS this will select the closest word edge, in this case the cursor is placed
-      // at the end of the word 'Bonaventure|'.
-      expect(controller.selection.isCollapsed, true);
-      expect(controller.selection.baseOffset, 35);
-      expect(find.byType(CupertinoButton), findsNothing);
+    await tester.tapAt(vPos);
+    await tester.pump(const Duration(milliseconds: 500));
+    // First tap moved the cursor. Here we tap the position where 'v' is located.
+    // On iOS this will select the closest word edge, in this case the cursor is placed
+    // at the end of the word 'Bonaventure|'.
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, 35);
+    expect(find.byType(CupertinoButton), findsNothing);
 
-      await tester.tapAt(vPos);
-      await tester.pumpAndSettle(const Duration(milliseconds: 500));
-      // Second tap toggles the toolbar. Here we tap on 'v' again, and select the word edge. Since
-      // the selection has not changed we toggle the toolbar.
-      expect(controller.selection.isCollapsed, true);
-      expect(controller.selection.baseOffset, 35);
-      expectCupertinoToolbarForCollapsedSelection();
+    await tester.tapAt(vPos);
+    await tester.pumpAndSettle(const Duration(milliseconds: 500));
+    // Second tap toggles the toolbar. Here we tap on 'v' again, and select the word edge. Since
+    // the selection has not changed we toggle the toolbar.
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, 35);
+    expectCupertinoToolbarForCollapsedSelection();
 
-      // Tap the 'v' position again to hide the toolbar.
-      await tester.tapAt(vPos);
-      await tester.pumpAndSettle();
-      expect(controller.selection.isCollapsed, true);
-      expect(controller.selection.baseOffset, 35);
-      expect(find.byType(CupertinoButton), findsNothing);
+    // Tap the 'v' position again to hide the toolbar.
+    await tester.tapAt(vPos);
+    await tester.pumpAndSettle();
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, 35);
+    expect(find.byType(CupertinoButton), findsNothing);
 
-      // Long press at the end of the first line to move the cursor to the end of the first line
-      // where the word wrap is. Since there is a word wrap here, and the direction of the text is LTR,
-      // the TextAffinity will be upstream and against the natural direction. The toolbar is also
-      // shown after a long press.
-      await tester.longPressAt(endPos);
-      await tester.pumpAndSettle(const Duration(milliseconds: 500));
-      expect(controller.selection.isCollapsed, true);
-      expect(controller.selection.baseOffset, 46);
-      expect(controller.selection.affinity, TextAffinity.upstream);
-      expectCupertinoToolbarForCollapsedSelection();
+    // Long press at the end of the first line to move the cursor to the end of the first line
+    // where the word wrap is. Since there is a word wrap here, and the direction of the text is LTR,
+    // the TextAffinity will be upstream and against the natural direction. The toolbar is also
+    // shown after a long press.
+    await tester.longPressAt(endPos);
+    await tester.pumpAndSettle(const Duration(milliseconds: 500));
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, 46);
+    expect(controller.selection.affinity, TextAffinity.upstream);
+    expectCupertinoToolbarForCollapsedSelection();
 
-      // Tap at the same position to toggle the toolbar.
-      await tester.tapAt(endPos);
-      await tester.pumpAndSettle();
-      expect(controller.selection.isCollapsed, true);
-      expect(controller.selection.baseOffset, 46);
-      expect(controller.selection.affinity, TextAffinity.upstream);
-      expectNoCupertinoToolbar();
+    // Tap at the same position to toggle the toolbar.
+    await tester.tapAt(endPos);
+    await tester.pumpAndSettle();
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, 46);
+    expect(controller.selection.affinity, TextAffinity.upstream);
+    expectNoCupertinoToolbar();
 
-      // Tap at the beginning of the second line to move the cursor to the front of the first word on the
-      // second line, where the word wrap is. Since there is a word wrap here, and the direction of the text is LTR,
-      // the TextAffinity will be downstream and following the natural direction. The toolbar will be hidden after this tap.
-      await tester.tapAt(begPos + Offset(0.0, lineHeight));
-      await tester.pumpAndSettle();
-      expect(controller.selection.isCollapsed, true);
-      expect(controller.selection.baseOffset, 46);
-      expect(controller.selection.affinity, TextAffinity.downstream);
-      expectNoCupertinoToolbar();
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-  );
+    // Tap at the beginning of the second line to move the cursor to the front of the first word on the
+    // second line, where the word wrap is. Since there is a word wrap here, and the direction of the text is LTR,
+    // the TextAffinity will be downstream and following the natural direction. The toolbar will be hidden after this tap.
+    await tester.tapAt(begPos + Offset(0.0, lineHeight));
+    await tester.pumpAndSettle();
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, 46);
+    expect(controller.selection.affinity, TextAffinity.downstream);
+    expectNoCupertinoToolbar();
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
 
-  testWidgets(
-    'Tapping on a non-collapsed selection toggles the toolbar and retains the selection',
-    (WidgetTester tester) async {
-      final controller = TextEditingController(text: 'Atwater Peel Sherbrooke Bonaventure');
-      addTearDown(controller.dispose);
-      // On iOS/iPadOS, during a tap we select the edge of the word closest to the tap.
-      await tester.pumpWidget(
-        CupertinoApp(
-          home: Center(child: CupertinoTextField(controller: controller)),
-        ),
-      );
+  testWidgets('Tapping on a non-collapsed selection toggles the toolbar and retains the selection', (
+    WidgetTester tester,
+  ) async {
+    final controller = TextEditingController(text: 'Atwater Peel Sherbrooke Bonaventure');
+    addTearDown(controller.dispose);
+    // On iOS/iPadOS, during a tap we select the edge of the word closest to the tap.
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(child: CupertinoTextField(controller: controller)),
+      ),
+    );
 
-      final Offset vPos = textOffsetToPosition(tester, 29); // Index of 'Bonav|enture'.
-      final Offset ePos =
-          textOffsetToPosition(tester, 35) +
-          const Offset(
-            7.0,
-            0.0,
-          ); // Index of 'Bonaventure|' + Offset(7.0,0), which taps slightly to the right of the end of the text.
-      final Offset wPos = textOffsetToPosition(tester, 3); // Index of 'Atw|ater'.
+    final Offset vPos = textOffsetToPosition(tester, 29); // Index of 'Bonav|enture'.
+    final Offset ePos =
+        textOffsetToPosition(tester, 35) +
+        const Offset(
+          7.0,
+          0.0,
+        ); // Index of 'Bonaventure|' + Offset(7.0,0), which taps slightly to the right of the end of the text.
+    final Offset wPos = textOffsetToPosition(tester, 3); // Index of 'Atw|ater'.
 
-      // This tap just puts the cursor somewhere different than where the double
-      // tap will occur to test that the double tap moves the existing cursor first.
-      await tester.tapAt(wPos);
-      await tester.pump(const Duration(milliseconds: 500));
+    // This tap just puts the cursor somewhere different than where the double
+    // tap will occur to test that the double tap moves the existing cursor first.
+    await tester.tapAt(wPos);
+    await tester.pump(const Duration(milliseconds: 500));
 
-      await tester.tapAt(vPos);
-      await tester.pump(const Duration(milliseconds: 50));
-      // First tap moved the cursor.
-      expect(controller.selection.isCollapsed, true);
-      expect(controller.selection.baseOffset, 35);
-      await tester.tapAt(vPos);
-      await tester.pumpAndSettle(const Duration(milliseconds: 500));
+    await tester.tapAt(vPos);
+    await tester.pump(const Duration(milliseconds: 50));
+    // First tap moved the cursor.
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, 35);
+    await tester.tapAt(vPos);
+    await tester.pumpAndSettle(const Duration(milliseconds: 500));
 
-      // Second tap selects the word around the cursor.
-      expect(controller.selection, const TextSelection(baseOffset: 24, extentOffset: 35));
+    // Second tap selects the word around the cursor.
+    expect(controller.selection, const TextSelection(baseOffset: 24, extentOffset: 35));
 
-      expectCupertinoToolbarForPartialSelection();
+    expectCupertinoToolbarForPartialSelection();
 
-      // Tap the selected word to hide the toolbar and retain the selection.
-      await tester.tapAt(vPos);
-      await tester.pumpAndSettle();
-      expect(controller.selection, const TextSelection(baseOffset: 24, extentOffset: 35));
-      expect(find.byType(CupertinoButton), findsNothing);
+    // Tap the selected word to hide the toolbar and retain the selection.
+    await tester.tapAt(vPos);
+    await tester.pumpAndSettle();
+    expect(controller.selection, const TextSelection(baseOffset: 24, extentOffset: 35));
+    expect(find.byType(CupertinoButton), findsNothing);
 
-      // Tap the selected word to show the toolbar and retain the selection.
-      await tester.tapAt(vPos);
-      await tester.pumpAndSettle();
-      expect(controller.selection, const TextSelection(baseOffset: 24, extentOffset: 35));
+    // Tap the selected word to show the toolbar and retain the selection.
+    await tester.tapAt(vPos);
+    await tester.pumpAndSettle();
+    expect(controller.selection, const TextSelection(baseOffset: 24, extentOffset: 35));
 
-      expectCupertinoToolbarForPartialSelection();
+    expectCupertinoToolbarForPartialSelection();
 
-      // Tap past the selected word to move the cursor and hide the toolbar.
-      await tester.tapAt(ePos);
-      await tester.pumpAndSettle();
-      expect(controller.selection.isCollapsed, true);
-      expect(controller.selection.baseOffset, 35);
+    // Tap past the selected word to move the cursor and hide the toolbar.
+    await tester.tapAt(ePos);
+    await tester.pumpAndSettle();
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, 35);
 
-      expect(find.byType(CupertinoButton), findsNothing);
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-  );
+    expect(find.byType(CupertinoButton), findsNothing);
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
 
   testWidgets(
     'double tap selects word for non-Apple platforms',
@@ -2500,191 +2482,181 @@ void main() {
     }),
   );
 
-  testWidgets(
-    'double tapping a space selects the previous word on iOS',
-    (WidgetTester tester) async {
-      final controller = TextEditingController(text: ' blah blah  \n  blah');
-      addTearDown(controller.dispose);
-      await tester.pumpWidget(
-        CupertinoApp(
-          home: Center(child: CupertinoTextField(controller: controller, maxLines: 2)),
-        ),
-      );
+  testWidgets('double tapping a space selects the previous word on iOS', (
+    WidgetTester tester,
+  ) async {
+    final controller = TextEditingController(text: ' blah blah  \n  blah');
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(child: CupertinoTextField(controller: controller, maxLines: 2)),
+      ),
+    );
 
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, -1);
-      expect(controller.value.selection.extentOffset, -1);
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, -1);
+    expect(controller.value.selection.extentOffset, -1);
 
-      // Put the cursor at the end of the field.
-      await tester.tapAt(textOffsetToPosition(tester, 19));
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, 19);
-      expect(controller.value.selection.extentOffset, 19);
+    // Put the cursor at the end of the field.
+    await tester.tapAt(textOffsetToPosition(tester, 19));
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, 19);
+    expect(controller.value.selection.extentOffset, 19);
 
-      // Double tapping the second space selects the previous word.
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.tapAt(textOffsetToPosition(tester, 5));
-      await tester.pump(const Duration(milliseconds: 50));
-      await tester.tapAt(textOffsetToPosition(tester, 5));
-      await tester.pumpAndSettle();
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, 1);
-      expect(controller.value.selection.extentOffset, 5);
+    // Double tapping the second space selects the previous word.
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.tapAt(textOffsetToPosition(tester, 5));
+    await tester.pump(const Duration(milliseconds: 50));
+    await tester.tapAt(textOffsetToPosition(tester, 5));
+    await tester.pumpAndSettle();
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, 1);
+    expect(controller.value.selection.extentOffset, 5);
 
-      // Put the cursor at the end of the field.
-      await tester.tapAt(textOffsetToPosition(tester, 19));
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, 19);
-      expect(controller.value.selection.extentOffset, 19);
+    // Put the cursor at the end of the field.
+    await tester.tapAt(textOffsetToPosition(tester, 19));
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, 19);
+    expect(controller.value.selection.extentOffset, 19);
 
-      // Double tapping the first space selects the space.
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.tapAt(textOffsetToPosition(tester, 0));
-      await tester.pump(const Duration(milliseconds: 50));
-      await tester.tapAt(textOffsetToPosition(tester, 0));
-      await tester.pumpAndSettle();
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, 0);
-      expect(controller.value.selection.extentOffset, 1);
+    // Double tapping the first space selects the space.
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.tapAt(textOffsetToPosition(tester, 0));
+    await tester.pump(const Duration(milliseconds: 50));
+    await tester.tapAt(textOffsetToPosition(tester, 0));
+    await tester.pumpAndSettle();
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, 0);
+    expect(controller.value.selection.extentOffset, 1);
 
-      // Put the cursor at the end of the field.
-      await tester.tapAt(textOffsetToPosition(tester, 19));
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, 19);
-      expect(controller.value.selection.extentOffset, 19);
+    // Put the cursor at the end of the field.
+    await tester.tapAt(textOffsetToPosition(tester, 19));
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, 19);
+    expect(controller.value.selection.extentOffset, 19);
 
-      // Double tapping the last space selects all previous contiguous spaces on
-      // both lines and the previous word.
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.tapAt(textOffsetToPosition(tester, 14));
-      await tester.pump(const Duration(milliseconds: 50));
-      await tester.tapAt(textOffsetToPosition(tester, 14));
-      await tester.pumpAndSettle();
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, 6);
-      expect(controller.value.selection.extentOffset, 14);
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-  );
+    // Double tapping the last space selects all previous contiguous spaces on
+    // both lines and the previous word.
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.tapAt(textOffsetToPosition(tester, 14));
+    await tester.pump(const Duration(milliseconds: 50));
+    await tester.tapAt(textOffsetToPosition(tester, 14));
+    await tester.pumpAndSettle();
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, 6);
+    expect(controller.value.selection.extentOffset, 14);
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
 
-  testWidgets(
-    'double tapping a space selects the space on Mac',
-    (WidgetTester tester) async {
-      final controller = TextEditingController(text: ' blah blah');
-      addTearDown(controller.dispose);
-      await tester.pumpWidget(
-        CupertinoApp(
-          home: Center(child: CupertinoTextField(controller: controller)),
-        ),
-      );
+  testWidgets('double tapping a space selects the space on Mac', (WidgetTester tester) async {
+    final controller = TextEditingController(text: ' blah blah');
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(child: CupertinoTextField(controller: controller)),
+      ),
+    );
 
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, -1);
-      expect(controller.value.selection.extentOffset, -1);
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, -1);
+    expect(controller.value.selection.extentOffset, -1);
 
-      // Put the cursor at the end of the field.
-      await tester.tapAt(textOffsetToPosition(tester, 10));
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, 10);
-      expect(controller.value.selection.extentOffset, 10);
+    // Put the cursor at the end of the field.
+    await tester.tapAt(textOffsetToPosition(tester, 10));
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, 10);
+    expect(controller.value.selection.extentOffset, 10);
 
-      // Double tapping the second space selects it.
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.tapAt(textOffsetToPosition(tester, 5));
-      await tester.pump(const Duration(milliseconds: 50));
-      await tester.tapAt(textOffsetToPosition(tester, 5));
-      await tester.pumpAndSettle();
+    // Double tapping the second space selects it.
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.tapAt(textOffsetToPosition(tester, 5));
+    await tester.pump(const Duration(milliseconds: 50));
+    await tester.tapAt(textOffsetToPosition(tester, 5));
+    await tester.pumpAndSettle();
 
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, 5);
-      expect(controller.value.selection.extentOffset, 6);
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, 5);
+    expect(controller.value.selection.extentOffset, 6);
 
-      // Tap at the end of the text to move the selection to the end. On some
-      // platforms, the context menu "Cut" button blocks this tap, so move it out
-      // of the way by an Offset.
-      await tester.tapAt(textOffsetToPosition(tester, 10) + const Offset(200.0, 0.0));
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, 10);
-      expect(controller.value.selection.extentOffset, 10);
+    // Tap at the end of the text to move the selection to the end. On some
+    // platforms, the context menu "Cut" button blocks this tap, so move it out
+    // of the way by an Offset.
+    await tester.tapAt(textOffsetToPosition(tester, 10) + const Offset(200.0, 0.0));
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, 10);
+    expect(controller.value.selection.extentOffset, 10);
 
-      // Double tapping the first space selects it.
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.tapAt(textOffsetToPosition(tester, 0));
-      await tester.pump(const Duration(milliseconds: 50));
-      await tester.tapAt(textOffsetToPosition(tester, 0));
-      await tester.pumpAndSettle();
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, 0);
-      expect(controller.value.selection.extentOffset, 1);
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.macOS}),
-  );
+    // Double tapping the first space selects it.
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.tapAt(textOffsetToPosition(tester, 0));
+    await tester.pump(const Duration(milliseconds: 50));
+    await tester.tapAt(textOffsetToPosition(tester, 0));
+    await tester.pumpAndSettle();
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, 0);
+    expect(controller.value.selection.extentOffset, 1);
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.macOS}));
 
-  testWidgets(
-    'double clicking a space selects the space on Mac',
-    (WidgetTester tester) async {
-      final controller = TextEditingController(text: ' blah blah');
-      addTearDown(controller.dispose);
-      await tester.pumpWidget(
-        CupertinoApp(
-          home: Center(child: CupertinoTextField(controller: controller)),
-        ),
-      );
+  testWidgets('double clicking a space selects the space on Mac', (WidgetTester tester) async {
+    final controller = TextEditingController(text: ' blah blah');
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(child: CupertinoTextField(controller: controller)),
+      ),
+    );
 
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, -1);
-      expect(controller.value.selection.extentOffset, -1);
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, -1);
+    expect(controller.value.selection.extentOffset, -1);
 
-      // Put the cursor at the end of the field.
-      final TestGesture gesture = await tester.startGesture(
-        textOffsetToPosition(tester, 10),
-        pointer: 7,
-        kind: PointerDeviceKind.mouse,
-      );
-      await tester.pump();
-      await gesture.up();
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, 10);
-      expect(controller.value.selection.extentOffset, 10);
+    // Put the cursor at the end of the field.
+    final TestGesture gesture = await tester.startGesture(
+      textOffsetToPosition(tester, 10),
+      pointer: 7,
+      kind: PointerDeviceKind.mouse,
+    );
+    await tester.pump();
+    await gesture.up();
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, 10);
+    expect(controller.value.selection.extentOffset, 10);
 
-      // Double tapping the second space selects it.
-      await tester.pump(const Duration(milliseconds: 500));
-      await gesture.down(textOffsetToPosition(tester, 5));
-      await tester.pump();
-      await gesture.up();
-      await tester.pump(const Duration(milliseconds: 50));
-      await gesture.down(textOffsetToPosition(tester, 5));
-      await tester.pump();
-      await gesture.up();
-      await tester.pumpAndSettle(kDoubleTapTimeout);
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, 5);
-      expect(controller.value.selection.extentOffset, 6);
+    // Double tapping the second space selects it.
+    await tester.pump(const Duration(milliseconds: 500));
+    await gesture.down(textOffsetToPosition(tester, 5));
+    await tester.pump();
+    await gesture.up();
+    await tester.pump(const Duration(milliseconds: 50));
+    await gesture.down(textOffsetToPosition(tester, 5));
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle(kDoubleTapTimeout);
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, 5);
+    expect(controller.value.selection.extentOffset, 6);
 
-      // Put the cursor at the end of the field.
-      await gesture.down(textOffsetToPosition(tester, 10));
-      await tester.pump();
-      await gesture.up();
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, 10);
-      expect(controller.value.selection.extentOffset, 10);
+    // Put the cursor at the end of the field.
+    await gesture.down(textOffsetToPosition(tester, 10));
+    await tester.pump();
+    await gesture.up();
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, 10);
+    expect(controller.value.selection.extentOffset, 10);
 
-      // Double tapping the first space selects it.
-      await tester.pump(const Duration(milliseconds: 500));
-      await gesture.down(textOffsetToPosition(tester, 0));
-      await tester.pump();
-      await gesture.up();
-      await tester.pump(const Duration(milliseconds: 50));
-      await gesture.down(textOffsetToPosition(tester, 0));
-      await tester.pump();
-      await gesture.up();
-      await tester.pumpAndSettle();
-      expect(controller.value.selection, isNotNull);
-      expect(controller.value.selection.baseOffset, 0);
-      expect(controller.value.selection.extentOffset, 1);
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.macOS}),
-  );
+    // Double tapping the first space selects it.
+    await tester.pump(const Duration(milliseconds: 500));
+    await gesture.down(textOffsetToPosition(tester, 0));
+    await tester.pump();
+    await gesture.up();
+    await tester.pump(const Duration(milliseconds: 50));
+    await gesture.down(textOffsetToPosition(tester, 0));
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle();
+    expect(controller.value.selection, isNotNull);
+    expect(controller.value.selection.baseOffset, 0);
+    expect(controller.value.selection.extentOffset, 1);
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.macOS}));
 
   testWidgets('An obscured CupertinoTextField is not selectable when disabled', (
     WidgetTester tester,
@@ -3352,59 +3324,55 @@ void main() {
     }),
   );
 
-  testWidgets(
-    'double tap chains work',
-    (WidgetTester tester) async {
-      final controller = TextEditingController(text: 'Atwater Peel Sherbrooke Bonaventure');
-      addTearDown(controller.dispose);
-      await tester.pumpWidget(
-        CupertinoApp(
-          home: Center(child: CupertinoTextField(controller: controller)),
-        ),
-      );
+  testWidgets('double tap chains work', (WidgetTester tester) async {
+    final controller = TextEditingController(text: 'Atwater Peel Sherbrooke Bonaventure');
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(child: CupertinoTextField(controller: controller)),
+      ),
+    );
 
-      final Offset textFieldStart = tester.getTopLeft(find.byType(CupertinoTextField));
+    final Offset textFieldStart = tester.getTopLeft(find.byType(CupertinoTextField));
 
-      await tester.tapAt(textFieldStart + const Offset(50.0, 5.0));
-      await tester.pump(const Duration(milliseconds: 50));
-      expect(
-        controller.selection,
-        const TextSelection.collapsed(offset: 7, affinity: TextAffinity.upstream),
-      );
-      await tester.tapAt(textFieldStart + const Offset(50.0, 5.0));
-      await tester.pumpAndSettle();
-      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
-      expectCupertinoToolbarForPartialSelection();
+    await tester.tapAt(textFieldStart + const Offset(50.0, 5.0));
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(
+      controller.selection,
+      const TextSelection.collapsed(offset: 7, affinity: TextAffinity.upstream),
+    );
+    await tester.tapAt(textFieldStart + const Offset(50.0, 5.0));
+    await tester.pumpAndSettle();
+    expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
+    expectCupertinoToolbarForPartialSelection();
 
-      // Double tap selecting the same word somewhere else is fine.
-      await tester.tapAt(textFieldStart + const Offset(100.0, 5.0));
-      await tester.pump(const Duration(milliseconds: 50));
-      // First tap hides the toolbar, and retains the selection.
-      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
-      expect(find.byType(CupertinoButton), findsNothing);
-      // Second tap shows the toolbar, and retains the selection.
-      await tester.tapAt(textFieldStart + const Offset(100.0, 5.0));
-      // Wait for the consecutive tap timer to timeout so the next
-      // tap is not detected as a triple tap.
-      await tester.pumpAndSettle(kDoubleTapTimeout);
-      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
-      expectCupertinoToolbarForPartialSelection();
+    // Double tap selecting the same word somewhere else is fine.
+    await tester.tapAt(textFieldStart + const Offset(100.0, 5.0));
+    await tester.pump(const Duration(milliseconds: 50));
+    // First tap hides the toolbar, and retains the selection.
+    expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
+    expect(find.byType(CupertinoButton), findsNothing);
+    // Second tap shows the toolbar, and retains the selection.
+    await tester.tapAt(textFieldStart + const Offset(100.0, 5.0));
+    // Wait for the consecutive tap timer to timeout so the next
+    // tap is not detected as a triple tap.
+    await tester.pumpAndSettle(kDoubleTapTimeout);
+    expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
+    expectCupertinoToolbarForPartialSelection();
 
-      await tester.tapAt(textFieldStart + const Offset(150.0, 5.0));
-      await tester.pump(const Duration(milliseconds: 50));
-      // First tap moved the cursor and hides the toolbar.
-      expect(
-        controller.selection,
-        const TextSelection.collapsed(offset: 12, affinity: TextAffinity.upstream),
-      );
-      expect(find.byType(CupertinoButton), findsNothing);
-      await tester.tapAt(textFieldStart + const Offset(150.0, 5.0));
-      await tester.pumpAndSettle();
-      expect(controller.selection, const TextSelection(baseOffset: 8, extentOffset: 12));
-      expectCupertinoToolbarForPartialSelection();
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-  );
+    await tester.tapAt(textFieldStart + const Offset(150.0, 5.0));
+    await tester.pump(const Duration(milliseconds: 50));
+    // First tap moved the cursor and hides the toolbar.
+    expect(
+      controller.selection,
+      const TextSelection.collapsed(offset: 12, affinity: TextAffinity.upstream),
+    );
+    expect(find.byType(CupertinoButton), findsNothing);
+    await tester.tapAt(textFieldStart + const Offset(150.0, 5.0));
+    await tester.pumpAndSettle();
+    expect(controller.selection, const TextSelection(baseOffset: 8, extentOffset: 12));
+    expectCupertinoToolbarForPartialSelection();
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
 
   group('Triple tap/click', () {
     const testValueA =
@@ -3479,65 +3447,63 @@ void main() {
       skip: true, // https://github.com/flutter/flutter/issues/123415
     );
 
-    testWidgets(
-      'Can triple tap to select a paragraph on mobile platforms',
-      (WidgetTester tester) async {
-        final controller = TextEditingController();
-        addTearDown(controller.dispose);
-        final isTargetPlatformApple = defaultTargetPlatform == TargetPlatform.iOS;
+    testWidgets('Can triple tap to select a paragraph on mobile platforms', (
+      WidgetTester tester,
+    ) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+      final isTargetPlatformApple = defaultTargetPlatform == TargetPlatform.iOS;
 
-        await tester.pumpWidget(
-          CupertinoApp(
-            home: Center(
-              child: CupertinoTextField(
-                dragStartBehavior: DragStartBehavior.down,
-                controller: controller,
-                maxLines: null,
-              ),
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: CupertinoTextField(
+              dragStartBehavior: DragStartBehavior.down,
+              controller: controller,
+              maxLines: null,
             ),
           ),
-        );
+        ),
+      );
 
-        await tester.enterText(find.byType(CupertinoTextField), testValueB);
-        // Skip past scrolling animation.
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 200));
-        expect(controller.value.text, testValueB);
+      await tester.enterText(find.byType(CupertinoTextField), testValueB);
+      // Skip past scrolling animation.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(controller.value.text, testValueB);
 
-        final Offset firstLinePos =
-            tester.getTopLeft(find.byType(CupertinoTextField)) + const Offset(50.0, 9.0);
+      final Offset firstLinePos =
+          tester.getTopLeft(find.byType(CupertinoTextField)) + const Offset(50.0, 9.0);
 
-        // Tap on text field to gain focus, and move the selection.
-        final TestGesture gesture = await tester.startGesture(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Tap on text field to gain focus, and move the selection.
+      final TestGesture gesture = await tester.startGesture(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, isTargetPlatformApple ? 5 : 3);
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, isTargetPlatformApple ? 5 : 3);
 
-        // Here we tap on same position again, to register a double tap. This will select
-        // the word at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Here we tap on same position again, to register a double tap. This will select
+      // the word at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 5);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 5);
 
-        // Here we tap on same position again, to register a triple tap. This will select
-        // the paragraph at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pumpAndSettle();
+      // Here we tap on same position again, to register a triple tap. This will select
+      // the paragraph at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 22);
-      },
-      variant: TargetPlatformVariant.mobile(),
-    );
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 22);
+    }, variant: TargetPlatformVariant.mobile());
 
     testWidgets(
       'Triple click at the beginning of a line should not select the previous paragraph',
@@ -3600,67 +3566,65 @@ void main() {
       variant: TargetPlatformVariant.all(excluding: <TargetPlatform>{TargetPlatform.linux}),
     );
 
-    testWidgets(
-      'Triple click at the end of text should select the previous paragraph',
-      (WidgetTester tester) async {
-        // Regression test for https://github.com/flutter/flutter/issues/132126.
-        final controller = TextEditingController();
-        addTearDown(controller.dispose);
+    testWidgets('Triple click at the end of text should select the previous paragraph', (
+      WidgetTester tester,
+    ) async {
+      // Regression test for https://github.com/flutter/flutter/issues/132126.
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
 
-        await tester.pumpWidget(
-          CupertinoApp(
-            home: Center(
-              child: CupertinoTextField(
-                dragStartBehavior: DragStartBehavior.down,
-                controller: controller,
-                maxLines: null,
-              ),
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: CupertinoTextField(
+              dragStartBehavior: DragStartBehavior.down,
+              controller: controller,
+              maxLines: null,
             ),
           ),
-        );
+        ),
+      );
 
-        await tester.enterText(find.byType(CupertinoTextField), testValueB);
-        // Skip past scrolling animation.
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 200));
-        expect(controller.value.text, testValueB);
+      await tester.enterText(find.byType(CupertinoTextField), testValueB);
+      // Skip past scrolling animation.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(controller.value.text, testValueB);
 
-        final Offset endOfTextPos = textOffsetToPosition(tester, 74);
+      final Offset endOfTextPos = textOffsetToPosition(tester, 74);
 
-        // Click on text field to gain focus, and move the selection.
-        final TestGesture gesture = await tester.startGesture(
-          endOfTextPos,
-          kind: PointerDeviceKind.mouse,
-        );
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Click on text field to gain focus, and move the selection.
+      final TestGesture gesture = await tester.startGesture(
+        endOfTextPos,
+        kind: PointerDeviceKind.mouse,
+      );
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, 74);
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, 74);
 
-        // Here we click on same position again, to register a double click.
-        await gesture.down(endOfTextPos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Here we click on same position again, to register a double click.
+      await gesture.down(endOfTextPos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.baseOffset, 74);
-        expect(controller.selection.extentOffset, 74);
+      expect(controller.selection.baseOffset, 74);
+      expect(controller.selection.extentOffset, 74);
 
-        // Here we click on same position again, to register a triple click. This will select
-        // the paragraph at the clicked position.
-        await gesture.down(endOfTextPos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
-        await tester.pumpAndSettle();
+      // Here we click on same position again, to register a triple click. This will select
+      // the paragraph at the clicked position.
+      await gesture.down(endOfTextPos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 57);
-        expect(controller.selection.extentOffset, 74);
-      },
-      variant: TargetPlatformVariant.all(excluding: <TargetPlatform>{TargetPlatform.linux}),
-    );
+      expect(controller.selection.baseOffset, 57);
+      expect(controller.selection.extentOffset, 74);
+    }, variant: TargetPlatformVariant.all(excluding: <TargetPlatform>{TargetPlatform.linux}));
 
     testWidgets(
       'triple tap chains work on Non-Apple mobile platforms',
@@ -3733,79 +3697,75 @@ void main() {
       }),
     );
 
-    testWidgets(
-      'triple tap chains work on Apple platforms',
-      (WidgetTester tester) async {
-        final controller = TextEditingController(
-          text: 'Atwater Peel Sherbrooke Bonaventure\nThe fox jumped over the fence.',
-        );
-        addTearDown(controller.dispose);
-        await tester.pumpWidget(
-          CupertinoApp(
-            home: Center(
-              child: Center(child: CupertinoTextField(controller: controller, maxLines: null)),
-            ),
+    testWidgets('triple tap chains work on Apple platforms', (WidgetTester tester) async {
+      final controller = TextEditingController(
+        text: 'Atwater Peel Sherbrooke Bonaventure\nThe fox jumped over the fence.',
+      );
+      addTearDown(controller.dispose);
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: Center(child: CupertinoTextField(controller: controller, maxLines: null)),
           ),
-        );
+        ),
+      );
 
-        final Offset textfieldStart = tester.getTopLeft(find.byType(CupertinoTextField));
+      final Offset textfieldStart = tester.getTopLeft(find.byType(CupertinoTextField));
 
-        await tester.tapAt(textfieldStart + const Offset(50.0, 9.0));
-        await tester.pump(const Duration(milliseconds: 50));
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, 7);
+      await tester.tapAt(textfieldStart + const Offset(50.0, 9.0));
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, 7);
 
-        await tester.tapAt(textfieldStart + const Offset(50.0, 9.0));
-        await tester.pump();
-        expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
-        expectCupertinoToolbarForPartialSelection();
+      await tester.tapAt(textfieldStart + const Offset(50.0, 9.0));
+      await tester.pump();
+      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
+      expectCupertinoToolbarForPartialSelection();
 
-        await tester.tapAt(textfieldStart + const Offset(50.0, 9.0));
-        await tester.pumpAndSettle(kDoubleTapTimeout);
-        expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 36));
+      await tester.tapAt(textfieldStart + const Offset(50.0, 9.0));
+      await tester.pumpAndSettle(kDoubleTapTimeout);
+      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 36));
 
-        // Triple tap selecting the same paragraph somewhere else is fine.
-        await tester.tapAt(textfieldStart + const Offset(100.0, 9.0));
-        await tester.pump(const Duration(milliseconds: 50));
-        // First tap hides the toolbar and retains the selection.
-        expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 36));
-        expect(find.byType(CupertinoButton), findsNothing);
+      // Triple tap selecting the same paragraph somewhere else is fine.
+      await tester.tapAt(textfieldStart + const Offset(100.0, 9.0));
+      await tester.pump(const Duration(milliseconds: 50));
+      // First tap hides the toolbar and retains the selection.
+      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 36));
+      expect(find.byType(CupertinoButton), findsNothing);
 
-        // Second tap shows the toolbar and selects the word.
-        await tester.tapAt(textfieldStart + const Offset(100.0, 9.0));
-        await tester.pump();
-        expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
-        expectCupertinoToolbarForPartialSelection();
+      // Second tap shows the toolbar and selects the word.
+      await tester.tapAt(textfieldStart + const Offset(100.0, 9.0));
+      await tester.pump();
+      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
+      expectCupertinoToolbarForPartialSelection();
 
-        // Third tap shows the toolbar and selects the paragraph.
-        await tester.tapAt(textfieldStart + const Offset(100.0, 9.0));
-        await tester.pumpAndSettle(kDoubleTapTimeout);
-        expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 36));
-        expectCupertinoToolbarForPartialSelection();
+      // Third tap shows the toolbar and selects the paragraph.
+      await tester.tapAt(textfieldStart + const Offset(100.0, 9.0));
+      await tester.pumpAndSettle(kDoubleTapTimeout);
+      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 36));
+      expectCupertinoToolbarForPartialSelection();
 
-        await tester.tapAt(textfieldStart + const Offset(150.0, 25.0));
-        await tester.pump(const Duration(milliseconds: 50));
-        // First tap moved the cursor and hid the toolbar.
-        expect(
-          controller.selection,
-          const TextSelection.collapsed(offset: 50, affinity: TextAffinity.upstream),
-        );
-        expect(find.byType(CupertinoButton), findsNothing);
+      await tester.tapAt(textfieldStart + const Offset(150.0, 25.0));
+      await tester.pump(const Duration(milliseconds: 50));
+      // First tap moved the cursor and hid the toolbar.
+      expect(
+        controller.selection,
+        const TextSelection.collapsed(offset: 50, affinity: TextAffinity.upstream),
+      );
+      expect(find.byType(CupertinoButton), findsNothing);
 
-        // Second tap selects the word.
-        await tester.tapAt(textfieldStart + const Offset(150.0, 25.0));
-        await tester.pump();
-        expect(controller.selection, const TextSelection(baseOffset: 44, extentOffset: 50));
-        expectCupertinoToolbarForPartialSelection();
+      // Second tap selects the word.
+      await tester.tapAt(textfieldStart + const Offset(150.0, 25.0));
+      await tester.pump();
+      expect(controller.selection, const TextSelection(baseOffset: 44, extentOffset: 50));
+      expectCupertinoToolbarForPartialSelection();
 
-        // Third tap selects the paragraph and shows the toolbar.
-        await tester.tapAt(textfieldStart + const Offset(150.0, 25.0));
-        await tester.pumpAndSettle();
-        expect(controller.selection, const TextSelection(baseOffset: 36, extentOffset: 66));
-        expectCupertinoToolbarForPartialSelection();
-      },
-      variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-    );
+      // Third tap selects the paragraph and shows the toolbar.
+      await tester.tapAt(textfieldStart + const Offset(150.0, 25.0));
+      await tester.pumpAndSettle();
+      expect(controller.selection, const TextSelection(baseOffset: 36, extentOffset: 66));
+      expectCupertinoToolbarForPartialSelection();
+    }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
 
     testWidgets('triple click chains work', (WidgetTester tester) async {
       final controller = TextEditingController(text: testValueA);
@@ -3955,438 +3915,422 @@ void main() {
       );
     }, variant: TargetPlatformVariant.desktop());
 
-    testWidgets(
-      'Can triple tap to select all on a single-line textfield on mobile platforms',
-      (WidgetTester tester) async {
-        final controller = TextEditingController(text: testValueB);
-        addTearDown(controller.dispose);
-        final isTargetPlatformApple = defaultTargetPlatform == TargetPlatform.iOS;
+    testWidgets('Can triple tap to select all on a single-line textfield on mobile platforms', (
+      WidgetTester tester,
+    ) async {
+      final controller = TextEditingController(text: testValueB);
+      addTearDown(controller.dispose);
+      final isTargetPlatformApple = defaultTargetPlatform == TargetPlatform.iOS;
 
-        await tester.pumpWidget(
-          CupertinoApp(
-            home: Center(child: CupertinoTextField(controller: controller)),
-          ),
-        );
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(child: CupertinoTextField(controller: controller)),
+        ),
+      );
 
-        final Offset firstLinePos =
-            tester.getTopLeft(find.byType(CupertinoTextField)) + const Offset(50.0, 9.0);
+      final Offset firstLinePos =
+          tester.getTopLeft(find.byType(CupertinoTextField)) + const Offset(50.0, 9.0);
 
-        // Tap on text field to gain focus, and set selection somewhere on the first word.
-        final TestGesture gesture = await tester.startGesture(firstLinePos, pointer: 7);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Tap on text field to gain focus, and set selection somewhere on the first word.
+      final TestGesture gesture = await tester.startGesture(firstLinePos, pointer: 7);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, isTargetPlatformApple ? 5 : 3);
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, isTargetPlatformApple ? 5 : 3);
 
-        // Here we tap on same position again, to register a double tap. This will select
-        // the word at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Here we tap on same position again, to register a double tap. This will select
+      // the word at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 5);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 5);
 
-        // Here we tap on same position again, to register a triple tap. This will select
-        // the entire text field if it is a single-line field.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pumpAndSettle();
+      // Here we tap on same position again, to register a triple tap. This will select
+      // the entire text field if it is a single-line field.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 74);
-      },
-      variant: TargetPlatformVariant.mobile(),
-    );
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 74);
+    }, variant: TargetPlatformVariant.mobile());
 
-    testWidgets(
-      'Can triple click to select all on a single-line textfield on desktop platforms',
-      (WidgetTester tester) async {
-        final controller = TextEditingController(text: testValueA);
-        addTearDown(controller.dispose);
+    testWidgets('Can triple click to select all on a single-line textfield on desktop platforms', (
+      WidgetTester tester,
+    ) async {
+      final controller = TextEditingController(text: testValueA);
+      addTearDown(controller.dispose);
 
-        await tester.pumpWidget(
-          CupertinoApp(
-            home: Center(
-              child: CupertinoTextField(
-                dragStartBehavior: DragStartBehavior.down,
-                controller: controller,
-              ),
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: CupertinoTextField(
+              dragStartBehavior: DragStartBehavior.down,
+              controller: controller,
             ),
           ),
-        );
+        ),
+      );
 
-        final Offset firstLinePos = textOffsetToPosition(tester, 5);
+      final Offset firstLinePos = textOffsetToPosition(tester, 5);
 
-        // Tap on text field to gain focus, and set selection to 'i|s' on the first line.
-        final TestGesture gesture = await tester.startGesture(
-          firstLinePos,
-          pointer: 7,
-          kind: PointerDeviceKind.mouse,
-        );
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Tap on text field to gain focus, and set selection to 'i|s' on the first line.
+      final TestGesture gesture = await tester.startGesture(
+        firstLinePos,
+        pointer: 7,
+        kind: PointerDeviceKind.mouse,
+      );
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, 5);
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, 5);
 
-        // Here we tap on same position again, to register a double tap. This will select
-        // the word at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Here we tap on same position again, to register a double tap. This will select
+      // the word at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.baseOffset, 4);
-        expect(controller.selection.extentOffset, 6);
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 6);
 
-        // Here we tap on same position again, to register a triple tap. This will select
-        // the entire text field if it is a single-line field.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pumpAndSettle();
+      // Here we tap on same position again, to register a triple tap. This will select
+      // the entire text field if it is a single-line field.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 72);
-      },
-      variant: TargetPlatformVariant.desktop(),
-    );
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 72);
+    }, variant: TargetPlatformVariant.desktop());
 
-    testWidgets(
-      'Can triple click to select a line on Linux',
-      (WidgetTester tester) async {
-        final controller = TextEditingController();
-        addTearDown(controller.dispose);
+    testWidgets('Can triple click to select a line on Linux', (WidgetTester tester) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
 
-        await tester.pumpWidget(
-          CupertinoApp(
-            home: Center(
-              child: CupertinoTextField(
-                dragStartBehavior: DragStartBehavior.down,
-                controller: controller,
-                maxLines: null,
-              ),
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: CupertinoTextField(
+              dragStartBehavior: DragStartBehavior.down,
+              controller: controller,
+              maxLines: null,
             ),
           ),
-        );
+        ),
+      );
 
-        await tester.enterText(find.byType(CupertinoTextField), testValueA);
-        // Skip past scrolling animation.
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 200));
-        expect(controller.value.text, testValueA);
+      await tester.enterText(find.byType(CupertinoTextField), testValueA);
+      // Skip past scrolling animation.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(controller.value.text, testValueA);
 
-        final Offset firstLinePos = textOffsetToPosition(tester, 5);
+      final Offset firstLinePos = textOffsetToPosition(tester, 5);
 
-        // Tap on text field to gain focus, and set selection to 'i|s' on the first line.
-        final TestGesture gesture = await tester.startGesture(
-          firstLinePos,
-          pointer: 7,
-          kind: PointerDeviceKind.mouse,
-        );
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Tap on text field to gain focus, and set selection to 'i|s' on the first line.
+      final TestGesture gesture = await tester.startGesture(
+        firstLinePos,
+        pointer: 7,
+        kind: PointerDeviceKind.mouse,
+      );
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, 5);
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, 5);
 
-        // Here we tap on same position again, to register a double tap. This will select
-        // the word at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Here we tap on same position again, to register a double tap. This will select
+      // the word at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.baseOffset, 4);
-        expect(controller.selection.extentOffset, 6);
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 6);
 
-        // Here we tap on same position again, to register a triple tap. This will select
-        // the paragraph at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pumpAndSettle();
+      // Here we tap on same position again, to register a triple tap. This will select
+      // the paragraph at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 19);
-      },
-      variant: TargetPlatformVariant.only(TargetPlatform.linux),
-    );
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 19);
+    }, variant: TargetPlatformVariant.only(TargetPlatform.linux));
 
-    testWidgets(
-      'Can triple click to select a paragraph',
-      (WidgetTester tester) async {
-        final controller = TextEditingController();
-        addTearDown(controller.dispose);
+    testWidgets('Can triple click to select a paragraph', (WidgetTester tester) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
 
-        await tester.pumpWidget(
-          CupertinoApp(
-            home: Center(
-              child: CupertinoTextField(
-                dragStartBehavior: DragStartBehavior.down,
-                controller: controller,
-                maxLines: null,
-              ),
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: CupertinoTextField(
+              dragStartBehavior: DragStartBehavior.down,
+              controller: controller,
+              maxLines: null,
             ),
           ),
-        );
+        ),
+      );
 
-        await tester.enterText(find.byType(CupertinoTextField), testValueA);
-        // Skip past scrolling animation.
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 200));
-        expect(controller.value.text, testValueA);
+      await tester.enterText(find.byType(CupertinoTextField), testValueA);
+      // Skip past scrolling animation.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(controller.value.text, testValueA);
 
-        final Offset firstLinePos = textOffsetToPosition(tester, 5);
+      final Offset firstLinePos = textOffsetToPosition(tester, 5);
 
-        // Tap on text field to gain focus, and set selection to 'i|s' on the first line.
-        final TestGesture gesture = await tester.startGesture(
-          firstLinePos,
-          pointer: 7,
-          kind: PointerDeviceKind.mouse,
-        );
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Tap on text field to gain focus, and set selection to 'i|s' on the first line.
+      final TestGesture gesture = await tester.startGesture(
+        firstLinePos,
+        pointer: 7,
+        kind: PointerDeviceKind.mouse,
+      );
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, 5);
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, 5);
 
-        // Here we tap on same position again, to register a double tap. This will select
-        // the word at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Here we tap on same position again, to register a double tap. This will select
+      // the word at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.baseOffset, 4);
-        expect(controller.selection.extentOffset, 6);
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 6);
 
-        // Here we tap on same position again, to register a triple tap. This will select
-        // the paragraph at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pumpAndSettle();
+      // Here we tap on same position again, to register a triple tap. This will select
+      // the paragraph at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 20);
-      },
-      variant: TargetPlatformVariant.all(excluding: <TargetPlatform>{TargetPlatform.linux}),
-    );
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 20);
+    }, variant: TargetPlatformVariant.all(excluding: <TargetPlatform>{TargetPlatform.linux}));
 
-    testWidgets(
-      'Can triple click + drag to select line by line on Linux',
-      (WidgetTester tester) async {
-        final controller = TextEditingController();
-        addTearDown(controller.dispose);
+    testWidgets('Can triple click + drag to select line by line on Linux', (
+      WidgetTester tester,
+    ) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
 
-        await tester.pumpWidget(
-          CupertinoApp(
-            home: Center(
-              child: CupertinoTextField(
-                dragStartBehavior: DragStartBehavior.down,
-                controller: controller,
-                maxLines: null,
-              ),
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: CupertinoTextField(
+              dragStartBehavior: DragStartBehavior.down,
+              controller: controller,
+              maxLines: null,
             ),
           ),
-        );
+        ),
+      );
 
-        await tester.enterText(find.byType(CupertinoTextField), testValueA);
-        // Skip past scrolling animation.
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 200));
-        expect(controller.value.text, testValueA);
+      await tester.enterText(find.byType(CupertinoTextField), testValueA);
+      // Skip past scrolling animation.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(controller.value.text, testValueA);
 
-        final Offset firstLinePos = textOffsetToPosition(tester, 5);
+      final Offset firstLinePos = textOffsetToPosition(tester, 5);
 
-        // Tap on text field to gain focus, and set selection to 'i|s' on the first line.
-        final TestGesture gesture = await tester.startGesture(
-          firstLinePos,
-          pointer: 7,
-          kind: PointerDeviceKind.mouse,
-        );
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Tap on text field to gain focus, and set selection to 'i|s' on the first line.
+      final TestGesture gesture = await tester.startGesture(
+        firstLinePos,
+        pointer: 7,
+        kind: PointerDeviceKind.mouse,
+      );
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, 5);
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, 5);
 
-        // Here we tap on same position again, to register a double tap. This will select
-        // the word at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Here we tap on same position again, to register a double tap. This will select
+      // the word at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.baseOffset, 4);
-        expect(controller.selection.extentOffset, 6);
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 6);
 
-        // Here we tap on the same position again, to register a triple tap. This will select
-        // the line at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pumpAndSettle();
+      // Here we tap on the same position again, to register a triple tap. This will select
+      // the line at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 19);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 19);
 
-        // Drag, down after the triple tap, to select line by line.
-        // Moving down will extend the selection to the second line.
-        await gesture.moveTo(firstLinePos + const Offset(0, 10.0));
-        await tester.pumpAndSettle();
+      // Drag, down after the triple tap, to select line by line.
+      // Moving down will extend the selection to the second line.
+      await gesture.moveTo(firstLinePos + const Offset(0, 10.0));
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 35);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 35);
 
-        // Moving down will extend the selection to the third line.
-        await gesture.moveTo(firstLinePos + const Offset(0, 20.0));
-        await tester.pumpAndSettle();
+      // Moving down will extend the selection to the third line.
+      await gesture.moveTo(firstLinePos + const Offset(0, 20.0));
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 54);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 54);
 
-        // Moving down will extend the selection to the last line.
-        await gesture.moveTo(firstLinePos + const Offset(0, 40.0));
-        await tester.pumpAndSettle();
+      // Moving down will extend the selection to the last line.
+      await gesture.moveTo(firstLinePos + const Offset(0, 40.0));
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 72);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 72);
 
-        // Moving up will extend the selection to the third line.
-        await gesture.moveTo(firstLinePos + const Offset(0, 20.0));
-        await tester.pumpAndSettle();
+      // Moving up will extend the selection to the third line.
+      await gesture.moveTo(firstLinePos + const Offset(0, 20.0));
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 54);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 54);
 
-        // Moving up will extend the selection to the second line.
-        await gesture.moveTo(firstLinePos + const Offset(0, 10.0));
-        await tester.pumpAndSettle();
+      // Moving up will extend the selection to the second line.
+      await gesture.moveTo(firstLinePos + const Offset(0, 10.0));
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 35);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 35);
 
-        // Moving up will extend the selection to the first line.
-        await gesture.moveTo(firstLinePos);
-        await tester.pumpAndSettle();
+      // Moving up will extend the selection to the first line.
+      await gesture.moveTo(firstLinePos);
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 19);
-      },
-      variant: TargetPlatformVariant.only(TargetPlatform.linux),
-    );
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 19);
+    }, variant: TargetPlatformVariant.only(TargetPlatform.linux));
 
-    testWidgets(
-      'Can triple click + drag to select paragraph by paragraph',
-      (WidgetTester tester) async {
-        final controller = TextEditingController();
-        addTearDown(controller.dispose);
+    testWidgets('Can triple click + drag to select paragraph by paragraph', (
+      WidgetTester tester,
+    ) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
 
-        await tester.pumpWidget(
-          CupertinoApp(
-            home: Center(
-              child: CupertinoTextField(
-                dragStartBehavior: DragStartBehavior.down,
-                controller: controller,
-                maxLines: null,
-              ),
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: CupertinoTextField(
+              dragStartBehavior: DragStartBehavior.down,
+              controller: controller,
+              maxLines: null,
             ),
           ),
-        );
+        ),
+      );
 
-        await tester.enterText(find.byType(CupertinoTextField), testValueA);
-        // Skip past scrolling animation.
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 200));
-        expect(controller.value.text, testValueA);
+      await tester.enterText(find.byType(CupertinoTextField), testValueA);
+      // Skip past scrolling animation.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(controller.value.text, testValueA);
 
-        final Offset firstLinePos = textOffsetToPosition(tester, 5);
+      final Offset firstLinePos = textOffsetToPosition(tester, 5);
 
-        // Tap on text field to gain focus, and set selection to 'i|s' on the first line.
-        final TestGesture gesture = await tester.startGesture(
-          firstLinePos,
-          pointer: 7,
-          kind: PointerDeviceKind.mouse,
-        );
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Tap on text field to gain focus, and set selection to 'i|s' on the first line.
+      final TestGesture gesture = await tester.startGesture(
+        firstLinePos,
+        pointer: 7,
+        kind: PointerDeviceKind.mouse,
+      );
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, 5);
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, 5);
 
-        // Here we tap on same position again, to register a double tap. This will select
-        // the word at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
+      // Here we tap on same position again, to register a double tap. This will select
+      // the word at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(controller.selection.baseOffset, 4);
-        expect(controller.selection.extentOffset, 6);
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 6);
 
-        // Here we tap on the same position again, to register a triple tap. This will select
-        // the paragraph at the tapped position.
-        await gesture.down(firstLinePos);
-        await tester.pumpAndSettle();
+      // Here we tap on the same position again, to register a triple tap. This will select
+      // the paragraph at the tapped position.
+      await gesture.down(firstLinePos);
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 20);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 20);
 
-        // Drag, down after the triple tap, to select paragraph by paragraph.
-        // Moving down will extend the selection to the second line.
-        await gesture.moveTo(firstLinePos + const Offset(0, 10.0));
-        await tester.pumpAndSettle();
+      // Drag, down after the triple tap, to select paragraph by paragraph.
+      // Moving down will extend the selection to the second line.
+      await gesture.moveTo(firstLinePos + const Offset(0, 10.0));
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 36);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 36);
 
-        // Moving down will extend the selection to the third line.
-        await gesture.moveTo(firstLinePos + const Offset(0, 20.0));
-        await tester.pumpAndSettle();
+      // Moving down will extend the selection to the third line.
+      await gesture.moveTo(firstLinePos + const Offset(0, 20.0));
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 55);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 55);
 
-        // Moving down will extend the selection to the last line.
-        await gesture.moveTo(firstLinePos + const Offset(0, 40.0));
-        await tester.pumpAndSettle();
+      // Moving down will extend the selection to the last line.
+      await gesture.moveTo(firstLinePos + const Offset(0, 40.0));
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 72);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 72);
 
-        // Moving up will extend the selection to the third line.
-        await gesture.moveTo(firstLinePos + const Offset(0, 20.0));
-        await tester.pumpAndSettle();
+      // Moving up will extend the selection to the third line.
+      await gesture.moveTo(firstLinePos + const Offset(0, 20.0));
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 55);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 55);
 
-        // Moving up will extend the selection to the second line.
-        await gesture.moveTo(firstLinePos + const Offset(0, 10.0));
-        await tester.pumpAndSettle();
+      // Moving up will extend the selection to the second line.
+      await gesture.moveTo(firstLinePos + const Offset(0, 10.0));
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 36);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 36);
 
-        // Moving up will extend the selection to the first line.
-        await gesture.moveTo(firstLinePos);
-        await tester.pumpAndSettle();
+      // Moving up will extend the selection to the first line.
+      await gesture.moveTo(firstLinePos);
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 20);
-      },
-      variant: TargetPlatformVariant.all(excluding: <TargetPlatform>{TargetPlatform.linux}),
-    );
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 20);
+    }, variant: TargetPlatformVariant.all(excluding: <TargetPlatform>{TargetPlatform.linux}));
 
     testWidgets(
       'Going past triple click retains the selection on Apple platforms',
@@ -4560,92 +4504,88 @@ void main() {
       }),
     );
 
-    testWidgets(
-      'Double click and triple click alternate on Windows',
-      (WidgetTester tester) async {
-        final controller = TextEditingController(text: testValueA);
-        addTearDown(controller.dispose);
-        await tester.pumpWidget(
-          CupertinoApp(
-            home: Center(
-              child: Center(child: CupertinoTextField(controller: controller, maxLines: null)),
-            ),
+    testWidgets('Double click and triple click alternate on Windows', (WidgetTester tester) async {
+      final controller = TextEditingController(text: testValueA);
+      addTearDown(controller.dispose);
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: Center(child: CupertinoTextField(controller: controller, maxLines: null)),
           ),
-        );
+        ),
+      );
 
-        final Offset textFieldStart = tester.getTopLeft(find.byType(CupertinoTextField));
+      final Offset textFieldStart = tester.getTopLeft(find.byType(CupertinoTextField));
 
-        // First click moves the cursor to the point of the click, not the edge of
-        // the clicked word.
-        final TestGesture gesture = await tester.startGesture(
-          textFieldStart + const Offset(200.0, 9.0),
-          pointer: 7,
-          kind: PointerDeviceKind.mouse,
-        );
-        await tester.pump();
-        await gesture.up();
-        await tester.pump(const Duration(milliseconds: 50));
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, 12);
+      // First click moves the cursor to the point of the click, not the edge of
+      // the clicked word.
+      final TestGesture gesture = await tester.startGesture(
+        textFieldStart + const Offset(200.0, 9.0),
+        pointer: 7,
+        kind: PointerDeviceKind.mouse,
+      );
+      await tester.pump();
+      await gesture.up();
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, 12);
 
-        // Second click selects the word.
-        await gesture.down(textFieldStart + const Offset(200.0, 9.0));
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
-        expect(controller.selection, const TextSelection(baseOffset: 11, extentOffset: 15));
+      // Second click selects the word.
+      await gesture.down(textFieldStart + const Offset(200.0, 9.0));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+      expect(controller.selection, const TextSelection(baseOffset: 11, extentOffset: 15));
 
-        // Triple click selects the paragraph.
-        await gesture.down(textFieldStart + const Offset(200.0, 9.0));
-        await tester.pump();
-        await gesture.up();
-        await tester.pumpAndSettle();
-        expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 20));
+      // Triple click selects the paragraph.
+      await gesture.down(textFieldStart + const Offset(200.0, 9.0));
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
+      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 20));
 
-        // Clicking again selects the word.
-        await gesture.down(textFieldStart + const Offset(200.0, 9.0));
-        await tester.pump();
-        await gesture.up();
-        await tester.pump(const Duration(milliseconds: 50));
-        expect(controller.selection, const TextSelection(baseOffset: 11, extentOffset: 15));
+      // Clicking again selects the word.
+      await gesture.down(textFieldStart + const Offset(200.0, 9.0));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(controller.selection, const TextSelection(baseOffset: 11, extentOffset: 15));
 
-        await gesture.down(textFieldStart + const Offset(200.0, 9.0));
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
-        // Clicking again selects the paragraph.
-        expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 20));
+      await gesture.down(textFieldStart + const Offset(200.0, 9.0));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+      // Clicking again selects the paragraph.
+      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 20));
 
-        await gesture.down(textFieldStart + const Offset(200.0, 9.0));
-        await tester.pump();
-        await gesture.up();
-        await tester.pumpAndSettle();
-        // Clicking again selects the word.
-        expect(controller.selection, const TextSelection(baseOffset: 11, extentOffset: 15));
+      await gesture.down(textFieldStart + const Offset(200.0, 9.0));
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
+      // Clicking again selects the word.
+      expect(controller.selection, const TextSelection(baseOffset: 11, extentOffset: 15));
 
-        await gesture.down(textFieldStart + const Offset(200.0, 9.0));
-        await tester.pump();
-        await gesture.up();
-        await tester.pump(const Duration(milliseconds: 50));
-        // Clicking again selects the paragraph.
-        expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 20));
+      await gesture.down(textFieldStart + const Offset(200.0, 9.0));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump(const Duration(milliseconds: 50));
+      // Clicking again selects the paragraph.
+      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 20));
 
-        await gesture.down(textFieldStart + const Offset(200.0, 9.0));
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
-        // Clicking again selects the word.
-        expect(controller.selection, const TextSelection(baseOffset: 11, extentOffset: 15));
+      await gesture.down(textFieldStart + const Offset(200.0, 9.0));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+      // Clicking again selects the word.
+      expect(controller.selection, const TextSelection(baseOffset: 11, extentOffset: 15));
 
-        await gesture.down(textFieldStart + const Offset(200.0, 9.0));
-        await tester.pump();
-        await gesture.up();
-        await tester.pumpAndSettle();
-        // Clicking again selects the paragraph.
-        expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 20));
-      },
-      variant: TargetPlatformVariant.only(TargetPlatform.windows),
-    );
+      await gesture.down(textFieldStart + const Offset(200.0, 9.0));
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
+      // Clicking again selects the paragraph.
+      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 20));
+    }, variant: TargetPlatformVariant.only(TargetPlatform.windows));
   });
 
   testWidgets('force press selects word', (WidgetTester tester) async {
@@ -4800,213 +4740,203 @@ void main() {
     ),
   );
 
-  testWidgets(
-    'Can drag one handle past the other on iOS',
-    (WidgetTester tester) async {
-      final controller = TextEditingController(text: 'abc def ghi');
-      addTearDown(controller.dispose);
-      // On iOS/iPadOS, during a tap we select the edge of the word closest to the tap.
-      // On macOS, we select the precise position of the tap.
-      final isTargetPlatformIOS = defaultTargetPlatform == TargetPlatform.iOS;
-      // Provide a [TextSelectionControls] that builds selection handles.
-      final TextSelectionControls selectionControls = CupertinoTextSelectionHandleControls();
+  testWidgets('Can drag one handle past the other on iOS', (WidgetTester tester) async {
+    final controller = TextEditingController(text: 'abc def ghi');
+    addTearDown(controller.dispose);
+    // On iOS/iPadOS, during a tap we select the edge of the word closest to the tap.
+    // On macOS, we select the precise position of the tap.
+    final isTargetPlatformIOS = defaultTargetPlatform == TargetPlatform.iOS;
+    // Provide a [TextSelectionControls] that builds selection handles.
+    final TextSelectionControls selectionControls = CupertinoTextSelectionHandleControls();
 
-      await tester.pumpWidget(
-        CupertinoApp(
-          home: Center(
-            child: CupertinoTextField(
-              dragStartBehavior: DragStartBehavior.down,
-              controller: controller,
-              selectionControls: selectionControls,
-              style: const TextStyle(fontSize: 10.0),
-            ),
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(
+          child: CupertinoTextField(
+            dragStartBehavior: DragStartBehavior.down,
+            controller: controller,
+            selectionControls: selectionControls,
+            style: const TextStyle(fontSize: 10.0),
           ),
         ),
-      );
+      ),
+    );
 
-      // Double tap on 'e' to select 'def'.
-      final Offset ePos = textOffsetToPosition(tester, 5);
-      await tester.tapAt(ePos, pointer: 7);
-      await tester.pump(const Duration(milliseconds: 50));
-      expect(controller.selection.isCollapsed, isTrue);
-      expect(controller.selection.baseOffset, isTargetPlatformIOS ? 7 : 5);
-      await tester.tapAt(ePos, pointer: 7);
-      await tester.pumpAndSettle();
-      expect(controller.selection.baseOffset, 4);
-      expect(controller.selection.extentOffset, 7);
+    // Double tap on 'e' to select 'def'.
+    final Offset ePos = textOffsetToPosition(tester, 5);
+    await tester.tapAt(ePos, pointer: 7);
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(controller.selection.isCollapsed, isTrue);
+    expect(controller.selection.baseOffset, isTargetPlatformIOS ? 7 : 5);
+    await tester.tapAt(ePos, pointer: 7);
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 4);
+    expect(controller.selection.extentOffset, 7);
 
-      final RenderEditable renderEditable = findRenderEditable(tester);
-      final List<TextSelectionPoint> endpoints = globalize(
-        renderEditable.getEndpointsForSelection(controller.selection),
-        renderEditable,
-      );
-      expect(endpoints.length, 2);
+    final RenderEditable renderEditable = findRenderEditable(tester);
+    final List<TextSelectionPoint> endpoints = globalize(
+      renderEditable.getEndpointsForSelection(controller.selection),
+      renderEditable,
+    );
+    expect(endpoints.length, 2);
 
-      // On Mac, the toolbar blocks the drag on the right handle, so hide it.
-      final EditableTextState editableTextState = tester.state(find.byType(EditableText));
-      editableTextState.hideToolbar(false);
-      await tester.pumpAndSettle();
+    // On Mac, the toolbar blocks the drag on the right handle, so hide it.
+    final EditableTextState editableTextState = tester.state(find.byType(EditableText));
+    editableTextState.hideToolbar(false);
+    await tester.pumpAndSettle();
 
-      // Drag the right handle until there's only 1 char selected.
-      // We use a small offset because the endpoint is on the very corner
-      // of the handle.
-      final Offset handlePos = endpoints[1].point;
-      Offset newHandlePos = textOffsetToPosition(tester, 5); // Position of 'e'.
-      final TestGesture gesture = await tester.startGesture(handlePos, pointer: 7);
-      await tester.pump();
-      await gesture.moveTo(newHandlePos);
-      await tester.pump();
-      expect(controller.selection.baseOffset, 4);
-      expect(controller.selection.extentOffset, 5);
+    // Drag the right handle until there's only 1 char selected.
+    // We use a small offset because the endpoint is on the very corner
+    // of the handle.
+    final Offset handlePos = endpoints[1].point;
+    Offset newHandlePos = textOffsetToPosition(tester, 5); // Position of 'e'.
+    final TestGesture gesture = await tester.startGesture(handlePos, pointer: 7);
+    await tester.pump();
+    await gesture.moveTo(newHandlePos);
+    await tester.pump();
+    expect(controller.selection.baseOffset, 4);
+    expect(controller.selection.extentOffset, 5);
 
-      newHandlePos = textOffsetToPosition(tester, 2); // Position of 'c'.
-      await gesture.moveTo(newHandlePos);
-      await tester.pump();
-      await gesture.up();
-      await tester.pump();
+    newHandlePos = textOffsetToPosition(tester, 2); // Position of 'c'.
+    await gesture.moveTo(newHandlePos);
+    await tester.pump();
+    await gesture.up();
+    await tester.pump();
 
-      // The selection inverts moving beyond the left handle.
-      expect(controller.selection.baseOffset, 4);
-      expect(controller.selection.extentOffset, 2);
-    },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-  );
+    // The selection inverts moving beyond the left handle.
+    expect(controller.selection.baseOffset, 4);
+    expect(controller.selection.extentOffset, 2);
+  }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
-  testWidgets(
-    'assertion error is not thrown when attempting to drag both selection handles',
-    (WidgetTester tester) async {
-      // Regression test for https://github.com/flutter/flutter/issues/168578.
-      final controller = TextEditingController(text: 'abc def ghi');
-      addTearDown(controller.dispose);
+  testWidgets('assertion error is not thrown when attempting to drag both selection handles', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/168578.
+    final controller = TextEditingController(text: 'abc def ghi');
+    addTearDown(controller.dispose);
 
-      await tester.pumpWidget(
-        CupertinoApp(
-          home: Center(
-            child: CupertinoTextField(
-              dragStartBehavior: DragStartBehavior.down,
-              controller: controller,
-              style: const TextStyle(fontSize: 10.0),
-            ),
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(
+          child: CupertinoTextField(
+            dragStartBehavior: DragStartBehavior.down,
+            controller: controller,
+            style: const TextStyle(fontSize: 10.0),
           ),
         ),
-      );
+      ),
+    );
 
-      // Double tap on 'e' to select 'def'.
-      final Offset ePos = textOffsetToPosition(tester, 5);
-      await tester.tapAt(ePos, pointer: 7);
-      await tester.pump(const Duration(milliseconds: 50));
-      expect(controller.selection.isCollapsed, isTrue);
-      expect(controller.selection.baseOffset, 7);
-      await tester.tapAt(ePos, pointer: 7);
-      await tester.pumpAndSettle();
-      expect(controller.selection.baseOffset, 4);
-      expect(controller.selection.extentOffset, 7);
+    // Double tap on 'e' to select 'def'.
+    final Offset ePos = textOffsetToPosition(tester, 5);
+    await tester.tapAt(ePos, pointer: 7);
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(controller.selection.isCollapsed, isTrue);
+    expect(controller.selection.baseOffset, 7);
+    await tester.tapAt(ePos, pointer: 7);
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 4);
+    expect(controller.selection.extentOffset, 7);
 
-      final RenderEditable renderEditable = findRenderEditable(tester);
-      final List<TextSelectionPoint> endpoints = globalize(
-        renderEditable.getEndpointsForSelection(controller.selection),
-        renderEditable,
-      );
-      expect(endpoints.length, 2);
+    final RenderEditable renderEditable = findRenderEditable(tester);
+    final List<TextSelectionPoint> endpoints = globalize(
+      renderEditable.getEndpointsForSelection(controller.selection),
+      renderEditable,
+    );
+    expect(endpoints.length, 2);
 
-      // Drag the end handle to 'g'.
-      final Offset endHandlePos = endpoints[1].point;
-      Offset newHandlePos = textOffsetToPosition(tester, 9); // Position of 'g'.
-      final TestGesture endHandleGesture = await tester.startGesture(endHandlePos, pointer: 7);
-      await tester.pump();
-      await endHandleGesture.moveTo(newHandlePos);
-      await tester.pump();
-      expect(controller.selection.baseOffset, 4);
-      expect(controller.selection.extentOffset, 9);
+    // Drag the end handle to 'g'.
+    final Offset endHandlePos = endpoints[1].point;
+    Offset newHandlePos = textOffsetToPosition(tester, 9); // Position of 'g'.
+    final TestGesture endHandleGesture = await tester.startGesture(endHandlePos, pointer: 7);
+    await tester.pump();
+    await endHandleGesture.moveTo(newHandlePos);
+    await tester.pump();
+    expect(controller.selection.baseOffset, 4);
+    expect(controller.selection.extentOffset, 9);
 
-      // Attempt to drag the start handle to the start of the text.
-      final Offset startHandlePos = endpoints[0].point;
-      newHandlePos = textOffsetToPosition(tester, 0);
-      final TestGesture startHandleGesture = await tester.startGesture(startHandlePos, pointer: 8);
-      await tester.pump();
-      await startHandleGesture.moveTo(newHandlePos);
-      await tester.pump();
-      await startHandleGesture.up();
-      await tester.pump();
+    // Attempt to drag the start handle to the start of the text.
+    final Offset startHandlePos = endpoints[0].point;
+    newHandlePos = textOffsetToPosition(tester, 0);
+    final TestGesture startHandleGesture = await tester.startGesture(startHandlePos, pointer: 8);
+    await tester.pump();
+    await startHandleGesture.moveTo(newHandlePos);
+    await tester.pump();
+    await startHandleGesture.up();
+    await tester.pump();
 
-      // Drag the end handle to the end of the text after releasing the start handle.
-      newHandlePos = textOffsetToPosition(tester, 11); // Position of 'i'.
-      await tester.pump();
-      await endHandleGesture.moveTo(newHandlePos);
-      await tester.pump();
-      await endHandleGesture.up();
-      await tester.pump();
+    // Drag the end handle to the end of the text after releasing the start handle.
+    newHandlePos = textOffsetToPosition(tester, 11); // Position of 'i'.
+    await tester.pump();
+    await endHandleGesture.moveTo(newHandlePos);
+    await tester.pump();
+    await endHandleGesture.up();
+    await tester.pump();
 
-      expect(tester.takeException(), isNull);
-      expect(controller.selection.baseOffset, 4);
-      expect(controller.selection.extentOffset, 11);
-    },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-  );
+    expect(tester.takeException(), isNull);
+    expect(controller.selection.baseOffset, 4);
+    expect(controller.selection.extentOffset, 11);
+  }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
-  testWidgets(
-    'Can only drag one handle at a time on iOS',
-    (WidgetTester tester) async {
-      final controller = TextEditingController(text: 'abc def ghi');
-      addTearDown(controller.dispose);
+  testWidgets('Can only drag one handle at a time on iOS', (WidgetTester tester) async {
+    final controller = TextEditingController(text: 'abc def ghi');
+    addTearDown(controller.dispose);
 
-      await tester.pumpWidget(
-        CupertinoApp(
-          home: Center(
-            child: CupertinoTextField(
-              dragStartBehavior: DragStartBehavior.down,
-              controller: controller,
-              style: const TextStyle(fontSize: 10.0),
-            ),
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(
+          child: CupertinoTextField(
+            dragStartBehavior: DragStartBehavior.down,
+            controller: controller,
+            style: const TextStyle(fontSize: 10.0),
           ),
         ),
-      );
+      ),
+    );
 
-      // Double tap on 'e' to select 'def'.
-      final Offset ePos = textOffsetToPosition(tester, 5);
-      await tester.tapAt(ePos, pointer: 7);
-      await tester.pump(const Duration(milliseconds: 50));
-      expect(controller.selection.isCollapsed, isTrue);
-      expect(controller.selection.baseOffset, 7);
-      await tester.tapAt(ePos, pointer: 7);
-      await tester.pumpAndSettle();
-      expect(controller.selection.baseOffset, 4);
-      expect(controller.selection.extentOffset, 7);
+    // Double tap on 'e' to select 'def'.
+    final Offset ePos = textOffsetToPosition(tester, 5);
+    await tester.tapAt(ePos, pointer: 7);
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(controller.selection.isCollapsed, isTrue);
+    expect(controller.selection.baseOffset, 7);
+    await tester.tapAt(ePos, pointer: 7);
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 4);
+    expect(controller.selection.extentOffset, 7);
 
-      final RenderEditable renderEditable = findRenderEditable(tester);
-      final List<TextSelectionPoint> endpoints = globalize(
-        renderEditable.getEndpointsForSelection(controller.selection),
-        renderEditable,
-      );
-      expect(endpoints.length, 2);
+    final RenderEditable renderEditable = findRenderEditable(tester);
+    final List<TextSelectionPoint> endpoints = globalize(
+      renderEditable.getEndpointsForSelection(controller.selection),
+      renderEditable,
+    );
+    expect(endpoints.length, 2);
 
-      // Drag the end handle to the end of the text.
-      final Offset endHandlePos = endpoints[1].point;
-      Offset newHandlePos = textOffsetToPosition(tester, 11); // Position of 'i'.
-      final TestGesture endHandleGesture = await tester.startGesture(endHandlePos, pointer: 7);
-      await tester.pump();
-      await endHandleGesture.moveTo(newHandlePos);
-      await tester.pump();
-      expect(controller.selection.baseOffset, 4);
-      expect(controller.selection.extentOffset, 11);
+    // Drag the end handle to the end of the text.
+    final Offset endHandlePos = endpoints[1].point;
+    Offset newHandlePos = textOffsetToPosition(tester, 11); // Position of 'i'.
+    final TestGesture endHandleGesture = await tester.startGesture(endHandlePos, pointer: 7);
+    await tester.pump();
+    await endHandleGesture.moveTo(newHandlePos);
+    await tester.pump();
+    expect(controller.selection.baseOffset, 4);
+    expect(controller.selection.extentOffset, 11);
 
-      // Attempt to drag the start handle to the start of the text.
-      final Offset startHandlePos = endpoints[0].point;
-      newHandlePos = textOffsetToPosition(tester, 0);
-      final TestGesture startHandleGesture = await tester.startGesture(startHandlePos, pointer: 8);
-      await tester.pump();
-      await startHandleGesture.moveTo(newHandlePos);
-      await tester.pump();
-      await startHandleGesture.up();
-      await endHandleGesture.up();
-      await tester.pump();
+    // Attempt to drag the start handle to the start of the text.
+    final Offset startHandlePos = endpoints[0].point;
+    newHandlePos = textOffsetToPosition(tester, 0);
+    final TestGesture startHandleGesture = await tester.startGesture(startHandlePos, pointer: 8);
+    await tester.pump();
+    await startHandleGesture.moveTo(newHandlePos);
+    await tester.pump();
+    await startHandleGesture.up();
+    await endHandleGesture.up();
+    await tester.pump();
 
-      // The start handle does not cause the selection to change.
-      expect(controller.selection.baseOffset, 4);
-      expect(controller.selection.extentOffset, 11);
-    },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-  );
+    // The start handle does not cause the selection to change.
+    expect(controller.selection.baseOffset, 4);
+    expect(controller.selection.extentOffset, 11);
+  }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
   testWidgets(
     'Can only drag one selection handle at a time on Android web',
@@ -5623,61 +5553,59 @@ void main() {
     variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
   );
 
-  testWidgets(
-    'Can move cursor when dragging, when tap is on collapsed selection (iOS)',
-    (WidgetTester tester) async {
-      final controller = TextEditingController();
-      addTearDown(controller.dispose);
+  testWidgets('Can move cursor when dragging, when tap is on collapsed selection (iOS)', (
+    WidgetTester tester,
+  ) async {
+    final controller = TextEditingController();
+    addTearDown(controller.dispose);
 
-      await tester.pumpWidget(
-        CupertinoApp(
-          home: CupertinoPageScaffold(
-            child: CupertinoTextField(
-              dragStartBehavior: DragStartBehavior.down,
-              controller: controller,
-            ),
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: CupertinoPageScaffold(
+          child: CupertinoTextField(
+            dragStartBehavior: DragStartBehavior.down,
+            controller: controller,
           ),
         ),
-      );
+      ),
+    );
 
-      const testValue = 'abc def ghi';
-      await tester.enterText(find.byType(CupertinoTextField), testValue);
-      await tester.pumpAndSettle(const Duration(milliseconds: 200));
+    const testValue = 'abc def ghi';
+    await tester.enterText(find.byType(CupertinoTextField), testValue);
+    await tester.pumpAndSettle(const Duration(milliseconds: 200));
 
-      final Offset ePos = textOffsetToPosition(tester, testValue.indexOf('e'));
-      final Offset iPos = textOffsetToPosition(tester, testValue.indexOf('i'));
+    final Offset ePos = textOffsetToPosition(tester, testValue.indexOf('e'));
+    final Offset iPos = textOffsetToPosition(tester, testValue.indexOf('i'));
 
-      // Tap on text field to gain focus, and set selection to '|g'. On iOS
-      // the selection is set to the word edge closest to the tap position.
-      // We await for [kDoubleTapTimeout] after the up event, so our next down
-      // event does not register as a double tap.
-      final TestGesture gesture = await tester.startGesture(ePos);
-      await tester.pump();
-      await gesture.up();
-      await tester.pumpAndSettle(kDoubleTapTimeout);
+    // Tap on text field to gain focus, and set selection to '|g'. On iOS
+    // the selection is set to the word edge closest to the tap position.
+    // We await for [kDoubleTapTimeout] after the up event, so our next down
+    // event does not register as a double tap.
+    final TestGesture gesture = await tester.startGesture(ePos);
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle(kDoubleTapTimeout);
 
-      expect(controller.selection.isCollapsed, true);
-      expect(controller.selection.baseOffset, 7);
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, 7);
 
-      // If the position we tap during a drag start is on the collapsed selection, then
-      // we can move the cursor with a drag.
-      // Here we tap on '|g', where our selection was previously, and move to '|i'.
-      await gesture.down(textOffsetToPosition(tester, 7));
-      await tester.pump();
-      await gesture.moveTo(iPos);
-      await tester.pumpAndSettle();
+    // If the position we tap during a drag start is on the collapsed selection, then
+    // we can move the cursor with a drag.
+    // Here we tap on '|g', where our selection was previously, and move to '|i'.
+    await gesture.down(textOffsetToPosition(tester, 7));
+    await tester.pump();
+    await gesture.moveTo(iPos);
+    await tester.pumpAndSettle();
 
-      expect(controller.selection.isCollapsed, true);
-      expect(controller.selection.baseOffset, testValue.indexOf('i'));
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, testValue.indexOf('i'));
 
-      // End gesture and skip the magnifier hide animation, so it can release
-      // resources.
-      await gesture.up();
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 150));
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-  );
+    // End gesture and skip the magnifier hide animation, so it can release
+    // resources.
+    await gesture.up();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 150));
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
 
   testWidgets(
     'Can move cursor when dragging, when tap is on collapsed selection (iOS) - multiline',
@@ -9472,77 +9400,75 @@ void main() {
       );
     });
 
-    testWidgets(
-      'Can drag handles to show, unshow, and update magnifier',
-      (WidgetTester tester) async {
-        final controller = TextEditingController();
-        addTearDown(controller.dispose);
-        await tester.pumpWidget(
-          CupertinoApp(
-            home: CupertinoPageScaffold(
-              child: Builder(
-                builder: (BuildContext context) => CupertinoTextField(
-                  dragStartBehavior: DragStartBehavior.down,
-                  controller: controller,
-                  magnifierConfiguration: TextMagnifierConfiguration(
-                    magnifierBuilder:
-                        (
-                          _,
-                          MagnifierController controller,
-                          ValueNotifier<MagnifierInfo> localMagnifierInfo,
-                        ) {
-                          magnifierInfo = localMagnifierInfo;
-                          return fakeMagnifier;
-                        },
-                  ),
+    testWidgets('Can drag handles to show, unshow, and update magnifier', (
+      WidgetTester tester,
+    ) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: CupertinoPageScaffold(
+            child: Builder(
+              builder: (BuildContext context) => CupertinoTextField(
+                dragStartBehavior: DragStartBehavior.down,
+                controller: controller,
+                magnifierConfiguration: TextMagnifierConfiguration(
+                  magnifierBuilder:
+                      (
+                        _,
+                        MagnifierController controller,
+                        ValueNotifier<MagnifierInfo> localMagnifierInfo,
+                      ) {
+                        magnifierInfo = localMagnifierInfo;
+                        return fakeMagnifier;
+                      },
                 ),
               ),
             ),
           ),
-        );
+        ),
+      );
 
-        const testValue = 'abc def ghi';
-        await tester.enterText(find.byType(CupertinoTextField), testValue);
+      const testValue = 'abc def ghi';
+      await tester.enterText(find.byType(CupertinoTextField), testValue);
 
-        // Double tap the 'e' to select 'def'.
-        await tester.tapAt(textOffsetToPosition(tester, testValue.indexOf('e')));
-        await tester.pump(const Duration(milliseconds: 30));
-        await tester.tapAt(textOffsetToPosition(tester, testValue.indexOf('e')));
-        await tester.pump(const Duration(milliseconds: 30));
+      // Double tap the 'e' to select 'def'.
+      await tester.tapAt(textOffsetToPosition(tester, testValue.indexOf('e')));
+      await tester.pump(const Duration(milliseconds: 30));
+      await tester.tapAt(textOffsetToPosition(tester, testValue.indexOf('e')));
+      await tester.pump(const Duration(milliseconds: 30));
 
-        final TextSelection selection = controller.selection;
+      final TextSelection selection = controller.selection;
 
-        final RenderEditable renderEditable = findRenderEditable(tester);
-        final List<TextSelectionPoint> endpoints = globalize(
-          renderEditable.getEndpointsForSelection(selection),
-          renderEditable,
-        );
+      final RenderEditable renderEditable = findRenderEditable(tester);
+      final List<TextSelectionPoint> endpoints = globalize(
+        renderEditable.getEndpointsForSelection(selection),
+        renderEditable,
+      );
 
-        // Drag the right handle 2 letters to the right.
-        final Offset handlePos = endpoints.last.point + const Offset(1.0, 1.0);
-        final TestGesture gesture = await tester.startGesture(handlePos, pointer: 7);
+      // Drag the right handle 2 letters to the right.
+      final Offset handlePos = endpoints.last.point + const Offset(1.0, 1.0);
+      final TestGesture gesture = await tester.startGesture(handlePos, pointer: 7);
 
-        Offset? firstDragGesturePosition;
+      Offset? firstDragGesturePosition;
 
-        await gesture.moveTo(textOffsetToPosition(tester, testValue.length - 2));
-        await tester.pump();
+      await gesture.moveTo(textOffsetToPosition(tester, testValue.length - 2));
+      await tester.pump();
 
-        expect(find.byKey(fakeMagnifier.key!), findsOneWidget);
-        firstDragGesturePosition = magnifierInfo.value.globalGesturePosition;
+      expect(find.byKey(fakeMagnifier.key!), findsOneWidget);
+      firstDragGesturePosition = magnifierInfo.value.globalGesturePosition;
 
-        await gesture.moveTo(textOffsetToPosition(tester, testValue.length));
-        await tester.pump();
+      await gesture.moveTo(textOffsetToPosition(tester, testValue.length));
+      await tester.pump();
 
-        // Expect the position the magnifier gets to have moved.
-        expect(firstDragGesturePosition, isNot(magnifierInfo.value.globalGesturePosition));
+      // Expect the position the magnifier gets to have moved.
+      expect(firstDragGesturePosition, isNot(magnifierInfo.value.globalGesturePosition));
 
-        await gesture.up();
-        await tester.pump();
+      await gesture.up();
+      await tester.pump();
 
-        expect(find.byKey(fakeMagnifier.key!), findsNothing);
-      },
-      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-    );
+      expect(find.byKey(fakeMagnifier.key!), findsNothing);
+    }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
     testWidgets(
       'Can drag to show, unshow, and update magnifier',
@@ -9652,243 +9578,237 @@ void main() {
       }),
     );
 
-    testWidgets(
-      'Can long press to show, unshow, and update magnifier on non-Apple platforms',
-      (WidgetTester tester) async {
-        final controller = TextEditingController();
-        addTearDown(controller.dispose);
-        final isTargetPlatformAndroid = defaultTargetPlatform == TargetPlatform.android;
-        await tester.pumpWidget(
-          CupertinoApp(
-            home: Center(
-              child: CupertinoTextField(
-                dragStartBehavior: DragStartBehavior.down,
-                controller: controller,
-                magnifierConfiguration: TextMagnifierConfiguration(
-                  magnifierBuilder:
-                      (
-                        _,
-                        MagnifierController controller,
-                        ValueNotifier<MagnifierInfo> localMagnifierInfo,
-                      ) {
-                        magnifierInfo = localMagnifierInfo;
-                        return fakeMagnifier;
-                      },
-                ),
+    testWidgets('Can long press to show, unshow, and update magnifier on non-Apple platforms', (
+      WidgetTester tester,
+    ) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+      final isTargetPlatformAndroid = defaultTargetPlatform == TargetPlatform.android;
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: CupertinoTextField(
+              dragStartBehavior: DragStartBehavior.down,
+              controller: controller,
+              magnifierConfiguration: TextMagnifierConfiguration(
+                magnifierBuilder:
+                    (
+                      _,
+                      MagnifierController controller,
+                      ValueNotifier<MagnifierInfo> localMagnifierInfo,
+                    ) {
+                      magnifierInfo = localMagnifierInfo;
+                      return fakeMagnifier;
+                    },
               ),
             ),
           ),
-        );
+        ),
+      );
 
-        const testValue = 'abc def ghi';
-        await tester.enterText(find.byType(CupertinoTextField), testValue);
-        await tester.pumpAndSettle();
+      const testValue = 'abc def ghi';
+      await tester.enterText(find.byType(CupertinoTextField), testValue);
+      await tester.pumpAndSettle();
 
-        // Tap at 'e' to move the cursor before the 'e'.
-        await tester.tapAt(textOffsetToPosition(tester, testValue.indexOf('e')));
-        await tester.pumpAndSettle(const Duration(milliseconds: 300));
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, isTargetPlatformAndroid ? 5 : 4);
-        expect(find.byKey(fakeMagnifier.key!), findsNothing);
+      // Tap at 'e' to move the cursor before the 'e'.
+      await tester.tapAt(textOffsetToPosition(tester, testValue.indexOf('e')));
+      await tester.pumpAndSettle(const Duration(milliseconds: 300));
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, isTargetPlatformAndroid ? 5 : 4);
+      expect(find.byKey(fakeMagnifier.key!), findsNothing);
 
-        // Long press the 'e' to select 'def' and show the magnifier.
-        final TestGesture gesture = await tester.startGesture(
-          textOffsetToPosition(tester, testValue.indexOf('e')),
-        );
-        await tester.pumpAndSettle(const Duration(milliseconds: 1000));
-        expect(controller.selection.baseOffset, 4);
-        expect(controller.selection.extentOffset, 7);
-        expect(find.byKey(fakeMagnifier.key!), findsOneWidget);
+      // Long press the 'e' to select 'def' and show the magnifier.
+      final TestGesture gesture = await tester.startGesture(
+        textOffsetToPosition(tester, testValue.indexOf('e')),
+      );
+      await tester.pumpAndSettle(const Duration(milliseconds: 1000));
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 7);
+      expect(find.byKey(fakeMagnifier.key!), findsOneWidget);
 
-        final Offset firstLongPressGesturePosition = magnifierInfo.value.globalGesturePosition;
+      final Offset firstLongPressGesturePosition = magnifierInfo.value.globalGesturePosition;
 
-        // Move the gesture to 'h' to extend the selection to 'ghi'.
-        await gesture.moveTo(textOffsetToPosition(tester, testValue.indexOf('h')));
-        await tester.pumpAndSettle();
-        expect(controller.selection.baseOffset, 4);
-        expect(controller.selection.extentOffset, 11);
-        expect(find.byKey(fakeMagnifier.key!), findsOneWidget);
-        // Expect the position the magnifier gets to have moved.
-        expect(firstLongPressGesturePosition, isNot(magnifierInfo.value.globalGesturePosition));
+      // Move the gesture to 'h' to extend the selection to 'ghi'.
+      await gesture.moveTo(textOffsetToPosition(tester, testValue.indexOf('h')));
+      await tester.pumpAndSettle();
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 11);
+      expect(find.byKey(fakeMagnifier.key!), findsOneWidget);
+      // Expect the position the magnifier gets to have moved.
+      expect(firstLongPressGesturePosition, isNot(magnifierInfo.value.globalGesturePosition));
 
-        // End the long press to hide the magnifier.
-        await gesture.up();
-        await tester.pumpAndSettle();
-        expect(find.byKey(fakeMagnifier.key!), findsNothing);
-      },
-      variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.android}),
-    );
+      // End the long press to hide the magnifier.
+      await gesture.up();
+      await tester.pumpAndSettle();
+      expect(find.byKey(fakeMagnifier.key!), findsNothing);
+    }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.android}));
 
-    testWidgets(
-      'Can long press to show, unshow, and update magnifier on iOS',
-      (WidgetTester tester) async {
-        final controller = TextEditingController();
-        addTearDown(controller.dispose);
-        final isTargetPlatformAndroid = defaultTargetPlatform == TargetPlatform.android;
-        await tester.pumpWidget(
-          CupertinoApp(
-            home: Center(
-              child: CupertinoTextField(
-                dragStartBehavior: DragStartBehavior.down,
-                controller: controller,
-                magnifierConfiguration: TextMagnifierConfiguration(
-                  magnifierBuilder:
-                      (
-                        _,
-                        MagnifierController controller,
-                        ValueNotifier<MagnifierInfo> localMagnifierInfo,
-                      ) {
-                        magnifierInfo = localMagnifierInfo;
-                        return fakeMagnifier;
-                      },
-                ),
+    testWidgets('Can long press to show, unshow, and update magnifier on iOS', (
+      WidgetTester tester,
+    ) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+      final isTargetPlatformAndroid = defaultTargetPlatform == TargetPlatform.android;
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: CupertinoTextField(
+              dragStartBehavior: DragStartBehavior.down,
+              controller: controller,
+              magnifierConfiguration: TextMagnifierConfiguration(
+                magnifierBuilder:
+                    (
+                      _,
+                      MagnifierController controller,
+                      ValueNotifier<MagnifierInfo> localMagnifierInfo,
+                    ) {
+                      magnifierInfo = localMagnifierInfo;
+                      return fakeMagnifier;
+                    },
               ),
             ),
           ),
-        );
+        ),
+      );
 
-        const testValue = 'abc def ghi';
-        await tester.enterText(find.byType(CupertinoTextField), testValue);
-        await tester.pumpAndSettle();
+      const testValue = 'abc def ghi';
+      await tester.enterText(find.byType(CupertinoTextField), testValue);
+      await tester.pumpAndSettle();
 
-        // Tap at 'e' to set the selection to position 5 on Android.
-        // Tap at 'e' to set the selection to the closest word edge, which is position 4 on iOS.
-        await tester.tapAt(textOffsetToPosition(tester, testValue.indexOf('e')));
-        await tester.pumpAndSettle(const Duration(milliseconds: 300));
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, isTargetPlatformAndroid ? 5 : 7);
-        expect(find.byKey(fakeMagnifier.key!), findsNothing);
+      // Tap at 'e' to set the selection to position 5 on Android.
+      // Tap at 'e' to set the selection to the closest word edge, which is position 4 on iOS.
+      await tester.tapAt(textOffsetToPosition(tester, testValue.indexOf('e')));
+      await tester.pumpAndSettle(const Duration(milliseconds: 300));
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, isTargetPlatformAndroid ? 5 : 7);
+      expect(find.byKey(fakeMagnifier.key!), findsNothing);
 
-        // Long press the 'e' to move the cursor in front of the 'e' and show the magnifier.
-        final TestGesture gesture = await tester.startGesture(
-          textOffsetToPosition(tester, testValue.indexOf('e')),
-        );
-        await tester.pumpAndSettle(const Duration(milliseconds: 1000));
-        expect(controller.selection.baseOffset, 5);
-        expect(controller.selection.extentOffset, 5);
-        expect(find.byKey(fakeMagnifier.key!), findsOneWidget);
+      // Long press the 'e' to move the cursor in front of the 'e' and show the magnifier.
+      final TestGesture gesture = await tester.startGesture(
+        textOffsetToPosition(tester, testValue.indexOf('e')),
+      );
+      await tester.pumpAndSettle(const Duration(milliseconds: 1000));
+      expect(controller.selection.baseOffset, 5);
+      expect(controller.selection.extentOffset, 5);
+      expect(find.byKey(fakeMagnifier.key!), findsOneWidget);
 
-        final Offset firstLongPressGesturePosition = magnifierInfo.value.globalGesturePosition;
+      final Offset firstLongPressGesturePosition = magnifierInfo.value.globalGesturePosition;
 
-        // Move the gesture to 'h' to update the magnifier and move the cursor to 'h'.
-        await gesture.moveTo(textOffsetToPosition(tester, testValue.indexOf('h')));
-        await tester.pumpAndSettle();
-        expect(controller.selection.baseOffset, 9);
-        expect(controller.selection.extentOffset, 9);
-        expect(find.byKey(fakeMagnifier.key!), findsOneWidget);
-        // Expect the position the magnifier gets to have moved.
-        expect(firstLongPressGesturePosition, isNot(magnifierInfo.value.globalGesturePosition));
+      // Move the gesture to 'h' to update the magnifier and move the cursor to 'h'.
+      await gesture.moveTo(textOffsetToPosition(tester, testValue.indexOf('h')));
+      await tester.pumpAndSettle();
+      expect(controller.selection.baseOffset, 9);
+      expect(controller.selection.extentOffset, 9);
+      expect(find.byKey(fakeMagnifier.key!), findsOneWidget);
+      // Expect the position the magnifier gets to have moved.
+      expect(firstLongPressGesturePosition, isNot(magnifierInfo.value.globalGesturePosition));
 
-        // End the long press to hide the magnifier.
-        await gesture.up();
-        await tester.pumpAndSettle();
-        expect(find.byKey(fakeMagnifier.key!), findsNothing);
-      },
-      variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-    );
+      // End the long press to hide the magnifier.
+      await gesture.up();
+      await tester.pumpAndSettle();
+      expect(find.byKey(fakeMagnifier.key!), findsNothing);
+    }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
 
-    testWidgets(
-      'Can double tap and drag to show, unshow, and update magnifier',
-      (WidgetTester tester) async {
-        final controller = TextEditingController();
-        addTearDown(controller.dispose);
-        MagnifierController? magnifierController;
-        await tester.pumpWidget(
-          CupertinoApp(
-            home: Center(
-              child: CupertinoTextField(
-                dragStartBehavior: DragStartBehavior.down,
-                controller: controller,
-                magnifierConfiguration: TextMagnifierConfiguration(
-                  magnifierBuilder:
-                      (
-                        BuildContext context,
-                        MagnifierController controller,
-                        ValueNotifier<MagnifierInfo> localMagnifierInfo,
-                      ) {
-                        magnifierController = controller;
-                        return CupertinoTextMagnifier(
-                          controller: controller,
-                          magnifierInfo: localMagnifierInfo,
-                        );
-                      },
-                ),
+    testWidgets('Can double tap and drag to show, unshow, and update magnifier', (
+      WidgetTester tester,
+    ) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+      MagnifierController? magnifierController;
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: CupertinoTextField(
+              dragStartBehavior: DragStartBehavior.down,
+              controller: controller,
+              magnifierConfiguration: TextMagnifierConfiguration(
+                magnifierBuilder:
+                    (
+                      BuildContext context,
+                      MagnifierController controller,
+                      ValueNotifier<MagnifierInfo> localMagnifierInfo,
+                    ) {
+                      magnifierController = controller;
+                      return CupertinoTextMagnifier(
+                        controller: controller,
+                        magnifierInfo: localMagnifierInfo,
+                      );
+                    },
               ),
             ),
           ),
-        );
+        ),
+      );
 
-        const testValue = 'one two three four five six seven';
-        await tester.enterText(find.byType(CupertinoTextField), testValue);
-        await tester.pumpAndSettle();
+      const testValue = 'one two three four five six seven';
+      await tester.enterText(find.byType(CupertinoTextField), testValue);
+      await tester.pumpAndSettle();
 
-        // Tap at 'e' to set the selection to the closest word edge, which is position 3 on iOS.
-        final Offset initialPosition = textOffsetToPosition(tester, testValue.indexOf('e'));
-        await tester.tapAt(initialPosition);
-        await tester.pumpAndSettle(const Duration(milliseconds: 300));
-        expect(controller.selection.isCollapsed, true);
-        expect(controller.selection.baseOffset, 3);
-        expect(magnifierController, isNull);
+      // Tap at 'e' to set the selection to the closest word edge, which is position 3 on iOS.
+      final Offset initialPosition = textOffsetToPosition(tester, testValue.indexOf('e'));
+      await tester.tapAt(initialPosition);
+      await tester.pumpAndSettle(const Duration(milliseconds: 300));
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, 3);
+      expect(magnifierController, isNull);
 
-        // Double tap the 'e' to select 'one'.
-        final TestGesture gesture = await tester.startGesture(initialPosition);
-        await tester.pump();
-        await gesture.up();
-        await tester.pump();
-        await gesture.down(initialPosition);
-        await tester.pumpAndSettle();
-        expect(controller.selection.isCollapsed, false);
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 3);
-        expect(magnifierController, isNull);
+      // Double tap the 'e' to select 'one'.
+      final TestGesture gesture = await tester.startGesture(initialPosition);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+      await gesture.down(initialPosition);
+      await tester.pumpAndSettle();
+      expect(controller.selection.isCollapsed, false);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 3);
+      expect(magnifierController, isNull);
 
-        // Drag immediately after the double tap to select 'one two three four' and show the magnifier.
-        await gesture.moveTo(textOffsetToPosition(tester, 16));
-        await tester.pumpAndSettle();
+      // Drag immediately after the double tap to select 'one two three four' and show the magnifier.
+      await gesture.moveTo(textOffsetToPosition(tester, 16));
+      await tester.pumpAndSettle();
 
-        expect(controller.selection.isCollapsed, false);
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 18);
-        expect(magnifierController, isNotNull);
-        expect(magnifierController!.shown, true);
+      expect(controller.selection.isCollapsed, false);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 18);
+      expect(magnifierController, isNotNull);
+      expect(magnifierController!.shown, true);
 
-        // Dragging down at the same position should hide the cupertino magnifier when it
-        // exceeds its `hideBelowThreshold`.
-        await gesture.moveTo(textOffsetToPosition(tester, 16) + const Offset(0.0, 50.0));
-        await tester.pumpAndSettle();
-        expect(controller.selection.isCollapsed, false);
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 18);
-        expect(magnifierController, isNotNull);
-        expect(magnifierController!.shown, false);
+      // Dragging down at the same position should hide the cupertino magnifier when it
+      // exceeds its `hideBelowThreshold`.
+      await gesture.moveTo(textOffsetToPosition(tester, 16) + const Offset(0.0, 50.0));
+      await tester.pumpAndSettle();
+      expect(controller.selection.isCollapsed, false);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 18);
+      expect(magnifierController, isNotNull);
+      expect(magnifierController!.shown, false);
 
-        // Keep draging to select 'one two three four five' while the position continues to
-        // exceed the `hideBelowThreshold` keeping the magnifier hidden.
-        await gesture.moveTo(textOffsetToPosition(tester, 20) + const Offset(0.0, 50.0));
-        await tester.pumpAndSettle();
-        expect(controller.selection.isCollapsed, false);
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 23);
-        expect(magnifierController, isNotNull);
-        expect(magnifierController!.shown, false);
+      // Keep draging to select 'one two three four five' while the position continues to
+      // exceed the `hideBelowThreshold` keeping the magnifier hidden.
+      await gesture.moveTo(textOffsetToPosition(tester, 20) + const Offset(0.0, 50.0));
+      await tester.pumpAndSettle();
+      expect(controller.selection.isCollapsed, false);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 23);
+      expect(magnifierController, isNotNull);
+      expect(magnifierController!.shown, false);
 
-        // Remove offset that is used to exceed threshold, this should reveal the magnifier.
-        await gesture.moveTo(textOffsetToPosition(tester, 20));
-        await tester.pumpAndSettle();
-        expect(controller.selection.isCollapsed, false);
-        expect(controller.selection.baseOffset, 0);
-        expect(controller.selection.extentOffset, 23);
-        expect(magnifierController, isNotNull);
-        expect(magnifierController!.shown, true);
+      // Remove offset that is used to exceed threshold, this should reveal the magnifier.
+      await gesture.moveTo(textOffsetToPosition(tester, 20));
+      await tester.pumpAndSettle();
+      expect(controller.selection.isCollapsed, false);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 23);
+      expect(magnifierController, isNotNull);
+      expect(magnifierController!.shown, true);
 
-        // End the drag to hide the magnifier.
-        await gesture.up();
-        await tester.pumpAndSettle();
-        expect(magnifierController, isNotNull);
-        expect(magnifierController!.shown, false);
-      },
-      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-    );
+      // End the drag to hide the magnifier.
+      await gesture.up();
+      await tester.pumpAndSettle();
+      expect(magnifierController, isNotNull);
+      expect(magnifierController!.shown, false);
+    }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
     testWidgets(
       'cancelling long press hides magnifier',
@@ -10611,95 +10531,90 @@ void main() {
     semantics.dispose();
   }, variant: TargetPlatformVariant.all());
 
-  testWidgets(
-    'when disabled does not listen to onFocus events or gain focus',
-    (WidgetTester tester) async {
-      final semantics = SemanticsTester(tester);
-      final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;
-      final focusNode = FocusNode();
-      addTearDown(focusNode.dispose);
-      await tester.pumpWidget(
-        CupertinoApp(home: CupertinoTextField(focusNode: focusNode, enabled: false)),
-      );
-      expect(
-        semantics,
-        hasSemantics(
-          TestSemantics.root(
-            children: <TestSemantics>[
-              TestSemantics(
-                id: 1,
-                textDirection: TextDirection.ltr,
-                children: <TestSemantics>[
-                  TestSemantics(
-                    id: 2,
-                    children: <TestSemantics>[
-                      TestSemantics(
-                        id: 3,
-                        flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
-                        children: <TestSemantics>[
-                          TestSemantics(
-                            id: 4,
-                            inputType: ui.SemanticsInputType.text,
-                            flags: <SemanticsFlag>[
-                              SemanticsFlag.isTextField,
-                              SemanticsFlag.isFocusable,
-                              SemanticsFlag.hasEnabledState,
-                              SemanticsFlag.isReadOnly,
+  testWidgets('when disabled does not listen to onFocus events or gain focus', (
+    WidgetTester tester,
+  ) async {
+    final semantics = SemanticsTester(tester);
+    final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;
+    final focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+    await tester.pumpWidget(
+      CupertinoApp(home: CupertinoTextField(focusNode: focusNode, enabled: false)),
+    );
+    expect(
+      semantics,
+      hasSemantics(
+        TestSemantics.root(
+          children: <TestSemantics>[
+            TestSemantics(
+              id: 1,
+              textDirection: TextDirection.ltr,
+              children: <TestSemantics>[
+                TestSemantics(
+                  id: 2,
+                  children: <TestSemantics>[
+                    TestSemantics(
+                      id: 3,
+                      flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
+                      children: <TestSemantics>[
+                        TestSemantics(
+                          id: 4,
+                          inputType: ui.SemanticsInputType.text,
+                          flags: <SemanticsFlag>[
+                            SemanticsFlag.isTextField,
+                            SemanticsFlag.isFocusable,
+                            SemanticsFlag.hasEnabledState,
+                            SemanticsFlag.isReadOnly,
+                          ],
+                          actions: <SemanticsAction>[
+                            if (defaultTargetPlatform == TargetPlatform.linux ||
+                                defaultTargetPlatform == TargetPlatform.windows ||
+                                defaultTargetPlatform == TargetPlatform.macOS) ...<SemanticsAction>[
+                              SemanticsAction.didGainAccessibilityFocus,
+                              SemanticsAction.didLoseAccessibilityFocus,
                             ],
-                            actions: <SemanticsAction>[
-                              if (defaultTargetPlatform == TargetPlatform.linux ||
-                                  defaultTargetPlatform == TargetPlatform.windows ||
-                                  defaultTargetPlatform ==
-                                      TargetPlatform.macOS) ...<SemanticsAction>[
-                                SemanticsAction.didGainAccessibilityFocus,
-                                SemanticsAction.didLoseAccessibilityFocus,
-                              ],
-                            ],
-                          ),
-                        ],
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            ],
-          ),
-          ignoreRect: true,
-          ignoreTransform: true,
+                          ],
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ],
         ),
-      );
+        ignoreRect: true,
+        ignoreTransform: true,
+      ),
+    );
 
-      expect(focusNode.hasFocus, isFalse);
-      semanticsOwner.performAction(4, SemanticsAction.focus);
-      await tester.pumpAndSettle();
-      expect(focusNode.hasFocus, isFalse);
-      semantics.dispose();
-    },
-    variant: TargetPlatformVariant.all(),
-  );
+    expect(focusNode.hasFocus, isFalse);
+    semanticsOwner.performAction(4, SemanticsAction.focus);
+    await tester.pumpAndSettle();
+    expect(focusNode.hasFocus, isFalse);
+    semantics.dispose();
+  }, variant: TargetPlatformVariant.all());
 
-  testWidgets(
-    'when receives SemanticsAction.focus while already focused, shows keyboard',
-    (WidgetTester tester) async {
-      final semantics = SemanticsTester(tester);
-      final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;
-      final focusNode = FocusNode();
-      addTearDown(focusNode.dispose);
-      await tester.pumpWidget(CupertinoApp(home: CupertinoTextField(focusNode: focusNode)));
-      focusNode.requestFocus();
-      await tester.pumpAndSettle();
+  testWidgets('when receives SemanticsAction.focus while already focused, shows keyboard', (
+    WidgetTester tester,
+  ) async {
+    final semantics = SemanticsTester(tester);
+    final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;
+    final focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+    await tester.pumpWidget(CupertinoApp(home: CupertinoTextField(focusNode: focusNode)));
+    focusNode.requestFocus();
+    await tester.pumpAndSettle();
 
-      tester.testTextInput.log.clear();
-      expect(focusNode.hasFocus, isTrue);
-      semanticsOwner.performAction(4, SemanticsAction.focus);
-      await tester.pumpAndSettle();
-      expect(focusNode.hasFocus, isTrue);
-      expect(tester.testTextInput.log.single.method, 'TextInput.show');
+    tester.testTextInput.log.clear();
+    expect(focusNode.hasFocus, isTrue);
+    semanticsOwner.performAction(4, SemanticsAction.focus);
+    await tester.pumpAndSettle();
+    expect(focusNode.hasFocus, isTrue);
+    expect(tester.testTextInput.log.single.method, 'TextInput.show');
 
-      semantics.dispose();
-    },
-    variant: TargetPlatformVariant.all(),
-  );
+    semantics.dispose();
+  }, variant: TargetPlatformVariant.all());
 
   testWidgets(
     'when receives SemanticsAction.focus while focused but read-only, does not show keyboard',


### PR DESCRIPTION
Issue: Part of https://github.com/flutter/flutter/issues/182636.

Cupertino tests import `../widgets/semantics_tester.dart`, which is one of the test utility cross-imports that blocks moving Material and Cupertino tests to separate packages.

Fix:

- Copies the existing `packages/flutter/test/widgets/semantics_tester.dart` helper to `packages/flutter/test/cupertino/semantics_tester.dart`.
- Rewrites the affected Cupertino tests to import the local helper.
- Keeps behavior changes out of scope. The new Cupertino helper is intended to match the existing widgets/material helper so reviewer feedback and future fixes can apply consistently across copies.
- Leaves the remaining cross-import utilities for separate PRs.

Tests:

- `./bin/dart --enable-asserts dev/tools/bin/format.dart`
- `./bin/dart --enable-asserts dev/bots/check_tests_cross_imports.dart --test=packages/flutter/test`
- `./bin/flutter analyze packages/flutter/test/cupertino/action_sheet_test.dart packages/flutter/test/cupertino/bottom_tab_bar_test.dart packages/flutter/test/cupertino/button_test.dart packages/flutter/test/cupertino/checkbox_test.dart packages/flutter/test/cupertino/dialog_test.dart packages/flutter/test/cupertino/menu_anchor_test.dart packages/flutter/test/cupertino/nav_bar_test.dart packages/flutter/test/cupertino/picker_test.dart packages/flutter/test/cupertino/radio_test.dart packages/flutter/test/cupertino/route_test.dart packages/flutter/test/cupertino/segmented_control_test.dart packages/flutter/test/cupertino/semantics_tester.dart packages/flutter/test/cupertino/sliding_segmented_control_test.dart packages/flutter/test/cupertino/switch_test.dart packages/flutter/test/cupertino/text_field_test.dart`
- `git diff --check`

Earlier verification before the formatter-only amend:

- `./bin/flutter test packages/flutter/test/cupertino/action_sheet_test.dart packages/flutter/test/cupertino/bottom_tab_bar_test.dart packages/flutter/test/cupertino/button_test.dart packages/flutter/test/cupertino/checkbox_test.dart packages/flutter/test/cupertino/dialog_test.dart packages/flutter/test/cupertino/menu_anchor_test.dart packages/flutter/test/cupertino/nav_bar_test.dart packages/flutter/test/cupertino/picker_test.dart packages/flutter/test/cupertino/radio_test.dart packages/flutter/test/cupertino/route_test.dart packages/flutter/test/cupertino/segmented_control_test.dart packages/flutter/test/cupertino/sliding_segmented_control_test.dart packages/flutter/test/cupertino/switch_test.dart packages/flutter/test/cupertino/text_field_test.dart`

Risk:

- Test-only change.
- The line count is mostly from duplicating the existing semantics helper so Cupertino tests no longer cross-import the widgets helper.
- Six existing Cupertino test files also have formatter-only changes because the Linux analyze shard requires every touched Dart file to pass `dev/tools/bin/format.dart`.
- The public `Check Code Freeze` job is failing because this PR touches frozen Cupertino test paths; review/label guidance is needed for that repository policy gate.
