### PR TITLE
Allow target platform override teardown in widget tests

### DIFF
--- a/packages/flutter/lib/src/foundation/debug.dart
+++ b/packages/flutter/lib/src/foundation/debug.dart
@@ -31,19 +31,15 @@ export 'print.dart' show DebugPrintCallback;
 /// override [debugPrint] themselves and want to check that their own custom
 /// value wasn't overridden by a test.
 ///
-/// The `debugDefaultTargetPlatformOverrideValue` argument can be specified
-/// to indicate the expected value of [debugDefaultTargetPlatformOverride].
-///
 /// See [the foundation library](foundation/foundation-library.html)
 /// for a complete list.
 bool debugAssertAllFoundationVarsUnset(
   String reason, {
   DebugPrintCallback debugPrintOverride = debugPrintThrottled,
-  TargetPlatform? debugDefaultTargetPlatformOverrideValue,
 }) {
   assert(() {
     if (debugPrint != debugPrintOverride ||
-        debugDefaultTargetPlatformOverride != debugDefaultTargetPlatformOverrideValue ||
+        debugDefaultTargetPlatformOverride != null ||
         debugDoublePrecision != null ||
         debugBrightnessOverride != null) {
       throw FlutterError(reason);

--- a/packages/flutter/lib/src/foundation/debug.dart
+++ b/packages/flutter/lib/src/foundation/debug.dart
@@ -31,15 +31,19 @@ export 'print.dart' show DebugPrintCallback;
 /// override [debugPrint] themselves and want to check that their own custom
 /// value wasn't overridden by a test.
 ///
+/// The `debugDefaultTargetPlatformOverrideValue` argument can be specified
+/// to indicate the expected value of [debugDefaultTargetPlatformOverride].
+///
 /// See [the foundation library](foundation/foundation-library.html)
 /// for a complete list.
 bool debugAssertAllFoundationVarsUnset(
   String reason, {
   DebugPrintCallback debugPrintOverride = debugPrintThrottled,
+  TargetPlatform? debugDefaultTargetPlatformOverrideValue,
 }) {
   assert(() {
     if (debugPrint != debugPrintOverride ||
-        debugDefaultTargetPlatformOverride != null ||
+        debugDefaultTargetPlatformOverride != debugDefaultTargetPlatformOverrideValue ||
         debugDoublePrecision != null ||
         debugBrightnessOverride != null) {
       throw FlutterError(reason);

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -2013,6 +2013,10 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   bool _pendingInvariantVerification = false;
 
   /// Defers invariant verification until [verifyInvariantsAfterTestTearDown].
+  ///
+  /// This is used by [testWidgets], which can install package:test tearDown
+  /// callbacks around [runTest]. Direct [runTest] callers still verify
+  /// invariants before [postTest].
   @protected
   void deferInvariantsUntilAfterTestTearDown() {
     _verifyInvariantsAfterTestTearDown = true;

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1996,8 +1996,11 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
       _verifyReportTestExceptionUnset(reportTestExceptionBeforeTest);
       _verifyErrorWidgetBuilderUnset(errorWidgetBuilderBeforeTest);
       _verifyShouldPropagateDevicePointerEventsUnset(shouldPropagateDevicePointerEventsBeforeTest);
-      _verifyInvariants(allowDebugDefaultTargetPlatformOverride: true);
-      _verifyInvariantsAfterTestTearDown = true;
+      if (_verifyInvariantsAfterTestTearDown) {
+        _pendingInvariantVerification = true;
+      } else {
+        _verifyInvariants();
+      }
     }
 
     assert(inTest);
@@ -2007,8 +2010,15 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   late bool _beforeTestCheckIntrinsicSizes;
 
   bool _verifyInvariantsAfterTestTearDown = false;
+  bool _pendingInvariantVerification = false;
 
-  void _verifyInvariants({bool allowDebugDefaultTargetPlatformOverride = false}) {
+  /// Defers invariant verification until [verifyInvariantsAfterTestTearDown].
+  @protected
+  void deferInvariantsUntilAfterTestTearDown() {
+    _verifyInvariantsAfterTestTearDown = true;
+  }
+
+  void _verifyInvariants() {
     assert(
       debugAssertNoTransientCallbacks(
         'An animation is still running even after the widget tree was disposed.',
@@ -2024,9 +2034,6 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
       debugAssertAllFoundationVarsUnset(
         'The value of a foundation debug variable was changed by the test.',
         debugPrintOverride: debugPrintOverride,
-        debugDefaultTargetPlatformOverrideValue: allowDebugDefaultTargetPlatformOverride
-            ? debugDefaultTargetPlatformOverride
-            : null,
       ),
     );
     assert(
@@ -2066,16 +2073,13 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   /// Called after user-registered `addTearDown` callbacks have run.
   @protected
   void verifyInvariantsAfterTestTearDown() {
-    if (!_verifyInvariantsAfterTestTearDown) {
+    final bool shouldVerifyInvariants = _pendingInvariantVerification;
+    _verifyInvariantsAfterTestTearDown = false;
+    _pendingInvariantVerification = false;
+    if (!shouldVerifyInvariants) {
       return;
     }
-    _verifyInvariantsAfterTestTearDown = false;
-    assert(
-      debugAssertAllFoundationVarsUnset(
-        'The value of a foundation debug variable was changed by the test.',
-        debugPrintOverride: debugPrintOverride,
-      ),
-    );
+    _verifyInvariants();
   }
 
   void _verifyAutoUpdateGoldensUnset(bool valueBeforeTest) {
@@ -2567,10 +2571,8 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
   }
 
   @override
-  void _verifyInvariants({bool allowDebugDefaultTargetPlatformOverride = false}) {
-    super._verifyInvariants(
-      allowDebugDefaultTargetPlatformOverride: allowDebugDefaultTargetPlatformOverride,
-    );
+  void _verifyInvariants() {
+    super._verifyInvariants();
 
     assert(inTest);
 

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1996,7 +1996,8 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
       _verifyReportTestExceptionUnset(reportTestExceptionBeforeTest);
       _verifyErrorWidgetBuilderUnset(errorWidgetBuilderBeforeTest);
       _verifyShouldPropagateDevicePointerEventsUnset(shouldPropagateDevicePointerEventsBeforeTest);
-      _verifyInvariants();
+      _verifyInvariants(allowDebugDefaultTargetPlatformOverride: true);
+      _verifyInvariantsAfterTestTearDown = true;
     }
 
     assert(inTest);
@@ -2005,7 +2006,9 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
 
   late bool _beforeTestCheckIntrinsicSizes;
 
-  void _verifyInvariants() {
+  bool _verifyInvariantsAfterTestTearDown = false;
+
+  void _verifyInvariants({bool allowDebugDefaultTargetPlatformOverride = false}) {
     assert(
       debugAssertNoTransientCallbacks(
         'An animation is still running even after the widget tree was disposed.',
@@ -2021,6 +2024,9 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
       debugAssertAllFoundationVarsUnset(
         'The value of a foundation debug variable was changed by the test.',
         debugPrintOverride: debugPrintOverride,
+        debugDefaultTargetPlatformOverrideValue: allowDebugDefaultTargetPlatformOverride
+            ? debugDefaultTargetPlatformOverride
+            : null,
       ),
     );
     assert(
@@ -2053,6 +2059,21 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
     assert(
       debugAssertAllServicesVarsUnset(
         'The value of a services debug variable was changed by the test.',
+      ),
+    );
+  }
+
+  /// Called after user-registered `addTearDown` callbacks have run.
+  @protected
+  void verifyInvariantsAfterTestTearDown() {
+    if (!_verifyInvariantsAfterTestTearDown) {
+      return;
+    }
+    _verifyInvariantsAfterTestTearDown = false;
+    assert(
+      debugAssertAllFoundationVarsUnset(
+        'The value of a foundation debug variable was changed by the test.',
+        debugPrintOverride: debugPrintOverride,
       ),
     );
   }
@@ -2546,8 +2567,10 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
   }
 
   @override
-  void _verifyInvariants() {
-    super._verifyInvariants();
+  void _verifyInvariants({bool allowDebugDefaultTargetPlatformOverride = false}) {
+    super._verifyInvariants(
+      allowDebugDefaultTargetPlatformOverride: allowDebugDefaultTargetPlatformOverride,
+    );
 
     assert(inTest);
 

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -181,6 +181,9 @@ void testWidgets(
           semanticsHandle = tester.ensureSemantics();
         }
         test_package.addTearDown(binding.postTest);
+        // This internal hook must run after user addTearDown callbacks and before postTest.
+        // ignore: invalid_use_of_protected_member
+        test_package.addTearDown(binding.verifyInvariantsAfterTestTearDown);
         return binding.runTest(
           () async {
             debugResetSemanticsIdCounter();

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -180,8 +180,10 @@ void testWidgets(
         if (semanticsEnabled) {
           semanticsHandle = tester.ensureSemantics();
         }
+        // Invariant verification must run after user addTearDown callbacks and before postTest.
+        // ignore: invalid_use_of_protected_member
+        binding.deferInvariantsUntilAfterTestTearDown();
         test_package.addTearDown(binding.postTest);
-        // This internal hook must run after user addTearDown callbacks and before postTest.
         // ignore: invalid_use_of_protected_member
         test_package.addTearDown(binding.verifyInvariantsAfterTestTearDown);
         return binding.runTest(

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -180,7 +180,10 @@ void testWidgets(
         if (semanticsEnabled) {
           semanticsHandle = tester.ensureSemantics();
         }
-        // Invariant verification must run after user addTearDown callbacks and before postTest.
+        // testWidgets owns the package:test tearDown callbacks, so it can
+        // defer binding invariant verification until after user addTearDown
+        // callbacks and before postTest. Lower-level binding.runTest callers
+        // keep the immediate invariant check inside runTest.
         // ignore: invalid_use_of_protected_member
         binding.deferInvariantsUntilAfterTestTearDown();
         test_package.addTearDown(binding.postTest);

--- a/packages/flutter_test/test/bindings_invariants_test.dart
+++ b/packages/flutter_test/test/bindings_invariants_test.dart
@@ -6,14 +6,17 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('debugDefaultTargetPlatformOverride can be reset with addTearDown', (
+  testWidgets('foundation debug variables can be reset with addTearDown', (
     WidgetTester tester,
   ) async {
     debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    debugDoublePrecision = 3;
     addTearDown(() {
       debugDefaultTargetPlatformOverride = null;
+      debugDoublePrecision = null;
     });
 
     expect(defaultTargetPlatform, TargetPlatform.macOS);
+    expect(debugDoublePrecision, 3);
   });
 }

--- a/packages/flutter_test/test/bindings_invariants_test.dart
+++ b/packages/flutter_test/test/bindings_invariants_test.dart
@@ -1,0 +1,19 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('debugDefaultTargetPlatformOverride can be reset with addTearDown', (
+    WidgetTester tester,
+  ) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    addTearDown(() {
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    expect(defaultTargetPlatform, TargetPlatform.macOS);
+  });
+}


### PR DESCRIPTION
Issue: Fixes https://github.com/flutter/flutter/issues/110488.

`testWidgets` used to verify Flutter test invariants before package:test executed per-test `addTearDown` callbacks. That made cleanup such as `addTearDown(() => debugDefaultTargetPlatformOverride = null)` fail even though it is the safer cleanup pattern when the test body can fail before manual cleanup runs. The same ordering problem applies to other Flutter debug invariants, not just the target platform override.

Fix: Defer the full Flutter invariant verification for `testWidgets` until after user `addTearDown` callbacks have run, but before `postTest` resets binding state. Direct `binding.runTest` callers keep the existing immediate invariant verification unless they explicitly opt into the deferred hook.

Tests:

- `./bin/flutter test packages/flutter_test/test/bindings_invariants_test.dart`
- `./bin/flutter test packages/flutter_test/test/widget_tester_test.dart`
- `./bin/flutter test packages/flutter_test/test/event_simulation_test.dart --plain-name "debugKeyEventSimulatorTransitModeOverride overrides default transit mode"`
- `./bin/flutter analyze packages/flutter/lib/src/foundation/debug.dart packages/flutter_test/lib/src/binding.dart packages/flutter_test/lib/src/widget_tester.dart packages/flutter_test/test/bindings_invariants_test.dart`
- `./bin/dart format --output=none --set-exit-if-changed packages/flutter/lib/src/foundation/debug.dart packages/flutter_test/lib/src/binding.dart packages/flutter_test/lib/src/widget_tester.dart packages/flutter_test/test/bindings_invariants_test.dart`
- `git diff --check`

Risk: This is limited to flutter_test binding cleanup. The invariant checks still run before `postTest`; tests that leave debug state dirty after their `addTearDown` callbacks still fail.
