### PR TITLE
Fix SwiftPM identity for path dependency plugins

### DIFF
--- a/packages/flutter_tools/lib/src/macos/swift_package_manager.dart
+++ b/packages/flutter_tools/lib/src/macos/swift_package_manager.dart
@@ -150,10 +150,7 @@ class SwiftPackageManager {
         continue;
       }
 
-      // Use the plugin basename as the symlink plugin directory name since the basename has the
-      // version number in it. This will make the symlink name change when the plugin version
-      // changes, which forces Xcode to re-process the package manifest.
-      final String basename = _fileSystem.directory(plugin.path).basename;
+      final String symlinkName = _pluginSymlinkName(plugin);
 
       // Check if the plugin has a dependency on another Flutter plugin.
       // If the plugin has a dependency on another plugin, copy the plugin to the SourcePackages
@@ -166,13 +163,13 @@ class SwiftPackageManager {
           plugin: plugin,
           pluginDependencies: pluginDependencies,
           pathRelativeTo: pathRelativeTo,
-          basename: basename,
+          symlinkName: symlinkName,
           platform: platform,
           manifestContent: manifestContent,
         );
       }
 
-      final Link pluginSymlink = symlinkDirectory.childLink(basename);
+      final Link pluginSymlink = symlinkDirectory.childLink(symlinkName);
       ErrorHandlingFileSystem.deleteIfExists(pluginSymlink);
       pluginSymlink.createSync(packagePath);
       final String packageRelativePath = _fileSystem.path.relative(
@@ -196,6 +193,26 @@ class SwiftPackageManager {
       );
     }
     return (packageDependencies, targetDependencies);
+  }
+
+  /// Returns the name to use for the generated symlink to a plugin's Swift package.
+  ///
+  /// Hosted packages use a root directory like `plugin_name-1.0.0`; preserving that
+  /// versioned name forces Xcode to reprocess the manifest when the package version changes.
+  /// Path dependencies may live in an arbitrary repository directory. In that case the
+  /// symlink name must match the Dart package name so SwiftPM's path identity matches the
+  /// explicit package dependency name.
+  String _pluginSymlinkName(Plugin plugin) {
+    final String basename = _fileSystem.directory(plugin.path).basename;
+    if (basename == plugin.name) {
+      return basename;
+    }
+    final versionedPluginPrefix = '${plugin.name}-';
+    if (basename.startsWith(versionedPluginPrefix) &&
+        Version.parse(basename.substring(versionedPluginPrefix.length)) != null) {
+      return basename;
+    }
+    return plugin.name;
   }
 
   /// Checks if the plugin has a dependency on another Flutter plugin and returns a list of paths
@@ -238,7 +255,7 @@ class SwiftPackageManager {
         if (pluginDependency == null) {
           continue;
         }
-        final newPath = '"../${_fileSystem.directory(pluginDependency.path).basename}"';
+        final newPath = '"../${_pluginSymlinkName(pluginDependency)}"';
         if (path == newPath) {
           continue;
         }
@@ -258,7 +275,7 @@ class SwiftPackageManager {
     required Plugin plugin,
     required List<({String original, String replacement})> pluginDependencies,
     required String pathRelativeTo,
-    required String basename,
+    required String symlinkName,
     required FlutterDarwinPlatform platform,
     required String manifestContent,
   }) {
@@ -267,7 +284,7 @@ class SwiftPackageManager {
           _fileSystem.path.join(
             platform.buildDirectory(config: _config, fileSystem: _fileSystem),
             'SourcePackages',
-            basename,
+            symlinkName,
           ),
         )
         .absolute

--- a/packages/flutter_tools/test/general.shard/macos/swift_package_manager_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/swift_package_manager_test.dart
@@ -262,6 +262,76 @@ let package = Package(
 ''');
           });
 
+          testWithoutContext(
+            'uses package name symlink for path dependency with different root',
+            () async {
+              final fs = MemoryFileSystem();
+              final processManager = FakeProcessManager.any();
+              final logger = BufferLogger.test();
+              final project = FakeXcodeProject(platform: platform.name, fileSystem: fs);
+
+              final plugin = FakePlugin(
+                name: 'device_plugin',
+                rootDirectoryName: 'NUXXXXX_DEVICE_PLUGIN_Lib',
+                platforms: <String, PluginPlatform>{platform.name: FakePluginPlatform()},
+              );
+              fs.file('${plugin.path}/${platform.name}/${plugin.name}/Package.swift')
+                ..createSync(recursive: true)
+                ..writeAsStringSync('');
+              final spm = SwiftPackageManager(
+                fileSystem: fs,
+                templateRenderer: const MustacheTemplateRenderer(),
+                processUtils: ProcessUtils(processManager: processManager, logger: logger),
+                config: FakeConfig(),
+              );
+
+              await spm.generatePluginsSwiftPackage(<Plugin>[plugin], platform, project);
+
+              expect(project.relativeSwiftPackagesDirectory.childLink('device_plugin'), exists);
+              expect(
+                project.relativeSwiftPackagesDirectory.childLink('device_plugin').targetSync(),
+                '${plugin.path}/${platform.name}/device_plugin',
+              );
+              expect(
+                project.flutterPluginSwiftPackageManifest.readAsStringSync(),
+                contains('.package(name: "device_plugin", path: "../.packages/device_plugin")'),
+              );
+            },
+          );
+
+          testWithoutContext(
+            'uses package name symlink when root has invalid version suffix',
+            () async {
+              final fs = MemoryFileSystem();
+              final processManager = FakeProcessManager.any();
+              final logger = BufferLogger.test();
+              final project = FakeXcodeProject(platform: platform.name, fileSystem: fs);
+
+              final plugin = FakePlugin(
+                name: 'device_plugin',
+                rootDirectoryName: 'device_plugin-dev-build',
+                platforms: <String, PluginPlatform>{platform.name: FakePluginPlatform()},
+              );
+              fs.file('${plugin.path}/${platform.name}/${plugin.name}/Package.swift')
+                ..createSync(recursive: true)
+                ..writeAsStringSync('');
+              final spm = SwiftPackageManager(
+                fileSystem: fs,
+                templateRenderer: const MustacheTemplateRenderer(),
+                processUtils: ProcessUtils(processManager: processManager, logger: logger),
+                config: FakeConfig(),
+              );
+
+              await spm.generatePluginsSwiftPackage(<Plugin>[plugin], platform, project);
+
+              expect(project.relativeSwiftPackagesDirectory.childLink('device_plugin'), exists);
+              expect(
+                project.flutterPluginSwiftPackageManifest.readAsStringSync(),
+                contains('.package(name: "device_plugin", path: "../.packages/device_plugin")'),
+              );
+            },
+          );
+
           testWithoutContext('generate with multiple dependencies', () async {
             final fs = MemoryFileSystem();
             final processManager = FakeProcessManager.any();
@@ -609,8 +679,12 @@ class FakeXcodeProject extends Fake implements IosProject {
 }
 
 class FakePlugin extends Fake implements Plugin {
-  FakePlugin({required this.name, required this.platforms, this.hasSwiftPackage = true})
-    : path = '/local/path/to/plugins/$name-1.0.0';
+  FakePlugin({
+    required this.name,
+    required this.platforms,
+    this.hasSwiftPackage = true,
+    String? rootDirectoryName,
+  }) : path = '/local/path/to/plugins/${rootDirectoryName ?? '$name-1.0.0'}';
 
   @override
   final String name;


### PR DESCRIPTION
Fixes #186881.

When a SwiftPM plugin is used through a path dependency, its repository/root folder can differ from its Dart package name. Flutter was using that root folder name for the generated `.packages` symlink, which could give SwiftPM a path identity that did not match the explicit package dependency name.

This preserves the existing versioned symlink behavior for hosted packages like `plugin_name-1.0.0`, but uses the Dart package name when the plugin root basename is not the package name or a package-version basename. The tests also cover an invalid version-like suffix such as `plugin_name-dev-build`.

Tests:
- `../../bin/dart test test/general.shard/macos/swift_package_manager_test.dart`
- `./bin/flutter analyze packages/flutter_tools/lib/src/macos/swift_package_manager.dart packages/flutter_tools/test/general.shard/macos/swift_package_manager_test.dart`
- `./bin/dart format --output=none --set-exit-if-changed packages/flutter_tools/lib/src/macos/swift_package_manager.dart packages/flutter_tools/test/general.shard/macos/swift_package_manager_test.dart`
- `git diff --check`
