### PR TITLE
Improve async dispose diagnostics

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1299,6 +1299,10 @@ abstract class State<T extends StatefulWidget> with Diagnosticable {
   /// Implementations of this method should end with a call to the inherited
   /// method, as in `super.dispose()`.
   ///
+  /// This method must not be marked `async`. If a subclass starts asynchronous
+  /// work from this method, it must not wait for the work to complete before
+  /// calling `super.dispose()` synchronously.
+  ///
   /// ## Caveats
   ///
   /// This method is _not_ invoked at times where a developer might otherwise
@@ -6027,7 +6031,21 @@ class StatefulElement extends ComponentElement {
   @override
   void unmount() {
     super.unmount();
-    state.dispose();
+    final Object? debugCheckForReturnedFuture = state.dispose() as dynamic;
+    assert(() {
+      if (debugCheckForReturnedFuture is Future) {
+        throw FlutterError.fromParts(<DiagnosticsNode>[
+          ErrorSummary('${state.runtimeType}.dispose() returned a Future.'),
+          ErrorDescription('State.dispose() must be a void method without an `async` keyword.'),
+          ErrorHint(
+            'Rather than awaiting on asynchronous work directly inside of dispose, '
+            'call a separate method to do this work without awaiting it, and call '
+            'super.dispose() synchronously.',
+          ),
+        ]);
+      }
+      return true;
+    }());
     assert(() {
       if (state._debugLifecycleState == _StateLifecycle.defunct) {
         return true;

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -1222,6 +1222,21 @@ void main() {
     }, throwsFlutterError);
   });
 
+  testWidgets('Async State.dispose throws a targeted FlutterError', (WidgetTester tester) async {
+    await tester.pumpWidget(const _AsyncDisposeWidget());
+
+    await tester.pumpWidget(const SizedBox());
+
+    final dynamic exception = tester.takeException();
+    expect(exception, isFlutterError);
+    expect(exception.toString(), contains('_AsyncDisposeWidgetState.dispose() returned a Future.'));
+    expect(
+      exception.toString(),
+      contains('State.dispose() must be a void method without an `async` keyword.'),
+    );
+    expect(exception.toString(), contains('call super.dispose() synchronously.'));
+  });
+
   testWidgets('State toString', (WidgetTester tester) async {
     final state = TestState();
     expect(state.toString(), contains('no widget'));
@@ -2444,6 +2459,25 @@ class _StatefulWidgetSpyState extends State<StatefulWidgetSpy> {
     widget.onBuild?.call(context);
     return widget.child;
   }
+}
+
+class _AsyncDisposeWidget extends StatefulWidget {
+  const _AsyncDisposeWidget();
+
+  @override
+  State<_AsyncDisposeWidget> createState() => _AsyncDisposeWidgetState();
+}
+
+class _AsyncDisposeWidgetState extends State<_AsyncDisposeWidget> {
+  @override
+  // ignore: avoid_void_async, intentionally verifies the framework diagnostic.
+  void dispose() async {
+    await Future<void>.value();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const SizedBox();
 }
 
 class RenderObjectWidgetSpy extends LeafRenderObjectWidget {


### PR DESCRIPTION
Fixes #148031

## Summary
- detect async State.dispose overrides that return a Future and report a targeted FlutterError
- clarify in State.dispose docs that implementations must not be marked async and must call super.dispose() synchronously
- add a focused framework regression test for the new diagnostic

## Tests
- ./bin/dart format --output=none --set-exit-if-changed packages/flutter/lib/src/widgets/framework.dart packages/flutter/test/widgets/framework_test.dart
- ./bin/flutter test packages/flutter/test/widgets/framework_test.dart --plain-name Async State.dispose throws a targeted FlutterError
- ./bin/flutter analyze packages/flutter/lib/src/widgets/framework.dart packages/flutter/test/widgets/framework_test.dart
- git diff --check