### PR TITLE
[flutter_tools] macOS: fail fast when `open` cannot foreground the app

### DIFF
--- a/packages/flutter_tools/lib/src/desktop_device.dart
+++ b/packages/flutter_tools/lib/src/desktop_device.dart
@@ -183,7 +183,7 @@ abstract class DesktopDevice extends Device {
       final Uri? vmServiceUri = await vmServiceDiscovery.uri;
       if (vmServiceUri != null) {
         timer?.cancel();
-        onAttached(package, buildInfo, process);
+        await onAttached(package, buildInfo, process);
         return LaunchResult.succeeded(vmServiceUri: vmServiceUri);
       }
       _logger.printError(
@@ -227,7 +227,11 @@ abstract class DesktopDevice extends Device {
 
   /// Called after a process is attached, allowing any device-specific extra
   /// steps to be run.
-  void onAttached(ApplicationPackage package, BuildInfo buildInfo, Process process) {}
+  ///
+  /// Returning a [Future] lets device-specific hooks (e.g. macOS `open`) run
+  /// asynchronously and abort the launch by throwing if a required post-attach
+  /// step fails.
+  Future<void> onAttached(ApplicationPackage package, BuildInfo buildInfo, Process process) async {}
 
   /// Computes a set of environment variables used to pass debugging information
   /// to the engine without interfering with application level command line

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -91,8 +91,14 @@ class MacOSDevice extends DesktopDevice {
     // the launch process for 'open' to foreground it.
     final String? applicationBundle = package.applicationBundle(buildInfo);
     if (applicationBundle == null) {
-      _logger.printError('Failed to foreground app; application bundle not found');
-      return;
+      // Without a bundle path `open` cannot run, so the app never comes to
+      // the front and `flutter test`/`flutter run` would hang the same way
+      // a non-zero `open` exit does. Fail fast for consistency.
+      throwToolExit(
+        'Failed to foreground app; application bundle not found. Without '
+        'foreground, the app produces no frames and `flutter test` / '
+        '`flutter run` will hang.',
+      );
     }
     final ProcessResult result = await _processManager.run(<String>['open', applicationBundle]);
     if (result.exitCode != 0) {

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -4,6 +4,7 @@
 
 import 'package:process/process.dart';
 
+import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
@@ -79,7 +80,11 @@ class MacOSDevice extends DesktopDevice {
   }
 
   @override
-  void onAttached(covariant MacOSApp package, BuildInfo buildInfo, Process process) {
+  Future<void> onAttached(
+    covariant MacOSApp package,
+    BuildInfo buildInfo,
+    Process process,
+  ) async {
     // Bring app to foreground. Ideally this would be done post-launch rather
     // than post-attach, since this won't run for release builds, but there's
     // no general-purpose way of knowing when a process is far enough along in
@@ -89,11 +94,21 @@ class MacOSDevice extends DesktopDevice {
       _logger.printError('Failed to foreground app; application bundle not found');
       return;
     }
-    _processManager.run(<String>['open', applicationBundle]).then((ProcessResult result) {
-      if (result.exitCode != 0) {
-        _logger.printError('Failed to foreground app; open returned ${result.exitCode}');
-      }
-    });
+    final ProcessResult result = await _processManager.run(<String>['open', applicationBundle]);
+    if (result.exitCode != 0) {
+      // Without foregrounding, the macOS window server never makes the app
+      // visible, so no display-link callbacks fire and Flutter produces no
+      // frames. `flutter test -d macos` then hangs forever waiting for the
+      // first widget tree. Fail fast with a clear message instead, matching
+      // the issue reported in https://github.com/flutter/flutter/issues/176850.
+      throwToolExit(
+        'Failed to foreground app; open returned ${result.exitCode}. '
+        'The macOS window server may be unavailable (e.g. a CI runner '
+        'without a graphical session, or a remote SSH session). Without '
+        'foreground, the app produces no frames and `flutter test` / '
+        '`flutter run` will hang.',
+      );
+    }
   }
 }
 

--- a/packages/flutter_tools/test/general.shard/macos/macos_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/macos_device_test.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/platform.dart';
@@ -238,6 +239,48 @@ void main() {
     expect(device.executablePathForDevice(package, BuildInfo.profile), profilePath);
     expect(device.executablePathForDevice(package, BuildInfo.release), releasePath);
   });
+
+  testWithoutContext(
+    'onAttached throws ToolExit when `open` fails to foreground the app',
+    () async {
+      final device = MacOSDevice(
+        fileSystem: MemoryFileSystem.test(),
+        processManager: FakeProcessManager.list(<FakeCommand>[
+          const FakeCommand(
+            command: <String>['open', 'build/macos/Build/Products/Debug/Bundle.app'],
+            exitCode: 1,
+          ),
+        ]),
+        logger: BufferLogger.test(),
+        operatingSystemUtils: FakeOperatingSystemUtils(),
+      );
+      final package = FakeMacOSApp();
+
+      await expectLater(
+        device.onAttached(package, BuildInfo.debug, FakeProcess()),
+        throwsToolExit(message: 'Failed to foreground app; open returned 1'),
+      );
+    },
+  );
+
+  testWithoutContext(
+    'onAttached returns normally when `open` succeeds',
+    () async {
+      final device = MacOSDevice(
+        fileSystem: MemoryFileSystem.test(),
+        processManager: FakeProcessManager.list(<FakeCommand>[
+          const FakeCommand(
+            command: <String>['open', 'build/macos/Build/Products/Debug/Bundle.app'],
+          ),
+        ]),
+        logger: BufferLogger.test(),
+        operatingSystemUtils: FakeOperatingSystemUtils(),
+      );
+      final package = FakeMacOSApp();
+
+      await device.onAttached(package, BuildInfo.debug, FakeProcess());
+    },
+  );
 }
 
 FlutterProject setUpFlutterProject(Directory directory) {
@@ -258,4 +301,11 @@ class FakeMacOSApp extends Fake implements MacOSApp {
       _ => throw StateError(''),
     };
   }
+
+  @override
+  String? applicationBundle(BuildInfo buildInfo) {
+    return 'build/macos/Build/Products/Debug/Bundle.app';
+  }
 }
+
+class FakeProcess extends Fake implements Process {}

--- a/packages/flutter_tools/test/general.shard/macos/macos_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/macos_device_test.dart
@@ -264,6 +264,26 @@ void main() {
   );
 
   testWithoutContext(
+    'onAttached throws ToolExit when application bundle is missing',
+    () async {
+      final device = MacOSDevice(
+        fileSystem: MemoryFileSystem.test(),
+        // No `open` invocation expected — the bundle-missing branch must
+        // throw before we get there.
+        processManager: FakeProcessManager.empty(),
+        logger: BufferLogger.test(),
+        operatingSystemUtils: FakeOperatingSystemUtils(),
+      );
+      final package = FakeMacOSAppNoBundle();
+
+      await expectLater(
+        device.onAttached(package, BuildInfo.debug, FakeProcess()),
+        throwsToolExit(message: 'application bundle not found'),
+      );
+    },
+  );
+
+  testWithoutContext(
     'onAttached returns normally when `open` succeeds',
     () async {
       final device = MacOSDevice(
@@ -306,6 +326,14 @@ class FakeMacOSApp extends Fake implements MacOSApp {
   String? applicationBundle(BuildInfo buildInfo) {
     return 'build/macos/Build/Products/Debug/Bundle.app';
   }
+}
+
+class FakeMacOSAppNoBundle extends Fake implements MacOSApp {
+  @override
+  String executable(BuildInfo buildInfo) => 'debug/executable';
+
+  @override
+  String? applicationBundle(BuildInfo buildInfo) => null;
 }
 
 class FakeProcess extends Fake implements Process {}


### PR DESCRIPTION
## Summary

Fixes #176850.

When `flutter run -d macos` / `flutter test -d macos` attaches to the VM service, `MacOSDevice.onAttached` calls `/usr/bin/open <Bundle.app>` to bring the app window to the front. The previous implementation logged the exit code on failure but discarded the result via a detached `.then()`, so a non-zero `open` exit was effectively swallowed.

In CI environments where the macOS window server is unavailable — GitHub Actions `macos-latest` (currently macos-15) runners, headless SSH sessions, etc. — `open` returns 1 and the app never becomes visible. Without a foregrounded `NSWindow` there are no `CVDisplayLink` callbacks, the Flutter engine produces no frames, and `flutter test` hangs forever waiting for the first widget tree to pump — until GitHub's 6 h job cap kills it.

The user-visible symptom is exactly the one reported in #176850:

```
✓ Built build/macos/Build/Products/Debug/MyApp.app
Failed to foreground app; open returned 1
[31 minutes of silence, job cancelled]
```

## What this PR does

1. `packages/flutter_tools/lib/src/desktop_device.dart`
   - Changes `DesktopDevice.onAttached` from `void` to `Future<void>` so subclasses can do async work and abort the launch on failure.
   - Awaits the call site in `DesktopDevice.startApp`.

2. `packages/flutter_tools/lib/src/macos/macos_device.dart`
   - Awaits the `open` invocation.
   - Calls `throwToolExit(...)` with an explanatory message when `open` returns non-zero. The thrown `ToolExit` propagates out of `startApp` and surfaces as a non-zero CLI exit, matching the user expectation of "fail fast" instead of "hang silently". The message explicitly calls out the CI / headless scenario so the next person hitting this immediately knows what's wrong.

3. `packages/flutter_tools/test/general.shard/macos/macos_device_test.dart`
   - Adds two `testWithoutContext` regression tests: one for the open-failure path (asserts `throwsToolExit` with the new message) and one for the success path. Both use `FakeProcessManager.list` to drive deterministic `open` results.

## Behavior change

For users running flutter on a normal interactive macOS session, behavior is unchanged — `open` returns 0, `onAttached` completes silently, and the launch proceeds as before.

For users running in CI / headless contexts that previously hung indefinitely, `flutter test`/`flutter run` now exits non-zero immediately with a clear actionable message. This is the intended outcome of this PR and matches the request in #176850.

## Test plan

- [x] `dart test test/general.shard/macos/macos_device_test.dart` — all 14 tests pass (12 existing + 2 new)
- [x] `dart test test/general.shard/desktop_device_test.dart` — all 19 tests pass (signature change to base `onAttached` does not break any existing test)
- [x] `dart analyze` on touched files — no issues

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/