### PR TITLE
[Impeller] Support instanced rendering across all backends

### DIFF
--- a/engine/src/flutter/impeller/core/shader_types.h
+++ b/engine/src/flutter/impeller/core/shader_types.h
@@ -196,15 +196,36 @@ struct ShaderStageIOSlot {
   }
 };
 
+/// @brief  Whether a vertex buffer binding advances its read position once
+///         per vertex or once per instance.
+///
+///         An instance-rate binding supplies per-instance data (such as a
+///         per-instance model transform) to an instanced draw. It maps to
+///         `MTLVertexStepFunctionPerInstance`, `VK_VERTEX_INPUT_RATE_INSTANCE`,
+///         and a `glVertexAttribDivisor` of 1.
+enum class VertexInputRate {
+  /// The binding is read once per vertex. This is the default.
+  kVertex,
+  /// The binding is read once per instance.
+  kInstance,
+};
+
 struct ShaderStageBufferLayout {
   size_t stride;
   size_t binding;
+  /// The rate at which this binding advances during a draw. Defaults to
+  /// per-vertex; an instanced draw reads per-instance bindings once per
+  /// instance.
+  VertexInputRate input_rate = VertexInputRate::kVertex;
 
-  constexpr size_t GetHash() const { return fml::HashCombine(stride, binding); }
+  constexpr size_t GetHash() const {
+    return fml::HashCombine(stride, binding, input_rate);
+  }
 
   constexpr bool operator==(const ShaderStageBufferLayout& other) const {
-    return stride == other.stride &&  //
-           binding == other.binding;
+    return stride == other.stride &&    //
+           binding == other.binding &&  //
+           input_rate == other.input_rate;
   }
 };
 

--- a/engine/src/flutter/impeller/fixtures/BUILD.gn
+++ b/engine/src/flutter/impeller/fixtures/BUILD.gn
@@ -51,6 +51,8 @@ impeller_shaders("shader_fixtures") {
     "impeller.vert",
     "inactive_uniforms.frag",
     "inactive_uniforms.vert",
+    "instanced_attributes.frag",
+    "instanced_attributes.vert",
     "instanced_draw.frag",
     "instanced_draw.vert",
     "mipmaps.frag",

--- a/engine/src/flutter/impeller/fixtures/instanced_attributes.frag
+++ b/engine/src/flutter/impeller/fixtures/instanced_attributes.frag
@@ -1,0 +1,11 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+in vec4 v_color;
+
+out vec4 frag_color;
+
+void main() {
+  frag_color = v_color;
+}

--- a/engine/src/flutter/impeller/fixtures/instanced_attributes.vert
+++ b/engine/src/flutter/impeller/fixtures/instanced_attributes.vert
@@ -1,0 +1,26 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+uniform FrameInfo {
+  mat4 mvp;
+}
+frame_info;
+
+// Per-vertex geometry. Sourced from a binding that advances once per vertex.
+in vec2 vertex_position;
+
+// Per-instance data. Sourced from a binding that advances once per instance.
+// Using instance-rate vertex attributes rather than gl_InstanceIndex keeps
+// this shader portable down to OpenGL ES 2.0, which has no instance-ID
+// builtin.
+in vec2 instance_offset;
+in vec4 instance_color;
+
+out vec4 v_color;
+
+void main() {
+  gl_Position =
+      frame_info.mvp * vec4(vertex_position + instance_offset, 0.0, 1.0);
+  v_color = instance_color;
+}

--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -59,6 +59,8 @@ bool BufferBindingsGLES::RegisterVertexStageInput(
       attrib.normalized = GL_FALSE;
       attrib.offset = input.offset;
       attrib.stride = layout.stride;
+      attrib.divisor =
+          layout.input_rate == VertexInputRate::kInstance ? 1u : 0u;
       vertex_attrib_arrays[layout_i].push_back(attrib);
     }
   }
@@ -214,6 +216,15 @@ bool BufferBindingsGLES::BindVertexAttributes(const ProcTableGLES& gl,
                            reinterpret_cast<const GLvoid*>(static_cast<GLsizei>(
                                vertex_offset + array.offset))  // pointer
     );
+    // Set the instancing divisor when the driver supports it. It is core
+    // on ES 3.0+ and comes from GL_EXT_instanced_arrays on ES 2.0. When
+    // unavailable, only per-vertex (divisor 0) bindings are possible,
+    // which is the default. Setting it for every attribute (including
+    // divisor 0) also clears any stale divisor left by a prior pipeline,
+    // which matters on ES, where there is no vertex array object.
+    if (gl.VertexAttribDivisorEXT.IsAvailable()) {
+      gl.VertexAttribDivisorEXT(array.index, array.divisor);
+    }
   }
 
   return true;

--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -4,6 +4,7 @@
 
 #include "impeller/renderer/backend/gles/buffer_bindings_gles.h"
 
+#include <cstdint>
 #include <cstring>
 #include <vector>
 
@@ -201,6 +202,22 @@ bool BufferBindingsGLES::BindVertexAttributes(const ProcTableGLES& gl,
     return false;
   }
 
+  // For an emulated instanced draw (instance > 0), a binding whose attributes
+  // are all vertex-rate (divisor 0) does not change across instances, so the
+  // state bound for instance 0 still applies. Skip the redundant re-binding.
+  if (instance > 0u) {
+    bool has_instance_rate = false;
+    for (const auto& array : vertex_attrib_arrays_[binding]) {
+      if (array.vertex_attrib_divisor != 0u) {
+        has_instance_rate = true;
+        break;
+      }
+    }
+    if (!has_instance_rate) {
+      return true;
+    }
+  }
+
   if (!gl.GetCapabilities()->IsES()) {
     FML_DCHECK(vertex_array_object_ == 0);
     gl.GenVertexArrays(1, &vertex_array_object_);
@@ -223,7 +240,7 @@ bool BufferBindingsGLES::BindVertexAttributes(const ProcTableGLES& gl,
                            array.normalized,  // normalized
                            array.stride,      // stride
                            reinterpret_cast<const GLvoid*>(
-                               static_cast<GLsizei>(attribute_offset))  // ptr
+                               static_cast<uintptr_t>(attribute_offset))  // ptr
     );
     // Set the instancing divisor when the driver supports it. It is core
     // on ES 3.0+ and comes from GL_EXT_instanced_arrays on ES 2.0. When

--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -195,7 +195,8 @@ bool BufferBindingsGLES::ReadUniformsBindingsV2(const ProcTableGLES& gl,
 
 bool BufferBindingsGLES::BindVertexAttributes(const ProcTableGLES& gl,
                                               size_t binding,
-                                              size_t vertex_offset) {
+                                              size_t vertex_offset,
+                                              size_t instance) {
   if (binding >= vertex_attrib_arrays_.size()) {
     return false;
   }
@@ -208,13 +209,21 @@ bool BufferBindingsGLES::BindVertexAttributes(const ProcTableGLES& gl,
 
   for (const auto& array : vertex_attrib_arrays_[binding]) {
     gl.EnableVertexAttribArray(array.index);
+    // For an emulated instanced draw, an instance-rate attribute is
+    // re-pointed at instance `instance`, since there is no hardware divisor
+    // to advance it. A non-instanced or hardware-instanced draw passes
+    // instance 0 and lets the divisor (if any) do the stepping.
+    size_t attribute_offset = vertex_offset + array.offset;
+    if (array.divisor != 0u) {
+      attribute_offset += instance * static_cast<size_t>(array.stride);
+    }
     gl.VertexAttribPointer(array.index,       // index
                            array.size,        // size (must be 1, 2, 3, or 4)
                            array.type,        // type
                            array.normalized,  // normalized
                            array.stride,      // stride
-                           reinterpret_cast<const GLvoid*>(static_cast<GLsizei>(
-                               vertex_offset + array.offset))  // pointer
+                           reinterpret_cast<const GLvoid*>(
+                               static_cast<GLsizei>(attribute_offset))  // ptr
     );
     // Set the instancing divisor when the driver supports it. It is core
     // on ES 3.0+ and comes from GL_EXT_instanced_arrays on ES 2.0. When

--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -59,7 +59,7 @@ bool BufferBindingsGLES::RegisterVertexStageInput(
       attrib.normalized = GL_FALSE;
       attrib.offset = input.offset;
       attrib.stride = layout.stride;
-      attrib.divisor =
+      attrib.vertex_attrib_divisor =
           layout.input_rate == VertexInputRate::kInstance ? 1u : 0u;
       vertex_attrib_arrays[layout_i].push_back(attrib);
     }
@@ -214,7 +214,7 @@ bool BufferBindingsGLES::BindVertexAttributes(const ProcTableGLES& gl,
     // to advance it. A non-instanced or hardware-instanced draw passes
     // instance 0 and lets the divisor (if any) do the stepping.
     size_t attribute_offset = vertex_offset + array.offset;
-    if (array.divisor != 0u) {
+    if (array.vertex_attrib_divisor != 0u) {
       attribute_offset += instance * static_cast<size_t>(array.stride);
     }
     gl.VertexAttribPointer(array.index,       // index
@@ -232,7 +232,7 @@ bool BufferBindingsGLES::BindVertexAttributes(const ProcTableGLES& gl,
     // divisor 0) also clears any stale divisor left by a prior pipeline,
     // which matters on ES, where there is no vertex array object.
     if (gl.VertexAttribDivisorEXT.IsAvailable()) {
-      gl.VertexAttribDivisorEXT(array.index, array.divisor);
+      gl.VertexAttribDivisorEXT(array.index, array.vertex_attrib_divisor);
     }
   }
 

--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.h
@@ -69,6 +69,8 @@ class BufferBindingsGLES {
     GLenum normalized = GL_FALSE;
     GLsizei stride = 0u;
     GLsizei offset = 0u;
+    // glVertexAttribDivisor value: 0 advances per vertex, 1 per instance.
+    GLuint divisor = 0u;
   };
   std::vector<std::vector<VertexAttribPointer>> vertex_attrib_arrays_;
 

--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.h
@@ -40,9 +40,16 @@ class BufferBindingsGLES {
 
   bool ReadUniformsBindings(const ProcTableGLES& gl, GLuint program);
 
+  /// Bind the vertex attributes for buffer slot [binding].
+  ///
+  /// [instance] re-points instance-rate attributes at the given instance,
+  /// used to emulate an instanced draw on drivers without hardware
+  /// instancing support. It is 0 for a non-instanced or hardware-instanced
+  /// draw.
   bool BindVertexAttributes(const ProcTableGLES& gl,
                             size_t binding,
-                            size_t vertex_offset);
+                            size_t vertex_offset,
+                            size_t instance = 0);
 
   bool BindUniformData(const ProcTableGLES& gl,
                        const std::vector<TextureAndSampler>& bound_textures,

--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.h
@@ -77,7 +77,7 @@ class BufferBindingsGLES {
     GLsizei stride = 0u;
     GLsizei offset = 0u;
     // glVertexAttribDivisor value: 0 advances per vertex, 1 per instance.
-    GLuint divisor = 0u;
+    GLuint vertex_attrib_divisor = 0u;
   };
   std::vector<std::vector<VertexAttribPointer>> vertex_attrib_arrays_;
 

--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles_unittests.cc
@@ -233,8 +233,12 @@ TEST(BufferBindingsGLESTest, BindVertexAttributesSetsInstanceRateDivisor) {
                                                 layouts));
   // Binding 0 is per-vertex (divisor 0); binding 1 is per-instance
   // (divisor 1).
-  EXPECT_TRUE(bindings.BindVertexAttributes(mock_gl->GetProcTable(), 0, 0, 0));
-  EXPECT_TRUE(bindings.BindVertexAttributes(mock_gl->GetProcTable(), 1, 0, 0));
+  EXPECT_TRUE(bindings.BindVertexAttributes(mock_gl->GetProcTable(),
+                                            /*binding=*/0, /*vertex_offset=*/0,
+                                            /*instance=*/0));
+  EXPECT_TRUE(bindings.BindVertexAttributes(mock_gl->GetProcTable(),
+                                            /*binding=*/1, /*vertex_offset=*/0,
+                                            /*instance=*/0));
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles_unittests.cc
@@ -184,5 +184,58 @@ TEST(BufferBindingsGLESTest, BindUniformFailsWithoutFloatType) {
                                         Range{0, 1}));
 }
 
+// An instanced draw reaches per-instance data through instance-rate vertex
+// attributes. A vertex layout with an instance-rate binding must set a
+// glVertexAttribDivisor of 1 on that binding's attributes, while a
+// per-vertex binding keeps a divisor of 0.
+TEST(BufferBindingsGLESTest, BindVertexAttributesSetsInstanceRateDivisor) {
+  auto mock_gles_impl = std::make_unique<::testing::NiceMock<MockGLESImpl>>();
+  EXPECT_CALL(*mock_gles_impl, VertexAttribDivisorEXT(0, 0)).Times(1);
+  EXPECT_CALL(*mock_gles_impl, VertexAttribDivisorEXT(1, 1)).Times(1);
+  std::shared_ptr<MockGLES> mock_gl = MockGLES::Init(std::move(mock_gles_impl));
+
+  BufferBindingsGLES bindings;
+
+  ShaderStageIOSlot per_vertex_input = {
+      .name = "position",
+      .location = 0,
+      .set = 0,
+      .binding = 0,
+      .type = ShaderType::kFloat,
+      .bit_width = sizeof(float) * 8,
+      .vec_size = 2,
+      .columns = 1,
+      .offset = 0,
+  };
+  ShaderStageIOSlot per_instance_input = {
+      .name = "instance_offset",
+      .location = 1,
+      .set = 0,
+      .binding = 1,
+      .type = ShaderType::kFloat,
+      .bit_width = sizeof(float) * 8,
+      .vec_size = 2,
+      .columns = 1,
+      .offset = 0,
+  };
+  std::vector<ShaderStageIOSlot> inputs = {per_vertex_input,
+                                           per_instance_input};
+  std::vector<ShaderStageBufferLayout> layouts = {
+      ShaderStageBufferLayout{.stride = sizeof(float) * 2,
+                              .binding = 0,
+                              .input_rate = VertexInputRate::kVertex},
+      ShaderStageBufferLayout{.stride = sizeof(float) * 2,
+                              .binding = 1,
+                              .input_rate = VertexInputRate::kInstance},
+  };
+
+  ASSERT_TRUE(bindings.RegisterVertexStageInput(mock_gl->GetProcTable(), inputs,
+                                                layouts));
+  // Binding 0 is per-vertex (divisor 0); binding 1 is per-instance
+  // (divisor 1).
+  EXPECT_TRUE(bindings.BindVertexAttributes(mock_gl->GetProcTable(), 0, 0, 0));
+  EXPECT_TRUE(bindings.BindVertexAttributes(mock_gl->GetProcTable(), 1, 0, 0));
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_gles.h
@@ -16,7 +16,7 @@ namespace impeller {
 class PipelineLibraryGLES;
 
 namespace testing {
-class RenderPassGLESViewportTest;
+class RenderPassGLESCommandTest;
 }  // namespace testing
 
 class PipelineGLES final
@@ -45,7 +45,7 @@ class PipelineGLES final
 
  private:
   friend PipelineLibraryGLES;
-  friend class testing::RenderPassGLESViewportTest;
+  friend class testing::RenderPassGLESCommandTest;
 
   std::shared_ptr<ReactorGLES> reactor_;
   std::shared_ptr<UniqueHandleGLES> handle_;

--- a/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
@@ -286,7 +286,8 @@ void(glDepthRange)(GLdouble n, GLdouble f);
   PROC(BeginQueryEXT);                      \
   PROC(EndQueryEXT);                        \
   PROC(GetQueryObjectuivEXT);               \
-  PROC(BlitFramebufferANGLE);
+  PROC(BlitFramebufferANGLE);               \
+  PROC(VertexAttribDivisorEXT);
 
 enum class DebugResourceType {
   kTexture,

--- a/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
@@ -287,7 +287,9 @@ void(glDepthRange)(GLdouble n, GLdouble f);
   PROC(EndQueryEXT);                        \
   PROC(GetQueryObjectuivEXT);               \
   PROC(BlitFramebufferANGLE);               \
-  PROC(VertexAttribDivisorEXT);
+  PROC(VertexAttribDivisorEXT);             \
+  PROC(DrawArraysInstancedEXT);             \
+  PROC(DrawElementsInstancedEXT);
 
 enum class DebugResourceType {
   kTexture,

--- a/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -148,7 +148,8 @@ struct RenderPassData {
 static bool BindVertexBuffer(const ProcTableGLES& gl,
                              BufferBindingsGLES* vertex_desc_gles,
                              const BufferView& vertex_buffer_view,
-                             size_t buffer_index) {
+                             size_t buffer_index,
+                             size_t instance = 0) {
   if (!vertex_buffer_view) {
     return false;
   }
@@ -169,7 +170,7 @@ static bool BindVertexBuffer(const ProcTableGLES& gl,
   /// Bind the vertex attributes associated with vertex buffer.
   ///
   if (!vertex_desc_gles->BindVertexAttributes(
-          gl, buffer_index, vertex_buffer_view.GetRange().offset)) {
+          gl, buffer_index, vertex_buffer_view.GetRange().offset, instance)) {
     return false;
   }
 
@@ -520,10 +521,23 @@ static void EncodeViewport(const ProcTableGLES& gl,
     //--------------------------------------------------------------------------
     /// Finally! Invoke the draw call.
     ///
-    if (command.index_type == IndexType::kNone) {
-      gl.DrawArrays(mode, command.base_vertex, command.element_count);
-    } else {
-      // Bind the index buffer if necessary.
+    /// An instanced draw uses the hardware instanced entry points when the
+    /// driver exposes them (ES 3.0 core, or GL_EXT_instanced_arrays on ES
+    /// 2.0). When it does not, the draw is emulated by repeating it once per
+    /// instance, re-pointing the instance-rate vertex attributes at each
+    /// instance in between.
+    ///
+    const bool instanced = command.instance_count > 1u;
+    const bool hardware_instanced = instanced &&  //
+                                    gl.DrawArraysInstancedEXT.IsAvailable() &&
+                                    gl.DrawElementsInstancedEXT.IsAvailable() &&
+                                    gl.VertexAttribDivisorEXT.IsAvailable();
+    const bool emulate_instanced = instanced && !hardware_instanced;
+    const GLsizei instance_count = static_cast<GLsizei>(command.instance_count);
+
+    // Bind the index buffer once, before any (possibly repeated) draw.
+    const GLvoid* index_offset = nullptr;
+    if (command.index_type != IndexType::kNone) {
       auto index_buffer_view = command.index_buffer;
       const DeviceBuffer* index_buffer = index_buffer_view.GetBuffer();
       const auto& index_buffer_gles = DeviceBufferGLES::Cast(*index_buffer);
@@ -531,12 +545,42 @@ static void EncodeViewport(const ProcTableGLES& gl,
               DeviceBufferGLES::BindingType::kElementArrayBuffer)) {
         return false;
       }
-      gl.DrawElements(mode,                             // mode
-                      command.element_count,            // count
-                      ToIndexType(command.index_type),  // type
-                      reinterpret_cast<const GLvoid*>(static_cast<GLsizei>(
-                          index_buffer_view.GetRange().offset))  // indices
-      );
+      index_offset = reinterpret_cast<const GLvoid*>(
+          static_cast<GLsizei>(index_buffer_view.GetRange().offset));
+    }
+
+    const size_t draw_count = emulate_instanced ? command.instance_count : 1u;
+    for (size_t instance = 0; instance < draw_count; instance++) {
+      // The vertex buffers were already bound above for instance 0. When
+      // emulating, re-point the instance-rate attributes at each subsequent
+      // instance.
+      if (emulate_instanced && instance > 0u) {
+        for (size_t i = 0; i < command.vertex_buffers.length; i++) {
+          if (!BindVertexBuffer(
+                  gl, vertex_desc_gles,
+                  vertex_buffers[i + command.vertex_buffers.offset], i,
+                  instance)) {
+            return false;
+          }
+        }
+      }
+      if (command.index_type == IndexType::kNone) {
+        if (hardware_instanced) {
+          gl.DrawArraysInstancedEXT(mode, command.base_vertex,
+                                    command.element_count, instance_count);
+        } else {
+          gl.DrawArrays(mode, command.base_vertex, command.element_count);
+        }
+      } else {
+        if (hardware_instanced) {
+          gl.DrawElementsInstancedEXT(mode, command.element_count,
+                                      ToIndexType(command.index_type),
+                                      index_offset, instance_count);
+        } else {
+          gl.DrawElements(mode, command.element_count,
+                          ToIndexType(command.index_type), index_offset);
+        }
+      }
     }
 
     //--------------------------------------------------------------------------

--- a/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -549,7 +549,16 @@ static void EncodeViewport(const ProcTableGLES& gl,
           static_cast<GLsizei>(index_buffer_view.GetRange().offset));
     }
 
-    const size_t draw_count = emulate_instanced ? command.instance_count : 1u;
+    // An instance count of zero draws nothing, matching the Metal and Vulkan
+    // backends. The hardware path issues a single instanced call; the
+    // emulation path repeats the draw once per instance; every other case is
+    // a single ordinary draw.
+    size_t draw_count = 1u;
+    if (command.instance_count == 0u) {
+      draw_count = 0u;
+    } else if (emulate_instanced) {
+      draw_count = command.instance_count;
+    }
     for (size_t instance = 0; instance < draw_count; instance++) {
       // The vertex buffers were already bound above for instance 0. When
       // emulating, re-point the instance-rate attributes at each subsequent

--- a/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -535,9 +535,16 @@ static void EncodeViewport(const ProcTableGLES& gl,
     const bool emulate_instanced = instanced && !hardware_instanced;
     const GLsizei instance_count = static_cast<GLsizei>(command.instance_count);
 
+    // A draw is indexed only when a real index type was set. A command that
+    // never bound an index buffer leaves `index_type` at its `kUnknown`
+    // default, which must be treated as non-indexed (matching the Metal and
+    // Vulkan backends, which key off the presence of the index buffer).
+    const bool is_indexed = command.index_type != IndexType::kNone &&
+                            command.index_type != IndexType::kUnknown;
+
     // Bind the index buffer once, before any (possibly repeated) draw.
     const GLvoid* index_offset = nullptr;
-    if (command.index_type != IndexType::kNone) {
+    if (is_indexed) {
       auto index_buffer_view = command.index_buffer;
       const DeviceBuffer* index_buffer = index_buffer_view.GetBuffer();
       const auto& index_buffer_gles = DeviceBufferGLES::Cast(*index_buffer);
@@ -552,7 +559,7 @@ static void EncodeViewport(const ProcTableGLES& gl,
     // A non-instanced draw of the bound geometry. Used directly for ordinary
     // draws and once per instance when emulating instancing.
     const auto draw_geometry = [&]() {
-      if (command.index_type == IndexType::kNone) {
+      if (!is_indexed) {
         gl.DrawArrays(mode, command.base_vertex, command.element_count);
       } else {
         gl.DrawElements(mode, command.element_count,
@@ -582,7 +589,7 @@ static void EncodeViewport(const ProcTableGLES& gl,
       }
     } else if (hardware_instanced) {
       // A single instanced call covers every instance.
-      if (command.index_type == IndexType::kNone) {
+      if (!is_indexed) {
         gl.DrawArraysInstancedEXT(mode, command.base_vertex,
                                   command.element_count, instance_count);
       } else {

--- a/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -546,7 +546,7 @@ static void EncodeViewport(const ProcTableGLES& gl,
         return false;
       }
       index_offset = reinterpret_cast<const GLvoid*>(
-          static_cast<GLsizei>(index_buffer_view.GetRange().offset));
+          static_cast<uintptr_t>(index_buffer_view.GetRange().offset));
     }
 
     // A non-instanced draw of the bound geometry. Used directly for ordinary

--- a/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -549,47 +549,49 @@ static void EncodeViewport(const ProcTableGLES& gl,
           static_cast<GLsizei>(index_buffer_view.GetRange().offset));
     }
 
-    // An instance count of zero draws nothing, matching the Metal and Vulkan
-    // backends. The hardware path issues a single instanced call; the
-    // emulation path repeats the draw once per instance; every other case is
-    // a single ordinary draw.
-    size_t draw_count = 1u;
+    // A non-instanced draw of the bound geometry. Used directly for ordinary
+    // draws and once per instance when emulating instancing.
+    const auto draw_geometry = [&]() {
+      if (command.index_type == IndexType::kNone) {
+        gl.DrawArrays(mode, command.base_vertex, command.element_count);
+      } else {
+        gl.DrawElements(mode, command.element_count,
+                        ToIndexType(command.index_type), index_offset);
+      }
+    };
+
     if (command.instance_count == 0u) {
-      draw_count = 0u;
+      // A zero instance count draws nothing, matching the Metal and Vulkan
+      // backends.
     } else if (emulate_instanced) {
-      draw_count = command.instance_count;
-    }
-    for (size_t instance = 0; instance < draw_count; instance++) {
-      // The vertex buffers were already bound above for instance 0. When
-      // emulating, re-point the instance-rate attributes at each subsequent
-      // instance.
-      if (emulate_instanced && instance > 0u) {
-        for (size_t i = 0; i < command.vertex_buffers.length; i++) {
-          if (!BindVertexBuffer(
-                  gl, vertex_desc_gles,
-                  vertex_buffers[i + command.vertex_buffers.offset], i,
-                  instance)) {
-            return false;
+      // Repeat the draw once per instance, re-pointing the instance-rate
+      // vertex attributes at each instance in between. The vertex buffers
+      // were already bound above for instance 0.
+      for (size_t instance = 0; instance < command.instance_count; instance++) {
+        if (instance > 0u) {
+          for (size_t i = 0; i < command.vertex_buffers.length; i++) {
+            if (!BindVertexBuffer(
+                    gl, vertex_desc_gles,
+                    vertex_buffers[i + command.vertex_buffers.offset], i,
+                    instance)) {
+              return false;
+            }
           }
         }
+        draw_geometry();
       }
+    } else if (hardware_instanced) {
+      // A single instanced call covers every instance.
       if (command.index_type == IndexType::kNone) {
-        if (hardware_instanced) {
-          gl.DrawArraysInstancedEXT(mode, command.base_vertex,
-                                    command.element_count, instance_count);
-        } else {
-          gl.DrawArrays(mode, command.base_vertex, command.element_count);
-        }
+        gl.DrawArraysInstancedEXT(mode, command.base_vertex,
+                                  command.element_count, instance_count);
       } else {
-        if (hardware_instanced) {
-          gl.DrawElementsInstancedEXT(mode, command.element_count,
-                                      ToIndexType(command.index_type),
-                                      index_offset, instance_count);
-        } else {
-          gl.DrawElements(mode, command.element_count,
-                          ToIndexType(command.index_type), index_offset);
-        }
+        gl.DrawElementsInstancedEXT(mode, command.element_count,
+                                    ToIndexType(command.index_type),
+                                    index_offset, instance_count);
       }
+    } else {
+      draw_geometry();
     }
 
     //--------------------------------------------------------------------------

--- a/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles_unittests.cc
@@ -398,7 +398,10 @@ TEST_F(RenderPassGLESCommandTest, HardwareInstancedArrayDraw) {
   render_pass->SetInstanceCount(4);
   EXPECT_TRUE(render_pass->Draw().ok());
 
-  EXPECT_CALL(mock_gl_impl_ref, DrawArraysInstancedEXT(_, 0, 3, 4)).Times(1);
+  EXPECT_CALL(mock_gl_impl_ref,
+              DrawArraysInstancedEXT(/*mode=*/_, /*first=*/0, /*count=*/3,
+                                     /*instancecount=*/4))
+      .Times(1);
   EXPECT_CALL(mock_gl_impl_ref, DrawArrays(_, _, _)).Times(0);
 
   EXPECT_TRUE(render_pass->EncodeCommands());
@@ -429,7 +432,9 @@ TEST_F(RenderPassGLESCommandTest, HardwareInstancedElementsDraw) {
   render_pass->SetInstanceCount(4);
   EXPECT_TRUE(render_pass->Draw().ok());
 
-  EXPECT_CALL(mock_gl_impl_ref, DrawElementsInstancedEXT(_, 6, _, _, 4))
+  EXPECT_CALL(mock_gl_impl_ref,
+              DrawElementsInstancedEXT(/*mode=*/_, /*count=*/6, /*type=*/_,
+                                       /*indices=*/_, /*instancecount=*/4))
       .Times(1);
   EXPECT_CALL(mock_gl_impl_ref, DrawElements(_, _, _, _)).Times(0);
 
@@ -453,7 +458,9 @@ TEST_F(RenderPassGLESCommandTest, EmulatedInstancedArrayDraw) {
   render_pass->SetInstanceCount(4);
   EXPECT_TRUE(render_pass->Draw().ok());
 
-  EXPECT_CALL(mock_gl_impl_ref, DrawArrays(_, 0, 3)).Times(4);
+  EXPECT_CALL(mock_gl_impl_ref,
+              DrawArrays(/*mode=*/_, /*first=*/0, /*count=*/3))
+      .Times(4);
   EXPECT_CALL(mock_gl_impl_ref, DrawArraysInstancedEXT(_, _, _, _)).Times(0);
 
   EXPECT_TRUE(render_pass->EncodeCommands());
@@ -484,7 +491,9 @@ TEST_F(RenderPassGLESCommandTest, EmulatedInstancedElementsDraw) {
   render_pass->SetInstanceCount(4);
   EXPECT_TRUE(render_pass->Draw().ok());
 
-  EXPECT_CALL(mock_gl_impl_ref, DrawElements(_, 6, _, _)).Times(4);
+  EXPECT_CALL(mock_gl_impl_ref,
+              DrawElements(/*mode=*/_, /*count=*/6, /*type=*/_, /*indices=*/_))
+      .Times(4);
   EXPECT_CALL(mock_gl_impl_ref, DrawElementsInstancedEXT(_, _, _, _, _))
       .Times(0);
 
@@ -506,7 +515,9 @@ TEST_F(RenderPassGLESCommandTest, NonInstancedDrawIssuesSingleDrawArrays) {
   render_pass->SetIndexBuffer({}, IndexType::kNone);
   EXPECT_TRUE(render_pass->Draw().ok());
 
-  EXPECT_CALL(mock_gl_impl_ref, DrawArrays(_, 0, 3)).Times(1);
+  EXPECT_CALL(mock_gl_impl_ref,
+              DrawArrays(/*mode=*/_, /*first=*/0, /*count=*/3))
+      .Times(1);
   EXPECT_CALL(mock_gl_impl_ref, DrawArraysInstancedEXT(_, _, _, _)).Times(0);
 
   EXPECT_TRUE(render_pass->EncodeCommands());

--- a/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles_unittests.cc
@@ -513,5 +513,27 @@ TEST_F(RenderPassGLESCommandTest, NonInstancedDrawIssuesSingleDrawArrays) {
   EXPECT_TRUE(reactor->React());
 }
 
+// A command with an explicit instance count of zero draws nothing, matching
+// the Metal and Vulkan backends.
+TEST_F(RenderPassGLESCommandTest, ZeroInstanceCountIssuesNoDraw) {
+  auto ctx = CreateRenderPassGLESContext();
+  testing::NiceMock<MockGLESImpl>& mock_gl_impl_ref = ctx.mock_gl_impl_ref;
+  std::shared_ptr<RenderPass>& render_pass = ctx.render_pass;
+  std::shared_ptr<PipelineGLES>& pipeline = ctx.pipeline;
+  std::shared_ptr<ReactorGLES>& reactor = ctx.reactor;
+
+  render_pass->SetPipeline(PipelineRef(pipeline));
+  render_pass->SetElementCount(3);
+  render_pass->SetIndexBuffer({}, IndexType::kNone);
+  render_pass->SetInstanceCount(0);
+  EXPECT_TRUE(render_pass->Draw().ok());
+
+  EXPECT_CALL(mock_gl_impl_ref, DrawArrays(_, _, _)).Times(0);
+  EXPECT_CALL(mock_gl_impl_ref, DrawArraysInstancedEXT(_, _, _, _)).Times(0);
+
+  EXPECT_TRUE(render_pass->EncodeCommands());
+  EXPECT_TRUE(reactor->React());
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles_unittests.cc
@@ -6,6 +6,7 @@
 #include "flutter/testing/testing.h"  // IWYU pragma: keep
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "impeller/core/device_buffer.h"
 #include "impeller/core/formats.h"
 #include "impeller/renderer/backend/gles/command_buffer_gles.h"
 #include "impeller/renderer/backend/gles/context_gles.h"
@@ -58,13 +59,25 @@ class RenderPassGLESWithDiscardFrameBufferExtTest
     : public TestWithParam<DiscardFrameBufferParams> {};
 
 namespace {
-std::shared_ptr<ContextGLES> CreateFakeGLESContext() {
-  auto dummy_gl_procs = std::make_unique<ProcTableGLES>(kMockResolverGLES);
+std::shared_ptr<ContextGLES> CreateFakeGLESContext(
+    ProcTableGLES::Resolver resolver = kMockResolverGLES) {
+  auto dummy_gl_procs = std::make_unique<ProcTableGLES>(std::move(resolver));
   auto dummy_shader_library = std::vector<std::shared_ptr<fml::Mapping>>{};
   auto flags = Flags{};
   return ContextGLES::Create(flags, std::move(dummy_gl_procs),
                              dummy_shader_library, false);
 }
+
+struct RenderPassGLESContext {
+  std::shared_ptr<MockGLES> mock_gl;
+  testing::NiceMock<MockGLESImpl>& mock_gl_impl_ref;
+  std::shared_ptr<ContextGLES> context;
+  std::shared_ptr<MockWorker> dummy_worker;
+  std::shared_ptr<ReactorGLES> reactor;
+  std::shared_ptr<CommandBuffer> command_buffer;
+  std::shared_ptr<RenderPass> render_pass;
+  std::shared_ptr<PipelineGLES> pipeline;
+};
 }  // namespace
 
 TEST_P(RenderPassGLESWithDiscardFrameBufferExtTest, DiscardFramebufferExt) {
@@ -218,26 +231,21 @@ TEST(RenderPassGLESTest, ResolvingMultisampleTextureCachesResolveFBO) {
   }
 }
 
-class RenderPassGLESViewportTest : public ::testing::Test {
+class RenderPassGLESCommandTest : public ::testing::Test {
  protected:
-  struct RenderPassGLESContext {
-    std::shared_ptr<MockGLES> mock_gl;
-    testing::NiceMock<MockGLESImpl>& mock_gl_impl_ref;
-    std::shared_ptr<ContextGLES> context;
-    std::shared_ptr<MockWorker> dummy_worker;
-    std::shared_ptr<ReactorGLES> reactor;
-    std::shared_ptr<CommandBuffer> command_buffer;
-    std::shared_ptr<RenderPass> render_pass;
-    std::shared_ptr<PipelineGLES> pipeline;
-  };
-
-  RenderPassGLESContext CreateRenderPassGLESContext() {
+  // Builds a mock OpenGL ES context with a render pass and a minimal
+  // pipeline. The [resolver] controls which GL entry points the backend can
+  // see, which is how a caller selects the hardware or emulated instancing
+  // path.
+  static RenderPassGLESContext CreateRenderPassGLESContext(
+      ProcTableGLES::Resolver resolver = kMockResolverGLES) {
     std::unique_ptr<NiceMock<MockGLESImpl>> mock_gl_impl =
         std::make_unique<NiceMock<MockGLESImpl>>();
     testing::NiceMock<MockGLESImpl>& mock_gl_impl_ref = *mock_gl_impl;
     std::shared_ptr<MockGLES> mock_gl = MockGLES::Init(std::move(mock_gl_impl));
 
-    std::shared_ptr<ContextGLES> context = CreateFakeGLESContext();
+    std::shared_ptr<ContextGLES> context =
+        CreateFakeGLESContext(std::move(resolver));
     std::shared_ptr<MockWorker> dummy_worker = std::make_shared<MockWorker>();
     context->AddReactorWorker(dummy_worker);
     std::shared_ptr<ReactorGLES> reactor = context->GetReactor();
@@ -281,7 +289,7 @@ class RenderPassGLESViewportTest : public ::testing::Test {
   }
 };
 
-TEST_F(RenderPassGLESViewportTest, ViewportCachedAcrossCommands) {
+TEST_F(RenderPassGLESCommandTest, ViewportCachedAcrossCommands) {
   auto ctx = CreateRenderPassGLESContext();
   testing::NiceMock<MockGLESImpl>& mock_gl_impl_ref = ctx.mock_gl_impl_ref;
   std::shared_ptr<RenderPass>& render_pass = ctx.render_pass;
@@ -317,7 +325,7 @@ TEST_F(RenderPassGLESViewportTest, ViewportCachedAcrossCommands) {
   EXPECT_TRUE(reactor->React());
 }
 
-TEST_F(RenderPassGLESViewportTest,
+TEST_F(RenderPassGLESCommandTest,
        CommandsWithoutViewportGetRenderPassViewport) {
   auto ctx = CreateRenderPassGLESContext();
   testing::NiceMock<MockGLESImpl>& mock_gl_impl_ref = ctx.mock_gl_impl_ref;
@@ -353,7 +361,7 @@ TEST_F(RenderPassGLESViewportTest,
 // Sibling regression guard for the bug fixed alongside this test on the
 // Vulkan backend. The GLES backend has always honored the X offset; this
 // asserts that explicitly so a future change can't silently regress it.
-TEST_F(RenderPassGLESViewportTest, ViewportWithNonZeroXOffsetReachesGL) {
+TEST_F(RenderPassGLESCommandTest, ViewportWithNonZeroXOffsetReachesGL) {
   auto ctx = CreateRenderPassGLESContext();
   testing::NiceMock<MockGLESImpl>& mock_gl_impl_ref = ctx.mock_gl_impl_ref;
   std::shared_ptr<RenderPass>& render_pass = ctx.render_pass;
@@ -369,6 +377,137 @@ TEST_F(RenderPassGLESViewportTest, ViewportWithNonZeroXOffsetReachesGL) {
 
   EXPECT_CALL(mock_gl_impl_ref, Viewport(_, _, _, _)).Times(0);
   EXPECT_CALL(mock_gl_impl_ref, Viewport(25, 0, 50, 100)).Times(1);
+
+  EXPECT_TRUE(render_pass->EncodeCommands());
+  EXPECT_TRUE(reactor->React());
+}
+
+// When the driver exposes the hardware instancing entry points, a
+// non-indexed instanced command issues a single glDrawArraysInstanced call
+// that carries the instance count.
+TEST_F(RenderPassGLESCommandTest, HardwareInstancedArrayDraw) {
+  auto ctx = CreateRenderPassGLESContext();
+  testing::NiceMock<MockGLESImpl>& mock_gl_impl_ref = ctx.mock_gl_impl_ref;
+  std::shared_ptr<RenderPass>& render_pass = ctx.render_pass;
+  std::shared_ptr<PipelineGLES>& pipeline = ctx.pipeline;
+  std::shared_ptr<ReactorGLES>& reactor = ctx.reactor;
+
+  render_pass->SetPipeline(PipelineRef(pipeline));
+  render_pass->SetElementCount(3);
+  render_pass->SetIndexBuffer({}, IndexType::kNone);
+  render_pass->SetInstanceCount(4);
+  EXPECT_TRUE(render_pass->Draw().ok());
+
+  EXPECT_CALL(mock_gl_impl_ref, DrawArraysInstancedEXT(_, 0, 3, 4)).Times(1);
+  EXPECT_CALL(mock_gl_impl_ref, DrawArrays(_, _, _)).Times(0);
+
+  EXPECT_TRUE(render_pass->EncodeCommands());
+  EXPECT_TRUE(reactor->React());
+}
+
+// The indexed counterpart: a hardware instanced indexed command issues a
+// single glDrawElementsInstanced call.
+TEST_F(RenderPassGLESCommandTest, HardwareInstancedElementsDraw) {
+  auto ctx = CreateRenderPassGLESContext();
+  testing::NiceMock<MockGLESImpl>& mock_gl_impl_ref = ctx.mock_gl_impl_ref;
+  std::shared_ptr<RenderPass>& render_pass = ctx.render_pass;
+  std::shared_ptr<PipelineGLES>& pipeline = ctx.pipeline;
+  std::shared_ptr<ReactorGLES>& reactor = ctx.reactor;
+
+  DeviceBufferDescriptor index_desc;
+  index_desc.size = 6 * sizeof(uint16_t);
+  index_desc.storage_mode = StorageMode::kHostVisible;
+  auto index_buffer = std::static_pointer_cast<Context>(ctx.context)
+                          ->GetResourceAllocator()
+                          ->CreateBuffer(index_desc);
+  ASSERT_TRUE(index_buffer);
+
+  render_pass->SetPipeline(PipelineRef(pipeline));
+  render_pass->SetElementCount(6);
+  ASSERT_TRUE(render_pass->SetIndexBuffer(
+      DeviceBuffer::AsBufferView(index_buffer), IndexType::k16bit));
+  render_pass->SetInstanceCount(4);
+  EXPECT_TRUE(render_pass->Draw().ok());
+
+  EXPECT_CALL(mock_gl_impl_ref, DrawElementsInstancedEXT(_, 6, _, _, 4))
+      .Times(1);
+  EXPECT_CALL(mock_gl_impl_ref, DrawElements(_, _, _, _)).Times(0);
+
+  EXPECT_TRUE(render_pass->EncodeCommands());
+  EXPECT_TRUE(reactor->React());
+}
+
+// When the hardware instancing entry points are missing, a non-indexed
+// instanced command is emulated by repeating the plain draw once per
+// instance.
+TEST_F(RenderPassGLESCommandTest, EmulatedInstancedArrayDraw) {
+  auto ctx = CreateRenderPassGLESContext(kMockResolverGLESWithoutInstancing);
+  testing::NiceMock<MockGLESImpl>& mock_gl_impl_ref = ctx.mock_gl_impl_ref;
+  std::shared_ptr<RenderPass>& render_pass = ctx.render_pass;
+  std::shared_ptr<PipelineGLES>& pipeline = ctx.pipeline;
+  std::shared_ptr<ReactorGLES>& reactor = ctx.reactor;
+
+  render_pass->SetPipeline(PipelineRef(pipeline));
+  render_pass->SetElementCount(3);
+  render_pass->SetIndexBuffer({}, IndexType::kNone);
+  render_pass->SetInstanceCount(4);
+  EXPECT_TRUE(render_pass->Draw().ok());
+
+  EXPECT_CALL(mock_gl_impl_ref, DrawArrays(_, 0, 3)).Times(4);
+  EXPECT_CALL(mock_gl_impl_ref, DrawArraysInstancedEXT(_, _, _, _)).Times(0);
+
+  EXPECT_TRUE(render_pass->EncodeCommands());
+  EXPECT_TRUE(reactor->React());
+}
+
+// The indexed counterpart of the emulation path: the plain indexed draw is
+// repeated once per instance.
+TEST_F(RenderPassGLESCommandTest, EmulatedInstancedElementsDraw) {
+  auto ctx = CreateRenderPassGLESContext(kMockResolverGLESWithoutInstancing);
+  testing::NiceMock<MockGLESImpl>& mock_gl_impl_ref = ctx.mock_gl_impl_ref;
+  std::shared_ptr<RenderPass>& render_pass = ctx.render_pass;
+  std::shared_ptr<PipelineGLES>& pipeline = ctx.pipeline;
+  std::shared_ptr<ReactorGLES>& reactor = ctx.reactor;
+
+  DeviceBufferDescriptor index_desc;
+  index_desc.size = 6 * sizeof(uint16_t);
+  index_desc.storage_mode = StorageMode::kHostVisible;
+  auto index_buffer = std::static_pointer_cast<Context>(ctx.context)
+                          ->GetResourceAllocator()
+                          ->CreateBuffer(index_desc);
+  ASSERT_TRUE(index_buffer);
+
+  render_pass->SetPipeline(PipelineRef(pipeline));
+  render_pass->SetElementCount(6);
+  ASSERT_TRUE(render_pass->SetIndexBuffer(
+      DeviceBuffer::AsBufferView(index_buffer), IndexType::k16bit));
+  render_pass->SetInstanceCount(4);
+  EXPECT_TRUE(render_pass->Draw().ok());
+
+  EXPECT_CALL(mock_gl_impl_ref, DrawElements(_, 6, _, _)).Times(4);
+  EXPECT_CALL(mock_gl_impl_ref, DrawElementsInstancedEXT(_, _, _, _, _))
+      .Times(0);
+
+  EXPECT_TRUE(render_pass->EncodeCommands());
+  EXPECT_TRUE(reactor->React());
+}
+
+// Regression guard: a command with no instance count set draws a single
+// instance through the plain, non-instanced entry point.
+TEST_F(RenderPassGLESCommandTest, NonInstancedDrawIssuesSingleDrawArrays) {
+  auto ctx = CreateRenderPassGLESContext();
+  testing::NiceMock<MockGLESImpl>& mock_gl_impl_ref = ctx.mock_gl_impl_ref;
+  std::shared_ptr<RenderPass>& render_pass = ctx.render_pass;
+  std::shared_ptr<PipelineGLES>& pipeline = ctx.pipeline;
+  std::shared_ptr<ReactorGLES>& reactor = ctx.reactor;
+
+  render_pass->SetPipeline(PipelineRef(pipeline));
+  render_pass->SetElementCount(3);
+  render_pass->SetIndexBuffer({}, IndexType::kNone);
+  EXPECT_TRUE(render_pass->Draw().ok());
+
+  EXPECT_CALL(mock_gl_impl_ref, DrawArrays(_, 0, 3)).Times(1);
+  EXPECT_CALL(mock_gl_impl_ref, DrawArraysInstancedEXT(_, _, _, _)).Times(0);
 
   EXPECT_TRUE(render_pass->EncodeCommands());
   EXPECT_TRUE(reactor->React());

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.cc
@@ -356,6 +356,53 @@ void mockInvalidateFramebuffer(GLenum target,
 static_assert(CheckSameSignature<decltype(mockInvalidateFramebuffer),  //
                                  decltype(glInvalidateFramebuffer)>::value);
 
+void mockDrawArrays(GLenum mode, GLint first, GLsizei count) {
+  CallMockMethod(&IMockGLESImpl::DrawArrays, mode, first, count);
+}
+
+static_assert(CheckSameSignature<decltype(mockDrawArrays),  //
+                                 decltype(glDrawArrays)>::value);
+
+void mockDrawElements(GLenum mode,
+                      GLsizei count,
+                      GLenum type,
+                      const void* indices) {
+  CallMockMethod(&IMockGLESImpl::DrawElements, mode, count, type, indices);
+}
+
+static_assert(CheckSameSignature<decltype(mockDrawElements),  //
+                                 decltype(glDrawElements)>::value);
+
+void mockDrawArraysInstancedEXT(GLenum mode,
+                                GLint first,
+                                GLsizei count,
+                                GLsizei instancecount) {
+  CallMockMethod(&IMockGLESImpl::DrawArraysInstancedEXT, mode, first, count,
+                 instancecount);
+}
+
+static_assert(CheckSameSignature<decltype(mockDrawArraysInstancedEXT),  //
+                                 decltype(glDrawArraysInstancedEXT)>::value);
+
+void mockDrawElementsInstancedEXT(GLenum mode,
+                                  GLsizei count,
+                                  GLenum type,
+                                  const void* indices,
+                                  GLsizei instancecount) {
+  CallMockMethod(&IMockGLESImpl::DrawElementsInstancedEXT, mode, count, type,
+                 indices, instancecount);
+}
+
+static_assert(CheckSameSignature<decltype(mockDrawElementsInstancedEXT),  //
+                                 decltype(glDrawElementsInstancedEXT)>::value);
+
+void mockVertexAttribDivisorEXT(GLuint index, GLuint divisor) {
+  CallMockMethod(&IMockGLESImpl::VertexAttribDivisorEXT, index, divisor);
+}
+
+static_assert(CheckSameSignature<decltype(mockVertexAttribDivisorEXT),  //
+                                 decltype(glVertexAttribDivisorEXT)>::value);
+
 // static
 std::shared_ptr<MockGLES> MockGLES::Init(
     std::unique_ptr<MockGLESImpl> impl,
@@ -468,9 +515,35 @@ const ProcTableGLES::Resolver kMockResolverGLES = [](const char* name) {
     return reinterpret_cast<void*>(mockInvalidateFramebuffer);
   } else if (strcmp(name, "glViewport") == 0) {
     return reinterpret_cast<void*>(mockViewport);
+  } else if (strcmp(name, "glDrawArrays") == 0) {
+    return reinterpret_cast<void*>(mockDrawArrays);
+  } else if (strcmp(name, "glDrawElements") == 0) {
+    return reinterpret_cast<void*>(mockDrawElements);
+  } else if (strcmp(name, "glDrawArraysInstancedEXT") == 0) {
+    return reinterpret_cast<void*>(mockDrawArraysInstancedEXT);
+  } else if (strcmp(name, "glDrawElementsInstancedEXT") == 0) {
+    return reinterpret_cast<void*>(mockDrawElementsInstancedEXT);
+  } else if (strcmp(name, "glVertexAttribDivisorEXT") == 0) {
+    return reinterpret_cast<void*>(mockVertexAttribDivisorEXT);
   } else {
     return reinterpret_cast<void*>(&doNothing);
   }
+};
+
+const ProcTableGLES::Resolver kMockResolverGLESWithoutInstancing =
+    [](const char* name) -> void* {
+  // Hide the hardware instancing entry points so the OpenGL ES backend takes
+  // its emulation path. The proc table retries these names with the "EXT"
+  // suffix stripped, so both spellings are rejected here.
+  if (strcmp(name, "glDrawArraysInstancedEXT") == 0 ||
+      strcmp(name, "glDrawArraysInstanced") == 0 ||
+      strcmp(name, "glDrawElementsInstancedEXT") == 0 ||
+      strcmp(name, "glDrawElementsInstanced") == 0 ||
+      strcmp(name, "glVertexAttribDivisorEXT") == 0 ||
+      strcmp(name, "glVertexAttribDivisor") == 0) {
+    return nullptr;
+  }
+  return kMockResolverGLES(name);
 };
 
 MockGLES::MockGLES(ProcTableGLES::Resolver resolver)

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.h
@@ -16,6 +16,11 @@ namespace testing {
 
 extern const ProcTableGLES::Resolver kMockResolverGLES;
 
+/// A resolver that behaves like |kMockResolverGLES| but hides the hardware
+/// instancing entry points, so the OpenGL ES backend exercises its
+/// instanced-draw emulation fallback.
+extern const ProcTableGLES::Resolver kMockResolverGLESWithoutInstancing;
+
 class IMockGLESImpl {
  public:
   virtual ~IMockGLESImpl() = default;
@@ -101,6 +106,21 @@ class IMockGLESImpl {
                                      const GLenum* attachments) {};
   virtual void GetIntegerv(GLenum name, GLint* attachments) {};
   virtual void Viewport(GLint x, GLint y, GLsizei width, GLsizei height) {}
+  virtual void DrawArrays(GLenum mode, GLint first, GLsizei count) {}
+  virtual void DrawElements(GLenum mode,
+                            GLsizei count,
+                            GLenum type,
+                            const void* indices) {}
+  virtual void DrawArraysInstancedEXT(GLenum mode,
+                                      GLint first,
+                                      GLsizei count,
+                                      GLsizei instancecount) {}
+  virtual void DrawElementsInstancedEXT(GLenum mode,
+                                        GLsizei count,
+                                        GLenum type,
+                                        const void* indices,
+                                        GLsizei instancecount) {}
+  virtual void VertexAttribDivisorEXT(GLuint index, GLuint divisor) {}
 };
 
 class MockGLESImpl : public IMockGLESImpl {
@@ -245,6 +265,30 @@ class MockGLESImpl : public IMockGLESImpl {
   MOCK_METHOD(void,
               Viewport,
               (GLint x, GLint y, GLsizei width, GLsizei height),
+              (override));
+  MOCK_METHOD(void,
+              DrawArrays,
+              (GLenum mode, GLint first, GLsizei count),
+              (override));
+  MOCK_METHOD(void,
+              DrawElements,
+              (GLenum mode, GLsizei count, GLenum type, const void* indices),
+              (override));
+  MOCK_METHOD(void,
+              DrawArraysInstancedEXT,
+              (GLenum mode, GLint first, GLsizei count, GLsizei instancecount),
+              (override));
+  MOCK_METHOD(void,
+              DrawElementsInstancedEXT,
+              (GLenum mode,
+               GLsizei count,
+               GLenum type,
+               const void* indices,
+               GLsizei instancecount),
+              (override));
+  MOCK_METHOD(void,
+              VertexAttribDivisorEXT,
+              (GLuint index, GLuint divisor),
               (override));
 };
 

--- a/engine/src/flutter/impeller/renderer/backend/metal/vertex_descriptor_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/vertex_descriptor_mtl.mm
@@ -198,7 +198,9 @@ bool VertexDescriptorMTL::SetStageInputsAndLayout(
                            layout.binding];
     vertex_layout.stride = layout.stride;
     vertex_layout.stepRate = 1u;
-    vertex_layout.stepFunction = MTLVertexStepFunctionPerVertex;
+    vertex_layout.stepFunction = layout.input_rate == VertexInputRate::kInstance
+                                     ? MTLVertexStepFunctionPerInstance
+                                     : MTLVertexStepFunctionPerVertex;
   }
   return true;
 }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_vk.cc
@@ -407,7 +407,10 @@ fml::StatusOr<vk::UniquePipeline> MakePipeline(
   for (const ShaderStageBufferLayout& layout : stage_buffer_layouts) {
     vk::VertexInputBindingDescription binding_description;
     binding_description.setBinding(layout.binding);
-    binding_description.setInputRate(vk::VertexInputRate::eVertex);
+    binding_description.setInputRate(layout.input_rate ==
+                                             VertexInputRate::kInstance
+                                         ? vk::VertexInputRate::eInstance
+                                         : vk::VertexInputRate::eVertex);
     binding_description.setStride(layout.stride);
     buffer_descs.push_back(binding_description);
   }

--- a/engine/src/flutter/impeller/renderer/renderer_golden_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/renderer_golden_unittests.cc
@@ -20,6 +20,8 @@
 #include "impeller/core/texture_descriptor.h"
 #include "impeller/fixtures/baby.frag.h"
 #include "impeller/fixtures/baby.vert.h"
+#include "impeller/fixtures/instanced_attributes.frag.h"
+#include "impeller/fixtures/instanced_attributes.vert.h"
 #include "impeller/fixtures/texture.frag.h"
 #include "impeller/fixtures/texture.vert.h"
 #include "impeller/geometry/color.h"
@@ -85,6 +87,115 @@ TEST_P(RendererGoldenTest, BabysFirstTriangle) {
     FS::FragInfo frag_info;
     frag_info.time = 0.0f;
     FS::BindFragInfo(pass, host_buffer->EmplaceUniform(frag_info));
+
+    return pass.Draw().ok();
+  }));
+}
+
+// Ported from RendererTest.CanRenderInstancedWithVertexAttributes. Renders an
+// instanced draw whose per-instance data arrives through an instance-rate
+// vertex buffer binding rather than an instance-ID builtin. This is the only
+// portable instancing mechanism on OpenGL ES. Per-instance offsets and colors
+// are fixed so the golden is deterministic.
+TEST_P(RendererGoldenTest, CanRenderInstancedWithVertexAttributes) {
+  using VS = InstancedAttributesVertexShader;
+  using FS = InstancedAttributesFragmentShader;
+
+  std::shared_ptr<Context> context = GetContext();
+  ASSERT_TRUE(context);
+
+  auto desc = PipelineBuilder<VS, FS>::MakeDefaultPipelineDescriptor(*context);
+  ASSERT_TRUE(desc.has_value());
+  // Match the golden harness render target: single-sampled, no depth/stencil.
+  desc->SetSampleCount(SampleCount::kCount1);
+  desc->ClearStencilAttachments();
+  desc->ClearDepthAttachment();
+
+  // Per-instance data is laid out contiguously, one record per instance.
+  struct InstanceData {
+    Vector2 offset;
+    Vector4 color;
+  };
+
+  // Two vertex bindings: binding 0 carries per-vertex geometry and advances
+  // once per vertex; binding 1 carries per-instance data and advances once
+  // per instance.
+  auto vertex_desc = std::make_shared<VertexDescriptor>();
+  ShaderStageIOSlot position_slot = VS::kInputVertexPosition;
+  ShaderStageIOSlot offset_slot = VS::kInputInstanceOffset;
+  ShaderStageIOSlot color_slot = VS::kInputInstanceColor;
+  position_slot.binding = 0;
+  position_slot.offset = 0;
+  offset_slot.binding = 1;
+  offset_slot.offset = offsetof(InstanceData, offset);
+  color_slot.binding = 1;
+  color_slot.offset = offsetof(InstanceData, color);
+  const std::vector<ShaderStageIOSlot> io_slots = {position_slot, offset_slot,
+                                                   color_slot};
+  const std::vector<ShaderStageBufferLayout> layouts = {
+      ShaderStageBufferLayout{.stride = sizeof(Vector2),
+                              .binding = 0,
+                              .input_rate = VertexInputRate::kVertex},
+      ShaderStageBufferLayout{.stride = sizeof(InstanceData),
+                              .binding = 1,
+                              .input_rate = VertexInputRate::kInstance},
+  };
+  vertex_desc->RegisterDescriptorSetLayouts(VS::kDescriptorSetLayouts);
+  vertex_desc->RegisterDescriptorSetLayouts(FS::kDescriptorSetLayouts);
+  vertex_desc->SetStageInputs(io_slots, layouts);
+  desc->SetVertexDescriptor(std::move(vertex_desc));
+  auto pipeline =
+      context->GetPipelineLibrary()->GetPipeline(std::move(desc)).Get();
+  ASSERT_TRUE(pipeline);
+
+  // A single triangle, drawn once per instance.
+  std::array<Vector2, 3> geometry = {
+      Vector2{0, 0},
+      Vector2{0, 100},
+      Vector2{100, 0},
+  };
+
+  static constexpr size_t kInstanceCount = 4u;
+  std::array<InstanceData, kInstanceCount> instances = {
+      InstanceData{Vector2{0, 0}, Vector4{1, 0, 0, 1}},
+      InstanceData{Vector2{120, 0}, Vector4{0, 1, 0, 1}},
+      InstanceData{Vector2{0, 120}, Vector4{0, 0, 1, 1}},
+      InstanceData{Vector2{120, 120}, Vector4{1, 1, 0, 1}},
+  };
+
+  auto geometry_buffer = context->GetResourceAllocator()->CreateBufferWithCopy(
+      reinterpret_cast<uint8_t*>(geometry.data()),
+      geometry.size() * sizeof(Vector2));
+  auto instance_buffer = context->GetResourceAllocator()->CreateBufferWithCopy(
+      reinterpret_cast<uint8_t*>(instances.data()),
+      instances.size() * sizeof(InstanceData));
+  ASSERT_TRUE(geometry_buffer && instance_buffer);
+
+  auto host_buffer = HostBuffer::Create(
+      context->GetResourceAllocator(), context->GetIdleWaiter(),
+      context->GetCapabilities()->GetMinimumUniformAlignment());
+
+  ASSERT_TRUE(OpenPlaygroundHere([&](RenderPass& pass) -> bool {
+    // The harness runs the callback once per pass; start each from a clean
+    // host buffer.
+    host_buffer->Reset();
+    pass.SetCommandLabel("InstancedAttributes");
+    pass.SetPipeline(pipeline);
+
+    std::array<BufferView, 2> vertex_buffers = {
+        BufferView(geometry_buffer,
+                   Range(0, geometry.size() * sizeof(Vector2))),
+        BufferView(instance_buffer,
+                   Range(0, instances.size() * sizeof(InstanceData))),
+    };
+    pass.SetVertexBuffer(vertex_buffers.data(), vertex_buffers.size());
+    pass.SetElementCount(geometry.size());
+    pass.SetInstanceCount(kInstanceCount);
+
+    VS::FrameInfo frame_info;
+    frame_info.mvp =
+        pass.GetOrthographicTransform() * Matrix::MakeScale(GetContentScale());
+    VS::BindFrameInfo(pass, host_buffer->EmplaceUniform(frame_info));
 
     return pass.Draw().ok();
   }));

--- a/engine/src/flutter/impeller/renderer/renderer_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/renderer_unittests.cc
@@ -18,6 +18,8 @@
 #include "impeller/fixtures/impeller.vert.h"
 #include "impeller/fixtures/inactive_uniforms.frag.h"
 #include "impeller/fixtures/inactive_uniforms.vert.h"
+#include "impeller/fixtures/instanced_attributes.frag.h"
+#include "impeller/fixtures/instanced_attributes.vert.h"
 #include "impeller/fixtures/instanced_draw.frag.h"
 #include "impeller/fixtures/instanced_draw.vert.h"
 #include "impeller/fixtures/mipmaps.frag.h"
@@ -420,7 +422,13 @@ TEST_P(RendererTest, CanRenderToTexture) {
 
 TEST_P(RendererTest, CanRenderInstanced) {
   if (GetParam() == PlaygroundBackend::kOpenGLES) {
-    GTEST_SKIP() << "Instancing is not supported on OpenGL.";
+    // This test drives instancing through gl_InstanceIndex and a storage
+    // buffer, both of which require OpenGL ES 3.1. The portable instance-rate
+    // vertex attribute path, which works down to OpenGL ES 2.0, is covered by
+    // CanRenderInstancedWithVertexAttributes.
+    GTEST_SKIP() << "This test's instance-ID mechanism requires OpenGL ES 3.1; "
+                    "CanRenderInstancedWithVertexAttributes covers the "
+                    "portable instance-rate path.";
   }
   using VS = InstancedDrawVertexShader;
   using FS = InstancedDrawFragmentShader;
@@ -476,6 +484,107 @@ TEST_P(RendererTest, CanRenderInstanced) {
     data_host_buffer->Reset();
     return true;
   }));
+}
+
+// Renders an instanced draw whose per-instance data arrives through an
+// instance-rate vertex buffer binding rather than an instance-ID builtin.
+// This exercises the instance-rate vertex input path on every backend,
+// including OpenGL ES, where it is the only portable instancing mechanism.
+TEST_P(RendererTest, CanRenderInstancedWithVertexAttributes) {
+  using VS = InstancedAttributesVertexShader;
+  using FS = InstancedAttributesFragmentShader;
+  auto context = GetContext();
+  ASSERT_TRUE(context);
+  auto desc = PipelineBuilder<VS, FS>::MakeDefaultPipelineDescriptor(*context);
+  ASSERT_TRUE(desc.has_value());
+  desc->SetSampleCount(SampleCount::kCount4);
+  desc->SetStencilAttachmentDescriptors(std::nullopt);
+
+  // Per-instance data is laid out contiguously, one record per instance.
+  struct InstanceData {
+    Vector2 offset;
+    Vector4 color;
+  };
+
+  // Two vertex bindings: binding 0 carries per-vertex geometry and advances
+  // once per vertex; binding 1 carries per-instance data and advances once
+  // per instance.
+  auto vertex_desc = std::make_shared<VertexDescriptor>();
+  ShaderStageIOSlot position_slot = VS::kInputVertexPosition;
+  ShaderStageIOSlot offset_slot = VS::kInputInstanceOffset;
+  ShaderStageIOSlot color_slot = VS::kInputInstanceColor;
+  position_slot.binding = 0;
+  position_slot.offset = 0;
+  offset_slot.binding = 1;
+  offset_slot.offset = offsetof(InstanceData, offset);
+  color_slot.binding = 1;
+  color_slot.offset = offsetof(InstanceData, color);
+  const std::vector<ShaderStageIOSlot> io_slots = {position_slot, offset_slot,
+                                                   color_slot};
+  const std::vector<ShaderStageBufferLayout> layouts = {
+      ShaderStageBufferLayout{.stride = sizeof(Vector2),
+                              .binding = 0,
+                              .input_rate = VertexInputRate::kVertex},
+      ShaderStageBufferLayout{.stride = sizeof(InstanceData),
+                              .binding = 1,
+                              .input_rate = VertexInputRate::kInstance},
+  };
+  vertex_desc->RegisterDescriptorSetLayouts(VS::kDescriptorSetLayouts);
+  vertex_desc->RegisterDescriptorSetLayouts(FS::kDescriptorSetLayouts);
+  vertex_desc->SetStageInputs(io_slots, layouts);
+  desc->SetVertexDescriptor(std::move(vertex_desc));
+  auto pipeline =
+      context->GetPipelineLibrary()->GetPipeline(std::move(desc)).Get();
+  ASSERT_TRUE(pipeline);
+
+  // A single triangle, drawn once per instance.
+  std::array<Vector2, 3> geometry = {
+      Vector2{0, 0},
+      Vector2{0, 100},
+      Vector2{100, 0},
+  };
+
+  static constexpr size_t kInstanceCount = 4u;
+  std::array<InstanceData, kInstanceCount> instances = {
+      InstanceData{Vector2{0, 0}, Vector4{1, 0, 0, 1}},
+      InstanceData{Vector2{120, 0}, Vector4{0, 1, 0, 1}},
+      InstanceData{Vector2{0, 120}, Vector4{0, 0, 1, 1}},
+      InstanceData{Vector2{120, 120}, Vector4{1, 1, 0, 1}},
+  };
+
+  auto geometry_buffer = context->GetResourceAllocator()->CreateBufferWithCopy(
+      reinterpret_cast<uint8_t*>(geometry.data()),
+      geometry.size() * sizeof(Vector2));
+  auto instance_buffer = context->GetResourceAllocator()->CreateBufferWithCopy(
+      reinterpret_cast<uint8_t*>(instances.data()),
+      instances.size() * sizeof(InstanceData));
+  ASSERT_TRUE(geometry_buffer && instance_buffer);
+
+  auto [data_host_buffer, indexes_host_buffer] = createHostBuffers(context);
+  SinglePassCallback callback = [&](RenderPass& pass) -> bool {
+    pass.SetCommandLabel("InstancedAttributes");
+    pass.SetPipeline(pipeline);
+
+    std::array<BufferView, 2> vertex_buffers = {
+        BufferView(geometry_buffer,
+                   Range(0, geometry.size() * sizeof(Vector2))),
+        BufferView(instance_buffer,
+                   Range(0, instances.size() * sizeof(InstanceData))),
+    };
+    pass.SetVertexBuffer(vertex_buffers.data(), vertex_buffers.size());
+    pass.SetElementCount(geometry.size());
+    pass.SetInstanceCount(kInstanceCount);
+
+    VS::FrameInfo frame_info;
+    frame_info.mvp =
+        pass.GetOrthographicTransform() * Matrix::MakeScale(GetContentScale());
+    VS::BindFrameInfo(pass, data_host_buffer->EmplaceUniform(frame_info));
+
+    bool result = pass.Draw().ok();
+    data_host_buffer->Reset();
+    return result;
+  };
+  OpenPlaygroundHere(callback);
 }
 
 TEST_P(RendererTest, CanBlitTextureToTexture) {

--- a/engine/src/flutter/impeller/renderer/renderer_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/renderer_unittests.cc
@@ -18,8 +18,6 @@
 #include "impeller/fixtures/impeller.vert.h"
 #include "impeller/fixtures/inactive_uniforms.frag.h"
 #include "impeller/fixtures/inactive_uniforms.vert.h"
-#include "impeller/fixtures/instanced_attributes.frag.h"
-#include "impeller/fixtures/instanced_attributes.vert.h"
 #include "impeller/fixtures/instanced_draw.frag.h"
 #include "impeller/fixtures/instanced_draw.vert.h"
 #include "impeller/fixtures/mipmaps.frag.h"
@@ -484,107 +482,6 @@ TEST_P(RendererTest, CanRenderInstanced) {
     data_host_buffer->Reset();
     return true;
   }));
-}
-
-// Renders an instanced draw whose per-instance data arrives through an
-// instance-rate vertex buffer binding rather than an instance-ID builtin.
-// This exercises the instance-rate vertex input path on every backend,
-// including OpenGL ES, where it is the only portable instancing mechanism.
-TEST_P(RendererTest, CanRenderInstancedWithVertexAttributes) {
-  using VS = InstancedAttributesVertexShader;
-  using FS = InstancedAttributesFragmentShader;
-  auto context = GetContext();
-  ASSERT_TRUE(context);
-  auto desc = PipelineBuilder<VS, FS>::MakeDefaultPipelineDescriptor(*context);
-  ASSERT_TRUE(desc.has_value());
-  desc->SetSampleCount(SampleCount::kCount4);
-  desc->SetStencilAttachmentDescriptors(std::nullopt);
-
-  // Per-instance data is laid out contiguously, one record per instance.
-  struct InstanceData {
-    Vector2 offset;
-    Vector4 color;
-  };
-
-  // Two vertex bindings: binding 0 carries per-vertex geometry and advances
-  // once per vertex; binding 1 carries per-instance data and advances once
-  // per instance.
-  auto vertex_desc = std::make_shared<VertexDescriptor>();
-  ShaderStageIOSlot position_slot = VS::kInputVertexPosition;
-  ShaderStageIOSlot offset_slot = VS::kInputInstanceOffset;
-  ShaderStageIOSlot color_slot = VS::kInputInstanceColor;
-  position_slot.binding = 0;
-  position_slot.offset = 0;
-  offset_slot.binding = 1;
-  offset_slot.offset = offsetof(InstanceData, offset);
-  color_slot.binding = 1;
-  color_slot.offset = offsetof(InstanceData, color);
-  const std::vector<ShaderStageIOSlot> io_slots = {position_slot, offset_slot,
-                                                   color_slot};
-  const std::vector<ShaderStageBufferLayout> layouts = {
-      ShaderStageBufferLayout{.stride = sizeof(Vector2),
-                              .binding = 0,
-                              .input_rate = VertexInputRate::kVertex},
-      ShaderStageBufferLayout{.stride = sizeof(InstanceData),
-                              .binding = 1,
-                              .input_rate = VertexInputRate::kInstance},
-  };
-  vertex_desc->RegisterDescriptorSetLayouts(VS::kDescriptorSetLayouts);
-  vertex_desc->RegisterDescriptorSetLayouts(FS::kDescriptorSetLayouts);
-  vertex_desc->SetStageInputs(io_slots, layouts);
-  desc->SetVertexDescriptor(std::move(vertex_desc));
-  auto pipeline =
-      context->GetPipelineLibrary()->GetPipeline(std::move(desc)).Get();
-  ASSERT_TRUE(pipeline);
-
-  // A single triangle, drawn once per instance.
-  std::array<Vector2, 3> geometry = {
-      Vector2{0, 0},
-      Vector2{0, 100},
-      Vector2{100, 0},
-  };
-
-  static constexpr size_t kInstanceCount = 4u;
-  std::array<InstanceData, kInstanceCount> instances = {
-      InstanceData{Vector2{0, 0}, Vector4{1, 0, 0, 1}},
-      InstanceData{Vector2{120, 0}, Vector4{0, 1, 0, 1}},
-      InstanceData{Vector2{0, 120}, Vector4{0, 0, 1, 1}},
-      InstanceData{Vector2{120, 120}, Vector4{1, 1, 0, 1}},
-  };
-
-  auto geometry_buffer = context->GetResourceAllocator()->CreateBufferWithCopy(
-      reinterpret_cast<uint8_t*>(geometry.data()),
-      geometry.size() * sizeof(Vector2));
-  auto instance_buffer = context->GetResourceAllocator()->CreateBufferWithCopy(
-      reinterpret_cast<uint8_t*>(instances.data()),
-      instances.size() * sizeof(InstanceData));
-  ASSERT_TRUE(geometry_buffer && instance_buffer);
-
-  auto [data_host_buffer, indexes_host_buffer] = createHostBuffers(context);
-  SinglePassCallback callback = [&](RenderPass& pass) -> bool {
-    pass.SetCommandLabel("InstancedAttributes");
-    pass.SetPipeline(pipeline);
-
-    std::array<BufferView, 2> vertex_buffers = {
-        BufferView(geometry_buffer,
-                   Range(0, geometry.size() * sizeof(Vector2))),
-        BufferView(instance_buffer,
-                   Range(0, instances.size() * sizeof(InstanceData))),
-    };
-    pass.SetVertexBuffer(vertex_buffers.data(), vertex_buffers.size());
-    pass.SetElementCount(geometry.size());
-    pass.SetInstanceCount(kInstanceCount);
-
-    VS::FrameInfo frame_info;
-    frame_info.mvp =
-        pass.GetOrthographicTransform() * Matrix::MakeScale(GetContentScale());
-    VS::BindFrameInfo(pass, data_host_buffer->EmplaceUniform(frame_info));
-
-    bool result = pass.Draw().ok();
-    data_host_buffer->Reset();
-    return result;
-  };
-  OpenPlaygroundHere(callback);
 }
 
 TEST_P(RendererTest, CanBlitTextureToTexture) {


### PR DESCRIPTION
Progress on https://github.com/flutter/flutter/issues/154145.

Instanced drawing was started in Impeller long ago but remains incomplete to today. A command could carry an instance count, Metal and Vulkan honored it, but OpenGL ES ignored it, no backend had per-instance vertex data, and there was zero test coverage.

This fills those gaps in a fully portable way that works _everywhere_, including emulation on rare GLES 2 drivers that don't support the required extensions! No capability checks required to safely use.

Super useful for Flutter GPU-based renderers, but I think some stuff in Impeller's 2D renderer may be able benefit from this too. One of the original early motivations we started implementing this years ago was to reduce the vertex load for glyph atlas rendering, for example.

## Example usage

On the shader side there is nothing instancing-specific. Per-instance values are declared as ordinary vertex `in` attributes, identical to per-vertex ones; the shader does no indexing and never references `gl_InstanceIndex`.

```glsl
uniform FrameInfo {
  mat4 mvp;
}
frame_info;

in vec2 vertex_position;  // supplied per vertex
in vec2 instance_offset;  // supplied per instance
in vec4 instance_color;   // supplied per instance

out vec4 v_color;

void main() {
  gl_Position = frame_info.mvp * vec4(vertex_position + instance_offset, 0.0, 1.0);
  v_color = instance_color;
}
```

On the Impeller side, instancing is driven through the existing pipeline and render pass APIs. The only new surface is the per-binding input rate: a binding is marked instance-rate on the `VertexDescriptor`, geometry and per-instance data are bound as separate vertex buffers, and the draw carries an instance count.

```cpp
// Binding 0 advances once per vertex; binding 1 advances once per instance.
auto vertex_desc = std::make_shared<VertexDescriptor>();
vertex_desc->SetStageInputs(
    /*inputs=*/{position_slot, instance_offset_slot, instance_color_slot},
    /*layouts=*/{
        ShaderStageBufferLayout{.stride = sizeof(Vector2),
                                .binding = 0,
                                .input_rate = VertexInputRate::kVertex},
        ShaderStageBufferLayout{.stride = sizeof(InstanceData),
                                .binding = 1,
                                .input_rate = VertexInputRate::kInstance},
    });
pipeline_desc->SetVertexDescriptor(std::move(vertex_desc));

// One draw call renders `instance_count` copies of the geometry.
pass.SetVertexBuffer({geometry_view, instance_data_view});
pass.SetElementCount(vertex_count);
pass.SetInstanceCount(instance_count);
pass.Draw();
```

A complete, runnable version is the new [`CanRenderInstancedWithVertexAttributes`](https://github.com/bdero/flutter/blob/8f835895165add4f0e628d775b9d28c55ae3663a/engine/src/flutter/impeller/renderer/renderer_unittests.cc#L545-L640) test, paired with the [`instanced_attributes.vert`](https://github.com/bdero/flutter/blob/8f835895165add4f0e628d775b9d28c55ae3663a/engine/src/flutter/impeller/fixtures/instanced_attributes.vert) fixture shown above.

Note that the `VertexDescriptor` is assembled by hand rather than from `impellerc`'s reflected shader structs. Whether a binding is per-instance is pipeline state, not something expressible in shader source, so there is no static codegen for it: generating it would first require deciding how to annotate which shader inputs are per-instance, which is something we could add down the road if we find it'd be convenient for stuff in the entities framework.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
