### PR TITLE
[Impeller] Fix hardcoded Vulkan validation state in C API

### DIFF
--- a/engine/src/flutter/impeller/toolkit/interop/backend/vulkan/context_vk.cc
+++ b/engine/src/flutter/impeller/toolkit/interop/backend/vulkan/context_vk.cc
@@ -49,7 +49,7 @@ ScopedObject<Context> ContextVK::Create(const Settings& settings) {
   impeller::ContextVK::Settings impeller_settings;
   impeller_settings.shader_libraries_data = CreateShaderLibraryMappings();
   impeller_settings.cache_directory = fml::paths::GetCachesDirectory();
-  impeller_settings.enable_validation = true;
+  impeller_settings.enable_validation = settings.enable_validation;
   sContextVKProcAddressCallback = settings.instance_proc_address_callback;
   impeller_settings.proc_address_callback = ContextVKGetInstanceProcAddress;
   impeller_settings.flags = impeller::Flags{};


### PR DESCRIPTION
Make the standalone Impeller Vulkan interop layer respect `ImpellerContextVulkanSettings.enable_vulkan_validation`.

The C API already exposes this setting and `ContextVK::Settings` reads it, but `ContextVK::Create` currently forces `impeller_settings.enable_validation = true`. This means callers cannot disable Vulkan validation through the public standalone SDK API.

This PR changes the interop layer to pass through `settings.enable_validation`.

Fixes flutter/flutter#186764

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

I did not run the engine test suite locally. This PR is test-exempt because it only forwards an existing public C API setting to the existing Vulkan renderer setting.
