### PR TITLE
Fix layers rendering semantics startup

### DIFF
--- a/examples/layers/rendering/src/binding.dart
+++ b/examples/layers/rendering/src/binding.dart
@@ -31,6 +31,9 @@ class ViewRenderingFlutterBinding extends RenderingFlutterBinding {
     _renderView = initRenderView(PlatformDispatcher.instance.implicitView!);
     _renderView.child = _root;
     _root = null;
+    if (rootPipelineOwner.semanticsOwner != null) {
+      _renderView.scheduleInitialSemantics();
+    }
   }
 
   RenderBox? _root;
@@ -56,13 +59,19 @@ class ViewRenderingFlutterBinding extends RenderingFlutterBinding {
   PipelineOwner createRootPipelineOwner() {
     return PipelineOwner(
       onSemanticsOwnerCreated: () {
-        renderView.scheduleInitialSemantics();
+        if (rootPipelineOwner.rootNode case final RenderView renderView) {
+          renderView.scheduleInitialSemantics();
+        }
       },
       onSemanticsUpdate: (SemanticsUpdate update) {
-        renderView.updateSemantics(update);
+        if (rootPipelineOwner.rootNode case final RenderView renderView) {
+          renderView.updateSemantics(update);
+        }
       },
       onSemanticsOwnerDisposed: () {
-        renderView.clearSemantics();
+        if (rootPipelineOwner.rootNode case final RenderView renderView) {
+          renderView.clearSemantics();
+        }
       },
     );
   }

--- a/examples/layers/test/rendering_binding_test.dart
+++ b/examples/layers/test/rendering_binding_test.dart
@@ -1,0 +1,24 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../rendering/src/binding.dart';
+
+void main() {
+  test('ViewRenderingFlutterBinding initializes when platform semantics is enabled', () {
+    final binding = _SemanticsEnabledViewRenderingFlutterBinding(root: RenderPositionedBox());
+
+    expect(RendererBinding.instance, same(binding));
+    expect(binding.rootPipelineOwner.semanticsOwner, isNotNull);
+  });
+}
+
+class _SemanticsEnabledViewRenderingFlutterBinding extends ViewRenderingFlutterBinding {
+  _SemanticsEnabledViewRenderingFlutterBinding({super.root});
+
+  @override
+  bool get semanticsEnabled => true;
+}


### PR DESCRIPTION
Fixes #160157

The layers rendering example binding can receive a semantics owner while `RendererBinding.initInstances()` is still running, before `ViewRenderingFlutterBinding` has created its `RenderView`. Its root pipeline callbacks were reading the late `renderView` field, which throws when platform semantics are already enabled.

This makes those callbacks tolerate the temporarily missing root render view and schedules initial semantics after the view is installed if the semantics owner already exists.

Verification:
- `./bin/dart format --output=none --set-exit-if-changed examples/layers/rendering/src/binding.dart examples/layers/test/rendering_binding_test.dart`
- `./bin/flutter test examples/layers/test/rendering_binding_test.dart`
- `./bin/flutter test examples/layers/test/smoketests/rendering/hello_world_test.dart`
- `./bin/flutter test examples/layers/test/smoketests/rendering`
- `./bin/flutter analyze examples/layers/rendering/src/binding.dart examples/layers/test/rendering_binding_test.dart`
- `./bin/flutter analyze examples/layers`
- `./bin/flutter test examples/layers/test`
- `git diff --cached --check`