### PR TITLE
Remove the Y coordinate flip workaround in the Material stretch effect shader now that it is no longer required by the Impeller GLES back end

### DIFF
--- a/packages/flutter/lib/src/material/shaders/stretch_effect.frag
+++ b/packages/flutter/lib/src/material/shaders/stretch_effect.frag
@@ -149,11 +149,7 @@ void main() {
   ) : in_v_norm;
 
   uv.x = out_u_norm;
-  #ifdef IMPELLER_TARGET_OPENGLES
-  uv.y = 1.0 - out_v_norm;
-  #else
   uv.y = out_v_norm;
-  #endif
 
   frag_color = texture(u_texture, uv);
 }


### PR DESCRIPTION
https://github.com/flutter/flutter/pull/186556 makes the behavior of the Y axis in the GLES back end consistent with other Impeller back ends.  Shaders will render incorrectly if they continue to flip the Y axis based on "#ifdef IMPELLER_TARGET_OPENGLES".