### PR TITLE
[web] Rename WebParagraph goldens

### DIFF
--- a/engine/src/flutter/lib/web_ui/test/webparagraph/paragraph_performance_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/webparagraph/paragraph_performance_test.dart
@@ -70,14 +70,14 @@ Future<void> testMain() async {
       }
     }
 
-    await matchGoldenFile('$image.png', region: region);
+    await matchGoldenFile('web_paragraph.$image.png', region: region);
     WebParagraphProfiler.log();
   }
 
   test(
     'Dummy test to warm up GPU',
     () async {
-      await draw('dummyText', 'Dummy text', 'Dummy text', 1, 1);
+      await draw('dummy_text', 'Dummy text', 'Dummy text', 1, 1);
     },
     timeout: Timeout.none,
     skip: true,
@@ -86,7 +86,7 @@ Future<void> testMain() async {
   test(
     'Build/Layout/Paint small text',
     () async {
-      await draw('smallText', 'Abcdef', 'Small text', 10, 100);
+      await draw('small_text', 'Abcdef', 'Small text', 10, 100);
     },
     timeout: Timeout.none,
     skip: true,
@@ -95,7 +95,7 @@ Future<void> testMain() async {
   test(
     'Build/Layout/Paint medium text',
     () async {
-      await draw('mediumText', 'Abcdef ghijkl mnopqrs tuvwxyz.', 'Medium text', 10, 100);
+      await draw('medium_text', 'Abcdef ghijkl mnopqrs tuvwxyz.', 'Medium text', 10, 100);
     },
     timeout: Timeout.none,
     skip: true,
@@ -105,7 +105,7 @@ Future<void> testMain() async {
     'Build/Layout/Paint large text',
     () async {
       await draw(
-        'largeText',
+        'large_text',
         'Abcdef ghijkl mnopqrs tuvwxyz. Abcdef ghijkl mnopqrs tuvwxyz. Abcdef ghijkl mnopqrs tuvwxyz. '
             'Abcdef ghijkl mnopqrs tuvwxyz. Abcdef ghijkl mnopqrs tuvwxyz. Abcdef ghijkl mnopqrs tuvwxyz. '
             'Abcdef ghijkl mnopqrs tuvwxyz. Abcdef ghijkl mnopqrs tuvwxyz. Abcdef ghijkl mnopqrs tuvwxyz. '
@@ -166,7 +166,7 @@ Future<void> testMain() async {
         });
       }
 
-      await matchGoldenFile('textSize.png', region: region);
+      await matchGoldenFile('web_paragraph.text_size.png', region: region);
       WebParagraphProfiler.log();
     },
     timeout: Timeout.none,

--- a/engine/src/flutter/lib/web_ui/test/webparagraph/paragraph_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/webparagraph/paragraph_test.dart
@@ -39,7 +39,7 @@ Future<void> testMain() async {
     paragraph.paint(canvas, const Offset(0, 100));
     canvas.drawRect(const Rect.fromLTWH(250, 0, 100, 200), redPaint);
     await drawPictureUsingCurrentRenderer(recorder.endRecording());
-    await matchGoldenFile('web_paragraph_ltr_1.png', region: region);
+    await matchGoldenFile('web_paragraph.ltr_1.png', region: region);
   });
 
   test('Draw WebParagraph LTR text with multiple lines', () async {
@@ -61,7 +61,7 @@ Future<void> testMain() async {
     paragraph.layout(const ParagraphConstraints(width: 500));
     paragraph.paint(canvas, Offset.zero);
     await drawPictureUsingCurrentRenderer(recorder.endRecording());
-    await matchGoldenFile('web_paragraph_canvas_multilined_ltr.png', region: region);
+    await matchGoldenFile('web_paragraph.multiline_ltr.png', region: region);
   });
 
   test('Draw WebParagraph RTL text 1 line', () async {
@@ -82,7 +82,7 @@ Future<void> testMain() async {
     paragraph.layout(const ParagraphConstraints(width: double.infinity));
     paragraph.paint(canvas, Offset.zero);
     await drawPictureUsingCurrentRenderer(recorder.endRecording());
-    await matchGoldenFile('web_paragraph_1_rtl.png', region: region);
+    await matchGoldenFile('web_paragraph.rtl_1.png', region: region);
   });
 
   // Small line breaking difference with Chrome
@@ -104,7 +104,7 @@ Future<void> testMain() async {
     paragraph.layout(const ParagraphConstraints(width: 300));
     paragraph.paint(canvas, Offset.zero);
     await drawPictureUsingCurrentRenderer(recorder.endRecording());
-    await matchGoldenFile('web_paragraph_canvas_multilined_rtl.png', region: region);
+    await matchGoldenFile('web_paragraph.multiline_rtl.png', region: region);
   });
 
   test('Draw WebParagraph LTR/RTL 1 Line in ltr', () async {
@@ -125,96 +125,59 @@ Future<void> testMain() async {
     paragraph.layout(const ParagraphConstraints(width: 300));
     paragraph.paint(canvas, Offset.zero);
     await drawPictureUsingCurrentRenderer(recorder.endRecording());
-    await matchGoldenFile('web_paragraph_canvas_mix_1_ltr.png', region: region);
+    await matchGoldenFile('web_paragraph.mix_1_ltr.png', region: region);
   });
 
-  test('Draw WebParagraph LTR/RTL 1 Line', () async {
-    final recorder = PictureRecorder();
-    final canvas = Canvas(recorder, region);
+  for (final dir in <String>['ltr', 'rtl']) {
+    test('Draw mixed WebParagraph multi Line with `$dir` default', () async {
+      final recorder = PictureRecorder();
+      final canvas = Canvas(recorder, region);
+      canvas.drawColor(const Color(0xFFFFFFFF), BlendMode.src);
 
-    final arialStyle = WebParagraphStyle(
-      fontFamily: 'Arial',
-      fontSize: 50,
-      color: const Color(0xFF000000),
-    );
-    final builder = WebParagraphBuilder(arialStyle);
-    builder.pushStyle(WebTextStyle(color: const Color(0xFF000000)));
-    builder.addText('ABC لم def');
-    final WebParagraph paragraph = builder.build();
-    paragraph.layout(const ParagraphConstraints(width: 300));
-    paragraph.paint(canvas, Offset.zero);
-    await drawPictureUsingCurrentRenderer(recorder.endRecording());
-    await matchGoldenFile('web_paragraph_canvas_mix1_multilined_ltr.png', region: region);
-  });
+      final arialStyle = WebParagraphStyle(
+        fontFamily: 'Arial',
+        fontSize: 50,
+        textDirection: TextDirection.values.byName(dir),
+      );
+      final builder = WebParagraphBuilder(arialStyle);
+      builder.pushStyle(WebTextStyle(color: const Color(0xFF000000)));
+      builder.addText('لABC لم def لل لم ghi');
+      final WebParagraph paragraph = builder.build();
+      paragraph.layout(const ParagraphConstraints(width: 300));
+      paragraph.paint(canvas, Offset.zero);
+      await drawPictureUsingCurrentRenderer(recorder.endRecording());
+      await matchGoldenFile('web_paragraph.mix_multiline_$dir.png', region: region);
+    });
 
-  test('Draw WebParagraph LTR/RTL multi Line with RTL default left aligned', () async {
-    final recorder = PictureRecorder();
-    final canvas = Canvas(recorder, region);
-    canvas.drawColor(const Color(0xFFFFFFFF), BlendMode.src);
+    for (final align in <String>['left', 'right']) {
+      test('Draw mixed WebParagraph multi Line with `$dir` default $align aligned', () async {
+        final recorder = PictureRecorder();
+        final canvas = Canvas(recorder, region);
+        canvas.drawColor(const Color(0xFFFFFFFF), BlendMode.src);
 
-    final arialStyle = WebParagraphStyle(
-      fontFamily: 'Arial',
-      fontSize: 50,
-      textDirection: TextDirection.rtl,
-    );
-    final builder = WebParagraphBuilder(arialStyle);
-    builder.pushStyle(WebTextStyle(color: const Color(0xFF000000)));
-    builder.addText('لABC لم def لل لم ghi');
-    //لABC لم def لل لم ghi
-    final WebParagraph paragraph = builder.build();
-    paragraph.layout(const ParagraphConstraints(width: 300));
-    paragraph.paint(canvas, Offset.zero);
-    await drawPictureUsingCurrentRenderer(recorder.endRecording());
-    await matchGoldenFile('web_paragraph_canvas_mix1_multilined_rtl.png', region: region);
-  });
-
-  test('Draw WebParagraph LTR/RTL multi Line with LTR left aligned', () async {
-    final recorder = PictureRecorder();
-    final canvas = Canvas(recorder, region);
-    canvas.drawColor(const Color(0xFFFFFFFF), BlendMode.src);
-
-    final arialStyle = WebParagraphStyle(
-      textDirection: TextDirection.ltr,
-      textAlign: TextAlign.left,
-      fontFamily: 'Arial',
-      fontSize: 50,
-      color: const Color(0xFF000000),
-    );
-    final builder = WebParagraphBuilder(arialStyle);
-    builder.pushStyle(WebTextStyle(color: const Color(0xFF000000)));
-    builder.addText(
-      'إنالسيطرةعلىاxyz لعالمعباvwx رةقبيحةstu للغاpqr ية-أmno فضلأjkl نأسميهاghi تحسيناdef لعاabc لم',
-    );
-    final WebParagraph paragraph = builder.build();
-    paragraph.layout(const ParagraphConstraints(width: 300));
-    paragraph.paint(canvas, Offset.zero);
-    await drawPictureUsingCurrentRenderer(recorder.endRecording());
-    await matchGoldenFile('web_paragraph_canvas_mix_multilined_ltr.png', region: region);
-  });
-
-  test('Draw WebParagraph LTR/RTL multi Line with RTL right aligned', () async {
-    final recorder = PictureRecorder();
-    final canvas = Canvas(recorder, region);
-    canvas.drawColor(const Color(0xFFFFFFFF), BlendMode.src);
-
-    final arialStyle = WebParagraphStyle(
-      textDirection: TextDirection.rtl,
-      textAlign: TextAlign.right,
-      fontFamily: 'Arial',
-      fontSize: 50,
-      color: const Color(0xFF000000),
-    );
-    final builder = WebParagraphBuilder(arialStyle);
-    builder.pushStyle(WebTextStyle(color: const Color(0xFF000000)));
-    builder.addText(
-      'إنالسيطرةعلىاxyz لعالمعباvwx رةقبيحةstu للغاpqr ية-أmno فضلأjkl نأسميهاghi تحسيناdef لعاabc لم',
-    );
-    final WebParagraph paragraph = builder.build();
-    paragraph.layout(const ParagraphConstraints(width: 300));
-    paragraph.paint(canvas, Offset.zero);
-    await drawPictureUsingCurrentRenderer(recorder.endRecording());
-    await matchGoldenFile('web_paragraph_canvas_mix_multilined_rtl.png', region: region);
-  });
+        final arialStyle = WebParagraphStyle(
+          textDirection: TextDirection.values.byName(dir),
+          textAlign: TextAlign.values.byName(align),
+          fontFamily: 'Arial',
+          fontSize: 50,
+          color: const Color(0xFF000000),
+        );
+        final builder = WebParagraphBuilder(arialStyle);
+        builder.pushStyle(WebTextStyle(color: const Color(0xFF000000)));
+        builder.addText(
+          'إنالسيطرةعلىاxyz لعالمعباvwx رةقبيحةstu للغاpqr ية-أmno فضلأjkl نأسميهاghi تحسيناdef لعاabc لم',
+        );
+        final WebParagraph paragraph = builder.build();
+        paragraph.layout(const ParagraphConstraints(width: 300));
+        paragraph.paint(canvas, Offset.zero);
+        await drawPictureUsingCurrentRenderer(recorder.endRecording());
+        await matchGoldenFile(
+          'web_paragraph.mix_multiline_${dir}_align_$align.png',
+          region: region,
+        );
+      });
+    }
+  }
 
   test('Draw WebParagraph multicolored text', () async {
     final recorder = PictureRecorder();
@@ -256,7 +219,7 @@ Future<void> testMain() async {
     paragraph.layout(const ParagraphConstraints(width: 250));
     paragraph.paint(canvas, Offset.zero);
     await drawPictureUsingCurrentRenderer(recorder.endRecording());
-    await matchGoldenFile('web_paragraph_multicolored.png', region: region);
+    await matchGoldenFile('web_paragraph.multicolor.png', region: region);
   });
 
   test('Draw WebParagraph multicolored background text', () async {
@@ -317,7 +280,7 @@ Future<void> testMain() async {
     paragraph.layout(const ParagraphConstraints(width: 250));
     paragraph.paint(canvas, Offset.zero);
     await drawPictureUsingCurrentRenderer(recorder.endRecording());
-    await matchGoldenFile('web_paragraph_multicolored_background.png', region: region);
+    await matchGoldenFile('web_paragraph.multicolor_background.png', region: region);
   });
 
   test('Draw WebParagraph multiple font styles text', () async {
@@ -371,7 +334,7 @@ Future<void> testMain() async {
     paragraph.layout(const ParagraphConstraints(width: 250));
     paragraph.paint(canvas, Offset.zero);
     await drawPictureUsingCurrentRenderer(recorder.endRecording());
-    await matchGoldenFile('web_paragraph_multifontstyled.png', region: region);
+    await matchGoldenFile('web_paragraph.multifontstyle.png', region: region);
   });
 
   test('Draw WebParagraph multiple shadows text', () async {
@@ -453,7 +416,7 @@ Future<void> testMain() async {
     paragraph.layout(const ParagraphConstraints(width: 400));
     paragraph.paint(canvas, const Offset(50, 50));
     await drawPictureUsingCurrentRenderer(recorder.endRecording());
-    await matchGoldenFile('web_paragraph_multishadows.png', region: region);
+    await matchGoldenFile('web_paragraph.multishadows.png', region: region);
   });
 
   test('Draw WebParagraph multiple decorations on text', () async {
@@ -533,7 +496,7 @@ Future<void> testMain() async {
     paragraph.layout(const ParagraphConstraints(width: 400));
     paragraph.paint(canvas, Offset.zero);
     await drawPictureUsingCurrentRenderer(recorder.endRecording());
-    await matchGoldenFile('web_paragraph_multidecorated.png', region: region);
+    await matchGoldenFile('web_paragraph.multidecoration.png', region: region);
   });
 
   test('Draw WebParagraph multiple fonts text', () async {
@@ -592,7 +555,7 @@ Future<void> testMain() async {
     paragraph.layout(const ParagraphConstraints(width: 250));
     paragraph.paint(canvas, Offset.zero);
     await drawPictureUsingCurrentRenderer(recorder.endRecording());
-    await matchGoldenFile('web_paragraph_multiplefont.png', region: region);
+    await matchGoldenFile('web_paragraph.multifont.png', region: region);
   });
 
   test('Draw WebParagraph letter/word spacing text', () async {
@@ -627,7 +590,7 @@ Future<void> testMain() async {
     paragraph.layout(const ParagraphConstraints(width: 250));
     paragraph.paint(canvas, Offset.zero);
     await drawPictureUsingCurrentRenderer(recorder.endRecording());
-    await matchGoldenFile('web_paragraph_letter_word_spacing.png', region: region);
+    await matchGoldenFile('web_paragraph.letter_word_spacing.png', region: region);
   });
 
   test('Query WebParagraph.GetBoxesForRange LTR text 1 line', () async {
@@ -704,7 +667,7 @@ Future<void> testMain() async {
     }
 
     await drawPictureUsingCurrentRenderer(recorder.endRecording());
-    await matchGoldenFile('web_paragraph_query_boxes_ltr_1.png', region: region);
+    await matchGoldenFile('web_paragraph.query_boxes_ltr_1.png', region: region);
   });
 
   test('Query WebParagraph.Placeholders', () async {
@@ -812,7 +775,7 @@ Future<void> testMain() async {
     }
 
     await drawPictureUsingCurrentRenderer(recorder.endRecording());
-    await matchGoldenFile('web_paragraph_placeholders_1_line.png', region: region);
+    await matchGoldenFile('web_paragraph.placeholders_1_line.png', region: region);
   });
 
   test('Draw WebParagraph with fontFeatures', () async {
@@ -853,7 +816,7 @@ Future<void> testMain() async {
     paragraph.layout(const ParagraphConstraints(width: 250));
     paragraph.paint(canvas, Offset.zero);
     await drawPictureUsingCurrentRenderer(recorder.endRecording());
-    await matchGoldenFile('web_paragraph_font_features.png', region: region);
+    await matchGoldenFile('web_paragraph.font_features.png', region: region);
   });
 
   test('Draw WebParagraph with fontVariations', () async {
@@ -899,11 +862,11 @@ Future<void> testMain() async {
     builder.pop();
     builder.addText('Italic.\n');
 
-    //final WebParagraph paragraph = builder.build();
-    //paragraph.layout(const ParagraphConstraints(width: 250));
-    //paragraph.paintOnCanvasKit(canvas, const Offset(0, 0));
+    final WebParagraph paragraph = builder.build();
+    paragraph.layout(const ParagraphConstraints(width: 250));
+    paragraph.paint(canvas, Offset.zero);
     await drawPictureUsingCurrentRenderer(recorder.endRecording());
-    await matchGoldenFile('web_paragraph_font_variations.png', region: region);
+    await matchGoldenFile('web_paragraph.font_variations.png', region: region);
   });
 
   test('Draw WebParagraph multicolored background text', () async {
@@ -939,7 +902,7 @@ Future<void> testMain() async {
     paragraph.layout(const ParagraphConstraints(width: 250));
     paragraph.paint(canvas, Offset.zero);
     await drawPictureUsingCurrentRenderer(recorder.endRecording());
-    await matchGoldenFile('web_paragraph_black_and_white_background.png', region: region);
+    await matchGoldenFile('web_paragraph.black_and_white_background.png', region: region);
   });
 
   test('Pixels', () async {
@@ -973,7 +936,7 @@ Future<void> testMain() async {
       paragraph.paint(canvas, const Offset(100, 100));
     }
     await drawPictureUsingCurrentRenderer(recorder.endRecording());
-    await matchGoldenFile('pixels.png', region: region);
+    await matchGoldenFile('web_paragraph.pixels.png', region: region);
   });
 
   test('Ellipsis LTR', () async {
@@ -1008,7 +971,7 @@ Future<void> testMain() async {
       paragraph.paint(canvas, const Offset(100, 100));
     }
     await drawPictureUsingCurrentRenderer(recorder.endRecording());
-    await matchGoldenFile('ellipsisLTR.png', region: region);
+    await matchGoldenFile('web_paragraph.ellipsis_ltr.png', region: region);
   });
 
   test('Ellipsis RTL', () async {
@@ -1045,7 +1008,7 @@ Future<void> testMain() async {
       paragraph.paint(canvas, const Offset(100, 100));
     }
     await drawPictureUsingCurrentRenderer(recorder.endRecording());
-    await matchGoldenFile('ellipsisRTL.png', region: region);
+    await matchGoldenFile('web_paragraph.ellipsis_rtl.png', region: region);
   });
 
   test('MaxLines, no ellipsis', () async {
@@ -1082,7 +1045,7 @@ Future<void> testMain() async {
       paragraph.paint(canvas, const Offset(100, 100));
     }
     await drawPictureUsingCurrentRenderer(recorder.endRecording());
-    await matchGoldenFile('maxLines2.png', region: region);
+    await matchGoldenFile('web_paragraph.max_lines_2.png', region: region);
   });
 
   test('Paragraph with different locales for the same language', () async {
@@ -1117,7 +1080,7 @@ Future<void> testMain() async {
     paragraph.paint(canvas, const Offset(100, 100));
 
     await drawPictureUsingCurrentRenderer(recorder.endRecording());
-    await matchGoldenFile('locales.png', region: region);
+    await matchGoldenFile('web_paragraph.locales.png', region: region);
   });
 
   test('NoHeightMultiplier', () async {
@@ -1148,7 +1111,7 @@ Future<void> testMain() async {
     canvas.drawParagraph(paragraph, Offset.zero);
 
     await drawPictureUsingCurrentRenderer(recorder.endRecording());
-    await matchGoldenFile('NoHeightMultiplier.png', region: region);
+    await matchGoldenFile('web_paragraph.no_height_multiplier.png', region: region);
     EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(1.0);
   });
 
@@ -1180,7 +1143,7 @@ Future<void> testMain() async {
     canvas.drawParagraph(paragraph, Offset.zero);
 
     await drawPictureUsingCurrentRenderer(recorder.endRecording());
-    await matchGoldenFile('HeightMultiplier143.png', region: region);
+    await matchGoldenFile('web_paragraph.height_multiplier_143.png', region: region);
     EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(1.0);
   });
 
@@ -1212,7 +1175,7 @@ Future<void> testMain() async {
     //printParagraphMetrics(paragraph);
 
     await drawPictureUsingCurrentRenderer(recorder.endRecording());
-    await matchGoldenFile('zoom2.png', region: region);
+    await matchGoldenFile('web_paragraph.zoom_2.png', region: region);
     EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(1.0);
   });
 
@@ -1245,7 +1208,7 @@ Future<void> testMain() async {
     canvas.drawParagraph(paragraph, Offset.zero);
 
     await drawPictureUsingCurrentRenderer(recorder.endRecording());
-    await matchGoldenFile('zoom05.png', region: region);
+    await matchGoldenFile('web_paragraph.zoom_05.png', region: region);
     EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(1.0);
   });
 }


### PR DESCRIPTION
Adding a `web_paragraph.` prefix to all WebPargraph goldens.

Part of https://github.com/flutter/flutter/issues/172561