### PR TITLE
Defensively clean up scrollable _hold/_drag in _handleDragCancel (#172174)

### DIFF
--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -904,8 +904,26 @@ class ScrollableState extends State<Scrollable>
     assert(_hold == null || _drag == null);
     _hold?.cancel();
     _drag?.cancel();
-    assert(_hold == null);
-    assert(_drag == null);
+    // _hold and _drag are normally nulled out by the dispose callbacks that
+    // [HoldScrollActivity] / [DragScrollActivity] invoke (through
+    // `position.hold(_disposeHold)` / `position.drag(_, _disposeDrag)`).
+    // Those callbacks fire when `beginActivity` disposes the previous
+    // activity. However, when the cancel comes in *while another activity
+    // transition is already in flight* (e.g. another widget takes over the
+    // gesture arena via a horizontal PageView swipe), `beginActivity` may
+    // be skipped and the dispose callbacks never run.
+    //
+    // Defensively null out the references so the next drag-down on this
+    // scrollable does not trip `assert(_hold == null)` in [_handleDragDown]
+    // or `assert(_drag == null)` in [_handleDragStart].
+    //
+    // Regression test for https://github.com/flutter/flutter/issues/172174.
+    if (_hold != null) {
+      _disposeHold();
+    }
+    if (_drag != null) {
+      _disposeDrag();
+    }
   }
 
   void _disposeHold() {

--- a/packages/flutter/test/widgets/scrollable_animations_test.dart
+++ b/packages/flutter/test/widgets/scrollable_animations_test.dart
@@ -156,6 +156,56 @@ void main() {
     // The drag stops the animation, and the drag extent is respected.
     expect(controller.position.pixels, (animationExtent / 2) - dragExtent);
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/172174.
+  // When the gesture arena cancels a vertical drag while the scroll position
+  // is still animating ballistically (e.g. a PageView swipe takes over from
+  // a SingleChildScrollView that was flick-scrolling), `_handleDragCancel`
+  // previously tripped `assert(_hold == null)` because `_hold.cancel()` did
+  // not run the dispose callback synchronously.
+  testWidgets('Drag cancel during ballistic activity leaves _hold/_drag cleaned up', (
+    WidgetTester tester,
+  ) async {
+    final controller = ScrollController();
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: ListView(
+          controller: controller,
+          dragStartBehavior: DragStartBehavior.down,
+          children: List<Widget>.generate(
+            80,
+            (int i) => Text('$i', textDirection: TextDirection.ltr),
+          ),
+        ),
+      ),
+    );
+
+    // Kick off an animation so a ballistic activity is in flight when the
+    // next pointer arrives.
+    controller.position.animateTo(
+      100.0,
+      duration: const Duration(seconds: 1),
+      curve: Curves.linear,
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 250));
+
+    // Pointer-down begins a HoldScrollActivity (`_handleDragDown`).
+    final TestGesture gesture = await tester.startGesture(
+      tester.getCenter(find.byType(Scrollable)),
+    );
+
+    // Cancel the gesture before it ever becomes a drag (`_handleDragCancel`).
+    await gesture.cancel();
+    await tester.pump();
+
+    // The bug previously tripped `assert(_hold == null)` here. As a stricter
+    // post-condition, a fresh drag should be possible immediately after.
+    await tester.drag(find.byType(Scrollable), const Offset(0.0, -50.0));
+    await tester.pumpAndSettle();
+  });
 }
 
 void expectNoAnimation() {


### PR DESCRIPTION
Fixes #172174.

## Description

`ScrollableState._handleDragCancel` asserts that `_hold` and `_drag` are both null after calling `cancel()` on each. Those calls rely on the activity's dispose callback (registered via `position.hold(_disposeHold)` / `position.drag(_, _disposeDrag)`) to run synchronously when `beginActivity` swaps the activity.

When the cancel arrives while another activity transition is already in flight — the reporter's case is a horizontal PageView swipe taking over the gesture arena from a `SingleChildScrollView` that was flick-scrolling — `beginActivity` may be skipped and the dispose callbacks never run, so:

- `assert(_hold == null)` in `_handleDragCancel` trips, and
- the lingering `_hold` causes `assert(_hold == null)` in `_handleDragDown` to trip on the very next pointer-down.

Both assertion locations (lines 906 and 864 in the original report) match this pattern.

## Fix

Mirror the defensive pattern that #164392 introduced for `_handleDragStart`: after the cancel calls, explicitly run `_disposeHold` / `_disposeDrag` if the references survived. The existing dispose callback registration handles cleanup whenever `beginActivity` does run, so the explicit calls are a no-op in the common path and only kick in to recover from the race.

Added a regression test in `scrollable_animations_test.dart` that:

1. Starts a `ScrollPosition.animateTo` so a ballistic activity is in flight.
2. Begins a pointer-down (creates a `HoldScrollActivity`).
3. Cancels the pointer before it becomes a drag.
4. Immediately starts a fresh drag.

Without the fix, step 4 retrips `assert(_hold == null)`; with the fix it succeeds.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making.
- [x] I am willing to follow-up on review comments in a timely manner.

[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/