### PR TITLE
refactor: Centralize copying of drag events when handling scrollbar scrolling

### DIFF
--- a/packages/flutter/lib/src/cupertino/scrollbar.dart
+++ b/packages/flutter/lib/src/cupertino/scrollbar.dart
@@ -177,15 +177,15 @@ class _CupertinoScrollbarState extends RawScrollbarState<CupertinoScrollbar> {
   // on the scrollbar thumb and then drags the scrollbar without releasing.
 
   @override
-  void handleThumbPressStart(Offset localPosition) {
-    super.handleThumbPressStart(localPosition);
+  void handleThumbPressStart(DragStartDetails details) {
+    super.handleThumbPressStart(details);
     final Axis? direction = getScrollbarDirection();
     if (direction == null) {
       return;
     }
     _pressStartAxisPosition = switch (direction) {
-      Axis.vertical => localPosition.dy,
-      Axis.horizontal => localPosition.dx,
+      Axis.vertical => details.localPosition.dy,
+      Axis.horizontal => details.localPosition.dx,
     };
   }
 
@@ -199,16 +199,16 @@ class _CupertinoScrollbarState extends RawScrollbarState<CupertinoScrollbar> {
   }
 
   @override
-  void handleThumbPressEnd(Offset localPosition, Velocity velocity) {
+  void handleThumbPressEnd(DragEndDetails details) {
     final Axis? direction = getScrollbarDirection();
     if (direction == null) {
       return;
     }
     _thicknessAnimationController.reverse();
-    super.handleThumbPressEnd(localPosition, velocity);
+    super.handleThumbPressEnd(details);
     final (double axisPosition, double axisVelocity) = switch (direction) {
-      Axis.horizontal => (localPosition.dx, velocity.pixelsPerSecond.dx),
-      Axis.vertical => (localPosition.dy, velocity.pixelsPerSecond.dy),
+      Axis.horizontal => (details.localPosition.dx, details.velocity.pixelsPerSecond.dx),
+      Axis.vertical => (details.localPosition.dy, details.velocity.pixelsPerSecond.dy),
     };
     if (axisPosition != _pressStartAxisPosition && axisVelocity.abs() < 10) {
       HapticFeedback.mediumImpact();

--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -363,16 +363,16 @@ class _MaterialScrollbarState extends RawScrollbarState<_MaterialScrollbar> {
   }
 
   @override
-  void handleThumbPressStart(Offset localPosition) {
-    super.handleThumbPressStart(localPosition);
+  void handleThumbPressStart(DragStartDetails details) {
+    super.handleThumbPressStart(details);
     setState(() {
       _dragIsActive = true;
     });
   }
 
   @override
-  void handleThumbPressEnd(Offset localPosition, Velocity velocity) {
-    super.handleThumbPressEnd(localPosition, velocity);
+  void handleThumbPressEnd(DragEndDetails details) {
+    super.handleThumbPressEnd(details);
     setState(() {
       _dragIsActive = false;
     });

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -1722,9 +1722,12 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
   /// Handler called when a long press gesture has started.
   ///
   /// Begins the fade out animation and creates the thumb's DragScrollController.
+  ///
+  /// It receives a copy of [details] that has been enhanced with the computed
+  /// [DragStartDetails.localPosition].
   @protected
   @mustCallSuper
-  void handleThumbPressStart(Offset localPosition) {
+  void handleThumbPressStart(DragStartDetails details) {
     assert(_debugCheckHasValidScrollPosition());
     final Axis? direction = getScrollbarDirection();
     if (direction == null) {
@@ -1735,28 +1738,26 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
 
     assert(_thumbDrag == null);
     final ScrollPosition position = _cachedController!.position;
-    final renderBox = _scrollbarPainterKey.currentContext!.findRenderObject()! as RenderBox;
-    final details = DragStartDetails(
-      localPosition: localPosition,
-      globalPosition: renderBox.localToGlobal(localPosition),
-    );
     _thumbDrag = position.drag(details, _disposeThumbDrag);
     assert(_thumbDrag != null);
     assert(_thumbHold == null);
 
-    _startDragScrollbarAxisOffset = localPosition;
-    _lastDragUpdateOffset = localPosition;
+    _startDragScrollbarAxisOffset = details.localPosition;
+    _lastDragUpdateOffset = details.localPosition;
     _startDragThumbOffset = scrollbarPainter.getThumbScrollOffset();
   }
 
   /// Handler called when a currently active long press gesture moves.
   ///
   /// Updates the position of the child scrollable via the _drag ScrollDragController.
+  ///
+  /// It receives a copy of [details] that has been enhanced with the computed
+  /// [DragUpdateDetails.localPosition].
   @protected
   @mustCallSuper
-  void handleThumbPressUpdate(Offset localPosition) {
+  void handleThumbPressUpdate(DragUpdateDetails details) {
     assert(_debugCheckHasValidScrollPosition());
-    if (_lastDragUpdateOffset == localPosition) {
+    if (_lastDragUpdateOffset == details.localPosition) {
       return;
     }
     final ScrollPosition position = _cachedController!.position;
@@ -1773,7 +1774,7 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
       return;
     }
 
-    final double? primaryDelta = _getPrimaryDelta(localPosition);
+    final double? primaryDelta = _getPrimaryDelta(details.localPosition);
     if (primaryDelta == null) {
       return;
     }
@@ -1782,24 +1783,28 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
       Axis.horizontal => Offset(primaryDelta, 0),
       Axis.vertical => Offset(0, primaryDelta),
     };
-    final renderBox = _scrollbarPainterKey.currentContext!.findRenderObject()! as RenderBox;
     final scrollDetails = DragUpdateDetails(
       delta: delta,
       primaryDelta: primaryDelta,
-      globalPosition: renderBox.localToGlobal(localPosition),
-      localPosition: localPosition,
+      globalPosition: details.globalPosition,
+      localPosition: details.localPosition,
+      sourceTimeStamp: details.sourceTimeStamp,
+      kind: details.kind,
     );
     _thumbDrag!.update(
       scrollDetails,
     ); // Triggers updates to the ScrollPosition and ScrollbarPainter
 
-    _lastDragUpdateOffset = localPosition;
+    _lastDragUpdateOffset = details.localPosition;
   }
 
   /// Handler called when a long press has ended.
+  ///
+  /// It receives a copy of [details] that has been enhanced with the computed
+  /// [DragEndDetails.localPosition].
   @protected
   @mustCallSuper
-  void handleThumbPressEnd(Offset localPosition, Velocity velocity) {
+  void handleThumbPressEnd(DragEndDetails details) {
     assert(_debugCheckHasValidScrollPosition());
     final Axis? direction = getScrollbarDirection();
     if (direction == null) {
@@ -1820,13 +1825,12 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
     // dragging on the trackpad or with a stylus.
     final TargetPlatform platform = ScrollConfiguration.of(context).getPlatform(context);
     final Velocity adjustedVelocity = switch (platform) {
-      TargetPlatform.iOS || TargetPlatform.android => -velocity,
+      TargetPlatform.iOS || TargetPlatform.android => -details.velocity,
       _ => Velocity.zero,
     };
-    final renderBox = _scrollbarPainterKey.currentContext!.findRenderObject()! as RenderBox;
-    final details = DragEndDetails(
-      localPosition: localPosition,
-      globalPosition: renderBox.localToGlobal(localPosition),
+    final scrollDetails = DragEndDetails(
+      localPosition: details.localPosition,
+      globalPosition: details.globalPosition,
       velocity: adjustedVelocity,
       primaryVelocity: switch (direction) {
         Axis.horizontal => adjustedVelocity.pixelsPerSecond.dx,
@@ -1834,7 +1838,7 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
       },
     );
 
-    _thumbDrag?.end(details);
+    _thumbDrag?.end(scrollDetails);
     assert(_thumbDrag == null);
 
     _startDragScrollbarAxisOffset = null;
@@ -1989,15 +1993,35 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
   }
 
   void _handleThumbDragStart(DragStartDetails details) {
-    handleThumbPressStart(_globalToScrollbar(details.globalPosition));
+    final detailsWithLocalPosition = DragStartDetails(
+      globalPosition: details.globalPosition,
+      localPosition: _globalToScrollbar(details.globalPosition),
+      sourceTimeStamp: details.sourceTimeStamp,
+      kind: details.kind,
+    );
+    handleThumbPressStart(detailsWithLocalPosition);
   }
 
   void _handleThumbDragUpdate(DragUpdateDetails details) {
-    handleThumbPressUpdate(_globalToScrollbar(details.globalPosition));
+    final detailsWithLocalPosition = DragUpdateDetails(
+      globalPosition: details.globalPosition,
+      localPosition: _globalToScrollbar(details.globalPosition),
+      sourceTimeStamp: details.sourceTimeStamp,
+      delta: details.delta,
+      primaryDelta: details.primaryDelta,
+      kind: details.kind,
+    );
+    handleThumbPressUpdate(detailsWithLocalPosition);
   }
 
   void _handleThumbDragEnd(DragEndDetails details) {
-    handleThumbPressEnd(_globalToScrollbar(details.globalPosition), details.velocity);
+    final detailsWithLocalPosition = DragEndDetails(
+      globalPosition: details.globalPosition,
+      localPosition: _globalToScrollbar(details.globalPosition),
+      velocity: details.velocity,
+      primaryVelocity: details.primaryVelocity,
+    );
+    handleThumbPressEnd(detailsWithLocalPosition);
   }
 
   void _handleThumbDragCancel() {


### PR DESCRIPTION
[this is a rethread of https://github.com/flutter/flutter/pull/181110]

addressing the comments:
* data driven fix - I looked into this, but unfortunately I don't think it fits - it seems to key off of method name changes; signature-only changes do not appear to be supported. As I mentioned this is a trivial change in the guts of scrollbars, so while technically breaking change (if someone is extending it directly), end users probably wouldn't notice this, and anyone creating their own custom scrollbars have a clear path forward.
* keeping both versions of the methods: I also considered this but that unfortunately doesn't help with the ultimate buttons goal, because anyone calling the old signature just doesn't give enough information to fully reconstruct the event. the reason for this change is to force callers to provide the entire event thus guaranteeing we have the info needed to propagate button (and better future proofing against any other such changes).
* copyWith and nullability - agreeing with the confusing semantics of copyWith exposed by @Renzo-Olivares , so I just removed it. this makes this PR much simpler, and the final state still a bit "brittle", in the sense that future event additions need to be aware of updating the ad-hoc copies, but it is still a much nicer state than before, and fully unblocks my ultimate goal of exposing `buttons`, so I am happy with it.

---

[original description]

This PR changes the signatures of `handleThumbPressStart`, `handleThumbPressUpdate`, and `handleThumbPressEnd`, related to scrollbar handling, to take in a copy of the original event with the `localPosition` added inside, instead of separate fields.

This centralizes the copying of these events by the generic platform code (while still allowing some of them to re-copy based on implementation details), ensures that additional fields are propagated (such as `kind` when it exists, `buttons` when it is eventually added, and others) and simplifies the method signature significantly, future proofing it to future additions.

This was extracted from https://github.com/flutter/flutter/pull/176968 in an attempt to simplify it, and it will make it possible to add the missing `buttons` property to these events more easily.

Note: this is a public signature change but only if people are creating their own custom scrollbar implementations (?) without using either the material or cupertino ones; and on top of that should be very trivial to fix. But please advise if there are concerns.

Note: this has no test changes because it is a refactor which should have zero change in behaviour; the existing tests passing is proof of it working.

Note: this PR assumes that the `renderBox.localToGlobal(localPosition)` computation that was previously done was essentially the _reverse_ of the global -> local computation, so essentially the flow was `global --(global to local)--> local --(local to global)--> global` (the second step being there just because we didn't provide the original global to the method). So this is saving a computation step and should not change the behaviour. I will let the tests be the judge of this assumption but please let me know if there are concerns.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
