### PR TITLE
Scope NavigationBar sample ScaffoldMessenger

### DIFF
--- a/examples/api/lib/material/navigation_bar/navigation_bar.2.dart
+++ b/examples/api/lib/material/navigation_bar/navigation_bar.2.dart
@@ -369,25 +369,30 @@ class DestinationView extends StatefulWidget {
 class _DestinationViewState extends State<DestinationView> {
   @override
   Widget build(BuildContext context) {
-    return Navigator(
-      key: widget.navigatorKey,
-      onGenerateRoute: (RouteSettings settings) {
-        return MaterialPageRoute<void>(
-          settings: settings,
-          builder: (BuildContext context) {
-            switch (settings.name) {
-              case '/':
-                return RootPage(destination: widget.destination);
-              case '/list':
-                return ListPage(destination: widget.destination);
-              case '/text':
-                return TextPage(destination: widget.destination);
-            }
-            assert(false);
-            return const SizedBox();
-          },
-        );
-      },
+    // The nested Navigator has its own Scaffolds, so it also needs its own
+    // ScaffoldMessenger to present SnackBars and MaterialBanners inside the
+    // destination instead of above the root Scaffold.
+    return ScaffoldMessenger(
+      child: Navigator(
+        key: widget.navigatorKey,
+        onGenerateRoute: (RouteSettings settings) {
+          return MaterialPageRoute<void>(
+            settings: settings,
+            builder: (BuildContext context) {
+              switch (settings.name) {
+                case '/':
+                  return RootPage(destination: widget.destination);
+                case '/list':
+                  return ListPage(destination: widget.destination);
+                case '/text':
+                  return TextPage(destination: widget.destination);
+              }
+              assert(false);
+              return const SizedBox();
+            },
+          );
+        },
+      ),
     );
   }
 }

--- a/examples/api/test/material/navigation_bar/navigation_bar.2_test.dart
+++ b/examples/api/test/material/navigation_bar/navigation_bar.2_test.dart
@@ -79,6 +79,44 @@ void main() {
     expect(find.text('Teal ListPage - /list'), findsOneWidget);
   });
 
+  testWidgets(
+    'RootPage presents material banners below the destination app bar',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(const MaterialApp(home: example.Home()));
+
+      final Finder appBarFinder = find.widgetWithText(
+        AppBar,
+        'Teal RootPage - /',
+      );
+      expect(appBarFinder, findsOneWidget);
+      final BuildContext rootPageContext = tester.element(appBarFinder);
+      ScaffoldMessenger.of(rootPageContext).showMaterialBanner(
+        MaterialBanner(
+          content: const Text('Destination banner'),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () {
+                ScaffoldMessenger.of(
+                  rootPageContext,
+                ).hideCurrentMaterialBanner();
+              },
+              child: const Text('Dismiss'),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final double appBarBottom = tester
+          .getBottomLeft(find.widgetWithText(AppBar, 'Teal RootPage - /'))
+          .dy;
+      final double bannerTop = tester
+          .getTopLeft(find.byType(MaterialBanner))
+          .dy;
+      expect(bannerTop, greaterThanOrEqualTo(appBarBottom));
+    },
+  );
+
   testWidgets('ListPage', (WidgetTester tester) async {
     await tester.pumpWidget(const MaterialApp(home: example.Home()));
     expect(find.text('Teal RootPage - /'), findsOneWidget);


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/117155

## Issue
The `NavigationBar` nested navigator sample keeps destination pages inside their own nested `Navigator`, but those pages still inherited the root `ScaffoldMessenger` from `MaterialApp`. Calling `ScaffoldMessenger.of(context)` from a destination page therefore presented `MaterialBanner`s and `SnackBar`s on the root scaffold instead of the destination scaffold.

## Fix
Wrap each `DestinationView` navigator in its own `ScaffoldMessenger`, matching the nested scaffolds owned by that navigator. This keeps destination-scoped scaffold features inside the selected destination while preserving the existing nested navigator routing behavior.

## Tests
- [x] `./bin/flutter test examples/api/test/material/navigation_bar/navigation_bar.2_test.dart --plain-name 'RootPage presents material banners below the destination app bar'` failed before the fix and passed after it
- [x] `./bin/flutter test examples/api/test/material/navigation_bar/navigation_bar.2_test.dart`
- [x] `./bin/flutter analyze examples/api/lib/material/navigation_bar/navigation_bar.2.dart examples/api/test/material/navigation_bar/navigation_bar.2_test.dart`
- [x] `./bin/dart format --output=none --set-exit-if-changed examples/api/lib/material/navigation_bar/navigation_bar.2.dart examples/api/test/material/navigation_bar/navigation_bar.2_test.dart`
- [x] `git diff --check`

## Risk
Changed files: one API sample and its existing focused test. The change only scopes scaffold messenger lookup for each nested destination navigator; route generation, destination persistence, dialogs, and bottom-sheet behavior remain unchanged.
