### PR TITLE
Add actionable error message when FlutterFramework injection fails

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_swift_package.dart
+++ b/packages/flutter_tools/lib/src/commands/build_swift_package.dart
@@ -28,6 +28,7 @@ import '../flutter_plugins.dart';
 import '../ios/xcodeproj.dart';
 import '../macos/cocoapod_utils.dart';
 import '../macos/cocoapods.dart';
+import '../macos/darwin_dependency_management.dart';
 import '../macos/swift_package_manager.dart';
 import '../macos/swift_packages.dart';
 import '../macos/xcode.dart';
@@ -1081,32 +1082,58 @@ class FlutterPluginSwiftDependencies {
     required List<String> targetNames,
     required Directory workingDirectory,
   }) async {
-    final ProcessResult result = await _utils.processManager.run([
-      'swift',
-      'package',
-      'add-dependency',
-      '../FlutterFramework',
-      '--type',
-      'path',
-    ], workingDirectory: workingDirectory.path);
-    if (result.exitCode != 0) {
-      throwToolExit('Failed to add FlutterFramework as a dependency. ${result.stderr}');
-    }
-    for (final targetName in targetNames) {
-      final ProcessResult targetResult = await _utils.processManager.run([
+    try {
+      final ProcessResult result = await _utils.processManager.run([
         'swift',
         'package',
-        'add-target-dependency',
-        kFlutterGeneratedFrameworkSwiftPackageTargetName,
-        targetName,
-        '--package',
-        kFlutterGeneratedFrameworkSwiftPackageTargetName,
+        'add-dependency',
+        '../FlutterFramework',
+        '--type',
+        'path',
       ], workingDirectory: workingDirectory.path);
-      if (targetResult.exitCode != 0) {
-        throwToolExit(
-          'Failed to add FlutterFramework as a target dependency. ${targetResult.stderr}',
-        );
+      if (result.exitCode != 0) {
+        throwToolExit('Failed to add FlutterFramework as a dependency. ${result.stderr}');
       }
+      for (final targetName in targetNames) {
+        final ProcessResult targetResult = await _utils.processManager.run([
+          'swift',
+          'package',
+          'add-target-dependency',
+          kFlutterGeneratedFrameworkSwiftPackageTargetName,
+          targetName,
+          '--package',
+          kFlutterGeneratedFrameworkSwiftPackageTargetName,
+        ], workingDirectory: workingDirectory.path);
+        if (targetResult.exitCode != 0) {
+          throwToolExit(
+            'Failed to add FlutterFramework as a target dependency. ${targetResult.stderr}',
+          );
+        }
+      }
+      final ProcessResult modifiedManifest = await _utils.processManager.run([
+        'swift',
+        'package',
+        'dump-package',
+      ], workingDirectory: workingDirectory.path);
+      if (modifiedManifest.exitCode != 0) {
+        throwToolExit('Failed to parse modified package. ${modifiedManifest.stderr}');
+      }
+    } on ToolExit catch (e) {
+      final buffer = StringBuffer();
+      if (e.message != null) {
+        buffer.writeln(e.message);
+      }
+      buffer.writeln();
+      buffer.writeln(
+        'Failed to add FlutterFramework to package ${workingDirectory.basename}. $_kFileAnIssue '
+        'and include the above error.',
+      );
+      buffer.writeln();
+      buffer.writeln(
+        'Please also contact the plugin maintainer and request they adopt the FlutterFramework '
+        "dependency in their plugin's Package.swift file as instructed in $kSwiftPackageManagerDocsUrl.",
+      );
+      throwToolExit(buffer.toString());
     }
   }
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_swift_package_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_swift_package_test.dart
@@ -6,6 +6,7 @@ import 'package:args/command_runner.dart';
 import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/artifacts.dart';
+import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
@@ -2148,6 +2149,7 @@ let package = Package(
               'FlutterFramework',
             ],
           ),
+          const FakeCommand(command: ['swift', 'package', 'dump-package']),
         ]);
 
         final testUtils = BuildSwiftPackageUtils(
@@ -2326,6 +2328,7 @@ let package = Package(
               'FlutterFramework',
             ],
           ),
+          const FakeCommand(command: ['swift', 'package', 'dump-package']),
         ]);
 
         final testUtils = BuildSwiftPackageUtils(
@@ -2437,6 +2440,7 @@ let package = Package(
               'FlutterFramework',
             ],
           ),
+          const FakeCommand(command: ['swift', 'package', 'dump-package']),
           const FakeCommand(
             command: ['swift', 'package', 'dump-package'],
             stdout:
@@ -2463,6 +2467,7 @@ let package = Package(
               'FlutterFramework',
             ],
           ),
+          const FakeCommand(command: ['swift', 'package', 'dump-package']),
         ]);
 
         final testUtils = BuildSwiftPackageUtils(
@@ -2572,6 +2577,7 @@ let package = Package(
                 'FlutterFramework',
               ],
             ),
+            const FakeCommand(command: ['swift', 'package', 'dump-package']),
           ]);
 
           final testUtils = BuildSwiftPackageUtils(
@@ -2700,6 +2706,137 @@ let package = Package(
             cacheDirectory: cacheDir,
             plugins: [pluginA],
             pluginsDirectory: pluginsDir,
+          );
+
+          expect(processManager, hasNoRemainingExpectations);
+        },
+      );
+
+      testWithoutContext(
+        'processPlugins logs error and continues if injecting Flutter dependency fails',
+        () async {
+          final fs = MemoryFileSystem.test();
+          final logger = BufferLogger.test();
+          const FlutterDarwinPlatform targetPlatform = .ios;
+
+          final pluginA = FakePlugin(name: 'PluginA', darwinPlatform: targetPlatform);
+
+          final Directory appDirectory = fs.directory('/path/to/my_flutter_app')
+            ..createSync(recursive: true);
+          fs.currentDirectory = appDirectory;
+
+          fs.file(commandFilePath).createSync(recursive: true);
+          fs
+              .directory(pluginA.path)
+              .childDirectory('ios')
+              .childDirectory('PluginA')
+              .childFile('Package.swift')
+            ..createSync(recursive: true)
+            ..writeAsStringSync(_pluginManifest(pluginName: 'PluginA'));
+
+          final processManager = FakeProcessManager.list([
+            const FakeCommand(
+              command: ['swift', 'package', 'dump-package'],
+              stdout: '''
+{
+  "platforms": [
+    {
+      "platformName": "ios",
+      "version": "13.0"
+    }
+  ],
+  "targets": [
+    {
+      "name": "PluginA",
+      "type": "regular"
+    }
+  ],
+  "dependencies": []
+}
+''',
+            ),
+            const FakeCommand(
+              command: [
+                'swift',
+                'package',
+                'add-dependency',
+                '../FlutterFramework',
+                '--type',
+                'path',
+              ],
+            ),
+            const FakeCommand(
+              command: [
+                'swift',
+                'package',
+                'add-target-dependency',
+                'FlutterFramework',
+                'PluginA',
+                '--package',
+                'FlutterFramework',
+              ],
+            ),
+            const FakeCommand(
+              command: ['swift', 'package', 'dump-package'],
+              exitCode: 1,
+              stderr: 'Failed to parse.',
+            ),
+          ]);
+
+          final testUtils = BuildSwiftPackageUtils(
+            analytics: FakeAnalytics(),
+            artifacts: FakeArtifacts(
+              '/path/to/flutter/bin/cache/artifacts/engine/ios/Flutter.xcframework',
+            ),
+            buildSystem: FakeBuildSystem(),
+            cache: FakeCache(fs, '/path/to/flutter'),
+            fileSystem: fs,
+            flutterRoot: '/path/to/flutter',
+            flutterVersion: FakeFlutterVersion(),
+            logger: logger,
+            platform: FakePlatform(),
+            processManager: processManager,
+            project: FakeFlutterProject(directory: appDirectory),
+            templateRenderer: const MustacheTemplateRenderer(),
+            xcode: FakeXcode(),
+          );
+
+          final pluginSwiftDependencies = FlutterPluginSwiftDependencies(
+            targetPlatform: targetPlatform,
+            utils: testUtils,
+          );
+
+          final Directory cacheDir = fs.directory('output/.cache')..createSync(recursive: true);
+          final Directory pluginsDir = appDirectory.childDirectory(
+            'output/FlutterPluginRegistrant/Plugins',
+          )..createSync(recursive: true);
+
+          await expectLater(
+            pluginSwiftDependencies.processPlugins(
+              cacheDirectory: cacheDir,
+              plugins: [pluginA],
+              pluginsDirectory: pluginsDir,
+            ),
+            throwsA(
+              isA<ToolExit>()
+                  .having(
+                    (ToolExit e) => e.message,
+                    'message',
+                    contains('Failed to parse modified package. Failed to parse.'),
+                  )
+                  .having(
+                    (ToolExit e) => e.message,
+                    'message',
+                    contains(
+                      'Failed to add FlutterFramework to package PluginA. Please file an issue',
+                    ),
+                  )
+                  .having(
+                    (ToolExit e) => e.message,
+                    'message',
+                    contains('Please also contact the plugin maintainer'),
+                  ),
+            ),
           );
 
           expect(processManager, hasNoRemainingExpectations);


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
