### PR TITLE
[Tool Robustness] Gracefully handle asynchronous subprocess crashes and connection timeouts

### DIFF
--- a/packages/flutter_tools/lib/src/commands/analyze_once.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze_once.dart
@@ -95,8 +95,9 @@ class AnalyzeOnce extends AnalyzeBase {
           if (!analysisCompleter.isCompleted) {
             analysisCompleter.completeError(
               // Include the last 20 lines of server output in exception message
-              Exception(
+              _AnalysisServerExitException(
                 'analysis server exited with code $exitCode and output:\n${server.getLogs(20)}',
+                exitCode,
               ),
             );
           }
@@ -112,7 +113,11 @@ class AnalyzeOnce extends AnalyzeBase {
           ? logger.startProgress('Analyzing $message...')
           : null;
 
-      await analysisCompleter.future;
+      try {
+        await analysisCompleter.future;
+      } on _AnalysisServerExitException catch (error) {
+        throwToolExit(error.message, exitCode: error.exitCode);
+      }
     } finally {
       await server.dispose();
       progress?.cancel();
@@ -172,4 +177,10 @@ class AnalyzeOnce extends AnalyzeBase {
     }
     return false;
   }
+}
+
+class _AnalysisServerExitException implements Exception {
+  _AnalysisServerExitException(this.message, this.exitCode);
+  final String message;
+  final int? exitCode;
 }

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -817,119 +817,111 @@ class ResidentWebRunner extends ResidentRunner {
     if (supportsServiceProtocol) {
       assert(connectDebug != null);
       unawaited(
-        connectDebug!
-            .then((connectionResult) async {
-              _connectionResult = connectionResult;
-              final DebugConnection debugConnection = connectionResult!.debugConnection!;
-              unawaited(debugConnection.onDone.whenComplete(_cleanupAndExit));
+        connectDebug!.then((connectionResult) async {
+          _connectionResult = connectionResult;
+          final DebugConnection debugConnection = connectionResult!.debugConnection!;
+          unawaited(debugConnection.onDone.whenComplete(_cleanupAndExit));
 
-              void onLogEvent(vmservice.Event event) {
-                final String message = processVmServiceMessage(event);
-                _logger.printStatus(message);
-              }
+          void onLogEvent(vmservice.Event event) {
+            final String message = processVmServiceMessage(event);
+            _logger.printStatus(message);
+          }
 
-              // This flag is needed to manage breakpoints properly.
-              if (debuggingOptions.startPaused && debuggingOptions.debuggingEnabled) {
-                try {
-                  final vmservice.Response result = await _vmService.service.setFlag(
-                    'pause_isolates_on_start',
-                    'true',
-                  );
-                  if (result is! vmservice.Success) {
-                    _logger.printError('setFlag failure: $result');
-                  }
-                } on Exception catch (e) {
-                  _logger.printError(
-                    'Failed to set pause_isolates_on_start=true, proceeding. '
-                    'Error: $e',
-                  );
-                }
-              }
-
-              _stdOutSub = _vmService.service.onStdoutEvent.listen(onLogEvent);
-              _stdErrSub = _vmService.service.onStderrEvent.listen(onLogEvent);
-              _serviceSub = _vmService.service.onServiceEvent.listen(_onServiceEvent);
-              try {
-                await _vmService.service.streamListen(vmservice.EventStreams.kStdout);
-              } on vmservice.RPCError {
-                // It is safe to ignore this error because we expect an error to be
-                // thrown if we're already subscribed.
-              }
-              try {
-                await _vmService.service.streamListen(vmservice.EventStreams.kStderr);
-              } on vmservice.RPCError {
-                // It is safe to ignore this error because we expect an error to be
-                // thrown if we're already subscribed.
-              }
-              try {
-                await _vmService.service.streamListen(vmservice.EventStreams.kService);
-              } on vmservice.RPCError {
-                // It is safe to ignore this error because we expect an error to be
-                // thrown if we're already subscribed.
-              }
-              try {
-                await _vmService.service.streamListen(vmservice.EventStreams.kIsolate);
-              } on vmservice.RPCError {
-                // It is safe to ignore this error because we expect an error to be
-                // thrown if we're not already subscribed.
-              }
-              final Device device = flutterDevice!.device!;
-              await setUpVmService(
-                reloadSources: (String isolateId, {bool? force, bool? pause}) async {
-                  await restart(pause: pause);
-                },
-                device: device,
-                flutterProject: flutterProject,
-                printStructuredErrorLogMethod: printStructuredErrorLog,
-                vmService: _vmService.service,
+          // This flag is needed to manage breakpoints properly.
+          if (debuggingOptions.startPaused && debuggingOptions.debuggingEnabled) {
+            try {
+              final vmservice.Response result = await _vmService.service.setFlag(
+                'pause_isolates_on_start',
+                'true',
               );
-
-              final Uri websocketUri = Uri.parse(debugConnection.uri);
-              flutterDevice!.vmService = _vmService;
-              if (debugConnection.devToolsUri != null) {
-                (flutterDevice!.device! as WebDevice).devToolsUri = Uri.parse(
-                  debugConnection.devToolsUri!,
-                );
+              if (result is! vmservice.Success) {
+                _logger.printError('setFlag failure: $result');
               }
-
-              // Run main immediately if the app is not started paused or if there
-              // is no debugger attached. Otherwise, runMain when a resume event
-              // is received.
-              if (!debuggingOptions.startPaused || !supportsServiceProtocol) {
-                _connectionResult!.appConnection!.runMain();
-              } else {
-                late StreamSubscription<void> resumeSub;
-                resumeSub = _vmService.service.onDebugEvent.listen((vmservice.Event event) {
-                  if (event.type == vmservice.EventKind.kResume) {
-                    _connectionResult!.appConnection!.runMain();
-                    resumeSub.cancel();
-                  }
-                });
-              }
-
-              if (debuggingOptions.vmserviceOutFile != null) {
-                _fileSystem.file(debuggingOptions.vmserviceOutFile)
-                  ..createSync(recursive: true)
-                  ..writeAsStringSync(websocketUri.toString());
-              }
-              // TODO(bkonyi): consider removing this log message and using only the standard VM
-              // service message instead.
-              _logger.printStatus('Debug service listening on $websocketUri');
-              final connectionInfo = DebugConnectionInfo(
-                wsUri: websocketUri,
-                devToolsUri: debugConnection.devToolsUri?.toUri(),
-                dtdUri: debugConnection.dtdUri?.toUri(),
-              );
-              printDebuggerList(connectionInfo: connectionInfo);
-              connectionInfoCompleter?.complete(connectionInfo);
-            })
-            .catchError((Object error, StackTrace stackTrace) {
+            } on Exception catch (e) {
               _logger.printError(
-                'Failed to establish connection with the web debug service: $error',
+                'Failed to set pause_isolates_on_start=true, proceeding. '
+                'Error: $e',
               );
-              appFailedToStart();
-              throwToolExit('Failed to connect to the web debug service.');
-            }),
+            }
+          }
+
+          _stdOutSub = _vmService.service.onStdoutEvent.listen(onLogEvent);
+          _stdErrSub = _vmService.service.onStderrEvent.listen(onLogEvent);
+          _serviceSub = _vmService.service.onServiceEvent.listen(_onServiceEvent);
+          try {
+            await _vmService.service.streamListen(vmservice.EventStreams.kStdout);
+          } on vmservice.RPCError {
+            // It is safe to ignore this error because we expect an error to be
+            // thrown if we're already subscribed.
+          }
+          try {
+            await _vmService.service.streamListen(vmservice.EventStreams.kStderr);
+          } on vmservice.RPCError {
+            // It is safe to ignore this error because we expect an error to be
+            // thrown if we're already subscribed.
+          }
+          try {
+            await _vmService.service.streamListen(vmservice.EventStreams.kService);
+          } on vmservice.RPCError {
+            // It is safe to ignore this error because we expect an error to be
+            // thrown if we're already subscribed.
+          }
+          try {
+            await _vmService.service.streamListen(vmservice.EventStreams.kIsolate);
+          } on vmservice.RPCError {
+            // It is safe to ignore this error because we expect an error to be
+            // thrown if we're not already subscribed.
+          }
+          final Device device = flutterDevice!.device!;
+          await setUpVmService(
+            reloadSources: (String isolateId, {bool? force, bool? pause}) async {
+              await restart(pause: pause);
+            },
+            device: device,
+            flutterProject: flutterProject,
+            printStructuredErrorLogMethod: printStructuredErrorLog,
+            vmService: _vmService.service,
+          );
+
+          final Uri websocketUri = Uri.parse(debugConnection.uri);
+          flutterDevice!.vmService = _vmService;
+          if (debugConnection.devToolsUri != null) {
+            (flutterDevice!.device! as WebDevice).devToolsUri = Uri.parse(
+              debugConnection.devToolsUri!,
+            );
+          }
+
+          // Run main immediately if the app is not started paused or if there
+          // is no debugger attached. Otherwise, runMain when a resume event
+          // is received.
+          if (!debuggingOptions.startPaused || !supportsServiceProtocol) {
+            _connectionResult!.appConnection!.runMain();
+          } else {
+            late StreamSubscription<void> resumeSub;
+            resumeSub = _vmService.service.onDebugEvent.listen((vmservice.Event event) {
+              if (event.type == vmservice.EventKind.kResume) {
+                _connectionResult!.appConnection!.runMain();
+                resumeSub.cancel();
+              }
+            });
+          }
+
+          if (debuggingOptions.vmserviceOutFile != null) {
+            _fileSystem.file(debuggingOptions.vmserviceOutFile)
+              ..createSync(recursive: true)
+              ..writeAsStringSync(websocketUri.toString());
+          }
+          // TODO(bkonyi): consider removing this log message and using only the standard VM
+          // service message instead.
+          _logger.printStatus('Debug service listening on $websocketUri');
+          final connectionInfo = DebugConnectionInfo(
+            wsUri: websocketUri,
+            devToolsUri: debugConnection.devToolsUri?.toUri(),
+            dtdUri: debugConnection.dtdUri?.toUri(),
+          );
+          printDebuggerList(connectionInfo: connectionInfo);
+          connectionInfoCompleter?.complete(connectionInfo);
+        }),
       );
     } else {
       connectionInfoCompleter?.complete(DebugConnectionInfo());

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -391,6 +391,13 @@ class ResidentWebRunner extends ResidentRunner {
       appFailedToStart();
       _logger.printError(error.toString(), stackTrace: stackTrace);
       throwToolExit(kExitMessage);
+    } on TimeoutException catch (error, stackTrace) {
+      appFailedToStart();
+      _logger.printError(
+        'Failed to establish connection with the web debug service: $error',
+        stackTrace: stackTrace,
+      );
+      throwToolExit('Failed to connect to the web debug service.');
     } on DartDevelopmentServiceException catch (error) {
       // The application may have started shutting down before DDS was able to finish establishing
       // its connection to DWDS. Don't treat this as an unhandled exception.
@@ -810,111 +817,119 @@ class ResidentWebRunner extends ResidentRunner {
     if (supportsServiceProtocol) {
       assert(connectDebug != null);
       unawaited(
-        connectDebug!.then((connectionResult) async {
-          _connectionResult = connectionResult;
-          final DebugConnection debugConnection = connectionResult!.debugConnection!;
-          unawaited(debugConnection.onDone.whenComplete(_cleanupAndExit));
+        connectDebug!
+            .then((connectionResult) async {
+              _connectionResult = connectionResult;
+              final DebugConnection debugConnection = connectionResult!.debugConnection!;
+              unawaited(debugConnection.onDone.whenComplete(_cleanupAndExit));
 
-          void onLogEvent(vmservice.Event event) {
-            final String message = processVmServiceMessage(event);
-            _logger.printStatus(message);
-          }
-
-          // This flag is needed to manage breakpoints properly.
-          if (debuggingOptions.startPaused && debuggingOptions.debuggingEnabled) {
-            try {
-              final vmservice.Response result = await _vmService.service.setFlag(
-                'pause_isolates_on_start',
-                'true',
-              );
-              if (result is! vmservice.Success) {
-                _logger.printError('setFlag failure: $result');
+              void onLogEvent(vmservice.Event event) {
+                final String message = processVmServiceMessage(event);
+                _logger.printStatus(message);
               }
-            } on Exception catch (e) {
-              _logger.printError(
-                'Failed to set pause_isolates_on_start=true, proceeding. '
-                'Error: $e',
+
+              // This flag is needed to manage breakpoints properly.
+              if (debuggingOptions.startPaused && debuggingOptions.debuggingEnabled) {
+                try {
+                  final vmservice.Response result = await _vmService.service.setFlag(
+                    'pause_isolates_on_start',
+                    'true',
+                  );
+                  if (result is! vmservice.Success) {
+                    _logger.printError('setFlag failure: $result');
+                  }
+                } on Exception catch (e) {
+                  _logger.printError(
+                    'Failed to set pause_isolates_on_start=true, proceeding. '
+                    'Error: $e',
+                  );
+                }
+              }
+
+              _stdOutSub = _vmService.service.onStdoutEvent.listen(onLogEvent);
+              _stdErrSub = _vmService.service.onStderrEvent.listen(onLogEvent);
+              _serviceSub = _vmService.service.onServiceEvent.listen(_onServiceEvent);
+              try {
+                await _vmService.service.streamListen(vmservice.EventStreams.kStdout);
+              } on vmservice.RPCError {
+                // It is safe to ignore this error because we expect an error to be
+                // thrown if we're already subscribed.
+              }
+              try {
+                await _vmService.service.streamListen(vmservice.EventStreams.kStderr);
+              } on vmservice.RPCError {
+                // It is safe to ignore this error because we expect an error to be
+                // thrown if we're already subscribed.
+              }
+              try {
+                await _vmService.service.streamListen(vmservice.EventStreams.kService);
+              } on vmservice.RPCError {
+                // It is safe to ignore this error because we expect an error to be
+                // thrown if we're already subscribed.
+              }
+              try {
+                await _vmService.service.streamListen(vmservice.EventStreams.kIsolate);
+              } on vmservice.RPCError {
+                // It is safe to ignore this error because we expect an error to be
+                // thrown if we're not already subscribed.
+              }
+              final Device device = flutterDevice!.device!;
+              await setUpVmService(
+                reloadSources: (String isolateId, {bool? force, bool? pause}) async {
+                  await restart(pause: pause);
+                },
+                device: device,
+                flutterProject: flutterProject,
+                printStructuredErrorLogMethod: printStructuredErrorLog,
+                vmService: _vmService.service,
               );
-            }
-          }
 
-          _stdOutSub = _vmService.service.onStdoutEvent.listen(onLogEvent);
-          _stdErrSub = _vmService.service.onStderrEvent.listen(onLogEvent);
-          _serviceSub = _vmService.service.onServiceEvent.listen(_onServiceEvent);
-          try {
-            await _vmService.service.streamListen(vmservice.EventStreams.kStdout);
-          } on vmservice.RPCError {
-            // It is safe to ignore this error because we expect an error to be
-            // thrown if we're already subscribed.
-          }
-          try {
-            await _vmService.service.streamListen(vmservice.EventStreams.kStderr);
-          } on vmservice.RPCError {
-            // It is safe to ignore this error because we expect an error to be
-            // thrown if we're already subscribed.
-          }
-          try {
-            await _vmService.service.streamListen(vmservice.EventStreams.kService);
-          } on vmservice.RPCError {
-            // It is safe to ignore this error because we expect an error to be
-            // thrown if we're already subscribed.
-          }
-          try {
-            await _vmService.service.streamListen(vmservice.EventStreams.kIsolate);
-          } on vmservice.RPCError {
-            // It is safe to ignore this error because we expect an error to be
-            // thrown if we're not already subscribed.
-          }
-          final Device device = flutterDevice!.device!;
-          await setUpVmService(
-            reloadSources: (String isolateId, {bool? force, bool? pause}) async {
-              await restart(pause: pause);
-            },
-            device: device,
-            flutterProject: flutterProject,
-            printStructuredErrorLogMethod: printStructuredErrorLog,
-            vmService: _vmService.service,
-          );
+              final Uri websocketUri = Uri.parse(debugConnection.uri);
+              flutterDevice!.vmService = _vmService;
+              if (debugConnection.devToolsUri != null) {
+                (flutterDevice!.device! as WebDevice).devToolsUri = Uri.parse(
+                  debugConnection.devToolsUri!,
+                );
+              }
 
-          final Uri websocketUri = Uri.parse(debugConnection.uri);
-          flutterDevice!.vmService = _vmService;
-          if (debugConnection.devToolsUri != null) {
-            (flutterDevice!.device! as WebDevice).devToolsUri = Uri.parse(
-              debugConnection.devToolsUri!,
-            );
-          }
-
-          // Run main immediately if the app is not started paused or if there
-          // is no debugger attached. Otherwise, runMain when a resume event
-          // is received.
-          if (!debuggingOptions.startPaused || !supportsServiceProtocol) {
-            _connectionResult!.appConnection!.runMain();
-          } else {
-            late StreamSubscription<void> resumeSub;
-            resumeSub = _vmService.service.onDebugEvent.listen((vmservice.Event event) {
-              if (event.type == vmservice.EventKind.kResume) {
+              // Run main immediately if the app is not started paused or if there
+              // is no debugger attached. Otherwise, runMain when a resume event
+              // is received.
+              if (!debuggingOptions.startPaused || !supportsServiceProtocol) {
                 _connectionResult!.appConnection!.runMain();
-                resumeSub.cancel();
+              } else {
+                late StreamSubscription<void> resumeSub;
+                resumeSub = _vmService.service.onDebugEvent.listen((vmservice.Event event) {
+                  if (event.type == vmservice.EventKind.kResume) {
+                    _connectionResult!.appConnection!.runMain();
+                    resumeSub.cancel();
+                  }
+                });
               }
-            });
-          }
 
-          if (debuggingOptions.vmserviceOutFile != null) {
-            _fileSystem.file(debuggingOptions.vmserviceOutFile)
-              ..createSync(recursive: true)
-              ..writeAsStringSync(websocketUri.toString());
-          }
-          // TODO(bkonyi): consider removing this log message and using only the standard VM
-          // service message instead.
-          _logger.printStatus('Debug service listening on $websocketUri');
-          final connectionInfo = DebugConnectionInfo(
-            wsUri: websocketUri,
-            devToolsUri: debugConnection.devToolsUri?.toUri(),
-            dtdUri: debugConnection.dtdUri?.toUri(),
-          );
-          printDebuggerList(connectionInfo: connectionInfo);
-          connectionInfoCompleter?.complete(connectionInfo);
-        }),
+              if (debuggingOptions.vmserviceOutFile != null) {
+                _fileSystem.file(debuggingOptions.vmserviceOutFile)
+                  ..createSync(recursive: true)
+                  ..writeAsStringSync(websocketUri.toString());
+              }
+              // TODO(bkonyi): consider removing this log message and using only the standard VM
+              // service message instead.
+              _logger.printStatus('Debug service listening on $websocketUri');
+              final connectionInfo = DebugConnectionInfo(
+                wsUri: websocketUri,
+                devToolsUri: debugConnection.devToolsUri?.toUri(),
+                dtdUri: debugConnection.dtdUri?.toUri(),
+              );
+              printDebuggerList(connectionInfo: connectionInfo);
+              connectionInfoCompleter?.complete(connectionInfo);
+            })
+            .catchError((Object error, StackTrace stackTrace) {
+              _logger.printError(
+                'Failed to establish connection with the web debug service: $error',
+              );
+              appFailedToStart();
+              throwToolExit('Failed to connect to the web debug service.');
+            }),
       );
     } else {
       connectionInfoCompleter?.complete(DebugConnectionInfo());

--- a/packages/flutter_tools/test/commands.shard/hermetic/analyze_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/analyze_test.dart
@@ -9,6 +9,7 @@ import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/artifacts.dart';
+import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
@@ -105,6 +106,44 @@ void main() {
               'description',
               contains('analysis server exited with code $SIGABRT and output:\n[stderr] $stderr'),
             ),
+          ),
+        );
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+      },
+    );
+
+    testUsingContext(
+      'Analysis server premature exit with 255 throws ToolExit',
+      () async {
+        const stderr = 'Fatal error in analyzer';
+        processManager.addCommands(<FakeCommand>[
+          const FakeCommand(
+            command: <String>[
+              'Artifact.engineDartSdkPath/bin/dart',
+              'language-server',
+              '--dart-sdk',
+              'Artifact.engineDartSdkPath',
+              '--disable-server-feature-completion',
+              '--disable-server-feature-search',
+              '--suppress-analytics',
+            ],
+            exitCode: 255,
+            stderr: stderr,
+          ),
+        ]);
+        await expectLater(
+          runner.run(<String>['analyze']),
+          throwsA(
+            isA<ToolExit>()
+                .having(
+                  (ToolExit e) => e.message,
+                  'message',
+                  contains('analysis server exited with code 255 and output:\n[stderr] $stderr'),
+                )
+                .having((ToolExit e) => e.exitCode, 'exitCode', equals(255)),
           ),
         );
       },

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -1964,6 +1964,33 @@ flutter:
   );
 
   testUsingContext(
+    'ResidentWebRunner throws ToolExit when DWDS debug connection times out',
+    () async {
+      final logger = BufferLogger.test();
+      final ResidentRunner residentWebRunner = setUpResidentRunner(flutterDevice, logger: logger);
+      fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+      setupMocks();
+      webDevFS.exception = TimeoutException('Connection timed out');
+
+      await expectLater(
+        residentWebRunner.run,
+        throwsToolExit(message: 'Failed to connect to the web debug service.'),
+      );
+      expect(
+        logger.errorText,
+        contains(
+          'Failed to establish connection with the web debug service: TimeoutException: Connection timed out',
+        ),
+      );
+    },
+    overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      ProcessManager: () => processManager,
+      Pub: ThrowingPub.new,
+    },
+  );
+
+  testUsingContext(
     'throws when port is an integer outside the valid TCP range',
     () async {
       final logger = BufferLogger.test();


### PR DESCRIPTION
Avoid crashing the flutter tool when the analysis server subprocess exits prematurely (e.g. with 255) or when the web debug connection times out.

For the analysis server, we introduce a private _AnalysisServerExitException and map it to a clean ToolExit when awaiting the analysis.

For the web runner, we attach a .catchError handler to the connectDebug future to handle connection timeouts, printing a clear error and exiting via ToolExit instead of raising an unhandled async error.

Fixes https://github.com/flutter/flutter/issues/186962
Fixes https://github.com/flutter/flutter/issues/186963