### PR TITLE
(WIP) Deprecate Material and Cupertino

### DIFF
--- a/packages/flutter/lib/fix_data/fix_material/fix_material.yaml
+++ b/packages/flutter/lib/fix_data/fix_material/fix_material.yaml
@@ -26,6 +26,13 @@
 #     * WidgetState: fix_widget_state.yaml
 version: 1
 transforms:
+  - title: 'migrate from flutter/material.dart to material_ui/material_ui.dart.'
+    date: 2026-05-08
+    library: 'package:flutter/material.dart'
+    changes:
+      - kind: 'replacedby'
+        newlibrary: 'package:material_ui/material_ui.dart'
+
   # Changes made in https://github.com/flutter/flutter/pull/179776
   - title: 'Replaced by cupertino CupertinoPageTransitionsBuilder'
     date: 2026-01-15

--- a/packages/flutter/lib/fix_data/fix_material/fix_material.yaml
+++ b/packages/flutter/lib/fix_data/fix_material/fix_material.yaml
@@ -30,8 +30,8 @@ transforms:
     date: 2026-05-08
     library: 'package:flutter/material.dart'
     changes:
-      - kind: 'replacedby'
-        newlibrary: 'package:material_ui/material_ui.dart'
+      - kind: 'replacedBy'
+        newLibrary: 'package:material_ui/material_ui.dart'
 
   # Changes made in https://github.com/flutter/flutter/pull/179776
   - title: 'Replaced by cupertino CupertinoPageTransitionsBuilder'

--- a/packages/flutter/lib/material.dart
+++ b/packages/flutter/lib/material.dart
@@ -14,6 +14,10 @@
 ///    for a catalog of commonly-used Material component widgets.
 ///  * [m3.material.io](https://m3.material.io/) for the Material 3 specification
 ///  * [m2.material.io](https://m2.material.io/) for the Material 2 specification
+@Deprecated(
+  'Use the `material_ui` package instead. '
+  'This feature was deprecated after v3.47.',
+)
 library material;
 
 export 'src/material/about.dart';

--- a/packages/flutter/test_fixes/material/material.dart.expect
+++ b/packages/flutter/test_fixes/material/material.dart.expect
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   // Generic reference variables.


### PR DESCRIPTION
Material is moving to [material_ui](https://pub.dev/packages/material_ui) and Cupertino is moving to [cupertino_ui](https://pub.dev/packages/cupertino_ui). Once we're ready for those packages to be used, we should deprecate the old libraries so that users receive a deprecation warning and are encouraged to migrate. This PR should not be merged until then.

https://github.com/flutter/flutter/issues/172942

### TODOs

 - [ ] Deprecate and add a dart fix for Cupertino.
 - [x] Publish material_ui and cupertino_ui at v1.0.0.
 - [ ] Land the dart fixes from this PR in material_ui and cupertino_ui.
 - [ ] Migrate the whole framework to the new packages.
 - [ ] Make sure we're ready for most Flutter users to get nudged to migrate.
 - [ ] Land this PR.