### PR TITLE
Respect disallowed stretch on fling end

### DIFF
--- a/packages/flutter/lib/src/widgets/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/widgets/overscroll_indicator.dart
@@ -724,7 +724,10 @@ class _StretchingOverscrollIndicatorState extends State<StretchingOverscrollIndi
       // from a different axis bubbles up, do nothing.
       return false;
     }
-    if (notification is OverscrollNotification) {
+    if (notification is ScrollStartNotification) {
+      _accepted = true;
+      _totalOverscroll = 0.0;
+    } else if (notification is OverscrollNotification) {
       _lastOverscrollNotification = notification;
       if (_lastNotification.runtimeType is! OverscrollNotification) {
         final confirmationNotification = OverscrollIndicatorNotification(
@@ -770,7 +773,9 @@ class _StretchingOverscrollIndicatorState extends State<StretchingOverscrollIndi
 
       // Since the overscrolling ended, we reset the total overscroll amount.
       _totalOverscroll = 0.0;
-      _stretchController.scrollEnd(velocity);
+      if (_accepted) {
+        _stretchController.scrollEnd(velocity);
+      }
     } else if (notification is ScrollUpdateNotification) {
       _totalOverscroll = 0.0;
       _stretchController.scrollEnd(0.0);

--- a/packages/flutter/test/widgets/overscroll_stretch_indicator_test.dart
+++ b/packages/flutter/test/widgets/overscroll_stretch_indicator_test.dart
@@ -9,6 +9,7 @@ library;
 
 import 'dart:ui' as ui;
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -597,6 +598,105 @@ void main() {
 
     await gesture.up();
     await tester.pumpAndSettle();
+  });
+
+  testWidgets('Disallow stretching overscroll during a fling', (WidgetTester tester) async {
+    final GlobalKey box1Key = GlobalKey();
+    final GlobalKey box2Key = GlobalKey();
+    final GlobalKey box3Key = GlobalKey();
+    final controller = ScrollController();
+    addTearDown(controller.dispose);
+
+    double indicatorNotification = 0;
+    await tester.pumpWidget(
+      NotificationListener<OverscrollIndicatorNotification>(
+        onNotification: (OverscrollIndicatorNotification notification) {
+          notification.disallowIndicator();
+          indicatorNotification += 1;
+          return false;
+        },
+        child: buildTest(box1Key, box2Key, box3Key, controller),
+      ),
+    );
+
+    expect(find.byType(StretchingOverscrollIndicator), findsOneWidget);
+    expect(find.byType(GlowingOverscrollIndicator), findsNothing);
+    expect(indicatorNotification, 0.0);
+
+    controller.jumpTo(controller.position.maxScrollExtent);
+    await tester.pump();
+
+    final Drag drag = controller.position.drag(DragStartDetails(), () {});
+    drag.update(
+      DragUpdateDetails(
+        globalPosition: Offset.zero,
+        delta: const Offset(0.0, -5000.0),
+        primaryDelta: -5000.0,
+      ),
+    );
+    drag.end(
+      DragEndDetails(
+        velocity: const Velocity(pixelsPerSecond: Offset(0.0, -5000.0)),
+        primaryVelocity: -5000.0,
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 16));
+
+    expect(indicatorNotification, 1.0);
+    expect(findStretchEffect(tester).stretchStrength, 0.0);
+  });
+
+  testWidgets('Disallowed stretch does not persist into a new scroll sequence', (
+    WidgetTester tester,
+  ) async {
+    final GlobalKey box1Key = GlobalKey();
+    final GlobalKey box2Key = GlobalKey();
+    final GlobalKey box3Key = GlobalKey();
+    final controller = ScrollController();
+    addTearDown(controller.dispose);
+
+    var disallowStretch = true;
+    double indicatorNotification = 0;
+    await tester.pumpWidget(
+      NotificationListener<OverscrollIndicatorNotification>(
+        onNotification: (OverscrollIndicatorNotification notification) {
+          if (disallowStretch) {
+            notification.disallowIndicator();
+          }
+          indicatorNotification += 1;
+          return false;
+        },
+        child: buildTest(box1Key, box2Key, box3Key, controller),
+      ),
+    );
+
+    expect(find.byType(StretchingOverscrollIndicator), findsOneWidget);
+    expect(find.byType(GlowingOverscrollIndicator), findsNothing);
+    expect(indicatorNotification, 0.0);
+
+    final TestGesture disallowedGesture = await tester.startGesture(
+      tester.getCenter(find.byType(CustomScrollView)),
+    );
+    await disallowedGesture.moveBy(const Offset(0.0, 200.0));
+    await tester.pumpAndSettle();
+    await disallowedGesture.up();
+    await tester.pumpAndSettle();
+
+    expect(indicatorNotification, 1.0);
+    expect(findStretchEffect(tester).stretchStrength, 0.0);
+
+    disallowStretch = false;
+    controller.jumpTo(controller.position.maxScrollExtent / 2.0);
+    await tester.pump();
+
+    await tester.fling(find.byType(CustomScrollView), const Offset(0.0, -50.0), 10000.0);
+    await tester.pump(const Duration(milliseconds: 100));
+    await tester.pump(const Duration(milliseconds: 100));
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(indicatorNotification, 2.0);
+    expect(findStretchEffect(tester).stretchStrength, isNot(0.0));
   });
 
   testWidgets('Stretch does not overflow bounds of container', (WidgetTester tester) async {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/186484

## Issue

`StretchingOverscrollIndicator` honors `OverscrollIndicatorNotification.disallowIndicator()` for drag overscroll notifications, but the release path still passed the drag-end velocity to `_StretchController.scrollEnd`. A quick fling could therefore start a stretch animation after the indicator was disallowed.

## Fix

The scroll-end stretch animation now runs only when the current overscroll sequence was accepted. The accepted state is reset when a new `ScrollStartNotification` arrives so a disallowed sequence does not block later independent scroll sequences.

## Tests

Added regression coverage for:

- A fast fling past the trailing edge after a listener calls `disallowIndicator()`.
- A disallowed drag sequence followed by a new accepted fling from the middle of the scroll range.

Verified locally:

- Before the reset fix, `Disallowed stretch does not persist into a new scroll sequence` failed with `Expected: not <0.0>` and `Actual: <-0.0>`.
- `./bin/flutter test packages/flutter/test/widgets/overscroll_stretch_indicator_test.dart --name 'Disallow stretching overscroll|Disallowed stretch does not persist into a new scroll sequence'`
- `./bin/flutter analyze packages/flutter/lib/src/widgets/overscroll_indicator.dart packages/flutter/test/widgets/overscroll_stretch_indicator_test.dart`
- `./bin/dart format --output=none --set-exit-if-changed packages/flutter/lib/src/widgets/overscroll_indicator.dart packages/flutter/test/widgets/overscroll_stretch_indicator_test.dart`
- `git diff --check`

I previously ran the full `overscroll_stretch_indicator_test.dart`; it hit existing local golden mismatches in the horizontal stretch golden tests, unrelated to this non-golden disallow regression.

## Risk

Two-file framework/test change. The behavior change is scoped to the disallowed overscroll path and resets the accepted flag at the start of each new scroll sequence; accepted overscroll sequences still call `scrollEnd` as before.
