### PR TITLE
Clarify build side effects in docs

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -269,10 +269,12 @@ class TextEditingController extends ValueNotifier<TextEditingValue> {
   /// reasonable selection range within the new [text].
   ///
   /// Setting this notifies all the listeners of this [TextEditingController]
-  /// that they need to update (it calls [notifyListeners]). For this reason,
-  /// this value should only be set between frames, e.g. in response to user
-  /// actions, not during the build, layout, or paint phases. This property can
-  /// be set from a listener added to this [TextEditingController].
+  /// that they need to update (it calls [notifyListeners]). Because listeners
+  /// are notified synchronously, they can call [State.setState] or otherwise
+  /// mark parts of the widget tree dirty. For this reason, this value should
+  /// only be set between frames, e.g. in response to user actions, and not
+  /// during the build, layout, or paint phases. This property can be set from
+  /// a listener added to this [TextEditingController].
   set text(String newText) {
     value = value.copyWith(
       text: newText,

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -536,7 +536,9 @@ abstract class StatelessWidget extends Widget {
   /// in a given [BuildContext] and when the dependencies of this widget change
   /// (e.g., an [InheritedWidget] referenced by this widget changes). This
   /// method can potentially be called in every frame and should not have any side
-  /// effects beyond building a widget.
+  /// effects beyond building a widget. For example, triggering [State.setState]
+  /// or notifying listeners during this method can mark parts of the widget
+  /// tree dirty while the framework is already building widgets.
   ///
   /// The framework replaces the subtree below this widget with the widget
   /// returned by this method, either by updating the existing subtree or by
@@ -1354,7 +1356,9 @@ abstract class State<T extends StatefulWidget> with Diagnosticable {
   ///    the tree at another location.
   ///
   /// This method can potentially be called in every frame and should not have
-  /// any side effects beyond building a widget.
+  /// any side effects beyond building a widget. For example, calling
+  /// [State.setState] or notifying listeners during this method can mark parts
+  /// of the widget tree dirty while the framework is already building widgets.
   ///
   /// The framework replaces the subtree below this widget with the widget
   /// returned by this method, either by updating the existing subtree or by


### PR DESCRIPTION
Fixes flutter/flutter#46728

## Issue

`TextEditingController.text` warned against setting the value during build, layout, or paint because it notifies listeners, but it did not explain why synchronous listener notification is unsafe during those phases. The general `build` docs also said to avoid side effects without naming the failure mode.

## Fix

Clarify that `TextEditingController.text` notifies listeners synchronously, and that those listeners can call `State.setState` or otherwise mark parts of the widget tree dirty. Also expand the `StatelessWidget.build` and `State.build` docs with the same concrete example of side effects marking widgets dirty while the framework is already building.

## Tests

- `./bin/dart format --output=none --set-exit-if-changed packages/flutter/lib/src/widgets/editable_text.dart packages/flutter/lib/src/widgets/framework.dart`
- `./bin/flutter analyze packages/flutter/lib/src/widgets/editable_text.dart packages/flutter/lib/src/widgets/framework.dart`
- `git diff --check`

No widget tests were added because this is a documentation-only change.

## Risk

Docs-only change touching two framework API doc files. No runtime behavior, generated output, or public API surface changed.
