### PR TITLE
Clarify route transition animations

### DIFF
--- a/packages/flutter/lib/src/widgets/pages.dart
+++ b/packages/flutter/lib/src/widgets/pages.dart
@@ -114,6 +114,13 @@ class PageRouteBuilder<T> extends PageRoute<T> {
   /// {@template flutter.widgets.pageRouteBuilder.transitionsBuilder}
   /// Used to build the route's transitions.
   ///
+  /// The [animation] argument drives this route's own entrance and exit
+  /// transition. The [secondaryAnimation] argument drives transitions for this
+  /// route when another route is pushed on top of it or popped from above it, if
+  /// both routes allow transition coordination. See
+  /// [TransitionRoute.canTransitionTo] and
+  /// [TransitionRoute.canTransitionFrom].
+  ///
   /// See [ModalRoute.buildTransitions] for complete definition of the parameters.
   /// {@endtemplate}
   ///

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -2802,6 +2802,17 @@ typedef RoutePageBuilder =
 /// Signature for the function that builds a route's transitions.
 /// Used in [PageRouteBuilder] and [showGeneralDialog].
 ///
+/// The [animation] argument drives this route's transition when it is pushed
+/// onto or popped off the [Navigator]. The [secondaryAnimation] argument lets
+/// this route coordinate with the transition of the route above it: when a new
+/// route is pushed on top of this one, this route's [secondaryAnimation] runs
+/// from 0.0 to 1.0, and when that route is popped it runs from 1.0 to 0.0.
+///
+/// A route only receives a running [secondaryAnimation] when this route's
+/// [TransitionRoute.canTransitionTo] method and the next route's
+/// [TransitionRoute.canTransitionFrom] method both return true. Otherwise,
+/// [secondaryAnimation] remains [kAlwaysDismissedAnimation].
+///
 /// See [ModalRoute.buildTransitions] for complete definition of the parameters.
 typedef RouteTransitionsBuilder =
     Widget Function(


### PR DESCRIPTION
Issue: fixes https://github.com/flutter/flutter/issues/23206

The `PageRouteBuilder` and `RouteTransitionsBuilder` docs pointed readers to `ModalRoute.buildTransitions`, but the callback docs themselves did not explain the practical difference between the primary `animation` and `secondaryAnimation` parameters.

Fix:

Clarify that `animation` drives the route's own push/pop transition, while `secondaryAnimation` lets the route coordinate with a route pushed above it. The docs now also mention that `secondaryAnimation` only runs when the adjacent routes allow transition coordination through `canTransitionTo`/`canTransitionFrom`.

Tests:

- `./bin/dart format --output=none --set-exit-if-changed packages/flutter/lib/src/widgets/routes.dart packages/flutter/lib/src/widgets/pages.dart`
- `./bin/flutter analyze packages/flutter/lib/src/widgets/routes.dart packages/flutter/lib/src/widgets/pages.dart`
- `git diff --check`

Risk:

Docs-only change in two route API comments. No runtime behavior changes.
