### PR TITLE
Clarify ActivityAware v1 embedding support

### DIFF
--- a/docs/platforms/android/Upgrading-pre-1.12-Android-projects.md
+++ b/docs/platforms/android/Upgrading-pre-1.12-Android-projects.md
@@ -12,6 +12,8 @@ Your existing full-Flutter projects aren't immediately affected and will continu
 
 However, the new Android wrappers also introduce a new set of Android plugin development APIs. Plugins developed exclusively on the new plugins API will not work on older pre-1.12 Android projects. Building a pre-1.12 Android project that uses plugins created after 1.12 will yield a build-time error unless the plugin developer explicitly opted to create a second backward compatible implementation.
 
+Plugins that implement the new `ActivityAware` interface receive its callbacks only when the plugin is registered with the new Android embedding. Pre-1.12 Android projects that still use the old embedding invoke the plugin's v1 `registerWith` implementation instead, and do not invoke `ActivityAware` callbacks. Plugin authors who need to support those projects should keep a v1 `registerWith` path for any `Activity` access they need.
+
 Add-to-app was not officially supported on the old Android APIs. If you followed the experimental instructions in the wiki for add-to-app prior to 1.12, you should follow the migration steps under the [add-to-app section](#add-to-app-migration) below.
 
 # Full-Flutter app migration

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/plugins/FlutterPlugin.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/plugins/FlutterPlugin.java
@@ -64,6 +64,12 @@ import io.flutter.view.TextureRegistry;
  * for background behavior. Additionally, all plugins must respect that a {@code Activity}s may come
  * and go over time, thus requiring plugins to cleanup resources and recreate those resources as the
  * {@code Activity} comes and goes.
+ *
+ * <p>{@code ActivityAware} callbacks are invoked by the v2 Android embedding. The deprecated v1
+ * embedding invokes a plugin's static {@code registerWith} method instead and does not invoke
+ * {@code ActivityAware} callbacks. Plugins that support pre-1.12 Android projects should keep
+ * their v1 {@code registerWith} implementation for any {@code Activity} access needed by that
+ * embedding.
  */
 public interface FlutterPlugin {
 

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/plugins/activity/ActivityAware.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/plugins/activity/ActivityAware.java
@@ -10,6 +10,12 @@ import androidx.annotation.NonNull;
  * {@link io.flutter.embedding.engine.plugins.FlutterPlugin} that is interested in {@link
  * android.app.Activity} lifecycle events related to a {@link
  * io.flutter.embedding.engine.FlutterEngine} running within the given {@link android.app.Activity}.
+ *
+ * <p>This interface is part of the v2 Android embedding. The deprecated v1 embedding based on
+ * {@link io.flutter.app.FlutterActivity} and
+ * {@link io.flutter.plugin.common.PluginRegistry.Registrar} does not invoke these callbacks.
+ * Plugins that continue to support pre-1.12 Android projects should keep a separate v1 {@code
+ * registerWith} implementation for any {@link android.app.Activity} access they need.
  */
 public interface ActivityAware {
   /**


### PR DESCRIPTION
Fixes flutter/flutter#59556

## Description

`ActivityAware` is part of the v2 Android embedding, but the existing Javadocs did not say what happens for pre-1.12 projects still using the v1 embedding. This clarifies that v1 embedding projects invoke a plugin static `registerWith` path instead and do not call `ActivityAware` callbacks.

The change updates the `ActivityAware` Javadoc, the related `FlutterPlugin` overview, and the local pre-1.12 Android migration note.

## Tests

- `git diff --check`

Not run: engine Java formatting, because this checkout does not have the hermetic Java/google-java-format artifacts under `engine/src/flutter/third_party` without `gclient sync`.

## Risk

Docs-only change. No generated output.