### PR TITLE
Document key event simulation platforms

### DIFF
--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// @docImport 'dart:io';
-///
 /// @docImport 'package:flutter/scheduler.dart';
 /// @docImport 'package:flutter_driver/flutter_driver.dart';
 ///
@@ -2185,10 +2183,7 @@ abstract class WidgetController {
   /// This only simulates key events coming from a physical keyboard, not from a
   /// soft keyboard.
   ///
-  /// Specify `platform` as one of the platforms allowed in
-  /// [Platform.operatingSystem] to make the event appear to be from
-  /// that type of system. If not specified, defaults to "web" on web, and the
-  /// operating system name based on [defaultTargetPlatform] everywhere else.
+  /// {@macro flutter.flutter_test.keyEventSimulationPlatform}
   ///
   /// Specify the `physicalKey` for the event to override what is included in
   /// the simulated event. If not specified, it uses a default from the US
@@ -2232,10 +2227,7 @@ abstract class WidgetController {
   /// This only simulates key down events coming from a physical keyboard, not
   /// from a soft keyboard.
   ///
-  /// Specify `platform` as one of the platforms allowed in
-  /// [Platform.operatingSystem] to make the event appear to be from
-  /// that type of system. If not specified, defaults to "web" on web, and the
-  /// operating system name based on [defaultTargetPlatform] everywhere else.
+  /// {@macro flutter.flutter_test.keyEventSimulationPlatform}
   ///
   /// Specify the `physicalKey` for the event to override what is included in
   /// the simulated event. If not specified, it uses a default from the US
@@ -2274,10 +2266,7 @@ abstract class WidgetController {
   /// This only simulates key up events coming from a physical keyboard,
   /// not from a soft keyboard.
   ///
-  /// Specify `platform` as one of the platforms allowed in
-  /// [Platform.operatingSystem] to make the event appear to be from
-  /// that type of system. If not specified, defaults to "web" on web, and the
-  /// operating system name based on [defaultTargetPlatform] everywhere else.
+  /// {@macro flutter.flutter_test.keyEventSimulationPlatform}
   ///
   /// Specify the `physicalKey` for the event to override what is included in
   /// the simulated event. If not specified, it uses a default from the US
@@ -2304,10 +2293,7 @@ abstract class WidgetController {
   /// This only simulates key repeat events coming from a physical keyboard, not
   /// from a soft keyboard.
   ///
-  /// Specify `platform` as one of the platforms allowed in
-  /// [Platform.operatingSystem] to make the event appear to be from
-  /// that type of system. If not specified, defaults to "web" on web, and the
-  /// operating system name based on [defaultTargetPlatform] everywhere else.
+  /// {@macro flutter.flutter_test.keyEventSimulationPlatform}
   ///
   /// Specify the `physicalKey` for the event to override what is included in
   /// the simulated event. If not specified, it uses a default from the US

--- a/packages/flutter_test/lib/src/event_simulation.dart
+++ b/packages/flutter_test/lib/src/event_simulation.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
@@ -726,10 +725,17 @@ abstract final class KeyEventSimulator {
   /// This only simulates key presses coming from a physical keyboard, not from a
   /// soft keyboard.
   ///
-  /// Specify `platform` as one of the platforms allowed in
-  /// [Platform.operatingSystem] to make the event appear to be from that type of
-  /// system. Defaults to "web" on web, and the operating system name based on
+  /// {@template flutter.flutter_test.keyEventSimulationPlatform}
+  /// Specify `platform` as one of `android`, `fuchsia`, `ios`, `linux`, `macos`,
+  /// `web`, and `windows` to make the event appear to be from that type of
+  /// system. Defaults to "web" on web, and the lowercased name of
   /// [defaultTargetPlatform] everywhere else.
+  ///
+  /// The `platform` value selects the platform key map used to synthesize the
+  /// event. Not every [LogicalKeyboardKey] or [PhysicalKeyboardKey] is
+  /// available on every platform; simulating a key that is not in the selected
+  /// platform's key map can throw.
+  /// {@endtemplate}
   ///
   /// Keys that are down when the test completes are cleared after each test.
   ///
@@ -775,10 +781,7 @@ abstract final class KeyEventSimulator {
   /// This only simulates key presses coming from a physical keyboard, not from a
   /// soft keyboard.
   ///
-  /// Specify `platform` as one of the platforms allowed in
-  /// [Platform.operatingSystem] to make the event appear to be from that type of
-  /// system. Defaults to "web" on web, and the operating system name based on
-  /// [defaultTargetPlatform] everywhere else.
+  /// {@macro flutter.flutter_test.keyEventSimulationPlatform}
   ///
   /// Returns true if the key event was handled by the framework.
   ///
@@ -821,10 +824,7 @@ abstract final class KeyEventSimulator {
   /// This only simulates key presses coming from a physical keyboard, not from a
   /// soft keyboard.
   ///
-  /// Specify `platform` as one of the platforms allowed in
-  /// [Platform.operatingSystem] to make the event appear to be from that type of
-  /// system. Defaults to "web" on web, and the operating system name based on
-  /// [defaultTargetPlatform] everywhere else.
+  /// {@macro flutter.flutter_test.keyEventSimulationPlatform}
   ///
   /// Returns true if the key event was handled by the framework.
   ///
@@ -872,10 +872,7 @@ abstract final class KeyEventSimulator {
 /// soft keyboard, and it can only simulate keys that appear in the key maps
 /// such as [kAndroidToLogicalKey], [kMacOsToPhysicalKey], etc.
 ///
-/// Specify `platform` as one of the platforms allowed in
-/// [Platform.operatingSystem] to make the event appear to be from that type of
-/// system. Defaults to "web" on web, and the operating system name based on
-/// [defaultTargetPlatform] everywhere else.
+/// {@macro flutter.flutter_test.keyEventSimulationPlatform}
 ///
 /// Keys that are down when the test completes are cleared after each test.
 ///
@@ -912,10 +909,7 @@ Future<bool> simulateKeyDownEvent(
 /// soft keyboard, and it can only simulate keys that appear in the key maps
 /// such as [kAndroidToLogicalKey], [kMacOsToPhysicalKey], etc.
 ///
-/// Specify `platform` as one of the platforms allowed in
-/// [Platform.operatingSystem] to make the event appear to be from that type of
-/// system. Defaults to "web" on web, and the operating system name based on
-/// [defaultTargetPlatform] everywhere else.
+/// {@macro flutter.flutter_test.keyEventSimulationPlatform}
 ///
 /// Returns true if the key event was handled by the framework.
 ///
@@ -945,10 +939,7 @@ Future<bool> simulateKeyUpEvent(
 /// This only simulates key presses coming from a physical keyboard, not from a
 /// soft keyboard.
 ///
-/// Specify `platform` as one of the platforms allowed in
-/// [Platform.operatingSystem] to make the event appear to be from that type of
-/// system. Defaults to "web" on web, and the operating system name based on
-/// [defaultTargetPlatform] everywhere else.
+/// {@macro flutter.flutter_test.keyEventSimulationPlatform}
 ///
 /// Returns true if the key event was handled by the framework.
 ///

--- a/packages/flutter_test/lib/src/event_simulation.dart
+++ b/packages/flutter_test/lib/src/event_simulation.dart
@@ -734,7 +734,7 @@ abstract final class KeyEventSimulator {
   /// The `platform` value selects the platform key map used to synthesize the
   /// event. Not every [LogicalKeyboardKey] or [PhysicalKeyboardKey] is
   /// available on every platform; simulating a key that is not in the selected
-  /// platform's key map can throw.
+  /// platform's key map throws an assertion error.
   /// {@endtemplate}
   ///
   /// Keys that are down when the test completes are cleared after each test.


### PR DESCRIPTION
Fixes #133295.

Clarifies the platform parameter used by WidgetTester key simulation helpers and the lower-level key event simulation functions:

- lists the accepted raw platform strings
- explains that the platform selects the key map used to synthesize the event
- notes that some keys are not available on every platform and can throw when simulated

This is an API-docs-only change.

## Pre-launch Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I read the AI contribution guidelines and understand my responsibilities, or I am not using AI tools.
- [x] I read the Tree Hygiene wiki page, which explains my responsibilities.
- [x] I read and followed the Flutter Style Guide.
- [x] I signed the CLA.
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation.
- [x] I added new tests to check the change I am making, or this PR is test-exempt.
- [x] All existing and new tests are passing.