### PR TITLE
Move nested scroll view tests to Material

### DIFF
--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -120,7 +120,6 @@ class TestsCrossImportChecker {
     'packages/flutter/test/widgets/heroes_test.dart',
     'packages/flutter/test/widgets/drawer_test.dart',
     'packages/flutter/test/widgets/editable_text_cursor_test.dart',
-    'packages/flutter/test/widgets/nested_scroll_view_test.dart',
     'packages/flutter/test/widgets/scrollable_selection_test.dart',
     'packages/flutter/test/widgets/page_transitions_builder_test.dart',
     'packages/flutter/test/widgets/selectable_region_context_menu_test.dart',

--- a/packages/flutter/test/material/nested_scroll_view_test.dart
+++ b/packages/flutter/test/material/nested_scroll_view_test.dart
@@ -2394,66 +2394,74 @@ void main() {
       );
     }
 
-    testWidgets('overscroll, hold for 0 velocity, and release', (WidgetTester tester) async {
-      // Dragging into an overscroll and holding so that when released, the
-      // ballistic scroll activity has a 0 velocity.
-      final controller = ScrollController();
-      addTearDown(controller.dispose);
-      await tester.pumpWidget(buildBallisticTest(controller));
-      // Last item of the inner scroll view.
-      expect(find.text('Item 49'), findsNothing);
+    testWidgets(
+      'overscroll, hold for 0 velocity, and release',
+      (WidgetTester tester) async {
+        // Dragging into an overscroll and holding so that when released, the
+        // ballistic scroll activity has a 0 velocity.
+        final controller = ScrollController();
+        addTearDown(controller.dispose);
+        await tester.pumpWidget(buildBallisticTest(controller));
+        // Last item of the inner scroll view.
+        expect(find.text('Item 49'), findsNothing);
 
-      // Scroll to bottom
-      await tester.fling(find.text('Item 3'), const Offset(0.0, -50.0), 10000.0);
-      await tester.pumpAndSettle();
+        // Scroll to bottom
+        await tester.fling(find.text('Item 3'), const Offset(0.0, -50.0), 10000.0);
+        await tester.pumpAndSettle();
 
-      // End of list
-      expect(find.text('Item 49'), findsOneWidget);
-      expect(tester.getCenter(find.text('Item 49')).dy, equals(585.0));
+        // End of list
+        expect(find.text('Item 49'), findsOneWidget);
+        expect(tester.getCenter(find.text('Item 49')).dy, equals(585.0));
 
-      // Overscroll, dragging like this will release with 0 velocity.
-      await tester.drag(find.text('Item 49'), const Offset(0.0, -50.0));
-      await tester.pump();
-      // If handled correctly, the last item should still be visible and
-      // progressing back down to the bottom edge, instead of jumping further
-      // up the list and out of view.
-      expect(find.text('Item 49'), findsOneWidget);
-      await tester.pumpAndSettle();
-      expect(tester.getCenter(find.text('Item 49')).dy, equals(585.0));
-    }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
+        // Overscroll, dragging like this will release with 0 velocity.
+        await tester.drag(find.text('Item 49'), const Offset(0.0, -50.0));
+        await tester.pump();
+        // If handled correctly, the last item should still be visible and
+        // progressing back down to the bottom edge, instead of jumping further
+        // up the list and out of view.
+        expect(find.text('Item 49'), findsOneWidget);
+        await tester.pumpAndSettle();
+        expect(tester.getCenter(find.text('Item 49')).dy, equals(585.0));
+      },
+      variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
+    );
 
-    testWidgets('overscroll, release, and tap', (WidgetTester tester) async {
-      // Tapping while an inner ballistic scroll activity is in progress will
-      // trigger a secondary ballistic scroll activity with a 0 velocity.
-      final controller = ScrollController();
-      addTearDown(controller.dispose);
-      await tester.pumpWidget(buildBallisticTest(controller));
-      // Last item of the inner scroll view.
-      expect(find.text('Item 49'), findsNothing);
+    testWidgets(
+      'overscroll, release, and tap',
+      (WidgetTester tester) async {
+        // Tapping while an inner ballistic scroll activity is in progress will
+        // trigger a secondary ballistic scroll activity with a 0 velocity.
+        final controller = ScrollController();
+        addTearDown(controller.dispose);
+        await tester.pumpWidget(buildBallisticTest(controller));
+        // Last item of the inner scroll view.
+        expect(find.text('Item 49'), findsNothing);
 
-      // Scroll to bottom
-      await tester.fling(find.text('Item 3'), const Offset(0.0, -50.0), 10000.0);
-      await tester.pumpAndSettle();
+        // Scroll to bottom
+        await tester.fling(find.text('Item 3'), const Offset(0.0, -50.0), 10000.0);
+        await tester.pumpAndSettle();
 
-      // End of list
-      expect(find.text('Item 49'), findsOneWidget);
-      expect(tester.getCenter(find.text('Item 49')).dy, equals(585.0));
+        // End of list
+        expect(find.text('Item 49'), findsOneWidget);
+        expect(tester.getCenter(find.text('Item 49')).dy, equals(585.0));
 
-      // Fling again to trigger first ballistic activity.
-      await tester.fling(find.text('Item 48'), const Offset(0.0, -50.0), 10000.0);
-      await tester.pump();
+        // Fling again to trigger first ballistic activity.
+        await tester.fling(find.text('Item 48'), const Offset(0.0, -50.0), 10000.0);
+        await tester.pump();
 
-      // Tap after releasing the overscroll to trigger secondary inner ballistic
-      // scroll activity with 0 velocity.
-      await tester.tap(find.text('Item 49'));
-      await tester.pumpAndSettle();
+        // Tap after releasing the overscroll to trigger secondary inner ballistic
+        // scroll activity with 0 velocity.
+        await tester.tap(find.text('Item 49'));
+        await tester.pumpAndSettle();
 
-      // If handled correctly, the ballistic scroll activity should finish
-      // closing out the overscrolled area, with the last item visible at the
-      // bottom.
-      expect(find.text('Item 49'), findsOneWidget);
-      expect(tester.getCenter(find.text('Item 49')).dy, equals(585.0));
-    }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
+        // If handled correctly, the ballistic scroll activity should finish
+        // closing out the overscrolled area, with the last item visible at the
+        // bottom.
+        expect(find.text('Item 49'), findsOneWidget);
+        expect(tester.getCenter(find.text('Item 49')).dy, equals(585.0));
+      },
+      variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
+    );
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/63978

--- a/packages/flutter/test/material/nested_scroll_view_test.dart
+++ b/packages/flutter/test/material/nested_scroll_view_test.dart
@@ -12,7 +12,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import '../rendering/rendering_tester.dart' show TestClipPaintingContext;
-import 'list_tile_tester.dart';
+import '../widgets/list_tile_tester.dart';
 
 class _CustomPhysics extends ClampingScrollPhysics {
   const _CustomPhysics({super.parent});
@@ -2394,74 +2394,66 @@ void main() {
       );
     }
 
-    testWidgets(
-      'overscroll, hold for 0 velocity, and release',
-      (WidgetTester tester) async {
-        // Dragging into an overscroll and holding so that when released, the
-        // ballistic scroll activity has a 0 velocity.
-        final controller = ScrollController();
-        addTearDown(controller.dispose);
-        await tester.pumpWidget(buildBallisticTest(controller));
-        // Last item of the inner scroll view.
-        expect(find.text('Item 49'), findsNothing);
+    testWidgets('overscroll, hold for 0 velocity, and release', (WidgetTester tester) async {
+      // Dragging into an overscroll and holding so that when released, the
+      // ballistic scroll activity has a 0 velocity.
+      final controller = ScrollController();
+      addTearDown(controller.dispose);
+      await tester.pumpWidget(buildBallisticTest(controller));
+      // Last item of the inner scroll view.
+      expect(find.text('Item 49'), findsNothing);
 
-        // Scroll to bottom
-        await tester.fling(find.text('Item 3'), const Offset(0.0, -50.0), 10000.0);
-        await tester.pumpAndSettle();
+      // Scroll to bottom
+      await tester.fling(find.text('Item 3'), const Offset(0.0, -50.0), 10000.0);
+      await tester.pumpAndSettle();
 
-        // End of list
-        expect(find.text('Item 49'), findsOneWidget);
-        expect(tester.getCenter(find.text('Item 49')).dy, equals(585.0));
+      // End of list
+      expect(find.text('Item 49'), findsOneWidget);
+      expect(tester.getCenter(find.text('Item 49')).dy, equals(585.0));
 
-        // Overscroll, dragging like this will release with 0 velocity.
-        await tester.drag(find.text('Item 49'), const Offset(0.0, -50.0));
-        await tester.pump();
-        // If handled correctly, the last item should still be visible and
-        // progressing back down to the bottom edge, instead of jumping further
-        // up the list and out of view.
-        expect(find.text('Item 49'), findsOneWidget);
-        await tester.pumpAndSettle();
-        expect(tester.getCenter(find.text('Item 49')).dy, equals(585.0));
-      },
-      variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-    );
+      // Overscroll, dragging like this will release with 0 velocity.
+      await tester.drag(find.text('Item 49'), const Offset(0.0, -50.0));
+      await tester.pump();
+      // If handled correctly, the last item should still be visible and
+      // progressing back down to the bottom edge, instead of jumping further
+      // up the list and out of view.
+      expect(find.text('Item 49'), findsOneWidget);
+      await tester.pumpAndSettle();
+      expect(tester.getCenter(find.text('Item 49')).dy, equals(585.0));
+    }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
 
-    testWidgets(
-      'overscroll, release, and tap',
-      (WidgetTester tester) async {
-        // Tapping while an inner ballistic scroll activity is in progress will
-        // trigger a secondary ballistic scroll activity with a 0 velocity.
-        final controller = ScrollController();
-        addTearDown(controller.dispose);
-        await tester.pumpWidget(buildBallisticTest(controller));
-        // Last item of the inner scroll view.
-        expect(find.text('Item 49'), findsNothing);
+    testWidgets('overscroll, release, and tap', (WidgetTester tester) async {
+      // Tapping while an inner ballistic scroll activity is in progress will
+      // trigger a secondary ballistic scroll activity with a 0 velocity.
+      final controller = ScrollController();
+      addTearDown(controller.dispose);
+      await tester.pumpWidget(buildBallisticTest(controller));
+      // Last item of the inner scroll view.
+      expect(find.text('Item 49'), findsNothing);
 
-        // Scroll to bottom
-        await tester.fling(find.text('Item 3'), const Offset(0.0, -50.0), 10000.0);
-        await tester.pumpAndSettle();
+      // Scroll to bottom
+      await tester.fling(find.text('Item 3'), const Offset(0.0, -50.0), 10000.0);
+      await tester.pumpAndSettle();
 
-        // End of list
-        expect(find.text('Item 49'), findsOneWidget);
-        expect(tester.getCenter(find.text('Item 49')).dy, equals(585.0));
+      // End of list
+      expect(find.text('Item 49'), findsOneWidget);
+      expect(tester.getCenter(find.text('Item 49')).dy, equals(585.0));
 
-        // Fling again to trigger first ballistic activity.
-        await tester.fling(find.text('Item 48'), const Offset(0.0, -50.0), 10000.0);
-        await tester.pump();
+      // Fling again to trigger first ballistic activity.
+      await tester.fling(find.text('Item 48'), const Offset(0.0, -50.0), 10000.0);
+      await tester.pump();
 
-        // Tap after releasing the overscroll to trigger secondary inner ballistic
-        // scroll activity with 0 velocity.
-        await tester.tap(find.text('Item 49'));
-        await tester.pumpAndSettle();
+      // Tap after releasing the overscroll to trigger secondary inner ballistic
+      // scroll activity with 0 velocity.
+      await tester.tap(find.text('Item 49'));
+      await tester.pumpAndSettle();
 
-        // If handled correctly, the ballistic scroll activity should finish
-        // closing out the overscrolled area, with the last item visible at the
-        // bottom.
-        expect(find.text('Item 49'), findsOneWidget);
-        expect(tester.getCenter(find.text('Item 49')).dy, equals(585.0));
-      },
-      variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-    );
+      // If handled correctly, the ballistic scroll activity should finish
+      // closing out the overscrolled area, with the last item visible at the
+      // bottom.
+      expect(find.text('Item 49'), findsOneWidget);
+      expect(tester.getCenter(find.text('Item 49')).dy, equals(585.0));
+    }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}));
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/63978


### PR DESCRIPTION
Part of flutter/flutter#177414.

## Summary

Moves nested_scroll_view_test.dart from the widgets test directory to the Material test directory.

This test file exercises Material scaffolding, SliverAppBar, AppBar, TabBar, TabBarView, and Material theming throughout the suite, so the Material library should own this cross-library coverage.

Also removes the old widgets cross-import allowlist entry from dev/bots/check_tests_cross_imports.dart.

## Tests

- bin/cache/dart-sdk/bin/dart --enable-asserts dev/bots/check_tests_cross_imports.dart
- bin/cache/dart-sdk/bin/dart analyze packages/flutter/test/material/nested_scroll_view_test.dart dev/bots/check_tests_cross_imports.dart
- ./bin/flutter analyze --no-pub packages/flutter/test/material/nested_scroll_view_test.dart dev/bots/check_tests_cross_imports.dart
- ./bin/flutter test --no-pub packages/flutter/test/material/nested_scroll_view_test.dart