### PR TITLE
Fix non-independant tests in draggable_test.dart

### DIFF
--- a/packages/flutter/test/widgets/draggable_test.dart
+++ b/packages/flutter/test/widgets/draggable_test.dart
@@ -53,7 +53,7 @@ void main() {
     expect(moveCount, 0);
 
     final Offset firstLocation = tester.getCenter(find.text('Source'));
-    final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    final TestGesture gesture = await tester.startGesture(firstLocation);
     await tester.pump();
 
     expect(accepted, isEmpty);
@@ -293,7 +293,7 @@ void main() {
     expect(leftBehind['Target 2'], equals(0));
 
     final Offset firstLocation = tester.getCenter(find.text('Source'));
-    final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    final TestGesture gesture = await tester.startGesture(firstLocation);
     await tester.pump();
 
     expect(leftBehind['Target 1'], equals(0));
@@ -363,7 +363,7 @@ void main() {
     expect(leftBehind['Target 2'], equals(0));
 
     final Offset firstLocation = tester.getCenter(find.text('Source'));
-    final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    final TestGesture gesture = await tester.startGesture(firstLocation);
     await tester.pump();
 
     expect(leftBehind['Target 1'], equals(0));
@@ -432,7 +432,7 @@ void main() {
     expect(targetMoveCount['Target 2'], equals(0));
 
     final Offset firstLocation = tester.getCenter(find.text('Source'));
-    final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    final TestGesture gesture = await tester.startGesture(firstLocation);
     await tester.pump();
 
     expect(targetMoveCount['Target 1'], equals(0));
@@ -504,7 +504,7 @@ void main() {
     expect(targetMoveCount['Target 2'], equals(0));
 
     final Offset firstLocation = tester.getCenter(find.text('Source'));
-    final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    final TestGesture gesture = await tester.startGesture(firstLocation);
     await tester.pump();
 
     expect(targetMoveCount['Target 1'], equals(0));
@@ -563,7 +563,7 @@ void main() {
     expect(onMoveCalled, isFalse);
 
     final Offset firstLocation = tester.getCenter(find.text('Source'));
-    final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    final TestGesture gesture = await tester.startGesture(firstLocation);
     await tester.pump();
 
     expect(onMoveCalled, isFalse);
@@ -636,7 +636,7 @@ void main() {
     // drag and drop
 
     firstLocation = tester.getCenter(find.text('Source'));
-    TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    TestGesture gesture = await tester.startGesture(firstLocation);
     await tester.pump();
 
     secondLocation = tester.getCenter(find.text('Target'));
@@ -652,7 +652,7 @@ void main() {
     // drag and tap and drop
 
     firstLocation = tester.getCenter(find.text('Source'));
-    gesture = await tester.startGesture(firstLocation, pointer: 7);
+    gesture = await tester.startGesture(firstLocation);
     await tester.pump();
 
     secondLocation = tester.getCenter(find.text('Target'));
@@ -714,7 +714,7 @@ void main() {
     events.clear();
 
     firstLocation = tester.getCenter(find.text('Button'));
-    final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    final TestGesture gesture = await tester.startGesture(firstLocation);
     await tester.pump();
 
     secondLocation = tester.getCenter(find.text('Target'));
@@ -766,7 +766,7 @@ void main() {
     expect(events, isEmpty);
 
     firstLocation = tester.getCenter(find.text('Source'));
-    final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    final TestGesture gesture = await tester.startGesture(firstLocation);
     await tester.pump();
 
     secondLocation = tester.getCenter(find.text('Target'));
@@ -813,7 +813,7 @@ void main() {
     expect(events, isEmpty);
 
     firstLocation = tester.getCenter(find.text('Source'));
-    final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    final TestGesture gesture = await tester.startGesture(firstLocation);
     await tester.pump();
 
     await tester.pump(const Duration(seconds: 20));
@@ -881,7 +881,7 @@ void main() {
     expect(events, isEmpty);
     firstLocation = tester.getCenter(find.text('V'));
     secondLocation = tester.getCenter(find.text('Target'));
-    TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    TestGesture gesture = await tester.startGesture(firstLocation);
     await tester.pump();
     await gesture.moveTo(secondLocation);
     await tester.pump();
@@ -896,7 +896,7 @@ void main() {
     firstLocation = tester.getTopLeft(find.text('H'));
     secondLocation = tester.getTopRight(find.text('H'));
     thirdLocation = tester.getCenter(find.text('Target'));
-    gesture = await tester.startGesture(firstLocation, pointer: 7);
+    gesture = await tester.startGesture(firstLocation);
     await tester.pump();
     await gesture.moveTo(secondLocation);
     await tester.pump();
@@ -914,7 +914,7 @@ void main() {
     firstLocation = tester.getTopLeft(find.text('V'));
     secondLocation = tester.getTopRight(find.text('V'));
     thirdLocation = tester.getCenter(find.text('Target'));
-    gesture = await tester.startGesture(firstLocation, pointer: 7);
+    gesture = await tester.startGesture(firstLocation);
     await tester.pump();
     await gesture.moveTo(secondLocation);
     await tester.pump();
@@ -931,7 +931,7 @@ void main() {
     expect(events, isEmpty);
     firstLocation = tester.getCenter(find.text('H'));
     secondLocation = tester.getCenter(find.text('Target'));
-    gesture = await tester.startGesture(firstLocation, pointer: 7);
+    gesture = await tester.startGesture(firstLocation);
     await tester.pump();
     await gesture.moveTo(secondLocation);
     await tester.pump(); // scrolls off screen!
@@ -996,7 +996,7 @@ void main() {
     expect(events, isEmpty);
     firstLocation = tester.getCenter(find.text('H'));
     secondLocation = tester.getCenter(find.text('Target'));
-    TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    TestGesture gesture = await tester.startGesture(firstLocation);
     await tester.pump();
     await gesture.moveTo(secondLocation);
     await tester.pump();
@@ -1011,7 +1011,7 @@ void main() {
     firstLocation = tester.getTopLeft(find.text('V'));
     secondLocation = tester.getBottomLeft(find.text('V'));
     thirdLocation = tester.getCenter(find.text('Target'));
-    gesture = await tester.startGesture(firstLocation, pointer: 7);
+    gesture = await tester.startGesture(firstLocation);
     await tester.pump();
     await gesture.moveTo(secondLocation);
     await tester.pump();
@@ -1029,7 +1029,7 @@ void main() {
     firstLocation = tester.getTopLeft(find.text('H'));
     secondLocation = tester.getBottomLeft(find.text('H'));
     thirdLocation = tester.getCenter(find.text('Target'));
-    gesture = await tester.startGesture(firstLocation, pointer: 7);
+    gesture = await tester.startGesture(firstLocation);
     await tester.pump();
     await gesture.moveTo(secondLocation);
     await tester.pump();
@@ -1046,7 +1046,7 @@ void main() {
     expect(events, isEmpty);
     firstLocation = tester.getCenter(find.text('V'));
     secondLocation = tester.getCenter(find.text('Target'));
-    gesture = await tester.startGesture(firstLocation, pointer: 7);
+    gesture = await tester.startGesture(firstLocation);
     await tester.pump();
     await gesture.moveTo(secondLocation);
     await tester.pump(); // scrolls off screen!
@@ -1111,7 +1111,7 @@ void main() {
       final Offset firstLocation = tester.getTopLeft(find.text('N'));
       final Offset secondLocation = firstLocation + const Offset(300.0, 300.0);
       final Offset thirdLocation = firstLocation + const Offset(-300.0, -300.0);
-      final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+      final TestGesture gesture = await tester.startGesture(firstLocation);
       await tester.pump();
       await gesture.moveTo(secondLocation);
       await tester.pump();
@@ -1126,7 +1126,7 @@ void main() {
       final Offset firstLocation = tester.getTopLeft(find.text('H'));
       final Offset secondLocation = firstLocation + const Offset(300.0, 0.0);
       final Offset thirdLocation = firstLocation + const Offset(-300.0, 0.0);
-      final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+      final TestGesture gesture = await tester.startGesture(firstLocation);
       await tester.pump();
       await gesture.moveTo(secondLocation);
       await tester.pump();
@@ -1144,7 +1144,7 @@ void main() {
       final Offset secondWidgetLocation = firstLocation + const Offset(300.0, 0.0);
       final Offset thirdDragLocation = firstLocation + const Offset(-300.0, -200.0);
       final Offset thirdWidgetLocation = firstLocation + const Offset(-300.0, 0.0);
-      final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+      final TestGesture gesture = await tester.startGesture(firstLocation);
       await tester.pump();
       await gesture.moveTo(secondDragLocation);
       await tester.pump();
@@ -1159,7 +1159,7 @@ void main() {
       final Offset firstLocation = tester.getTopLeft(find.text('V'));
       final Offset secondLocation = firstLocation + const Offset(0.0, 300.0);
       final Offset thirdLocation = firstLocation + const Offset(0.0, -300.0);
-      final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+      final TestGesture gesture = await tester.startGesture(firstLocation);
       await tester.pump();
       await gesture.moveTo(secondLocation);
       await tester.pump();
@@ -1177,7 +1177,7 @@ void main() {
       final Offset secondWidgetLocation = firstLocation + const Offset(0.0, 300.0);
       final Offset thirdDragLocation = firstLocation + const Offset(-200.0, -300.0);
       final Offset thirdWidgetLocation = firstLocation + const Offset(0.0, -300.0);
-      final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+      final TestGesture gesture = await tester.startGesture(firstLocation);
       await tester.pump();
       await gesture.moveTo(secondDragLocation);
       await tester.pump();
@@ -1185,6 +1185,9 @@ void main() {
       await gesture.moveTo(thirdDragLocation);
       await tester.pump();
       expect(tester.getTopLeft(find.text('V')), thirdWidgetLocation);
+
+      await gesture.up();
+      await tester.pump();
     });
   });
 
@@ -1245,7 +1248,7 @@ void main() {
       expect(find.text('Dragging'), findsNothing);
 
       final Offset firstLocation = tester.getCenter(find.text('Source'));
-      final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+      final TestGesture gesture = await tester.startGesture(firstLocation);
       await tester.pump();
 
       expect(updated, 0);
@@ -1282,7 +1285,7 @@ void main() {
       expect(find.text('Vertical Dragging'), findsNothing);
 
       final Offset firstLocation = tester.getCenter(find.text('Vertical Source'));
-      final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+      final TestGesture gesture = await tester.startGesture(firstLocation);
       await tester.pump();
 
       expect(updated, 0);
@@ -1319,7 +1322,7 @@ void main() {
       expect(find.text('Horizontal Dragging'), findsNothing);
 
       final Offset firstLocation = tester.getCenter(find.text('Horizontal Source'));
-      final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+      final TestGesture gesture = await tester.startGesture(firstLocation);
       await tester.pump();
 
       expect(updated, 0);
@@ -1386,7 +1389,7 @@ void main() {
     expect(onDraggableCanceledCalled, isFalse);
 
     final Offset firstLocation = tester.getCenter(find.text('Source'));
-    final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    final TestGesture gesture = await tester.startGesture(firstLocation);
     await tester.pump();
 
     expect(accepted, isEmpty);
@@ -1463,7 +1466,7 @@ void main() {
     expect(onDraggableCanceledCalled, isFalse);
 
     final Offset firstLocation = tester.getTopLeft(find.text('Source'));
-    final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    final TestGesture gesture = await tester.startGesture(firstLocation);
     await tester.pump();
 
     expect(accepted, isEmpty);
@@ -1541,7 +1544,7 @@ void main() {
       expect(onDraggableCanceledCalled, isFalse);
 
       final Offset firstLocation = tester.getTopLeft(find.text('Source'));
-      final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+      final TestGesture gesture = await tester.startGesture(firstLocation);
       await tester.pump();
 
       expect(accepted, isEmpty);
@@ -1679,7 +1682,7 @@ void main() {
     expect(onDragEndCalled, isFalse);
 
     final Offset firstLocation = tester.getTopLeft(find.text('Source'));
-    final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    final TestGesture gesture = await tester.startGesture(firstLocation);
     await tester.pump();
 
     expect(accepted, isEmpty);
@@ -1759,7 +1762,7 @@ void main() {
       expect(onDragEndCalled, isFalse);
 
       final Offset firstLocation = tester.getTopLeft(find.text('Source'));
-      final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+      final TestGesture gesture = await tester.startGesture(firstLocation);
       await tester.pump();
 
       expect(accepted, isEmpty);
@@ -1826,7 +1829,7 @@ void main() {
       expect(find.text('Rejected'), findsNothing);
 
       final Offset firstLocation = tester.getTopLeft(find.text('Source'));
-      final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+      final TestGesture gesture = await tester.startGesture(firstLocation);
       await tester.pump();
 
       expect(find.text('Dragging'), findsOneWidget);
@@ -1888,7 +1891,7 @@ void main() {
     expect(find.text('Rejected'), findsNothing);
 
     final Offset firstLocation = tester.getTopLeft(find.text('Source'));
-    final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    final TestGesture gesture = await tester.startGesture(firstLocation);
     await tester.pump();
 
     expect(find.text('Dragging'), findsOneWidget);
@@ -1912,7 +1915,7 @@ void main() {
     expect(numberOfTimesOnDraggableCanceledCalled, 1);
 
     // Drag and drop the Draggable onto the Target a second time.
-    final TestGesture secondGesture = await tester.startGesture(firstLocation, pointer: 7);
+    final TestGesture secondGesture = await tester.startGesture(firstLocation);
     await tester.pump();
 
     expect(find.text('Dragging'), findsOneWidget);
@@ -1975,7 +1978,7 @@ void main() {
     expect(onDragCompletedCalled, isFalse);
 
     final Offset firstLocation = tester.getTopLeft(find.text('Source'));
-    final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    final TestGesture gesture = await tester.startGesture(firstLocation);
     await tester.pump();
 
     expect(accepted, isEmpty);
@@ -2047,7 +2050,7 @@ void main() {
       expect(onDragCompletedCalled, isFalse);
 
       final Offset firstLocation = tester.getTopLeft(find.text('Source'));
-      final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+      final TestGesture gesture = await tester.startGesture(firstLocation);
       await tester.pump();
 
       expect(accepted, isEmpty);
@@ -2120,7 +2123,7 @@ void main() {
     expect(onDragEndCalled, isFalse);
 
     final Offset firstLocation = tester.getCenter(find.text('Source'));
-    final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    final TestGesture gesture = await tester.startGesture(firstLocation);
     await tester.pump();
 
     expect(accepted, isEmpty);
@@ -2203,7 +2206,7 @@ void main() {
     expect(events, isEmpty);
 
     firstLocation = tester.getCenter(find.text('Source'));
-    final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    final TestGesture gesture = await tester.startGesture(firstLocation);
     await tester.pump();
 
     await tester.pump(const Duration(seconds: 20));
@@ -2267,7 +2270,7 @@ void main() {
     expect(onDragCompletedCalled, isFalse);
 
     final Offset firstLocation = tester.getCenter(find.text('Source'));
-    final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    final TestGesture gesture = await tester.startGesture(firstLocation);
     await tester.pump();
 
     expect(accepted, isEmpty);
@@ -2361,7 +2364,7 @@ void main() {
     final Offset targetLocation = tester.getCenter(find.text('Target1'));
 
     // Drag the double draggable.
-    final TestGesture doubleGesture = await tester.startGesture(doubleLocation, pointer: 7);
+    final TestGesture doubleGesture = await tester.startGesture(doubleLocation);
     await tester.pump();
 
     expect(acceptedInts, isEmpty);
@@ -2396,7 +2399,7 @@ void main() {
     acceptedDoublesDetails.clear();
 
     // Drag the int draggable.
-    final TestGesture intGesture = await tester.startGesture(intLocation, pointer: 7);
+    final TestGesture intGesture = await tester.startGesture(intLocation);
     await tester.pump();
 
     expect(acceptedInts, isEmpty);
@@ -2538,7 +2541,7 @@ void main() {
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
 
-    final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    final TestGesture gesture = await tester.startGesture(firstLocation);
     await tester.pump();
 
     expect(accepted, isEmpty);
@@ -2557,7 +2560,7 @@ void main() {
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
 
-    final TestGesture gesture1 = await tester.startGesture(firstLocation, pointer: 8);
+    final TestGesture gesture1 = await tester.startGesture(firstLocation);
     await tester.pump();
 
     expect(accepted, isEmpty);
@@ -2566,7 +2569,7 @@ void main() {
     expect(find.text('Dragging'), findsOneWidget);
     expect(find.text('Target'), findsOneWidget);
 
-    final TestGesture gesture2 = await tester.startGesture(firstLocation, pointer: 9);
+    final TestGesture gesture2 = await tester.startGesture(firstLocation);
     await tester.pump();
 
     expect(accepted, isEmpty);
@@ -2575,7 +2578,7 @@ void main() {
     expect(find.text('Dragging'), findsNWidgets(2));
     expect(find.text('Target'), findsOneWidget);
 
-    final TestGesture gesture3 = await tester.startGesture(firstLocation, pointer: 10);
+    final TestGesture gesture3 = await tester.startGesture(firstLocation);
     await tester.pump();
 
     expect(accepted, isEmpty);
@@ -2662,7 +2665,7 @@ void main() {
     expect(find.text('Target'), findsOneWidget);
 
     final Offset firstLocation = tester.getCenter(find.text('Source'));
-    final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    final TestGesture gesture = await tester.startGesture(firstLocation);
     await tester.pump();
 
     expect(onAcceptCalled, isFalse);
@@ -2768,14 +2771,8 @@ void main() {
       ),
     );
 
-    final TestGesture firstGesture = await tester.startGesture(
-      const Offset(10.0, 10.0),
-      pointer: 24,
-    );
-    final TestGesture secondGesture = await tester.startGesture(
-      const Offset(10.0, 20.0),
-      pointer: 25,
-    );
+    final TestGesture firstGesture = await tester.startGesture(const Offset(10.0, 10.0));
+    final TestGesture secondGesture = await tester.startGesture(const Offset(10.0, 20.0));
 
     await firstGesture.moveBy(const Offset(100.0, 0.0));
     await secondGesture.up();
@@ -2818,7 +2815,7 @@ void main() {
     expect(events, isEmpty);
 
     firstLocation = tester.getCenter(find.text('Source'));
-    final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    final TestGesture gesture = await tester.startGesture(firstLocation);
     await tester.pump();
 
     await tester.pump(const Duration(seconds: 20));
@@ -2870,7 +2867,7 @@ void main() {
     expect(find.text('Target'), findsOneWidget);
 
     final Offset firstLocation = tester.getCenter(find.text('Source'));
-    final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    final TestGesture gesture = await tester.startGesture(firstLocation);
     await tester.pump();
 
     expect(accepted, isEmpty);
@@ -2984,7 +2981,7 @@ void main() {
     expect(onDragEndCalled, isFalse);
 
     final Offset firstLocation = tester.getCenter(find.text('Source'));
-    final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    final TestGesture gesture = await tester.startGesture(firstLocation);
     await tester.pump();
 
     expect(accepted, isEmpty);
@@ -3072,7 +3069,7 @@ void main() {
     expect(onDragCompletedCalled, isFalse);
 
     final Offset firstLocation = tester.getCenter(find.text('Source'));
-    final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    final TestGesture gesture = await tester.startGesture(firstLocation);
     await tester.pump();
 
     expect(accepted, isEmpty);
@@ -3136,7 +3133,7 @@ void main() {
     expect(onDragStartedCalled, isFalse);
 
     final Offset firstLocation = tester.getCenter(find.text('Source'));
-    final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    final TestGesture gesture = await tester.startGesture(firstLocation);
     await tester.pump();
 
     expect(find.text('Source'), findsOneWidget);
@@ -3173,7 +3170,7 @@ void main() {
     expect(find.text('Dragging'), findsNothing);
     expect(onDragStartedCalled, isFalse);
     final Offset firstLocation = tester.getCenter(find.text('Source'));
-    final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    final TestGesture gesture = await tester.startGesture(firstLocation);
     await tester.pump();
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
@@ -3212,7 +3209,7 @@ void main() {
     expect(find.text('Dragging'), findsNothing);
     expect(onDragStartedCalled, isFalse);
     final Offset firstLocation = tester.getCenter(find.text('Source'));
-    final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    final TestGesture gesture = await tester.startGesture(firstLocation);
     await tester.pump();
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
@@ -3302,7 +3299,7 @@ void main() {
     );
 
     final Offset firstLocation = tester.getCenter(find.text('Source'));
-    final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    final TestGesture gesture = await tester.startGesture(firstLocation);
     await tester.pump();
 
     final Offset secondLocation = tester.getCenter(find.text('Target 1'));
@@ -3319,6 +3316,9 @@ void main() {
       find.descendant(of: find.byType(Overlay).last, matching: find.text('Dragging')),
       findsNothing,
     );
+
+    await gesture.up();
+    await tester.pump();
   });
 
   testWidgets('Drag feedback is put on root overlay with [rootOverlay] flag', (
@@ -3364,7 +3364,7 @@ void main() {
     );
 
     final Offset firstLocation = tester.getCenter(find.text('Source'));
-    final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    final TestGesture gesture = await tester.startGesture(firstLocation);
     await tester.pump(kLongPressTimeout);
 
     final Offset secondLocation = tester.getCenter(find.text('Target 1'));
@@ -3433,7 +3433,7 @@ void main() {
     expect(accepted, isEmpty);
 
     final Offset firstLocation = tester.getCenter(find.text('Source'));
-    final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    final TestGesture gesture = await tester.startGesture(firstLocation);
     await tester.pump();
 
     final Offset secondLocation = tester.getCenter(find.text('Target'));
@@ -3469,7 +3469,7 @@ void main() {
       expect(accepted, isEmpty);
 
       final Offset firstLocation = tester.getCenter(find.text('Source'));
-      final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+      final TestGesture gesture = await tester.startGesture(firstLocation);
       await tester.pump();
 
       final Offset secondLocation = tester.getCenter(find.text('Target'));
@@ -3513,7 +3513,7 @@ void main() {
       expect(accepted, isEmpty);
 
       final Offset firstLocation = tester.getCenter(find.text('Source'));
-      final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+      final TestGesture gesture = await tester.startGesture(firstLocation);
       await tester.pump();
 
       final Offset secondLocation = tester.getCenter(find.text('Target'));
@@ -3636,7 +3636,7 @@ void main() {
 
     final Offset firstLocation = tester.getTopLeft(find.text('N'));
     final Offset secondLocation = firstLocation + const Offset(300.0, 300.0);
-    final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    final TestGesture gesture = await tester.startGesture(firstLocation);
     await tester.pump();
     await gesture.moveTo(secondLocation);
     await tester.pump();
@@ -3696,6 +3696,9 @@ void main() {
       ),
     );
     semantics.dispose();
+
+    await gesture.up();
+    await tester.pump();
   });
 
   testWidgets('Drag and drop - when a dragAnchorStrategy is provided it gets called', (
@@ -3722,7 +3725,7 @@ void main() {
     );
 
     final Offset location = tester.getCenter(find.text('Source'));
-    final TestGesture gesture = await tester.startGesture(location, pointer: 7);
+    final TestGesture gesture = await tester.startGesture(location);
 
     expect(dragAnchorStrategyCalled, true);
 
@@ -3943,7 +3946,7 @@ void main() {
     );
 
     final Offset location = tester.getCenter(find.text('Target'));
-    final TestGesture gesture = await tester.startGesture(location, pointer: 7);
+    final TestGesture gesture = await tester.startGesture(location);
     final Offset secondLocation = location + const Offset(7.0, 7.0);
     await gesture.moveTo(secondLocation);
     await tester.pump();
@@ -3974,7 +3977,7 @@ void main() {
     );
 
     final Offset location = tester.getCenter(find.text('Target'));
-    final TestGesture gesture = await tester.startGesture(location, pointer: 7);
+    final TestGesture gesture = await tester.startGesture(location);
     await tester.pump(kLongPressTimeout);
 
     final Offset secondLocation = location + const Offset(7.0, 7.0);
@@ -3983,6 +3986,9 @@ void main() {
 
     await tester.tap(find.text('Draggable'));
     expect(onTap, true);
+
+    await gesture.up();
+    await tester.pump();
   });
 
   testWidgets('configurable DragTarget hit test behavior', (WidgetTester tester) async {
@@ -4039,14 +4045,14 @@ void main() {
     await tester.pumpWidget(build(null));
     final Offset firstLocation = tester.getCenter(find.text('Source'));
     expect(find.text('Dragging'), findsNothing);
-    final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    final TestGesture gesture = await tester.startGesture(firstLocation);
     await tester.pump();
     expect(find.text('Dragging'), findsOneWidget);
     await gesture.up();
 
     await tester.pumpWidget(build((int buttons) => buttons == kSecondaryButton));
     expect(find.text('Dragging'), findsNothing);
-    final TestGesture gesture1 = await tester.startGesture(firstLocation, pointer: 8);
+    final TestGesture gesture1 = await tester.startGesture(firstLocation);
     await tester.pump();
     expect(find.text('Dragging'), findsNothing);
     await gesture1.up();
@@ -4055,14 +4061,14 @@ void main() {
       build((int buttons) => buttons & kTertiaryButton != 0 || buttons & kPrimaryButton != 0),
     );
     expect(find.text('Dragging'), findsNothing);
-    final TestGesture gesture2 = await tester.startGesture(firstLocation, pointer: 8);
+    final TestGesture gesture2 = await tester.startGesture(firstLocation);
     await tester.pump();
     expect(find.text('Dragging'), findsOneWidget);
     await gesture2.up();
 
     await tester.pumpWidget(build((int buttons) => false));
     expect(find.text('Dragging'), findsNothing);
-    final TestGesture gesture3 = await tester.startGesture(firstLocation, pointer: 8);
+    final TestGesture gesture3 = await tester.startGesture(firstLocation);
     await tester.pump();
     expect(find.text('Dragging'), findsNothing);
     await gesture3.up();
@@ -4120,7 +4126,7 @@ Future<void> _testLongPressDraggableHapticFeedback({
   expect(onDragStartedCalled, isFalse);
 
   final Offset firstLocation = tester.getCenter(find.text('Source'));
-  final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+  final TestGesture gesture = await tester.startGesture(firstLocation);
   await tester.pump();
 
   expect(find.text('Source'), findsOneWidget);
@@ -4191,7 +4197,7 @@ Future<void> _testChildAnchorFeedbackPosition({
   expect(dragStartedCount, 0);
 
   final Offset firstLocation = tester.getCenter(find.text('Source'));
-  final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+  final TestGesture gesture = await tester.startGesture(firstLocation);
   await tester.pump();
 
   expect(accepted, isEmpty);
@@ -4216,6 +4222,9 @@ Future<void> _testChildAnchorFeedbackPosition({
   final Offset sourceTopLeft = tester.getTopLeft(find.text('Source'));
   final Offset dragOffset = secondLocation - firstLocation;
   expect(feedbackTopLeft, equals(sourceTopLeft + dragOffset));
+
+  await gesture.up();
+  await tester.pump();
 }
 
 class DragTargetData {}

--- a/packages/flutter/test/widgets/draggable_test.dart
+++ b/packages/flutter/test/widgets/draggable_test.dart
@@ -1119,6 +1119,8 @@ void main() {
       await gesture.moveTo(thirdLocation);
       await tester.pump();
       expect(tester.getTopLeft(find.text('N')), thirdLocation);
+      await gesture.up();
+      await tester.pump();
     });
 
     testWidgets('Horizontal axis draggable moves horizontally', (WidgetTester tester) async {
@@ -1134,6 +1136,8 @@ void main() {
       await gesture.moveTo(thirdLocation);
       await tester.pump();
       expect(tester.getTopLeft(find.text('H')), thirdLocation);
+      await gesture.up();
+      await tester.pump();
     });
 
     testWidgets('Horizontal axis draggable does not move vertically', (WidgetTester tester) async {
@@ -1152,6 +1156,8 @@ void main() {
       await gesture.moveTo(thirdDragLocation);
       await tester.pump();
       expect(tester.getTopLeft(find.text('H')), thirdWidgetLocation);
+      await gesture.up();
+      await tester.pump();
     });
 
     testWidgets('Vertical axis draggable moves vertically', (WidgetTester tester) async {
@@ -1167,6 +1173,8 @@ void main() {
       await gesture.moveTo(thirdLocation);
       await tester.pump();
       expect(tester.getTopLeft(find.text('V')), thirdLocation);
+      await gesture.up();
+      await tester.pump();
     });
 
     testWidgets('Vertical axis draggable does not move horizontally', (WidgetTester tester) async {
@@ -3381,6 +3389,8 @@ void main() {
       find.descendant(of: find.byType(Overlay).last, matching: find.text('Dragging')),
       findsNothing,
     );
+    await gesture.up();
+    await tester.pump();
   });
 
   testWidgets('configurable DragTarget hit test behavior', (WidgetTester tester) async {
@@ -3953,6 +3963,9 @@ void main() {
 
     await tester.tap(find.text('Draggable'));
     expect(onTap, true);
+
+    await gesture.up();
+    await tester.pump();
   });
 
   testWidgets('configurable feedback ignore pointer behavior - LongPressDraggable', (

--- a/packages/flutter/test/widgets/draggable_test.dart
+++ b/packages/flutter/test/widgets/draggable_test.dart
@@ -1847,6 +1847,9 @@ void main() {
       expect(find.text('Dragging'), findsOneWidget);
       expect(find.text('Target'), findsOneWidget);
       expect(find.text('Rejected'), findsNothing);
+
+      await gesture.up();
+      await tester.pump();
     },
   );
 

--- a/packages/flutter/test/widgets/draggable_test.dart
+++ b/packages/flutter/test/widgets/draggable_test.dart
@@ -2,13 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(gspencergoog): Remove this tag once this test's state leaks/test
-// dependencies have been fixed.
-// https://github.com/flutter/flutter/issues/85160
-// Fails with "flutter test --test-randomize-ordering-seed=123"
-@Tags(<String>['no-shuffle'])
-library;
-
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -1834,9 +1834,9 @@ abstract class WidgetController {
   /// [startGesture] method is called without an explicit pointer identifier.
   int get nextPointer => _nextPointer;
 
-  int _nextPointer = 1;
+  static int _nextPointer = 1;
 
-  int _getNextPointer() {
+  static int _getNextPointer() {
     final int result = _nextPointer;
     _nextPointer += 1;
     return result;

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -1834,9 +1834,9 @@ abstract class WidgetController {
   /// [startGesture] method is called without an explicit pointer identifier.
   int get nextPointer => _nextPointer;
 
-  static int _nextPointer = 1;
+  int _nextPointer = 1;
 
-  static int _getNextPointer() {
+  int _getNextPointer() {
     final int result = _nextPointer;
     _nextPointer += 1;
     return result;


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/85160


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
