### PR TITLE
Fix Cupertino sheet covered top gap transition

### DIFF
--- a/packages/flutter/lib/src/cupertino/sheet.dart
+++ b/packages/flutter/lib/src/cupertino/sheet.dart
@@ -546,13 +546,13 @@ class _CupertinoSheetTransitionState extends State<CupertinoSheetTransition>
         child: AnimatedBuilder(
           animation: _stretchDragAnimation,
           builder: (BuildContext context, Widget? child) {
-            return Padding(
-              padding: EdgeInsets.only(
-                top: MediaQuery.heightOf(context) * _stretchDragAnimation.value,
-              ),
-              child: _coverSheetSecondaryTransition(
-                widget.secondaryRouteAnimation,
-                _coverSheetPrimaryTransition(
+            return _coverSheetSecondaryTransition(
+              widget.secondaryRouteAnimation,
+              Padding(
+                padding: EdgeInsets.only(
+                  top: MediaQuery.heightOf(context) * _stretchDragAnimation.value,
+                ),
+                child: _coverSheetPrimaryTransition(
                   context,
                   widget.primaryRouteAnimation,
                   widget.linearTransition,

--- a/packages/flutter/test/cupertino/sheet_test.dart
+++ b/packages/flutter/test/cupertino/sheet_test.dart
@@ -315,6 +315,79 @@ void main() {
     );
   });
 
+  testWidgets('covered sheet applies secondary transition outside top gap', (
+    WidgetTester tester,
+  ) async {
+    final GlobalKey scaffoldKey = GlobalKey();
+    const pageTwoKey = ValueKey<String>('page-two');
+
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: CupertinoPageScaffold(
+          key: scaffoldKey,
+          child: Center(
+            child: CupertinoButton(
+              onPressed: () {
+                Navigator.push<void>(
+                  scaffoldKey.currentContext!,
+                  CupertinoSheetRoute<void>(
+                    builder: (BuildContext context) {
+                      return CupertinoPageScaffold(
+                        key: pageTwoKey,
+                        child: Center(
+                          child: CupertinoButton(
+                            onPressed: () {
+                              Navigator.push<void>(
+                                context,
+                                CupertinoSheetRoute<void>(
+                                  builder: (BuildContext context) {
+                                    return const CupertinoPageScaffold(
+                                      child: Center(child: Text('Page 3')),
+                                    );
+                                  },
+                                ),
+                              );
+                            },
+                            child: const Text('Push Page 3'),
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                );
+              },
+              child: const Text('Push Page 2'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Push Page 2'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Push Page 3'));
+    await tester.pumpAndSettle();
+
+    final pageTwoAncestors = <Widget>[];
+    tester.element(find.byKey(pageTwoKey)).visitAncestorElements((Element ancestor) {
+      pageTwoAncestors.add(ancestor.widget);
+      return true;
+    });
+
+    final int topGapPaddingIndex = pageTwoAncestors.indexWhere((Widget widget) {
+      return widget is Padding &&
+          widget.padding is EdgeInsets &&
+          (widget.padding as EdgeInsets).top > 0.0;
+    });
+    final int secondaryScaleTransitionIndex = pageTwoAncestors.indexWhere((Widget widget) {
+      return widget is ScaleTransition;
+    });
+
+    expect(topGapPaddingIndex, isNonNegative);
+    expect(secondaryScaleTransitionIndex, isNonNegative);
+    expect(topGapPaddingIndex, lessThan(secondaryScaleTransitionIndex));
+  });
+
   testWidgets('by default showCupertinoSheet does not enable nested navigation', (
     WidgetTester tester,
   ) async {

--- a/packages/flutter/test/cupertino/sheet_test.dart
+++ b/packages/flutter/test/cupertino/sheet_test.dart
@@ -315,6 +315,85 @@ void main() {
     );
   });
 
+  testWidgets('covered sheet does not reveal the root route through its top gap', (
+    WidgetTester tester,
+  ) async {
+    final GlobalKey scaffoldKey = GlobalKey();
+
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: CupertinoPageScaffold(
+          key: scaffoldKey,
+          child: Column(
+            children: <Widget>[
+              const Text('Page 1'),
+              CupertinoButton(
+                onPressed: () {
+                  Navigator.push<void>(
+                    scaffoldKey.currentContext!,
+                    CupertinoSheetRoute<void>(
+                      builder: (BuildContext context) {
+                        return CupertinoPageScaffold(
+                          child: Column(
+                            children: <Widget>[
+                              const Text('Page 2'),
+                              CupertinoButton(
+                                onPressed: () {
+                                  Navigator.push<void>(
+                                    context,
+                                    CupertinoSheetRoute<void>(
+                                      builder: (BuildContext context) {
+                                        return const CupertinoPageScaffold(child: Text('Page 3'));
+                                      },
+                                    ),
+                                  );
+                                },
+                                child: const Text('Push Page 3'),
+                              ),
+                            ],
+                          ),
+                        );
+                      },
+                    ),
+                  );
+                },
+                child: const Text('Push Page 2'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Push Page 2'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Push Page 3'));
+    await tester.pumpAndSettle();
+
+    final double page1Top = tester
+        .getTopLeft(
+          find.ancestor(of: find.text('Page 1'), matching: find.byType(CupertinoPageScaffold)),
+        )
+        .dy;
+    final double page2Top = tester
+        .getTopLeft(
+          find.ancestor(of: find.text('Page 2'), matching: find.byType(CupertinoPageScaffold)),
+        )
+        .dy;
+    final double page3Top = tester
+        .getTopLeft(
+          find.ancestor(of: find.text('Page 3'), matching: find.byType(CupertinoPageScaffold)),
+        )
+        .dy;
+
+    // Sheet 2 moves up above Page 1 so that the root route (Page 1) is completely hidden behind
+    // Sheet 2.
+    expect(page2Top, lessThanOrEqualTo(page1Top));
+    // Sheet 3 is stacked on top of Sheet 2, with Sheet 2 peeking out above Sheet 3.
+    expect(page2Top, lessThanOrEqualTo(page3Top));
+  });
+
   testWidgets('by default showCupertinoSheet does not enable nested navigation', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION
Fixes #187057

This fixes a visual issue in stacked `CupertinoSheetRoute`s where the top gap of a covered sheet can reveal a lower route.

When a sheet is covered by another sheet, the covered sheet is translated and scaled by its secondary route animation. However, its top gap was outside that secondary transition. In a stack such as:

Root route -> Sheet 2 -> Sheet 3

the top gap could remain visually separate from the covered sheet's transition, allowing the root route background to show through at the top of the sheet stack.

This change applies the covered sheet's secondary transition outside its top gap padding, so the covered sheet and its top gap move and scale together.

A regression test was added to verify that a covered sheet applies its secondary transition outside the top gap.

## Tests

```bash
flutter test packages/flutter/test/cupertino/sheet_test.dart
dart analyze packages/flutter/lib/src/cupertino/sheet.dart packages/flutter/test/cupertino/sheet_test.dart
```


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

## Problem

When multiple `CupertinoSheetRoute`s are stacked, the covered sheet's top gap can reveal a lower route.

For example:

Root route -> Sheet 2 -> Sheet 3

If the root route has a distinct background color, that color can become visible above the covered sheet. This makes the sheet stack look incorrect because the root route should remain hidden behind the sheet stack.

## Videos

Before this PR:

https://github.com/user-attachments/assets/ff3bbbf2-480a-42d7-a16d-bae12a22e622

After this PR:

https://github.com/user-attachments/assets/8220e0f3-d69c-420c-9ee4-82011f582ee7

