### PR TITLE
Fix AnimatedList.separated tail reinsertion

### DIFF
--- a/packages/flutter/lib/src/widgets/animated_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/animated_scroll_view.dart
@@ -714,7 +714,7 @@ abstract class _AnimatedScrollViewState<T extends _AnimatedScrollView> extends S
       _sliverAnimatedMultiBoxKey.currentState!.insertAllItems(index, length, duration: duration);
     } else {
       final int itemIndex = _computeItemIndex(index);
-      final int lengthWithSeparators = _itemsCount == 0 ? length * 2 - 1 : length * 2;
+      final int lengthWithSeparators = _visibleItemsCount == 0 ? length * 2 - 1 : length * 2;
       _sliverAnimatedMultiBoxKey.currentState!.insertAllItems(
         itemIndex,
         lengthWithSeparators,
@@ -822,14 +822,19 @@ abstract class _AnimatedScrollViewState<T extends _AnimatedScrollView> extends S
 
   int get _outgoingItemsCount => _sliverAnimatedMultiBoxKey.currentState!._outgoingItems.length;
 
+  /// The number of underlying children not currently animating out.
+  ///
+  /// For [AnimatedList.separated], this includes both items and separators.
+  int get _visibleItemsCount => _itemsCount - _outgoingItemsCount;
+
   // Helper method to compute the index for the item to insert or remove considering the separators in between.
   int _computeItemIndex(int index) {
     if (index == 0) {
       return index;
     }
-    final int itemsAndSeparatorsCount = _itemsCount;
+    final int itemsAndSeparatorsCount = _visibleItemsCount;
     final int separatorsCount = itemsAndSeparatorsCount ~/ 2;
-    final int separatedItemsCount = _itemsCount - separatorsCount;
+    final int separatedItemsCount = itemsAndSeparatorsCount - separatorsCount;
 
     final isNewLastIndex = index == separatedItemsCount;
     final int indexAdjustedForSeparators = index * 2;

--- a/packages/flutter/test/widgets/animated_list_test.dart
+++ b/packages/flutter/test/widgets/animated_list_test.dart
@@ -1279,6 +1279,107 @@ void main() {
     },
   );
 
+  testWidgets('AnimatedList.separated reinserts a removed tail item', (WidgetTester tester) async {
+    Widget itemBuilder(BuildContext context, int index, Animation<double> animation) {
+      return SizedBox(height: 100.0, child: Center(child: Text('item $index')));
+    }
+
+    Widget separatorBuilder(BuildContext context, int index, Animation<double> animation) {
+      return SizedBox(height: 10.0, child: Center(child: Text('separator $index')));
+    }
+
+    Widget removedSeparatorBuilder(BuildContext context, int index, Animation<double> animation) {
+      return SizedBox(height: 10.0, child: Center(child: Text('removing separator $index')));
+    }
+
+    final listKey = GlobalKey<AnimatedListState>();
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: AnimatedList.separated(
+          key: listKey,
+          initialItemCount: 2,
+          itemBuilder: itemBuilder,
+          separatorBuilder: separatorBuilder,
+          removedSeparatorBuilder: removedSeparatorBuilder,
+        ),
+      ),
+    );
+
+    listKey.currentState!.removeItem(1, (BuildContext context, Animation<double> animation) {
+      return const SizedBox(height: 100.0, child: Center(child: Text('removing item 1')));
+    }, duration: const Duration(milliseconds: 100));
+
+    // Before the fix this triggered an "itemIndex >= 0 && itemIndex <= _itemsCount"
+    // assertion inside _SliverAnimatedMultiBoxAdaptorState.insertItem.
+    listKey.currentState!.insertItem(1, duration: const Duration(milliseconds: 100));
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('item 0'), findsOneWidget);
+    expect(find.text('item 1'), findsOneWidget);
+    expect(find.text('removing item 1'), findsOneWidget);
+    expect(find.text('removing separator 0'), findsOneWidget);
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('item 0'), findsOneWidget);
+    expect(find.text('separator 0'), findsOneWidget);
+    expect(find.text('item 1'), findsOneWidget);
+    expect(find.text('removing item 1'), findsNothing);
+    expect(find.text('removing separator 0'), findsNothing);
+  });
+
+  testWidgets('AnimatedList.separated inserts all after emptying', (WidgetTester tester) async {
+    Widget itemBuilder(BuildContext context, int index, Animation<double> animation) {
+      return SizedBox(height: 100.0, child: Center(child: Text('item $index')));
+    }
+
+    Widget separatorBuilder(BuildContext context, int index, Animation<double> animation) {
+      return SizedBox(height: 10.0, child: Center(child: Text('separator $index')));
+    }
+
+    Widget removedSeparatorBuilder(BuildContext context, int index, Animation<double> animation) {
+      return SizedBox(height: 10.0, child: Center(child: Text('removing separator $index')));
+    }
+
+    final listKey = GlobalKey<AnimatedListState>();
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: AnimatedList.separated(
+          key: listKey,
+          initialItemCount: 1,
+          itemBuilder: itemBuilder,
+          separatorBuilder: separatorBuilder,
+          removedSeparatorBuilder: removedSeparatorBuilder,
+        ),
+      ),
+    );
+
+    listKey.currentState!.removeItem(0, (BuildContext context, Animation<double> animation) {
+      return const SizedBox(height: 100.0, child: Center(child: Text('removing item 0')));
+    }, duration: const Duration(milliseconds: 100));
+
+    listKey.currentState!.insertAllItems(0, 2, duration: const Duration(milliseconds: 100));
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('item 0'), findsOneWidget);
+    expect(find.text('separator 0'), findsOneWidget);
+    expect(find.text('item 1'), findsOneWidget);
+    expect(find.text('removing item 0'), findsOneWidget);
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('item 0'), findsOneWidget);
+    expect(find.text('separator 0'), findsOneWidget);
+    expect(find.text('item 1'), findsOneWidget);
+    expect(find.text('removing item 0'), findsNothing);
+  });
+
   testWidgets('AnimatedList does not crash at zero area', (WidgetTester tester) async {
     tester.view.physicalSize = Size.zero;
     final controller = ScrollController();


### PR DESCRIPTION
Fixes #179029.

When `AnimatedList.separated` removes an item, the underlying sliver keeps the removed item and separator alive until their outgoing animations finish. The public list semantics treat those entries as removed immediately, so separated-list index mapping must ignore outgoing children when a caller inserts another item in the same frame.

This updates the separated-list index calculation to use the visible child count, and applies the same visible-count check when `insertAllItems` decides whether separators are needed for a logically empty list.

Verification:
- `./bin/dart format --output=none --set-exit-if-changed packages/flutter/lib/src/widgets/animated_scroll_view.dart packages/flutter/test/widgets/animated_list_test.dart`
- `./bin/flutter analyze packages/flutter/lib/src/widgets/animated_scroll_view.dart packages/flutter/test/widgets/animated_list_test.dart`
- `./bin/flutter test packages/flutter/test/widgets/animated_list_test.dart`
- `git diff --check`