### PR TITLE
Improve ScrollController multiple position error

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_controller.dart
+++ b/packages/flutter/lib/src/widgets/scroll_controller.dart
@@ -166,10 +166,21 @@ class ScrollController extends ChangeNotifier {
   /// Returns the attached [ScrollPosition], from which the actual scroll offset
   /// of the [ScrollView] can be obtained.
   ///
-  /// Calling this is only valid when only a single position is attached.
+  /// Calling this is only valid when exactly one position is attached. If
+  /// multiple positions are attached, use [positions] to inspect them all.
   ScrollPosition get position {
     assert(_positions.isNotEmpty, 'ScrollController not attached to any scroll views.');
-    assert(_positions.length == 1, 'ScrollController attached to multiple scroll views.');
+    assert(
+      _positions.length == 1,
+      'ScrollController attached to multiple scroll views.\n'
+      'The ScrollController.position getter can only be used when a single '
+      'ScrollPosition is attached.\n'
+      'Some ScrollController operations, including reading the position, require '
+      'the controller to be attached to exactly one Scrollable. If multiple '
+      'Scrollables need independent scroll positions, use a separate '
+      'ScrollController for each.\n'
+      'To access all attached positions, use the ScrollController.positions getter.',
+    );
     return _positions.single;
   }
 

--- a/packages/flutter/test/widgets/scroll_controller_test.dart
+++ b/packages/flutter/test/widgets/scroll_controller_test.dart
@@ -236,7 +236,23 @@ void main() {
     );
 
     expect(() => controller.offset, throwsAssertionError);
-    expect(() => controller.position, throwsAssertionError);
+    expect(
+      () => controller.position,
+      throwsA(
+        isAssertionError.having(
+          (AssertionError error) => error.message,
+          'message',
+          allOf(
+            contains(
+              'The ScrollController.position getter can only be used when a single '
+              'ScrollPosition is attached.',
+            ),
+            isNot(contains('PrimaryScrollController')),
+            isNot(contains('primary')),
+          ),
+        ),
+      ),
+    );
   });
 
   testWidgets('Write operations on ScrollControllers with no positions fail', (


### PR DESCRIPTION
Part of #81152.

This improves the generic `ScrollController.position` diagnostics when the controller is attached to more than one `ScrollPosition`. The assertion now explains that the single-position getter requires exactly one attached position, suggests using `ScrollController.positions` when all positions are needed, and points users toward separate controllers when multiple scrollables need independent positions.

The message intentionally avoids `primary` / `PrimaryScrollController` guidance because that context is not always available from the base `ScrollController` API.

Validation:
- `./bin/dart format --output=none --set-exit-if-changed packages/flutter/lib/src/widgets/scroll_controller.dart packages/flutter/test/widgets/scroll_controller_test.dart`
- `./bin/flutter analyze packages/flutter/lib/src/widgets/scroll_controller.dart packages/flutter/test/widgets/scroll_controller_test.dart`
- `./bin/flutter test packages/flutter/test/widgets/scroll_controller_test.dart --plain-name 'Read operations on ScrollControllers with more than one position fail'`
- `./bin/flutter test packages/flutter/test/widgets/scroll_controller_test.dart`
- `git diff --check upstream/master...HEAD`
