### PR TITLE
TestSemantics: Fix three typo bugs

### DIFF
--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -508,7 +508,7 @@ class TestSemantics {
       );
     }
 
-    if (controlsNodes != controlsNodes && !setEquals(controlsNodes, node.controlsNodes)) {
+    if (controlsNodes != node.controlsNodes && !setEquals(controlsNodes, node.controlsNodes)) {
       return fail(
         'expected node id $id to controls nodes $controlsNodes but found controlling nodes ${node.controlsNodes}',
       );
@@ -715,7 +715,7 @@ class SemanticsTester {
       if (first[i] is LocaleStringAttribute &&
           (second[i] is! LocaleStringAttribute ||
               second[i].range != first[i].range ||
-              (second[i] as LocaleStringAttribute).locale !=
+              (first[i] as LocaleStringAttribute).locale !=
                   (second[i] as LocaleStringAttribute).locale)) {
         return false;
       }
@@ -1180,7 +1180,7 @@ class _IncludesNodeWith extends Matcher {
              scrollExtentMin != null ||
              maxValueLength != null ||
              currentValueLength != null ||
-             inputType != null,
+             inputType != null ||
          minValue != null || maxValue != null,
        );
   final AttributedString? attributedLabel;


### PR DESCRIPTION
Fix three bugs in TestSemantics:

1. Locale comparison: was comparing second[i] to itself, changed to first[i] vs second[i]
2. controlsNodes comparison: was comparing variable to itself, changed to node.controlsNodes
3. Stray comma in assert: inputType != null, → inputType != null ||

Fixes #185900