### PR TITLE
Add a context menu override to TextSelectionThemeData

### DIFF
--- a/examples/api/lib/material/theme_data/theme_data.1.dart
+++ b/examples/api/lib/material/theme_data/theme_data.1.dart
@@ -1,0 +1,188 @@
+// Copyright 2026 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'dart:math';
+
+void main() {
+  runApp(const ThemeDataExampleApp());
+}
+
+//
+// This app's theme provides a custom context menu in the TextSelectionThemeData.
+//
+
+class ThemeDataExampleApp extends StatefulWidget {
+  const ThemeDataExampleApp({super.key});
+
+  @override
+  State<ThemeDataExampleApp> createState() => _ThemeDataExampleAppState();
+}
+
+class _ThemeDataExampleAppState extends State<ThemeDataExampleApp> {
+  late ColorScheme colorScheme;
+
+  void _showDialog(BuildContext context) {
+    Navigator.of(context).push(
+      DialogRoute<void>(
+        context: context,
+        builder: (BuildContext context) =>
+            const AlertDialog(title: Text('You clicked print!')),
+      ),
+    );
+  }
+
+  Color _getRandomColor() {
+    return Color.fromARGB(
+      255,
+      Random().nextInt(256),
+      Random().nextInt(256),
+      Random().nextInt(256),
+    );
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    colorScheme = ColorScheme.fromSeed(
+      brightness: MediaQuery.platformBrightnessOf(context),
+      seedColor: _getRandomColor(),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'ThemeData Demo',
+      theme: ThemeData(
+        colorScheme: colorScheme,
+        textSelectionTheme: TextSelectionThemeData(
+          cursorColor: colorScheme.tertiary,
+          selectionColor: colorScheme.tertiary.withAlpha(128),
+          selectionHandleColor: colorScheme.tertiary,
+          contextMenuBuilder: (context, editableTextState) =>
+              AdaptiveTextSelectionToolbar.buttonItems(
+                anchors: editableTextState.contextMenuAnchors,
+                buttonItems: <ContextMenuButtonItem>[
+                  ContextMenuButtonItem(
+                    onPressed: () {
+                      ContextMenuController.removeAny();
+                      _showDialog(context);
+                    },
+                    label: 'Print',
+                  ),
+                  ContextMenuButtonItem(
+                    onPressed: () {
+                      ContextMenuController.removeAny();
+                      setState(() {
+                        colorScheme = ColorScheme.fromSeed(
+                          brightness: MediaQuery.platformBrightnessOf(context),
+                          seedColor: _getRandomColor(),
+                        );
+                      });
+                    },
+                    label: 'Generate a new ColorScheme',
+                  ),
+                ],
+              ),
+        ),
+      ),
+      home: const Home(),
+    );
+  }
+}
+
+class Home extends StatefulWidget {
+  const Home({super.key});
+
+  @override
+  State<Home> createState() => _HomeState();
+}
+
+class _HomeState extends State<Home> {
+  int textFieldValue = 8;
+
+  @override
+  void initState() {
+    super.initState();
+    // On web, disable the browser's context menu since this example uses a custom
+    // Flutter-rendered context menu.
+    if (kIsWeb) {
+      BrowserContextMenu.disableContextMenu();
+    }
+  }
+
+  @override
+  void dispose() {
+    if (kIsWeb) {
+      BrowserContextMenu.enableContextMenu();
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme colorScheme = theme.colorScheme;
+    final double pointCount = textFieldValue.toDouble();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(
+          'Bring up the context menu on the text field to see the customized menu items.  Valid range for points is 8-13.',
+        ),
+      ),
+      body: AnimatedContainer(
+        duration: const Duration(milliseconds: 500),
+        alignment: .center,
+        decoration: ShapeDecoration(
+          color: colorScheme.tertiaryContainer,
+          shape: StarBorder(
+            points: pointCount,
+            pointRounding: 0.4,
+            valleyRounding: 0.6,
+            side: BorderSide(width: 9, color: colorScheme.tertiary),
+          ),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Text(
+              'Points: ',
+              style: theme.textTheme.titleLarge!.copyWith(
+                color: colorScheme.onPrimaryContainer,
+              ),
+            ),
+            IntrinsicWidth(
+              child: TextField(
+                textAlign: TextAlign.left,
+                decoration: InputDecoration(border: OutlineInputBorder()),
+                controller: TextEditingController(
+                  text: textFieldValue.toString(),
+                ),
+                onChanged: (value) {
+                  final int? parsedValue = int.tryParse(value);
+                  if (parsedValue != null &&
+                      parsedValue >= 8 &&
+                      parsedValue <= 13) {
+                    setState(() {
+                      textFieldValue = parsedValue;
+                    });
+                  }
+                },
+                style: theme.textTheme.titleLarge!.copyWith(
+                  color: colorScheme.onPrimaryContainer,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/packages/flutter/lib/src/material/search_anchor.dart
+++ b/packages/flutter/lib/src/material/search_anchor.dart
@@ -11,6 +11,7 @@ import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/src/material/text_selection_theme.dart';
 import 'package:flutter/widgets.dart';
 
 import 'adaptive_text_selection_toolbar.dart';
@@ -1262,7 +1263,7 @@ class _SearchAnchorWithSearchBar extends SearchAnchor {
     super.textInputAction,
     super.keyboardType,
     EdgeInsets scrollPadding = const EdgeInsets.all(20.0),
-    EditableTextContextMenuBuilder contextMenuBuilder = SearchBar._defaultContextMenuBuilder,
+    EditableTextContextMenuBuilder contextMenuBuilder = _SearchBarState._defaultContextMenuBuilder,
     super.enabled,
     super.smartDashesType,
     super.smartQuotesType,
@@ -1431,7 +1432,7 @@ class SearchBar extends StatefulWidget {
     this.textInputAction,
     this.keyboardType,
     this.scrollPadding = const EdgeInsets.all(20.0),
-    this.contextMenuBuilder = _defaultContextMenuBuilder,
+    this.contextMenuBuilder,
     this.readOnly = false,
     this.smartDashesType,
     this.smartQuotesType,
@@ -1623,16 +1624,6 @@ class SearchBar extends StatefulWidget {
   ///    configuration option on a standalone [TextField].
   final SmartQuotesType? smartQuotesType;
 
-  static Widget _defaultContextMenuBuilder(
-    BuildContext context,
-    EditableTextState editableTextState,
-  ) {
-    if (SystemContextMenu.isSupportedByField(editableTextState)) {
-      return SystemContextMenu.editableText(editableTextState: editableTextState);
-    }
-    return AdaptiveTextSelectionToolbar.editableText(editableTextState: editableTextState);
-  }
-
   @override
   State<SearchBar> createState() => _SearchBarState();
 }
@@ -1656,6 +1647,16 @@ class _SearchBarState extends State<SearchBar> {
     _internalStatesController.dispose();
     _internalFocusNode?.dispose();
     super.dispose();
+  }
+
+  static Widget _defaultContextMenuBuilder(
+    BuildContext context,
+    EditableTextState editableTextState,
+  ) {
+    if (SystemContextMenu.isSupportedByField(editableTextState)) {
+      return SystemContextMenu.editableText(editableTextState: editableTextState);
+    }
+    return AdaptiveTextSelectionToolbar.editableText(editableTextState: editableTextState);
   }
 
   @override
@@ -1820,7 +1821,10 @@ class _SearchBarState extends State<SearchBar> {
                             textInputAction: widget.textInputAction,
                             keyboardType: widget.keyboardType,
                             scrollPadding: widget.scrollPadding,
-                            contextMenuBuilder: widget.contextMenuBuilder,
+                            contextMenuBuilder:
+                                widget.contextMenuBuilder ??
+                                TextSelectionTheme.of(context).contextMenuBuilder ??
+                                _defaultContextMenuBuilder,
                             smartDashesType: widget.smartDashesType,
                             smartQuotesType: widget.smartQuotesType,
                           ),

--- a/packages/flutter/lib/src/material/selectable_text.dart
+++ b/packages/flutter/lib/src/material/selectable_text.dart
@@ -15,6 +15,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:flutter/src/material/text_selection_theme.dart';
 
 import 'adaptive_text_selection_toolbar.dart';
 import 'desktop_text_selection.dart';
@@ -196,7 +197,7 @@ class SelectableText extends StatefulWidget {
     this.textHeightBehavior,
     this.textWidthBasis,
     this.onSelectionChanged,
-    this.contextMenuBuilder = _defaultContextMenuBuilder,
+    this.contextMenuBuilder,
     this.magnifierConfiguration,
   }) : assert(maxLines == null || maxLines > 0),
        assert(minLines == null || minLines > 0),
@@ -255,7 +256,7 @@ class SelectableText extends StatefulWidget {
     this.textHeightBehavior,
     this.textWidthBasis,
     this.onSelectionChanged,
-    this.contextMenuBuilder = _defaultContextMenuBuilder,
+    this.contextMenuBuilder,
     this.magnifierConfiguration,
   }) : assert(maxLines == null || maxLines > 0),
        assert(minLines == null || minLines > 0),
@@ -442,13 +443,6 @@ class SelectableText extends StatefulWidget {
 
   /// {@macro flutter.widgets.EditableText.contextMenuBuilder}
   final EditableTextContextMenuBuilder? contextMenuBuilder;
-
-  static Widget _defaultContextMenuBuilder(
-    BuildContext context,
-    EditableTextState editableTextState,
-  ) {
-    return AdaptiveTextSelectionToolbar.editableText(editableTextState: editableTextState);
-  }
 
   /// The configuration for the magnifier used when the text is selected.
   ///
@@ -666,6 +660,13 @@ class _SelectableTextState extends State<SelectableText>
     return false;
   }
 
+  static Widget _defaultContextMenuBuilder(
+    BuildContext context,
+    EditableTextState editableTextState,
+  ) {
+    return AdaptiveTextSelectionToolbar.editableText(editableTextState: editableTextState);
+  }
+
   @override
   Widget build(BuildContext context) {
     // TODO(garyq): Assert to block WidgetSpans from being used here are removed,
@@ -797,7 +798,10 @@ class _SelectableTextState extends State<SelectableText>
         scrollPhysics: widget.scrollPhysics,
         scrollBehavior: widget.scrollBehavior,
         autofillHints: null,
-        contextMenuBuilder: widget.contextMenuBuilder,
+        contextMenuBuilder:
+            widget.contextMenuBuilder ??
+            TextSelectionTheme.of(context).contextMenuBuilder ??
+            _defaultContextMenuBuilder,
       ),
     );
 

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -16,6 +16,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/src/material/text_selection_theme.dart';
 
 import 'adaptive_text_selection_toolbar.dart';
 import 'color_scheme.dart';
@@ -323,7 +324,7 @@ class TextField extends StatefulWidget {
     this.stylusHandwritingEnabled = EditableText.defaultStylusHandwritingEnabled,
     this.enableIMEPersonalizedLearning = true,
     this.enableInlinePrediction,
-    this.contextMenuBuilder = _defaultContextMenuBuilder,
+    this.contextMenuBuilder,
     this.canRequestFocus = true,
     this.spellCheckConfiguration,
     this.magnifierConfiguration,
@@ -874,6 +875,8 @@ class TextField extends StatefulWidget {
   ///  * [AdaptiveTextSelectionToolbar], which is built by default.
   ///  * [BrowserContextMenu], which allows the browser's context menu on web to
   ///    be disabled and Flutter-rendered context menus to appear.
+  ///  * [ThemeData.textSelectionTheme], which provides a way to override the
+  ///    default context menu.
   final EditableTextContextMenuBuilder? contextMenuBuilder;
 
   /// Determine whether this text field can request the primary focus.
@@ -888,16 +891,6 @@ class TextField extends StatefulWidget {
 
   /// {@macro flutter.services.TextInputConfiguration.hintLocales}
   final List<Locale>? hintLocales;
-
-  static Widget _defaultContextMenuBuilder(
-    BuildContext context,
-    EditableTextState editableTextState,
-  ) {
-    if (SystemContextMenu.isSupportedByField(editableTextState)) {
-      return SystemContextMenu.editableText(editableTextState: editableTextState);
-    }
-    return AdaptiveTextSelectionToolbar.editableText(editableTextState: editableTextState);
-  }
 
   /// {@macro flutter.widgets.EditableText.spellCheckConfiguration}
   ///
@@ -1526,6 +1519,16 @@ class _TextFieldState extends State<TextField>
     return providedStyle.merge(stateStyle);
   }
 
+  static Widget _defaultContextMenuBuilder(
+    BuildContext context,
+    EditableTextState editableTextState,
+  ) {
+    if (SystemContextMenu.isSupportedByField(editableTextState)) {
+      return SystemContextMenu.editableText(editableTextState: editableTextState);
+    }
+    return AdaptiveTextSelectionToolbar.editableText(editableTextState: editableTextState);
+  }
+
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterial(context));
@@ -1752,7 +1755,10 @@ class _TextFieldState extends State<TextField>
           enableIMEPersonalizedLearning: widget.enableIMEPersonalizedLearning,
           enableInlinePrediction: widget.enableInlinePrediction,
           contentInsertionConfiguration: widget.contentInsertionConfiguration,
-          contextMenuBuilder: widget.contextMenuBuilder,
+          contextMenuBuilder:
+              widget.contextMenuBuilder ??
+              TextSelectionTheme.of(context).contextMenuBuilder ??
+              _defaultContextMenuBuilder,
           spellCheckConfiguration: spellCheckConfiguration,
           magnifierConfiguration:
               widget.magnifierConfiguration ?? TextMagnifier.adaptiveMagnifierConfiguration,

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -12,6 +12,7 @@ import 'adaptive_text_selection_toolbar.dart';
 import 'input_decorator.dart';
 import 'material_state.dart';
 import 'text_field.dart';
+import 'text_selection_theme.dart';
 
 export 'package:flutter/services.dart' show SmartDashesType, SmartQuotesType;
 
@@ -171,7 +172,7 @@ class TextFormField extends FormField<String> {
     super.restorationId,
     bool enableIMEPersonalizedLearning = true,
     MouseCursor? mouseCursor,
-    EditableTextContextMenuBuilder? contextMenuBuilder = _defaultContextMenuBuilder,
+    EditableTextContextMenuBuilder? contextMenuBuilder,
     SpellCheckConfiguration? spellCheckConfiguration,
     TextMagnifierConfiguration? magnifierConfiguration,
     UndoHistoryController? undoController,
@@ -293,7 +294,10 @@ class TextFormField extends FormField<String> {
                scrollController: scrollController,
                enableIMEPersonalizedLearning: enableIMEPersonalizedLearning,
                mouseCursor: mouseCursor,
-               contextMenuBuilder: contextMenuBuilder,
+               contextMenuBuilder:
+                   contextMenuBuilder ??
+                   TextSelectionTheme.of(state.context).contextMenuBuilder ??
+                   _defaultContextMenuBuilder,
                spellCheckConfiguration: spellCheckConfiguration,
                magnifierConfiguration: magnifierConfiguration,
                undoController: undoController,

--- a/packages/flutter/lib/src/material/text_selection_theme.dart
+++ b/packages/flutter/lib/src/material/text_selection_theme.dart
@@ -36,7 +36,12 @@ import 'theme.dart';
 @immutable
 class TextSelectionThemeData with Diagnosticable {
   /// Creates the set of properties used to configure [TextField]s.
-  const TextSelectionThemeData({this.cursorColor, this.selectionColor, this.selectionHandleColor});
+  const TextSelectionThemeData({
+    this.cursorColor,
+    this.selectionColor,
+    this.selectionHandleColor,
+    this.contextMenuBuilder,
+  });
 
   /// The color of the cursor in the text field.
   ///
@@ -58,17 +63,31 @@ class TextSelectionThemeData with Diagnosticable {
   /// containing your [TextField] or [SelectableText] with a [CupertinoTheme].
   final Color? selectionHandleColor;
 
+  /// {@macro flutter.widgets.EditableText.contextMenuBuilder}
+  ///
+  /// Provides a way to globally override the default Flutter context menu for
+  /// text fields and selectable text.
+  ///
+  /// See also:
+  ///
+  ///  * [AdaptiveTextSelectionToolbar], which is built by default.
+  ///  * [BrowserContextMenu], which allows the browser's context menu on web to
+  ///    be disabled and Flutter-rendered context menus to appear.
+  final EditableTextContextMenuBuilder? contextMenuBuilder;
+
   /// Creates a copy of this object with the given fields replaced with the
   /// specified values.
   TextSelectionThemeData copyWith({
     Color? cursorColor,
     Color? selectionColor,
     Color? selectionHandleColor,
+    EditableTextContextMenuBuilder? contextMenuBuilder,
   }) {
     return TextSelectionThemeData(
       cursorColor: cursorColor ?? this.cursorColor,
       selectionColor: selectionColor ?? this.selectionColor,
       selectionHandleColor: selectionHandleColor ?? this.selectionHandleColor,
+      contextMenuBuilder: contextMenuBuilder ?? this.contextMenuBuilder,
     );
   }
 
@@ -89,11 +108,13 @@ class TextSelectionThemeData with Diagnosticable {
       cursorColor: Color.lerp(a?.cursorColor, b?.cursorColor, t),
       selectionColor: Color.lerp(a?.selectionColor, b?.selectionColor, t),
       selectionHandleColor: Color.lerp(a?.selectionHandleColor, b?.selectionHandleColor, t),
+      // TODO: Should anything happen with contextMenuBuilder here?
     );
   }
 
   @override
-  int get hashCode => Object.hash(cursorColor, selectionColor, selectionHandleColor);
+  int get hashCode =>
+      Object.hash(cursorColor, selectionColor, selectionHandleColor, contextMenuBuilder);
 
   @override
   bool operator ==(Object other) {
@@ -106,7 +127,8 @@ class TextSelectionThemeData with Diagnosticable {
     return other is TextSelectionThemeData &&
         other.cursorColor == cursorColor &&
         other.selectionColor == selectionColor &&
-        other.selectionHandleColor == selectionHandleColor;
+        other.selectionHandleColor == selectionHandleColor &&
+        other.contextMenuBuilder == contextMenuBuilder;
   }
 
   @override
@@ -115,6 +137,13 @@ class TextSelectionThemeData with Diagnosticable {
     properties.add(ColorProperty('cursorColor', cursorColor, defaultValue: null));
     properties.add(ColorProperty('selectionColor', selectionColor, defaultValue: null));
     properties.add(ColorProperty('selectionHandleColor', selectionHandleColor, defaultValue: null));
+    properties.add(
+      DiagnosticsProperty<EditableTextContextMenuBuilder>(
+        'contextMenuBuilder',
+        contextMenuBuilder,
+        defaultValue: null,
+      ),
+    );
   }
 }
 

--- a/packages/flutter/test/material/search_anchor_test.dart
+++ b/packages/flutter/test/material/search_anchor_test.dart
@@ -3786,6 +3786,137 @@ void main() {
       );
     });
 
+    testWidgets('SearchBar uses ThemeData.textSelectionTheme contextMenuBuilder', (
+      WidgetTester tester,
+    ) async {
+      Widget themeDataContextMenuBuilder(
+        BuildContext context,
+        EditableTextState editableTextState,
+      ) {
+        return const Icon(Icons.search);
+      }
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            textSelectionTheme: TextSelectionThemeData(
+              contextMenuBuilder: themeDataContextMenuBuilder,
+            ),
+          ),
+          home: const Material(child: SearchBar()),
+        ),
+      );
+
+      final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
+      final BuildContext searchBarContext = tester.element(find.byType(SearchBar));
+      final Widget contextMenu = editableTextState.widget.contextMenuBuilder!(
+        searchBarContext,
+        editableTextState,
+      );
+
+      expect(contextMenu, isA<Icon>());
+    });
+
+    testWidgets('SearchBar prefers local TextSelectionTheme contextMenuBuilder', (
+      WidgetTester tester,
+    ) async {
+      Widget themeDataContextMenuBuilder(
+        BuildContext context,
+        EditableTextState editableTextState,
+      ) {
+        return const Icon(Icons.search);
+      }
+
+      Widget localTextSelectionThemeContextMenuBuilder(
+        BuildContext context,
+        EditableTextState editableTextState,
+      ) {
+        return const Placeholder();
+      }
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            textSelectionTheme: TextSelectionThemeData(
+              contextMenuBuilder: themeDataContextMenuBuilder,
+            ),
+          ),
+          home: Material(
+            child: TextSelectionTheme(
+              data: TextSelectionThemeData(
+                contextMenuBuilder: localTextSelectionThemeContextMenuBuilder,
+              ),
+              child: const SearchBar(),
+            ),
+          ),
+        ),
+      );
+
+      final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
+      final BuildContext searchBarContext = tester.element(find.byType(SearchBar));
+      final Widget contextMenu = editableTextState.widget.contextMenuBuilder!(
+        searchBarContext,
+        editableTextState,
+      );
+
+      expect(contextMenu, isA<Placeholder>());
+      expect(contextMenu, isNot(isA<Icon>()));
+    });
+
+    testWidgets('SearchBar.contextMenuBuilder overrides TextSelectionTheme and ThemeData', (
+      WidgetTester tester,
+    ) async {
+      Widget themeDataContextMenuBuilder(
+        BuildContext context,
+        EditableTextState editableTextState,
+      ) {
+        return const Icon(Icons.search);
+      }
+
+      Widget localTextSelectionThemeContextMenuBuilder(
+        BuildContext context,
+        EditableTextState editableTextState,
+      ) {
+        return const Placeholder();
+      }
+
+      Widget searchBarContextMenuBuilder(
+        BuildContext context,
+        EditableTextState editableTextState,
+      ) {
+        return const SizedBox();
+      }
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            textSelectionTheme: TextSelectionThemeData(
+              contextMenuBuilder: themeDataContextMenuBuilder,
+            ),
+          ),
+          home: Material(
+            child: TextSelectionTheme(
+              data: TextSelectionThemeData(
+                contextMenuBuilder: localTextSelectionThemeContextMenuBuilder,
+              ),
+              child: SearchBar(contextMenuBuilder: searchBarContextMenuBuilder),
+            ),
+          ),
+        ),
+      );
+
+      final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
+      final BuildContext searchBarContext = tester.element(find.byType(SearchBar));
+      final Widget contextMenu = editableTextState.widget.contextMenuBuilder!(
+        searchBarContext,
+        editableTextState,
+      );
+
+      expect(contextMenu, isA<SizedBox>());
+      expect(contextMenu, isNot(isA<Placeholder>()));
+      expect(contextMenu, isNot(isA<Icon>()));
+    });
+
     testWidgets('SearchAnchor.bar.contextMenuBuilder is passed through to EditableText', (
       WidgetTester tester,
     ) async {

--- a/packages/flutter/test/material/selectable_text_test.dart
+++ b/packages/flutter/test/material/selectable_text_test.dart
@@ -5682,6 +5682,140 @@ void main() {
   );
 
   group('context menu', () {
+    testWidgets('SelectableText uses ThemeData.textSelectionTheme contextMenuBuilder', (
+      WidgetTester tester,
+    ) async {
+      Widget themeDataContextMenuBuilder(
+        BuildContext context,
+        EditableTextState editableTextState,
+      ) {
+        return const Placeholder();
+      }
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            textSelectionTheme: TextSelectionThemeData(
+              contextMenuBuilder: themeDataContextMenuBuilder,
+            ),
+          ),
+          home: const Material(child: SelectableText('one two three')),
+        ),
+      );
+
+      final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
+      final BuildContext selectableTextContext = tester.element(find.byType(SelectableText));
+      final Widget contextMenu = editableTextState.widget.contextMenuBuilder!(
+        selectableTextContext,
+        editableTextState,
+      );
+
+      expect(contextMenu, isA<Placeholder>());
+    });
+
+    testWidgets('SelectableText prefers local TextSelectionTheme contextMenuBuilder', (
+      WidgetTester tester,
+    ) async {
+      Widget themeDataContextMenuBuilder(
+        BuildContext context,
+        EditableTextState editableTextState,
+      ) {
+        return const Placeholder();
+      }
+
+      Widget localTextSelectionThemeContextMenuBuilder(
+        BuildContext context,
+        EditableTextState editableTextState,
+      ) {
+        return const Icon(Icons.search);
+      }
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            textSelectionTheme: TextSelectionThemeData(
+              contextMenuBuilder: themeDataContextMenuBuilder,
+            ),
+          ),
+          home: Material(
+            child: TextSelectionTheme(
+              data: TextSelectionThemeData(
+                contextMenuBuilder: localTextSelectionThemeContextMenuBuilder,
+              ),
+              child: const SelectableText('one two three'),
+            ),
+          ),
+        ),
+      );
+
+      final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
+      final BuildContext selectableTextContext = tester.element(find.byType(SelectableText));
+      final Widget contextMenu = editableTextState.widget.contextMenuBuilder!(
+        selectableTextContext,
+        editableTextState,
+      );
+
+      expect(contextMenu, isA<Icon>());
+      expect(contextMenu, isNot(isA<Placeholder>()));
+    });
+
+    testWidgets('SelectableText.contextMenuBuilder overrides TextSelectionTheme and ThemeData', (
+      WidgetTester tester,
+    ) async {
+      Widget themeDataContextMenuBuilder(
+        BuildContext context,
+        EditableTextState editableTextState,
+      ) {
+        return const Placeholder();
+      }
+
+      Widget localTextSelectionThemeContextMenuBuilder(
+        BuildContext context,
+        EditableTextState editableTextState,
+      ) {
+        return const Icon(Icons.search);
+      }
+
+      Widget selectableTextContextMenuBuilder(
+        BuildContext context,
+        EditableTextState editableTextState,
+      ) {
+        return const SizedBox();
+      }
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            textSelectionTheme: TextSelectionThemeData(
+              contextMenuBuilder: themeDataContextMenuBuilder,
+            ),
+          ),
+          home: Material(
+            child: TextSelectionTheme(
+              data: TextSelectionThemeData(
+                contextMenuBuilder: localTextSelectionThemeContextMenuBuilder,
+              ),
+              child: SelectableText(
+                'one two three',
+                contextMenuBuilder: selectableTextContextMenuBuilder,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
+      final BuildContext selectableTextContext = tester.element(find.byType(SelectableText));
+      final Widget contextMenu = editableTextState.widget.contextMenuBuilder!(
+        selectableTextContext,
+        editableTextState,
+      );
+
+      expect(contextMenu, isA<SizedBox>());
+      expect(contextMenu, isNot(isA<Icon>()));
+      expect(contextMenu, isNot(isA<Placeholder>()));
+    });
+
     // Regression test for https://github.com/flutter/flutter/issues/169001.
     testWidgets(
       'iOS does not use the system context menu by default even when supported',

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -17279,6 +17279,137 @@ void main() {
       skip: kIsWeb, // [intended] on web the browser handles the context menu.
     );
 
+    testWidgets('TextField uses ThemeData.textSelectionTheme contextMenuBuilder', (
+      WidgetTester tester,
+    ) async {
+      Widget themeDataContextMenuBuilder(
+        BuildContext context,
+        EditableTextState editableTextState,
+      ) {
+        return const Placeholder();
+      }
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            textSelectionTheme: TextSelectionThemeData(
+              contextMenuBuilder: themeDataContextMenuBuilder,
+            ),
+          ),
+          home: const Material(child: TextField()),
+        ),
+      );
+
+      final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
+      final BuildContext textFieldContext = tester.element(find.byType(TextField));
+      final Widget contextMenu = editableTextState.widget.contextMenuBuilder!(
+        textFieldContext,
+        editableTextState,
+      );
+
+      expect(contextMenu, isA<Placeholder>());
+    });
+
+    testWidgets('TextField prefers local TextSelectionTheme contextMenuBuilder', (
+      WidgetTester tester,
+    ) async {
+      Widget themeDataContextMenuBuilder(
+        BuildContext context,
+        EditableTextState editableTextState,
+      ) {
+        return const Placeholder();
+      }
+
+      Widget localTextSelectionThemeContextMenuBuilder(
+        BuildContext context,
+        EditableTextState editableTextState,
+      ) {
+        return const Icon(Icons.search);
+      }
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            textSelectionTheme: TextSelectionThemeData(
+              contextMenuBuilder: themeDataContextMenuBuilder,
+            ),
+          ),
+          home: Material(
+            child: TextSelectionTheme(
+              data: TextSelectionThemeData(
+                contextMenuBuilder: localTextSelectionThemeContextMenuBuilder,
+              ),
+              child: const TextField(),
+            ),
+          ),
+        ),
+      );
+
+      final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
+      final BuildContext textFieldContext = tester.element(find.byType(TextField));
+      final Widget contextMenu = editableTextState.widget.contextMenuBuilder!(
+        textFieldContext,
+        editableTextState,
+      );
+
+      expect(contextMenu, isA<Icon>());
+      expect(contextMenu, isNot(isA<Placeholder>()));
+    });
+
+    testWidgets('TextField.contextMenuBuilder overrides TextSelectionTheme and ThemeData', (
+      WidgetTester tester,
+    ) async {
+      Widget themeDataContextMenuBuilder(
+        BuildContext context,
+        EditableTextState editableTextState,
+      ) {
+        return const Placeholder();
+      }
+
+      Widget localTextSelectionThemeContextMenuBuilder(
+        BuildContext context,
+        EditableTextState editableTextState,
+      ) {
+        return const Icon(Icons.search);
+      }
+
+      Widget textFieldContextMenuBuilder(
+        BuildContext context,
+        EditableTextState editableTextState,
+      ) {
+        return const SizedBox();
+      }
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            textSelectionTheme: TextSelectionThemeData(
+              contextMenuBuilder: themeDataContextMenuBuilder,
+            ),
+          ),
+          home: Material(
+            child: TextSelectionTheme(
+              data: TextSelectionThemeData(
+                contextMenuBuilder: localTextSelectionThemeContextMenuBuilder,
+              ),
+              child: TextField(contextMenuBuilder: textFieldContextMenuBuilder),
+            ),
+          ),
+        ),
+      );
+
+      final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
+      final BuildContext textFieldContext = tester.element(find.byType(TextField));
+      final Widget contextMenu = editableTextState.widget.contextMenuBuilder!(
+        textFieldContext,
+        editableTextState,
+      );
+
+      expect(contextMenu, isA<SizedBox>());
+      expect(contextMenu, isNot(isA<Icon>()));
+      expect(contextMenu, isNot(isA<Placeholder>()));
+    });
+
     testWidgets(
       'iOS uses the system context menu by default if supported',
       (WidgetTester tester) async {

--- a/packages/flutter/test/material/text_form_field_test.dart
+++ b/packages/flutter/test/material/text_form_field_test.dart
@@ -1739,6 +1739,122 @@ void main() {
   );
 
   group('context menu', () {
+    testWidgets('TextFormField uses ThemeData.textSelectionTheme contextMenuBuilder', (
+      WidgetTester tester,
+    ) async {
+      Widget themeDataContextMenuBuilder(
+        BuildContext context,
+        EditableTextState editableTextState,
+      ) {
+        return const Placeholder();
+      }
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            textSelectionTheme: TextSelectionThemeData(
+              contextMenuBuilder: themeDataContextMenuBuilder,
+            ),
+          ),
+          home: Material(child: TextFormField()),
+        ),
+      );
+
+      final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
+      final BuildContext textFormFieldContext = tester.element(find.byType(TextFormField));
+      final Widget contextMenu = editableTextState.widget.contextMenuBuilder!(
+        textFormFieldContext,
+        editableTextState,
+      );
+
+      expect(contextMenu, isA<Placeholder>());
+    });
+
+    testWidgets('TextFormField prefers local TextSelectionTheme contextMenuBuilder', (
+      WidgetTester tester,
+    ) async {
+      Widget themeDataContextMenuBuilder(
+        BuildContext context,
+        EditableTextState editableTextState,
+      ) {
+        return const Placeholder();
+      }
+
+      Widget localTextSelectionThemeContextMenuBuilder(
+        BuildContext context,
+        EditableTextState editableTextState,
+      ) {
+        return const Icon(Icons.search);
+      }
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            textSelectionTheme: TextSelectionThemeData(
+              contextMenuBuilder: themeDataContextMenuBuilder,
+            ),
+          ),
+          home: Material(
+            child: TextSelectionTheme(
+              data: TextSelectionThemeData(
+                contextMenuBuilder: localTextSelectionThemeContextMenuBuilder,
+              ),
+              child: TextFormField(),
+            ),
+          ),
+        ),
+      );
+
+      final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
+      final BuildContext textFormFieldContext = tester.element(find.byType(TextFormField));
+      final Widget contextMenu = editableTextState.widget.contextMenuBuilder!(
+        textFormFieldContext,
+        editableTextState,
+      );
+
+      expect(contextMenu, isA<Icon>());
+      expect(contextMenu, isNot(isA<Placeholder>()));
+    });
+
+    testWidgets('TextFormField.contextMenuBuilder overrides ThemeData.textSelectionTheme', (
+      WidgetTester tester,
+    ) async {
+      Widget themeDataContextMenuBuilder(
+        BuildContext context,
+        EditableTextState editableTextState,
+      ) {
+        return const Placeholder();
+      }
+
+      Widget textFormFieldContextMenuBuilder(
+        BuildContext context,
+        EditableTextState editableTextState,
+      ) {
+        return const SizedBox();
+      }
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            textSelectionTheme: TextSelectionThemeData(
+              contextMenuBuilder: themeDataContextMenuBuilder,
+            ),
+          ),
+          home: Material(child: TextFormField(contextMenuBuilder: textFormFieldContextMenuBuilder)),
+        ),
+      );
+
+      final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
+      final BuildContext textFormFieldContext = tester.element(find.byType(TextFormField));
+      final Widget contextMenu = editableTextState.widget.contextMenuBuilder!(
+        textFormFieldContext,
+        editableTextState,
+      );
+
+      expect(contextMenu, isA<SizedBox>());
+      expect(contextMenu, isNot(isA<Placeholder>()));
+    });
+
     testWidgets(
       'iOS uses the system context menu by default if supported',
       (WidgetTester tester) async {

--- a/packages/flutter/test/material/text_selection_theme_test.dart
+++ b/packages/flutter/test/material/text_selection_theme_test.dart
@@ -6,7 +6,32 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+class CustomContextMenu extends AdaptiveTextSelectionToolbar {
+  const CustomContextMenu.buttonItems({
+    super.key,
+    required super.anchors,
+    required super.buttonItems,
+  }) : super.buttonItems();
+}
+
 void main() {
+  CustomContextMenu defaultContextMenuBuilder(
+    BuildContext context,
+    EditableTextState editableTextState,
+  ) {
+    return CustomContextMenu.buttonItems(
+      anchors: editableTextState.contextMenuAnchors,
+      buttonItems: <ContextMenuButtonItem>[
+        ContextMenuButtonItem(
+          onPressed: () {
+            ContextMenuController.removeAny();
+          },
+          label: 'Context Button Item',
+        ),
+      ],
+    );
+  }
+
   test('TextSelectionThemeData copyWith, ==, hashCode basics', () {
     expect(const TextSelectionThemeData(), const TextSelectionThemeData().copyWith());
     expect(
@@ -26,6 +51,7 @@ void main() {
     expect(theme.cursorColor, null);
     expect(theme.selectionColor, null);
     expect(theme.selectionHandleColor, null);
+    expect(theme.contextMenuBuilder, null);
   });
 
   testWidgets('Default TextSelectionThemeData debugFillProperties', (WidgetTester tester) async {
@@ -42,10 +68,11 @@ void main() {
 
   testWidgets('TextSelectionThemeData implements debugFillProperties', (WidgetTester tester) async {
     final builder = DiagnosticPropertiesBuilder();
-    const TextSelectionThemeData(
-      cursorColor: Color(0xffeeffaa),
-      selectionColor: Color(0x88888888),
-      selectionHandleColor: Color(0xaabbccdd),
+    TextSelectionThemeData(
+      cursorColor: const Color(0xffeeffaa),
+      selectionColor: const Color(0x88888888),
+      selectionHandleColor: const Color(0xaabbccdd),
+      contextMenuBuilder: defaultContextMenuBuilder,
     ).debugFillProperties(builder);
 
     final List<String> description = builder.properties
@@ -57,6 +84,7 @@ void main() {
       'cursorColor: ${const Color(0xffeeffaa)}',
       'selectionColor: ${const Color(0x88888888)}',
       'selectionHandleColor: ${const Color(0xaabbccdd)}',
+      'contextMenuBuilder: Closure: (BuildContext, EditableTextState) => CustomContextMenu',
     ]);
   });
 
@@ -86,6 +114,12 @@ void main() {
     final RenderEditable renderEditable = editableTextState.renderEditable;
     expect(renderEditable.cursorColor, defaultCursorColor);
     expect(renderEditable.selectionColor, defaultSelectionColor);
+
+    final BuildContext textFieldContext = tester.element(find.byType(TextField));
+    final EditableTextContextMenuBuilder? themeContextMenuBuilder = TextSelectionTheme.of(
+      textFieldContext,
+    ).contextMenuBuilder;
+    expect(themeContextMenuBuilder, null);
 
     // Test the selection handle color.
     await tester.pumpWidget(
@@ -136,6 +170,12 @@ void main() {
     expect(renderEditable.cursorColor, defaultCursorColor);
     expect(renderEditable.selectionColor, defaultSelectionColor);
 
+    final BuildContext textFieldContext = tester.element(find.byType(TextField));
+    final EditableTextContextMenuBuilder? themeContextMenuBuilder = TextSelectionTheme.of(
+      textFieldContext,
+    ).contextMenuBuilder;
+    expect(themeContextMenuBuilder, null);
+
     // Test the selection handle color.
     await tester.pumpWidget(
       MaterialApp(
@@ -159,10 +199,11 @@ void main() {
   });
 
   testWidgets('ThemeData.textSelectionTheme will be used if provided', (WidgetTester tester) async {
-    const textSelectionTheme = TextSelectionThemeData(
-      cursorColor: Color(0xffaabbcc),
-      selectionColor: Color(0x88888888),
-      selectionHandleColor: Color(0x00ccbbaa),
+    final textSelectionTheme = TextSelectionThemeData(
+      cursorColor: const Color(0xffaabbcc),
+      selectionColor: const Color(0x88888888),
+      selectionHandleColor: const Color(0x00ccbbaa),
+      contextMenuBuilder: defaultContextMenuBuilder,
     );
     final ThemeData theme = ThemeData.fallback().copyWith(textSelectionTheme: textSelectionTheme);
 
@@ -184,6 +225,11 @@ void main() {
     final RenderEditable renderEditable = editableTextState.renderEditable;
     expect(renderEditable.cursorColor, textSelectionTheme.cursorColor);
     expect(renderEditable.selectionColor, textSelectionTheme.selectionColor);
+    final BuildContext textFieldContext = tester.element(find.byType(TextField));
+    final EditableTextContextMenuBuilder? themeContextMenuBuilder = TextSelectionTheme.of(
+      textFieldContext,
+    ).contextMenuBuilder;
+    expect(themeContextMenuBuilder, textSelectionTheme.contextMenuBuilder);
 
     // Test the selection handle color.
     await tester.pumpWidget(
@@ -218,10 +264,11 @@ void main() {
     final ThemeData theme = ThemeData.fallback().copyWith(
       textSelectionTheme: defaultTextSelectionTheme,
     );
-    const widgetTextSelectionTheme = TextSelectionThemeData(
-      cursorColor: Color(0xffddeeff),
-      selectionColor: Color(0x44444444),
-      selectionHandleColor: Color(0x00ffeedd),
+    final widgetTextSelectionTheme = TextSelectionThemeData(
+      cursorColor: const Color(0xffddeeff),
+      selectionColor: const Color(0x44444444),
+      selectionHandleColor: const Color(0x00ffeedd),
+      contextMenuBuilder: defaultContextMenuBuilder,
     );
 
     EditableText.debugDeterministicCursor = true;
@@ -232,10 +279,10 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         theme: theme,
-        home: const Material(
+        home: Material(
           child: TextSelectionTheme(
             data: widgetTextSelectionTheme,
-            child: TextField(autofocus: true),
+            child: const TextField(autofocus: true),
           ),
         ),
       ),
@@ -245,6 +292,12 @@ void main() {
     final RenderEditable renderEditable = editableTextState.renderEditable;
     expect(renderEditable.cursorColor, widgetTextSelectionTheme.cursorColor);
     expect(renderEditable.selectionColor, widgetTextSelectionTheme.selectionColor);
+
+    final BuildContext textFieldContext = tester.element(find.byType(TextField));
+    final EditableTextContextMenuBuilder? themeContextMenuBuilder = TextSelectionTheme.of(
+      textFieldContext,
+    ).contextMenuBuilder;
+    expect(themeContextMenuBuilder, widgetTextSelectionTheme.contextMenuBuilder);
 
     // Test the selection handle color.
     await tester.pumpWidget(
@@ -279,20 +332,20 @@ void main() {
     final ThemeData theme = ThemeData.fallback().copyWith(
       textSelectionTheme: defaultTextSelectionTheme,
     );
-    const widgetTextSelectionTheme = TextSelectionThemeData(
-      cursorColor: Color(0xffddeeff),
-      selectionHandleColor: Color(0x00ffeedd),
-    );
+    const widgetTextSelectionTheme = TextSelectionThemeData(cursorColor: Color(0xffddeeff));
     const cursorColor = Color(0x88888888);
 
     // Test TextField's cursor color.
     await tester.pumpWidget(
       MaterialApp(
         theme: theme,
-        home: const Material(
+        home: Material(
           child: TextSelectionTheme(
             data: widgetTextSelectionTheme,
-            child: TextField(cursorColor: cursorColor),
+            child: TextField(
+              cursorColor: cursorColor,
+              contextMenuBuilder: defaultContextMenuBuilder,
+            ),
           ),
         ),
       ),
@@ -301,15 +354,20 @@ void main() {
     final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
     final RenderEditable renderEditable = editableTextState.renderEditable;
     expect(renderEditable.cursorColor, cursorColor.withAlpha(0));
+    expect(editableTextState.widget.contextMenuBuilder, defaultContextMenuBuilder);
 
     // Test SelectableText's cursor color.
     await tester.pumpWidget(
       MaterialApp(
         theme: theme,
-        home: const Material(
+        home: Material(
           child: TextSelectionTheme(
             data: widgetTextSelectionTheme,
-            child: SelectableText('foobar', cursorColor: cursorColor),
+            child: SelectableText(
+              'foobar',
+              cursorColor: cursorColor,
+              contextMenuBuilder: defaultContextMenuBuilder,
+            ),
           ),
         ),
       ),
@@ -318,6 +376,7 @@ void main() {
     final EditableTextState selectableTextState = tester.firstState(find.byType(EditableText));
     final RenderEditable renderSelectable = selectableTextState.renderEditable;
     expect(renderSelectable.cursorColor, cursorColor.withAlpha(0));
+    expect(selectableTextState.widget.contextMenuBuilder, defaultContextMenuBuilder);
   });
 
   testWidgets('TextSelectionThem overrides DefaultSelectionStyle', (WidgetTester tester) async {
@@ -336,9 +395,10 @@ void main() {
           child: Container(
             key: defaultSelectionStyle,
             child: TextSelectionTheme(
-              data: const TextSelectionThemeData(
+              data: TextSelectionThemeData(
                 selectionColor: themeSelectionColor,
                 cursorColor: themeCursorColor,
+                contextMenuBuilder: defaultContextMenuBuilder,
               ),
               child: Placeholder(key: themeStyle),
             ),
@@ -353,9 +413,15 @@ void main() {
     expect(style.selectionColor, defaultSelectionColor);
     expect(style.cursorColor, defaultCursorColor);
 
+    TextSelectionThemeData textSelectionTheme = TextSelectionTheme.of(defaultSelectionStyleContext);
+    expect(textSelectionTheme.contextMenuBuilder, null);
+
     final BuildContext themeStyleContext = tester.element(find.byKey(themeStyle));
     style = DefaultSelectionStyle.of(themeStyleContext);
     expect(style.selectionColor, themeSelectionColor);
     expect(style.cursorColor, themeCursorColor);
+
+    textSelectionTheme = TextSelectionTheme.of(themeStyleContext);
+    expect(textSelectionTheme.contextMenuBuilder, defaultContextMenuBuilder);
   });
 }


### PR DESCRIPTION
In certain Android app configurations, it is desirable to suppress the long-press context menu on text fields entirely — for example, in focused or restricted UI environments where exposing system-level UI (share sheet, app chooser dialogs) is undesirable or disruptive to the user experience.

The only option today is to pass contextMenuBuilder explicitly to every TextField and TextFormField in the codebase, which is impractical at scale. More critically, this approach does not cover Flutter's own widgets that embed TextField or TextFormField internally, such as TimePickerDialog, DatePickerDialog, DropdownMenu, or any third-party package using TextField internally. There is no way to suppress the context menu in those without forking Flutter or the package.

This PR adds a contextMenuBuilder field to TextSelectionThemeData, which widgets that use a contextMenuBuilder resolve before falling back to their default.  This allows a developer to provide an override for the context menu at the MaterialApp level.

This PR address https://github.com/flutter/flutter/issues/183227

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.