### PR TITLE
Linux glyph gamma correction

### DIFF
--- a/engine/src/flutter/impeller/display_list/aiks_dl_text_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_text_unittests.cc
@@ -19,6 +19,7 @@
 #include "impeller/display_list/dl_dispatcher.h"
 #include "impeller/display_list/dl_text_impeller.h"
 #include "impeller/entity/contents/content_context.h"
+#include "impeller/entity/contents/solid_color_contents.h"
 #include "impeller/entity/contents/text_contents.h"
 #include "impeller/entity/entity.h"
 #include "impeller/geometry/matrix.h"
@@ -1095,6 +1096,56 @@ TEST_P(AiksTest, TextWithNonUniformScale) {
   builder.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
+}
+
+TEST_P(AiksTest, TextGammaCorrectionGoldenTest) {
+  constexpr const char* font_fixture = "Roboto-Regular.ttf";
+  auto c_font_fixture = std::string(font_fixture);
+  auto mapping = flutter::testing::OpenFixtureAsSkData(c_font_fixture.c_str());
+  ASSERT_TRUE(mapping);
+
+  sk_sp<SkFontMgr> font_mgr = txt::GetDefaultFontManager();
+  SkFont sk_font(/*typeface=*/font_mgr->makeFromData(mapping), /*size=*/60);
+  sk_font.setSubpixel(true);
+
+  auto blob_corrected =
+      SkTextBlob::MakeFromString("Gamma Corrected (true)", sk_font);
+  ASSERT_TRUE(blob_corrected);
+  auto text_frame_corrected = MakeTextFrameFromTextBlobSkia(blob_corrected);
+  text_frame_corrected->SetEnableGammaCorrectionOverride(true);
+
+  auto blob_uncorrected =
+      SkTextBlob::MakeFromString("Gamma Corrected (false)", sk_font);
+  ASSERT_TRUE(blob_uncorrected);
+  auto text_frame_uncorrected = MakeTextFrameFromTextBlobSkia(blob_uncorrected);
+  text_frame_uncorrected->SetEnableGammaCorrectionOverride(false);
+
+  auto callback = [&]() -> sk_sp<flutter::DisplayList> {
+    DisplayListBuilder builder;
+
+    DlPaint bg_paint;
+    bg_paint.setColor(DlColor::ARGB(1.0, 0.1, 0.1, 0.1));
+    builder.DrawPaint(bg_paint);
+
+    DlPaint text_paint;
+    text_paint.setColor(DlColor::kWhite());
+
+    builder.DrawText(/*text=*/DlTextImpeller::Make(text_frame_corrected),
+                     /*x=*/50, /*y=*/100, /*paint=*/text_paint);
+    builder.DrawText(/*text=*/DlTextImpeller::Make(text_frame_uncorrected),
+                     /*x=*/50, /*y=*/200, /*paint=*/text_paint);
+
+    builder.DrawText(/*text=*/DlTextImpeller::Make(text_frame_corrected),
+                     /*x=*/50, /*y=*/300, /*paint=*/text_paint);
+    DlPaint diff_paint = text_paint;
+    diff_paint.setBlendMode(DlBlendMode::kDifference);
+    builder.DrawText(/*text=*/DlTextImpeller::Make(text_frame_uncorrected),
+                     /*x=*/50, /*y=*/300, /*paint=*/diff_paint);
+
+    return builder.Build();
+  };
+
+  ASSERT_TRUE(OpenPlaygroundHere(callback));
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/display_list/aiks_dl_text_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_text_unittests.cc
@@ -1112,13 +1112,13 @@ TEST_P(AiksTest, TextGammaCorrectionGoldenTest) {
       SkTextBlob::MakeFromString("Gamma Corrected (true)", sk_font);
   ASSERT_TRUE(blob_corrected);
   auto text_frame_corrected = MakeTextFrameFromTextBlobSkia(blob_corrected);
-  text_frame_corrected->SetEnableGammaCorrectionOverride(true);
+  text_frame_corrected->SetEnableGammaCorrection(true);
 
   auto blob_uncorrected =
       SkTextBlob::MakeFromString("Gamma Corrected (false)", sk_font);
   ASSERT_TRUE(blob_uncorrected);
   auto text_frame_uncorrected = MakeTextFrameFromTextBlobSkia(blob_uncorrected);
-  text_frame_uncorrected->SetEnableGammaCorrectionOverride(false);
+  text_frame_uncorrected->SetEnableGammaCorrection(false);
 
   auto callback = [&]() -> sk_sp<flutter::DisplayList> {
     DisplayListBuilder builder;

--- a/engine/src/flutter/impeller/entity/contents/text_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/text_contents.cc
@@ -267,6 +267,9 @@ bool TextContents::Render(const ContentContext& renderer,
   frag_info.use_text_color = force_text_color_ ? 1.0 : 0.0;
   frag_info.text_color = ToVector(color.Premultiply());
   frag_info.is_color_glyph = type == GlyphAtlas::Type::kColorBitmap;
+  Scalar luma =
+      color.red * 0.2126f + color.green * 0.7152f + color.blue * 0.0722f;
+  frag_info.text_contrast = 1.0f + luma * 0.4f;
 
   FS::BindFragInfo(
       pass, renderer.GetTransientsDataBuffer().EmplaceUniform(frag_info));

--- a/engine/src/flutter/impeller/entity/contents/text_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/text_contents.cc
@@ -42,20 +42,12 @@ Point SizeToPoint(Size size) {
 using VS = GlyphAtlasPipeline::VertexShader;
 using FS = GlyphAtlasPipeline::FragmentShader;
 
-TextContents::TextContents()
-    : enable_gamma_correction_(kPlatformGammaCorrectionDefault) {}
+TextContents::TextContents() {}
 
 TextContents::~TextContents() = default;
 
 void TextContents::SetTextFrame(const std::shared_ptr<TextFrame>& frame) {
   frame_ = frame;
-  if (frame) {
-    std::optional<bool> override_value =
-        frame->GetEnableGammaCorrectionOverride();
-    if (override_value.has_value()) {
-      enable_gamma_correction_ = override_value.value();
-    }
-  }
 }
 
 void TextContents::SetColor(Color color) {
@@ -80,10 +72,6 @@ void TextContents::SetScreenTransform(const Matrix& transform) {
 
 void TextContents::SetForceTextColor(bool value) {
   force_text_color_ = value;
-}
-
-void TextContents::SetEnableGammaCorrection(bool value) {
-  enable_gamma_correction_ = value;
 }
 
 std::optional<Rect> TextContents::GetCoverage(const Entity& entity) const {
@@ -296,7 +284,9 @@ bool TextContents::Render(const ContentContext& renderer,
   frag_info.use_text_color = force_text_color_ ? 1.0 : 0.0;
   frag_info.text_color = ToVector(color.Premultiply());
   frag_info.is_color_glyph = type == GlyphAtlas::Type::kColorBitmap;
-  if (enable_gamma_correction_) {
+  bool enable_gamma_correction = frame_->GetEnableGammaCorrection().value_or(
+      kPlatformGammaCorrectionDefault);
+  if (enable_gamma_correction) {
     // Calculate relative luminance using Rec. 709 luma coefficients.
     Scalar luma =
         color.red * 0.2126f + color.green * 0.7152f + color.blue * 0.0722f;

--- a/engine/src/flutter/impeller/entity/contents/text_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/text_contents.cc
@@ -267,10 +267,22 @@ bool TextContents::Render(const ContentContext& renderer,
   frag_info.use_text_color = force_text_color_ ? 1.0 : 0.0;
   frag_info.text_color = ToVector(color.Premultiply());
   frag_info.is_color_glyph = type == GlyphAtlas::Type::kColorBitmap;
-#if FML_OS_LINUX || FML_OS_WIN
+#if FML_OS_LINUX
+  // TODO(gaaclarke): Investigate if this is still needed for Windows.
+  // On Linux we use FreeType to rasterize glyphs. FreeType does not perform
+  // gamma correction itself during rasterization. Because we render in linear
+  // space, light text on a dark background would look too thin without
+  // correction. To compensate, we calculate a contrast/gamma correction factor
+  // based on the text color's luminance, which is used in the shader to adjust
+  // the glyph's coverage.
+  // Calculate relative luminance using Rec. 709 luma coefficients.
   Scalar luma =
       color.red * 0.2126f + color.green * 0.7152f + color.blue * 0.0722f;
-  frag_info.text_contrast = 1.0f + luma * 1.2f;
+  // The contrast/gamma exponent applied in the shader ranges from 1.0 for black
+  // text to 2.2 (standard sRGB gamma) for white text. This interpolates the
+  // exponent based on the text color's luminance.
+  constexpr Scalar kMaxContrastBoost = 1.2f;
+  frag_info.text_contrast = 1.0f + luma * kMaxContrastBoost;
 #else
   frag_info.text_contrast = 1.0f;
 #endif

--- a/engine/src/flutter/impeller/entity/contents/text_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/text_contents.cc
@@ -270,7 +270,7 @@ bool TextContents::Render(const ContentContext& renderer,
 #if FML_OS_LINUX || FML_OS_WIN
   Scalar luma =
       color.red * 0.2126f + color.green * 0.7152f + color.blue * 0.0722f;
-  frag_info.text_contrast = 1.0f + luma * 1.0f;
+  frag_info.text_contrast = 1.0f + luma * 1.2f;
 #else
   frag_info.text_contrast = 1.0f;
 #endif

--- a/engine/src/flutter/impeller/entity/contents/text_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/text_contents.cc
@@ -269,7 +269,7 @@ bool TextContents::Render(const ContentContext& renderer,
   frag_info.is_color_glyph = type == GlyphAtlas::Type::kColorBitmap;
   Scalar luma =
       color.red * 0.2126f + color.green * 0.7152f + color.blue * 0.0722f;
-  frag_info.text_contrast = 1.0f + luma * 0.4f;
+  frag_info.text_contrast = 1.0f + luma * 1.0f;
 
   FS::BindFragInfo(
       pass, renderer.GetTransientsDataBuffer().EmplaceUniform(frag_info));

--- a/engine/src/flutter/impeller/entity/contents/text_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/text_contents.cc
@@ -18,19 +18,44 @@
 #include "impeller/typographer/glyph_atlas.h"
 
 namespace impeller {
+namespace {
+
+// TODO(gaaclarke): Investigate if this is still needed for Windows.
+// On Linux we use FreeType to rasterize glyphs. FreeType does not perform
+// gamma correction itself during rasterization. Because we render in linear
+// space, light text on a dark background would look too thin without
+// correction. To compensate, we calculate a contrast/gamma correction
+// factor based on the text color's luminance, which is used in the shader
+// to adjust the glyph's coverage.
+constexpr bool kPlatformGammaCorrectionDefault =
+#if FML_OS_LINUX
+    true;
+#else
+    false;
+#endif
+
 Point SizeToPoint(Size size) {
   return Point(size.width, size.height);
 }
+}  // namespace
 
 using VS = GlyphAtlasPipeline::VertexShader;
 using FS = GlyphAtlasPipeline::FragmentShader;
 
-TextContents::TextContents() = default;
+TextContents::TextContents()
+    : enable_gamma_correction_(kPlatformGammaCorrectionDefault) {}
 
 TextContents::~TextContents() = default;
 
 void TextContents::SetTextFrame(const std::shared_ptr<TextFrame>& frame) {
   frame_ = frame;
+  if (frame) {
+    std::optional<bool> override_value =
+        frame->GetEnableGammaCorrectionOverride();
+    if (override_value.has_value()) {
+      enable_gamma_correction_ = override_value.value();
+    }
+  }
 }
 
 void TextContents::SetColor(Color color) {
@@ -55,6 +80,10 @@ void TextContents::SetScreenTransform(const Matrix& transform) {
 
 void TextContents::SetForceTextColor(bool value) {
   force_text_color_ = value;
+}
+
+void TextContents::SetEnableGammaCorrection(bool value) {
+  enable_gamma_correction_ = value;
 }
 
 std::optional<Rect> TextContents::GetCoverage(const Entity& entity) const {
@@ -267,25 +296,18 @@ bool TextContents::Render(const ContentContext& renderer,
   frag_info.use_text_color = force_text_color_ ? 1.0 : 0.0;
   frag_info.text_color = ToVector(color.Premultiply());
   frag_info.is_color_glyph = type == GlyphAtlas::Type::kColorBitmap;
-#if FML_OS_LINUX
-  // TODO(gaaclarke): Investigate if this is still needed for Windows.
-  // On Linux we use FreeType to rasterize glyphs. FreeType does not perform
-  // gamma correction itself during rasterization. Because we render in linear
-  // space, light text on a dark background would look too thin without
-  // correction. To compensate, we calculate a contrast/gamma correction factor
-  // based on the text color's luminance, which is used in the shader to adjust
-  // the glyph's coverage.
-  // Calculate relative luminance using Rec. 709 luma coefficients.
-  Scalar luma =
-      color.red * 0.2126f + color.green * 0.7152f + color.blue * 0.0722f;
-  // The contrast/gamma exponent applied in the shader ranges from 1.0 for black
-  // text to 2.2 (standard sRGB gamma) for white text. This interpolates the
-  // exponent based on the text color's luminance.
-  constexpr Scalar kMaxContrastBoost = 1.2f;
-  frag_info.text_contrast = 1.0f + luma * kMaxContrastBoost;
-#else
-  frag_info.text_contrast = 1.0f;
-#endif
+  if (enable_gamma_correction_) {
+    // Calculate relative luminance using Rec. 709 luma coefficients.
+    Scalar luma =
+        color.red * 0.2126f + color.green * 0.7152f + color.blue * 0.0722f;
+    // The contrast/gamma exponent applied in the shader ranges from 1.0 for
+    // black text to 2.2 (standard sRGB gamma) for white text. This interpolates
+    // the exponent based on the text color's luminance.
+    constexpr Scalar kMaxGammaCorrection = 1.2f;
+    frag_info.text_contrast = 1.0f + luma * kMaxGammaCorrection;
+  } else {
+    frag_info.text_contrast = 1.0f;
+  }
 
   FS::BindFragInfo(
       pass, renderer.GetTransientsDataBuffer().EmplaceUniform(frag_info));

--- a/engine/src/flutter/impeller/entity/contents/text_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/text_contents.cc
@@ -267,9 +267,13 @@ bool TextContents::Render(const ContentContext& renderer,
   frag_info.use_text_color = force_text_color_ ? 1.0 : 0.0;
   frag_info.text_color = ToVector(color.Premultiply());
   frag_info.is_color_glyph = type == GlyphAtlas::Type::kColorBitmap;
+#if FML_OS_LINUX || FML_OS_WIN
   Scalar luma =
       color.red * 0.2126f + color.green * 0.7152f + color.blue * 0.0722f;
   frag_info.text_contrast = 1.0f + luma * 1.0f;
+#else
+  frag_info.text_contrast = 1.0f;
+#endif
 
   FS::BindFragInfo(
       pass, renderer.GetTransientsDataBuffer().EmplaceUniform(frag_info));

--- a/engine/src/flutter/impeller/entity/contents/text_contents.h
+++ b/engine/src/flutter/impeller/entity/contents/text_contents.h
@@ -36,6 +36,13 @@ class TextContents final : public Contents {
   ///        This is used to ensure that mask blurs work correctly on emoji.
   void SetForceTextColor(bool value);
 
+  /// @brief Toggle the platform-specific contrast and gamma correction in the
+  ///        fragment shader.
+  ///
+  ///        By default, this is true on Linux to compensate for FreeType
+  ///        rasterization in linear space, and false elsewhere.
+  void SetEnableGammaCorrection(bool value);
+
   /// Must be set after text frame.
   void SetTextProperties(Color color,
                          const std::optional<StrokeParameters>& stroke);
@@ -104,6 +111,7 @@ class TextContents final : public Contents {
   Point position_;
   Matrix screen_transform_;
   bool force_text_color_ = false;
+  bool enable_gamma_correction_ = false;
   Color color_;
   GlyphProperties properties_;
 

--- a/engine/src/flutter/impeller/entity/contents/text_contents.h
+++ b/engine/src/flutter/impeller/entity/contents/text_contents.h
@@ -36,13 +36,6 @@ class TextContents final : public Contents {
   ///        This is used to ensure that mask blurs work correctly on emoji.
   void SetForceTextColor(bool value);
 
-  /// @brief Toggle the platform-specific contrast and gamma correction in the
-  ///        fragment shader.
-  ///
-  ///        By default, this is true on Linux to compensate for FreeType
-  ///        rasterization in linear space, and false elsewhere.
-  void SetEnableGammaCorrection(bool value);
-
   /// Must be set after text frame.
   void SetTextProperties(Color color,
                          const std::optional<StrokeParameters>& stroke);
@@ -111,7 +104,6 @@ class TextContents final : public Contents {
   Point position_;
   Matrix screen_transform_;
   bool force_text_color_ = false;
-  bool enable_gamma_correction_ = false;
   Color color_;
   GlyphProperties properties_;
 

--- a/engine/src/flutter/impeller/entity/shaders/glyph_atlas.frag
+++ b/engine/src/flutter/impeller/entity/shaders/glyph_atlas.frag
@@ -14,6 +14,7 @@ uniform FragInfo {
   float is_color_glyph;
   float use_text_color;
   f16vec4 text_color;
+  float text_contrast;
 }
 frag_info;
 
@@ -31,10 +32,16 @@ void main() {
       frag_color = value * frag_info.text_color.aaaa;
     }
   } else {
+    float coverage;
     if (use_alpha_color_channel == 1.0) {
-      frag_color = value.aaaa * frag_info.text_color;
+      coverage = float(value.a);
     } else {
-      frag_color = value.rrrr * frag_info.text_color;
+      coverage = float(value.r);
     }
+
+    coverage =
+        1.0 - pow(clamp(1.0 - coverage, 0.0, 1.0), frag_info.text_contrast);
+
+    frag_color = f16vec4(coverage) * frag_info.text_color;
   }
 }

--- a/engine/src/flutter/impeller/entity/shaders/glyph_atlas.frag
+++ b/engine/src/flutter/impeller/entity/shaders/glyph_atlas.frag
@@ -40,6 +40,9 @@ void main() {
     }
 
     if (frag_info.text_contrast != 1.0) {
+      // Applies gamma correction to take into account we are performing in
+      // linear space but some fonts are expecting to operate in gamma space.
+      // https://www.desmos.com/calculator/gsblcyg5vv
       coverage =
           1.0 - pow(clamp(1.0 - coverage, 0.0, 1.0), frag_info.text_contrast);
     }

--- a/engine/src/flutter/impeller/entity/shaders/glyph_atlas.frag
+++ b/engine/src/flutter/impeller/entity/shaders/glyph_atlas.frag
@@ -43,8 +43,7 @@ void main() {
       // Applies gamma correction to take into account we are performing in
       // linear space but some fonts are expecting to operate in gamma space.
       // https://www.desmos.com/calculator/gsblcyg5vv
-      coverage =
-          1.0 - pow(clamp(1.0 - coverage, 0.0, 1.0), frag_info.text_contrast);
+      coverage = 1.0 - pow(1.0 - coverage, frag_info.text_contrast);
     }
 
     frag_color = f16vec4(coverage) * frag_info.text_color;

--- a/engine/src/flutter/impeller/entity/shaders/glyph_atlas.frag
+++ b/engine/src/flutter/impeller/entity/shaders/glyph_atlas.frag
@@ -39,8 +39,10 @@ void main() {
       coverage = float(value.r);
     }
 
-    coverage =
-        1.0 - pow(clamp(1.0 - coverage, 0.0, 1.0), frag_info.text_contrast);
+    if (frag_info.text_contrast != 1.0) {
+      coverage =
+          1.0 - pow(clamp(1.0 - coverage, 0.0, 1.0), frag_info.text_contrast);
+    }
 
     frag_color = f16vec4(coverage) * frag_info.text_color;
   }

--- a/engine/src/flutter/impeller/tools/malioc.json
+++ b/engine/src/flutter/impeller/tools/malioc.json
@@ -4442,7 +4442,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 100,
+          "fp16_arithmetic": 42,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -4450,10 +4450,10 @@
               "texture"
             ],
             "longest_path_cycles": [
+              0.1875,
               0.109375,
-              0.03125,
-              0.109375,
-              0.0,
+              0.1875,
+              0.125,
               0.0,
               0.25,
               0.25
@@ -4485,10 +4485,10 @@
               "texture"
             ],
             "total_cycles": [
+              0.21875,
+              0.171875,
+              0.21875,
               0.125,
-              0.0625,
-              0.125,
-              0.0,
               0.0,
               0.25,
               0.25
@@ -4496,8 +4496,8 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 6,
-          "work_registers_used": 19
+          "uniform_registers_used": 8,
+          "work_registers_used": 20
         }
       }
     },
@@ -4511,12 +4511,10 @@
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
-              "arithmetic",
-              "load_store",
-              "texture"
+              "arithmetic"
             ],
             "longest_path_cycles": [
-              1.0,
+              1.9800000190734863,
               1.0,
               1.0
             ],
@@ -4539,7 +4537,7 @@
               "arithmetic"
             ],
             "total_cycles": [
-              2.6666667461395264,
+              4.0,
               1.0,
               1.0
             ]
@@ -9147,7 +9145,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 100,
+          "fp16_arithmetic": 33,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -9155,10 +9153,10 @@
               "texture"
             ],
             "longest_path_cycles": [
-              0.078125,
-              0.03125,
-              0.078125,
-              0.0,
+              0.140625,
+              0.109375,
+              0.140625,
+              0.125,
               0.0,
               0.25,
               0.25
@@ -9177,9 +9175,9 @@
               "texture"
             ],
             "shortest_path_cycles": [
-              0.0625,
+              0.078125,
               0.03125,
-              0.0625,
+              0.078125,
               0.0,
               0.0,
               0.25,
@@ -9190,10 +9188,10 @@
               "texture"
             ],
             "total_cycles": [
-              0.09375,
-              0.0625,
-              0.09375,
-              0.0,
+              0.171875,
+              0.140625,
+              0.171875,
+              0.125,
               0.0,
               0.25,
               0.25
@@ -9201,8 +9199,8 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 8,
-          "work_registers_used": 6
+          "uniform_registers_used": 10,
+          "work_registers_used": 7
         }
       }
     }

--- a/engine/src/flutter/impeller/typographer/text_frame.h
+++ b/engine/src/flutter/impeller/typographer/text_frame.h
@@ -6,6 +6,7 @@
 #define FLUTTER_IMPELLER_TYPOGRAPHER_TEXT_FRAME_H_
 
 #include <cstdint>
+#include <optional>
 
 #include "flutter/display_list/geometry/dl_path.h"
 #include "fml/status_or.h"
@@ -91,11 +92,19 @@ class TextFrame {
 
   fml::StatusOr<flutter::DlPath> GetPath() const;
 
+  void SetEnableGammaCorrectionOverride(std::optional<bool> value) {
+    enable_gamma_correction_override_ = value;
+  }
+  std::optional<bool> GetEnableGammaCorrectionOverride() const {
+    return enable_gamma_correction_override_;
+  }
+
  private:
   std::vector<TextRun> runs_;
   Rect bounds_;
   bool has_color_;
   const PathCreator path_creator_;
+  std::optional<bool> enable_gamma_correction_override_ = std::nullopt;
 };
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/typographer/text_frame.h
+++ b/engine/src/flutter/impeller/typographer/text_frame.h
@@ -92,11 +92,17 @@ class TextFrame {
 
   fml::StatusOr<flutter::DlPath> GetPath() const;
 
-  void SetEnableGammaCorrectionOverride(std::optional<bool> value) {
-    enable_gamma_correction_override_ = value;
+  /// @brief Toggle the platform-specific contrast and gamma correction in the
+  ///        fragment shader.
+  ///
+  ///        By default, this is true on Linux to compensate for FreeType
+  ///        rasterization in linear space, and false elsewhere. Setting a
+  ///        value overrides this default behavior.
+  void SetEnableGammaCorrection(std::optional<bool> value) {
+    enable_gamma_correction_ = value;
   }
-  std::optional<bool> GetEnableGammaCorrectionOverride() const {
-    return enable_gamma_correction_override_;
+  std::optional<bool> GetEnableGammaCorrection() const {
+    return enable_gamma_correction_;
   }
 
  private:
@@ -104,7 +110,7 @@ class TextFrame {
   Rect bounds_;
   bool has_color_;
   const PathCreator path_creator_;
-  std::optional<bool> enable_gamma_correction_override_ = std::nullopt;
+  std::optional<bool> enable_gamma_correction_ = std::nullopt;
 };
 
 }  // namespace impeller


### PR DESCRIPTION
fixes: https://github.com/flutter/flutter/issues/186975

Impeller renders in the linear space, whereas the glyphs coming from freetype are assuming gamma space.  This resulted in light text looking washed out but dark text looking fine.

This PR introduces a gamma correction that boost's the gamma of a color based on it's luminance, so black colors look the same, but light colors get boosted to the tune of 2.2, which is the gamma value for sRGB.

## images

(These are screenshots taking over chrome remote desktop, thus some compression artifacts)

### before

<img width="584" height="224" alt="before" src="https://github.com/user-attachments/assets/9db20c5d-3077-49f9-977f-a08e040cced6" />


### after

<img width="776" height="328" alt="after" src="https://github.com/user-attachments/assets/5b24e57b-e0a4-4cf4-a05f-c29b4592234a" />


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
