### PR TITLE
[Tool/iOS] Fix temp directory cleanup crashes and add robust file verification

### DIFF
--- a/packages/flutter_tools/lib/src/ios/core_devices.dart
+++ b/packages/flutter_tools/lib/src/ios/core_devices.dart
@@ -502,8 +502,7 @@ class IOSCoreDeviceControl {
       'apps',
       '--device',
       deviceId,
-      if (bundleId != null) '--bundle-id',
-      bundleId!,
+      if (bundleId != null) ...<String>['--bundle-id', bundleId],
       '--json-output',
       output.path,
     ];
@@ -511,6 +510,10 @@ class IOSCoreDeviceControl {
     try {
       await _processUtils.run(command, throwOnError: true);
 
+      if (!output.existsSync()) {
+        _logger.printTrace('devicectl output file does not exist: ${output.path}');
+        return <Object?>[];
+      }
       final String stringOutput = output.readAsStringSync();
 
       try {
@@ -532,7 +535,7 @@ class IOSCoreDeviceControl {
       _logger.printError('Error executing devicectl: $err');
       return <Object?>[];
     } finally {
-      tempDirectory.deleteSync(recursive: true);
+      ErrorHandlingFileSystem.deleteIfExists(tempDirectory, recursive: true);
     }
   }
 
@@ -587,6 +590,11 @@ class IOSCoreDeviceControl {
 
     try {
       await _processUtils.run(command, throwOnError: true);
+
+      if (!output.existsSync()) {
+        _logger.printTrace('devicectl output file does not exist: ${output.path}');
+        return (false, null);
+      }
       final String stringOutput = output.readAsStringSync();
 
       try {
@@ -609,7 +617,7 @@ class IOSCoreDeviceControl {
       _logger.printTrace('Error executing devicectl: $err');
       return (false, null);
     } finally {
-      tempDirectory.deleteSync(recursive: true);
+      ErrorHandlingFileSystem.deleteIfExists(tempDirectory, recursive: true);
     }
   }
 
@@ -640,6 +648,11 @@ class IOSCoreDeviceControl {
 
     try {
       await _processUtils.run(command, throwOnError: true);
+
+      if (!output.existsSync()) {
+        _logger.printTrace('devicectl output file does not exist: ${output.path}');
+        return false;
+      }
       final String stringOutput = output.readAsStringSync();
 
       try {
@@ -658,7 +671,7 @@ class IOSCoreDeviceControl {
       _logger.printError('Error executing devicectl: $err');
       return false;
     } finally {
-      tempDirectory.deleteSync(recursive: true);
+      ErrorHandlingFileSystem.deleteIfExists(tempDirectory, recursive: true);
     }
   }
 
@@ -732,6 +745,11 @@ class IOSCoreDeviceControl {
 
     try {
       await _processUtils.run(command, throwOnError: true);
+
+      if (!output.existsSync()) {
+        _logger.printTrace('devicectl output file does not exist: ${output.path}');
+        return null;
+      }
       final String stringOutput = output.readAsStringSync();
 
       try {
@@ -752,7 +770,7 @@ class IOSCoreDeviceControl {
       _logger.printTrace('Error executing devicectl: $err');
       return null;
     } finally {
-      tempDirectory.deleteSync(recursive: true);
+      ErrorHandlingFileSystem.deleteIfExists(tempDirectory, recursive: true);
     }
   }
 

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -10,6 +10,7 @@ import 'package:unified_analytics/unified_analytics.dart';
 
 import '../artifacts.dart';
 import '../base/config.dart';
+import '../base/error_handling_io.dart';
 import '../base/file_system.dart';
 import '../base/fingerprint.dart';
 import '../base/io.dart';
@@ -606,7 +607,7 @@ Future<XcodeBuildResult> buildXcodeProject({
       }
     }
   } finally {
-    tempDir.deleteSync(recursive: true);
+    ErrorHandlingFileSystem.deleteIfExists(tempDir, recursive: true);
   }
   if (buildResult != null && buildResult.exitCode != 0) {
     globals.printStatus('Failed to build iOS app');

--- a/packages/flutter_tools/test/general.shard/ios/core_devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/core_devices_test.dart
@@ -3880,6 +3880,282 @@ invalid JSON
         expect(logger.traceText, contains('Error reading output file'));
       });
     });
+
+    group('Robust cleanup and error handling', () {
+      const deviceId = 'device-id';
+      const bundleId = 'com.example.flutterApp';
+      const bundlePath = '/path/to/com.example.flutterApp';
+
+      testWithoutContext('getInstalledApps does not crash if temp directory deleted', () async {
+        final File tempFile = fileSystem.systemTempDirectory
+            .childDirectory('core_devices.rand0')
+            .childFile('core_device_app_list.json');
+        fakeProcessManager.addCommand(
+          FakeCommand(
+            command: <String>[
+              'xcrun',
+              'devicectl',
+              'device',
+              'info',
+              'apps',
+              '--device',
+              deviceId,
+              '--json-output',
+              tempFile.path,
+            ],
+            onRun: (_) {
+              tempFile.writeAsStringSync('{"result": {"apps": []}}');
+              tempFile.parent.deleteSync(recursive: true);
+            },
+          ),
+        );
+
+        final List<IOSCoreDeviceInstalledApp> apps = await deviceControl.getInstalledApps(
+          deviceId: deviceId,
+        );
+        expect(apps, isEmpty);
+        expect(fakeProcessManager, hasNoRemainingExpectations);
+      });
+
+      testWithoutContext('getInstalledApps does not crash if output file missing', () async {
+        final File tempFile = fileSystem.systemTempDirectory
+            .childDirectory('core_devices.rand0')
+            .childFile('core_device_app_list.json');
+        fakeProcessManager.addCommand(
+          FakeCommand(
+            command: <String>[
+              'xcrun',
+              'devicectl',
+              'device',
+              'info',
+              'apps',
+              '--device',
+              deviceId,
+              '--json-output',
+              tempFile.path,
+            ],
+            onRun: (_) {
+              if (tempFile.existsSync()) {
+                tempFile.deleteSync();
+              }
+            },
+          ),
+        );
+
+        final List<IOSCoreDeviceInstalledApp> apps = await deviceControl.getInstalledApps(
+          deviceId: deviceId,
+        );
+        expect(apps, isEmpty);
+        expect(fakeProcessManager, hasNoRemainingExpectations);
+        expect(logger.traceText, contains('devicectl output file does not exist'));
+      });
+
+      testWithoutContext('installApp does not crash if temp directory deleted', () async {
+        final File tempFile = fileSystem.systemTempDirectory
+            .childDirectory('core_devices.rand0')
+            .childFile('install_results.json');
+        fakeProcessManager.addCommand(
+          FakeCommand(
+            command: <String>[
+              'xcrun',
+              'devicectl',
+              'device',
+              'install',
+              'app',
+              '--device',
+              deviceId,
+              bundlePath,
+              '--json-output',
+              tempFile.path,
+            ],
+            onRun: (_) {
+              tempFile.writeAsStringSync('{"info": {"outcome": "success"}}');
+              tempFile.parent.deleteSync(recursive: true);
+            },
+          ),
+        );
+
+        final (bool status, IOSCoreDeviceInstallResult? result) = await deviceControl.installApp(
+          deviceId: deviceId,
+          bundlePath: bundlePath,
+        );
+        expect(status, isFalse);
+        expect(result, isNull);
+        expect(fakeProcessManager, hasNoRemainingExpectations);
+      });
+
+      testWithoutContext('installApp does not crash if output file missing', () async {
+        final File tempFile = fileSystem.systemTempDirectory
+            .childDirectory('core_devices.rand0')
+            .childFile('install_results.json');
+        fakeProcessManager.addCommand(
+          FakeCommand(
+            command: <String>[
+              'xcrun',
+              'devicectl',
+              'device',
+              'install',
+              'app',
+              '--device',
+              deviceId,
+              bundlePath,
+              '--json-output',
+              tempFile.path,
+            ],
+            onRun: (_) {
+              if (tempFile.existsSync()) {
+                tempFile.deleteSync();
+              }
+            },
+          ),
+        );
+
+        final (bool status, IOSCoreDeviceInstallResult? result) = await deviceControl.installApp(
+          deviceId: deviceId,
+          bundlePath: bundlePath,
+        );
+        expect(status, isFalse);
+        expect(result, isNull);
+        expect(fakeProcessManager, hasNoRemainingExpectations);
+        expect(logger.traceText, contains('devicectl output file does not exist'));
+      });
+
+      testWithoutContext('uninstallApp does not crash if temp directory deleted', () async {
+        final File tempFile = fileSystem.systemTempDirectory
+            .childDirectory('core_devices.rand0')
+            .childFile('uninstall_results.json');
+        fakeProcessManager.addCommand(
+          FakeCommand(
+            command: <String>[
+              'xcrun',
+              'devicectl',
+              'device',
+              'uninstall',
+              'app',
+              '--device',
+              deviceId,
+              bundleId,
+              '--json-output',
+              tempFile.path,
+            ],
+            onRun: (_) {
+              tempFile.writeAsStringSync('{"info": {"outcome": "success"}}');
+              tempFile.parent.deleteSync(recursive: true);
+            },
+          ),
+        );
+
+        final bool status = await deviceControl.uninstallApp(
+          deviceId: deviceId,
+          bundleId: bundleId,
+        );
+        expect(status, isFalse);
+        expect(fakeProcessManager, hasNoRemainingExpectations);
+      });
+
+      testWithoutContext('uninstallApp does not crash if output file missing', () async {
+        final File tempFile = fileSystem.systemTempDirectory
+            .childDirectory('core_devices.rand0')
+            .childFile('uninstall_results.json');
+        fakeProcessManager.addCommand(
+          FakeCommand(
+            command: <String>[
+              'xcrun',
+              'devicectl',
+              'device',
+              'uninstall',
+              'app',
+              '--device',
+              deviceId,
+              bundleId,
+              '--json-output',
+              tempFile.path,
+            ],
+            onRun: (_) {
+              if (tempFile.existsSync()) {
+                tempFile.deleteSync();
+              }
+            },
+          ),
+        );
+
+        final bool status = await deviceControl.uninstallApp(
+          deviceId: deviceId,
+          bundleId: bundleId,
+        );
+        expect(status, isFalse);
+        expect(fakeProcessManager, hasNoRemainingExpectations);
+        expect(logger.traceText, contains('devicectl output file does not exist'));
+      });
+
+      testWithoutContext('launchApp does not crash if temp directory deleted', () async {
+        final File tempFile = fileSystem.systemTempDirectory
+            .childDirectory('core_devices.rand0')
+            .childFile('launch_results.json');
+        fakeProcessManager.addCommand(
+          FakeCommand(
+            command: <String>[
+              'xcrun',
+              'devicectl',
+              'device',
+              'process',
+              'launch',
+              '--device',
+              deviceId,
+              '--json-output',
+              tempFile.path,
+              bundleId,
+            ],
+            onRun: (_) {
+              tempFile.writeAsStringSync('{"info": {"outcome": "success"}}');
+              tempFile.parent.deleteSync(recursive: true);
+            },
+          ),
+        );
+
+        final IOSCoreDeviceLaunchResult? result = await deviceControl.launchApp(
+          deviceId: deviceId,
+          bundleId: bundleId,
+        );
+        expect(result, isNull);
+        expect(fakeProcessManager, hasNoRemainingExpectations);
+      });
+
+      testWithoutContext('launchApp does not crash if output file missing', () async {
+        final File tempFile = fileSystem.systemTempDirectory
+            .childDirectory('core_devices.rand0')
+            .childFile('launch_results.json');
+        fakeProcessManager.addCommand(
+          FakeCommand(
+            command: <String>[
+              'xcrun',
+              'devicectl',
+              'device',
+              'process',
+              'launch',
+              '--device',
+              deviceId,
+              '--json-output',
+              tempFile.path,
+              bundleId,
+            ],
+            onRun: (_) {
+              if (tempFile.existsSync()) {
+                tempFile.deleteSync();
+              }
+            },
+          ),
+        );
+
+        final IOSCoreDeviceLaunchResult? result = await deviceControl.launchApp(
+          deviceId: deviceId,
+          bundleId: bundleId,
+        );
+        expect(result, isNull);
+        expect(fakeProcessManager, hasNoRemainingExpectations);
+        expect(logger.traceText, contains('devicectl output file does not exist'));
+      });
+    });
   });
 }
 

--- a/packages/flutter_tools/test/general.shard/ios/mac_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/mac_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/config.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/base/version.dart';
 import 'package:flutter_tools/src/build_info.dart';
@@ -16,10 +17,12 @@ import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/darwin/darwin.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/flutter_manifest.dart';
+import 'package:flutter_tools/src/ios/application_package.dart';
 import 'package:flutter_tools/src/ios/code_signing.dart';
 import 'package:flutter_tools/src/ios/mac.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
 import 'package:flutter_tools/src/ios/xcresult.dart';
+import 'package:flutter_tools/src/macos/xcode.dart';
 import 'package:flutter_tools/src/platform_plugins.dart';
 import 'package:flutter_tools/src/plugins.dart';
 import 'package:flutter_tools/src/project.dart';
@@ -1196,6 +1199,134 @@ duplicate symbol '_$s29plugin_1_name23PluginNamePluginC9setDouble3key5valueySS_S
       expect(fingerprintFile.readAsStringSync(), correctHeaderFingerprint);
     });
   });
+
+  group('buildXcodeProject', () {
+    late MemoryFileSystem fs;
+    late BufferLogger logger;
+    late FakeProcessManager fakeProcessManager;
+    late FakeXcodeProjectInterpreterForBuild xcodeProjectInterpreter;
+    late FakeXcodeForBuild xcode;
+    late FakeIosProjectForBuild iosProject;
+    late FakeBuildableIOSApp app;
+    late FakeFlutterProjectForBuild fakeFlutterProject;
+    late FakeFlutterProjectFactoryForBuild fakeFlutterProjectFactory;
+    late FakeArtifacts fakeArtifacts;
+
+    setUp(() {
+      fs = MemoryFileSystem.test();
+      logger = BufferLogger.test();
+      fakeProcessManager = FakeProcessManager.empty();
+      xcodeProjectInterpreter = FakeXcodeProjectInterpreterForBuild();
+      xcode = FakeXcodeForBuild();
+      fakeFlutterProject = FakeFlutterProjectForBuild(fileSystem: fs);
+      fakeFlutterProject.manifest = FakeFlutterManifest();
+      iosProject = fakeFlutterProject.ios as FakeIosProjectForBuild;
+      app = FakeBuildableIOSApp(project: iosProject);
+      fakeFlutterProjectFactory = FakeFlutterProjectFactoryForBuild(fakeFlutterProject);
+
+      final Directory frameworkDir = fs.systemTempDirectory.childDirectory('Flutter.xcframework');
+      frameworkDir.childDirectory('Flutter.framework').createSync(recursive: true);
+      fakeArtifacts = FakeArtifacts(frameworkPath: frameworkDir.path);
+
+      // Create required files for upgradePbxProjWithFlutterAssets
+      iosProject.xcodeProjectInfoFile.createSync(recursive: true);
+      iosProject.xcodeProjectInfoFile.writeAsStringSync('// empty pbxproj');
+
+      // Create pubspec.yaml to avoid warnings/errors about missing version
+      fs.file('pubspec.yaml').writeAsStringSync('''
+name: app_name
+version: 1.0.0+1
+''');
+
+      // Create package_config.json to avoid findPlugins failure
+      fakeFlutterProject.packageConfig.createSync(recursive: true);
+      fakeFlutterProject.packageConfig.writeAsStringSync(
+        '{"configVersion": 2, "packages": [{"name": "my_app", "rootUri": "../", "packageUri": "lib/", "languageVersion": "3.0"}]}',
+      );
+
+      // Create package_graph.json to avoid findPlugins failure
+      final File packageGraph = fakeFlutterProject.directory
+          .childDirectory('.dart_tool')
+          .childFile('package_graph.json');
+      packageGraph.createSync(recursive: true);
+      packageGraph.writeAsStringSync(
+        '{"configVersion": 1, "packages": [{"name": "my_app", "dependencies": [], "devDependencies": []}]}',
+      );
+    });
+
+    testUsingContext(
+      'does not crash if temp directory is deleted during build',
+      () async {
+        fakeProcessManager.addCommand(
+          FakeCommand(
+            command: <Pattern>[
+              'xcrun',
+              'xcodebuild',
+              '-configuration',
+              'Debug',
+              '-quiet',
+              '-allowProvisioningUpdates',
+              '-allowProvisioningDeviceRegistration',
+              '-workspace',
+              'Runner.xcworkspace',
+              '-scheme',
+              'Runner',
+              'BUILD_DIR=/build/ios',
+              '-sdk',
+              'iphoneos',
+              '-destination',
+              'generic/platform=iOS',
+              '-resultBundlePath',
+              RegExp(r'.*/temporary_xcresult_bundle'),
+              '-resultBundleVersion',
+              '3',
+              'FLUTTER_SUPPRESS_ANALYTICS=true',
+              'COMPILER_INDEX_STORE_ENABLE=NO',
+            ],
+            onRun: (_) {
+              // Delete everything in temp directory to simulate async deletion
+              for (final FileSystemEntity entity in fs.systemTempDirectory.listSync()) {
+                if (entity is Directory &&
+                    entity.basename.startsWith('flutter_ios_build_temp_dir')) {
+                  entity.deleteSync(recursive: true);
+                }
+              }
+            },
+          ),
+        );
+
+        fakeProcessManager.addCommand(
+          const FakeCommand(
+            command: <String>[
+              'xattr',
+              '-w',
+              'com.apple.xcode.CreatedByBuildSystem',
+              'true',
+              'build/ios/iphoneos',
+            ],
+          ),
+        );
+
+        final XcodeBuildResult result = await buildXcodeProject(
+          app: app,
+          buildInfo: BuildInfo.debug,
+        );
+
+        expect(result.success, isTrue);
+        expect(fakeProcessManager, hasNoRemainingExpectations);
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fs,
+        ProcessManager: () => fakeProcessManager,
+        Logger: () => logger,
+        XcodeProjectInterpreter: () => xcodeProjectInterpreter,
+        Xcode: () => xcode,
+        Platform: () => FakePlatform(operatingSystem: 'macos'),
+        FlutterProjectFactory: () => fakeFlutterProjectFactory,
+        Artifacts: () => fakeArtifacts,
+      },
+    );
+  });
 }
 
 class FakeIosProject extends Fake implements IosProject {
@@ -1257,11 +1388,17 @@ class FakeFlutterProject extends Fake implements FlutterProject {
   File get packageConfig => directory.childDirectory('.dart_tool').childFile('package_config.json');
 
   @override
+  File get gitignoreFile => directory.childFile('.gitignore');
+
+  @override
   late final IosProject ios = FakeIosProject(
     fileSystem: fileSystem,
     usesSwiftPackageManager: usesSwiftPackageManager,
     plugins: _plugins,
   );
+
+  @override
+  late final MacOSProject macos = FakeMacOSProject();
 
   @override
   final bool isModule;
@@ -1275,6 +1412,12 @@ class FakeFlutterManifest extends Fake implements FlutterManifest {
   String get appName => 'my_app';
 
   @override
+  String? get buildName => '1.0.0';
+
+  @override
+  String? get buildNumber => '1';
+
+  @override
   YamlMap toYaml() => YamlMap.wrap(<String, String>{});
 }
 
@@ -1282,6 +1425,10 @@ class FakeArtifacts extends Fake implements Artifacts {
   FakeArtifacts({required this.frameworkPath});
 
   final String frameworkPath;
+
+  @override
+  LocalEngineInfo? get localEngineInfo => null;
+
   @override
   String getArtifactPath(
     Artifact artifact, {
@@ -1380,4 +1527,161 @@ class FakeFlutterProjectWithAbsoluteDirectory extends FakeFlutterProject {
 
   @override
   Directory get directory => fileSystem.directory('/app_name');
+}
+
+class FakeXcodeForBuild extends Fake implements Xcode {
+  @override
+  Future<List<String>> fetchDependenciesAndGenerateXcodebuildArgs(
+    XcodeBasedProject xcodeProject,
+    Directory buildDirectory, {
+    bool skipPackageUpdatesAndValidation = true,
+  }) async {
+    return <String>['xcrun', 'xcodebuild'];
+  }
+
+  @override
+  Version get currentVersion => Version(15, 0, 0);
+
+  @override
+  bool get isRequiredVersionSatisfactory => true;
+
+  @override
+  List<String> xcrunCommand() => <String>['xcrun'];
+}
+
+class FakeIosProjectForBuild extends FakeIosProject {
+  FakeIosProjectForBuild({required super.fileSystem, required FlutterProject parent})
+    : _parent = parent;
+
+  final FlutterProject _parent;
+
+  @override
+  FlutterProject get parent => _parent;
+
+  @override
+  bool existsSync() => true;
+
+  @override
+  File? get xcodeWorkspaceSharedSettings => null;
+
+  @override
+  File get xcodeProjectWorkspaceData =>
+      hostAppRoot.childDirectory('project.xcworkspace').childFile('contents.xcworkspacedata');
+
+  @override
+  File get appFrameworkInfoPlist => hostAppRoot.childFile('AppFrameworkInfo.plist');
+
+  @override
+  File xcodeProjectSchemeFile({String? scheme}) => hostAppRoot.childFile('scheme.xcscheme');
+
+  @override
+  File get defaultHostInfoPlist => hostAppRoot.childFile('Info.plist');
+
+  @override
+  File get appDelegateSwift => hostAppRoot.childDirectory('Runner').childFile('AppDelegate.swift');
+
+  @override
+  Future<XcodeProjectInfo?> projectInfo() async {
+    return XcodeProjectInfo(
+      <String>[],
+      <String>['Debug', 'Release'],
+      <String>['Runner'],
+      BufferLogger.test(),
+    );
+  }
+
+  @override
+  Directory get xcodeWorkspace => hostAppRoot.childDirectory('Runner.xcworkspace');
+
+  @override
+  Directory get flutterFrameworkSwiftPackageDirectory =>
+      hostAppRoot.childDirectory('FlutterGeneratedPluginSwiftPackage');
+
+  @override
+  File get lldbInitFile => hostAppRoot.childFile('lldbinit');
+
+  @override
+  Future<bool> pluginsSupportArmSimulator({required bool printWarnings}) async => true;
+
+  @override
+  File get generatedXcodePropertiesFile => hostAppRoot.childFile('Generated.xcconfig');
+
+  @override
+  File get generatedEnvironmentVariableExportScript =>
+      hostAppRoot.childFile('GeneratedEnvironmentVariables.sh');
+
+  @override
+  File get generatedNativeIntegrationEnvironmentFile =>
+      hostAppRoot.childFile('GeneratedNativeIntegrationEnvironment.sh');
+
+  @override
+  Future<bool> containsWatchCompanion({
+    required XcodeProjectInfo projectInfo,
+    required BuildInfo buildInfo,
+    String? deviceId,
+  }) async => false;
+
+  @override
+  Future<Map<String, String>> buildSettingsForBuildInfo(
+    BuildInfo? buildInfo, {
+    String? scheme,
+    String? configuration,
+    String? target,
+    EnvironmentType environmentType = EnvironmentType.physical,
+    String? deviceId,
+    bool isWatch = false,
+  }) async {
+    return <String, String>{'TARGET_BUILD_DIR': 'build/ios/iphoneos', 'WRAPPER_NAME': 'Runner.app'};
+  }
+}
+
+class FakeBuildableIOSApp extends Fake implements BuildableIOSApp {
+  FakeBuildableIOSApp({required this.project});
+
+  @override
+  final IosProject project;
+}
+
+class FakeXcodeProjectInterpreterForBuild extends FakeXcodeProjectInterpreter {
+  FakeXcodeProjectInterpreterForBuild({
+    super.schemes = const <String>['Runner'],
+    this.buildConfigurations = const <String>['Debug', 'Release'],
+  });
+
+  final List<String> buildConfigurations;
+
+  @override
+  Future<XcodeProjectInfo?> getInfo(
+    XcodeBasedProject xcodeProject, {
+    String? projectFilename,
+    required Directory buildDirectory,
+  }) async {
+    return XcodeProjectInfo(<String>[], buildConfigurations, schemes, BufferLogger.test());
+  }
+}
+
+class FakeFlutterProjectFactoryForBuild implements FlutterProjectFactory {
+  FakeFlutterProjectFactoryForBuild(this.project);
+  final FlutterProject project;
+
+  @override
+  FlutterProject fromDirectory(Directory directory) {
+    return project;
+  }
+
+  @override
+  Map<String, FlutterProject> get projects => <String, FlutterProject>{};
+}
+
+class FakeFlutterProjectForBuild extends FakeFlutterProject {
+  FakeFlutterProjectForBuild({required super.fileSystem});
+
+  @override
+  IosProject get ios => _ios;
+  late final IosProject _ios = FakeIosProjectForBuild(fileSystem: fileSystem, parent: this);
+}
+
+class FakeMacOSProject extends Fake implements MacOSProject {
+  @override
+  bool existsSync() => false;
 }


### PR DESCRIPTION
Replace deleteSync with ErrorHandlingFileSystem.deleteIfExists inside finally blocks in core_devices.dart and mac.dart to avoid crashes when temp directories are deleted asynchronously.

Add robust file verification checks before calling readAsStringSync() on command output files in core_devices.dart to handle missing output files gracefully.

Write unit tests in core_devices_test.dart and mac_test.dart to verify the robust cleanup and error handling behavior.

Fixes https://github.com/flutter/flutter/issues/186954

TAG=agy
CONV=92efecfa-7b87-4033-976e-a9a19502cc2e
