### PR TITLE
Preserve web drive target paths outside lib

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -25,6 +25,7 @@ import '../base/time.dart';
 import '../base/utils.dart';
 import '../build_info.dart';
 import '../cache.dart';
+import '../compile.dart';
 import '../dart/language_version.dart';
 import '../devfs.dart';
 import '../device.dart';
@@ -739,15 +740,26 @@ class ResidentWebRunner extends ResidentRunner {
       Uri? importedEntrypoint = packageConfig!.toPackageUri(mainUri);
       // Special handling for entrypoints that are not under lib, such as test scripts.
       if (importedEntrypoint == null) {
-        final String parent = _fileSystem.file(mainUri).parent.path;
-        flutterDevices.first.generator!
-          ..addFileSystemRoot(parent)
-          ..addFileSystemRoot(_fileSystem.directory('test').absolute.path);
-        importedEntrypoint = Uri(
-          scheme: 'org-dartlang-app',
-          host: '',
-          path: '/${mainUri.pathSegments.last}',
-        );
+        final File mainFile = _fileSystem.file(mainUri).absolute;
+        final String projectRoot = flutterProject.directory.absolute.path;
+        final ResidentCompiler generator = flutterDevices.first.generator!;
+        if (_fileSystem.path.isWithin(projectRoot, mainFile.path)) {
+          generator.addFileSystemRoot(projectRoot);
+          final String relativeMainPath = _fileSystem.path.relative(
+            mainFile.path,
+            from: projectRoot,
+          );
+          final String uriPath = _fileSystem.path.toUri(relativeMainPath).path;
+          importedEntrypoint = Uri(scheme: 'org-dartlang-app', path: '/$uriPath');
+        } else {
+          generator
+            ..addFileSystemRoot(mainFile.parent.path)
+            ..addFileSystemRoot(flutterProject.directory.childDirectory('test').absolute.path);
+          importedEntrypoint = Uri(
+            scheme: 'org-dartlang-app',
+            path: '/${mainUri.pathSegments.last}',
+          );
+        }
       }
       final LanguageVersion languageVersion = determineLanguageVersion(
         _fileSystem.file(mainUri),

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -1609,6 +1609,81 @@ name: my_app
   );
 
   testUsingContext(
+    'generates project-relative imports for non-package web entrypoints',
+    () async {
+      final String target = fileSystem.path.join('integration_test', 'foo', 'bar_test.dart');
+      fileSystem.file(target).createSync(recursive: true);
+      final ResidentRunner residentWebRunner = setUpResidentRunner(flutterDevice, target: target);
+      fakeVmServiceHost = FakeVmServiceHost(
+        requests: <VmServiceExpectation>[...kAttachExpectations],
+      );
+      setupMocks();
+
+      final connectionInfoCompleter = Completer<DebugConnectionInfo>();
+      unawaited(residentWebRunner.run(connectionInfoCompleter: connectionInfoCompleter));
+      await connectionInfoCompleter.future;
+
+      expect(webDevFS.mainUri, isNotNull);
+      final String entrypointContents = fileSystem.file(webDevFS.mainUri).readAsStringSync();
+      expect(
+        entrypointContents,
+        contains("import 'org-dartlang-app:/integration_test/foo/bar_test.dart' as entrypoint;"),
+      );
+      expect(residentCompiler.fileSystemRoots, contains(fileSystem.currentDirectory.absolute.path));
+    },
+    overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      ProcessManager: () => processManager,
+      Pub: ThrowingPub.new,
+    },
+  );
+
+  testUsingContext(
+    'keeps fallback filesystem roots for entrypoints outside the project',
+    () async {
+      final Directory projectDirectory = fileSystem.systemTempDirectory.childDirectory('project')
+        ..createSync(recursive: true);
+      fileSystem.currentDirectory = projectDirectory;
+      fileSystem.file('pubspec.yaml').writeAsStringSync('''
+name: my_app
+''');
+      writePackageConfigFiles(directory: projectDirectory, mainLibName: 'my_app');
+
+      final Directory externalDirectory = fileSystem.systemTempDirectory.childDirectory(
+        'external-entrypoint',
+      )..createSync(recursive: true);
+      final String target = externalDirectory.childFile('bar_test.dart').path;
+      fileSystem.file(target).createSync();
+      final ResidentRunner residentWebRunner = setUpResidentRunner(flutterDevice, target: target);
+      fakeVmServiceHost = FakeVmServiceHost(
+        requests: <VmServiceExpectation>[...kAttachExpectations],
+      );
+      setupMocks();
+
+      final connectionInfoCompleter = Completer<DebugConnectionInfo>();
+      unawaited(residentWebRunner.run(connectionInfoCompleter: connectionInfoCompleter));
+      await connectionInfoCompleter.future;
+
+      expect(webDevFS.mainUri, isNotNull);
+      final String entrypointContents = fileSystem.file(webDevFS.mainUri).readAsStringSync();
+      expect(
+        entrypointContents,
+        contains("import 'org-dartlang-app:/bar_test.dart' as entrypoint;"),
+      );
+      expect(residentCompiler.fileSystemRoots, contains(externalDirectory.path));
+      expect(
+        residentCompiler.fileSystemRoots,
+        contains(projectDirectory.childDirectory('test').absolute.path),
+      );
+    },
+    overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      ProcessManager: () => processManager,
+      Pub: ThrowingPub.new,
+    },
+  );
+
+  testUsingContext(
     'Sends launched app.webLaunchUrl event for Chrome device',
     () async {
       final logger = BufferLogger.test();
@@ -2004,9 +2079,11 @@ ResidentRunner setUpResidentRunner(
   Logger? logger,
   SystemClock? systemClock,
   DebuggingOptions? debuggingOptions,
+  String? target,
 }) {
   return ResidentWebRunner(
     flutterDevice,
+    target: target,
     flutterProject: FlutterProject.fromDirectoryTest(globals.fs.currentDirectory),
     debuggingOptions: debuggingOptions ?? DebuggingOptions.enabled(BuildInfo.debug),
     analytics: globals.analytics,
@@ -2111,6 +2188,8 @@ class FakeChromeDevice extends Fake implements ChromiumDevice {}
 class FakeWipDebugger extends Fake implements WipDebugger {}
 
 class FakeResidentCompiler extends Fake implements ResidentCompiler {
+  final List<String> fileSystemRoots = <String>[];
+
   @override
   Future<CompilerOutput> recompile(
     Uri mainUri,
@@ -2140,7 +2219,9 @@ class FakeResidentCompiler extends Fake implements ResidentCompiler {
   }
 
   @override
-  void addFileSystemRoot(String root) {}
+  void addFileSystemRoot(String root) {
+    fileSystemRoots.add(root);
+  }
 }
 
 class FakeWebDevFS extends Fake implements WebDevFS {


### PR DESCRIPTION
Issue: Fixes https://github.com/flutter/flutter/issues/102469. For web `flutter drive` targets outside `lib/`, the generated web entrypoint imported the target as only `org-dartlang-app:/<basename>`. Relative imports with `..` were then normalized from the virtual root instead of the target's project-relative directory, so files like `../../utils/add.dart` resolved to the wrong `org-dartlang-app` path.

Fix: For non-package web entrypoints that are inside the Flutter project, add the project root as the compiler filesystem root and import the target using its project-relative `org-dartlang-app` URI. Entrypoints outside the project keep the existing parent-directory fallback, including the existing test-directory filesystem root.

Tests:
- `../../bin/dart test test/general.shard/resident_web_runner_test.dart --plain-name "generates project-relative imports for non-package web entrypoints"`
- `../../bin/dart test test/general.shard/resident_web_runner_test.dart --plain-name "keeps fallback filesystem roots for entrypoints outside the project"`
- `../../bin/dart test test/general.shard/resident_web_runner_test.dart`
- `../../bin/dart analyze lib/src/isolated/resident_web_runner.dart test/general.shard/resident_web_runner_test.dart`
- `git diff --check`

Risk: Low. The change is limited to web resident-runner entrypoint generation for targets that are not resolved through the package config, with focused regression tests covering the generated import path and both filesystem-root branches.
