### PR TITLE
Drop stale TextStyle.package when fontFamily changes via copyWith/apply/merge (#108230)

### DIFF
--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -931,7 +931,14 @@ class TextStyle with Diagnosticable {
       debugLabel: newDebugLabel,
       fontFamily: fontFamily ?? _fontFamily,
       fontFamilyFallback: fontFamilyFallback ?? _fontFamilyFallback,
-      package: package ?? _package,
+      // The `package` argument prefixes the [fontFamily] (and
+      // [fontFamilyFallback]) with `packages/$package/`. When the caller
+      // supplies a new [fontFamily] without an explicit [package], the
+      // original style's package was prefixing the new family — almost
+      // always wrong, because the new family is unrelated to the original
+      // package. Only inherit `_package` when [fontFamily] is unchanged.
+      // See https://github.com/flutter/flutter/issues/108230.
+      package: package ?? (fontFamily == null ? _package : null),
       overflow: overflow ?? this.overflow,
     );
   }
@@ -1046,7 +1053,10 @@ class TextStyle with Diagnosticable {
           ? null
           : decorationThickness! * decorationThicknessFactor + decorationThicknessDelta,
       overflow: overflow ?? this.overflow,
-      package: package ?? _package,
+      // See the matching comment in [copyWith]. When [apply] receives a new
+      // [fontFamily] but no explicit [package], the original style's package
+      // must not prefix the new family.
+      package: package ?? (fontFamily == null ? _package : null),
       debugLabel: modifiedDebugLabel,
     );
   }

--- a/packages/flutter/test/painting/text_style_test.dart
+++ b/packages/flutter/test/painting/text_style_test.dart
@@ -374,6 +374,38 @@ void main() {
     expect(lerp2.fontFamilyFallback, <String>['packages/p/fallback2']);
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/108230.
+  //
+  // `TextStyle.merge(otherStyle)` (and the `copyWith` / `apply` paths it
+  // builds on) used to keep the original style's `package` even when
+  // [otherStyle] supplied a brand-new `fontFamily` with no package. That
+  // produced fontFamily strings like `packages/wiredash/Roboto`, where
+  // `Roboto` has nothing to do with the `wiredash` package.
+  test('TextStyle merge/copyWith/apply drop stale package when fontFamily changes', () {
+    const TextStyle baseStyle = TextStyle(fontFamily: 'Inter', package: 'wiredash');
+    expect(baseStyle.fontFamily, 'packages/wiredash/Inter');
+
+    // merge with a style that supplies a new fontFamily and no package.
+    final TextStyle merged = baseStyle.merge(const TextStyle(fontFamily: 'Roboto'));
+    expect(merged.fontFamily, 'Roboto');
+
+    // copyWith only changing fontFamily should also drop the stale package.
+    final TextStyle copied = baseStyle.copyWith(fontFamily: 'Roboto');
+    expect(copied.fontFamily, 'Roboto');
+
+    // apply only changing fontFamily should also drop the stale package.
+    final TextStyle applied = baseStyle.apply(fontFamily: 'Roboto');
+    expect(applied.fontFamily, 'Roboto');
+
+    // copyWith that does NOT change fontFamily keeps the original package.
+    final TextStyle untouched = baseStyle.copyWith(fontSize: 12);
+    expect(untouched.fontFamily, 'packages/wiredash/Inter');
+
+    // copyWith that supplies BOTH fontFamily and package uses the new package.
+    final TextStyle bothExplicit = baseStyle.copyWith(fontFamily: 'Roboto', package: 'other_pkg');
+    expect(bothExplicit.fontFamily, 'packages/other_pkg/Roboto');
+  });
+
   test('TextStyle font family fallback', () {
     const s1 = TextStyle(fontFamilyFallback: <String>['Roboto', 'test']);
     expect(s1.fontFamilyFallback![0], 'Roboto');


### PR DESCRIPTION
`TextStyle` stores the `package` argument so the published `fontFamily` (and `fontFamilyFallback`) become `packages/<package>/<family>`. `copyWith` and `apply` previously inherited the original style's `_package` whenever the caller did not provide a new `package`, even when the caller supplied a brand-new `fontFamily`. That meant `baseStyle.copyWith(fontFamily: 'Roboto')` (and the `merge` paths that build on it) produced names like `packages/<old-pkg>/Roboto`, where Roboto has nothing to do with the old package.

Inherit `_package` only when `fontFamily` is unchanged. Callers that want to preserve the package while changing the family can still pass it explicitly. Existing tests `TextStyle using package font` and `TextStyle package font merge` exercise the unchanged-fontFamily path and continue to pass; added a new test in `packages/flutter/test/painting/text_style_test.dart` covering all four entry points (`merge`, `copyWith`, `apply`, and the explicit "keep package by re-supplying" case).

Fixes #108230.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md