### PR TITLE
Clarify layout callback debug flag docs

### DIFF
--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -2254,8 +2254,8 @@ abstract class RenderBox extends RenderObject {
       if (size is _DebugSize) {
         assert(size._owner == this);
         final RenderObject? parent = this.parent;
-        // Whether the size getter is accessed during layout (but not in a
-        // layout callback).
+        // Size reads during an invokeLayoutCallback are outside regular layout
+        // because layout callbacks run in a special mutation-permitted phase.
         final bool doingRegularLayout =
             !(RenderObject.debugActiveLayout?.debugDoingThisLayoutWithCallback ?? true);
         final bool sizeAccessAllowed =

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2571,6 +2571,16 @@ abstract class RenderObject with DiagnosticableTreeMixin implements HitTestTarge
   bool? _isRelayoutBoundary;
 
   /// Whether [invokeLayoutCallback] for this render object is currently running.
+  ///
+  /// Layout callbacks are a special part of this render object's layout phase:
+  /// they are allowed to mutate child lists and dirty render subtrees while the
+  /// callback is executing. This flag lets debug-only assertions distinguish
+  /// that special callback phase from the regular [performLayout] body.
+  ///
+  /// This does not imply that a widget rebuild is currently in progress. A
+  /// layout callback can trigger rebuild work by mutating the render or element
+  /// tree, but this flag only describes the synchronous callback passed to
+  /// [invokeLayoutCallback].
   bool get debugDoingThisLayoutWithCallback => _doingThisLayoutWithCallback;
   bool _doingThisLayoutWithCallback = false;
 


### PR DESCRIPTION
Fixes #128913

## Summary
- Explain that debugDoingThisLayoutWithCallback marks the synchronous invokeLayoutCallback phase.
- Clarify that layout callbacks are a mutation-permitted phase distinct from regular performLayout work and widget rebuild work.
- Update the related RenderBox.size debug assertion comment to name why layout callbacks are excluded from regular layout.

## Tests
- ./bin/dart format --output=none --set-exit-if-changed packages/flutter/lib/src/rendering/object.dart packages/flutter/lib/src/rendering/box.dart
- ./bin/flutter analyze packages/flutter/lib/src/rendering/object.dart packages/flutter/lib/src/rendering/box.dart
- git diff --check