### PR TITLE
Add primitive shadows to rendering benchmark

### DIFF
--- a/engine/src/flutter/display_list/benchmarking/dl_benchmarks.cc
+++ b/engine/src/flutter/display_list/benchmarking/dl_benchmarks.cc
@@ -114,6 +114,8 @@ DlPaint GetPaintForRun(unsigned attributes) {
     paint.setStrokeWidth(0.0f);
   } else if (attributes & kWideStroke10) {
     paint.setStrokeWidth(10.0f);
+  } else if (attributes & kWideStroke20) {
+    paint.setStrokeWidth(20.0f);
   } else {
     paint.setStrokeWidth(1.0f);
   }
@@ -1637,13 +1639,13 @@ constexpr int kAAHairlinePrimitive =
     kAntiAliasing | kStrokedStyle | kHairlineStroke;
 constexpr int kAAStroked10Primitive =
     kAntiAliasing | kStrokedStyle | kWideStroke10;
-constexpr int kAAFilledShadow5Primitive =
+constexpr int kFilledShadow5Primitive =
     kFilledStyle | kShadow5;
-constexpr int kAAFilledShadow10Primitive =
+constexpr int kFilledShadow10Primitive =
     kFilledStyle | kShadow10;
-constexpr int kAAStroked10Shadow5Primitive =
+constexpr int kStroked10Shadow5Primitive =
     kStrokedStyle | kWideStroke10 | kShadow5;
-constexpr int kAAStroked20Shadow10Primitive =
+constexpr int kStroked20Shadow10Primitive =
     kStrokedStyle | kWideStroke20 | kShadow10;
 
 #define BENCHMARK_OVERHEAD(FUNC, BACKEND)                                    \
@@ -1672,15 +1674,15 @@ constexpr int kAAStroked20Shadow10Primitive =
 #define DRAW_BENCHMARK_PRIMITIVES_LINE(BACKEND)                              \
   DRAW_BENCHMARK_PRIMITIVE(BACKEND, Line, AAHairline)                        \
   DRAW_BENCHMARK_PRIMITIVE(BACKEND, Line, AAStroked10)                       \
-  DRAW_BENCHMARK_SHADOW_PRIMITIVE(BACKEND, Line, AAStroked10Shadow5)         \
-  DRAW_BENCHMARK_SHADOW_PRIMITIVE(BACKEND, Line, AAStroked20Shadow10)        \
+  DRAW_BENCHMARK_SHADOW_PRIMITIVE(BACKEND, Line, Stroked10Shadow5)           \
+  DRAW_BENCHMARK_SHADOW_PRIMITIVE(BACKEND, Line, Stroked20Shadow10)          \
 
 #define DRAW_BENCHMARK_PRIMITIVES_TYPE(BACKEND, TYPE)                        \
   DRAW_BENCHMARK_PRIMITIVE(BACKEND, TYPE, AAFilled)                          \
   DRAW_BENCHMARK_PRIMITIVE(BACKEND, TYPE, AAHairline)                        \
   DRAW_BENCHMARK_PRIMITIVE(BACKEND, TYPE, AAStroked10)                       \
-  DRAW_BENCHMARK_SHADOW_PRIMITIVE(BACKEND, TYPE, AAFilledShadow5)            \
-  DRAW_BENCHMARK_SHADOW_PRIMITIVE(BACKEND, TYPE, AAFilledShadow10)           \
+  DRAW_BENCHMARK_SHADOW_PRIMITIVE(BACKEND, TYPE, FilledShadow5)              \
+  DRAW_BENCHMARK_SHADOW_PRIMITIVE(BACKEND, TYPE, FilledShadow10)             \
 
 #define DRAW_BENCHMARK_PRIMITIVE_SUITE(BACKEND)                              \
   BENCHMARK_OVERHEAD(SyncOverhead, BACKEND)                                  \

--- a/engine/src/flutter/display_list/benchmarking/dl_benchmarks.cc
+++ b/engine/src/flutter/display_list/benchmarking/dl_benchmarks.cc
@@ -118,6 +118,16 @@ DlPaint GetPaintForRun(unsigned attributes) {
     paint.setStrokeWidth(1.0f);
   }
 
+  if (attributes & kShadow5) {
+    static auto blur5filter =
+        DlBlurMaskFilter::Make(DlBlurStyle::kNormal, 5.0f);
+    paint.setMaskFilter(blur5filter);
+  } else if (attributes & kShadow10) {
+    static auto blur10filter =
+        DlBlurMaskFilter::Make(DlBlurStyle::kNormal, 10.0f);
+    paint.setMaskFilter(blur10filter);
+  }
+
   paint.setAntiAlias(attributes & kAntiAliasing);
   return paint;
 }
@@ -1625,53 +1635,57 @@ constexpr int kAAFilledPrimitive =
     kAntiAliasing | kFilledStyle;
 constexpr int kAAHairlinePrimitive =
     kAntiAliasing | kStrokedStyle | kHairlineStroke;
-constexpr int kAAStroke10Primitive =
+constexpr int kAAStroked10Primitive =
     kAntiAliasing | kStrokedStyle | kWideStroke10;
+constexpr int kAAFilledShadow5Primitive =
+    kFilledStyle | kShadow5;
+constexpr int kAAFilledShadow10Primitive =
+    kFilledStyle | kShadow10;
+constexpr int kAAStroked10Shadow5Primitive =
+    kStrokedStyle | kWideStroke10 | kShadow5;
+constexpr int kAAStroked20Shadow10Primitive =
+    kStrokedStyle | kWideStroke20 | kShadow10;
 
-#define BENCHMARK_PRIMITIVE_SYNC_OVERHEAD(BACKEND)                           \
-  BENCHMARK_CAPTURE(BM_SyncOverhead, BACKEND, BackendType::k##BACKEND)       \
+#define BENCHMARK_OVERHEAD(FUNC, BACKEND)                                    \
+  BENCHMARK_CAPTURE(BM_##FUNC, BACKEND, BackendType::k##BACKEND)             \
       ->RangeMultiplier(4)                                                   \
       ->Range(16, 1024)                                                      \
       ->UseRealTime()                                                        \
       ->Unit(benchmark::kNanosecond);
 
-#define BENCHMARK_PRIMITIVE_EMPTY_DISPLAY_LIST_OVERHEAD(BACKEND)             \
-  BENCHMARK_CAPTURE(BM_EmptyDisplayList, BACKEND, BackendType::k##BACKEND)   \
-      ->RangeMultiplier(4)                                                   \
-      ->Range(16, 1024)                                                      \
-      ->UseRealTime()                                                        \
-      ->Unit(benchmark::kNanosecond);
-
-#define BENCHMARK_PRIMITIVE_SINGLE_OP_DISPLAY_LIST_OVERHEAD(BACKEND)         \
-  BENCHMARK_CAPTURE(BM_SingleOpDisplayList, BACKEND,                         \
-                    BackendType::k##BACKEND)                                 \
-      ->RangeMultiplier(4)                                                   \
-      ->Range(16, 1024)                                                      \
-      ->UseRealTime()                                                        \
-      ->Unit(benchmark::kNanosecond);
-
-#define DRAW_BENCHMARK_PRIMITIVES(BACKEND, TYPE, ATTRIBUTES)                 \
+#define DRAW_BENCHMARK_PRIMITIVES_LIMITS(BACKEND, TYPE, ATTRIBUTES,          \
+                                         MIN, MAX, MULT)                     \
   BENCHMARK_CAPTURE(BM_Draw##TYPE, ATTRIBUTES/BACKEND,                       \
                     BackendType::k##BACKEND,                                 \
                     k##ATTRIBUTES##Primitive)                                \
-      ->RangeMultiplier(4)                                                   \
-      ->Range(16, 1024)                                                      \
+      ->RangeMultiplier(MULT)                                                \
+      ->Range(MIN, MAX)                                                      \
       ->UseRealTime()                                                        \
       ->Unit(benchmark::kMillisecond);
 
+#define DRAW_BENCHMARK_PRIMITIVE(BACKEND, TYPE, ATTRIBUTES)                  \
+  DRAW_BENCHMARK_PRIMITIVES_LIMITS(BACKEND, TYPE, ATTRIBUTES, 16, 1024, 4)
+
+#define DRAW_BENCHMARK_SHADOW_PRIMITIVE(BACKEND, TYPE, ATTRIBUTES)           \
+  DRAW_BENCHMARK_PRIMITIVES_LIMITS(BACKEND, TYPE, ATTRIBUTES, 64, 256, 4)
+
 #define DRAW_BENCHMARK_PRIMITIVES_LINE(BACKEND)                              \
-  DRAW_BENCHMARK_PRIMITIVES(BACKEND, Line, AAHairline)                       \
-  DRAW_BENCHMARK_PRIMITIVES(BACKEND, Line, AAStroke10)
+  DRAW_BENCHMARK_PRIMITIVE(BACKEND, Line, AAHairline)                        \
+  DRAW_BENCHMARK_PRIMITIVE(BACKEND, Line, AAStroked10)                       \
+  DRAW_BENCHMARK_SHADOW_PRIMITIVE(BACKEND, Line, AAStroked10Shadow5)         \
+  DRAW_BENCHMARK_SHADOW_PRIMITIVE(BACKEND, Line, AAStroked20Shadow10)        \
 
 #define DRAW_BENCHMARK_PRIMITIVES_TYPE(BACKEND, TYPE)                        \
-  DRAW_BENCHMARK_PRIMITIVES(BACKEND, TYPE, AAFilled)                         \
-  DRAW_BENCHMARK_PRIMITIVES(BACKEND, TYPE, AAHairline)                       \
-  DRAW_BENCHMARK_PRIMITIVES(BACKEND, TYPE, AAStroke10)                       \
+  DRAW_BENCHMARK_PRIMITIVE(BACKEND, TYPE, AAFilled)                          \
+  DRAW_BENCHMARK_PRIMITIVE(BACKEND, TYPE, AAHairline)                        \
+  DRAW_BENCHMARK_PRIMITIVE(BACKEND, TYPE, AAStroked10)                       \
+  DRAW_BENCHMARK_SHADOW_PRIMITIVE(BACKEND, TYPE, AAFilledShadow5)            \
+  DRAW_BENCHMARK_SHADOW_PRIMITIVE(BACKEND, TYPE, AAFilledShadow10)           \
 
 #define DRAW_BENCHMARK_PRIMITIVE_SUITE(BACKEND)                              \
-  BENCHMARK_PRIMITIVE_SYNC_OVERHEAD(BACKEND)                                 \
-  BENCHMARK_PRIMITIVE_EMPTY_DISPLAY_LIST_OVERHEAD(BACKEND)                   \
-  BENCHMARK_PRIMITIVE_SINGLE_OP_DISPLAY_LIST_OVERHEAD(BACKEND)               \
+  BENCHMARK_OVERHEAD(SyncOverhead, BACKEND)                                  \
+  BENCHMARK_OVERHEAD(EmptyDisplayList, BACKEND)                              \
+  BENCHMARK_OVERHEAD(SingleOpDisplayList, BACKEND)                           \
   DRAW_BENCHMARK_PRIMITIVES_LINE(BACKEND)                                    \
   DRAW_BENCHMARK_PRIMITIVES_TYPE(BACKEND, Rect)                              \
   DRAW_BENCHMARK_PRIMITIVES_TYPE(BACKEND, Oval)                              \

--- a/engine/src/flutter/display_list/benchmarking/dl_benchmarks.cc
+++ b/engine/src/flutter/display_list/benchmarking/dl_benchmarks.cc
@@ -114,8 +114,6 @@ DlPaint GetPaintForRun(unsigned attributes) {
     paint.setStrokeWidth(0.0f);
   } else if (attributes & kWideStroke10) {
     paint.setStrokeWidth(10.0f);
-  } else if (attributes & kWideStroke20) {
-    paint.setStrokeWidth(20.0f);
   } else {
     paint.setStrokeWidth(1.0f);
   }
@@ -1637,16 +1635,12 @@ constexpr int kAAFilledPrimitive =
     kAntiAliasing | kFilledStyle;
 constexpr int kAAHairlinePrimitive =
     kAntiAliasing | kStrokedStyle | kHairlineStroke;
-constexpr int kAAStroked10Primitive =
+constexpr int kAAStroke10Primitive =
     kAntiAliasing | kStrokedStyle | kWideStroke10;
 constexpr int kFilledShadow5Primitive =
     kFilledStyle | kShadow5;
 constexpr int kFilledShadow10Primitive =
     kFilledStyle | kShadow10;
-constexpr int kStroked10Shadow5Primitive =
-    kStrokedStyle | kWideStroke10 | kShadow5;
-constexpr int kStroked20Shadow10Primitive =
-    kStrokedStyle | kWideStroke20 | kShadow10;
 
 #define BENCHMARK_OVERHEAD(FUNC, BACKEND)                                    \
   BENCHMARK_CAPTURE(BM_##FUNC, BACKEND, BackendType::k##BACKEND)             \
@@ -1673,14 +1667,12 @@ constexpr int kStroked20Shadow10Primitive =
 
 #define DRAW_BENCHMARK_PRIMITIVES_LINE(BACKEND)                              \
   DRAW_BENCHMARK_PRIMITIVE(BACKEND, Line, AAHairline)                        \
-  DRAW_BENCHMARK_PRIMITIVE(BACKEND, Line, AAStroked10)                       \
-  DRAW_BENCHMARK_SHADOW_PRIMITIVE(BACKEND, Line, Stroked10Shadow5)           \
-  DRAW_BENCHMARK_SHADOW_PRIMITIVE(BACKEND, Line, Stroked20Shadow10)          \
+  DRAW_BENCHMARK_PRIMITIVE(BACKEND, Line, AAStroke10)                        \
 
 #define DRAW_BENCHMARK_PRIMITIVES_TYPE(BACKEND, TYPE)                        \
   DRAW_BENCHMARK_PRIMITIVE(BACKEND, TYPE, AAFilled)                          \
   DRAW_BENCHMARK_PRIMITIVE(BACKEND, TYPE, AAHairline)                        \
-  DRAW_BENCHMARK_PRIMITIVE(BACKEND, TYPE, AAStroked10)                       \
+  DRAW_BENCHMARK_PRIMITIVE(BACKEND, TYPE, AAStroke10)                        \
   DRAW_BENCHMARK_SHADOW_PRIMITIVE(BACKEND, TYPE, FilledShadow5)              \
   DRAW_BENCHMARK_SHADOW_PRIMITIVE(BACKEND, TYPE, FilledShadow10)             \
 

--- a/engine/src/flutter/display_list/benchmarking/dl_benchmarks.h
+++ b/engine/src/flutter/display_list/benchmarking/dl_benchmarks.h
@@ -21,10 +21,9 @@ enum BenchmarkAttributes {
   kFilledStyle = 1 << 1,
   kHairlineStroke = 1 << 2,
   kWideStroke10 = 1 << 3,
-  kWideStroke20 = 1 << 4,
-  kAntiAliasing = 1 << 5,
-  kShadow5 = 1 << 6,
-  kShadow10 = 1 << 7,
+  kAntiAliasing = 1 << 4,
+  kShadow5 = 1 << 5,
+  kShadow10 = 1 << 6,
 };
 
 enum class RRectType {

--- a/engine/src/flutter/display_list/benchmarking/dl_benchmarks.h
+++ b/engine/src/flutter/display_list/benchmarking/dl_benchmarks.h
@@ -21,7 +21,10 @@ enum BenchmarkAttributes {
   kFilledStyle = 1 << 1,
   kHairlineStroke = 1 << 2,
   kWideStroke10 = 1 << 3,
-  kAntiAliasing = 1 << 4
+  kWideStroke20 = 1 << 4,
+  kAntiAliasing = 1 << 5,
+  kShadow5 = 1 << 6,
+  kShadow10 = 1 << 7,
 };
 
 enum class RRectType {


### PR DESCRIPTION
Adds benchmarking of the primitive shadows to the primitive rendering benchmark in preparation for performance work on the shadow rendering code.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.