### PR TITLE
[Engine] Fix silent buffer mismatch bug in FML Win32 CommandLineFromPlatform

### DIFF
--- a/engine/src/flutter/fml/command_line.h
+++ b/engine/src/flutter/fml/command_line.h
@@ -225,6 +225,10 @@ inline CommandLine CommandLineFromIteratorsWithArgv0(const std::string& argv0,
 // Returns an empty optional if this is not supported on the host platform.
 //
 // This can be useful on platforms where argv may not be provided as UTF-8.
+#ifdef _WIN32
+CommandLine CommandLineFromWideArgv(int argc, const wchar_t* const* argv);
+#endif
+
 std::optional<CommandLine> CommandLineFromPlatform();
 
 // Builds a |CommandLine| from the usual argc/argv.

--- a/engine/src/flutter/fml/command_line_unittest.cc
+++ b/engine/src/flutter/fml/command_line_unittest.cc
@@ -443,5 +443,34 @@ TEST(CommandLineTest, CommandLineToArgv) {
   }
 }
 
+#ifdef _WIN32
+TEST(CommandLineTest, CommandLineFromWideArgvUnicode) {
+  // Non-ASCII and UTF-8 unicode characters (accented e/o, ink_sparkle,
+  // Cyrillic, Japanese)
+  const wchar_t* const wide_argv[] = {
+      L"my_program", L"--user=J\u00e9r\u00f4me", L"--shader=ink_sparkle",
+      L"\u0439\u0446\u0443\u043a\u0435\u043d", L"\u65e5\u672c\u8a9e"};
+
+  const auto cl = CommandLineFromWideArgv(5, wide_argv);
+
+  EXPECT_TRUE(cl.has_argv0());
+  EXPECT_EQ("my_program", cl.argv0());
+
+  EXPECT_EQ(2u, cl.options().size());
+  EXPECT_EQ("user", cl.options()[0].name);
+  // Accent e and o: Jérôme in UTF-8
+  EXPECT_EQ("J\xc3\xa9r\xc3\xb4me", cl.options()[0].value);
+  EXPECT_EQ("shader", cl.options()[1].name);
+  EXPECT_EQ("ink_sparkle", cl.options()[1].value);
+
+  EXPECT_EQ(2u, cl.positional_args().size());
+  // Cyrillic string in UTF-8
+  EXPECT_EQ("\xd0\xb9\xd1\x86\xd1\x83\xd0\xba\xd0\xb5\xd0\xbd",
+            cl.positional_args()[0]);
+  // Japanese string in UTF-8
+  EXPECT_EQ("\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e", cl.positional_args()[1]);
+}
+#endif
+
 }  // namespace
 }  // namespace fml

--- a/engine/src/flutter/fml/platform/win/command_line_win.cc
+++ b/engine/src/flutter/fml/platform/win/command_line_win.cc
@@ -11,6 +11,20 @@
 
 namespace fml {
 
+CommandLine CommandLineFromWideArgv(int argc, const wchar_t* const* argv) {
+  std::vector<std::string> utf8_argv;
+  for (int i = 0; i < argc; ++i) {
+    const wchar_t* arg = argv[i];
+    int arg_len = WideCharToMultiByte(CP_UTF8, 0, arg, wcslen(arg), nullptr, 0,
+                                      nullptr, nullptr);
+    std::string utf8_arg(arg_len, 0);
+    WideCharToMultiByte(CP_UTF8, 0, arg, wcslen(arg), utf8_arg.data(),
+                        utf8_arg.size(), nullptr, nullptr);
+    utf8_argv.push_back(std::move(utf8_arg));
+  }
+  return CommandLineFromIterators(utf8_argv.begin(), utf8_argv.end());
+}
+
 std::optional<CommandLine> CommandLineFromPlatform() {
   wchar_t* command_line = GetCommandLineW();
   int unicode_argc;
@@ -19,17 +33,7 @@ std::optional<CommandLine> CommandLineFromPlatform() {
   if (!unicode_argv) {
     return std::nullopt;
   }
-  std::vector<std::string> utf8_argv;
-  for (int i = 0; i < unicode_argc; ++i) {
-    wchar_t* arg = unicode_argv[i];
-    int arg_len = WideCharToMultiByte(CP_UTF8, 0, arg, wcslen(arg), nullptr, 0,
-                                      nullptr, nullptr);
-    std::string utf8_arg(arg_len, 0);
-    WideCharToMultiByte(CP_UTF8, 0, arg, -1, utf8_arg.data(), utf8_arg.size(),
-                        nullptr, nullptr);
-    utf8_argv.push_back(std::move(utf8_arg));
-  }
-  return CommandLineFromIterators(utf8_argv.begin(), utf8_argv.end());
+  return CommandLineFromWideArgv(unicode_argc, unicode_argv.get());
 }
 
 }  // namespace fml


### PR DESCRIPTION
### Description
This pull request resolves a critical, long-standing C++ bug inside FML's Windows platform `CommandLineFromPlatform` command-line parser that caused all wide-character UTF-8 command arguments to be silently discarded and corrupted.

* **The Bug:** In `fml/platform/win/command_line_win.cc`, `WideCharToMultiByte` was being passed `-1` as the input length (cbMultiByte) inside the string conversion loop. This instructed the Win32 API to write the converted UTF-8 string *plus* an extra null terminator. However, the pre-allocated buffer size `utf8_arg` only had space for `arg_len` (which excludes the null terminator). Consequently, the Win32 API failed with `ERROR_INSUFFICIENT_BUFFER` and returned `0`, leaving the string argument completely empty or corrupted.
* **The Fallback & Crash:** Due to this silent conversion failure, the FML parser always fell back to standard narrow-character command-line arguments (`argc/argv`). This caused all non-ASCII (UTF-8) characters in paths (such as usernames containing accented letters like `Jérôme` or East Asian characters) to be corrupted. Downstream compiled tools like `impellerc` (the Impeller shader compiler) received these corrupted paths and crashed with `ShaderCompilerException` (exit code `-1073741819` Access Violation / Segmentation Fault) when compiling Material Design shaders.
* **The Fix:** Resolves the buffer mismatch by passing `wcslen(arg)` to the second `WideCharToMultiByte` call, matching the pre-allocated buffer size perfectly and ensuring that all UTF-8 wide paths are correctly preserved and parsed on Windows.

Fixes https://github.com/flutter/flutter/issues/186955