### PR TITLE
Add Semantics custom control sample

### DIFF
--- a/examples/api/lib/widgets/basic/semantics.0.dart
+++ b/examples/api/lib/widgets/basic/semantics.0.dart
@@ -8,9 +8,9 @@ import 'package:flutter/services.dart';
 /// Flutter code sample for a custom button that uses [Semantics].
 ///
 /// This sample shows how to expose a custom interactive control as a button to
-/// assistive technologies. [Semantics] supplies the button role, enabled state,
-/// and tap action, while [FocusableActionDetector] and [GestureDetector] handle
-/// keyboard focus, hover, shortcuts, and pointer taps.
+/// assistive technologies. [Semantics] supplies the button role and enabled
+/// state, while [FocusableActionDetector] and [GestureDetector] handle keyboard
+/// focus, hover, shortcuts, and taps.
 
 void main() => runApp(const SemanticsExampleApp());
 
@@ -109,7 +109,6 @@ class _AccessibleButtonState extends State<AccessibleButton> {
       button: true,
       container: true,
       enabled: _enabled,
-      onTap: _enabled ? _activate : null,
       child: FocusableActionDetector(
         enabled: _enabled,
         actions: <Type, Action<Intent>>{
@@ -130,9 +129,6 @@ class _AccessibleButtonState extends State<AccessibleButton> {
         onShowFocusHighlight: _handleFocusHighlight,
         onShowHoverHighlight: _handleHoverHighlight,
         child: GestureDetector(
-          // The enclosing Semantics widget supplies the button role and semantic
-          // tap action, so this detector only handles pointer input.
-          excludeFromSemantics: true,
           onTap: _enabled ? _activate : null,
           child: DecoratedBox(
             decoration: BoxDecoration(

--- a/examples/api/lib/widgets/basic/semantics.0.dart
+++ b/examples/api/lib/widgets/basic/semantics.0.dart
@@ -1,0 +1,161 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// Flutter code sample for a custom button that uses [Semantics].
+///
+/// This sample shows how to expose a custom interactive control as a button to
+/// assistive technologies. [Semantics] supplies the button role, enabled state,
+/// and tap action, while [FocusableActionDetector] and [GestureDetector] handle
+/// keyboard focus, hover, shortcuts, and pointer taps.
+
+void main() => runApp(const SemanticsExampleApp());
+
+class SemanticsExampleApp extends StatelessWidget {
+  const SemanticsExampleApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(home: SemanticsExample());
+  }
+}
+
+class SemanticsExample extends StatefulWidget {
+  const SemanticsExample({super.key});
+
+  @override
+  State<SemanticsExample> createState() => _SemanticsExampleState();
+}
+
+class _SemanticsExampleState extends State<SemanticsExample> {
+  int _count = 0;
+
+  void _increment() {
+    setState(() {
+      _count += 1;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Semantics Sample')),
+      body: Center(
+        child: AccessibleButton(
+          onPressed: _increment,
+          child: Text('Count: $_count'),
+        ),
+      ),
+    );
+  }
+}
+
+class AccessibleButton extends StatefulWidget {
+  const AccessibleButton({
+    super.key,
+    required this.onPressed,
+    required this.child,
+  });
+
+  final VoidCallback? onPressed;
+  final Widget child;
+
+  @override
+  State<AccessibleButton> createState() => _AccessibleButtonState();
+}
+
+class _AccessibleButtonState extends State<AccessibleButton> {
+  bool _focused = false;
+  bool _hovering = false;
+
+  bool get _enabled => widget.onPressed != null;
+
+  void _activate() {
+    widget.onPressed?.call();
+  }
+
+  void _handleFocusHighlight(bool value) {
+    setState(() {
+      _focused = value;
+    });
+  }
+
+  void _handleHoverHighlight(bool value) {
+    setState(() {
+      _hovering = value;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    final Color background;
+    final Color foreground;
+    if (!_enabled) {
+      background = colors.surfaceContainerHighest;
+      foreground = colors.onSurfaceVariant;
+    } else if (_hovering) {
+      background = colors.primaryContainer;
+      foreground = colors.onPrimaryContainer;
+    } else {
+      background = colors.primary;
+      foreground = colors.onPrimary;
+    }
+
+    return Semantics(
+      button: true,
+      container: true,
+      enabled: _enabled,
+      onTap: _enabled ? _activate : null,
+      child: FocusableActionDetector(
+        enabled: _enabled,
+        actions: <Type, Action<Intent>>{
+          ActivateIntent: CallbackAction<Intent>(
+            onInvoke: (Intent intent) {
+              _activate();
+              return null;
+            },
+          ),
+        },
+        shortcuts: const <ShortcutActivator, Intent>{
+          SingleActivator(LogicalKeyboardKey.enter): ActivateIntent(),
+          SingleActivator(LogicalKeyboardKey.space): ActivateIntent(),
+        },
+        mouseCursor: _enabled
+            ? SystemMouseCursors.click
+            : SystemMouseCursors.basic,
+        onShowFocusHighlight: _handleFocusHighlight,
+        onShowHoverHighlight: _handleHoverHighlight,
+        child: GestureDetector(
+          // The enclosing Semantics widget supplies the button role and semantic
+          // tap action, so this detector only handles pointer input.
+          excludeFromSemantics: true,
+          onTap: _enabled ? _activate : null,
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: background,
+              border: Border.all(
+                color: _focused ? colors.secondary : Colors.transparent,
+                width: 3,
+              ),
+              borderRadius: BorderRadius.circular(6),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              child: DefaultTextStyle(
+                style: TextStyle(
+                  color: foreground,
+                  fontWeight: FontWeight.bold,
+                ),
+                child: widget.child,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/examples/api/test/widgets/basic/semantics.0_test.dart
+++ b/examples/api/test/widgets/basic/semantics.0_test.dart
@@ -1,0 +1,61 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_api_samples/widgets/basic/semantics.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Finder semanticsButton() {
+    return find.byWidgetPredicate(
+      (Widget widget) =>
+          widget is Semantics && widget.properties.button == true,
+    );
+  }
+
+  testWidgets('custom button has button semantics', (
+    WidgetTester tester,
+  ) async {
+    final SemanticsHandle handle = tester.ensureSemantics();
+    try {
+      await tester.pumpWidget(const example.SemanticsExampleApp());
+
+      expect(
+        tester.getSemantics(semanticsButton()),
+        matchesSemantics(
+          label: 'Count: 0',
+          hasTapAction: true,
+          hasFocusAction: true,
+          isButton: true,
+          isFocusable: true,
+          hasEnabledState: true,
+          isEnabled: true,
+        ),
+      );
+    } finally {
+      handle.dispose();
+    }
+  });
+
+  testWidgets('custom button responds to tap and keyboard activation', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const example.SemanticsExampleApp());
+
+    expect(find.text('Count: 0'), findsOneWidget);
+
+    await tester.tap(find.text('Count: 0'));
+    await tester.pump();
+
+    expect(find.text('Count: 1'), findsOneWidget);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pump();
+
+    expect(find.text('Count: 2'), findsOneWidget);
+  });
+}

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -7781,6 +7781,23 @@ class MetaData extends SingleChildRenderObjectWidget {
 /// {@youtube 560 315 https://www.youtube.com/watch?v=NvtMt_DtFrQ}
 ///
 /// {@macro flutter.widgets.SemanticsBase}
+///
+/// [GestureDetector] adds semantic tap actions automatically when possible. Use
+/// [Semantics] when a custom control also needs to describe a role, enabled
+/// state, or other semantic properties that the gesture alone does not provide.
+/// If [Semantics] supplies the semantic action, for example with
+/// [SemanticsProperties.onTap], set [GestureDetector.excludeFromSemantics] to
+/// true on the pointer detector to avoid exposing duplicate semantic actions.
+///
+/// {@tool dartpad}
+/// This example shows a custom button that uses [Semantics] to expose a button
+/// role, enabled state, and tap action, [FocusableActionDetector] to handle
+/// focus, hover, and keyboard activation, and [GestureDetector] to handle
+/// pointer taps.
+///
+/// ** See code in examples/api/lib/widgets/basic/semantics.0.dart **
+/// {@end-tool}
+///
 ///  * [SliverSemantics], the sliver variant of this widget.
 @immutable
 class Semantics extends _SemanticsBase {


### PR DESCRIPTION
Fixes #118137

## Summary

- document when `Semantics` is needed for custom interactive controls beyond `GestureDetector`'s automatic tap semantics
- add a Semantics API sample that exposes a button role, enabled state, tap action, focus/hover handling, keyboard activation, and pointer taps
- add API sample tests for semantics, tap, and keyboard activation

## Tests

- `./bin/dart format --output=none --set-exit-if-changed packages/flutter/lib/src/widgets/basic.dart examples/api/lib/widgets/basic/semantics.0.dart examples/api/test/widgets/basic/semantics.0_test.dart`
- `./bin/flutter test examples/api/test/widgets/basic/semantics.0_test.dart`
- `./bin/flutter analyze packages/flutter/lib/src/widgets/basic.dart packages/flutter/lib/src/widgets/actions.dart examples/api/lib/widgets/basic/semantics.0.dart examples/api/test/widgets/basic/semantics.0_test.dart`
- `./bin/dart --enable-asserts dev/bots/analyze_snippet_code.dart packages/flutter/lib/src/widgets`
- `git diff --check`
