### PR TITLE
Clarify WidgetStatesController value snapshots

### DIFF
--- a/packages/flutter/lib/src/widgets/widget_state.dart
+++ b/packages/flutter/lib/src/widgets/widget_state.dart
@@ -1113,7 +1113,15 @@ class WidgetStatePropertyAll<T> implements WidgetStateProperty<T> {
 ///
 /// The controller's [value] is its current set of states. Listeners
 /// are notified whenever the [value] changes. The [value] should only be
-/// changed with [update]; it should not be modified directly.
+/// changed with [update]; it should not be modified directly. The controller
+/// mutates the current [value] set when applying updates. To retain a snapshot
+/// that will not change with later controller updates, create a copy:
+///
+/// {@tool snippet}
+/// ```dart
+/// final Set<WidgetState> states = controller.value.toSet();
+/// ```
+/// {@end-tool}
 ///
 /// The controller's [value] represents the set of states that a
 /// widget's visual properties, typically [WidgetStateProperty]
@@ -1143,6 +1151,9 @@ class WidgetStatesController extends ValueNotifier<Set<WidgetState>> {
 
   /// Adds [state] to [value] if [add] is true, and removes it otherwise,
   /// and notifies listeners if [value] has changed.
+  ///
+  /// This mutates the existing [value] set. It does not replace [value] with a
+  /// new set.
   void update(WidgetState state, bool add) {
     final bool valueChanged = add ? value.add(state) : value.remove(state);
     if (valueChanged) {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/167916.

Clarifies that `WidgetStatesController.update` mutates the controller's existing `value` set, and documents the copy pattern callers should use when they need a stable snapshot.

## Pre-launch Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I read the Tree Hygiene wiki page, which explains my responsibilities.
- [x] I read and followed the Flutter Style Guide and the C++, Objective-C, Java style guides.
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation.
- [x] I ran `./bin/dart format --output=none --set-exit-if-changed packages/flutter/lib/src/widgets/widget_state.dart`.
- [x] I ran `./bin/flutter analyze packages/flutter/lib/src/widgets/widget_state.dart`.
- [x] I ran `git diff --check`.
