### PR TITLE
Clarify PointerEvent buttons state

### DIFF
--- a/packages/flutter/lib/src/gestures/events.dart
+++ b/packages/flutter/lib/src/gestures/events.dart
@@ -350,6 +350,11 @@ abstract class PointerEvent with Diagnosticable {
   /// Bit field using the *Button constants such as [kPrimaryMouseButton],
   /// [kSecondaryStylusButton], etc.
   ///
+  /// This value represents the buttons that are currently pressed when the
+  /// event is dispatched, not the button that caused the event. For example,
+  /// a [PointerUpEvent] usually has a value of 0 because the button that
+  /// triggered the event is no longer pressed.
+  ///
   /// For example, if this has the value 6 and the
   /// [kind] is [PointerDeviceKind.invertedStylus], then this indicates an
   /// upside-down stylus with both its primary and secondary buttons pressed.


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/110448.

Clarifies that `PointerEvent.buttons` reports the buttons currently pressed when the event is dispatched, not the button that caused the event. In particular, this explains why `PointerUpEvent.buttons` is usually `0` after the released button is no longer pressed.

Tests:
- `./bin/dart format --output=none --set-exit-if-changed packages/flutter/lib/src/gestures/events.dart`
- `./bin/flutter test packages/flutter/test/gestures/gesture_binding_test.dart --plain-name 'Should synthesize kPrimaryButton for touch when no button is set'`
- `./bin/flutter analyze packages/flutter/lib/src/gestures/events.dart`
- `git diff --check`
