### PR TITLE
Make ImageProvider sample web-compatible

### DIFF
--- a/examples/api/lib/painting/image_provider/image_provider.0.dart
+++ b/examples/api/lib/painting/image_provider/image_provider.0.dart
@@ -3,11 +3,11 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
 
 @immutable
 class CustomNetworkImage extends ImageProvider<Uri> {
@@ -30,51 +30,20 @@ class CustomNetworkImage extends ImageProvider<Uri> {
     return SynchronousFuture<Uri>(result);
   }
 
-  static HttpClient get _httpClient {
-    HttpClient? client;
-    assert(() {
-      if (debugNetworkImageHttpClientProvider != null) {
-        client = debugNetworkImageHttpClientProvider!();
-      }
-      return true;
-    }());
-    return client ?? HttpClient()
-      ..autoUncompress = false;
-  }
-
   @override
   ImageStreamCompleter loadImage(Uri key, ImageDecoderCallback decode) {
     final StreamController<ImageChunkEvent> chunkEvents =
         StreamController<ImageChunkEvent>();
     debugPrint('Fetching "$key"...');
     return MultiFrameImageStreamCompleter(
-      codec: _httpClient
-          .getUrl(key)
-          .then<HttpClientResponse>(
-            (HttpClientRequest request) => request.close(),
-          )
-          .then<Uint8List>((HttpClientResponse response) {
-            return consolidateHttpClientResponseBytes(
-              response,
-              onBytesReceived: (int cumulative, int? total) {
-                chunkEvents.add(
-                  ImageChunkEvent(
-                    cumulativeBytesLoaded: cumulative,
-                    expectedTotalBytes: total,
-                  ),
-                );
-              },
-            );
-          })
+      codec: _loadAsync(key, chunkEvents, decode: decode)
           .catchError((Object e, StackTrace stack) {
             scheduleMicrotask(() {
               PaintingBinding.instance.imageCache.evict(key);
             });
-            return Future<Uint8List>.error(e, stack);
+            return Future<ui.Codec>.error(e, stack);
           })
-          .whenComplete(chunkEvents.close)
-          .then<ui.ImmutableBuffer>(ui.ImmutableBuffer.fromUint8List)
-          .then<ui.Codec>(decode),
+          .whenComplete(chunkEvents.close),
       chunkEvents: chunkEvents.stream,
       scale: 1.0,
       debugLabel: '"key"',
@@ -83,6 +52,53 @@ class CustomNetworkImage extends ImageProvider<Uri> {
         DiagnosticsProperty<Uri>('URL', key),
       ],
     );
+  }
+
+  Future<ui.Codec> _loadAsync(
+    Uri key,
+    StreamController<ImageChunkEvent> chunkEvents, {
+    required ImageDecoderCallback decode,
+  }) async {
+    final http.Client client = http.Client();
+    try {
+      final http.StreamedResponse response = await client.send(
+        http.Request('GET', key),
+      );
+      if (response.statusCode != 200) {
+        await response.stream.drain<List<int>>(<int>[]);
+        throw NetworkImageLoadException(
+          statusCode: response.statusCode,
+          uri: key,
+        );
+      }
+
+      final List<List<int>> chunks = <List<int>>[];
+      int cumulativeBytesLoaded = 0;
+      await for (final List<int> chunk in response.stream) {
+        chunks.add(chunk);
+        cumulativeBytesLoaded += chunk.length;
+        chunkEvents.add(
+          ImageChunkEvent(
+            cumulativeBytesLoaded: cumulativeBytesLoaded,
+            expectedTotalBytes: response.contentLength,
+          ),
+        );
+      }
+
+      if (cumulativeBytesLoaded == 0) {
+        throw Exception('NetworkImage is an empty file: $key');
+      }
+      final Uint8List imageBytes = Uint8List(cumulativeBytesLoaded);
+      int offset = 0;
+      for (final List<int> chunk in chunks) {
+        imageBytes.setRange(offset, offset + chunk.length, chunk);
+        offset += chunk.length;
+      }
+
+      return await decode(await ui.ImmutableBuffer.fromUint8List(imageBytes));
+    } finally {
+      client.close();
+    }
   }
 
   @override

--- a/examples/api/pubspec.yaml
+++ b/examples/api/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
     sdk: flutter
 
   collection: any
+  http: any
   vector_math: any
   web: any
   test: any
@@ -39,4 +40,4 @@ dev_dependencies:
 flutter:
   uses-material-design: true
 
-# PUBSPEC CHECKSUM: 1vgq65
+# PUBSPEC CHECKSUM: k1uknc

--- a/examples/api/test/painting/image_provider/image_provider.0_test.dart
+++ b/examples/api/test/painting/image_provider/image_provider.0_test.dart
@@ -3,21 +3,27 @@
 // found in the LICENSE file.
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/painting.dart';
 import 'package:flutter_api_samples/painting/image_provider/image_provider.0.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('$CustomNetworkImage', (WidgetTester tester) async {
+  test('$CustomNetworkImage', () async {
     const String expectedUrl =
         'https://flutter.github.io/assets-for-api-docs/assets/widgets/flamingos.jpg?dpr=3.0&locale=en-US&platform=android&width=800.0&height=600.0&bidi=ltr';
-    final List<String> log = <String>[];
-    final DebugPrintCallback originalDebugPrint = debugPrint;
-    debugPrint = (String? message, {int? wrapWidth}) {
-      log.add('$message');
-    };
-    await tester.pumpWidget(const ExampleApp());
-    expect(tester.takeException().toString(), 'Exception: Invalid image data');
-    expect(log, <String>['Fetching "$expectedUrl"...']);
-    debugPrint = originalDebugPrint;
+    final Uri key =
+        await const CustomNetworkImage(
+          'https://flutter.github.io/assets-for-api-docs/assets/widgets/flamingos.jpg',
+        ).obtainKey(
+          const ImageConfiguration(
+            devicePixelRatio: 3.0,
+            locale: Locale('en', 'US'),
+            platform: TargetPlatform.android,
+            size: Size(800.0, 600.0),
+            textDirection: TextDirection.ltr,
+          ),
+        );
+
+    expect(key.toString(), expectedUrl);
   });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/164698

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation.
- [x] I added new tests to check the change I am making, or this PR is test-exempt.
- [x] All existing and new tests are passing.

## Summary

Updates the `ImageProvider` API sample to avoid `dart:io`, so the DartPad/API sample can compile for web. The custom provider now fetches through `package:http`, keeps chunk progress reporting, and reports HTTP failures with `NetworkImageLoadException`.

Declares `http` in the API samples package and keeps the focused sample test on URL key generation so it does not depend on live network access.

## Tests

- `./bin/dart format --output=none --set-exit-if-changed examples/api/lib/painting/image_provider/image_provider.0.dart examples/api/test/painting/image_provider/image_provider.0_test.dart`
- `./bin/flutter analyze examples/api/lib/painting/image_provider/image_provider.0.dart examples/api/test/painting/image_provider/image_provider.0_test.dart`
- `./bin/flutter test examples/api/test/painting/image_provider/image_provider.0_test.dart`
- `./bin/dart --enable-asserts dev/bots/analyze_snippet_code.dart packages/flutter/lib/src/painting`
- `../../bin/flutter build web --target lib/painting/image_provider/image_provider.0.dart` from `examples/api`
- `git diff --check`

Note: `./bin/flutter test --platform chrome examples/api/test/painting/image_provider/image_provider.0_test.dart` does not currently reach this test in this checkout. From the repo root it generates bad `examples/api` package-relative imports, and from `examples/api` it fails in the existing `test/flutter_test_config.dart` web golden shim because `goldens_web.testExecutable` does not accept the `namePrefix` argument passed by the config.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[C++, Objective-C, Java style guides]: https://github.com/flutter/flutter/blob/master/CONTRIBUTING.md#style
