### PR TITLE
Fix RangeError in PredictiveBackEvent.fromMap

### DIFF
--- a/packages/flutter/lib/src/material/predictive_back_page_transitions_builder.dart
+++ b/packages/flutter/lib/src/material/predictive_back_page_transitions_builder.dart
@@ -459,6 +459,7 @@ class _PredictiveBackSharedElementPageTransitionState
         begin: switch (widget.currentBackEvent?.swipeEdge) {
           SwipeEdge.left => Offset(xShift, _getYShiftPosition(screenSize.height)),
           SwipeEdge.right => Offset(-xShift, _getYShiftPosition(screenSize.height)),
+          SwipeEdge.none => Offset(xShift, _getYShiftPosition(screenSize.height)),
           null => Offset(xShift, _getYShiftPosition(screenSize.height)),
         },
         end: Offset.zero,

--- a/packages/flutter/lib/src/services/predictive_back_event.dart
+++ b/packages/flutter/lib/src/services/predictive_back_event.dart
@@ -34,13 +34,33 @@ final class PredictiveBackEvent {
   /// Creates an [PredictiveBackEvent] from a Map, typically used when converting
   /// data received from a platform channel.
   factory PredictiveBackEvent.fromMap(Map<String?, Object?> map) {
-    final touchOffset = map['touchOffset'] as List<Object?>?;
+    final Object? rawTouchOffset = map['touchOffset'];
+    final List<Object?>? touchOffsetList = rawTouchOffset is List<Object?> ? rawTouchOffset : null;
+    final Offset? parsedTouchOffset;
+    if (touchOffsetList != null &&
+        touchOffsetList.length >= 2 &&
+        touchOffsetList[0] is num &&
+        touchOffsetList[1] is num) {
+      parsedTouchOffset = Offset(
+        (touchOffsetList[0]! as num).toDouble(),
+        (touchOffsetList[1]! as num).toDouble(),
+      );
+    } else {
+      parsedTouchOffset = null;
+    }
+
+    final Object? rawSwipeEdge = map['swipeEdge'];
+    final SwipeEdge parsedSwipeEdge;
+    if (rawSwipeEdge is int && rawSwipeEdge >= 0 && rawSwipeEdge < SwipeEdge.values.length) {
+      parsedSwipeEdge = SwipeEdge.values[rawSwipeEdge];
+    } else {
+      parsedSwipeEdge = SwipeEdge.left;
+    }
+
     return PredictiveBackEvent._(
-      touchOffset: touchOffset == null
-          ? null
-          : Offset((touchOffset[0]! as num).toDouble(), (touchOffset[1]! as num).toDouble()),
+      touchOffset: parsedTouchOffset,
       progress: (map['progress']! as num).toDouble(),
-      swipeEdge: SwipeEdge.values[map['swipeEdge']! as int],
+      swipeEdge: parsedSwipeEdge,
     );
   }
 

--- a/packages/flutter/lib/src/services/predictive_back_event.dart
+++ b/packages/flutter/lib/src/services/predictive_back_event.dart
@@ -16,6 +16,11 @@ enum SwipeEdge {
 
   /// Indicates that the swipe gesture starts from the right edge of the screen.
   right,
+
+  /// Indicates that the swipe gesture does not start from either edge.
+  ///
+  /// Introduced in Android API 36 (BackEvent.EDGE_NONE).
+  none,
 }
 
 /// Object used to report back gesture progress in Android.
@@ -54,7 +59,7 @@ final class PredictiveBackEvent {
     if (rawSwipeEdge is int && rawSwipeEdge >= 0 && rawSwipeEdge < SwipeEdge.values.length) {
       parsedSwipeEdge = SwipeEdge.values[rawSwipeEdge];
     } else {
-      parsedSwipeEdge = SwipeEdge.left;
+      parsedSwipeEdge = SwipeEdge.none;
     }
 
     return PredictiveBackEvent._(

--- a/packages/flutter/test/services/predictive_back_event_test.dart
+++ b/packages/flutter/test/services/predictive_back_event_test.dart
@@ -26,6 +26,16 @@ void main() {
     expect(event.isButtonEvent, isFalse);
   });
 
+  test('fromMap can be created with valid Map - SwipeEdge.none', () async {
+    final event = PredictiveBackEvent.fromMap(const <String?, Object?>{
+      'touchOffset': <double>[0.0, 100.0],
+      'progress': 0.0,
+      'swipeEdge': 2,
+    });
+    expect(event.swipeEdge, SwipeEdge.none);
+    expect(event.isButtonEvent, isFalse);
+  });
+
   test('fromMap can be created with valid Map - isButtonEvent zero position', () async {
     final event = PredictiveBackEvent.fromMap(const <String?, Object?>{
       'touchOffset': <double>[0.0, 0.0],
@@ -73,13 +83,40 @@ void main() {
     expect(event.touchOffset, isNull);
   });
 
-  test('fromMap handles invalid swipeEdge safely', () async {
+  test('fromMap handles invalid swipeEdge safely - out of bounds positive', () async {
     final event = PredictiveBackEvent.fromMap(const <String?, Object?>{
       'touchOffset': <double>[0.0, 100.0],
       'progress': 0.0,
-      'swipeEdge': 2,
+      'swipeEdge': 3,
     });
-    expect(event.swipeEdge, SwipeEdge.left);
+    expect(event.swipeEdge, SwipeEdge.none);
+  });
+
+  test('fromMap handles invalid swipeEdge safely - out of bounds negative', () async {
+    final event = PredictiveBackEvent.fromMap(const <String?, Object?>{
+      'touchOffset': <double>[0.0, 100.0],
+      'progress': 0.0,
+      'swipeEdge': -1,
+    });
+    expect(event.swipeEdge, SwipeEdge.none);
+  });
+
+  test('fromMap handles invalid swipeEdge safely - invalid type', () async {
+    final event = PredictiveBackEvent.fromMap(const <String?, Object?>{
+      'touchOffset': <double>[0.0, 100.0],
+      'progress': 0.0,
+      'swipeEdge': 'invalid',
+    });
+    expect(event.swipeEdge, SwipeEdge.none);
+  });
+
+  test('fromMap handles invalid swipeEdge safely - null', () async {
+    final event = PredictiveBackEvent.fromMap(const <String?, Object?>{
+      'touchOffset': <double>[0.0, 100.0],
+      'progress': 0.0,
+      'swipeEdge': null,
+    });
+    expect(event.swipeEdge, SwipeEdge.none);
   });
 
   test('equality when created with the same parameters', () async {

--- a/packages/flutter/test/services/predictive_back_event_test.dart
+++ b/packages/flutter/test/services/predictive_back_event_test.dart
@@ -55,15 +55,31 @@ void main() {
     );
   });
 
-  test('fromMap throws when given invalid swipeEdge', () async {
-    expect(
-      () => PredictiveBackEvent.fromMap(const <String?, Object?>{
-        'touchOffset': <double>[0.0, 100.0],
-        'progress': 0.0,
-        'swipeEdge': 2,
-      }),
-      throwsRangeError,
-    );
+  test('fromMap handles empty touchOffset list safely', () async {
+    final event = PredictiveBackEvent.fromMap(const <String?, Object?>{
+      'touchOffset': <double>[],
+      'progress': 0.0,
+      'swipeEdge': 0,
+    });
+    expect(event.touchOffset, isNull);
+  });
+
+  test('fromMap handles 1-element touchOffset list safely', () async {
+    final event = PredictiveBackEvent.fromMap(const <String?, Object?>{
+      'touchOffset': <double>[0.0],
+      'progress': 0.0,
+      'swipeEdge': 0,
+    });
+    expect(event.touchOffset, isNull);
+  });
+
+  test('fromMap handles invalid swipeEdge safely', () async {
+    final event = PredictiveBackEvent.fromMap(const <String?, Object?>{
+      'touchOffset': <double>[0.0, 100.0],
+      'progress': 0.0,
+      'swipeEdge': 2,
+    });
+    expect(event.swipeEdge, SwipeEdge.left);
   });
 
   test('equality when created with the same parameters', () async {


### PR DESCRIPTION
Adds defensive checks and handles Android's BackEvent.EDGE_NONE.

Fixes: #186168:

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.