### PR TITLE
[tool] Refactor artifacts.dart to use enhanced enums and reduce duplication

### DIFF
--- a/dev/tools/localization/localizations_utils.dart
+++ b/dev/tools/localization/localizations_utils.dart
@@ -200,7 +200,7 @@ void exitWithError(String errorMessage) {
 }
 
 void checkCwdIsRepoRoot(String commandName) {
-  final bool isRepoRoot = Directory('.git').existsSync();
+  final bool isRepoRoot = Directory('.git').existsSync() || File('.git').existsSync();
 
   if (!isRepoRoot) {
     exitWithError(

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -519,7 +519,7 @@ class CachedArtifacts implements Artifacts {
           hostPlatform = HostPlatform.darwin_x64;
         }
 
-        final String hostPlatformName = getNameForHostPlatform(hostPlatform);
+        final String hostPlatformName = hostPlatform.cliName;
         return _fileSystem.path.join(engineDir, hostPlatformName, artifact.getFileName(_platform));
       case Artifact.engineDartSdkPath:
       case Artifact.engineDartBinary:
@@ -1129,7 +1129,7 @@ class CachedLocalEngineArtifacts implements Artifacts {
       case Artifact.skyEnginePath:
         return _fileSystem.path.join(_hostEngineOutPath, 'gen', 'dart-pkg', artifactFileName);
       case Artifact.fuchsiaKernelCompiler:
-        final String hostPlatform = getNameForHostPlatform(getCurrentHostPlatform());
+        final String hostPlatform = getCurrentHostPlatform().cliName;
         final modeName = mode!.isRelease ? 'release' : mode.toString();
         final dartBinaries = 'dart_binaries-$modeName-$hostPlatform';
         return _fileSystem.path.join(

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -28,79 +28,112 @@ import 'globals.dart' as globals;
 /// Defines what engine artifacts are available (not necessarily on each platform).
 enum Artifact {
   /// The tool which compiles a dart kernel file into native code.
-  genSnapshot,
-  genSnapshotArm64,
-  genSnapshotRiscv64,
-  genSnapshotX64,
+  genSnapshot('gen_snapshot'),
+  genSnapshotArm64('gen_snapshot_arm64'),
+  genSnapshotRiscv64('gen_snapshot_riscv64'),
+  genSnapshotX64('gen_snapshot_x64'),
 
   /// The flutter tester binary.
-  flutterTester,
-  flutterFramework,
-  flutterFrameworkDsym,
-  flutterXcframework,
+  flutterTester('flutter_tester', isExecutable: true),
+  flutterFramework('Flutter.framework'),
+  flutterFrameworkDsym('Flutter.framework.dSYM'),
+  flutterXcframework('Flutter.xcframework'),
 
   /// The framework directory of the macOS desktop.
-  flutterMacOSFramework,
-  flutterMacOSFrameworkDsym,
-  flutterMacOSXcframework,
-  vmSnapshotData,
-  isolateSnapshotData,
-  icuData,
-  platformKernelDill,
-  platformLibrariesJson,
-  flutterPatchedSdkPath,
+  flutterMacOSFramework('FlutterMacOS.framework'),
+  flutterMacOSFrameworkDsym('FlutterMacOS.framework.dSYM'),
+  flutterMacOSXcframework('FlutterMacOS.xcframework'),
+  vmSnapshotData('vm_isolate_snapshot.bin'),
+  isolateSnapshotData('isolate_snapshot.bin'),
+  icuData('icudtl.dat'),
+  platformKernelDill('platform_strong.dill'),
+  platformLibrariesJson('libraries.json'),
+  flutterPatchedSdkPath('', isPatchedSdk: true),
 
   /// The root directory of the dart SDK.
-  engineDartSdkPath,
+  engineDartSdkPath('dart-sdk'),
 
   /// The dart binary used to execute any of the required snapshots.
-  engineDartBinary,
+  engineDartBinary('dart', isExecutable: true),
 
   /// The dart binary for running aot snapshots
-  engineDartAotRuntime,
+  engineDartAotRuntime('dartaotruntime', isExecutable: true),
 
   /// The snapshot of frontend_server compiler.
-  frontendServerSnapshotForEngineDartSdk,
+  frontendServerSnapshotForEngineDartSdk('frontend_server_aot.dart.snapshot'),
 
   /// The root of the Linux desktop sources.
-  linuxDesktopPath,
+  linuxDesktopPath.directory(),
   // The root of the cpp headers for Linux desktop.
-  linuxHeaders,
+  linuxHeaders('flutter_linux'),
 
   /// The root of the Windows desktop sources.
-  windowsDesktopPath,
+  windowsDesktopPath.directory(),
 
   /// The root of the cpp client code for Windows desktop.
-  windowsCppClientWrapper,
+  windowsCppClientWrapper('cpp_client_wrapper'),
 
   /// The root of the sky_engine package.
-  skyEnginePath,
+  skyEnginePath('sky_engine'),
 
   // Fuchsia artifacts from the engine prebuilts.
-  fuchsiaKernelCompiler,
-  fuchsiaFlutterRunner,
+  fuchsiaKernelCompiler('kernel_compiler.snapshot'),
+  fuchsiaFlutterRunner('', isFuchsiaRunner: true),
 
   /// Tools related to subsetting or icon font files.
-  fontSubset,
-  constFinder,
+  fontSubset('font-subset', isExecutable: true),
+  constFinder('const_finder.dart.snapshot'),
 
   /// The location of file generators.
-  flutterToolsFileGenerators,
+  flutterToolsFileGenerators.directory();
+
+  const Artifact(
+    this._fileName, {
+    this.isExecutable = false,
+    this.isPatchedSdk = false,
+    this.isFuchsiaRunner = false,
+  });
+
+  const Artifact.directory()
+    : _fileName = '',
+      isExecutable = false,
+      isPatchedSdk = false,
+      isFuchsiaRunner = false;
+
+  final String _fileName;
+  final bool isExecutable;
+  final bool isPatchedSdk;
+  final bool isFuchsiaRunner;
+
+  String? getFileName(Platform hostPlatform, [BuildMode? mode]) {
+    if (isPatchedSdk) {
+      assert(false, 'No filename for sdk path, should not be invoked');
+      return null;
+    }
+    if (isFuchsiaRunner) {
+      assert(mode != null, 'BuildMode is required for fuchsiaFlutterRunner');
+      final jitOrAot = mode!.isJit ? '_jit' : '_aot';
+      final productOrNo = mode.isRelease ? '_product' : '';
+      return 'flutter$jitOrAot${productOrNo}_runner-0.far';
+    }
+    final exe = (isExecutable && hostPlatform.isWindows) ? '.exe' : '';
+    return '$_fileName$exe';
+  }
 }
 
 /// A subset of [Artifact]s that are platform and build mode independent
 enum HostArtifact {
   /// The root of the web implementation of the dart SDK.
-  flutterWebSdk,
+  flutterWebSdk.directory(),
 
   /// The libraries JSON file for web release builds.
-  flutterWebLibrariesJson,
+  flutterWebLibrariesJson('libraries.json'),
 
   // The flutter.js bootstrapping file provided by the engine.
-  flutterJsDirectory,
+  flutterJsDirectory('flutter_js'),
 
   /// Folder that contains platform dill files for the web sdk.
-  webPlatformKernelFolder,
+  webPlatformKernelFolder('kernel'),
 
   // **NOTE**: All of the precompiled SDKs, summaries, and source maps are
   // strictly with sound null-safety, there is no longer support for unsound
@@ -109,34 +142,56 @@ enum HostArtifact {
   // See https://github.com/flutter/flutter/issues/162846.
 
   /// The summary dill for the dartdevc target.
-  webPlatformDDCKernelDill,
+  webPlatformDDCKernelDill('ddc_outline.dill'),
 
   /// The summary dill for the dart2js target.
-  webPlatformDart2JSKernelDill,
+  webPlatformDart2JSKernelDill('dart2js_platform.dill'),
 
   /// The precompiled SDKs and sourcemaps for web debug builds with the AMD module system.
   // TODO(markzipan): delete these when DDC's AMD module system is deprecated, https://github.com/flutter/flutter/issues/142060.
-  webPrecompiledAmdCanvaskitSdk,
-  webPrecompiledAmdCanvaskitSdkSourcemaps,
+  webPrecompiledAmdCanvaskitSdk('dart_sdk.js'),
+  webPrecompiledAmdCanvaskitSdkSourcemaps('dart_sdk.js.map'),
 
   /// The precompiled SDKs and sourcemaps for web debug builds with the DDC
   /// library bundle module system. Only SDKs built with sound null-safety are
   /// provided here.
-  webPrecompiledDdcLibraryBundleCanvaskitSdk,
-  webPrecompiledDdcLibraryBundleCanvaskitSdkSourcemaps,
+  webPrecompiledDdcLibraryBundleCanvaskitSdk('dart_sdk.js'),
+  webPrecompiledDdcLibraryBundleCanvaskitSdkSourcemaps('dart_sdk.js.map'),
 
-  iosDeploy,
-  idevicesyslog,
-  idevicescreenshot,
-  iproxy,
+  iosDeploy('ios-deploy'),
+  idevicesyslog('idevicesyslog'),
+  idevicescreenshot('idevicescreenshot'),
+  iproxy('iproxy'),
 
   /// The root of the sky_engine package.
-  skyEnginePath,
+  skyEnginePath('sky_engine'),
 
   // The Impeller shader compiler.
-  impellerc,
+  impellerc('impellerc', isExecutable: true),
   // Impeller's tessellation library.
-  libtessellator,
+  libtessellator('libtessellator', isDll: true);
+
+  const HostArtifact(this._fileName, {this.isExecutable = false, this.isDll = false});
+
+  const HostArtifact.directory() : _fileName = '', isExecutable = false, isDll = false;
+
+  final String _fileName;
+  final bool isExecutable;
+  final bool isDll;
+
+  String getFileName(Platform platform) {
+    if (isDll) {
+      var dll = '.so';
+      if (platform.isWindows) {
+        dll = '.dll';
+      } else if (platform.isMacOS) {
+        dll = '.dylib';
+      }
+      return '$_fileName$dll';
+    }
+    final exe = (isExecutable && platform.isWindows) ? '.exe' : '';
+    return '$_fileName$exe';
+  }
 }
 
 // TODO(knopp): Remove once darwin artifacts are universal and moved out of darwin-x64
@@ -169,121 +224,6 @@ TargetPlatform? _mapTargetPlatform(TargetPlatform? targetPlatform) {
     case TargetPlatform.unsupported:
     case null:
       return targetPlatform;
-  }
-}
-
-String? _artifactToFileName(Artifact artifact, Platform hostPlatform, [BuildMode? mode]) {
-  final exe = hostPlatform.isWindows ? '.exe' : '';
-  switch (artifact) {
-    case Artifact.genSnapshot:
-      return 'gen_snapshot';
-    case Artifact.genSnapshotArm64:
-      return 'gen_snapshot_arm64';
-    case Artifact.genSnapshotRiscv64:
-      return 'gen_snapshot_riscv64';
-    case Artifact.genSnapshotX64:
-      return 'gen_snapshot_x64';
-    case Artifact.flutterTester:
-      return 'flutter_tester$exe';
-    case Artifact.flutterFramework:
-      return 'Flutter.framework';
-    case Artifact.flutterFrameworkDsym:
-      return 'Flutter.framework.dSYM';
-    case Artifact.flutterXcframework:
-      return 'Flutter.xcframework';
-    case Artifact.flutterMacOSFramework:
-      return 'FlutterMacOS.framework';
-    case Artifact.flutterMacOSFrameworkDsym:
-      return 'FlutterMacOS.framework.dSYM';
-    case Artifact.flutterMacOSXcframework:
-      return 'FlutterMacOS.xcframework';
-    case Artifact.vmSnapshotData:
-      return 'vm_isolate_snapshot.bin';
-    case Artifact.isolateSnapshotData:
-      return 'isolate_snapshot.bin';
-    case Artifact.icuData:
-      return 'icudtl.dat';
-    case Artifact.platformKernelDill:
-      return 'platform_strong.dill';
-    case Artifact.platformLibrariesJson:
-      return 'libraries.json';
-    case Artifact.flutterPatchedSdkPath:
-      assert(false, 'No filename for sdk path, should not be invoked');
-      return null;
-    case Artifact.engineDartSdkPath:
-      return 'dart-sdk';
-    case Artifact.engineDartBinary:
-      return 'dart$exe';
-    case Artifact.engineDartAotRuntime:
-      return 'dartaotruntime$exe';
-    case Artifact.frontendServerSnapshotForEngineDartSdk:
-      return 'frontend_server_aot.dart.snapshot';
-    case Artifact.linuxDesktopPath:
-      return '';
-    case Artifact.linuxHeaders:
-      return 'flutter_linux';
-    case Artifact.windowsCppClientWrapper:
-      return 'cpp_client_wrapper';
-    case Artifact.windowsDesktopPath:
-      return '';
-    case Artifact.skyEnginePath:
-      return 'sky_engine';
-    case Artifact.fuchsiaKernelCompiler:
-      return 'kernel_compiler.snapshot';
-    case Artifact.fuchsiaFlutterRunner:
-      final jitOrAot = mode!.isJit ? '_jit' : '_aot';
-      final productOrNo = mode.isRelease ? '_product' : '';
-      return 'flutter$jitOrAot${productOrNo}_runner-0.far';
-    case Artifact.fontSubset:
-      return 'font-subset$exe';
-    case Artifact.constFinder:
-      return 'const_finder.dart.snapshot';
-    case Artifact.flutterToolsFileGenerators:
-      return '';
-  }
-}
-
-String _hostArtifactToFileName(HostArtifact artifact, Platform platform) {
-  final exe = platform.isWindows ? '.exe' : '';
-  var dll = '.so';
-  if (platform.isWindows) {
-    dll = '.dll';
-  } else if (platform.isMacOS) {
-    dll = '.dylib';
-  }
-  switch (artifact) {
-    case HostArtifact.flutterWebSdk:
-      return '';
-    case HostArtifact.flutterJsDirectory:
-      return 'flutter_js';
-    case HostArtifact.iosDeploy:
-      return 'ios-deploy';
-    case HostArtifact.idevicesyslog:
-      return 'idevicesyslog';
-    case HostArtifact.idevicescreenshot:
-      return 'idevicescreenshot';
-    case HostArtifact.iproxy:
-      return 'iproxy';
-    case HostArtifact.skyEnginePath:
-      return 'sky_engine';
-    case HostArtifact.webPlatformKernelFolder:
-      return 'kernel';
-    case HostArtifact.webPlatformDDCKernelDill:
-      return 'ddc_outline.dill';
-    case HostArtifact.webPlatformDart2JSKernelDill:
-      return 'dart2js_platform.dill';
-    case HostArtifact.flutterWebLibrariesJson:
-      return 'libraries.json';
-    case HostArtifact.webPrecompiledAmdCanvaskitSdk:
-    case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSdk:
-      return 'dart_sdk.js';
-    case HostArtifact.webPrecompiledAmdCanvaskitSdkSourcemaps:
-    case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSdkSourcemaps:
-      return 'dart_sdk.js.map';
-    case HostArtifact.impellerc:
-      return 'impellerc$exe';
-    case HostArtifact.libtessellator:
-      return 'libtessellator$dll';
   }
 }
 
@@ -436,66 +376,36 @@ class CachedArtifacts implements Artifacts {
   FileSystemEntity getHostArtifact(HostArtifact artifact) {
     switch (artifact) {
       case HostArtifact.flutterWebSdk:
-        final String path = _getFlutterWebSdkPath();
-        return _fileSystem.directory(path);
       case HostArtifact.flutterWebLibrariesJson:
-        final String path = _fileSystem.path.join(
-          _getFlutterWebSdkPath(),
-          _hostArtifactToFileName(artifact, _platform),
-        );
-        return _fileSystem.file(path);
       case HostArtifact.flutterJsDirectory:
-        final String path = _fileSystem.path.join(_getFlutterWebSdkPath(), 'flutter_js');
-        return _fileSystem.directory(path);
       case HostArtifact.webPlatformKernelFolder:
-        final String path = _fileSystem.path.join(_getFlutterWebSdkPath(), 'kernel');
-        return _fileSystem.file(path);
       case HostArtifact.webPlatformDDCKernelDill:
       case HostArtifact.webPlatformDart2JSKernelDill:
-        final String path = _fileSystem.path.join(
-          _getFlutterWebSdkPath(),
-          'kernel',
-          _hostArtifactToFileName(artifact, _platform),
-        );
-        return _fileSystem.file(path);
       case HostArtifact.webPrecompiledAmdCanvaskitSdk:
       case HostArtifact.webPrecompiledAmdCanvaskitSdkSourcemaps:
-        final String path = _fileSystem.path.join(
-          _getFlutterWebSdkPath(),
-          'kernel',
-          'amd-canvaskit',
-          _hostArtifactToFileName(artifact, _platform),
-        );
-        return _fileSystem.file(path);
       case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSdk:
       case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSdkSourcemaps:
-        final String path = _fileSystem.path.join(
-          _getFlutterWebSdkPath(),
-          'kernel',
-          'ddcLibraryBundle-canvaskit',
-          _hostArtifactToFileName(artifact, _platform),
-        );
-        return _fileSystem.file(path);
+        return _resolveWebArtifact(artifact, _getFlutterWebSdkPath(), _fileSystem, _platform);
       case HostArtifact.idevicesyslog:
       case HostArtifact.idevicescreenshot:
-        final String artifactFileName = _hostArtifactToFileName(artifact, _platform);
+        final String artifactFileName = artifact.getFileName(_platform);
         return _cache.getArtifactDirectory('libimobiledevice').childFile(artifactFileName);
       case HostArtifact.skyEnginePath:
         final Directory dartPackageDirectory = _cache.getCacheDir('pkg');
         final String path = _fileSystem.path.join(
           dartPackageDirectory.path,
-          _hostArtifactToFileName(artifact, _platform),
+          artifact.getFileName(_platform),
         );
         return _fileSystem.directory(path);
       case HostArtifact.iosDeploy:
-        final String artifactFileName = _hostArtifactToFileName(artifact, _platform);
+        final String artifactFileName = artifact.getFileName(_platform);
         return _cache.getArtifactDirectory('ios-deploy').childFile(artifactFileName);
       case HostArtifact.iproxy:
-        final String artifactFileName = _hostArtifactToFileName(artifact, _platform);
+        final String artifactFileName = artifact.getFileName(_platform);
         return _cache.getArtifactDirectory('libusbmuxd').childFile(artifactFileName);
       case HostArtifact.impellerc:
       case HostArtifact.libtessellator:
-        final String artifactFileName = _hostArtifactToFileName(artifact, _platform);
+        final String artifactFileName = artifact.getFileName(_platform);
         final String engineDir = _getEngineArtifactsPath(
           _currentHostPlatform(_platform, _operatingSystemUtils),
         )!;
@@ -557,7 +467,7 @@ class CachedArtifacts implements Artifacts {
       case Artifact.genSnapshotArm64:
       case Artifact.genSnapshotRiscv64:
       case Artifact.genSnapshotX64:
-        return _fileSystem.path.join(engineDir, _artifactToFileName(artifact, _platform));
+        return _fileSystem.path.join(engineDir, artifact.getFileName(_platform));
       case Artifact.engineDartSdkPath:
       case Artifact.engineDartBinary:
       case Artifact.engineDartAotRuntime:
@@ -609,11 +519,7 @@ class CachedArtifacts implements Artifacts {
         }
 
         final String hostPlatformName = getNameForHostPlatform(hostPlatform);
-        return _fileSystem.path.join(
-          engineDir,
-          hostPlatformName,
-          _artifactToFileName(artifact, _platform),
-        );
+        return _fileSystem.path.join(engineDir, hostPlatformName, artifact.getFileName(_platform));
       case Artifact.engineDartSdkPath:
       case Artifact.engineDartBinary:
       case Artifact.engineDartAotRuntime:
@@ -657,7 +563,7 @@ class CachedArtifacts implements Artifacts {
       case Artifact.genSnapshotRiscv64:
       case Artifact.genSnapshotX64:
       case Artifact.flutterXcframework:
-        final String artifactFileName = _artifactToFileName(artifact, _platform)!;
+        final String artifactFileName = artifact.getFileName(_platform)!;
         final String engineDir = _getEngineArtifactsPath(platform, mode)!;
         return _fileSystem.path.join(engineDir, artifactFileName);
       case Artifact.flutterFramework:
@@ -714,13 +620,13 @@ class CachedArtifacts implements Artifacts {
         const artifactFileName = 'flutter_runner_patched_sdk';
         return _fileSystem.path.join(root, runtime, artifactFileName);
       case Artifact.platformKernelDill:
-        final String artifactFileName = _artifactToFileName(artifact, _platform, mode)!;
+        final String artifactFileName = artifact.getFileName(_platform, mode)!;
         return _fileSystem.path.join(root, runtime, 'flutter_runner_patched_sdk', artifactFileName);
       case Artifact.fuchsiaKernelCompiler:
-        final String artifactFileName = _artifactToFileName(artifact, _platform, mode)!;
+        final String artifactFileName = artifact.getFileName(_platform, mode)!;
         return _fileSystem.path.join(root, runtime, 'dart_binaries', artifactFileName);
       case Artifact.fuchsiaFlutterRunner:
-        final String artifactFileName = _artifactToFileName(artifact, _platform, mode)!;
+        final String artifactFileName = artifact.getFileName(_platform, mode)!;
         return _fileSystem.path.join(root, runtime, artifactFileName);
       case Artifact.constFinder:
       case Artifact.flutterFramework:
@@ -776,7 +682,7 @@ class CachedArtifacts implements Artifacts {
           _dartSdkPath(_cache),
           'bin',
           'snapshots',
-          _artifactToFileName(artifact, _platform),
+          artifact.getFileName(_platform),
         );
       case Artifact.flutterTester:
       case Artifact.vmSnapshotData:
@@ -787,18 +693,18 @@ class CachedArtifacts implements Artifacts {
         return _fileSystem.path.join(
           engineArtifactsPath,
           platformDirName,
-          _artifactToFileName(artifact, _platform, mode),
+          artifact.getFileName(_platform, mode),
         );
       case Artifact.platformKernelDill:
         return _fileSystem.path.join(
           _getFlutterPatchedSdkPath(mode),
-          _artifactToFileName(artifact, _platform),
+          artifact.getFileName(_platform),
         );
       case Artifact.platformLibrariesJson:
         return _fileSystem.path.join(
           _getFlutterPatchedSdkPath(mode),
           'lib',
-          _artifactToFileName(artifact, _platform),
+          artifact.getFileName(_platform),
         );
       case Artifact.flutterPatchedSdkPath:
         return _getFlutterPatchedSdkPath(mode);
@@ -806,11 +712,7 @@ class CachedArtifacts implements Artifacts {
         return _dartSdkPath(_cache);
       case Artifact.engineDartBinary:
       case Artifact.engineDartAotRuntime:
-        return _fileSystem.path.join(
-          _dartSdkPath(_cache),
-          'bin',
-          _artifactToFileName(artifact, _platform),
-        );
+        return _fileSystem.path.join(_dartSdkPath(_cache), 'bin', artifact.getFileName(_platform));
       case Artifact.flutterMacOSFramework:
         String platformDirName = _enginePlatformDirectoryName(platform);
         if (mode == BuildMode.profile || mode == BuildMode.release) {
@@ -848,7 +750,7 @@ class CachedArtifacts implements Artifacts {
         return _fileSystem.path.join(
           engineArtifactsPath,
           platformDirName,
-          _artifactToFileName(artifact, _platform, mode),
+          artifact.getFileName(_platform, mode),
         );
       case Artifact.windowsCppClientWrapper:
         final String platformDirName = _enginePlatformDirectoryName(platform);
@@ -856,20 +758,17 @@ class CachedArtifacts implements Artifacts {
         return _fileSystem.path.join(
           engineArtifactsPath,
           platformDirName,
-          _artifactToFileName(artifact, _platform, mode),
+          artifact.getFileName(_platform, mode),
         );
       case Artifact.skyEnginePath:
         final Directory dartPackageDirectory = _cache.getCacheDir('pkg');
-        return _fileSystem.path.join(
-          dartPackageDirectory.path,
-          _artifactToFileName(artifact, _platform),
-        );
+        return _fileSystem.path.join(dartPackageDirectory.path, artifact.getFileName(_platform));
       case Artifact.fontSubset:
       case Artifact.constFinder:
         return _cache
             .getArtifactDirectory('engine')
             .childDirectory(_enginePlatformDirectoryName(platform))
-            .childFile(_artifactToFileName(artifact, _platform, mode)!)
+            .childFile(artifact.getFileName(_platform, mode)!)
             .path;
       case Artifact.flutterFramework:
       case Artifact.flutterFrameworkDsym:
@@ -957,7 +856,7 @@ Directory _getIosFlutterFrameworkPlatformDirectory(
 ) {
   final Directory xcframeworkDirectory = fileSystem
       .directory(engineDirectory)
-      .childDirectory(_artifactToFileName(Artifact.flutterXcframework, hostPlatform)!);
+      .childDirectory(Artifact.flutterXcframework.getFileName(hostPlatform)!);
 
   if (!xcframeworkDirectory.existsSync()) {
     throwToolExit(
@@ -995,9 +894,7 @@ String _getIosFrameworkPath(
     fileSystem,
     hostPlatform,
   );
-  return platformDir
-      .childDirectory(_artifactToFileName(Artifact.flutterFramework, hostPlatform)!)
-      .path;
+  return platformDir.childDirectory(Artifact.flutterFramework.getFileName(hostPlatform)!).path;
 }
 
 /// Returns the path to Flutter.framework.dSYM.
@@ -1015,7 +912,7 @@ String _getIosFrameworkDsymPath(
   );
   return platformDir
       .childDirectory('dSYMs')
-      .childDirectory(_artifactToFileName(Artifact.flutterFrameworkDsym, hostPlatform)!)
+      .childDirectory(Artifact.flutterFrameworkDsym.getFileName(hostPlatform)!)
       .path;
 }
 
@@ -1032,7 +929,7 @@ Directory _getMacOSFrameworkPlatformDirectory(
 ) {
   final Directory xcframeworkDirectory = fileSystem
       .directory(engineDirectory)
-      .childDirectory(_artifactToFileName(Artifact.flutterMacOSXcframework, hostPlatform)!);
+      .childDirectory(Artifact.flutterMacOSXcframework.getFileName(hostPlatform)!);
 
   if (!xcframeworkDirectory.existsSync()) {
     throwToolExit(
@@ -1064,7 +961,7 @@ String _getMacOSFrameworkPath(
     hostPlatform,
   );
   return platformDirectory
-      .childDirectory(_artifactToFileName(Artifact.flutterMacOSFramework, hostPlatform)!)
+      .childDirectory(Artifact.flutterMacOSFramework.getFileName(hostPlatform)!)
       .path;
 }
 
@@ -1081,7 +978,7 @@ String _getMacOSFrameworkDsymPath(
   );
   return platformDirectory
       .childDirectory('dSYMs')
-      .childDirectory(_artifactToFileName(Artifact.flutterMacOSFrameworkDsym, hostPlatform)!)
+      .childDirectory(Artifact.flutterMacOSFrameworkDsym.getFileName(hostPlatform)!)
       .path;
 }
 
@@ -1101,7 +998,6 @@ class CachedLocalEngineArtifacts implements Artifacts {
          targetOutPath: engineOutPath,
          hostOutPath: _hostEngineOutPath,
        ),
-       _cache = cache,
        _processManager = processManager,
        _platform = platform,
        _operatingSystemUtils = operatingSystemUtils,
@@ -1119,7 +1015,6 @@ class CachedLocalEngineArtifacts implements Artifacts {
 
   final String _hostEngineOutPath;
   final FileSystem _fileSystem;
-  final Cache _cache;
   final ProcessManager _processManager;
   final Platform _platform;
   final OperatingSystemUtils _operatingSystemUtils;
@@ -1128,67 +1023,9 @@ class CachedLocalEngineArtifacts implements Artifacts {
   @override
   FileSystemEntity getHostArtifact(HostArtifact artifact) {
     switch (artifact) {
-      case HostArtifact.flutterWebSdk:
-        final String path = _getFlutterWebSdkPath();
-        return _fileSystem.directory(path);
-      case HostArtifact.flutterWebLibrariesJson:
-        final String path = _fileSystem.path.join(
-          _getFlutterWebSdkPath(),
-          _hostArtifactToFileName(artifact, _platform),
-        );
-        return _fileSystem.file(path);
-      case HostArtifact.flutterJsDirectory:
-        final String path = _fileSystem.path.join(_getFlutterWebSdkPath(), 'flutter_js');
-        return _fileSystem.directory(path);
-      case HostArtifact.webPlatformKernelFolder:
-        final String path = _fileSystem.path.join(_getFlutterWebSdkPath(), 'kernel');
-        return _fileSystem.file(path);
-      case HostArtifact.webPlatformDDCKernelDill:
-      case HostArtifact.webPlatformDart2JSKernelDill:
-        final String path = _fileSystem.path.join(
-          _getFlutterWebSdkPath(),
-          'kernel',
-          _hostArtifactToFileName(artifact, _platform),
-        );
-        return _fileSystem.file(path);
-      case HostArtifact.webPrecompiledAmdCanvaskitSdk:
-      case HostArtifact.webPrecompiledAmdCanvaskitSdkSourcemaps:
-        final String path = _fileSystem.path.join(
-          _getFlutterWebSdkPath(),
-          'kernel',
-          'amd-canvaskit',
-          _hostArtifactToFileName(artifact, _platform),
-        );
-        return _fileSystem.file(path);
-      case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSdk:
-      case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSdkSourcemaps:
-        final String path = _fileSystem.path.join(
-          _getFlutterWebSdkPath(),
-          'kernel',
-          'ddcLibraryBundle-canvaskit',
-          _hostArtifactToFileName(artifact, _platform),
-        );
-        return _fileSystem.file(path);
-      case HostArtifact.idevicesyslog:
-      case HostArtifact.idevicescreenshot:
-        final String artifactFileName = _hostArtifactToFileName(artifact, _platform);
-        return _cache.getArtifactDirectory('libimobiledevice').childFile(artifactFileName);
-      case HostArtifact.skyEnginePath:
-        final Directory dartPackageDirectory = _cache.getCacheDir('pkg');
-        final String path = _fileSystem.path.join(
-          dartPackageDirectory.path,
-          _hostArtifactToFileName(artifact, _platform),
-        );
-        return _fileSystem.directory(path);
-      case HostArtifact.iosDeploy:
-        final String artifactFileName = _hostArtifactToFileName(artifact, _platform);
-        return _cache.getArtifactDirectory('ios-deploy').childFile(artifactFileName);
-      case HostArtifact.iproxy:
-        final String artifactFileName = _hostArtifactToFileName(artifact, _platform);
-        return _cache.getArtifactDirectory('libusbmuxd').childFile(artifactFileName);
       case HostArtifact.impellerc:
       case HostArtifact.libtessellator:
-        final String artifactFileName = _hostArtifactToFileName(artifact, _platform);
+        final String artifactFileName = artifact.getFileName(_platform);
         final File file = _fileSystem.file(
           _fileSystem.path.join(_hostEngineOutPath, artifactFileName),
         );
@@ -1196,6 +1033,22 @@ class CachedLocalEngineArtifacts implements Artifacts {
           return _backupCache.getHostArtifact(artifact);
         }
         return file;
+      case HostArtifact.flutterWebSdk:
+      case HostArtifact.flutterWebLibrariesJson:
+      case HostArtifact.flutterJsDirectory:
+      case HostArtifact.webPlatformKernelFolder:
+      case HostArtifact.webPlatformDDCKernelDill:
+      case HostArtifact.webPlatformDart2JSKernelDill:
+      case HostArtifact.webPrecompiledAmdCanvaskitSdk:
+      case HostArtifact.webPrecompiledAmdCanvaskitSdkSourcemaps:
+      case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSdk:
+      case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSdkSourcemaps:
+      case HostArtifact.idevicesyslog:
+      case HostArtifact.idevicescreenshot:
+      case HostArtifact.skyEnginePath:
+      case HostArtifact.iosDeploy:
+      case HostArtifact.iproxy:
+        return _backupCache.getHostArtifact(artifact);
     }
   }
 
@@ -1211,7 +1064,7 @@ class CachedLocalEngineArtifacts implements Artifacts {
     final isDirectoryArtifact = artifact == Artifact.flutterPatchedSdkPath;
     final String? artifactFileName = isDirectoryArtifact
         ? null
-        : _artifactToFileName(artifact, _platform, mode);
+        : artifact.getFileName(_platform, mode);
     switch (artifact) {
       case Artifact.genSnapshot:
       case Artifact.genSnapshotArm64:
@@ -1332,8 +1185,8 @@ class CachedLocalEngineArtifacts implements Artifacts {
 
     // If we couldn't find a built dart sdk, let's look for a prebuilt one.
     final String prebuiltPath = _fileSystem.path.join(
-      _getFlutterPrebuiltsPath(),
-      _getPrebuiltTarget(),
+      _getFlutterPrebuiltsPath(_hostEngineOutPath, _fileSystem),
+      _getPrebuiltTarget(_platform, _operatingSystemUtils),
       'dart-sdk',
     );
     if (_fileSystem.isDirectorySync(prebuiltPath)) {
@@ -1343,47 +1196,6 @@ class CachedLocalEngineArtifacts implements Artifacts {
     throwToolExit(
       'Unable to find a built dart sdk at: "$builtPath" or a prebuilt dart sdk at: "$prebuiltPath"',
     );
-  }
-
-  String _getFlutterPrebuiltsPath() {
-    final String engineSrcPath = _fileSystem.path.dirname(
-      _fileSystem.path.dirname(_hostEngineOutPath),
-    );
-    return _fileSystem.path.join(engineSrcPath, 'flutter', 'prebuilts');
-  }
-
-  String _getPrebuiltTarget() {
-    final TargetPlatform hostPlatform = _currentHostPlatform(_platform, _operatingSystemUtils);
-    switch (hostPlatform) {
-      case TargetPlatform.darwin:
-        return 'macos-x64';
-      case TargetPlatform.linux_riscv64:
-        return 'linux-riscv64';
-      case TargetPlatform.linux_arm64:
-        return 'linux-arm64';
-      case TargetPlatform.linux_x64:
-        return 'linux-x64';
-      case TargetPlatform.windows_x64:
-        return 'windows-x64';
-      case TargetPlatform.windows_arm64:
-        return 'windows-arm64';
-      case TargetPlatform.ios:
-      case TargetPlatform.android:
-      case TargetPlatform.android_arm:
-      case TargetPlatform.android_arm64:
-      case TargetPlatform.android_x64:
-      case TargetPlatform.fuchsia_arm64:
-      case TargetPlatform.fuchsia_x64:
-      case TargetPlatform.web_javascript:
-      case TargetPlatform.tester:
-        throwToolExit('Unsupported host platform: $hostPlatform');
-      case TargetPlatform.unsupported:
-        TargetPlatform.throwUnsupportedTarget();
-    }
-  }
-
-  String _getFlutterWebSdkPath() {
-    return _fileSystem.path.join(localEngineInfo.targetOutPath, 'flutter_web_sdk');
   }
 
   String _genSnapshotPath(Artifact artifact) {
@@ -1396,7 +1208,7 @@ class CachedLocalEngineArtifacts implements Artifacts {
       'clang_arm64',
       'clang_riscv64',
     ];
-    final String genSnapshotName = _artifactToFileName(artifact, _platform)!;
+    final String genSnapshotName = artifact.getFileName(_platform)!;
     for (final clangDir in clangDirs) {
       final String genSnapshotPath = _fileSystem.path.join(
         localEngineInfo.targetOutPath,
@@ -1413,7 +1225,7 @@ class CachedLocalEngineArtifacts implements Artifacts {
   String _flutterTesterPath(TargetPlatform platform) {
     return _fileSystem.path.join(
       localEngineInfo.hostOutPath,
-      _artifactToFileName(Artifact.flutterTester, _platform),
+      Artifact.flutterTester.getFileName(_platform),
     );
   }
 
@@ -1456,14 +1268,14 @@ class CachedLocalWebSdkArtifacts implements Artifacts {
           return _fileSystem.path.join(
             _getDartSdkPath(),
             'bin',
-            _artifactToFileName(artifact, _platform, mode),
+            artifact.getFileName(_platform, mode),
           );
         case Artifact.frontendServerSnapshotForEngineDartSdk:
           return _fileSystem.path.join(
             _getDartSdkPath(),
             'bin',
             'snapshots',
-            _artifactToFileName(artifact, _platform, mode),
+            artifact.getFileName(_platform, mode),
           );
         case Artifact.genSnapshot:
         case Artifact.genSnapshotArm64:
@@ -1511,46 +1323,16 @@ class CachedLocalWebSdkArtifacts implements Artifacts {
   FileSystemEntity getHostArtifact(HostArtifact artifact) {
     switch (artifact) {
       case HostArtifact.flutterWebSdk:
-        final String path = _getFlutterWebSdkPath();
-        return _fileSystem.directory(path);
       case HostArtifact.flutterWebLibrariesJson:
-        final String path = _fileSystem.path.join(
-          _getFlutterWebSdkPath(),
-          _hostArtifactToFileName(artifact, _platform),
-        );
-        return _fileSystem.file(path);
       case HostArtifact.flutterJsDirectory:
-        final String path = _fileSystem.path.join(_getFlutterWebSdkPath(), 'flutter_js');
-        return _fileSystem.directory(path);
       case HostArtifact.webPlatformKernelFolder:
-        final String path = _fileSystem.path.join(_getFlutterWebSdkPath(), 'kernel');
-        return _fileSystem.file(path);
       case HostArtifact.webPlatformDDCKernelDill:
       case HostArtifact.webPlatformDart2JSKernelDill:
-        final String path = _fileSystem.path.join(
-          _getFlutterWebSdkPath(),
-          'kernel',
-          _hostArtifactToFileName(artifact, _platform),
-        );
-        return _fileSystem.file(path);
       case HostArtifact.webPrecompiledAmdCanvaskitSdk:
       case HostArtifact.webPrecompiledAmdCanvaskitSdkSourcemaps:
-        final String path = _fileSystem.path.join(
-          _getFlutterWebSdkPath(),
-          'kernel',
-          'amd-canvaskit',
-          _hostArtifactToFileName(artifact, _platform),
-        );
-        return _fileSystem.file(path);
       case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSdk:
       case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSdkSourcemaps:
-        final String path = _fileSystem.path.join(
-          _getFlutterWebSdkPath(),
-          'kernel',
-          'ddcLibraryBundle-canvaskit',
-          _hostArtifactToFileName(artifact, _platform),
-        );
-        return _fileSystem.file(path);
+        return _resolveWebArtifact(artifact, _getFlutterWebSdkPath(), _fileSystem, _platform);
       case HostArtifact.iosDeploy:
       case HostArtifact.idevicesyslog:
       case HostArtifact.idevicescreenshot:
@@ -1570,8 +1352,8 @@ class CachedLocalWebSdkArtifacts implements Artifacts {
 
     // If we couldn't find a built dart sdk, let's look for a prebuilt one.
     final String prebuiltPath = _fileSystem.path.join(
-      _getFlutterPrebuiltsPath(),
-      _getPrebuiltTarget(),
+      _getFlutterPrebuiltsPath(_webSdkPath, _fileSystem),
+      _getPrebuiltTarget(_platform, _operatingSystemUtils),
       'dart-sdk',
     );
     if (_fileSystem.isDirectorySync(prebuiltPath)) {
@@ -1579,41 +1361,6 @@ class CachedLocalWebSdkArtifacts implements Artifacts {
     }
 
     throwToolExit('Unable to find a prebuilt dart sdk at: "$prebuiltPath"');
-  }
-
-  String _getFlutterPrebuiltsPath() {
-    final String engineSrcPath = _fileSystem.path.dirname(_fileSystem.path.dirname(_webSdkPath));
-    return _fileSystem.path.join(engineSrcPath, 'flutter', 'prebuilts');
-  }
-
-  String _getPrebuiltTarget() {
-    final TargetPlatform hostPlatform = _currentHostPlatform(_platform, _operatingSystemUtils);
-    switch (hostPlatform) {
-      case TargetPlatform.darwin:
-        return 'macos-x64';
-      case TargetPlatform.linux_arm64:
-        return 'linux-arm64';
-      case TargetPlatform.linux_riscv64:
-        return 'linux-riscv64';
-      case TargetPlatform.linux_x64:
-        return 'linux-x64';
-      case TargetPlatform.windows_x64:
-        return 'windows-x64';
-      case TargetPlatform.windows_arm64:
-        return 'windows-arm64';
-      case TargetPlatform.ios:
-      case TargetPlatform.android:
-      case TargetPlatform.android_arm:
-      case TargetPlatform.android_arm64:
-      case TargetPlatform.android_x64:
-      case TargetPlatform.fuchsia_arm64:
-      case TargetPlatform.fuchsia_x64:
-      case TargetPlatform.web_javascript:
-      case TargetPlatform.tester:
-        throwToolExit('Unsupported host platform: $hostPlatform');
-      case TargetPlatform.unsupported:
-        TargetPlatform.throwUnsupportedTarget();
-    }
   }
 
   String _getFlutterWebSdkPath() {
@@ -1773,4 +1520,85 @@ String _getFileGeneratorsPath() {
     'web',
     'file_generators',
   );
+}
+
+FileSystemEntity _resolveWebArtifact(
+  HostArtifact artifact,
+  String webSdkPath,
+  FileSystem fileSystem,
+  Platform platform,
+) {
+  switch (artifact) {
+    case HostArtifact.flutterWebSdk:
+      return fileSystem.directory(webSdkPath);
+    case HostArtifact.flutterWebLibrariesJson:
+      return fileSystem.file(fileSystem.path.join(webSdkPath, artifact.getFileName(platform)));
+    case HostArtifact.flutterJsDirectory:
+      return fileSystem.directory(fileSystem.path.join(webSdkPath, artifact.getFileName(platform)));
+    case HostArtifact.webPlatformKernelFolder:
+      return fileSystem.file(fileSystem.path.join(webSdkPath, artifact.getFileName(platform)));
+    case HostArtifact.webPlatformDDCKernelDill:
+    case HostArtifact.webPlatformDart2JSKernelDill:
+      return fileSystem.file(
+        fileSystem.path.join(webSdkPath, 'kernel', artifact.getFileName(platform)),
+      );
+    case HostArtifact.webPrecompiledAmdCanvaskitSdk:
+    case HostArtifact.webPrecompiledAmdCanvaskitSdkSourcemaps:
+      return fileSystem.file(
+        fileSystem.path.join(webSdkPath, 'kernel', 'amd-canvaskit', artifact.getFileName(platform)),
+      );
+    case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSdk:
+    case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSdkSourcemaps:
+      return fileSystem.file(
+        fileSystem.path.join(
+          webSdkPath,
+          'kernel',
+          'ddcLibraryBundle-canvaskit',
+          artifact.getFileName(platform),
+        ),
+      );
+    case HostArtifact.iosDeploy:
+    case HostArtifact.idevicesyslog:
+    case HostArtifact.idevicescreenshot:
+    case HostArtifact.iproxy:
+    case HostArtifact.skyEnginePath:
+    case HostArtifact.impellerc:
+    case HostArtifact.libtessellator:
+      throw ArgumentError('Not a web artifact: $artifact');
+  }
+}
+
+String _getFlutterPrebuiltsPath(String baseOutPath, FileSystem fileSystem) {
+  final String engineSrcPath = fileSystem.path.dirname(fileSystem.path.dirname(baseOutPath));
+  return fileSystem.path.join(engineSrcPath, 'flutter', 'prebuilts');
+}
+
+String _getPrebuiltTarget(Platform platform, OperatingSystemUtils operatingSystemUtils) {
+  final TargetPlatform hostPlatform = _currentHostPlatform(platform, operatingSystemUtils);
+  switch (hostPlatform) {
+    case TargetPlatform.darwin:
+      return 'macos-x64';
+    case TargetPlatform.linux_riscv64:
+      return 'linux-riscv64';
+    case TargetPlatform.linux_arm64:
+      return 'linux-arm64';
+    case TargetPlatform.linux_x64:
+      return 'linux-x64';
+    case TargetPlatform.windows_x64:
+      return 'windows-x64';
+    case TargetPlatform.windows_arm64:
+      return 'windows-arm64';
+    case TargetPlatform.ios:
+    case TargetPlatform.android:
+    case TargetPlatform.android_arm:
+    case TargetPlatform.android_arm64:
+    case TargetPlatform.android_x64:
+    case TargetPlatform.fuchsia_arm64:
+    case TargetPlatform.fuchsia_x64:
+    case TargetPlatform.web_javascript:
+    case TargetPlatform.tester:
+      throwToolExit('Unsupported host platform: $hostPlatform');
+    case TargetPlatform.unsupported:
+      TargetPlatform.throwUnsupportedTarget();
+  }
 }

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -200,7 +200,7 @@ String _enginePlatformDirectoryName(TargetPlatform platform) {
   if (platform == TargetPlatform.darwin) {
     return 'darwin-x64';
   }
-  return getNameForTargetPlatform(platform);
+  return platform.getName();
 }
 
 // Remove android target platform type.

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -105,14 +105,15 @@ enum Artifact {
   final bool isPatchedSdk;
   final bool isFuchsiaRunner;
 
-  String? getFileName(Platform hostPlatform, [BuildMode? mode]) {
+  String getFileName(Platform hostPlatform, [BuildMode? mode]) {
     if (isPatchedSdk) {
-      assert(false, 'No filename for sdk path, should not be invoked');
-      return null;
+      throw StateError('No filename for sdk path, should not be invoked');
     }
     if (isFuchsiaRunner) {
-      assert(mode != null, 'BuildMode is required for fuchsiaFlutterRunner');
-      final jitOrAot = mode!.isJit ? '_jit' : '_aot';
+      if (mode == null) {
+        throw ArgumentError('BuildMode is required for fuchsiaFlutterRunner');
+      }
+      final jitOrAot = mode.isJit ? '_jit' : '_aot';
       final productOrNo = mode.isRelease ? '_product' : '';
       return 'flutter$jitOrAot${productOrNo}_runner-0.far';
     }
@@ -563,7 +564,7 @@ class CachedArtifacts implements Artifacts {
       case Artifact.genSnapshotRiscv64:
       case Artifact.genSnapshotX64:
       case Artifact.flutterXcframework:
-        final String artifactFileName = artifact.getFileName(_platform)!;
+        final String artifactFileName = artifact.getFileName(_platform);
         final String engineDir = _getEngineArtifactsPath(platform, mode)!;
         return _fileSystem.path.join(engineDir, artifactFileName);
       case Artifact.flutterFramework:
@@ -620,13 +621,13 @@ class CachedArtifacts implements Artifacts {
         const artifactFileName = 'flutter_runner_patched_sdk';
         return _fileSystem.path.join(root, runtime, artifactFileName);
       case Artifact.platformKernelDill:
-        final String artifactFileName = artifact.getFileName(_platform, mode)!;
+        final String artifactFileName = artifact.getFileName(_platform, mode);
         return _fileSystem.path.join(root, runtime, 'flutter_runner_patched_sdk', artifactFileName);
       case Artifact.fuchsiaKernelCompiler:
-        final String artifactFileName = artifact.getFileName(_platform, mode)!;
+        final String artifactFileName = artifact.getFileName(_platform, mode);
         return _fileSystem.path.join(root, runtime, 'dart_binaries', artifactFileName);
       case Artifact.fuchsiaFlutterRunner:
-        final String artifactFileName = artifact.getFileName(_platform, mode)!;
+        final String artifactFileName = artifact.getFileName(_platform, mode);
         return _fileSystem.path.join(root, runtime, artifactFileName);
       case Artifact.constFinder:
       case Artifact.flutterFramework:
@@ -768,7 +769,7 @@ class CachedArtifacts implements Artifacts {
         return _cache
             .getArtifactDirectory('engine')
             .childDirectory(_enginePlatformDirectoryName(platform))
-            .childFile(artifact.getFileName(_platform, mode)!)
+            .childFile(artifact.getFileName(_platform, mode))
             .path;
       case Artifact.flutterFramework:
       case Artifact.flutterFrameworkDsym:
@@ -856,7 +857,7 @@ Directory _getIosFlutterFrameworkPlatformDirectory(
 ) {
   final Directory xcframeworkDirectory = fileSystem
       .directory(engineDirectory)
-      .childDirectory(Artifact.flutterXcframework.getFileName(hostPlatform)!);
+      .childDirectory(Artifact.flutterXcframework.getFileName(hostPlatform));
 
   if (!xcframeworkDirectory.existsSync()) {
     throwToolExit(
@@ -894,7 +895,7 @@ String _getIosFrameworkPath(
     fileSystem,
     hostPlatform,
   );
-  return platformDir.childDirectory(Artifact.flutterFramework.getFileName(hostPlatform)!).path;
+  return platformDir.childDirectory(Artifact.flutterFramework.getFileName(hostPlatform)).path;
 }
 
 /// Returns the path to Flutter.framework.dSYM.
@@ -912,7 +913,7 @@ String _getIosFrameworkDsymPath(
   );
   return platformDir
       .childDirectory('dSYMs')
-      .childDirectory(Artifact.flutterFrameworkDsym.getFileName(hostPlatform)!)
+      .childDirectory(Artifact.flutterFrameworkDsym.getFileName(hostPlatform))
       .path;
 }
 
@@ -929,7 +930,7 @@ Directory _getMacOSFrameworkPlatformDirectory(
 ) {
   final Directory xcframeworkDirectory = fileSystem
       .directory(engineDirectory)
-      .childDirectory(Artifact.flutterMacOSXcframework.getFileName(hostPlatform)!);
+      .childDirectory(Artifact.flutterMacOSXcframework.getFileName(hostPlatform));
 
   if (!xcframeworkDirectory.existsSync()) {
     throwToolExit(
@@ -961,7 +962,7 @@ String _getMacOSFrameworkPath(
     hostPlatform,
   );
   return platformDirectory
-      .childDirectory(Artifact.flutterMacOSFramework.getFileName(hostPlatform)!)
+      .childDirectory(Artifact.flutterMacOSFramework.getFileName(hostPlatform))
       .path;
 }
 
@@ -978,7 +979,7 @@ String _getMacOSFrameworkDsymPath(
   );
   return platformDirectory
       .childDirectory('dSYMs')
-      .childDirectory(Artifact.flutterMacOSFrameworkDsym.getFileName(hostPlatform)!)
+      .childDirectory(Artifact.flutterMacOSFrameworkDsym.getFileName(hostPlatform))
       .path;
 }
 
@@ -1208,7 +1209,7 @@ class CachedLocalEngineArtifacts implements Artifacts {
       'clang_arm64',
       'clang_riscv64',
     ];
-    final String genSnapshotName = artifact.getFileName(_platform)!;
+    final String genSnapshotName = artifact.getFileName(_platform);
     for (final clangDir in clangDirs) {
       final String genSnapshotPath = _fileSystem.path.join(
         localEngineInfo.targetOutPath,

--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -123,7 +123,7 @@ class AOTSnapshotter {
     assert(platform != TargetPlatform.ios || darwinArch != null);
 
     if (!_isValidAotPlatform(platform, buildMode)) {
-      _logger.printError('${getNameForTargetPlatform(platform)} does not support AOT compilation.');
+      _logger.printError('${platform.getName()} does not support AOT compilation.');
       return 1;
     }
 
@@ -226,7 +226,7 @@ class AOTSnapshotter {
     // The name of the debug file must contain additional information about
     // the architecture, since a single build command may produce
     // multiple debug files.
-    final String archName = getNameForTargetPlatform(platform, darwinArch: darwinArch);
+    final String archName = platform.getName(darwinArch: darwinArch);
     final debugFilename = 'app.$archName.symbols';
     final bool shouldSplitDebugInfo = splitDebugInfo?.isNotEmpty ?? false;
     if (shouldSplitDebugInfo) {

--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -622,3 +622,6 @@ enum HostPlatform {
   final String cliName;
   final String platformName;
 }
+
+@Deprecated('Use HostPlatform.cliName instead')
+String getNameForHostPlatform(HostPlatform platform) => platform.cliName;

--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -275,7 +275,7 @@ class _PosixUtils extends OperatingSystemUtils {
           '  exit code: ${hostPlatformCheck.exitCode}\n'
           '  stdout: ${hostPlatformCheck.stdout.trimRight()}\n'
           '  stderr: ${hostPlatformCheck.stderr.trimRight()}\n'
-          'Assuming host platform is ${getNameForHostPlatform(_hostPlatform!)}.',
+          'Assuming host platform is ${_hostPlatform!.cliName}.',
         );
       } else if (hostPlatformCheck.stdout.trim().endsWith('x86_64')) {
         _hostPlatform = HostPlatform.linux_x64;
@@ -377,7 +377,7 @@ class _MacOSUtils extends _PosixUtils {
         _processUtils.runSync(<String>['uname', '-m']),
       ];
       if (results.every((RunResult result) => result.exitCode == 0)) {
-        String osName = getNameForHostPlatform(hostPlatform);
+        String osName = hostPlatform.cliName;
         // If the script is running in Rosetta, "uname -m" will return x86_64.
         if (hostPlatform == HostPlatform.darwin_arm64 && results[3].stdout.contains('x86_64')) {
           osName = '$osName (Rosetta)';
@@ -609,33 +609,16 @@ String? findProjectRoot(FileSystem fileSystem, [String? directory]) {
 }
 
 enum HostPlatform {
-  darwin_x64,
-  darwin_arm64,
-  linux_x64,
-  linux_arm64,
-  linux_riscv64,
-  windows_x64,
-  windows_arm64;
+  darwin_x64('darwin-x64', 'x64'),
+  darwin_arm64('darwin-arm64', 'arm64'),
+  linux_x64('linux-x64', 'x64'),
+  linux_arm64('linux-arm64', 'arm64'),
+  linux_riscv64('linux-riscv64', 'riscv64'),
+  windows_x64('windows-x64', 'x64'),
+  windows_arm64('windows-arm64', 'arm64');
 
-  String get platformName => switch (this) {
-    darwin_x64 => 'x64',
-    darwin_arm64 => 'arm64',
-    linux_x64 => 'x64',
-    linux_arm64 => 'arm64',
-    linux_riscv64 => 'riscv64',
-    windows_x64 => 'x64',
-    windows_arm64 => 'arm64',
-  };
-}
+  const HostPlatform(this.cliName, this.platformName);
 
-String getNameForHostPlatform(HostPlatform platform) {
-  return switch (platform) {
-    HostPlatform.darwin_x64 => 'darwin-x64',
-    HostPlatform.darwin_arm64 => 'darwin-arm64',
-    HostPlatform.linux_x64 => 'linux-x64',
-    HostPlatform.linux_arm64 => 'linux-arm64',
-    HostPlatform.linux_riscv64 => 'linux-riscv64',
-    HostPlatform.windows_x64 => 'windows-x64',
-    HostPlatform.windows_arm64 => 'windows-arm64',
-  };
+  final String cliName;
+  final String platformName;
 }

--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -623,5 +623,6 @@ enum HostPlatform {
   final String platformName;
 }
 
+// flutter_ignore: deprecation_syntax (see analyze.dart)
 @Deprecated('Use HostPlatform.cliName instead')
 String getNameForHostPlatform(HostPlatform platform) => platform.cliName;

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -621,105 +621,108 @@ bool isEmulatorBuildMode(BuildMode mode) {
 }
 
 enum TargetPlatform {
-  android,
-  ios,
-  darwin,
-  linux_x64,
-  linux_arm64,
-  linux_riscv64,
-  windows_x64,
-  windows_arm64,
-  fuchsia_arm64,
-  fuchsia_x64,
-  tester,
-  web_javascript,
+  android('android'),
+  ios('ios'),
+  darwin('darwin'),
+  linux_x64('linux-x64'),
+  linux_arm64('linux-arm64'),
+  linux_riscv64('linux-riscv64'),
+  windows_x64('windows-x64'),
+  windows_arm64('windows-arm64'),
+  fuchsia_arm64('fuchsia-arm64'),
+  fuchsia_x64('fuchsia-x64'),
+  tester('flutter-tester'),
+  web_javascript('web-javascript'),
   // The arch specific android target platforms are soft-deprecated.
   // Instead of using TargetPlatform as a combination arch + platform
   // the code will be updated to carry arch information in [DarwinArch]
   // and [AndroidArch].
-  android_arm,
-  android_arm64,
-  android_x64,
-  unsupported;
+  android_arm('android-arm'),
+  android_arm64('android-arm64'),
+  android_x64('android-x64'),
+  unsupported('unsupported');
 
-  String get fuchsiaArchForTargetPlatform {
-    switch (this) {
-      case fuchsia_arm64:
-        return 'arm64';
-      case fuchsia_x64:
-        return 'x64';
-      case android:
-      case android_arm:
-      case android_arm64:
-      case android_x64:
-      case darwin:
-      case ios:
-      case linux_arm64:
-      case linux_riscv64:
-      case linux_x64:
-      case tester:
-      case web_javascript:
-      case windows_x64:
-      case windows_arm64:
-      case unsupported:
-        throw UnsupportedError('Unexpected Fuchsia platform $this');
-    }
+  const TargetPlatform(this._defaultName);
+
+  factory TargetPlatform.fromName(String name) {
+    return switch (name) {
+      'android' => TargetPlatform.android,
+      'android-arm' => TargetPlatform.android_arm,
+      'android-arm64' => TargetPlatform.android_arm64,
+      'android-x64' => TargetPlatform.android_x64,
+      'fuchsia-arm64' => TargetPlatform.fuchsia_arm64,
+      'fuchsia-x64' => TargetPlatform.fuchsia_x64,
+      'ios' => TargetPlatform.ios,
+      // For backward-compatibility and also for Tester, where it must match
+      // host platform name (HostPlatform.darwin_x64)
+      'darwin' || 'darwin-x64' || 'darwin-arm64' => TargetPlatform.darwin,
+      'linux-x64' => TargetPlatform.linux_x64,
+      'linux-arm64' => TargetPlatform.linux_arm64,
+      'linux-riscv64' => TargetPlatform.linux_riscv64,
+      'windows-x64' => TargetPlatform.windows_x64,
+      'windows-arm64' => TargetPlatform.windows_arm64,
+      'web-javascript' => TargetPlatform.web_javascript,
+      'flutter-tester' => TargetPlatform.tester,
+      _ => throw Exception('Unsupported platform name "$name"'),
+    };
   }
 
-  String get osName {
-    switch (this) {
-      case linux_x64:
-      case linux_arm64:
-      case linux_riscv64:
-        return 'linux';
-      case darwin:
-        return 'macos';
-      case windows_x64:
-      case windows_arm64:
-        return 'windows';
-      case android:
-      case android_arm:
-      case android_arm64:
-      case android_x64:
-        return 'android';
-      case fuchsia_arm64:
-      case fuchsia_x64:
-        return 'fuchsia';
-      case ios:
-        return 'ios';
-      case tester:
-        return 'flutter-tester';
-      case web_javascript:
-        return 'web';
-      case unsupported:
-        throw UnsupportedError('Unexpected target platform $this');
-    }
+  final String _defaultName;
+
+  String getName({DarwinArch? darwinArch}) {
+    return switch (this) {
+      TargetPlatform.ios when darwinArch != null => 'ios-${darwinArch.name}',
+      TargetPlatform.darwin when darwinArch != null => 'darwin-${darwinArch.name}',
+      _ => _defaultName,
+    };
   }
 
-  String get simpleName {
-    switch (this) {
-      case linux_x64:
-      case darwin:
-      case windows_x64:
-        return 'x64';
-      case linux_arm64:
-      case windows_arm64:
-        return 'arm64';
-      case linux_riscv64:
-        return 'riscv64';
-      case android:
-      case android_arm:
-      case android_arm64:
-      case android_x64:
-      case fuchsia_arm64:
-      case fuchsia_x64:
-      case ios:
-      case tester:
-      case web_javascript:
-      case unsupported:
-        throw UnsupportedError('Unexpected target platform $this');
-    }
-  }
+  String get fuchsiaArchForTargetPlatform => switch (this) {
+    fuchsia_arm64 => 'arm64',
+    fuchsia_x64 => 'x64',
+    android ||
+    android_arm ||
+    android_arm64 ||
+    android_x64 ||
+    darwin ||
+    ios ||
+    linux_arm64 ||
+    linux_riscv64 ||
+    linux_x64 ||
+    tester ||
+    web_javascript ||
+    windows_x64 ||
+    windows_arm64 ||
+    unsupported => throw UnsupportedError('Unexpected Fuchsia platform $this'),
+  };
+
+  String get osName => switch (this) {
+    linux_x64 || linux_arm64 || linux_riscv64 => 'linux',
+    darwin => 'macos',
+    windows_x64 || windows_arm64 => 'windows',
+    android || android_arm || android_arm64 || android_x64 => 'android',
+    fuchsia_arm64 || fuchsia_x64 => 'fuchsia',
+    ios => 'ios',
+    tester => 'flutter-tester',
+    web_javascript => 'web',
+    unsupported => throw UnsupportedError('Unexpected target platform $this'),
+  };
+
+  String get simpleName => switch (this) {
+    linux_x64 || darwin || windows_x64 => 'x64',
+    linux_arm64 || windows_arm64 => 'arm64',
+    linux_riscv64 => 'riscv64',
+    android ||
+    android_arm ||
+    android_arm64 ||
+    android_x64 ||
+    fuchsia_arm64 ||
+    fuchsia_x64 ||
+    ios ||
+    tester ||
+    web_javascript ||
+    unsupported => throw UnsupportedError('Unexpected target platform $this'),
+  };
 
   static Never throwUnsupportedTarget() =>
       throw UnsupportedError('Target platform is unsupported.');
@@ -828,52 +831,6 @@ List<DarwinArch> getDarwinArchsFromEnv(Map<String, String> defines) {
   const defaultDarwinArchitectures = <DarwinArch>[DarwinArch.x86_64, DarwinArch.arm64];
   return defines[kDarwinArchs]?.split(' ').map(getDarwinArchForName).toList() ??
       defaultDarwinArchitectures;
-}
-
-String getNameForTargetPlatform(TargetPlatform platform, {DarwinArch? darwinArch}) {
-  return switch (platform) {
-    TargetPlatform.ios when darwinArch != null => 'ios-${darwinArch.name}',
-    TargetPlatform.darwin when darwinArch != null => 'darwin-${darwinArch.name}',
-    TargetPlatform.ios => 'ios',
-    TargetPlatform.darwin => 'darwin',
-    TargetPlatform.android_arm => 'android-arm',
-    TargetPlatform.android_arm64 => 'android-arm64',
-    TargetPlatform.android_x64 => 'android-x64',
-    TargetPlatform.linux_x64 => 'linux-x64',
-    TargetPlatform.linux_arm64 => 'linux-arm64',
-    TargetPlatform.linux_riscv64 => 'linux-riscv64',
-    TargetPlatform.windows_x64 => 'windows-x64',
-    TargetPlatform.windows_arm64 => 'windows-arm64',
-    TargetPlatform.fuchsia_arm64 => 'fuchsia-arm64',
-    TargetPlatform.fuchsia_x64 => 'fuchsia-x64',
-    TargetPlatform.tester => 'flutter-tester',
-    TargetPlatform.web_javascript => 'web-javascript',
-    TargetPlatform.android => 'android',
-    TargetPlatform.unsupported => 'unsupported',
-  };
-}
-
-TargetPlatform getTargetPlatformForName(String platform) {
-  return switch (platform) {
-    'android' => TargetPlatform.android,
-    'android-arm' => TargetPlatform.android_arm,
-    'android-arm64' => TargetPlatform.android_arm64,
-    'android-x64' => TargetPlatform.android_x64,
-    'fuchsia-arm64' => TargetPlatform.fuchsia_arm64,
-    'fuchsia-x64' => TargetPlatform.fuchsia_x64,
-    'ios' => TargetPlatform.ios,
-    // For backward-compatibility and also for Tester, where it must match
-    // host platform name (HostPlatform.darwin_x64)
-    'darwin' || 'darwin-x64' || 'darwin-arm64' => TargetPlatform.darwin,
-    'linux-x64' => TargetPlatform.linux_x64,
-    'linux-arm64' => TargetPlatform.linux_arm64,
-    'linux-riscv64' => TargetPlatform.linux_riscv64,
-    'windows-x64' => TargetPlatform.windows_x64,
-    'windows-arm64' => TargetPlatform.windows_arm64,
-    'web-javascript' => TargetPlatform.web_javascript,
-    'flutter-tester' => TargetPlatform.tester,
-    _ => throw Exception('Unsupported platform name "$platform"'),
-  };
 }
 
 AndroidArch getAndroidArchForName(String platform) {

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -1188,3 +1188,13 @@ String? _uncapitalize(String? s) {
   }
   return s.substring(0, 1).toLowerCase() + s.substring(1);
 }
+
+@Deprecated('Use TargetPlatform.getName() instead')
+String getNameForTargetPlatform(TargetPlatform platform, {DarwinArch? darwinArch}) {
+  return platform.getName(darwinArch: darwinArch);
+}
+
+@Deprecated('Use TargetPlatform.fromName() instead')
+TargetPlatform getTargetPlatformForName(String platform) {
+  return TargetPlatform.fromName(platform);
+}

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -1189,11 +1189,13 @@ String? _uncapitalize(String? s) {
   return s.substring(0, 1).toLowerCase() + s.substring(1);
 }
 
+// flutter_ignore: deprecation_syntax (see analyze.dart)
 @Deprecated('Use TargetPlatform.getName() instead')
 String getNameForTargetPlatform(TargetPlatform platform, {DarwinArch? darwinArch}) {
   return platform.getName(darwinArch: darwinArch);
 }
 
+// flutter_ignore: deprecation_syntax (see analyze.dart)
 @Deprecated('Use TargetPlatform.fromName() instead')
 TargetPlatform getTargetPlatformForName(String platform) {
   return TargetPlatform.fromName(platform);

--- a/packages/flutter_tools/lib/src/build_system/targets/android.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/android.dart
@@ -177,13 +177,13 @@ class AndroidAot extends AotElfBase {
 
   /// The name of the produced Android ABI.
   String get _androidAbiName {
-    return getAndroidArchForName(getNameForTargetPlatform(targetPlatform)).archName;
+    return getAndroidArchForName(targetPlatform.getName()).archName;
   }
 
   @override
   String get name =>
       'android_aot_${buildMode.cliName}_'
-      '${getNameForTargetPlatform(targetPlatform)}';
+      '${targetPlatform.getName()}';
 
   /// The specific Android ABI we are building for.
   final TargetPlatform targetPlatform;
@@ -304,13 +304,13 @@ class AndroidAotBundle extends Target {
 
   /// The name of the produced Android ABI.
   String get _androidAbiName {
-    return getAndroidArchForName(getNameForTargetPlatform(dependency.targetPlatform)).archName;
+    return getAndroidArchForName(dependency.targetPlatform.getName()).archName;
   }
 
   @override
   String get name =>
       'android_aot_bundle_${dependency.buildMode.cliName}_'
-      '${getNameForTargetPlatform(dependency.targetPlatform)}';
+      '${dependency.targetPlatform.getName()}';
 
   TargetPlatform get targetPlatform => dependency.targetPlatform;
 
@@ -382,13 +382,13 @@ class AndroidAotDeferredComponentsBundle extends Target {
 
   /// The name of the produced Android ABI.
   String get _androidAbiName {
-    return getAndroidArchForName(getNameForTargetPlatform(dependency.targetPlatform)).archName;
+    return getAndroidArchForName(dependency.targetPlatform.getName()).archName;
   }
 
   @override
   String get name =>
       'android_aot_deferred_components_bundle_${dependency.buildMode.cliName}_'
-      '${getNameForTargetPlatform(dependency.targetPlatform)}';
+      '${dependency.targetPlatform.getName()}';
 
   TargetPlatform get targetPlatform => dependency.targetPlatform;
 

--- a/packages/flutter_tools/lib/src/build_system/targets/common.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/common.dart
@@ -205,7 +205,7 @@ class KernelSnapshot extends Target {
     final String targetFileAbsolute = environment.fileSystem.file(targetFile).absolute.path;
     // everything besides 'false' is considered to be enabled.
     final trackWidgetCreation = environment.defines[kTrackWidgetCreation] != 'false';
-    final TargetPlatform targetPlatform = getTargetPlatformForName(targetPlatformEnvironment);
+    final targetPlatform = TargetPlatform.fromName(targetPlatformEnvironment);
 
     // This configuration is all optional.
     final String? frontendServerStarterPath = environment.defines[kFrontendServerStarterPath];
@@ -386,7 +386,7 @@ abstract class AotElfBase extends Target {
       kExtraGenSnapshotOptions,
     );
     final buildMode = BuildMode.fromCliName(buildModeEnvironment);
-    final TargetPlatform targetPlatform = getTargetPlatformForName(targetPlatformEnvironment);
+    final targetPlatform = TargetPlatform.fromName(targetPlatformEnvironment);
     final String? splitDebugInfo = environment.defines[kSplitDebugInfo];
     final dartObfuscation = environment.defines[kDartObfuscation] == 'true';
     final String? codeSizeDirectory = environment.defines[kCodeSizeDirectory];

--- a/packages/flutter_tools/lib/src/build_system/targets/dart_plugin_registrant.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/dart_plugin_registrant.dart
@@ -50,7 +50,7 @@ class DartPluginRegistrantTarget extends Target {
     final String? platformName = environment.defines[kTargetPlatform];
     final TargetPlatform? targetPlatform = platformName == null
         ? null
-        : getTargetPlatformForName(platformName);
+        : TargetPlatform.fromName(platformName);
     // TODO(stuartmorgan): Investigate removing this check entirely; ideally the
     // source generation step shouldn't be platform dependent, and the generated
     // code should just do the right thing on every platform.

--- a/packages/flutter_tools/lib/src/build_system/targets/deferred_components.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/deferred_components.dart
@@ -39,9 +39,7 @@ class DeferredComponentsGenSnapshotValidatorTarget extends Target {
     return <String>[
       for (final AndroidAotDeferredComponentsBundle target in deferredComponentsDependencies)
         if (deferredComponentsTargets.contains(target.name))
-          getAndroidArchForName(
-            getNameForTargetPlatform(target.dependency.targetPlatform),
-          ).archName,
+          getAndroidArchForName(target.dependency.targetPlatform.getName()).archName,
     ];
   }
 

--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -69,7 +69,7 @@ abstract class AotAssemblyBase extends Target {
       kExtraGenSnapshotOptions,
     );
     final buildMode = BuildMode.fromCliName(environmentBuildMode);
-    final TargetPlatform targetPlatform = getTargetPlatformForName(environmentTargetPlatform);
+    final targetPlatform = TargetPlatform.fromName(environmentTargetPlatform);
     final String? splitDebugInfo = environment.defines[kSplitDebugInfo];
     final dartObfuscation = environment.defines[kDartObfuscation] == 'true';
     final List<DarwinArch> darwinArchs =

--- a/packages/flutter_tools/lib/src/build_system/targets/linux.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/linux.dart
@@ -202,7 +202,7 @@ class DebugBundleLinuxAssets extends BundleLinuxAssets {
   const DebugBundleLinuxAssets(super.targetPlatform);
 
   @override
-  String get name => 'debug_bundle_${getNameForTargetPlatform(targetPlatform)}_assets';
+  String get name => 'debug_bundle_${targetPlatform.getName()}_assets';
 
   @override
   List<Source> get inputs => <Source>[const Source.pattern('{BUILD_DIR}/app.dill')];
@@ -217,7 +217,7 @@ class ProfileBundleLinuxAssets extends BundleLinuxAssets {
   const ProfileBundleLinuxAssets(super.targetPlatform);
 
   @override
-  String get name => 'profile_bundle_${getNameForTargetPlatform(targetPlatform)}_assets';
+  String get name => 'profile_bundle_${targetPlatform.getName()}_assets';
 
   @override
   List<Source> get outputs => const <Source>[];
@@ -233,7 +233,7 @@ class ReleaseBundleLinuxAssets extends BundleLinuxAssets {
   const ReleaseBundleLinuxAssets(super.targetPlatform);
 
   @override
-  String get name => 'release_bundle_${getNameForTargetPlatform(targetPlatform)}_assets';
+  String get name => 'release_bundle_${targetPlatform.getName()}_assets';
 
   @override
   List<Source> get outputs => const <Source>[];

--- a/packages/flutter_tools/lib/src/build_system/targets/macos.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/macos.dart
@@ -286,7 +286,7 @@ class CompileMacOSFramework extends Target {
       environment.defines,
       kExtraGenSnapshotOptions,
     );
-    final TargetPlatform targetPlatform = getTargetPlatformForName(targetPlatformEnvironment);
+    final targetPlatform = TargetPlatform.fromName(targetPlatformEnvironment);
     final List<DarwinArch> darwinArchs = getDarwinArchsFromEnv(environment.defines);
     if (targetPlatform != TargetPlatform.darwin) {
       throw Exception('compile_macos_framework is only supported for darwin TargetPlatform.');

--- a/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
@@ -379,7 +379,7 @@ TargetPlatform _getTargetPlatformFromEnvironment(Environment environment, String
   if (targetPlatformEnvironment == null) {
     throw MissingDefineException(kTargetPlatform, name);
   }
-  return getTargetPlatformForName(targetPlatformEnvironment);
+  return TargetPlatform.fromName(targetPlatformEnvironment);
 }
 
 Future<FlutterNativeAssetsBuildRunner> createFlutterNativeAssetsBuildRunner(

--- a/packages/flutter_tools/lib/src/build_system/targets/windows.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/windows.dart
@@ -199,7 +199,7 @@ class ReleaseBundleWindowsAssets extends BundleWindowsAssets {
   const ReleaseBundleWindowsAssets(super.targetPlatform);
 
   @override
-  String get name => 'release_bundle_${getNameForTargetPlatform(targetPlatform)}_assets';
+  String get name => 'release_bundle_${targetPlatform.getName()}_assets';
 
   @override
   List<Source> get outputs => const <Source>[];
@@ -215,7 +215,7 @@ class ProfileBundleWindowsAssets extends BundleWindowsAssets {
   const ProfileBundleWindowsAssets(super.targetPlatform);
 
   @override
-  String get name => 'profile_bundle_${getNameForTargetPlatform(targetPlatform)}_assets';
+  String get name => 'profile_bundle_${targetPlatform.getName()}_assets';
 
   @override
   List<Source> get outputs => const <Source>[];
@@ -231,7 +231,7 @@ class DebugBundleWindowsAssets extends BundleWindowsAssets {
   const DebugBundleWindowsAssets(super.targetPlatform);
 
   @override
-  String get name => 'debug_bundle_${getNameForTargetPlatform(targetPlatform)}_assets';
+  String get name => 'debug_bundle_${targetPlatform.getName()}_assets';
 
   @override
   List<Source> get inputs => <Source>[const Source.pattern('{BUILD_DIR}/app.dill')];

--- a/packages/flutter_tools/lib/src/bundle_builder.dart
+++ b/packages/flutter_tools/lib/src/bundle_builder.dart
@@ -59,7 +59,7 @@ class BundleBuilder {
           : globals.flutterVersion.engineRevision,
       defines: <String, String>{
         // used by the KernelSnapshot target
-        kTargetPlatform: getNameForTargetPlatform(platform),
+        kTargetPlatform: platform.getName(),
         kTargetFile: mainPath,
         kDeferredComponents: 'false',
         ...buildInfo.toBuildSystemEnvironment(),

--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -194,7 +194,7 @@ class AssembleCommand extends FlutterCommand {
       return super.requiredArtifacts;
     }
 
-    final TargetPlatform targetPlatform = getTargetPlatformForName(platform);
+    final targetPlatform = TargetPlatform.fromName(platform);
     final DevelopmentArtifact? artifact = artifactFromTargetPlatform(targetPlatform);
     if (artifact != null) {
       return <DevelopmentArtifact>{artifact};

--- a/packages/flutter_tools/lib/src/commands/build_bundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_bundle.dart
@@ -109,7 +109,7 @@ class BuildBundleCommand extends BuildSubCommand {
   @override
   Future<FlutterCommandResult> runCommand() async {
     final String targetPlatform = stringArg('target-platform')!;
-    final TargetPlatform platform = getTargetPlatformForName(targetPlatform);
+    final platform = TargetPlatform.fromName(targetPlatform);
     // Check for target platforms that are only allowed via feature flags.
     switch (platform) {
       case TargetPlatform.darwin:

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -798,7 +798,7 @@ end
           flutterRootDir: globals.fs.directory(Cache.flutterRoot),
           defines: <String, String>{
             kTargetFile: targetFile,
-            kTargetPlatform: getNameForTargetPlatform(TargetPlatform.ios),
+            kTargetPlatform: TargetPlatform.ios.getName(),
             kIosArchs: defaultIOSArchsForEnvironment(
               sdkType,
               globals.artifacts!,

--- a/packages/flutter_tools/lib/src/commands/build_linux.dart
+++ b/packages/flutter_tools/lib/src/commands/build_linux.dart
@@ -69,7 +69,7 @@ class BuildLinuxCommand extends BuildSubCommand {
   @override
   Future<FlutterCommandResult> runCommand() async {
     final BuildInfo buildInfo = await getBuildInfo();
-    final TargetPlatform targetPlatform = getTargetPlatformForName(stringArg('target-platform')!);
+    final targetPlatform = TargetPlatform.fromName(stringArg('target-platform')!);
     final needCrossBuild =
         _operatingSystemUtils.hostPlatform.platformName != targetPlatform.simpleName;
 

--- a/packages/flutter_tools/lib/src/commands/build_macos_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_macos_framework.dart
@@ -258,7 +258,7 @@ end
         flutterRootDir: globals.fs.directory(Cache.flutterRoot),
         defines: <String, String>{
           kTargetFile: targetFile,
-          kTargetPlatform: getNameForTargetPlatform(TargetPlatform.darwin),
+          kTargetPlatform: TargetPlatform.darwin.getName(),
           kDarwinArchs: defaultMacOSArchsForEnvironment(
             globals.artifacts!,
           ).map((DarwinArch e) => e.name).join(' '),

--- a/packages/flutter_tools/lib/src/commands/build_swift_package.dart
+++ b/packages/flutter_tools/lib/src/commands/build_swift_package.dart
@@ -1258,7 +1258,7 @@ class AppFrameworkAndNativeAssetsDependencies {
       flutterRootDir: _utils.fileSystem.directory(_utils.flutterRoot),
       defines: <String, String>{
         kTargetFile: targetFile,
-        kTargetPlatform: getNameForTargetPlatform(platform.targetPlatform),
+        kTargetPlatform: platform.targetPlatform.getName(),
         ...await _platformDefines(platform, sdk),
         ...buildInfo.toBuildSystemEnvironment(),
         kBuildSwiftPackage: 'true',

--- a/packages/flutter_tools/lib/src/commands/build_windows.dart
+++ b/packages/flutter_tools/lib/src/commands/build_windows.dart
@@ -67,7 +67,7 @@ class BuildWindowsCommand extends BuildSubCommand {
     final defaultTargetPlatform = (_operatingSystemUtils.hostPlatform == HostPlatform.windows_arm64)
         ? 'windows-arm64'
         : 'windows-x64';
-    final TargetPlatform targetPlatform = getTargetPlatformForName(defaultTargetPlatform);
+    final targetPlatform = TargetPlatform.fromName(defaultTargetPlatform);
 
     await buildWindows(
       project.windows,

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -1151,7 +1151,7 @@ class DeviceDomain extends Domain {
 
   /// Creates an application package from a file in the temp directory.
   Future<String> uploadApplicationPackage(Map<String, Object?> args) async {
-    final TargetPlatform targetPlatform = getTargetPlatformForName(
+    final targetPlatform = TargetPlatform.fromName(
       _getStringArg(args, 'targetPlatform', required: true)!,
     );
     final File applicationBinary = daemon.proxyDomain.tempDirectory.childFile(
@@ -1409,7 +1409,7 @@ Future<Map<String, Object?>> _deviceToMap(Device device) async {
   return <String, Object?>{
     'id': device.id,
     'name': device.displayName,
-    'platform': getNameForTargetPlatform(await device.targetPlatform),
+    'platform': (await device.targetPlatform).getName(),
     'emulator': await device.isLocalEmulator,
     'category': device.category?.toString(),
     'platformType': device.platformType?.toString(),

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -555,7 +555,7 @@ class RunCommand extends RunCommandBase {
     if (devices!.length > 1) {
       return '$command/all';
     }
-    return '$command/${getNameForTargetPlatform(await devices![0].targetPlatform)}';
+    return '$command/${(await devices![0].targetPlatform).getName()}';
   }
 
   @override
@@ -598,7 +598,7 @@ class RunCommand extends RunCommandBase {
       if (device is IOSDevice && device.isWirelesslyConnected) {
         anyWirelessIOSDevices = true;
       }
-      deviceType = getNameForTargetPlatform(platform);
+      deviceType = platform.getName();
       deviceOsVersion = await device.sdkNameAndVersion;
       isEmulator = await device.isLocalEmulator;
     } else {
@@ -964,10 +964,7 @@ class RunCommand extends RunCommandBase {
       timingLabelParts: <String?>[
         if (hotMode) 'hot' else 'cold',
         getBuildMode().cliName,
-        if (devices!.length == 1)
-          getNameForTargetPlatform(await devices![0].targetPlatform)
-        else
-          'multiple',
+        if (devices!.length == 1) (await devices![0].targetPlatform).getName() else 'multiple',
         if (devices!.length == 1 && await devices![0].isLocalEmulator) 'emulator' else null,
       ],
       endTimeOverride: appStartedTime,

--- a/packages/flutter_tools/lib/src/custom_devices/custom_device_config.dart
+++ b/packages/flutter_tools/lib/src/custom_devices/custom_device_config.dart
@@ -135,7 +135,7 @@ class CustomDeviceConfig {
 
     late TargetPlatform? platform;
     try {
-      platform = archString == null ? null : getTargetPlatformForName(archString);
+      platform = archString == null ? null : TargetPlatform.fromName(archString);
     } on UnsupportedError {
       throw const CustomDeviceRevivalException.fromDescriptions(
         _kPlatform,
@@ -523,7 +523,7 @@ class CustomDeviceConfig {
       _kId: id,
       _kLabel: label,
       _kSdkNameAndVersion: sdkNameAndVersion,
-      _kPlatform: platform == null ? null : getNameForTargetPlatform(platform!),
+      _kPlatform: platform?.getName(),
       _kEnabled: enabled,
       _kPingCommand: pingCommand,
       _kPingSuccessRegex: pingSuccessRegex?.pattern,

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -708,8 +708,7 @@ abstract class Device {
   Future<TargetPlatform> get targetPlatform;
 
   /// Platform name for display only.
-  Future<String> get targetPlatformDisplayName async =>
-      getNameForTargetPlatform(await targetPlatform);
+  Future<String> get targetPlatformDisplayName async => (await targetPlatform).getName();
 
   Future<String> get sdkNameAndVersion;
 
@@ -883,7 +882,7 @@ abstract class Device {
       'name': name,
       'id': id,
       'isSupported': await isSupported(),
-      'targetPlatform': getNameForTargetPlatform(await targetPlatform),
+      'targetPlatform': (await targetPlatform).getName(),
       'emulator': isLocalEmu,
       'sdk': await sdkNameAndVersion,
       'capabilities': <String, Object>{

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -448,7 +448,7 @@ class ResidentWebRunner extends ResidentRunner {
       status = _logger.startProgress('Performing hot reload...', progressId: 'hot.reload');
     }
 
-    final String targetPlatform = getNameForTargetPlatform(TargetPlatform.web_javascript);
+    final String targetPlatform = TargetPlatform.web_javascript.getName();
     final String sdkName = await flutterDevice!.device!.sdkNameAndVersion;
 
     // Will be null if there is no report.

--- a/packages/flutter_tools/lib/src/linux/build_linux.dart
+++ b/packages/flutter_tools/lib/src/linux/build_linux.dart
@@ -115,7 +115,7 @@ Future<void> buildLinux(
   );
 
   if (buildInfo.codeSizeDirectory != null && sizeAnalyzer != null) {
-    final String arch = getNameForTargetPlatform(targetPlatform);
+    final String arch = targetPlatform.getName();
     final File codeSizeFile = globals.fs
         .directory(buildInfo.codeSizeDirectory)
         .childFile('snapshot.$arch.json');
@@ -175,7 +175,7 @@ Future<void> _runCmake(
       '-G',
       'Ninja',
       '-DCMAKE_BUILD_TYPE=$buildFlag',
-      '-DFLUTTER_TARGET_PLATFORM=${getNameForTargetPlatform(targetPlatform)}',
+      '-DFLUTTER_TARGET_PLATFORM=${targetPlatform.getName()}',
       // Support cross-building for arm64 targets on x64 hosts.
       // (Cross-building for x64 on arm64 hosts isn't supported now.)
       if (needCrossBuild) '-DFLUTTER_TARGET_PLATFORM_SYSROOT=$targetSysroot',

--- a/packages/flutter_tools/lib/src/proxied_devices/devices.dart
+++ b/packages/flutter_tools/lib/src/proxied_devices/devices.dart
@@ -119,7 +119,7 @@ class ProxiedDevices extends PollingDeviceDiscovery {
       enableDdsProxy: _enableDdsProxy,
       category: Category.fromString(_cast<String>(device['category'])),
       platformType: PlatformType.fromString(_cast<String>(device['platformType'])),
-      targetPlatform: getTargetPlatformForName(_cast<String>(device['platform'])),
+      targetPlatform: TargetPlatform.fromName(_cast<String>(device['platform'])),
       ephemeral: _cast<bool>(device['ephemeral']),
       isConnected: _cast<bool?>(device['isConnected']) ?? true,
       connectionInterface: connectionInterface ?? DeviceConnectionInterface.attached,
@@ -481,7 +481,7 @@ class ProxiedDevice extends Device {
 
     final String id = _cast<String>(
       await connection.sendRequest('device.uploadApplicationPackage', <String, Object>{
-        'targetPlatform': getNameForTargetPlatform(_targetPlatform),
+        'targetPlatform': _targetPlatform.getName(),
         'applicationBinary': fileName,
       }),
     );

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -156,7 +156,7 @@ class HotRunner extends ResidentRunner {
       case 1:
         final Device device = flutterDevices.first.device!;
         final TargetPlatform targetPlatform = await device.targetPlatform;
-        _targetPlatformName = getNameForTargetPlatform(targetPlatform);
+        _targetPlatformName = targetPlatform.getName();
         _targetPlatforms.add(targetPlatform);
         _sdkName = await device.sdkNameAndVersion;
         _emulator = await device.isLocalEmulator;

--- a/packages/flutter_tools/lib/src/windows/build_windows.dart
+++ b/packages/flutter_tools/lib/src/windows/build_windows.dart
@@ -136,7 +136,7 @@ Future<void> buildWindows(
   );
 
   if (buildInfo.codeSizeDirectory != null && sizeAnalyzer != null) {
-    final String arch = getNameForTargetPlatform(targetPlatform);
+    final String arch = targetPlatform.getName();
     final File codeSizeFile = globals.fs
         .directory(buildInfo.codeSizeDirectory)
         .childFile('snapshot.$arch.json');
@@ -200,7 +200,7 @@ Future<void> _runCmakeGeneration({
       generator,
       '-A',
       getCmakeWindowsArch(targetPlatform),
-      '-DFLUTTER_TARGET_PLATFORM=${getNameForTargetPlatform(targetPlatform)}',
+      '-DFLUTTER_TARGET_PLATFORM=${targetPlatform.getName()}',
     ], trace: true);
   } on ArgumentError {
     throwToolExit("cmake not found. Run 'flutter doctor' for more information.");

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -1991,8 +1991,7 @@ class FakeDevice extends Fake implements Device {
   Future<String> get sdkNameAndVersion => Future<String>.value(_sdkNameAndVersion);
 
   @override
-  Future<String> get targetPlatformDisplayName async =>
-      getNameForTargetPlatform(await targetPlatform);
+  Future<String> get targetPlatformDisplayName async => (await targetPlatform).getName();
 
   @override
   DeviceLogReader getLogReader({ApplicationPackage? app, bool includePastLogs = false}) {

--- a/packages/flutter_tools/test/general.shard/android/android_device_start_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_start_test.dart
@@ -54,7 +54,7 @@ void main() {
     TargetPlatform.android_x64,
   ]) {
     testWithoutContext('AndroidDevice.startApp allows release builds on $targetPlatform', () async {
-      final String arch = getAndroidArchForName(getNameForTargetPlatform(targetPlatform)).archName;
+      final String arch = getAndroidArchForName(targetPlatform.getName()).archName;
       final device = AndroidDevice(
         '1234',
         modelID: 'TestModel',

--- a/packages/flutter_tools/test/general.shard/build_info_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_info_test.dart
@@ -107,13 +107,10 @@ void main() {
   });
 
   testWithoutContext('getNameForTargetPlatform on Darwin arches', () {
-    expect(getNameForTargetPlatform(TargetPlatform.ios, darwinArch: DarwinArch.arm64), 'ios-arm64');
-    expect(getNameForTargetPlatform(TargetPlatform.ios, darwinArch: DarwinArch.armv7), 'ios-armv7');
-    expect(
-      getNameForTargetPlatform(TargetPlatform.ios, darwinArch: DarwinArch.x86_64),
-      'ios-x86_64',
-    );
-    expect(getNameForTargetPlatform(TargetPlatform.android), isNot(contains('ios')));
+    expect(TargetPlatform.ios.getName(darwinArch: DarwinArch.arm64), 'ios-arm64');
+    expect(TargetPlatform.ios.getName(darwinArch: DarwinArch.armv7), 'ios-armv7');
+    expect(TargetPlatform.ios.getName(darwinArch: DarwinArch.x86_64), 'ios-x86_64');
+    expect(TargetPlatform.android.getName(), isNot(contains('ios')));
   });
 
   testUsingContext(

--- a/packages/flutter_tools/test/general.shard/build_system/targets/common_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/common_test.dart
@@ -73,110 +73,98 @@ void main() {
     iosEnvironment.buildDir.createSync(recursive: true);
   });
 
-  testUsingContext(
-    'KernelSnapshot throws error if missing build mode',
-    () async {
-      androidEnvironment.defines.remove(kBuildMode);
-      expect(
-        const KernelSnapshot().build(androidEnvironment),
-        throwsA(isA<MissingDefineException>()),
-      );
-    },
-    overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()},
-  );
+  testUsingContext('KernelSnapshot throws error if missing build mode', () async {
+    androidEnvironment.defines.remove(kBuildMode);
+    expect(
+      const KernelSnapshot().build(androidEnvironment),
+      throwsA(isA<MissingDefineException>()),
+    );
+  }, overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()});
 
-  testUsingContext(
-    'KernelSnapshot handles null result from kernel compilation',
-    () async {
-      fileSystem.file('.dart_tool/package_config.json')
-        ..createSync(recursive: true)
-        ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
-      final String build = androidEnvironment.buildDir.path;
-      final String flutterPatchedSdkPath = artifacts.getArtifactPath(
-        Artifact.flutterPatchedSdkPath,
-        platform: TargetPlatform.android_arm,
-        mode: BuildMode.profile,
-      );
-      processManager.addCommands(<FakeCommand>[
-        FakeCommand(
-          command: <String>[
-            artifacts.getArtifactPath(Artifact.engineDartAotRuntime),
-            artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
-            '--sdk-root',
-            '$flutterPatchedSdkPath/',
-            '--target=flutter',
-            '--no-print-incremental-dependencies',
-            ...buildModeOptions(BuildMode.profile, <String>[]),
-            '--track-widget-creation',
-            '--aot',
-            '--tfa',
-            '--target-os',
-            'android',
-            '--packages',
-            '/.dart_tool/package_config.json',
-            '--output-dill',
-            '$build/app.dill',
-            '--depfile',
-            '$build/kernel_snapshot_program.d',
-            '--verbosity=error',
-            'file:///lib/main.dart',
-          ],
-          exitCode: 1,
-        ),
-      ]);
+  testUsingContext('KernelSnapshot handles null result from kernel compilation', () async {
+    fileSystem.file('.dart_tool/package_config.json')
+      ..createSync(recursive: true)
+      ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
+    final String build = androidEnvironment.buildDir.path;
+    final String flutterPatchedSdkPath = artifacts.getArtifactPath(
+      Artifact.flutterPatchedSdkPath,
+      platform: TargetPlatform.android_arm,
+      mode: BuildMode.profile,
+    );
+    processManager.addCommands(<FakeCommand>[
+      FakeCommand(
+        command: <String>[
+          artifacts.getArtifactPath(Artifact.engineDartAotRuntime),
+          artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
+          '--sdk-root',
+          '$flutterPatchedSdkPath/',
+          '--target=flutter',
+          '--no-print-incremental-dependencies',
+          ...buildModeOptions(BuildMode.profile, <String>[]),
+          '--track-widget-creation',
+          '--aot',
+          '--tfa',
+          '--target-os',
+          'android',
+          '--packages',
+          '/.dart_tool/package_config.json',
+          '--output-dill',
+          '$build/app.dill',
+          '--depfile',
+          '$build/kernel_snapshot_program.d',
+          '--verbosity=error',
+          'file:///lib/main.dart',
+        ],
+        exitCode: 1,
+      ),
+    ]);
 
-      await expectLater(() => const KernelSnapshot().build(androidEnvironment), throwsException);
-      expect(processManager, hasNoRemainingExpectations);
-    },
-    overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()},
-  );
+    await expectLater(() => const KernelSnapshot().build(androidEnvironment), throwsException);
+    expect(processManager, hasNoRemainingExpectations);
+  }, overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()});
 
-  testUsingContext(
-    'KernelSnapshot does use track widget creation on profile builds',
-    () async {
-      fileSystem.file('.dart_tool/package_config.json')
-        ..createSync(recursive: true)
-        ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
-      final String build = androidEnvironment.buildDir.path;
-      final String flutterPatchedSdkPath = artifacts.getArtifactPath(
-        Artifact.flutterPatchedSdkPath,
-        platform: TargetPlatform.android_arm,
-        mode: BuildMode.profile,
-      );
-      processManager.addCommands(<FakeCommand>[
-        FakeCommand(
-          command: <String>[
-            artifacts.getArtifactPath(Artifact.engineDartAotRuntime),
-            artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
-            '--sdk-root',
-            '$flutterPatchedSdkPath/',
-            '--target=flutter',
-            '--no-print-incremental-dependencies',
-            ...buildModeOptions(BuildMode.profile, <String>[]),
-            '--track-widget-creation',
-            '--aot',
-            '--tfa',
-            '--target-os',
-            'android',
-            '--packages',
-            '/.dart_tool/package_config.json',
-            '--output-dill',
-            '$build/app.dill',
-            '--depfile',
-            '$build/kernel_snapshot_program.d',
-            '--verbosity=error',
-            'file:///lib/main.dart',
-          ],
-          stdout: 'result $kBoundaryKey\n$kBoundaryKey\n$kBoundaryKey $build/app.dill 0\n',
-        ),
-      ]);
+  testUsingContext('KernelSnapshot does use track widget creation on profile builds', () async {
+    fileSystem.file('.dart_tool/package_config.json')
+      ..createSync(recursive: true)
+      ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
+    final String build = androidEnvironment.buildDir.path;
+    final String flutterPatchedSdkPath = artifacts.getArtifactPath(
+      Artifact.flutterPatchedSdkPath,
+      platform: TargetPlatform.android_arm,
+      mode: BuildMode.profile,
+    );
+    processManager.addCommands(<FakeCommand>[
+      FakeCommand(
+        command: <String>[
+          artifacts.getArtifactPath(Artifact.engineDartAotRuntime),
+          artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
+          '--sdk-root',
+          '$flutterPatchedSdkPath/',
+          '--target=flutter',
+          '--no-print-incremental-dependencies',
+          ...buildModeOptions(BuildMode.profile, <String>[]),
+          '--track-widget-creation',
+          '--aot',
+          '--tfa',
+          '--target-os',
+          'android',
+          '--packages',
+          '/.dart_tool/package_config.json',
+          '--output-dill',
+          '$build/app.dill',
+          '--depfile',
+          '$build/kernel_snapshot_program.d',
+          '--verbosity=error',
+          'file:///lib/main.dart',
+        ],
+        stdout: 'result $kBoundaryKey\n$kBoundaryKey\n$kBoundaryKey $build/app.dill 0\n',
+      ),
+    ]);
 
-      await const KernelSnapshot().build(androidEnvironment);
+    await const KernelSnapshot().build(androidEnvironment);
 
-      expect(processManager, hasNoRemainingExpectations);
-    },
-    overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()},
-  );
+    expect(processManager, hasNoRemainingExpectations);
+  }, overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()});
 
   testUsingContext(
     'KernelSnapshot correctly handles an empty string in ExtraFrontEndOptions',
@@ -225,157 +213,145 @@ void main() {
     overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()},
   );
 
-  testUsingContext(
-    'KernelSnapshot correctly forwards FrontendServerStarterPath',
-    () async {
-      fileSystem.file('.dart_tool/package_config.json')
-        ..createSync(recursive: true)
-        ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
-      final String build = androidEnvironment.buildDir.path;
-      final String flutterPatchedSdkPath = artifacts.getArtifactPath(
-        Artifact.flutterPatchedSdkPath,
-        platform: TargetPlatform.android_arm,
-        mode: BuildMode.profile,
-      );
-      processManager.addCommands(<FakeCommand>[
-        FakeCommand(
-          command: <String>[
-            artifacts.getArtifactPath(Artifact.engineDartBinary),
-            'path/to/frontend_server_starter.dart',
-            '--sdk-root',
-            '$flutterPatchedSdkPath/',
-            '--target=flutter',
-            '--no-print-incremental-dependencies',
-            ...buildModeOptions(BuildMode.profile, <String>[]),
-            '--track-widget-creation',
-            '--aot',
-            '--tfa',
-            '--target-os',
-            'android',
-            '--packages',
-            '/.dart_tool/package_config.json',
-            '--output-dill',
-            '$build/app.dill',
-            '--depfile',
-            '$build/kernel_snapshot_program.d',
-            '--verbosity=error',
-            'file:///lib/main.dart',
-          ],
-          stdout: 'result $kBoundaryKey\n$kBoundaryKey\n$kBoundaryKey $build/app.dill 0\n',
-        ),
-      ]);
+  testUsingContext('KernelSnapshot correctly forwards FrontendServerStarterPath', () async {
+    fileSystem.file('.dart_tool/package_config.json')
+      ..createSync(recursive: true)
+      ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
+    final String build = androidEnvironment.buildDir.path;
+    final String flutterPatchedSdkPath = artifacts.getArtifactPath(
+      Artifact.flutterPatchedSdkPath,
+      platform: TargetPlatform.android_arm,
+      mode: BuildMode.profile,
+    );
+    processManager.addCommands(<FakeCommand>[
+      FakeCommand(
+        command: <String>[
+          artifacts.getArtifactPath(Artifact.engineDartBinary),
+          'path/to/frontend_server_starter.dart',
+          '--sdk-root',
+          '$flutterPatchedSdkPath/',
+          '--target=flutter',
+          '--no-print-incremental-dependencies',
+          ...buildModeOptions(BuildMode.profile, <String>[]),
+          '--track-widget-creation',
+          '--aot',
+          '--tfa',
+          '--target-os',
+          'android',
+          '--packages',
+          '/.dart_tool/package_config.json',
+          '--output-dill',
+          '$build/app.dill',
+          '--depfile',
+          '$build/kernel_snapshot_program.d',
+          '--verbosity=error',
+          'file:///lib/main.dart',
+        ],
+        stdout: 'result $kBoundaryKey\n$kBoundaryKey\n$kBoundaryKey $build/app.dill 0\n',
+      ),
+    ]);
 
-      await const KernelSnapshot().build(
-        androidEnvironment
-          ..defines[kFrontendServerStarterPath] = 'path/to/frontend_server_starter.dart',
-      );
+    await const KernelSnapshot().build(
+      androidEnvironment
+        ..defines[kFrontendServerStarterPath] = 'path/to/frontend_server_starter.dart',
+    );
 
-      expect(processManager, hasNoRemainingExpectations);
-    },
-    overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()},
-  );
+    expect(processManager, hasNoRemainingExpectations);
+  }, overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()});
 
-  testUsingContext(
-    'KernelSnapshot correctly forwards ExtraFrontEndOptions',
-    () async {
-      fileSystem.file('.dart_tool/package_config.json')
-        ..createSync(recursive: true)
-        ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
-      final String build = androidEnvironment.buildDir.path;
-      final String flutterPatchedSdkPath = artifacts.getArtifactPath(
-        Artifact.flutterPatchedSdkPath,
-        platform: TargetPlatform.android_arm,
-        mode: BuildMode.profile,
-      );
-      processManager.addCommands(<FakeCommand>[
-        FakeCommand(
-          command: <String>[
-            artifacts.getArtifactPath(Artifact.engineDartAotRuntime),
-            artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
-            '--sdk-root',
-            '$flutterPatchedSdkPath/',
-            '--target=flutter',
-            '--no-print-incremental-dependencies',
-            ...buildModeOptions(BuildMode.profile, <String>[]),
-            '--track-widget-creation',
-            '--aot',
-            '--tfa',
-            '--target-os',
-            'android',
-            '--packages',
-            '/.dart_tool/package_config.json',
-            '--output-dill',
-            '$build/app.dill',
-            '--depfile',
-            '$build/kernel_snapshot_program.d',
-            '--verbosity=error',
-            'foo',
-            'bar',
-            'file:///lib/main.dart',
-          ],
-          stdout: 'result $kBoundaryKey\n$kBoundaryKey\n$kBoundaryKey $build/app.dill 0\n',
-        ),
-      ]);
+  testUsingContext('KernelSnapshot correctly forwards ExtraFrontEndOptions', () async {
+    fileSystem.file('.dart_tool/package_config.json')
+      ..createSync(recursive: true)
+      ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
+    final String build = androidEnvironment.buildDir.path;
+    final String flutterPatchedSdkPath = artifacts.getArtifactPath(
+      Artifact.flutterPatchedSdkPath,
+      platform: TargetPlatform.android_arm,
+      mode: BuildMode.profile,
+    );
+    processManager.addCommands(<FakeCommand>[
+      FakeCommand(
+        command: <String>[
+          artifacts.getArtifactPath(Artifact.engineDartAotRuntime),
+          artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
+          '--sdk-root',
+          '$flutterPatchedSdkPath/',
+          '--target=flutter',
+          '--no-print-incremental-dependencies',
+          ...buildModeOptions(BuildMode.profile, <String>[]),
+          '--track-widget-creation',
+          '--aot',
+          '--tfa',
+          '--target-os',
+          'android',
+          '--packages',
+          '/.dart_tool/package_config.json',
+          '--output-dill',
+          '$build/app.dill',
+          '--depfile',
+          '$build/kernel_snapshot_program.d',
+          '--verbosity=error',
+          'foo',
+          'bar',
+          'file:///lib/main.dart',
+        ],
+        stdout: 'result $kBoundaryKey\n$kBoundaryKey\n$kBoundaryKey $build/app.dill 0\n',
+      ),
+    ]);
 
-      await const KernelSnapshot().build(
-        androidEnvironment..defines[kExtraFrontEndOptions] = 'foo,bar',
-      );
+    await const KernelSnapshot().build(
+      androidEnvironment..defines[kExtraFrontEndOptions] = 'foo,bar',
+    );
 
-      expect(processManager, hasNoRemainingExpectations);
-    },
-    overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()},
-  );
+    expect(processManager, hasNoRemainingExpectations);
+  }, overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()});
 
-  testUsingContext(
-    'KernelSnapshot can disable track-widget-creation on debug builds',
-    () async {
-      fileSystem.file('.dart_tool/package_config.json')
-        ..createSync(recursive: true)
-        ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
+  testUsingContext('KernelSnapshot can disable track-widget-creation on debug builds', () async {
+    fileSystem.file('.dart_tool/package_config.json')
+      ..createSync(recursive: true)
+      ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
 
-      final String build = androidEnvironment.buildDir.path;
-      final String flutterPatchedSdkPath = artifacts.getArtifactPath(
-        Artifact.flutterPatchedSdkPath,
-        platform: TargetPlatform.android_arm,
-        mode: BuildMode.debug,
-      );
-      processManager.addCommands(<FakeCommand>[
-        FakeCommand(
-          command: <String>[
-            artifacts.getArtifactPath(Artifact.engineDartAotRuntime),
-            artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
-            '--sdk-root',
-            '$flutterPatchedSdkPath/',
-            '--target=flutter',
-            '--no-print-incremental-dependencies',
-            ...buildModeOptions(BuildMode.debug, <String>[]),
-            '--no-link-platform',
-            '--packages',
-            '/.dart_tool/package_config.json',
-            '--output-dill',
-            '$build/app.dill',
-            '--depfile',
-            '$build/kernel_snapshot_program.d',
-            '--incremental',
-            '--initialize-from-dill',
-            '$build/app.dill',
-            '--verbosity=error',
-            'file:///lib/main.dart',
-          ],
-          stdout: 'result $kBoundaryKey\n$kBoundaryKey\n$kBoundaryKey $build/app.dill 0\n',
-        ),
-      ]);
+    final String build = androidEnvironment.buildDir.path;
+    final String flutterPatchedSdkPath = artifacts.getArtifactPath(
+      Artifact.flutterPatchedSdkPath,
+      platform: TargetPlatform.android_arm,
+      mode: BuildMode.debug,
+    );
+    processManager.addCommands(<FakeCommand>[
+      FakeCommand(
+        command: <String>[
+          artifacts.getArtifactPath(Artifact.engineDartAotRuntime),
+          artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
+          '--sdk-root',
+          '$flutterPatchedSdkPath/',
+          '--target=flutter',
+          '--no-print-incremental-dependencies',
+          ...buildModeOptions(BuildMode.debug, <String>[]),
+          '--no-link-platform',
+          '--packages',
+          '/.dart_tool/package_config.json',
+          '--output-dill',
+          '$build/app.dill',
+          '--depfile',
+          '$build/kernel_snapshot_program.d',
+          '--incremental',
+          '--initialize-from-dill',
+          '$build/app.dill',
+          '--verbosity=error',
+          'file:///lib/main.dart',
+        ],
+        stdout: 'result $kBoundaryKey\n$kBoundaryKey\n$kBoundaryKey $build/app.dill 0\n',
+      ),
+    ]);
 
-      await const KernelSnapshot().build(
-        androidEnvironment
-          ..defines[kBuildMode] = BuildMode.debug.cliName
-          ..defines[kTrackWidgetCreation] = 'false',
-      );
+    await const KernelSnapshot().build(
+      androidEnvironment
+        ..defines[kBuildMode] = BuildMode.debug.cliName
+        ..defines[kTrackWidgetCreation] = 'false',
+    );
 
-      expect(processManager, hasNoRemainingExpectations);
-    },
-    overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()},
-  );
+    expect(processManager, hasNoRemainingExpectations);
+  }, overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()});
 
   testUsingContext(
     'KernelSnapshot forces platform linking on debug for darwin target platforms',
@@ -640,64 +616,60 @@ void main() {
     },
   );
 
-  testUsingContext(
-    'KernelSnapshot does use track widget creation on debug builds',
-    () async {
-      fileSystem.file('.dart_tool/package_config.json')
-        ..createSync(recursive: true)
-        ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
-      final testEnvironment = Environment.test(
-        fileSystem.currentDirectory,
-        defines: <String, String>{
-          kBuildMode: BuildMode.debug.cliName,
-          kTargetPlatform: TargetPlatform.android_arm.getName(),
-        },
-        processManager: processManager,
-        artifacts: artifacts,
-        fileSystem: fileSystem,
-        logger: logger,
-      );
-      final String build = testEnvironment.buildDir.path;
-      final String flutterPatchedSdkPath = artifacts.getArtifactPath(
-        Artifact.flutterPatchedSdkPath,
-        platform: TargetPlatform.android_arm,
-        mode: BuildMode.debug,
-      );
-      processManager.addCommands(<FakeCommand>[
-        FakeCommand(
-          command: <String>[
-            artifacts.getArtifactPath(Artifact.engineDartAotRuntime),
-            artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
-            '--sdk-root',
-            '$flutterPatchedSdkPath/',
-            '--target=flutter',
-            '--no-print-incremental-dependencies',
-            ...buildModeOptions(BuildMode.debug, <String>[]),
-            '--track-widget-creation',
-            '--no-link-platform',
-            '--packages',
-            '/.dart_tool/package_config.json',
-            '--output-dill',
-            '$build/app.dill',
-            '--depfile',
-            '$build/kernel_snapshot_program.d',
-            '--incremental',
-            '--initialize-from-dill',
-            '$build/app.dill',
-            '--verbosity=error',
-            'file:///lib/main.dart',
-          ],
-          stdout:
-              'result $kBoundaryKey\n$kBoundaryKey\n$kBoundaryKey /build/653e11a8e6908714056a57cd6b4f602a/app.dill 0\n',
-        ),
-      ]);
+  testUsingContext('KernelSnapshot does use track widget creation on debug builds', () async {
+    fileSystem.file('.dart_tool/package_config.json')
+      ..createSync(recursive: true)
+      ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
+    final testEnvironment = Environment.test(
+      fileSystem.currentDirectory,
+      defines: <String, String>{
+        kBuildMode: BuildMode.debug.cliName,
+        kTargetPlatform: TargetPlatform.android_arm.getName(),
+      },
+      processManager: processManager,
+      artifacts: artifacts,
+      fileSystem: fileSystem,
+      logger: logger,
+    );
+    final String build = testEnvironment.buildDir.path;
+    final String flutterPatchedSdkPath = artifacts.getArtifactPath(
+      Artifact.flutterPatchedSdkPath,
+      platform: TargetPlatform.android_arm,
+      mode: BuildMode.debug,
+    );
+    processManager.addCommands(<FakeCommand>[
+      FakeCommand(
+        command: <String>[
+          artifacts.getArtifactPath(Artifact.engineDartAotRuntime),
+          artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
+          '--sdk-root',
+          '$flutterPatchedSdkPath/',
+          '--target=flutter',
+          '--no-print-incremental-dependencies',
+          ...buildModeOptions(BuildMode.debug, <String>[]),
+          '--track-widget-creation',
+          '--no-link-platform',
+          '--packages',
+          '/.dart_tool/package_config.json',
+          '--output-dill',
+          '$build/app.dill',
+          '--depfile',
+          '$build/kernel_snapshot_program.d',
+          '--incremental',
+          '--initialize-from-dill',
+          '$build/app.dill',
+          '--verbosity=error',
+          'file:///lib/main.dart',
+        ],
+        stdout:
+            'result $kBoundaryKey\n$kBoundaryKey\n$kBoundaryKey /build/653e11a8e6908714056a57cd6b4f602a/app.dill 0\n',
+      ),
+    ]);
 
-      await const KernelSnapshot().build(testEnvironment);
+    await const KernelSnapshot().build(testEnvironment);
 
-      expect(processManager, hasNoRemainingExpectations);
-    },
-    overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()},
-  );
+    expect(processManager, hasNoRemainingExpectations);
+  }, overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()});
 
   testUsingContext('AotElfProfile Produces correct output directory', () async {
     final String build = androidEnvironment.buildDir.path;

--- a/packages/flutter_tools/test/general.shard/build_system/targets/common_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/common_test.dart
@@ -73,98 +73,110 @@ void main() {
     iosEnvironment.buildDir.createSync(recursive: true);
   });
 
-  testUsingContext('KernelSnapshot throws error if missing build mode', () async {
-    androidEnvironment.defines.remove(kBuildMode);
-    expect(
-      const KernelSnapshot().build(androidEnvironment),
-      throwsA(isA<MissingDefineException>()),
-    );
-  }, overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()});
+  testUsingContext(
+    'KernelSnapshot throws error if missing build mode',
+    () async {
+      androidEnvironment.defines.remove(kBuildMode);
+      expect(
+        const KernelSnapshot().build(androidEnvironment),
+        throwsA(isA<MissingDefineException>()),
+      );
+    },
+    overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()},
+  );
 
-  testUsingContext('KernelSnapshot handles null result from kernel compilation', () async {
-    fileSystem.file('.dart_tool/package_config.json')
-      ..createSync(recursive: true)
-      ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
-    final String build = androidEnvironment.buildDir.path;
-    final String flutterPatchedSdkPath = artifacts.getArtifactPath(
-      Artifact.flutterPatchedSdkPath,
-      platform: TargetPlatform.android_arm,
-      mode: BuildMode.profile,
-    );
-    processManager.addCommands(<FakeCommand>[
-      FakeCommand(
-        command: <String>[
-          artifacts.getArtifactPath(Artifact.engineDartAotRuntime),
-          artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
-          '--sdk-root',
-          '$flutterPatchedSdkPath/',
-          '--target=flutter',
-          '--no-print-incremental-dependencies',
-          ...buildModeOptions(BuildMode.profile, <String>[]),
-          '--track-widget-creation',
-          '--aot',
-          '--tfa',
-          '--target-os',
-          'android',
-          '--packages',
-          '/.dart_tool/package_config.json',
-          '--output-dill',
-          '$build/app.dill',
-          '--depfile',
-          '$build/kernel_snapshot_program.d',
-          '--verbosity=error',
-          'file:///lib/main.dart',
-        ],
-        exitCode: 1,
-      ),
-    ]);
+  testUsingContext(
+    'KernelSnapshot handles null result from kernel compilation',
+    () async {
+      fileSystem.file('.dart_tool/package_config.json')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
+      final String build = androidEnvironment.buildDir.path;
+      final String flutterPatchedSdkPath = artifacts.getArtifactPath(
+        Artifact.flutterPatchedSdkPath,
+        platform: TargetPlatform.android_arm,
+        mode: BuildMode.profile,
+      );
+      processManager.addCommands(<FakeCommand>[
+        FakeCommand(
+          command: <String>[
+            artifacts.getArtifactPath(Artifact.engineDartAotRuntime),
+            artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
+            '--sdk-root',
+            '$flutterPatchedSdkPath/',
+            '--target=flutter',
+            '--no-print-incremental-dependencies',
+            ...buildModeOptions(BuildMode.profile, <String>[]),
+            '--track-widget-creation',
+            '--aot',
+            '--tfa',
+            '--target-os',
+            'android',
+            '--packages',
+            '/.dart_tool/package_config.json',
+            '--output-dill',
+            '$build/app.dill',
+            '--depfile',
+            '$build/kernel_snapshot_program.d',
+            '--verbosity=error',
+            'file:///lib/main.dart',
+          ],
+          exitCode: 1,
+        ),
+      ]);
 
-    await expectLater(() => const KernelSnapshot().build(androidEnvironment), throwsException);
-    expect(processManager, hasNoRemainingExpectations);
-  }, overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()});
+      await expectLater(() => const KernelSnapshot().build(androidEnvironment), throwsException);
+      expect(processManager, hasNoRemainingExpectations);
+    },
+    overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()},
+  );
 
-  testUsingContext('KernelSnapshot does use track widget creation on profile builds', () async {
-    fileSystem.file('.dart_tool/package_config.json')
-      ..createSync(recursive: true)
-      ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
-    final String build = androidEnvironment.buildDir.path;
-    final String flutterPatchedSdkPath = artifacts.getArtifactPath(
-      Artifact.flutterPatchedSdkPath,
-      platform: TargetPlatform.android_arm,
-      mode: BuildMode.profile,
-    );
-    processManager.addCommands(<FakeCommand>[
-      FakeCommand(
-        command: <String>[
-          artifacts.getArtifactPath(Artifact.engineDartAotRuntime),
-          artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
-          '--sdk-root',
-          '$flutterPatchedSdkPath/',
-          '--target=flutter',
-          '--no-print-incremental-dependencies',
-          ...buildModeOptions(BuildMode.profile, <String>[]),
-          '--track-widget-creation',
-          '--aot',
-          '--tfa',
-          '--target-os',
-          'android',
-          '--packages',
-          '/.dart_tool/package_config.json',
-          '--output-dill',
-          '$build/app.dill',
-          '--depfile',
-          '$build/kernel_snapshot_program.d',
-          '--verbosity=error',
-          'file:///lib/main.dart',
-        ],
-        stdout: 'result $kBoundaryKey\n$kBoundaryKey\n$kBoundaryKey $build/app.dill 0\n',
-      ),
-    ]);
+  testUsingContext(
+    'KernelSnapshot does use track widget creation on profile builds',
+    () async {
+      fileSystem.file('.dart_tool/package_config.json')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
+      final String build = androidEnvironment.buildDir.path;
+      final String flutterPatchedSdkPath = artifacts.getArtifactPath(
+        Artifact.flutterPatchedSdkPath,
+        platform: TargetPlatform.android_arm,
+        mode: BuildMode.profile,
+      );
+      processManager.addCommands(<FakeCommand>[
+        FakeCommand(
+          command: <String>[
+            artifacts.getArtifactPath(Artifact.engineDartAotRuntime),
+            artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
+            '--sdk-root',
+            '$flutterPatchedSdkPath/',
+            '--target=flutter',
+            '--no-print-incremental-dependencies',
+            ...buildModeOptions(BuildMode.profile, <String>[]),
+            '--track-widget-creation',
+            '--aot',
+            '--tfa',
+            '--target-os',
+            'android',
+            '--packages',
+            '/.dart_tool/package_config.json',
+            '--output-dill',
+            '$build/app.dill',
+            '--depfile',
+            '$build/kernel_snapshot_program.d',
+            '--verbosity=error',
+            'file:///lib/main.dart',
+          ],
+          stdout: 'result $kBoundaryKey\n$kBoundaryKey\n$kBoundaryKey $build/app.dill 0\n',
+        ),
+      ]);
 
-    await const KernelSnapshot().build(androidEnvironment);
+      await const KernelSnapshot().build(androidEnvironment);
 
-    expect(processManager, hasNoRemainingExpectations);
-  }, overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()});
+      expect(processManager, hasNoRemainingExpectations);
+    },
+    overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()},
+  );
 
   testUsingContext(
     'KernelSnapshot correctly handles an empty string in ExtraFrontEndOptions',
@@ -213,145 +225,157 @@ void main() {
     overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()},
   );
 
-  testUsingContext('KernelSnapshot correctly forwards FrontendServerStarterPath', () async {
-    fileSystem.file('.dart_tool/package_config.json')
-      ..createSync(recursive: true)
-      ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
-    final String build = androidEnvironment.buildDir.path;
-    final String flutterPatchedSdkPath = artifacts.getArtifactPath(
-      Artifact.flutterPatchedSdkPath,
-      platform: TargetPlatform.android_arm,
-      mode: BuildMode.profile,
-    );
-    processManager.addCommands(<FakeCommand>[
-      FakeCommand(
-        command: <String>[
-          artifacts.getArtifactPath(Artifact.engineDartBinary),
-          'path/to/frontend_server_starter.dart',
-          '--sdk-root',
-          '$flutterPatchedSdkPath/',
-          '--target=flutter',
-          '--no-print-incremental-dependencies',
-          ...buildModeOptions(BuildMode.profile, <String>[]),
-          '--track-widget-creation',
-          '--aot',
-          '--tfa',
-          '--target-os',
-          'android',
-          '--packages',
-          '/.dart_tool/package_config.json',
-          '--output-dill',
-          '$build/app.dill',
-          '--depfile',
-          '$build/kernel_snapshot_program.d',
-          '--verbosity=error',
-          'file:///lib/main.dart',
-        ],
-        stdout: 'result $kBoundaryKey\n$kBoundaryKey\n$kBoundaryKey $build/app.dill 0\n',
-      ),
-    ]);
+  testUsingContext(
+    'KernelSnapshot correctly forwards FrontendServerStarterPath',
+    () async {
+      fileSystem.file('.dart_tool/package_config.json')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
+      final String build = androidEnvironment.buildDir.path;
+      final String flutterPatchedSdkPath = artifacts.getArtifactPath(
+        Artifact.flutterPatchedSdkPath,
+        platform: TargetPlatform.android_arm,
+        mode: BuildMode.profile,
+      );
+      processManager.addCommands(<FakeCommand>[
+        FakeCommand(
+          command: <String>[
+            artifacts.getArtifactPath(Artifact.engineDartBinary),
+            'path/to/frontend_server_starter.dart',
+            '--sdk-root',
+            '$flutterPatchedSdkPath/',
+            '--target=flutter',
+            '--no-print-incremental-dependencies',
+            ...buildModeOptions(BuildMode.profile, <String>[]),
+            '--track-widget-creation',
+            '--aot',
+            '--tfa',
+            '--target-os',
+            'android',
+            '--packages',
+            '/.dart_tool/package_config.json',
+            '--output-dill',
+            '$build/app.dill',
+            '--depfile',
+            '$build/kernel_snapshot_program.d',
+            '--verbosity=error',
+            'file:///lib/main.dart',
+          ],
+          stdout: 'result $kBoundaryKey\n$kBoundaryKey\n$kBoundaryKey $build/app.dill 0\n',
+        ),
+      ]);
 
-    await const KernelSnapshot().build(
-      androidEnvironment
-        ..defines[kFrontendServerStarterPath] = 'path/to/frontend_server_starter.dart',
-    );
+      await const KernelSnapshot().build(
+        androidEnvironment
+          ..defines[kFrontendServerStarterPath] = 'path/to/frontend_server_starter.dart',
+      );
 
-    expect(processManager, hasNoRemainingExpectations);
-  }, overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()});
+      expect(processManager, hasNoRemainingExpectations);
+    },
+    overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()},
+  );
 
-  testUsingContext('KernelSnapshot correctly forwards ExtraFrontEndOptions', () async {
-    fileSystem.file('.dart_tool/package_config.json')
-      ..createSync(recursive: true)
-      ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
-    final String build = androidEnvironment.buildDir.path;
-    final String flutterPatchedSdkPath = artifacts.getArtifactPath(
-      Artifact.flutterPatchedSdkPath,
-      platform: TargetPlatform.android_arm,
-      mode: BuildMode.profile,
-    );
-    processManager.addCommands(<FakeCommand>[
-      FakeCommand(
-        command: <String>[
-          artifacts.getArtifactPath(Artifact.engineDartAotRuntime),
-          artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
-          '--sdk-root',
-          '$flutterPatchedSdkPath/',
-          '--target=flutter',
-          '--no-print-incremental-dependencies',
-          ...buildModeOptions(BuildMode.profile, <String>[]),
-          '--track-widget-creation',
-          '--aot',
-          '--tfa',
-          '--target-os',
-          'android',
-          '--packages',
-          '/.dart_tool/package_config.json',
-          '--output-dill',
-          '$build/app.dill',
-          '--depfile',
-          '$build/kernel_snapshot_program.d',
-          '--verbosity=error',
-          'foo',
-          'bar',
-          'file:///lib/main.dart',
-        ],
-        stdout: 'result $kBoundaryKey\n$kBoundaryKey\n$kBoundaryKey $build/app.dill 0\n',
-      ),
-    ]);
+  testUsingContext(
+    'KernelSnapshot correctly forwards ExtraFrontEndOptions',
+    () async {
+      fileSystem.file('.dart_tool/package_config.json')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
+      final String build = androidEnvironment.buildDir.path;
+      final String flutterPatchedSdkPath = artifacts.getArtifactPath(
+        Artifact.flutterPatchedSdkPath,
+        platform: TargetPlatform.android_arm,
+        mode: BuildMode.profile,
+      );
+      processManager.addCommands(<FakeCommand>[
+        FakeCommand(
+          command: <String>[
+            artifacts.getArtifactPath(Artifact.engineDartAotRuntime),
+            artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
+            '--sdk-root',
+            '$flutterPatchedSdkPath/',
+            '--target=flutter',
+            '--no-print-incremental-dependencies',
+            ...buildModeOptions(BuildMode.profile, <String>[]),
+            '--track-widget-creation',
+            '--aot',
+            '--tfa',
+            '--target-os',
+            'android',
+            '--packages',
+            '/.dart_tool/package_config.json',
+            '--output-dill',
+            '$build/app.dill',
+            '--depfile',
+            '$build/kernel_snapshot_program.d',
+            '--verbosity=error',
+            'foo',
+            'bar',
+            'file:///lib/main.dart',
+          ],
+          stdout: 'result $kBoundaryKey\n$kBoundaryKey\n$kBoundaryKey $build/app.dill 0\n',
+        ),
+      ]);
 
-    await const KernelSnapshot().build(
-      androidEnvironment..defines[kExtraFrontEndOptions] = 'foo,bar',
-    );
+      await const KernelSnapshot().build(
+        androidEnvironment..defines[kExtraFrontEndOptions] = 'foo,bar',
+      );
 
-    expect(processManager, hasNoRemainingExpectations);
-  }, overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()});
+      expect(processManager, hasNoRemainingExpectations);
+    },
+    overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()},
+  );
 
-  testUsingContext('KernelSnapshot can disable track-widget-creation on debug builds', () async {
-    fileSystem.file('.dart_tool/package_config.json')
-      ..createSync(recursive: true)
-      ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
+  testUsingContext(
+    'KernelSnapshot can disable track-widget-creation on debug builds',
+    () async {
+      fileSystem.file('.dart_tool/package_config.json')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
 
-    final String build = androidEnvironment.buildDir.path;
-    final String flutterPatchedSdkPath = artifacts.getArtifactPath(
-      Artifact.flutterPatchedSdkPath,
-      platform: TargetPlatform.android_arm,
-      mode: BuildMode.debug,
-    );
-    processManager.addCommands(<FakeCommand>[
-      FakeCommand(
-        command: <String>[
-          artifacts.getArtifactPath(Artifact.engineDartAotRuntime),
-          artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
-          '--sdk-root',
-          '$flutterPatchedSdkPath/',
-          '--target=flutter',
-          '--no-print-incremental-dependencies',
-          ...buildModeOptions(BuildMode.debug, <String>[]),
-          '--no-link-platform',
-          '--packages',
-          '/.dart_tool/package_config.json',
-          '--output-dill',
-          '$build/app.dill',
-          '--depfile',
-          '$build/kernel_snapshot_program.d',
-          '--incremental',
-          '--initialize-from-dill',
-          '$build/app.dill',
-          '--verbosity=error',
-          'file:///lib/main.dart',
-        ],
-        stdout: 'result $kBoundaryKey\n$kBoundaryKey\n$kBoundaryKey $build/app.dill 0\n',
-      ),
-    ]);
+      final String build = androidEnvironment.buildDir.path;
+      final String flutterPatchedSdkPath = artifacts.getArtifactPath(
+        Artifact.flutterPatchedSdkPath,
+        platform: TargetPlatform.android_arm,
+        mode: BuildMode.debug,
+      );
+      processManager.addCommands(<FakeCommand>[
+        FakeCommand(
+          command: <String>[
+            artifacts.getArtifactPath(Artifact.engineDartAotRuntime),
+            artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
+            '--sdk-root',
+            '$flutterPatchedSdkPath/',
+            '--target=flutter',
+            '--no-print-incremental-dependencies',
+            ...buildModeOptions(BuildMode.debug, <String>[]),
+            '--no-link-platform',
+            '--packages',
+            '/.dart_tool/package_config.json',
+            '--output-dill',
+            '$build/app.dill',
+            '--depfile',
+            '$build/kernel_snapshot_program.d',
+            '--incremental',
+            '--initialize-from-dill',
+            '$build/app.dill',
+            '--verbosity=error',
+            'file:///lib/main.dart',
+          ],
+          stdout: 'result $kBoundaryKey\n$kBoundaryKey\n$kBoundaryKey $build/app.dill 0\n',
+        ),
+      ]);
 
-    await const KernelSnapshot().build(
-      androidEnvironment
-        ..defines[kBuildMode] = BuildMode.debug.cliName
-        ..defines[kTrackWidgetCreation] = 'false',
-    );
+      await const KernelSnapshot().build(
+        androidEnvironment
+          ..defines[kBuildMode] = BuildMode.debug.cliName
+          ..defines[kTrackWidgetCreation] = 'false',
+      );
 
-    expect(processManager, hasNoRemainingExpectations);
-  }, overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()});
+      expect(processManager, hasNoRemainingExpectations);
+    },
+    overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()},
+  );
 
   testUsingContext(
     'KernelSnapshot forces platform linking on debug for darwin target platforms',
@@ -616,60 +640,64 @@ void main() {
     },
   );
 
-  testUsingContext('KernelSnapshot does use track widget creation on debug builds', () async {
-    fileSystem.file('.dart_tool/package_config.json')
-      ..createSync(recursive: true)
-      ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
-    final testEnvironment = Environment.test(
-      fileSystem.currentDirectory,
-      defines: <String, String>{
-        kBuildMode: BuildMode.debug.cliName,
-        kTargetPlatform: TargetPlatform.android_arm.getName(),
-      },
-      processManager: processManager,
-      artifacts: artifacts,
-      fileSystem: fileSystem,
-      logger: logger,
-    );
-    final String build = testEnvironment.buildDir.path;
-    final String flutterPatchedSdkPath = artifacts.getArtifactPath(
-      Artifact.flutterPatchedSdkPath,
-      platform: TargetPlatform.android_arm,
-      mode: BuildMode.debug,
-    );
-    processManager.addCommands(<FakeCommand>[
-      FakeCommand(
-        command: <String>[
-          artifacts.getArtifactPath(Artifact.engineDartAotRuntime),
-          artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
-          '--sdk-root',
-          '$flutterPatchedSdkPath/',
-          '--target=flutter',
-          '--no-print-incremental-dependencies',
-          ...buildModeOptions(BuildMode.debug, <String>[]),
-          '--track-widget-creation',
-          '--no-link-platform',
-          '--packages',
-          '/.dart_tool/package_config.json',
-          '--output-dill',
-          '$build/app.dill',
-          '--depfile',
-          '$build/kernel_snapshot_program.d',
-          '--incremental',
-          '--initialize-from-dill',
-          '$build/app.dill',
-          '--verbosity=error',
-          'file:///lib/main.dart',
-        ],
-        stdout:
-            'result $kBoundaryKey\n$kBoundaryKey\n$kBoundaryKey /build/653e11a8e6908714056a57cd6b4f602a/app.dill 0\n',
-      ),
-    ]);
+  testUsingContext(
+    'KernelSnapshot does use track widget creation on debug builds',
+    () async {
+      fileSystem.file('.dart_tool/package_config.json')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
+      final testEnvironment = Environment.test(
+        fileSystem.currentDirectory,
+        defines: <String, String>{
+          kBuildMode: BuildMode.debug.cliName,
+          kTargetPlatform: TargetPlatform.android_arm.getName(),
+        },
+        processManager: processManager,
+        artifacts: artifacts,
+        fileSystem: fileSystem,
+        logger: logger,
+      );
+      final String build = testEnvironment.buildDir.path;
+      final String flutterPatchedSdkPath = artifacts.getArtifactPath(
+        Artifact.flutterPatchedSdkPath,
+        platform: TargetPlatform.android_arm,
+        mode: BuildMode.debug,
+      );
+      processManager.addCommands(<FakeCommand>[
+        FakeCommand(
+          command: <String>[
+            artifacts.getArtifactPath(Artifact.engineDartAotRuntime),
+            artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
+            '--sdk-root',
+            '$flutterPatchedSdkPath/',
+            '--target=flutter',
+            '--no-print-incremental-dependencies',
+            ...buildModeOptions(BuildMode.debug, <String>[]),
+            '--track-widget-creation',
+            '--no-link-platform',
+            '--packages',
+            '/.dart_tool/package_config.json',
+            '--output-dill',
+            '$build/app.dill',
+            '--depfile',
+            '$build/kernel_snapshot_program.d',
+            '--incremental',
+            '--initialize-from-dill',
+            '$build/app.dill',
+            '--verbosity=error',
+            'file:///lib/main.dart',
+          ],
+          stdout:
+              'result $kBoundaryKey\n$kBoundaryKey\n$kBoundaryKey /build/653e11a8e6908714056a57cd6b4f602a/app.dill 0\n',
+        ),
+      ]);
 
-    await const KernelSnapshot().build(testEnvironment);
+      await const KernelSnapshot().build(testEnvironment);
 
-    expect(processManager, hasNoRemainingExpectations);
-  }, overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()});
+      expect(processManager, hasNoRemainingExpectations);
+    },
+    overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()},
+  );
 
   testUsingContext('AotElfProfile Produces correct output directory', () async {
     final String build = androidEnvironment.buildDir.path;

--- a/packages/flutter_tools/test/general.shard/build_system/targets/common_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/common_test.dart
@@ -49,7 +49,7 @@ void main() {
       fileSystem.currentDirectory,
       defines: <String, String>{
         kBuildMode: BuildMode.profile.cliName,
-        kTargetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
+        kTargetPlatform: TargetPlatform.android_arm.getName(),
       },
       inputs: <String, String>{},
       artifacts: artifacts,
@@ -62,7 +62,7 @@ void main() {
       fileSystem.currentDirectory,
       defines: <String, String>{
         kBuildMode: BuildMode.profile.cliName,
-        kTargetPlatform: getNameForTargetPlatform(TargetPlatform.ios),
+        kTargetPlatform: TargetPlatform.ios.getName(),
       },
       inputs: <String, String>{},
       artifacts: artifacts,
@@ -393,7 +393,7 @@ void main() {
 
       await const KernelSnapshot().build(
         androidEnvironment
-          ..defines[kTargetPlatform] = getNameForTargetPlatform(TargetPlatform.darwin)
+          ..defines[kTargetPlatform] = TargetPlatform.darwin.getName()
           ..defines[kBuildMode] = BuildMode.debug.cliName
           ..defines[kTrackWidgetCreation] = 'false',
       );
@@ -487,7 +487,7 @@ void main() {
 
       await const KernelSnapshot().build(
         iosEnvironment
-          ..defines[kTargetPlatform] = getNameForTargetPlatform(TargetPlatform.ios)
+          ..defines[kTargetPlatform] = TargetPlatform.ios.getName()
           ..defines[kBuildMode] = BuildMode.debug.cliName
           ..defines[kFlavor] = 'strawberry'
           ..defines[kXcodeConfiguration] = 'Debug-chocolate'
@@ -544,7 +544,7 @@ void main() {
 
       await const KernelSnapshot().build(
         iosEnvironment
-          ..defines[kTargetPlatform] = getNameForTargetPlatform(TargetPlatform.darwin)
+          ..defines[kTargetPlatform] = TargetPlatform.darwin.getName()
           ..defines[kBuildMode] = BuildMode.debug.cliName
           ..defines[kFlavor] = 'strawberry'
           ..defines[kXcodeConfiguration] = 'Debug-chocolate'
@@ -600,7 +600,7 @@ void main() {
 
       await const KernelSnapshot().build(
         iosEnvironment
-          ..defines[kTargetPlatform] = getNameForTargetPlatform(TargetPlatform.darwin)
+          ..defines[kTargetPlatform] = TargetPlatform.darwin.getName()
           ..defines[kBuildMode] = BuildMode.debug.cliName
           ..defines[kDartDefines] = base64Encode(utf8.encode('FLUTTER_APP_FLAVOR=vanilla'))
           ..defines[kFlavor] = 'strawberry'
@@ -624,7 +624,7 @@ void main() {
       fileSystem.currentDirectory,
       defines: <String, String>{
         kBuildMode: BuildMode.debug.cliName,
-        kTargetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
+        kTargetPlatform: TargetPlatform.android_arm.getName(),
       },
       processManager: processManager,
       artifacts: artifacts,

--- a/packages/flutter_tools/test/general.shard/isolated/build_system/targets/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/build_system/targets/native_assets_test.dart
@@ -66,23 +66,15 @@ void main() {
     androidEnvironment.buildDir.createSync(recursive: true);
   });
 
-  testUsingContext(
-    'no dependency on KernelSnapshot',
-    () async {
-      const target = BuildHooks();
-      expect(target.dependencies, isNot(isA<KernelSnapshot>()));
-    },
-    overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()},
-  );
+  testUsingContext('no dependency on KernelSnapshot', () async {
+    const target = BuildHooks();
+    expect(target.dependencies, isNot(isA<KernelSnapshot>()));
+  }, overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()});
 
-  testUsingContext(
-    'NativeAssets throws error if missing target platform',
-    () async {
-      iosEnvironment.defines.remove(kTargetPlatform);
-      expect(const BuildHooks().build(iosEnvironment), throwsA(isA<MissingDefineException>()));
-    },
-    overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()},
-  );
+  testUsingContext('NativeAssets throws error if missing target platform', () async {
+    iosEnvironment.defines.remove(kTargetPlatform);
+    expect(const BuildHooks().build(iosEnvironment), throwsA(isA<MissingDefineException>()));
+  }, overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags()});
 
   testUsingContext('NativeAssets defaults to ios archs if missing', () async {
     writePackageConfigFiles(directory: iosEnvironment.projectDir, mainLibName: 'my_app');

--- a/packages/flutter_tools/test/general.shard/isolated/build_system/targets/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/build_system/targets/native_assets_test.dart
@@ -39,7 +39,7 @@ void main() {
       fileSystem.currentDirectory,
       defines: <String, String>{
         kBuildMode: BuildMode.profile.cliName,
-        kTargetPlatform: getNameForTargetPlatform(TargetPlatform.ios),
+        kTargetPlatform: TargetPlatform.ios.getName(),
         kIosArchs: 'arm64',
         kSdkRoot: 'path/to/iPhoneOS.sdk',
       },
@@ -53,7 +53,7 @@ void main() {
       fileSystem.currentDirectory,
       defines: <String, String>{
         kBuildMode: BuildMode.profile.cliName,
-        kTargetPlatform: getNameForTargetPlatform(TargetPlatform.android),
+        kTargetPlatform: TargetPlatform.android.getName(),
         kAndroidArchs: AndroidArch.arm64_v8a.platformName,
       },
       inputs: <String, String>{},

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -239,7 +239,7 @@ void main() {
         contains(
           Event.hotRunnerInfo(
             label: 'exception',
-            targetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
+            targetPlatform: TargetPlatform.android_arm.getName(),
             sdkName: 'Android',
             emulator: false,
             fullRestart: false,
@@ -307,7 +307,7 @@ void main() {
         contains(
           Event.hotRunnerInfo(
             label: 'reload-barred',
-            targetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
+            targetPlatform: TargetPlatform.android_arm.getName(),
             sdkName: 'Android',
             emulator: false,
             fullRestart: false,
@@ -360,7 +360,7 @@ void main() {
         contains(
           Event.hotRunnerInfo(
             label: 'exception',
-            targetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
+            targetPlatform: TargetPlatform.android_arm.getName(),
             sdkName: 'Android',
             emulator: false,
             fullRestart: false,
@@ -580,7 +580,7 @@ void main() {
       expect(event.eventData['label'], 'reload');
       expect(
         event.eventData['targetPlatform'],
-        getNameForTargetPlatform(TargetPlatform.android_arm),
+        TargetPlatform.android_arm.getName(),
       );
     }),
   );
@@ -729,7 +729,7 @@ void main() {
       expect(newEvent.eventData['label'], 'restart');
       expect(
         newEvent.eventData['targetPlatform'],
-        getNameForTargetPlatform(TargetPlatform.android_arm),
+        TargetPlatform.android_arm.getName(),
       );
     }),
   );
@@ -948,7 +948,7 @@ void main() {
         contains(
           Event.hotRunnerInfo(
             label: 'exception',
-            targetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
+            targetPlatform: TargetPlatform.android_arm.getName(),
             sdkName: 'Android',
             emulator: false,
             fullRestart: true,

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -578,10 +578,7 @@ void main() {
       final Event event = fakeAnalytics.sentEvents.first;
       expect(event.eventName.label, 'hot_runner_info');
       expect(event.eventData['label'], 'reload');
-      expect(
-        event.eventData['targetPlatform'],
-        TargetPlatform.android_arm.getName(),
-      );
+      expect(event.eventData['targetPlatform'], TargetPlatform.android_arm.getName());
     }),
   );
 
@@ -727,10 +724,7 @@ void main() {
       expect(hotRunnerInfoEvents, hasLength(1));
       final Event newEvent = hotRunnerInfoEvents.first;
       expect(newEvent.eventData['label'], 'restart');
-      expect(
-        newEvent.eventData['targetPlatform'],
-        TargetPlatform.android_arm.getName(),
-      );
+      expect(newEvent.eventData['targetPlatform'], TargetPlatform.android_arm.getName());
     }),
   );
 

--- a/packages/flutter_tools/test/general.shard/runner/target_devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/target_devices_test.dart
@@ -3215,8 +3215,7 @@ class FakeDevice extends Fake implements Device {
   Category? get category => Category.mobile;
 
   @override
-  Future<String> get targetPlatformDisplayName async =>
-      getNameForTargetPlatform(await targetPlatform);
+  Future<String> get targetPlatformDisplayName async => (await targetPlatform).getName();
 }
 
 class FakeIOSDevice extends Fake implements IOSDevice {

--- a/packages/flutter_tools/test/general.shard/runner/target_devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/target_devices_test.dart
@@ -645,24 +645,22 @@ If you would like your app to run on android or fuchsia, consider running `flutt
             terminal = FakeTerminal();
           });
 
-          testUsingContext(
-            'including attached, wireless, unsupported devices',
-            () async {
-              deviceManager.androidDiscoverer.deviceList = <Device>[
-                attachedAndroidDevice1,
-                attachedUnsupportedAndroidDevice,
-                attachedUnsupportedForProjectAndroidDevice,
-                wirelessAndroidDevice1,
-                wirelessUnsupportedAndroidDevice,
-                wirelessUnsupportedForProjectAndroidDevice,
-              ];
-              terminal.setPrompt(<String>['1', '2', 'q', 'Q'], '2');
+          testUsingContext('including attached, wireless, unsupported devices', () async {
+            deviceManager.androidDiscoverer.deviceList = <Device>[
+              attachedAndroidDevice1,
+              attachedUnsupportedAndroidDevice,
+              attachedUnsupportedForProjectAndroidDevice,
+              wirelessAndroidDevice1,
+              wirelessUnsupportedAndroidDevice,
+              wirelessUnsupportedForProjectAndroidDevice,
+            ];
+            terminal.setPrompt(<String>['1', '2', 'q', 'Q'], '2');
 
-              final List<Device>? devices = await targetDevices.findAllTargetDevices();
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
 
-              expect(
-                logger.statusText,
-                equals('''
+            expect(
+              logger.statusText,
+              equals('''
 Connected devices:
 target-device-1 (mobile) • xxx • android • Android 10
 
@@ -672,14 +670,12 @@ target-device-5 (wireless) (mobile) • xxx • android • Android 10
 [1]: target-device-1 (xxx)
 [2]: target-device-5 (wireless) (xxx)
 '''),
-              );
-              expect(devices, <Device>[wirelessAndroidDevice1]);
-              expect(deviceManager.androidDiscoverer.devicesCalled, 2);
-              expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
-              expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
-            },
-            overrides: <Type, Generator>{AnsiTerminal: () => terminal},
-          );
+            );
+            expect(devices, <Device>[wirelessAndroidDevice1]);
+            expect(deviceManager.androidDiscoverer.devicesCalled, 2);
+            expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+            expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+          }, overrides: <Type, Generator>{AnsiTerminal: () => terminal});
 
           testUsingContext('including only attached devices', () async {
             deviceManager.androidDiscoverer.deviceList = <Device>[
@@ -742,23 +738,21 @@ target-device-6 (wireless) (mobile) • xxx • android • Android 10
             terminal = FakeTerminal(stdinHasTerminal: false);
           });
 
-          testUsingContext(
-            'including attached, wireless, unsupported devices',
-            () async {
-              deviceManager.androidDiscoverer.deviceList = <Device>[
-                attachedAndroidDevice1,
-                attachedUnsupportedAndroidDevice,
-                attachedUnsupportedForProjectAndroidDevice,
-                wirelessAndroidDevice1,
-                wirelessUnsupportedAndroidDevice,
-                wirelessUnsupportedForProjectAndroidDevice,
-              ];
+          testUsingContext('including attached, wireless, unsupported devices', () async {
+            deviceManager.androidDiscoverer.deviceList = <Device>[
+              attachedAndroidDevice1,
+              attachedUnsupportedAndroidDevice,
+              attachedUnsupportedForProjectAndroidDevice,
+              wirelessAndroidDevice1,
+              wirelessUnsupportedAndroidDevice,
+              wirelessUnsupportedForProjectAndroidDevice,
+            ];
 
-              final List<Device>? devices = await targetDevices.findAllTargetDevices();
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
 
-              expect(
-                logger.statusText,
-                equals('''
+            expect(
+              logger.statusText,
+              equals('''
 More than one device connected; please specify a device with the '-d <deviceId>' flag, or use '-d all' to act on all devices.
 
 target-device-1 (mobile) • xxx • android • Android 10
@@ -768,14 +762,12 @@ Wirelessly connected devices:
 target-device-5 (wireless) (mobile) • xxx • android • Android 10
 target-device-8 (wireless) (mobile) • xxx • android • Android 10
 '''),
-              );
-              expect(devices, isNull);
-              expect(deviceManager.androidDiscoverer.devicesCalled, 4);
-              expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
-              expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
-            },
-            overrides: <Type, Generator>{AnsiTerminal: () => terminal},
-          );
+            );
+            expect(devices, isNull);
+            expect(deviceManager.androidDiscoverer.devicesCalled, 4);
+            expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+            expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+          }, overrides: <Type, Generator>{AnsiTerminal: () => terminal});
 
           testUsingContext('including only attached devices', () async {
             deviceManager.androidDiscoverer.deviceList = <Device>[
@@ -838,24 +830,22 @@ target-device-6 (wireless) (mobile) • xxx • android • Android 10
             terminal = FakeTerminal();
           });
 
-          testUsingContext(
-            'including attached, wireless, unsupported devices',
-            () async {
-              deviceManager.androidDiscoverer.deviceList = <Device>[
-                attachedAndroidDevice1,
-                attachedUnsupportedAndroidDevice,
-                attachedUnsupportedForProjectAndroidDevice,
-                wirelessAndroidDevice1,
-                wirelessUnsupportedAndroidDevice,
-                wirelessUnsupportedForProjectAndroidDevice,
-              ];
-              terminal.setPrompt(<String>['1', '2', '3', '4', 'q', 'Q'], '2');
+          testUsingContext('including attached, wireless, unsupported devices', () async {
+            deviceManager.androidDiscoverer.deviceList = <Device>[
+              attachedAndroidDevice1,
+              attachedUnsupportedAndroidDevice,
+              attachedUnsupportedForProjectAndroidDevice,
+              wirelessAndroidDevice1,
+              wirelessUnsupportedAndroidDevice,
+              wirelessUnsupportedForProjectAndroidDevice,
+            ];
+            terminal.setPrompt(<String>['1', '2', '3', '4', 'q', 'Q'], '2');
 
-              final List<Device>? devices = await targetDevices.findAllTargetDevices();
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
 
-              expect(
-                logger.statusText,
-                equals('''
+            expect(
+              logger.statusText,
+              equals('''
 Found 4 devices with name or id matching target-device:
 target-device-1 (mobile) • xxx • android • Android 10
 target-device-4 (mobile) • xxx • android • Android 10
@@ -869,14 +859,12 @@ target-device-8 (wireless) (mobile) • xxx • android • Android 10
 [3]: target-device-5 (wireless) (xxx)
 [4]: target-device-8 (wireless) (xxx)
 '''),
-              );
-              expect(devices, <Device>[attachedUnsupportedForProjectAndroidDevice]);
-              expect(deviceManager.androidDiscoverer.devicesCalled, 3);
-              expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
-              expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
-            },
-            overrides: <Type, Generator>{AnsiTerminal: () => terminal},
-          );
+            );
+            expect(devices, <Device>[attachedUnsupportedForProjectAndroidDevice]);
+            expect(deviceManager.androidDiscoverer.devicesCalled, 3);
+            expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+            expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+          }, overrides: <Type, Generator>{AnsiTerminal: () => terminal});
 
           testUsingContext('including only attached devices', () async {
             deviceManager.androidDiscoverer.deviceList = <Device>[
@@ -961,23 +949,21 @@ target-device-1 (mobile) • xxx • android • Android 10
             expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
           }, overrides: <Type, Generator>{AnsiTerminal: () => terminal});
 
-          testUsingContext(
-            'including matching attached, wireless, unsupported devices',
-            () async {
-              deviceManager.androidDiscoverer.deviceList = <Device>[
-                attachedAndroidDevice1,
-                attachedUnsupportedAndroidDevice,
-                attachedUnsupportedForProjectAndroidDevice,
-                wirelessAndroidDevice1,
-                wirelessUnsupportedAndroidDevice,
-                wirelessUnsupportedForProjectAndroidDevice,
-              ];
+          testUsingContext('including matching attached, wireless, unsupported devices', () async {
+            deviceManager.androidDiscoverer.deviceList = <Device>[
+              attachedAndroidDevice1,
+              attachedUnsupportedAndroidDevice,
+              attachedUnsupportedForProjectAndroidDevice,
+              wirelessAndroidDevice1,
+              wirelessUnsupportedAndroidDevice,
+              wirelessUnsupportedForProjectAndroidDevice,
+            ];
 
-              final List<Device>? devices = await targetDevices.findAllTargetDevices();
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
 
-              expect(
-                logger.statusText,
-                equals('''
+            expect(
+              logger.statusText,
+              equals('''
 Found 4 devices with name or id matching target-device:
 target-device-1 (mobile) • xxx • android • Android 10
 target-device-4 (mobile) • xxx • android • Android 10
@@ -986,14 +972,12 @@ Wirelessly connected devices:
 target-device-5 (wireless) (mobile) • xxx • android • Android 10
 target-device-8 (wireless) (mobile) • xxx • android • Android 10
 '''),
-              );
-              expect(devices, isNull);
-              expect(deviceManager.androidDiscoverer.devicesCalled, 3);
-              expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
-              expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
-            },
-            overrides: <Type, Generator>{AnsiTerminal: () => terminal},
-          );
+            );
+            expect(devices, isNull);
+            expect(deviceManager.androidDiscoverer.devicesCalled, 3);
+            expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+            expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+          }, overrides: <Type, Generator>{AnsiTerminal: () => terminal});
 
           testUsingContext('including only attached devices', () async {
             deviceManager.androidDiscoverer.deviceList = <Device>[
@@ -1702,18 +1686,16 @@ No devices found yet. Checking for wireless devices...
             logger = TestBufferLogger.test(terminal: terminal);
           });
 
-          testUsingContext(
-            'when single non-ephemeral attached device',
-            () async {
-              deviceManager.iosDiscoverer.deviceList = <Device>[nonEphemeralDevice];
+          testUsingContext('when single non-ephemeral attached device', () async {
+            deviceManager.iosDiscoverer.deviceList = <Device>[nonEphemeralDevice];
 
-              final targetDevices = TestTargetDevicesWithExtendedWirelessDeviceDiscovery(
-                deviceManager: deviceManager,
-                logger: logger,
-              );
-              targetDevices.waitForWirelessBeforeInput = true;
-              targetDevices.deviceSelection.input = <String>['1'];
-              logger.originalStatusText = '''
+            final targetDevices = TestTargetDevicesWithExtendedWirelessDeviceDiscovery(
+              deviceManager: deviceManager,
+              logger: logger,
+            );
+            targetDevices.waitForWirelessBeforeInput = true;
+            targetDevices.deviceSelection.input = <String>['1'];
+            logger.originalStatusText = '''
 Connected devices:
 target-device-9 (mobile) • xxx • ios • iOS 16
 
@@ -1722,11 +1704,11 @@ Checking for wireless devices...
 [1]: target-device-9 (xxx)
 ''';
 
-              final List<Device>? devices = await targetDevices.findAllTargetDevices();
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
 
-              expect(
-                logger.statusText,
-                equals('''
+            expect(
+              logger.statusText,
+              equals('''
 Connected devices:
 target-device-9 (mobile) • xxx • ios • iOS 16
 
@@ -1734,36 +1716,32 @@ No wireless devices were found.
 
 [1]: target-device-9 (xxx)
 Please choose one (or "q" to quit): '''),
-              );
-              expect(devices, <Device>[nonEphemeralDevice]);
-              expect(deviceManager.iosDiscoverer.devicesCalled, 2);
-              expect(deviceManager.iosDiscoverer.discoverDevicesCalled, 1);
-              expect(deviceManager.iosDiscoverer.numberOfTimesPolled, 2);
-            },
-            overrides: <Type, Generator>{AnsiTerminal: () => terminal},
-          );
+            );
+            expect(devices, <Device>[nonEphemeralDevice]);
+            expect(deviceManager.iosDiscoverer.devicesCalled, 2);
+            expect(deviceManager.iosDiscoverer.discoverDevicesCalled, 1);
+            expect(deviceManager.iosDiscoverer.numberOfTimesPolled, 2);
+          }, overrides: <Type, Generator>{AnsiTerminal: () => terminal});
 
-          testUsingContext(
-            'handle invalid options for device',
-            () async {
-              deviceManager.iosDiscoverer.deviceList = <Device>[nonEphemeralDevice];
+          testUsingContext('handle invalid options for device', () async {
+            deviceManager.iosDiscoverer.deviceList = <Device>[nonEphemeralDevice];
 
-              final targetDevices = TestTargetDevicesWithExtendedWirelessDeviceDiscovery(
-                deviceManager: deviceManager,
-                logger: logger,
-              );
-              targetDevices.waitForWirelessBeforeInput = true;
+            final targetDevices = TestTargetDevicesWithExtendedWirelessDeviceDiscovery(
+              deviceManager: deviceManager,
+              logger: logger,
+            );
+            targetDevices.waitForWirelessBeforeInput = true;
 
-              // Having the '0' first is an invalid choice for a device, the second
-              // item in the list is a '2' which is out of range since we only have
-              // one item in the deviceList. The final item in the list, is '1'
-              // which is a valid option though which will return a valid device
-              //
-              // Important: if none of the values in the list are valid, the test will
-              // hang indefinitely since the [userSelectDevice()] method uses a while
-              // loop to listen for valid devices
-              targetDevices.deviceSelection.input = <String>['0', '2', '1'];
-              logger.originalStatusText = '''
+            // Having the '0' first is an invalid choice for a device, the second
+            // item in the list is a '2' which is out of range since we only have
+            // one item in the deviceList. The final item in the list, is '1'
+            // which is a valid option though which will return a valid device
+            //
+            // Important: if none of the values in the list are valid, the test will
+            // hang indefinitely since the [userSelectDevice()] method uses a while
+            // loop to listen for valid devices
+            targetDevices.deviceSelection.input = <String>['0', '2', '1'];
+            logger.originalStatusText = '''
 Connected devices:
 target-device-9 (mobile) • xxx • ios • iOS 16
 
@@ -1772,11 +1750,11 @@ Checking for wireless devices...
 [1]: target-device-9 (xxx)
 ''';
 
-              final List<Device>? devices = await targetDevices.findAllTargetDevices();
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
 
-              expect(
-                logger.statusText,
-                equals('''
+            expect(
+              logger.statusText,
+              equals('''
 Connected devices:
 target-device-9 (mobile) • xxx • ios • iOS 16
 
@@ -1784,11 +1762,9 @@ No wireless devices were found.
 
 [1]: target-device-9 (xxx)
 Please choose one (or "q" to quit): '''),
-              );
-              expect(devices, <Device>[nonEphemeralDevice]);
-            },
-            overrides: <Type, Generator>{AnsiTerminal: () => terminal},
-          );
+            );
+            expect(devices, <Device>[nonEphemeralDevice]);
+          }, overrides: <Type, Generator>{AnsiTerminal: () => terminal});
         });
 
         group('without stdinHasTerminal', () {
@@ -1802,26 +1778,22 @@ Please choose one (or "q" to quit): '''),
             );
           });
 
-          testUsingContext(
-            'when single non-ephemeral attached device',
-            () async {
-              deviceManager.iosDiscoverer.deviceList = <Device>[nonEphemeralDevice];
+          testUsingContext('when single non-ephemeral attached device', () async {
+            deviceManager.iosDiscoverer.deviceList = <Device>[nonEphemeralDevice];
 
-              final List<Device>? devices = await targetDevices.findAllTargetDevices();
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
 
-              expect(
-                logger.statusText,
-                equals('''
+            expect(
+              logger.statusText,
+              equals('''
 Checking for wireless devices...
 '''),
-              );
-              expect(devices, <Device>[nonEphemeralDevice]);
-              expect(deviceManager.iosDiscoverer.devicesCalled, 2);
-              expect(deviceManager.iosDiscoverer.discoverDevicesCalled, 1);
-              expect(deviceManager.iosDiscoverer.numberOfTimesPolled, 2);
-            },
-            overrides: <Type, Generator>{AnsiTerminal: () => terminal},
-          );
+            );
+            expect(devices, <Device>[nonEphemeralDevice]);
+            expect(deviceManager.iosDiscoverer.devicesCalled, 2);
+            expect(deviceManager.iosDiscoverer.discoverDevicesCalled, 1);
+            expect(deviceManager.iosDiscoverer.numberOfTimesPolled, 2);
+          }, overrides: <Type, Generator>{AnsiTerminal: () => terminal});
         });
       });
 
@@ -2092,31 +2064,29 @@ Checking for wireless devices...
             );
           });
 
-          testUsingContext(
-            'including attached, wireless, unsupported devices',
-            () async {
-              deviceManager.iosDiscoverer.deviceList = <Device>[
-                attachedIOSDevice1,
-                attachedIOSDevice2,
-                attachedUnsupportedIOSDevice,
-                attachedUnsupportedForProjectIOSDevice,
-                disconnectedWirelessIOSDevice1,
-                disconnectedWirelessUnsupportedIOSDevice,
-                disconnectedWirelessUnsupportedForProjectIOSDevice,
-              ];
-              deviceManager.iosDiscoverer.refreshDeviceList = <Device>[
-                attachedIOSDevice1,
-                attachedIOSDevice2,
-                attachedUnsupportedIOSDevice,
-                attachedUnsupportedForProjectIOSDevice,
-                connectedWirelessIOSDevice1,
-                connectedWirelessUnsupportedIOSDevice,
-                connectedWirelessUnsupportedForProjectIOSDevice,
-              ];
+          testUsingContext('including attached, wireless, unsupported devices', () async {
+            deviceManager.iosDiscoverer.deviceList = <Device>[
+              attachedIOSDevice1,
+              attachedIOSDevice2,
+              attachedUnsupportedIOSDevice,
+              attachedUnsupportedForProjectIOSDevice,
+              disconnectedWirelessIOSDevice1,
+              disconnectedWirelessUnsupportedIOSDevice,
+              disconnectedWirelessUnsupportedForProjectIOSDevice,
+            ];
+            deviceManager.iosDiscoverer.refreshDeviceList = <Device>[
+              attachedIOSDevice1,
+              attachedIOSDevice2,
+              attachedUnsupportedIOSDevice,
+              attachedUnsupportedForProjectIOSDevice,
+              connectedWirelessIOSDevice1,
+              connectedWirelessUnsupportedIOSDevice,
+              connectedWirelessUnsupportedForProjectIOSDevice,
+            ];
 
-              targetDevices.waitForWirelessBeforeInput = true;
-              targetDevices.deviceSelection.input = <String>['3'];
-              logger.originalStatusText = '''
+            targetDevices.waitForWirelessBeforeInput = true;
+            targetDevices.deviceSelection.input = <String>['3'];
+            logger.originalStatusText = '''
 Connected devices:
 target-device-1 (mobile) • xxx • ios • iOS 16
 target-device-2 (mobile) • xxx • ios • iOS 16
@@ -2127,11 +2097,11 @@ Checking for wireless devices...
 [2]: target-device-2 (xxx)
 ''';
 
-              final List<Device>? devices = await targetDevices.findAllTargetDevices();
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
 
-              expect(
-                logger.statusText,
-                equals('''
+            expect(
+              logger.statusText,
+              equals('''
 Connected devices:
 target-device-1 (mobile) • xxx • ios • iOS 16
 target-device-2 (mobile) • xxx • ios • iOS 16
@@ -2143,14 +2113,12 @@ target-device-5 (wireless) (mobile) • xxx • ios • iOS 16
 [2]: target-device-2 (xxx)
 [3]: target-device-5 (wireless) (xxx)
 Please choose one (or "q" to quit): '''),
-              );
-              expect(devices, <Device>[connectedWirelessIOSDevice1]);
-              expect(deviceManager.iosDiscoverer.devicesCalled, 2);
-              expect(deviceManager.iosDiscoverer.discoverDevicesCalled, 1);
-              expect(deviceManager.iosDiscoverer.numberOfTimesPolled, 2);
-            },
-            overrides: <Type, Generator>{AnsiTerminal: () => terminal},
-          );
+            );
+            expect(devices, <Device>[connectedWirelessIOSDevice1]);
+            expect(deviceManager.iosDiscoverer.devicesCalled, 2);
+            expect(deviceManager.iosDiscoverer.discoverDevicesCalled, 1);
+            expect(deviceManager.iosDiscoverer.numberOfTimesPolled, 2);
+          }, overrides: <Type, Generator>{AnsiTerminal: () => terminal});
 
           testUsingContext('including only attached devices', () async {
             deviceManager.iosDiscoverer.deviceList = <Device>[
@@ -2239,26 +2207,24 @@ target-device-6 (wireless) (mobile) • xxx • ios • iOS 16
               );
             });
 
-            testUsingContext(
-              'and waits for wireless devices to return',
-              () async {
-                deviceManager.iosDiscoverer.deviceList = <Device>[
-                  attachedIOSDevice1,
-                  attachedIOSDevice2,
-                  disconnectedWirelessIOSDevice1,
-                ];
-                deviceManager.iosDiscoverer.refreshDeviceList = <Device>[
-                  attachedIOSDevice1,
-                  attachedIOSDevice2,
-                  connectedWirelessIOSDevice1,
-                ];
+            testUsingContext('and waits for wireless devices to return', () async {
+              deviceManager.iosDiscoverer.deviceList = <Device>[
+                attachedIOSDevice1,
+                attachedIOSDevice2,
+                disconnectedWirelessIOSDevice1,
+              ];
+              deviceManager.iosDiscoverer.refreshDeviceList = <Device>[
+                attachedIOSDevice1,
+                attachedIOSDevice2,
+                connectedWirelessIOSDevice1,
+              ];
 
-                terminal.setPrompt(<String>['1', '2', '3', 'q', 'Q'], '1');
-                final List<Device>? devices = await targetDevices.findAllTargetDevices();
+              terminal.setPrompt(<String>['1', '2', '3', 'q', 'Q'], '1');
+              final List<Device>? devices = await targetDevices.findAllTargetDevices();
 
-                expect(
-                  logger.statusText,
-                  equals('''
+              expect(
+                logger.statusText,
+                equals('''
 Checking for wireless devices...
 
 Connected devices:
@@ -2272,14 +2238,12 @@ target-device-5 (wireless) (mobile) • xxx • ios • iOS 16
 [2]: target-device-2 (xxx)
 [3]: target-device-5 (wireless) (xxx)
 '''),
-                );
-                expect(devices, <Device>[attachedIOSDevice1]);
-                expect(deviceManager.iosDiscoverer.devicesCalled, 2);
-                expect(deviceManager.iosDiscoverer.discoverDevicesCalled, 1);
-                expect(deviceManager.iosDiscoverer.numberOfTimesPolled, 2);
-              },
-              overrides: <Type, Generator>{AnsiTerminal: () => terminal},
-            );
+              );
+              expect(devices, <Device>[attachedIOSDevice1]);
+              expect(deviceManager.iosDiscoverer.devicesCalled, 2);
+              expect(deviceManager.iosDiscoverer.discoverDevicesCalled, 1);
+              expect(deviceManager.iosDiscoverer.numberOfTimesPolled, 2);
+            }, overrides: <Type, Generator>{AnsiTerminal: () => terminal});
           });
 
           group('with verbose logging', () {
@@ -2291,17 +2255,15 @@ target-device-5 (wireless) (mobile) • xxx • ios • iOS 16
               );
             });
 
-            testUsingContext(
-              'including only attached devices',
-              () async {
-                deviceManager.iosDiscoverer.deviceList = <Device>[
-                  attachedIOSDevice1,
-                  attachedIOSDevice2,
-                ];
+            testUsingContext('including only attached devices', () async {
+              deviceManager.iosDiscoverer.deviceList = <Device>[
+                attachedIOSDevice1,
+                attachedIOSDevice2,
+              ];
 
-                targetDevices.waitForWirelessBeforeInput = true;
-                targetDevices.deviceSelection.input = <String>['2'];
-                logger.originalStatusText = '''
+              targetDevices.waitForWirelessBeforeInput = true;
+              targetDevices.deviceSelection.input = <String>['2'];
+              logger.originalStatusText = '''
 Connected devices:
 target-device-1 (mobile) • xxx • ios • iOS 16
 target-device-2 (mobile) • xxx • ios • iOS 16
@@ -2312,11 +2274,11 @@ Checking for wireless devices...
 [2]: target-device-2 (xxx)
 ''';
 
-                final List<Device>? devices = await targetDevices.findAllTargetDevices();
+              final List<Device>? devices = await targetDevices.findAllTargetDevices();
 
-                expect(
-                  logger.statusText,
-                  equals('''
+              expect(
+                logger.statusText,
+                equals('''
 Connected devices:
 target-device-1 (mobile) • xxx • ios • iOS 16
 target-device-2 (mobile) • xxx • ios • iOS 16
@@ -2333,33 +2295,29 @@ target-device-2 (mobile) • xxx • ios • iOS 16
 [1]: target-device-1 (xxx)
 [2]: target-device-2 (xxx)
 Please choose one (or "q" to quit): '''),
-                );
+              );
 
-                expect(devices, <Device>[attachedIOSDevice2]);
-                expect(deviceManager.iosDiscoverer.devicesCalled, 2);
-                expect(deviceManager.iosDiscoverer.discoverDevicesCalled, 1);
-                expect(deviceManager.iosDiscoverer.numberOfTimesPolled, 2);
-              },
-              overrides: <Type, Generator>{AnsiTerminal: () => terminal},
-            );
+              expect(devices, <Device>[attachedIOSDevice2]);
+              expect(deviceManager.iosDiscoverer.devicesCalled, 2);
+              expect(deviceManager.iosDiscoverer.discoverDevicesCalled, 1);
+              expect(deviceManager.iosDiscoverer.numberOfTimesPolled, 2);
+            }, overrides: <Type, Generator>{AnsiTerminal: () => terminal});
 
-            testUsingContext(
-              'including attached and wireless devices',
-              () async {
-                deviceManager.iosDiscoverer.deviceList = <Device>[
-                  attachedIOSDevice1,
-                  attachedIOSDevice2,
-                  disconnectedWirelessIOSDevice1,
-                ];
-                deviceManager.iosDiscoverer.refreshDeviceList = <Device>[
-                  attachedIOSDevice1,
-                  attachedIOSDevice2,
-                  connectedWirelessIOSDevice1,
-                ];
+            testUsingContext('including attached and wireless devices', () async {
+              deviceManager.iosDiscoverer.deviceList = <Device>[
+                attachedIOSDevice1,
+                attachedIOSDevice2,
+                disconnectedWirelessIOSDevice1,
+              ];
+              deviceManager.iosDiscoverer.refreshDeviceList = <Device>[
+                attachedIOSDevice1,
+                attachedIOSDevice2,
+                connectedWirelessIOSDevice1,
+              ];
 
-                targetDevices.waitForWirelessBeforeInput = true;
-                targetDevices.deviceSelection.input = <String>['2'];
-                logger.originalStatusText = '''
+              targetDevices.waitForWirelessBeforeInput = true;
+              targetDevices.deviceSelection.input = <String>['2'];
+              logger.originalStatusText = '''
 Connected devices:
 target-device-1 (mobile) • xxx • ios • iOS 16
 target-device-2 (mobile) • xxx • ios • iOS 16
@@ -2369,11 +2327,11 @@ Checking for wireless devices...
 [1]: target-device-1 (xxx)
 [2]: target-device-2 (xxx)
 ''';
-                final List<Device>? devices = await targetDevices.findAllTargetDevices();
+              final List<Device>? devices = await targetDevices.findAllTargetDevices();
 
-                expect(
-                  logger.statusText,
-                  equals('''
+              expect(
+                logger.statusText,
+                equals('''
 Connected devices:
 target-device-1 (mobile) • xxx • ios • iOS 16
 target-device-2 (mobile) • xxx • ios • iOS 16
@@ -2393,15 +2351,13 @@ target-device-5 (wireless) (mobile) • xxx • ios • iOS 16
 [2]: target-device-2 (xxx)
 [3]: target-device-5 (wireless) (xxx)
 Please choose one (or "q" to quit): '''),
-                );
+              );
 
-                expect(devices, <Device>[attachedIOSDevice2]);
-                expect(deviceManager.iosDiscoverer.devicesCalled, 2);
-                expect(deviceManager.iosDiscoverer.discoverDevicesCalled, 1);
-                expect(deviceManager.iosDiscoverer.numberOfTimesPolled, 2);
-              },
-              overrides: <Type, Generator>{AnsiTerminal: () => terminal},
-            );
+              expect(devices, <Device>[attachedIOSDevice2]);
+              expect(deviceManager.iosDiscoverer.devicesCalled, 2);
+              expect(deviceManager.iosDiscoverer.discoverDevicesCalled, 1);
+              expect(deviceManager.iosDiscoverer.numberOfTimesPolled, 2);
+            }, overrides: <Type, Generator>{AnsiTerminal: () => terminal});
           });
         });
 
@@ -2417,33 +2373,31 @@ Please choose one (or "q" to quit): '''),
             );
           });
 
-          testUsingContext(
-            'including attached, wireless, unsupported devices',
-            () async {
-              deviceManager.iosDiscoverer.deviceList = <Device>[
-                attachedIOSDevice1,
-                attachedIOSDevice2,
-                attachedUnsupportedIOSDevice,
-                attachedUnsupportedForProjectIOSDevice,
-                disconnectedWirelessIOSDevice1,
-                disconnectedWirelessUnsupportedIOSDevice,
-                disconnectedWirelessUnsupportedForProjectIOSDevice,
-              ];
-              deviceManager.iosDiscoverer.deviceList = <Device>[
-                attachedIOSDevice1,
-                attachedIOSDevice2,
-                attachedUnsupportedIOSDevice,
-                attachedUnsupportedForProjectIOSDevice,
-                connectedWirelessIOSDevice1,
-                connectedWirelessUnsupportedIOSDevice,
-                connectedWirelessUnsupportedForProjectIOSDevice,
-              ];
+          testUsingContext('including attached, wireless, unsupported devices', () async {
+            deviceManager.iosDiscoverer.deviceList = <Device>[
+              attachedIOSDevice1,
+              attachedIOSDevice2,
+              attachedUnsupportedIOSDevice,
+              attachedUnsupportedForProjectIOSDevice,
+              disconnectedWirelessIOSDevice1,
+              disconnectedWirelessUnsupportedIOSDevice,
+              disconnectedWirelessUnsupportedForProjectIOSDevice,
+            ];
+            deviceManager.iosDiscoverer.deviceList = <Device>[
+              attachedIOSDevice1,
+              attachedIOSDevice2,
+              attachedUnsupportedIOSDevice,
+              attachedUnsupportedForProjectIOSDevice,
+              connectedWirelessIOSDevice1,
+              connectedWirelessUnsupportedIOSDevice,
+              connectedWirelessUnsupportedForProjectIOSDevice,
+            ];
 
-              final List<Device>? devices = await targetDevices.findAllTargetDevices();
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
 
-              expect(
-                logger.statusText,
-                equals('''
+            expect(
+              logger.statusText,
+              equals('''
 Checking for wireless devices...
 
 More than one device connected; please specify a device with the '-d <deviceId>' flag, or use '-d all' to act on all devices.
@@ -2456,14 +2410,12 @@ Wirelessly connected devices:
 target-device-5 (wireless) (mobile) • xxx • ios • iOS 16
 target-device-8 (wireless) (mobile) • xxx • ios • iOS 16
 '''),
-              );
-              expect(devices, isNull);
-              expect(deviceManager.iosDiscoverer.devicesCalled, 4);
-              expect(deviceManager.iosDiscoverer.discoverDevicesCalled, 1);
-              expect(deviceManager.iosDiscoverer.numberOfTimesPolled, 2);
-            },
-            overrides: <Type, Generator>{AnsiTerminal: () => terminal},
-          );
+            );
+            expect(devices, isNull);
+            expect(deviceManager.iosDiscoverer.devicesCalled, 4);
+            expect(deviceManager.iosDiscoverer.discoverDevicesCalled, 1);
+            expect(deviceManager.iosDiscoverer.numberOfTimesPolled, 2);
+          }, overrides: <Type, Generator>{AnsiTerminal: () => terminal});
 
           testUsingContext('including only attached devices', () async {
             deviceManager.iosDiscoverer.deviceList = <Device>[
@@ -2540,29 +2492,27 @@ target-device-6 (wireless) (mobile) • xxx • ios • iOS 16
             );
           });
 
-          testUsingContext(
-            'including attached, wireless, unsupported devices',
-            () async {
-              deviceManager.iosDiscoverer.deviceList = <Device>[
-                attachedIOSDevice1,
-                attachedUnsupportedIOSDevice,
-                attachedUnsupportedForProjectIOSDevice,
-                disconnectedWirelessIOSDevice1,
-                disconnectedWirelessUnsupportedIOSDevice,
-                disconnectedWirelessUnsupportedForProjectIOSDevice,
-              ];
-              deviceManager.iosDiscoverer.refreshDeviceList = <Device>[
-                attachedIOSDevice1,
-                attachedUnsupportedIOSDevice,
-                attachedUnsupportedForProjectIOSDevice,
-                connectedWirelessIOSDevice1,
-                connectedWirelessUnsupportedIOSDevice,
-                connectedWirelessUnsupportedForProjectIOSDevice,
-              ];
+          testUsingContext('including attached, wireless, unsupported devices', () async {
+            deviceManager.iosDiscoverer.deviceList = <Device>[
+              attachedIOSDevice1,
+              attachedUnsupportedIOSDevice,
+              attachedUnsupportedForProjectIOSDevice,
+              disconnectedWirelessIOSDevice1,
+              disconnectedWirelessUnsupportedIOSDevice,
+              disconnectedWirelessUnsupportedForProjectIOSDevice,
+            ];
+            deviceManager.iosDiscoverer.refreshDeviceList = <Device>[
+              attachedIOSDevice1,
+              attachedUnsupportedIOSDevice,
+              attachedUnsupportedForProjectIOSDevice,
+              connectedWirelessIOSDevice1,
+              connectedWirelessUnsupportedIOSDevice,
+              connectedWirelessUnsupportedForProjectIOSDevice,
+            ];
 
-              targetDevices.waitForWirelessBeforeInput = true;
-              targetDevices.deviceSelection.input = <String>['3'];
-              logger.originalStatusText = '''
+            targetDevices.waitForWirelessBeforeInput = true;
+            targetDevices.deviceSelection.input = <String>['3'];
+            logger.originalStatusText = '''
 Found multiple devices with name or id matching target-device:
 target-device-1 (mobile) • xxx • ios • iOS 16
 target-device-4 (mobile) • xxx • ios • iOS 16
@@ -2572,11 +2522,11 @@ Checking for wireless devices...
 [1]: target-device-1 (xxx)
 [2]: target-device-4 (xxx)
 ''';
-              final List<Device>? devices = await targetDevices.findAllTargetDevices();
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
 
-              expect(
-                logger.statusText,
-                equals('''
+            expect(
+              logger.statusText,
+              equals('''
 Found multiple devices with name or id matching target-device:
 target-device-1 (mobile) • xxx • ios • iOS 16
 target-device-4 (mobile) • xxx • ios • iOS 16
@@ -2590,15 +2540,13 @@ target-device-8 (wireless) (mobile) • xxx • ios • iOS 16
 [3]: target-device-5 (wireless) (xxx)
 [4]: target-device-8 (wireless) (xxx)
 Please choose one (or "q" to quit): '''),
-              );
-              expect(devices, <Device>[connectedWirelessIOSDevice1]);
-              expect(deviceManager.iosDiscoverer.devicesCalled, 3);
-              expect(deviceManager.iosDiscoverer.discoverDevicesCalled, 1);
-              expect(deviceManager.iosDiscoverer.numberOfTimesPolled, 2);
-              expect(deviceManager.iosDiscoverer.xcdevice.waitedForDeviceToConnect, isFalse);
-            },
-            overrides: <Type, Generator>{AnsiTerminal: () => terminal},
-          );
+            );
+            expect(devices, <Device>[connectedWirelessIOSDevice1]);
+            expect(deviceManager.iosDiscoverer.devicesCalled, 3);
+            expect(deviceManager.iosDiscoverer.discoverDevicesCalled, 1);
+            expect(deviceManager.iosDiscoverer.numberOfTimesPolled, 2);
+            expect(deviceManager.iosDiscoverer.xcdevice.waitedForDeviceToConnect, isFalse);
+          }, overrides: <Type, Generator>{AnsiTerminal: () => terminal});
 
           testUsingContext('including only attached devices', () async {
             deviceManager.iosDiscoverer.deviceList = <Device>[
@@ -2713,31 +2661,29 @@ target-device-1 (mobile) • xxx • ios • iOS 16
             expect(deviceManager.iosDiscoverer.xcdevice.waitedForDeviceToConnect, isFalse);
           }, overrides: <Type, Generator>{AnsiTerminal: () => terminal});
 
-          testUsingContext(
-            'including matching attached, wireless, unsupported devices',
-            () async {
-              deviceManager.iosDiscoverer.deviceList = <Device>[
-                attachedIOSDevice1,
-                attachedUnsupportedIOSDevice,
-                attachedUnsupportedForProjectIOSDevice,
-                disconnectedWirelessIOSDevice1,
-                disconnectedWirelessUnsupportedIOSDevice,
-                disconnectedWirelessUnsupportedForProjectIOSDevice,
-              ];
-              deviceManager.iosDiscoverer.refreshDeviceList = <Device>[
-                attachedIOSDevice1,
-                attachedUnsupportedIOSDevice,
-                attachedUnsupportedForProjectIOSDevice,
-                connectedWirelessIOSDevice1,
-                connectedWirelessUnsupportedIOSDevice,
-                connectedWirelessUnsupportedForProjectIOSDevice,
-              ];
+          testUsingContext('including matching attached, wireless, unsupported devices', () async {
+            deviceManager.iosDiscoverer.deviceList = <Device>[
+              attachedIOSDevice1,
+              attachedUnsupportedIOSDevice,
+              attachedUnsupportedForProjectIOSDevice,
+              disconnectedWirelessIOSDevice1,
+              disconnectedWirelessUnsupportedIOSDevice,
+              disconnectedWirelessUnsupportedForProjectIOSDevice,
+            ];
+            deviceManager.iosDiscoverer.refreshDeviceList = <Device>[
+              attachedIOSDevice1,
+              attachedUnsupportedIOSDevice,
+              attachedUnsupportedForProjectIOSDevice,
+              connectedWirelessIOSDevice1,
+              connectedWirelessUnsupportedIOSDevice,
+              connectedWirelessUnsupportedForProjectIOSDevice,
+            ];
 
-              final List<Device>? devices = await targetDevices.findAllTargetDevices();
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
 
-              expect(
-                logger.statusText,
-                equals('''
+            expect(
+              logger.statusText,
+              equals('''
 Checking for wireless devices...
 
 Found 4 devices with name or id matching target-device:
@@ -2748,15 +2694,13 @@ Wirelessly connected devices:
 target-device-5 (wireless) (mobile) • xxx • ios • iOS 16
 target-device-8 (wireless) (mobile) • xxx • ios • iOS 16
 '''),
-              );
-              expect(devices, isNull);
-              expect(deviceManager.iosDiscoverer.devicesCalled, 3);
-              expect(deviceManager.iosDiscoverer.discoverDevicesCalled, 1);
-              expect(deviceManager.iosDiscoverer.numberOfTimesPolled, 2);
-              expect(deviceManager.iosDiscoverer.xcdevice.waitedForDeviceToConnect, isFalse);
-            },
-            overrides: <Type, Generator>{AnsiTerminal: () => terminal},
-          );
+            );
+            expect(devices, isNull);
+            expect(deviceManager.iosDiscoverer.devicesCalled, 3);
+            expect(deviceManager.iosDiscoverer.discoverDevicesCalled, 1);
+            expect(deviceManager.iosDiscoverer.numberOfTimesPolled, 2);
+            expect(deviceManager.iosDiscoverer.xcdevice.waitedForDeviceToConnect, isFalse);
+          }, overrides: <Type, Generator>{AnsiTerminal: () => terminal});
 
           testUsingContext('including only attached devices', () async {
             deviceManager.iosDiscoverer.deviceList = <Device>[


### PR DESCRIPTION
Refactors `Artifact` and `HostArtifact` to enhanced enums, encapsulating filename mapping logic and introducing a `.directory()` constructor for directory-representing values.

Also simplifies `getHostArtifact` implementations across different `Artifacts` classes by delegating non-engine artifacts and consolidating web SDK artifact resolution to a shared helper.
