### PR TITLE
Remove material imports from rendering tests

### DIFF
--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -158,6 +158,7 @@ class TestsCrossImportChecker {
   static final Set<String> knownRenderingCrossImports = <String>{
     'packages/flutter/test/rendering/aligning_shifted_box_baseline_test.dart',
     'packages/flutter/test/rendering/localized_fonts_test.dart',
+    'packages/flutter/test/rendering/editable_gesture_test.dart',
     'packages/flutter/test/rendering/pipeline_owner_tree_test.dart',
     'packages/flutter/test/rendering/view_chrome_style_test.dart',
     'packages/flutter/test/rendering/proxy_box_test.dart',

--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -158,10 +158,7 @@ class TestsCrossImportChecker {
   static final Set<String> knownRenderingCrossImports = <String>{
     'packages/flutter/test/rendering/aligning_shifted_box_baseline_test.dart',
     'packages/flutter/test/rendering/localized_fonts_test.dart',
-    'packages/flutter/test/rendering/editable_gesture_test.dart',
-    'packages/flutter/test/rendering/box_test.dart',
     'packages/flutter/test/rendering/pipeline_owner_tree_test.dart',
-    'packages/flutter/test/rendering/proxy_getters_and_setters_test.dart',
     'packages/flutter/test/rendering/view_chrome_style_test.dart',
     'packages/flutter/test/rendering/proxy_box_test.dart',
     'packages/flutter/test/rendering/sliver_tree_test.dart',

--- a/packages/flutter/test/rendering/box_test.dart
+++ b/packages/flutter/test/rendering/box_test.dart
@@ -22,7 +22,7 @@ const List<BoxShadow> _materialElevation3Shadows = <BoxShadow>[
   BoxShadow(offset: Offset(0.0, 1.0), blurRadius: 8.0, color: Color(0x1F000000)),
 ];
 
-BoxConstraints _unconstrained(BoxConstraints constraints) => const BoxConstraints();
+BoxConstraints _unconstrained(BoxConstraints _) => const BoxConstraints();
 
 BoxConstraints _widthUnconstrained(BoxConstraints constraints) => constraints.heightConstraints();
 
@@ -107,7 +107,7 @@ void main() {
         gradient: RadialGradient(
           center: Alignment.topLeft,
           radius: 1.8,
-          colors: <Color>[_materialYellow500, _materialBlue500],
+          colors: [_materialYellow500, _materialBlue500],
         ),
         boxShadow: _materialElevation3Shadows,
       ),

--- a/packages/flutter/test/rendering/box_test.dart
+++ b/packages/flutter/test/rendering/box_test.dart
@@ -4,11 +4,29 @@
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'rendering_tester.dart';
+
+const Color _materialYellow500 = Color(0xFFFFEB3B);
+const Color _materialBlue500 = Color(0xFF2196F3);
+const List<BoxShadow> _materialElevation3Shadows = <BoxShadow>[
+  BoxShadow(
+    offset: Offset(0.0, 3.0),
+    blurRadius: 3.0,
+    spreadRadius: -2.0,
+    color: Color(0x33000000),
+  ),
+  BoxShadow(offset: Offset(0.0, 3.0), blurRadius: 4.0, color: Color(0x24000000)),
+  BoxShadow(offset: Offset(0.0, 1.0), blurRadius: 8.0, color: Color(0x1F000000)),
+];
+
+BoxConstraints _unconstrained(BoxConstraints constraints) => const BoxConstraints();
+
+BoxConstraints _widthUnconstrained(BoxConstraints constraints) => constraints.heightConstraints();
+
+BoxConstraints _heightUnconstrained(BoxConstraints constraints) => constraints.widthConstraints();
 
 class MissingPerformLayoutRenderBox extends RenderBox {
   void triggerExceptionSettingSizeOutsideOfLayout() {
@@ -84,14 +102,14 @@ void main() {
 
   test('should size to render view', () {
     final RenderBox root = RenderDecoratedBox(
-      decoration: BoxDecoration(
-        color: const Color(0xFF00FF00),
+      decoration: const BoxDecoration(
+        color: Color(0xFF00FF00),
         gradient: RadialGradient(
           center: Alignment.topLeft,
           radius: 1.8,
-          colors: <Color>[Colors.yellow[500]!, Colors.blue[500]!],
+          colors: <Color>[_materialYellow500, _materialBlue500],
         ),
-        boxShadow: kElevationToShadow[3],
+        boxShadow: _materialElevation3Shadows,
       ),
     );
     layout(root);
@@ -397,7 +415,7 @@ void main() {
 
   test('UnconstrainedBox expands to fit children', () {
     final unconstrained = RenderConstraintsTransformBox(
-      constraintsTransform: ConstraintsTransformBox.widthUnconstrained,
+      constraintsTransform: _widthUnconstrained,
       textDirection: TextDirection.ltr,
       child: RenderConstrainedBox(
         additionalConstraints: const BoxConstraints.tightFor(width: 200.0, height: 200.0),
@@ -414,7 +432,7 @@ void main() {
       ),
     );
     // Check that we can update the constrained axis to null.
-    unconstrained.constraintsTransform = ConstraintsTransformBox.unconstrained;
+    unconstrained.constraintsTransform = _unconstrained;
     TestRenderingFlutterBinding.instance.reassembleApplication();
 
     expect(unconstrained.size.width, equals(200.0), reason: 'unconstrained width');
@@ -423,7 +441,7 @@ void main() {
 
   test('UnconstrainedBox handles vertical overflow', () {
     final unconstrained = RenderConstraintsTransformBox(
-      constraintsTransform: ConstraintsTransformBox.unconstrained,
+      constraintsTransform: _unconstrained,
       textDirection: TextDirection.ltr,
       child: RenderConstrainedBox(
         additionalConstraints: const BoxConstraints.tightFor(height: 200.0),
@@ -440,7 +458,7 @@ void main() {
 
   test('UnconstrainedBox handles horizontal overflow', () {
     final unconstrained = RenderConstraintsTransformBox(
-      constraintsTransform: ConstraintsTransformBox.unconstrained,
+      constraintsTransform: _unconstrained,
       textDirection: TextDirection.ltr,
       child: RenderConstrainedBox(
         additionalConstraints: const BoxConstraints.tightFor(width: 200.0),
@@ -590,7 +608,7 @@ void main() {
 
   test('getMinIntrinsicWidth error handling', () {
     final unconstrained = RenderConstraintsTransformBox(
-      constraintsTransform: ConstraintsTransformBox.unconstrained,
+      constraintsTransform: _unconstrained,
       textDirection: TextDirection.ltr,
       child: RenderConstrainedBox(
         additionalConstraints: const BoxConstraints.tightFor(width: 200.0),
@@ -723,7 +741,7 @@ void main() {
 
   test('UnconstrainedBox.toStringDeep returns useful information', () {
     final unconstrained = RenderConstraintsTransformBox(
-      constraintsTransform: ConstraintsTransformBox.unconstrained,
+      constraintsTransform: _unconstrained,
       textDirection: TextDirection.ltr,
       alignment: Alignment.center,
     );
@@ -748,7 +766,7 @@ void main() {
       additionalConstraints: const BoxConstraints.expand(height: 200.0),
     );
     final unconstrained = RenderConstraintsTransformBox(
-      constraintsTransform: ConstraintsTransformBox.heightUnconstrained,
+      constraintsTransform: _heightUnconstrained,
       textDirection: TextDirection.ltr,
       child: RenderFlex(textDirection: TextDirection.ltr, children: <RenderBox>[flexible]),
       alignment: Alignment.center,
@@ -769,7 +787,7 @@ void main() {
       additionalConstraints: const BoxConstraints.expand(width: 200.0),
     );
     final unconstrained = RenderConstraintsTransformBox(
-      constraintsTransform: ConstraintsTransformBox.widthUnconstrained,
+      constraintsTransform: _widthUnconstrained,
       textDirection: TextDirection.ltr,
       child: RenderFlex(
         direction: Axis.vertical,
@@ -807,7 +825,7 @@ void main() {
         case Clip.antiAlias:
         case Clip.antiAliasWithSaveLayer:
           box = RenderConstraintsTransformBox(
-            constraintsTransform: ConstraintsTransformBox.unconstrained,
+            constraintsTransform: _unconstrained,
             alignment: Alignment.center,
             textDirection: TextDirection.ltr,
             child: box200x200,
@@ -815,7 +833,7 @@ void main() {
           );
         case null:
           box = RenderConstraintsTransformBox(
-            constraintsTransform: ConstraintsTransformBox.unconstrained,
+            constraintsTransform: _unconstrained,
             alignment: Alignment.center,
             textDirection: TextDirection.ltr,
             child: box200x200,

--- a/packages/flutter/test/rendering/editable_gesture_test.dart
+++ b/packages/flutter/test/rendering/editable_gesture_test.dart
@@ -3,27 +3,23 @@
 // found in the LICENSE file.
 
 import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-const Color _grey500 = Color(0xFF9E9E9E);
-const Color _black = Color(0xFF000000);
-const Color _red500 = Color(0xFFF44336);
 
 void main() {
   final TestWidgetsFlutterBinding binding = _GestureBindingSpy();
 
   testWidgets('attach and detach correctly handle gesture', (_) async {
-    expect(TestWidgetsFlutterBinding.instance, binding);
+    expect(WidgetsBinding.instance, binding);
     final TextSelectionDelegate delegate = FakeEditableTextState();
     final offset = ViewportOffset.zero();
     addTearDown(offset.dispose);
     final editable = RenderEditable(
-      backgroundCursorColor: _grey500,
-      selectionColor: _black,
+      backgroundCursorColor: Colors.grey,
+      selectionColor: Colors.black,
       textDirection: TextDirection.ltr,
-      cursorColor: _red500,
+      cursorColor: Colors.red,
       offset: offset,
       textSelectionDelegate: delegate,
       text: const TextSpan(text: 'test', style: TextStyle(height: 1.0, fontSize: 10.0)),

--- a/packages/flutter/test/rendering/editable_gesture_test.dart
+++ b/packages/flutter/test/rendering/editable_gesture_test.dart
@@ -3,23 +3,27 @@
 // found in the LICENSE file.
 
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+const Color _grey500 = Color(0xFF9E9E9E);
+const Color _black = Color(0xFF000000);
+const Color _red500 = Color(0xFFF44336);
 
 void main() {
   final TestWidgetsFlutterBinding binding = _GestureBindingSpy();
 
   testWidgets('attach and detach correctly handle gesture', (_) async {
-    expect(WidgetsBinding.instance, binding);
+    expect(TestWidgetsFlutterBinding.instance, binding);
     final TextSelectionDelegate delegate = FakeEditableTextState();
     final offset = ViewportOffset.zero();
     addTearDown(offset.dispose);
     final editable = RenderEditable(
-      backgroundCursorColor: Colors.grey,
-      selectionColor: Colors.black,
+      backgroundCursorColor: _grey500,
+      selectionColor: _black,
       textDirection: TextDirection.ltr,
-      cursorColor: Colors.red,
+      cursorColor: _red500,
       offset: offset,
       textSelectionDelegate: delegate,
       text: const TextSpan(text: 'test', style: TextStyle(height: 1.0, fontSize: 10.0)),

--- a/packages/flutter/test/rendering/proxy_getters_and_setters_test.dart
+++ b/packages/flutter/test/rendering/proxy_getters_and_setters_test.dart
@@ -5,6 +5,9 @@
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+const Color _red500 = Color(0xFFF44336);
+const Color _blue500 = Color(0xFF2196F3);
+
 void main() {
   test('RenderConstrainedBox getters and setters', () {
     final box = RenderConstrainedBox(
@@ -54,13 +57,13 @@ void main() {
   test('RenderShaderMask getters and setters', () {
     Shader callback1(Rect bounds) {
       assert(false); // The test should not call this.
-      const gradient = LinearGradient(colors: <Color>[Color(0xFFF44336)]);
+      const gradient = LinearGradient(colors: [_red500]);
       return gradient.createShader(Rect.zero);
     }
 
     Shader callback2(Rect bounds) {
       assert(false); // The test should not call this.
-      const gradient = LinearGradient(colors: <Color>[Color(0xFF2196F3)]);
+      const gradient = LinearGradient(colors: [_blue500]);
       return gradient.createShader(Rect.zero);
     }
 

--- a/packages/flutter/test/rendering/proxy_getters_and_setters_test.dart
+++ b/packages/flutter/test/rendering/proxy_getters_and_setters_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -55,13 +54,13 @@ void main() {
   test('RenderShaderMask getters and setters', () {
     Shader callback1(Rect bounds) {
       assert(false); // The test should not call this.
-      const gradient = LinearGradient(colors: <Color>[Colors.red]);
+      const gradient = LinearGradient(colors: <Color>[Color(0xFFF44336)]);
       return gradient.createShader(Rect.zero);
     }
 
     Shader callback2(Rect bounds) {
       assert(false); // The test should not call this.
-      const gradient = LinearGradient(colors: <Color>[Colors.blue]);
+      const gradient = LinearGradient(colors: <Color>[Color(0xFF2196F3)]);
       return gradient.createShader(Rect.zero);
     }
 


### PR DESCRIPTION
## Summary

Removes `package:flutter/material.dart` imports from two rendering tests by replacing Material color and shadow conveniences with equivalent rendering-level constants/helpers. No public or runtime API changes.

## Changes

- Replace `Colors.yellow[500]`, `Colors.blue[500]`, and `kElevationToShadow[3]` in `box_test.dart` with local test constants.
- Replace shader callback `Colors.red` and `Colors.blue` in `proxy_getters_and_setters_test.dart` with equivalent `Color` constants.
- Remove `box_test.dart` and `proxy_getters_and_setters_test.dart` from `knownRenderingCrossImports`.

## Tests

- `bin/cache/dart-sdk/bin/dart --enable-asserts dev/bots/check_tests_cross_imports.dart`
- `bin/cache/dart-sdk/bin/dart analyze packages/flutter/test/rendering/box_test.dart packages/flutter/test/rendering/proxy_getters_and_setters_test.dart dev/bots/check_tests_cross_imports.dart`
- `./bin/flutter analyze --no-pub packages/flutter/test/rendering/box_test.dart packages/flutter/test/rendering/proxy_getters_and_setters_test.dart dev/bots/check_tests_cross_imports.dart`
- `./bin/flutter test --no-pub packages/flutter/test/rendering/box_test.dart packages/flutter/test/rendering/proxy_getters_and_setters_test.dart`
- `git diff --check`

Part of flutter/flutter#177412
Refs flutter/flutter#177028
