### PR TITLE
Use resolved implementation plugins with SwiftPM

### DIFF
--- a/packages/flutter_tools/lib/src/darwin/darwin.dart
+++ b/packages/flutter_tools/lib/src/darwin/darwin.dart
@@ -9,6 +9,7 @@ import '../base/version.dart';
 import '../build_info.dart';
 import '../ios/xcodeproj.dart';
 import '../macos/swift_packages.dart';
+import '../platform_plugins.dart';
 import '../project.dart';
 
 /// Encapsulates platform-specific values for Darwin targets ([ios] and [macos]).
@@ -64,6 +65,13 @@ enum FlutterDarwinPlatform {
 
   /// A list of supported [XcodeSdk].
   final List<XcodeSdk> sdks;
+
+  String get pluginConfigKey {
+    return switch (this) {
+      ios => IOSPlugin.kConfigKey,
+      macos => MacOSPlugin.kConfigKey,
+    };
+  }
 
   /// Minimum supported version for the platform.
   Version deploymentTarget() {

--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -1487,10 +1487,18 @@ bool hasPlugins(FlutterProject project) {
 ///
 /// Uses [_resolvePluginImplementations] with [_PluginResolutionType.nativeOrDart]
 /// to find which plugins are resolved for the given platform.
-List<Plugin> resolvePluginImplementationsForPlatform(List<Plugin> plugins, String platformKey) {
+///
+/// If [quiet] is true, validation and resolution errors or warnings will not
+/// be printed.
+List<Plugin> resolvePluginImplementationsForPlatform(
+  List<Plugin> plugins,
+  String platformKey, {
+  bool quiet = false,
+}) {
   final Map<String, List<Plugin>> pluginsByPlatform = _resolvePluginImplementations(
     plugins,
     pluginResolutionType: _PluginResolutionType.nativeOrDart,
+    quiet: quiet,
   );
   return pluginsByPlatform[platformKey] ?? [];
 }
@@ -1531,9 +1539,13 @@ List<PluginInterfaceResolution> resolvePlatformImplementation(
 /// see [resolvePlatformImplementation].
 ///
 /// Only plugins which provide the according platform implementation are returned.
+///
+/// If [quiet] is true, validation and resolution errors or warnings will not
+/// be printed.
 Map<String, List<Plugin>> _resolvePluginImplementations(
   List<Plugin> plugins, {
   required _PluginResolutionType pluginResolutionType,
+  bool quiet = false,
 }) {
   final pluginsByPlatform = <String, List<Plugin>>{
     AndroidPlugin.kConfigKey: <Plugin>[],
@@ -1556,6 +1568,7 @@ Map<String, List<Plugin>> _resolvePluginImplementations(
       plugins,
       platformKey,
       pluginResolutionType: pluginResolutionType,
+      quiet: quiet,
     );
 
     if (hasPlatformPluginPubspecError) {
@@ -1577,11 +1590,15 @@ Map<String, List<Plugin>> _resolvePluginImplementations(
 
 /// Resolves the plugins for the given [platformKey] (Dart-only or native
 /// implementations).
+///
+/// If [quiet] is true, validation and resolution errors or warnings will not
+/// be printed.
 (List<Plugin> pluginImplementations, bool hasPluginPubspecError, bool hasResolutionError)
 _resolvePluginImplementationsByPlatform(
   Iterable<Plugin> plugins,
   String platformKey, {
   _PluginResolutionType pluginResolutionType = _PluginResolutionType.nativeOrDart,
+  bool quiet = false,
 }) {
   var hasPluginPubspecError = false;
   var hasResolutionError = false;
@@ -1599,7 +1616,9 @@ _resolvePluginImplementationsByPlatform(
       pluginResolutionType: pluginResolutionType,
     );
     if (error != null) {
-      globals.printError(error);
+      if (!quiet) {
+        globals.printError(error);
+      }
       hasPluginPubspecError = true;
       continue;
     }
@@ -1638,18 +1657,22 @@ _resolvePluginImplementationsByPlatform(
           }
         } else {
           // Only warn, if neither an implementation for native nor for Dart is given.
-          globals.printWarning(
-            'Package ${plugin.name}:$platformKey references $defaultImplPluginName:$platformKey as the default plugin, but it does not provide an inline implementation.\n'
-            'Ask the maintainers of ${plugin.name} to either avoid referencing a default implementation via `platforms: $platformKey: default_package: $defaultImplPluginName` '
-            'or add an inline implementation to $defaultImplPluginName via `platforms: $platformKey:` `pluginClass` or `dartPluginClass`.\n',
-          );
+          if (!quiet) {
+            globals.printWarning(
+              'Package ${plugin.name}:$platformKey references $defaultImplPluginName:$platformKey as the default plugin, but it does not provide an inline implementation.\n'
+              'Ask the maintainers of ${plugin.name} to either avoid referencing a default implementation via `platforms: $platformKey: default_package: $defaultImplPluginName` '
+              'or add an inline implementation to $defaultImplPluginName via `platforms: $platformKey:` `pluginClass` or `dartPluginClass`.\n',
+            );
+          }
         }
       } else {
-        globals.printWarning(
-          'Package ${plugin.name}:$platformKey references $defaultImplPluginName:$platformKey as the default plugin, but the package does not exist, or is not a plugin package.\n'
-          'Ask the maintainers of ${plugin.name} to either avoid referencing a default implementation via `platforms: $platformKey: default_package: $defaultImplPluginName` '
-          'or create a plugin named $defaultImplPluginName.\n',
-        );
+        if (!quiet) {
+          globals.printWarning(
+            'Package ${plugin.name}:$platformKey references $defaultImplPluginName:$platformKey as the default plugin, but the package does not exist, or is not a plugin package.\n'
+            'Ask the maintainers of ${plugin.name} to either avoid referencing a default implementation via `platforms: $platformKey: default_package: $defaultImplPluginName` '
+            'or create a plugin named $defaultImplPluginName.\n',
+          );
+        }
       }
     }
     if (implementsPluginName != null) {
@@ -1671,7 +1694,9 @@ _resolvePluginImplementationsByPlatform(
       defaultPackage: defaultImplementations[implCandidatesEntry.key],
     );
     if (error != null) {
-      globals.printError(error);
+      if (!quiet) {
+        globals.printError(error);
+      }
       hasResolutionError = true;
     } else if (resolution != null) {
       pluginResolution[implCandidatesEntry.key] = resolution;

--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -1448,7 +1448,6 @@ Future<void> injectPlugins(
         darwinDependencyManagement ??
         DarwinDependencyManagement(
           project: project,
-          plugins: plugins,
           cocoapods: globals.cocoaPods,
           swiftPackageManager: SwiftPackageManager(
             fileSystem: globals.fs,
@@ -1463,10 +1462,16 @@ Future<void> injectPlugins(
           config: globals.config,
         );
     if (iosPlatform) {
-      await darwinDependencyManagerSetup.setUp(platform: FlutterDarwinPlatform.ios);
+      await darwinDependencyManagerSetup.setUp(
+        platform: FlutterDarwinPlatform.ios,
+        plugins: pluginsByPlatform[IOSPlugin.kConfigKey]!,
+      );
     }
     if (macOSPlatform) {
-      await darwinDependencyManagerSetup.setUp(platform: FlutterDarwinPlatform.macos);
+      await darwinDependencyManagerSetup.setUp(
+        platform: FlutterDarwinPlatform.macos,
+        plugins: pluginsByPlatform[MacOSPlugin.kConfigKey]!,
+      );
     }
   }
 }
@@ -1476,6 +1481,18 @@ Future<void> injectPlugins(
 /// Assumes [refreshPluginsList] has been called since last change to `pubspec.yaml`.
 bool hasPlugins(FlutterProject project) {
   return _readFileContent(project.flutterPluginsDependenciesFile) != null;
+}
+
+/// Resolves the plugin implementations for the platform specified by [platformKey].
+///
+/// Uses [_resolvePluginImplementations] with [_PluginResolutionType.nativeOrDart]
+/// to find which plugins are resolved for the given platform.
+List<Plugin> resolvePluginImplementationsForPlatform(List<Plugin> plugins, String platformKey) {
+  final Map<String, List<Plugin>> pluginsByPlatform = _resolvePluginImplementations(
+    plugins,
+    pluginResolutionType: _PluginResolutionType.nativeOrDart,
+  );
+  return pluginsByPlatform[platformKey] ?? [];
 }
 
 /// Resolves the plugin implementations for all platforms.

--- a/packages/flutter_tools/lib/src/macos/darwin_dependency_management.dart
+++ b/packages/flutter_tools/lib/src/macos/darwin_dependency_management.dart
@@ -202,6 +202,7 @@ class DarwinDependencyManagement {
     final List<Plugin> filteredPlugins = resolvePluginImplementationsForPlatform(
       plugins,
       platform.pluginConfigKey,
+      quiet: true,
     );
     for (final plugin in filteredPlugins) {
       final bool pluginSupportsSwiftPM = plugin.supportSwiftPackageManagerForPlatform(

--- a/packages/flutter_tools/lib/src/macos/darwin_dependency_management.dart
+++ b/packages/flutter_tools/lib/src/macos/darwin_dependency_management.dart
@@ -11,6 +11,7 @@ import '../base/logger.dart';
 import '../darwin/darwin.dart';
 import '../features.dart';
 import '../flutter_manifest.dart';
+import '../flutter_plugins.dart';
 import '../ios/xcodeproj.dart';
 import '../plugins.dart';
 import '../project.dart';
@@ -24,7 +25,6 @@ import 'swift_package_manager.dart';
 class DarwinDependencyManagement {
   DarwinDependencyManagement({
     required FlutterProject project,
-    required List<Plugin> plugins,
     required CocoaPods? cocoapods,
     required SwiftPackageManager swiftPackageManager,
     required FileSystem fileSystem,
@@ -35,7 +35,6 @@ class DarwinDependencyManagement {
   }) : _config = config,
        _xcodeProjectInterpreter = xcodeProjectInterpreter,
        _project = project,
-       _plugins = plugins,
        _cocoapods = cocoapods,
        _swiftPackageManager = swiftPackageManager,
        _fileSystem = fileSystem,
@@ -43,7 +42,6 @@ class DarwinDependencyManagement {
        _analytics = analytics;
 
   final FlutterProject _project;
-  final List<Plugin> _plugins;
   final CocoaPods? _cocoapods;
   final SwiftPackageManager _swiftPackageManager;
   final FileSystem _fileSystem;
@@ -64,10 +62,13 @@ class DarwinDependencyManagement {
   /// Swift Package Manager requires a generated Package.swift and certain
   /// settings in the Xcode project's project.pbxproj and xcscheme (done later
   /// before build).
-  Future<void> setUp({required FlutterDarwinPlatform platform}) async {
+  Future<void> setUp({
+    required FlutterDarwinPlatform platform,
+    required List<Plugin> plugins,
+  }) async {
     final XcodeBasedProject xcodeProject = platform.xcodeProject(_project);
     if (xcodeProject.usesSwiftPackageManager) {
-      await _swiftPackageManager.generatePluginsSwiftPackage(_plugins, platform, xcodeProject);
+      await _swiftPackageManager.generatePluginsSwiftPackage(plugins, platform, xcodeProject);
 
       // Start the SwiftPM dependency resolution in the background.
       await _xcodeProjectInterpreter?.prefetchSwiftPackagesForProject(
@@ -98,6 +99,7 @@ class DarwinDependencyManagement {
     final (:int totalCount, :int swiftPackageCount, :int podCount) = await _countPluginsPerManager(
       platform: platform,
       xcodeProject: xcodeProject,
+      plugins: plugins,
     );
 
     final bool useCocoapods;
@@ -108,7 +110,7 @@ class DarwinDependencyManagement {
       // is not empty, regardless of if plugins are CocoaPod compatible. This
       // is done because `processPodsIfNeeded` uses `hasPlugins` to determine
       // whether to run.
-      useCocoapods = _plugins.isNotEmpty;
+      useCocoapods = plugins.isNotEmpty;
     }
 
     if (useCocoapods) {
@@ -143,11 +145,12 @@ class DarwinDependencyManagement {
   Future<({int totalCount, int swiftPackageCount, int podCount})> _countPluginsPerManager({
     required FlutterDarwinPlatform platform,
     required XcodeBasedProject xcodeProject,
+    required List<Plugin> plugins,
   }) async {
     var pluginCount = 0;
     var swiftPackageCount = 0;
     var cocoapodCount = 0;
-    for (final Plugin plugin in _plugins) {
+    for (final plugin in plugins) {
       final bool pluginSupportsSwiftPM = plugin.supportSwiftPackageManagerForPlatform(
         _fileSystem,
         platform.name,
@@ -196,7 +199,11 @@ class DarwinDependencyManagement {
 
     final swiftPackageOnlyPlugins = <String>[];
     final cocoapodOnlyPlugins = <String>[];
-    for (final plugin in plugins) {
+    final List<Plugin> filteredPlugins = resolvePluginImplementationsForPlatform(
+      plugins,
+      platform.pluginConfigKey,
+    );
+    for (final plugin in filteredPlugins) {
       final bool pluginSupportsSwiftPM = plugin.supportSwiftPackageManagerForPlatform(
         fileSystem,
         platform.name,

--- a/packages/flutter_tools/test/general.shard/macos/darwin_dependency_management_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/darwin_dependency_management_test.dart
@@ -1224,11 +1224,11 @@ flutter:
         isDirectDependency: false,
         isDevDependency: false,
       );
-
-      fileSystem.file('/foo_ios/ios/foo_ios/Package.swift').createSync(recursive: true);
+      fileSystem.file('/foo_ios/ios/foo_ios.podspec').createSync(recursive: true);
       fileSystem
           .file('/foo_ios_override/ios/foo_ios_override/Package.swift')
           .createSync(recursive: true);
+      fileSystem.file('/foo_ios_override/ios/foo_ios_override.podspec').createSync(recursive: true);
 
       final plugins = <Plugin>[
         appFacingPlugin,
@@ -1237,24 +1237,16 @@ flutter:
         overrideIosPlatformPlugin,
       ];
 
-      expect(
-        () => DarwinDependencyManagement.validatePluginSupport(
-          platform: FlutterDarwinPlatform.ios,
-          xcodeProject: project,
-          plugins: plugins,
-          fileSystem: fileSystem,
-          logger: logger,
-          cocoapods: cocoapods,
-        ),
-        throwsToolExit(
-          message:
-              'The following plugin(s) are only compatible with Swift Package Manager:\n'
-              '  - foo_ios_override\n\n'
-              'Try enabling Swift Package Manager by running '
-              '"flutter config --enable-swift-package-manager" or remove the '
-              'plugin as a dependency.',
-        ),
+      await DarwinDependencyManagement.validatePluginSupport(
+        platform: FlutterDarwinPlatform.ios,
+        xcodeProject: project,
+        plugins: plugins,
+        fileSystem: fileSystem,
+        logger: logger,
+        cocoapods: cocoapods,
       );
+      expect(logger.warningText, isEmpty);
+      expect(logger.errorText, isEmpty);
     });
 
     testWithoutContext('when plugin supports platform but has no podspec or manifest', () async {

--- a/packages/flutter_tools/test/general.shard/macos/darwin_dependency_management_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/darwin_dependency_management_test.dart
@@ -14,6 +14,7 @@ import 'package:flutter_tools/src/macos/swift_package_manager.dart';
 import 'package:flutter_tools/src/platform_plugins.dart';
 import 'package:flutter_tools/src/plugins.dart';
 import 'package:flutter_tools/src/project.dart';
+import 'package:pub_semver/pub_semver.dart';
 import 'package:test/fake.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 
@@ -55,7 +56,6 @@ void main() {
                   usesSwiftPackageManager: true,
                   fileSystem: testFileSystem,
                 ),
-                plugins: plugins,
                 cocoapods: cocoaPods,
                 swiftPackageManager: swiftPackageManager,
                 fileSystem: testFileSystem,
@@ -64,7 +64,7 @@ void main() {
                 xcodeProjectInterpreter: FakeXcodeProjectInterpreter(),
                 config: FakeConfig(),
               );
-              await dependencyManagement.setUp(platform: platform);
+              await dependencyManagement.setUp(platform: platform, plugins: plugins);
               expect(swiftPackageManager.generated, isTrue);
               expect(cocoaPods.podfileSetup, isTrue);
               expect(
@@ -119,7 +119,6 @@ void main() {
 
                 final dependencyManagement = DarwinDependencyManagement(
                   project: project,
-                  plugins: plugins,
                   cocoapods: cocoaPods,
                   swiftPackageManager: swiftPackageManager,
                   fileSystem: testFileSystem,
@@ -130,7 +129,7 @@ void main() {
                   xcodeProjectInterpreter: FakeXcodeProjectInterpreter(),
                   config: FakeConfig(),
                 );
-                await dependencyManagement.setUp(platform: platform);
+                await dependencyManagement.setUp(platform: platform, plugins: plugins);
                 expect(swiftPackageManager.generated, isTrue);
                 expect(cocoaPods.podfileSetup, isFalse);
                 expect(
@@ -187,7 +186,6 @@ void main() {
 
                 final dependencyManagement = DarwinDependencyManagement(
                   project: project,
-                  plugins: plugins,
                   cocoapods: cocoaPods,
                   swiftPackageManager: swiftPackageManager,
                   fileSystem: testFileSystem,
@@ -198,7 +196,7 @@ void main() {
                   xcodeProjectInterpreter: FakeXcodeProjectInterpreter(),
                   config: FakeConfig(),
                 );
-                await dependencyManagement.setUp(platform: platform);
+                await dependencyManagement.setUp(platform: platform, plugins: plugins);
                 expect(swiftPackageManager.generated, isTrue);
                 expect(cocoaPods.podfileSetup, isFalse);
                 expect(
@@ -258,7 +256,6 @@ void main() {
                 );
                 final dependencyManagement = DarwinDependencyManagement(
                   project: project,
-                  plugins: plugins,
                   cocoapods: cocoaPods,
                   swiftPackageManager: swiftPackageManager,
                   fileSystem: testFileSystem,
@@ -269,7 +266,7 @@ void main() {
                   xcodeProjectInterpreter: FakeXcodeProjectInterpreter(),
                   config: FakeConfig(),
                 );
-                await dependencyManagement.setUp(platform: platform);
+                await dependencyManagement.setUp(platform: platform, plugins: plugins);
                 expect(swiftPackageManager.generated, isTrue);
                 expect(cocoaPods.podfileSetup, isFalse);
                 expect(
@@ -330,7 +327,6 @@ void main() {
 
                 final dependencyManagement = DarwinDependencyManagement(
                   project: project,
-                  plugins: plugins,
                   cocoapods: cocoaPods,
                   swiftPackageManager: swiftPackageManager,
                   fileSystem: testFileSystem,
@@ -341,7 +337,7 @@ void main() {
                   xcodeProjectInterpreter: FakeXcodeProjectInterpreter(),
                   config: FakeConfig(),
                 );
-                await dependencyManagement.setUp(platform: platform);
+                await dependencyManagement.setUp(platform: platform, plugins: plugins);
                 expect(swiftPackageManager.generated, isTrue);
                 expect(cocoaPods.podfileSetup, isFalse);
                 expect(
@@ -407,7 +403,6 @@ void main() {
 
               final dependencyManagement = DarwinDependencyManagement(
                 project: project,
-                plugins: plugins,
                 cocoapods: cocoaPods,
                 swiftPackageManager: swiftPackageManager,
                 fileSystem: testFileSystem,
@@ -418,7 +413,7 @@ void main() {
                 xcodeProjectInterpreter: FakeXcodeProjectInterpreter(),
                 config: FakeConfig(),
               );
-              await dependencyManagement.setUp(platform: platform);
+              await dependencyManagement.setUp(platform: platform, plugins: plugins);
               expect(swiftPackageManager.generated, isTrue);
               expect(cocoaPods.podfileSetup, isTrue);
               expect(
@@ -473,7 +468,6 @@ void main() {
 
               final dependencyManagement = DarwinDependencyManagement(
                 project: project,
-                plugins: plugins,
                 cocoapods: cocoaPods,
                 swiftPackageManager: swiftPackageManager,
                 fileSystem: testFileSystem,
@@ -482,7 +476,7 @@ void main() {
                 xcodeProjectInterpreter: FakeXcodeProjectInterpreter(),
                 config: FakeConfig(),
               );
-              await dependencyManagement.setUp(platform: platform);
+              await dependencyManagement.setUp(platform: platform, plugins: plugins);
               expect(swiftPackageManager.generated, isTrue);
               expect(cocoaPods.podfileSetup, isTrue);
               expect(
@@ -524,7 +518,6 @@ void main() {
 
               final dependencyManagement = DarwinDependencyManagement(
                 project: FakeFlutterProject(fileSystem: testFileSystem),
-                plugins: plugins,
                 cocoapods: cocoaPods,
                 swiftPackageManager: swiftPackageManager,
                 fileSystem: testFileSystem,
@@ -533,7 +526,7 @@ void main() {
                 xcodeProjectInterpreter: FakeXcodeProjectInterpreter(),
                 config: FakeConfig(),
               );
-              await dependencyManagement.setUp(platform: platform);
+              await dependencyManagement.setUp(platform: platform, plugins: plugins);
               expect(swiftPackageManager.generated, isFalse);
               expect(cocoaPods.podfileSetup, isTrue);
               expect(
@@ -578,7 +571,6 @@ void main() {
                   fileSystem: testFileSystem,
                   compatibleWithSwiftPackageManager: true,
                 ),
-                plugins: plugins,
                 cocoapods: cocoaPods,
                 swiftPackageManager: swiftPackageManager,
                 fileSystem: testFileSystem,
@@ -587,7 +579,7 @@ void main() {
                 xcodeProjectInterpreter: FakeXcodeProjectInterpreter(),
                 config: FakeConfig(),
               );
-              await dependencyManagement.setUp(platform: platform);
+              await dependencyManagement.setUp(platform: platform, plugins: plugins);
               expect(swiftPackageManager.generated, isFalse);
               expect(cocoaPods.podfileSetup, isTrue);
               expect(
@@ -629,7 +621,6 @@ void main() {
 
               final dependencyManagement = DarwinDependencyManagement(
                 project: FakeFlutterProject(fileSystem: testFileSystem, isModule: true),
-                plugins: plugins,
                 cocoapods: cocoaPods,
                 swiftPackageManager: swiftPackageManager,
                 fileSystem: testFileSystem,
@@ -640,7 +631,7 @@ void main() {
                 xcodeProjectInterpreter: FakeXcodeProjectInterpreter(),
                 config: FakeConfig(),
               );
-              await dependencyManagement.setUp(platform: platform);
+              await dependencyManagement.setUp(platform: platform, plugins: plugins);
               expect(swiftPackageManager.generated, isFalse);
               expect(cocoaPods.podfileSetup, isFalse);
               expect(testAnalytics.sentEvents, isEmpty);
@@ -673,7 +664,6 @@ void main() {
 
         final dependencyManagement = DarwinDependencyManagement(
           project: project,
-          plugins: [],
           cocoapods: cocoaPods,
           swiftPackageManager: swiftPackageManager,
           fileSystem: testFileSystem,
@@ -682,7 +672,7 @@ void main() {
           xcodeProjectInterpreter: FakeXcodeProjectInterpreter(),
           config: FakeConfig(),
         );
-        await dependencyManagement.setUp(platform: FlutterDarwinPlatform.macos);
+        await dependencyManagement.setUp(platform: FlutterDarwinPlatform.macos, plugins: []);
         expect(xcodeProject.outputFileList.readAsStringSync(), 'Something else');
       },
     );
@@ -966,7 +956,6 @@ version: 0.0.1
         // Directory is NOT an example app (default 'app_name'), so validation should be skipped.
         final dependencyManagement = DarwinDependencyManagement(
           project: FakeFlutterProject(fileSystem: testFileSystem),
-          plugins: [plugin],
           cocoapods: FakeCocoaPods(),
           swiftPackageManager: FakeSwiftPackageManager(),
           fileSystem: testFileSystem,
@@ -978,7 +967,7 @@ version: 0.0.1
           config: FakeConfig(),
         );
 
-        await dependencyManagement.setUp(platform: FlutterDarwinPlatform.ios);
+        await dependencyManagement.setUp(platform: FlutterDarwinPlatform.ios, plugins: [plugin]);
         // The example-app-specific warning (always contains the docs URL) should not fire.
         expect(testLogger.warningText, isNot(contains(kSwiftPackageManagerDocsUrl)));
       });
@@ -1008,7 +997,6 @@ version: 0.0.1
             fileSystem: testFileSystem,
             directoryOverride: '/my_plugin/example',
           ),
-          plugins: [plugin],
           cocoapods: FakeCocoaPods(),
           swiftPackageManager: FakeSwiftPackageManager(),
           fileSystem: testFileSystem,
@@ -1020,7 +1008,7 @@ version: 0.0.1
           config: FakeConfig(),
         );
 
-        await dependencyManagement.setUp(platform: FlutterDarwinPlatform.ios);
+        await dependencyManagement.setUp(platform: FlutterDarwinPlatform.ios, plugins: [plugin]);
         // Should not fire the example-app-specific warning (always contains the docs URL).
         expect(testLogger.warningText, isNot(contains(kSwiftPackageManagerDocsUrl)));
       });
@@ -1047,7 +1035,6 @@ version: 0.0.1
             fileSystem: testFileSystem,
             directoryOverride: '/my_plugin/example',
           ),
-          plugins: [plugin],
           cocoapods: FakeCocoaPods(),
           swiftPackageManager: FakeSwiftPackageManager(expectedPlugins: [plugin]),
           fileSystem: testFileSystem,
@@ -1059,7 +1046,7 @@ version: 0.0.1
           config: FakeConfig(),
         );
 
-        await dependencyManagement.setUp(platform: FlutterDarwinPlatform.ios);
+        await dependencyManagement.setUp(platform: FlutterDarwinPlatform.ios, plugins: [plugin]);
         expect(testLogger.warningText, isNot(contains(kSwiftPackageManagerDocsUrl)));
       });
 
@@ -1087,7 +1074,6 @@ version: 0.0.1
             fileSystem: testFileSystem,
             directoryOverride: '/my_plugin/example',
           ),
-          plugins: [plugin],
           cocoapods: FakeCocoaPods(),
           swiftPackageManager: FakeSwiftPackageManager(expectedPlugins: [plugin]),
           fileSystem: testFileSystem,
@@ -1099,7 +1085,7 @@ version: 0.0.1
           config: FakeConfig(),
         );
 
-        await dependencyManagement.setUp(platform: FlutterDarwinPlatform.ios);
+        await dependencyManagement.setUp(platform: FlutterDarwinPlatform.ios, plugins: [plugin]);
         expect(testLogger.warningText, isNot(contains(kSwiftPackageManagerDocsUrl)));
       });
 
@@ -1137,7 +1123,6 @@ flutter:
             fileSystem: testFileSystem,
             directoryOverride: '/my_plugin/example',
           ),
-          plugins: [plugin],
           cocoapods: FakeCocoaPods(),
           swiftPackageManager: FakeSwiftPackageManager(expectedPlugins: [plugin]),
           fileSystem: testFileSystem,
@@ -1149,7 +1134,7 @@ flutter:
           config: FakeConfig(),
         );
 
-        await dependencyManagement.setUp(platform: FlutterDarwinPlatform.ios);
+        await dependencyManagement.setUp(platform: FlutterDarwinPlatform.ios, plugins: [plugin]);
         expect(testLogger.warningText, isNot(contains(kSwiftPackageManagerDocsUrl)));
       });
     });
@@ -1173,6 +1158,103 @@ flutter:
       );
 
       expect(logger.warningText, isEmpty);
+    });
+
+    testWithoutContext('filters plugins for the correct implementation', () async {
+      final fileSystem = MemoryFileSystem.test();
+      final logger = BufferLogger.test();
+      final cocoapods = FakeCocoaPods();
+      final project = FakeIosProject(
+        fileSystem: fileSystem,
+        usesSwiftPackageManager: false,
+        compatibleWithSwiftPackageManager: true,
+      );
+
+      final appFacingPlugin = Plugin(
+        name: 'foo',
+        path: '',
+        defaultPackagePlatforms: const <String, String>{IOSPlugin.kConfigKey: 'foo_ios'},
+        pluginDartClassPlatforms: const <String, DartPluginClassAndFilePair>{},
+        platforms: const <String, PluginPlatform>{},
+        dependencies: const <String>[],
+        isDirectDependency: true,
+        isDevDependency: false,
+      );
+      final iosPlatformPlugin = Plugin(
+        name: 'foo_ios',
+        path: '/foo_ios',
+        implementsPackage: 'foo',
+        defaultPackagePlatforms: const <String, String>{},
+        pluginDartClassPlatforms: const <String, DartPluginClassAndFilePair>{},
+        platforms: const <String, PluginPlatform>{
+          IOSPlugin.kConfigKey: IOSPlugin(name: 'foo_ios', classPrefix: ''),
+        },
+        dependencies: const <String>[],
+        isDirectDependency: false,
+        isDevDependency: false,
+      );
+      final overrideIosPlatformPlugin = Plugin(
+        name: 'foo_ios_override',
+        path: '/foo_ios_override',
+        implementsPackage: 'foo',
+        defaultPackagePlatforms: const <String, String>{},
+        pluginDartClassPlatforms: const <String, DartPluginClassAndFilePair>{},
+        platforms: const <String, PluginPlatform>{
+          IOSPlugin.kConfigKey: IOSPlugin(name: 'foo_ios_override', classPrefix: ''),
+        },
+        dependencies: const <String>[],
+        isDirectDependency: true,
+        isDevDependency: false,
+      );
+      final androidPlatformPlugin = Plugin(
+        name: 'foo_android',
+        path: '/foo_android',
+        implementsPackage: 'foo',
+        defaultPackagePlatforms: const <String, String>{},
+        pluginDartClassPlatforms: const <String, DartPluginClassAndFilePair>{},
+        platforms: <String, PluginPlatform>{
+          AndroidPlugin.kConfigKey: AndroidPlugin(
+            name: 'foo_android',
+            package: 'com.example',
+            pluginPath: '',
+            fileSystem: fileSystem,
+          ),
+        },
+        dependencies: const <String>[],
+        isDirectDependency: false,
+        isDevDependency: false,
+      );
+
+      fileSystem.file('/foo_ios/ios/foo_ios/Package.swift').createSync(recursive: true);
+      fileSystem
+          .file('/foo_ios_override/ios/foo_ios_override/Package.swift')
+          .createSync(recursive: true);
+
+      final plugins = <Plugin>[
+        appFacingPlugin,
+        iosPlatformPlugin,
+        androidPlatformPlugin,
+        overrideIosPlatformPlugin,
+      ];
+
+      expect(
+        () => DarwinDependencyManagement.validatePluginSupport(
+          platform: FlutterDarwinPlatform.ios,
+          xcodeProject: project,
+          plugins: plugins,
+          fileSystem: fileSystem,
+          logger: logger,
+          cocoapods: cocoapods,
+        ),
+        throwsToolExit(
+          message:
+              'The following plugin(s) are only compatible with Swift Package Manager:\n'
+              '  - foo_ios_override\n\n'
+              'Try enabling Swift Package Manager by running '
+              '"flutter config --enable-swift-package-manager" or remove the '
+              'plugin as a dependency.',
+        ),
+      );
     });
 
     testWithoutContext('when plugin supports platform but has no podspec or manifest', () async {
@@ -1654,6 +1736,25 @@ class FakePlugin extends Fake implements Plugin {
 
   @override
   final Map<String, PluginPlatform> platforms;
+
+  @override
+  String? get implementsPackage => null;
+
+  @override
+  Map<String, String> get defaultPackagePlatforms => const <String, String>{};
+
+  @override
+  Map<String, DartPluginClassAndFilePair> get pluginDartClassPlatforms =>
+      const <String, DartPluginClassAndFilePair>{};
+
+  @override
+  bool get isDirectDependency => true;
+
+  @override
+  bool get isDevDependency => false;
+
+  @override
+  VersionConstraint? get flutterConstraint => null;
 
   @override
   String? pluginSwiftPackageManifestPath(FileSystem fileSystem, String platform) {

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -2849,6 +2849,117 @@ flutter:
       expect(iosResolved, isNot(contains(appFacingPlugin)));
       expect(iosResolved, isNot(contains(androidPlatformPlugin)));
     });
+
+    testUsingContext('respects quiet parameter', () {
+      final appFacingPluginNoDefaultPackage = Plugin(
+        name: 'foo',
+        path: '',
+        defaultPackagePlatforms: const <String, String>{IOSPlugin.kConfigKey: 'foo_ios'},
+        pluginDartClassPlatforms: const <String, DartPluginClassAndFilePair>{},
+        platforms: const <String, PluginPlatform>{},
+        dependencies: const <String>[],
+        isDirectDependency: true,
+        isDevDependency: false,
+      );
+      final appFacingPluginWithNoInlineImplDefault = Plugin(
+        name: 'bar',
+        path: '',
+        defaultPackagePlatforms: const <String, String>{IOSPlugin.kConfigKey: 'bar_ios'},
+        pluginDartClassPlatforms: const <String, DartPluginClassAndFilePair>{},
+        platforms: const <String, PluginPlatform>{},
+        dependencies: const <String>[],
+        isDirectDependency: true,
+        isDevDependency: false,
+      );
+      final barIosWithNoInlineImpl = Plugin(
+        name: 'bar_ios',
+        path: '',
+        defaultPackagePlatforms: const <String, String>{},
+        pluginDartClassPlatforms: const <String, DartPluginClassAndFilePair>{},
+        platforms: const <String, PluginPlatform>{},
+        dependencies: const <String>[],
+        isDirectDependency: false,
+        isDevDependency: false,
+      );
+      final invalidPlugin = Plugin(
+        name: 'invalid_plugin',
+        path: '',
+        implementsPackage: 'some_package',
+        defaultPackagePlatforms: const <String, String>{IOSPlugin.kConfigKey: 'some_default'},
+        pluginDartClassPlatforms: const <String, DartPluginClassAndFilePair>{},
+        platforms: const <String, PluginPlatform>{},
+        dependencies: const <String>[],
+        isDirectDependency: true,
+        isDevDependency: false,
+      );
+      final directImpl1 = Plugin(
+        name: 'impl1',
+        path: '',
+        implementsPackage: 'conflict_foo',
+        defaultPackagePlatforms: const <String, String>{},
+        pluginDartClassPlatforms: const <String, DartPluginClassAndFilePair>{},
+        platforms: const <String, PluginPlatform>{
+          IOSPlugin.kConfigKey: IOSPlugin(name: 'impl1', classPrefix: ''),
+        },
+        dependencies: const <String>[],
+        isDirectDependency: true,
+        isDevDependency: false,
+      );
+      final directImpl2 = Plugin(
+        name: 'impl2',
+        path: '',
+        implementsPackage: 'conflict_foo',
+        defaultPackagePlatforms: const <String, String>{},
+        pluginDartClassPlatforms: const <String, DartPluginClassAndFilePair>{},
+        platforms: const <String, PluginPlatform>{
+          IOSPlugin.kConfigKey: IOSPlugin(name: 'impl2', classPrefix: ''),
+        },
+        dependencies: const <String>[],
+        isDirectDependency: true,
+        isDevDependency: false,
+      );
+
+      final plugins = <Plugin>[
+        appFacingPluginNoDefaultPackage,
+        appFacingPluginWithNoInlineImplDefault,
+        barIosWithNoInlineImpl,
+        invalidPlugin,
+        directImpl1,
+        directImpl2,
+      ];
+
+      expect(
+        () => resolvePluginImplementationsForPlatform(plugins, IOSPlugin.kConfigKey, quiet: true),
+        throwsToolExit(),
+      );
+      expect(testLogger.warningText, isEmpty);
+      expect(testLogger.errorText, isEmpty);
+
+      expect(
+        () => resolvePluginImplementationsForPlatform(plugins, IOSPlugin.kConfigKey),
+        throwsToolExit(),
+      );
+      expect(
+        testLogger.warningText,
+        contains('references foo_ios:ios as the default plugin, but the package does not exist'),
+      );
+      expect(
+        testLogger.warningText,
+        contains(
+          'references bar_ios:ios as the default plugin, but it does not provide an inline implementation',
+        ),
+      );
+      expect(
+        testLogger.errorText,
+        contains(
+          'invalid_plugin:ios provides an implementation for some_package and also references a default implementation',
+        ),
+      );
+      expect(
+        testLogger.errorText,
+        contains('conflict_foo:ios has conflicting direct dependency implementations'),
+      );
+    });
   });
 
   group('buildPubspecCache', () {

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -2734,6 +2734,123 @@ flutter:
     },
   );
 
+  group('resolvePluginImplementationsForPlatform', () {
+    testWithoutContext('filters plugins based on platformKey', () {
+      final iosPlugin = Plugin(
+        name: 'ios_plugin',
+        path: '',
+        defaultPackagePlatforms: const <String, String>{},
+        pluginDartClassPlatforms: const <String, DartPluginClassAndFilePair>{},
+        platforms: const <String, PluginPlatform>{
+          IOSPlugin.kConfigKey: IOSPlugin(name: 'ios_plugin', classPrefix: ''),
+        },
+        dependencies: const <String>[],
+        isDirectDependency: true,
+        isDevDependency: false,
+      );
+      final macosPlugin = Plugin(
+        name: 'macos_plugin',
+        path: '',
+        defaultPackagePlatforms: const <String, String>{},
+        pluginDartClassPlatforms: const <String, DartPluginClassAndFilePair>{},
+        platforms: const <String, PluginPlatform>{
+          MacOSPlugin.kConfigKey: MacOSPlugin(name: 'macos_plugin'),
+        },
+        dependencies: const <String>[],
+        isDirectDependency: true,
+        isDevDependency: false,
+      );
+      final plugins = <Plugin>[iosPlugin, macosPlugin];
+
+      final List<Plugin> iosResolved = resolvePluginImplementationsForPlatform(
+        plugins,
+        IOSPlugin.kConfigKey,
+      );
+      expect(iosResolved, contains(iosPlugin));
+      expect(iosResolved, isNot(contains(macosPlugin)));
+
+      final List<Plugin> macosResolved = resolvePluginImplementationsForPlatform(
+        plugins,
+        MacOSPlugin.kConfigKey,
+      );
+      expect(macosResolved, contains(macosPlugin));
+      expect(macosResolved, isNot(contains(iosPlugin)));
+    });
+
+    testWithoutContext('ensures the correct federated implementation is selected', () {
+      final fs = MemoryFileSystem.test();
+      final appFacingPlugin = Plugin(
+        name: 'foo',
+        path: '',
+        defaultPackagePlatforms: const <String, String>{IOSPlugin.kConfigKey: 'foo_ios'},
+        pluginDartClassPlatforms: const <String, DartPluginClassAndFilePair>{},
+        platforms: const <String, PluginPlatform>{},
+        dependencies: const <String>[],
+        isDirectDependency: true,
+        isDevDependency: false,
+      );
+      final iosPlatformPlugin = Plugin(
+        name: 'foo_ios',
+        path: '',
+        implementsPackage: 'foo',
+        defaultPackagePlatforms: const <String, String>{},
+        pluginDartClassPlatforms: const <String, DartPluginClassAndFilePair>{},
+        platforms: const <String, PluginPlatform>{
+          IOSPlugin.kConfigKey: IOSPlugin(name: 'foo_ios', classPrefix: ''),
+        },
+        dependencies: const <String>[],
+        isDirectDependency: false,
+        isDevDependency: false,
+      );
+      final overrideIosPlatformPlugin = Plugin(
+        name: 'foo_ios_override',
+        path: '',
+        implementsPackage: 'foo',
+        defaultPackagePlatforms: const <String, String>{},
+        pluginDartClassPlatforms: const <String, DartPluginClassAndFilePair>{},
+        platforms: const <String, PluginPlatform>{
+          IOSPlugin.kConfigKey: IOSPlugin(name: 'foo_ios_override', classPrefix: ''),
+        },
+        dependencies: const <String>[],
+        isDirectDependency: true,
+        isDevDependency: false,
+      );
+      final androidPlatformPlugin = Plugin(
+        name: 'foo_android',
+        path: '',
+        implementsPackage: 'foo',
+        defaultPackagePlatforms: const <String, String>{},
+        pluginDartClassPlatforms: const <String, DartPluginClassAndFilePair>{},
+        platforms: <String, PluginPlatform>{
+          AndroidPlugin.kConfigKey: AndroidPlugin(
+            name: 'foo_android',
+            package: 'com.example',
+            pluginPath: '',
+            fileSystem: fs,
+          ),
+        },
+        dependencies: const <String>[],
+        isDirectDependency: false,
+        isDevDependency: false,
+      );
+      final plugins = <Plugin>[
+        appFacingPlugin,
+        iosPlatformPlugin,
+        androidPlatformPlugin,
+        overrideIosPlatformPlugin,
+      ];
+
+      final List<Plugin> iosResolved = resolvePluginImplementationsForPlatform(
+        plugins,
+        IOSPlugin.kConfigKey,
+      );
+      expect(iosResolved, contains(overrideIosPlatformPlugin));
+      expect(iosResolved, isNot(contains(iosPlatformPlugin)));
+      expect(iosResolved, isNot(contains(appFacingPlugin)));
+      expect(iosResolved, isNot(contains(androidPlatformPlugin)));
+    });
+  });
+
   group('buildPubspecCache', () {
     late MemoryFileSystem fs;
 
@@ -3087,7 +3204,10 @@ class FakeDarwinDependencyManagement extends Fake implements DarwinDependencyMan
   List<FlutterDarwinPlatform> setupPlatforms = <FlutterDarwinPlatform>[];
 
   @override
-  Future<void> setUp({required FlutterDarwinPlatform platform}) async {
+  Future<void> setUp({
+    required FlutterDarwinPlatform platform,
+    required List<Plugin> plugins,
+  }) async {
     setupPlatforms.add(platform);
   }
 }


### PR DESCRIPTION
When you use a federated plugin, it can have a default package per platform. However, app developers can override the default package by adding a different package that implements the federated plugin as a direct dependency. For example, the federated plugin `google_maps_flutter` has `google_maps_flutter_ios` set as it's default package for iOS. App developers can add `google_maps_flutter_sdk_10` to their app's pubspec.yaml to override the default plugin and use `google_maps_flutter_sdk_10` instead. 

SwiftPM was not previously handling this use case. This PR fixes that.

Fixes https://github.com/flutter/flutter/issues/186770.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
