### PR TITLE
Fix live test pointer cancellation source

### DIFF
--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -2936,6 +2936,10 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
   /// Events dispatched by [TestGesture] are not affected by this.
   HitTestDispatcher? deviceEventDispatcher;
 
+  /// Framework code may asynchronously cancel a pointer after the test-dispatched
+  /// event has reset the source back to device.
+  final Set<int> _testPointerIds = <int>{};
+
   /// Dispatch an event to the targets found by a hit test on its position.
   ///
   /// If the [pointerEventSource] is [TestBindingEventSource.test], then
@@ -2947,8 +2951,22 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
   /// forwarded to [deviceEventDispatcher].
   @override
   void handlePointerEvent(PointerEvent event) {
+    if (pointerEventSource == TestBindingEventSource.device &&
+        event is PointerCancelEvent &&
+        _testPointerIds.contains(event.pointer)) {
+      withPointerEventSource(TestBindingEventSource.test, () => handlePointerEvent(event));
+      return;
+    }
+
     switch (pointerEventSource) {
       case TestBindingEventSource.test:
+        if (event is PointerDownEvent || event is PointerPanZoomStartEvent) {
+          _testPointerIds.add(event.pointer);
+        } else if (event is PointerUpEvent ||
+            event is PointerCancelEvent ||
+            event is PointerPanZoomEndEvent) {
+          _testPointerIds.remove(event.pointer);
+        }
         RenderView? target;
         for (final RenderView renderView in renderViews) {
           if (renderView.flutterView.viewId == event.viewId) {
@@ -3103,6 +3121,7 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
   @override
   void postTest() {
     super.postTest();
+    _testPointerIds.clear();
     assert(!_expectingFrame);
     assert(_pendingFrame == null);
     _inTest = false;

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -2936,8 +2936,21 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
   /// Events dispatched by [TestGesture] are not affected by this.
   HitTestDispatcher? deviceEventDispatcher;
 
-  /// Framework code may asynchronously cancel a pointer after the test-dispatched
-  /// event has reset the source back to device.
+  // Tracks active pointer IDs that were initiated by test gestures (i.e.
+  // dispatched under [TestBindingEventSource.test]).
+  //
+  // A pointer stream initiated by a test gesture belongs to
+  // [TestBindingEventSource.test] throughout its entire lifecycle. However,
+  // framework operations (such as `Navigator.cancelPointer` during route
+  // transitions) may dispatch a synthetic [PointerCancelEvent] while
+  // [pointerEventSource] is set to [TestBindingEventSource.device].
+  //
+  // This set tracks active test pointers from
+  // `PointerDown`/`PointerPanZoomStart` until
+  // `PointerUp`/`PointerCancel`/`PointerPanZoomEnd`, allowing
+  // [handlePointerEvent] to identify and re-route framework-generated
+  // cancellation events back through the `test` source so active gesture
+  // recognizers can process them correctly.
   final Set<int> _testPointerIds = <int>{};
 
   /// Dispatch an event to the targets found by a hit test on its position.
@@ -2951,6 +2964,9 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
   /// forwarded to [deviceEventDispatcher].
   @override
   void handlePointerEvent(PointerEvent event) {
+    // Ensure all events belonging to a test pointer stream are processed under
+    // TestBindingEventSource.test, even if a framework-generated cancellation
+    // arrives while pointerEventSource is set to 'device'.
     if (pointerEventSource == TestBindingEventSource.device &&
         event is PointerCancelEvent &&
         _testPointerIds.contains(event.pointer)) {

--- a/packages/flutter_test/test/live_binding_test.dart
+++ b/packages/flutter_test/test/live_binding_test.dart
@@ -76,43 +76,32 @@ void main() {
   ) async {
     var longPresses = 0;
     await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: Navigator(
-          onGenerateRoute: (RouteSettings settings) {
-            return PageRouteBuilder<void>(
-              transitionDuration: Duration.zero,
-              pageBuilder:
-                  (
-                    BuildContext context,
-                    Animation<double> animation,
-                    Animation<double> secondaryAnimation,
-                  ) {
-                    return GestureDetector(
-                      onLongPress: () {
-                        longPresses++;
-                        Navigator.of(context).push<void>(
-                          RawDialogRoute<void>(
-                            transitionDuration: Duration.zero,
-                            pageBuilder:
-                                (
-                                  BuildContext context,
-                                  Animation<double> animation,
-                                  Animation<double> secondaryAnimation,
-                                ) {
-                                  return GestureDetector(
-                                    onTap: () {
-                                      Navigator.of(context).pop();
-                                    },
-                                    child: const Center(child: Text('Popup')),
-                                  );
-                                },
-                          ),
-                        );
-                      },
-                      child: const Center(child: Text('Show dialog')),
-                    );
-                  },
+      TestWidgetsApp(
+        home: Builder(
+          builder: (BuildContext context) {
+            return GestureDetector(
+              onLongPress: () {
+                longPresses++;
+                Navigator.of(context).push<void>(
+                  PageRouteBuilder<void>(
+                    transitionDuration: Duration.zero,
+                    pageBuilder:
+                        (
+                          BuildContext context,
+                          Animation<double> animation,
+                          Animation<double> secondaryAnimation,
+                        ) {
+                          return GestureDetector(
+                            onTap: () {
+                              Navigator.of(context).pop();
+                            },
+                            child: const Center(child: Text('Popup')),
+                          );
+                        },
+                  ),
+                );
+              },
+              child: const Center(child: Text('Show dialog')),
             );
           },
         ),

--- a/packages/flutter_test/test/live_binding_test.dart
+++ b/packages/flutter_test/test/live_binding_test.dart
@@ -71,6 +71,69 @@ void main() {
     expect(invocations, 3);
   });
 
+  testWidgets('long press can reopen a dialog route after dismissing it', (
+    WidgetTester tester,
+  ) async {
+    var longPresses = 0;
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Navigator(
+          onGenerateRoute: (RouteSettings settings) {
+            return PageRouteBuilder<void>(
+              transitionDuration: Duration.zero,
+              pageBuilder:
+                  (
+                    BuildContext context,
+                    Animation<double> animation,
+                    Animation<double> secondaryAnimation,
+                  ) {
+                    return GestureDetector(
+                      onLongPress: () {
+                        longPresses++;
+                        Navigator.of(context).push<void>(
+                          RawDialogRoute<void>(
+                            transitionDuration: Duration.zero,
+                            pageBuilder:
+                                (
+                                  BuildContext context,
+                                  Animation<double> animation,
+                                  Animation<double> secondaryAnimation,
+                                ) {
+                                  return GestureDetector(
+                                    onTap: () {
+                                      Navigator.of(context).pop();
+                                    },
+                                    child: const Center(child: Text('Popup')),
+                                  );
+                                },
+                          ),
+                        );
+                      },
+                      child: const Center(child: Text('Show dialog')),
+                    );
+                  },
+            );
+          },
+        ),
+      ),
+    );
+
+    await tester.longPress(find.text('Show dialog'));
+    await tester.pumpAndSettle();
+    expect(longPresses, 1);
+    expect(find.text('Popup'), findsOneWidget);
+
+    await tester.tap(find.text('Popup'));
+    await tester.pumpAndSettle();
+    expect(find.text('Popup'), findsNothing);
+
+    await tester.longPress(find.text('Show dialog'));
+    await tester.pumpAndSettle();
+    expect(longPresses, 2);
+    expect(find.text('Popup'), findsOneWidget);
+  });
+
   testWidgets('setSurfaceSize works', (WidgetTester tester) async {
     addTearDown(binding.resetLayers);
     await tester.pumpWidget(const TestWidgetsApp(home: Center(child: Text('Test'))));


### PR DESCRIPTION
Fixes #98804.

## Root cause
`Navigator.cancelPointer` can dispatch a synthetic `PointerCancelEvent` after a `WidgetTester` gesture has reset `LiveTestWidgetsFlutterBinding.pointerEventSource` back to `device`. The live binding then treats that cancel as a device event and sends it to `deviceEventDispatcher` instead of the recognizer that started from the test gesture. That leaves the long-press recognizer in `possible`, so a later long press never schedules its deadline callback.

## Fix
Track active test pointer IDs in `LiveTestWidgetsFlutterBinding` and route framework-generated cancels for those pointers back through the test event source. Add a live binding regression that long-presses to open a dialog, dismisses it, then long-presses again.

## Tests
- `./bin/dart format packages/flutter_test/lib/src/binding.dart packages/flutter_test/test/live_binding_test.dart`
- `./bin/flutter test packages/flutter_test/test/live_binding_test.dart --plain-name "long press can reopen a dialog after dismissing it"`
- `./bin/flutter test packages/flutter_test/test/live_binding_test.dart`
- `./bin/flutter analyze packages/flutter_test/lib/src/binding.dart packages/flutter_test/test/live_binding_test.dart`
- `./bin/flutter test packages/integration_test/test/binding_test.dart`
- `git diff --check`
