### PR TITLE
Clarify opacity hit testing and semantics

### DIFF
--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -306,10 +306,16 @@ class Directionality extends _UbiquitousInheritedWidget {
 ///
 /// ## Hit testing
 ///
+/// This widget affects painting and semantics only. At an [opacity] of zero,
+/// the child is not painted and is excluded from the semantics tree unless
+/// [alwaysIncludeSemantics] is true.
+///
 /// Setting the [opacity] to zero does not prevent hit testing from being applied
 /// to the descendants of the [Opacity] widget. This can be confusing for the
 /// user, who may not see anything, and may believe the area of the interface
 /// where the [Opacity] is hiding a widget to be non-interactive.
+/// With the default semantics behavior, this can also cause an invisible widget
+/// to be interactive without being exposed to assistive technologies.
 ///
 /// With certain widgets, such as [Flow], that compute their positions only when
 /// they are painted, this can actually lead to bugs (from unexpected geometry
@@ -358,7 +364,8 @@ class Opacity extends SingleChildRenderObjectWidget {
   /// When true, regardless of the opacity settings the child semantic
   /// information is exposed as if the widget were fully visible. This is
   /// useful in cases where labels may be hidden during animations that
-  /// would otherwise contribute relevant semantics.
+  /// would otherwise contribute relevant semantics. When false, semantics are
+  /// excluded when [opacity] is zero.
   final bool alwaysIncludeSemantics;
 
   @override

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -1814,11 +1814,17 @@ class _AnimatedSlideState extends ImplicitlyAnimatedWidgetState<AnimatedSlide> {
 ///
 /// ## Hit testing
 ///
+/// This widget affects painting and semantics only. At an [opacity] of zero,
+/// the child is not painted and is excluded from the semantics tree unless
+/// [alwaysIncludeSemantics] is true.
+///
 /// Setting the [opacity] to zero does not prevent hit testing from being
 /// applied to the descendants of the [AnimatedOpacity] widget. This can be
 /// confusing for the user, who may not see anything, and may believe the area
 /// of the interface where the [AnimatedOpacity] is hiding a widget to be
-/// non-interactive.
+/// non-interactive. With the default semantics behavior, this can also cause an
+/// invisible widget to be interactive without being exposed to assistive
+/// technologies.
 ///
 /// With certain widgets, such as [Flow], that compute their positions only when
 /// they are painted, this can actually lead to bugs (from unexpected geometry
@@ -1870,7 +1876,8 @@ class AnimatedOpacity extends ImplicitlyAnimatedWidget {
   /// When true, regardless of the opacity settings the child semantic
   /// information is exposed as if the widget were fully visible. This is
   /// useful in cases where labels may be hidden during animations that
-  /// would otherwise contribute relevant semantics.
+  /// would otherwise contribute relevant semantics. When false, semantics are
+  /// excluded when [opacity] is zero.
   final bool alwaysIncludeSemantics;
 
   @override
@@ -1928,11 +1935,17 @@ class _AnimatedOpacityState extends ImplicitlyAnimatedWidgetState<AnimatedOpacit
 ///
 /// ## Hit testing
 ///
+/// This widget affects painting and semantics only. At an [opacity] of zero,
+/// the sliver child is not painted and is excluded from the semantics tree
+/// unless [alwaysIncludeSemantics] is true.
+///
 /// Setting the [opacity] to zero does not prevent hit testing from being
 /// applied to the descendants of the [SliverAnimatedOpacity] widget. This can
 /// be confusing for the user, who may not see anything, and may believe the
 /// area of the interface where the [SliverAnimatedOpacity] is hiding a widget
-/// to be non-interactive.
+/// to be non-interactive. With the default semantics behavior, this can also
+/// cause an invisible widget to be interactive without being exposed to
+/// assistive technologies.
 ///
 /// With certain widgets, such as [Flow], that compute their positions only when
 /// they are painted, this can actually lead to bugs (from unexpected geometry
@@ -1981,7 +1994,8 @@ class SliverAnimatedOpacity extends ImplicitlyAnimatedWidget {
   /// When true, regardless of the opacity settings the sliver child's semantic
   /// information is exposed as if the widget were fully visible. This is
   /// useful in cases where labels may be hidden during animations that
-  /// would otherwise contribute relevant semantics.
+  /// would otherwise contribute relevant semantics. When false, semantics are
+  /// excluded when [opacity] is zero.
   final bool alwaysIncludeSemantics;
 
   @override

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -1323,6 +1323,24 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement
 /// ** See code in examples/api/lib/widgets/sliver/sliver_opacity.1.dart **
 /// {@end-tool}
 ///
+/// ## Hit testing
+///
+/// This widget affects painting and semantics only. At an [opacity] of zero,
+/// the sliver child is not painted and is excluded from the semantics tree
+/// unless [alwaysIncludeSemantics] is true.
+///
+/// Setting the [opacity] to zero does not prevent hit testing from being
+/// applied to the descendants of the [SliverOpacity] widget. This can be
+/// confusing for the user, who may not see anything, and may believe the area
+/// of the interface where the [SliverOpacity] is hiding a widget to be
+/// non-interactive. With the default semantics behavior, this can also cause an
+/// invisible widget to be interactive without being exposed to assistive
+/// technologies.
+///
+/// To avoid such problems, it is generally a good idea to use a
+/// [SliverIgnorePointer] widget when setting the [opacity] to zero. This
+/// prevents interactions with any children in the subtree.
+///
 /// See also:
 ///
 ///  * [Opacity], which can apply a uniform alpha effect to its child using the
@@ -1363,7 +1381,8 @@ class SliverOpacity extends SingleChildRenderObjectWidget {
   /// When true, regardless of the opacity settings, the sliver child semantic
   /// information is exposed as if the widget were fully visible. This is
   /// useful in cases where labels may be hidden during animations that
-  /// would otherwise contribute relevant semantics.
+  /// would otherwise contribute relevant semantics. When false, semantics are
+  /// excluded when [opacity] is zero.
   final bool alwaysIncludeSemantics;
 
   @override

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -562,11 +562,17 @@ class SizeTransition extends AnimatedWidget {
 ///
 /// ## Hit testing
 ///
-/// Setting the [opacity] to zero does not prevent hit testing from being
-/// applied to the descendants of the [FadeTransition] widget. This can be
-/// confusing for the user, who may not see anything, and may believe the area
-/// of the interface where the [FadeTransition] is hiding a widget to be
-/// non-interactive.
+/// This widget affects painting and semantics only. When the [opacity]
+/// animation has a value of zero, the child is not painted and is excluded from
+/// the semantics tree unless [alwaysIncludeSemantics] is true.
+///
+/// When the [opacity] animation reaches zero, hit testing is still applied to
+/// the descendants of the [FadeTransition] widget. This can be confusing for
+/// the user, who may not see anything, and may believe the area of the
+/// interface where the [FadeTransition] is hiding a widget to be
+/// non-interactive. With the default semantics behavior, this can also cause an
+/// invisible widget to be interactive without being exposed to assistive
+/// technologies.
 ///
 /// With certain widgets, such as [Flow], that compute their positions only when
 /// they are painted, this can actually lead to bugs (from unexpected geometry
@@ -610,7 +616,8 @@ class FadeTransition extends SingleChildRenderObjectWidget {
   /// When true, regardless of the opacity settings the child semantic
   /// information is exposed as if the widget were fully visible. This is
   /// useful in cases where labels may be hidden during animations that
-  /// would otherwise contribute relevant semantics.
+  /// would otherwise contribute relevant semantics. When false, semantics are
+  /// excluded when the [opacity] value is zero.
   final bool alwaysIncludeSemantics;
 
   @override
@@ -656,11 +663,17 @@ class FadeTransition extends SingleChildRenderObjectWidget {
 ///
 /// ## Hit testing
 ///
-/// Setting the [opacity] to zero does not prevent hit testing from being
-/// applied to the descendants of the [SliverFadeTransition] widget. This can be
-/// confusing for the user, who may not see anything, and may believe the area
-/// of the interface where the [SliverFadeTransition] is hiding a widget to be
-/// non-interactive.
+/// This widget affects painting and semantics only. When the [opacity]
+/// animation has a value of zero, the sliver child is not painted and is
+/// excluded from the semantics tree unless [alwaysIncludeSemantics] is true.
+///
+/// When the [opacity] animation reaches zero, hit testing is still applied to
+/// the descendants of the [SliverFadeTransition] widget. This can be confusing
+/// for the user, who may not see anything, and may believe the area of the
+/// interface where the [SliverFadeTransition] is hiding a widget to be
+/// non-interactive. With the default semantics behavior, this can also cause an
+/// invisible widget to be interactive without being exposed to assistive
+/// technologies.
 ///
 /// With certain widgets, such as [Flow], that compute their positions only when
 /// they are painted, this can actually lead to bugs (from unexpected geometry
@@ -703,7 +716,8 @@ class SliverFadeTransition extends SingleChildRenderObjectWidget {
   /// When true, regardless of the opacity settings the sliver child's semantic
   /// information is exposed as if the widget were fully visible. This is
   /// useful in cases where labels may be hidden during animations that
-  /// would otherwise contribute relevant semantics.
+  /// would otherwise contribute relevant semantics. When false, semantics are
+  /// excluded when the [opacity] value is zero.
   final bool alwaysIncludeSemantics;
 
   @override


### PR DESCRIPTION
Fixes flutter/flutter#12283.

Opacity-related widgets already warned that opacity 0.0 still hit tests, but did not make the zero-opacity semantics behavior explicit alongside that warning.

This updates Opacity, SliverOpacity, AnimatedOpacity, SliverAnimatedOpacity, FadeTransition, and SliverFadeTransition docs to state that zero opacity excludes semantics unless alwaysIncludeSemantics is true, while hit testing remains separate and can still reach invisible children. It also points sliver users to SliverIgnorePointer for non-interactive hidden content, matching the box Opacity guidance.

Verification:
- ./bin/dart format packages/flutter/lib/src/widgets/basic.dart packages/flutter/lib/src/widgets/sliver.dart packages/flutter/lib/src/widgets/implicit_animations.dart packages/flutter/lib/src/widgets/transitions.dart
- ./bin/flutter analyze packages/flutter/lib/src/widgets/basic.dart packages/flutter/lib/src/widgets/sliver.dart packages/flutter/lib/src/widgets/implicit_animations.dart packages/flutter/lib/src/widgets/transitions.dart
- git diff --check