### PR TITLE
Update Vulkan enum values

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -268,8 +268,8 @@ RenderPassVK::RenderPassVK(const std::shared_ptr<const Context>& context,
   command_buffer_vk_.setScissor(0, 1, &scissor);
 
   // Set the initial stencil reference.
-  command_buffer_vk_.setStencilReference(
-      vk::StencilFaceFlagBits::eFrontAndBack, 0u);
+  command_buffer_vk_.setStencilReference(vk::StencilFaceFlagBits::eFrontAndBack,
+                                         0u);
 
   is_valid_ = true;
 }
@@ -387,8 +387,8 @@ void RenderPassVK::SetStencilReference(uint32_t value) {
     return;
   }
   current_stencil_ = value;
-  command_buffer_vk_.setStencilReference(
-      vk::StencilFaceFlagBits::eFrontAndBack, value);
+  command_buffer_vk_.setStencilReference(vk::StencilFaceFlagBits::eFrontAndBack,
+                                         value);
 }
 
 // |RenderPass|

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -269,7 +269,7 @@ RenderPassVK::RenderPassVK(const std::shared_ptr<const Context>& context,
 
   // Set the initial stencil reference.
   command_buffer_vk_.setStencilReference(
-      vk::StencilFaceFlagBits::eVkStencilFrontAndBack, 0u);
+      vk::StencilFaceFlagBits::eFrontAndBack, 0u);
 
   is_valid_ = true;
 }
@@ -388,7 +388,7 @@ void RenderPassVK::SetStencilReference(uint32_t value) {
   }
   current_stencil_ = value;
   command_buffer_vk_.setStencilReference(
-      vk::StencilFaceFlagBits::eVkStencilFrontAndBack, value);
+      vk::StencilFaceFlagBits::eFrontAndBack, value);
 }
 
 // |RenderPass|


### PR DESCRIPTION
`eVkStencilFrontAndBack` has been removed in the vulkan headers in https://github.com/KhronosGroup/Vulkan-Hpp/pull/2549

Change that to `eFrontAndBack`, which has the same value: https://github.com/KhronosGroup/Vulkan-Headers/blob/main/include/vulkan/vulkan_core.h#L3374