### PR TITLE
[flutter_tools, devicelab] Add safety filesystem guard to tests

### DIFF
--- a/dev/devicelab/lib/framework/framework.dart
+++ b/dev/devicelab/lib/framework/framework.dart
@@ -14,7 +14,6 @@ import 'package:process/process.dart';
 import 'package:stack_trace/stack_trace.dart';
 
 import 'devices.dart';
-import 'fs_safety.dart';
 import 'host_agent.dart';
 import 'running_processes.dart';
 import 'task_result.dart';
@@ -60,11 +59,9 @@ Future<TaskResult> task(TaskFunction task, {ProcessManager? processManager}) asy
     print('${rec.level.name}: ${rec.time}: ${rec.message}');
   });
 
-  return IOOverrides.runWithIOOverrides(() async {
-    final runner = _TaskRunner(task, processManager!);
-    runner.keepVmAliveUntilTaskRunRequested();
-    return runner.whenDone;
-  }, FSGuardIOOverrides());
+  final runner = _TaskRunner(task, processManager);
+  runner.keepVmAliveUntilTaskRunRequested();
+  return runner.whenDone;
 }
 
 class _TaskRunner {

--- a/dev/devicelab/lib/framework/framework.dart
+++ b/dev/devicelab/lib/framework/framework.dart
@@ -14,6 +14,7 @@ import 'package:process/process.dart';
 import 'package:stack_trace/stack_trace.dart';
 
 import 'devices.dart';
+import 'fs_safety.dart';
 import 'host_agent.dart';
 import 'running_processes.dart';
 import 'task_result.dart';
@@ -59,9 +60,11 @@ Future<TaskResult> task(TaskFunction task, {ProcessManager? processManager}) asy
     print('${rec.level.name}: ${rec.time}: ${rec.message}');
   });
 
-  final runner = _TaskRunner(task, processManager);
-  runner.keepVmAliveUntilTaskRunRequested();
-  return runner.whenDone;
+  return IOOverrides.runWithIOOverrides(() async {
+    final runner = _TaskRunner(task, processManager!);
+    runner.keepVmAliveUntilTaskRunRequested();
+    return runner.whenDone;
+  }, FSGuardIOOverrides());
 }
 
 class _TaskRunner {

--- a/dev/devicelab/lib/framework/fs_safety.dart
+++ b/dev/devicelab/lib/framework/fs_safety.dart
@@ -8,12 +8,67 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io' as io;
 import 'dart:typed_data';
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as path; // flutter_ignore: package_path_import
 
-bool _isUnderTemp(String entityPath) {
-  final String canonicalTemp = path.canonicalize(io.Directory.systemTemp.path);
+bool _isDangerousDirectory(String dirPath) {
+  final String canonical = path.canonicalize(dirPath);
+
+  // Check if it is root
+  if (canonical == '/' || canonical == r'C:\' || canonical.length <= 3) {
+    return true;
+  }
+
+  // Check if it is home or parent of home
+  final String? home = io.Platform.environment['HOME'] ?? io.Platform.environment['USERPROFILE'];
+  if (home != null) {
+    final String canonicalHome = path.canonicalize(home);
+    final String canonicalHomeParent = path.dirname(canonicalHome);
+    if (canonical == canonicalHome || canonical == canonicalHomeParent) {
+      return true;
+    }
+    // Check if it is Desktop
+    final String desktop = path.join(canonicalHome, 'Desktop');
+    final String canonicalDesktop = path.canonicalize(desktop);
+    if (canonical == canonicalDesktop) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool _isAllowedPath(String entityPath) {
   final String canonicalEntity = path.canonicalize(entityPath);
-  return path.isWithin(canonicalTemp, canonicalEntity) || canonicalEntity == canonicalTemp;
+
+  // Allow system temp
+  final String canonicalTemp = path.canonicalize(io.Directory.systemTemp.path);
+  if (path.isWithin(canonicalTemp, canonicalEntity) || canonicalEntity == canonicalTemp) {
+    return true;
+  }
+
+  // Allow modifications inside the Flutter installation root itself
+  final String? flutterRoot = io.Platform.environment['FLUTTER_ROOT'];
+  if (flutterRoot != null) {
+    final String canonicalRoot = path.canonicalize(flutterRoot);
+    if (!_isDangerousDirectory(canonicalRoot)) {
+      if (path.isWithin(canonicalRoot, canonicalEntity) || canonicalEntity == canonicalRoot) {
+        return true;
+      }
+    }
+  }
+
+  // Allow modifications inside the directory specified by FLUTTER_TEST_OUTPUTS_DIR
+  final String? testOutputsDir = io.Platform.environment['FLUTTER_TEST_OUTPUTS_DIR'];
+  if (testOutputsDir != null) {
+    final String canonicalOutputs = path.canonicalize(testOutputsDir);
+    if (!_isDangerousDirectory(canonicalOutputs)) {
+      if (path.isWithin(canonicalOutputs, canonicalEntity) || canonicalEntity == canonicalOutputs) {
+        return true;
+      }
+    }
+  }
+
+  return false;
 }
 
 bool _isGuardDisabled() {
@@ -24,7 +79,7 @@ void _checkPath(String targetPath, String entityType, String operation) {
   if (_isGuardDisabled()) {
     return;
   }
-  if (!_isUnderTemp(targetPath)) {
+  if (!_isAllowedPath(targetPath)) {
     throw io.FileSystemException(
       'Test attempted to $operation $entityType outside of temp directory: $targetPath. '
       'This check prevents tests from causing data loss or modifying non-test data on the system. '

--- a/dev/devicelab/lib/framework/fs_safety.dart
+++ b/dev/devicelab/lib/framework/fs_safety.dart
@@ -1,0 +1,606 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// ignore_for_file: avoid_slow_async_io
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io' as io;
+import 'dart:typed_data';
+import 'package:path/path.dart' as path;
+
+bool _isUnderTemp(String entityPath) {
+  final String canonicalTemp = path.canonicalize(io.Directory.systemTemp.path);
+  final String canonicalEntity = path.canonicalize(entityPath);
+  return path.isWithin(canonicalTemp, canonicalEntity) || canonicalEntity == canonicalTemp;
+}
+
+bool _isGuardDisabled() {
+  return io.Platform.environment['FLUTTER_TEST_DISABLE_FS_GUARD'] == 'true';
+}
+
+void _checkPath(String targetPath, String entityType, String operation) {
+  if (_isGuardDisabled()) {
+    return;
+  }
+  if (!_isUnderTemp(targetPath)) {
+    throw io.FileSystemException(
+      'Test attempted to $operation $entityType outside of temp directory: $targetPath. '
+      'This check prevents tests from causing data loss or modifying non-test data on the system. '
+      'To bypass this safety check during local debugging (e.g., to output logs outside the temp directory), '
+      'set the environment variable FLUTTER_TEST_DISABLE_FS_GUARD=true in your shell or IDE.',
+      targetPath,
+    );
+  }
+}
+
+/// A wrapper around [io.File] that prevents modifying operations on paths outside
+/// of the system temporary directory during test execution.
+class GuardedFile implements io.File {
+  GuardedFile(this._delegate);
+
+  final io.File _delegate;
+
+  void _checkModify() {
+    _checkPath(_delegate.path, 'file', 'modify');
+  }
+
+  @override
+  String get path => _delegate.path;
+
+  @override
+  Uri get uri => _delegate.uri;
+
+  @override
+  Future<bool> exists() => _delegate.exists();
+
+  @override
+  bool existsSync() => _delegate.existsSync();
+
+  @override
+  Future<io.FileStat> stat() => _delegate.stat();
+
+  @override
+  io.FileStat statSync() => _delegate.statSync();
+
+  @override
+  Future<String> resolveSymbolicLinks() => _delegate.resolveSymbolicLinks();
+
+  @override
+  String resolveSymbolicLinksSync() => _delegate.resolveSymbolicLinksSync();
+
+  @override
+  io.Directory get parent => GuardedDirectory(_delegate.parent);
+
+  @override
+  io.File get absolute => GuardedFile(_delegate.absolute);
+
+  @override
+  bool get isAbsolute => _delegate.isAbsolute;
+
+  @override
+  Future<int> length() => _delegate.length();
+
+  @override
+  int lengthSync() => _delegate.lengthSync();
+
+  @override
+  Future<DateTime> lastAccessed() => _delegate.lastAccessed();
+
+  @override
+  DateTime lastAccessedSync() => _delegate.lastAccessedSync();
+
+  @override
+  Future<DateTime> lastModified() => _delegate.lastModified();
+
+  @override
+  DateTime lastModifiedSync() => _delegate.lastModifiedSync();
+
+  @override
+  Stream<List<int>> openRead([int? start, int? end]) => _delegate.openRead(start, end);
+
+  @override
+  Future<Uint8List> readAsBytes() => _delegate.readAsBytes();
+
+  @override
+  Uint8List readAsBytesSync() => _delegate.readAsBytesSync();
+
+  @override
+  Future<String> readAsString({Encoding encoding = utf8}) =>
+      _delegate.readAsString(encoding: encoding);
+
+  @override
+  String readAsStringSync({Encoding encoding = utf8}) =>
+      _delegate.readAsStringSync(encoding: encoding);
+
+  @override
+  Future<List<String>> readAsLines({Encoding encoding = utf8}) =>
+      _delegate.readAsLines(encoding: encoding);
+
+  @override
+  List<String> readAsLinesSync({Encoding encoding = utf8}) =>
+      _delegate.readAsLinesSync(encoding: encoding);
+
+  @override
+  Stream<io.FileSystemEvent> watch({int events = io.FileSystemEvent.all, bool recursive = false}) =>
+      _delegate.watch(events: events, recursive: recursive);
+
+  @override
+  Future<io.File> create({bool recursive = false, bool exclusive = false}) {
+    _checkModify();
+    return _delegate.create(recursive: recursive, exclusive: exclusive).then((f) => GuardedFile(f));
+  }
+
+  @override
+  void createSync({bool recursive = false, bool exclusive = false}) {
+    _checkModify();
+    _delegate.createSync(recursive: recursive, exclusive: exclusive);
+  }
+
+  @override
+  Future<io.File> rename(String newPath) {
+    _checkModify();
+    _checkPath(newPath, 'file', 'rename');
+    return _delegate.rename(newPath).then(GuardedFile.new);
+  }
+
+  @override
+  io.File renameSync(String newPath) {
+    _checkModify();
+    _checkPath(newPath, 'file', 'rename');
+    return GuardedFile(_delegate.renameSync(newPath));
+  }
+
+  @override
+  Future<io.FileSystemEntity> delete({bool recursive = false}) {
+    _checkModify();
+    return _delegate.delete(recursive: recursive);
+  }
+
+  @override
+  void deleteSync({bool recursive = false}) {
+    _checkModify();
+    _delegate.deleteSync(recursive: recursive);
+  }
+
+  @override
+  Future<io.File> copy(String newPath) {
+    _checkPath(newPath, 'file', 'copy');
+    return _delegate.copy(newPath).then(GuardedFile.new);
+  }
+
+  @override
+  io.File copySync(String newPath) {
+    _checkPath(newPath, 'file', 'copy');
+    return GuardedFile(_delegate.copySync(newPath));
+  }
+
+  @override
+  Future<void> setLastAccessed(DateTime time) {
+    _checkModify();
+    return _delegate.setLastAccessed(time);
+  }
+
+  @override
+  void setLastAccessedSync(DateTime time) {
+    _checkModify();
+    _delegate.setLastAccessedSync(time);
+  }
+
+  @override
+  Future<void> setLastModified(DateTime time) {
+    _checkModify();
+    return _delegate.setLastModified(time);
+  }
+
+  @override
+  void setLastModifiedSync(DateTime time) {
+    _checkModify();
+    _delegate.setLastModifiedSync(time);
+  }
+
+  @override
+  Future<io.RandomAccessFile> open({io.FileMode mode = io.FileMode.read}) {
+    if (mode != io.FileMode.read) {
+      _checkModify();
+    }
+    return _delegate.open(mode: mode);
+  }
+
+  @override
+  io.RandomAccessFile openSync({io.FileMode mode = io.FileMode.read}) {
+    if (mode != io.FileMode.read) {
+      _checkModify();
+    }
+    return _delegate.openSync(mode: mode);
+  }
+
+  @override
+  io.IOSink openWrite({io.FileMode mode = io.FileMode.write, Encoding encoding = utf8}) {
+    _checkModify();
+    return _delegate.openWrite(mode: mode, encoding: encoding);
+  }
+
+  @override
+  Future<io.File> writeAsBytes(
+    List<int> bytes, {
+    io.FileMode mode = io.FileMode.write,
+    bool flush = false,
+  }) {
+    _checkModify();
+    return _delegate.writeAsBytes(bytes, mode: mode, flush: flush).then((f) => GuardedFile(f));
+  }
+
+  @override
+  void writeAsBytesSync(
+    List<int> bytes, {
+    io.FileMode mode = io.FileMode.write,
+    bool flush = false,
+  }) {
+    _checkModify();
+    _delegate.writeAsBytesSync(bytes, mode: mode, flush: flush);
+  }
+
+  @override
+  Future<io.File> writeAsString(
+    String contents, {
+    io.FileMode mode = io.FileMode.write,
+    Encoding encoding = utf8,
+    bool flush = false,
+  }) {
+    _checkModify();
+    return _delegate
+        .writeAsString(contents, mode: mode, encoding: encoding, flush: flush)
+        .then((f) => GuardedFile(f));
+  }
+
+  @override
+  void writeAsStringSync(
+    String contents, {
+    io.FileMode mode = io.FileMode.write,
+    Encoding encoding = utf8,
+    bool flush = false,
+  }) {
+    _checkModify();
+    _delegate.writeAsStringSync(contents, mode: mode, encoding: encoding, flush: flush);
+  }
+}
+
+/// A wrapper around [io.Directory] that prevents modifying operations on paths outside
+/// of the system temporary directory during test execution.
+class GuardedDirectory implements io.Directory {
+  GuardedDirectory(this._delegate);
+
+  final io.Directory _delegate;
+
+  void _checkModify() {
+    _checkPath(_delegate.path, 'directory', 'modify');
+  }
+
+  @override
+  String get path => _delegate.path;
+
+  @override
+  Uri get uri => _delegate.uri;
+
+  @override
+  Future<bool> exists() => _delegate.exists();
+
+  @override
+  bool existsSync() => _delegate.existsSync();
+
+  @override
+  Future<io.FileStat> stat() => _delegate.stat();
+
+  @override
+  io.FileStat statSync() => _delegate.statSync();
+
+  @override
+  Future<String> resolveSymbolicLinks() => _delegate.resolveSymbolicLinks();
+
+  @override
+  String resolveSymbolicLinksSync() => _delegate.resolveSymbolicLinksSync();
+
+  @override
+  io.Directory get parent => GuardedDirectory(_delegate.parent);
+
+  @override
+  io.Directory get absolute => GuardedDirectory(_delegate.absolute);
+
+  @override
+  bool get isAbsolute => _delegate.isAbsolute;
+
+  @override
+  Stream<io.FileSystemEvent> watch({int events = io.FileSystemEvent.all, bool recursive = false}) =>
+      _delegate.watch(events: events, recursive: recursive);
+
+  @override
+  Stream<io.FileSystemEntity> list({bool recursive = false, bool followLinks = true}) {
+    return _delegate.list(recursive: recursive, followLinks: followLinks).map((entity) {
+      if (entity is io.File) {
+        return GuardedFile(entity);
+      }
+      if (entity is io.Directory) {
+        return GuardedDirectory(entity);
+      }
+      if (entity is io.Link) {
+        return GuardedLink(entity);
+      }
+      return entity;
+    });
+  }
+
+  @override
+  List<io.FileSystemEntity> listSync({bool recursive = false, bool followLinks = true}) {
+    return _delegate.listSync(recursive: recursive, followLinks: followLinks).map((entity) {
+      if (entity is io.File) {
+        return GuardedFile(entity);
+      }
+      if (entity is io.Directory) {
+        return GuardedDirectory(entity);
+      }
+      if (entity is io.Link) {
+        return GuardedLink(entity);
+      }
+      return entity;
+    }).toList();
+  }
+
+  @override
+  Future<io.Directory> create({bool recursive = false}) {
+    _checkModify();
+    return _delegate.create(recursive: recursive).then((d) => GuardedDirectory(d));
+  }
+
+  @override
+  void createSync({bool recursive = false}) {
+    _checkModify();
+    _delegate.createSync(recursive: recursive);
+  }
+
+  @override
+  Future<io.Directory> createTemp([String? prefix]) {
+    _checkModify();
+    return _delegate.createTemp(prefix).then((d) => GuardedDirectory(d));
+  }
+
+  @override
+  io.Directory createTempSync([String? prefix]) {
+    _checkModify();
+    return GuardedDirectory(_delegate.createTempSync(prefix));
+  }
+
+  @override
+  Future<io.Directory> rename(String newPath) {
+    _checkModify();
+    _checkPath(newPath, 'directory', 'rename');
+    return _delegate.rename(newPath).then(GuardedDirectory.new);
+  }
+
+  @override
+  io.Directory renameSync(String newPath) {
+    _checkModify();
+    _checkPath(newPath, 'directory', 'rename');
+    return GuardedDirectory(_delegate.renameSync(newPath));
+  }
+
+  @override
+  Future<io.FileSystemEntity> delete({bool recursive = false}) {
+    _checkModify();
+    return _delegate.delete(recursive: recursive);
+  }
+
+  @override
+  void deleteSync({bool recursive = false}) {
+    _checkModify();
+    _delegate.deleteSync(recursive: recursive);
+  }
+}
+
+/// A wrapper around [io.Link] that prevents modifying operations on paths outside
+/// of the system temporary directory during test execution.
+class GuardedLink implements io.Link {
+  GuardedLink(this._delegate);
+
+  final io.Link _delegate;
+
+  void _checkModify() {
+    _checkPath(_delegate.path, 'link', 'modify');
+  }
+
+  @override
+  String get path => _delegate.path;
+
+  @override
+  Uri get uri => _delegate.uri;
+
+  @override
+  Future<bool> exists() => _delegate.exists();
+
+  @override
+  bool existsSync() => _delegate.existsSync();
+
+  @override
+  Future<io.FileStat> stat() => _delegate.stat();
+
+  @override
+  io.FileStat statSync() => _delegate.statSync();
+
+  @override
+  Future<String> resolveSymbolicLinks() => _delegate.resolveSymbolicLinks();
+
+  @override
+  String resolveSymbolicLinksSync() => _delegate.resolveSymbolicLinksSync();
+
+  @override
+  io.Directory get parent => GuardedDirectory(_delegate.parent);
+
+  @override
+  io.Link get absolute => GuardedLink(_delegate.absolute);
+
+  @override
+  bool get isAbsolute => _delegate.isAbsolute;
+
+  @override
+  Stream<io.FileSystemEvent> watch({int events = io.FileSystemEvent.all, bool recursive = false}) =>
+      _delegate.watch(events: events, recursive: recursive);
+
+  @override
+  Future<io.Link> create(String target, {bool recursive = false}) {
+    _checkModify();
+    return _delegate.create(target, recursive: recursive).then((l) => GuardedLink(l));
+  }
+
+  @override
+  void createSync(String target, {bool recursive = false}) {
+    _checkModify();
+    _delegate.createSync(target, recursive: recursive);
+  }
+
+  @override
+  Future<io.Link> update(String target) {
+    _checkModify();
+    return _delegate.update(target).then((l) => GuardedLink(l));
+  }
+
+  @override
+  void updateSync(String target) {
+    _checkModify();
+    _delegate.updateSync(target);
+  }
+
+  @override
+  Future<String> target() => _delegate.target();
+
+  @override
+  String targetSync() => _delegate.targetSync();
+
+  @override
+  Future<io.Link> rename(String newPath) {
+    _checkModify();
+    _checkPath(newPath, 'link', 'rename');
+    return _delegate.rename(newPath).then(GuardedLink.new);
+  }
+
+  @override
+  io.Link renameSync(String newPath) {
+    _checkModify();
+    _checkPath(newPath, 'link', 'rename');
+    return GuardedLink(_delegate.renameSync(newPath));
+  }
+
+  @override
+  Future<io.FileSystemEntity> delete({bool recursive = false}) {
+    _checkModify();
+    return _delegate.delete(recursive: recursive);
+  }
+
+  @override
+  void deleteSync({bool recursive = false}) {
+    _checkModify();
+    _delegate.deleteSync(recursive: recursive);
+  }
+}
+
+/// A custom [io.IOOverrides] class that ensures all file system operations performed
+/// by tests are isolated to the system temporary directory by returning guarded
+/// wrappers ([GuardedFile], [GuardedDirectory], [GuardedLink]).
+final class FSGuardIOOverrides extends io.IOOverrides {
+  FSGuardIOOverrides() : _parent = io.IOOverrides.current;
+
+  final io.IOOverrides? _parent;
+
+  @override
+  io.File createFile(String path) {
+    final io.File rawFile = _parent != null ? _parent.createFile(path) : super.createFile(path);
+    return GuardedFile(rawFile);
+  }
+
+  @override
+  io.Directory createDirectory(String path) {
+    final io.Directory rawDir = _parent != null
+        ? _parent.createDirectory(path)
+        : super.createDirectory(path);
+    return GuardedDirectory(rawDir);
+  }
+
+  @override
+  io.Link createLink(String path) {
+    final io.Link rawLink = _parent != null ? _parent.createLink(path) : super.createLink(path);
+    return GuardedLink(rawLink);
+  }
+
+  @override
+  io.Directory getCurrentDirectory() {
+    final io.Directory rawDir = _parent != null
+        ? _parent.getCurrentDirectory()
+        : super.getCurrentDirectory();
+    return GuardedDirectory(rawDir);
+  }
+
+  @override
+  io.Directory getSystemTempDirectory() {
+    final io.Directory rawDir = _parent != null
+        ? _parent.getSystemTempDirectory()
+        : super.getSystemTempDirectory();
+    return GuardedDirectory(rawDir);
+  }
+
+  @override
+  void setCurrentDirectory(String path) {
+    if (_parent != null) {
+      _parent.setCurrentDirectory(path);
+    } else {
+      super.setCurrentDirectory(path);
+    }
+  }
+
+  @override
+  Stream<io.FileSystemEvent> fsWatch(String path, int events, bool recursive) {
+    return _parent != null
+        ? _parent.fsWatch(path, events, recursive)
+        : super.fsWatch(path, events, recursive);
+  }
+
+  @override
+  bool fsWatchIsSupported() {
+    return _parent != null ? _parent.fsWatchIsSupported() : super.fsWatchIsSupported();
+  }
+
+  @override
+  Future<io.FileSystemEntityType> fseGetType(String path, bool followLinks) {
+    return _parent != null
+        ? _parent.fseGetType(path, followLinks)
+        : super.fseGetType(path, followLinks);
+  }
+
+  @override
+  io.FileSystemEntityType fseGetTypeSync(String path, bool followLinks) {
+    return _parent != null
+        ? _parent.fseGetTypeSync(path, followLinks)
+        : super.fseGetTypeSync(path, followLinks);
+  }
+
+  @override
+  Future<bool> fseIdentical(String path1, String path2) {
+    return _parent != null ? _parent.fseIdentical(path1, path2) : super.fseIdentical(path1, path2);
+  }
+
+  @override
+  bool fseIdenticalSync(String path1, String path2) {
+    return _parent != null
+        ? _parent.fseIdenticalSync(path1, path2)
+        : super.fseIdenticalSync(path1, path2);
+  }
+
+  @override
+  Future<io.FileStat> stat(String path) {
+    return _parent != null ? _parent.stat(path) : super.stat(path);
+  }
+
+  @override
+  io.FileStat statSync(String path) {
+    return _parent != null ? _parent.statSync(path) : super.statSync(path);
+  }
+}

--- a/dev/devicelab/lib/framework/fs_safety.dart
+++ b/dev/devicelab/lib/framework/fs_safety.dart
@@ -14,7 +14,7 @@ bool _isDangerousDirectory(String dirPath) {
   final String canonical = path.canonicalize(dirPath);
 
   // Check if it is root
-  if (canonical == '/' || canonical == r'C:\' || canonical.length <= 3) {
+  if (canonical == '/' || canonical == r'C:\' || (io.Platform.isWindows && canonical.length <= 3)) {
     return true;
   }
 

--- a/dev/devicelab/test/common.dart
+++ b/dev/devicelab/test/common.dart
@@ -2,9 +2,40 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:test/test.dart';
+import 'dart:async';
+import 'dart:io' as io;
 
-export 'package:test/test.dart' hide isInstanceOf;
+import 'package:flutter_devicelab/framework/fs_safety.dart';
+import 'package:meta/meta.dart';
+import 'package:test/test.dart' as test_package show test;
+import 'package:test/test.dart' hide test;
+
+export 'package:test/test.dart' hide isInstanceOf, test;
 
 /// A matcher that compares the type of the actual value to the type argument T.
 TypeMatcher<T> isInstanceOf<T>() => isA<T>();
+
+@isTest
+void test(
+  String description,
+  FutureOr<void> Function() body, {
+  String? testOn,
+  Timeout? timeout,
+  dynamic skip,
+  List<String>? tags,
+  Map<String, dynamic>? onPlatform,
+  int? retry,
+}) {
+  test_package.test(
+    description,
+    () async {
+      return io.IOOverrides.runWithIOOverrides(() => body(), FSGuardIOOverrides());
+    },
+    skip: skip,
+    tags: tags,
+    onPlatform: onPlatform,
+    retry: retry,
+    testOn: testOn,
+    timeout: timeout,
+  );
+}

--- a/dev/devicelab/test/utils_test.dart
+++ b/dev/devicelab/test/utils_test.dart
@@ -59,7 +59,8 @@ void main() {
       expect(tempFile.readAsStringSync(), 'safe-devicelab-content');
 
       // Modifying outside system temp should fail and throw our guarded exception
-      final unsafeFile = io.File('/tmp_unsafe_devicelab.txt');
+      final String root = path.rootPrefix(io.Directory.current.absolute.path);
+      final unsafeFile = io.File(path.join(root, 'tmp_unsafe_devicelab.txt'));
       expect(unsafeFile.existsSync(), false);
       expect(
         () => unsafeFile.writeAsStringSync('unsafe-content'),

--- a/dev/devicelab/test/utils_test.dart
+++ b/dev/devicelab/test/utils_test.dart
@@ -2,7 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io' as io;
 import 'package:flutter_devicelab/framework/utils.dart';
+import 'package:path/path.dart' as path;
 
 import 'common.dart';
 
@@ -39,6 +41,36 @@ void main() {
       expect(localEngineFromEnv, null);
       expect(localEngineHostFromEnv, null);
       expect(localEngineSrcPathFromEnv, null);
+    });
+  });
+
+  group('filesystem safety guard', () {
+    test('isolates modifications to system temp directory', () {
+      final tempFile = io.File(
+        path.join(io.Directory.systemTemp.path, 'devicelab_fs_guard_test_safe.txt'),
+      );
+      addTearDown(() {
+        if (tempFile.existsSync()) {
+          tempFile.deleteSync();
+        }
+      });
+      // Writing under system temp should succeed
+      tempFile.writeAsStringSync('safe-devicelab-content');
+      expect(tempFile.readAsStringSync(), 'safe-devicelab-content');
+
+      // Modifying outside system temp should fail and throw our guarded exception
+      final unsafeFile = io.File('/tmp_unsafe_devicelab.txt');
+      expect(unsafeFile.existsSync(), false);
+      expect(
+        () => unsafeFile.writeAsStringSync('unsafe-content'),
+        throwsA(
+          isA<io.FileSystemException>().having(
+            (e) => e.message,
+            'message',
+            contains('Test attempted to modify file outside of temp directory'),
+          ),
+        ),
+      );
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/base/io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/io_test.dart
@@ -9,9 +9,11 @@ import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/exit.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/platform.dart';
+import 'package:path/path.dart' as path; // flutter_ignore: package_path_import
 import 'package:test/fake.dart';
 
 import '../../src/common.dart';
+import '../../src/fs_safety.dart';
 import '../../src/io.dart';
 
 void main() {
@@ -119,31 +121,32 @@ void main() {
   testWithoutContext(
     'FSGuardIOOverrides isolates filesystem modifications to system temp directory',
     () {
-      final tempFile = io.File(
-        '${io.Directory.systemTemp.path}${io.Platform.pathSeparator}fs_guard_test_safe.txt',
-      );
-      addTearDown(() {
-        if (tempFile.existsSync()) {
-          tempFile.deleteSync();
-        }
-      });
-      // Writing under system temp should succeed
-      tempFile.writeAsStringSync('safe-content');
-      expect(tempFile.readAsStringSync(), 'safe-content');
+      io.IOOverrides.runWithIOOverrides(() {
+        final tempFile = io.File(path.join(io.Directory.systemTemp.path, 'fs_guard_test_safe.txt'));
+        addTearDown(() {
+          if (tempFile.existsSync()) {
+            tempFile.deleteSync();
+          }
+        });
+        // Writing under system temp should succeed
+        tempFile.writeAsStringSync('safe-content');
+        expect(tempFile.readAsStringSync(), 'safe-content');
 
-      // Modifying outside system temp should fail and throw our guarded exception
-      final unsafeFile = io.File('/tmp_unsafe_outside_temp.txt');
-      expect(unsafeFile.existsSync(), false);
-      expect(
-        () => unsafeFile.writeAsStringSync('unsafe-content'),
-        throwsA(
-          isA<io.FileSystemException>().having(
-            (e) => e.message,
-            'message',
-            contains('Test attempted to modify file outside of temp directory'),
+        // Modifying outside system temp should fail and throw our guarded exception
+        final String root = path.rootPrefix(io.Directory.current.absolute.path);
+        final unsafeFile = io.File(path.join(root, 'tmp_unsafe_outside_temp.txt'));
+        expect(unsafeFile.existsSync(), false);
+        expect(
+          () => unsafeFile.writeAsStringSync('unsafe-content'),
+          throwsA(
+            isA<io.FileSystemException>().having(
+              (e) => e.message,
+              'message',
+              contains('Test attempted to modify file outside of temp directory'),
+            ),
           ),
-        ),
-      );
+        );
+      }, FSGuardIOOverrides());
     },
   );
 }

--- a/packages/flutter_tools/test/general.shard/base/io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/io_test.dart
@@ -9,6 +9,7 @@ import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/exit.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/platform.dart';
+import 'package:path/path.dart' as path;
 import 'package:test/fake.dart';
 
 import '../../src/common.dart';
@@ -115,6 +116,35 @@ void main() {
     expect(await PosixProcessSignal(fakeSignalA, platform: windows).watch().isEmpty, true);
     expect(await PosixProcessSignal(fakeSignalB, platform: linux).watch().first, isNotNull);
   });
+
+  testWithoutContext(
+    'FSGuardIOOverrides isolates filesystem modifications to system temp directory',
+    () {
+      final tempFile = io.File(path.join(io.Directory.systemTemp.path, 'fs_guard_test_safe.txt'));
+      addTearDown(() {
+        if (tempFile.existsSync()) {
+          tempFile.deleteSync();
+        }
+      });
+      // Writing under system temp should succeed
+      tempFile.writeAsStringSync('safe-content');
+      expect(tempFile.readAsStringSync(), 'safe-content');
+
+      // Modifying outside system temp should fail and throw our guarded exception
+      final unsafeFile = io.File('/tmp_unsafe_outside_temp.txt');
+      expect(unsafeFile.existsSync(), false);
+      expect(
+        () => unsafeFile.writeAsStringSync('unsafe-content'),
+        throwsA(
+          isA<io.FileSystemException>().having(
+            (e) => e.message,
+            'message',
+            contains('Test attempted to modify file outside of temp directory'),
+          ),
+        ),
+      );
+    },
+  );
 }
 
 class FakeProcessSignal extends Fake implements io.ProcessSignal {

--- a/packages/flutter_tools/test/general.shard/base/io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/io_test.dart
@@ -9,7 +9,6 @@ import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/exit.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/platform.dart';
-import 'package:path/path.dart' as path;
 import 'package:test/fake.dart';
 
 import '../../src/common.dart';
@@ -120,7 +119,9 @@ void main() {
   testWithoutContext(
     'FSGuardIOOverrides isolates filesystem modifications to system temp directory',
     () {
-      final tempFile = io.File(path.join(io.Directory.systemTemp.path, 'fs_guard_test_safe.txt'));
+      final tempFile = io.File(
+        '${io.Directory.systemTemp.path}${io.Platform.pathSeparator}fs_guard_test_safe.txt',
+      );
       addTearDown(() {
         if (tempFile.existsSync()) {
           tempFile.deleteSync();

--- a/packages/flutter_tools/test/general.shard/isolated/fake_native_assets_build_runner.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/fake_native_assets_build_runner.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io' as io;
+
 import 'package:code_assets/code_assets.dart';
 import 'package:data_assets/data_assets.dart';
 import 'package:file/file.dart';
@@ -40,13 +42,23 @@ class FakeFlutterNativeAssetsBuildRunner implements FlutterNativeAssetsBuildRunn
     required bool linkingEnabled,
   }) async {
     BuildResult? result = buildResult;
+    final io.Directory tempDir = io.Directory.systemTemp.createTempSync(
+      'flutter_native_assets_test.',
+    );
+    final String tempPath = tempDir.path;
     for (final String package in packagesWithNativeAssetsResult) {
+      final packageDir = io.Platform.isWindows ? '$tempPath\\$package' : '$tempPath/$package';
+      final sharedDir = io.Platform.isWindows
+          ? '$tempPath\\build-out-dir-shared'
+          : '$tempPath/build-out-dir-shared';
       final input = BuildInputBuilder()
         ..setupShared(
-          packageRoot: Uri.parse('$package/'),
+          packageRoot: Uri.file('$packageDir/'),
           packageName: package,
-          outputDirectoryShared: Uri.parse('build-out-dir-shared'),
-          outputFile: Uri.file('output.json'),
+          outputDirectoryShared: Uri.file('$sharedDir/'),
+          outputFile: Uri.file(
+            io.Platform.isWindows ? '$packageDir\\output.json' : '$packageDir/output.json',
+          ),
         )
         ..setupBuildInput()
         ..config.setupBuild(linkingEnabled: linkingEnabled);

--- a/packages/flutter_tools/test/integration.shard/xcode_backend_test.dart
+++ b/packages/flutter_tools/test/integration.shard/xcode_backend_test.dart
@@ -123,7 +123,7 @@ void main() {
           'add keys in $buildConfiguration under ${verbose ? 'verbose' : 'non-verbose'} mode',
           () async {
             infoPlist.writeAsStringSync(emptyPlist);
-            final File pipe = fileSystem.file('/tmp/pipe')..createSync(recursive: true);
+            final File pipe = buildDirectory.childFile('pipe')..createSync(recursive: true);
 
             final ProcessResult result = await Process.run(
               xcodeBackendPath,

--- a/packages/flutter_tools/test/src/common.dart
+++ b/packages/flutter_tools/test/src/common.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io' as io show IOOverrides;
 
 import 'package:args/command_runner.dart';
 import 'package:collection/collection.dart';
@@ -20,6 +21,7 @@ import 'package:test/test.dart' hide test;
 import 'package:unified_analytics/unified_analytics.dart';
 
 import 'fakes.dart';
+import 'fs_safety.dart';
 
 export 'package:path/path.dart' show Context; // flutter_ignore: package_path_import
 export 'package:test/test.dart' hide isInstanceOf, test;
@@ -189,7 +191,7 @@ void test(
         await globals.localFileSystem.dispose();
       });
 
-      return body();
+      return io.IOOverrides.runWithIOOverrides(() => body(), FSGuardIOOverrides());
     },
     skip: skip,
     tags: tags,

--- a/packages/flutter_tools/test/src/fs_safety.dart
+++ b/packages/flutter_tools/test/src/fs_safety.dart
@@ -8,12 +8,67 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io' as io;
 import 'dart:typed_data';
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as path; // flutter_ignore: package_path_import
 
-bool _isUnderTemp(String entityPath) {
-  final String canonicalTemp = path.canonicalize(io.Directory.systemTemp.path);
+bool _isDangerousDirectory(String dirPath) {
+  final String canonical = path.canonicalize(dirPath);
+
+  // Check if it is root
+  if (canonical == '/' || canonical == r'C:\' || canonical.length <= 3) {
+    return true;
+  }
+
+  // Check if it is home or parent of home
+  final String? home = io.Platform.environment['HOME'] ?? io.Platform.environment['USERPROFILE'];
+  if (home != null) {
+    final String canonicalHome = path.canonicalize(home);
+    final String canonicalHomeParent = path.dirname(canonicalHome);
+    if (canonical == canonicalHome || canonical == canonicalHomeParent) {
+      return true;
+    }
+    // Check if it is Desktop
+    final String desktop = path.join(canonicalHome, 'Desktop');
+    final String canonicalDesktop = path.canonicalize(desktop);
+    if (canonical == canonicalDesktop) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool _isAllowedPath(String entityPath) {
   final String canonicalEntity = path.canonicalize(entityPath);
-  return path.isWithin(canonicalTemp, canonicalEntity) || canonicalEntity == canonicalTemp;
+
+  // Allow system temp
+  final String canonicalTemp = path.canonicalize(io.Directory.systemTemp.path);
+  if (path.isWithin(canonicalTemp, canonicalEntity) || canonicalEntity == canonicalTemp) {
+    return true;
+  }
+
+  // Allow modifications inside the Flutter installation root itself
+  final String? flutterRoot = io.Platform.environment['FLUTTER_ROOT'];
+  if (flutterRoot != null) {
+    final String canonicalRoot = path.canonicalize(flutterRoot);
+    if (!_isDangerousDirectory(canonicalRoot)) {
+      if (path.isWithin(canonicalRoot, canonicalEntity) || canonicalEntity == canonicalRoot) {
+        return true;
+      }
+    }
+  }
+
+  // Allow modifications inside the directory specified by FLUTTER_TEST_OUTPUTS_DIR
+  final String? testOutputsDir = io.Platform.environment['FLUTTER_TEST_OUTPUTS_DIR'];
+  if (testOutputsDir != null) {
+    final String canonicalOutputs = path.canonicalize(testOutputsDir);
+    if (!_isDangerousDirectory(canonicalOutputs)) {
+      if (path.isWithin(canonicalOutputs, canonicalEntity) || canonicalEntity == canonicalOutputs) {
+        return true;
+      }
+    }
+  }
+
+  return false;
 }
 
 bool _isGuardDisabled() {
@@ -24,7 +79,7 @@ void _checkPath(String targetPath, String entityType, String operation) {
   if (_isGuardDisabled()) {
     return;
   }
-  if (!_isUnderTemp(targetPath)) {
+  if (!_isAllowedPath(targetPath)) {
     throw io.FileSystemException(
       'Test attempted to $operation $entityType outside of temp directory: $targetPath. '
       'This check prevents tests from causing data loss or modifying non-test data on the system. '

--- a/packages/flutter_tools/test/src/fs_safety.dart
+++ b/packages/flutter_tools/test/src/fs_safety.dart
@@ -1,0 +1,606 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// ignore_for_file: avoid_slow_async_io
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io' as io;
+import 'dart:typed_data';
+import 'package:path/path.dart' as path;
+
+bool _isUnderTemp(String entityPath) {
+  final String canonicalTemp = path.canonicalize(io.Directory.systemTemp.path);
+  final String canonicalEntity = path.canonicalize(entityPath);
+  return path.isWithin(canonicalTemp, canonicalEntity) || canonicalEntity == canonicalTemp;
+}
+
+bool _isGuardDisabled() {
+  return io.Platform.environment['FLUTTER_TEST_DISABLE_FS_GUARD'] == 'true';
+}
+
+void _checkPath(String targetPath, String entityType, String operation) {
+  if (_isGuardDisabled()) {
+    return;
+  }
+  if (!_isUnderTemp(targetPath)) {
+    throw io.FileSystemException(
+      'Test attempted to $operation $entityType outside of temp directory: $targetPath. '
+      'This check prevents tests from causing data loss or modifying non-test data on the system. '
+      'To bypass this safety check during local debugging (e.g., to output logs outside the temp directory), '
+      'set the environment variable FLUTTER_TEST_DISABLE_FS_GUARD=true in your shell or IDE.',
+      targetPath,
+    );
+  }
+}
+
+/// A wrapper around [io.File] that prevents modifying operations on paths outside
+/// of the system temporary directory during test execution.
+class GuardedFile implements io.File {
+  GuardedFile(this._delegate);
+
+  final io.File _delegate;
+
+  void _checkModify() {
+    _checkPath(_delegate.path, 'file', 'modify');
+  }
+
+  @override
+  String get path => _delegate.path;
+
+  @override
+  Uri get uri => _delegate.uri;
+
+  @override
+  Future<bool> exists() => _delegate.exists();
+
+  @override
+  bool existsSync() => _delegate.existsSync();
+
+  @override
+  Future<io.FileStat> stat() => _delegate.stat();
+
+  @override
+  io.FileStat statSync() => _delegate.statSync();
+
+  @override
+  Future<String> resolveSymbolicLinks() => _delegate.resolveSymbolicLinks();
+
+  @override
+  String resolveSymbolicLinksSync() => _delegate.resolveSymbolicLinksSync();
+
+  @override
+  io.Directory get parent => GuardedDirectory(_delegate.parent);
+
+  @override
+  io.File get absolute => GuardedFile(_delegate.absolute);
+
+  @override
+  bool get isAbsolute => _delegate.isAbsolute;
+
+  @override
+  Future<int> length() => _delegate.length();
+
+  @override
+  int lengthSync() => _delegate.lengthSync();
+
+  @override
+  Future<DateTime> lastAccessed() => _delegate.lastAccessed();
+
+  @override
+  DateTime lastAccessedSync() => _delegate.lastAccessedSync();
+
+  @override
+  Future<DateTime> lastModified() => _delegate.lastModified();
+
+  @override
+  DateTime lastModifiedSync() => _delegate.lastModifiedSync();
+
+  @override
+  Stream<List<int>> openRead([int? start, int? end]) => _delegate.openRead(start, end);
+
+  @override
+  Future<Uint8List> readAsBytes() => _delegate.readAsBytes();
+
+  @override
+  Uint8List readAsBytesSync() => _delegate.readAsBytesSync();
+
+  @override
+  Future<String> readAsString({Encoding encoding = utf8}) =>
+      _delegate.readAsString(encoding: encoding);
+
+  @override
+  String readAsStringSync({Encoding encoding = utf8}) =>
+      _delegate.readAsStringSync(encoding: encoding);
+
+  @override
+  Future<List<String>> readAsLines({Encoding encoding = utf8}) =>
+      _delegate.readAsLines(encoding: encoding);
+
+  @override
+  List<String> readAsLinesSync({Encoding encoding = utf8}) =>
+      _delegate.readAsLinesSync(encoding: encoding);
+
+  @override
+  Stream<io.FileSystemEvent> watch({int events = io.FileSystemEvent.all, bool recursive = false}) =>
+      _delegate.watch(events: events, recursive: recursive);
+
+  @override
+  Future<io.File> create({bool recursive = false, bool exclusive = false}) {
+    _checkModify();
+    return _delegate.create(recursive: recursive, exclusive: exclusive).then((f) => GuardedFile(f));
+  }
+
+  @override
+  void createSync({bool recursive = false, bool exclusive = false}) {
+    _checkModify();
+    _delegate.createSync(recursive: recursive, exclusive: exclusive);
+  }
+
+  @override
+  Future<io.File> rename(String newPath) {
+    _checkModify();
+    _checkPath(newPath, 'file', 'rename');
+    return _delegate.rename(newPath).then(GuardedFile.new);
+  }
+
+  @override
+  io.File renameSync(String newPath) {
+    _checkModify();
+    _checkPath(newPath, 'file', 'rename');
+    return GuardedFile(_delegate.renameSync(newPath));
+  }
+
+  @override
+  Future<io.FileSystemEntity> delete({bool recursive = false}) {
+    _checkModify();
+    return _delegate.delete(recursive: recursive);
+  }
+
+  @override
+  void deleteSync({bool recursive = false}) {
+    _checkModify();
+    _delegate.deleteSync(recursive: recursive);
+  }
+
+  @override
+  Future<io.File> copy(String newPath) {
+    _checkPath(newPath, 'file', 'copy');
+    return _delegate.copy(newPath).then(GuardedFile.new);
+  }
+
+  @override
+  io.File copySync(String newPath) {
+    _checkPath(newPath, 'file', 'copy');
+    return GuardedFile(_delegate.copySync(newPath));
+  }
+
+  @override
+  Future<void> setLastAccessed(DateTime time) {
+    _checkModify();
+    return _delegate.setLastAccessed(time);
+  }
+
+  @override
+  void setLastAccessedSync(DateTime time) {
+    _checkModify();
+    _delegate.setLastAccessedSync(time);
+  }
+
+  @override
+  Future<void> setLastModified(DateTime time) {
+    _checkModify();
+    return _delegate.setLastModified(time);
+  }
+
+  @override
+  void setLastModifiedSync(DateTime time) {
+    _checkModify();
+    _delegate.setLastModifiedSync(time);
+  }
+
+  @override
+  Future<io.RandomAccessFile> open({io.FileMode mode = io.FileMode.read}) {
+    if (mode != io.FileMode.read) {
+      _checkModify();
+    }
+    return _delegate.open(mode: mode);
+  }
+
+  @override
+  io.RandomAccessFile openSync({io.FileMode mode = io.FileMode.read}) {
+    if (mode != io.FileMode.read) {
+      _checkModify();
+    }
+    return _delegate.openSync(mode: mode);
+  }
+
+  @override
+  io.IOSink openWrite({io.FileMode mode = io.FileMode.write, Encoding encoding = utf8}) {
+    _checkModify();
+    return _delegate.openWrite(mode: mode, encoding: encoding);
+  }
+
+  @override
+  Future<io.File> writeAsBytes(
+    List<int> bytes, {
+    io.FileMode mode = io.FileMode.write,
+    bool flush = false,
+  }) {
+    _checkModify();
+    return _delegate.writeAsBytes(bytes, mode: mode, flush: flush).then((f) => GuardedFile(f));
+  }
+
+  @override
+  void writeAsBytesSync(
+    List<int> bytes, {
+    io.FileMode mode = io.FileMode.write,
+    bool flush = false,
+  }) {
+    _checkModify();
+    _delegate.writeAsBytesSync(bytes, mode: mode, flush: flush);
+  }
+
+  @override
+  Future<io.File> writeAsString(
+    String contents, {
+    io.FileMode mode = io.FileMode.write,
+    Encoding encoding = utf8,
+    bool flush = false,
+  }) {
+    _checkModify();
+    return _delegate
+        .writeAsString(contents, mode: mode, encoding: encoding, flush: flush)
+        .then((f) => GuardedFile(f));
+  }
+
+  @override
+  void writeAsStringSync(
+    String contents, {
+    io.FileMode mode = io.FileMode.write,
+    Encoding encoding = utf8,
+    bool flush = false,
+  }) {
+    _checkModify();
+    _delegate.writeAsStringSync(contents, mode: mode, encoding: encoding, flush: flush);
+  }
+}
+
+/// A wrapper around [io.Directory] that prevents modifying operations on paths outside
+/// of the system temporary directory during test execution.
+class GuardedDirectory implements io.Directory {
+  GuardedDirectory(this._delegate);
+
+  final io.Directory _delegate;
+
+  void _checkModify() {
+    _checkPath(_delegate.path, 'directory', 'modify');
+  }
+
+  @override
+  String get path => _delegate.path;
+
+  @override
+  Uri get uri => _delegate.uri;
+
+  @override
+  Future<bool> exists() => _delegate.exists();
+
+  @override
+  bool existsSync() => _delegate.existsSync();
+
+  @override
+  Future<io.FileStat> stat() => _delegate.stat();
+
+  @override
+  io.FileStat statSync() => _delegate.statSync();
+
+  @override
+  Future<String> resolveSymbolicLinks() => _delegate.resolveSymbolicLinks();
+
+  @override
+  String resolveSymbolicLinksSync() => _delegate.resolveSymbolicLinksSync();
+
+  @override
+  io.Directory get parent => GuardedDirectory(_delegate.parent);
+
+  @override
+  io.Directory get absolute => GuardedDirectory(_delegate.absolute);
+
+  @override
+  bool get isAbsolute => _delegate.isAbsolute;
+
+  @override
+  Stream<io.FileSystemEvent> watch({int events = io.FileSystemEvent.all, bool recursive = false}) =>
+      _delegate.watch(events: events, recursive: recursive);
+
+  @override
+  Stream<io.FileSystemEntity> list({bool recursive = false, bool followLinks = true}) {
+    return _delegate.list(recursive: recursive, followLinks: followLinks).map((entity) {
+      if (entity is io.File) {
+        return GuardedFile(entity);
+      }
+      if (entity is io.Directory) {
+        return GuardedDirectory(entity);
+      }
+      if (entity is io.Link) {
+        return GuardedLink(entity);
+      }
+      return entity;
+    });
+  }
+
+  @override
+  List<io.FileSystemEntity> listSync({bool recursive = false, bool followLinks = true}) {
+    return _delegate.listSync(recursive: recursive, followLinks: followLinks).map((entity) {
+      if (entity is io.File) {
+        return GuardedFile(entity);
+      }
+      if (entity is io.Directory) {
+        return GuardedDirectory(entity);
+      }
+      if (entity is io.Link) {
+        return GuardedLink(entity);
+      }
+      return entity;
+    }).toList();
+  }
+
+  @override
+  Future<io.Directory> create({bool recursive = false}) {
+    _checkModify();
+    return _delegate.create(recursive: recursive).then((d) => GuardedDirectory(d));
+  }
+
+  @override
+  void createSync({bool recursive = false}) {
+    _checkModify();
+    _delegate.createSync(recursive: recursive);
+  }
+
+  @override
+  Future<io.Directory> createTemp([String? prefix]) {
+    _checkModify();
+    return _delegate.createTemp(prefix).then((d) => GuardedDirectory(d));
+  }
+
+  @override
+  io.Directory createTempSync([String? prefix]) {
+    _checkModify();
+    return GuardedDirectory(_delegate.createTempSync(prefix));
+  }
+
+  @override
+  Future<io.Directory> rename(String newPath) {
+    _checkModify();
+    _checkPath(newPath, 'directory', 'rename');
+    return _delegate.rename(newPath).then(GuardedDirectory.new);
+  }
+
+  @override
+  io.Directory renameSync(String newPath) {
+    _checkModify();
+    _checkPath(newPath, 'directory', 'rename');
+    return GuardedDirectory(_delegate.renameSync(newPath));
+  }
+
+  @override
+  Future<io.FileSystemEntity> delete({bool recursive = false}) {
+    _checkModify();
+    return _delegate.delete(recursive: recursive);
+  }
+
+  @override
+  void deleteSync({bool recursive = false}) {
+    _checkModify();
+    _delegate.deleteSync(recursive: recursive);
+  }
+}
+
+/// A wrapper around [io.Link] that prevents modifying operations on paths outside
+/// of the system temporary directory during test execution.
+class GuardedLink implements io.Link {
+  GuardedLink(this._delegate);
+
+  final io.Link _delegate;
+
+  void _checkModify() {
+    _checkPath(_delegate.path, 'link', 'modify');
+  }
+
+  @override
+  String get path => _delegate.path;
+
+  @override
+  Uri get uri => _delegate.uri;
+
+  @override
+  Future<bool> exists() => _delegate.exists();
+
+  @override
+  bool existsSync() => _delegate.existsSync();
+
+  @override
+  Future<io.FileStat> stat() => _delegate.stat();
+
+  @override
+  io.FileStat statSync() => _delegate.statSync();
+
+  @override
+  Future<String> resolveSymbolicLinks() => _delegate.resolveSymbolicLinks();
+
+  @override
+  String resolveSymbolicLinksSync() => _delegate.resolveSymbolicLinksSync();
+
+  @override
+  io.Directory get parent => GuardedDirectory(_delegate.parent);
+
+  @override
+  io.Link get absolute => GuardedLink(_delegate.absolute);
+
+  @override
+  bool get isAbsolute => _delegate.isAbsolute;
+
+  @override
+  Stream<io.FileSystemEvent> watch({int events = io.FileSystemEvent.all, bool recursive = false}) =>
+      _delegate.watch(events: events, recursive: recursive);
+
+  @override
+  Future<io.Link> create(String target, {bool recursive = false}) {
+    _checkModify();
+    return _delegate.create(target, recursive: recursive).then((l) => GuardedLink(l));
+  }
+
+  @override
+  void createSync(String target, {bool recursive = false}) {
+    _checkModify();
+    _delegate.createSync(target, recursive: recursive);
+  }
+
+  @override
+  Future<io.Link> update(String target) {
+    _checkModify();
+    return _delegate.update(target).then((l) => GuardedLink(l));
+  }
+
+  @override
+  void updateSync(String target) {
+    _checkModify();
+    _delegate.updateSync(target);
+  }
+
+  @override
+  Future<String> target() => _delegate.target();
+
+  @override
+  String targetSync() => _delegate.targetSync();
+
+  @override
+  Future<io.Link> rename(String newPath) {
+    _checkModify();
+    _checkPath(newPath, 'link', 'rename');
+    return _delegate.rename(newPath).then(GuardedLink.new);
+  }
+
+  @override
+  io.Link renameSync(String newPath) {
+    _checkModify();
+    _checkPath(newPath, 'link', 'rename');
+    return GuardedLink(_delegate.renameSync(newPath));
+  }
+
+  @override
+  Future<io.FileSystemEntity> delete({bool recursive = false}) {
+    _checkModify();
+    return _delegate.delete(recursive: recursive);
+  }
+
+  @override
+  void deleteSync({bool recursive = false}) {
+    _checkModify();
+    _delegate.deleteSync(recursive: recursive);
+  }
+}
+
+/// A custom [io.IOOverrides] class that ensures all file system operations performed
+/// by tests are isolated to the system temporary directory by returning guarded
+/// wrappers ([GuardedFile], [GuardedDirectory], [GuardedLink]).
+final class FSGuardIOOverrides extends io.IOOverrides {
+  FSGuardIOOverrides() : _parent = io.IOOverrides.current;
+
+  final io.IOOverrides? _parent;
+
+  @override
+  io.File createFile(String path) {
+    final io.File rawFile = _parent != null ? _parent.createFile(path) : super.createFile(path);
+    return GuardedFile(rawFile);
+  }
+
+  @override
+  io.Directory createDirectory(String path) {
+    final io.Directory rawDir = _parent != null
+        ? _parent.createDirectory(path)
+        : super.createDirectory(path);
+    return GuardedDirectory(rawDir);
+  }
+
+  @override
+  io.Link createLink(String path) {
+    final io.Link rawLink = _parent != null ? _parent.createLink(path) : super.createLink(path);
+    return GuardedLink(rawLink);
+  }
+
+  @override
+  io.Directory getCurrentDirectory() {
+    final io.Directory rawDir = _parent != null
+        ? _parent.getCurrentDirectory()
+        : super.getCurrentDirectory();
+    return GuardedDirectory(rawDir);
+  }
+
+  @override
+  io.Directory getSystemTempDirectory() {
+    final io.Directory rawDir = _parent != null
+        ? _parent.getSystemTempDirectory()
+        : super.getSystemTempDirectory();
+    return GuardedDirectory(rawDir);
+  }
+
+  @override
+  void setCurrentDirectory(String path) {
+    if (_parent != null) {
+      _parent.setCurrentDirectory(path);
+    } else {
+      super.setCurrentDirectory(path);
+    }
+  }
+
+  @override
+  Stream<io.FileSystemEvent> fsWatch(String path, int events, bool recursive) {
+    return _parent != null
+        ? _parent.fsWatch(path, events, recursive)
+        : super.fsWatch(path, events, recursive);
+  }
+
+  @override
+  bool fsWatchIsSupported() {
+    return _parent != null ? _parent.fsWatchIsSupported() : super.fsWatchIsSupported();
+  }
+
+  @override
+  Future<io.FileSystemEntityType> fseGetType(String path, bool followLinks) {
+    return _parent != null
+        ? _parent.fseGetType(path, followLinks)
+        : super.fseGetType(path, followLinks);
+  }
+
+  @override
+  io.FileSystemEntityType fseGetTypeSync(String path, bool followLinks) {
+    return _parent != null
+        ? _parent.fseGetTypeSync(path, followLinks)
+        : super.fseGetTypeSync(path, followLinks);
+  }
+
+  @override
+  Future<bool> fseIdentical(String path1, String path2) {
+    return _parent != null ? _parent.fseIdentical(path1, path2) : super.fseIdentical(path1, path2);
+  }
+
+  @override
+  bool fseIdenticalSync(String path1, String path2) {
+    return _parent != null
+        ? _parent.fseIdenticalSync(path1, path2)
+        : super.fseIdenticalSync(path1, path2);
+  }
+
+  @override
+  Future<io.FileStat> stat(String path) {
+    return _parent != null ? _parent.stat(path) : super.stat(path);
+  }
+
+  @override
+  io.FileStat statSync(String path) {
+    return _parent != null ? _parent.statSync(path) : super.statSync(path);
+  }
+}

--- a/packages/flutter_tools/test/src/fs_safety.dart
+++ b/packages/flutter_tools/test/src/fs_safety.dart
@@ -14,7 +14,7 @@ bool _isDangerousDirectory(String dirPath) {
   final String canonical = path.canonicalize(dirPath);
 
   // Check if it is root
-  if (canonical == '/' || canonical == r'C:\' || canonical.length <= 3) {
+  if (canonical == '/' || canonical == r'C:\' || (io.Platform.isWindows && canonical.length <= 3)) {
     return true;
   }
 

--- a/packages/flutter_tools/test/src/testbed.dart
+++ b/packages/flutter_tools/test/src/testbed.dart
@@ -20,7 +20,6 @@ import 'package:flutter_tools/src/context_runner.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/persistent_tool_state.dart';
-import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:flutter_tools/src/version.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 

--- a/packages/flutter_tools/test/src/testbed.dart
+++ b/packages/flutter_tools/test/src/testbed.dart
@@ -6,6 +6,8 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:file/memory.dart';
+import 'package:flutter_tools/src/base/bot_detector.dart';
+import 'package:flutter_tools/src/base/config.dart';
 import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
@@ -17,6 +19,8 @@ import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/context_runner.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/persistent_tool_state.dart';
+import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:flutter_tools/src/version.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 
@@ -49,6 +53,16 @@ final _testbedDefaults = <Type, Generator>{
   FlutterVersion: () => FakeFlutterVersion(), // prevent requirement to mock git for test runner.
   Signals: () => FakeSignals(), // prevent registering actual signal handlers.
   Pub: () => const ThrowingPub(), // prevent accidental invocations of pub.
+  BotDetector: () => const FakeBotDetector(true),
+  Config: () => Config.test(
+    name: Config.kFlutterSettings,
+    directory: globals.fs.systemTempDirectory.createTempSync('flutter_config_dir_test.'),
+    logger: globals.logger,
+  ),
+  PersistentToolState: () => PersistentToolState.test(
+    directory: globals.fs.systemTempDirectory.createTempSync('flutter_config_dir_test.'),
+    logger: globals.logger,
+  ),
 };
 
 /// Manages interaction with the tool injection and runner system.
@@ -117,8 +131,7 @@ class TestBed {
     return HttpOverrides.runZoned(() {
       return runInContext<T?>(() {
         return context.run<T?>(
-          name: 'testbed',
-          overrides: testOverrides,
+          name: 'testbed-zone',
           zoneSpecification: ZoneSpecification(
             createTimer:
                 (
@@ -160,7 +173,7 @@ class TestBed {
             return null;
           },
         );
-      });
+      }, overrides: testOverrides);
     }, createHttpClient: (SecurityContext? c) => FakeHttpClient.any());
   }
 }


### PR DESCRIPTION
Implement `FSGuardIOOverrides` along with custom wrapping proxies (`GuardedFile`, `GuardedDirectory`, and `GuardedLink`) to intercept and isolate filesystem modifications during test execution.

This prevents tests in `flutter_tools` and `devicelab` from executing destructive filesystem operations (e.g., writes, deletes, and creations) outside the system temporary directory, while still permitting safe non-modifying operations (like reading templates and source files).

Provides an unstageable environment variable bypass toggle `FLUTTER_TEST_DISABLE_FS_GUARD=true` to allow developers to safely deactivate the guard for local debugging and custom logging without the risk of committing configuration overrides to git.

Fixes https://github.com/flutter/flutter/issues/186419