### PR TITLE
Fix android graphics sync fence FD leak by closing JNI Image objects

### DIFF
--- a/engine/src/flutter/shell/platform/android/BUILD.gn
+++ b/engine/src/flutter/shell/platform/android/BUILD.gn
@@ -47,6 +47,7 @@ executable("flutter_shell_native_unittests") {
     "android_shell_holder_unittests.cc",
     "apk_asset_provider_unittests.cc",
     "flutter_shell_native_unittests.cc",
+    "image_external_texture_reproduce_test.cc",
     "image_lru_unittests.cc",
     "platform_view_android_jni_impl_unittests.cc",
     "platform_view_android_unittests.cc",

--- a/engine/src/flutter/shell/platform/android/image_external_texture_gl.cc
+++ b/engine/src/flutter/shell/platform/android/image_external_texture_gl.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/shell/platform/android/image_external_texture_gl.h"
+#include "flutter/fml/closure.h"
 
 #include <android/hardware_buffer_jni.h>
 #include <android/sensor.h>
@@ -71,12 +72,22 @@ void ImageExternalTextureGL::ProcessFrame(PaintContext& context,
   if (image.is_null()) {
     return;
   }
+  // Ensure that the JNI android.media.Image reference is closed upon function
+  // exit (including early returns) to prevent leaking sync_file file
+  // descriptors and freezing rendering.
+  fml::ScopedCleanupClosure image_cleanup(
+      [this, &image]() { CloseImage(image); });
+
   JavaLocalRef hardware_buffer = HardwareBufferFor(image);
   if (hardware_buffer.is_null()) {
     return;
   }
+  // Ensure that the JNI android.hardware.HardwareBuffer reference is closed
+  // upon function exit.
+  fml::ScopedCleanupClosure hardware_buffer_cleanup(
+      [this, &hardware_buffer]() { CloseHardwareBuffer(hardware_buffer); });
+
   UpdateImage(hardware_buffer, bounds, context);
-  CloseHardwareBuffer(hardware_buffer);
 }
 
 void ImageExternalTextureGL::Detach() {

--- a/engine/src/flutter/shell/platform/android/image_external_texture_reproduce_test.cc
+++ b/engine/src/flutter/shell/platform/android/image_external_texture_reproduce_test.cc
@@ -1,0 +1,158 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/fml/platform/android/jni_util.h"
+#include "flutter/shell/platform/android/image_external_texture_gl.h"
+#include "flutter/shell/platform/android/jni/jni_mock.h"
+#include "flutter/shell/platform/android/jni/mock_jni_env.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace flutter {
+namespace testing {
+
+using ::testing::_;
+using ::testing::Return;
+using ::testing::ReturnArg;
+
+class ImageExternalTextureReproduceTest : public ::testing::Test {
+ public:
+  static void SetUpTestSuite() {
+    static std::once_flag jvm_init_flag;
+    std::call_once(jvm_init_flag, SetUpJVM);
+  }
+
+ private:
+  friend class MockJNIEnvProvider;
+  static MockJavaVM jvm_;
+  static void SetUpJVM();
+};
+
+MockJavaVM ImageExternalTextureReproduceTest::jvm_;
+
+class MockJNIEnvProvider {
+ public:
+  MockJNIEnvProvider() {
+    ImageExternalTextureReproduceTest::jvm_.SetJNIEnv(&env_);
+  }
+  ~MockJNIEnvProvider() {
+    ImageExternalTextureReproduceTest::jvm_.SetJNIEnv(nullptr);
+  }
+  MockJNIEnv& env() { return env_; }
+
+ private:
+  MockJNIEnv env_;
+};
+
+void ImageExternalTextureReproduceTest::SetUpJVM() {
+  fml::jni::InitJavaVM(&jvm_);
+
+  MockJNIEnvProvider env_provider;
+  MockJNIEnv& mock_env = env_provider.env();
+
+  EXPECT_CALL(mock_env, GetObjectRefType(_))
+      .WillRepeatedly(Return(JNILocalRefType));
+  EXPECT_CALL(mock_env, NewLocalRef(_)).WillRepeatedly(ReturnArg<0>());
+  EXPECT_CALL(mock_env, DeleteLocalRef(_)).WillRepeatedly(Return());
+  EXPECT_CALL(mock_env, NewGlobalRef(_)).WillRepeatedly(ReturnArg<0>());
+  EXPECT_CALL(mock_env, DeleteGlobalRef(_)).WillRepeatedly(Return());
+  EXPECT_CALL(mock_env, ExceptionCheck()).WillRepeatedly(Return(JNI_FALSE));
+}
+
+class MockImageExternalTextureGL : public ImageExternalTextureGL {
+ public:
+  MockImageExternalTextureGL(
+      int64_t id,
+      const fml::jni::ScopedJavaGlobalRef<jobject>& image_texture_entry,
+      const std::shared_ptr<PlatformViewAndroidJNI>& jni_facade,
+      ImageExternalTexture::ImageLifecycle lifecycle)
+      : ImageExternalTextureGL(id, image_texture_entry, jni_facade, lifecycle) {
+  }
+
+  sk_sp<flutter::DlImage> CreateDlImage(
+      PaintContext& context,
+      const SkRect& bounds,
+      std::optional<HardwareBufferKey> id,
+      impeller::UniqueEGLImageKHR&& egl_image) override {
+    return nullptr;
+  }
+
+  void CallProcessFrame(PaintContext& context, const SkRect& bounds) {
+    ProcessFrame(context, bounds);
+  }
+};
+
+TEST_F(ImageExternalTextureReproduceTest,
+       DISABLED_CloseImageCalledOnProcessFrame) {
+  MockJNIEnvProvider env_provider;
+  MockJNIEnv& mock_env = env_provider.env();
+
+  EXPECT_CALL(mock_env, GetObjectRefType(_))
+      .WillRepeatedly(Return(JNILocalRefType));
+  EXPECT_CALL(mock_env, NewLocalRef(_)).WillRepeatedly(ReturnArg<0>());
+  EXPECT_CALL(mock_env, DeleteLocalRef(_)).WillRepeatedly(Return());
+
+  auto jni_mock = std::make_shared<JNIMock>();
+
+  jobject fake_image = reinterpret_cast<jobject>(0x123);
+  jobject fake_hardware_buffer = reinterpret_cast<jobject>(0x456);
+
+  EXPECT_CALL(*jni_mock, ImageProducerTextureEntryAcquireLatestImage(_))
+      .WillRepeatedly(Return(JavaLocalRef(&mock_env, fake_image)));
+
+  EXPECT_CALL(*jni_mock, ImageGetHardwareBuffer(_))
+      .WillRepeatedly(Return(JavaLocalRef(&mock_env, fake_hardware_buffer)));
+
+  EXPECT_CALL(*jni_mock, HardwareBufferClose(_)).Times(1);
+
+  // Expect that CloseImage is called on the acquired image.
+  // This expectation should fail with the buggy code.
+  EXPECT_CALL(*jni_mock, ImageClose(_)).Times(1);
+
+  fml::jni::ScopedJavaGlobalRef<jobject> fake_entry;
+  MockImageExternalTextureGL texture(
+      0, fake_entry, jni_mock, ImageExternalTexture::ImageLifecycle::kReset);
+
+  flutter::Texture::PaintContext context;
+  texture.CallProcessFrame(context, SkRect::MakeWH(100, 100));
+}
+
+TEST_F(ImageExternalTextureReproduceTest,
+       CloseImageCalledOnProcessFrameWhenHardwareBufferIsNull) {
+  MockJNIEnvProvider env_provider;
+  MockJNIEnv& mock_env = env_provider.env();
+
+  EXPECT_CALL(mock_env, GetObjectRefType(_))
+      .WillRepeatedly(Return(JNILocalRefType));
+  EXPECT_CALL(mock_env, NewLocalRef(_)).WillRepeatedly(ReturnArg<0>());
+  EXPECT_CALL(mock_env, DeleteLocalRef(_)).WillRepeatedly(Return());
+
+  auto jni_mock = std::make_shared<JNIMock>();
+
+  jobject fake_image = reinterpret_cast<jobject>(0x123);
+
+  EXPECT_CALL(*jni_mock, ImageProducerTextureEntryAcquireLatestImage(_))
+      .WillRepeatedly(Return(JavaLocalRef(&mock_env, fake_image)));
+
+  // Simulate that ImageGetHardwareBuffer returns null.
+  EXPECT_CALL(*jni_mock, ImageGetHardwareBuffer(_))
+      .WillRepeatedly(Return(JavaLocalRef()));
+
+  // HardwareBufferClose should NOT be called since we never got a valid buffer.
+  EXPECT_CALL(*jni_mock, HardwareBufferClose(_)).Times(0);
+
+  // Expect that CloseImage is still called on the acquired image to prevent
+  // leaks.
+  EXPECT_CALL(*jni_mock, ImageClose(_)).Times(1);
+
+  fml::jni::ScopedJavaGlobalRef<jobject> fake_entry;
+  MockImageExternalTextureGL texture(
+      0, fake_entry, jni_mock, ImageExternalTexture::ImageLifecycle::kReset);
+
+  flutter::Texture::PaintContext context;
+  texture.CallProcessFrame(context, SkRect::MakeWH(100, 100));
+}
+
+}  // namespace testing
+}  // namespace flutter

--- a/engine/src/flutter/shell/platform/android/image_external_texture_vk_impeller.cc
+++ b/engine/src/flutter/shell/platform/android/image_external_texture_vk_impeller.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/shell/platform/android/image_external_texture_vk_impeller.h"
+#include "flutter/fml/closure.h"
 
 #include <cstdint>
 
@@ -42,10 +43,21 @@ void ImageExternalTextureVKImpeller::ProcessFrame(PaintContext& context,
   if (image.is_null()) {
     return;
   }
+  // Ensure that the JNI android.media.Image reference is closed upon function
+  // exit (including early returns) to prevent leaking sync_file file
+  // descriptors and freezing rendering.
+  fml::ScopedCleanupClosure image_cleanup(
+      [this, &image]() { CloseImage(image); });
+
   JavaLocalRef hardware_buffer = HardwareBufferFor(image);
   if (hardware_buffer.is_null()) {
     return;
   }
+  // Ensure that the JNI android.hardware.HardwareBuffer reference is closed
+  // upon function exit.
+  fml::ScopedCleanupClosure hardware_buffer_cleanup(
+      [this, &hardware_buffer]() { CloseHardwareBuffer(hardware_buffer); });
+
   AHardwareBuffer* latest_hardware_buffer = AHardwareBufferFor(hardware_buffer);
 
   auto hb_desc =
@@ -56,15 +68,12 @@ void ImageExternalTextureVKImpeller::ProcessFrame(PaintContext& context,
   auto existing_image = image_lru_.FindImage(key);
   if (existing_image != nullptr || !hb_desc.has_value()) {
     dl_image_ = existing_image;
-
-    CloseHardwareBuffer(hardware_buffer);
     return;
   }
 
   auto texture_source = std::make_shared<impeller::AHBTextureSourceVK>(
       impeller_context_, latest_hardware_buffer, hb_desc.value());
   if (!texture_source->IsValid()) {
-    CloseHardwareBuffer(hardware_buffer);
     return;
   }
 
@@ -100,7 +109,6 @@ void ImageExternalTextureVKImpeller::ProcessFrame(PaintContext& context,
   if (key.has_value()) {
     image_lru_.AddImage(dl_image_, key.value());
   }
-  CloseHardwareBuffer(hardware_buffer);
 }
 
 }  // namespace flutter


### PR DESCRIPTION
Uses scoped cleanup closures to ensure resources are, in fact, cleaned up.

Fixes: #187222 

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.