### PR TITLE
Document TextPainter placeholder dimensions

### DIFF
--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -61,8 +61,8 @@ enum TextOverflow {
 /// Holds the [Size] and baseline required to represent the dimensions of
 /// a placeholder in text.
 ///
-/// Placeholders specify an empty space in the text layout, which is used
-/// to later render arbitrary inline widgets into defined by a [WidgetSpan].
+/// Placeholders specify an empty space in the text layout that can later be
+/// used to render arbitrary inline widgets defined by a [WidgetSpan].
 ///
 /// See also:
 ///
@@ -1055,8 +1055,20 @@ class TextPainter {
   /// Sets the dimensions of each placeholder in [text].
   ///
   /// The number of [PlaceholderDimensions] provided should be the same as the
-  /// number of [PlaceholderSpan]s in text. Passing in an empty or null `value`
-  /// will do nothing.
+  /// number of [PlaceholderSpan]s in [text]. The dimensions correspond to the
+  /// [PlaceholderSpan]s in the order they appear during a preorder traversal of
+  /// the [InlineSpan] tree.
+  ///
+  /// Call this before [layout] when [text] contains [PlaceholderSpan]s and the
+  /// [TextPainter] needs to reserve space for them, such as when directly
+  /// measuring or painting a paragraph that contains placeholders. After
+  /// layout, [inlinePlaceholderBoxes] reports the text-space boxes reserved for
+  /// those placeholders, which can be used to position separately painted
+  /// children. This is usually unnecessary when using [Text], [RichText], or
+  /// [EditableText] because those widgets lay out their embedded widgets and set
+  /// the placeholder dimensions automatically.
+  ///
+  /// Passing in an empty or null `value` will do nothing.
   ///
   /// If [layout] is attempted without setting the placeholder dimensions, the
   /// placeholders will be ignored in the text layout and no valid

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -1054,19 +1054,10 @@ class TextPainter {
 
   /// Sets the dimensions of each placeholder in [text].
   ///
-  /// The number of [PlaceholderDimensions] provided should be the same as the
-  /// number of [PlaceholderSpan]s in [text]. The dimensions correspond to the
-  /// [PlaceholderSpan]s in the order they appear during a preorder traversal of
-  /// the [InlineSpan] tree.
-  ///
-  /// Call this before [layout] when [text] contains [PlaceholderSpan]s and the
-  /// [TextPainter] needs to reserve space for them, such as when directly
-  /// measuring or painting a paragraph that contains placeholders. After
-  /// layout, [inlinePlaceholderBoxes] reports the text-space boxes reserved for
-  /// those placeholders, which can be used to position separately painted
-  /// children. This is usually unnecessary when using [Text], [RichText], or
-  /// [EditableText] because those widgets lay out their embedded widgets and set
-  /// the placeholder dimensions automatically.
+  /// Call this before [layout] when [text] contains [PlaceholderSpan]s to
+  /// reserve space for them. After layout, [inlinePlaceholderBoxes] reports the
+  /// text-space boxes reserved for those placeholders, which should be used to
+  /// position the [PlaceholderSpan]s.
   ///
   /// Passing in an empty or null `value` will do nothing.
   ///

--- a/packages/flutter/lib/src/widgets/widget_span.dart
+++ b/packages/flutter/lib/src/widgets/widget_span.dart
@@ -27,9 +27,13 @@ import 'framework.dart';
 /// [WidgetSpan]s. Child [Text] and [RichText] widgets will be laid out
 /// independently and occupy a rectangular space in the parent text layout.
 ///
-/// [WidgetSpan]s will be ignored when passed into a [TextPainter] directly.
-/// To properly layout and paint the [child] widget, [WidgetSpan] should be
-/// passed into a [Text.rich] widget.
+/// A [WidgetSpan] will be ignored when passed into a [TextPainter] directly
+/// unless [TextPainter.setPlaceholderDimensions] is used to reserve space for
+/// the placeholder. Direct [TextPainter] callers are also responsible for
+/// laying out and painting the [child] widget separately, using
+/// [TextPainter.inlinePlaceholderBoxes] to determine where the placeholder
+/// space was reserved. To properly layout and paint the [child] widget
+/// automatically, pass [WidgetSpan] into a [Text.rich] or [RichText] widget.
 ///
 /// {@tool snippet}
 ///
@@ -160,12 +164,23 @@ class WidgetSpan extends PlaceholderSpan {
     List<PlaceholderDimensions>? dimensions,
   }) {
     assert(debugAssertIsValid());
-    assert(dimensions != null);
+    assert(
+      dimensions != null,
+      'WidgetSpan requires PlaceholderDimensions to be set on the TextPainter. '
+      'Call TextPainter.setPlaceholderDimensions with the dimensions of each '
+      'WidgetSpan before calling TextPainter.layout, or use Text.rich, RichText, '
+      'or EditableText to lay out and paint the inline widgets automatically.',
+    );
     final hasStyle = style != null;
     if (hasStyle) {
       builder.pushStyle(style!.getTextStyle(textScaler: textScaler));
     }
-    assert(builder.placeholderCount < dimensions!.length);
+    assert(
+      builder.placeholderCount < dimensions!.length,
+      'WidgetSpan requires a PlaceholderDimensions entry for each WidgetSpan. '
+      'The dimensions list has fewer entries than the number of WidgetSpans in '
+      'the InlineSpan tree.',
+    );
     final PlaceholderDimensions currentDimensions = dimensions![builder.placeholderCount];
     builder.addPlaceholder(
       currentDimensions.size.width,

--- a/packages/flutter/lib/src/widgets/widget_span.dart
+++ b/packages/flutter/lib/src/widgets/widget_span.dart
@@ -166,10 +166,9 @@ class WidgetSpan extends PlaceholderSpan {
     assert(debugAssertIsValid());
     assert(
       dimensions != null,
-      'WidgetSpan requires PlaceholderDimensions to be set on the TextPainter. '
+      'PlaceholderSpan requires PlaceholderDimensions to be set on the TextPainter. '
       'Call TextPainter.setPlaceholderDimensions with the dimensions of each '
-      'WidgetSpan before calling TextPainter.layout, or use Text.rich, RichText, '
-      'or EditableText to lay out and paint the inline widgets automatically.',
+      'PlaceholderSpan before calling TextPainter.layout.',
     );
     final hasStyle = style != null;
     if (hasStyle) {
@@ -177,8 +176,8 @@ class WidgetSpan extends PlaceholderSpan {
     }
     assert(
       builder.placeholderCount < dimensions!.length,
-      'WidgetSpan requires a PlaceholderDimensions entry for each WidgetSpan. '
-      'The dimensions list has fewer entries than the number of WidgetSpans in '
+      'PlaceholderSpan requires a PlaceholderDimensions entry for each PlaceholderSpan. '
+      'The dimensions list has fewer entries than the number of PlaceholderSpans in '
       'the InlineSpan tree.',
     );
     final PlaceholderDimensions currentDimensions = dimensions![builder.placeholderCount];

--- a/packages/flutter/test/widgets/widget_span_test.dart
+++ b/packages/flutter/test/widgets/widget_span_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui' as ui;
+
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -61,6 +63,21 @@ void main() {
       20, // c
       14, // d
     ]);
+  });
+
+  test('WidgetSpan build explains missing placeholder dimensions', () {
+    final builder = ui.ParagraphBuilder(ui.ParagraphStyle());
+
+    expect(
+      () => const WidgetSpan(child: SizedBox()).build(builder),
+      throwsA(
+        isA<AssertionError>().having(
+          (AssertionError error) => error.toString(),
+          'message',
+          contains('TextPainter.setPlaceholderDimensions'),
+        ),
+      ),
+    );
   });
 }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/49883.

Issue: `WidgetSpan` with a direct `TextPainter` failed with a bare `dimensions != null` assertion. The API docs also did not clearly explain how `PlaceholderDimensions` map to placeholder spans or when direct `TextPainter` callers need to provide them.

Fix:

- Clarifies `TextPainter.setPlaceholderDimensions` docs for placeholder ordering, direct `TextPainter` usage, and `inlinePlaceholderBoxes`.
- Clarifies `WidgetSpan` docs for direct `TextPainter` callers versus `Text.rich` / `RichText`.
- Adds actionable assertion messages for missing or insufficient `PlaceholderDimensions`, so the runtime failure points users at `TextPainter.setPlaceholderDimensions` and the widget alternatives.

Tests:

- `./bin/dart format --output=none --set-exit-if-changed packages/flutter/lib/src/painting/text_painter.dart packages/flutter/lib/src/widgets/widget_span.dart packages/flutter/test/widgets/widget_span_test.dart`
- `./bin/flutter test packages/flutter/test/widgets/widget_span_test.dart`
- `./bin/flutter analyze packages/flutter/lib/src/painting/text_painter.dart packages/flutter/lib/src/widgets/widget_span.dart packages/flutter/test/widgets/widget_span_test.dart`
- `git diff --check`

Risk: Low. The runtime behavior is unchanged outside debug assertions; the code change only improves assertion messages for invalid direct `TextPainter` usage.
