### PR TITLE
[Impeller] Add block-compressed texture format support (BC, ETC2, ASTC)

### DIFF
--- a/engine/src/flutter/impeller/core/allocator.cc
+++ b/engine/src/flutter/impeller/core/allocator.cc
@@ -55,6 +55,19 @@ std::shared_ptr<Texture> Allocator::CreateTexture(const TextureDescriptor& desc,
     return nullptr;
   }
 
+  if (IsCompressed(desc.format)) {
+    // Block-compressed textures are sample-only. They cannot be rendered to,
+    // written from a shader, or allocated as transient attachments.
+    if (desc.usage & TextureUsage::kRenderTarget ||
+        desc.usage & TextureUsage::kShaderWrite ||
+        desc.storage_mode == StorageMode::kDeviceTransient) {
+      VALIDATION_LOG << "Compressed texture format "
+                     << PixelFormatToString(desc.format)
+                     << " can only be used as a sample-only texture.";
+      return nullptr;
+    }
+  }
+
   if (desc.mip_count > desc.size.MipCount()) {
     VALIDATION_LOG << "Requested mip_count " << desc.mip_count
                    << " exceeds maximum supported for size " << desc.size;

--- a/engine/src/flutter/impeller/core/allocator_unittests.cc
+++ b/engine/src/flutter/impeller/core/allocator_unittests.cc
@@ -132,6 +132,7 @@ TEST(AllocatorTest, CompressedFormatClassification) {
   EXPECT_TRUE(IsCompressed(PixelFormat::kBC1RGBAUNormInt));
   EXPECT_TRUE(IsCompressed(PixelFormat::kETC2RGBA8UNormInt));
   EXPECT_TRUE(IsCompressed(PixelFormat::kASTC8x8LDR));
+  EXPECT_TRUE(IsCompressed(PixelFormat::kASTC4x4HDR));
 
   EXPECT_EQ(CompressedTextureFamilyForFormat(PixelFormat::kBC7RGBAUNormInt),
             CompressedTextureFamily::kBC);
@@ -139,6 +140,8 @@ TEST(AllocatorTest, CompressedFormatClassification) {
             CompressedTextureFamily::kETC2);
   EXPECT_EQ(CompressedTextureFamilyForFormat(PixelFormat::kASTC4x4LDR),
             CompressedTextureFamily::kASTC);
+  EXPECT_EQ(CompressedTextureFamilyForFormat(PixelFormat::kASTC8x8HDR),
+            CompressedTextureFamily::kASTCHDR);
 }
 
 TEST(AllocatorTest, CompressedFormatBlockMath) {
@@ -147,6 +150,8 @@ TEST(AllocatorTest, CompressedFormatBlockMath) {
             4u);
   EXPECT_EQ(CompressedBlockWidthForPixelFormat(PixelFormat::kASTC8x8LDR), 8u);
   EXPECT_EQ(CompressedBlockHeightForPixelFormat(PixelFormat::kASTC8x8LDR), 8u);
+  EXPECT_EQ(CompressedBlockWidthForPixelFormat(PixelFormat::kASTC4x4HDR), 4u);
+  EXPECT_EQ(CompressedBlockHeightForPixelFormat(PixelFormat::kASTC8x8HDR), 8u);
   // Uncompressed formats report a 1x1 block.
   EXPECT_EQ(CompressedBlockWidthForPixelFormat(PixelFormat::kR8G8B8A8UNormInt),
             1u);
@@ -156,6 +161,7 @@ TEST(AllocatorTest, CompressedFormatBlockMath) {
   EXPECT_EQ(BytesPerBlockForPixelFormat(PixelFormat::kETC2RGB8UNormInt), 8u);
   EXPECT_EQ(BytesPerBlockForPixelFormat(PixelFormat::kBC3RGBAUNormInt), 16u);
   EXPECT_EQ(BytesPerBlockForPixelFormat(PixelFormat::kASTC4x4LDR), 16u);
+  EXPECT_EQ(BytesPerBlockForPixelFormat(PixelFormat::kASTC8x8HDR), 16u);
   // Uncompressed falls back to bytes-per-pixel.
   EXPECT_EQ(BytesPerBlockForPixelFormat(PixelFormat::kR8G8B8A8UNormInt), 4u);
 }

--- a/engine/src/flutter/impeller/core/allocator_unittests.cc
+++ b/engine/src/flutter/impeller/core/allocator_unittests.cc
@@ -126,5 +126,71 @@ TEST(AllocatorTest, RangeTest) {
   }
 }
 
+TEST(AllocatorTest, CompressedFormatClassification) {
+  EXPECT_FALSE(IsCompressed(PixelFormat::kR8G8B8A8UNormInt));
+  EXPECT_FALSE(IsCompressed(PixelFormat::kR32Float));
+  EXPECT_TRUE(IsCompressed(PixelFormat::kBC1RGBAUNormInt));
+  EXPECT_TRUE(IsCompressed(PixelFormat::kETC2RGBA8UNormInt));
+  EXPECT_TRUE(IsCompressed(PixelFormat::kASTC8x8LDR));
+
+  EXPECT_EQ(CompressedTextureFamilyForFormat(PixelFormat::kBC7RGBAUNormInt),
+            CompressedTextureFamily::kBC);
+  EXPECT_EQ(CompressedTextureFamilyForFormat(PixelFormat::kETC2RGB8UNormInt),
+            CompressedTextureFamily::kETC2);
+  EXPECT_EQ(CompressedTextureFamilyForFormat(PixelFormat::kASTC4x4LDR),
+            CompressedTextureFamily::kASTC);
+}
+
+TEST(AllocatorTest, CompressedFormatBlockMath) {
+  // Block dimensions: everything here is 4x4 except ASTC 8x8.
+  EXPECT_EQ(CompressedBlockWidthForPixelFormat(PixelFormat::kBC1RGBAUNormInt),
+            4u);
+  EXPECT_EQ(CompressedBlockWidthForPixelFormat(PixelFormat::kASTC8x8LDR), 8u);
+  EXPECT_EQ(CompressedBlockHeightForPixelFormat(PixelFormat::kASTC8x8LDR), 8u);
+  // Uncompressed formats report a 1x1 block.
+  EXPECT_EQ(CompressedBlockWidthForPixelFormat(PixelFormat::kR8G8B8A8UNormInt),
+            1u);
+
+  // Bytes per block: BC1/ETC2-RGB8 are 8 bytes, the rest here are 16.
+  EXPECT_EQ(BytesPerBlockForPixelFormat(PixelFormat::kBC1RGBAUNormInt), 8u);
+  EXPECT_EQ(BytesPerBlockForPixelFormat(PixelFormat::kETC2RGB8UNormInt), 8u);
+  EXPECT_EQ(BytesPerBlockForPixelFormat(PixelFormat::kBC3RGBAUNormInt), 16u);
+  EXPECT_EQ(BytesPerBlockForPixelFormat(PixelFormat::kASTC4x4LDR), 16u);
+  // Uncompressed falls back to bytes-per-pixel.
+  EXPECT_EQ(BytesPerBlockForPixelFormat(PixelFormat::kR8G8B8A8UNormInt), 4u);
+}
+
+TEST(AllocatorTest, CompressedFormatRegionByteSizes) {
+  // BC1: 4x4 blocks of 8 bytes. Dimensions round up to whole blocks.
+  EXPECT_EQ(BytesForTextureRegion(PixelFormat::kBC1RGBAUNormInt, 4, 4), 8u);
+  EXPECT_EQ(BytesForTextureRegion(PixelFormat::kBC1RGBAUNormInt, 8, 8), 32u);
+  EXPECT_EQ(BytesForTextureRegion(PixelFormat::kBC1RGBAUNormInt, 5, 5), 32u);
+  EXPECT_EQ(BytesPerRowForTextureWidth(PixelFormat::kBC1RGBAUNormInt, 8), 16u);
+
+  // ASTC 8x8: a single 16-byte block covers up to 8x8 texels.
+  EXPECT_EQ(BytesForTextureRegion(PixelFormat::kASTC8x8LDR, 8, 8), 16u);
+  EXPECT_EQ(BytesForTextureRegion(PixelFormat::kASTC8x8LDR, 9, 9), 64u);
+
+  // Uncompressed math is unchanged: width * height * bytes-per-pixel.
+  EXPECT_EQ(BytesForTextureRegion(PixelFormat::kR8G8B8A8UNormInt, 100, 100),
+            40000u);
+  EXPECT_EQ(BytesPerRowForTextureWidth(PixelFormat::kR8G8B8A8UNormInt, 100),
+            400u);
+}
+
+TEST(AllocatorTest, CompressedTextureDescriptorByteSizes) {
+  {
+    TextureDescriptor desc = {.format = PixelFormat::kBC1RGBAUNormInt,
+                              .size = ISize(8, 8)};
+    EXPECT_EQ(desc.GetByteSizeOfBaseMipLevel(), 32u);
+    EXPECT_EQ(desc.GetBytesPerRow(), 16u);
+  }
+  {
+    TextureDescriptor desc = {.format = PixelFormat::kASTC8x8LDR,
+                              .size = ISize(16, 16)};
+    EXPECT_EQ(desc.GetByteSizeOfBaseMipLevel(), 64u);
+  }
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/engine/src/flutter/impeller/core/formats.h
+++ b/engine/src/flutter/impeller/core/formats.h
@@ -115,7 +115,110 @@ enum class PixelFormat : uint8_t {
   kS8UInt,
   kD24UnormS8Uint,
   kD32FloatS8UInt,
+  // Block-compressed formats. These are sample-only; they cannot be used as
+  // render targets, storage textures, or transient attachments, and their
+  // support varies by device (see `Capabilities::SupportsTextureCompression`).
+  kBC1RGBAUNormInt,
+  kBC1RGBAUNormIntSRGB,
+  kBC3RGBAUNormInt,
+  kBC3RGBAUNormIntSRGB,
+  kBC5RGUNormInt,
+  kBC7RGBAUNormInt,
+  kBC7RGBAUNormIntSRGB,
+  kETC2RGB8UNormInt,
+  kETC2RGB8UNormIntSRGB,
+  kETC2RGBA8UNormInt,
+  kETC2RGBA8UNormIntSRGB,
+  kASTC4x4LDR,
+  kASTC4x4LDRSRGB,
+  kASTC8x8LDR,
+  kASTC8x8LDRSRGB,
 };
+
+//------------------------------------------------------------------------------
+/// @brief      The family of a block-compressed pixel format. Whole families
+///             are gated behind a single device feature, mirroring the three
+///             optional compression features exposed by WebGPU.
+///
+enum class CompressedTextureFamily {
+  /// S3TC, RGTC, and BPTC (BC1 through BC7). Desktop GPUs.
+  kBC,
+  /// ETC2 and EAC. Mobile, OpenGL ES 3.0, and WebGL2.
+  kETC2,
+  /// ASTC LDR. Modern mobile and some desktop.
+  kASTC,
+};
+
+/// @brief Whether `format` is a block-compressed format.
+constexpr bool IsCompressed(PixelFormat format) {
+  switch (format) {
+    case PixelFormat::kBC1RGBAUNormInt:
+    case PixelFormat::kBC1RGBAUNormIntSRGB:
+    case PixelFormat::kBC3RGBAUNormInt:
+    case PixelFormat::kBC3RGBAUNormIntSRGB:
+    case PixelFormat::kBC5RGUNormInt:
+    case PixelFormat::kBC7RGBAUNormInt:
+    case PixelFormat::kBC7RGBAUNormIntSRGB:
+    case PixelFormat::kETC2RGB8UNormInt:
+    case PixelFormat::kETC2RGB8UNormIntSRGB:
+    case PixelFormat::kETC2RGBA8UNormInt:
+    case PixelFormat::kETC2RGBA8UNormIntSRGB:
+    case PixelFormat::kASTC4x4LDR:
+    case PixelFormat::kASTC4x4LDRSRGB:
+    case PixelFormat::kASTC8x8LDR:
+    case PixelFormat::kASTC8x8LDRSRGB:
+      return true;
+    default:
+      return false;
+  }
+}
+
+/// @brief The compression family that `format` belongs to. Only valid for
+///        formats where `IsCompressed` is true.
+constexpr CompressedTextureFamily CompressedTextureFamilyForFormat(
+    PixelFormat format) {
+  switch (format) {
+    case PixelFormat::kBC1RGBAUNormInt:
+    case PixelFormat::kBC1RGBAUNormIntSRGB:
+    case PixelFormat::kBC3RGBAUNormInt:
+    case PixelFormat::kBC3RGBAUNormIntSRGB:
+    case PixelFormat::kBC5RGUNormInt:
+    case PixelFormat::kBC7RGBAUNormInt:
+    case PixelFormat::kBC7RGBAUNormIntSRGB:
+      return CompressedTextureFamily::kBC;
+    case PixelFormat::kETC2RGB8UNormInt:
+    case PixelFormat::kETC2RGB8UNormIntSRGB:
+    case PixelFormat::kETC2RGBA8UNormInt:
+    case PixelFormat::kETC2RGBA8UNormIntSRGB:
+      return CompressedTextureFamily::kETC2;
+    default:
+      return CompressedTextureFamily::kASTC;
+  }
+}
+
+/// @brief The width, in texels, of one compression block. Uncompressed formats
+///        report 1.
+constexpr size_t CompressedBlockWidthForPixelFormat(PixelFormat format) {
+  switch (format) {
+    case PixelFormat::kASTC8x8LDR:
+    case PixelFormat::kASTC8x8LDRSRGB:
+      return 8u;
+    default:
+      return IsCompressed(format) ? 4u : 1u;
+  }
+}
+
+/// @brief The height, in texels, of one compression block. Uncompressed formats
+///        report 1.
+constexpr size_t CompressedBlockHeightForPixelFormat(PixelFormat format) {
+  switch (format) {
+    case PixelFormat::kASTC8x8LDR:
+    case PixelFormat::kASTC8x8LDRSRGB:
+      return 8u;
+    default:
+      return IsCompressed(format) ? 4u : 1u;
+  }
+}
 
 constexpr bool IsDepthWritable(PixelFormat format) {
   switch (format) {
@@ -174,6 +277,36 @@ constexpr const char* PixelFormatToString(PixelFormat format) {
       return "D32FloatS8UInt";
     case PixelFormat::kR32Float:
       return "R32Float";
+    case PixelFormat::kBC1RGBAUNormInt:
+      return "BC1RGBAUNormInt";
+    case PixelFormat::kBC1RGBAUNormIntSRGB:
+      return "BC1RGBAUNormIntSRGB";
+    case PixelFormat::kBC3RGBAUNormInt:
+      return "BC3RGBAUNormInt";
+    case PixelFormat::kBC3RGBAUNormIntSRGB:
+      return "BC3RGBAUNormIntSRGB";
+    case PixelFormat::kBC5RGUNormInt:
+      return "BC5RGUNormInt";
+    case PixelFormat::kBC7RGBAUNormInt:
+      return "BC7RGBAUNormInt";
+    case PixelFormat::kBC7RGBAUNormIntSRGB:
+      return "BC7RGBAUNormIntSRGB";
+    case PixelFormat::kETC2RGB8UNormInt:
+      return "ETC2RGB8UNormInt";
+    case PixelFormat::kETC2RGB8UNormIntSRGB:
+      return "ETC2RGB8UNormIntSRGB";
+    case PixelFormat::kETC2RGBA8UNormInt:
+      return "ETC2RGBA8UNormInt";
+    case PixelFormat::kETC2RGBA8UNormIntSRGB:
+      return "ETC2RGBA8UNormIntSRGB";
+    case PixelFormat::kASTC4x4LDR:
+      return "ASTC4x4LDR";
+    case PixelFormat::kASTC4x4LDRSRGB:
+      return "ASTC4x4LDRSRGB";
+    case PixelFormat::kASTC8x8LDR:
+      return "ASTC8x8LDR";
+    case PixelFormat::kASTC8x8LDRSRGB:
+      return "ASTC8x8LDRSRGB";
   }
   FML_UNREACHABLE();
 }
@@ -493,8 +626,78 @@ constexpr size_t BytesPerPixelForPixelFormat(PixelFormat format) {
       return 8u;
     case PixelFormat::kR32G32B32A32Float:
       return 16u;
+    // Block-compressed formats have no meaningful bytes-per-pixel. Use
+    // `BytesPerBlockForPixelFormat` together with the block dimensions instead.
+    case PixelFormat::kBC1RGBAUNormInt:
+    case PixelFormat::kBC1RGBAUNormIntSRGB:
+    case PixelFormat::kBC3RGBAUNormInt:
+    case PixelFormat::kBC3RGBAUNormIntSRGB:
+    case PixelFormat::kBC5RGUNormInt:
+    case PixelFormat::kBC7RGBAUNormInt:
+    case PixelFormat::kBC7RGBAUNormIntSRGB:
+    case PixelFormat::kETC2RGB8UNormInt:
+    case PixelFormat::kETC2RGB8UNormIntSRGB:
+    case PixelFormat::kETC2RGBA8UNormInt:
+    case PixelFormat::kETC2RGBA8UNormIntSRGB:
+    case PixelFormat::kASTC4x4LDR:
+    case PixelFormat::kASTC4x4LDRSRGB:
+    case PixelFormat::kASTC8x8LDR:
+    case PixelFormat::kASTC8x8LDRSRGB:
+      return 0u;
   }
   return 0u;
+}
+
+/// @brief The number of bytes used to store one block of `format`. For
+///        uncompressed formats a block is a single pixel, so this matches
+///        `BytesPerPixelForPixelFormat`.
+constexpr size_t BytesPerBlockForPixelFormat(PixelFormat format) {
+  switch (format) {
+    case PixelFormat::kBC1RGBAUNormInt:
+    case PixelFormat::kBC1RGBAUNormIntSRGB:
+    case PixelFormat::kETC2RGB8UNormInt:
+    case PixelFormat::kETC2RGB8UNormIntSRGB:
+      return 8u;
+    case PixelFormat::kBC3RGBAUNormInt:
+    case PixelFormat::kBC3RGBAUNormIntSRGB:
+    case PixelFormat::kBC5RGUNormInt:
+    case PixelFormat::kBC7RGBAUNormInt:
+    case PixelFormat::kBC7RGBAUNormIntSRGB:
+    case PixelFormat::kETC2RGBA8UNormInt:
+    case PixelFormat::kETC2RGBA8UNormIntSRGB:
+    case PixelFormat::kASTC4x4LDR:
+    case PixelFormat::kASTC4x4LDRSRGB:
+    case PixelFormat::kASTC8x8LDR:
+    case PixelFormat::kASTC8x8LDRSRGB:
+      return 16u;
+    default:
+      return BytesPerPixelForPixelFormat(format);
+  }
+}
+
+/// @brief The number of bytes required to store a `width` x `height` texel
+///        region in `format`. Block-compressed formats round the dimensions up
+///        to whole blocks. Uncompressed formats reduce to `width * height *
+///        bytes-per-pixel`.
+constexpr size_t BytesForTextureRegion(PixelFormat format,
+                                       int64_t width,
+                                       int64_t height) {
+  const size_t block_width = CompressedBlockWidthForPixelFormat(format);
+  const size_t block_height = CompressedBlockHeightForPixelFormat(format);
+  const size_t w = width <= 0 ? 0u : static_cast<size_t>(width);
+  const size_t h = height <= 0 ? 0u : static_cast<size_t>(height);
+  const size_t blocks_wide = (w + block_width - 1u) / block_width;
+  const size_t blocks_high = (h + block_height - 1u) / block_height;
+  return blocks_wide * blocks_high * BytesPerBlockForPixelFormat(format);
+}
+
+/// @brief The number of bytes in a single row of texel blocks for a texture of
+///        the given `width` in `format`.
+constexpr size_t BytesPerRowForTextureWidth(PixelFormat format, int64_t width) {
+  const size_t block_width = CompressedBlockWidthForPixelFormat(format);
+  const size_t w = width <= 0 ? 0u : static_cast<size_t>(width);
+  const size_t blocks_wide = (w + block_width - 1u) / block_width;
+  return blocks_wide * BytesPerBlockForPixelFormat(format);
 }
 
 //------------------------------------------------------------------------------

--- a/engine/src/flutter/impeller/core/formats.h
+++ b/engine/src/flutter/impeller/core/formats.h
@@ -136,9 +136,9 @@ enum class PixelFormat : uint8_t {
 };
 
 //------------------------------------------------------------------------------
-/// @brief      The family of a block-compressed pixel format. Whole families
-///             are gated behind a single device feature, mirroring the three
-///             optional compression features exposed by WebGPU.
+/// @brief      The family of a block-compressed pixel format. GPUs support
+///             compressed formats on a per-family basis, so each family is
+///             gated behind a single device feature.
 ///
 enum class CompressedTextureFamily {
   /// S3TC, RGTC, and BPTC (BC1 through BC7). Desktop GPUs.
@@ -191,9 +191,15 @@ constexpr CompressedTextureFamily CompressedTextureFamilyForFormat(
     case PixelFormat::kETC2RGBA8UNormInt:
     case PixelFormat::kETC2RGBA8UNormIntSRGB:
       return CompressedTextureFamily::kETC2;
-    default:
+    case PixelFormat::kASTC4x4LDR:
+    case PixelFormat::kASTC4x4LDRSRGB:
+    case PixelFormat::kASTC8x8LDR:
+    case PixelFormat::kASTC8x8LDRSRGB:
       return CompressedTextureFamily::kASTC;
+    default:
+      break;
   }
+  FML_UNREACHABLE();
 }
 
 /// @brief The width, in texels, of one compression block. Uncompressed formats
@@ -203,8 +209,22 @@ constexpr size_t CompressedBlockWidthForPixelFormat(PixelFormat format) {
     case PixelFormat::kASTC8x8LDR:
     case PixelFormat::kASTC8x8LDRSRGB:
       return 8u;
+    case PixelFormat::kBC1RGBAUNormInt:
+    case PixelFormat::kBC1RGBAUNormIntSRGB:
+    case PixelFormat::kBC3RGBAUNormInt:
+    case PixelFormat::kBC3RGBAUNormIntSRGB:
+    case PixelFormat::kBC5RGUNormInt:
+    case PixelFormat::kBC7RGBAUNormInt:
+    case PixelFormat::kBC7RGBAUNormIntSRGB:
+    case PixelFormat::kETC2RGB8UNormInt:
+    case PixelFormat::kETC2RGB8UNormIntSRGB:
+    case PixelFormat::kETC2RGBA8UNormInt:
+    case PixelFormat::kETC2RGBA8UNormIntSRGB:
+    case PixelFormat::kASTC4x4LDR:
+    case PixelFormat::kASTC4x4LDRSRGB:
+      return 4u;
     default:
-      return IsCompressed(format) ? 4u : 1u;
+      return 1u;
   }
 }
 
@@ -215,8 +235,22 @@ constexpr size_t CompressedBlockHeightForPixelFormat(PixelFormat format) {
     case PixelFormat::kASTC8x8LDR:
     case PixelFormat::kASTC8x8LDRSRGB:
       return 8u;
+    case PixelFormat::kBC1RGBAUNormInt:
+    case PixelFormat::kBC1RGBAUNormIntSRGB:
+    case PixelFormat::kBC3RGBAUNormInt:
+    case PixelFormat::kBC3RGBAUNormIntSRGB:
+    case PixelFormat::kBC5RGUNormInt:
+    case PixelFormat::kBC7RGBAUNormInt:
+    case PixelFormat::kBC7RGBAUNormIntSRGB:
+    case PixelFormat::kETC2RGB8UNormInt:
+    case PixelFormat::kETC2RGB8UNormIntSRGB:
+    case PixelFormat::kETC2RGBA8UNormInt:
+    case PixelFormat::kETC2RGBA8UNormIntSRGB:
+    case PixelFormat::kASTC4x4LDR:
+    case PixelFormat::kASTC4x4LDRSRGB:
+      return 4u;
     default:
-      return IsCompressed(format) ? 4u : 1u;
+      return 1u;
   }
 }
 

--- a/engine/src/flutter/impeller/core/formats.h
+++ b/engine/src/flutter/impeller/core/formats.h
@@ -133,6 +133,9 @@ enum class PixelFormat : uint8_t {
   kASTC4x4LDRSRGB,
   kASTC8x8LDR,
   kASTC8x8LDRSRGB,
+  // ASTC HDR has no sRGB variant; the data is already linear floating point.
+  kASTC4x4HDR,
+  kASTC8x8HDR,
 };
 
 //------------------------------------------------------------------------------
@@ -147,6 +150,8 @@ enum class CompressedTextureFamily {
   kETC2,
   /// ASTC LDR. Modern mobile and some desktop.
   kASTC,
+  /// ASTC HDR. A separate device feature from ASTC LDR.
+  kASTCHDR,
 };
 
 /// @brief Whether `format` is a block-compressed format.
@@ -167,6 +172,8 @@ constexpr bool IsCompressed(PixelFormat format) {
     case PixelFormat::kASTC4x4LDRSRGB:
     case PixelFormat::kASTC8x8LDR:
     case PixelFormat::kASTC8x8LDRSRGB:
+    case PixelFormat::kASTC4x4HDR:
+    case PixelFormat::kASTC8x8HDR:
       return true;
     default:
       return false;
@@ -196,6 +203,9 @@ constexpr CompressedTextureFamily CompressedTextureFamilyForFormat(
     case PixelFormat::kASTC8x8LDR:
     case PixelFormat::kASTC8x8LDRSRGB:
       return CompressedTextureFamily::kASTC;
+    case PixelFormat::kASTC4x4HDR:
+    case PixelFormat::kASTC8x8HDR:
+      return CompressedTextureFamily::kASTCHDR;
     default:
       break;
   }
@@ -208,6 +218,7 @@ constexpr size_t CompressedBlockWidthForPixelFormat(PixelFormat format) {
   switch (format) {
     case PixelFormat::kASTC8x8LDR:
     case PixelFormat::kASTC8x8LDRSRGB:
+    case PixelFormat::kASTC8x8HDR:
       return 8u;
     case PixelFormat::kBC1RGBAUNormInt:
     case PixelFormat::kBC1RGBAUNormIntSRGB:
@@ -222,6 +233,7 @@ constexpr size_t CompressedBlockWidthForPixelFormat(PixelFormat format) {
     case PixelFormat::kETC2RGBA8UNormIntSRGB:
     case PixelFormat::kASTC4x4LDR:
     case PixelFormat::kASTC4x4LDRSRGB:
+    case PixelFormat::kASTC4x4HDR:
       return 4u;
     default:
       return 1u;
@@ -234,6 +246,7 @@ constexpr size_t CompressedBlockHeightForPixelFormat(PixelFormat format) {
   switch (format) {
     case PixelFormat::kASTC8x8LDR:
     case PixelFormat::kASTC8x8LDRSRGB:
+    case PixelFormat::kASTC8x8HDR:
       return 8u;
     case PixelFormat::kBC1RGBAUNormInt:
     case PixelFormat::kBC1RGBAUNormIntSRGB:
@@ -248,6 +261,7 @@ constexpr size_t CompressedBlockHeightForPixelFormat(PixelFormat format) {
     case PixelFormat::kETC2RGBA8UNormIntSRGB:
     case PixelFormat::kASTC4x4LDR:
     case PixelFormat::kASTC4x4LDRSRGB:
+    case PixelFormat::kASTC4x4HDR:
       return 4u;
     default:
       return 1u;
@@ -341,6 +355,10 @@ constexpr const char* PixelFormatToString(PixelFormat format) {
       return "ASTC8x8LDR";
     case PixelFormat::kASTC8x8LDRSRGB:
       return "ASTC8x8LDRSRGB";
+    case PixelFormat::kASTC4x4HDR:
+      return "ASTC4x4HDR";
+    case PixelFormat::kASTC8x8HDR:
+      return "ASTC8x8HDR";
   }
   FML_UNREACHABLE();
 }
@@ -677,6 +695,8 @@ constexpr size_t BytesPerPixelForPixelFormat(PixelFormat format) {
     case PixelFormat::kASTC4x4LDRSRGB:
     case PixelFormat::kASTC8x8LDR:
     case PixelFormat::kASTC8x8LDRSRGB:
+    case PixelFormat::kASTC4x4HDR:
+    case PixelFormat::kASTC8x8HDR:
       return 0u;
   }
   return 0u;
@@ -703,6 +723,8 @@ constexpr size_t BytesPerBlockForPixelFormat(PixelFormat format) {
     case PixelFormat::kASTC4x4LDRSRGB:
     case PixelFormat::kASTC8x8LDR:
     case PixelFormat::kASTC8x8LDRSRGB:
+    case PixelFormat::kASTC4x4HDR:
+    case PixelFormat::kASTC8x8HDR:
       return 16u;
     default:
       return BytesPerPixelForPixelFormat(format);

--- a/engine/src/flutter/impeller/core/texture_descriptor.h
+++ b/engine/src/flutter/impeller/core/texture_descriptor.h
@@ -79,10 +79,7 @@ struct TextureDescriptor {
     if (!IsValid()) {
       return 0u;
     }
-    const size_t block_width = CompressedBlockWidthForPixelFormat(format);
-    const size_t w = size.width <= 0 ? 0u : static_cast<size_t>(size.width);
-    const size_t blocks_wide = (w + block_width - 1u) / block_width;
-    return blocks_wide * BytesPerBlockForPixelFormat(format);
+    return BytesPerRowForTextureWidth(format, size.width);
   }
 
   constexpr bool SamplingOptionsAreValid() const {

--- a/engine/src/flutter/impeller/core/texture_descriptor.h
+++ b/engine/src/flutter/impeller/core/texture_descriptor.h
@@ -45,11 +45,19 @@ struct TextureDescriptor {
   SampleCount sample_count = SampleCount::kCount1;
   CompressionType compression_type = CompressionType::kLossless;
 
+  /// @brief The number of bytes required to store an image of the given texel
+  ///        dimensions in this format. Block-compressed formats round the
+  ///        dimensions up to whole blocks.
+  constexpr size_t GetByteSizeForDimensions(int64_t width,
+                                            int64_t height) const {
+    return BytesForTextureRegion(format, width, height);
+  }
+
   constexpr size_t GetByteSizeOfBaseMipLevel() const {
     if (!IsValid()) {
       return 0u;
     }
-    return size.Area() * BytesPerPixelForPixelFormat(format);
+    return GetByteSizeForDimensions(size.width, size.height);
   }
 
   constexpr size_t GetByteSizeOfAllMipLevels() const {
@@ -60,8 +68,7 @@ struct TextureDescriptor {
     int64_t width = size.width;
     int64_t height = size.height;
     for (auto i = 0u; i < mip_count; i++) {
-      result +=
-          ISize(width, height).Area() * BytesPerPixelForPixelFormat(format);
+      result += GetByteSizeForDimensions(width, height);
       width /= 2;
       height /= 2;
     }
@@ -72,7 +79,10 @@ struct TextureDescriptor {
     if (!IsValid()) {
       return 0u;
     }
-    return size.width * BytesPerPixelForPixelFormat(format);
+    const size_t block_width = CompressedBlockWidthForPixelFormat(format);
+    const size_t w = size.width <= 0 ? 0u : static_cast<size_t>(size.width);
+    const size_t blocks_wide = (w + block_width - 1u) / block_width;
+    return blocks_wide * BytesPerBlockForPixelFormat(format);
   }
 
   constexpr bool SamplingOptionsAreValid() const {

--- a/engine/src/flutter/impeller/renderer/backend/gles/blit_command_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/blit_command_gles.cc
@@ -249,9 +249,9 @@ bool BlitCopyBufferToTextureCommandGLES::Encode(
                             gles_format->internal_format,  // internal format
                             mip_width,                     // width
                             mip_height,                    // height
-                            0u,                        // border
-                            source.GetRange().length,  // image size
-                            tex_data);                 // data
+                            0u,                            // border
+                            source.GetRange().length,      // image size
+                            tex_data);                     // data
     texture_gles.MarkSliceMipLevelInitialized(slice, mip_level);
     return true;
   }

--- a/engine/src/flutter/impeller/renderer/backend/gles/blit_command_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/blit_command_gles.cc
@@ -178,8 +178,9 @@ bool BlitCopyBufferToTextureCommandGLES::Encode(
 
   if (!tex_descriptor.IsValid() ||
       source.GetRange().length !=
-          BytesPerPixelForPixelFormat(tex_descriptor.format) *
-              destination_region.Area()) {
+          BytesForTextureRegion(tex_descriptor.format,
+                                destination_region.GetWidth(),
+                                destination_region.GetHeight())) {
     return false;
   }
 
@@ -226,6 +227,23 @@ bool BlitCopyBufferToTextureCommandGLES::Encode(
   gl.BindTexture(texture_type, gl_handle.value());
   const GLvoid* tex_data =
       source.GetBuffer()->OnGetContents() + source.GetRange().offset;
+
+  // Block-compressed textures cannot be allocated empty and then filled with a
+  // sub-image; the whole mip level is uploaded at once with
+  // glCompressedTexImage2D. Callers must overwrite a full mip level.
+  if (gles_format->is_compressed) {
+    gl.PixelStorei(GL_UNPACK_ALIGNMENT, 1);
+    gl.CompressedTexImage2D(texture_target,                // target
+                            mip_level,                     // LOD level
+                            gles_format->internal_format,  // internal format
+                            destination_region.GetWidth(),
+                            destination_region.GetHeight(),
+                            0u,                        // border
+                            source.GetRange().length,  // image size
+                            tex_data);                 // data
+    texture_gles.MarkSliceMipLevelInitialized(slice, mip_level);
+    return true;
+  }
 
   // GL_INVALID_OPERATION if the requested mip level has not been defined by
   // a previous glTexImage2D operation. Allocate the requested mip lazily on

--- a/engine/src/flutter/impeller/renderer/backend/gles/blit_command_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/blit_command_gles.cc
@@ -229,15 +229,26 @@ bool BlitCopyBufferToTextureCommandGLES::Encode(
       source.GetBuffer()->OnGetContents() + source.GetRange().offset;
 
   // Block-compressed textures cannot be allocated empty and then filled with a
-  // sub-image; the whole mip level is uploaded at once with
-  // glCompressedTexImage2D. Callers must overwrite a full mip level.
+  // sub-image; glCompressedTexImage2D redefines the entire mip level. Require
+  // the upload to cover the full mip level starting at the origin.
   if (gles_format->is_compressed) {
+    const auto mip_width =
+        std::max<int32_t>(1, tex_descriptor.size.width >> mip_level);
+    const auto mip_height =
+        std::max<int32_t>(1, tex_descriptor.size.height >> mip_level);
+    if (destination_region.GetX() != 0 || destination_region.GetY() != 0 ||
+        destination_region.GetWidth() != mip_width ||
+        destination_region.GetHeight() != mip_height) {
+      VALIDATION_LOG << "Compressed textures must be uploaded as a full mip "
+                        "level starting at the origin.";
+      return false;
+    }
     gl.PixelStorei(GL_UNPACK_ALIGNMENT, 1);
     gl.CompressedTexImage2D(texture_target,                // target
                             mip_level,                     // LOD level
                             gles_format->internal_format,  // internal format
-                            destination_region.GetWidth(),
-                            destination_region.GetHeight(),
+                            mip_width,                     // width
+                            mip_height,                    // height
                             0u,                        // border
                             source.GetRange().length,  // image size
                             tex_data);                 // data

--- a/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.cc
@@ -29,13 +29,24 @@ static const constexpr char* kMultisampledRenderToTexture2Ext =
 // https://registry.khronos.org/OpenGL/extensions/OES/OES_element_index_uint.txt
 static const constexpr char* kElementIndexUintExt = "GL_OES_element_index_uint";
 
+// The BC family spans three separate OpenGL ES extensions: S3TC (BC1-BC3),
+// RGTC (BC5), and BPTC (BC7). All three are required to report kBC support.
 // https://registry.khronos.org/OpenGL/extensions/EXT/EXT_texture_compression_s3tc.txt
 static const constexpr char* kTextureCompressionS3TCExt =
     "GL_EXT_texture_compression_s3tc";
+// https://registry.khronos.org/OpenGL/extensions/EXT/EXT_texture_compression_rgtc.txt
+static const constexpr char* kTextureCompressionRGTCExt =
+    "GL_EXT_texture_compression_rgtc";
+// https://registry.khronos.org/OpenGL/extensions/EXT/EXT_texture_compression_bptc.txt
+static const constexpr char* kTextureCompressionBPTCExt =
+    "GL_EXT_texture_compression_bptc";
 
 // https://registry.khronos.org/OpenGL/extensions/KHR/KHR_texture_compression_astc_hdr.txt
 static const constexpr char* kTextureCompressionAstcLdrExt =
     "GL_KHR_texture_compression_astc_ldr";
+// https://registry.khronos.org/OpenGL/extensions/OES/OES_texture_compression_astc.txt
+static const constexpr char* kTextureCompressionAstcOesExt =
+    "GL_OES_texture_compression_astc";
 
 CapabilitiesGLES::CapabilitiesGLES(const ProcTableGLES& gl) {
   {
@@ -156,12 +167,16 @@ CapabilitiesGLES::CapabilitiesGLES(const ProcTableGLES& gl) {
   is_es_ = desc->IsES();
   is_angle_ = desc->IsANGLE();
 
-  // ETC2 and EAC are mandatory in OpenGL ES 3.0. S3TC (BC) and ASTC are gated
-  // behind extensions and are not present on most mobile or desktop GLES.
+  // ETC2 and EAC are mandatory in OpenGL ES 3.0. BC and ASTC are gated behind
+  // extensions and are not present on most mobile or desktop GLES. The whole BC
+  // family requires S3TC, RGTC, and BPTC to all be present.
   supports_texture_compression_bc_ =
-      desc->HasExtension(kTextureCompressionS3TCExt);
+      desc->HasExtension(kTextureCompressionS3TCExt) &&
+      desc->HasExtension(kTextureCompressionRGTCExt) &&
+      desc->HasExtension(kTextureCompressionBPTCExt);
   supports_texture_compression_astc_ =
-      desc->HasExtension(kTextureCompressionAstcLdrExt);
+      desc->HasExtension(kTextureCompressionAstcLdrExt) ||
+      desc->HasExtension(kTextureCompressionAstcOesExt);
   supports_texture_compression_etc2_ =
       desc->IsES() && desc->GetGlVersion().major_version >= 3;
 }

--- a/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.cc
@@ -29,6 +29,14 @@ static const constexpr char* kMultisampledRenderToTexture2Ext =
 // https://registry.khronos.org/OpenGL/extensions/OES/OES_element_index_uint.txt
 static const constexpr char* kElementIndexUintExt = "GL_OES_element_index_uint";
 
+// https://registry.khronos.org/OpenGL/extensions/EXT/EXT_texture_compression_s3tc.txt
+static const constexpr char* kTextureCompressionS3TCExt =
+    "GL_EXT_texture_compression_s3tc";
+
+// https://registry.khronos.org/OpenGL/extensions/KHR/KHR_texture_compression_astc_hdr.txt
+static const constexpr char* kTextureCompressionAstcLdrExt =
+    "GL_KHR_texture_compression_astc_ldr";
+
 CapabilitiesGLES::CapabilitiesGLES(const ProcTableGLES& gl) {
   {
     GLint value = 0;
@@ -147,6 +155,15 @@ CapabilitiesGLES::CapabilitiesGLES(const ProcTableGLES& gl) {
   }
   is_es_ = desc->IsES();
   is_angle_ = desc->IsANGLE();
+
+  // ETC2 and EAC are mandatory in OpenGL ES 3.0. S3TC (BC) and ASTC are gated
+  // behind extensions and are not present on most mobile or desktop GLES.
+  supports_texture_compression_bc_ =
+      desc->HasExtension(kTextureCompressionS3TCExt);
+  supports_texture_compression_astc_ =
+      desc->HasExtension(kTextureCompressionAstcLdrExt);
+  supports_texture_compression_etc2_ =
+      desc->IsES() && desc->GetGlVersion().major_version >= 3;
 }
 
 bool CapabilitiesGLES::IsES() const {
@@ -235,6 +252,19 @@ bool CapabilitiesGLES::Supports32BitPrimitiveIndices() const {
 }
 
 bool CapabilitiesGLES::SupportsExtendedRangeFormats() const {
+  return false;
+}
+
+bool CapabilitiesGLES::SupportsTextureCompression(
+    CompressedTextureFamily family) const {
+  switch (family) {
+    case CompressedTextureFamily::kBC:
+      return supports_texture_compression_bc_;
+    case CompressedTextureFamily::kETC2:
+      return supports_texture_compression_etc2_;
+    case CompressedTextureFamily::kASTC:
+      return supports_texture_compression_astc_;
+  }
   return false;
 }
 

--- a/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.cc
@@ -47,6 +47,9 @@ static const constexpr char* kTextureCompressionAstcLdrExt =
 // https://registry.khronos.org/OpenGL/extensions/OES/OES_texture_compression_astc.txt
 static const constexpr char* kTextureCompressionAstcOesExt =
     "GL_OES_texture_compression_astc";
+// https://registry.khronos.org/OpenGL/extensions/KHR/KHR_texture_compression_astc_hdr.txt
+static const constexpr char* kTextureCompressionAstcHdrExt =
+    "GL_KHR_texture_compression_astc_hdr";
 
 CapabilitiesGLES::CapabilitiesGLES(const ProcTableGLES& gl) {
   {
@@ -174,8 +177,16 @@ CapabilitiesGLES::CapabilitiesGLES(const ProcTableGLES& gl) {
       desc->HasExtension(kTextureCompressionS3TCExt) &&
       desc->HasExtension(kTextureCompressionRGTCExt) &&
       desc->HasExtension(kTextureCompressionBPTCExt);
+  // Either extension is sufficient: both expose the same LDR 2D ASTC internal
+  // formats this backend uses. KHR is the common one; OES is a superset that
+  // also adds HDR and 3D, which are not used here.
   supports_texture_compression_astc_ =
       desc->HasExtension(kTextureCompressionAstcLdrExt) ||
+      desc->HasExtension(kTextureCompressionAstcOesExt);
+  // HDR reuses the same internal formats as LDR, gated by a separate extension.
+  // The OES extension is a superset that also covers HDR.
+  supports_texture_compression_astc_hdr_ =
+      desc->HasExtension(kTextureCompressionAstcHdrExt) ||
       desc->HasExtension(kTextureCompressionAstcOesExt);
   supports_texture_compression_etc2_ =
       desc->IsES() && desc->GetGlVersion().major_version >= 3;
@@ -279,6 +290,8 @@ bool CapabilitiesGLES::SupportsTextureCompression(
       return supports_texture_compression_etc2_;
     case CompressedTextureFamily::kASTC:
       return supports_texture_compression_astc_;
+    case CompressedTextureFamily::kASTCHDR:
+      return supports_texture_compression_astc_hdr_;
   }
   return false;
 }

--- a/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.h
@@ -123,6 +123,10 @@ class CapabilitiesGLES final
   bool SupportsExtendedRangeFormats() const override;
 
   // |Capabilities|
+  bool SupportsTextureCompression(
+      CompressedTextureFamily family) const override;
+
+  // |Capabilities|
   PixelFormat GetDefaultColorFormat() const override;
 
   // |Capabilities|
@@ -152,6 +156,9 @@ class CapabilitiesGLES final
   bool supports_32bit_primitive_indices_ = false;
   bool is_angle_ = false;
   bool is_es_ = false;
+  bool supports_texture_compression_bc_ = false;
+  bool supports_texture_compression_etc2_ = false;
+  bool supports_texture_compression_astc_ = false;
   PixelFormat default_glyph_atlas_format_ = PixelFormat::kUnknown;
 };
 

--- a/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.h
@@ -159,6 +159,7 @@ class CapabilitiesGLES final
   bool supports_texture_compression_bc_ = false;
   bool supports_texture_compression_etc2_ = false;
   bool supports_texture_compression_astc_ = false;
+  bool supports_texture_compression_astc_hdr_ = false;
   PixelFormat default_glyph_atlas_format_ = PixelFormat::kUnknown;
 };
 

--- a/engine/src/flutter/impeller/renderer/backend/gles/formats_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/formats_gles.cc
@@ -4,6 +4,56 @@
 
 #include "impeller/renderer/backend/gles/formats_gles.h"
 
+// Compressed texture internal formats. ETC2/EAC are core in OpenGL ES 3.0, but
+// the S3TC (BC1/BC3), RGTC (BC5), BPTC (BC7), and ASTC enums come from
+// extension headers that are not present on every platform, so they are
+// guarded here.
+#ifndef GL_COMPRESSED_RGBA_S3TC_DXT1_EXT
+#define GL_COMPRESSED_RGBA_S3TC_DXT1_EXT 0x83F1
+#endif
+#ifndef GL_COMPRESSED_RGBA_S3TC_DXT5_EXT
+#define GL_COMPRESSED_RGBA_S3TC_DXT5_EXT 0x83F3
+#endif
+#ifndef GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT1_EXT
+#define GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT1_EXT 0x8C4D
+#endif
+#ifndef GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT5_EXT
+#define GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT5_EXT 0x8C4F
+#endif
+#ifndef GL_COMPRESSED_RG_RGTC2
+#define GL_COMPRESSED_RG_RGTC2 0x8DBD
+#endif
+#ifndef GL_COMPRESSED_RGBA_BPTC_UNORM
+#define GL_COMPRESSED_RGBA_BPTC_UNORM 0x8E8C
+#endif
+#ifndef GL_COMPRESSED_SRGB_ALPHA_BPTC_UNORM
+#define GL_COMPRESSED_SRGB_ALPHA_BPTC_UNORM 0x8E8D
+#endif
+#ifndef GL_COMPRESSED_RGB8_ETC2
+#define GL_COMPRESSED_RGB8_ETC2 0x9274
+#endif
+#ifndef GL_COMPRESSED_SRGB8_ETC2
+#define GL_COMPRESSED_SRGB8_ETC2 0x9275
+#endif
+#ifndef GL_COMPRESSED_RGBA8_ETC2_EAC
+#define GL_COMPRESSED_RGBA8_ETC2_EAC 0x9278
+#endif
+#ifndef GL_COMPRESSED_SRGB8_ALPHA8_ETC2_EAC
+#define GL_COMPRESSED_SRGB8_ALPHA8_ETC2_EAC 0x9279
+#endif
+#ifndef GL_COMPRESSED_RGBA_ASTC_4x4_KHR
+#define GL_COMPRESSED_RGBA_ASTC_4x4_KHR 0x93B0
+#endif
+#ifndef GL_COMPRESSED_RGBA_ASTC_8x8_KHR
+#define GL_COMPRESSED_RGBA_ASTC_8x8_KHR 0x93B7
+#endif
+#ifndef GL_COMPRESSED_SRGB8_ALPHA8_ASTC_4x4_KHR
+#define GL_COMPRESSED_SRGB8_ALPHA8_ASTC_4x4_KHR 0x93D0
+#endif
+#ifndef GL_COMPRESSED_SRGB8_ALPHA8_ASTC_8x8_KHR
+#define GL_COMPRESSED_SRGB8_ALPHA8_ASTC_8x8_KHR 0x93D7
+#endif
+
 namespace impeller {
 
 std::string DebugToFramebufferError(int status) {
@@ -80,6 +130,68 @@ std::optional<PixelFormatGLES> ToPixelFormatGLES(PixelFormat pixel_format,
       format.internal_format = GL_DEPTH_STENCIL;
       format.external_format = GL_DEPTH_STENCIL;
       format.type = GL_UNSIGNED_INT_24_8;
+      break;
+    // Block-compressed formats. Only the internal format is meaningful; the
+    // data is uploaded with glCompressedTexImage2D rather than glTexImage2D.
+    case PixelFormat::kBC1RGBAUNormInt:
+      format.internal_format = GL_COMPRESSED_RGBA_S3TC_DXT1_EXT;
+      format.is_compressed = true;
+      break;
+    case PixelFormat::kBC1RGBAUNormIntSRGB:
+      format.internal_format = GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT1_EXT;
+      format.is_compressed = true;
+      break;
+    case PixelFormat::kBC3RGBAUNormInt:
+      format.internal_format = GL_COMPRESSED_RGBA_S3TC_DXT5_EXT;
+      format.is_compressed = true;
+      break;
+    case PixelFormat::kBC3RGBAUNormIntSRGB:
+      format.internal_format = GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT5_EXT;
+      format.is_compressed = true;
+      break;
+    case PixelFormat::kBC5RGUNormInt:
+      format.internal_format = GL_COMPRESSED_RG_RGTC2;
+      format.is_compressed = true;
+      break;
+    case PixelFormat::kBC7RGBAUNormInt:
+      format.internal_format = GL_COMPRESSED_RGBA_BPTC_UNORM;
+      format.is_compressed = true;
+      break;
+    case PixelFormat::kBC7RGBAUNormIntSRGB:
+      format.internal_format = GL_COMPRESSED_SRGB_ALPHA_BPTC_UNORM;
+      format.is_compressed = true;
+      break;
+    case PixelFormat::kETC2RGB8UNormInt:
+      format.internal_format = GL_COMPRESSED_RGB8_ETC2;
+      format.is_compressed = true;
+      break;
+    case PixelFormat::kETC2RGB8UNormIntSRGB:
+      format.internal_format = GL_COMPRESSED_SRGB8_ETC2;
+      format.is_compressed = true;
+      break;
+    case PixelFormat::kETC2RGBA8UNormInt:
+      format.internal_format = GL_COMPRESSED_RGBA8_ETC2_EAC;
+      format.is_compressed = true;
+      break;
+    case PixelFormat::kETC2RGBA8UNormIntSRGB:
+      format.internal_format = GL_COMPRESSED_SRGB8_ALPHA8_ETC2_EAC;
+      format.is_compressed = true;
+      break;
+    case PixelFormat::kASTC4x4LDR:
+      format.internal_format = GL_COMPRESSED_RGBA_ASTC_4x4_KHR;
+      format.is_compressed = true;
+      break;
+    case PixelFormat::kASTC4x4LDRSRGB:
+      format.internal_format = GL_COMPRESSED_SRGB8_ALPHA8_ASTC_4x4_KHR;
+      format.is_compressed = true;
+      break;
+    case PixelFormat::kASTC8x8LDR:
+      format.internal_format = GL_COMPRESSED_RGBA_ASTC_8x8_KHR;
+      format.is_compressed = true;
+      break;
+    case PixelFormat::kASTC8x8LDRSRGB:
+      format.internal_format = GL_COMPRESSED_SRGB8_ALPHA8_ASTC_8x8_KHR;
+      format.is_compressed = true;
       break;
     case PixelFormat::kUnknown:
     case PixelFormat::kD32FloatS8UInt:

--- a/engine/src/flutter/impeller/renderer/backend/gles/formats_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/formats_gles.cc
@@ -193,6 +193,16 @@ std::optional<PixelFormatGLES> ToPixelFormatGLES(PixelFormat pixel_format,
       format.internal_format = GL_COMPRESSED_SRGB8_ALPHA8_ASTC_8x8_KHR;
       format.is_compressed = true;
       break;
+    // ASTC HDR uses the same internal formats as LDR; the HDR profile is
+    // selected by the GL_KHR_texture_compression_astc_hdr extension.
+    case PixelFormat::kASTC4x4HDR:
+      format.internal_format = GL_COMPRESSED_RGBA_ASTC_4x4_KHR;
+      format.is_compressed = true;
+      break;
+    case PixelFormat::kASTC8x8HDR:
+      format.internal_format = GL_COMPRESSED_RGBA_ASTC_8x8_KHR;
+      format.is_compressed = true;
+      break;
     case PixelFormat::kUnknown:
     case PixelFormat::kD32FloatS8UInt:
     case PixelFormat::kR8G8UNormInt:

--- a/engine/src/flutter/impeller/renderer/backend/gles/formats_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/formats_gles.h
@@ -200,6 +200,9 @@ struct PixelFormatGLES {
   GLint internal_format = 0;
   GLenum external_format = GL_NONE;
   GLenum type = GL_NONE;
+  // When true, the data must be uploaded with glCompressedTexImage2D and only
+  // `internal_format` is meaningful.
+  bool is_compressed = false;
 };
 
 std::optional<PixelFormatGLES> ToPixelFormatGLES(PixelFormat format,

--- a/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
@@ -224,6 +224,8 @@ struct GLProc {
   PROC(StencilOpSeparate);                   \
   PROC(TexImage2D);                          \
   PROC(TexSubImage2D);                       \
+  PROC(CompressedTexImage2D);                \
+  PROC(CompressedTexSubImage2D);             \
   PROC(TexParameteri);                       \
   PROC(TexParameterfv);                      \
   PROC(Uniform1fv);                          \

--- a/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.cc
@@ -281,53 +281,53 @@ bool TextureGLES::OnSetContents(std::shared_ptr<const fml::Mapping> mapping,
   }
 
   ReactorGLES::Operation texture_upload =
-      [handle = handle_,                                              //
-       mapping,                                                      //
-       format = gles_format.value(),                                //
-       size = tex_descriptor.size,                                  //
-       image_size = tex_descriptor.GetByteSizeOfBaseMipLevel(),     //
-       texture_type,                                                //
-       texture_target                                               //
+      [handle = handle_,                                         //
+       mapping,                                                  //
+       format = gles_format.value(),                             //
+       size = tex_descriptor.size,                               //
+       image_size = tex_descriptor.GetByteSizeOfBaseMipLevel(),  //
+       texture_type,                                             //
+       texture_target                                            //
   ](const auto& reactor) {
-    auto gl_handle = reactor.GetGLHandle(handle);
-    if (!gl_handle.has_value()) {
-      VALIDATION_LOG
-          << "Texture was collected before it could be uploaded to the GPU.";
-      return;
-    }
-    const auto& gl = reactor.GetProcTable();
-    gl.BindTexture(texture_type, gl_handle.value());
-    const GLvoid* tex_data = nullptr;
-    if (mapping) {
-      tex_data = mapping->GetMapping();
-    }
+        auto gl_handle = reactor.GetGLHandle(handle);
+        if (!gl_handle.has_value()) {
+          VALIDATION_LOG << "Texture was collected before it could be uploaded "
+                            "to the GPU.";
+          return;
+        }
+        const auto& gl = reactor.GetProcTable();
+        gl.BindTexture(texture_type, gl_handle.value());
+        const GLvoid* tex_data = nullptr;
+        if (mapping) {
+          tex_data = mapping->GetMapping();
+        }
 
-    {
-      TRACE_EVENT1("impeller", "TexImage2DUpload", "Bytes",
-                   std::to_string(mapping->GetSize()).c_str());
-      gl.PixelStorei(GL_UNPACK_ALIGNMENT, 1);
-      if (format.is_compressed) {
-        gl.CompressedTexImage2D(texture_target,          // target
-                                0u,                      // LOD level
-                                format.internal_format,  // internal format
-                                size.width,              // width
-                                size.height,             // height
-                                0u,                      // border
-                                image_size,              // image size
-                                tex_data);               // data
-      } else {
-        gl.TexImage2D(texture_target,          // target
-                      0u,                      // LOD level
-                      format.internal_format,  // internal format
-                      size.width,              // width
-                      size.height,             // height
-                      0u,                      // border
-                      format.external_format,  // format
-                      format.type,             // type
-                      tex_data);               // data
-      }
-    }
-  };
+        {
+          TRACE_EVENT1("impeller", "TexImage2DUpload", "Bytes",
+                       std::to_string(mapping->GetSize()).c_str());
+          gl.PixelStorei(GL_UNPACK_ALIGNMENT, 1);
+          if (format.is_compressed) {
+            gl.CompressedTexImage2D(texture_target,          // target
+                                    0u,                      // LOD level
+                                    format.internal_format,  // internal format
+                                    size.width,              // width
+                                    size.height,             // height
+                                    0u,                      // border
+                                    image_size,              // image size
+                                    tex_data);               // data
+          } else {
+            gl.TexImage2D(texture_target,          // target
+                          0u,                      // LOD level
+                          format.internal_format,  // internal format
+                          size.width,              // width
+                          size.height,             // height
+                          0u,                      // border
+                          format.external_format,  // format
+                          format.type,             // type
+                          tex_data);               // data
+          }
+        }
+      };
 
   const bool added = reactor_->AddOperation(texture_upload);
   if (added) {

--- a/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.cc
@@ -55,6 +55,8 @@ static bool IsDepthStencilFormat(PixelFormat format) {
     case PixelFormat::kASTC4x4LDRSRGB:
     case PixelFormat::kASTC8x8LDR:
     case PixelFormat::kASTC8x8LDRSRGB:
+    case PixelFormat::kASTC4x4HDR:
+    case PixelFormat::kASTC8x8HDR:
       return false;
   }
   FML_UNREACHABLE();
@@ -381,6 +383,8 @@ static std::optional<GLenum> ToRenderBufferFormat(PixelFormat format) {
     case PixelFormat::kASTC4x4LDRSRGB:
     case PixelFormat::kASTC8x8LDR:
     case PixelFormat::kASTC8x8LDRSRGB:
+    case PixelFormat::kASTC4x4HDR:
+    case PixelFormat::kASTC8x8HDR:
       return std::nullopt;
   }
   FML_UNREACHABLE();

--- a/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.cc
@@ -40,6 +40,21 @@ static bool IsDepthStencilFormat(PixelFormat format) {
     case PixelFormat::kB10G10R10XRSRGB:
     case PixelFormat::kB10G10R10A10XR:
     case PixelFormat::kR32Float:
+    case PixelFormat::kBC1RGBAUNormInt:
+    case PixelFormat::kBC1RGBAUNormIntSRGB:
+    case PixelFormat::kBC3RGBAUNormInt:
+    case PixelFormat::kBC3RGBAUNormIntSRGB:
+    case PixelFormat::kBC5RGUNormInt:
+    case PixelFormat::kBC7RGBAUNormInt:
+    case PixelFormat::kBC7RGBAUNormIntSRGB:
+    case PixelFormat::kETC2RGB8UNormInt:
+    case PixelFormat::kETC2RGB8UNormIntSRGB:
+    case PixelFormat::kETC2RGBA8UNormInt:
+    case PixelFormat::kETC2RGBA8UNormIntSRGB:
+    case PixelFormat::kASTC4x4LDR:
+    case PixelFormat::kASTC4x4LDRSRGB:
+    case PixelFormat::kASTC8x8LDR:
+    case PixelFormat::kASTC8x8LDRSRGB:
       return false;
   }
   FML_UNREACHABLE();
@@ -265,12 +280,14 @@ bool TextureGLES::OnSetContents(std::shared_ptr<const fml::Mapping> mapping,
     return false;
   }
 
-  ReactorGLES::Operation texture_upload = [handle = handle_,              //
-                                           mapping,                       //
-                                           format = gles_format.value(),  //
-                                           size = tex_descriptor.size,    //
-                                           texture_type,                  //
-                                           texture_target                 //
+  ReactorGLES::Operation texture_upload =
+      [handle = handle_,                                              //
+       mapping,                                                      //
+       format = gles_format.value(),                                //
+       size = tex_descriptor.size,                                  //
+       image_size = tex_descriptor.GetByteSizeOfBaseMipLevel(),     //
+       texture_type,                                                //
+       texture_target                                               //
   ](const auto& reactor) {
     auto gl_handle = reactor.GetGLHandle(handle);
     if (!gl_handle.has_value()) {
@@ -289,15 +306,26 @@ bool TextureGLES::OnSetContents(std::shared_ptr<const fml::Mapping> mapping,
       TRACE_EVENT1("impeller", "TexImage2DUpload", "Bytes",
                    std::to_string(mapping->GetSize()).c_str());
       gl.PixelStorei(GL_UNPACK_ALIGNMENT, 1);
-      gl.TexImage2D(texture_target,          // target
-                    0u,                      // LOD level
-                    format.internal_format,  // internal format
-                    size.width,              // width
-                    size.height,             // height
-                    0u,                      // border
-                    format.external_format,  // format
-                    format.type,             // type
-                    tex_data);               // data
+      if (format.is_compressed) {
+        gl.CompressedTexImage2D(texture_target,          // target
+                                0u,                      // LOD level
+                                format.internal_format,  // internal format
+                                size.width,              // width
+                                size.height,             // height
+                                0u,                      // border
+                                image_size,              // image size
+                                tex_data);               // data
+      } else {
+        gl.TexImage2D(texture_target,          // target
+                      0u,                      // LOD level
+                      format.internal_format,  // internal format
+                      size.width,              // width
+                      size.height,             // height
+                      0u,                      // border
+                      format.external_format,  // format
+                      format.type,             // type
+                      tex_data);               // data
+      }
     }
   };
 
@@ -338,6 +366,21 @@ static std::optional<GLenum> ToRenderBufferFormat(PixelFormat format) {
     case PixelFormat::kB10G10R10XR:
     case PixelFormat::kB10G10R10A10XR:
     case PixelFormat::kR32Float:
+    case PixelFormat::kBC1RGBAUNormInt:
+    case PixelFormat::kBC1RGBAUNormIntSRGB:
+    case PixelFormat::kBC3RGBAUNormInt:
+    case PixelFormat::kBC3RGBAUNormIntSRGB:
+    case PixelFormat::kBC5RGUNormInt:
+    case PixelFormat::kBC7RGBAUNormInt:
+    case PixelFormat::kBC7RGBAUNormIntSRGB:
+    case PixelFormat::kETC2RGB8UNormInt:
+    case PixelFormat::kETC2RGB8UNormIntSRGB:
+    case PixelFormat::kETC2RGBA8UNormInt:
+    case PixelFormat::kETC2RGBA8UNormIntSRGB:
+    case PixelFormat::kASTC4x4LDR:
+    case PixelFormat::kASTC4x4LDRSRGB:
+    case PixelFormat::kASTC8x8LDR:
+    case PixelFormat::kASTC8x8LDRSRGB:
       return std::nullopt;
   }
   FML_UNREACHABLE();

--- a/engine/src/flutter/impeller/renderer/backend/metal/blit_pass_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/blit_pass_mtl.mm
@@ -208,10 +208,9 @@ bool BlitPassMTL::OnCopyBufferToTextureCommand(
   auto source_size_mtl = MTLSizeMake(destination_region.GetWidth(),
                                      destination_region.GetHeight(), 1);
 
-  auto destination_bytes_per_pixel =
-      BytesPerPixelForPixelFormat(destination->GetTextureDescriptor().format);
   auto source_bytes_per_row =
-      destination_region.GetWidth() * destination_bytes_per_pixel;
+      BytesPerRowForTextureWidth(destination->GetTextureDescriptor().format,
+                                 destination_region.GetWidth());
 
 #ifdef IMPELLER_DEBUG
   if (is_metal_trace_active_) {

--- a/engine/src/flutter/impeller/renderer/backend/metal/context_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/context_mtl.mm
@@ -49,6 +49,20 @@ static bool DeviceSupportsExtendedRangeFormats(id<MTLDevice> device) {
   return [device supportsFamily:MTLGPUFamilyApple3];
 }
 
+// See "Pixel Format Capabilities" in the Metal Feature Set Tables:
+// https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf
+// BC formats are available on the Mac family and on Apple7+ (A14/M1 and newer).
+static bool DeviceSupportsTextureCompressionBC(id<MTLDevice> device) {
+  return [device supportsFamily:MTLGPUFamilyMac2] ||
+         [device supportsFamily:MTLGPUFamilyApple7];
+}
+
+// ETC2 and ASTC are available on all Apple GPU families but not on the Mac
+// (Intel/AMD) family.
+static bool DeviceSupportsTextureCompressionMobile(id<MTLDevice> device) {
+  return [device supportsFamily:MTLGPUFamilyApple2];
+}
+
 static std::unique_ptr<Capabilities> InferMetalCapabilities(
     id<MTLDevice> device,
     PixelFormat color_format) {
@@ -70,6 +84,15 @@ static std::unique_ptr<Capabilities> InferMetalCapabilities(
       .SetMaximumRenderPassAttachmentSize(DeviceMaxTextureSizeSupported(device))
       .SetSupportsExtendedRangeFormats(
           DeviceSupportsExtendedRangeFormats(device))
+      .SetSupportsTextureCompression(
+          CompressedTextureFamily::kBC,
+          DeviceSupportsTextureCompressionBC(device))
+      .SetSupportsTextureCompression(
+          CompressedTextureFamily::kETC2,
+          DeviceSupportsTextureCompressionMobile(device))
+      .SetSupportsTextureCompression(
+          CompressedTextureFamily::kASTC,
+          DeviceSupportsTextureCompressionMobile(device))
 #if FML_OS_IOS && !TARGET_OS_SIMULATOR
       .SetMinimumUniformAlignment(16)
 #else

--- a/engine/src/flutter/impeller/renderer/backend/metal/context_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/context_mtl.mm
@@ -84,9 +84,8 @@ static std::unique_ptr<Capabilities> InferMetalCapabilities(
       .SetMaximumRenderPassAttachmentSize(DeviceMaxTextureSizeSupported(device))
       .SetSupportsExtendedRangeFormats(
           DeviceSupportsExtendedRangeFormats(device))
-      .SetSupportsTextureCompression(
-          CompressedTextureFamily::kBC,
-          DeviceSupportsTextureCompressionBC(device))
+      .SetSupportsTextureCompression(CompressedTextureFamily::kBC,
+                                     DeviceSupportsTextureCompressionBC(device))
       .SetSupportsTextureCompression(
           CompressedTextureFamily::kETC2,
           DeviceSupportsTextureCompressionMobile(device))

--- a/engine/src/flutter/impeller/renderer/backend/metal/context_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/context_mtl.mm
@@ -57,10 +57,15 @@ static bool DeviceSupportsTextureCompressionBC(id<MTLDevice> device) {
          [device supportsFamily:MTLGPUFamilyApple7];
 }
 
-// ETC2 and ASTC are available on all Apple GPU families but not on the Mac
+// ETC2 and ASTC LDR are available on all Apple GPU families but not on the Mac
 // (Intel/AMD) family.
 static bool DeviceSupportsTextureCompressionMobile(id<MTLDevice> device) {
   return [device supportsFamily:MTLGPUFamilyApple2];
+}
+
+// ASTC HDR requires Apple GPU family 6 (A13) or later.
+static bool DeviceSupportsTextureCompressionAstcHdr(id<MTLDevice> device) {
+  return [device supportsFamily:MTLGPUFamilyApple6];
 }
 
 static std::unique_ptr<Capabilities> InferMetalCapabilities(
@@ -92,6 +97,9 @@ static std::unique_ptr<Capabilities> InferMetalCapabilities(
       .SetSupportsTextureCompression(
           CompressedTextureFamily::kASTC,
           DeviceSupportsTextureCompressionMobile(device))
+      .SetSupportsTextureCompression(
+          CompressedTextureFamily::kASTCHDR,
+          DeviceSupportsTextureCompressionAstcHdr(device))
 #if FML_OS_IOS && !TARGET_OS_SIMULATOR
       .SetMinimumUniformAlignment(16)
 #else

--- a/engine/src/flutter/impeller/renderer/backend/metal/formats_mtl.h
+++ b/engine/src/flutter/impeller/renderer/backend/metal/formats_mtl.h
@@ -73,6 +73,25 @@ MTLPixelFormat SafeMTLPixelFormatBGR10_XR();
 /// Returns PixelFormat::kUnknown if MTLPixelFormatBGR10_XR isn't supported.
 MTLPixelFormat SafeMTLPixelFormatBGRA10_XR();
 
+/// Safe accessors for the block-compressed formats. Each returns
+/// MTLPixelFormatInvalid on platforms or OS versions where the format is not
+/// available (BC is macOS only; ETC2 and ASTC require macOS 11.0+).
+MTLPixelFormat SafeMTLPixelFormatBC1_RGBA();
+MTLPixelFormat SafeMTLPixelFormatBC1_RGBA_sRGB();
+MTLPixelFormat SafeMTLPixelFormatBC3_RGBA();
+MTLPixelFormat SafeMTLPixelFormatBC3_RGBA_sRGB();
+MTLPixelFormat SafeMTLPixelFormatBC5_RGUnorm();
+MTLPixelFormat SafeMTLPixelFormatBC7_RGBAUnorm();
+MTLPixelFormat SafeMTLPixelFormatBC7_RGBAUnorm_sRGB();
+MTLPixelFormat SafeMTLPixelFormatETC2_RGB8();
+MTLPixelFormat SafeMTLPixelFormatETC2_RGB8_sRGB();
+MTLPixelFormat SafeMTLPixelFormatEAC_RGBA8();
+MTLPixelFormat SafeMTLPixelFormatEAC_RGBA8_sRGB();
+MTLPixelFormat SafeMTLPixelFormatASTC_4x4_LDR();
+MTLPixelFormat SafeMTLPixelFormatASTC_4x4_sRGB();
+MTLPixelFormat SafeMTLPixelFormatASTC_8x8_LDR();
+MTLPixelFormat SafeMTLPixelFormatASTC_8x8_sRGB();
+
 constexpr MTLPixelFormat ToMTLPixelFormat(PixelFormat format) {
   switch (format) {
     case PixelFormat::kUnknown:
@@ -110,35 +129,35 @@ constexpr MTLPixelFormat ToMTLPixelFormat(PixelFormat format) {
     case PixelFormat::kR32Float:
       return MTLPixelFormatR32Float;
     case PixelFormat::kBC1RGBAUNormInt:
-      return MTLPixelFormatBC1_RGBA;
+      return SafeMTLPixelFormatBC1_RGBA();
     case PixelFormat::kBC1RGBAUNormIntSRGB:
-      return MTLPixelFormatBC1_RGBA_sRGB;
+      return SafeMTLPixelFormatBC1_RGBA_sRGB();
     case PixelFormat::kBC3RGBAUNormInt:
-      return MTLPixelFormatBC3_RGBA;
+      return SafeMTLPixelFormatBC3_RGBA();
     case PixelFormat::kBC3RGBAUNormIntSRGB:
-      return MTLPixelFormatBC3_RGBA_sRGB;
+      return SafeMTLPixelFormatBC3_RGBA_sRGB();
     case PixelFormat::kBC5RGUNormInt:
-      return MTLPixelFormatBC5_RGUnorm;
+      return SafeMTLPixelFormatBC5_RGUnorm();
     case PixelFormat::kBC7RGBAUNormInt:
-      return MTLPixelFormatBC7_RGBAUnorm;
+      return SafeMTLPixelFormatBC7_RGBAUnorm();
     case PixelFormat::kBC7RGBAUNormIntSRGB:
-      return MTLPixelFormatBC7_RGBAUnorm_sRGB;
+      return SafeMTLPixelFormatBC7_RGBAUnorm_sRGB();
     case PixelFormat::kETC2RGB8UNormInt:
-      return MTLPixelFormatETC2_RGB8;
+      return SafeMTLPixelFormatETC2_RGB8();
     case PixelFormat::kETC2RGB8UNormIntSRGB:
-      return MTLPixelFormatETC2_RGB8_sRGB;
+      return SafeMTLPixelFormatETC2_RGB8_sRGB();
     case PixelFormat::kETC2RGBA8UNormInt:
-      return MTLPixelFormatEAC_RGBA8;
+      return SafeMTLPixelFormatEAC_RGBA8();
     case PixelFormat::kETC2RGBA8UNormIntSRGB:
-      return MTLPixelFormatEAC_RGBA8_sRGB;
+      return SafeMTLPixelFormatEAC_RGBA8_sRGB();
     case PixelFormat::kASTC4x4LDR:
-      return MTLPixelFormatASTC_4x4_LDR;
+      return SafeMTLPixelFormatASTC_4x4_LDR();
     case PixelFormat::kASTC4x4LDRSRGB:
-      return MTLPixelFormatASTC_4x4_sRGB;
+      return SafeMTLPixelFormatASTC_4x4_sRGB();
     case PixelFormat::kASTC8x8LDR:
-      return MTLPixelFormatASTC_8x8_LDR;
+      return SafeMTLPixelFormatASTC_8x8_LDR();
     case PixelFormat::kASTC8x8LDRSRGB:
-      return MTLPixelFormatASTC_8x8_sRGB;
+      return SafeMTLPixelFormatASTC_8x8_sRGB();
   }
   return MTLPixelFormatInvalid;
 };

--- a/engine/src/flutter/impeller/renderer/backend/metal/formats_mtl.h
+++ b/engine/src/flutter/impeller/renderer/backend/metal/formats_mtl.h
@@ -91,6 +91,8 @@ MTLPixelFormat SafeMTLPixelFormatASTC_4x4_LDR();
 MTLPixelFormat SafeMTLPixelFormatASTC_4x4_sRGB();
 MTLPixelFormat SafeMTLPixelFormatASTC_8x8_LDR();
 MTLPixelFormat SafeMTLPixelFormatASTC_8x8_sRGB();
+MTLPixelFormat SafeMTLPixelFormatASTC_4x4_HDR();
+MTLPixelFormat SafeMTLPixelFormatASTC_8x8_HDR();
 
 constexpr MTLPixelFormat ToMTLPixelFormat(PixelFormat format) {
   switch (format) {
@@ -158,6 +160,10 @@ constexpr MTLPixelFormat ToMTLPixelFormat(PixelFormat format) {
       return SafeMTLPixelFormatASTC_8x8_LDR();
     case PixelFormat::kASTC8x8LDRSRGB:
       return SafeMTLPixelFormatASTC_8x8_sRGB();
+    case PixelFormat::kASTC4x4HDR:
+      return SafeMTLPixelFormatASTC_4x4_HDR();
+    case PixelFormat::kASTC8x8HDR:
+      return SafeMTLPixelFormatASTC_8x8_HDR();
   }
   return MTLPixelFormatInvalid;
 };

--- a/engine/src/flutter/impeller/renderer/backend/metal/formats_mtl.h
+++ b/engine/src/flutter/impeller/renderer/backend/metal/formats_mtl.h
@@ -109,6 +109,36 @@ constexpr MTLPixelFormat ToMTLPixelFormat(PixelFormat format) {
       return SafeMTLPixelFormatBGRA10_XR();
     case PixelFormat::kR32Float:
       return MTLPixelFormatR32Float;
+    case PixelFormat::kBC1RGBAUNormInt:
+      return MTLPixelFormatBC1_RGBA;
+    case PixelFormat::kBC1RGBAUNormIntSRGB:
+      return MTLPixelFormatBC1_RGBA_sRGB;
+    case PixelFormat::kBC3RGBAUNormInt:
+      return MTLPixelFormatBC3_RGBA;
+    case PixelFormat::kBC3RGBAUNormIntSRGB:
+      return MTLPixelFormatBC3_RGBA_sRGB;
+    case PixelFormat::kBC5RGUNormInt:
+      return MTLPixelFormatBC5_RGUnorm;
+    case PixelFormat::kBC7RGBAUNormInt:
+      return MTLPixelFormatBC7_RGBAUnorm;
+    case PixelFormat::kBC7RGBAUNormIntSRGB:
+      return MTLPixelFormatBC7_RGBAUnorm_sRGB;
+    case PixelFormat::kETC2RGB8UNormInt:
+      return MTLPixelFormatETC2_RGB8;
+    case PixelFormat::kETC2RGB8UNormIntSRGB:
+      return MTLPixelFormatETC2_RGB8_sRGB;
+    case PixelFormat::kETC2RGBA8UNormInt:
+      return MTLPixelFormatEAC_RGBA8;
+    case PixelFormat::kETC2RGBA8UNormIntSRGB:
+      return MTLPixelFormatEAC_RGBA8_sRGB;
+    case PixelFormat::kASTC4x4LDR:
+      return MTLPixelFormatASTC_4x4_LDR;
+    case PixelFormat::kASTC4x4LDRSRGB:
+      return MTLPixelFormatASTC_4x4_sRGB;
+    case PixelFormat::kASTC8x8LDR:
+      return MTLPixelFormatASTC_8x8_LDR;
+    case PixelFormat::kASTC8x8LDRSRGB:
+      return MTLPixelFormatASTC_8x8_sRGB;
   }
   return MTLPixelFormatInvalid;
 };

--- a/engine/src/flutter/impeller/renderer/backend/metal/formats_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/formats_mtl.mm
@@ -143,4 +143,127 @@ MTLPixelFormat SafeMTLPixelFormatBGRA10_XR() {
   }
 }
 
+// BC formats are only available on macOS; referencing the enum values when
+// compiling for iOS is a hard error, so they are guarded at compile time.
+MTLPixelFormat SafeMTLPixelFormatBC1_RGBA() {
+#if !FML_OS_IOS
+  if (@available(macOS 10.11, *)) {
+    return MTLPixelFormatBC1_RGBA;
+  }
+#endif  // FML_OS_IOS
+  return MTLPixelFormatInvalid;
+}
+
+MTLPixelFormat SafeMTLPixelFormatBC1_RGBA_sRGB() {
+#if !FML_OS_IOS
+  if (@available(macOS 10.11, *)) {
+    return MTLPixelFormatBC1_RGBA_sRGB;
+  }
+#endif  // FML_OS_IOS
+  return MTLPixelFormatInvalid;
+}
+
+MTLPixelFormat SafeMTLPixelFormatBC3_RGBA() {
+#if !FML_OS_IOS
+  if (@available(macOS 10.11, *)) {
+    return MTLPixelFormatBC3_RGBA;
+  }
+#endif  // FML_OS_IOS
+  return MTLPixelFormatInvalid;
+}
+
+MTLPixelFormat SafeMTLPixelFormatBC3_RGBA_sRGB() {
+#if !FML_OS_IOS
+  if (@available(macOS 10.11, *)) {
+    return MTLPixelFormatBC3_RGBA_sRGB;
+  }
+#endif  // FML_OS_IOS
+  return MTLPixelFormatInvalid;
+}
+
+MTLPixelFormat SafeMTLPixelFormatBC5_RGUnorm() {
+#if !FML_OS_IOS
+  if (@available(macOS 10.11, *)) {
+    return MTLPixelFormatBC5_RGUnorm;
+  }
+#endif  // FML_OS_IOS
+  return MTLPixelFormatInvalid;
+}
+
+MTLPixelFormat SafeMTLPixelFormatBC7_RGBAUnorm() {
+#if !FML_OS_IOS
+  if (@available(macOS 10.11, *)) {
+    return MTLPixelFormatBC7_RGBAUnorm;
+  }
+#endif  // FML_OS_IOS
+  return MTLPixelFormatInvalid;
+}
+
+MTLPixelFormat SafeMTLPixelFormatBC7_RGBAUnorm_sRGB() {
+#if !FML_OS_IOS
+  if (@available(macOS 10.11, *)) {
+    return MTLPixelFormatBC7_RGBAUnorm_sRGB;
+  }
+#endif  // FML_OS_IOS
+  return MTLPixelFormatInvalid;
+}
+
+// ETC2 and ASTC are available on iOS and on macOS 11.0+. The macOS deployment
+// target is below 11.0, so the references are version-guarded.
+MTLPixelFormat SafeMTLPixelFormatETC2_RGB8() {
+  if (@available(macOS 11.0, *)) {
+    return MTLPixelFormatETC2_RGB8;
+  }
+  return MTLPixelFormatInvalid;
+}
+
+MTLPixelFormat SafeMTLPixelFormatETC2_RGB8_sRGB() {
+  if (@available(macOS 11.0, *)) {
+    return MTLPixelFormatETC2_RGB8_sRGB;
+  }
+  return MTLPixelFormatInvalid;
+}
+
+MTLPixelFormat SafeMTLPixelFormatEAC_RGBA8() {
+  if (@available(macOS 11.0, *)) {
+    return MTLPixelFormatEAC_RGBA8;
+  }
+  return MTLPixelFormatInvalid;
+}
+
+MTLPixelFormat SafeMTLPixelFormatEAC_RGBA8_sRGB() {
+  if (@available(macOS 11.0, *)) {
+    return MTLPixelFormatEAC_RGBA8_sRGB;
+  }
+  return MTLPixelFormatInvalid;
+}
+
+MTLPixelFormat SafeMTLPixelFormatASTC_4x4_LDR() {
+  if (@available(macOS 11.0, *)) {
+    return MTLPixelFormatASTC_4x4_LDR;
+  }
+  return MTLPixelFormatInvalid;
+}
+
+MTLPixelFormat SafeMTLPixelFormatASTC_4x4_sRGB() {
+  if (@available(macOS 11.0, *)) {
+    return MTLPixelFormatASTC_4x4_sRGB;
+  }
+  return MTLPixelFormatInvalid;
+}
+
+MTLPixelFormat SafeMTLPixelFormatASTC_8x8_LDR() {
+  if (@available(macOS 11.0, *)) {
+    return MTLPixelFormatASTC_8x8_LDR;
+  }
+  return MTLPixelFormatInvalid;
+}
+
+MTLPixelFormat SafeMTLPixelFormatASTC_8x8_sRGB() {
+  if (@available(macOS 11.0, *)) {
+    return MTLPixelFormatASTC_8x8_sRGB;
+  }
+  return MTLPixelFormatInvalid;
+}
+
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/metal/formats_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/formats_mtl.mm
@@ -266,4 +266,18 @@ MTLPixelFormat SafeMTLPixelFormatASTC_8x8_sRGB() {
   return MTLPixelFormatInvalid;
 }
 
+MTLPixelFormat SafeMTLPixelFormatASTC_4x4_HDR() {
+  if (@available(macOS 11.0, *)) {
+    return MTLPixelFormatASTC_4x4_HDR;
+  }
+  return MTLPixelFormatInvalid;
+}
+
+MTLPixelFormat SafeMTLPixelFormatASTC_8x8_HDR() {
+  if (@available(macOS 11.0, *)) {
+    return MTLPixelFormatASTC_8x8_HDR;
+  }
+  return MTLPixelFormatInvalid;
+}
+
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
@@ -225,6 +225,8 @@ static const char* GetExtensionName(OptionalDeviceExtensionVK ext) {
       return "VK_KHR_portability_subset";
     case OptionalDeviceExtensionVK::kEXTImageCompressionControl:
       return VK_EXT_IMAGE_COMPRESSION_CONTROL_EXTENSION_NAME;
+    case OptionalDeviceExtensionVK::kEXTTextureCompressionAstcHdr:
+      return VK_EXT_TEXTURE_COMPRESSION_ASTC_HDR_EXTENSION_NAME;
     case OptionalDeviceExtensionVK::kLast:
       return "Unknown";
   }
@@ -430,6 +432,12 @@ CapabilitiesVK::GetEnabledDeviceFeatures(
     supported_chain
         .unlink<vk::PhysicalDeviceImageCompressionControlFeaturesEXT>();
   }
+  if (!IsExtensionInList(
+          enabled_extensions.value(),
+          OptionalDeviceExtensionVK::kEXTTextureCompressionAstcHdr)) {
+    supported_chain
+        .unlink<vk::PhysicalDeviceTextureCompressionASTCHDRFeatures>();
+  }
 
   device.getFeatures2(&supported_chain.get());
 
@@ -473,6 +481,23 @@ CapabilitiesVK::GetEnabledDeviceFeatures(
   } else {
     required_chain
         .unlink<vk::PhysicalDeviceImageCompressionControlFeaturesEXT>();
+  }
+
+  // VK_EXT_texture_compression_astc_hdr
+  if (IsExtensionInList(
+          enabled_extensions.value(),
+          OptionalDeviceExtensionVK::kEXTTextureCompressionAstcHdr)) {
+    auto& required =
+        required_chain
+            .get<vk::PhysicalDeviceTextureCompressionASTCHDRFeatures>();
+    const auto& supported =
+        supported_chain
+            .get<vk::PhysicalDeviceTextureCompressionASTCHDRFeatures>();
+
+    required.textureCompressionASTC_HDR = supported.textureCompressionASTC_HDR;
+  } else {
+    required_chain
+        .unlink<vk::PhysicalDeviceTextureCompressionASTCHDRFeatures>();
   }
 
   // Vulkan 1.1
@@ -637,6 +662,13 @@ bool CapabilitiesVK::SetPhysicalDevice(
     supports_texture_compression_etc2_ = features.textureCompressionETC2;
     supports_texture_compression_astc_ = features.textureCompressionASTC_LDR;
   }
+
+  supports_texture_compression_astc_hdr_ =
+      enabled_features
+          .isLinked<vk::PhysicalDeviceTextureCompressionASTCHDRFeatures>() &&
+      enabled_features
+          .get<vk::PhysicalDeviceTextureCompressionASTCHDRFeatures>()
+          .textureCompressionASTC_HDR;
 
   max_render_pass_attachment_size_ =
       ISize{device_properties_.limits.maxFramebufferWidth,
@@ -858,6 +890,8 @@ bool CapabilitiesVK::SupportsTextureCompression(
       return supports_texture_compression_etc2_;
     case CompressedTextureFamily::kASTC:
       return supports_texture_compression_astc_;
+    case CompressedTextureFamily::kASTCHDR:
+      return supports_texture_compression_astc_hdr_;
   }
   return false;
 }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
@@ -631,6 +631,13 @@ bool CapabilitiesVK::SetPhysicalDevice(
           .get<vk::PhysicalDeviceImageCompressionControlFeaturesEXT>()
           .imageCompressionControl;
 
+  {
+    const auto& features = enabled_features.get().features;
+    supports_texture_compression_bc_ = features.textureCompressionBC;
+    supports_texture_compression_etc2_ = features.textureCompressionETC2;
+    supports_texture_compression_astc_ = features.textureCompressionASTC_LDR;
+  }
+
   max_render_pass_attachment_size_ =
       ISize{device_properties_.limits.maxFramebufferWidth,
             device_properties_.limits.maxFramebufferHeight};
@@ -839,6 +846,19 @@ bool CapabilitiesVK::SupportsExternalSemaphoreExtensions() const {
 }
 
 bool CapabilitiesVK::SupportsExtendedRangeFormats() const {
+  return false;
+}
+
+bool CapabilitiesVK::SupportsTextureCompression(
+    CompressedTextureFamily family) const {
+  switch (family) {
+    case CompressedTextureFamily::kBC:
+      return supports_texture_compression_bc_;
+    case CompressedTextureFamily::kETC2:
+      return supports_texture_compression_etc2_;
+    case CompressedTextureFamily::kASTC:
+      return supports_texture_compression_astc_;
+  }
   return false;
 }
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.h
@@ -151,6 +151,14 @@ enum class OptionalDeviceExtensionVK : uint32_t {
   ///
   kEXTImageCompressionControl,
 
+  //----------------------------------------------------------------------------
+  /// For sampling ASTC HDR block-compressed textures. Promoted to core in
+  /// Vulkan 1.3, but gated here on the extension for broader device coverage.
+  ///
+  /// https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_texture_compression_astc_hdr.html
+  ///
+  kEXTTextureCompressionAstcHdr,
+
   kLast,
 };
 
@@ -211,7 +219,8 @@ class CapabilitiesVK final : public Capabilities,
       vk::StructureChain<vk::PhysicalDeviceFeatures2,
                          vk::PhysicalDeviceSamplerYcbcrConversionFeaturesKHR,
                          vk::PhysicalDevice16BitStorageFeatures,
-                         vk::PhysicalDeviceImageCompressionControlFeaturesEXT>;
+                         vk::PhysicalDeviceImageCompressionControlFeaturesEXT,
+                         vk::PhysicalDeviceTextureCompressionASTCHDRFeatures>;
 
   std::optional<PhysicalDeviceFeatures> GetEnabledDeviceFeatures(
       const vk::PhysicalDevice& physical_device) const;
@@ -348,6 +357,7 @@ class CapabilitiesVK final : public Capabilities,
   bool supports_texture_compression_bc_ = false;
   bool supports_texture_compression_etc2_ = false;
   bool supports_texture_compression_astc_ = false;
+  bool supports_texture_compression_astc_hdr_ = false;
   bool is_valid_ = false;
 
   // The embedder.h API is responsible for providing the instance and device

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.h
@@ -267,6 +267,10 @@ class CapabilitiesVK final : public Capabilities,
   bool SupportsExtendedRangeFormats() const override;
 
   // |Capabilities|
+  bool SupportsTextureCompression(
+      CompressedTextureFamily family) const override;
+
+  // |Capabilities|
   PixelFormat GetDefaultColorFormat() const override;
 
   // |Capabilities|
@@ -341,6 +345,9 @@ class CapabilitiesVK final : public Capabilities,
   bool has_primitive_restart_ = true;
   bool has_framebuffer_fetch_ = true;
   bool supports_external_fence_and_semaphore_ = false;
+  bool supports_texture_compression_bc_ = false;
+  bool supports_texture_compression_etc2_ = false;
+  bool supports_texture_compression_astc_ = false;
   bool is_valid_ = false;
 
   // The embedder.h API is responsible for providing the instance and device

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/formats_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/formats_vk.h
@@ -207,6 +207,10 @@ constexpr vk::Format ToVKImageFormat(PixelFormat format) {
       return vk::Format::eAstc8x8UnormBlock;
     case PixelFormat::kASTC8x8LDRSRGB:
       return vk::Format::eAstc8x8SrgbBlock;
+    case PixelFormat::kASTC4x4HDR:
+      return vk::Format::eAstc4x4SfloatBlock;
+    case PixelFormat::kASTC8x8HDR:
+      return vk::Format::eAstc8x8SfloatBlock;
   }
 
   FML_UNREACHABLE();
@@ -474,6 +478,8 @@ constexpr bool PixelFormatIsDepthStencil(PixelFormat format) {
     case PixelFormat::kASTC4x4LDRSRGB:
     case PixelFormat::kASTC8x8LDR:
     case PixelFormat::kASTC8x8LDRSRGB:
+    case PixelFormat::kASTC4x4HDR:
+    case PixelFormat::kASTC8x8HDR:
       return false;
     case PixelFormat::kS8UInt:
     case PixelFormat::kD24UnormS8Uint:
@@ -589,6 +595,8 @@ constexpr vk::ImageAspectFlags ToVKImageAspectFlags(PixelFormat format) {
     case PixelFormat::kASTC4x4LDRSRGB:
     case PixelFormat::kASTC8x8LDR:
     case PixelFormat::kASTC8x8LDRSRGB:
+    case PixelFormat::kASTC4x4HDR:
+    case PixelFormat::kASTC8x8HDR:
       return vk::ImageAspectFlagBits::eColor;
     case PixelFormat::kS8UInt:
       return vk::ImageAspectFlagBits::eStencil;
@@ -679,6 +687,8 @@ constexpr vk::ImageAspectFlags ToImageAspectFlags(PixelFormat format) {
     case PixelFormat::kASTC4x4LDRSRGB:
     case PixelFormat::kASTC8x8LDR:
     case PixelFormat::kASTC8x8LDRSRGB:
+    case PixelFormat::kASTC4x4HDR:
+    case PixelFormat::kASTC8x8HDR:
       return vk::ImageAspectFlagBits::eColor;
     case PixelFormat::kS8UInt:
       return vk::ImageAspectFlagBits::eStencil;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/formats_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/formats_vk.h
@@ -177,6 +177,36 @@ constexpr vk::Format ToVKImageFormat(PixelFormat format) {
       return vk::Format::eR8G8Unorm;
     case PixelFormat::kR32Float:
       return vk::Format::eR32Sfloat;
+    case PixelFormat::kBC1RGBAUNormInt:
+      return vk::Format::eBc1RgbaUnormBlock;
+    case PixelFormat::kBC1RGBAUNormIntSRGB:
+      return vk::Format::eBc1RgbaSrgbBlock;
+    case PixelFormat::kBC3RGBAUNormInt:
+      return vk::Format::eBc3UnormBlock;
+    case PixelFormat::kBC3RGBAUNormIntSRGB:
+      return vk::Format::eBc3SrgbBlock;
+    case PixelFormat::kBC5RGUNormInt:
+      return vk::Format::eBc5UnormBlock;
+    case PixelFormat::kBC7RGBAUNormInt:
+      return vk::Format::eBc7UnormBlock;
+    case PixelFormat::kBC7RGBAUNormIntSRGB:
+      return vk::Format::eBc7SrgbBlock;
+    case PixelFormat::kETC2RGB8UNormInt:
+      return vk::Format::eEtc2R8G8B8UnormBlock;
+    case PixelFormat::kETC2RGB8UNormIntSRGB:
+      return vk::Format::eEtc2R8G8B8SrgbBlock;
+    case PixelFormat::kETC2RGBA8UNormInt:
+      return vk::Format::eEtc2R8G8B8A8UnormBlock;
+    case PixelFormat::kETC2RGBA8UNormIntSRGB:
+      return vk::Format::eEtc2R8G8B8A8SrgbBlock;
+    case PixelFormat::kASTC4x4LDR:
+      return vk::Format::eAstc4x4UnormBlock;
+    case PixelFormat::kASTC4x4LDRSRGB:
+      return vk::Format::eAstc4x4SrgbBlock;
+    case PixelFormat::kASTC8x8LDR:
+      return vk::Format::eAstc8x8UnormBlock;
+    case PixelFormat::kASTC8x8LDRSRGB:
+      return vk::Format::eAstc8x8SrgbBlock;
   }
 
   FML_UNREACHABLE();
@@ -429,6 +459,21 @@ constexpr bool PixelFormatIsDepthStencil(PixelFormat format) {
     case PixelFormat::kB10G10R10XRSRGB:
     case PixelFormat::kB10G10R10A10XR:
     case PixelFormat::kR32Float:
+    case PixelFormat::kBC1RGBAUNormInt:
+    case PixelFormat::kBC1RGBAUNormIntSRGB:
+    case PixelFormat::kBC3RGBAUNormInt:
+    case PixelFormat::kBC3RGBAUNormIntSRGB:
+    case PixelFormat::kBC5RGUNormInt:
+    case PixelFormat::kBC7RGBAUNormInt:
+    case PixelFormat::kBC7RGBAUNormIntSRGB:
+    case PixelFormat::kETC2RGB8UNormInt:
+    case PixelFormat::kETC2RGB8UNormIntSRGB:
+    case PixelFormat::kETC2RGBA8UNormInt:
+    case PixelFormat::kETC2RGBA8UNormIntSRGB:
+    case PixelFormat::kASTC4x4LDR:
+    case PixelFormat::kASTC4x4LDRSRGB:
+    case PixelFormat::kASTC8x8LDR:
+    case PixelFormat::kASTC8x8LDRSRGB:
       return false;
     case PixelFormat::kS8UInt:
     case PixelFormat::kD24UnormS8Uint:
@@ -529,6 +574,21 @@ constexpr vk::ImageAspectFlags ToVKImageAspectFlags(PixelFormat format) {
     case PixelFormat::kB10G10R10XRSRGB:
     case PixelFormat::kB10G10R10A10XR:
     case PixelFormat::kR32Float:
+    case PixelFormat::kBC1RGBAUNormInt:
+    case PixelFormat::kBC1RGBAUNormIntSRGB:
+    case PixelFormat::kBC3RGBAUNormInt:
+    case PixelFormat::kBC3RGBAUNormIntSRGB:
+    case PixelFormat::kBC5RGUNormInt:
+    case PixelFormat::kBC7RGBAUNormInt:
+    case PixelFormat::kBC7RGBAUNormIntSRGB:
+    case PixelFormat::kETC2RGB8UNormInt:
+    case PixelFormat::kETC2RGB8UNormIntSRGB:
+    case PixelFormat::kETC2RGBA8UNormInt:
+    case PixelFormat::kETC2RGBA8UNormIntSRGB:
+    case PixelFormat::kASTC4x4LDR:
+    case PixelFormat::kASTC4x4LDRSRGB:
+    case PixelFormat::kASTC8x8LDR:
+    case PixelFormat::kASTC8x8LDRSRGB:
       return vk::ImageAspectFlagBits::eColor;
     case PixelFormat::kS8UInt:
       return vk::ImageAspectFlagBits::eStencil;
@@ -604,6 +664,21 @@ constexpr vk::ImageAspectFlags ToImageAspectFlags(PixelFormat format) {
     case PixelFormat::kB10G10R10XRSRGB:
     case PixelFormat::kB10G10R10A10XR:
     case PixelFormat::kR32Float:
+    case PixelFormat::kBC1RGBAUNormInt:
+    case PixelFormat::kBC1RGBAUNormIntSRGB:
+    case PixelFormat::kBC3RGBAUNormInt:
+    case PixelFormat::kBC3RGBAUNormIntSRGB:
+    case PixelFormat::kBC5RGUNormInt:
+    case PixelFormat::kBC7RGBAUNormInt:
+    case PixelFormat::kBC7RGBAUNormIntSRGB:
+    case PixelFormat::kETC2RGB8UNormInt:
+    case PixelFormat::kETC2RGB8UNormIntSRGB:
+    case PixelFormat::kETC2RGBA8UNormInt:
+    case PixelFormat::kETC2RGBA8UNormIntSRGB:
+    case PixelFormat::kASTC4x4LDR:
+    case PixelFormat::kASTC4x4LDRSRGB:
+    case PixelFormat::kASTC8x8LDR:
+    case PixelFormat::kASTC8x8LDRSRGB:
       return vk::ImageAspectFlagBits::eColor;
     case PixelFormat::kS8UInt:
       return vk::ImageAspectFlagBits::eStencil;

--- a/engine/src/flutter/impeller/renderer/blit_pass.cc
+++ b/engine/src/flutter/impeller/renderer/blit_pass.cc
@@ -136,9 +136,10 @@ bool BlitPass::AddCopy(BufferView source,
     return false;
   }
 
-  auto bytes_per_pixel =
-      BytesPerPixelForPixelFormat(destination->GetTextureDescriptor().format);
-  auto bytes_per_region = destination_region_value.Area() * bytes_per_pixel;
+  auto bytes_per_region =
+      BytesForTextureRegion(destination->GetTextureDescriptor().format,
+                            destination_region_value.GetWidth(),
+                            destination_region_value.GetHeight());
 
   if (source.GetRange().length != bytes_per_region) {
     VALIDATION_LOG

--- a/engine/src/flutter/impeller/renderer/capabilities.cc
+++ b/engine/src/flutter/impeller/renderer/capabilities.cc
@@ -113,6 +113,8 @@ class StandardCapabilities final : public Capabilities {
         return supports_texture_compression_etc2_;
       case CompressedTextureFamily::kASTC:
         return supports_texture_compression_astc_;
+      case CompressedTextureFamily::kASTCHDR:
+        return supports_texture_compression_astc_hdr_;
     }
     return false;
   }
@@ -148,7 +150,8 @@ class StandardCapabilities final : public Capabilities {
                        bool needs_partitioned_host_buffer,
                        bool supports_texture_compression_bc,
                        bool supports_texture_compression_etc2,
-                       bool supports_texture_compression_astc)
+                       bool supports_texture_compression_astc,
+                       bool supports_texture_compression_astc_hdr)
       : supports_offscreen_msaa_(supports_offscreen_msaa),
         supports_ssbo_(supports_ssbo),
         supports_texture_to_texture_blits_(supports_texture_to_texture_blits),
@@ -171,7 +174,9 @@ class StandardCapabilities final : public Capabilities {
         minimum_uniform_alignment_(minimum_uniform_alignment),
         supports_texture_compression_bc_(supports_texture_compression_bc),
         supports_texture_compression_etc2_(supports_texture_compression_etc2),
-        supports_texture_compression_astc_(supports_texture_compression_astc) {}
+        supports_texture_compression_astc_(supports_texture_compression_astc),
+        supports_texture_compression_astc_hdr_(
+            supports_texture_compression_astc_hdr) {}
 
   friend class CapabilitiesBuilder;
 
@@ -196,6 +201,7 @@ class StandardCapabilities final : public Capabilities {
   bool supports_texture_compression_bc_ = false;
   bool supports_texture_compression_etc2_ = false;
   bool supports_texture_compression_astc_ = false;
+  bool supports_texture_compression_astc_hdr_ = false;
 
   StandardCapabilities(const StandardCapabilities&) = delete;
 
@@ -311,6 +317,9 @@ CapabilitiesBuilder& CapabilitiesBuilder::SetSupportsTextureCompression(
     case CompressedTextureFamily::kASTC:
       supports_texture_compression_astc_ = value;
       break;
+    case CompressedTextureFamily::kASTCHDR:
+      supports_texture_compression_astc_hdr_ = value;
+      break;
   }
   return *this;
 }
@@ -350,7 +359,8 @@ std::unique_ptr<Capabilities> CapabilitiesBuilder::Build() {
       needs_partitioned_host_buffer_,                                      //
       supports_texture_compression_bc_,                                    //
       supports_texture_compression_etc2_,                                  //
-      supports_texture_compression_astc_                                   //
+      supports_texture_compression_astc_,                                  //
+      supports_texture_compression_astc_hdr_                               //
       ));
 }
 

--- a/engine/src/flutter/impeller/renderer/capabilities.cc
+++ b/engine/src/flutter/impeller/renderer/capabilities.cc
@@ -104,6 +104,20 @@ class StandardCapabilities final : public Capabilities {
   }
 
   // |Capabilities|
+  bool SupportsTextureCompression(
+      CompressedTextureFamily family) const override {
+    switch (family) {
+      case CompressedTextureFamily::kBC:
+        return supports_texture_compression_bc_;
+      case CompressedTextureFamily::kETC2:
+        return supports_texture_compression_etc2_;
+      case CompressedTextureFamily::kASTC:
+        return supports_texture_compression_astc_;
+    }
+    return false;
+  }
+
+  // |Capabilities|
   size_t GetMinimumUniformAlignment() const override {
     return minimum_uniform_alignment_;
   }
@@ -131,7 +145,10 @@ class StandardCapabilities final : public Capabilities {
                        PixelFormat default_glyph_atlas_format,
                        ISize default_maximum_render_pass_attachment_size,
                        size_t minimum_uniform_alignment,
-                       bool needs_partitioned_host_buffer)
+                       bool needs_partitioned_host_buffer,
+                       bool supports_texture_compression_bc,
+                       bool supports_texture_compression_etc2,
+                       bool supports_texture_compression_astc)
       : supports_offscreen_msaa_(supports_offscreen_msaa),
         supports_ssbo_(supports_ssbo),
         supports_texture_to_texture_blits_(supports_texture_to_texture_blits),
@@ -151,7 +168,10 @@ class StandardCapabilities final : public Capabilities {
         default_glyph_atlas_format_(default_glyph_atlas_format),
         default_maximum_render_pass_attachment_size_(
             default_maximum_render_pass_attachment_size),
-        minimum_uniform_alignment_(minimum_uniform_alignment) {}
+        minimum_uniform_alignment_(minimum_uniform_alignment),
+        supports_texture_compression_bc_(supports_texture_compression_bc),
+        supports_texture_compression_etc2_(supports_texture_compression_etc2),
+        supports_texture_compression_astc_(supports_texture_compression_astc) {}
 
   friend class CapabilitiesBuilder;
 
@@ -173,6 +193,9 @@ class StandardCapabilities final : public Capabilities {
   PixelFormat default_glyph_atlas_format_ = PixelFormat::kUnknown;
   ISize default_maximum_render_pass_attachment_size_ = ISize(1, 1);
   size_t minimum_uniform_alignment_ = 256;
+  bool supports_texture_compression_bc_ = false;
+  bool supports_texture_compression_etc2_ = false;
+  bool supports_texture_compression_astc_ = false;
 
   StandardCapabilities(const StandardCapabilities&) = delete;
 
@@ -275,6 +298,23 @@ CapabilitiesBuilder& CapabilitiesBuilder::SetSupportsExtendedRangeFormats(
   return *this;
 }
 
+CapabilitiesBuilder& CapabilitiesBuilder::SetSupportsTextureCompression(
+    CompressedTextureFamily family,
+    bool value) {
+  switch (family) {
+    case CompressedTextureFamily::kBC:
+      supports_texture_compression_bc_ = value;
+      break;
+    case CompressedTextureFamily::kETC2:
+      supports_texture_compression_etc2_ = value;
+      break;
+    case CompressedTextureFamily::kASTC:
+      supports_texture_compression_astc_ = value;
+      break;
+  }
+  return *this;
+}
+
 CapabilitiesBuilder& CapabilitiesBuilder::SetMinimumUniformAlignment(
     size_t value) {
   minimum_uniform_alignment_ = value;
@@ -307,7 +347,10 @@ std::unique_ptr<Capabilities> CapabilitiesBuilder::Build() {
       default_glyph_atlas_format_.value_or(PixelFormat::kUnknown),         //
       default_maximum_render_pass_attachment_size_.value_or(ISize{1, 1}),  //
       minimum_uniform_alignment_,                                          //
-      needs_partitioned_host_buffer_                                       //
+      needs_partitioned_host_buffer_,                                      //
+      supports_texture_compression_bc_,                                    //
+      supports_texture_compression_etc2_,                                  //
+      supports_texture_compression_astc_                                   //
       ));
 }
 

--- a/engine/src/flutter/impeller/renderer/capabilities.h
+++ b/engine/src/flutter/impeller/renderer/capabilities.h
@@ -216,6 +216,7 @@ class CapabilitiesBuilder {
   bool supports_texture_compression_bc_ = false;
   bool supports_texture_compression_etc2_ = false;
   bool supports_texture_compression_astc_ = false;
+  bool supports_texture_compression_astc_hdr_ = false;
   std::optional<PixelFormat> default_color_format_ = std::nullopt;
   std::optional<PixelFormat> default_stencil_format_ = std::nullopt;
   std::optional<PixelFormat> default_depth_stencil_format_ = std::nullopt;

--- a/engine/src/flutter/impeller/renderer/capabilities.h
+++ b/engine/src/flutter/impeller/renderer/capabilities.h
@@ -127,6 +127,13 @@ class Capabilities {
   /// Vulkan and GLES.
   virtual bool SupportsExtendedRangeFormats() const = 0;
 
+  /// @brief Whether the given family of block-compressed texture formats is
+  ///        supported by this device. Compressed formats are sample-only and
+  ///        their support varies by hardware, so callers must check this before
+  ///        allocating a compressed texture.
+  virtual bool SupportsTextureCompression(
+      CompressedTextureFamily family) const = 0;
+
   /// @brief The minimum alignment of uniform value offsets in bytes.
   virtual size_t GetMinimumUniformAlignment() const = 0;
 
@@ -177,6 +184,10 @@ class CapabilitiesBuilder {
 
   CapabilitiesBuilder& SetSupportsExtendedRangeFormats(bool value);
 
+  CapabilitiesBuilder& SetSupportsTextureCompression(
+      CompressedTextureFamily family,
+      bool value);
+
   CapabilitiesBuilder& SetDefaultGlyphAtlasFormat(PixelFormat value);
 
   CapabilitiesBuilder& SetSupportsTriangleFan(bool value);
@@ -202,6 +213,9 @@ class CapabilitiesBuilder {
   bool supports_triangle_fan_ = false;
   bool supports_extended_range_formats_ = false;
   bool needs_partitioned_host_buffer_ = false;
+  bool supports_texture_compression_bc_ = false;
+  bool supports_texture_compression_etc2_ = false;
+  bool supports_texture_compression_astc_ = false;
   std::optional<PixelFormat> default_color_format_ = std::nullopt;
   std::optional<PixelFormat> default_stencil_format_ = std::nullopt;
   std::optional<PixelFormat> default_depth_stencil_format_ = std::nullopt;

--- a/engine/src/flutter/impeller/renderer/capabilities_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/capabilities_unittests.cc
@@ -77,6 +77,28 @@ TEST(CapabilitiesTest, MaxRenderPassAttachmentSize) {
   EXPECT_EQ(mutated->GetMaximumRenderPassAttachmentSize(), ISize(100, 100));
 }
 
+TEST(CapabilitiesTest, SupportsTextureCompression) {
+  auto defaults = CapabilitiesBuilder().Build();
+  EXPECT_FALSE(
+      defaults->SupportsTextureCompression(CompressedTextureFamily::kBC));
+  EXPECT_FALSE(
+      defaults->SupportsTextureCompression(CompressedTextureFamily::kETC2));
+  EXPECT_FALSE(
+      defaults->SupportsTextureCompression(CompressedTextureFamily::kASTC));
+
+  // Each family is gated independently.
+  auto mutated =
+      CapabilitiesBuilder()
+          .SetSupportsTextureCompression(CompressedTextureFamily::kETC2, true)
+          .Build();
+  EXPECT_FALSE(
+      mutated->SupportsTextureCompression(CompressedTextureFamily::kBC));
+  EXPECT_TRUE(
+      mutated->SupportsTextureCompression(CompressedTextureFamily::kETC2));
+  EXPECT_FALSE(
+      mutated->SupportsTextureCompression(CompressedTextureFamily::kASTC));
+}
+
 TEST(CapabilitiesTest, MinUniformAlignment) {
   auto defaults = CapabilitiesBuilder().Build();
   EXPECT_EQ(defaults->GetMinimumUniformAlignment(), 256u);

--- a/engine/src/flutter/impeller/renderer/capabilities_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/capabilities_unittests.cc
@@ -85,6 +85,8 @@ TEST(CapabilitiesTest, SupportsTextureCompression) {
       defaults->SupportsTextureCompression(CompressedTextureFamily::kETC2));
   EXPECT_FALSE(
       defaults->SupportsTextureCompression(CompressedTextureFamily::kASTC));
+  EXPECT_FALSE(
+      defaults->SupportsTextureCompression(CompressedTextureFamily::kASTCHDR));
 
   // Each family is gated independently.
   auto mutated =
@@ -97,6 +99,18 @@ TEST(CapabilitiesTest, SupportsTextureCompression) {
       mutated->SupportsTextureCompression(CompressedTextureFamily::kETC2));
   EXPECT_FALSE(
       mutated->SupportsTextureCompression(CompressedTextureFamily::kASTC));
+  EXPECT_FALSE(
+      mutated->SupportsTextureCompression(CompressedTextureFamily::kASTCHDR));
+
+  // ASTC LDR and HDR are distinct families.
+  auto astc_hdr = CapabilitiesBuilder()
+                      .SetSupportsTextureCompression(
+                          CompressedTextureFamily::kASTCHDR, true)
+                      .Build();
+  EXPECT_FALSE(
+      astc_hdr->SupportsTextureCompression(CompressedTextureFamily::kASTC));
+  EXPECT_TRUE(
+      astc_hdr->SupportsTextureCompression(CompressedTextureFamily::kASTCHDR));
 }
 
 TEST(CapabilitiesTest, MinUniformAlignment) {

--- a/engine/src/flutter/impeller/renderer/renderer_golden_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/renderer_golden_unittests.cc
@@ -9,12 +9,21 @@
 
 #ifdef IMPELLER_GOLDEN_TESTS
 
+#include <array>
+#include <cstdint>
+#include <vector>
+
 #include "flutter/impeller/golden_tests/golden_playground_test.h"
 #include "impeller/core/formats.h"
 #include "impeller/core/host_buffer.h"
+#include "impeller/core/sampler_descriptor.h"
+#include "impeller/core/texture_descriptor.h"
 #include "impeller/fixtures/baby.frag.h"
 #include "impeller/fixtures/baby.vert.h"
+#include "impeller/fixtures/texture.frag.h"
+#include "impeller/fixtures/texture.vert.h"
 #include "impeller/geometry/color.h"
+#include "impeller/geometry/matrix.h"
 #include "impeller/playground/playground_test.h"
 #include "impeller/renderer/pipeline_builder.h"
 #include "impeller/renderer/pipeline_library.h"
@@ -76,6 +85,89 @@ TEST_P(RendererGoldenTest, BabysFirstTriangle) {
     FS::FragInfo frag_info;
     frag_info.time = 0.0f;
     FS::BindFragInfo(pass, host_buffer->EmplaceUniform(frag_info));
+
+    return pass.Draw().ok();
+  }));
+}
+
+// Uploads a block-compressed (BC1/DXT1) texture and samples it onto a
+// fullscreen quad. The texture is an 8x8 image laid out as a 2x2 grid of solid
+// color blocks, so the golden is four colored quadrants. BC1 is the most widely
+// supported compressed family on desktop GPUs; backends without it are skipped.
+TEST_P(RendererGoldenTest, CanRenderBC1CompressedTexture) {
+  using VS = TextureVertexShader;
+  using FS = TextureFragmentShader;
+
+  std::shared_ptr<Context> context = GetContext();
+  ASSERT_TRUE(context);
+
+  if (!context->GetCapabilities()->SupportsTextureCompression(
+          CompressedTextureFamily::kBC)) {
+    GTEST_SKIP() << "Backend does not support BC texture compression.";
+  }
+
+  // A solid-color BC1 block stores the color in both RGB565 endpoints with
+  // all-zero selector bits, which decodes to a single opaque color.
+  auto bc1_solid_block = [](uint16_t rgb565) -> std::array<uint8_t, 8> {
+    const auto lo = static_cast<uint8_t>(rgb565 & 0xFF);
+    const auto hi = static_cast<uint8_t>(rgb565 >> 8);
+    return {{lo, hi, lo, hi, 0, 0, 0, 0}};
+  };
+  // RGB565: red, green, blue, white.
+  const std::array<std::array<uint8_t, 8>, 4> blocks = {{
+      bc1_solid_block(0xF800), bc1_solid_block(0x07E0),
+      bc1_solid_block(0x001F), bc1_solid_block(0xFFFF)}};
+  std::vector<uint8_t> data;
+  for (const auto& block : blocks) {
+    data.insert(data.end(), block.begin(), block.end());
+  }
+
+  TextureDescriptor texture_desc;
+  texture_desc.storage_mode = StorageMode::kHostVisible;
+  texture_desc.format = PixelFormat::kBC1RGBAUNormInt;
+  texture_desc.size = ISize{8, 8};
+  texture_desc.mip_count = 1u;
+  texture_desc.usage = TextureUsage::kShaderRead;
+  auto texture = context->GetResourceAllocator()->CreateTexture(texture_desc);
+  ASSERT_TRUE(texture);
+  ASSERT_TRUE(texture->SetContents(data.data(), data.size()));
+
+  auto desc = PipelineBuilder<VS, FS>::MakeDefaultPipelineDescriptor(*context);
+  ASSERT_TRUE(desc.has_value());
+  desc->SetSampleCount(SampleCount::kCount1);
+  desc->ClearStencilAttachments();
+  desc->ClearDepthAttachment();
+  auto pipeline = context->GetPipelineLibrary()->GetPipeline(desc).Get();
+  ASSERT_TRUE(pipeline);
+
+  // A fullscreen quad in normalized device coordinates with an identity MVP.
+  VertexBufferBuilder<VS::PerVertexData> vertex_buffer_builder;
+  vertex_buffer_builder.AddVertices({
+      {{-1, -1, 0.0}, {0.0, 0.0}},
+      {{1, -1, 0.0}, {1.0, 0.0}},
+      {{1, 1, 0.0}, {1.0, 1.0}},
+      {{-1, -1, 0.0}, {0.0, 0.0}},
+      {{1, 1, 0.0}, {1.0, 1.0}},
+      {{-1, 1, 0.0}, {0.0, 1.0}},
+  });
+  auto vertex_buffer = vertex_buffer_builder.CreateVertexBuffer(
+      *context->GetResourceAllocator());
+
+  const auto& sampler = context->GetSamplerLibrary()->GetSampler({});
+
+  auto host_buffer = HostBuffer::Create(
+      context->GetResourceAllocator(), context->GetIdleWaiter(),
+      context->GetCapabilities()->GetMinimumUniformAlignment());
+
+  ASSERT_TRUE(OpenPlaygroundHere([&](RenderPass& pass) -> bool {
+    host_buffer->Reset();
+    pass.SetPipeline(pipeline);
+    pass.SetVertexBuffer(vertex_buffer);
+
+    VS::UniformBuffer uniforms;
+    uniforms.mvp = Matrix();
+    VS::BindUniformBuffer(pass, host_buffer->EmplaceUniform(uniforms));
+    FS::BindTextureContents(pass, texture, sampler);
 
     return pass.Draw().ok();
   }));

--- a/engine/src/flutter/impeller/renderer/renderer_golden_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/renderer_golden_unittests.cc
@@ -189,7 +189,8 @@ TEST_P(RendererGoldenTest, CanRenderBC1CompressedTexture) {
 
 // Uploads an ETC2 RGB8 texture and samples it onto a fullscreen quad. ETC2 is
 // the standard compressed family on OpenGL ES 3.0 and mobile GPUs; backends
-// without it are skipped. The golden is a single flat mid-gray fill.
+// without it are skipped. The 8x8 image is a 2x2 grid of solid color blocks, so
+// the golden is the same four colored quadrants as the BC1 and ASTC goldens.
 TEST_P(RendererGoldenTest, CanRenderETC2CompressedTexture) {
   std::shared_ptr<Context> context = GetContext();
   ASSERT_TRUE(context);
@@ -198,25 +199,34 @@ TEST_P(RendererGoldenTest, CanRenderETC2CompressedTexture) {
     GTEST_SKIP() << "Backend does not support ETC2 texture compression.";
   }
 
-  // In "individual" mode (the differential bit is 0), an ETC2 RGB8 block
-  // decodes exactly like ETC1. With both 4x4 sub-blocks sharing one base color
-  // and every pixel selecting the same intensity modifier, the block resolves
-  // to a single flat color. The 8x8 image is a 2x2 grid of identical 4x4
-  // blocks.
-  const std::array<uint8_t, 8> etc2_solid_block = {0x88, 0x88, 0x88, 0x00,
-                                                   0xFF, 0xFF, 0x00, 0x00};
+  // A solid-color ETC2 RGB8 block in "individual" mode (differential bit 0,
+  // which decodes like ETC1). The 64-bit block is laid out big-endian (byte 0
+  // most significant): byte 0 = R nibbles (R1,R2), byte 1 = G, byte 2 = B,
+  // byte 3 = codeword/diff/flip bits (all 0), bytes 4..7 = the two pixel-index
+  // bit planes. Both sub-blocks share the base color and every texel uses index
+  // 0 (all-zero planes), so the block is one flat color.
+  auto etc2_solid_block = [](uint8_t r, uint8_t g,
+                             uint8_t b) -> std::array<uint8_t, 8> {
+    return {{r, g, b, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  };
+  // Red, green, blue, white. Each channel byte is 0xFF (nibble 0xF, ~255) or
+  // 0x00.
+  const std::array<std::array<uint8_t, 8>, 4> blocks = {
+      {etc2_solid_block(0xFF, 0x00, 0x00), etc2_solid_block(0x00, 0xFF, 0x00),
+       etc2_solid_block(0x00, 0x00, 0xFF), etc2_solid_block(0xFF, 0xFF, 0xFF)}};
   std::vector<uint8_t> data;
-  for (int i = 0; i < 4; ++i) {
-    data.insert(data.end(), etc2_solid_block.begin(), etc2_solid_block.end());
+  for (const auto& block : blocks) {
+    data.insert(data.end(), block.begin(), block.end());
   }
 
   DrawCompressedTextureGolden(*this, PixelFormat::kETC2RGB8UNormInt, data,
                               ISize{8, 8});
 }
 
-// Uploads an ASTC 8x8 LDR texture and samples it onto a fullscreen quad. ASTC
+// Uploads an ASTC 4x4 LDR texture and samples it onto a fullscreen quad. ASTC
 // is common on modern mobile and some desktop GPUs; backends without it are
-// skipped. The golden is a single solid opaque-blue fill.
+// skipped. The 8x8 image is a 2x2 grid of solid color blocks, so the golden is
+// the same four colored quadrants as the BC1 and ETC2 goldens.
 TEST_P(RendererGoldenTest, CanRenderASTCCompressedTexture) {
   std::shared_ptr<Context> context = GetContext();
   ASSERT_TRUE(context);
@@ -227,14 +237,27 @@ TEST_P(RendererGoldenTest, CanRenderASTCCompressedTexture) {
 
   // An ASTC void-extent block encodes one constant color directly: the 0xFC
   // 0xFD header marks a 2D LDR void-extent with the "no extent" sentinel
-  // coordinates (all ones), followed by four little-endian UNORM16 channels.
-  // This block is opaque blue (R=0, G=0, B=1, A=1). A single 8x8 ASTC block
-  // tiles the 8x8 image exactly once.
-  const std::vector<uint8_t> data = {0xFC, 0xFD, 0xFF, 0xFF, 0xFF, 0xFF,
-                                     0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00,
-                                     0xFF, 0xFF, 0xFF, 0xFF};
+  // coordinates (all ones), followed by four little-endian UNORM16 channels
+  // (R, G, B, A). Alpha is opaque.
+  auto astc_solid_block = [](uint16_t r, uint16_t g,
+                             uint16_t b) -> std::array<uint8_t, 16> {
+    return {{0xFC, 0xFD, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+             static_cast<uint8_t>(r & 0xFF), static_cast<uint8_t>(r >> 8),
+             static_cast<uint8_t>(g & 0xFF), static_cast<uint8_t>(g >> 8),
+             static_cast<uint8_t>(b & 0xFF), static_cast<uint8_t>(b >> 8), 0xFF,
+             0xFF}};
+  };
+  // Red, green, blue, white.
+  const std::array<std::array<uint8_t, 16>, 4> blocks = {
+      {astc_solid_block(0xFFFF, 0, 0), astc_solid_block(0, 0xFFFF, 0),
+       astc_solid_block(0, 0, 0xFFFF),
+       astc_solid_block(0xFFFF, 0xFFFF, 0xFFFF)}};
+  std::vector<uint8_t> data;
+  for (const auto& block : blocks) {
+    data.insert(data.end(), block.begin(), block.end());
+  }
 
-  DrawCompressedTextureGolden(*this, PixelFormat::kASTC8x8LDR, data,
+  DrawCompressedTextureGolden(*this, PixelFormat::kASTC4x4LDR, data,
                               ISize{8, 8});
 }
 

--- a/engine/src/flutter/impeller/renderer/renderer_golden_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/renderer_golden_unittests.cc
@@ -114,9 +114,9 @@ TEST_P(RendererGoldenTest, CanRenderBC1CompressedTexture) {
     return {{lo, hi, lo, hi, 0, 0, 0, 0}};
   };
   // RGB565: red, green, blue, white.
-  const std::array<std::array<uint8_t, 8>, 4> blocks = {{
-      bc1_solid_block(0xF800), bc1_solid_block(0x07E0),
-      bc1_solid_block(0x001F), bc1_solid_block(0xFFFF)}};
+  const std::array<std::array<uint8_t, 8>, 4> blocks = {
+      {bc1_solid_block(0xF800), bc1_solid_block(0x07E0),
+       bc1_solid_block(0x001F), bc1_solid_block(0xFFFF)}};
   std::vector<uint8_t> data;
   for (const auto& block : blocks) {
     data.insert(data.end(), block.begin(), block.end());

--- a/engine/src/flutter/impeller/renderer/renderer_golden_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/renderer_golden_unittests.cc
@@ -90,47 +90,29 @@ TEST_P(RendererGoldenTest, BabysFirstTriangle) {
   }));
 }
 
-// Uploads a block-compressed (BC1/DXT1) texture and samples it onto a
-// fullscreen quad. The texture is an 8x8 image laid out as a 2x2 grid of solid
-// color blocks, so the golden is four colored quadrants. BC1 is the most widely
-// supported compressed family on desktop GPUs; backends without it are skipped.
-TEST_P(RendererGoldenTest, CanRenderBC1CompressedTexture) {
+// Samples a sample-only block-compressed texture across a fullscreen quad
+// through the golden harness. The pixel format and the raw block bytes are the
+// only things that differ between the compressed families; the texture upload,
+// pipeline, quad, and draw are shared by every compressed-format golden below.
+static void DrawCompressedTextureGolden(GoldenPlaygroundTest& test,
+                                        PixelFormat format,
+                                        const std::vector<uint8_t>& block_data,
+                                        ISize size) {
   using VS = TextureVertexShader;
   using FS = TextureFragmentShader;
 
-  std::shared_ptr<Context> context = GetContext();
+  std::shared_ptr<Context> context = test.GetContext();
   ASSERT_TRUE(context);
-
-  if (!context->GetCapabilities()->SupportsTextureCompression(
-          CompressedTextureFamily::kBC)) {
-    GTEST_SKIP() << "Backend does not support BC texture compression.";
-  }
-
-  // A solid-color BC1 block stores the color in both RGB565 endpoints with
-  // all-zero selector bits, which decodes to a single opaque color.
-  auto bc1_solid_block = [](uint16_t rgb565) -> std::array<uint8_t, 8> {
-    const auto lo = static_cast<uint8_t>(rgb565 & 0xFF);
-    const auto hi = static_cast<uint8_t>(rgb565 >> 8);
-    return {{lo, hi, lo, hi, 0, 0, 0, 0}};
-  };
-  // RGB565: red, green, blue, white.
-  const std::array<std::array<uint8_t, 8>, 4> blocks = {
-      {bc1_solid_block(0xF800), bc1_solid_block(0x07E0),
-       bc1_solid_block(0x001F), bc1_solid_block(0xFFFF)}};
-  std::vector<uint8_t> data;
-  for (const auto& block : blocks) {
-    data.insert(data.end(), block.begin(), block.end());
-  }
 
   TextureDescriptor texture_desc;
   texture_desc.storage_mode = StorageMode::kHostVisible;
-  texture_desc.format = PixelFormat::kBC1RGBAUNormInt;
-  texture_desc.size = ISize{8, 8};
+  texture_desc.format = format;
+  texture_desc.size = size;
   texture_desc.mip_count = 1u;
   texture_desc.usage = TextureUsage::kShaderRead;
   auto texture = context->GetResourceAllocator()->CreateTexture(texture_desc);
   ASSERT_TRUE(texture);
-  ASSERT_TRUE(texture->SetContents(data.data(), data.size()));
+  ASSERT_TRUE(texture->SetContents(block_data.data(), block_data.size()));
 
   auto desc = PipelineBuilder<VS, FS>::MakeDefaultPipelineDescriptor(*context);
   ASSERT_TRUE(desc.has_value());
@@ -159,7 +141,7 @@ TEST_P(RendererGoldenTest, CanRenderBC1CompressedTexture) {
       context->GetResourceAllocator(), context->GetIdleWaiter(),
       context->GetCapabilities()->GetMinimumUniformAlignment());
 
-  ASSERT_TRUE(OpenPlaygroundHere([&](RenderPass& pass) -> bool {
+  ASSERT_TRUE(test.OpenPlaygroundHere([&](RenderPass& pass) -> bool {
     host_buffer->Reset();
     pass.SetPipeline(pipeline);
     pass.SetVertexBuffer(vertex_buffer);
@@ -171,6 +153,89 @@ TEST_P(RendererGoldenTest, CanRenderBC1CompressedTexture) {
 
     return pass.Draw().ok();
   }));
+}
+
+// Uploads a block-compressed (BC1/DXT1) texture and samples it onto a
+// fullscreen quad. The texture is an 8x8 image laid out as a 2x2 grid of solid
+// color blocks, so the golden is four colored quadrants. BC1 is the most widely
+// supported compressed family on desktop GPUs; backends without it are skipped.
+TEST_P(RendererGoldenTest, CanRenderBC1CompressedTexture) {
+  std::shared_ptr<Context> context = GetContext();
+  ASSERT_TRUE(context);
+  if (!context->GetCapabilities()->SupportsTextureCompression(
+          CompressedTextureFamily::kBC)) {
+    GTEST_SKIP() << "Backend does not support BC texture compression.";
+  }
+
+  // A solid-color BC1 block stores the color in both RGB565 endpoints with
+  // all-zero selector bits, which decodes to a single opaque color.
+  auto bc1_solid_block = [](uint16_t rgb565) -> std::array<uint8_t, 8> {
+    const auto lo = static_cast<uint8_t>(rgb565 & 0xFF);
+    const auto hi = static_cast<uint8_t>(rgb565 >> 8);
+    return {{lo, hi, lo, hi, 0, 0, 0, 0}};
+  };
+  // RGB565: red, green, blue, white.
+  const std::array<std::array<uint8_t, 8>, 4> blocks = {
+      {bc1_solid_block(0xF800), bc1_solid_block(0x07E0),
+       bc1_solid_block(0x001F), bc1_solid_block(0xFFFF)}};
+  std::vector<uint8_t> data;
+  for (const auto& block : blocks) {
+    data.insert(data.end(), block.begin(), block.end());
+  }
+
+  DrawCompressedTextureGolden(*this, PixelFormat::kBC1RGBAUNormInt, data,
+                              ISize{8, 8});
+}
+
+// Uploads an ETC2 RGB8 texture and samples it onto a fullscreen quad. ETC2 is
+// the standard compressed family on OpenGL ES 3.0 and mobile GPUs; backends
+// without it are skipped. The golden is a single flat mid-gray fill.
+TEST_P(RendererGoldenTest, CanRenderETC2CompressedTexture) {
+  std::shared_ptr<Context> context = GetContext();
+  ASSERT_TRUE(context);
+  if (!context->GetCapabilities()->SupportsTextureCompression(
+          CompressedTextureFamily::kETC2)) {
+    GTEST_SKIP() << "Backend does not support ETC2 texture compression.";
+  }
+
+  // In "individual" mode (the differential bit is 0), an ETC2 RGB8 block
+  // decodes exactly like ETC1. With both 4x4 sub-blocks sharing one base color
+  // and every pixel selecting the same intensity modifier, the block resolves
+  // to a single flat color. The 8x8 image is a 2x2 grid of identical 4x4
+  // blocks.
+  const std::array<uint8_t, 8> etc2_solid_block = {0x88, 0x88, 0x88, 0x00,
+                                                   0xFF, 0xFF, 0x00, 0x00};
+  std::vector<uint8_t> data;
+  for (int i = 0; i < 4; ++i) {
+    data.insert(data.end(), etc2_solid_block.begin(), etc2_solid_block.end());
+  }
+
+  DrawCompressedTextureGolden(*this, PixelFormat::kETC2RGB8UNormInt, data,
+                              ISize{8, 8});
+}
+
+// Uploads an ASTC 8x8 LDR texture and samples it onto a fullscreen quad. ASTC
+// is common on modern mobile and some desktop GPUs; backends without it are
+// skipped. The golden is a single solid opaque-blue fill.
+TEST_P(RendererGoldenTest, CanRenderASTCCompressedTexture) {
+  std::shared_ptr<Context> context = GetContext();
+  ASSERT_TRUE(context);
+  if (!context->GetCapabilities()->SupportsTextureCompression(
+          CompressedTextureFamily::kASTC)) {
+    GTEST_SKIP() << "Backend does not support ASTC texture compression.";
+  }
+
+  // An ASTC void-extent block encodes one constant color directly: the 0xFC
+  // 0xFD header marks a 2D LDR void-extent with the "no extent" sentinel
+  // coordinates (all ones), followed by four little-endian UNORM16 channels.
+  // This block is opaque blue (R=0, G=0, B=1, A=1). A single 8x8 ASTC block
+  // tiles the 8x8 image exactly once.
+  const std::vector<uint8_t> data = {0xFC, 0xFD, 0xFF, 0xFF, 0xFF, 0xFF,
+                                     0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00,
+                                     0xFF, 0xFF, 0xFF, 0xFF};
+
+  DrawCompressedTextureGolden(*this, PixelFormat::kASTC8x8LDR, data,
+                              ISize{8, 8});
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/renderer/testing/mocks.h
+++ b/engine/src/flutter/impeller/renderer/testing/mocks.h
@@ -252,6 +252,10 @@ class MockCapabilities : public Capabilities {
   MOCK_METHOD(bool, SupportsPrimitiveRestart, (), (const override));
   MOCK_METHOD(bool, Supports32BitPrimitiveIndices, (), (const override));
   MOCK_METHOD(bool, SupportsExtendedRangeFormats, (), (const override));
+  MOCK_METHOD(bool,
+              SupportsTextureCompression,
+              (CompressedTextureFamily),
+              (const override));
   MOCK_METHOD(PixelFormat, GetDefaultColorFormat, (), (const, override));
   MOCK_METHOD(PixelFormat, GetDefaultStencilFormat, (), (const, override));
   MOCK_METHOD(PixelFormat, GetDefaultDepthStencilFormat, (), (const, override));

--- a/engine/src/flutter/lib/gpu/formats.h
+++ b/engine/src/flutter/lib/gpu/formats.h
@@ -153,6 +153,8 @@ constexpr FlutterGPUPixelFormat FromImpellerPixelFormat(
     case impeller::PixelFormat::kASTC4x4LDRSRGB:
     case impeller::PixelFormat::kASTC8x8LDR:
     case impeller::PixelFormat::kASTC8x8LDRSRGB:
+    case impeller::PixelFormat::kASTC4x4HDR:
+    case impeller::PixelFormat::kASTC8x8HDR:
       return FlutterGPUPixelFormat::kUnknown;
   }
 }

--- a/engine/src/flutter/lib/gpu/formats.h
+++ b/engine/src/flutter/lib/gpu/formats.h
@@ -137,6 +137,23 @@ constexpr FlutterGPUPixelFormat FromImpellerPixelFormat(
       return FlutterGPUPixelFormat::kD24UnormS8Uint;
     case impeller::PixelFormat::kD32FloatS8UInt:
       return FlutterGPUPixelFormat::kD32FloatS8UInt;
+    // Block-compressed formats are not yet exposed by the Flutter GPU API.
+    case impeller::PixelFormat::kBC1RGBAUNormInt:
+    case impeller::PixelFormat::kBC1RGBAUNormIntSRGB:
+    case impeller::PixelFormat::kBC3RGBAUNormInt:
+    case impeller::PixelFormat::kBC3RGBAUNormIntSRGB:
+    case impeller::PixelFormat::kBC5RGUNormInt:
+    case impeller::PixelFormat::kBC7RGBAUNormInt:
+    case impeller::PixelFormat::kBC7RGBAUNormIntSRGB:
+    case impeller::PixelFormat::kETC2RGB8UNormInt:
+    case impeller::PixelFormat::kETC2RGB8UNormIntSRGB:
+    case impeller::PixelFormat::kETC2RGBA8UNormInt:
+    case impeller::PixelFormat::kETC2RGBA8UNormIntSRGB:
+    case impeller::PixelFormat::kASTC4x4LDR:
+    case impeller::PixelFormat::kASTC4x4LDRSRGB:
+    case impeller::PixelFormat::kASTC8x8LDR:
+    case impeller::PixelFormat::kASTC8x8LDRSRGB:
+      return FlutterGPUPixelFormat::kUnknown;
   }
 }
 

--- a/engine/src/flutter/lib/gpu/lib/src/context.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/context.dart
@@ -158,9 +158,7 @@ base class GpuContext extends NativeFieldWrapperClass1 {
       enableShaderWriteUsage,
       mipLevelCount,
     );
-    if (!result.isValid) {
-      throw Exception('Texture creation failed');
-    }
+    // `Texture._initialize` throws on failure, so `result` is always valid here.
     return result;
   }
 

--- a/engine/src/flutter/lib/gpu/lib/src/texture.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/texture.dart
@@ -65,6 +65,11 @@ base class Texture extends NativeFieldWrapperClass1 {
       enableShaderWriteUsage,
       mipLevelCount,
     );
+    if (!_valid) {
+      // The engine logs the specific reason (for example, a compressed format
+      // used with render target or shader write usage, which is sample-only).
+      throw Exception('Failed to create texture.');
+    }
   }
 
   GpuContext _gpuContext;

--- a/engine/src/flutter/lib/gpu/lib/src/texture.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/texture.dart
@@ -68,7 +68,7 @@ base class Texture extends NativeFieldWrapperClass1 {
     if (!_valid) {
       // The engine logs the specific reason (for example, a compressed format
       // used with render target or shader write usage, which is sample-only).
-      throw Exception('Failed to create texture.');
+      throw Exception('Texture creation failed');
     }
   }
 

--- a/engine/src/flutter/shell/common/rasterizer.cc
+++ b/engine/src/flutter/shell/common/rasterizer.cc
@@ -951,6 +951,8 @@ Rasterizer::ScreenshotFormat ToScreenshotFormat(impeller::PixelFormat format) {
     case impeller::PixelFormat::kASTC4x4LDRSRGB:
     case impeller::PixelFormat::kASTC8x8LDR:
     case impeller::PixelFormat::kASTC8x8LDRSRGB:
+    case impeller::PixelFormat::kASTC4x4HDR:
+    case impeller::PixelFormat::kASTC8x8HDR:
       FML_DCHECK(false);
       return Rasterizer::ScreenshotFormat::kUnknown;
     case impeller::PixelFormat::kR8G8B8A8UNormInt:

--- a/engine/src/flutter/shell/common/rasterizer.cc
+++ b/engine/src/flutter/shell/common/rasterizer.cc
@@ -936,6 +936,21 @@ Rasterizer::ScreenshotFormat ToScreenshotFormat(impeller::PixelFormat format) {
     case impeller::PixelFormat::kB10G10R10XR:
     case impeller::PixelFormat::kB10G10R10A10XR:
     case impeller::PixelFormat::kR32Float:
+    case impeller::PixelFormat::kBC1RGBAUNormInt:
+    case impeller::PixelFormat::kBC1RGBAUNormIntSRGB:
+    case impeller::PixelFormat::kBC3RGBAUNormInt:
+    case impeller::PixelFormat::kBC3RGBAUNormIntSRGB:
+    case impeller::PixelFormat::kBC5RGUNormInt:
+    case impeller::PixelFormat::kBC7RGBAUNormInt:
+    case impeller::PixelFormat::kBC7RGBAUNormIntSRGB:
+    case impeller::PixelFormat::kETC2RGB8UNormInt:
+    case impeller::PixelFormat::kETC2RGB8UNormIntSRGB:
+    case impeller::PixelFormat::kETC2RGBA8UNormInt:
+    case impeller::PixelFormat::kETC2RGBA8UNormIntSRGB:
+    case impeller::PixelFormat::kASTC4x4LDR:
+    case impeller::PixelFormat::kASTC4x4LDRSRGB:
+    case impeller::PixelFormat::kASTC8x8LDR:
+    case impeller::PixelFormat::kASTC8x8LDRSRGB:
       FML_DCHECK(false);
       return Rasterizer::ScreenshotFormat::kUnknown;
     case impeller::PixelFormat::kR8G8B8A8UNormInt:


### PR DESCRIPTION
Works towards #148443. Design doc: #178632. The Flutter GPU API surface is tracked separately in #187073.

Adds block-compressed texture support to Impeller for the BC, ETC2, and ASTC format families. Compressed format support varies by device, so a new capability query, `Capabilities::SupportsTextureCompression(family)`, lets callers check before allocating. Detection uses Vulkan device features, OpenGLES extension strings, and Metal GPU families.

Compressed textures are sample-only and are validated as such at allocation: they cannot be render targets, storage textures, or transient attachments. Texture sizing math is now block-aware on every backend, and OpenGLES gains a `glCompressedTexImage2D` upload path.

The format set is BC1, BC3, BC5, BC7, ETC2 RGB8, ETC2 RGBA8, ASTC 4x4/8x8 LDR, and ASTC 4x4/8x8 HDR, with sRGB variants where applicable (HDR has no sRGB variant). PVRTC and ETC1 are left for a follow-up.

These formats are not yet exposed by the Flutter GPU API surface.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md


