### PR TITLE
Add a tag to the Linux platform properties in .ci.yaml that specifies x64 CPUs

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -25,6 +25,7 @@ platform_properties:
       os: Ubuntu
       cores: "8"
       device_type: none
+      cpu: x86
       ignore_flakiness: "true"
 
   linux:
@@ -35,6 +36,7 @@ platform_properties:
         ]
       os: Ubuntu
       cores: "8"
+      cpu: x86
       device_type: none
 
   # The current android emulator config names can be found here:

--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -22,6 +22,7 @@ platform_properties:
       device_type: none
       os: Ubuntu
       cores: "8"
+      cpu: x86
   mac:
     properties:
       # CIPD flutter/java/openjdk/$platform


### PR DESCRIPTION
Some arm64 LUCI build machines have been added to the staging pool to support new targets that will build on arm64.
(see https://github.com/flutter/flutter/issues/186695)

However, the linux-arm64 build environment currently does not support all capabilities available on linux-x64.  For example, some CIPD packages used by builders have not been published for linux-arm64.
(see https://github.com/flutter/flutter/issues/187103)

For now, .ci.yaml targets using the "linux" platform should continue to be scheduled only on linux-x64.