### PR TITLE
DO NOT MERGE: TEST ONLY [macOS] Preserve static text accessibility role for read-only textfields

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMac.h
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMac.h
@@ -30,6 +30,9 @@ class FlutterPlatformNodeDelegateMac : public FlutterPlatformNodeDelegate {
   void NodeDataChanged(const ui::AXNodeData& old_node_data,
                        const ui::AXNodeData& new_node_data) override;
 
+  // |ui::AXPlatformNodeDelegateBase|
+  const ui::AXNodeData& GetData() const override;
+
   //---------------------------------------------------------------------------
   /// @brief      Gets the live region text of this node in UTF-8 format. This
   ///             is useful to determine the changes in between semantics
@@ -55,6 +58,7 @@ class FlutterPlatformNodeDelegateMac : public FlutterPlatformNodeDelegate {
   ui::AXPlatformNode* ax_platform_node_;
   std::weak_ptr<AccessibilityBridge> bridge_;
   __weak FlutterViewController* view_controller_;
+  mutable ui::AXNodeData cached_data_;
 
   gfx::RectF ConvertBoundsFromLocalToScreen(
       const gfx::RectF& local_bounds) const;

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMac.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMac.mm
@@ -27,7 +27,7 @@ FlutterPlatformNodeDelegateMac::FlutterPlatformNodeDelegateMac(
 
 void FlutterPlatformNodeDelegateMac::Init(std::weak_ptr<OwnerBridge> bridge, ui::AXNode* node) {
   FlutterPlatformNodeDelegate::Init(bridge, node);
-  if (GetData().IsTextField()) {
+  if (GetData().IsTextField() && !GetData().IsReadOnlyOrDisabled()) {
     ax_platform_node_ = new FlutterTextPlatformNode(this, view_controller_);
   } else {
     ax_platform_node_ = ui::AXPlatformNode::Create(this);
@@ -37,13 +37,27 @@ void FlutterPlatformNodeDelegateMac::Init(std::weak_ptr<OwnerBridge> bridge, ui:
 
 void FlutterPlatformNodeDelegateMac::NodeDataChanged(const ui::AXNodeData& old_node_data,
                                                      const ui::AXNodeData& new_node_data) {
-  if (old_node_data.IsTextField() && !new_node_data.IsTextField()) {
+  bool old_is_editable_textfield =
+      old_node_data.IsTextField() && !old_node_data.IsReadOnlyOrDisabled();
+  bool new_is_editable_textfield =
+      new_node_data.IsTextField() && !new_node_data.IsReadOnlyOrDisabled();
+  if (old_is_editable_textfield && !new_is_editable_textfield) {
     ax_platform_node_->Destroy();
     ax_platform_node_ = ui::AXPlatformNode::Create(this);
-  } else if (!old_node_data.IsTextField() && new_node_data.IsTextField()) {
+  } else if (!old_is_editable_textfield && new_is_editable_textfield) {
     ax_platform_node_->Destroy();
     ax_platform_node_ = new FlutterTextPlatformNode(this, view_controller_);
   }
+}
+
+const ui::AXNodeData& FlutterPlatformNodeDelegateMac::GetData() const {
+  const ui::AXNodeData& data = FlutterPlatformNodeDelegate::GetData();
+  if (data.IsTextField() && data.IsReadOnlyOrDisabled()) {
+    cached_data_ = data;
+    cached_data_.role = ax::mojom::Role::kStaticText;
+    return cached_data_;
+  }
+  return data;
 }
 
 FlutterPlatformNodeDelegateMac::~FlutterPlatformNodeDelegateMac() {

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
@@ -32,6 +32,7 @@ FlutterViewController* CreateTestViewController() {
 TEST(FlutterPlatformNodeDelegateMac, Basics) {
   FlutterViewController* viewController = CreateTestViewController();
   FlutterEngine* engine = viewController.engine;
+  [viewController loadView];
   engine.semanticsEnabled = YES;
   auto bridge = viewController.accessibilityBridge.lock();
   // Initialize ax node data.
@@ -60,9 +61,11 @@ TEST(FlutterPlatformNodeDelegateMac, Basics) {
   // Verify the accessibility attribute matches.
   NSAccessibilityElement* native_accessibility =
       root_platform_node_delegate->GetNativeViewAccessible();
+  ASSERT_NE(native_accessibility, nil);
   std::string value = [native_accessibility.accessibilityValue UTF8String];
   EXPECT_TRUE(value == "accessibility");
-  EXPECT_EQ(native_accessibility.accessibilityRole, NSAccessibilityStaticTextRole);
+  EXPECT_TRUE(
+      [native_accessibility.accessibilityRole isEqualToString:NSAccessibilityStaticTextRole]);
   EXPECT_EQ([native_accessibility.accessibilityChildren count], 0u);
   [engine shutDownEngine];
 }
@@ -70,6 +73,7 @@ TEST(FlutterPlatformNodeDelegateMac, Basics) {
 TEST(FlutterPlatformNodeDelegateMac, SelectableTextHasCorrectSemantics) {
   FlutterViewController* viewController = CreateTestViewController();
   FlutterEngine* engine = viewController.engine;
+  [viewController loadView];
   engine.semanticsEnabled = YES;
   auto bridge = viewController.accessibilityBridge.lock();
   // Initialize ax node data.
@@ -99,9 +103,11 @@ TEST(FlutterPlatformNodeDelegateMac, SelectableTextHasCorrectSemantics) {
   // Verify the accessibility attribute matches.
   NSAccessibilityElement* native_accessibility =
       root_platform_node_delegate->GetNativeViewAccessible();
+  ASSERT_NE(native_accessibility, nil);
   std::string value = [native_accessibility.accessibilityValue UTF8String];
   EXPECT_EQ(value, "selectable text");
-  EXPECT_EQ(native_accessibility.accessibilityRole, NSAccessibilityStaticTextRole);
+  EXPECT_TRUE(
+      [native_accessibility.accessibilityRole isEqualToString:NSAccessibilityStaticTextRole]);
   EXPECT_EQ([native_accessibility.accessibilityChildren count], 0u);
   NSRange selection = native_accessibility.accessibilitySelectedTextRange;
   EXPECT_EQ(selection.location, 1u);
@@ -113,6 +119,7 @@ TEST(FlutterPlatformNodeDelegateMac, SelectableTextHasCorrectSemantics) {
 TEST(FlutterPlatformNodeDelegateMac, SelectableTextWithoutSelectionReturnZeroRange) {
   FlutterViewController* viewController = CreateTestViewController();
   FlutterEngine* engine = viewController.engine;
+  [viewController loadView];
   engine.semanticsEnabled = YES;
   auto bridge = viewController.accessibilityBridge.lock();
   // Initialize ax node data.
@@ -142,6 +149,7 @@ TEST(FlutterPlatformNodeDelegateMac, SelectableTextWithoutSelectionReturnZeroRan
   // Verify the accessibility attribute matches.
   NSAccessibilityElement* native_accessibility =
       root_platform_node_delegate->GetNativeViewAccessible();
+  ASSERT_NE(native_accessibility, nil);
   NSRange selection = native_accessibility.accessibilitySelectedTextRange;
   EXPECT_TRUE(selection.location == NSNotFound);
   EXPECT_EQ(selection.length, 0u);


### PR DESCRIPTION
Commit c6f7839 updated accessibility role mapping such that read-only text fields are mapped to `ax::mojom::Role::kTextField`. On macOS, read-only text fields are intentionally treated as static text. Because of the role change, the macOS embedder incorrectly instantiated `FlutterTextPlatformNode` for read-only text fields, leading to detached accessibility elements and test crashes.

This updates the macOS platform node delegate to only instantiate a FlutterTextPlatformNode when the target text field is fully editable and not read-only or disabled. Read-only text fields are now explicitly returned as standard static text elements. This matches current behaviour but makes it explicit in the platform node delegate for macOS.

I've also updated the unit tests to call loadView on the viewController. In a running app, the view controller will always be loaded, so this better approximates reality in the tests... and avoids bugs such as those caught in https://github.com/flutter/flutter/pull/184501.

Issue: https://github.com/flutter/flutter/issues/184559

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
