### PR TITLE
[macOS][gn] Use arm64 clang in copy_info_plist.py on arm64 Macs

### DIFF
--- a/engine/src/flutter/build/copy_info_plist.py
+++ b/engine/src/flutter/build/copy_info_plist.py
@@ -15,6 +15,7 @@ usage: copy_info_plist.py --source <src_path> --destination <dest_path>
 
 import argparse
 import os
+import platform
 import subprocess
 
 import git_revision
@@ -24,10 +25,11 @@ _src_root_dir = os.path.join(_script_dir, '..', '..')
 
 
 def get_clang_version():
-  clang_executable = str(
-      os.path.join(_src_root_dir, 'flutter', 'buildtools', 'mac-x64', 'clang', 'bin', 'clang++')
+  arch = 'arm64' if platform.machine() in ('arm64', 'aarch64') else 'x64'
+  clang_executable = os.path.join(
+      _src_root_dir, 'flutter', 'buildtools', f'mac-{arch}', 'clang', 'bin', 'clang++'
   )
-  version = subprocess.check_output([clang_executable, '--version'])
+  version = subprocess.check_output([clang_executable, '--version'], text=True)
   return version.splitlines()[0]
 
 


### PR DESCRIPTION
This eliminates instances of clang host toolchain path that assumes clang-x64 on macOS hosts and instead uses the toolchain for the host architecture.

Also updates the subprocess.check_output() call with `text=True` to return a string back instead of raw bytes, which is what we want in this case.

Note that if the build is intentionally invoked under Rosetta 2 -- for example by running `arch -x86_64 BUILD_COMMAND`, `host_cpu` will evaluate to `x86_64`. As such, it is still possible to run builds using the x64 toolchain on demand, but the default behaviour is now to build consistently with the appropriate clang toolchain for the host CPU architecture.

No test changes because the build (and existing tests) are the test.

Issue: https://github.com/flutter/flutter/issues/103386

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
