### PR TITLE
[flutter_tools] Honor "optional": true on ARB placeholders (#177158)

### DIFF
--- a/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
@@ -127,7 +127,13 @@ List<String> generateMethodParameters(
         'the "type" attribute to "${placeholder.type}".',
       );
     }
-    return '${useNamedParameters ? 'required ' : ''}${placeholder.type} ${placeholder.name}';
+    // When `optional: true` is set on the placeholder, declare the parameter
+    // as nullable and (for named parameters) drop the `required` keyword so
+    // the caller can pass `null` or omit the argument. See
+    // https://github.com/flutter/flutter/issues/177158.
+    final String requiredKeyword = (useNamedParameters && !placeholder.optional) ? 'required ' : '';
+    final String typeSuffix = placeholder.optional ? '?' : '';
+    return '$requiredKeyword${placeholder.type}$typeSuffix ${placeholder.name}';
   }).toList();
 }
 

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n_types.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n_types.dart
@@ -235,7 +235,8 @@ class Placeholder {
       type = _stringAttribute(resourceId, name, attributes, 'type'),
       format = _stringAttribute(resourceId, name, attributes, 'format'),
       optionalParameters = _optionalParameters(resourceId, name, attributes),
-      isCustomDateFormat = _boolAttribute(resourceId, name, attributes, 'isCustomDateFormat');
+      isCustomDateFormat = _boolAttribute(resourceId, name, attributes, 'isCustomDateFormat'),
+      optional = _boolAttribute(resourceId, name, attributes, 'optional') ?? false;
 
   final String resourceId;
   final String name;
@@ -243,6 +244,15 @@ class Placeholder {
   final String? format;
   final List<OptionalParameter> optionalParameters;
   final bool? isCustomDateFormat;
+
+  /// Whether this placeholder is optional. When `true`, the generated method
+  /// signature declares the parameter as nullable and (for named parameters)
+  /// omits the `required` keyword, so callers may pass `null` or omit the
+  /// argument entirely.
+  ///
+  /// Set via the `"optional": true` entry on a placeholder in the ARB
+  /// `@<resource>.placeholders` map.
+  final bool optional;
   // The following will be initialized after all messages are parsed in the Message constructor.
   String? type;
   bool isPlural = false;

--- a/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
@@ -1728,6 +1728,68 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
         },
       );
 
+      // Regression test for https://github.com/flutter/flutter/issues/177158.
+      //
+      // An explicit `"optional": false` should behave identically to omitting
+      // the field: the parameter remains non-nullable.
+      testWithoutContext('"optional": false leaves placeholder non-nullable', () {
+        setupLocalizations(<String, String>{
+          'en': '''
+{
+  "greet": "Hi {name}",
+  "@greet": {
+    "placeholders": {
+      "name": { "type": "String", "optional": false }
+    }
+  }
+}''',
+        });
+        expect(getGeneratedFileContent(locale: 'en'), contains('String greet(String name) {'));
+      });
+
+      // Regression test for https://github.com/flutter/flutter/issues/177158.
+      //
+      // The nullable suffix should be appended regardless of the placeholder's
+      // declared type, not just for `String`.
+      testWithoutContext('"optional": true marks non-String placeholders nullable', () {
+        setupLocalizations(<String, String>{
+          'en': '''
+{
+  "items": "You have {count} items",
+  "@items": {
+    "placeholders": {
+      "count": { "type": "int", "optional": true }
+    }
+  }
+}''',
+        });
+        expect(getGeneratedFileContent(locale: 'en'), contains('String items(int? count) {'));
+      });
+
+      // Regression test for https://github.com/flutter/flutter/issues/177158.
+      //
+      // When a message mixes required and optional placeholders, only the
+      // optional one should drop `required` and gain the nullable suffix;
+      // siblings remain `required` and non-nullable.
+      testWithoutContext('"optional": true is applied per-placeholder, not message-wide', () {
+        setupLocalizations(<String, String>{
+          'en': '''
+{
+  "greet": "Hi {name}{title}",
+  "@greet": {
+    "placeholders": {
+      "name": { "type": "String" },
+      "title": { "type": "String", "optional": true }
+    }
+  }
+}''',
+        }, useNamedParameters: true);
+        expect(
+          getGeneratedFileContent(locale: 'en'),
+          contains('String greet({required String name, String? title}) {'),
+        );
+      });
+
       testWithoutContext(
         'braces are ignored as special characters if placeholder does not exist',
         () {

--- a/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
@@ -1687,6 +1687,47 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
         expect(getGeneratedFileContent(locale: 'es'), contains('String helloWorld(Object name) {'));
       });
 
+      // Regression test for https://github.com/flutter/flutter/issues/177158.
+      //
+      // A placeholder marked `"optional": true` in the ARB metadata should
+      // produce a nullable parameter in the generated method signature.
+      testWithoutContext('marks placeholder as nullable when "optional": true', () {
+        setupLocalizations(<String, String>{
+          'en': '''
+{
+  "greet": "Hi {name}",
+  "@greet": {
+    "placeholders": {
+      "name": { "type": "String", "optional": true }
+    }
+  }
+}''',
+        });
+        expect(getGeneratedFileContent(locale: 'en'), contains('String greet(String? name) {'));
+      });
+
+      // Regression test for https://github.com/flutter/flutter/issues/177158.
+      //
+      // Same as above but with `use-named-parameters`: an optional placeholder
+      // should drop the `required` keyword and be nullable.
+      testWithoutContext(
+        'marks placeholder as nullable and drops `required` when "optional": true with named parameters',
+        () {
+          setupLocalizations(<String, String>{
+            'en': '''
+{
+  "greet": "Hi {name}",
+  "@greet": {
+    "placeholders": {
+      "name": { "type": "String", "optional": true }
+    }
+  }
+}''',
+          }, useNamedParameters: true);
+          expect(getGeneratedFileContent(locale: 'en'), contains('String greet({String? name}) {'));
+        },
+      );
+
       testWithoutContext(
         'braces are ignored as special characters if placeholder does not exist',
         () {


### PR DESCRIPTION
ARB metadata allows marking a placeholder as `"optional": true` on a per-resource basis (used for ICU `select` branches that may not supply the value), but `gen_l10n` silently ignored the flag: the generated method signature kept the parameter non-nullable, and with `use-named-parameters` it kept the `required` keyword.

`Placeholder` now reads the `optional` attribute via the existing `_boolAttribute` helper (defaulting to `false`). `generateMethodParameters` consults it to (1) drop the `required` keyword for named parameters and (2) append `?` to the parameter type. Added two regression tests in `packages/flutter_tools/test/general.shard/generate_localizations_test.dart` covering positional (`String greet(String? name)`) and named (`String greet({String? name})`) modes.

Fixes #177158.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md