### PR TITLE
Clarify transparent Material InkWell docs

### DIFF
--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -289,9 +289,9 @@ typedef _CheckContext = bool Function(BuildContext context);
 ///
 /// If this is not possible for some reason, e.g. because you are using an
 /// opaque [CustomPaint] widget, alternatively consider using a second
-/// [Material] above the opaque widget but below the [InkResponse] (as an
-/// ancestor to the ink response). The [MaterialType.transparency] material
-/// kind can be used for this purpose.
+/// [Material] with [MaterialType.transparency] on top of the opaque widget.
+/// The [InkResponse] must be a descendant of this [Material] so the ink effects
+/// are painted on the transparent [Material] over the opaque widget.
 ///
 /// See also:
 ///
@@ -1465,9 +1465,9 @@ class _InkResponseState extends State<_InkResponseStateWidget>
 ///
 /// If this is not possible for some reason, e.g. because you are using an
 /// opaque [CustomPaint] widget, alternatively consider using a second
-/// [Material] above the opaque widget but below the [InkWell] (as an
-/// ancestor to the ink well). The [MaterialType.transparency] material
-/// kind can be used for this purpose.
+/// [Material] with [MaterialType.transparency] on top of the opaque widget.
+/// The [InkWell] must be a descendant of this [Material] so the ink effects are
+/// painted on the transparent [Material] over the opaque widget.
 ///
 /// ### InkWell isn't clipping properly
 ///


### PR DESCRIPTION
## Description

Clarifies the InkResponse and InkWell troubleshooting docs for cases where an opaque widget hides ink splashes. The transparent Material recommendation now states that the transparent Material should be above the opaque widget and that the ink widget should be its descendant.

## Related Issue

Fixes https://github.com/flutter/flutter/issues/168659.

## Tests

- `./bin/dart format --output=none --set-exit-if-changed packages/flutter/lib/src/material/ink_well.dart`
- `./bin/flutter analyze packages/flutter/lib/src/material/ink_well.dart`
- `git diff --check`
