### PR TITLE
[Android] Reset system UI visibility flags when setting edge-to-edge mode

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
@@ -456,7 +456,10 @@ public class PlatformPlugin {
    * io.flutter.embedding.android.FlutterFragmentActivity}.
    */
   private void enableEdgeToEdge() {
+    // Clear previously applied system UI visibility flags to ensure that
+    // WindowInsetsControllerCompat can correctly configure the window.
     activity.getWindow().getDecorView().setSystemUiVisibility(0);
+
     WindowCompat.setDecorFitsSystemWindows(activity.getWindow(), false);
   }
 

--- a/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
@@ -456,6 +456,7 @@ public class PlatformPlugin {
    * io.flutter.embedding.android.FlutterFragmentActivity}.
    */
   private void enableEdgeToEdge() {
+    activity.getWindow().getDecorView().setSystemUiVisibility(0);
     WindowCompat.setDecorFitsSystemWindows(activity.getWindow(), false);
   }
 

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
@@ -652,16 +652,15 @@ public class PlatformPluginTest {
       PlatformChannel.SystemUiMode.IMMERSIVE,
       PlatformChannel.SystemUiMode.IMMERSIVE_STICKY
     };
+    try (MockedStatic<WindowCompat> windowCompatMock = mockStatic(WindowCompat.class)) {
+      for (PlatformChannel.SystemUiMode mode : modes) {
+        View fakeDecorView = mock(View.class);
+        Window fakeWindow = mock(Window.class);
+        Activity mockActivity = mock(Activity.class);
+        when(fakeWindow.getDecorView()).thenReturn(fakeDecorView);
+        when(mockActivity.getWindow()).thenReturn(fakeWindow);
+        PlatformPlugin platformPlugin = new PlatformPlugin(mockActivity, mockPlatformChannel);
 
-    for (PlatformChannel.SystemUiMode mode : modes) {
-      View fakeDecorView = mock(View.class);
-      Window fakeWindow = mock(Window.class);
-      Activity mockActivity = mock(Activity.class);
-      when(fakeWindow.getDecorView()).thenReturn(fakeDecorView);
-      when(mockActivity.getWindow()).thenReturn(fakeWindow);
-      PlatformPlugin platformPlugin = new PlatformPlugin(mockActivity, mockPlatformChannel);
-
-      try (MockedStatic<WindowCompat> windowCompatMock = mockStatic(WindowCompat.class)) {
         platformPlugin.mPlatformMessageHandler.showSystemUiMode(mode);
         platformPlugin.mPlatformMessageHandler.showSystemUiMode(
             PlatformChannel.SystemUiMode.EDGE_TO_EDGE);

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
@@ -662,52 +662,12 @@ public class PlatformPluginTest {
       PlatformPlugin platformPlugin = new PlatformPlugin(mockActivity, mockPlatformChannel);
 
       try (MockedStatic<WindowCompat> windowCompatMock = mockStatic(WindowCompat.class)) {
-        // First, enter target mode.
         platformPlugin.mPlatformMessageHandler.showSystemUiMode(mode);
-
-        // Then transition to EDGE_TO_EDGE.
         platformPlugin.mPlatformMessageHandler.showSystemUiMode(
             PlatformChannel.SystemUiMode.EDGE_TO_EDGE);
 
-        // Should call setSystemUiVisibility(0) to clear active visibility-hiding flags.
         verify(fakeDecorView).setSystemUiVisibility(0);
         windowCompatMock.verify(() -> WindowCompat.setDecorFitsSystemWindows(fakeWindow, false));
-      }
-    }
-  }
-
-  @SuppressWarnings("deprecation")
-  @Config(sdk = API_LEVELS.API_29)
-  @Test
-  public void switchFromEdgeToEdgeToAnyMode_restoresDecorFitsSystemWindows() {
-    PlatformChannel.SystemUiMode[] modes = {
-      PlatformChannel.SystemUiMode.LEAN_BACK,
-      PlatformChannel.SystemUiMode.IMMERSIVE,
-      PlatformChannel.SystemUiMode.IMMERSIVE_STICKY
-    };
-
-    for (PlatformChannel.SystemUiMode mode : modes) {
-      View fakeDecorView = mock(View.class);
-      Window fakeWindow = mock(Window.class);
-      Activity mockActivity = mock(Activity.class);
-      when(fakeWindow.getDecorView()).thenReturn(fakeDecorView);
-      when(mockActivity.getWindow()).thenReturn(fakeWindow);
-      PlatformPlugin platformPlugin = new PlatformPlugin(mockActivity, mockPlatformChannel);
-
-      try (MockedStatic<WindowCompat> windowCompatMock = mockStatic(WindowCompat.class)) {
-        // First, enter EDGE_TO_EDGE mode.
-        platformPlugin.mPlatformMessageHandler.showSystemUiMode(
-            PlatformChannel.SystemUiMode.EDGE_TO_EDGE);
-        windowCompatMock.verify(() -> WindowCompat.setDecorFitsSystemWindows(fakeWindow, false));
-
-        // Clear static mock calls to simplify verification of subsequent transitions.
-        windowCompatMock.clearInvocations();
-
-        // Then transition to the target mode.
-        platformPlugin.mPlatformMessageHandler.showSystemUiMode(mode);
-
-        // Should restore decor fits system windows when leaving edge-to-edge.
-        windowCompatMock.verify(() -> WindowCompat.setDecorFitsSystemWindows(fakeWindow, true));
       }
     }
   }

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
@@ -644,6 +644,75 @@ public class PlatformPluginTest {
   }
 
   @SuppressWarnings("deprecation")
+  @Config(sdk = API_LEVELS.API_29)
+  @Test
+  public void switchFromAnyModeToEdgeToEdge_clearsSystemUiVisibility() {
+    PlatformChannel.SystemUiMode[] modes = {
+      PlatformChannel.SystemUiMode.LEAN_BACK,
+      PlatformChannel.SystemUiMode.IMMERSIVE,
+      PlatformChannel.SystemUiMode.IMMERSIVE_STICKY
+    };
+
+    for (PlatformChannel.SystemUiMode mode : modes) {
+      View fakeDecorView = mock(View.class);
+      Window fakeWindow = mock(Window.class);
+      Activity mockActivity = mock(Activity.class);
+      when(fakeWindow.getDecorView()).thenReturn(fakeDecorView);
+      when(mockActivity.getWindow()).thenReturn(fakeWindow);
+      PlatformPlugin platformPlugin = new PlatformPlugin(mockActivity, mockPlatformChannel);
+
+      try (MockedStatic<WindowCompat> windowCompatMock = mockStatic(WindowCompat.class)) {
+        // First, enter target mode.
+        platformPlugin.mPlatformMessageHandler.showSystemUiMode(mode);
+
+        // Then transition to EDGE_TO_EDGE.
+        platformPlugin.mPlatformMessageHandler.showSystemUiMode(
+            PlatformChannel.SystemUiMode.EDGE_TO_EDGE);
+
+        // Should call setSystemUiVisibility(0) to clear active visibility-hiding flags.
+        verify(fakeDecorView).setSystemUiVisibility(0);
+        windowCompatMock.verify(() -> WindowCompat.setDecorFitsSystemWindows(fakeWindow, false));
+      }
+    }
+  }
+
+  @SuppressWarnings("deprecation")
+  @Config(sdk = API_LEVELS.API_29)
+  @Test
+  public void switchFromEdgeToEdgeToAnyMode_restoresDecorFitsSystemWindows() {
+    PlatformChannel.SystemUiMode[] modes = {
+      PlatformChannel.SystemUiMode.LEAN_BACK,
+      PlatformChannel.SystemUiMode.IMMERSIVE,
+      PlatformChannel.SystemUiMode.IMMERSIVE_STICKY
+    };
+
+    for (PlatformChannel.SystemUiMode mode : modes) {
+      View fakeDecorView = mock(View.class);
+      Window fakeWindow = mock(Window.class);
+      Activity mockActivity = mock(Activity.class);
+      when(fakeWindow.getDecorView()).thenReturn(fakeDecorView);
+      when(mockActivity.getWindow()).thenReturn(fakeWindow);
+      PlatformPlugin platformPlugin = new PlatformPlugin(mockActivity, mockPlatformChannel);
+
+      try (MockedStatic<WindowCompat> windowCompatMock = mockStatic(WindowCompat.class)) {
+        // First, enter EDGE_TO_EDGE mode.
+        platformPlugin.mPlatformMessageHandler.showSystemUiMode(
+            PlatformChannel.SystemUiMode.EDGE_TO_EDGE);
+        windowCompatMock.verify(() -> WindowCompat.setDecorFitsSystemWindows(fakeWindow, false));
+
+        // Clear static mock calls to simplify verification of subsequent transitions.
+        windowCompatMock.clearInvocations();
+
+        // Then transition to the target mode.
+        platformPlugin.mPlatformMessageHandler.showSystemUiMode(mode);
+
+        // Should restore decor fits system windows when leaving edge-to-edge.
+        windowCompatMock.verify(() -> WindowCompat.setDecorFitsSystemWindows(fakeWindow, true));
+      }
+    }
+  }
+
+  @SuppressWarnings("deprecation")
   // FLAG_TRANSLUCENT_STATUS, FLAG_TRANSLUCENT_NAVIGATION
   @Config(sdk = API_LEVELS.API_29)
   @Test


### PR DESCRIPTION
Resets system UI visibility flags before setting edge-to-edge mode if requested.

System UI visibility flags will be set if the developer requests a non-edge-to-edge `SystemUiMode`, which can (and does in practice) conflict with [laying out a window edge-to-edge](https://developer.android.com/develop/ui/views/layout/edge-to-edge-manually#lay-out-in-full-screen). This is why [the docs](https://developer.android.com/reference/androidx/core/view/WindowCompat#setDecorFitsSystemWindows(android.view.Window,boolean)) warn against setting system UI visibility flags altogether; see https://github.com/flutter/flutter/issues/133074 for details.

Fixes https://github.com/flutter/flutter/issues/186723.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
