### PR TITLE
Assert TextStyle height is not NaN

### DIFF
--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -28,6 +28,8 @@ const String _kColorBackgroundWarning =
     'Cannot provide both a backgroundColor and a background\n'
     'The backgroundColor argument is just a shorthand for "background: Paint()..color = color".';
 
+const _kTextStyleHeightNaNWarning = 'TextStyle.height must not be NaN.';
+
 // Examples can assume:
 // late BuildContext context;
 
@@ -508,7 +510,9 @@ class TextStyle with Diagnosticable {
        _fontFamilyFallback = fontFamilyFallback,
        _package = package,
        assert(color == null || foreground == null, _kColorForegroundWarning),
-       assert(backgroundColor == null || background == null, _kColorBackgroundWarning);
+       assert(backgroundColor == null || background == null, _kColorBackgroundWarning),
+       // The equality check rejects NaN while remaining valid in const constructor assertions.
+       assert(height == null || height == height, _kTextStyleHeightNaNWarning);
 
   /// Whether null values in this [TextStyle] can be replaced with their value
   /// in another [TextStyle] using [merge].
@@ -1401,6 +1405,7 @@ class TextStyle with Diagnosticable {
     StrutStyle? strutStyle,
   }) {
     assert(maxLines == null || maxLines > 0);
+    assert(height == null || !height.isNaN, _kTextStyleHeightNaNWarning);
     final TextLeadingDistribution? leadingDistribution = this.leadingDistribution;
     final TextHeightBehavior? effectiveTextHeightBehavior =
         textHeightBehavior ??

--- a/packages/flutter/test/painting/text_style_test.dart
+++ b/packages/flutter/test/painting/text_style_test.dart
@@ -314,6 +314,29 @@ void main() {
     expect(ps7, equals(ui.ParagraphStyle(textDirection: TextDirection.rtl, fontSize: 14.0)));
   });
 
+  test('TextStyle rejects NaN height', () {
+    expect(
+      () => TextStyle(height: double.nan),
+      throwsA(
+        isA<AssertionError>().having(
+          (AssertionError error) => error.toString(),
+          'message',
+          contains('TextStyle.height must not be NaN.'),
+        ),
+      ),
+    );
+    expect(
+      () => const TextStyle().getParagraphStyle(height: double.nan),
+      throwsA(
+        isA<AssertionError>().having(
+          (AssertionError error) => error.toString(),
+          'message',
+          contains('TextStyle.height must not be NaN.'),
+        ),
+      ),
+    );
+  });
+
   test('TextStyle using package font', () {
     const s6 = TextStyle(fontFamily: 'test');
     expect(s6.fontFamily, 'test');


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/175248

Prevents `TextStyle(height: double.nan)` and `getParagraphStyle(height: double.nan)` from passing NaN line heights down to dart:ui in debug mode. This produces a clear assertion before platform-specific text layout failures.

Tests:
- `./bin/dart format --output=none --set-exit-if-changed packages/flutter/lib/src/painting/text_style.dart packages/flutter/test/painting/text_style_test.dart`
- `./bin/flutter test packages/flutter/test/painting/text_style_test.dart`
- `./bin/flutter analyze packages/flutter/lib/src/painting/text_style.dart packages/flutter/test/painting/text_style_test.dart`
- `git diff --check`