### PR TITLE
[Tool Robustness] Proactively validate path limits and UTF-8 support in ShaderCompiler

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/tools/shader_compiler.dart
+++ b/packages/flutter_tools/lib/src/build_system/tools/shader_compiler.dart
@@ -14,6 +14,7 @@ import '../../base/error_handling_io.dart';
 import '../../base/file_system.dart';
 import '../../base/io.dart';
 import '../../base/logger.dart';
+import '../../base/platform.dart';
 import '../../build_info.dart';
 import '../../convert.dart';
 import '../../devfs.dart';
@@ -94,15 +95,18 @@ class ShaderCompiler {
     required Logger logger,
     required FileSystem fileSystem,
     required Artifacts artifacts,
+    Platform platform = const LocalPlatform(),
   }) : _processManager = processManager,
        _logger = logger,
        _fs = fileSystem,
-       _artifacts = artifacts;
+       _artifacts = artifacts,
+       _platform = platform;
 
   final ProcessManager _processManager;
   final Logger _logger;
   final FileSystem _fs;
   final Artifacts _artifacts;
+  final Platform _platform;
 
   List<String> _shaderTargetsFromTargetPlatform(TargetPlatform targetPlatform) {
     switch (targetPlatform) {
@@ -164,6 +168,30 @@ class ShaderCompiler {
     required TargetPlatform targetPlatform,
     bool fatal = true,
   }) async {
+    if (_platform.isWindows) {
+      final String absoluteInputPath = input.absolute.path;
+      final String absoluteOutputPath = _fs.path.absolute(outputPath);
+      final nonAscii = RegExp(r'[^\x00-\x7F]');
+      if (nonAscii.hasMatch(absoluteInputPath) || nonAscii.hasMatch(absoluteOutputPath)) {
+        throw ShaderCompilerException._(
+          'The shader compilation path contains non-ASCII characters:\n'
+          '  Input: "$absoluteInputPath"\n'
+          '  Output: "$absoluteOutputPath"\n'
+          'The Impeller shader compiler (impellerc) does not support non-ASCII characters in file paths on Windows. '
+          r'Please move your project or Flutter SDK to a path containing only standard ASCII characters (e.g., C:\projects\my_app).',
+        );
+      }
+
+      if (absoluteInputPath.length >= 260 || absoluteOutputPath.length >= 260) {
+        throw ShaderCompilerException._(
+          'The shader compilation path exceeds Windows MAX_PATH (260 characters):\n'
+          '  Input: "$absoluteInputPath"\n'
+          '  Output: "$absoluteOutputPath"\n'
+          r'Please move your project to a shorter path (e.g., C:\projects\my_app).',
+        );
+      }
+    }
+
     final File impellerc = _fs.file(_artifacts.getHostArtifact(HostArtifact.impellerc));
     if (!impellerc.existsSync()) {
       throw ShaderCompilerException._(
@@ -194,10 +222,11 @@ class ShaderCompiler {
     _logger.printTrace('impellerc command: $cmd');
     final ProcessResult result = await _processManager.run(cmd, stderrEncoding: utf8);
     if (result.exitCode != 0) {
+      final bool isCrash = result.exitCode < 0;
       // Maybe retry impellerc command without --sksl.
-      if (!(shaderTargets.length > 1 && shaderTargets.contains('--sksl'))) {
-        // The original command did not target sksl or targeted only sksl, so
-        // we can't retry without --sksl.
+      if (isCrash || !(shaderTargets.length > 1 && shaderTargets.contains('--sksl'))) {
+        // The process crashed or the original command did not target sksl or
+        // targeted only sksl, so we can't retry without --sksl.
         _logger.printError('impellerc failure: ${result.stderr}');
         failure = true;
       } else {
@@ -229,9 +258,21 @@ class ShaderCompiler {
 
     if (failure) {
       if (fatal) {
+        final int exitCode = result.exitCode;
+        if (exitCode < 0) {
+          throw ShaderCompilerException._(
+            'Shader compilation of "${input.path}" to "$outputPath" '
+            'failed because the Impeller shader compiler crashed (exit code $exitCode).\n'
+            'This may be caused by a system access violation, stack overflow, or antivirus interference.\n'
+            'Try the following troubleshooting steps:\n'
+            '  1. Run "flutter clean" and try again.\n'
+            '  2. Check if your antivirus or Ransomware Protection is blocking "impellerc".\n'
+            '  3. Temporarily disable Impeller by running with "--no-enable-impeller" if applicable.',
+          );
+        }
         throw ShaderCompilerException._(
           'Shader compilation of "${input.path}" to "$outputPath" '
-          'failed with exit code ${result.exitCode}.',
+          'failed with exit code $exitCode.',
         );
       }
       return false;

--- a/packages/flutter_tools/test/general.shard/build_system/targets/shader_compiler_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/shader_compiler_test.dart
@@ -8,6 +8,7 @@ import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/tools/shader_compiler.dart';
 import 'package:flutter_tools/src/devfs.dart';
@@ -537,4 +538,119 @@ void main() {
     expect(fileSystem.file('/.tmp_rand0/0.8255140718871702.temp.spirv'), isNot(exists));
     expect(fileSystem.file('/.tmp_rand0/0.8255140718871702.temp'), isNot(exists));
   });
+
+  testWithoutContext(
+    'compileShader throws ShaderCompilerException when paths contain non-ASCII characters on Windows',
+    () async {
+      final processManager = FakeProcessManager.empty();
+      final platform = FakePlatform(operatingSystem: 'windows');
+      final shaderCompiler = ShaderCompiler(
+        processManager: processManager,
+        logger: logger,
+        fileSystem: fileSystem,
+        artifacts: artifacts,
+        platform: platform,
+      );
+
+      const nonAsciiInputPath = '/shaders/é_shader.frag';
+      fileSystem.file(nonAsciiInputPath).createSync(recursive: true);
+
+      expect(
+        () => shaderCompiler.compileShader(
+          input: fileSystem.file(nonAsciiInputPath),
+          outputPath: outputPath,
+          targetPlatform: TargetPlatform.android,
+        ),
+        throwsA(
+          isA<ShaderCompilerException>().having(
+            (ShaderCompilerException e) => e.toString(),
+            'message',
+            contains('contains non-ASCII characters'),
+          ),
+        ),
+      );
+    },
+  );
+
+  testWithoutContext(
+    'compileShader throws ShaderCompilerException when paths exceed 260 characters on Windows',
+    () async {
+      final processManager = FakeProcessManager.empty();
+      final platform = FakePlatform(operatingSystem: 'windows');
+      final shaderCompiler = ShaderCompiler(
+        processManager: processManager,
+        logger: logger,
+        fileSystem: fileSystem,
+        artifacts: artifacts,
+        platform: platform,
+      );
+
+      final String longName = 'a' * 250;
+      final longInputPath = '/shaders/$longName.frag';
+      fileSystem.file(longInputPath).createSync(recursive: true);
+
+      expect(
+        () => shaderCompiler.compileShader(
+          input: fileSystem.file(longInputPath),
+          outputPath: outputPath,
+          targetPlatform: TargetPlatform.android,
+        ),
+        throwsA(
+          isA<ShaderCompilerException>().having(
+            (ShaderCompilerException e) => e.toString(),
+            'message',
+            contains('exceeds Windows MAX_PATH'),
+          ),
+        ),
+      );
+    },
+  );
+
+  testWithoutContext(
+    'compileShader throws custom ShaderCompilerException when impellerc crashes with negative exit code',
+    () async {
+      final processManager = FakeProcessManager.list(<FakeCommand>[
+        FakeCommand(
+          command: <String>[
+            impellerc,
+            '--sksl',
+            '--iplr',
+            '--json',
+            '--sl=$outputPath',
+            '--spirv=$outputSpirvPath',
+            '--input=$notFragPath',
+            '--input-type=frag',
+            '--include=$fragDir',
+            '--include=$shaderLibDir',
+          ],
+          exitCode: -1073741819, // Access Violation
+        ),
+      ]);
+      final shaderCompiler = ShaderCompiler(
+        processManager: processManager,
+        logger: logger,
+        fileSystem: fileSystem,
+        artifacts: artifacts,
+      );
+
+      expect(
+        () => shaderCompiler.compileShader(
+          input: fileSystem.file(notFragPath),
+          outputPath: outputPath,
+          targetPlatform: TargetPlatform.web_javascript,
+        ),
+        throwsA(
+          isA<ShaderCompilerException>().having(
+            (ShaderCompilerException e) => e.toString(),
+            'message',
+            allOf(
+              contains('Impeller shader compiler crashed (exit code -1073741819)'),
+              contains('antivirus interference'),
+              contains('troubleshooting steps'),
+            ),
+          ),
+        ),
+      );
+    },
+  );
 }


### PR DESCRIPTION
Proactively validates paths passed to the Impeller shader compiler (impellerc) on Windows. Specifically:
1. Validates paths containing non-ASCII (UTF-8) characters.
2. Validates paths exceeding Windows MAX_PATH (260 characters).
3. Gracefully handles impellerc crashes with negative exit codes and translates them into clean, helpful error suggestions.

Fixes https://github.com/flutter/flutter/issues/186955