### PR TITLE
Move Material scrollbar regression test to material

### DIFF
--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -115,7 +115,6 @@ class TestsCrossImportChecker {
     'packages/flutter/test/widgets/implicit_animations_test.dart',
     'packages/flutter/test/widgets/routes_transition_test.dart',
     'packages/flutter/test/widgets/editable_text_test.dart',
-    'packages/flutter/test/widgets/scrollbar_test.dart',
     'packages/flutter/test/widgets/inherited_test.dart',
     'packages/flutter/test/widgets/heroes_test.dart',
     'packages/flutter/test/widgets/drawer_test.dart',

--- a/packages/flutter/test/material/scrollbar_test.dart
+++ b/packages/flutter/test/material/scrollbar_test.dart
@@ -1854,7 +1854,7 @@ The provided ScrollController cannot be shared by multiple ScrollView widgets.''
 
   // Regression test for https://github.com/flutter/flutter/issues/141348.
   testWidgets(
-    'Scrollbar should not shown due to precision error on desktop',
+    'Scrollbar should not be shown due to precision error on desktop',
     (WidgetTester tester) async {
       Widget buildFrame(Size size) {
         tester.view.physicalSize = size;
@@ -1883,7 +1883,7 @@ The provided ScrollController cannot be shared by multiple ScrollView widgets.''
 
       // Scroll on the Scrollbar.
       final pointer = TestPointer(1, ui.PointerDeviceKind.mouse);
-      pointer.hover(tester.getCenter(find.byType(Scrollbar)));
+      await tester.sendEventToBinding(pointer.hover(tester.getCenter(find.byType(Scrollbar))));
       await tester.sendEventToBinding(pointer.scroll(const Offset(0.0, 10.0)));
       await tester.pumpAndSettle();
 

--- a/packages/flutter/test/material/scrollbar_test.dart
+++ b/packages/flutter/test/material/scrollbar_test.dart
@@ -1852,6 +1852,48 @@ The provided ScrollController cannot be shared by multiple ScrollView widgets.''
     scrollController.dispose();
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/141348.
+  testWidgets(
+    'Scrollbar should not shown due to precision error on desktop',
+    (WidgetTester tester) async {
+      Widget buildFrame(Size size) {
+        tester.view.physicalSize = size;
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.reset);
+        return MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: DatePickerDialog(
+                initialDate: DateTime(2020, DateTime.may), // Month with six rows.
+                firstDate: DateTime(2010),
+                lastDate: DateTime(2030),
+              ),
+            ),
+          ),
+        );
+      }
+
+      const screenSizePortrait = Size(400, 600);
+      await tester.pumpWidget(buildFrame(screenSizePortrait));
+      await tester.pumpAndSettle();
+
+      // Scrollbar is not shown.
+      expect(find.byType(Scrollbar), findsOneWidget);
+      expect(find.byType(Scrollbar), isNot(paints..rect()));
+
+      // Scroll on the Scrollbar.
+      final pointer = TestPointer(1, ui.PointerDeviceKind.mouse);
+      pointer.hover(tester.getCenter(find.byType(Scrollbar)));
+      await tester.sendEventToBinding(pointer.scroll(const Offset(0.0, 10.0)));
+      await tester.pumpAndSettle();
+
+      // Scrollbar is still not shown.
+      expect(find.byType(Scrollbar), findsOneWidget);
+      expect(find.byType(Scrollbar), isNot(paints..rect()));
+    },
+    variant: TargetPlatformVariant.desktop(),
+  );
+
   testWidgets('Scrollbar does not crash at zero area', (WidgetTester tester) async {
     await tester.pumpWidget(
       const MaterialApp(

--- a/packages/flutter/test/widgets/scrollbar_test.dart
+++ b/packages/flutter/test/widgets/scrollbar_test.dart
@@ -5,8 +5,8 @@
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/src/physics/utils.dart' show nearEqual;
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 const Color _kScrollbarColor = Color(0xFF123456);
@@ -3621,48 +3621,6 @@ The provided ScrollController cannot be shared by multiple ScrollView widgets.''
     expect(horizontalScrollController.offset, greaterThan(0.0));
   });
 
-  // Regression test for https://github.com/flutter/flutter/issues/141348.
-  testWidgets(
-    'Scrollbar should not shown due to precision error on desktop',
-    (WidgetTester tester) async {
-      Widget buildFrame(Size size) {
-        tester.view.physicalSize = size;
-        tester.view.devicePixelRatio = 1.0;
-        addTearDown(tester.view.reset);
-        return MaterialApp(
-          home: Scaffold(
-            body: Center(
-              child: DatePickerDialog(
-                initialDate: DateTime(2020, DateTime.may), // Month with six rows.
-                firstDate: DateTime(2010),
-                lastDate: DateTime(2030),
-              ),
-            ),
-          ),
-        );
-      }
-
-      const screenSizePortrait = Size(400, 600);
-      await tester.pumpWidget(buildFrame(screenSizePortrait));
-      await tester.pumpAndSettle();
-
-      // Scrollbar is not shown.
-      expect(find.byType(Scrollbar), findsOneWidget);
-      expect(find.byType(Scrollbar), isNot(paints..rect()));
-
-      // Scroll on the Scrollbar.
-      final pointer = TestPointer(1, ui.PointerDeviceKind.mouse);
-      pointer.hover(tester.getCenter(find.byType(Scrollbar)));
-      await tester.sendEventToBinding(pointer.scroll(const Offset(0.0, 10.0)));
-      await tester.pumpAndSettle();
-
-      // Scrollbar is still not shown.
-      expect(find.byType(Scrollbar), findsOneWidget);
-      expect(find.byType(Scrollbar), isNot(paints..rect()));
-    },
-    variant: TargetPlatformVariant.desktop(),
-  );
-
   test('with EdgeInsetsDirectional', () {
     const size = Size(60, 80);
     final ScrollMetrics metrics = defaultMetrics.copyWith(
@@ -3750,8 +3708,8 @@ The provided ScrollController cannot be shared by multiple ScrollView widgets.''
                 data: const MediaQueryData(),
                 child: Column(
                   children: <Widget>[
-                    ElevatedButton(
-                      onPressed: () {
+                    GestureDetector(
+                      onTap: () {
                         setState(() {
                           // This reproduces the exact scenario from the linked issue:
                           // Initially the controller is null, thumbVisibility is false, and interactive is false.
@@ -3761,6 +3719,7 @@ The provided ScrollController cannot be shared by multiple ScrollView widgets.''
                           interactive = true;
                         });
                       },
+                      behavior: HitTestBehavior.opaque,
                       child: const Text('Enable Scrollbar'),
                     ),
                     Expanded(


### PR DESCRIPTION
Part of flutter/flutter#177414
Refs flutter/flutter#177028

## Summary
- Moves the Material-owned `DatePickerDialog` scrollbar precision regression test from `packages/flutter/test/widgets/scrollbar_test.dart` to `packages/flutter/test/material/scrollbar_test.dart`.
- Removes the remaining Material dependency from the widgets scrollbar test.
- Removes `packages/flutter/test/widgets/scrollbar_test.dart` from the widgets cross-import allowlist.

## Tests
- `bin/cache/dart-sdk/bin/dart --enable-asserts dev/bots/check_tests_cross_imports.dart`
- `bin/cache/dart-sdk/bin/dart analyze packages/flutter/test/widgets/scrollbar_test.dart packages/flutter/test/material/scrollbar_test.dart dev/bots/check_tests_cross_imports.dart`
- `./bin/flutter analyze --no-pub packages/flutter/test/widgets/scrollbar_test.dart packages/flutter/test/material/scrollbar_test.dart dev/bots/check_tests_cross_imports.dart`
- `./bin/flutter test --no-pub packages/flutter/test/widgets/scrollbar_test.dart packages/flutter/test/material/scrollbar_test.dart`
- `git diff --summary --find-renames`
- `git diff --check`