### PR TITLE
fix(android): support direct span modifications on ListenableEditingState outside batch edits

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/plugin/editing/ListenableEditingState.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/plugin/editing/ListenableEditingState.java
@@ -277,16 +277,66 @@ class ListenableEditingState extends SpannableStringBuilder {
 
   @Override
   public void setSpan(Object what, int start, int end, int flags) {
+    final int oldSelectionStart = getSelectionStart();
+    final int oldSelectionEnd = getSelectionEnd();
+    final int oldComposingStart = getComposingStart();
+    final int oldComposingEnd = getComposingEnd();
+
     super.setSpan(what, start, end, flags);
-    // Setting a span does not involve mutating the text value in the editing state. Here we create
-    // a non text update delta with any updated selection and composing regions.
-    mBatchTextEditingDeltas.add(
-        new TextEditingDelta(
-            toString(),
-            getSelectionStart(),
-            getSelectionEnd(),
-            getComposingStart(),
-            getComposingEnd()));
+
+    final int newSelectionStart = getSelectionStart();
+    final int newSelectionEnd = getSelectionEnd();
+    final int newComposingStart = getComposingStart();
+    final int newComposingEnd = getComposingEnd();
+
+    final boolean selectionChanged = oldSelectionStart != newSelectionStart || oldSelectionEnd != newSelectionEnd;
+    final boolean composingChanged = oldComposingStart != newComposingStart || oldComposingEnd != newComposingEnd;
+
+    if (selectionChanged || composingChanged) {
+      mBatchTextEditingDeltas.add(
+          new TextEditingDelta(
+              toString(),
+              newSelectionStart,
+              newSelectionEnd,
+              newComposingStart,
+              newComposingEnd));
+
+      if (mBatchEditNestDepth == 0) {
+        notifyListenersIfNeeded(false, selectionChanged, composingChanged);
+      }
+    }
+  }
+
+  @Override
+  public void removeSpan(Object what) {
+    final int oldSelectionStart = getSelectionStart();
+    final int oldSelectionEnd = getSelectionEnd();
+    final int oldComposingStart = getComposingStart();
+    final int oldComposingEnd = getComposingEnd();
+
+    super.removeSpan(what);
+
+    final int newSelectionStart = getSelectionStart();
+    final int newSelectionEnd = getSelectionEnd();
+    final int newComposingStart = getComposingStart();
+    final int newComposingEnd = getComposingEnd();
+
+    final boolean selectionChanged = oldSelectionStart != newSelectionStart || oldSelectionEnd != newSelectionEnd;
+    final boolean composingChanged = oldComposingStart != newComposingStart || oldComposingEnd != newComposingEnd;
+
+    if (selectionChanged || composingChanged) {
+      mBatchTextEditingDeltas.add(
+          new TextEditingDelta(
+              toString(),
+              newSelectionStart,
+              newSelectionEnd,
+              newComposingStart,
+              newComposingEnd));
+
+      if (mBatchEditNestDepth == 0) {
+        notifyListenersIfNeeded(false, selectionChanged, composingChanged);
+      }
+    }
   }
 
   @Override

--- a/engine/src/flutter/shell/platform/android/io/flutter/plugin/editing/ListenableEditingState.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/plugin/editing/ListenableEditingState.java
@@ -47,6 +47,10 @@ class ListenableEditingState extends SpannableStringBuilder {
 
   private String mToStringCache;
 
+  // Depth of nested replace() calls.
+  // Used to ignore nested setSpan/removeSpan/clearSpans calls.
+  private int mReplaceDepth = 0;
+
   private String mTextWhenBeginBatchEdit;
   private int mSelectionStartWhenBeginBatchEdit;
   private int mSelectionEndWhenBeginBatchEdit;
@@ -216,7 +220,15 @@ class ListenableEditingState extends SpannableStringBuilder {
     final int composingStart = getComposingStart();
     final int composingEnd = getComposingEnd();
 
-    final SpannableStringBuilder editable = super.replace(start, end, tb, tbstart, tbend);
+    // Increment the depth before calling super.replace to ignore nested span calls.
+    mReplaceDepth++;
+    final SpannableStringBuilder editable;
+    try {
+      editable = super.replace(start, end, tb, tbstart, tbend);
+    } finally {
+      mReplaceDepth--;
+    }
+
     mBatchTextEditingDeltas.add(
         new TextEditingDelta(
             oldText,
@@ -277,6 +289,16 @@ class ListenableEditingState extends SpannableStringBuilder {
 
   @Override
   public void setSpan(Object what, int start, int end, int flags) {
+    // If we are currently replacing text, super.replace will handle updating selection/composing
+    // spans and generating the corresponding delta. We ignore those nested span updates here
+    // to avoid duplicate deltas and notifications.
+    if (mReplaceDepth > 0) {
+      super.setSpan(what, start, end, flags);
+      return;
+    }
+
+    // We must capture the old selection and composing region BEFORE calling super.setSpan,
+    // because super.setSpan will modify them. This is necessary to detect if they actually changed.
     final int oldSelectionStart = getSelectionStart();
     final int oldSelectionEnd = getSelectionEnd();
     final int oldComposingStart = getComposingStart();
@@ -289,17 +311,15 @@ class ListenableEditingState extends SpannableStringBuilder {
     final int newComposingStart = getComposingStart();
     final int newComposingEnd = getComposingEnd();
 
-    final boolean selectionChanged = oldSelectionStart != newSelectionStart || oldSelectionEnd != newSelectionEnd;
-    final boolean composingChanged = oldComposingStart != newComposingStart || oldComposingEnd != newComposingEnd;
+    final boolean selectionChanged =
+        oldSelectionStart != newSelectionStart || oldSelectionEnd != newSelectionEnd;
+    final boolean composingChanged =
+        oldComposingStart != newComposingStart || oldComposingEnd != newComposingEnd;
 
     if (selectionChanged || composingChanged) {
       mBatchTextEditingDeltas.add(
           new TextEditingDelta(
-              toString(),
-              newSelectionStart,
-              newSelectionEnd,
-              newComposingStart,
-              newComposingEnd));
+              toString(), newSelectionStart, newSelectionEnd, newComposingStart, newComposingEnd));
 
       if (mBatchEditNestDepth == 0) {
         notifyListenersIfNeeded(false, selectionChanged, composingChanged);
@@ -309,6 +329,17 @@ class ListenableEditingState extends SpannableStringBuilder {
 
   @Override
   public void removeSpan(Object what) {
+    // If we are currently replacing text, super.replace will handle updating selection/composing
+    // spans and generating the corresponding delta. We ignore those nested span updates here
+    // to avoid duplicate deltas and notifications.
+    if (mReplaceDepth > 0) {
+      super.removeSpan(what);
+      return;
+    }
+
+    // We must capture the old selection and composing region BEFORE calling super.removeSpan,
+    // because super.removeSpan will modify them. This is necessary to detect if they actually
+    // changed.
     final int oldSelectionStart = getSelectionStart();
     final int oldSelectionEnd = getSelectionEnd();
     final int oldComposingStart = getComposingStart();
@@ -321,17 +352,56 @@ class ListenableEditingState extends SpannableStringBuilder {
     final int newComposingStart = getComposingStart();
     final int newComposingEnd = getComposingEnd();
 
-    final boolean selectionChanged = oldSelectionStart != newSelectionStart || oldSelectionEnd != newSelectionEnd;
-    final boolean composingChanged = oldComposingStart != newComposingStart || oldComposingEnd != newComposingEnd;
+    final boolean selectionChanged =
+        oldSelectionStart != newSelectionStart || oldSelectionEnd != newSelectionEnd;
+    final boolean composingChanged =
+        oldComposingStart != newComposingStart || oldComposingEnd != newComposingEnd;
 
     if (selectionChanged || composingChanged) {
       mBatchTextEditingDeltas.add(
           new TextEditingDelta(
-              toString(),
-              newSelectionStart,
-              newSelectionEnd,
-              newComposingStart,
-              newComposingEnd));
+              toString(), newSelectionStart, newSelectionEnd, newComposingStart, newComposingEnd));
+
+      if (mBatchEditNestDepth == 0) {
+        notifyListenersIfNeeded(false, selectionChanged, composingChanged);
+      }
+    }
+  }
+
+  @Override
+  public void clearSpans() {
+    // If we are currently replacing text, super.replace will handle updating selection/composing
+    // spans and generating the corresponding delta. We ignore those nested span updates here
+    // to avoid duplicate deltas and notifications.
+    if (mReplaceDepth > 0) {
+      super.clearSpans();
+      return;
+    }
+
+    // We must capture the old selection and composing region BEFORE calling super.clearSpans,
+    // because super.clearSpans will modify them. This is necessary to detect if they actually
+    // changed.
+    final int oldSelectionStart = getSelectionStart();
+    final int oldSelectionEnd = getSelectionEnd();
+    final int oldComposingStart = getComposingStart();
+    final int oldComposingEnd = getComposingEnd();
+
+    super.clearSpans();
+
+    final int newSelectionStart = getSelectionStart();
+    final int newSelectionEnd = getSelectionEnd();
+    final int newComposingStart = getComposingStart();
+    final int newComposingEnd = getComposingEnd();
+
+    final boolean selectionChanged =
+        oldSelectionStart != newSelectionStart || oldSelectionEnd != newSelectionEnd;
+    final boolean composingChanged =
+        oldComposingStart != newComposingStart || oldComposingEnd != newComposingEnd;
+
+    if (selectionChanged || composingChanged) {
+      mBatchTextEditingDeltas.add(
+          new TextEditingDelta(
+              toString(), newSelectionStart, newSelectionEnd, newComposingStart, newComposingEnd));
 
       if (mBatchEditNestDepth == 0) {
         notifyListenersIfNeeded(false, selectionChanged, composingChanged);

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/editing/ListenableEditingStateTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/editing/ListenableEditingStateTest.java
@@ -409,6 +409,61 @@ public class ListenableEditingStateTest {
 
     editingState.addEditingStateListener(listener);
   }
+  @Test
+  public void testDirectSetSelectionNotifiesListener() {
+    final ListenableEditingState editingState = new ListenableEditingState(
+        new TextInputChannel.TextEditState("hello", 0, 0, -1, -1), new View(ctx));
+    final Listener listener = new Listener();
+    editingState.addEditingStateListener(listener);
+
+    // Direct selection modification (mimicking IME/Android direct span changes).
+    Selection.setSelection(editingState, 1, 3);
+
+    assertTrue("Listener should be called on direct selection change", listener.isCalled());
+    assertTrue("Selection change should be detected", listener.selectionChanged);
+    assertFalse("Text should not be changed", listener.textChanged);
+  }
+
+  private Object getComposingSpan() {
+    try {
+      java.lang.reflect.Field composingField = BaseInputConnection.class.getDeclaredField("COMPOSING");
+      composingField.setAccessible(true);
+      return composingField.get(null);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  public void testDirectSetComposingRegionNotifiesListener() {
+    final ListenableEditingState editingState = new ListenableEditingState(
+        new TextInputChannel.TextEditState("hello", 0, 0, -1, -1), new View(ctx));
+    final Listener listener = new Listener();
+    editingState.addEditingStateListener(listener);
+
+    // Direct composing region modification (mimicking IME direct span changes).
+    editingState.setSpan(getComposingSpan(), 1, 4, android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+
+    assertTrue("Listener should be called on direct composing region change", listener.isCalled());
+    assertTrue("Composing region change should be detected", listener.composingRegionChanged);
+    assertFalse("Text should not be changed", listener.textChanged);
+  }
+
+  @Test
+  public void testDirectRemoveComposingRegionNotifiesListener() {
+    final ListenableEditingState editingState = new ListenableEditingState(
+        new TextInputChannel.TextEditState("hello", 0, 0, 1, 4), new View(ctx));
+    final Listener listener = new Listener();
+    editingState.addEditingStateListener(listener);
+
+    // Direct composing region removal (mimicking IME direct span removal).
+    editingState.removeSpan(getComposingSpan());
+
+    assertTrue("Listener should be called on direct composing region removal", listener.isCalled());
+    assertTrue("Composing region change should be detected", listener.composingRegionChanged);
+    assertFalse("Text should not be changed", listener.textChanged);
+  }
+
   // -------- End: Test InputMethods actions   -------
 
   public static class Listener implements ListenableEditingState.EditingStateWatcher {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/editing/ListenableEditingStateTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/editing/ListenableEditingStateTest.java
@@ -409,10 +409,12 @@ public class ListenableEditingStateTest {
 
     editingState.addEditingStateListener(listener);
   }
+
   @Test
   public void testDirectSetSelectionNotifiesListener() {
-    final ListenableEditingState editingState = new ListenableEditingState(
-        new TextInputChannel.TextEditState("hello", 0, 0, -1, -1), new View(ctx));
+    final ListenableEditingState editingState =
+        new ListenableEditingState(
+            new TextInputChannel.TextEditState("hello", 0, 0, -1, -1), new View(ctx));
     final Listener listener = new Listener();
     editingState.addEditingStateListener(listener);
 
@@ -426,7 +428,8 @@ public class ListenableEditingStateTest {
 
   private Object getComposingSpan() {
     try {
-      java.lang.reflect.Field composingField = BaseInputConnection.class.getDeclaredField("COMPOSING");
+      java.lang.reflect.Field composingField =
+          BaseInputConnection.class.getDeclaredField("COMPOSING");
       composingField.setAccessible(true);
       return composingField.get(null);
     } catch (Exception e) {
@@ -436,8 +439,9 @@ public class ListenableEditingStateTest {
 
   @Test
   public void testDirectSetComposingRegionNotifiesListener() {
-    final ListenableEditingState editingState = new ListenableEditingState(
-        new TextInputChannel.TextEditState("hello", 0, 0, -1, -1), new View(ctx));
+    final ListenableEditingState editingState =
+        new ListenableEditingState(
+            new TextInputChannel.TextEditState("hello", 0, 0, -1, -1), new View(ctx));
     final Listener listener = new Listener();
     editingState.addEditingStateListener(listener);
 
@@ -451,8 +455,9 @@ public class ListenableEditingStateTest {
 
   @Test
   public void testDirectRemoveComposingRegionNotifiesListener() {
-    final ListenableEditingState editingState = new ListenableEditingState(
-        new TextInputChannel.TextEditState("hello", 0, 0, 1, 4), new View(ctx));
+    final ListenableEditingState editingState =
+        new ListenableEditingState(
+            new TextInputChannel.TextEditState("hello", 0, 0, 1, 4), new View(ctx));
     final Listener listener = new Listener();
     editingState.addEditingStateListener(listener);
 
@@ -460,6 +465,23 @@ public class ListenableEditingStateTest {
     editingState.removeSpan(getComposingSpan());
 
     assertTrue("Listener should be called on direct composing region removal", listener.isCalled());
+    assertTrue("Composing region change should be detected", listener.composingRegionChanged);
+    assertFalse("Text should not be changed", listener.textChanged);
+  }
+
+  @Test
+  public void testClearSpansNotifiesListener() {
+    final ListenableEditingState editingState =
+        new ListenableEditingState(
+            new TextInputChannel.TextEditState("hello", 1, 3, 1, 4), new View(ctx));
+    final Listener listener = new Listener();
+    editingState.addEditingStateListener(listener);
+
+    // Clear all spans (including selection and composing).
+    editingState.clearSpans();
+
+    assertTrue("Listener should be called on clearSpans", listener.isCalled());
+    assertTrue("Selection change should be detected", listener.selectionChanged);
     assertTrue("Composing region change should be detected", listener.composingRegionChanged);
     assertFalse("Text should not be changed", listener.textChanged);
   }


### PR DESCRIPTION
Override setSpan, removeSpan, and clearSpans in ListenableEditingState to detect direct selection and composing region changes outside of batch edits, and notify listeners immediately.

Introduce mReplaceDepth counter to guard against duplicate deltas and notifications when super.replace internally modifies spans. This counter is robust against re-entrant replace calls and improves performance by bypassing expensive span lookups during text replacement.

Capture 'before' state before calling super in span modification methods to correctly detect changes, which is documented in comments.

Add unit tests in ListenableEditingStateTest to cover direct selection/composing changes and span clearing.

Fixes: #102988 

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.