### PR TITLE
Add `InheritedElement.ubiquitous` constructor

### DIFF
--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -90,61 +90,14 @@ export 'package:flutter/services.dart' show AssetBundle;
 
 // BIDIRECTIONAL TEXT SUPPORT
 
-/// An [InheritedElement] that has hundreds of dependencies but will
-/// infrequently change. This provides a performance tradeoff where building
-/// the [Widget]s is faster but performing updates is slower.
-///
-/// |                     | _UbiquitousInheritedElement | InheritedElement |
-/// |---------------------|------------------------------|------------------|
-/// | insert (best case)  | O(1)                         | O(1)             |
-/// | insert (worst case) | O(1)                         | O(n)             |
-/// | search (best case)  | O(n)                         | O(1)             |
-/// | search (worst case) | O(n)                         | O(n)             |
-///
-/// Insert happens when building the [Widget] tree, search happens when updating
-/// [Widget]s.
-class _UbiquitousInheritedElement extends InheritedElement {
-  /// Creates an element that uses the given widget as its configuration.
-  _UbiquitousInheritedElement(super.widget);
-
-  @override
-  void setDependencies(Element dependent, Object? value) {
-    // This is where the cost of [InheritedElement] is incurred during build
-    // time of the widget tree. Omitting this bookkeeping is where the
-    // performance savings come from.
-    assert(value == null);
-  }
-
-  @override
-  Object? getDependencies(Element dependent) {
-    return null;
-  }
-
-  @override
-  void notifyClients(InheritedWidget oldWidget) {
-    _recurseChildren(this, (Element element) {
-      if (element.doesDependOnInheritedElement(this)) {
-        notifyDependent(oldWidget, element);
-      }
-    });
-  }
-
-  static void _recurseChildren(Element element, ElementVisitor visitor) {
-    element.visitChildren((Element child) {
-      _recurseChildren(child, visitor);
-    });
-    visitor(element);
-  }
-}
-
 /// See also:
 ///
-///  * [_UbiquitousInheritedElement], the [Element] for [_UbiquitousInheritedWidget].
+///  * [InheritedElement.ubiquitous], the [Element] for [_UbiquitousInheritedWidget].
 abstract class _UbiquitousInheritedWidget extends InheritedWidget {
   const _UbiquitousInheritedWidget({super.key, required super.child});
 
   @override
-  InheritedElement createElement() => _UbiquitousInheritedElement(this);
+  InheritedElement createElement() => InheritedElement.ubiquitous(this);
 }
 
 /// A widget that determines the ambient directionality of text and

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -6267,6 +6267,23 @@ class InheritedElement extends ProxyElement {
   /// Creates an element that uses the given widget as its configuration.
   InheritedElement(InheritedWidget super.widget);
 
+  /// Creates an [InheritedElement] that has many dependencies but will infrequently change.
+  /// {@template flutter.widgets.InheritedElement.ubiquitous}
+  /// This provides a performance tradeoff where building
+  /// the [Widget]s is faster but performing updates is slower.
+  ///
+  /// |                     | InheritedElement.ubiquitous | InheritedElement |
+  /// |---------------------|-----------------------------|------------------|
+  /// | insert (best case)  | O(1)                        | O(1)             |
+  /// | insert (worst case) | O(1)                        | O(n)             |
+  /// | search (best case)  | O(n)                        | O(1)             |
+  /// | search (worst case) | O(n)                        | O(n)             |
+  /// {@endtemplate}
+  ///
+  /// Insert happens when building the [Widget] tree, search happens when updating
+  /// [Widget]s.
+  factory InheritedElement.ubiquitous(InheritedWidget widget) = _UbiquitousInheritedElement;
+
   final Map<Element, Object?> _dependents = HashMap<Element, Object?>();
 
   @override
@@ -6440,6 +6457,38 @@ class InheritedElement extends ProxyElement {
       assert(dependent._dependencies!.contains(this));
       notifyDependent(oldWidget, dependent);
     }
+  }
+}
+
+class _UbiquitousInheritedElement extends InheritedElement {
+  /// Creates an element that uses the given widget as its configuration.
+  _UbiquitousInheritedElement(super.widget);
+
+  @override
+  void setDependencies(Element dependent, Object? value) {
+    // This is where the cost of [InheritedElement] is incurred during build
+    // time of the widget tree. Omitting this bookkeeping is where the
+    // performance savings come from.
+    assert(value == null);
+  }
+
+  @override
+  Object? getDependencies(Element dependent) => null;
+
+  @override
+  void notifyClients(InheritedWidget oldWidget) {
+    _recurseChildren(this, (Element element) {
+      if (element.doesDependOnInheritedElement(this)) {
+        notifyDependent(oldWidget, element);
+      }
+    });
+  }
+
+  static void _recurseChildren(Element element, ElementVisitor visitor) {
+    element.visitChildren((Element child) {
+      _recurseChildren(child, visitor);
+    });
+    visitor(element);
   }
 }
 

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -6267,7 +6267,8 @@ class InheritedElement extends ProxyElement {
   /// Creates an element that uses the given widget as its configuration.
   InheritedElement(InheritedWidget super.widget);
 
-  /// Creates an [InheritedElement] that has many dependencies but will infrequently change.
+  /// Creates an [InheritedElement] that has many dependencies but changes infrequently.
+  ///
   /// {@template flutter.widgets.InheritedElement.ubiquitous}
   /// This provides a performance tradeoff where building
   /// the [Widget]s is faster but performing updates is slower.

--- a/packages/flutter/test/widgets/inherited_test.dart
+++ b/packages/flutter/test/widgets/inherited_test.dart
@@ -84,6 +84,40 @@ class ThemedCard extends SingleChildRenderObjectWidget {
   }
 }
 
+class UbiquitousInheritedWidget extends InheritedWidget {
+  const UbiquitousInheritedWidget({super.key, required super.child});
+
+  @override
+  InheritedElement createElement() => InheritedElement.ubiquitous(this);
+
+  @override
+  bool updateShouldNotify(InheritedWidget oldWidget) => true;
+}
+
+/// [InheritedElement.ubiquitous] determines whether a rebuild is necessary by calling
+/// [Element.doesDependOnInheritedElement] for all descendant elements
+/// instead of updating and iterating through a map of dependents.
+///
+/// This widget can be used to verify that the appropriate method is being called.
+class UbiquitousDummyWidget extends StatelessWidget {
+  const UbiquitousDummyWidget({super.key});
+
+  static bool isDependent = false;
+
+  @override
+  StatelessElement createElement() => _UbiquitousDummyElement(this);
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}
+
+class _UbiquitousDummyElement extends StatelessElement {
+  _UbiquitousDummyElement(super.widget);
+
+  @override
+  bool doesDependOnInheritedElement(InheritedElement element) => UbiquitousDummyWidget.isDependent;
+}
+
 void main() {
   testWidgets('Inherited notifies dependents', (WidgetTester tester) async {
     final log = <TestInherited>[];
@@ -587,5 +621,44 @@ void main() {
     });
     await tester.pump();
     expectCardToMatchTheme();
+  });
+
+  testWidgets('InheritedElement.ubiquitous() constructor', (WidgetTester tester) async {
+    bool? dependentDirty;
+    var firstBuild = true;
+    const key = Key('key');
+
+    Future<void> rebuild() async {
+      tester.element(find.byKey(key)).markNeedsBuild();
+      await tester.pump();
+    }
+
+    await tester.pumpWidget(
+      Builder(
+        key: key,
+        builder: (context) {
+          return UbiquitousInheritedWidget(
+            child: Builder(
+              builder: (context) {
+                if (firstBuild) {
+                  firstBuild = false;
+                } else {
+                  dependentDirty = tester.element(find.byType(UbiquitousDummyWidget)).dirty;
+                }
+                return const UbiquitousDummyWidget();
+              },
+            ),
+          );
+        },
+      ),
+    );
+
+    UbiquitousDummyWidget.isDependent = false; // See UbiquitousDummyWidget class for more info.
+    await rebuild();
+    expect(dependentDirty, isFalse);
+
+    UbiquitousDummyWidget.isDependent = true;
+    await rebuild();
+    expect(dependentDirty, isTrue);
   });
 }


### PR DESCRIPTION
This PR exposes a public API for a performance tweak that can make Flutter apps start up more quickly.

<br>

From the [style guide](https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#avoid-exposing-api-oceans):

> A smaller API surface is easier to understand.

<br>

I believe the solution to #102993 with the smallest impact on Flutter's API surface is just to expose an alternate `InheritedElement` constructor. After this PR lands, we'll be able to configure `Theme` to use a ubiquitous inherited widget.