### PR TITLE
Fix std::vector out-of-bounds access in Flutter Android JNI and Delegate

### DIFF
--- a/engine/src/flutter/shell/platform/android/jni/mock_jni_env.h
+++ b/engine/src/flutter/shell/platform/android/jni/mock_jni_env.h
@@ -68,6 +68,8 @@ class MockableJNIEnv : public JNIEnv {
     jni_.NewGlobalRef = WrapNewGlobalRef;
     jni_.NewLocalRef = WrapNewLocalRef;
     jni_.RegisterNatives = WrapRegisterNatives;
+    jni_.GetArrayLength = WrapGetArrayLength;
+    jni_.GetIntArrayRegion = WrapGetIntArrayRegion;
   }
 
   virtual jobject CallObjectMethodV(jobject, jmethodID, va_list) = 0;
@@ -86,6 +88,8 @@ class MockableJNIEnv : public JNIEnv {
   virtual jobject NewGlobalRef(jobject) = 0;
   virtual jobject NewLocalRef(jobject) = 0;
   virtual jint RegisterNatives(jclass, const JNINativeMethod*, jint) = 0;
+  virtual jsize GetArrayLength(jarray) = 0;
+  virtual void GetIntArrayRegion(jintArray, jsize, jsize, jint*) = 0;
 
  private:
   static jobject WrapCallObjectMethod(JNIEnv* env,
@@ -168,6 +172,17 @@ class MockableJNIEnv : public JNIEnv {
     return static_cast<MockableJNIEnv*>(env)->RegisterNatives(clazz, methods,
                                                               nMethods);
   }
+  static jsize WrapGetArrayLength(JNIEnv* env, jarray array) {
+    return static_cast<MockableJNIEnv*>(env)->GetArrayLength(array);
+  }
+  static void WrapGetIntArrayRegion(JNIEnv* env,
+                                    jintArray array,
+                                    jsize start,
+                                    jsize len,
+                                    jint* buf) {
+    static_cast<MockableJNIEnv*>(env)->GetIntArrayRegion(array, start, len,
+                                                         buf);
+  }
 
   JNINativeInterface jni_ = {};
 };
@@ -207,6 +222,11 @@ class MockJNIEnv : public MockableJNIEnv {
   MOCK_METHOD(jint,
               RegisterNatives,
               (jclass, const JNINativeMethod*, jint),
+              (override));
+  MOCK_METHOD(jsize, GetArrayLength, (jarray), (override));
+  MOCK_METHOD(void,
+              GetIntArrayRegion,
+              (jintArray, jsize, jsize, jint*),
               (override));
 };
 

--- a/engine/src/flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.cc
@@ -187,122 +187,124 @@ void PlatformViewAndroidDelegate::UpdateSemantics(
     // If any of the encoding structure or length is changed, those locations
     // must be updated (at a minimum).
     std::vector<uint8_t> buffer(num_bytes);
-    int32_t* buffer_int32 = reinterpret_cast<int32_t*>(&buffer[0]);
-    float* buffer_float32 = reinterpret_cast<float*>(&buffer[0]);
 
-    std::vector<std::string> strings;
-    std::vector<std::vector<uint8_t>> string_attribute_args;
-    size_t position = 0;
-    for (const auto& value : update) {
-      // If you edit this code, make sure you update kBytesPerNode
-      // and/or kBytesPerChild above to match the number of values you are
-      // sending.
-      const flutter::SemanticsNode& node = value.second;
-      buffer_int32[position++] = node.id;
-      int64_t flags = flagsToInt64(node.flags);
-      std::memcpy(&buffer_int32[position], &flags, 8);
-      position += 2;
-      buffer_int32[position++] = node.actions;
-      buffer_int32[position++] = node.maxValueLength;
-      buffer_int32[position++] = node.currentValueLength;
-      buffer_int32[position++] = node.textSelectionBase;
-      buffer_int32[position++] = node.textSelectionExtent;
-      buffer_int32[position++] = node.platformViewId;
-      buffer_int32[position++] = node.scrollChildren;
-      buffer_int32[position++] = node.scrollIndex;
-      buffer_int32[position++] = node.traversalParent;
-      buffer_float32[position++] = static_cast<float>(node.scrollPosition);
-      buffer_float32[position++] = static_cast<float>(node.scrollExtentMax);
-      buffer_float32[position++] = static_cast<float>(node.scrollExtentMin);
-      buffer_int32[position++] = static_cast<int32_t>(node.role);
+    if (!buffer.empty()) {
+      int32_t* buffer_int32 = reinterpret_cast<int32_t*>(&buffer[0]);
+      float* buffer_float32 = reinterpret_cast<float*>(&buffer[0]);
 
-      putStringIntoBuffer(node.identifier, buffer_int32, &position, strings);
+      std::vector<std::string> strings;
+      std::vector<std::vector<uint8_t>> string_attribute_args;
+      size_t position = 0;
+      for (const auto& value : update) {
+        // If you edit this code, make sure you update kBytesPerNode
+        // and/or kBytesPerChild above to match the number of values you are
+        // sending.
+        const flutter::SemanticsNode& node = value.second;
+        buffer_int32[position++] = node.id;
+        int64_t flags = flagsToInt64(node.flags);
+        std::memcpy(&buffer_int32[position], &flags, 8);
+        position += 2;
+        buffer_int32[position++] = node.actions;
+        buffer_int32[position++] = node.maxValueLength;
+        buffer_int32[position++] = node.currentValueLength;
+        buffer_int32[position++] = node.textSelectionBase;
+        buffer_int32[position++] = node.textSelectionExtent;
+        buffer_int32[position++] = node.platformViewId;
+        buffer_int32[position++] = node.scrollChildren;
+        buffer_int32[position++] = node.scrollIndex;
+        buffer_int32[position++] = node.traversalParent;
+        buffer_float32[position++] = static_cast<float>(node.scrollPosition);
+        buffer_float32[position++] = static_cast<float>(node.scrollExtentMax);
+        buffer_float32[position++] = static_cast<float>(node.scrollExtentMin);
+        buffer_int32[position++] = static_cast<int32_t>(node.role);
 
-      putStringIntoBuffer(node.label, buffer_int32, &position, strings);
-      putStringAttributesIntoBuffer(node.labelAttributes, buffer_int32,
-                                    &position, string_attribute_args);
+        putStringIntoBuffer(node.identifier, buffer_int32, &position, strings);
 
-      putStringIntoBuffer(node.value, buffer_int32, &position, strings);
-      putStringAttributesIntoBuffer(node.valueAttributes, buffer_int32,
-                                    &position, string_attribute_args);
+        putStringIntoBuffer(node.label, buffer_int32, &position, strings);
+        putStringAttributesIntoBuffer(node.labelAttributes, buffer_int32,
+                                      &position, string_attribute_args);
 
-      putStringIntoBuffer(node.increasedValue, buffer_int32, &position,
-                          strings);
-      putStringAttributesIntoBuffer(node.increasedValueAttributes, buffer_int32,
-                                    &position, string_attribute_args);
+        putStringIntoBuffer(node.value, buffer_int32, &position, strings);
+        putStringAttributesIntoBuffer(node.valueAttributes, buffer_int32,
+                                      &position, string_attribute_args);
 
-      putStringIntoBuffer(node.decreasedValue, buffer_int32, &position,
-                          strings);
-      putStringAttributesIntoBuffer(node.decreasedValueAttributes, buffer_int32,
-                                    &position, string_attribute_args);
+        putStringIntoBuffer(node.increasedValue, buffer_int32, &position,
+                            strings);
+        putStringAttributesIntoBuffer(node.increasedValueAttributes,
+                                      buffer_int32, &position,
+                                      string_attribute_args);
 
-      putStringIntoBuffer(node.hint, buffer_int32, &position, strings);
-      putStringAttributesIntoBuffer(node.hintAttributes, buffer_int32,
-                                    &position, string_attribute_args);
+        putStringIntoBuffer(node.decreasedValue, buffer_int32, &position,
+                            strings);
+        putStringAttributesIntoBuffer(node.decreasedValueAttributes,
+                                      buffer_int32, &position,
+                                      string_attribute_args);
 
-      putStringIntoBuffer(node.tooltip, buffer_int32, &position, strings);
-      putStringIntoBuffer(node.linkUrl, buffer_int32, &position, strings);
-      putStringIntoBuffer(node.locale, buffer_int32, &position, strings);
-      putStringIntoBuffer(node.minValue, buffer_int32, &position, strings);
-      putStringIntoBuffer(node.maxValue, buffer_int32, &position, strings);
+        putStringIntoBuffer(node.hint, buffer_int32, &position, strings);
+        putStringAttributesIntoBuffer(node.hintAttributes, buffer_int32,
+                                      &position, string_attribute_args);
 
-      buffer_int32[position++] = node.headingLevel;
-      buffer_int32[position++] = node.textDirection;
-      buffer_float32[position++] = node.rect.left();
-      buffer_float32[position++] = node.rect.top();
-      buffer_float32[position++] = node.rect.right();
-      buffer_float32[position++] = node.rect.bottom();
-      node.transform.getColMajor(&buffer_float32[position]);
-      position += 16;
-      node.hitTestTransform.getColMajor(&buffer_float32[position]);
-      position += 16;
-      buffer_int32[position++] = node.childrenInTraversalOrder.size();
-      for (int32_t child : node.childrenInTraversalOrder) {
-        buffer_int32[position++] = child;
+        putStringIntoBuffer(node.tooltip, buffer_int32, &position, strings);
+        putStringIntoBuffer(node.linkUrl, buffer_int32, &position, strings);
+        putStringIntoBuffer(node.locale, buffer_int32, &position, strings);
+        putStringIntoBuffer(node.minValue, buffer_int32, &position, strings);
+        putStringIntoBuffer(node.maxValue, buffer_int32, &position, strings);
+
+        buffer_int32[position++] = node.headingLevel;
+        buffer_int32[position++] = node.textDirection;
+        buffer_float32[position++] = node.rect.left();
+        buffer_float32[position++] = node.rect.top();
+        buffer_float32[position++] = node.rect.right();
+        buffer_float32[position++] = node.rect.bottom();
+        node.transform.getColMajor(&buffer_float32[position]);
+        position += 16;
+        node.hitTestTransform.getColMajor(&buffer_float32[position]);
+        position += 16;
+        buffer_int32[position++] = node.childrenInTraversalOrder.size();
+        for (int32_t child : node.childrenInTraversalOrder) {
+          buffer_int32[position++] = child;
+        }
+
+        buffer_int32[position++] = node.childrenInHitTestOrder.size();
+        for (int32_t child : node.childrenInHitTestOrder) {
+          buffer_int32[position++] = child;
+        }
+
+        buffer_int32[position++] = node.customAccessibilityActions.size();
+        for (int32_t child : node.customAccessibilityActions) {
+          buffer_int32[position++] = child;
+        }
       }
-
-      buffer_int32[position++] = node.childrenInHitTestOrder.size();
-      for (int32_t child : node.childrenInHitTestOrder) {
-        buffer_int32[position++] = child;
-      }
-
-      buffer_int32[position++] = node.customAccessibilityActions.size();
-      for (int32_t child : node.customAccessibilityActions) {
-        buffer_int32[position++] = child;
-      }
+      jni_facade_->FlutterViewUpdateSemantics(buffer, strings,
+                                              string_attribute_args);
     }
 
     // custom accessibility actions.
     size_t num_action_bytes = actions.size() * kBytesPerAction;
     std::vector<uint8_t> actions_buffer(num_action_bytes);
-    int32_t* actions_buffer_int32 =
-        reinterpret_cast<int32_t*>(&actions_buffer[0]);
 
-    std::vector<std::string> action_strings;
-    size_t actions_position = 0;
-    for (const auto& value : actions) {
-      // If you edit this code, make sure you update kBytesPerAction
-      // to match the number of values you are
-      // sending.
-      const flutter::CustomAccessibilityAction& action = value.second;
-      actions_buffer_int32[actions_position++] = action.id;
-      actions_buffer_int32[actions_position++] = action.overrideId;
-      putStringIntoBuffer(action.label, actions_buffer_int32, &actions_position,
-                          action_strings);
-      putStringIntoBuffer(action.hint, actions_buffer_int32, &actions_position,
-                          action_strings);
-    }
-
-    // Calling NewDirectByteBuffer in API level 22 and below with a size of zero
-    // will cause a JNI crash.
     if (!actions_buffer.empty()) {
+      int32_t* actions_buffer_int32 =
+          reinterpret_cast<int32_t*>(&actions_buffer[0]);
+
+      std::vector<std::string> action_strings;
+      size_t actions_position = 0;
+      for (const auto& value : actions) {
+        // If you edit this code, make sure you update kBytesPerAction
+        // to match the number of values you are
+        // sending.
+        const flutter::CustomAccessibilityAction& action = value.second;
+        actions_buffer_int32[actions_position++] = action.id;
+        actions_buffer_int32[actions_position++] = action.overrideId;
+        putStringIntoBuffer(action.label, actions_buffer_int32,
+                            &actions_position, action_strings);
+        putStringIntoBuffer(action.hint, actions_buffer_int32,
+                            &actions_position, action_strings);
+      }
+      // Calling NewDirectByteBuffer in API level 22 and below with a size of
+      // zero will cause a JNI crash.
       jni_facade_->FlutterViewUpdateCustomAccessibilityActions(actions_buffer,
                                                                action_strings);
-    }
-
-    if (!buffer.empty()) {
-      jni_facade_->FlutterViewUpdateSemantics(buffer, strings,
-                                              string_attribute_args);
     }
   }
 }

--- a/engine/src/flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.cc
@@ -187,13 +187,13 @@ void PlatformViewAndroidDelegate::UpdateSemantics(
     // If any of the encoding structure or length is changed, those locations
     // must be updated (at a minimum).
     std::vector<uint8_t> buffer(num_bytes);
+    std::vector<std::string> strings;
+    std::vector<std::vector<uint8_t>> string_attribute_args;
 
     if (!buffer.empty()) {
       int32_t* buffer_int32 = reinterpret_cast<int32_t*>(buffer.data());
       float* buffer_float32 = reinterpret_cast<float*>(buffer.data());
 
-      std::vector<std::string> strings;
-      std::vector<std::vector<uint8_t>> string_attribute_args;
       size_t position = 0;
       for (const auto& value : update) {
         // If you edit this code, make sure you update kBytesPerNode

--- a/engine/src/flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.cc
@@ -189,8 +189,8 @@ void PlatformViewAndroidDelegate::UpdateSemantics(
     std::vector<uint8_t> buffer(num_bytes);
 
     if (!buffer.empty()) {
-      int32_t* buffer_int32 = reinterpret_cast<int32_t*>(&buffer[0]);
-      float* buffer_float32 = reinterpret_cast<float*>(&buffer[0]);
+      int32_t* buffer_int32 = reinterpret_cast<int32_t*>(buffer.data());
+      float* buffer_float32 = reinterpret_cast<float*>(buffer.data());
 
       std::vector<std::string> strings;
       std::vector<std::vector<uint8_t>> string_attribute_args;
@@ -275,8 +275,6 @@ void PlatformViewAndroidDelegate::UpdateSemantics(
           buffer_int32[position++] = child;
         }
       }
-      jni_facade_->FlutterViewUpdateSemantics(buffer, strings,
-                                              string_attribute_args);
     }
 
     // custom accessibility actions.
@@ -285,7 +283,7 @@ void PlatformViewAndroidDelegate::UpdateSemantics(
 
     if (!actions_buffer.empty()) {
       int32_t* actions_buffer_int32 =
-          reinterpret_cast<int32_t*>(&actions_buffer[0]);
+          reinterpret_cast<int32_t*>(actions_buffer.data());
 
       std::vector<std::string> action_strings;
       size_t actions_position = 0;
@@ -305,6 +303,11 @@ void PlatformViewAndroidDelegate::UpdateSemantics(
       // zero will cause a JNI crash.
       jni_facade_->FlutterViewUpdateCustomAccessibilityActions(actions_buffer,
                                                                action_strings);
+    }
+
+    if (!buffer.empty()) {
+      jni_facade_->FlutterViewUpdateSemantics(buffer, strings,
+                                              string_attribute_args);
     }
   }
 }

--- a/engine/src/flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate_unittests.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate_unittests.cc
@@ -367,5 +367,21 @@ TEST(PlatformViewShell,
   delegate->UpdateSemantics(update, actions);
 }
 
+TEST(PlatformViewShell, UpdateSemanticsEmptyDoesNotCrash) {
+  auto jni_mock = std::make_shared<JNIMock>();
+  auto delegate = std::make_unique<PlatformViewAndroidDelegate>(jni_mock);
+
+  EXPECT_CALL(*jni_mock, FlutterViewUpdateCustomAccessibilityActions(
+                             ::testing::_, ::testing::_))
+      .Times(0);
+  EXPECT_CALL(*jni_mock, FlutterViewUpdateSemantics(::testing::_, ::testing::_,
+                                                    ::testing::_))
+      .Times(0);
+
+  flutter::SemanticsNodeUpdates update;
+  flutter::CustomAccessibilityActionUpdates actions;
+  delegate->UpdateSemantics(update, actions);
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/engine/src/flutter/shell/platform/android/platform_view_android_jni_impl.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android_jni_impl.cc
@@ -365,19 +365,25 @@ static void SetViewportMetrics(JNIEnv* env,
   // javaDisplayFeaturesState cannot be null
   jsize rectSize = env->GetArrayLength(javaDisplayFeaturesBounds);
   std::vector<int> boundsIntVector(rectSize);
-  env->GetIntArrayRegion(javaDisplayFeaturesBounds, 0, rectSize,
-                         &boundsIntVector[0]);
+  if (rectSize > 0) {
+    env->GetIntArrayRegion(javaDisplayFeaturesBounds, 0, rectSize,
+                           &boundsIntVector[0]);
+  }
   std::vector<double> displayFeaturesBounds(boundsIntVector.begin(),
                                             boundsIntVector.end());
   jsize typeSize = env->GetArrayLength(javaDisplayFeaturesType);
   std::vector<int> displayFeaturesType(typeSize);
-  env->GetIntArrayRegion(javaDisplayFeaturesType, 0, typeSize,
-                         &displayFeaturesType[0]);
+  if (typeSize > 0) {
+    env->GetIntArrayRegion(javaDisplayFeaturesType, 0, typeSize,
+                           &displayFeaturesType[0]);
+  }
 
   jsize stateSize = env->GetArrayLength(javaDisplayFeaturesState);
   std::vector<int> displayFeaturesState(stateSize);
-  env->GetIntArrayRegion(javaDisplayFeaturesState, 0, stateSize,
-                         &displayFeaturesState[0]);
+  if (stateSize > 0) {
+    env->GetIntArrayRegion(javaDisplayFeaturesState, 0, stateSize,
+                           &displayFeaturesState[0]);
+  }
 
   const flutter::ViewportMetrics metrics{
       static_cast<double>(devicePixelRatio),  // p_device_pixel_ratio

--- a/engine/src/flutter/shell/platform/android/platform_view_android_jni_impl_unittests.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android_jni_impl_unittests.cc
@@ -8,6 +8,8 @@
 #include "flutter/fml/platform/android/jni_util.h"
 #include "flutter/fml/platform/android/jni_weak_ref.h"
 #include "flutter/fml/platform/android/scoped_java_ref.h"
+#include "flutter/shell/platform/android/android_shell_holder.h"
+#include "flutter/shell/platform/android/jni/jni_mock.h"
 #include "flutter/shell/platform/android/jni/mock_jni_env.h"
 #include "flutter/shell/platform/android/platform_view_android.h"
 #include "flutter/shell/platform/android/platform_view_android_jni_impl.h"
@@ -101,6 +103,74 @@ TEST_F(PlatformViewAndroidJNIImplTest, ImageGetHardwareBufferException) {
   fml::jni::ScopedJavaLocalRef<jobject> image(&mock_env,
                                               reinterpret_cast<jobject>(123));
   android_jni.ImageGetHardwareBuffer(image);
+}
+
+TEST_F(PlatformViewAndroidJNIImplTest, SetViewportMetricsEmptyArrays) {
+  MockJNIEnvProvider env_provider;
+  MockJNIEnv& mock_env = env_provider.env();
+
+  typedef void (*SetViewportMetricsFn)(
+      JNIEnv*, jobject, jlong, jfloat, jint, jint, jint, jint, jint, jint, jint,
+      jint, jint, jint, jint, jint, jint, jint, jint, jintArray, jintArray,
+      jintArray, jint, jint, jint, jint, jint, jint, jint, jint);
+
+  SetViewportMetricsFn set_viewport_metrics = nullptr;
+
+  const jclass kPlaceholderClass = reinterpret_cast<jclass>(100);
+  const jfieldID kPlaceholderFieldID = reinterpret_cast<jfieldID>(200);
+  const jmethodID kPlaceholderMethodID = reinterpret_cast<jmethodID>(300);
+
+  EXPECT_CALL(mock_env, GetObjectRefType(_))
+      .WillRepeatedly(Return(JNILocalRefType));
+  EXPECT_CALL(mock_env, NewLocalRef(_)).WillRepeatedly(ReturnArg<0>());
+  EXPECT_CALL(mock_env, DeleteLocalRef(_)).WillRepeatedly(Return());
+  EXPECT_CALL(mock_env, NewGlobalRef(_)).WillRepeatedly(ReturnArg<0>());
+  EXPECT_CALL(mock_env, DeleteGlobalRef(_)).WillRepeatedly(Return());
+  EXPECT_CALL(mock_env, FindClass(_)).WillRepeatedly(Return(kPlaceholderClass));
+  EXPECT_CALL(mock_env, GetFieldID(_, _, _))
+      .WillRepeatedly(Return(kPlaceholderFieldID));
+  EXPECT_CALL(mock_env, GetMethodID(_, _, _))
+      .WillRepeatedly(Return(kPlaceholderMethodID));
+  EXPECT_CALL(mock_env, GetStaticFieldID(_, _, _))
+      .WillRepeatedly(Return(kPlaceholderFieldID));
+  EXPECT_CALL(mock_env, GetStaticMethodID(_, _, _))
+      .WillRepeatedly(Return(kPlaceholderMethodID));
+  EXPECT_CALL(mock_env, ExceptionCheck()).WillRepeatedly(Return(JNI_FALSE));
+
+  EXPECT_CALL(mock_env, RegisterNatives(_, _, _))
+      .WillRepeatedly(
+          [&](jclass clazz, const JNINativeMethod* methods, jint nMethods) {
+            for (jint i = 0; i < nMethods; ++i) {
+              if (strcmp(methods[i].name, "nativeSetViewportMetrics") == 0) {
+                set_viewport_metrics =
+                    reinterpret_cast<SetViewportMetricsFn>(methods[i].fnPtr);
+              }
+            }
+            return 0;
+          });
+
+  PlatformViewAndroid::Register(&mock_env);
+
+  ASSERT_NE(set_viewport_metrics, nullptr);
+
+  EXPECT_CALL(mock_env, GetArrayLength(_)).WillRepeatedly(Return(0));
+  EXPECT_CALL(mock_env, GetIntArrayRegion(_, _, _, _)).Times(0);
+
+  Settings settings;
+  settings.enable_software_rendering = false;
+  auto jni = std::make_shared<JNIMock>();
+  auto holder = std::make_unique<AndroidShellHolder>(
+      settings, jni, AndroidRenderingAPI::kImpellerOpenGLES);
+
+  jobject jcaller = reinterpret_cast<jobject>(123);
+  jintArray bounds = reinterpret_cast<jintArray>(456);
+  jintArray type = reinterpret_cast<jintArray>(789);
+  jintArray state = reinterpret_cast<jintArray>(1011);
+
+  set_viewport_metrics(&mock_env, jcaller,
+                       reinterpret_cast<jlong>(holder.get()), 1.0f, 100, 100, 0,
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, bounds, type, state,
+                       0, 0, 0, 0, 0, 0, 0, 0);
 }
 
 }  // namespace testing


### PR DESCRIPTION
This CL addresses potential `std::vector` index out-of-bounds errors in the Flutter engine's Android native code, detected by libc++ hardening (go/cc-hardening-assertions). The issues stem from unsafe `&vector[0]` accesses on potentially empty vectors.

1.  **platform_view_android_jni_impl.cc (SetViewportMetrics):** Added size checks before using `GetIntArrayRegion` on vectors created from JNI arrays, which can be empty.
2.  **platform_view_android_delegate.cc (UpdateSemantics):** Moved buffer pointer initializations (e.g., `&buffer[0]`) and their usage to be within `!empty()` checks, preventing access on zero-sized vectors.

These changes ensure safe vector handling, particularly when empty data is passed via JNI.

See cl/922343981