### PR TITLE
Clarify async builder side effects

### DIFF
--- a/packages/flutter/lib/src/widgets/async.dart
+++ b/packages/flutter/lib/src/widgets/async.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'navigator.dart';
 /// @docImport 'value_listenable_builder.dart';
 library;
 
@@ -415,6 +416,12 @@ class StreamBuilder<T> extends StreamBuilderBase<T, AsyncSnapshot<T>> {
   ///
   /// This builder must only return a widget and should not have any side
   /// effects as it may be called multiple times.
+  ///
+  /// Side effects, such as calling [State.setState] or [Navigator.push], should
+  /// happen in callbacks or listeners that are executed outside of the build
+  /// method. For example, when a stream event should trigger navigation,
+  /// navigate from the stream listener, such as [Stream.listen], rather than
+  /// from this builder.
   final AsyncWidgetBuilder<T> builder;
 
   /// The data that will be used to create the initial snapshot.
@@ -568,6 +575,12 @@ class FutureBuilder<T> extends StatefulWidget {
   ///
   /// This builder must only return a widget and should not have any side
   /// effects as it may be called multiple times.
+  ///
+  /// Side effects, such as calling [State.setState] or [Navigator.push], should
+  /// happen in callbacks or listeners that are executed outside of the build
+  /// method. For example, when the future completes and triggers navigation,
+  /// navigate from the future's completion callback, such as [Future.then],
+  /// rather than from this builder.
   final AsyncWidgetBuilder<T> builder;
 
   /// The data that will be used to create the snapshots provided until a


### PR DESCRIPTION
Issue: Fixes https://github.com/flutter/flutter/issues/16218. `FutureBuilder.builder` and `StreamBuilder.builder` already warned that builders should be side-effect free, but they did not name common side effects like navigation or explain where result-driven logic should move instead.

Fix: Adds API-doc guidance to both builders that side effects such as `State.setState` and `Navigator.push` belong in callbacks or listeners outside the build method. The new text points stream-triggered navigation to stream listeners and future-triggered navigation to future callbacks, leaving the builder responsible only for describing UI from the current snapshot.

Tests: Documentation-only change. Verified with:
- `./bin/dart format packages/flutter/lib/src/widgets/async.dart`
- `./bin/flutter analyze packages/flutter/lib/src/widgets/async.dart`
- `git diff --check`

Risk: Limited to widgets API documentation in one file. No behavior, generated output, or test fixture changes.
