### PR TITLE
Update FlutterGeneratedPluginSwiftPackage deployment target during Xcode build

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.dart
+++ b/packages/flutter_tools/bin/xcode_backend.dart
@@ -631,13 +631,16 @@ class Context {
 
     final String targetPlatform;
     final String platformArches;
+    final String deploymentTarget;
     switch (platform) {
       case TargetPlatform.ios:
         targetPlatform = '-dTargetPlatform=ios';
         platformArches = '-dIosArchs=$archs';
+        deploymentTarget = environment['IPHONEOS_DEPLOYMENT_TARGET'] ?? '';
       case TargetPlatform.macos:
         targetPlatform = '-dTargetPlatform=darwin';
         platformArches = '-dDarwinArchs=$archs';
+        deploymentTarget = environment['MACOSX_DEPLOYMENT_TARGET'] ?? '';
     }
 
     flutterArgs.addAll(<String>[
@@ -664,6 +667,7 @@ class Context {
       '--ExtraFrontEndOptions=${environment['EXTRA_FRONT_END_OPTIONS'] ?? ''}',
       '-dSrcRoot=${environment['SRCROOT'] ?? ''}',
       '-dXcodeBuildScript=$command',
+      '-dDeploymentTarget=$deploymentTarget',
     ]);
 
     if (platform == TargetPlatform.ios) {

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -1159,6 +1159,11 @@ const kXcodeBuildScriptValueAddToAppBuild = 'build-add-to-app';
 /// Expects value of "true".
 const kBuildSwiftPackage = 'BuildSwiftPackage';
 
+/// The Darwin deployment target for a build.
+///
+/// This value will be set to the value of IPHONEOS_DEPLOYMENT_TARGET or MACOSX_DEPLOYMENT_TARGET.
+const kDeploymentTarget = 'DeploymentTarget';
+
 final Converter<String, String> _defineEncoder = utf8.encoder.fuse(base64.encoder);
 final Converter<String, String> _defineDecoder = base64.decoder.fuse(utf8.decoder);
 

--- a/packages/flutter_tools/lib/src/build_system/targets/darwin.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/darwin.dart
@@ -176,7 +176,7 @@ abstract class DarwinSwiftPackageMinimumDeployment extends Target {
         }
         if (changed ?? false) {
           printXcodeError(
-            'FlutterGeneratedPluginSwiftPackage minimum supported platform updated to $deploymentTarget, but Xcode cache is out of date.',
+            '$kFlutterGeneratedPluginSwiftPackageName minimum supported platform updated to $deploymentTarget, but Xcode cache is out of date.',
           );
           printXcodeError(
             'Please reset the manfiest cache by selecting File > Packages > Resolve Package Versions',

--- a/packages/flutter_tools/lib/src/build_system/targets/darwin.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/darwin.dart
@@ -5,10 +5,14 @@
 import 'package:meta/meta.dart';
 
 import '../../artifacts.dart';
+import '../../base/common.dart';
 import '../../base/io.dart';
 import '../../build_info.dart';
+import '../../convert.dart';
 import '../../darwin/darwin.dart';
 import '../../globals.dart' as globals show stdio;
+import '../../macos/swift_package_manager.dart';
+import '../../project.dart';
 import '../build_system.dart';
 
 abstract class UnpackDarwin extends Target {
@@ -120,6 +124,65 @@ abstract class UnpackDarwin extends Target {
         'lipo -info:\n'
         '$lipoInfo',
       );
+    }
+  }
+}
+
+abstract class DarwinSwiftPackageMinimumDeployment extends Target {
+  const DarwinSwiftPackageMinimumDeployment();
+
+  @visibleForOverriding
+  FlutterDarwinPlatform get darwinPlatform;
+
+  @override
+  List<Source> get inputs {
+    return <Source>[
+      const Source.pattern(
+        '{FLUTTER_ROOT}/packages/flutter_tools/lib/src/build_system/targets/darwin.dart',
+      ),
+    ];
+  }
+
+  @override
+  List<Source> get outputs => [];
+
+  @override
+  List<Target> get dependencies => [];
+
+  @override
+  Future<bool> canSkip(Environment environment) async {
+    return environment.defines[kXcodeBuildScript] != kXcodeBuildScriptValuePrepare;
+  }
+
+  @override
+  Future<void> build(Environment environment) async {
+    final FlutterProject flutterProject = FlutterProject.fromDirectory(environment.projectDir);
+    final XcodeBasedProject xcodeProject = darwinPlatform.xcodeProject(flutterProject);
+    if (xcodeProject.usesSwiftPackageManager) {
+      final String? deploymentTarget = environment.defines[kDeploymentTarget];
+      if (deploymentTarget != null) {
+        bool? changed;
+        try {
+          changed = SwiftPackageManager.updateMinimumDeployment(
+            platform: darwinPlatform,
+            project: xcodeProject,
+            deploymentTarget: deploymentTarget,
+          );
+        } on ToolExit catch (e) {
+          final String? errorMessage = e.message;
+          if (errorMessage != null && errorMessage.isNotEmpty) {
+            const LineSplitter().convert(errorMessage).forEach((line) => printXcodeError(line));
+          }
+        }
+        if (changed ?? false) {
+          printXcodeError(
+            'FlutterGeneratedPluginSwiftPackage minimum supported platform updated to $deploymentTarget, but Xcode cache is out of date.',
+          );
+          printXcodeError(
+            'Please reset the manfiest cache by selecting File > Packages > Resolve Package Versions',
+          );
+        }
+      }
     }
   }
 }

--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -257,7 +257,7 @@ abstract class UnpackIOS extends UnpackDarwin {
   List<Source> get outputs => const <Source>[kFlutterIOSFrameworkBinarySource];
 
   @override
-  List<Target> get dependencies => <Target>[];
+  List<Target> get dependencies => <Target>[const IosSwiftPackageMinimumDeployment()];
 
   @visibleForOverriding
   BuildMode get buildMode;
@@ -953,5 +953,30 @@ Future<void> _signFramework(Environment environment, File binary, BuildMode buil
       output.writeln(stderr);
     }
     throw Exception(output.toString());
+  }
+}
+
+class IosSwiftPackageMinimumDeployment extends DarwinSwiftPackageMinimumDeployment {
+  const IosSwiftPackageMinimumDeployment();
+
+  @override
+  String get name => 'ios_swift_package_minimum_deployment';
+
+  @override
+  FlutterDarwinPlatform get darwinPlatform => FlutterDarwinPlatform.ios;
+
+  @override
+  List<Source> get inputs {
+    return <Source>[
+      ...super.inputs,
+      Source.fromProject(
+        (FlutterProject project) => project.ios.xcodeProjectInfoFile,
+        optional: true,
+      ),
+      Source.fromProject(
+        (FlutterProject project) => project.ios.flutterPluginSwiftPackageManifest,
+        optional: true,
+      ),
+    ];
   }
 }

--- a/packages/flutter_tools/lib/src/build_system/targets/macos.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/macos.dart
@@ -48,7 +48,7 @@ abstract class UnpackMacOS extends UnpackDarwin {
   }
 
   @override
-  List<Target> get dependencies => <Target>[];
+  List<Target> get dependencies => <Target>[const MacOSSwiftPackageMinimumDeployment()];
 
   @override
   FlutterDarwinPlatform get darwinPlatform => FlutterDarwinPlatform.macos;
@@ -684,5 +684,30 @@ class ReleaseMacOSBundleFlutterAssets extends MacOSBundleFlutterAssets {
         );
       }
     }
+  }
+}
+
+class MacOSSwiftPackageMinimumDeployment extends DarwinSwiftPackageMinimumDeployment {
+  const MacOSSwiftPackageMinimumDeployment();
+
+  @override
+  String get name => 'macos_swift_package_minimum_deployment';
+
+  @override
+  FlutterDarwinPlatform get darwinPlatform => FlutterDarwinPlatform.macos;
+
+  @override
+  List<Source> get inputs {
+    return <Source>[
+      ...super.inputs,
+      Source.fromProject(
+        (FlutterProject project) => project.macos.xcodeProjectInfoFile,
+        optional: true,
+      ),
+      Source.fromProject(
+        (FlutterProject project) => project.macos.flutterPluginSwiftPackageManifest,
+        optional: true,
+      ),
+    ];
   }
 }

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -1431,13 +1431,12 @@ String? _swiftPackageManagerMinPlatformMismatchMessageFromStdout(String? stdout)
       highestSupportedVersion == null) {
     return null;
   }
-
-  return '''
-To fix this error, increase your app's minimum platform version from $highestSupportedVersion to at least $highestRequiredVersion or remove the $highestRequiredByProduct dependency.
-
-To increase your app's minimum platform version, follow these instructions:
-  https://docs.flutter.dev/packages-and-plugins/swift-package-manager/for-app-developers#how-to-use-a-swift-package-manager-flutter-plugin-that-requires-a-higher-os-version
-''';
+  return "To fix this error, increase your app's minimum platform version from "
+      '$highestSupportedVersion to at least $highestRequiredVersion or remove the '
+      '$highestRequiredByProduct dependency.\n'
+      'Then run "flutter build ios --config-only" to regenerate the project\'s configuration files.\n\n'
+      "To increase your app's minimum platform version, follow these instructions:\n"
+      '  https://docs.flutter.dev/packages-and-plugins/swift-package-manager/for-app-developers#how-to-use-a-swift-package-manager-flutter-plugin-that-requires-a-higher-os-version';
 }
 
 String? _parseModuleRedefinition(String message) {

--- a/packages/flutter_tools/lib/src/macos/swift_package_manager.dart
+++ b/packages/flutter_tools/lib/src/macos/swift_package_manager.dart
@@ -362,9 +362,11 @@ class SwiftPackageManager {
   }
 
   /// If the project's IPHONEOS_DEPLOYMENT_TARGET/MACOSX_DEPLOYMENT_TARGET is
-  /// higher than the FlutterGeneratedPluginSwiftPackage's default
+  /// higher than the FlutterGeneratedPluginSwiftPackage's current
   /// SupportedPlatform, increase the SupportedPlatform to match the project's
   /// deployment target.
+  ///
+  /// Returns `true` if the deployment target was changed, `false` otherwise.
   ///
   /// This is done for the use case of a plugin requiring a higher iOS/macOS
   /// version than FlutterGeneratedPluginSwiftPackage.
@@ -377,23 +379,41 @@ class SwiftPackageManager {
   /// To still be able to use the plugin, the user can increase the Xcode
   /// project's iOS/macOS deployment target and this will then increase the
   /// deployment target for FlutterGeneratedPluginSwiftPackage.
-  static void updateMinimumDeployment({
+  static bool updateMinimumDeployment({
     required XcodeBasedProject project,
     required FlutterDarwinPlatform platform,
     required String deploymentTarget,
   }) {
-    final Version? projectDeploymentTargetVersion = Version.parse(deploymentTarget);
-    final SwiftPackageSupportedPlatform defaultPlatform = platform.supportedPackagePlatform;
-    final SwiftPackagePlatform packagePlatform = platform.swiftPackagePlatform;
-
-    if (projectDeploymentTargetVersion == null ||
-        projectDeploymentTargetVersion <= defaultPlatform.version ||
-        !project.flutterPluginSwiftPackageManifest.existsSync()) {
-      return;
+    final regenerateMessage =
+        'Please run "flutter build ${platform.name} --config-only" '
+        "to regenerate the project's configuration files.";
+    final String manifestPath = project.flutterPluginSwiftPackageManifest.path;
+    if (!project.flutterPluginSwiftPackageManifest.existsSync()) {
+      throwToolExit('$manifestPath does not exist.\n\n$regenerateMessage');
     }
 
     final String manifestContents = project.flutterPluginSwiftPackageManifest.readAsStringSync();
-    final String oldSupportedPlatform = defaultPlatform.format();
+    final Version? currentVersion = Version.parse(
+      RegExp(
+        '${platform.swiftPackagePlatform.displayName}\\("([\\d\\.]+)"\\)',
+      ).firstMatch(manifestContents)?.group(1),
+    );
+    if (currentVersion == null) {
+      throwToolExit('Failed to parse platform from $manifestPath.\n\n$regenerateMessage');
+    }
+
+    final Version? projectDeploymentTargetVersion = Version.parse(deploymentTarget);
+    final SwiftPackagePlatform packagePlatform = platform.swiftPackagePlatform;
+
+    if (projectDeploymentTargetVersion == null ||
+        projectDeploymentTargetVersion <= currentVersion) {
+      return false;
+    }
+
+    final String oldSupportedPlatform = SwiftPackageSupportedPlatform(
+      platform: packagePlatform,
+      version: currentVersion,
+    ).format();
     final String newSupportedPlatform = SwiftPackageSupportedPlatform(
       platform: packagePlatform,
       version: projectDeploymentTargetVersion,
@@ -402,5 +422,6 @@ class SwiftPackageManager {
     project.flutterPluginSwiftPackageManifest.writeAsStringSync(
       manifestContents.replaceFirst(oldSupportedPlatform, newSupportedPlatform),
     );
+    return true;
   }
 }

--- a/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
@@ -15,8 +15,10 @@ import 'package:flutter_tools/src/base/version.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/build_system/targets/ios.dart';
+import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
+import 'package:flutter_tools/src/macos/xcode.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:test/fake.dart';
 import 'package:unified_analytics/unified_analytics.dart';
@@ -1600,6 +1602,140 @@ flutter:
       },
     );
   });
+
+  group('IosSwiftPackageMinimumDeployment', () {
+    late Environment environment;
+    late MemoryFileSystem fileSystem;
+    late FakeProcessManager processManager;
+    late BufferLogger logger;
+
+    setUp(() {
+      fileSystem = MemoryFileSystem.test();
+      processManager = FakeProcessManager.empty();
+      logger = BufferLogger.test();
+      environment = Environment.test(
+        fileSystem.currentDirectory,
+        defines: <String, String>{},
+        inputs: <String, String>{},
+        processManager: processManager,
+        artifacts: Artifacts.test(),
+        logger: logger,
+        fileSystem: fileSystem,
+      );
+    });
+
+    testWithoutContext('canSkip matches XcodeBuildScript value', () async {
+      const target = IosSwiftPackageMinimumDeployment();
+
+      environment.defines[kXcodeBuildScript] = kXcodeBuildScriptValuePrepare;
+      expect(await target.canSkip(environment), isFalse);
+
+      environment.defines[kXcodeBuildScript] = 'other';
+      expect(await target.canSkip(environment), isTrue);
+    });
+
+    testUsingContext('build does nothing if usesSwiftPackageManager is false', () async {
+      final Directory projectDir = fileSystem.directory('/project')..createSync();
+      environment = Environment.test(
+        fileSystem.currentDirectory,
+        projectDir: projectDir,
+        defines: <String, String>{},
+        inputs: <String, String>{},
+        processManager: processManager,
+        artifacts: Artifacts.test(),
+        logger: logger,
+        fileSystem: fileSystem,
+      );
+
+      const target = IosSwiftPackageMinimumDeployment();
+      await target.build(environment);
+
+      expect(logger.errorText, isEmpty);
+    });
+
+    testUsingContext(
+      'build catching ToolExit when manifest does not exist',
+      () async {
+        final Directory projectDir = fileSystem.directory('/project')..createSync();
+        projectDir
+            .childDirectory('ios')
+            .childDirectory('Runner.xcodeproj')
+            .createSync(recursive: true);
+        environment = Environment.test(
+          fileSystem.currentDirectory,
+          projectDir: projectDir,
+          defines: <String, String>{kDeploymentTarget: '14.0'},
+          inputs: <String, String>{},
+          processManager: processManager,
+          artifacts: Artifacts.test(),
+          logger: logger,
+          fileSystem: fileSystem,
+        );
+
+        const target = IosSwiftPackageMinimumDeployment();
+        await target.build(environment);
+
+        final fakeStdio = globals.stdio as FakeStdio;
+        expect(fakeStdio.buffer.toString(), contains('does not exist.'));
+      },
+      overrides: <Type, Generator>{
+        FeatureFlags: () => TestFeatureFlags(isSwiftPackageManagerEnabled: true),
+        Xcode: () => FakeXcode15(),
+        Stdio: () => FakeStdio(),
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+      },
+    );
+
+    testUsingContext(
+      'build successfully updates deployment target',
+      () async {
+        final Directory projectDir = fileSystem.directory('/project')..createSync();
+        projectDir
+            .childDirectory('ios')
+            .childDirectory('Runner.xcodeproj')
+            .createSync(recursive: true);
+
+        final File manifest = projectDir
+            .childDirectory('ios')
+            .childDirectory('Flutter')
+            .childDirectory('ephemeral')
+            .childDirectory('Packages')
+            .childDirectory('FlutterGeneratedPluginSwiftPackage')
+            .childFile('Package.swift');
+        manifest.createSync(recursive: true);
+        manifest.writeAsStringSync('.iOS("13.0")');
+
+        environment = Environment.test(
+          fileSystem.currentDirectory,
+          projectDir: projectDir,
+          defines: <String, String>{kDeploymentTarget: '14.0'},
+          inputs: <String, String>{},
+          processManager: processManager,
+          artifacts: Artifacts.test(),
+          logger: logger,
+          fileSystem: fileSystem,
+        );
+
+        const target = IosSwiftPackageMinimumDeployment();
+        await target.build(environment);
+
+        final fakeStdio = globals.stdio as FakeStdio;
+        expect(
+          fakeStdio.buffer.toString(),
+          contains('minimum supported platform updated to 14.0, but Xcode cache is out of date.'),
+        );
+        expect(manifest.readAsStringSync(), contains('.iOS("14.0")'));
+      },
+      overrides: <Type, Generator>{
+        FeatureFlags: () => TestFeatureFlags(isSwiftPackageManagerEnabled: true),
+        Xcode: () => FakeXcode15(),
+        Stdio: () => FakeStdio(),
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+      },
+    );
+  });
 }
 
 class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterpreter {
@@ -1634,4 +1770,9 @@ class FakeStdio extends Fake implements Stdio {
   void stderrWrite(String message, {void Function(String, dynamic, StackTrace)? fallback}) {
     buffer.writeln(message);
   }
+}
+
+class FakeXcode15 extends Fake implements Xcode {
+  @override
+  Version get currentVersion => Version(15, 0, 0);
 }

--- a/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
@@ -6,13 +6,16 @@ import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/version.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/build_system/targets/macos.dart';
 import 'package:flutter_tools/src/features.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
+import 'package:flutter_tools/src/macos/xcode.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:test/fake.dart';
 import 'package:unified_analytics/unified_analytics.dart';
@@ -936,6 +939,140 @@ void main() {
       },
     );
   });
+
+  group('MacOSSwiftPackageMinimumDeployment', () {
+    late Environment environment;
+    late MemoryFileSystem fileSystem;
+    late FakeProcessManager processManager;
+    late BufferLogger logger;
+
+    setUp(() {
+      fileSystem = MemoryFileSystem.test();
+      processManager = FakeProcessManager.empty();
+      logger = BufferLogger.test();
+      environment = Environment.test(
+        fileSystem.currentDirectory,
+        defines: <String, String>{},
+        inputs: <String, String>{},
+        processManager: processManager,
+        artifacts: Artifacts.test(),
+        logger: logger,
+        fileSystem: fileSystem,
+      );
+    });
+
+    testWithoutContext('canSkip matches XcodeBuildScript value', () async {
+      const target = MacOSSwiftPackageMinimumDeployment();
+
+      environment.defines[kXcodeBuildScript] = kXcodeBuildScriptValuePrepare;
+      expect(await target.canSkip(environment), isFalse);
+
+      environment.defines[kXcodeBuildScript] = 'other';
+      expect(await target.canSkip(environment), isTrue);
+    });
+
+    testUsingContext('build does nothing if usesSwiftPackageManager is false', () async {
+      final Directory projectDir = fileSystem.directory('/project')..createSync();
+      environment = Environment.test(
+        fileSystem.currentDirectory,
+        projectDir: projectDir,
+        defines: <String, String>{},
+        inputs: <String, String>{},
+        processManager: processManager,
+        artifacts: Artifacts.test(),
+        logger: logger,
+        fileSystem: fileSystem,
+      );
+
+      const target = MacOSSwiftPackageMinimumDeployment();
+      await target.build(environment);
+
+      expect(logger.errorText, isEmpty);
+    });
+
+    testUsingContext(
+      'build catching ToolExit when manifest does not exist',
+      () async {
+        final Directory projectDir = fileSystem.directory('/project')..createSync();
+        projectDir
+            .childDirectory('macos')
+            .childDirectory('Runner.xcodeproj')
+            .createSync(recursive: true);
+        environment = Environment.test(
+          fileSystem.currentDirectory,
+          projectDir: projectDir,
+          defines: <String, String>{kDeploymentTarget: '11.0'},
+          inputs: <String, String>{},
+          processManager: processManager,
+          artifacts: Artifacts.test(),
+          logger: logger,
+          fileSystem: fileSystem,
+        );
+
+        const target = MacOSSwiftPackageMinimumDeployment();
+        await target.build(environment);
+
+        final fakeStdio = globals.stdio as FakeStdio;
+        expect(fakeStdio.buffer.toString(), contains('does not exist.'));
+      },
+      overrides: <Type, Generator>{
+        FeatureFlags: () => TestFeatureFlags(isSwiftPackageManagerEnabled: true),
+        Xcode: () => FakeXcode15(),
+        Stdio: () => FakeStdio(),
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+      },
+    );
+
+    testUsingContext(
+      'build successfully updates deployment target',
+      () async {
+        final Directory projectDir = fileSystem.directory('/project')..createSync();
+        projectDir
+            .childDirectory('macos')
+            .childDirectory('Runner.xcodeproj')
+            .createSync(recursive: true);
+
+        final File manifest = projectDir
+            .childDirectory('macos')
+            .childDirectory('Flutter')
+            .childDirectory('ephemeral')
+            .childDirectory('Packages')
+            .childDirectory('FlutterGeneratedPluginSwiftPackage')
+            .childFile('Package.swift');
+        manifest.createSync(recursive: true);
+        manifest.writeAsStringSync('.macOS("10.15")');
+
+        environment = Environment.test(
+          fileSystem.currentDirectory,
+          projectDir: projectDir,
+          defines: <String, String>{kDeploymentTarget: '11.0'},
+          inputs: <String, String>{},
+          processManager: processManager,
+          artifacts: Artifacts.test(),
+          logger: logger,
+          fileSystem: fileSystem,
+        );
+
+        const target = MacOSSwiftPackageMinimumDeployment();
+        await target.build(environment);
+
+        final fakeStdio = globals.stdio as FakeStdio;
+        expect(
+          fakeStdio.buffer.toString(),
+          contains('minimum supported platform updated to 11.0, but Xcode cache is out of date.'),
+        );
+        expect(manifest.readAsStringSync(), contains('.macOS("11.0")'));
+      },
+      overrides: <Type, Generator>{
+        FeatureFlags: () => TestFeatureFlags(isSwiftPackageManagerEnabled: true),
+        Xcode: () => FakeXcode15(),
+        Stdio: () => FakeStdio(),
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+      },
+    );
+  });
 }
 
 class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterpreter {
@@ -961,4 +1098,18 @@ class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterprete
   }) async {
     return XcodeProjectInfo(<String>[], <String>[], schemes, BufferLogger.test());
   }
+}
+
+class FakeStdio extends Fake implements Stdio {
+  final buffer = StringBuffer();
+
+  @override
+  void stderrWrite(String message, {void Function(String, dynamic, StackTrace)? fallback}) {
+    buffer.writeln(message);
+  }
+}
+
+class FakeXcode15 extends Fake implements Xcode {
+  @override
+  Version get currentVersion => Version(15, 0, 0);
 }

--- a/packages/flutter_tools/test/general.shard/macos/swift_package_manager_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/swift_package_manager_test.dart
@@ -562,6 +562,152 @@ let package = Package(
         });
       });
     }
+
+    group('updateMinimumDeployment', () {
+      for (final platform in supportedPlatforms) {
+        group('for ${platform.name}', () {
+          testWithoutContext('throws ToolExit if manifest does not exist', () {
+            final fs = MemoryFileSystem();
+            final project = FakeXcodeProject(platform: platform.name, fileSystem: fs);
+
+            expect(
+              () => SwiftPackageManager.updateMinimumDeployment(
+                project: project,
+                platform: platform,
+                deploymentTarget: '14.0',
+              ),
+              throwsToolExit(
+                message:
+                    'does not exist.\n\nPlease run "flutter build ${platform.name} --config-only" '
+                    "to regenerate the project's configuration files.",
+              ),
+            );
+          });
+
+          testWithoutContext(
+            'throws ToolExit if manifest platform version is invalid or not found',
+            () {
+              final fs = MemoryFileSystem();
+              final project = FakeXcodeProject(platform: platform.name, fileSystem: fs);
+              project.flutterPluginSwiftPackageManifest.createSync(recursive: true);
+              project.flutterPluginSwiftPackageManifest.writeAsStringSync('''
+// Invalid manifest format with no platform info
+''');
+
+              expect(
+                () => SwiftPackageManager.updateMinimumDeployment(
+                  project: project,
+                  platform: platform,
+                  deploymentTarget: '14.0',
+                ),
+                throwsToolExit(
+                  message:
+                      'Failed to parse platform from ${project.flutterPluginSwiftPackageManifest.path}.\n\n'
+                      'Please run "flutter build ${platform.name} --config-only" '
+                      "to regenerate the project's configuration files.",
+                ),
+              );
+            },
+          );
+
+          testWithoutContext('returns false if new deployment target is invalid', () {
+            final fs = MemoryFileSystem();
+            final project = FakeXcodeProject(platform: platform.name, fileSystem: fs);
+            project.flutterPluginSwiftPackageManifest.createSync(recursive: true);
+            final platformString = platform == FlutterDarwinPlatform.ios
+                ? '.iOS("13.0")'
+                : '.macOS("10.15")';
+            project.flutterPluginSwiftPackageManifest.writeAsStringSync('''
+    platforms: [
+        $platformString
+    ],
+''');
+
+            final bool changed = SwiftPackageManager.updateMinimumDeployment(
+              project: project,
+              platform: platform,
+              deploymentTarget: 'invalid_version',
+            );
+
+            expect(changed, isFalse);
+          });
+
+          testWithoutContext(
+            'returns false if new deployment target is less than or equal to current',
+            () {
+              final fs = MemoryFileSystem();
+              final project = FakeXcodeProject(platform: platform.name, fileSystem: fs);
+              project.flutterPluginSwiftPackageManifest.createSync(recursive: true);
+              final platformString = platform == FlutterDarwinPlatform.ios
+                  ? '.iOS("13.0")'
+                  : '.macOS("10.15")';
+              project.flutterPluginSwiftPackageManifest.writeAsStringSync('''
+    platforms: [
+        $platformString
+    ],
+''');
+
+              final currentVersion = platform == FlutterDarwinPlatform.ios ? '13.0' : '10.15';
+              final lowerVersion = platform == FlutterDarwinPlatform.ios ? '12.0' : '10.14';
+
+              // Equal version
+              expect(
+                SwiftPackageManager.updateMinimumDeployment(
+                  project: project,
+                  platform: platform,
+                  deploymentTarget: currentVersion,
+                ),
+                isFalse,
+              );
+
+              // Lower version
+              expect(
+                SwiftPackageManager.updateMinimumDeployment(
+                  project: project,
+                  platform: platform,
+                  deploymentTarget: lowerVersion,
+                ),
+                isFalse,
+              );
+            },
+          );
+
+          testWithoutContext(
+            'updates manifest and returns true if new deployment target is greater than current',
+            () {
+              final fs = MemoryFileSystem();
+              final project = FakeXcodeProject(platform: platform.name, fileSystem: fs);
+              project.flutterPluginSwiftPackageManifest.createSync(recursive: true);
+              final platformString = platform == FlutterDarwinPlatform.ios
+                  ? '.iOS("13.0")'
+                  : '.macOS("10.15")';
+              project.flutterPluginSwiftPackageManifest.writeAsStringSync('''
+    platforms: [
+        $platformString
+    ],
+''');
+
+              final newVersion = platform == FlutterDarwinPlatform.ios ? '14.0' : '11.0';
+
+              final bool changed = SwiftPackageManager.updateMinimumDeployment(
+                project: project,
+                platform: platform,
+                deploymentTarget: newVersion,
+              );
+
+              expect(changed, isTrue);
+              final expectedPlatformString = platform == FlutterDarwinPlatform.ios
+                  ? '.iOS("14.0")'
+                  : '.macOS("11.0")';
+              expect(
+                project.flutterPluginSwiftPackageManifest.readAsStringSync(),
+                contains(expectedPlatformString),
+              );
+            },
+          );
+        });
+      }
+    });
   });
 }
 


### PR DESCRIPTION
When a SwiftPM plugin requires a higher version than the app currently supports, it'll produce an error like this:

```
The package product 'plugin-a' requires minimum platform version 15.0 for the iOS platform, but this
target supports 13.0

To fix this error, increase your app's minimum platform version from 13.0 to at least 15.0 or remove the plugin-a dependency.

To increase your app's minimum platform version, follow these instructions:
  https://docs.flutter.dev/packages-and-plugins/swift-package-manager/for-app-developers#how-to-use-a-swift-package-manager-flutter-plugin-that-requires-a-higher-os-version
```

However, after updating the minimum version of your app, if you don't run `flutter build ios --config` like the instructions say and you build from Xcode, you'll get the same error since `FlutterGeneratedPluginSwiftPackage` was not updated to the new minimum.

This PR adds logic to the pre-action script that checks if the `FlutterGeneratedPluginSwiftPackage` has been updated and if not, updates it and instructs the user to re-resolve their swift packages in Xcode.

<img width="812" height="98" alt="Screenshot 2026-05-22 at 1 45 26 PM" src="https://github.com/user-attachments/assets/7e3e4646-525f-47b7-9572-e41d79a40ca9" />

It also tweaks the guided message a bit to make it more apparent to run `flutter build ios --config-only`:
```
To fix this error, increase your app's minimum platform version from 13.0 to at least 15.0 or remove the plguin-a dependency.
Then run "flutter build ios --config-only" to regenerate the project's configuration files.

To increase your app's minimum platform version, follow these instructions:
  https://docs.flutter.dev/packages-and-plugins/swift-package-manager/for-app-developers#how-to-use-a-swift-package-manager-flutter-plugin-that-requires-a-higher-os-versio
```

Addresses https://github.com/flutter/flutter/issues/162196.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
