### PR TITLE
Clarify Navigator.replace old route requirement

### DIFF
--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -2552,6 +2552,11 @@ class Navigator extends StatefulWidget {
   ///
   /// The removed route is removed and completed with a `null` value.
   ///
+  /// The `oldRoute` must be the same [Route] object that is already installed
+  /// in this [Navigator]. For example, obtain the route with [ModalRoute.of]
+  /// from a [BuildContext] inside that route's subtree. Creating a new route
+  /// with the same [RouteSettings] will not identify the route to replace.
+  ///
   /// The new route, the route below the new route (if any), and the route above
   /// the new route, are all notified (see [Route.didReplace],
   /// [Route.didChangeNext], and [Route.didChangePrevious]). If the [Navigator]
@@ -5363,7 +5368,12 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   @optionalTypeArgs
   void replace<T extends Object?>({required Route<dynamic> oldRoute, required Route<T> newRoute}) {
     assert(!_debugLocked);
-    assert(oldRoute._isInstalledIn(this));
+    assert(
+      oldRoute._isInstalledIn(this),
+      'The oldRoute must be a route that is currently installed in this Navigator. '
+      'This usually means passing the same Route object that was passed to a push call '
+      'or obtained from ModalRoute.of(context), not a newly created Route with the same settings.',
+    );
     _replaceEntry(
       _RouteEntry(newRoute, pageBased: false, initialState: _RouteLifecycle.replace),
       oldRoute,
@@ -5385,7 +5395,12 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
     required RestorableRouteBuilder<T> newRouteBuilder,
     Object? arguments,
   }) {
-    assert(oldRoute._isInstalledIn(this));
+    assert(
+      oldRoute._isInstalledIn(this),
+      'The oldRoute must be a route that is currently installed in this Navigator. '
+      'This usually means passing the same Route object that was passed to a push call '
+      'or obtained from ModalRoute.of(context), not a newly created Route with the same settings.',
+    );
     assert(
       _debugIsStaticCallback(newRouteBuilder),
       'The provided routeBuilder must be a static function.',

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -1816,6 +1816,40 @@ void main() {
     expect(await pageAValue, null);
   });
 
+  testWidgets('replace reports when oldRoute is not installed', (WidgetTester tester) async {
+    final navigatorKey = GlobalKey<NavigatorState>();
+    await tester.pumpWidget(MaterialApp(navigatorKey: navigatorKey, home: const SizedBox.shrink()));
+
+    final oldRoute = MaterialPageRoute<void>(builder: (BuildContext context) => Container());
+    final newRoute = MaterialPageRoute<void>(builder: (BuildContext context) => Container());
+
+    final Matcher invalidOldRouteMatcher = throwsA(
+      isA<AssertionError>()
+          .having(
+            (AssertionError error) => error.message,
+            'message',
+            contains('oldRoute must be a route that is currently installed'),
+          )
+          .having(
+            (AssertionError error) => error.message,
+            'message',
+            contains('ModalRoute.of(context)'),
+          ),
+    );
+
+    expect(
+      () => navigatorKey.currentState!.replace<void>(oldRoute: oldRoute, newRoute: newRoute),
+      invalidOldRouteMatcher,
+    );
+    expect(
+      () => navigatorKey.currentState!.restorableReplace<void>(
+        oldRoute: oldRoute,
+        newRouteBuilder: _routeBuilder,
+      ),
+      invalidOldRouteMatcher,
+    );
+  });
+
   testWidgets('push named route and remove until where routes values are awaited', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/30748.

Clarifies that `Navigator.replace` needs the exact installed `Route` object for `oldRoute`, points readers to `ModalRoute.of(context)`, and improves the debug assertion when a non-installed route is passed. The new test covers both `replace` and `restorableReplace`.

Tests:
- `./bin/dart format --output=none --set-exit-if-changed packages/flutter/lib/src/widgets/navigator.dart`
- `./bin/flutter test packages/flutter/test/widgets/navigator_test.dart --plain-name 'replace reports when oldRoute is not installed'`
- `./bin/flutter test packages/flutter/test/widgets/navigator_test.dart`
- `./bin/flutter analyze packages/flutter/lib/src/widgets/navigator.dart packages/flutter/test/widgets/navigator_test.dart`
- `git diff --check`
