### PR TITLE
[flutter_tools] Fix widget_preview unawaited async write race condition

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_code_generator_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_code_generator_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:dart_style/dart_style.dart';
 import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
@@ -17,6 +18,7 @@ import 'package:flutter_tools/src/widget_preview/dependency_graph.dart';
 import 'package:flutter_tools/src/widget_preview/preview_code_generator.dart';
 import 'package:flutter_tools/src/widget_preview/preview_detector.dart';
 import 'package:process/process.dart';
+import 'package:pub_semver/pub_semver.dart';
 
 import '../../../src/common.dart';
 import '../../../src/context.dart';
@@ -466,16 +468,15 @@ List<_i1.WidgetPreview> previews() => [];
           projectRootPath: project.directory.absolute.path,
         );
 
-        final expectedDtdConnectionInfo =
-            '''
+        final String expectedDtdConnectionInfo = DartFormatter(languageVersion: Version.none)
+            .format('''
 // ignore_for_file: implementation_imports
 
 const String kWidgetPreviewDtdUri = '$dtdUri';
 const String kWidgetPreviewService = 'widget-preview-service';
 const String kWidgetPreviewScaffoldStream = 'widget-preview-stream';
-const String kProjectRootPath =
-    r'${project.directory.absolute.path}';
-''';
+const String kProjectRootPath = r'${project.directory.absolute.path}';
+''');
         expect(generatedDtdConnectionInfoFile.readAsStringSync(), expectedDtdConnectionInfo);
       },
     );

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/utils/preview_detector_test_utils.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/utils/preview_detector_test_utils.dart
@@ -156,7 +156,9 @@ Future<void> expectHasNoErrors({
 }
 
 /// Waits for a pubspec changed event to be detected after executing [changeOperation].
-Future<String> waitForPubspecChangeDetected({required FutureOr<void> Function() changeOperation}) async {
+Future<String> waitForPubspecChangeDetected({
+  required FutureOr<void> Function() changeOperation,
+}) async {
   final completer = Completer<String>();
   _onPubspecChangeDetected = (String path) {
     if (completer.isCompleted) {
@@ -169,7 +171,9 @@ Future<String> waitForPubspecChangeDetected({required FutureOr<void> Function() 
 }
 
 /// Waits for a package_config.json changed event to be detected after executing [changeOperation].
-Future<String> waitForPackageConfigChangeDetected({required FutureOr<void> Function() changeOperation}) async {
+Future<String> waitForPackageConfigChangeDetected({
+  required FutureOr<void> Function() changeOperation,
+}) async {
   final completer = Completer<String>();
   _onPackageConfigChangeDetected = (String path) {
     if (completer.isCompleted) {

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/utils/preview_detector_test_utils.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/utils/preview_detector_test_utils.dart
@@ -129,7 +129,7 @@ void _onPackageConfigChangeDetectedRoot(String path) {
 /// Test the files included in [filesWithErrors] contain errors after executing [changeOperation].
 Future<void> expectHasErrors({
   required WidgetPreviewProject project,
-  required void Function() changeOperation,
+  required FutureOr<void> Function() changeOperation,
   required Set<WidgetPreviewSourceFile> filesWithErrors,
 }) async {
   await waitForChangeDetected(
@@ -146,7 +146,7 @@ Future<void> expectHasErrors({
 /// errors.
 Future<void> expectHasNoErrors({
   required WidgetPreviewProject project,
-  required void Function() changeOperation,
+  required FutureOr<void> Function() changeOperation,
 }) async {
   await expectHasErrors(
     project: project,
@@ -156,7 +156,7 @@ Future<void> expectHasNoErrors({
 }
 
 /// Waits for a pubspec changed event to be detected after executing [changeOperation].
-Future<String> waitForPubspecChangeDetected({required void Function() changeOperation}) {
+Future<String> waitForPubspecChangeDetected({required FutureOr<void> Function() changeOperation}) async {
   final completer = Completer<String>();
   _onPubspecChangeDetected = (String path) {
     if (completer.isCompleted) {
@@ -164,12 +164,12 @@ Future<String> waitForPubspecChangeDetected({required void Function() changeOper
     }
     completer.complete(path);
   };
-  changeOperation();
+  await changeOperation();
   return completer.future;
 }
 
 /// Waits for a package_config.json changed event to be detected after executing [changeOperation].
-Future<String> waitForPackageConfigChangeDetected({required void Function() changeOperation}) {
+Future<String> waitForPackageConfigChangeDetected({required FutureOr<void> Function() changeOperation}) async {
   final completer = Completer<String>();
   _onPackageConfigChangeDetected = (String path) {
     if (completer.isCompleted) {
@@ -177,7 +177,7 @@ Future<String> waitForPackageConfigChangeDetected({required void Function() chan
     }
     completer.complete(path);
   };
-  changeOperation();
+  await changeOperation();
   return completer.future;
 }
 
@@ -203,7 +203,7 @@ Future<void> waitForChangeDetected({
 /// Waits for [n] change detected events after executing [changeOperation].
 Future<void> waitForNChangesDetected({
   required int n,
-  required void Function() changeOperation,
+  required FutureOr<void> Function() changeOperation,
 }) async {
   var changeCount = 0;
   final completer = Completer<void>();
@@ -216,7 +216,7 @@ Future<void> waitForNChangesDetected({
       completer.complete();
     }
   };
-  changeOperation();
+  await changeOperation();
   await completer.future;
 }
 


### PR DESCRIPTION
This PR resolves a deterministic race condition in `preview_detector_test_utils.dart`. The test helper `changeOperation` callback is converted to support and properly `await` `FutureOr<void>`, ensuring asynchronous package-configuration writes are fully completed before `tearDown` deletes the temporary workspace directories. This resolves flakiness and unhandled exceptions under high load in both Linux and Mac shards.

Fixes https://github.com/flutter/flutter/issues/186136