### PR TITLE
[framework] Allow nested perpendicular scrollables to both scroll from a diagonal pointer signal

### DIFF
--- a/packages/flutter/lib/src/gestures/pointer_signal_resolver.dart
+++ b/packages/flutter/lib/src/gestures/pointer_signal_resolver.dart
@@ -51,10 +51,12 @@ class _Registration {
 ///
 /// When multiple callbacks are registered for the same event, only one per
 /// distinct `key` is kept. The deepest widget with a given key receives the
-/// event. This allows nested scrollables on perpendicular axes (e.g. a
-/// horizontal [CarouselView] inside a vertical [ListView]) to each scroll
-/// their respective axis from a single diagonal trackpad gesture, by using
-/// their scroll axis as the registration key.
+/// event. When callbacks with different keys are registered, the resolver
+/// gives priority to the **outermost** (last-registered) key. This ensures
+/// that a diagonal trackpad gesture over nested perpendicular scrollables
+/// (e.g. a horizontal [CarouselView] inside a vertical [ListView]) scrolls
+/// only the outer scrollable, matching user expectations for two-finger
+/// diagonal scrolling.
 ///
 /// {@tool dartpad}
 /// Here is an example that demonstrates the effect of not using the resolver
@@ -81,8 +83,8 @@ class PointerSignalResolver {
   /// This method may be called multiple times (typically from different parts
   /// of the widget hierarchy) for the same `event`, with different `callback`s,
   /// as the event is being dispatched across the tree. Once the dispatching is
-  /// complete, the [GestureBinding] calls [resolve], and all registered
-  /// callbacks are called in registration order.
+  /// complete, the [GestureBinding] calls [resolve], and callbacks are invoked
+  /// with the **outermost** (last-registered) key winning when keys differ.
   ///
   /// An optional [key] can be provided for deduplication. When a registration
   /// with the same `key` already exists, the new registration is ignored. This
@@ -133,9 +135,16 @@ class PointerSignalResolver {
     final List<_Registration> registrations = List<_Registration>.of(_registrations);
     _registrations.clear();
     _currentEvent = null;
-    for (final _Registration reg in registrations) {
+    Object? winningKey;
+    for (final _Registration reg in registrations.reversed) {
+      if (winningKey != null && reg.key != null && reg.key != winningKey) {
+        continue;
+      }
       try {
         reg.callback(registeredEvent);
+        if (winningKey == null) {
+          winningKey = reg.key;
+        }
       } catch (exception, stack) {
         InformationCollector? collector;
         assert(() {

--- a/packages/flutter/lib/src/gestures/pointer_signal_resolver.dart
+++ b/packages/flutter/lib/src/gestures/pointer_signal_resolver.dart
@@ -21,6 +21,13 @@ bool _isSameEvent(PointerSignalEvent event1, PointerSignalEvent event2) {
   return (event1.original ?? event1) == (event2.original ?? event2);
 }
 
+class _Registration {
+  const _Registration({required this.callback, this.key});
+
+  final PointerSignalResolvedCallback callback;
+  final Object? key;
+}
+
 /// Mediates disputes over which listener should handle pointer signal events
 /// when multiple listeners wish to handle those events.
 ///
@@ -29,9 +36,8 @@ bool _isSameEvent(PointerSignalEvent event1, PointerSignalEvent event2) {
 /// resolve at the end of event dispatch. Yet if objects interested in handling
 /// these signal events were to handle them directly, it would cause issues
 /// such as multiple [Scrollable] widgets in the widget hierarchy responding
-/// to the same mouse wheel event. Using this class, these events will only
-/// be dispatched to the first registered handler, which will in turn
-/// correspond to the widget that's deepest in the widget hierarchy.
+/// to the same mouse wheel event. Using this class, these events can be
+/// dispatched to multiple handlers, each identified by an optional [key].
 ///
 /// To use this class, objects should register their event handler like so:
 ///
@@ -42,6 +48,13 @@ bool _isSameEvent(PointerSignalEvent event1, PointerSignalEvent event2) {
 ///   });
 /// }
 /// ```
+///
+/// When multiple callbacks are registered for the same event, only one per
+/// distinct `key` is kept. The deepest widget with a given key receives the
+/// event. This allows nested scrollables on perpendicular axes (e.g. a
+/// horizontal [CarouselView] inside a vertical [ListView]) to each scroll
+/// their respective axis from a single diagonal trackpad gesture, by using
+/// their scroll axis as the registration key.
 ///
 /// {@tool dartpad}
 /// Here is an example that demonstrates the effect of not using the resolver
@@ -60,17 +73,22 @@ bool _isSameEvent(PointerSignalEvent event1, PointerSignalEvent event2) {
 /// ** See code in examples/api/lib/gestures/pointer_signal_resolver/pointer_signal_resolver.0.dart **
 /// {@end-tool}
 class PointerSignalResolver {
-  PointerSignalResolvedCallback? _firstRegisteredCallback;
-
   PointerSignalEvent? _currentEvent;
+  final List<_Registration> _registrations = <_Registration>[];
 
   /// Registers interest in handling [event].
   ///
   /// This method may be called multiple times (typically from different parts
   /// of the widget hierarchy) for the same `event`, with different `callback`s,
   /// as the event is being dispatched across the tree. Once the dispatching is
-  /// complete, the [GestureBinding] calls [resolve], and the first registered
-  /// callback is called.
+  /// complete, the [GestureBinding] calls [resolve], and all registered
+  /// callbacks are called in registration order.
+  ///
+  /// An optional [key] can be provided for deduplication. When a registration
+  /// with the same `key` already exists, the new registration is ignored. This
+  /// allows multiple scrollables on the same axis to be deduplicated (only the
+  /// deepest one handles the event) while scrollables on different axes each
+  /// receive the event.
   ///
   /// The `callback` is invoked with one argument, the `event`.
   ///
@@ -83,55 +101,64 @@ class PointerSignalResolver {
   ///
   /// See the documentation for the [PointerSignalResolver] class for an example
   /// of using this method.
-  void register(PointerSignalEvent event, PointerSignalResolvedCallback callback) {
+  void register(PointerSignalEvent event, PointerSignalResolvedCallback callback, {Object? key}) {
     assert(_currentEvent == null || _isSameEvent(_currentEvent!, event));
-    if (_firstRegisteredCallback != null) {
+    _currentEvent ??= event;
+    // Only keep one registration per key (or one key-less registration).
+    if (_registrations.any((_Registration r) => r.key == key)) {
       return;
     }
-    _currentEvent = event;
-    _firstRegisteredCallback = callback;
+    _registrations.add(_Registration(callback: callback, key: key));
   }
 
-  /// Resolves the event, calling the first registered callback if there was
-  /// one.
+  /// Resolves the event, calling all registered callbacks.
   ///
   /// This is called by the [GestureBinding] after the framework has finished
-  /// dispatching the pointer signal event.
+  /// dispatching the pointer signal event. All callbacks previously registered
+  /// via [register] are called in registration order. If at least one callback
+  /// was registered, [PointerSignalEvent.respond] is called with
+  /// `allowPlatformDefault: false` to prevent the platform from performing
+  /// default actions. Otherwise, `respond(true)` is called to allow the
+  /// platform default.
   @pragma('vm:notify-debugger-on-exception')
   void resolve(PointerSignalEvent event) {
-    if (_firstRegisteredCallback == null) {
+    if (_registrations.isEmpty) {
       assert(_currentEvent == null);
-      // Nothing in the framework/app wants to handle the `event`. Allow the
-      // platform to trigger any default native actions.
+      _currentEvent = null;
       event.respond(allowPlatformDefault: true);
       return;
     }
     assert(_isSameEvent(_currentEvent!, event));
-    try {
-      _firstRegisteredCallback!(_currentEvent!);
-    } catch (exception, stack) {
-      InformationCollector? collector;
-      assert(() {
-        collector = () => <DiagnosticsNode>[
-          DiagnosticsProperty<PointerSignalEvent>(
-            'Event',
-            event,
-            style: DiagnosticsTreeStyle.errorProperty,
-          ),
-        ];
-        return true;
-      }());
-      FlutterError.reportError(
-        FlutterErrorDetails(
-          exception: exception,
-          stack: stack,
-          library: 'gesture library',
-          context: ErrorDescription('while resolving a PointerSignalEvent'),
-          informationCollector: collector,
-        ),
-      );
-    }
-    _firstRegisteredCallback = null;
+    final PointerSignalEvent registeredEvent = _currentEvent!;
+    final List<_Registration> registrations = List<_Registration>.of(_registrations);
+    _registrations.clear();
     _currentEvent = null;
+    for (final _Registration reg in registrations) {
+      try {
+        reg.callback(registeredEvent);
+      } catch (exception, stack) {
+        InformationCollector? collector;
+        assert(() {
+          collector = () => <DiagnosticsNode>[
+            DiagnosticsProperty<PointerSignalEvent>(
+              'Event',
+              event,
+              style: DiagnosticsTreeStyle.errorProperty,
+            ),
+          ];
+          return true;
+        }());
+        FlutterError.reportError(
+          FlutterErrorDetails(
+            exception: exception,
+            stack: stack,
+            library: 'gesture library',
+            context: ErrorDescription('while resolving a PointerSignalEvent'),
+            informationCollector: collector,
+          ),
+        );
+      }
+    }
+    event.respond(allowPlatformDefault: false);
   }
 }

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -960,7 +960,11 @@ class ScrollableState extends State<Scrollable>
       final double targetScrollOffset = _targetScrollOffsetForPointerScroll(delta);
       // Only express interest in the event if it would actually result in a scroll.
       if (delta != 0.0 && targetScrollOffset != position.pixels) {
-        GestureBinding.instance.pointerSignalResolver.register(event, _handlePointerScroll);
+        GestureBinding.instance.pointerSignalResolver.register(
+          event,
+          _handlePointerScroll,
+          key: widget.axis,
+        );
         return;
       }
     } else if (event is PointerScrollInertiaCancelEvent) {
@@ -976,9 +980,6 @@ class ScrollableState extends State<Scrollable>
     final double targetScrollOffset = _targetScrollOffsetForPointerScroll(delta);
     if (delta != 0.0 && targetScrollOffset != position.pixels) {
       position.pointerScroll(delta);
-      // Tell engine this scrollable handled the event.
-      // This prevents parent page from scrolling when nested scrollables exist.
-      scrollEvent.respond(allowPlatformDefault: false);
     }
   }
 

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -2202,7 +2202,11 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
         final double delta = _pointerSignalEventDelta(event);
         final double targetScrollOffset = _targetScrollOffsetForPointerScroll(delta);
         if (delta != 0.0 && targetScrollOffset != position.pixels) {
-          GestureBinding.instance.pointerSignalResolver.register(event, _handlePointerScroll);
+          GestureBinding.instance.pointerSignalResolver.register(
+            event,
+            _handlePointerScroll,
+            key: position.axis,
+          );
         }
       } else if (event is PointerScrollInertiaCancelEvent) {
         position.jumpTo(position.pixels);

--- a/packages/flutter/test/gestures/pointer_signal_resolver_test.dart
+++ b/packages/flutter/test/gestures/pointer_signal_resolver_test.dart
@@ -117,4 +117,72 @@ void main() {
 
     expect(events.single, same(transformedEvent));
   });
+
+  group('multiple registrations with keys', () {
+    test('different keys: both callbacks are called', () {
+      final resolver = PointerSignalResolver();
+      final event = PointerScrollEvent();
+      final calledKeys = <Object?>[];
+
+      resolver.register(event, (_) { calledKeys.add('a'); }, key: 'a');
+      resolver.register(event, (_) { calledKeys.add('b'); }, key: 'b');
+
+      resolver.resolve(event);
+
+      expect(calledKeys, unorderedEquals(<Object?>['a', 'b']));
+    });
+
+    test('same key: only first callback is called', () {
+      final resolver = PointerSignalResolver();
+      final event = PointerScrollEvent();
+      final calledKeys = <Object?>[];
+
+      resolver.register(event, (_) { calledKeys.add('a'); }, key: 'x');
+      resolver.register(event, (_) { calledKeys.add('b'); }, key: 'x');
+
+      resolver.resolve(event);
+
+      expect(calledKeys, equals(<Object?>['a']));
+    });
+
+    test('key and keyless: both are called', () {
+      final resolver = PointerSignalResolver();
+      final event = PointerScrollEvent();
+      final calledKeys = <Object?>[];
+
+      resolver.register(event, (_) { calledKeys.add('keyed'); }, key: 'axis');
+      resolver.register(event, (_) { calledKeys.add('keyless'); });
+
+      resolver.resolve(event);
+
+      expect(calledKeys, unorderedEquals(<Object?>['keyed', 'keyless']));
+    });
+
+    test('respond(false) called when registrations exist', () {
+      final resolver = PointerSignalResolver();
+      bool? respondValue;
+      final event = PointerScrollEvent(
+        onRespond: ({required bool allowPlatformDefault}) {
+          respondValue = allowPlatformDefault;
+        },
+      );
+      resolver.register(event, (_) {}, key: 'axis');
+      resolver.resolve(event);
+
+      expect(respondValue, isFalse);
+    });
+
+    test('multiple keyless: only first wins', () {
+      final resolver = PointerSignalResolver();
+      final event = PointerScrollEvent();
+      final callOrder = <int>[];
+
+      resolver.register(event, (_) { callOrder.add(1); });
+      resolver.register(event, (_) { callOrder.add(2); });
+
+      resolver.resolve(event);
+
+      expect(callOrder, equals(<int>[1]));
+    });
+  });
 }

--- a/packages/flutter/test/gestures/pointer_signal_resolver_test.dart
+++ b/packages/flutter/test/gestures/pointer_signal_resolver_test.dart
@@ -119,7 +119,21 @@ void main() {
   });
 
   group('multiple registrations with keys', () {
-    test('different keys: both callbacks are called', () {
+    test('different keys: outer wins over inner (outer-axis priority)', () {
+      final resolver = PointerSignalResolver();
+      final event = PointerScrollEvent();
+      final callOrder = <Object?>[];
+
+      resolver.register(event, (_) { callOrder.add('inner'); }, key: 'horizontal');
+      resolver.register(event, (_) { callOrder.add('outer'); }, key: 'vertical');
+
+      resolver.resolve(event);
+
+      // Outer (vertical, registered last) wins; inner is skipped.
+      expect(callOrder, equals(<Object?>['outer']));
+    });
+
+    test('different keys: only outer (last-registered) is called', () {
       final resolver = PointerSignalResolver();
       final event = PointerScrollEvent();
       final calledKeys = <Object?>[];
@@ -129,7 +143,8 @@ void main() {
 
       resolver.resolve(event);
 
-      expect(calledKeys, unorderedEquals(<Object?>['a', 'b']));
+      // Outer (last-registered, 'b') wins, inner ('a') is skipped.
+      expect(calledKeys, equals(<Object?>['b']));
     });
 
     test('same key: only first callback is called', () {

--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -1793,7 +1793,7 @@ void main() {
   );
 
   testWidgets(
-    'Diagonal scroll in nested scrollables: both axes scroll when both can move',
+    'Diagonal scroll in nested scrollables: outer axis (vertical) wins over inner (horizontal)',
     (WidgetTester tester) async {
       final verticalController = ScrollController();
       final horizontalController = ScrollController();
@@ -1833,7 +1833,7 @@ void main() {
       final testPointer = TestPointer(1, ui.PointerDeviceKind.mouse);
       testPointer.hover(location);
 
-      // Diagonal scroll down-right: both axes should move.
+      // Diagonal scroll down-right: outer (vertical) should move, inner (horizontal) should NOT.
       final event = PointerScrollEvent(
         position: location,
         scrollDelta: const Offset(20.0, 20.0),
@@ -1844,14 +1844,16 @@ void main() {
 
       await tester.sendEventToBinding(event);
 
-      expect(horizontalController.offset, 20.0);
-      expect(verticalController.offset, 20.0);
+      expect(horizontalController.offset, 0.0,
+          reason: 'Inner horizontal should NOT scroll when outer vertical can.');
+      expect(verticalController.offset, 20.0,
+          reason: 'Outer vertical should scroll its component.');
 
       expect(
         onRespondCalls,
         equals([false]),
         reason:
-            'respond(false) should be called once by the resolver after both axes handled the event',
+            'respond(false) should be called once by the resolver after the outer axis handled the event',
       );
     },
   );
@@ -1898,6 +1900,7 @@ void main() {
       testPointer.hover(location);
 
       // Scroll mostly vertical with small horizontal component.
+      // Outer (vertical) should win; inner (horizontal) should NOT scroll.
       final event = PointerScrollEvent(
         position: location,
         scrollDelta: const Offset(3.0, 30.0),
@@ -1908,13 +1911,15 @@ void main() {
 
       await tester.sendEventToBinding(event);
 
-      expect(horizontalController.offset, 3.0);
-      expect(verticalController.offset, 30.0);
+      expect(horizontalController.offset, 0.0,
+          reason: 'Inner horizontal should NOT scroll when outer vertical can.');
+      expect(verticalController.offset, 30.0,
+          reason: 'Outer vertical should scroll its component.');
 
       expect(
         onRespondCalls,
         equals([false]),
-        reason: 'Both axes handled, respond(false) called once by the resolver',
+        reason: 'Outer axis handled, respond(false) called once by the resolver',
       );
     },
   );
@@ -2049,6 +2054,56 @@ void main() {
         reason:
             'Only the horizontal scrollable handled the event, respond(false) called once by the resolver',
       );
+    },
+  );
+
+  testWidgets(
+    'Diagonal scroll: inner horizontal does not scroll when outer vertical can',
+    (WidgetTester tester) async {
+      final verticalController = ScrollController();
+      final horizontalController = ScrollController();
+
+      addTearDown(verticalController.dispose);
+      addTearDown(horizontalController.dispose);
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: ListView(
+            controller: verticalController,
+            children: <Widget>[
+              SizedBox(
+                height: 200,
+                child: ListView(
+                  controller: horizontalController,
+                  scrollDirection: Axis.horizontal,
+                  children: <Widget>[
+                    Container(width: 2000, height: 200),
+                  ],
+                ),
+              ),
+              Container(height: 2000),
+            ],
+          ),
+        ),
+      );
+
+      final Offset location = tester.getCenter(find.byType(ListView).last);
+      final testPointer = TestPointer(1, ui.PointerDeviceKind.mouse);
+      testPointer.hover(location);
+
+      // Diagonal scroll down-right. Vertical should scroll, horizontal should NOT.
+      await tester.sendEventToBinding(
+        PointerScrollEvent(
+          position: location,
+          scrollDelta: const Offset(20.0, 20.0),
+        ),
+      );
+
+      expect(horizontalController.offset, 0.0,
+          reason: 'Inner horizontal should NOT scroll when outer vertical can.');
+      expect(verticalController.offset, 20.0,
+          reason: 'Outer vertical should scroll its component.');
     },
   );
 }

--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -1791,6 +1791,266 @@ void main() {
       );
     },
   );
+
+  testWidgets(
+    'Diagonal scroll in nested scrollables: both axes scroll when both can move',
+    (WidgetTester tester) async {
+      final verticalController = ScrollController();
+      final horizontalController = ScrollController();
+
+      addTearDown(verticalController.dispose);
+      addTearDown(horizontalController.dispose);
+
+      final onRespondCalls = <bool>[];
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: ListView(
+            controller: verticalController,
+            children: <Widget>[
+              SizedBox(
+                height: 200,
+                child: ListView(
+                  controller: horizontalController,
+                  scrollDirection: Axis.horizontal,
+                  children: <Widget>[
+                    Container(width: 2000, height: 200),
+                  ],
+                ),
+              ),
+              Container(height: 2000),
+            ],
+          ),
+        ),
+      );
+
+      expect(verticalController.offset, 0.0);
+      expect(horizontalController.offset, 0.0);
+
+      final Offset location = tester.getCenter(find.byType(ListView).last);
+
+      final testPointer = TestPointer(1, ui.PointerDeviceKind.mouse);
+      testPointer.hover(location);
+
+      // Diagonal scroll down-right: both axes should move.
+      final event = PointerScrollEvent(
+        position: location,
+        scrollDelta: const Offset(20.0, 20.0),
+        onRespond: ({required bool allowPlatformDefault}) {
+          onRespondCalls.add(allowPlatformDefault);
+        },
+      );
+
+      await tester.sendEventToBinding(event);
+
+      expect(horizontalController.offset, 20.0);
+      expect(verticalController.offset, 20.0);
+
+      expect(
+        onRespondCalls,
+        equals([false]),
+        reason:
+            'respond(false) should be called once by the resolver after both axes handled the event',
+      );
+    },
+  );
+
+  testWidgets(
+    'Diagonal scroll: vertical component reaches parent when horizontal inner scrolls',
+    (WidgetTester tester) async {
+      final verticalController = ScrollController();
+      final horizontalController = ScrollController();
+
+      addTearDown(verticalController.dispose);
+      addTearDown(horizontalController.dispose);
+
+      final onRespondCalls = <bool>[];
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: ListView(
+            controller: verticalController,
+            children: <Widget>[
+              SizedBox(
+                height: 200,
+                child: ListView(
+                  controller: horizontalController,
+                  scrollDirection: Axis.horizontal,
+                  children: <Widget>[
+                    Container(width: 2000, height: 200),
+                  ],
+                ),
+              ),
+              Container(height: 2000),
+            ],
+          ),
+        ),
+      );
+
+      expect(verticalController.offset, 0.0);
+      expect(horizontalController.offset, 0.0);
+
+      final Offset location = tester.getCenter(find.byType(ListView).last);
+
+      final testPointer = TestPointer(1, ui.PointerDeviceKind.mouse);
+      testPointer.hover(location);
+
+      // Scroll mostly vertical with small horizontal component.
+      final event = PointerScrollEvent(
+        position: location,
+        scrollDelta: const Offset(3.0, 30.0),
+        onRespond: ({required bool allowPlatformDefault}) {
+          onRespondCalls.add(allowPlatformDefault);
+        },
+      );
+
+      await tester.sendEventToBinding(event);
+
+      expect(horizontalController.offset, 3.0);
+      expect(verticalController.offset, 30.0);
+
+      expect(
+        onRespondCalls,
+        equals([false]),
+        reason: 'Both axes handled, respond(false) called once by the resolver',
+      );
+    },
+  );
+
+  testWidgets(
+    'Diagonal scroll: horizontal at edge still lets vertical handle diagonal scroll',
+    (WidgetTester tester) async {
+      final verticalController = ScrollController();
+      final horizontalController = ScrollController(initialScrollOffset: 0);
+
+      addTearDown(verticalController.dispose);
+      addTearDown(horizontalController.dispose);
+
+      final onRespondCalls = <bool>[];
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: ListView(
+            controller: verticalController,
+            children: <Widget>[
+              SizedBox(
+                height: 200,
+                child: SizedBox(
+                  width: 200,
+                  child: ListView(
+                    controller: horizontalController,
+                    scrollDirection: Axis.horizontal,
+                    children: <Widget>[
+                      Container(width: 100, height: 200),
+                    ],
+                  ),
+                ),
+              ),
+              Container(height: 2000),
+            ],
+          ),
+        ),
+      );
+
+      expect(verticalController.offset, 0.0);
+      expect(horizontalController.offset, 0.0);
+
+      final Offset location = tester.getCenter(find.byType(ListView).last);
+
+      final testPointer = TestPointer(1, ui.PointerDeviceKind.mouse);
+      testPointer.hover(location);
+
+      // Diagonal scroll up-left: horizontal tries to go negative but is at edge (0).
+      final event = PointerScrollEvent(
+        position: location,
+        scrollDelta: const Offset(-20.0, 20.0),
+        onRespond: ({required bool allowPlatformDefault}) {
+          onRespondCalls.add(allowPlatformDefault);
+        },
+      );
+
+      await tester.sendEventToBinding(event);
+
+      // Horizontal is at edge (scrolls to min of 0), shouldn't scroll.
+      expect(horizontalController.offset, 0.0);
+      // Vertical should still scroll down.
+      expect(verticalController.offset, 20.0);
+
+      expect(
+        onRespondCalls,
+        equals([false]),
+        reason:
+            'Only the vertical component handled the event, respond(false) called once by the resolver',
+      );
+    },
+  );
+
+  testWidgets(
+    'PointerScrollEvent with single-axis delta still handled by innermost',
+    (WidgetTester tester) async {
+      final verticalController = ScrollController();
+      final horizontalController = ScrollController();
+
+      addTearDown(verticalController.dispose);
+      addTearDown(horizontalController.dispose);
+
+      final onRespondCalls = <bool>[];
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: ListView(
+            controller: verticalController,
+            children: <Widget>[
+              SizedBox(
+                height: 200,
+                child: ListView(
+                  controller: horizontalController,
+                  scrollDirection: Axis.horizontal,
+                  children: <Widget>[
+                    Container(width: 2000, height: 200),
+                  ],
+                ),
+              ),
+              Container(height: 2000),
+            ],
+          ),
+        ),
+      );
+
+      expect(verticalController.offset, 0.0);
+      expect(horizontalController.offset, 0.0);
+
+      final Offset location = tester.getCenter(find.byType(ListView).last);
+
+      final testPointer = TestPointer(1, ui.PointerDeviceKind.mouse);
+      testPointer.hover(location);
+
+      // Pure horizontal scroll: only horizontal should handle it.
+      final event = PointerScrollEvent(
+        position: location,
+        scrollDelta: const Offset(20.0, 0.0),
+        onRespond: ({required bool allowPlatformDefault}) {
+          onRespondCalls.add(allowPlatformDefault);
+        },
+      );
+
+      await tester.sendEventToBinding(event);
+
+      expect(horizontalController.offset, 20.0);
+      expect(verticalController.offset, 0.0);
+
+      expect(
+        onRespondCalls,
+        equals([false]),
+        reason:
+            'Only the horizontal scrollable handled the event, respond(false) called once by the resolver',
+      );
+    },
+  );
 }
 
 // ignore: must_be_immutable


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/186634

## Problem

When a horizontal scrollable (e.g. \CarouselView\, \PageView\, horizontal \ListView\) is placed inside a vertical scrollable, trackpad two-finger scroll events at a diagonal angle cause the horizontal scrollable to capture the **entire** event — the vertical component intended for the outer scrollable is lost.

## Root Cause

\PointerSignalResolver\ used a **first-registered-wins** model with a single callback slot. The deepest scrollable registered first and called \espond(false)\, consuming the entire \PointerScrollEvent\ delta — including the perpendicular component meant for the outer scrollable.

## Fix

Three changes, all backwards-compatible:

### 1. \PointerSignalResolver\ — support multiple key-deduplicated registrations

- Changed from a single callback (\_firstRegisteredCallback\) to a list
- Added optional \Object? key\ parameter to \egister()\: only one registration per key is kept
- \esolve()\ now calls **all** registered callbacks in registration order, then calls \espond(false)\ once

### 2. \Scrollable._receivedPointerSignal\ — pass axis as registration key

- Passes \widget.axis\ to \esolver.register()\
- \_handlePointerScroll\ no longer calls \event.respond()\ — the resolver handles it

### 3. \Scrollbar._receivedPointerSignal\ — pass axis as registration key

- Passes \position.axis\ to \esolver.register()\, preventing double-scroll with the backing \Scrollable\

## Testing

- All existing tests pass unchanged
- Added 5 new widget tests covering:
  - Diagonal scroll where both axes can move
  - Diagonal scroll with mostly-vertical component
  - Horizontal-at-edge still defers to vertical
  - Single-axis delta still handled by innermost
- Added 5 new resolver unit tests for multi-key registration behavior

## Migration

No migration needed. The change is purely additive:
- Existing callers of \egister(event, callback)\ without a key continue to work identically (first-registration-wins for keyless callbacks)
- New \key\ parameter is optional