### PR TITLE
Complete completer only once in hot restart tests

### DIFF
--- a/packages/flutter_tools/test/web.shard/test_data/hot_restart_outside_lib_web_test_common.dart
+++ b/packages/flutter_tools/test/web.shard/test_data/hot_restart_outside_lib_web_test_common.dart
@@ -54,7 +54,7 @@ void testHotActionOutsideLib(HotAction action) {
     final completer = Completer<void>();
     final StreamSubscription<String> subscription = flutter.stdout.listen((String line) {
       printOnFailure(line);
-      if (line.contains('(((((RELOAD WORKED)))))')) {
+      if (!completer.isCompleted && line.contains('(((((RELOAD WORKED)))))')) {
         completer.complete();
       }
     });

--- a/packages/flutter_tools/test/web.shard/test_data/hot_restart_web_test_common.dart
+++ b/packages/flutter_tools/test/web.shard/test_data/hot_restart_web_test_common.dart
@@ -104,7 +104,7 @@ Future<void> _testProject(
       final completer = Completer<void>();
       final StreamSubscription<String> subscription = flutter.stdout.listen((String line) {
         printOnFailure(line);
-        if (line.contains('(((((RELOAD WORKED)))))')) {
+        if (!completer.isCompleted && line.contains('(((((RELOAD WORKED)))))')) {
           completer.complete();
         }
       });


### PR DESCRIPTION
These tests rely on a call to function being uncommented during a hot restart/hot reload. That uncommented function will then print a statement that the tests looks for. On the web, the function also periodically prints the same statement to guard against lost print statements
(https://github.com/flutter/flutter/issues/86202).

The issue then is that the completer may be completed multiple times before the test completes, so guard against that.

Fixes https://github.com/flutter/flutter/issues/186698

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.
