### PR TITLE
Search view expands to full screen on device rotation

### DIFF
--- a/packages/flutter/lib/src/material/search_anchor.dart
+++ b/packages/flutter/lib/src/material/search_anchor.dart
@@ -839,6 +839,7 @@ class _SearchViewRoute extends PopupRoute<_SearchViewRoute> {
                 showFullScreenView: showFullScreenView,
                 animation: curvedAnimation!,
                 topPadding: topPadding,
+                viewMaxWidth: _rectTween.end!.width,
                 viewRect: viewRect,
                 viewBuilder: viewBuilder,
                 searchController: searchController,
@@ -885,6 +886,7 @@ class _ViewContent extends StatefulWidget {
     required this.showFullScreenView,
     required this.topPadding,
     required this.animation,
+    required this.viewMaxWidth,
     required this.viewRect,
     required this.searchController,
     required this.suggestionsBuilder,
@@ -917,6 +919,7 @@ class _ViewContent extends StatefulWidget {
   final bool showFullScreenView;
   final double topPadding;
   final Animation<double> animation;
+  final double viewMaxWidth;
   final Rect viewRect;
   final SearchController searchController;
   final SuggestionsBuilder suggestionsBuilder;
@@ -1105,120 +1108,116 @@ class _ViewContentState extends State<_ViewContent> {
       child: const Divider(height: 1),
     );
 
-    return LayoutBuilder(
-      builder: (BuildContext context, BoxConstraints constraints) {
-        return Align(
-          alignment: Alignment.topLeft,
-          child: Transform.translate(
-            offset: _viewRect.topLeft,
-            child: ConstrainedBox(
-              constraints: BoxConstraints(
-                minWidth: minWidth,
-                maxWidth: _viewRect.width,
-                minHeight: minHeight,
-                maxHeight: _viewRect.height,
-              ),
-              child: Padding(
-                padding: widget.showFullScreenView
-                    ? EdgeInsets.zero
-                    : (effectivePadding ?? EdgeInsets.zero),
-                child: Material(
-                  clipBehavior: Clip.antiAlias,
-                  shape: effectiveShape,
-                  color: effectiveBackgroundColor,
-                  surfaceTintColor: effectiveSurfaceTint,
-                  elevation: effectiveElevation,
-                  child: OverflowBox(
-                    alignment: Alignment.topLeft,
-                    maxWidth: math.min(constraints.maxWidth, _screenSize!.width),
-                    minWidth: 0,
-                    fit: OverflowBoxFit.deferToChild,
-                    child: FadeTransition(
-                      opacity: viewIconsFadeCurve,
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        children: <Widget>[
-                          Padding(
-                            padding: EdgeInsets.only(top: widget.topPadding),
-                            child: SafeArea(
-                              top: false,
-                              bottom: false,
-                              child: SearchBar(
-                                autoFocus: true,
-                                constraints:
-                                    headerConstraints ??
-                                    (widget.showFullScreenView
-                                        ? BoxConstraints(
-                                            minHeight: _SearchViewDefaultsM3.fullScreenBarHeight,
-                                          )
-                                        : null),
-                                padding: WidgetStatePropertyAll<EdgeInsetsGeometry?>(
-                                  effectiveBarPadding,
-                                ),
-                                leading: widget.viewLeading ?? defaultLeading,
-                                trailing: widget.viewTrailing ?? defaultTrailing,
-                                hintText: widget.viewHintText,
-                                backgroundColor: const MaterialStatePropertyAll<Color>(
-                                  Colors.transparent,
-                                ),
-                                overlayColor: const MaterialStatePropertyAll<Color>(
-                                  Colors.transparent,
-                                ),
-                                elevation: const MaterialStatePropertyAll<double>(0.0),
-                                textStyle: MaterialStatePropertyAll<TextStyle?>(effectiveTextStyle),
-                                hintStyle: MaterialStatePropertyAll<TextStyle?>(effectiveHintStyle),
-                                controller: _controller,
-                                onChanged: (String value) {
-                                  widget.viewOnChanged?.call(value);
-                                  updateSuggestions();
-                                },
-                                onSubmitted: widget.viewOnSubmitted,
-                                textCapitalization: widget.textCapitalization,
-                                textInputAction: widget.textInputAction,
-                                keyboardType: widget.keyboardType,
-                                smartDashesType: widget.smartDashesType,
-                                smartQuotesType: widget.smartQuotesType,
-                              ),
-                            ),
-                          ),
-                          if (!effectiveShrinkWrap ||
-                              minHeight > 0 ||
-                              widget.showFullScreenView ||
-                              result.isNotEmpty) ...<Widget>[
-                            FadeTransition(opacity: viewDividerFadeCurve, child: viewDivider),
-                            Flexible(
-                              fit: (effectiveShrinkWrap && !widget.showFullScreenView)
-                                  ? FlexFit.loose
-                                  : FlexFit.tight,
-                              child: FadeTransition(
-                                opacity: viewListFadeOnIntervalCurve,
-                                child: widget.viewBuilder == null
-                                    ? MediaQuery.removePadding(
-                                        context: context,
-                                        removeTop: true,
-                                        child: ListView(
-                                          padding: EdgeInsets.only(
-                                            bottom: MediaQuery.viewInsetsOf(context).bottom,
-                                          ),
-                                          shrinkWrap: effectiveShrinkWrap,
-                                          children: result.toList(),
-                                        ),
+    return Align(
+      alignment: Alignment.topLeft,
+      child: Transform.translate(
+        offset: _viewRect.topLeft,
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            minWidth: minWidth,
+            maxWidth: _viewRect.width,
+            minHeight: minHeight,
+            maxHeight: _viewRect.height,
+          ),
+          child: Padding(
+            padding: widget.showFullScreenView
+                ? EdgeInsets.zero
+                : (effectivePadding ?? EdgeInsets.zero),
+            child: Material(
+              clipBehavior: Clip.antiAlias,
+              shape: effectiveShape,
+              color: effectiveBackgroundColor,
+              surfaceTintColor: effectiveSurfaceTint,
+              elevation: effectiveElevation,
+              child: OverflowBox(
+                alignment: Alignment.topLeft,
+                maxWidth: widget.showFullScreenView
+                    ? _screenSize!.width
+                    : math.min(widget.viewMaxWidth, _screenSize!.width),
+                minWidth: 0,
+                fit: OverflowBoxFit.deferToChild,
+                child: FadeTransition(
+                  opacity: viewIconsFadeCurve,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: <Widget>[
+                      Padding(
+                        padding: EdgeInsets.only(top: widget.topPadding),
+                        child: SafeArea(
+                          top: false,
+                          bottom: false,
+                          child: SearchBar(
+                            autoFocus: true,
+                            constraints:
+                                headerConstraints ??
+                                (widget.showFullScreenView
+                                    ? BoxConstraints(
+                                        minHeight: _SearchViewDefaultsM3.fullScreenBarHeight,
                                       )
-                                    : widget.viewBuilder!(result),
-                              ),
+                                    : null),
+                            padding: WidgetStatePropertyAll<EdgeInsetsGeometry?>(
+                              effectiveBarPadding,
                             ),
-                          ],
-                        ],
+                            leading: widget.viewLeading ?? defaultLeading,
+                            trailing: widget.viewTrailing ?? defaultTrailing,
+                            hintText: widget.viewHintText,
+                            backgroundColor: const MaterialStatePropertyAll<Color>(
+                              Colors.transparent,
+                            ),
+                            overlayColor: const MaterialStatePropertyAll<Color>(Colors.transparent),
+                            elevation: const MaterialStatePropertyAll<double>(0.0),
+                            textStyle: MaterialStatePropertyAll<TextStyle?>(effectiveTextStyle),
+                            hintStyle: MaterialStatePropertyAll<TextStyle?>(effectiveHintStyle),
+                            controller: _controller,
+                            onChanged: (String value) {
+                              widget.viewOnChanged?.call(value);
+                              updateSuggestions();
+                            },
+                            onSubmitted: widget.viewOnSubmitted,
+                            textCapitalization: widget.textCapitalization,
+                            textInputAction: widget.textInputAction,
+                            keyboardType: widget.keyboardType,
+                            smartDashesType: widget.smartDashesType,
+                            smartQuotesType: widget.smartQuotesType,
+                          ),
+                        ),
                       ),
-                    ),
+                      if (!effectiveShrinkWrap ||
+                          minHeight > 0 ||
+                          widget.showFullScreenView ||
+                          result.isNotEmpty) ...<Widget>[
+                        FadeTransition(opacity: viewDividerFadeCurve, child: viewDivider),
+                        Flexible(
+                          fit: (effectiveShrinkWrap && !widget.showFullScreenView)
+                              ? FlexFit.loose
+                              : FlexFit.tight,
+                          child: FadeTransition(
+                            opacity: viewListFadeOnIntervalCurve,
+                            child: widget.viewBuilder == null
+                                ? MediaQuery.removePadding(
+                                    context: context,
+                                    removeTop: true,
+                                    child: ListView(
+                                      padding: EdgeInsets.only(
+                                        bottom: MediaQuery.viewInsetsOf(context).bottom,
+                                      ),
+                                      shrinkWrap: effectiveShrinkWrap,
+                                      children: result.toList(),
+                                    ),
+                                  )
+                                : widget.viewBuilder!(result),
+                          ),
+                        ),
+                      ],
+                    ],
                   ),
                 ),
               ),
             ),
           ),
-        );
-      },
+        ),
+      ),
     );
   }
 }

--- a/packages/flutter/lib/src/material/search_anchor.dart
+++ b/packages/flutter/lib/src/material/search_anchor.dart
@@ -1117,7 +1117,9 @@ class _ViewContentState extends State<_ViewContent> {
             child: ConstrainedBox(
               constraints: BoxConstraints(
                 minWidth: minWidth,
-                maxWidth: _viewRect.width,
+                maxWidth: widget.showFullScreenView
+                    ? math.max(constraints.maxWidth, minWidth)
+                    : _viewRect.width,
                 minHeight: minHeight,
                 maxHeight: widget.showFullScreenView
                     ? math.max(constraints.maxHeight, minHeight)

--- a/packages/flutter/lib/src/material/search_anchor.dart
+++ b/packages/flutter/lib/src/material/search_anchor.dart
@@ -1108,116 +1108,124 @@ class _ViewContentState extends State<_ViewContent> {
       child: const Divider(height: 1),
     );
 
-    return Align(
-      alignment: Alignment.topLeft,
-      child: Transform.translate(
-        offset: _viewRect.topLeft,
-        child: ConstrainedBox(
-          constraints: BoxConstraints(
-            minWidth: minWidth,
-            maxWidth: _viewRect.width,
-            minHeight: minHeight,
-            maxHeight: _viewRect.height,
-          ),
-          child: Padding(
-            padding: widget.showFullScreenView
-                ? EdgeInsets.zero
-                : (effectivePadding ?? EdgeInsets.zero),
-            child: Material(
-              clipBehavior: Clip.antiAlias,
-              shape: effectiveShape,
-              color: effectiveBackgroundColor,
-              surfaceTintColor: effectiveSurfaceTint,
-              elevation: effectiveElevation,
-              child: OverflowBox(
-                alignment: Alignment.topLeft,
-                maxWidth: widget.showFullScreenView
-                    ? _screenSize!.width
-                    : math.min(widget.viewMaxWidth, _screenSize!.width),
-                minWidth: 0,
-                fit: OverflowBoxFit.deferToChild,
-                child: FadeTransition(
-                  opacity: viewIconsFadeCurve,
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: <Widget>[
-                      Padding(
-                        padding: EdgeInsets.only(top: widget.topPadding),
-                        child: SafeArea(
-                          top: false,
-                          bottom: false,
-                          child: SearchBar(
-                            autoFocus: true,
-                            constraints:
-                                headerConstraints ??
-                                (widget.showFullScreenView
-                                    ? BoxConstraints(
-                                        minHeight: _SearchViewDefaultsM3.fullScreenBarHeight,
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        return Align(
+          alignment: Alignment.topLeft,
+          child: Transform.translate(
+            offset: _viewRect.topLeft,
+            child: ConstrainedBox(
+              constraints: BoxConstraints(
+                minWidth: minWidth,
+                maxWidth: _viewRect.width,
+                minHeight: minHeight,
+                maxHeight: widget.showFullScreenView
+                    ? math.max(constraints.maxHeight, minHeight)
+                    : _viewRect.height,
+              ),
+              child: Padding(
+                padding: widget.showFullScreenView
+                    ? EdgeInsets.zero
+                    : (effectivePadding ?? EdgeInsets.zero),
+                child: Material(
+                  clipBehavior: Clip.antiAlias,
+                  shape: effectiveShape,
+                  color: effectiveBackgroundColor,
+                  surfaceTintColor: effectiveSurfaceTint,
+                  elevation: effectiveElevation,
+                  child: OverflowBox(
+                    alignment: Alignment.topLeft,
+                    maxWidth: widget.showFullScreenView
+                        ? constraints.maxWidth
+                        : math.min(widget.viewMaxWidth, constraints.maxWidth),
+                    minWidth: 0,
+                    fit: OverflowBoxFit.deferToChild,
+                    child: FadeTransition(
+                      opacity: viewIconsFadeCurve,
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: <Widget>[
+                          Padding(
+                            padding: EdgeInsets.only(top: widget.topPadding),
+                            child: SafeArea(
+                              top: false,
+                              bottom: false,
+                              child: SearchBar(
+                                autoFocus: true,
+                                constraints:
+                                    headerConstraints ??
+                                    (widget.showFullScreenView
+                                        ? BoxConstraints(
+                                            minHeight: _SearchViewDefaultsM3.fullScreenBarHeight,
+                                          )
+                                        : null),
+                                padding: WidgetStatePropertyAll<EdgeInsetsGeometry?>(
+                                  effectiveBarPadding,
+                                ),
+                                leading: widget.viewLeading ?? defaultLeading,
+                                trailing: widget.viewTrailing ?? defaultTrailing,
+                                hintText: widget.viewHintText,
+                                backgroundColor: const MaterialStatePropertyAll<Color>(
+                                  Colors.transparent,
+                                ),
+                                overlayColor: const MaterialStatePropertyAll<Color>(
+                                  Colors.transparent,
+                                ),
+                                elevation: const MaterialStatePropertyAll<double>(0.0),
+                                textStyle: MaterialStatePropertyAll<TextStyle?>(effectiveTextStyle),
+                                hintStyle: MaterialStatePropertyAll<TextStyle?>(effectiveHintStyle),
+                                controller: _controller,
+                                onChanged: (String value) {
+                                  widget.viewOnChanged?.call(value);
+                                  updateSuggestions();
+                                },
+                                onSubmitted: widget.viewOnSubmitted,
+                                textCapitalization: widget.textCapitalization,
+                                textInputAction: widget.textInputAction,
+                                keyboardType: widget.keyboardType,
+                                smartDashesType: widget.smartDashesType,
+                                smartQuotesType: widget.smartQuotesType,
+                              ),
+                            ),
+                          ),
+                          if (!effectiveShrinkWrap ||
+                              minHeight > 0 ||
+                              widget.showFullScreenView ||
+                              result.isNotEmpty) ...<Widget>[
+                            FadeTransition(opacity: viewDividerFadeCurve, child: viewDivider),
+                            Flexible(
+                              fit: (effectiveShrinkWrap && !widget.showFullScreenView)
+                                  ? FlexFit.loose
+                                  : FlexFit.tight,
+                              child: FadeTransition(
+                                opacity: viewListFadeOnIntervalCurve,
+                                child: widget.viewBuilder == null
+                                    ? MediaQuery.removePadding(
+                                        context: context,
+                                        removeTop: true,
+                                        child: ListView(
+                                          padding: EdgeInsets.only(
+                                            bottom: MediaQuery.viewInsetsOf(context).bottom,
+                                          ),
+                                          shrinkWrap: effectiveShrinkWrap,
+                                          children: result.toList(),
+                                        ),
                                       )
-                                    : null),
-                            padding: WidgetStatePropertyAll<EdgeInsetsGeometry?>(
-                              effectiveBarPadding,
+                                    : widget.viewBuilder!(result),
+                              ),
                             ),
-                            leading: widget.viewLeading ?? defaultLeading,
-                            trailing: widget.viewTrailing ?? defaultTrailing,
-                            hintText: widget.viewHintText,
-                            backgroundColor: const MaterialStatePropertyAll<Color>(
-                              Colors.transparent,
-                            ),
-                            overlayColor: const MaterialStatePropertyAll<Color>(Colors.transparent),
-                            elevation: const MaterialStatePropertyAll<double>(0.0),
-                            textStyle: MaterialStatePropertyAll<TextStyle?>(effectiveTextStyle),
-                            hintStyle: MaterialStatePropertyAll<TextStyle?>(effectiveHintStyle),
-                            controller: _controller,
-                            onChanged: (String value) {
-                              widget.viewOnChanged?.call(value);
-                              updateSuggestions();
-                            },
-                            onSubmitted: widget.viewOnSubmitted,
-                            textCapitalization: widget.textCapitalization,
-                            textInputAction: widget.textInputAction,
-                            keyboardType: widget.keyboardType,
-                            smartDashesType: widget.smartDashesType,
-                            smartQuotesType: widget.smartQuotesType,
-                          ),
-                        ),
+                          ],
+                        ],
                       ),
-                      if (!effectiveShrinkWrap ||
-                          minHeight > 0 ||
-                          widget.showFullScreenView ||
-                          result.isNotEmpty) ...<Widget>[
-                        FadeTransition(opacity: viewDividerFadeCurve, child: viewDivider),
-                        Flexible(
-                          fit: (effectiveShrinkWrap && !widget.showFullScreenView)
-                              ? FlexFit.loose
-                              : FlexFit.tight,
-                          child: FadeTransition(
-                            opacity: viewListFadeOnIntervalCurve,
-                            child: widget.viewBuilder == null
-                                ? MediaQuery.removePadding(
-                                    context: context,
-                                    removeTop: true,
-                                    child: ListView(
-                                      padding: EdgeInsets.only(
-                                        bottom: MediaQuery.viewInsetsOf(context).bottom,
-                                      ),
-                                      shrinkWrap: effectiveShrinkWrap,
-                                      children: result.toList(),
-                                    ),
-                                  )
-                                : widget.viewBuilder!(result),
-                          ),
-                        ),
-                      ],
-                    ],
+                    ),
                   ),
                 ),
               ),
             ),
           ),
-        ),
-      ),
+        );
+      },
     );
   }
 }

--- a/packages/flutter/lib/src/material/search_anchor.dart
+++ b/packages/flutter/lib/src/material/search_anchor.dart
@@ -839,7 +839,6 @@ class _SearchViewRoute extends PopupRoute<_SearchViewRoute> {
                 showFullScreenView: showFullScreenView,
                 animation: curvedAnimation!,
                 topPadding: topPadding,
-                viewMaxWidth: _rectTween.end!.width,
                 viewRect: viewRect,
                 viewBuilder: viewBuilder,
                 searchController: searchController,
@@ -886,7 +885,6 @@ class _ViewContent extends StatefulWidget {
     required this.showFullScreenView,
     required this.topPadding,
     required this.animation,
-    required this.viewMaxWidth,
     required this.viewRect,
     required this.searchController,
     required this.suggestionsBuilder,
@@ -919,7 +917,6 @@ class _ViewContent extends StatefulWidget {
   final bool showFullScreenView;
   final double topPadding;
   final Animation<double> animation;
-  final double viewMaxWidth;
   final Rect viewRect;
   final SearchController searchController;
   final SuggestionsBuilder suggestionsBuilder;
@@ -1108,114 +1105,120 @@ class _ViewContentState extends State<_ViewContent> {
       child: const Divider(height: 1),
     );
 
-    return Align(
-      alignment: Alignment.topLeft,
-      child: Transform.translate(
-        offset: _viewRect.topLeft,
-        child: ConstrainedBox(
-          constraints: BoxConstraints(
-            minWidth: minWidth,
-            maxWidth: _viewRect.width,
-            minHeight: minHeight,
-            maxHeight: _viewRect.height,
-          ),
-          child: Padding(
-            padding: widget.showFullScreenView
-                ? EdgeInsets.zero
-                : (effectivePadding ?? EdgeInsets.zero),
-            child: Material(
-              clipBehavior: Clip.antiAlias,
-              shape: effectiveShape,
-              color: effectiveBackgroundColor,
-              surfaceTintColor: effectiveSurfaceTint,
-              elevation: effectiveElevation,
-              child: OverflowBox(
-                alignment: Alignment.topLeft,
-                maxWidth: math.min(widget.viewMaxWidth, _screenSize!.width),
-                minWidth: 0,
-                fit: OverflowBoxFit.deferToChild,
-                child: FadeTransition(
-                  opacity: viewIconsFadeCurve,
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: <Widget>[
-                      Padding(
-                        padding: EdgeInsets.only(top: widget.topPadding),
-                        child: SafeArea(
-                          top: false,
-                          bottom: false,
-                          child: SearchBar(
-                            autoFocus: true,
-                            constraints:
-                                headerConstraints ??
-                                (widget.showFullScreenView
-                                    ? BoxConstraints(
-                                        minHeight: _SearchViewDefaultsM3.fullScreenBarHeight,
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        return Align(
+          alignment: Alignment.topLeft,
+          child: Transform.translate(
+            offset: _viewRect.topLeft,
+            child: ConstrainedBox(
+              constraints: BoxConstraints(
+                minWidth: minWidth,
+                maxWidth: _viewRect.width,
+                minHeight: minHeight,
+                maxHeight: _viewRect.height,
+              ),
+              child: Padding(
+                padding: widget.showFullScreenView
+                    ? EdgeInsets.zero
+                    : (effectivePadding ?? EdgeInsets.zero),
+                child: Material(
+                  clipBehavior: Clip.antiAlias,
+                  shape: effectiveShape,
+                  color: effectiveBackgroundColor,
+                  surfaceTintColor: effectiveSurfaceTint,
+                  elevation: effectiveElevation,
+                  child: OverflowBox(
+                    alignment: Alignment.topLeft,
+                    maxWidth: math.min(constraints.maxWidth, _screenSize!.width),
+                    minWidth: 0,
+                    fit: OverflowBoxFit.deferToChild,
+                    child: FadeTransition(
+                      opacity: viewIconsFadeCurve,
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: <Widget>[
+                          Padding(
+                            padding: EdgeInsets.only(top: widget.topPadding),
+                            child: SafeArea(
+                              top: false,
+                              bottom: false,
+                              child: SearchBar(
+                                autoFocus: true,
+                                constraints:
+                                    headerConstraints ??
+                                    (widget.showFullScreenView
+                                        ? BoxConstraints(
+                                            minHeight: _SearchViewDefaultsM3.fullScreenBarHeight,
+                                          )
+                                        : null),
+                                padding: WidgetStatePropertyAll<EdgeInsetsGeometry?>(
+                                  effectiveBarPadding,
+                                ),
+                                leading: widget.viewLeading ?? defaultLeading,
+                                trailing: widget.viewTrailing ?? defaultTrailing,
+                                hintText: widget.viewHintText,
+                                backgroundColor: const MaterialStatePropertyAll<Color>(
+                                  Colors.transparent,
+                                ),
+                                overlayColor: const MaterialStatePropertyAll<Color>(
+                                  Colors.transparent,
+                                ),
+                                elevation: const MaterialStatePropertyAll<double>(0.0),
+                                textStyle: MaterialStatePropertyAll<TextStyle?>(effectiveTextStyle),
+                                hintStyle: MaterialStatePropertyAll<TextStyle?>(effectiveHintStyle),
+                                controller: _controller,
+                                onChanged: (String value) {
+                                  widget.viewOnChanged?.call(value);
+                                  updateSuggestions();
+                                },
+                                onSubmitted: widget.viewOnSubmitted,
+                                textCapitalization: widget.textCapitalization,
+                                textInputAction: widget.textInputAction,
+                                keyboardType: widget.keyboardType,
+                                smartDashesType: widget.smartDashesType,
+                                smartQuotesType: widget.smartQuotesType,
+                              ),
+                            ),
+                          ),
+                          if (!effectiveShrinkWrap ||
+                              minHeight > 0 ||
+                              widget.showFullScreenView ||
+                              result.isNotEmpty) ...<Widget>[
+                            FadeTransition(opacity: viewDividerFadeCurve, child: viewDivider),
+                            Flexible(
+                              fit: (effectiveShrinkWrap && !widget.showFullScreenView)
+                                  ? FlexFit.loose
+                                  : FlexFit.tight,
+                              child: FadeTransition(
+                                opacity: viewListFadeOnIntervalCurve,
+                                child: widget.viewBuilder == null
+                                    ? MediaQuery.removePadding(
+                                        context: context,
+                                        removeTop: true,
+                                        child: ListView(
+                                          padding: EdgeInsets.only(
+                                            bottom: MediaQuery.viewInsetsOf(context).bottom,
+                                          ),
+                                          shrinkWrap: effectiveShrinkWrap,
+                                          children: result.toList(),
+                                        ),
                                       )
-                                    : null),
-                            padding: WidgetStatePropertyAll<EdgeInsetsGeometry?>(
-                              effectiveBarPadding,
+                                    : widget.viewBuilder!(result),
+                              ),
                             ),
-                            leading: widget.viewLeading ?? defaultLeading,
-                            trailing: widget.viewTrailing ?? defaultTrailing,
-                            hintText: widget.viewHintText,
-                            backgroundColor: const MaterialStatePropertyAll<Color>(
-                              Colors.transparent,
-                            ),
-                            overlayColor: const MaterialStatePropertyAll<Color>(Colors.transparent),
-                            elevation: const MaterialStatePropertyAll<double>(0.0),
-                            textStyle: MaterialStatePropertyAll<TextStyle?>(effectiveTextStyle),
-                            hintStyle: MaterialStatePropertyAll<TextStyle?>(effectiveHintStyle),
-                            controller: _controller,
-                            onChanged: (String value) {
-                              widget.viewOnChanged?.call(value);
-                              updateSuggestions();
-                            },
-                            onSubmitted: widget.viewOnSubmitted,
-                            textCapitalization: widget.textCapitalization,
-                            textInputAction: widget.textInputAction,
-                            keyboardType: widget.keyboardType,
-                            smartDashesType: widget.smartDashesType,
-                            smartQuotesType: widget.smartQuotesType,
-                          ),
-                        ),
+                          ],
+                        ],
                       ),
-                      if (!effectiveShrinkWrap ||
-                          minHeight > 0 ||
-                          widget.showFullScreenView ||
-                          result.isNotEmpty) ...<Widget>[
-                        FadeTransition(opacity: viewDividerFadeCurve, child: viewDivider),
-                        Flexible(
-                          fit: (effectiveShrinkWrap && !widget.showFullScreenView)
-                              ? FlexFit.loose
-                              : FlexFit.tight,
-                          child: FadeTransition(
-                            opacity: viewListFadeOnIntervalCurve,
-                            child: widget.viewBuilder == null
-                                ? MediaQuery.removePadding(
-                                    context: context,
-                                    removeTop: true,
-                                    child: ListView(
-                                      padding: EdgeInsets.only(
-                                        bottom: MediaQuery.viewInsetsOf(context).bottom,
-                                      ),
-                                      shrinkWrap: effectiveShrinkWrap,
-                                      children: result.toList(),
-                                    ),
-                                  )
-                                : widget.viewBuilder!(result),
-                          ),
-                        ),
-                      ],
-                    ],
+                    ),
                   ),
                 ),
               ),
             ),
           ),
-        ),
-      ),
+        );
+      },
     );
   }
 }

--- a/packages/flutter/test/material/search_anchor_test.dart
+++ b/packages/flutter/test/material/search_anchor_test.dart
@@ -3495,9 +3495,9 @@ void main() {
     expect(box.size.height, 32);
   });
 
-  testWidgets(
-    'Tapping outside searchbar should unfocus the searchbar on mobile',
-    (WidgetTester tester) async {
+  testWidgets('Tapping outside searchbar should unfocus the searchbar on mobile', (
+    WidgetTester tester,
+  ) async {
     final focusNode = FocusNode(debugLabel: 'Test Node');
     addTearDown(focusNode.dispose);
     await tester.pumpWidget(
@@ -3537,9 +3537,7 @@ void main() {
     await tester.pump();
 
     expect(focusNode.hasPrimaryFocus, isFalse);
-    },
-    variant: TargetPlatformVariant.mobile(),
-  );
+  }, variant: TargetPlatformVariant.mobile());
 
   testWidgets('The default clear button only shows when text input is not empty '
       'on the search view', (WidgetTester tester) async {

--- a/packages/flutter/test/material/search_anchor_test.dart
+++ b/packages/flutter/test/material/search_anchor_test.dart
@@ -4434,6 +4434,74 @@ void main() {
     expect(rotatedSize.width, landscapeModeWidth);
     expect(rotatedSize.height, landscapeModeHeight);
   });
+
+  testWidgets('SearchAnchor full-screen height matches resized parent height', (
+    WidgetTester tester,
+  ) async {
+    addTearDown(tester.view.reset);
+
+    var parentHeight = 400.0;
+    late StateSetter setState;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        builder: (BuildContext context, Widget? child) {
+          return Scaffold(
+            body: StatefulBuilder(
+              builder: (BuildContext context, StateSetter stateSetter) {
+                setState = stateSetter;
+                return SizedBox(height: parentHeight, width: 800.0, child: child);
+              },
+            ),
+          );
+        },
+        home: Material(
+          child: SearchAnchor(
+            isFullScreen: true,
+            builder: (BuildContext context, SearchController controller) {
+              return IconButton(
+                icon: const Icon(Icons.search),
+                onPressed: () {
+                  controller.openView();
+                },
+              );
+            },
+            suggestionsBuilder: (BuildContext context, SearchController controller) {
+              return <Widget>[];
+            },
+          ),
+        ),
+      ),
+    );
+
+    // Open search view.
+    await tester.tap(find.byIcon(Icons.search));
+    await tester.pumpAndSettle();
+
+    // Verify search view height matches parent height (400.0).
+    Size size = getSearchViewSize(tester);
+    expect(size.height, 400.0);
+
+    // Resize the parent container to 500.0.
+    setState(() {
+      parentHeight = 500.0;
+    });
+    await tester.pumpAndSettle();
+
+    // Verify the view expands to 500.0.
+    size = getSearchViewSize(tester);
+    expect(size.height, 500.0);
+
+    // Resize the parent container to 300.0.
+    setState(() {
+      parentHeight = 300.0;
+    });
+    await tester.pumpAndSettle();
+
+    // Verify the view shrinks to 300.0.
+    size = getSearchViewSize(tester);
+    expect(size.height, 300.0);
+  });
 }
 
 Future<void> checkSearchBarDefaults(

--- a/packages/flutter/test/material/search_anchor_test.dart
+++ b/packages/flutter/test/material/search_anchor_test.dart
@@ -4435,6 +4435,7 @@ void main() {
     expect(rotatedSize.height, landscapeModeHeight);
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/186154.
   testWidgets('SearchAnchor full-screen height matches resized parent height', (
     WidgetTester tester,
   ) async {
@@ -4445,29 +4446,39 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
-        builder: (BuildContext context, Widget? child) {
-          return Scaffold(
-            body: StatefulBuilder(
-              builder: (BuildContext context, StateSetter stateSetter) {
-                setState = stateSetter;
-                return SizedBox(height: parentHeight, width: 800.0, child: child);
-              },
-            ),
-          );
-        },
-        home: Material(
-          child: SearchAnchor(
-            isFullScreen: true,
-            builder: (BuildContext context, SearchController controller) {
-              return IconButton(
-                icon: const Icon(Icons.search),
-                onPressed: () {
-                  controller.openView();
-                },
+        home: Scaffold(
+          body: StatefulBuilder(
+            builder: (BuildContext context, StateSetter stateSetter) {
+              setState = stateSetter;
+              return SizedBox(
+                height: parentHeight,
+                width: 800.0,
+                child: Navigator(
+                  onGenerateRoute: (RouteSettings settings) {
+                    return MaterialPageRoute<void>(
+                      builder: (BuildContext context) {
+                        return Scaffold(
+                          body: SearchAnchor(
+                            isFullScreen: true,
+                            builder: (BuildContext context, SearchController controller) {
+                              return IconButton(
+                                icon: const Icon(Icons.search),
+                                onPressed: () {
+                                  controller.openView();
+                                },
+                              );
+                            },
+                            suggestionsBuilder:
+                                (BuildContext context, SearchController controller) {
+                                  return <Widget>[];
+                                },
+                          ),
+                        );
+                      },
+                    );
+                  },
+                ),
               );
-            },
-            suggestionsBuilder: (BuildContext context, SearchController controller) {
-              return <Widget>[];
             },
           ),
         ),

--- a/packages/flutter/test/material/search_anchor_test.dart
+++ b/packages/flutter/test/material/search_anchor_test.dart
@@ -4436,12 +4436,11 @@ void main() {
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/186154.
-  testWidgets('SearchAnchor full-screen height matches resized parent height', (
-    WidgetTester tester,
-  ) async {
+  testWidgets('SearchAnchor resizes itself to match Navigator parent', (WidgetTester tester) async {
     addTearDown(tester.view.reset);
 
     var parentHeight = 400.0;
+    var parentWidth = 600.0;
     late StateSetter setState;
 
     await tester.pumpWidget(
@@ -4452,7 +4451,7 @@ void main() {
               setState = stateSetter;
               return SizedBox(
                 height: parentHeight,
-                width: 800.0,
+                width: parentWidth,
                 child: Navigator(
                   onGenerateRoute: (RouteSettings settings) {
                     return MaterialPageRoute<void>(
@@ -4489,29 +4488,34 @@ void main() {
     await tester.tap(find.byIcon(Icons.search));
     await tester.pumpAndSettle();
 
-    // Verify search view height matches parent height (400.0).
+    // Verify search view size matches parent.
     Size size = getSearchViewSize(tester);
     expect(size.height, 400.0);
+    expect(size.width, 600.0);
 
-    // Resize the parent container to 500.0.
+    // Resize the parent container larger.
     setState(() {
       parentHeight = 500.0;
+      parentWidth = 700.0;
     });
     await tester.pumpAndSettle();
 
-    // Verify the view expands to 500.0.
+    // Verify the view expands to match parent.
     size = getSearchViewSize(tester);
     expect(size.height, 500.0);
+    expect(size.width, 700.0);
 
-    // Resize the parent container to 300.0.
+    // Resize the parent container smaller.
     setState(() {
       parentHeight = 300.0;
+      parentWidth = 400.0;
     });
     await tester.pumpAndSettle();
 
-    // Verify the view shrinks to 300.0.
+    // Verify the view shrinks to match parent.
     size = getSearchViewSize(tester);
     expect(size.height, 300.0);
+    expect(size.width, 400.0);
   });
 }
 

--- a/packages/flutter/test/material/search_anchor_test.dart
+++ b/packages/flutter/test/material/search_anchor_test.dart
@@ -3498,45 +3498,45 @@ void main() {
   testWidgets(
     'Tapping outside searchbar should unfocus the searchbar on mobile',
     (WidgetTester tester) async {
-      final focusNode = FocusNode(debugLabel: 'Test Node');
-      addTearDown(focusNode.dispose);
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: SearchAnchor(
-              builder: (BuildContext context, SearchController controller) {
-                return SearchBar(
-                  controller: controller,
-                  onTap: () {
-                    controller.openView();
-                  },
-                  onTapOutside: (PointerDownEvent event) {
-                    focusNode.unfocus();
-                  },
-                  onChanged: (_) {
-                    controller.openView();
-                  },
-                  autoFocus: true,
-                  focusNode: focusNode,
-                );
-              },
-              suggestionsBuilder: (BuildContext context, SearchController controller) {
-                return List<ListTile>.generate(5, (int index) {
-                  final item = 'item $index';
-                  return ListTile(title: Text(item));
-                });
-              },
-            ),
+    final focusNode = FocusNode(debugLabel: 'Test Node');
+    addTearDown(focusNode.dispose);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SearchAnchor(
+            builder: (BuildContext context, SearchController controller) {
+              return SearchBar(
+                controller: controller,
+                onTap: () {
+                  controller.openView();
+                },
+                onTapOutside: (PointerDownEvent event) {
+                  focusNode.unfocus();
+                },
+                onChanged: (_) {
+                  controller.openView();
+                },
+                autoFocus: true,
+                focusNode: focusNode,
+              );
+            },
+            suggestionsBuilder: (BuildContext context, SearchController controller) {
+              return List<ListTile>.generate(5, (int index) {
+                final item = 'item $index';
+                return ListTile(title: Text(item));
+              });
+            },
           ),
         ),
-      );
-      await tester.pump();
-      expect(focusNode.hasPrimaryFocus, isTrue);
+      ),
+    );
+    await tester.pump();
+    expect(focusNode.hasPrimaryFocus, isTrue);
 
-      await tester.tapAt(const Offset(50, 50));
-      await tester.pump();
+    await tester.tapAt(const Offset(50, 50));
+    await tester.pump();
 
-      expect(focusNode.hasPrimaryFocus, isFalse);
+    expect(focusNode.hasPrimaryFocus, isFalse);
     },
     variant: TargetPlatformVariant.mobile(),
   );
@@ -4382,6 +4382,60 @@ void main() {
     await tester.pump();
     expect(find.text('X'), findsOne);
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/186154.
+  testWidgets('SearchAnchor full-screen view expands to fit screen when rotated', (
+    WidgetTester tester,
+  ) async {
+    addTearDown(tester.view.reset);
+
+    // Start in portrait mode.
+    const portraitModeWidth = 360.0;
+    const portraitModeHeight = 800.0;
+    tester.view.physicalSize = const Size(portraitModeWidth, portraitModeHeight);
+    tester.view.devicePixelRatio = 1.0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: SearchAnchor(
+            isFullScreen: true,
+            builder: (BuildContext context, SearchController controller) {
+              return IconButton(
+                icon: const Icon(Icons.search),
+                onPressed: () {
+                  controller.openView();
+                },
+              );
+            },
+            suggestionsBuilder: (BuildContext context, SearchController controller) {
+              return <Widget>[];
+            },
+          ),
+        ),
+      ),
+    );
+
+    // Open search view.
+    await tester.tap(find.byIcon(Icons.search));
+    await tester.pumpAndSettle();
+
+    // Verify starting sizes match portrait mode.
+    final Size startingSize = getSearchViewSize(tester);
+    expect(startingSize.width, portraitModeWidth);
+    expect(startingSize.height, portraitModeHeight);
+
+    // Rotate to landscape mode.
+    const landscapeModeWidth = portraitModeHeight;
+    const landscapeModeHeight = portraitModeWidth;
+    tester.view.physicalSize = const Size(landscapeModeWidth, landscapeModeHeight);
+    await tester.pumpAndSettle();
+
+    // Verify the view expands to match landscape mode.
+    final Size rotatedSize = getSearchViewSize(tester);
+    expect(rotatedSize.width, landscapeModeWidth);
+    expect(rotatedSize.height, landscapeModeHeight);
+  });
 }
 
 Future<void> checkSearchBarDefaults(
@@ -4480,5 +4534,11 @@ Finder findViewContent() {
 Material getSearchViewMaterial(WidgetTester tester) {
   return tester.widget<Material>(
     find.descendant(of: findViewContent(), matching: find.byType(Material)).first,
+  );
+}
+
+Size getSearchViewSize(WidgetTester tester) {
+  return tester.getSize(
+    find.descendant(of: findViewContent(), matching: find.byType(ConstrainedBox)).first,
   );
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/186154

The search anchor overlay now expands to fill the entire screen when the device is rotated and `isFullScreen` is true.
For non-mobile devices, the open search anchor overlay is similarly resized when the the device size is changed.

Previously we were calculating the search view's max width whenever the search view's route was pushed/popped. Switched to using the constraints provided by `LayoutBuilder` so that we can recalculate the view's max width during the layout phase when the device is rotated.

#### Before

<img width="920" height="456" alt="Screenshot 2026-05-13 at 4 29 34 PM" src="https://github.com/user-attachments/assets/6e66852f-c396-49ca-a304-ad46c203a54c" />

#### After

<img width="928" height="454" alt="Screenshot 2026-05-14 at 10 15 56 AM" src="https://github.com/user-attachments/assets/871770b1-8560-429a-95ab-00afd9c0bd78" />


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
