### PR TITLE
Clarify custom font weight metadata docs

### DIFF
--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -325,6 +325,12 @@ const String _kColorBackgroundWarning =
 /// outlines in the file are `italic` or `normal`. These values correspond to
 /// the [FontStyle] class and can be used in the [fontStyle] argument.
 ///
+/// For non-web font selection, these `weight` and `style` entries are
+/// descriptive: Flutter uses the weight and style metadata embedded in each
+/// font file when selecting the best match for [fontWeight] and [fontStyle].
+/// Set the `weight` and `style` entries to match the font files' metadata;
+/// these entries do not override incorrect metadata in the font files.
+///
 /// To select a custom font, create [TextStyle] using the [fontFamily]
 /// argument as shown in the example below:
 ///

--- a/packages/flutter_tools/templates/app/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/app/pubspec.yaml.tmpl
@@ -121,6 +121,12 @@ flutter:
   #       - asset: fonts/TrajanPro_Bold.ttf
   #         weight: 700
   #
+  # Note: the `weight` and `style` entries are descriptive on non-web
+  # platforms. Flutter selects the best-matching font file by reading the
+  # weight and style metadata embedded in each font file. Set the pubspec
+  # entries to match the font files' metadata; they do not override
+  # incorrect metadata in the font files.
+  #
   # For details regarding fonts from package dependencies,
   # see https://flutter.dev/to/font-from-package
 {{/withEmptyMain}}


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/50216

Clarifies the custom font documentation in `TextStyle` so developers know the `pubspec.yaml` weight/style descriptors should match the font file metadata, and that they do not override incorrect embedded metadata on non-web platforms.

Tests:
- `./bin/dart format --output=none --set-exit-if-changed packages/flutter/lib/src/painting/text_style.dart`
- `./bin/flutter analyze packages/flutter/lib/src/painting/text_style.dart`
- `git diff --check`