### PR TITLE
Document PrimaryScrollController keyboard fallback

### DIFF
--- a/packages/flutter/lib/src/widgets/primary_scroll_controller.dart
+++ b/packages/flutter/lib/src/widgets/primary_scroll_controller.dart
@@ -45,11 +45,18 @@ const Set<TargetPlatform> _kMobilePlatforms = <TargetPlatform>{
 /// views in a subtree. For example, the [Scaffold] uses this mechanism to
 /// implement the scroll-to-top gesture on iOS.
 ///
-/// Another default behavior handled by the PrimaryScrollController is default
-/// [ScrollAction]s. If a ScrollAction is not handled by an otherwise focused
-/// part of the application, the ScrollAction will be evaluated using the scroll
-/// view associated with a PrimaryScrollController, for example, when executing
-/// [Shortcuts] key events like page up and down.
+/// The PrimaryScrollController can also provide the fallback controller for
+/// default [ScrollAction]s. A [ScrollAction] first looks for an enclosing
+/// [Scrollable] around the current [primaryFocus]. If none is found, the
+/// PrimaryScrollController associated with that focus scope is considered for
+/// fallback handling, for example, when executing [Shortcuts] key events like
+/// page up and down, or the space bar on the web.
+///
+/// Only one [ScrollPosition] can be attached to the fallback controller when a
+/// [ScrollAction] is invoked. In layouts with multiple scroll views, make sure
+/// only the intended fallback scroll view can attach to the
+/// PrimaryScrollController; set [ScrollView.primary] to false or give other
+/// scroll views unique [ScrollController]s when needed.
 ///
 /// See also:
 ///   * [ScrollAction], an [Action] that scrolls the [Scrollable] that encloses

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -196,10 +196,19 @@ abstract class ScrollView extends StatelessWidget {
   /// sufficient content to actually scroll. Otherwise, by default the user can
   /// only scroll the view if it has sufficient content. See [physics].
   ///
-  /// Also when true, the scroll view is used for default [ScrollAction]s. If a
-  /// ScrollAction is not handled by an otherwise focused part of the application,
-  /// the ScrollAction will be evaluated using this scroll view, for example,
-  /// when executing [Shortcuts] key events like page up and down.
+  /// Also when true, the scroll view can be used for fallback [ScrollAction]s.
+  /// A [ScrollAction] first looks for an enclosing [Scrollable] around the
+  /// current [primaryFocus]. If none is found, the [PrimaryScrollController]
+  /// associated with that focus scope is considered, for example, when
+  /// executing [Shortcuts] key events like page up and down, or the space bar
+  /// on the web.
+  ///
+  /// Only one [ScrollPosition] can be attached to that fallback controller when
+  /// a [ScrollAction] is invoked. On mobile platforms, vertical scroll views
+  /// with no explicit [controller] can automatically inherit the
+  /// [PrimaryScrollController]. In layouts with multiple scroll views, set this
+  /// to false or provide unique [ScrollController]s for scroll views that
+  /// should not receive fallback [ScrollAction]s.
   ///
   /// On iOS, this also identifies the scroll view that will scroll to top in
   /// response to a tap in the status bar.


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/108735.

Clarifies that default `ScrollAction`s first look for an enclosing `Scrollable` around the current focus, then consider the scoped `PrimaryScrollController` as a fallback for shortcuts such as page up/down and the web spacebar shortcut.

Also documents the multiple-scroll-view constraint: only the intended fallback scroll view should attach to that controller, so other scroll views should use `primary: false` or unique `ScrollController`s when needed, including on mobile platforms where vertical scroll views can automatically inherit the `PrimaryScrollController`.

Tests:
- `./bin/dart format --output=none --set-exit-if-changed packages/flutter/lib/src/widgets/primary_scroll_controller.dart packages/flutter/lib/src/widgets/scroll_view.dart`
- `./bin/flutter analyze packages/flutter/lib/src/widgets/primary_scroll_controller.dart packages/flutter/lib/src/widgets/scroll_view.dart`
- `./bin/flutter test packages/flutter/test/widgets/scroll_view_test.dart --plain-name 'PrimaryScrollController provides fallback ScrollActions'`
- `git diff --check`
