### PR TITLE
Fix AnimatedList.separated.removeItem during in-flight remove animation

### DIFF
--- a/packages/flutter/lib/src/widgets/animated_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/animated_scroll_view.dart
@@ -689,11 +689,17 @@ abstract class _AnimatedScrollViewState<T extends _AnimatedScrollView> extends S
     if (widget.removedSeparatorBuilder == null) {
       _sliverAnimatedMultiBoxKey.currentState!.insertItem(index, duration: duration);
     } else {
-      final int itemIndex = _computeItemIndex(index);
+      // Snapshot the visible count *before* the first insertItem call. The
+      // call increments _itemsCount, so reading it afterwards would also
+      // count the just-inserted item and any in-flight outgoing items,
+      // producing a stale decision about whether a separator is needed.
+      final int visibleCount = _sliverAnimatedMultiBoxKey.currentState!._visibleItemsCount;
+      final int itemIndex = _computeItemIndex(index, visibleCount);
       _sliverAnimatedMultiBoxKey.currentState!.insertItem(itemIndex, duration: duration);
-      if (_itemsCount > 1) {
-        // Because `insertItem` moves the items after the index, we need to insert the separator
-        // at the same index as the item. If there is only one item, we don't need to insert a separator.
+      if (visibleCount > 0) {
+        // There was at least one visible item before this insertion, so the
+        // new item needs a separator alongside it. `insertItem` shifted the
+        // following items by one, so the separator goes at the same index.
         _sliverAnimatedMultiBoxKey.currentState!.insertItem(itemIndex, duration: duration);
       }
     }
@@ -713,8 +719,13 @@ abstract class _AnimatedScrollViewState<T extends _AnimatedScrollView> extends S
     if (widget.removedSeparatorBuilder == null) {
       _sliverAnimatedMultiBoxKey.currentState!.insertAllItems(index, length, duration: duration);
     } else {
-      final int itemIndex = _computeItemIndex(index);
-      final int lengthWithSeparators = _itemsCount == 0 ? length * 2 - 1 : length * 2;
+      // Snapshot the visible count once and reuse it for both the index
+      // computation and the leading-separator decision; reading _itemsCount
+      // would include in-flight outgoing items and could wrongly suppress
+      // the leading separator when no items are visible.
+      final int visibleCount = _sliverAnimatedMultiBoxKey.currentState!._visibleItemsCount;
+      final int itemIndex = _computeItemIndex(index, visibleCount);
+      final int lengthWithSeparators = visibleCount == 0 ? length * 2 - 1 : length * 2;
       _sliverAnimatedMultiBoxKey.currentState!.insertAllItems(
         itemIndex,
         lengthWithSeparators,
@@ -748,20 +759,23 @@ abstract class _AnimatedScrollViewState<T extends _AnimatedScrollView> extends S
       // There are no separators. Remove only the item.
       _sliverAnimatedMultiBoxKey.currentState!.removeItem(index, builder, duration: duration);
     } else {
-      final int itemIndex = _computeItemIndex(index);
-      // Remove the item
+      // Snapshot the visible count *before* issuing the first removeItem,
+      // because that call appends to _outgoingItems and would skew the value.
+      final int visibleCount = _sliverAnimatedMultiBoxKey.currentState!._visibleItemsCount;
+      final int itemIndex = _computeItemIndex(index, visibleCount);
+      // Remove the item.
       _sliverAnimatedMultiBoxKey.currentState!.removeItem(itemIndex, builder, duration: duration);
-      if (_itemsCount > 1) {
-        if (itemIndex == _itemsCount - 1) {
-          // The item was removed from the end of the list, so the separator to remove is the one at `last index` - 1.
+      if (visibleCount > 1) {
+        if (itemIndex == visibleCount - 1) {
+          // Removed the last visible item: also remove the separator before it.
           _sliverAnimatedMultiBoxKey.currentState!.removeItem(
             itemIndex - 1,
             _toRemovedItemBuilder(removedSeparatorBuilder, index - 1),
             duration: duration,
           );
         } else {
-          // The item was removed from the middle or beginning of the list,
-          // so the corresponding separator took its place and needs to be removed at `itemIndex`.
+          // Removed an item from the beginning or middle: the corresponding
+          // separator has taken its place; remove it at `itemIndex`.
           _sliverAnimatedMultiBoxKey.currentState!.removeItem(
             itemIndex,
             _toRemovedItemBuilder(removedSeparatorBuilder, index),
@@ -816,14 +830,13 @@ abstract class _AnimatedScrollViewState<T extends _AnimatedScrollView> extends S
 
   int get _itemsCount => _sliverAnimatedMultiBoxKey.currentState!._itemsCount;
 
-  // Helper method to compute the index for the item to insert or remove considering the separators in between.
-  int _computeItemIndex(int index) {
+  /// Helper method to compute the index for the item to insert or remove considering the separators in between.
+  int _computeItemIndex(int index, int visibleItemsAndSeparatorsCount) {
     if (index == 0) {
       return index;
     }
-    final int itemsAndSeparatorsCount = _itemsCount;
-    final int separatorsCount = itemsAndSeparatorsCount ~/ 2;
-    final int separatedItemsCount = _itemsCount - separatorsCount;
+    final int separatorsCount = visibleItemsAndSeparatorsCount ~/ 2;
+    final int separatedItemsCount = visibleItemsAndSeparatorsCount - separatorsCount;
 
     final isNewLastIndex = index == separatedItemsCount;
     final int indexAdjustedForSeparators = index * 2;
@@ -1274,6 +1287,10 @@ abstract class _SliverAnimatedMultiBoxAdaptorState<T extends _SliverAnimatedMult
   final List<_ActiveItem> _incomingItems = <_ActiveItem>[];
   final List<_ActiveItem> _outgoingItems = <_ActiveItem>[];
   int _itemsCount = 0;
+
+  /// Number of items+separators currently visible to the user, i.e. excluding
+  /// entries whose remove animation is still running.
+  int get _visibleItemsCount => _itemsCount - _outgoingItems.length;
 
   _ActiveItem? _removeActiveItemAt(List<_ActiveItem> items, int itemIndex) {
     final int i = binarySearch(items, _ActiveItem.index(itemIndex));

--- a/packages/flutter/test/widgets/animated_list_test.dart
+++ b/packages/flutter/test/widgets/animated_list_test.dart
@@ -1225,6 +1225,96 @@ void main() {
     );
     await tester.pump();
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/186361
+  //
+  // AnimatedList.separated.removeItem used `_itemsCount` (which still counts
+  // items whose remove animation is in flight) when computing the sliver index
+  // for the separator removal. Calling removeItem again before the previous
+  // animation settled therefore landed on the wrong slot, leaving stale items
+  // visible or removing the wrong separator.
+  testWidgets(
+    'AnimatedList.separated.removeItem uses visible item count when a previous remove is still animating',
+    (WidgetTester tester) async {
+      tester.view.physicalSize = const Size(600, 1800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      Widget itemBuilder(BuildContext context, int index, Animation<double> animation) {
+        return SizedBox(height: 100.0, child: Center(child: Text('item $index')));
+      }
+
+      Widget separatorBuilder(BuildContext context, int index, Animation<double> animation) {
+        return SizedBox(height: 100.0, child: Center(child: Text('separator after item $index')));
+      }
+
+      Widget removedItemBuilder(BuildContext context, Animation<double> animation) {
+        return const SizedBox(height: 100.0, child: Center(child: Text('removing item')));
+      }
+
+      Widget removedSeparatorBuilder(BuildContext context, int index, Animation<double> animation) {
+        return SizedBox(
+          height: 100.0,
+          child: Center(child: Text('removing separator after item $index')),
+        );
+      }
+
+      List<String?> visibleTexts() {
+        return find
+            .descendant(of: find.byType(SliverAnimatedList), matching: find.byType(Text))
+            .allCandidates
+            .map((Element e) => e.widget)
+            .whereType<Text>()
+            .map((Text t) => t.data)
+            .toList();
+      }
+
+      final listKey = GlobalKey<AnimatedListState>();
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: AnimatedList.separated(
+            key: listKey,
+            initialItemCount: 4,
+            itemBuilder: itemBuilder,
+            separatorBuilder: separatorBuilder,
+            removedSeparatorBuilder: removedSeparatorBuilder,
+          ),
+        ),
+      );
+
+      // Sanity: 4 items + 3 separators visible at start.
+      expect(visibleTexts(), <String>[
+        'item 0',
+        'separator after item 0',
+        'item 1',
+        'separator after item 1',
+        'item 2',
+        'separator after item 2',
+        'item 3',
+      ]);
+
+      // Start removing the last item. Pump a frame so the animation begins but
+      // intentionally do NOT pumpAndSettle: we want the next call to land
+      // while the first removal is still in flight.
+      listKey.currentState!.removeItem(3, removedItemBuilder);
+      await tester.pump();
+
+      // Now remove what is currently the last visible item. Without the fix,
+      // _computeItemIndex still saw 7 entries (4 items + 3 separators) and the
+      // separator-removal branch chose the wrong slot.
+      listKey.currentState!.removeItem(2, removedItemBuilder);
+      await tester.pump();
+
+      // Let every animation finish and verify the surviving items are correct:
+      // items 2 and 3 are gone along with their separators; items 0 and 1
+      // remain with exactly one separator between them.
+      await tester.pumpAndSettle();
+
+      expect(visibleTexts(), <String>['item 0', 'separator after item 0', 'item 1']);
+    },
+  );
 }
 
 class _StatefulListItem extends StatefulWidget {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Description

`AnimatedList.separated.removeItem` could throw
`itemIndex >= 0 && itemIndex < _itemsCount` (or silently remove the
wrong separator) when invoked while a previous remove animation was
still in flight. Root cause: `_computeItemIndex` read `_itemsCount`,
which still counts items that are mid-removal (those tracked in
`_outgoingItems`).

This change introduces `_visibleItemsCount` on
`_SliverAnimatedMultiBoxAdaptorState` (the count minus
`_outgoingItems`) and threads that snapshot through
`_computeItemIndex`. In `removeItem`, the snapshot is captured
*before* the first internal `removeItem` call, because that call
mutates `_outgoingItems` and would otherwise corrupt the value used
in the same flow.

Fixes #186361
https://github.com/flutter/flutter/issues/186361 

## Tests

Adds a regression test in `animated_list_test.dart` that starts a
removal of the last item, pumps a single frame so the animation is
still in flight, then removes what is now the last visible item.
With the fix, both removals complete and the final visible state is
the expected two items with one separator. Without the fix, the
test fails the way the bug was reported.

## Pre-launch Checklist

- [✅ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [✅ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [✅ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [✅ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [✅ ] I signed the [CLA].
- [✅ ] I listed at least one issue that this PR fixes in the description above.
- [✅ ] I updated/added relevant documentation (doc comments with `///`).
- [✅ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [✅ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [✅ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.
https://docs.github.com/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax
**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md