### PR TITLE
Avoid detached platform view placeholder callbacks

### DIFF
--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -1610,6 +1610,11 @@ class _PlatformViewPlaceholderBox extends RenderConstrainedBox {
     super.performLayout();
     // A call to `localToGlobal` requires waiting for a frame to render first.
     SchedulerBinding.instance.addPostFrameCallback((_) {
+      // The render object can be detached before this callback runs, for
+      // example when a viewport garbage-collects it during fast scrolling.
+      if (!attached) {
+        return;
+      }
       onLayout(size, localToGlobal(Offset.zero));
     }, debugLabel: 'PlatformViewPlaceholderBox.onLayout');
   }

--- a/packages/flutter/test/widgets/platform_view_test.dart
+++ b/packages/flutter/test/widgets/platform_view_test.dart
@@ -3904,6 +3904,54 @@ void main() {
       expect(() => creationParams.onPlatformViewCreated(creationParams.id), returnsNormally);
     });
 
+    testWidgets('PlatformViewLink placeholder does not crash when detached during fast scroll', (
+      WidgetTester tester,
+    ) async {
+      final scrollController = ScrollController();
+      addTearDown(scrollController.dispose);
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: ListView.builder(
+            controller: scrollController,
+            // Do not use itemExtent. That would use RenderSliverFixedExtentList,
+            // which garbage-collects before layout. RenderSliverList lays out
+            // children first, then garbage-collects them, which reproduces this
+            // bug.
+            itemCount: 200,
+            itemBuilder: (BuildContext context, int index) {
+              return SizedBox(
+                height: 100,
+                child: PlatformViewLink(
+                  viewType: 'webview',
+                  onCreatePlatformView: (PlatformViewCreationParams params) {
+                    final controller = FakeAndroidViewController(params.id, requiresSize: true);
+                    controller.create();
+                    // Leave the platform view in the placeholder state so the
+                    // placeholder render object remains active during layout.
+                    return controller;
+                  },
+                  surfaceFactory: (BuildContext context, PlatformViewController controller) {
+                    return PlatformViewSurface(
+                      gestureRecognizers: const <Factory<OneSequenceGestureRecognizer>>{},
+                      controller: controller,
+                      hitTestBehavior: PlatformViewHitTestBehavior.opaque,
+                    );
+                  },
+                ),
+              );
+            },
+          ),
+        ),
+      );
+
+      scrollController.jumpTo(5000);
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+    });
+
     testWidgets('PlatformViewLink widget survives widget tree change', (WidgetTester tester) async {
       final GlobalKey key = GlobalKey();
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();

--- a/packages/flutter/test/widgets/selectable_region_scroll_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_scroll_test.dart
@@ -1,0 +1,42 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'widgets_app_tester.dart';
+
+void main() {
+  // Regression test for https://github.com/flutter/flutter/issues/122680.
+  testWidgets(
+    'SelectableRegion in ListView.builder scrolls without error on desktop web',
+    (WidgetTester tester) async {
+      final scrollController = ScrollController();
+      addTearDown(scrollController.dispose);
+
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: ListView.builder(
+            controller: scrollController,
+            itemCount: 200,
+            itemBuilder: (BuildContext context, int index) {
+              return SelectableRegion(
+                selectionControls: emptyTextSelectionControls,
+                child: Text('Item $index\nLine 2\nLine 3'),
+              );
+            },
+          ),
+        ),
+      );
+
+      scrollController.jumpTo(5000);
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+    },
+    variant: TargetPlatformVariant.desktop(),
+    skip: !kIsWeb, // [intended] This test verifies web desktop behavior.
+  );
+}


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/122680

## What changed

`_PlatformViewPlaceholderBox.performLayout` schedules its `localToGlobal` call in a post-frame callback. During fast scrolling, a viewport can garbage-collect the placeholder render object before that callback runs. This checks `attached` before reading the global position.

The web-facing `SelectableRegion` regression now lives in a focused test file so the PR does not reformat the large existing `selectable_region_test.dart` file.

## Tests

Added regression coverage for:

- `PlatformViewLink` placeholders detached during a fast scroll.
- The reported web surface: `SelectableRegion` in a `ListView.builder` on desktop web.

Verified locally:

- Before the fix, the new `PlatformViewLink` regression failed with the `RenderObject.getTransformTo` attached assertion.
- `./bin/flutter test packages/flutter/test/widgets/platform_view_test.dart --plain-name 'PlatformViewLink placeholder does not crash when detached during fast scroll'`
- `./bin/flutter test packages/flutter/test/widgets/selectable_region_scroll_test.dart`
- From `packages/flutter`: `../../bin/flutter test --platform chrome test/widgets/selectable_region_scroll_test.dart`
- `./bin/flutter analyze packages/flutter/lib/src/widgets/platform_view.dart packages/flutter/test/widgets/platform_view_test.dart packages/flutter/test/widgets/selectable_region_scroll_test.dart`
- `./bin/dart --enable-asserts dev/tools/bin/format.dart`
- `git diff upstream/main...HEAD --check`
