### PR TITLE
Print trace when skipping flavor-specific and platform-specific assets

### DIFF
--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -1104,7 +1104,7 @@ class ManifestAssetBundle implements AssetBundle {
 
     result.removeWhere((_Asset asset, List<_Asset> variants) {
       if (!asset.matchesFlavor(flavor)) {
-        _logger.printWarning(
+        _logger.printTrace(
           'Skipping assets entry "${asset.entryUri.path}" since '
           'its configured flavor(s) did not match the provided flavor (if any).\n'
           'Configured flavors: ${asset.flavors.join(', ')}\n',
@@ -1112,7 +1112,7 @@ class ManifestAssetBundle implements AssetBundle {
         return true;
       }
       if (!asset.matchesPlatform(targetPlatform)) {
-        _logger.printWarning(
+        _logger.printTrace(
           'Skipping assets entry "${asset.entryUri.path}" since '
           'its configured platform(s) did not match the target platform.\n'
           'Configured platforms: ${asset.platforms.join(', ')}\n'

--- a/packages/flutter_tools/test/general.shard/build_system/targets/assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/assets_test.dart
@@ -174,6 +174,10 @@ flutter:
             logger.traceText,
             contains('Skipping assets entry "assets/strawberry/ice-cream.png"'),
           );
+          expect(
+            logger.traceText,
+            isNot(contains('Skipping assets entry "assets/common/image.png"')),
+          );
         },
         overrides: <Type, Generator>{
           FileSystem: () => fileSystem,
@@ -226,6 +230,10 @@ flutter:
           expect(
             logger.traceText,
             contains('Skipping assets entry "assets/vanilla/ice-cream.png"'),
+          );
+          expect(
+            logger.traceText,
+            isNot(contains('Skipping assets entry "assets/strawberry/ice-cream.png"')),
           );
         },
         overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/general.shard/build_system/targets/assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/assets_test.dart
@@ -846,6 +846,7 @@ flutter:
               isFalse,
               reason: 'Expected asset for $platform to be skipped when target is $targetPlatform',
             );
+            expect(logger.traceText, contains('Skipping assets entry "assets/test-$platform.txt"'));
           },
           overrides: <Type, Generator>{
             FileSystem: () => fileSystem,

--- a/packages/flutter_tools/test/general.shard/build_system/targets/assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/assets_test.dart
@@ -32,12 +32,13 @@ void main() {
 
   setUp(() {
     fileSystem = MemoryFileSystem.test();
+    logger = BufferLogger.test();
     environment = Environment.test(
       fileSystem.currentDirectory,
       processManager: FakeProcessManager.any(),
       artifacts: Artifacts.test(),
       fileSystem: fileSystem,
-      logger: BufferLogger.test(),
+      logger: logger,
       platform: FakePlatform(),
       defines: <String, String>{kBuildMode: BuildMode.debug.cliName},
     );
@@ -60,7 +61,6 @@ flutter:
     - assets/foo/bar.png
     - assets/wildcard/
 ''');
-    logger = BufferLogger.test();
   });
 
   testUsingContext(
@@ -166,6 +166,14 @@ flutter:
             ),
             isNot(exists),
           );
+          expect(
+            logger.traceText,
+            contains('Skipping assets entry "assets/vanilla/ice-cream.png"'),
+          );
+          expect(
+            logger.traceText,
+            contains('Skipping assets entry "assets/strawberry/ice-cream.png"'),
+          );
         },
         overrides: <Type, Generator>{
           FileSystem: () => fileSystem,
@@ -214,6 +222,10 @@ flutter:
               '${environment.buildDir.path}/flutter_assets/assets/strawberry/ice-cream.png',
             ),
             exists,
+          );
+          expect(
+            logger.traceText,
+            contains('Skipping assets entry "assets/vanilla/ice-cream.png"'),
           );
         },
         overrides: <Type, Generator>{


### PR DESCRIPTION
Replaces `printWarning()` with `printTrace()` when skipping an asset based on flavor or platform. The warning is non-actionable, as skipping assets is the expected behaviour. Leave as trace to help in debugging.

Fixes #186738

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
