### PR TITLE
Fix HostBuffer.emplace overflow at block boundary

### DIFF
--- a/engine/src/flutter/lib/gpu/lib/src/buffer.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/buffer.dart
@@ -266,7 +266,13 @@ base class HostBuffer {
     // If the padding is the full alignment size, then we're already aligned.
     // So reset the padding to zero.
     padding %= _gpuContext.minimumUniformByteAlignment;
-    if (_offsetCursor + padding >= blockLengthInBytes) {
+    // Allocate a new block if the upcoming write (cursor + padding +
+    // payload size) would extend past the end of the current block.
+    // Checking only `_offsetCursor + padding` is insufficient: if the
+    // cursor lands inside `[blockLengthInBytes - bytes.lengthInBytes,
+    // blockLengthInBytes)` the check would pass, but the subsequent
+    // `DeviceBuffer.overwrite` would reject the out-of-bounds write.
+    if (_offsetCursor + padding + bytes.lengthInBytes > blockLengthInBytes) {
       DeviceBuffer buffer = _allocateNewBlock(blockLengthInBytes);
       _buffers[_frameCursor].add(buffer);
       _bufferCursor++;

--- a/engine/src/flutter/testing/dart/gpu_test.dart
+++ b/engine/src/flutter/testing/dart/gpu_test.dart
@@ -252,6 +252,48 @@ void main() async {
     expect(view0.buffer, equals(view1.buffer));
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 
+  test('HostBuffer.emplace allocates a new block when the upcoming write '
+      'would extend past the current block end', () async {
+    // Regression test for https://github.com/flutter/flutter/issues/186526.
+    //
+    // The previous bounds check in `_allocateEmplacement` only considered
+    // the post-padding cursor, ignoring the size of the data about to be
+    // written. When the cursor landed inside
+    // `[blockLengthInBytes - bytes.lengthInBytes, blockLengthInBytes)`
+    // the check passed, and the subsequent `DeviceBuffer.overwrite` then
+    // failed because the write extended past the block end.
+    //
+    // Use a small `blockLengthInBytes` so the test does not need to
+    // allocate megabytes. The chosen sizes are constructed to be aligned
+    // for any `minimumUniformByteAlignment` value the platform might
+    // return (16/32/64/128/256), so the test is platform-independent.
+    const int blockLength = 1024;
+    final gpu.HostBuffer hostBuffer = gpu.gpuContext.createHostBuffer(
+      blockLengthInBytes: blockLength,
+    );
+
+    // First emplace: fill the cursor to (blockLength - 256). The size is
+    // a multiple of every alignment up to 256, so the next emplace's
+    // padding will be zero on every supported platform.
+    const int fillSize = blockLength - 256;
+    final gpu.BufferView fillView = hostBuffer.emplace(Uint8List(fillSize).buffer.asByteData());
+    expect(fillView.offsetInBytes, 0);
+    expect(fillView.lengthInBytes, fillSize);
+    expect(fillView.buffer.sizeInBytes, blockLength);
+
+    // Second emplace: 728 bytes. With the cursor at `fillSize` and zero
+    // padding, the write would extend to `fillSize + 728 = 1496 bytes`,
+    // overflowing the 1024-byte block. The fixed `_allocateEmplacement`
+    // must allocate a new block instead.
+    const int overflowingSize = 728;
+    final gpu.BufferView view = hostBuffer.emplace(Uint8List(overflowingSize).buffer.asByteData());
+
+    // The new view must reference a freshly-allocated block, not the
+    // original one, and start at offset 0 of that block.
+    expect(view.buffer, isNot(equals(fillView.buffer)));
+    expect(view.offsetInBytes, 0);
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
   test('GpuContext.createDeviceBuffer', () async {
     final gpu.DeviceBuffer deviceBuffer = gpu.gpuContext.createDeviceBuffer(
       gpu.StorageMode.hostVisible,


### PR DESCRIPTION
`HostBuffer._allocateEmplacement` decided whether to allocate a new block based on the post-padding cursor only, ignoring the size of the data being emplaced. When the cursor landed inside the range `[blockLengthInBytes - bytes.lengthInBytes, blockLengthInBytes)`, the check passed but the subsequent `DeviceBuffer.overwrite` rejected the write because it would extend past the block end, throwing:

  Failed to write range (offset=..., length=...) to HostBuffer-managed
  DeviceBuffer (frame=0, buffer=0, offset=...).

This was reproducible in flame_3d 3D apps once per-frame uniform traffic neared 1 MB at certain camera angles.

Include the upcoming write size in the boundary check:

    if (_offsetCursor + padding + bytes.lengthInBytes > blockLengthInBytes) {

The strict `>` (rather than `>=`) is intentional: a write that exactly fills the remaining space is valid and shouldn't waste a new block.

Adds a regression test that exercises the boundary by configuring a small `blockLengthInBytes` and emplacing a payload that would overflow the current block under the previous check.

Fixes #186526

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
