### PR TITLE
Restore ANSI colors from iOS simulator logs

### DIFF
--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -982,6 +982,26 @@ class _IOSSimulatorLogReader extends SharedIOSDeviceLogReader {
 
   //   "eventMessage" : "flutter: 21",
   static final _unifiedLoggingEventMessageRegex = RegExp(r'.*"eventMessage" : (".*")');
+  static final _appleEscapedAnsiSequenceRegex = RegExp(r'\\\^\[\[([0-9;?]*[ -/]*[@-~])');
+  static const _appleEscapedAnsiEscape = '<\u{2026}>';
+
+  /// Restores ANSI ESC bytes rendered as printable text by Apple unified logging.
+  ///
+  /// CSI introducers are reported as r'\^[[' and some later ESC bytes as
+  /// '<\u{2026}>'.
+  static String _restoreAppleEscapedAnsiSequences(String message) {
+    if (!_appleEscapedAnsiSequenceRegex.hasMatch(message) &&
+        !message.contains(_appleEscapedAnsiEscape)) {
+      return message;
+    }
+
+    final String restoredCsiSequences = message.replaceAllMapped(
+      _appleEscapedAnsiSequenceRegex,
+      (Match match) => '\x1B[${match.group(1)}',
+    );
+    return restoredCsiSequences.replaceAll(_appleEscapedAnsiEscape, '\x1B');
+  }
+
   void _onUnifiedLoggingLine(String line) {
     // The log command predicate handles filtering, so every log eventMessage should be decoded and added.
     final Match? eventMessageMatch = _unifiedLoggingEventMessageRegex.firstMatch(line);
@@ -990,7 +1010,7 @@ class _IOSSimulatorLogReader extends SharedIOSDeviceLogReader {
       try {
         final Object? decodedJson = jsonDecode(message);
         if (decodedJson is String) {
-          addLogToStream(decodedJson);
+          addLogToStream(_restoreAppleEscapedAnsiSequences(decodedJson));
         }
       } on FormatException {
         globals.printError('Logger returned non-JSON response: $message');

--- a/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
@@ -798,6 +798,66 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text''',
       );
 
       testUsingContext(
+        'log reader restores ANSI escape sequences rewritten by unified logging',
+        () async {
+          const logPredicate =
+              'eventType = logEvent AND processImagePath ENDSWITH "My Super Awesome App" '
+              'AND (senderImagePath ENDSWITH "/Flutter" OR senderImagePath ENDSWITH "/libswiftCore.dylib" '
+              'OR processImageUUID == senderImageUUID OR eventMessage CONTAINS "`UIScene` lifecycle '
+              'will soon be required" OR eventMessage CONTAINS "This process does not adopt UIScene '
+              'lifecycle.") AND NOT(eventMessage CONTAINS ": could not find icon '
+              'for representation -> com.apple.") AND NOT(eventMessage BEGINSWITH "assertion failed: ") '
+              'AND NOT(eventMessage CONTAINS " libxpc.dylib ")';
+          fakeProcessManager.addCommand(
+            const FakeCommand(
+              command: <String>[
+                'xcrun',
+                'simctl',
+                'spawn',
+                '123456',
+                'log',
+                'stream',
+                '--style',
+                'json',
+                '--predicate',
+                logPredicate,
+              ],
+              stdout: '''
+},{
+  "traceID" : 37579774151491588,
+  "eventMessage" : "\\\\^[[32m       test   <\u{2026}>[0m",
+  "eventType" : "logEvent"
+},{
+  "traceID" : 37579774151491588,
+  "eventMessage" : "<\u{2026}>[0mreset only",
+  "eventType" : "logEvent"
+},{
+''',
+            ),
+          );
+
+          final device = IOSSimulator(
+            '123456',
+            name: 'iPhone 11',
+            simulatorCategory: 'iOS 11.0',
+            simControl: simControl,
+            logger: logger,
+          );
+          final DeviceLogReader logReader = device.getLogReader(
+            app: await BuildableIOSApp.fromProject(mockIosProject, null),
+          );
+
+          final List<String> lines = await logReader.logLines.toList();
+          expect(lines, <String>['\x1B[32m       test   \x1B[0m', '\x1B[0mreset only']);
+          expect(fakeProcessManager, hasNoRemainingExpectations);
+        },
+        overrides: <Type, Generator>{
+          ProcessManager: () => fakeProcessManager,
+          FileSystem: () => fileSystem,
+        },
+      );
+
+      testUsingContext(
         'log reader handles bad output',
         () async {
           const logPredicate =


### PR DESCRIPTION
Issue

Fixes #20663.

Fix

Normalize the ANSI escape placeholders emitted by Apple unified logging before iOS Simulator log lines are forwarded to Flutter tooling output. The change restores CSI sequences such as color starts and resets after the eventMessage JSON string has been decoded.

Tests

- `../../bin/dart test test/general.shard/ios/simulators_test.dart`
- `../../bin/dart analyze lib/src/ios/simulators.dart test/general.shard/ios/simulators_test.dart`
- `./bin/dart format --output=none --set-exit-if-changed packages/flutter_tools/lib/src/ios/simulators.dart packages/flutter_tools/test/general.shard/ios/simulators_test.dart`
- `git diff --check`

Risk

Low. The normalization is limited to the iOS Simulator unified-log reader and only runs when the decoded message contains an Apple escaped ANSI CSI pattern or the later ESC placeholder reported in the issue.
