### PR TITLE
[macOS][gn] support both x64/arm64 macOS host clang toolchains for ASAN

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/BUILD.gn
+++ b/engine/src/flutter/shell/platform/darwin/ios/BUILD.gn
@@ -413,8 +413,10 @@ copy("copy_dylib") {
 copy("copy_asan_runtime_dylib") {
   visibility = [ ":*" ]
 
+  # TODO(cbracken): https://github.com/flutter/flutter/issues/186668
+  # Eliminate clang toolchain hardcoding.
   _libclang_base_path =
-      "$buildtools_path/mac-x64/clang/lib/clang/13.0.0/lib/darwin/"
+      "$buildtools_path/mac-${host_cpu}/clang/lib/clang/23/lib/darwin/"
 
   if (defined(use_ios_simulator) && use_ios_simulator) {
     _dylib_name = "libclang_rt.asan_iossim_dynamic.dylib"


### PR DESCRIPTION
When producing ASAN builds, link against the correct ASAN dylib path. Note that ASAN builds for iOS *are not* currently built or tested on CI, and have been broken for some time. Not only did we add a library with the incorrect architecture, but the toolchain path was incorrect.

Given that these builds do not receive automated testing for macOS/iOS and are intended purely for local testing, as well as the fact that ASAN builds for macOS/iOS are more limited in what they check for, we should consider whether we want to support ASAN builds for macOS/iOS at all or instead do such testing in Instruments, as Apple suggests. Due to platform differences, ASAN on macOS lacks functionality on Linux such as:

* LSAN
* Static initialisation order fiasco detection, due to Mach-O loader behaviour.
* DWARF symolification (dSYM files instead)
* DYLD_INSERT_LIBRARIES support (unlikely any of us use this)

Note that if the build is intentionally invoked under Rosetta 2 -- for example by running `arch -x86_64 BUILD_COMMAND`, `host_cpu` will evaluate to `x86_64`. As such, it is still possible to run builds using the x64 toolchain on demand, but the default behaviour is now to build consistently with the appropriate clang toolchain for the host CPU architecture.

Issue: https://github.com/flutter/flutter/issues/103386

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
