### PR TITLE
os.dart: Switch the codepage to UTF-8 when calling where.exe

### DIFF
--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:ffi' show Abi;
+import 'dart:convert' show utf8;
 
 import 'package:archive/archive.dart';
 import 'package:file/file.dart';
@@ -505,7 +506,7 @@ class _WindowsUtils extends OperatingSystemUtils {
       );
     }
     // `where` always returns all matches, not just the first one.
-    final ProcessResult result = _processManager.runSync(<String>['where', execName]);
+    final ProcessResult result = _processManager.runSync(<String>['chcp', '65001', '&&', 'where', execName], stdoutEncoding: utf8);
     if (result.exitCode != 0) {
       return const <File>[];
     }

--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -506,7 +506,7 @@ class _WindowsUtils extends OperatingSystemUtils {
       );
     }
     // `where` always returns all matches, not just the first one.
-    final ProcessResult result = _processManager.runSync(<String>['chcp', '65001', '&&', 'where', execName], stdoutEncoding: utf8);
+    final ProcessResult result = _processManager.runSync(<String>['chcp', '65001', '>', 'nul', '&&', 'where', execName], runInShell: true, stdoutEncoding: utf8);
     if (result.exitCode != 0) {
       return const <File>[];
     }


### PR DESCRIPTION
Currently the output of `where` on Windows is decoded using the system default code page queried through `GetACP()`. However, since `where` expects to be run from a console it uses the console output code page.

On a standard windows configuration these two code pages are different and one cannot be safely interpreted as the other. For example, in a U.S. locale this would cause the console code page 437 to be interpreted as code page 1252.

By prefixing the `where` command with `chcp 65001` we can ensure UTF-8 encoding is being used resolving the conflict and forcing an encoding that is much safer for filesystem paths.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
