### PR TITLE
[EditableText] refactor: Add double-tap word selection to EditableText via SerialTapGestureRecognizer

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -2075,10 +2075,10 @@ class RenderEditable extends RenderBox
 
   void _handleTapUp(SerialTapUpDetails details) {
     assert(!ignorePointer);
-    if (details.count == 2) {
-      handleDoubleTap();
-    } else {
+    if (details.count == 1) {
       handleTap();
+    } else if (details.count == 2) {
+      handleDoubleTap();
     }
   }
 

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1643,9 +1643,9 @@ class RenderEditable extends RenderBox
     _foregroundRenderObject?.attach(owner);
     _backgroundRenderObject?.attach(owner);
 
-    _tap = TapGestureRecognizer(debugOwner: this)
-      ..onTapDown = _handleTapDown
-      ..onTap = _handleTap;
+    _tap = SerialTapGestureRecognizer(debugOwner: this)
+      ..onSerialTapDown = _handleTapDown
+      ..onSerialTapUp = _handleTapUp;
     _longPress = LongPressGestureRecognizer(debugOwner: this)..onLongPress = _handleLongPress;
     _offset.addListener(markNeedsPaint);
     _showHideCursor();
@@ -2008,7 +2008,7 @@ class RenderEditable extends RenderBox
     }
   }
 
-  late TapGestureRecognizer _tap;
+  late SerialTapGestureRecognizer _tap;
   late LongPressGestureRecognizer _longPress;
 
   @override
@@ -2016,7 +2016,6 @@ class RenderEditable extends RenderBox
     assert(debugHandleEvent(event, entry));
     if (event is PointerDownEvent) {
       assert(!debugNeedsLayout);
-
       if (!ignorePointer) {
         // Propagates the pointer event to selection handlers.
         _tap.addPointer(event);
@@ -2053,9 +2052,15 @@ class RenderEditable extends RenderBox
     _lastTapDownPosition = details.globalPosition;
   }
 
-  void _handleTapDown(TapDownDetails details) {
+  void _handleTapDown(SerialTapDownDetails details) {
     assert(!ignorePointer);
-    handleTapDown(details);
+    handleTapDown(
+      TapDownDetails(
+        globalPosition: details.globalPosition,
+        localPosition: details.localPosition,
+        kind: details.kind,
+      ),
+    );
   }
 
   /// If [ignorePointer] is false (the default) then this method is called by
@@ -2068,9 +2073,13 @@ class RenderEditable extends RenderBox
     selectPosition(cause: SelectionChangedCause.tap);
   }
 
-  void _handleTap() {
+  void _handleTapUp(SerialTapUpDetails details) {
     assert(!ignorePointer);
-    handleTap();
+    if (details.count == 2) {
+      handleDoubleTap();
+    } else {
+      handleTap();
+    }
   }
 
   /// If [ignorePointer] is false (the default) then this method is called by

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -18596,6 +18596,124 @@ void main() {
     // [intended] only applies to platforms where we supply the context menu.
     skip: kIsWeb,
   );
+
+  testWidgets('EditableText supports double tap to select word', (WidgetTester tester) async {
+    controller = TextEditingController(text: 'hello world');
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: FocusScope(
+            node: focusScopeNode,
+            autofocus: true,
+            child: EditableText(
+              controller: controller,
+              focusNode: focusNode,
+              style: textStyle,
+              cursorColor: cursorColor,
+              backgroundCursorColor: Colors.grey,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Tap once to focus.
+    await tester.tap(find.byType(EditableText));
+    await tester.pumpAndSettle();
+
+    // Double tap on the word 'hello' to select it.
+    final Offset helloPosition = textOffsetToPosition(tester, 2);
+    await tester.tapAt(helloPosition);
+    await tester.pump(const Duration(milliseconds: 50));
+    await tester.tapAt(helloPosition);
+    await tester.pumpAndSettle();
+
+    expect(controller.selection.baseOffset, 0);
+    expect(controller.selection.extentOffset, 5);
+  });
+
+  testWidgets('EditableText supports double tap to select word with rendererIgnoresPointer false', (
+    WidgetTester tester,
+  ) async {
+    controller = TextEditingController(text: 'foo bar baz');
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: FocusScope(
+            node: focusScopeNode,
+            autofocus: true,
+            child: EditableText(
+              controller: controller,
+              focusNode: focusNode,
+              style: textStyle,
+              cursorColor: cursorColor,
+              backgroundCursorColor: Colors.grey,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Tap once to focus.
+    await tester.tap(find.byType(EditableText));
+    await tester.pumpAndSettle();
+
+    // Double tap on the word 'bar' to select it.
+    final Offset barPosition = textOffsetToPosition(tester, 5);
+    await tester.tapAt(barPosition);
+    await tester.pump(const Duration(milliseconds: 50));
+    await tester.tapAt(barPosition);
+    await tester.pumpAndSettle();
+
+    expect(controller.selection.baseOffset, 4);
+    expect(controller.selection.extentOffset, 7);
+  });
+
+  testWidgets(
+    'EditableText does not use built-in gesture detector when rendererIgnoresPointer is true',
+    (WidgetTester tester) async {
+      controller = TextEditingController(text: 'hello world');
+      await tester.pumpWidget(
+        MediaQuery(
+          data: const MediaQueryData(),
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: FocusScope(
+              node: focusScopeNode,
+              autofocus: true,
+              child: EditableText(
+                controller: controller,
+                focusNode: focusNode,
+                style: textStyle,
+                cursorColor: cursorColor,
+                backgroundCursorColor: Colors.grey,
+                rendererIgnoresPointer: true,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Tap once to focus.
+      await tester.tap(find.byType(EditableText));
+      await tester.pumpAndSettle();
+
+      // Double tap should not select a word because rendererIgnoresPointer is
+      // true, meaning an external gesture detector is expected to handle it.
+      final Offset helloPosition = textOffsetToPosition(tester, 2);
+      await tester.tapAt(helloPosition);
+      await tester.pump(const Duration(milliseconds: 50));
+      await tester.tapAt(helloPosition);
+      await tester.pumpAndSettle();
+
+      expect(controller.selection.baseOffset, isNot(0));
+      expect(controller.selection.extentOffset, isNot(5));
+    },
+  );
 }
 
 class UnsettableController extends TextEditingController {


### PR DESCRIPTION
Adds double-tap word selection support to `EditableText` by replacing `TapGestureRecognizer` with `SerialTapGestureRecognizer` in `RenderEditable`. This allows `RenderEditable` to distinguish between single taps (count=1 → `handleTap`) and double taps (count=2 → `handleDoubleTap`) using a single gesture recognizer that tracks tap count natively.

Previously, `EditableText` only supported single tap (cursor positioning) and long press (word selection) via `RenderEditable`'s internal gesture recognizers. Double-tap word selection was only available through `TextField`/`CupertinoTextField` which wrap `EditableText` with `TextSelectionGestureDetectorBuilder`.

Acknowledging [this comment](https://github.com/flutter/flutter/issues/138978#issuecomment-1848498633): the suggested workaround of wrapping `EditableText` with `TextSelectionGestureDetectorBuilder` is valid, but `EditableText` should support double-tap word selection out of the box. If a more comprehensive gesture solution (e.g. full `TextSelectionGestureDetectorBuilder` support) is preferred, happy to hear feedback on the right direction.

Fixes https://github.com/flutter/flutter/issues/138978

<details>
<summary>Approaches tried and why they didn't work</summary>

1. **Widget-level `TextSelectionGestureDetectorBuilder` wrapping `EditableText`** — The builder relies on `delegate.editableTextKey.currentContext` for `_isEditableTextMounted` checks and scrollable lookups (private members in `text_selection.dart`). Since `EditableTextState` can't assign a `GlobalKey` to itself, these checks always returned false/null, causing all gesture handlers to bail out early.

2. **Widget-level `TextSelectionGestureDetectorBuilder` with proxy GlobalKey** — Even after fixing the `GlobalKey` issue with a proxy subclass, the builder's platform-specific long press handling (e.g. on macOS: position cursor + show floating cursor instead of selecting word) differed from `RenderEditable`'s existing long press behavior, breaking 9+ existing tests.

3. **Widget-level `GestureDetector` with `onDoubleTapDown`/`onDoubleTap`** — The `GestureDetector`'s `DoubleTapGestureRecognizer` competed with `RenderEditable`'s internal `TapGestureRecognizer` in the gesture arena. The `TapGestureRecognizer` won both taps, so the double-tap was never recognized.

4. **Adding `DoubleTapGestureRecognizer` to `RenderEditable.handleEvent`** — Both recognizers received the same pointer events, but the tap recognizer accepted first, causing the double-tap handler to fire *after* the single-tap handler had already repositioned the cursor — overriding the word selection.

5. **Manual double-tap tracking with `DateTime.now()`** — Fragile in Flutter's test environment (`FakeAsync`), where the focus-tap and the first tap of the intended double-tap could be misdetected as a double-tap depending on how much time `pumpAndSettle` advanced.

</details>

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<details>
<summary>Code sample to verify</summary>

```dart
import 'package:flutter/material.dart';

const Color darkBlue = Color.fromARGB(255, 18, 32, 47);

void main() {
  runApp(MyApp());
}

class MyApp extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      theme: ThemeData.dark().copyWith(
        scaffoldBackgroundColor: darkBlue,
      ),
      debugShowCheckedModeBanner: false,
      home: Scaffold(
        body: Center(
          child: MyWidget(),
        ),
      ),
    );
  }
}

final controller = TextEditingController(text: 'hello world');
final focusNode = FocusNode();

class MyWidget extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return EditableText(
      controller: controller,
      focusNode: focusNode,
      backgroundCursorColor: Colors.yellow,
      cursorColor: Colors.red,
      selectionColor: Colors.blue.withOpacity(0.4),
      style: const TextStyle(),
    );
  }
}
```

</details>

Video:

https://github.com/user-attachments/assets/b348e567-0c23-48f7-9f23-3e8f0fafdf57

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md