### PR TITLE
Clarify precache enabled platforms help

### DIFF
--- a/packages/flutter_tools/lib/src/commands/precache.dart
+++ b/packages/flutter_tools/lib/src/commands/precache.dart
@@ -97,7 +97,9 @@ class PrecacheCommand extends FlutterCommand {
   final description =
       "Populate the Flutter tool's cache of binary artifacts.\n\n"
       'If no explicit platform flags are provided, this command will download the artifacts '
-      'for all currently enabled platforms';
+      'for every platform enabled by the current host and Flutter configuration. '
+      'Use "flutter config --list" to see explicit platform settings; "(Not set)" uses the '
+      'default for the current host.';
 
   @override
   final String category = FlutterCommandCategory.sdk;

--- a/packages/flutter_tools/test/commands.shard/hermetic/precache_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/precache_test.dart
@@ -21,6 +21,19 @@ void main() {
     cache.isUpToDateValue = false;
   });
 
+  testUsingContext('precache description explains currently enabled platforms', () {
+    final command = PrecacheCommand(
+      cache: cache,
+      logger: BufferLogger.test(),
+      platform: FakePlatform(environment: <String, String>{}),
+      featureFlags: TestFeatureFlags(),
+    );
+
+    expect(command.description, contains('enabled by the current host and Flutter configuration'));
+    expect(command.description, contains('flutter config --list'));
+    expect(command.description, contains('(Not set)'));
+  });
+
   testUsingContext('precache should acquire lock', () async {
     final Platform platform = FakePlatform(environment: <String, String>{});
     final command = PrecacheCommand(


### PR DESCRIPTION
Fixes #144656

This clarifies `flutter precache --help` so "currently enabled platforms" is tied to the current host and Flutter configuration, and points users at `flutter config --list` for explicit platform settings.

Verification:
- `./bin/flutter test packages/flutter_tools/test/commands.shard/hermetic/precache_test.dart`
- `./bin/flutter test packages/flutter_tools/test/general.shard/args_test.dart`
- `./bin/flutter analyze packages/flutter_tools/lib/src/commands/precache.dart packages/flutter_tools/test/commands.shard/hermetic/precache_test.dart`
- `git diff --check`