### PR TITLE
[web] Enable WebAssembly on latest Safari (Safari 26+)

### DIFF
--- a/engine/src/flutter/lib/web_ui/flutter_js/src/browser_environment.js
+++ b/engine/src/flutter/lib/web_ui/flutter_js/src/browser_environment.js
@@ -6,7 +6,7 @@
 export const defaultWasmSupport = {
   "blink": true,
   "gecko": false,
-  "webkit": false,
+  "webkit": true,
   "unknown": false,
 }
 
@@ -30,6 +30,25 @@ const getBrowserEngine = () => {
 /** @type {import("./types").BrowserEngine} */
 const browserEngine = getBrowserEngine();
 
+const getWebKitVersion = () => {
+  const ua = navigator.userAgent;
+  const versionMatch = ua.match(/Version\/(\d+)(?:\.(\d+))?/);
+  if (versionMatch) {
+    return {
+      major: parseInt(versionMatch[1], 10),
+      minor: parseInt(versionMatch[2] || "0", 10),
+    };
+  }
+  const iosMatch = ua.match(/(?:CPU iPhone OS|CPU OS) (\d+)(?:_(\d+))?/);
+  if (iosMatch) {
+    return {
+      major: parseInt(iosMatch[1], 10),
+      minor: parseInt(iosMatch[2] || "0", 10),
+    };
+  }
+  return null;
+};
+
 const hasImageCodecs = () => {
   if (typeof ImageDecoder === "undefined") {
     return false;
@@ -49,13 +68,22 @@ const hasChromiumBreakIterators = () => {
     (typeof Intl.Segmenter !== "undefined");
 }
 
-const supportsWasmGC = () => {
+export const supportsWasmGC = () => {
   // This attempts to instantiate a wasm module that only will validate if the
   // final WasmGC spec is implemented in the browser.
   //
   // Copied from https://github.com/GoogleChromeLabs/wasm-feature-detect/blob/main/src/detectors/gc/index.js
   const bytes = [0, 97, 115, 109, 1, 0, 0, 0, 1, 5, 1, 95, 1, 120, 0];
-  return WebAssembly.validate(new Uint8Array(bytes));
+  if (!WebAssembly.validate(new Uint8Array(bytes))) {
+    return false;
+  }
+  if (getBrowserEngine() === "webkit") {
+    const version = getWebKitVersion();
+    if (!version || version.major < 26) {
+      return false;
+    }
+  }
+  return true;
 }
 
 const detectWebGLVersion = () => {

--- a/engine/src/flutter/lib/web_ui/flutter_js/src/flutter.js
+++ b/engine/src/flutter/lib/web_ui/flutter_js/src/flutter.js
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import { FlutterLoader } from './loader.js';
+import { supportsWasmGC } from './browser_environment.js';
 
 if (!window._flutter) {
   window._flutter = {};
@@ -11,3 +12,5 @@ if (!window._flutter) {
 if (!window._flutter.loader) {
   window._flutter.loader = new FlutterLoader();
 }
+
+window._flutter._supportsWasmGC = supportsWasmGC;

--- a/engine/src/flutter/lib/web_ui/test/engine/browser_environment_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/browser_environment_test.dart
@@ -1,0 +1,87 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:js_interop';
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/src/engine/dom.dart';
+
+@JS('_flutter._supportsWasmGC')
+external bool supportsWasmGC();
+
+void mockUserAgent(String userAgent) {
+  objectConstructor.defineProperty(
+    domWindow.navigator as JSObject,
+    'userAgent',
+    DomPropertyDataDescriptor(value: userAgent, configurable: true),
+  );
+}
+
+void mockVendor(String vendor) {
+  objectConstructor.defineProperty(
+    domWindow.navigator as JSObject,
+    'vendor',
+    DomPropertyDataDescriptor(value: vendor, configurable: true),
+  );
+}
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+void testMain() {
+  group('browserEnvironment supportsWasmGC', () {
+    late String originalUserAgent;
+    late String originalVendor;
+
+    setUpAll(() {
+      originalUserAgent = domWindow.navigator.userAgent;
+      originalVendor = domWindow.navigator.vendor;
+    });
+
+    tearDownAll(() {
+      mockVendor(originalVendor);
+      mockUserAgent(originalUserAgent);
+    });
+
+    test('correctly identifies and gates WebKit / Safari versions', () {
+      // 1. Desktop Safari 18.2 UA (Crashing version)
+      mockVendor('Apple Computer, Inc.');
+      mockUserAgent(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 '
+        '(KHTML, like Gecko) Version/18.2 Safari/605.1.15',
+      );
+      expect(supportsWasmGC(), isFalse);
+
+      // 2. Desktop Safari 26.0 UA (Fixed version)
+      mockUserAgent(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 '
+        '(KHTML, like Gecko) Version/26.0 Safari/605.1.15',
+      );
+      expect(supportsWasmGC(), isTrue);
+
+      // 3. iOS WKWebView UA (iOS 18_2)
+      mockUserAgent(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 18_2 like Mac OS X) '
+        'AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148',
+      );
+      expect(supportsWasmGC(), isFalse);
+
+      // 4. iOS WKWebView UA (iOS 26_0)
+      mockUserAgent(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 26_0 like Mac OS X) '
+        'AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148',
+      );
+      expect(supportsWasmGC(), isTrue);
+
+      // 5. macOS WKWebView UA (Frozen OS version)
+      mockUserAgent(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) '
+        'AppleWebKit/605.1.15 (KHTML, like Gecko)',
+      );
+      expect(supportsWasmGC(), isFalse);
+    });
+  });
+}

--- a/engine/src/flutter/lib/web_ui/test/felt_config.yaml
+++ b/engine/src/flutter/lib/web_ui/test/felt_config.yaml
@@ -247,13 +247,11 @@ test-suites:
     test-bundle: dart2wasm-canvaskit-engine
     run-config: safari-wasm
     artifact-deps: [ canvaskit ]
-    enable-ci: false
 
   - name: safari-dart2wasm-skwasm-ui
     test-bundle: dart2wasm-skwasm-ui
     run-config: safari-wasm
     artifact-deps: [ skwasm ]
-    enable-ci: false
 
   - name: chrome-dart2wasm-canvaskit-engine
     test-bundle: dart2wasm-canvaskit-engine


### PR DESCRIPTION
Early implementations of WasmGC in Safari 18 syntactically validate WasmGC bytecode but crash at runtime during reference casting (WebKit Bug 295799). This change safely enables WebAssembly (both skwasm and dart2wasm + canvaskit) on Safari 26+ where WasmGC is fully stable, while ensuring older Safari builds defensively fall back to JavaScript (dart2js).

* browser_environment.js: Added getWebKitVersion() to reliably extract major/minor WebKit versions across standalone Safari (macOS/iOS), iPad Desktop Mode, and WKWebViews (using iOS OS version as a surrogate). Updated supportsWasmGC() to enforce a minimum WebKit major version threshold of 26, and enabled defaultWasmSupport["webkit"] = true.
* flutter.js: Exposed _supportsWasmGC on window._flutter to allow hermetic unit testing via Dart JS interop.
* browser_environment_test.dart: Added hermetic unit tests mocking navigator.vendor and navigator.userAgent to verify version gating across all 5 WebKit UA permutations.
* felt_config.yaml: Removed enable-ci: false from safari-dart2wasm-canvaskit-engine and safari-dart2wasm-skwasm-ui to re-enable automated CI testing.

Fixes https://github.com/flutter/flutter/issues/178893
