### PR TITLE
[Android] Make DartEntrypoint only optionally take a bundle path (#74828)

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
@@ -19,6 +19,7 @@ import io.flutter.util.TraceSection;
 import io.flutter.view.FlutterCallbackInformation;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Configures, bootstraps, and starts executing Dart code.
@@ -152,8 +153,17 @@ public class DartExecutor implements BinaryMessenger {
 
     try (TraceSection e = TraceSection.scoped("DartExecutor#executeDartEntrypoint")) {
       Log.v(TAG, "Executing Dart entrypoint: " + dartEntrypoint);
+      String pathToBundle = dartEntrypoint.pathToBundle;
+      if (pathToBundle == null) {
+        FlutterLoader flutterLoader = FlutterInjector.instance().flutterLoader();
+        if (!flutterLoader.initialized()) {
+          throw new AssertionError(
+              "DartEntrypoints can only be run once a FlutterEngine is created or the FlutterLoader is initialized.");
+        }
+        pathToBundle = flutterLoader.findAppBundlePath();
+      }
       flutterJNI.runBundleAndSnapshotFromLibrary(
-          dartEntrypoint.pathToBundle,
+          pathToBundle,
           dartEntrypoint.dartEntrypointFunctionName,
           dartEntrypoint.dartEntrypointLibrary,
           assetManager,
@@ -344,7 +354,7 @@ public class DartExecutor implements BinaryMessenger {
     }
 
     /** The path within the AssetManager where the app will look for assets. */
-    @NonNull public final String pathToBundle;
+    @Nullable public final String pathToBundle;
 
     /** The library or file location that contains the Dart entrypoint function. */
     @Nullable public final String dartEntrypointLibrary;
@@ -352,16 +362,22 @@ public class DartExecutor implements BinaryMessenger {
     /** The name of a Dart function to execute. */
     @NonNull public final String dartEntrypointFunctionName;
 
+    public DartEntrypoint(@NonNull String dartEntrypointFunctionName) {
+      this.pathToBundle = null;
+      this.dartEntrypointLibrary = null;
+      this.dartEntrypointFunctionName = dartEntrypointFunctionName;
+    }
+
     public DartEntrypoint(
-        @NonNull String pathToBundle, @NonNull String dartEntrypointFunctionName) {
+        @Nullable String pathToBundle, @NonNull String dartEntrypointFunctionName) {
       this.pathToBundle = pathToBundle;
       dartEntrypointLibrary = null;
       this.dartEntrypointFunctionName = dartEntrypointFunctionName;
     }
 
     public DartEntrypoint(
-        @NonNull String pathToBundle,
-        @NonNull String dartEntrypointLibrary,
+        @Nullable String pathToBundle,
+        @Nullable String dartEntrypointLibrary,
         @NonNull String dartEntrypointFunctionName) {
       this.pathToBundle = pathToBundle;
       this.dartEntrypointLibrary = dartEntrypointLibrary;
@@ -385,13 +401,13 @@ public class DartExecutor implements BinaryMessenger {
 
       DartEntrypoint that = (DartEntrypoint) o;
 
-      if (!pathToBundle.equals(that.pathToBundle)) return false;
+      if (!Objects.equals(pathToBundle, that.pathToBundle)) return false;
       return dartEntrypointFunctionName.equals(that.dartEntrypointFunctionName);
     }
 
     @Override
     public int hashCode() {
-      int result = pathToBundle.hashCode();
+      int result = pathToBundle != null ? pathToBundle.hashCode() : 0;
       result = 31 * result + dartEntrypointFunctionName.hashCode();
       return result;
     }

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/dart/DartExecutorTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/dart/DartExecutorTest.java
@@ -7,6 +7,7 @@ package io.flutter.embedding.engine.dart;
 import static junit.framework.TestCase.assertNotNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -85,5 +86,65 @@ public class DartExecutorTest {
     DartEntrypoint entrypoint = DartEntrypoint.createDefault();
     assertEquals(entrypoint.pathToBundle, "my/custom/path");
     assertEquals(entrypoint.dartEntrypointFunctionName, "main");
+  }
+
+  // ===========================================================================
+  // REPRODUCTION TESTS: Make DartEntrypoint only optionally take a bundle path.
+  // ===========================================================================
+
+  @Test
+  public void dartEntrypointCanBeConstructedWithoutBundlePath() {
+    DartEntrypoint entrypoint = new DartEntrypoint("customMain");
+    assertEquals(null, entrypoint.pathToBundle);
+    assertEquals("customMain", entrypoint.dartEntrypointFunctionName);
+    assertEquals(null, entrypoint.dartEntrypointLibrary);
+  }
+
+  @Test
+  public void dartEntrypointWithLibraryCanBeConstructedWithoutBundlePath() {
+    // Use the 3-arg constructor with null pathToBundle to avoid signature clash
+    DartEntrypoint entrypoint = new DartEntrypoint(null, "customLibrary", "customMain");
+    assertEquals(null, entrypoint.pathToBundle);
+    assertEquals("customLibrary", entrypoint.dartEntrypointLibrary);
+    assertEquals("customMain", entrypoint.dartEntrypointFunctionName);
+  }
+
+  @Test
+  public void executeDartEntrypointResolvesBundlePathFromInjector() {
+    when(mockFlutterLoader.initialized()).thenReturn(true);
+    when(mockFlutterLoader.findAppBundlePath()).thenReturn("injector/resolved/path");
+    FlutterInjector.setInstance(
+        new FlutterInjector.Builder().setFlutterLoader(mockFlutterLoader).build());
+
+    FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
+    DartExecutor executor = new DartExecutor(mockFlutterJNI, mock(AssetManager.class));
+
+    DartEntrypoint entrypoint = new DartEntrypoint("customMain");
+    executor.executeDartEntrypoint(entrypoint);
+
+    verify(mockFlutterJNI, times(1))
+        .runBundleAndSnapshotFromLibrary(
+            eq("injector/resolved/path"),
+            eq("customMain"),
+            eq(null),
+            any(AssetManager.class),
+            eq(null),
+            eq(0L));
+  }
+
+  @Test
+  public void executeDartEntrypointWithoutBundlePathThrowsWhenLoaderUninitialized() {
+    when(mockFlutterLoader.initialized()).thenReturn(false);
+    FlutterInjector.setInstance(
+        new FlutterInjector.Builder().setFlutterLoader(mockFlutterLoader).build());
+
+    DartEntrypoint entrypoint = new DartEntrypoint("customMain");
+    DartExecutor executor = new DartExecutor(mock(FlutterJNI.class), mock(AssetManager.class));
+
+    assertThrows(
+        AssertionError.class,
+        () -> {
+          executor.executeDartEntrypoint(entrypoint);
+        });
   }
 }


### PR DESCRIPTION
Make DartEntrypoint only optionally take a bundle path. 

Fixes: #74828 

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.