### PR TITLE
[Flutter GPU] WIP: Make Texture.overwrite async

### DIFF
--- a/engine/src/flutter/lib/gpu/lib/gpu.dart
+++ b/engine/src/flutter/lib/gpu/lib/gpu.dart
@@ -20,6 +20,7 @@
 ///  * [Flutter GPU documentation](https://github.com/flutter/flutter/blob/main/docs/engine/impeller/Flutter-GPU.md).
 library flutter_gpu;
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:developer' as developer;
 import 'dart:ffi';

--- a/engine/src/flutter/lib/gpu/lib/src/texture.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/texture.dart
@@ -148,9 +148,15 @@ base class Texture extends NativeFieldWrapperClass1 {
   /// (where `mipWidth` and `mipHeight` are the base dimensions right-shifted
   /// by [mipLevel], floored at 1).
   ///
-  /// Throws an exception if the write fails due to an internal error or if
-  /// any of the parameters are out of range.
-  void overwrite(ByteData sourceBytes, {int mipLevel = 0, int slice = 0}) {
+  /// Completes when the backend reports that the write is complete.
+  ///
+  /// Completes with an exception if the write fails due to an internal error
+  /// or if any of the parameters are out of range.
+  Future<void> overwrite(
+    ByteData sourceBytes, {
+    int mipLevel = 0,
+    int slice = 0,
+  }) async {
     if (mipLevel < 0 || mipLevel >= mipLevelCount) {
       throw Exception(
         'mipLevel ($mipLevel) must be in the range [0, $mipLevelCount) for this texture',
@@ -168,10 +174,24 @@ base class Texture extends NativeFieldWrapperClass1 {
         'The length of sourceBytes (bytes: ${sourceBytes.lengthInBytes}) must exactly match the size of mip level $mipLevel (bytes: $expectedSize)',
       );
     }
-    bool success = _overwrite(_gpuContext, sourceBytes, mipLevel, slice);
-    if (!success) {
-      throw Exception("Texture overwrite failed");
+    final Completer<void> completer = Completer<void>();
+    final String? error = _overwrite(
+      _gpuContext,
+      sourceBytes,
+      (bool success) {
+        if (success) {
+          completer.complete();
+        } else {
+          completer.completeError(Exception('Texture overwrite failed'));
+        }
+      },
+      mipLevel,
+      slice,
+    );
+    if (error != null) {
+      throw Exception(error);
     }
+    await completer.future;
   }
 
   ui.Image asImage() {
@@ -226,12 +246,13 @@ base class Texture extends NativeFieldWrapperClass1 {
   )
   external int _bytesPerTexel();
 
-  @Native<Bool Function(Pointer<Void>, Pointer<Void>, Handle, Int, Int)>(
-    symbol: 'InternalFlutterGpu_Texture_Overwrite',
-  )
-  external bool _overwrite(
+  @Native<
+    Handle Function(Pointer<Void>, Pointer<Void>, Handle, Handle, Int, Int)
+  >(symbol: 'InternalFlutterGpu_Texture_Overwrite')
+  external String? _overwrite(
     GpuContext gpuContext,
     ByteData bytes,
+    CompletionCallback completionCallback,
     int mipLevel,
     int slice,
   );

--- a/engine/src/flutter/lib/gpu/texture.cc
+++ b/engine/src/flutter/lib/gpu/texture.cc
@@ -4,6 +4,8 @@
 
 #include "flutter/lib/gpu/texture.h"
 
+#include <atomic>
+
 #include "flutter/lib/gpu/formats.h"
 #include "flutter/lib/ui/painting/image.h"
 #include "flutter/lib/ui/ui_dart_state.h"
@@ -23,6 +25,7 @@
 #if IMPELLER_SUPPORTS_RENDERING
 #include "impeller/display_list/dl_image_impeller.h"  // nogncheck
 #endif
+#include "tonic/converter/dart_converter.h"
 #include "third_party/tonic/typed_data/dart_byte_data.h"
 
 namespace flutter {
@@ -54,6 +57,13 @@ static int32_t MipDimensionAtLevel(int32_t base_dimension, uint32_t mip_level) {
   return shifted > 0 ? shifted : 1;
 }
 
+static void CompleteOverwriteWithError(
+    const impeller::CommandBuffer::CompletionCallback& completion_callback) {
+  if (completion_callback) {
+    completion_callback(impeller::CommandBuffer::Status::kError);
+  }
+}
+
 // Records a blit-pass that copies `source_bytes` into the given mip level and
 // slice of `texture` on `context`, then submits the command buffer. Returns
 // true if the encode and submit both succeed. The actual GPU upload may
@@ -65,33 +75,46 @@ static bool EncodeAndSubmitOverwrite(
     size_t source_length,
     impeller::IRect destination_region,
     uint32_t mip_level,
-    uint32_t slice) {
+    uint32_t slice,
+    const impeller::CommandBuffer::CompletionCallback& completion_callback) {
   auto command_buffer = context.CreateCommandBuffer();
   if (!command_buffer) {
     FML_LOG(ERROR) << "Failed to create command buffer for texture overwrite.";
+    CompleteOverwriteWithError(completion_callback);
     return false;
   }
   auto blit_pass = command_buffer->CreateBlitPass();
   if (!blit_pass) {
     FML_LOG(ERROR) << "Failed to create blit pass for texture overwrite.";
+    CompleteOverwriteWithError(completion_callback);
     return false;
   }
   impeller::BufferView buffer_view(staging_buffer,
                                    impeller::Range(0, source_length));
   if (!blit_pass->AddCopy(std::move(buffer_view), texture, destination_region,
                           /*label=*/"Texture.overwrite", mip_level, slice)) {
+    CompleteOverwriteWithError(completion_callback);
     return false;
   }
   if (!blit_pass->EncodeCommands()) {
+    CompleteOverwriteWithError(completion_callback);
     return false;
   }
-  return context.GetCommandQueue()->Submit({std::move(command_buffer)}).ok();
+  if (!context.GetCommandQueue()
+           ->Submit({std::move(command_buffer)}, completion_callback)
+           .ok()) {
+    CompleteOverwriteWithError(completion_callback);
+    return false;
+  }
+  return true;
 }
 
-bool Texture::Overwrite(Context& gpu_context,
-                        const tonic::DartByteData& source_bytes,
-                        uint32_t mip_level,
-                        uint32_t slice) {
+void Texture::Overwrite(
+    Context& gpu_context,
+    const tonic::DartByteData& source_bytes,
+    uint32_t mip_level,
+    uint32_t slice,
+    const impeller::CommandBuffer::CompletionCallback& completion_callback) {
   const uint8_t* data = static_cast<const uint8_t*>(source_bytes.data());
   const size_t length = source_bytes.length_in_bytes();
 
@@ -102,7 +125,8 @@ bool Texture::Overwrite(Context& gpu_context,
   if (!staging_buffer) {
     FML_LOG(ERROR) << "Failed to allocate staging buffer for texture "
                       "overwrite.";
-    return false;
+    CompleteOverwriteWithError(completion_callback);
+    return;
   }
 
   // Compute the destination region for the requested mip level. The
@@ -125,24 +149,27 @@ bool Texture::Overwrite(Context& gpu_context,
     auto context_shared = gpu_context.GetContextShared();
     task_runners.GetRasterTaskRunner()->PostTask(fml::MakeCopyable(
         [context_shared, texture = texture_, staging_buffer, length,
-         destination_region, mip_level, slice]() mutable {
+         destination_region, mip_level, slice,
+         completion_callback]() mutable {
           if (!EncodeAndSubmitOverwrite(*context_shared, texture,
                                         staging_buffer, length,
-                                        destination_region, mip_level, slice)) {
-            FML_LOG(ERROR) << "Failed to encode texture overwrite blit on the "
+                                        destination_region, mip_level, slice,
+                                        completion_callback)) {
+            FML_LOG(ERROR) << "Failed to submit Texture.overwrite on the "
                               "raster thread.";
           }
           context_shared->DisposeThreadLocalCachedResources();
         }));
-    return true;
+    return;
   }
 
   if (!EncodeAndSubmitOverwrite(impeller_context, texture_, staging_buffer,
-                                length, destination_region, mip_level, slice)) {
-    return false;
+                                length, destination_region, mip_level, slice,
+                                completion_callback)) {
+    impeller_context.DisposeThreadLocalCachedResources();
+    return;
   }
   impeller_context.DisposeThreadLocalCachedResources();
-  return true;
 }
 
 size_t Texture::GetBytesPerTexel() {
@@ -243,17 +270,59 @@ void InternalFlutterGpu_Texture_SetCoordinateSystem(
       flutter::gpu::ToImpellerTextureCoordinateSystem(coordinate_system));
 }
 
-bool InternalFlutterGpu_Texture_Overwrite(flutter::gpu::Texture* texture,
-                                          flutter::gpu::Context* gpu_context,
-                                          Dart_Handle source_byte_data,
-                                          int mip_level,
-                                          int slice) {
+Dart_Handle InternalFlutterGpu_Texture_Overwrite(
+    flutter::gpu::Texture* texture,
+    flutter::gpu::Context* gpu_context,
+    Dart_Handle source_byte_data,
+    Dart_Handle completion_callback,
+    int mip_level,
+    int slice) {
   if (mip_level < 0 || slice < 0) {
-    return false;
+    return tonic::ToDart("mipLevel and slice must be non-negative");
   }
-  return texture->Overwrite(*gpu_context, tonic::DartByteData(source_byte_data),
-                            static_cast<uint32_t>(mip_level),
-                            static_cast<uint32_t>(slice));
+  if (!Dart_IsClosure(completion_callback)) {
+    return tonic::ToDart("Completion callback must be a function");
+  }
+
+  auto dart_state = flutter::UIDartState::Current();
+  auto& task_runners = dart_state->GetTaskRunners();
+  auto persistent_completion_callback =
+      std::make_unique<tonic::DartPersistentValue>(dart_state,
+                                                   completion_callback);
+  auto completion_sent = std::make_shared<std::atomic_bool>(false);
+
+  auto ui_task_completion_callback = fml::MakeCopyable(
+      [callback = std::move(persistent_completion_callback),
+       task_runners,
+       completion_sent](impeller::CommandBuffer::Status status) mutable {
+        if (completion_sent->exchange(true)) {
+          return;
+        }
+        bool success = status != impeller::CommandBuffer::Status::kError;
+
+        auto ui_completion_task = fml::MakeCopyable(
+            [callback = std::move(callback), success]() mutable {
+              auto dart_state = callback->dart_state().lock();
+              if (!dart_state) {
+                // The root isolate could have died in the meantime.
+                return;
+              }
+              tonic::DartState::Scope scope(dart_state);
+
+              tonic::DartInvoke(callback->Get(), {tonic::ToDart(success)});
+
+              // callback is associated with the Dart isolate and must be
+              // deleted on the UI thread.
+              callback.reset();
+            });
+        task_runners.GetUITaskRunner()->PostTask(ui_completion_task);
+      });
+
+  texture->Overwrite(*gpu_context, tonic::DartByteData(source_byte_data),
+                     static_cast<uint32_t>(mip_level),
+                     static_cast<uint32_t>(slice),
+                     ui_task_completion_callback);
+  return Dart_Null();
 }
 
 extern int InternalFlutterGpu_Texture_BytesPerTexel(

--- a/engine/src/flutter/lib/gpu/texture.h
+++ b/engine/src/flutter/lib/gpu/texture.h
@@ -9,6 +9,7 @@
 #include "flutter/lib/gpu/export.h"
 #include "flutter/lib/ui/dart_wrapper.h"
 #include "impeller/core/formats.h"
+#include "impeller/renderer/command_buffer.h"
 #include "third_party/tonic/typed_data/dart_byte_data.h"
 
 namespace flutter {
@@ -27,10 +28,12 @@ class Texture : public RefCountedDartWrappable<Texture> {
 
   void SetCoordinateSystem(impeller::TextureCoordinateSystem coordinate_system);
 
-  bool Overwrite(Context& gpu_context,
-                 const tonic::DartByteData& source_bytes,
-                 uint32_t mip_level,
-                 uint32_t slice);
+  void Overwrite(
+      Context& gpu_context,
+      const tonic::DartByteData& source_bytes,
+      uint32_t mip_level,
+      uint32_t slice,
+      const impeller::CommandBuffer::CompletionCallback& completion_callback);
 
   size_t GetBytesPerTexel();
 
@@ -73,10 +76,11 @@ extern void InternalFlutterGpu_Texture_SetCoordinateSystem(
     int coordinate_system);
 
 FLUTTER_GPU_EXPORT
-extern bool InternalFlutterGpu_Texture_Overwrite(
+extern Dart_Handle InternalFlutterGpu_Texture_Overwrite(
     flutter::gpu::Texture* wrapper,
     flutter::gpu::Context* gpu_context,
     Dart_Handle source_byte_data,
+    Dart_Handle completion_callback,
     int mip_level,
     int slice);
 

--- a/engine/src/flutter/testing/dart/gpu_test.dart
+++ b/engine/src/flutter/testing/dart/gpu_test.dart
@@ -395,7 +395,7 @@ void main() async {
 
     const red = ui.Color.fromARGB(0xFF, 0xFF, 0, 0);
     const green = ui.Color.fromARGB(0xFF, 0, 0xFF, 0);
-    texture.overwrite(
+    await texture.overwrite(
       Int32List.fromList(<int>[red.value, green.value, green.value, red.value]).buffer.asByteData(),
     );
   }, skip: !(impellerEnabled && flutterGpuEnabled));
@@ -405,7 +405,7 @@ void main() async {
 
     const red = ui.Color.fromARGB(0xFF, 0xFF, 0, 0);
     try {
-      texture.overwrite(
+      await texture.overwrite(
         Int32List.fromList(<int>[red.value, red.value, red.value, red.value]).buffer.asByteData(),
       );
       fail('Exception not thrown for wrong buffer size.');
@@ -430,14 +430,16 @@ void main() async {
     const blue = ui.Color.fromARGB(0xFF, 0, 0, 0xFF);
 
     // Mip 0: 8x8 = 64 texels.
-    texture.overwrite(Int32List.fromList(List<int>.filled(64, red.value)).buffer.asByteData());
+    await texture.overwrite(
+      Int32List.fromList(List<int>.filled(64, red.value)).buffer.asByteData(),
+    );
     // Mip 1: 4x4 = 16 texels.
-    texture.overwrite(
+    await texture.overwrite(
       Int32List.fromList(List<int>.filled(16, blue.value)).buffer.asByteData(),
       mipLevel: 1,
     );
     // Mip 2: 2x2 = 4 texels.
-    texture.overwrite(
+    await texture.overwrite(
       Int32List.fromList(List<int>.filled(4, red.value)).buffer.asByteData(),
       mipLevel: 2,
     );
@@ -452,7 +454,10 @@ void main() async {
     );
     const red = ui.Color.fromARGB(0xFF, 0xFF, 0, 0);
     try {
-      texture.overwrite(Int32List.fromList(<int>[red.value]).buffer.asByteData(), mipLevel: 2);
+      await texture.overwrite(
+        Int32List.fromList(<int>[red.value]).buffer.asByteData(),
+        mipLevel: 2,
+      );
       fail('Exception not thrown for out-of-range mipLevel.');
     } catch (e) {
       expect(e.toString(), contains('mipLevel (2) must be in the range [0, 2)'));
@@ -463,7 +468,7 @@ void main() async {
     final gpu.Texture texture = gpu.gpuContext.createTexture(gpu.StorageMode.hostVisible, 2, 2);
     const red = ui.Color.fromARGB(0xFF, 0xFF, 0, 0);
     try {
-      texture.overwrite(
+      await texture.overwrite(
         Int32List.fromList(List<int>.filled(4, red.value)).buffer.asByteData(),
         slice: 1,
       );
@@ -491,7 +496,10 @@ void main() async {
     ];
     for (var slice = 0; slice < 6; slice++) {
       final int v = colors[slice].value;
-      texture.overwrite(Int32List.fromList(<int>[v, v, v, v]).buffer.asByteData(), slice: slice);
+      await texture.overwrite(
+        Int32List.fromList(<int>[v, v, v, v]).buffer.asByteData(),
+        slice: slice,
+      );
     }
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 


### PR DESCRIPTION
Related to https://github.com/flutter/flutter/pull/185890.

This makes `Texture.overwrite` return `Future<void>` so callers can await completion of the texture upload before sampling the texture.

On GLES, `Texture.overwrite` previously looked synchronous even though it posted upload work to the raster task runner. If the GLES backend could not submit that work yet, callers had no way to observe the failure or order initialization around upload completion. That is a common foot gun for Flutter GPU renderers because `gpuContext` existing does not mean every queued texture upload has completed.

This PR changes the native binding to complete a Dart callback from the command buffer completion path, routes encode and submit failures through that callback, and updates GPU tests to await texture overwrites.

Issue: none. Flutter GPU is experimental, and this is an intentional breaking correction to an experimental API.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
