### PR TITLE
examples: fix IndexedStack dispose memory leak

### DIFF
--- a/examples/api/lib/widgets/basic/indexed_stack.0.dart
+++ b/examples/api/lib/widgets/basic/indexed_stack.0.dart
@@ -97,6 +97,12 @@ class _IndexedStackExampleState extends State<IndexedStackExample> {
       ],
     );
   }
+  @override
+  void dispose() {
+    fieldText.dispose();
+    super.dispose();
+  }
+
 }
 
 class PersonTracker extends StatefulWidget {


### PR DESCRIPTION
## Problem

The IndexedStack example creates a `TextEditingController` but never disposes it, causing a memory leak.

## Solution

Add `dispose()` method to `_IndexedStackExampleState`:

```dart
@override
void dispose() {
  fieldText.dispose();
  super.dispose();
}
```

## File Modified

- `examples/api/lib/widgets/basic/indexed_stack.0.dart`

## Testing

- Example code only — no framework changes
- Standard Flutter example validation applies

Fixes #186324
