### PR TITLE
Validate dart define file newlines

### DIFF
--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1740,6 +1740,19 @@ abstract class FlutterCommand extends Command<void> {
         try {
           // Fix json convert Object value :type '_InternalLinkedHashMap<String, dynamic>' is not a subtype of type 'Map<String, Object>' in type cast
           (json.decode(configJsonRaw) as Map<String, dynamic>).forEach((String key, Object? value) {
+            if (key.contains('\n') || key.contains('\r')) {
+              throwToolExit(
+                'Keys in "--${FlutterOptions.kDartDefineFromFileOption}" must not contain newline characters.\n'
+                'A key in "$path" contains a newline.',
+              );
+            }
+            final stringValue = '$value';
+            if (stringValue.contains('\n') || stringValue.contains('\r')) {
+              throwToolExit(
+                'Values in "--${FlutterOptions.kDartDefineFromFileOption}" must not contain newline characters.\n'
+                'The value for "$key" in "$path" contains a newline.',
+              );
+            }
             dartDefineConfigJsonMap[key] = value;
           });
         } on FormatException catch (err) {

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -848,6 +848,66 @@ void main() {
       );
 
       testUsingContext(
+        'throws a ToolExit when a JSON file contains a newline value',
+        () async {
+          fileSystem.file(fileSystem.path.join('lib', 'main.dart')).createSync(recursive: true);
+          fileSystem.file('pubspec.yaml').createSync();
+          await fileSystem.file('config.json').writeAsString(r'''
+            {
+              "MY_ENV_VALUE": "json \n foo \n"
+            }
+          ''');
+
+          await dummyCommandRunner.run(<String>['dummy', '--dart-define-from-file=config.json']);
+          expect(
+            () => dummyCommand.getBuildInfo(forcedBuildMode: BuildMode.debug),
+            throwsToolExit(
+              message:
+                  'Values in "--${FlutterOptions.kDartDefineFromFileOption}" must not contain newline characters.\n'
+                  'The value for "MY_ENV_VALUE" in "config.json" contains a newline.',
+            ),
+          );
+        },
+        overrides: <Type, Generator>{
+          FileSystem: () => fileSystem,
+          Logger: () => logger,
+          FileSystemUtils: () => fileSystemUtils,
+          Platform: () => platform,
+          ProcessManager: () => processManager,
+        },
+      );
+
+      testUsingContext(
+        'throws a ToolExit when a JSON file contains a newline key',
+        () async {
+          fileSystem.file(fileSystem.path.join('lib', 'main.dart')).createSync(recursive: true);
+          fileSystem.file('pubspec.yaml').createSync();
+          await fileSystem.file('config.json').writeAsString(r'''
+            {
+              "MY\nENV\nKEY": "value"
+            }
+          ''');
+
+          await dummyCommandRunner.run(<String>['dummy', '--dart-define-from-file=config.json']);
+          expect(
+            () => dummyCommand.getBuildInfo(forcedBuildMode: BuildMode.debug),
+            throwsToolExit(
+              message:
+                  'Keys in "--${FlutterOptions.kDartDefineFromFileOption}" must not contain newline characters.\n'
+                  'A key in "config.json" contains a newline.',
+            ),
+          );
+        },
+        overrides: <Type, Generator>{
+          FileSystem: () => fileSystem,
+          Logger: () => logger,
+          FileSystemUtils: () => fileSystemUtils,
+          Platform: () => platform,
+          ProcessManager: () => processManager,
+        },
+      );
+
+      testUsingContext(
         'has values with identical keys from --dart-define take precedence',
         () async {
           fileSystem.file(fileSystem.path.join('lib', 'main.dart')).createSync(recursive: true);


### PR DESCRIPTION
Issue:
Fixes https://github.com/flutter/flutter/issues/129608.

JSON values loaded through `--dart-define-from-file` were decoded and forwarded into `BuildInfo.dartDefines` without checking whether their final `KEY=VALUE` string contained newline characters. Those newlines can split the generated frontend-server arguments and produce a confusing compile error that treats the `-D...` define as an input file.

Fix:
Validate decoded values from files before they are added to the dart defines map. If a value's string form contains `\n` or `\r`, the tool now exits with a targeted `ToolExit` that names the offending key and file instead of forwarding the unsupported value to the compiler.

The change is intentionally limited to the `--dart-define-from-file` path. It keeps the existing value conversion behavior for supported JSON values.

Tests:
Passed:

```sh
../../bin/dart format --output=none --set-exit-if-changed lib/src/runner/flutter_command.dart test/general.shard/runner/flutter_command_test.dart
../../bin/dart test test/general.shard/runner/flutter_command_test.dart --plain-name 'throws a ToolExit when a JSON file contains a newline value'
../../bin/dart analyze lib/src/runner/flutter_command.dart test/general.shard/runner/flutter_command_test.dart
../../bin/dart test test/general.shard/runner/flutter_command_test.dart
git diff --check
```

The new focused test failed before the implementation because `getBuildInfo` returned normally with the newline-bearing define.

Risk:
Changed files:

- `packages/flutter_tools/lib/src/runner/flutter_command.dart`
- `packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart`

This only rejects values that already cannot be safely forwarded as dart defines from files. No generated files or dependency state changed.
