### PR TITLE
Reshard build_tests from 5 to 6 shards with bringup: true

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -447,7 +447,8 @@ targets:
       - engine/**
       - DEPS
 
-  - name: Linux build_tests_1_5
+  - name: Linux build_tests_1_6
+    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -461,81 +462,103 @@ targets:
           {"dependency": "ninja", "version": "version:1.9.0"}
         ]
       shard: build_tests
-      subshard: "1_5"
+      subshard: "1_6"
+      tags: >
+        ["framework", "hostonly", "shard", "linux"]
+  - name: Linux build_tests_2_6
+    bringup: true
+    recipe: flutter/flutter_drone
+    timeout: 60
+    properties:
+      dependencies: >-
+        [
+          {"dependency": "android_sdk", "version": "version:36v8unmodified"},
+          {"dependency": "open_jdk", "version": "version:21"},
+          {"dependency": "goldctl", "version": "git_revision:031e93819017b95c3f2dfe463189c7b8d02f2f83"},
+          {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
+          {"dependency": "cmake", "version": "build_id:8787856497187628321"},
+          {"dependency": "ninja", "version": "version:1.9.0"}
+        ]
+      shard: build_tests
+      subshard: "2_6"
+      tags: >
+        ["framework", "hostonly", "shard", "linux"]
+  - name: Linux build_tests_3_6
+    bringup: true
+    recipe: flutter/flutter_drone
+    timeout: 60
+    properties:
+      dependencies: >-
+        [
+          {"dependency": "android_sdk", "version": "version:36v8unmodified"},
+          {"dependency": "open_jdk", "version": "version:21"},
+          {"dependency": "goldctl", "version": "git_revision:031e93819017b95c3f2dfe463189c7b8d02f2f83"},
+          {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
+          {"dependency": "cmake", "version": "build_id:8787856497187628321"},
+          {"dependency": "ninja", "version": "version:1.9.0"}
+        ]
+      shard: build_tests
+      subshard: "3_6"
+      tags: >
+        ["framework", "hostonly", "shard", "linux"]
+  - name: Linux build_tests_4_6
+    bringup: true
+    recipe: flutter/flutter_drone
+    timeout: 60
+    properties:
+      dependencies: >-
+        [
+          {"dependency": "android_sdk", "version": "version:36v8unmodified"},
+          {"dependency": "open_jdk", "version": "version:21"},
+          {"dependency": "goldctl", "version": "git_revision:031e93819017b95c3f2dfe463189c7b8d02f2f83"},
+          {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
+          {"dependency": "cmake", "version": "build_id:8787856497187628321"},
+          {"dependency": "ninja", "version": "version:1.9.0"}
+        ]
+      shard: build_tests
+      subshard: "4_6"
+      tags: >
+        ["framework", "hostonly", "shard", "linux"]
+  - name: Linux build_tests_5_6
+    bringup: true
+    recipe: flutter/flutter_drone
+    timeout: 60
+    properties:
+      dependencies: >-
+        [
+          {"dependency": "android_sdk", "version": "version:36v8unmodified"},
+          {"dependency": "open_jdk", "version": "version:21"},
+          {"dependency": "goldctl", "version": "git_revision:031e93819017b95c3f2dfe463189c7b8d02f2f83"},
+          {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
+          {"dependency": "cmake", "version": "build_id:8787856497187628321"},
+          {"dependency": "ninja", "version": "version:1.9.0"}
+        ]
+      shard: build_tests
+      subshard: "5_6"
+      tags: >
+        ["framework", "hostonly", "shard", "linux"]
+  - name: Linux build_tests_6_6
+    bringup: true
+    recipe: flutter/flutter_drone
+    timeout: 60
+    properties:
+      dependencies: >-
+        [
+          {"dependency": "android_sdk", "version": "version:36v8unmodified"},
+          {"dependency": "open_jdk", "version": "version:21"},
+          {"dependency": "goldctl", "version": "git_revision:031e93819017b95c3f2dfe463189c7b8d02f2f83"},
+          {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
+          {"dependency": "cmake", "version": "build_id:8787856497187628321"},
+          {"dependency": "ninja", "version": "version:1.9.0"}
+        ]
+      shard: build_tests
+      subshard: "6_6"
       tags: >
         ["framework", "hostonly", "shard", "linux"]
 
-  - name: Linux build_tests_2_5
-    recipe: flutter/flutter_drone
-    timeout: 60
-    properties:
-      dependencies: >-
-        [
-          {"dependency": "android_sdk", "version": "version:36v8unmodified"},
-          {"dependency": "open_jdk", "version": "version:21"},
-          {"dependency": "goldctl", "version": "git_revision:031e93819017b95c3f2dfe463189c7b8d02f2f83"},
-          {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
-          {"dependency": "cmake", "version": "build_id:8787856497187628321"},
-          {"dependency": "ninja", "version": "version:1.9.0"}
-        ]
-      shard: build_tests
-      subshard: "2_5"
-      tags: >
-        ["framework", "hostonly", "shard", "linux"]
 
-  - name: Linux build_tests_3_5
-    recipe: flutter/flutter_drone
-    timeout: 60
-    properties:
-      dependencies: >-
-        [
-          {"dependency": "android_sdk", "version": "version:36v8unmodified"},
-          {"dependency": "open_jdk", "version": "version:21"},
-          {"dependency": "goldctl", "version": "git_revision:031e93819017b95c3f2dfe463189c7b8d02f2f83"},
-          {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
-          {"dependency": "cmake", "version": "build_id:8787856497187628321"},
-          {"dependency": "ninja", "version": "version:1.9.0"}
-        ]
-      shard: build_tests
-      subshard: "3_5"
-      tags: >
-        ["framework", "hostonly", "shard", "linux"]
 
-  - name: Linux build_tests_4_5
-    recipe: flutter/flutter_drone
-    timeout: 60
-    properties:
-      dependencies: >-
-        [
-          {"dependency": "android_sdk", "version": "version:36v8unmodified"},
-          {"dependency": "open_jdk", "version": "version:21"},
-          {"dependency": "goldctl", "version": "git_revision:031e93819017b95c3f2dfe463189c7b8d02f2f83"},
-          {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
-          {"dependency": "cmake", "version": "build_id:8787856497187628321"},
-          {"dependency": "ninja", "version": "version:1.9.0"}
-        ]
-      shard: build_tests
-      subshard: "4_5"
-      tags: >
-        ["framework", "hostonly", "shard", "linux"]
 
-  - name: Linux build_tests_5_5
-    recipe: flutter/flutter_drone
-    timeout: 60
-    properties:
-      dependencies: >-
-        [
-          {"dependency": "android_sdk", "version": "version:36v8unmodified"},
-          {"dependency": "open_jdk", "version": "version:21"},
-          {"dependency": "goldctl", "version": "git_revision:031e93819017b95c3f2dfe463189c7b8d02f2f83"},
-          {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
-          {"dependency": "cmake", "version": "build_id:8787856497187628321"},
-          {"dependency": "ninja", "version": "version:1.9.0"}
-        ]
-      shard: build_tests
-      subshard: "5_5"
-      tags: >
-        ["framework", "hostonly", "shard", "linux"]
 
   - name: Linux ci_yaml flutter roller
     recipe: infra/ci_yaml
@@ -3710,7 +3733,8 @@ targets:
       - engine/**
       - DEPS
 
-  - name: Mac_x64 build_tests_1_5
+  - name: Mac_x64 build_tests_1_6
+    bringup: true
     recipe: flutter/flutter_drone
     presubmit: false # Rely on Mac_arm build_tests in presubmit.
     timeout: 60
@@ -3724,11 +3748,11 @@ targets:
           {"dependency": "goldctl", "version": "git_revision:031e93819017b95c3f2dfe463189c7b8d02f2f83"}
         ]
       shard: build_tests
-      subshard: "1_5"
+      subshard: "1_6"
       tags: >
         ["framework", "hostonly", "shard", "mac"]
-
-  - name: Mac_x64 build_tests_2_5
+  - name: Mac_x64 build_tests_2_6
+    bringup: true
     recipe: flutter/flutter_drone
     presubmit: false # Rely on Mac_arm build_tests in presubmit.
     timeout: 60
@@ -3742,11 +3766,11 @@ targets:
           {"dependency": "goldctl", "version": "git_revision:031e93819017b95c3f2dfe463189c7b8d02f2f83"}
         ]
       shard: build_tests
-      subshard: "2_5"
+      subshard: "2_6"
       tags: >
         ["framework", "hostonly", "shard", "mac"]
-
-  - name: Mac_x64 build_tests_3_5
+  - name: Mac_x64 build_tests_3_6
+    bringup: true
     recipe: flutter/flutter_drone
     presubmit: false # Rely on Mac_arm build_tests in presubmit.
     timeout: 60
@@ -3760,11 +3784,11 @@ targets:
           {"dependency": "goldctl", "version": "git_revision:031e93819017b95c3f2dfe463189c7b8d02f2f83"}
         ]
       shard: build_tests
-      subshard: "3_5"
+      subshard: "3_6"
       tags: >
         ["framework", "hostonly", "shard", "mac"]
-
-  - name: Mac_x64 build_tests_4_5
+  - name: Mac_x64 build_tests_4_6
+    bringup: true
     recipe: flutter/flutter_drone
     presubmit: false # Rely on Mac_arm build_tests in presubmit.
     timeout: 60
@@ -3778,11 +3802,11 @@ targets:
           {"dependency": "goldctl", "version": "git_revision:031e93819017b95c3f2dfe463189c7b8d02f2f83"}
         ]
       shard: build_tests
-      subshard: "4_5"
+      subshard: "4_6"
       tags: >
         ["framework", "hostonly", "shard", "mac"]
-
-  - name: Mac_x64 build_tests_5_5
+  - name: Mac_x64 build_tests_5_6
+    bringup: true
     recipe: flutter/flutter_drone
     presubmit: false # Rely on Mac_arm build_tests in presubmit.
     timeout: 60
@@ -3796,11 +3820,34 @@ targets:
           {"dependency": "goldctl", "version": "git_revision:031e93819017b95c3f2dfe463189c7b8d02f2f83"}
         ]
       shard: build_tests
-      subshard: "5_5"
+      subshard: "5_6"
+      tags: >
+        ["framework", "hostonly", "shard", "mac"]
+  - name: Mac_x64 build_tests_6_6
+    bringup: true
+    recipe: flutter/flutter_drone
+    presubmit: false # Rely on Mac_arm build_tests in presubmit.
+    timeout: 60
+    properties:
+      add_recipes_cq: "true"
+      dependencies: >-
+        [
+          {"dependency": "android_sdk", "version": "version:36v8unmodified"},
+          {"dependency": "open_jdk", "version": "version:21"},
+          {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
+          {"dependency": "goldctl", "version": "git_revision:031e93819017b95c3f2dfe463189c7b8d02f2f83"}
+        ]
+      shard: build_tests
+      subshard: "6_6"
       tags: >
         ["framework", "hostonly", "shard", "mac"]
 
-  - name: Mac_arm64 build_tests_1_5
+
+
+
+
+  - name: Mac_arm64 build_tests_1_6
+    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -3813,11 +3860,11 @@ targets:
           {"dependency": "goldctl", "version": "git_revision:031e93819017b95c3f2dfe463189c7b8d02f2f83"}
         ]
       shard: build_tests
-      subshard: "1_5"
+      subshard: "1_6"
       tags: >
         ["framework", "hostonly", "shard", "mac"]
-
-  - name: Mac_arm64 build_tests_2_5
+  - name: Mac_arm64 build_tests_2_6
+    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -3830,11 +3877,11 @@ targets:
           {"dependency": "goldctl", "version": "git_revision:031e93819017b95c3f2dfe463189c7b8d02f2f83"}
         ]
       shard: build_tests
-      subshard: "2_5"
+      subshard: "2_6"
       tags: >
         ["framework", "hostonly", "shard", "mac"]
-
-  - name: Mac_arm64 build_tests_3_5
+  - name: Mac_arm64 build_tests_3_6
+    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -3847,11 +3894,11 @@ targets:
           {"dependency": "goldctl", "version": "git_revision:031e93819017b95c3f2dfe463189c7b8d02f2f83"}
         ]
       shard: build_tests
-      subshard: "3_5"
+      subshard: "3_6"
       tags: >
         ["framework", "hostonly", "shard", "mac"]
-
-  - name: Mac_arm64 build_tests_4_5
+  - name: Mac_arm64 build_tests_4_6
+    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -3864,11 +3911,11 @@ targets:
           {"dependency": "goldctl", "version": "git_revision:031e93819017b95c3f2dfe463189c7b8d02f2f83"}
         ]
       shard: build_tests
-      subshard: "4_5"
+      subshard: "4_6"
       tags: >
         ["framework", "hostonly", "shard", "mac"]
-
-  - name: Mac_arm64 build_tests_5_5
+  - name: Mac_arm64 build_tests_5_6
+    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -3881,9 +3928,30 @@ targets:
           {"dependency": "goldctl", "version": "git_revision:031e93819017b95c3f2dfe463189c7b8d02f2f83"}
         ]
       shard: build_tests
-      subshard: "5_5"
+      subshard: "5_6"
       tags: >
         ["framework", "hostonly", "shard", "mac"]
+  - name: Mac_arm64 build_tests_6_6
+    bringup: true
+    recipe: flutter/flutter_drone
+    timeout: 60
+    properties:
+      add_recipes_cq: "true"
+      dependencies: >-
+        [
+          {"dependency": "android_sdk", "version": "version:36v8unmodified"},
+          {"dependency": "open_jdk", "version": "version:21"},
+          {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
+          {"dependency": "goldctl", "version": "git_revision:031e93819017b95c3f2dfe463189c7b8d02f2f83"}
+        ]
+      shard: build_tests
+      subshard: "6_6"
+      tags: >
+        ["framework", "hostonly", "shard", "mac"]
+
+
+
+
 
   - name: Mac_benchmark complex_layout_macos_impeller__start_up
     presubmit: false


### PR DESCRIPTION
This PR increases the subshard count for the build_tests shard from 5 to 6 across Linux, Mac_x64, and Mac_arm64 in .ci.yaml using the last subshard as the sharding template. It marks the newly added shards with bringup: true. Tagging: TAG=agy.