### PR TITLE
Support custom Flutter Gradle plugin repository URL

### DIFF
--- a/packages/flutter_tools/gradle/README.md
+++ b/packages/flutter_tools/gradle/README.md
@@ -33,10 +33,7 @@ overridden by setting the `JAVA_HOME` environment variable.
 This example sets the java version to 17 downloaded with brew and then runs the tests:
 `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home/ ./gradlew test`
 
-If your environment cannot resolve Flutter Gradle Plugin dependencies from the public Google Maven
-or Maven Central repositories, set `FLUTTER_ANDROID_GRADLE_PLUGIN_REPOSITORY` to the URL of a Maven
-repository that mirrors those dependencies. When set, this repository is checked before the public
-repositories for plugin and dependency resolution.
+If your environment is restricted and cannot resolve public dependencies, set `FLUTTER_GRADLE_PLUGIN_REPOSITORY_URL` to your custom Maven repository URL that mirrors the required Flutter Gradle Plugin dependencies.
 
 You can run all the tests in one file by passing in the fully qualified class name,
 e.g. `./gradlew test --tests com.flutter.gradle.BaseApplicationNameHandlerTest`, or one test in

--- a/packages/flutter_tools/gradle/README.md
+++ b/packages/flutter_tools/gradle/README.md
@@ -33,6 +33,11 @@ overridden by setting the `JAVA_HOME` environment variable.
 This example sets the java version to 17 downloaded with brew and then runs the tests:
 `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home/ ./gradlew test`
 
+If your environment cannot resolve Flutter Gradle Plugin dependencies from the public Google Maven
+or Maven Central repositories, set `FLUTTER_ANDROID_GRADLE_PLUGIN_REPOSITORY` to the URL of a Maven
+repository that mirrors those dependencies. When set, this repository is checked before the public
+repositories for plugin and dependency resolution.
+
 You can run all the tests in one file by passing in the fully qualified class name,
 e.g. `./gradlew test --tests com.flutter.gradle.BaseApplicationNameHandlerTest`, or one test in
 one file by passing in the fully qualified class name followed by the method name,

--- a/packages/flutter_tools/gradle/settings.gradle.kts
+++ b/packages/flutter_tools/gradle/settings.gradle.kts
@@ -1,7 +1,7 @@
 pluginManagement {
     repositories {
         val flutterAndroidGradlePluginRepository: String? =
-            System.getenv("FLUTTER_ANDROID_GRADLE_PLUGIN_REPOSITORY")
+            System.getenv("FLUTTER_GRADLE_PLUGIN_REPOSITORY_URL")
                 ?.trim()
                 ?.takeIf { it.isNotEmpty() }
         if (flutterAndroidGradlePluginRepository != null) {
@@ -19,7 +19,7 @@ dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         val flutterAndroidGradlePluginRepository: String? =
-            System.getenv("FLUTTER_ANDROID_GRADLE_PLUGIN_REPOSITORY")
+            System.getenv("FLUTTER_GRADLE_PLUGIN_REPOSITORY_URL")
                 ?.trim()
                 ?.takeIf { it.isNotEmpty() }
         if (flutterAndroidGradlePluginRepository != null) {

--- a/packages/flutter_tools/gradle/settings.gradle.kts
+++ b/packages/flutter_tools/gradle/settings.gradle.kts
@@ -1,6 +1,32 @@
+pluginManagement {
+    repositories {
+        val flutterAndroidGradlePluginRepository: String? =
+            System.getenv("FLUTTER_ANDROID_GRADLE_PLUGIN_REPOSITORY")
+                ?.trim()
+                ?.takeIf { it.isNotEmpty() }
+        if (flutterAndroidGradlePluginRepository != null) {
+            maven {
+                url = uri(flutterAndroidGradlePluginRepository)
+            }
+        }
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
+        val flutterAndroidGradlePluginRepository: String? =
+            System.getenv("FLUTTER_ANDROID_GRADLE_PLUGIN_REPOSITORY")
+                ?.trim()
+                ?.takeIf { it.isNotEmpty() }
+        if (flutterAndroidGradlePluginRepository != null) {
+            maven {
+                url = uri(flutterAndroidGradlePluginRepository)
+            }
+        }
         google()
         mavenCentral()
     }


### PR DESCRIPTION
## Summary

Adds `FLUTTER_GRADLE_PLUGIN_REPOSITORY_URL` as an optional Maven repository URL for the Flutter Gradle Plugin build.

When set, the repository is checked before the default public repositories for both plugin resolution and dependency resolution. This lets environments with internal Maven mirrors resolve the Flutter Gradle Plugin's Android/Kotlin build dependencies without editing files in the Flutter SDK.

Fixes https://github.com/flutter/flutter/issues/102256

## Validation

- Set `FLUTTER_GRADLE_PLUGIN_REPOSITORY_URL` to a temporary local Maven repository URL using `file://...`.
- Built a temporary Gradle app/project with that environment variable set and Gradle running offline.
- The build resolved a Gradle plugin from `pluginManagement.repositories` and a Maven dependency from `dependencyResolutionManagement.repositories` through the custom repository.
- Verified the Flutter Gradle Plugin project still configures and tests successfully with `gradle tasks` and `gradle test` under JDK 17.
