### PR TITLE
Fix mismatch between hit-test tree and traversal tree

### DIFF
--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -112,8 +112,9 @@ typedef SemanticsUpdateCallback = void Function(SemanticsUpdate update);
 ///
 /// Use [ChildSemanticsConfigurationsResultBuilder] to generate the return
 /// value.
-typedef ChildSemanticsConfigurationsDelegate =
-    ChildSemanticsConfigurationsResult Function(List<SemanticsConfiguration>);
+typedef ChildSemanticsConfigurationsDelegate = ChildSemanticsConfigurationsResult Function(
+  List<SemanticsConfiguration>,
+);
 
 /// Controls how accessibility focus is blocked.
 ///

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -4055,6 +4055,48 @@ class SemanticsNode with DiagnosticableTreeMixin {
     return childrenInTraversalOrder;
   }
 
+  List<SemanticsNode> _childrenInHitTestOrder() {
+    if (_children == null) {
+      return const <SemanticsNode>[];
+    }
+    // If the child node is a traversal child, but the current node is
+    // not a traversal parent, it means the child node should be
+    // grafted to be a child of a traversal parent node that has the
+    // same identifier as the child. However, if the traversal parent is not
+    // in the tree, after grafting, the child will not be in the tree as well.
+    // To keep the hit-test tree match the traversal tree, we also skip this
+    // node in childrenInHitTestOrder. Otherwise, the number of nodes in two
+    // trees will be different and user might accidentally hit test a node
+    // that will never be traversed.
+    bool shouldSkipInHitTest(SemanticsNode child) {
+      if (child._isTraversalChild && !_isTraversalParent) {
+        final SemanticsNode? traversalParent =
+            owner!._traversalParentNodes[child.getSemanticsData().traversalChildIdentifier];
+        return traversalParent == null;
+      }
+      return false;
+    }
+
+    final filtered = <SemanticsNode>[];
+    for (final SemanticsNode child in _children!) {
+      if (!shouldSkipInHitTest(child)) {
+        filtered.add(child);
+      }
+    }
+    return filtered;
+  }
+
+  Int32List _childrenIdInHitTestOrder() {
+    final List<SemanticsNode> children = _childrenInHitTestOrder();
+    final childrenInHitTestOrder = Int32List(children.length);
+    var index = 0;
+    for (int i = children.length - 1; i >= 0; i -= 1) {
+      childrenInHitTestOrder[index] = children[i].id;
+      index += 1;
+    }
+    return childrenInHitTestOrder;
+  }
+
   void _addToUpdate(SemanticsUpdateBuilder builder, Set<int> customSemanticsActionIdsUpdate) {
     assert(_dirty);
     final SemanticsData data = getSemanticsData();
@@ -4093,14 +4135,7 @@ class SemanticsNode with DiagnosticableTreeMixin {
       }
     } else {
       childrenInTraversalOrder = _childrenIdInTraversalOrder();
-
-      final int childCount = _children!.length;
-      // _children is sorted in paint order, so we invert it to get the hit test
-      // order.
-      childrenInHitTestOrder = Int32List(childCount);
-      for (int i = childCount - 1; i >= 0; i -= 1) {
-        childrenInHitTestOrder[i] = _children![childCount - i - 1].id;
-      }
+      childrenInHitTestOrder = _childrenIdInHitTestOrder();
     }
 
     Int32List? customSemanticsActionIds;
@@ -4539,7 +4574,7 @@ class SemanticsNode with DiagnosticableTreeMixin {
     }
 
     return switch (childOrder) {
-      DebugSemanticsDumpOrder.inverseHitTest => _children!,
+      DebugSemanticsDumpOrder.inverseHitTest => _childrenInHitTestOrder(),
       DebugSemanticsDumpOrder.traversalOrder => _childrenInTraversalOrder(),
     };
   }

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -4069,6 +4069,9 @@ class SemanticsNode with DiagnosticableTreeMixin {
     // trees will be different and user might accidentally hit test a node
     // that will never be traversed.
     bool shouldSkipInHitTest(SemanticsNode child) {
+      if (kIsWeb) {
+        return false;
+      }
       if (child._isTraversalChild && !_isTraversalParent) {
         final SemanticsNode? traversalParent =
             owner!._traversalParentNodes[child.getSemanticsData().traversalChildIdentifier];

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -4082,7 +4082,7 @@ class SemanticsNode with DiagnosticableTreeMixin {
 
   Int32List _childrenIdInHitTestOrder() {
     final List<SemanticsNode> children = _childrenInHitTestOrder();
-    return Int32List.fromList(children.reversed.map<int>((SemanticsNode c) => c.id).toList());
+    return Int32List.fromList(children.reversed.map<int>((SemanticsNode node) => node.id).toList());
   }
 
   void _addToUpdate(SemanticsUpdateBuilder builder, Set<int> customSemanticsActionIdsUpdate) {

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -4059,45 +4059,29 @@ class SemanticsNode with DiagnosticableTreeMixin {
     if (_children == null) {
       return const <SemanticsNode>[];
     }
-    // If the child node is a traversal child, but the current node is
-    // not a traversal parent, it means the child node should be
-    // grafted to be a child of a traversal parent node that has the
-    // same identifier as the child. However, if the traversal parent is not
-    // in the tree, after grafting, the child will not be in the tree as well.
-    // To keep the hit-test tree match the traversal tree, we also skip this
-    // node in childrenInHitTestOrder. Otherwise, the number of nodes in two
-    // trees will be different and user might accidentally hit test a node
-    // that will never be traversed.
-    bool shouldSkipInHitTest(SemanticsNode child) {
-      if (kIsWeb) {
-        return false;
-      }
-      if (child._isTraversalChild && !_isTraversalParent) {
-        final SemanticsNode? traversalParent =
-            owner!._traversalParentNodes[child.getSemanticsData().traversalChildIdentifier];
-        return traversalParent == null;
-      }
-      return false;
+    if (kIsWeb || _isTraversalParent) {
+      return _children!;
     }
 
-    final filtered = <SemanticsNode>[];
-    for (final SemanticsNode child in _children!) {
-      if (!shouldSkipInHitTest(child)) {
-        filtered.add(child);
+    // If a child node is not in the traversal tree after grafting, it is
+    // dropped from the hit-test tree to keep the two trees in sync.
+    // Otherwise, the user might accidentally hit test a node that cannot
+    // be traversed.
+    bool shouldNotSkipInHitTest(SemanticsNode child) {
+      if (child._isTraversalChild) {
+        final SemanticsNode? traversalParent =
+            owner!._traversalParentNodes[child.getSemanticsData().traversalChildIdentifier];
+        return traversalParent != null;
       }
+      return true;
     }
-    return filtered;
+
+    return _children!.where(shouldNotSkipInHitTest).toList();
   }
 
   Int32List _childrenIdInHitTestOrder() {
     final List<SemanticsNode> children = _childrenInHitTestOrder();
-    final childrenInHitTestOrder = Int32List(children.length);
-    var index = 0;
-    for (int i = children.length - 1; i >= 0; i -= 1) {
-      childrenInHitTestOrder[index] = children[i].id;
-      index += 1;
-    }
-    return childrenInHitTestOrder;
+    return Int32List.fromList(children.reversed.map<int>((SemanticsNode c) => c.id).toList());
   }
 
   void _addToUpdate(SemanticsUpdateBuilder builder, Set<int> customSemanticsActionIdsUpdate) {

--- a/packages/flutter/test/semantics/semantics_update_test.dart
+++ b/packages/flutter/test/semantics/semantics_update_test.dart
@@ -19,6 +19,7 @@ typedef SemanticsNodeUpdateObservation = ({
   String hint,
   List<StringAttribute>? hintAttributes,
   Int32List childrenInTraversalOrder,
+  Int32List childrenInHitTestOrder,
   Float64List transform,
 });
 
@@ -267,6 +268,43 @@ void main() {
     handle.dispose();
   }, skip: kIsWeb); // intended: the web engine handles the transform calculation itself.
 
+  testWidgets(
+    'Semantics update does not leak nodes to hit-test order when traversal parent is missing',
+    (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      // Pumps a placeholder to trigger the warm up frame.
+      await tester.pumpWidget(const Placeholder(), phase: EnginePhase.build);
+      SemanticsUpdateBuilderSpy.observations.clear();
+
+      const identifier = '111';
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Column(
+            children: <Widget>[
+              Semantics(
+                traversalChildIdentifier: identifier,
+                child: const SizedBox.square(dimension: 10),
+              ),
+              const SizedBox.square(dimension: 10),
+            ],
+          ),
+        ),
+      );
+
+      // SemanticsNode#0 (root) should have 0 children in both traversal order and hit-test order.
+      final SemanticsNodeUpdateObservation? rootObservation =
+          SemanticsUpdateBuilderSpy.observations[0];
+      expect(rootObservation, isNotNull);
+      expect(rootObservation!.childrenInTraversalOrder, isEmpty);
+      expect(rootObservation.childrenInHitTestOrder, isEmpty);
+
+      SemanticsUpdateBuilderSpy.observations.clear();
+      handle.dispose();
+    },
+    skip: kIsWeb,
+  );
+
   testWidgets('Semantics update removes detached OverlayPortal traversal child', (
     WidgetTester tester,
   ) async {
@@ -413,6 +451,7 @@ class SemanticsUpdateBuilderSpy extends Fake implements ui.SemanticsUpdateBuilde
       value: value,
       valueAttributes: valueAttributes,
       childrenInTraversalOrder: childrenInTraversalOrder,
+      childrenInHitTestOrder: childrenInHitTestOrder,
       transform: transform,
     );
   }

--- a/packages/flutter/test/semantics/semantics_update_test.dart
+++ b/packages/flutter/test/semantics/semantics_update_test.dart
@@ -302,7 +302,7 @@ void main() {
       SemanticsUpdateBuilderSpy.observations.clear();
       handle.dispose();
     },
-    skip: kIsWeb,
+    skip: kIsWeb, // intended: the web engine handles the tree grafting itself.
   );
 
   testWidgets('Semantics update removes detached OverlayPortal traversal child', (

--- a/packages/flutter/test/semantics/semantics_update_test.dart
+++ b/packages/flutter/test/semantics/semantics_update_test.dart
@@ -302,7 +302,7 @@ void main() {
       SemanticsUpdateBuilderSpy.observations.clear();
       handle.dispose();
     },
-    skip: kIsWeb, // intended: the web engine handles the tree grafting itself.
+    skip: kIsWeb, // [intended] the web engine handles the tree grafting itself.
   );
 
   testWidgets('Semantics update removes detached OverlayPortal traversal child', (


### PR DESCRIPTION
This PR is to update hit-test tree to make sure traversal tree and hit-test tree have the same number of nodes, even though they can have different shapes.

In OverlayPortal, if the child node is a traversal child, but the current node is not a traversal parent, it means the child node should be grafted to be a child of a traversal parent node that has the same identifier as the child. However, if the traversal parent is not in the tree, after grafting, the child will not be in the tree as well. To keep the hit-test tree match the traversal tree, we also skip this node in childrenInHitTestOrder. Otherwise, the number of nodes in two trees will be different and user might accidentally hit test a node that will never be traversed.

Fixes https://github.com/flutter/flutter/issues/184898

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
