### PR TITLE
[web] Fix cutoff text in WebParagraph

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/decorations.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/decorations.dart
@@ -96,8 +96,7 @@ class DomCanvasDecorationPainter {
         continue;
       }
 
-      final double height =
-          block.multipliedFontBoundingBoxAscent + block.multipliedFontBoundingBoxDescent;
+      final double height = block.multipliedHeight;
       final double ascent = block.multipliedFontBoundingBoxAscent;
       final double position = _calculatePosition(decoration, thickness, height, ascent);
 

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/layout.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/layout.dart
@@ -199,9 +199,6 @@ class TextLayout {
 
     final wrapper = TextWrapper(this);
     wrapper.breakLines(width);
-    for (final TextLine line in lines) {
-      paragraph.fullWidth = math.max(paragraph.fullWidth, line.fullWidth);
-    }
     paragraph.width = width;
     paragraph.maxIntrinsicWidth = wrapper.maxIntrinsicWidth;
     paragraph.minIntrinsicWidth = wrapper.minIntrinsicWidth;
@@ -485,20 +482,19 @@ class TextLayout {
   }
 
   void _calculatePaintBounds() {
-    // First, calculate the actual bounds of the entire paragraph.
-    double leftBound = double.infinity;
-    double topBound = double.infinity;
-    double rightBound = double.negativeInfinity;
-    double bottomBound = double.negativeInfinity;
+    double left = double.infinity;
+    double top = double.infinity;
+    double right = double.negativeInfinity;
+    double bottom = double.negativeInfinity;
 
     for (final TextLine line in lines) {
-      leftBound = math.min(leftBound, line.formattingShift + line.paintBoundsLeft);
-      topBound = math.min(topBound, line.baseline - line.paintBoundsAscent);
-      rightBound = math.max(rightBound, line.formattingShift + line.paintBoundsRight);
-      bottomBound = math.max(bottomBound, line.baseline + line.paintBoundsDescent);
+      left = math.min(left, line.formattingShift + line.paintBoundsLeft);
+      top = math.min(top, line.baseline - line.paintBoundsAscent);
+      right = math.max(right, line.formattingShift + line.paintBoundsRight);
+      bottom = math.max(bottom, line.baseline + line.paintBoundsDescent);
     }
 
-    paragraph.paintBounds = ui.Rect.fromLTRB(leftBound, topBound, rightBound, bottomBound);
+    paragraph.paintBounds = ui.Rect.fromLTRB(left, top, right, bottom);
   }
 
   static const epsilon = 0.001;

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/layout.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/layout.dart
@@ -71,6 +71,9 @@ class TextLayout {
     wrapText(width);
     formatLines(width);
 
+    // Calculate how much overflow is needed in all directions in order to paint the full glyphs.
+    calculatePaintOverflows();
+
     // TODO(jlavrova): Optimize. If lines are the same as the previous layout, we don't need to
     // clear the paint cache.
     paragraph.clearPaintCache();
@@ -381,15 +384,7 @@ class TextLayout {
             (line.visualBlocks.last as TextBlock).whitespacesWidth = trailingSpacesWidth;
           }
 
-          // Line always counts multipled metrics (no need for the others)
-          line.fontBoundingBoxAscent = math.max(
-            line.fontBoundingBoxAscent,
-            block.multipliedFontBoundingBoxAscent,
-          );
-          line.fontBoundingBoxDescent = math.max(
-            line.fontBoundingBoxDescent,
-            block.multipliedFontBoundingBoxDescent,
-          );
+          line.updateBoundingBox(block);
           blockWidth = block.advance.width;
         }
 
@@ -428,9 +423,7 @@ class TextLayout {
         continue;
       }
       block.calculatePlaceholderTop(line.fontBoundingBoxAscent, line.fontBoundingBoxDescent);
-      // Line always counts multipled metrics (no need for the others)
-      line.fontBoundingBoxAscent = math.max(line.fontBoundingBoxAscent, block.ascent);
-      line.fontBoundingBoxDescent = math.max(line.fontBoundingBoxDescent, block.descent);
+      line.updateBoundingBox(block);
     }
 
     line.advance = ui.Rect.fromLTWH(
@@ -482,7 +475,32 @@ class TextLayout {
     }
   }
 
-  static double epsilon = 0.001;
+  void calculatePaintOverflows() {
+    // First, calculate the actual bounds of the entire paragraph.
+    double leftBound = 0;
+    double topBound = 0;
+    double rightBound = 0;
+    double bottomBound = 0;
+
+    var maxWidth = 0.0;
+    for (final TextLine line in lines) {
+      leftBound = math.min(leftBound, line.formattingShift + line.actualBoundingBoxLeft);
+      topBound = math.min(topBound, line.baseline - line.actualBoundingBoxAscent);
+      rightBound = math.max(rightBound, line.formattingShift + line.actualBoundingBoxRight);
+      bottomBound = math.max(bottomBound, line.baseline + line.actualBoundingBoxDescent);
+
+      maxWidth = math.max(maxWidth, line.fullWidth);
+    }
+
+    paragraph.paintOverflows = (
+      left: math.max(0, -leftBound),
+      top: math.max(0, -topBound),
+      right: math.max(0, rightBound - maxWidth),
+      bottom: math.max(0, bottomBound - paragraph.height),
+    );
+  }
+
+  static const epsilon = 0.001;
 
   List<ui.TextBox> getBoxesForRange(
     int start,
@@ -940,14 +958,12 @@ abstract class WebCluster {
   int get endInSpan;
 
   // TODO(mdebbar): DISCUSS:
-  // Cluster's `bounds` and `advance` are relative to the span, which isn't very useful
-  // most of the time. Should we hide those and only show `width`/`height` since those
+  // Cluster's `advance` is relative to the span, which isn't very useful
+  // most of the time. Should we hide it and only show `width`/`height` since those
   // are still useful?
-  // Callsites that need `bounds` and `advance` are usually performing some kind of
+  // Callsites that need `advance` are usually performing some kind of
   // coordinate conversion to make them relative to the line, for example. We should
   // encapsulate that logic here and make it convenient to use.
-  ui.Rect get bounds;
-
   ui.Rect get advance;
 
   ParagraphSpan get span;
@@ -979,8 +995,6 @@ class TextCluster extends WebCluster {
   final int endInSpan;
 
   @override
-  late final ui.Rect bounds = span.getClusterBounds(this);
-  @override
   late final ui.Rect advance = span.getClusterSelection(this);
 
   final DomTextCluster _cluster;
@@ -998,7 +1012,7 @@ class TextCluster extends WebCluster {
 
   @override
   void addToContext(DomCanvasRenderingContext2D context, double x, double y) {
-    context.fillTextCluster(_cluster, /*left:*/ x, /*top:*/ y + span.fontBoundingBoxAscent);
+    context.fillTextCluster(_cluster, /*left:*/ x, /*top:*/ y);
   }
 
   @override
@@ -1023,8 +1037,6 @@ class EmptyCluster extends WebCluster {
   @override
   final int endInSpan = 0;
 
-  @override
-  late final ui.Rect bounds = ui.Rect.fromLTWH(0, 0, 0, height);
   @override
   late final ui.Rect advance = ui.Rect.fromLTWH(0, 0, 0, height);
 
@@ -1059,11 +1071,7 @@ class PlaceholderCluster extends WebCluster {
   WebTextStyle get style => span.style;
 
   @override
-  late final ui.Rect bounds = ui.Rect.fromLTWH(0, 0, span.width, span.height);
-
-  @override
-  // For placeholders bounds == advance
-  ui.Rect get advance => bounds;
+  late final ui.Rect advance = ui.Rect.fromLTWH(0, 0, span.width, span.height);
 
   @override
   void fillOnContext(DomCanvasRenderingContext2D context, {required double x, required double y}) {
@@ -1149,6 +1157,11 @@ class TextBlock extends LineBlock {
 
   @override
   late final ui.Rect advance = span.getBlockSelection(this);
+
+  late final ui.Rect actualBounds = span.getBlockBounds(this);
+
+  double get actualBoundingBoxAscent => -actualBounds.top;
+  double get actualBoundingBoxDescent => actualBounds.bottom;
 
   @override
   double spanShiftFromLineStart;
@@ -1291,11 +1304,15 @@ class TextLine {
       unscaledAscent: fontBoundingBoxAscent,
       height: advance.height,
       width: advance.width,
+      // TODO(jlavrova): This should be set to `formattingShift`, right?
+      //                 `advance.left` is always zero.
       left: advance.left,
-      baseline: advance.top + fontBoundingBoxAscent,
+      baseline: baseline,
       lineNumber: lineNumber,
     );
   }
+
+  double get baseline => advance.top + fontBoundingBoxAscent;
 
   double get height => fontBoundingBoxAscent + fontBoundingBoxDescent;
 
@@ -1310,10 +1327,41 @@ class TextLine {
   ui.Rect advance = ui.Rect.zero;
   double fontBoundingBoxAscent = 0.0;
   double fontBoundingBoxDescent = 0.0;
+
+  double actualBoundingBoxAscent = 0.0;
+  double actualBoundingBoxDescent = 0.0;
+  double actualBoundingBoxLeft = 0.0;
+  double actualBoundingBoxRight = 0.0;
+
   double formattingShift = 0.0; // For centered or right aligned text
   double trailingSpacesWidth = 0.0;
 
+  double get fullWidth => advance.width + formattingShift + trailingSpacesWidth;
+
   List<LineBlock> visualBlocks = <LineBlock>[];
+
+  void updateBoundingBox(LineBlock block) {
+    if (block is TextBlock) {
+      // Line always counts multipled metrics.
+      fontBoundingBoxAscent = math.max(
+        fontBoundingBoxAscent,
+        block.multipliedFontBoundingBoxAscent,
+      );
+      fontBoundingBoxDescent = math.max(
+        fontBoundingBoxDescent,
+        block.multipliedFontBoundingBoxDescent,
+      );
+      actualBoundingBoxAscent = math.max(actualBoundingBoxAscent, block.actualBoundingBoxAscent);
+      actualBoundingBoxDescent = math.max(actualBoundingBoxDescent, block.actualBoundingBoxDescent);
+      actualBoundingBoxLeft = math.min(actualBoundingBoxLeft, block.actualBounds.left);
+      actualBoundingBoxRight = math.max(actualBoundingBoxRight, block.actualBounds.right);
+    } else if (block is PlaceholderBlock) {
+      fontBoundingBoxAscent = math.max(fontBoundingBoxAscent, block.ascent);
+      fontBoundingBoxDescent = math.max(fontBoundingBoxDescent, block.descent);
+    } else {
+      throw UnsupportedError('Unknown block type: $block');
+    }
+  }
 }
 
 extension DomTextMetricsExtension on DomTextMetrics {

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/layout.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/layout.dart
@@ -71,8 +71,14 @@ class TextLayout {
     wrapText(width);
     formatLines(width);
 
-    // Calculate how much overflow is needed in all directions in order to paint the full glyphs.
-    calculatePaintOverflows();
+    if (paragraph.text.isNotEmpty) {
+      // When the paragraph is empty, instead of setting the bounds to a zero rect, we let it unset.
+      // This will make it easy to detect when there's a bug in our painting pipeline that's trying
+      // to paint an empty paragraph.
+
+      // Calculate the actual paint bounds of the paragraph.
+      _calculateActualBounds();
+    }
 
     // TODO(jlavrova): Optimize. If lines are the same as the previous layout, we don't need to
     // clear the paint cache.
@@ -193,6 +199,9 @@ class TextLayout {
 
     final wrapper = TextWrapper(this);
     wrapper.breakLines(width);
+    for (final TextLine line in lines) {
+      paragraph.fullWidth = math.max(paragraph.fullWidth, line.fullWidth);
+    }
     paragraph.width = width;
     paragraph.maxIntrinsicWidth = wrapper.maxIntrinsicWidth;
     paragraph.minIntrinsicWidth = wrapper.minIntrinsicWidth;
@@ -475,29 +484,21 @@ class TextLayout {
     }
   }
 
-  void calculatePaintOverflows() {
+  void _calculateActualBounds() {
     // First, calculate the actual bounds of the entire paragraph.
-    double leftBound = 0;
-    double topBound = 0;
-    double rightBound = 0;
-    double bottomBound = 0;
+    double leftBound = double.infinity;
+    double topBound = double.infinity;
+    double rightBound = double.negativeInfinity;
+    double bottomBound = double.negativeInfinity;
 
-    var maxWidth = 0.0;
     for (final TextLine line in lines) {
       leftBound = math.min(leftBound, line.formattingShift + line.actualBoundingBoxLeft);
       topBound = math.min(topBound, line.baseline - line.actualBoundingBoxAscent);
       rightBound = math.max(rightBound, line.formattingShift + line.actualBoundingBoxRight);
       bottomBound = math.max(bottomBound, line.baseline + line.actualBoundingBoxDescent);
-
-      maxWidth = math.max(maxWidth, line.fullWidth);
     }
 
-    paragraph.paintOverflows = (
-      left: math.max(0, -leftBound),
-      top: math.max(0, -topBound),
-      right: math.max(0, rightBound - maxWidth),
-      bottom: math.max(0, bottomBound - paragraph.height),
-    );
+    paragraph.actualBounds = ui.Rect.fromLTRB(leftBound, topBound, rightBound, bottomBound);
   }
 
   static const epsilon = 0.001;
@@ -1307,8 +1308,8 @@ class TextLine {
 
   double actualBoundingBoxAscent = 0.0;
   double actualBoundingBoxDescent = 0.0;
-  double actualBoundingBoxLeft = 0.0;
-  double actualBoundingBoxRight = 0.0;
+  double actualBoundingBoxLeft = double.infinity;
+  double actualBoundingBoxRight = double.negativeInfinity;
 
   double formattingShift = 0.0; // For centered or right aligned text
   double trailingSpacesWidth = 0.0;

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/layout.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/layout.dart
@@ -421,6 +421,7 @@ class TextLayout {
         // We place the ellipsis block at the beginning of the line (for RTL paragraph)
         line.visualBlocks.insert(0, ellipsisBlock);
       }
+      line.updateBoundingBox(ellipsisBlock);
     }
 
     // Now when we calculated all line metrics we have to correct placeholders that depend on it

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/layout.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/layout.dart
@@ -77,7 +77,7 @@ class TextLayout {
       // to paint an empty paragraph.
 
       // Calculate the actual paint bounds of the paragraph.
-      _calculateActualBounds();
+      _calculatePaintBounds();
     }
 
     // TODO(jlavrova): Optimize. If lines are the same as the previous layout, we don't need to
@@ -484,7 +484,7 @@ class TextLayout {
     }
   }
 
-  void _calculateActualBounds() {
+  void _calculatePaintBounds() {
     // First, calculate the actual bounds of the entire paragraph.
     double leftBound = double.infinity;
     double topBound = double.infinity;
@@ -492,13 +492,13 @@ class TextLayout {
     double bottomBound = double.negativeInfinity;
 
     for (final TextLine line in lines) {
-      leftBound = math.min(leftBound, line.formattingShift + line.actualBoundingBoxLeft);
-      topBound = math.min(topBound, line.baseline - line.actualBoundingBoxAscent);
-      rightBound = math.max(rightBound, line.formattingShift + line.actualBoundingBoxRight);
-      bottomBound = math.max(bottomBound, line.baseline + line.actualBoundingBoxDescent);
+      leftBound = math.min(leftBound, line.formattingShift + line.paintBoundsLeft);
+      topBound = math.min(topBound, line.baseline - line.paintBoundsAscent);
+      rightBound = math.max(rightBound, line.formattingShift + line.paintBoundsRight);
+      bottomBound = math.max(bottomBound, line.baseline + line.paintBoundsDescent);
     }
 
-    paragraph.actualBounds = ui.Rect.fromLTRB(leftBound, topBound, rightBound, bottomBound);
+    paragraph.paintBounds = ui.Rect.fromLTRB(leftBound, topBound, rightBound, bottomBound);
   }
 
   static const epsilon = 0.001;
@@ -1136,10 +1136,10 @@ class TextBlock extends LineBlock {
   @override
   late final ui.Rect advance = span.getBlockSelection(this);
 
-  late final ui.Rect actualBounds = span.getBlockBounds(this);
+  late final ui.Rect paintBounds = span.getBlockBounds(this);
 
-  double get actualBoundingBoxAscent => -actualBounds.top;
-  double get actualBoundingBoxDescent => actualBounds.bottom;
+  double get paintBoundsAscent => -paintBounds.top;
+  double get paintBoundsDescent => paintBounds.bottom;
 
   @override
   double spanShiftFromLineStart;
@@ -1306,10 +1306,10 @@ class TextLine {
   double fontBoundingBoxAscent = 0.0;
   double fontBoundingBoxDescent = 0.0;
 
-  double actualBoundingBoxAscent = 0.0;
-  double actualBoundingBoxDescent = 0.0;
-  double actualBoundingBoxLeft = double.infinity;
-  double actualBoundingBoxRight = double.negativeInfinity;
+  double paintBoundsAscent = 0.0;
+  double paintBoundsDescent = 0.0;
+  double paintBoundsLeft = double.infinity;
+  double paintBoundsRight = double.negativeInfinity;
 
   double formattingShift = 0.0; // For centered or right aligned text
   double trailingSpacesWidth = 0.0;
@@ -1329,13 +1329,15 @@ class TextLine {
         fontBoundingBoxDescent,
         block.multipliedFontBoundingBoxDescent,
       );
-      actualBoundingBoxAscent = math.max(actualBoundingBoxAscent, block.actualBoundingBoxAscent);
-      actualBoundingBoxDescent = math.max(actualBoundingBoxDescent, block.actualBoundingBoxDescent);
-      actualBoundingBoxLeft = math.min(actualBoundingBoxLeft, block.actualBounds.left);
-      actualBoundingBoxRight = math.max(actualBoundingBoxRight, block.actualBounds.right);
+      paintBoundsAscent = math.max(paintBoundsAscent, block.paintBoundsAscent);
+      paintBoundsDescent = math.max(paintBoundsDescent, block.paintBoundsDescent);
+      paintBoundsLeft = math.min(paintBoundsLeft, block.paintBounds.left);
+      paintBoundsRight = math.max(paintBoundsRight, block.paintBounds.right);
     } else if (block is PlaceholderBlock) {
       fontBoundingBoxAscent = math.max(fontBoundingBoxAscent, block.ascent);
       fontBoundingBoxDescent = math.max(fontBoundingBoxDescent, block.descent);
+      // There's no need to update paint bounds because placeholders aren't painted by the
+      // paragraph.
     } else {
       throw UnsupportedError('Unknown block type: $block');
     }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/layout.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/layout.dart
@@ -970,8 +970,6 @@ abstract class WebCluster {
 
   WebTextStyle get style;
 
-  void fillOnContext(DomCanvasRenderingContext2D context, {required double x, required double y});
-
   void addToContext(DomCanvasRenderingContext2D context, double x, double y);
 
   @override
@@ -998,17 +996,6 @@ class TextCluster extends WebCluster {
   late final ui.Rect advance = span.getClusterSelection(this);
 
   final DomTextCluster _cluster;
-
-  @override
-  void fillOnContext(DomCanvasRenderingContext2D context, {required double x, required double y}) {
-    context.fillTextCluster(
-      _cluster,
-      /*left:*/ 0,
-      /*top:*/ span.fontBoundingBoxAscent,
-      // TODO(mdebbar): Create a JS TextClusterOptions object instead of a Dart Map
-      <String, double>{'x': x, 'y': y},
-    );
-  }
 
   @override
   void addToContext(DomCanvasRenderingContext2D context, double x, double y) {
@@ -1041,11 +1028,6 @@ class EmptyCluster extends WebCluster {
   late final ui.Rect advance = ui.Rect.fromLTWH(0, 0, 0, height);
 
   @override
-  void fillOnContext(DomCanvasRenderingContext2D context, {required double x, required double y}) {
-    throw UnsupportedError('We should not call "fillOnContext" on an EmptyCluster');
-  }
-
-  @override
   String toString() {
     return 'EmptyCluster [$start:$end)';
   }
@@ -1072,11 +1054,6 @@ class PlaceholderCluster extends WebCluster {
 
   @override
   late final ui.Rect advance = ui.Rect.fromLTWH(0, 0, span.width, span.height);
-
-  @override
-  void fillOnContext(DomCanvasRenderingContext2D context, {required double x, required double y}) {
-    // No-op. Placeholders don't draw anything.
-  }
 
   @override
   void addToContext(DomCanvasRenderingContext2D context, double x, double y) {

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/painter.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/painter.dart
@@ -8,7 +8,6 @@ import 'package:ui/ui.dart' as ui;
 
 import '../dom.dart';
 import '../util.dart';
-import 'debug.dart';
 import 'decorations.dart';
 import 'layout.dart';
 import 'paragraph.dart';
@@ -54,10 +53,12 @@ void _resizePaintCanvas(double devicePixelRatio, ui.Rect rect) {
   ui.Offset offset,
   double devicePixelRatio,
 ) {
+  final WebParagraph paragraph = layout.paragraph;
+
   // Calculate the longest line taking in account the formatting shifts
-  double maxWidth = 0;
+  var maxWidth = 0.0;
   for (final TextLine line in layout.lines) {
-    final double lineWidth = line.advance.width + line.formattingShift + line.trailingSpacesWidth;
+    final double lineWidth = line.fullWidth;
     if (lineWidth > maxWidth) {
       maxWidth = lineWidth;
     }
@@ -68,23 +69,16 @@ void _resizePaintCanvas(double devicePixelRatio, ui.Rect rect) {
   final sourceRect = ui.Rect.fromLTWH(
     0,
     0,
-    (maxWidth * devicePixelRatio).ceilToDouble(),
-    (layout.paragraph.height * devicePixelRatio).ceilToDouble(),
+    ((maxWidth + paragraph.paintOverflows.horizontal) * devicePixelRatio).ceilToDouble(),
+    ((paragraph.height + paragraph.paintOverflows.vertical) * devicePixelRatio).ceilToDouble(),
   );
   // Target rect will be scaled by the canvas transform, so we don't scale it here
   final targetRect = ui.Rect.fromLTWH(
-    offset.dx,
-    offset.dy,
+    (offset.dx - paragraph.paintOverflows.left).floorToDouble(),
+    (offset.dy - paragraph.paintOverflows.top).floorToDouble(),
     (sourceRect.width / devicePixelRatio).ceilToDouble(),
     (sourceRect.height / devicePixelRatio).ceilToDouble(),
   );
-
-  if (WebParagraphDebug.logging) {
-    WebParagraphDebug.log(
-      'calculateParagraph source: ${sourceRect.left}:${sourceRect.right}x${sourceRect.top}:${sourceRect.bottom} => '
-      'target: ${targetRect.left}:${targetRect.right}x${targetRect.top}:${targetRect.bottom}',
-    );
-  }
 
   return (sourceRect, targetRect);
 }
@@ -207,11 +201,12 @@ abstract class WebParagraphPainter {
 class DomCanvasParagraphPainter {
   static void _fillAllBlocks(StyleElements styleElement, TextLayout layout) {
     // Paint the entire paragraph as a single image on Canvas2D
-    double yOffset = 0;
     for (final TextLine line in layout.lines) {
       _paintContext.save();
-      _paintContext.translate(line.formattingShift, yOffset);
-      yOffset += line.advance.height;
+      _paintContext.translate(
+        line.formattingShift,
+        line.baseline + layout.paragraph.paintOverflows.top,
+      );
 
       for (final LineBlock block in line.visualBlocks) {
         if (block is PlaceholderBlock) {
@@ -222,21 +217,15 @@ class DomCanvasParagraphPainter {
         _paintContext.save();
         switch (styleElement) {
           case StyleElements.shadows:
-            // For text and shadows we need to shift to the start of the block
-            _paintContext.translate(
-              block.spanShiftFromLineStart,
-              line.fontBoundingBoxAscent - block.rawFontBoundingBoxAscent,
-            );
+            // For text and shadows we need to shift to the start of the span
+            _paintContext.translate(block.spanShiftFromLineStart, 0);
             _fillBlockShadows(layout, block as TextBlock);
           case StyleElements.text:
-            // For text and shadows we need to shift to the start of the block
-            _paintContext.translate(
-              block.spanShiftFromLineStart,
-              line.fontBoundingBoxAscent - block.rawFontBoundingBoxAscent,
-            );
+            // For text and shadows we need to shift to the start of the span
+            _paintContext.translate(block.spanShiftFromLineStart, 0);
             _fillBlockText(layout, block as TextBlock);
           case StyleElements.decorations:
-            // For decorations we need to shift to the start of the line
+            // For decorations we need to shift to the start of the block
             _paintContext.translate(block.shiftFromLineStart, 0);
             // Let's calculate the sizes
             final (ui.Rect sourceRect, ui.Rect targetRect) = _calculateBlock(

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/painter.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/painter.dart
@@ -219,7 +219,7 @@ class DomCanvasParagraphPainter {
             _fillBlockText(layout, block as TextBlock);
           case StyleElements.decorations:
             // For decorations we need to shift to the start of the block
-            _paintContext.translate(block.shiftFromLineStart, 0);
+            _paintContext.translate(block.shiftFromLineStart, -line.fontBoundingBoxAscent);
             // Let's calculate the sizes
             final (ui.Rect sourceRect, ui.Rect targetRect) = _calculateBlock(
               block as TextBlock,

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/painter.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/painter.dart
@@ -49,33 +49,22 @@ void _resizePaintCanvas(double devicePixelRatio, ui.Rect rect) {
 
 /// Calculates the source (on Canvas2D) and target (on the output canvas) rectangles for the entire paragraph
 (ui.Rect sourceRect, ui.Rect targetRect) _calculateParagraph(
-  TextLayout layout,
+  WebParagraph paragraph,
   ui.Offset offset,
   double devicePixelRatio,
 ) {
-  final WebParagraph paragraph = layout.paragraph;
-
-  // Calculate the longest line taking in account the formatting shifts
-  var maxWidth = 0.0;
-  for (final TextLine line in layout.lines) {
-    final double lineWidth = line.fullWidth;
-    if (lineWidth > maxWidth) {
-      maxWidth = lineWidth;
-    }
-  }
-
   // Define the paragraph rect (using advances, not selected rects)
   // Source rect must take in account the scaling
   final sourceRect = ui.Rect.fromLTWH(
     0,
     0,
-    ((maxWidth + paragraph.paintOverflows.horizontal) * devicePixelRatio).ceilToDouble(),
-    ((paragraph.height + paragraph.paintOverflows.vertical) * devicePixelRatio).ceilToDouble(),
+    ((paragraph.actualBounds.width) * devicePixelRatio).ceilToDouble(),
+    ((paragraph.actualBounds.height) * devicePixelRatio).ceilToDouble(),
   );
   // Target rect will be scaled by the canvas transform, so we don't scale it here
   final targetRect = ui.Rect.fromLTWH(
-    (offset.dx - paragraph.paintOverflows.left).floorToDouble(),
-    (offset.dy - paragraph.paintOverflows.top).floorToDouble(),
+    (offset.dx + paragraph.actualBounds.left).floorToDouble(),
+    (offset.dy + paragraph.actualBounds.top).floorToDouble(),
     (sourceRect.width / devicePixelRatio).ceilToDouble(),
     (sourceRect.height / devicePixelRatio).ceilToDouble(),
   );
@@ -151,10 +140,14 @@ abstract class WebParagraphPainter {
 
   /// Paints the entire paragraph on Canvas2D
   void paint(ui.Canvas canvas, ui.Offset offset) {
+    if (_paragraph.text.isEmpty) {
+      return;
+    }
+
     final TextLayout layout = _paragraph.getLayout();
 
     final (ui.Rect sourceRect, ui.Rect targetRect) = _calculateParagraph(
-      layout,
+      _paragraph,
       offset,
       ui.window.devicePixelRatio,
     );
@@ -169,6 +162,9 @@ abstract class WebParagraphPainter {
       targetRect,
       generateParagraphImage: () {
         _resizePaintCanvas(ui.window.devicePixelRatio, sourceRect);
+
+        // We only want to paint the actual paint bounds of the paragraph.
+        _paintContext.translate(-_paragraph.actualBounds.left, -_paragraph.actualBounds.top);
 
         // Fill out all the blocks on Canvas2D canvas
         DomCanvasParagraphPainter._fillAllBlocks(StyleElements.shadows, layout);
@@ -203,10 +199,7 @@ class DomCanvasParagraphPainter {
     // Paint the entire paragraph as a single image on Canvas2D
     for (final TextLine line in layout.lines) {
       _paintContext.save();
-      _paintContext.translate(
-        line.formattingShift,
-        line.baseline + layout.paragraph.paintOverflows.top,
-      );
+      _paintContext.translate(line.formattingShift, line.baseline);
 
       for (final LineBlock block in line.visualBlocks) {
         if (block is PlaceholderBlock) {

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/painter.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/painter.dart
@@ -58,13 +58,13 @@ void _resizePaintCanvas(double devicePixelRatio, ui.Rect rect) {
   final sourceRect = ui.Rect.fromLTWH(
     0,
     0,
-    ((paragraph.actualBounds.width) * devicePixelRatio).ceilToDouble(),
-    ((paragraph.actualBounds.height) * devicePixelRatio).ceilToDouble(),
+    ((paragraph.paintBounds.width) * devicePixelRatio).ceilToDouble(),
+    ((paragraph.paintBounds.height) * devicePixelRatio).ceilToDouble(),
   );
   // Target rect will be scaled by the canvas transform, so we don't scale it here
   final targetRect = ui.Rect.fromLTWH(
-    (offset.dx + paragraph.actualBounds.left).floorToDouble(),
-    (offset.dy + paragraph.actualBounds.top).floorToDouble(),
+    (offset.dx + paragraph.paintBounds.left).floorToDouble(),
+    (offset.dy + paragraph.paintBounds.top).floorToDouble(),
     (sourceRect.width / devicePixelRatio).ceilToDouble(),
     (sourceRect.height / devicePixelRatio).ceilToDouble(),
   );
@@ -164,7 +164,7 @@ abstract class WebParagraphPainter {
         _resizePaintCanvas(ui.window.devicePixelRatio, sourceRect);
 
         // We only want to paint the actual paint bounds of the paragraph.
-        _paintContext.translate(-_paragraph.actualBounds.left, -_paragraph.actualBounds.top);
+        _paintContext.translate(-_paragraph.paintBounds.left, -_paragraph.paintBounds.top);
 
         // Fill out all the blocks on Canvas2D canvas
         DomCanvasParagraphPainter._fillAllBlocks(StyleElements.shadows, layout);

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/paragraph.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/paragraph.dart
@@ -881,8 +881,6 @@ class WebParagraph implements ui.Paragraph {
   @override
   double width = 0;
 
-  double fullWidth = 0;
-
   double maxLineWidthWithTrailingSpaces = 0; // without trailing spaces it would be longestLine
 
   List<TextLine> get lines => _layout.lines;

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/paragraph.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/paragraph.dart
@@ -888,7 +888,7 @@ class WebParagraph implements ui.Paragraph {
   List<TextLine> get lines => _layout.lines;
 
   /// The actual paint bounds of the paragraph.
-  late ui.Rect actualBounds;
+  late ui.Rect paintBounds;
 
   @override
   List<ui.TextBox> getBoxesForPlaceholders() => _layout.getBoxesForPlaceholders();

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/paragraph.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/paragraph.dart
@@ -847,13 +847,6 @@ class WebStrutStyle implements ui.StrutStyle {
   }
 }
 
-typedef PaintOverflows = ({double left, double top, double right, double bottom});
-
-extension PaintOverflowsSize on PaintOverflows {
-  double get horizontal => left + right;
-  double get vertical => top + bottom;
-}
-
 /// An implementation of [ui.Paragraph] based on the new Enhanced TextMetrics API.
 ///
 /// See: https://chromestatus.com/feature/5075532483657728
@@ -888,12 +881,14 @@ class WebParagraph implements ui.Paragraph {
   @override
   double width = 0;
 
+  double fullWidth = 0;
+
   double maxLineWidthWithTrailingSpaces = 0; // without trailing spaces it would be longestLine
 
   List<TextLine> get lines => _layout.lines;
 
-  /// The amount of overflow needed in each direction in order to paint all glyphs fully.
-  late PaintOverflows paintOverflows;
+  /// The actual paint bounds of the paragraph.
+  late ui.Rect actualBounds;
 
   @override
   List<ui.TextBox> getBoxesForPlaceholders() => _layout.getBoxesForPlaceholders();

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/paragraph.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/paragraph.dart
@@ -692,6 +692,19 @@ class TextSpan extends ParagraphSpan {
     );
   }
 
+  ui.Rect getBlockBounds(TextBlock block) {
+    final ui.Rect bounds = _metrics.getBounds(
+      block.textRange.start - start,
+      block.textRange.end - start,
+    );
+    return ui.Rect.fromLTWH(
+      bounds.left + block.spanShiftFromLineStart,
+      bounds.top,
+      bounds.width,
+      bounds.height,
+    );
+  }
+
   ui.Rect getBlockSelection(LineBlock block) {
     // This `selection` is relative to the span, but blocks should be positioned relative to the line.
     final ui.Rect selection = _metrics.getSelection(
@@ -834,6 +847,13 @@ class WebStrutStyle implements ui.StrutStyle {
   }
 }
 
+typedef PaintOverflows = ({double left, double top, double right, double bottom});
+
+extension PaintOverflowsSize on PaintOverflows {
+  double get horizontal => left + right;
+  double get vertical => top + bottom;
+}
+
 /// An implementation of [ui.Paragraph] based on the new Enhanced TextMetrics API.
 ///
 /// See: https://chromestatus.com/feature/5075532483657728
@@ -871,6 +891,9 @@ class WebParagraph implements ui.Paragraph {
   double maxLineWidthWithTrailingSpaces = 0; // without trailing spaces it would be longestLine
 
   List<TextLine> get lines => _layout.lines;
+
+  /// The amount of overflow needed in each direction in order to paint all glyphs fully.
+  late PaintOverflows paintOverflows;
 
   @override
   List<ui.TextBox> getBoxesForPlaceholders() => _layout.getBoxesForPlaceholders();

--- a/engine/src/flutter/lib/web_ui/test/webparagraph/paragraph_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/webparagraph/paragraph_test.dart
@@ -1211,4 +1211,41 @@ Future<void> testMain() async {
     await matchGoldenFile('web_paragraph.zoom_05.png', region: region);
     EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(1.0);
   });
+
+  test('paint overflows', () async {
+    final recorder = PictureRecorder();
+    const region = Rect.fromLTWH(0, 0, 1000, 500);
+    final canvas = Canvas(recorder, region);
+
+    // canvas.drawColor(const Color(0xFFFF0000), BlendMode.src);
+    final blackPaint = Paint()..color = const Color(0xFF000000);
+    final lightbluePaint = Paint()..color = const Color(0xFFDDEEFF);
+    final redPaint = Paint()..color = const Color(0xFFFF0000);
+
+    final paragraphStyle = ParagraphStyle();
+    final style = TextStyle(
+      foreground: blackPaint,
+      background: lightbluePaint,
+      fontSize: 40,
+      fontFamily: 'sans-serif',
+      fontStyle: FontStyle.italic,
+    );
+
+    final builder = ParagraphBuilder(paragraphStyle);
+    builder.pushStyle(style);
+    builder.addText('Top shelf');
+    builder.pop();
+    final Paragraph paragraph = builder.build();
+    paragraph.layout(const ParagraphConstraints(width: double.infinity));
+    final double fullWidth = paragraph.maxIntrinsicWidth;
+    paragraph.layout(ParagraphConstraints(width: fullWidth));
+    const offset = Offset(20, 20);
+    canvas.drawParagraph(paragraph, offset);
+
+    final paragraphRect = Rect.fromLTWH(offset.dx, offset.dy, fullWidth, paragraph.height);
+    canvas.drawRect(paragraphRect, redPaint..style = PaintingStyle.stroke);
+
+    await drawPictureUsingCurrentRenderer(recorder.endRecording());
+    await matchGoldenFile('web_paragraph.paint_overflows.png', region: paragraphRect.inflate(20.0));
+  });
 }

--- a/engine/src/flutter/lib/web_ui/test/webparagraph/paragraph_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/webparagraph/paragraph_test.dart
@@ -1248,7 +1248,7 @@ Future<void> testMain() async {
       final paragraphRect = Rect.fromLTWH(offset.dx, offset.dy, fullWidth, paragraph.height);
       canvas.drawRect(paragraphRect, redPaint..style = PaintingStyle.stroke);
 
-      final Rect paintRect = (paragraph as WebParagraph).actualBounds.shift(offset);
+      final Rect paintRect = (paragraph as WebParagraph).paintBounds.shift(offset);
       canvas.drawRect(paintRect, bluePaint..style = PaintingStyle.stroke);
 
       return paragraph;

--- a/engine/src/flutter/lib/web_ui/test/webparagraph/paragraph_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/webparagraph/paragraph_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:math' as math;
+
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
@@ -1221,31 +1223,51 @@ Future<void> testMain() async {
     final blackPaint = Paint()..color = const Color(0xFF000000);
     final lightbluePaint = Paint()..color = const Color(0xFFDDEEFF);
     final redPaint = Paint()..color = const Color(0xFFFF0000);
+    final bluePaint = Paint()..color = const Color(0xFF0000FF);
 
     final paragraphStyle = ParagraphStyle();
     final style = TextStyle(
       foreground: blackPaint,
       background: lightbluePaint,
-      fontSize: 40,
+      fontSize: 60,
       fontFamily: 'sans-serif',
       fontStyle: FontStyle.italic,
     );
 
-    final builder = ParagraphBuilder(paragraphStyle);
-    builder.pushStyle(style);
-    builder.addText('Top shelf');
-    builder.pop();
-    final Paragraph paragraph = builder.build();
-    paragraph.layout(const ParagraphConstraints(width: double.infinity));
-    final double fullWidth = paragraph.maxIntrinsicWidth;
-    paragraph.layout(ParagraphConstraints(width: fullWidth));
-    const offset = Offset(20, 20);
-    canvas.drawParagraph(paragraph, offset);
+    Paragraph drawParagraph(String text, Offset offset) {
+      final builder = ParagraphBuilder(paragraphStyle);
+      builder.pushStyle(style);
+      builder.addText(text);
+      builder.pop();
+      final Paragraph paragraph = builder.build();
+      paragraph.layout(const ParagraphConstraints(width: double.infinity));
+      final double fullWidth = paragraph.maxIntrinsicWidth;
+      paragraph.layout(ParagraphConstraints(width: fullWidth));
+      canvas.drawParagraph(paragraph, offset);
 
-    final paragraphRect = Rect.fromLTWH(offset.dx, offset.dy, fullWidth, paragraph.height);
-    canvas.drawRect(paragraphRect, redPaint..style = PaintingStyle.stroke);
+      final paragraphRect = Rect.fromLTWH(offset.dx, offset.dy, fullWidth, paragraph.height);
+      canvas.drawRect(paragraphRect, redPaint..style = PaintingStyle.stroke);
+
+      final Rect paintRect = (paragraph as WebParagraph).actualBounds.shift(offset);
+      canvas.drawRect(paintRect, bluePaint..style = PaintingStyle.stroke);
+
+      return paragraph;
+    }
+
+    var offset = const Offset(20, 20);
+    final Paragraph paragraph1 = drawParagraph('Top shelf', offset);
+    offset = offset.translate(0.0, paragraph1.height + 20.0);
+    final Paragraph paragraph2 = drawParagraph('no descent', offset);
 
     await drawPictureUsingCurrentRenderer(recorder.endRecording());
-    await matchGoldenFile('web_paragraph.paint_overflows.png', region: paragraphRect.inflate(20.0));
+    await matchGoldenFile(
+      'web_paragraph.paint_overflows.png',
+      region: Rect.fromLTWH(
+        0,
+        0,
+        offset.dx + math.max(paragraph1.maxIntrinsicWidth, paragraph2.maxIntrinsicWidth) + 20.0,
+        offset.dy + paragraph2.height + 20.0,
+      ),
+    );
   });
 }

--- a/engine/src/flutter/lib/web_ui/test/webparagraph/paragraph_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/webparagraph/paragraph_test.dart
@@ -956,24 +956,21 @@ Future<void> testMain() async {
       ellipsis: '...',
       maxLines: 1,
     );
-    final style30 = WebTextStyle(
-      foreground: blackPaint,
-      background: whitePaint,
-      fontSize: 30,
-      fontFamily: 'Roboto',
-    );
+    final style30 = WebTextStyle(foreground: blackPaint, background: whitePaint, fontSize: 40);
 
-    {
-      final builder = WebParagraphBuilder(paragraphStyle);
-      builder.pushStyle(style30);
-      builder.addText('This is a long text that should be ellipsized at the end');
-      builder.pop();
-      final WebParagraph paragraph = builder.build();
-      paragraph.layout(const ParagraphConstraints(width: 300));
-      paragraph.paint(canvas, const Offset(100, 100));
-    }
+    final builder = WebParagraphBuilder(paragraphStyle);
+    builder.pushStyle(style30);
+    builder.addText('This is a long text that should be ellipsized at the end');
+    builder.pop();
+    final WebParagraph paragraph = builder.build();
+    paragraph.layout(const ParagraphConstraints(width: 350));
+    paragraph.paint(canvas, const Offset(20, 20));
+
     await drawPictureUsingCurrentRenderer(recorder.endRecording());
-    await matchGoldenFile('web_paragraph.ellipsis_ltr.png', region: region);
+    await matchGoldenFile(
+      'web_paragraph.ellipsis_ltr.png',
+      region: const Rect.fromLTWH(0, 0, 500, 200),
+    );
   });
 
   test('Ellipsis RTL', () async {
@@ -992,25 +989,22 @@ Future<void> testMain() async {
       maxLines: 1,
       textDirection: TextDirection.rtl,
     );
-    final style30 = WebTextStyle(
-      foreground: blackPaint,
-      background: whitePaint,
-      fontSize: 30,
-      fontFamily: 'Roboto',
-    );
+    final style30 = WebTextStyle(foreground: blackPaint, background: whitePaint, fontSize: 40);
 
-    {
-      final builder = WebParagraphBuilder(paragraphStyle);
+    final builder = WebParagraphBuilder(paragraphStyle);
 
-      builder.pushStyle(style30);
-      builder.addText('إنالسيطرةعلىالعالمعبارةقبيحةللغاية-أفضلأنأسميهاتحسينالعالم');
-      builder.pop();
-      final WebParagraph paragraph = builder.build();
-      paragraph.layout(const ParagraphConstraints(width: 300));
-      paragraph.paint(canvas, const Offset(100, 100));
-    }
+    builder.pushStyle(style30);
+    builder.addText('إن السيطرة على العالم عبارة قبيحة للغاية - أفضل أن أسميها تحسين العالم');
+    builder.pop();
+    final WebParagraph paragraph = builder.build();
+    paragraph.layout(const ParagraphConstraints(width: 350));
+    paragraph.paint(canvas, const Offset(20, 20));
+
     await drawPictureUsingCurrentRenderer(recorder.endRecording());
-    await matchGoldenFile('web_paragraph.ellipsis_rtl.png', region: region);
+    await matchGoldenFile(
+      'web_paragraph.ellipsis_rtl.png',
+      region: const Rect.fromLTWH(0, 0, 500, 200),
+    );
   });
 
   test('MaxLines, no ellipsis', () async {


### PR DESCRIPTION
When a paragraph contains glyphs that extend beyond the bounds of the paragraph, they used to be cutoff. With this PR, we take glyph actual bounds into account when painting the paragraph.

This happens with the italic style when the last glyph is slanted beyond the width of the paragraph. It also happens with certain fonts that have very tall glyphs (example: [Homemade Apple](https://fonts.google.com/specimen/Homemade+Apple)).

| Before | After |
|-|-|
| <img width="200" height="86" alt="web_paragraph paint_overflows" src="https://github.com/user-attachments/assets/6ac913a1-f487-414d-8cda-2491f3ba82d6" /> | <img width="200" height="86" alt="web_paragraph paint_overflows" src="https://github.com/user-attachments/assets/2f3b7934-9f0b-48d0-aeea-1b259dd6f4a0" /> |

Part of https://github.com/flutter/flutter/issues/172561