### PR TITLE
Build script updates for syncing engine sources and building artifacts on linux-arm64

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -107,7 +107,7 @@ vars = {
   # logic or condition may not work if this flag is False.
   # TODO(zijiehe): Make this condition more strict to only download fuchsia
   # dependencies when necessary: b/40935282
-  'download_fuchsia_deps': 'host_os == "linux"',
+  'download_fuchsia_deps': 'host_os == "linux" and host_cpu == "x64"',
   # Downloads the fuchsia SDK as listed in fuchsia_sdk_path var. This variable
   # is currently only used for the Fuchsia LSC process and is not intended for
   # local development.
@@ -634,6 +634,7 @@ deps = {
         'version': 'version:21'
        }
      ],
+     'condition': 'not (host_os == "linux" and host_cpu == "arm64")',
      # Always download the JDK since java is required for running the formatter.
      'dep_type': 'cipd',
    },

--- a/engine/src/build/config/BUILDCONFIG.gn
+++ b/engine/src/build/config/BUILDCONFIG.gn
@@ -566,12 +566,7 @@ if (custom_toolchain != "") {
   set_default_toolchain("//build/toolchain/win:clang_$current_cpu")
 } else if (is_android) {
   if (host_os == "linux") {
-    # Use clang for the x86/64 Linux host builds.
-    if (host_cpu == "x86" || host_cpu == "x64" || host_cpu == "arm64") {
-      host_toolchain = "//build/toolchain/linux:clang_$host_cpu"
-    } else {
-      host_toolchain = "//build/toolchain/linux:$host_cpu"
-    }
+    host_toolchain = "//build/toolchain/linux:clang_$host_cpu"
   } else if (host_os == "mac") {
     host_toolchain = "//build/toolchain/mac:clang_$host_cpu"
   } else if (host_os == "win") {

--- a/engine/src/build/config/BUILDCONFIG.gn
+++ b/engine/src/build/config/BUILDCONFIG.gn
@@ -567,7 +567,7 @@ if (custom_toolchain != "") {
 } else if (is_android) {
   if (host_os == "linux") {
     # Use clang for the x86/64 Linux host builds.
-    if (host_cpu == "x86" || host_cpu == "x64") {
+    if (host_cpu == "x86" || host_cpu == "x64" || host_cpu == "arm64") {
       host_toolchain = "//build/toolchain/linux:clang_$host_cpu"
     } else {
       host_toolchain = "//build/toolchain/linux:$host_cpu"

--- a/engine/src/build/toolchain/android/BUILD.gn
+++ b/engine/src/build/toolchain/android/BUILD.gn
@@ -72,7 +72,7 @@ template("android_toolchain") {
     assert(invoker.is_clang)
     host_dir = ""
     if (host_os == "linux") {
-      host_dir = "linux-x64"
+      host_dir = "linux-${host_cpu}"
     } else if (host_os == "mac") {
       host_dir = "mac-${host_cpu}"
     } else {


### PR DESCRIPTION
https://github.com/flutter/flutter/pull/182552 added support in the Flutter tools for using a version of gen_snapshot that runs on linux-arm64 hosts and targets Android devices.

However, the engine build infrastructure is not currently set up to build this kind of gen_snapshot binary.

This PR contains changes needed to build engine artifacts on linux-arm64 machines.  With this PR a linux-arm64 build environment can:
* run "gclient sync"
* build targets like zip_archives/android-arm64-profile/linux-arm64.zip that were added in https://github.com/flutter/flutter/pull/182552