### PR TITLE
Apply ScrollbarTheme to iOS Scrollbar

### DIFF
--- a/packages/flutter/lib/src/cupertino/scrollbar.dart
+++ b/packages/flutter/lib/src/cupertino/scrollbar.dart
@@ -79,6 +79,7 @@ class CupertinoScrollbar extends RawScrollbar {
     super.controller,
     bool? thumbVisibility,
     double super.thickness = defaultThickness,
+    super.thumbColor,
     this.thicknessWhileDragging = defaultThicknessWhileDragging,
     Radius super.radius = defaultRadius,
     this.radiusWhileDragging = defaultRadiusWhileDragging,
@@ -159,7 +160,7 @@ class _CupertinoScrollbarState extends RawScrollbarState<CupertinoScrollbar> {
   @override
   void updateScrollbarPainter() {
     scrollbarPainter
-      ..color = CupertinoDynamicColor.resolve(_kScrollbarColor, context)
+      ..color = widget.thumbColor ?? CupertinoDynamicColor.resolve(_kScrollbarColor, context)
       ..textDirection = Directionality.of(context)
       ..thickness = _thickness
       ..mainAxisMargin = widget.mainAxisMargin

--- a/packages/flutter/lib/src/cupertino/scrollbar.dart
+++ b/packages/flutter/lib/src/cupertino/scrollbar.dart
@@ -86,6 +86,7 @@ class CupertinoScrollbar extends RawScrollbar {
     ScrollNotificationPredicate? notificationPredicate,
     super.scrollbarOrientation,
     super.mainAxisMargin = _kScrollbarMainAxisMargin,
+    super.interactive,
   }) : assert(thickness < double.infinity),
        assert(thicknessWhileDragging < double.infinity),
        super(

--- a/packages/flutter/lib/src/cupertino/scrollbar.dart
+++ b/packages/flutter/lib/src/cupertino/scrollbar.dart
@@ -161,7 +161,7 @@ class _CupertinoScrollbarState extends RawScrollbarState<CupertinoScrollbar> {
   @override
   void updateScrollbarPainter() {
     scrollbarPainter
-      ..color = widget.thumbColor ?? CupertinoDynamicColor.resolve(_kScrollbarColor, context)
+      ..color = CupertinoDynamicColor.resolve(widget.thumbColor ?? _kScrollbarColor, context)
       ..textDirection = Directionality.of(context)
       ..thickness = _thickness
       ..mainAxisMargin = widget.mainAxisMargin

--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -160,13 +160,18 @@ class Scrollbar extends StatelessWidget {
       final double? resolvedThicknessWhileDragging =
           thickness ?? scrollbarTheme.thickness?.resolve(draggedStates);
       final Radius? resolvedRadius = radius ?? scrollbarTheme.radius;
+      // CupertinoScrollbar paints a single thumb color, so only the resting
+      // state is resolved here; there is no dragged-color counterpart to
+      // thicknessWhileDragging. CupertinoScrollbar resolves any
+      // CupertinoDynamicColor against its own context.
+      final Color? resolvedThumbColor = scrollbarTheme.thumbColor?.resolve(states);
       return CupertinoScrollbar(
         thumbVisibility:
             thumbVisibility ?? scrollbarTheme.thumbVisibility?.resolve(states) ?? false,
         thickness: resolvedThickness ?? CupertinoScrollbar.defaultThickness,
         thicknessWhileDragging:
             resolvedThicknessWhileDragging ?? CupertinoScrollbar.defaultThicknessWhileDragging,
-        thumbColor: _resolveThumbColor(scrollbarTheme),
+        thumbColor: resolvedThumbColor,
         radius: resolvedRadius ?? CupertinoScrollbar.defaultRadius,
         radiusWhileDragging: resolvedRadius ?? CupertinoScrollbar.defaultRadiusWhileDragging,
         controller: controller,
@@ -187,12 +192,6 @@ class Scrollbar extends StatelessWidget {
       scrollbarOrientation: scrollbarOrientation,
       child: child,
     );
-  }
-
-  /// Resolves [ScrollbarThemeData.thumbColor] as a [WidgetStateProperty]
-  /// for use on the iOS [CupertinoScrollbar] path.
-  static Color? _resolveThumbColor(ScrollbarThemeData scrollbarTheme) {
-    return scrollbarTheme.thumbColor?.resolve(const <WidgetState>{});
   }
 }
 

--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -166,11 +166,12 @@ class Scrollbar extends StatelessWidget {
         thickness: resolvedThickness ?? CupertinoScrollbar.defaultThickness,
         thicknessWhileDragging:
             resolvedThicknessWhileDragging ?? CupertinoScrollbar.defaultThicknessWhileDragging,
-        thumbColor: scrollbarTheme.thumbColor?.resolve(states),
+        thumbColor: _resolveThumbColor(scrollbarTheme),
         radius: resolvedRadius ?? CupertinoScrollbar.defaultRadius,
         radiusWhileDragging: resolvedRadius ?? CupertinoScrollbar.defaultRadiusWhileDragging,
         controller: controller,
         notificationPredicate: notificationPredicate,
+        interactive: interactive ?? scrollbarTheme.interactive,
         scrollbarOrientation: scrollbarOrientation,
         child: child,
       );
@@ -186,6 +187,12 @@ class Scrollbar extends StatelessWidget {
       scrollbarOrientation: scrollbarOrientation,
       child: child,
     );
+  }
+
+  /// Resolves [ScrollbarThemeData.thumbColor] as a [WidgetStateProperty]
+  /// for use on the iOS [CupertinoScrollbar] path.
+  static Color? _resolveThumbColor(ScrollbarThemeData scrollbarTheme) {
+    return scrollbarTheme.thumbColor?.resolve(const <WidgetState>{});
   }
 }
 

--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -151,13 +151,24 @@ class Scrollbar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (Theme.of(context).platform == TargetPlatform.iOS) {
+    final ThemeData theme = Theme.of(context);
+    if (theme.platform == TargetPlatform.iOS) {
+      final ScrollbarThemeData scrollbarTheme = ScrollbarTheme.of(context);
+      const states = <WidgetState>{};
+      const draggedStates = <WidgetState>{WidgetState.dragged};
+      final double? resolvedThickness = thickness ?? scrollbarTheme.thickness?.resolve(states);
+      final double? resolvedThicknessWhileDragging =
+          thickness ?? scrollbarTheme.thickness?.resolve(draggedStates);
+      final Radius? resolvedRadius = radius ?? scrollbarTheme.radius;
       return CupertinoScrollbar(
-        thumbVisibility: thumbVisibility ?? false,
-        thickness: thickness ?? CupertinoScrollbar.defaultThickness,
-        thicknessWhileDragging: thickness ?? CupertinoScrollbar.defaultThicknessWhileDragging,
-        radius: radius ?? CupertinoScrollbar.defaultRadius,
-        radiusWhileDragging: radius ?? CupertinoScrollbar.defaultRadiusWhileDragging,
+        thumbVisibility:
+            thumbVisibility ?? scrollbarTheme.thumbVisibility?.resolve(states) ?? false,
+        thickness: resolvedThickness ?? CupertinoScrollbar.defaultThickness,
+        thicknessWhileDragging:
+            resolvedThicknessWhileDragging ?? CupertinoScrollbar.defaultThicknessWhileDragging,
+        thumbColor: scrollbarTheme.thumbColor?.resolve(states),
+        radius: resolvedRadius ?? CupertinoScrollbar.defaultRadius,
+        radiusWhileDragging: resolvedRadius ?? CupertinoScrollbar.defaultRadiusWhileDragging,
         controller: controller,
         notificationPredicate: notificationPredicate,
         scrollbarOrientation: scrollbarOrientation,

--- a/packages/flutter/test/cupertino/scrollbar_paint_test.dart
+++ b/packages/flutter/test/cupertino/scrollbar_paint_test.dart
@@ -54,6 +54,32 @@ void main() {
     );
   });
 
+  testWidgets('Paints custom thumb color', (WidgetTester tester) async {
+    const thumbColor = Color(0xff0000ff);
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: MediaQueryData(),
+          child: CupertinoScrollbar(
+            thumbColor: thumbColor,
+            child: SingleChildScrollView(child: SizedBox(width: 4000.0, height: 4000.0)),
+          ),
+        ),
+      ),
+    );
+
+    final TestGesture gesture = await tester.startGesture(
+      tester.getCenter(find.byType(SingleChildScrollView)),
+    );
+    await gesture.moveBy(_kGestureOffset);
+    await gesture.moveBy(Offset.zero.translate(-_kGestureOffset.dx, -_kGestureOffset.dy));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    expect(find.byType(CupertinoScrollbar), paints..rrect(color: thumbColor));
+  });
+
   testWidgets('Paints iOS spec with nav bar', (WidgetTester tester) async {
     await tester.pumpWidget(
       CupertinoApp(

--- a/packages/flutter/test/cupertino/scrollbar_paint_test.dart
+++ b/packages/flutter/test/cupertino/scrollbar_paint_test.dart
@@ -80,6 +80,37 @@ void main() {
     expect(find.byType(CupertinoScrollbar), paints..rrect(color: thumbColor));
   });
 
+  testWidgets('Resolves a CupertinoDynamicColor thumb color against the context', (
+    WidgetTester tester,
+  ) async {
+    const thumbColor = CupertinoDynamicColor.withBrightness(
+      color: Color(0xff0000ff),
+      darkColor: Color(0xff00ff00),
+    );
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: MediaQueryData(platformBrightness: Brightness.dark),
+          child: CupertinoScrollbar(
+            thumbColor: thumbColor,
+            child: SingleChildScrollView(child: SizedBox(width: 4000.0, height: 4000.0)),
+          ),
+        ),
+      ),
+    );
+
+    final TestGesture gesture = await tester.startGesture(
+      tester.getCenter(find.byType(SingleChildScrollView)),
+    );
+    await gesture.moveBy(_kGestureOffset);
+    await gesture.moveBy(Offset.zero.translate(-_kGestureOffset.dx, -_kGestureOffset.dy));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    expect(find.byType(CupertinoScrollbar), paints..rrect(color: thumbColor.darkColor));
+  });
+
   testWidgets('Paints iOS spec with nav bar', (WidgetTester tester) async {
     await tester.pumpWidget(
       CupertinoApp(

--- a/packages/flutter/test/material/scrollbar_theme_test.dart
+++ b/packages/flutter/test/material/scrollbar_theme_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:ui' as ui;
 
+import 'package:flutter/cupertino.dart' show CupertinoScrollbar;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -221,6 +222,46 @@ void main() {
     }),
   );
 
+  testWidgets('Scrollbar uses compatible ScrollbarTheme values on iOS', (
+    WidgetTester tester,
+  ) async {
+    final scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(
+          platform: TargetPlatform.iOS,
+          scrollbarTheme: ScrollbarThemeData(
+            thumbVisibility: WidgetStateProperty.all(true),
+            thickness: WidgetStateProperty.all(12.0),
+            thumbColor: WidgetStateProperty.all(Colors.blue),
+            radius: const Radius.circular(8.0),
+          ),
+        ),
+        home: ScrollConfiguration(
+          behavior: const NoScrollbarBehavior(),
+          child: Scrollbar(
+            controller: scrollController,
+            child: SingleChildScrollView(
+              controller: scrollController,
+              child: const SizedBox(width: 4000.0, height: 4000.0),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final CupertinoScrollbar scrollbar = tester.widget<CupertinoScrollbar>(
+      find.byType(CupertinoScrollbar),
+    );
+    expect(scrollbar.thumbVisibility, isTrue);
+    expect(scrollbar.thickness, 12.0);
+    expect(scrollbar.thicknessWhileDragging, 12.0);
+    expect(scrollbar.thumbColor, Colors.blue);
+    expect(scrollbar.radius, const Radius.circular(8.0));
+    expect(scrollbar.radiusWhileDragging, const Radius.circular(8.0));
+  });
+
   testWidgets('Scrollbar uses values from ScrollbarTheme if exists instead of values from Theme', (
     WidgetTester tester,
   ) async {
@@ -263,113 +304,107 @@ void main() {
     scrollController.dispose();
   });
 
-  testWidgets(
-    'ScrollbarTheme can disable gestures',
-    (WidgetTester tester) async {
-      final scrollController = ScrollController();
-      await tester.pumpWidget(
-        MaterialApp(
-          theme: ThemeData(
-            useMaterial3: false,
-            scrollbarTheme: const ScrollbarThemeData(interactive: false),
-          ),
-          home: Scrollbar(
-            thumbVisibility: true,
+  testWidgets('ScrollbarTheme can disable gestures', (WidgetTester tester) async {
+    final scrollController = ScrollController();
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(
+          useMaterial3: false,
+          scrollbarTheme: const ScrollbarThemeData(interactive: false),
+        ),
+        home: Scrollbar(
+          thumbVisibility: true,
+          controller: scrollController,
+          child: SingleChildScrollView(
             controller: scrollController,
-            child: SingleChildScrollView(
-              controller: scrollController,
-              child: const SizedBox(width: 4000.0, height: 4000.0),
-            ),
+            child: const SizedBox(width: 4000.0, height: 4000.0),
           ),
         ),
-      );
-      await tester.pumpAndSettle();
-      // Idle scrollbar behavior
-      expect(
-        find.byType(Scrollbar),
-        paints..rrect(
-          rrect: RRect.fromRectAndRadius(_kMaterialDesignInitialThumbRect, _kDefaultThumbRadius),
-          color: _kDefaultIdleThumbColor,
+      ),
+    );
+    await tester.pumpAndSettle();
+    // Idle scrollbar behavior
+    expect(
+      find.byType(Scrollbar),
+      paints..rrect(
+        rrect: RRect.fromRectAndRadius(_kMaterialDesignInitialThumbRect, _kDefaultThumbRadius),
+        color: _kDefaultIdleThumbColor,
+      ),
+    );
+
+    // Try to drag scrollbar.
+    const scrollAmount = 10.0;
+    final TestGesture dragScrollbarGesture = await tester.startGesture(const Offset(797.0, 45.0));
+    await tester.pumpAndSettle();
+    await dragScrollbarGesture.moveBy(const Offset(0.0, scrollAmount));
+    await tester.pumpAndSettle();
+    await dragScrollbarGesture.up();
+    await tester.pumpAndSettle();
+    // Expect no change
+    expect(
+      find.byType(Scrollbar),
+      paints..rrect(
+        rrect: RRect.fromRectAndRadius(_kMaterialDesignInitialThumbRect, _kDefaultThumbRadius),
+        color: _kDefaultIdleThumbColor,
+      ),
+    );
+
+    scrollController.dispose();
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.fuchsia}));
+
+  testWidgets('Scrollbar.interactive takes priority over ScrollbarTheme', (
+    WidgetTester tester,
+  ) async {
+    final scrollController = ScrollController();
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(
+          useMaterial3: false,
+          scrollbarTheme: const ScrollbarThemeData(interactive: false),
         ),
-      );
-
-      // Try to drag scrollbar.
-      const scrollAmount = 10.0;
-      final TestGesture dragScrollbarGesture = await tester.startGesture(const Offset(797.0, 45.0));
-      await tester.pumpAndSettle();
-      await dragScrollbarGesture.moveBy(const Offset(0.0, scrollAmount));
-      await tester.pumpAndSettle();
-      await dragScrollbarGesture.up();
-      await tester.pumpAndSettle();
-      // Expect no change
-      expect(
-        find.byType(Scrollbar),
-        paints..rrect(
-          rrect: RRect.fromRectAndRadius(_kMaterialDesignInitialThumbRect, _kDefaultThumbRadius),
-          color: _kDefaultIdleThumbColor,
-        ),
-      );
-
-      scrollController.dispose();
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.fuchsia}),
-  );
-
-  testWidgets(
-    'Scrollbar.interactive takes priority over ScrollbarTheme',
-    (WidgetTester tester) async {
-      final scrollController = ScrollController();
-      await tester.pumpWidget(
-        MaterialApp(
-          theme: ThemeData(
-            useMaterial3: false,
-            scrollbarTheme: const ScrollbarThemeData(interactive: false),
-          ),
-          home: Scrollbar(
-            interactive: true,
-            thumbVisibility: true,
+        home: Scrollbar(
+          interactive: true,
+          thumbVisibility: true,
+          controller: scrollController,
+          child: SingleChildScrollView(
             controller: scrollController,
-            child: SingleChildScrollView(
-              controller: scrollController,
-              child: const SizedBox(width: 4000.0, height: 4000.0),
-            ),
+            child: const SizedBox(width: 4000.0, height: 4000.0),
           ),
         ),
-      );
-      await tester.pumpAndSettle();
-      // Idle scrollbar behavior
-      expect(
-        find.byType(Scrollbar),
-        paints..rrect(
-          rrect: RRect.fromRectAndRadius(_kMaterialDesignInitialThumbRect, _kDefaultThumbRadius),
-          color: _kDefaultIdleThumbColor,
-        ),
-      );
+      ),
+    );
+    await tester.pumpAndSettle();
+    // Idle scrollbar behavior
+    expect(
+      find.byType(Scrollbar),
+      paints..rrect(
+        rrect: RRect.fromRectAndRadius(_kMaterialDesignInitialThumbRect, _kDefaultThumbRadius),
+        color: _kDefaultIdleThumbColor,
+      ),
+    );
 
-      // Drag scrollbar.
-      const scrollAmount = 10.0;
-      final TestGesture dragScrollbarGesture = await tester.startGesture(const Offset(797.0, 45.0));
-      await tester.pumpAndSettle();
-      await dragScrollbarGesture.moveBy(const Offset(0.0, scrollAmount));
-      await tester.pumpAndSettle();
-      await dragScrollbarGesture.up();
-      await tester.pumpAndSettle();
-      // Gestures handled by Scrollbar.
-      expect(
-        find.byType(Scrollbar),
-        paints..rrect(
-          rrect: RRect.fromRectAndRadius(
-            const Rect.fromLTRB(790.0, 10.0, 798.0, 100.0),
-            _kDefaultThumbRadius,
-          ),
-          color: _kDefaultIdleThumbColor,
+    // Drag scrollbar.
+    const scrollAmount = 10.0;
+    final TestGesture dragScrollbarGesture = await tester.startGesture(const Offset(797.0, 45.0));
+    await tester.pumpAndSettle();
+    await dragScrollbarGesture.moveBy(const Offset(0.0, scrollAmount));
+    await tester.pumpAndSettle();
+    await dragScrollbarGesture.up();
+    await tester.pumpAndSettle();
+    // Gestures handled by Scrollbar.
+    expect(
+      find.byType(Scrollbar),
+      paints..rrect(
+        rrect: RRect.fromRectAndRadius(
+          const Rect.fromLTRB(790.0, 10.0, 798.0, 100.0),
+          _kDefaultThumbRadius,
         ),
-      );
+        color: _kDefaultIdleThumbColor,
+      ),
+    );
 
-      scrollController.dispose();
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.fuchsia}),
-  );
+    scrollController.dispose();
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.fuchsia}));
 
   testWidgets(
     'Scrollbar widget properties take priority over theme',

--- a/packages/flutter/test/material/scrollbar_theme_test.dart
+++ b/packages/flutter/test/material/scrollbar_theme_test.dart
@@ -236,6 +236,7 @@ void main() {
             thickness: WidgetStateProperty.all(12.0),
             thumbColor: WidgetStateProperty.all(Colors.blue),
             radius: const Radius.circular(8.0),
+            interactive: false,
           ),
         ),
         home: ScrollConfiguration(
@@ -260,6 +261,7 @@ void main() {
     expect(scrollbar.thumbColor, Colors.blue);
     expect(scrollbar.radius, const Radius.circular(8.0));
     expect(scrollbar.radiusWhileDragging, const Radius.circular(8.0));
+    expect(scrollbar.interactive, false);
   });
 
   testWidgets('Scrollbar uses values from ScrollbarTheme if exists instead of values from Theme', (


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/143926

## Issue
Material `Scrollbar` adapts to `CupertinoScrollbar` on iOS, but that path ignored compatible `ThemeData.scrollbarTheme` values. As a result `thumbVisibility`, `thickness`, `radius`, and `thumbColor` set through `ScrollbarThemeData` were not reflected on iOS.

## Fix
Resolve the compatible `ScrollbarThemeData` values before constructing `CupertinoScrollbar` on the iOS path. `CupertinoScrollbar` now accepts an optional `thumbColor` and falls back to the native dynamic color when it is not provided. Track-related and interactive theme fields remain unchanged because they do not map to `CupertinoScrollbar` behavior.

## Tests
- [x] `./bin/flutter test packages/flutter/test/material/scrollbar_theme_test.dart --plain-name 'Scrollbar uses compatible ScrollbarTheme values on iOS'`
- [x] `./bin/flutter test packages/flutter/test/cupertino/scrollbar_paint_test.dart --plain-name 'Paints custom thumb color'`
- [x] `./bin/flutter test packages/flutter/test/material/scrollbar_theme_test.dart`
- [x] `./bin/flutter test packages/flutter/test/cupertino/scrollbar_paint_test.dart`
- [x] `./bin/flutter test packages/flutter/test/material/scrollbar_test.dart`
- [x] `./bin/flutter analyze packages/flutter/lib/src/cupertino/scrollbar.dart packages/flutter/lib/src/material/scrollbar.dart packages/flutter/test/material/scrollbar_theme_test.dart packages/flutter/test/cupertino/scrollbar_paint_test.dart`
- [x] `./bin/dart format --output=none --set-exit-if-changed packages/flutter/lib/src/cupertino/scrollbar.dart packages/flutter/lib/src/material/scrollbar.dart packages/flutter/test/material/scrollbar_theme_test.dart packages/flutter/test/cupertino/scrollbar_paint_test.dart`
- [x] `git diff --check`

## Risk
Changed files: two scrollbar implementation files and two focused scrollbar test files. The iOS Material `Scrollbar` path continues to use `CupertinoScrollbar` defaults when no compatible theme value is supplied. The mapping intentionally excludes track and gesture fields that do not apply to `CupertinoScrollbar`.
