### PR TITLE
Clarify Flutter Driver semantics finder docs

### DIFF
--- a/packages/flutter_driver/lib/src/common/find.dart
+++ b/packages/flutter_driver/lib/src/common/find.dart
@@ -8,6 +8,9 @@
 /// @docImport 'package:flutter_test/flutter_test.dart';
 library;
 
+// Examples can assume:
+// import 'package:flutter_driver/flutter_driver.dart';
+
 import 'dart:convert';
 
 import 'package:meta/meta.dart';
@@ -139,12 +142,26 @@ class ByTooltipMessage extends SerializableFinder {
   }
 }
 
-/// A Flutter Driver finder that finds widgets by semantic label.
+/// A Flutter Driver finder that finds widgets by semantics label.
 ///
 /// If the [label] property is a [String], the finder will try to find an exact
 /// match. If it is a [RegExp], it will return true for [RegExp.hasMatch].
+///
+/// Semantics must be enabled before Flutter Driver can match this finder. In a
+/// driver test, call [FlutterDriver.setSemantics] before using
+/// [CommonFinders.bySemanticsLabel]:
+///
+/// {@tool snippet}
+///
+/// ```dart
+/// Future<void> tapNext(FlutterDriver driver) async {
+///   await driver.setSemantics(true);
+///   await driver.tap(find.bySemanticsLabel('Next'));
+/// }
+/// ```
+/// {@end-tool}
 class BySemanticsLabel extends SerializableFinder {
-  /// Creates a semantic label finder given the [label].
+  /// Creates a semantics label finder given the [label].
   const BySemanticsLabel(this.label);
 
   /// A [Pattern] matching the label of a [SemanticsNode].

--- a/packages/flutter_driver/lib/src/driver/driver.dart
+++ b/packages/flutter_driver/lib/src/driver/driver.dart
@@ -826,6 +826,9 @@ class CommonFinders {
   SerializableFinder byTooltip(String message) => ByTooltipMessage(message);
 
   /// Finds widgets with the given semantics [label].
+  ///
+  /// Semantics must be enabled, for example by calling
+  /// [FlutterDriver.setSemantics] before using the returned finder.
   SerializableFinder bySemanticsLabel(Pattern label) => BySemanticsLabel(label);
 
   /// Finds widgets whose class name matches the given string.


### PR DESCRIPTION
Fixes #39619.

This updates the Flutter Driver semantics-label finder docs to state that semantics must be enabled before the finder can match, and adds a short `{@tool snippet}` example using `FlutterDriver.setSemantics(true)` before `find.bySemanticsLabel`.

Verification:
- `./bin/dart format --output=none --set-exit-if-changed packages/flutter_driver/lib/src/common/find.dart packages/flutter_driver/lib/src/driver/driver.dart`
- `./bin/flutter analyze packages/flutter_driver/lib/src/common/find.dart packages/flutter_driver/lib/src/driver/driver.dart`
- `./bin/flutter test packages/flutter_driver/test/src/real_tests/find_test.dart packages/flutter_driver/test/src/real_tests/flutter_driver_test.dart`
- `./bin/dart --enable-asserts dev/bots/analyze_snippet_code.dart packages/flutter_driver`
- `git diff --check`