### PR TITLE
Document Android Emulator raw key repeat behavior

### DIFF
--- a/packages/flutter/lib/src/services/raw_keyboard.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard.dart
@@ -749,6 +749,15 @@ typedef RawKeyEventHandler = bool Function(RawKeyEvent event);
 /// * Lock modes (such as CapsLock) only have their "enabled" state recorded.
 ///   There's no way to acquire their pressing state.
 ///
+/// Since [RawKeyboard] forwards platform key events without regularizing them,
+/// it also exposes platform-specific quirks directly. For example, some
+/// Android Emulator keyboard paths have reported a held hardware key as
+/// repeated down/up pairs, even though the same keyboard reports repeat events
+/// correctly on physical Android devices. Verify platform-specific key hold
+/// and repeat behavior on the target hardware when that distinction matters,
+/// or use [HardwareKeyboard] when app logic requires a regularized key event
+/// model.
+///
 /// See also:
 ///
 ///  * [RawKeyDownEvent] and [RawKeyUpEvent], the classes used to describe


### PR DESCRIPTION
Issue: Fixes flutter/flutter#72816. Android Emulator keyboard paths can report a held hardware key as repeated down/up pairs, while the same keyboard reports repeat events correctly on physical Android devices. `RawKeyboard` exposes raw platform events, so that emulator behavior is visible to apps listening at the raw layer.

Fix: Document the Android Emulator caveat in the `RawKeyboard` API docs, next to the existing comparison with `HardwareKeyboard`'s more regular event model. The change is intentionally limited to documentation because the issue discussion identifies this as an emulator/platform event source quirk rather than a Flutter framework behavior bug.

Tests: `./bin/dart format --output=none --set-exit-if-changed packages/flutter/lib/src/services/raw_keyboard.dart`; `./bin/flutter analyze packages/flutter/lib/src/services/raw_keyboard.dart`; `git diff --check`.

Risk: Docs-only change in one services API-doc file. No generated files or behavior changes.
