### PR TITLE
[Android] Add integration test for SystemUiMode transitions

### DIFF
--- a/dev/integration_tests/android_engine_test/README.md
+++ b/dev/integration_tests/android_engine_test/README.md
@@ -35,6 +35,7 @@ on an Android device or emulator.
 - [`platform_view/texture_layer_hybrid_composition_platform_view`](#platform_viewtexture_layer_hybrid_composition_platform_view)
 - [`platform_view/virtual_display_platform_view`](#platform_viewvirtual_display_platform_view)
 - [`platform_view_tap_color_change`](#platform_view_tap_color_change)
+- [`system_ui_mode_transitions`](#system_ui_mode_transitions)
 
 ### `flutter_rendered_blue_rectangle`
 
@@ -141,6 +142,29 @@ $ flutter run lib/platform_view_tap_color_change_main.dart
 
 # Run the test
 $ flutter drive lib/platform_view_tap_color_change_main_test.dart
+```
+
+### `system_ui_mode_transitions`
+
+This app exposes a Flutter Driver `requestData` handler that applies
+`SystemUiMode` values in sequence and reads the resulting decor-view
+`systemUiVisibility` flags via the `native_driver` method channel. The
+companion test driver asserts that switching to `edgeToEdge` from any
+hiding mode (`leanBack`/`immersive`/`immersiveSticky`) clears
+`FLAG_FULLSCREEN`/`FLAG_HIDE_NAVIGATION`, and that switching from
+`edgeToEdge` to a hiding mode applies the expected immersive flags.
+
+The regression-named test reproduces
+[#186723](https://github.com/flutter/flutter/issues/186723) on the
+`immersiveSticky → edgeToEdge` cell. Requires Android 10 (API 29) or
+later; older API levels skip.
+
+```sh
+# Run the app
+$ flutter run lib/system_ui_mode_transitions_main.dart
+
+# Run the test
+$ flutter drive lib/system_ui_mode_transitions_main.dart
 ```
 
 ## Deflaking

--- a/dev/integration_tests/android_engine_test/android/app/src/main/kotlin/com/example/native_driver_test/extensions/NativeDriverSupportPlugin.kt
+++ b/dev/integration_tests/android_engine_test/android/app/src/main/kotlin/com/example/native_driver_test/extensions/NativeDriverSupportPlugin.kt
@@ -60,6 +60,11 @@ class NativeDriverSupportPlugin :
             "ping" -> {
                 result.success(null)
             }
+            "get_system_ui_visibility" -> {
+                @Suppress("DEPRECATION")
+                val flags = activity.window.decorView.systemUiVisibility
+                result.success(mapOf("system_ui_visibility" to flags))
+            }
             "tap_view" -> {
                 // Decode the selector.
                 val kind = call.argument<String>("kind")

--- a/dev/integration_tests/android_engine_test/lib/system_ui_mode_transitions_main.dart
+++ b/dev/integration_tests/android_engine_test/lib/system_ui_mode_transitions_main.dart
@@ -1,0 +1,69 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:android_driver_extensions/extension.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_driver/driver_extension.dart';
+
+import 'src/allow_list_devices.dart';
+
+/// Test harness for verifying `SystemUiMode` transitions on Android.
+///
+/// The companion test driver issues `flutterDriver.requestData(...)` calls
+/// to apply modes and read the resulting decor-view `systemUiVisibility`
+/// flags, which is the most direct signal of the regression class addressed
+/// by https://github.com/flutter/flutter/pull/187207.
+const MethodChannel _nativeDriver = MethodChannel('native_driver');
+
+const Map<String, SystemUiMode> _modesByName = <String, SystemUiMode>{
+  'leanBack': SystemUiMode.leanBack,
+  'immersive': SystemUiMode.immersive,
+  'immersiveSticky': SystemUiMode.immersiveSticky,
+  'edgeToEdge': SystemUiMode.edgeToEdge,
+};
+
+void main() {
+  ensureAndroidDevice();
+  enableFlutterDriverExtension(
+    handler: _handleCommand,
+    commands: <CommandExtension>[nativeDriverCommands],
+  );
+  runApp(const _App());
+}
+
+Future<String> _handleCommand(String? command) async {
+  if (command == null || command.isEmpty) {
+    throw ArgumentError.value(command, 'command', 'must not be null or empty');
+  }
+  if (command == 'getSystemUiVisibility') {
+    final Map<Object?, Object?>? raw = await _nativeDriver
+        .invokeMethod<Map<Object?, Object?>>('get_system_ui_visibility');
+    final int flags = (raw?['system_ui_visibility'] as int?) ?? 0;
+    return json.encode(<String, Object?>{'systemUiVisibility': flags});
+  }
+  if (command.startsWith('applyMode:')) {
+    final String name = command.substring('applyMode:'.length);
+    final SystemUiMode? mode = _modesByName[name];
+    if (mode == null) {
+      throw ArgumentError.value(name, 'mode', 'unknown SystemUiMode');
+    }
+    await SystemChrome.setEnabledSystemUIMode(mode);
+    return json.encode(<String, Object?>{'mode': name});
+  }
+  throw ArgumentError.value(command, 'command', 'unrecognized');
+}
+
+class _App extends StatelessWidget {
+  const _App();
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      home: ColoredBox(color: Color(0xFF202020)),
+    );
+  }
+}

--- a/dev/integration_tests/android_engine_test/test_driver/system_ui_mode_transitions_main_test.dart
+++ b/dev/integration_tests/android_engine_test/test_driver/system_ui_mode_transitions_main_test.dart
@@ -1,0 +1,132 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:android_driver_extensions/native_driver.dart';
+import 'package:flutter_driver/flutter_driver.dart';
+import 'package:test/test.dart';
+
+/// Mirrors the [`android.view.View`](https://developer.android.com/reference/android/view/View)
+/// `SYSTEM_UI_FLAG_*` constants used by the `PlatformPlugin` Android embedding
+/// code. These are stable platform values.
+const int _kFlagHideNavigation = 0x2; // SYSTEM_UI_FLAG_HIDE_NAVIGATION
+const int _kFlagFullscreen = 0x4; // SYSTEM_UI_FLAG_FULLSCREEN
+const int _kFlagImmersive = 0x800; // SYSTEM_UI_FLAG_IMMERSIVE
+const int _kFlagImmersiveSticky = 0x1000; // SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+
+/// Edge-to-edge mode requires Android 10 (API 29) or later.
+const int _kEdgeToEdgeMinSdk = 29;
+
+late FlutterDriver flutterDriver;
+late NativeDriver nativeDriver;
+
+Future<void> _applyMode(String mode) async {
+  await flutterDriver.requestData('applyMode:$mode');
+}
+
+Future<int> _systemUiVisibility() async {
+  final String raw = await flutterDriver.requestData('getSystemUiVisibility');
+  final decoded = json.decode(raw) as Map<String, Object?>;
+  return decoded['systemUiVisibility']! as int;
+}
+
+Future<int> _transitionAndRead(String from, String to) async {
+  await _applyMode(from);
+  await _applyMode(to);
+  return _systemUiVisibility();
+}
+
+void main() {
+  setUpAll(() async {
+    flutterDriver = await FlutterDriver.connect();
+    nativeDriver = await AndroidNativeDriver.connect(flutterDriver);
+  });
+
+  tearDownAll(() async {
+    await nativeDriver.close();
+    await flutterDriver.close();
+  });
+
+  group('SystemUiMode transitions', () {
+    test(
+      'immersiveSticky → edgeToEdge clears FULLSCREEN/HIDE_NAVIGATION (regression for #186723)',
+      () async {
+        final int sdk = await nativeDriver.sdkVersion;
+        if (sdk < _kEdgeToEdgeMinSdk) {
+          markTestSkipped('edgeToEdge requires API $_kEdgeToEdgeMinSdk+, device is API $sdk');
+          return;
+        }
+        final int flags = await _transitionAndRead('immersiveSticky', 'edgeToEdge');
+        expect(
+          flags & (_kFlagFullscreen | _kFlagHideNavigation),
+          0,
+          reason:
+              'After switching to edgeToEdge, FULLSCREEN/HIDE_NAVIGATION must not '
+              'persist from the prior immersiveSticky mode. systemUiVisibility=0x'
+              '${flags.toRadixString(16)}',
+        );
+      },
+      timeout: Timeout.none,
+    );
+
+    test('immersive → edgeToEdge clears FULLSCREEN/HIDE_NAVIGATION', () async {
+      final int sdk = await nativeDriver.sdkVersion;
+      if (sdk < _kEdgeToEdgeMinSdk) {
+        markTestSkipped('edgeToEdge requires API $_kEdgeToEdgeMinSdk+, device is API $sdk');
+        return;
+      }
+      final int flags = await _transitionAndRead('immersive', 'edgeToEdge');
+      expect(flags & (_kFlagFullscreen | _kFlagHideNavigation), 0);
+    }, timeout: Timeout.none);
+
+    test('leanBack → edgeToEdge clears FULLSCREEN/HIDE_NAVIGATION', () async {
+      final int sdk = await nativeDriver.sdkVersion;
+      if (sdk < _kEdgeToEdgeMinSdk) {
+        markTestSkipped('edgeToEdge requires API $_kEdgeToEdgeMinSdk+, device is API $sdk');
+        return;
+      }
+      final int flags = await _transitionAndRead('leanBack', 'edgeToEdge');
+      expect(flags & (_kFlagFullscreen | _kFlagHideNavigation), 0);
+    }, timeout: Timeout.none);
+
+    test('edgeToEdge → immersive sets IMMERSIVE | FULLSCREEN | HIDE_NAVIGATION', () async {
+      final int sdk = await nativeDriver.sdkVersion;
+      if (sdk < _kEdgeToEdgeMinSdk) {
+        markTestSkipped('edgeToEdge requires API $_kEdgeToEdgeMinSdk+, device is API $sdk');
+        return;
+      }
+      final int flags = await _transitionAndRead('edgeToEdge', 'immersive');
+      const int expected = _kFlagImmersive | _kFlagFullscreen | _kFlagHideNavigation;
+      expect(flags & expected, expected);
+    }, timeout: Timeout.none);
+
+    test(
+      'edgeToEdge → immersiveSticky sets IMMERSIVE_STICKY | FULLSCREEN | HIDE_NAVIGATION',
+      () async {
+        final int sdk = await nativeDriver.sdkVersion;
+        if (sdk < _kEdgeToEdgeMinSdk) {
+          markTestSkipped('edgeToEdge requires API $_kEdgeToEdgeMinSdk+, device is API $sdk');
+          return;
+        }
+        final int flags = await _transitionAndRead('edgeToEdge', 'immersiveSticky');
+        const int expected = _kFlagImmersiveSticky | _kFlagFullscreen | _kFlagHideNavigation;
+        expect(flags & expected, expected);
+      },
+      timeout: Timeout.none,
+    );
+
+    test('edgeToEdge → leanBack sets FULLSCREEN | HIDE_NAVIGATION (no IMMERSIVE)', () async {
+      final int sdk = await nativeDriver.sdkVersion;
+      if (sdk < _kEdgeToEdgeMinSdk) {
+        markTestSkipped('edgeToEdge requires API $_kEdgeToEdgeMinSdk+, device is API $sdk');
+        return;
+      }
+      final int flags = await _transitionAndRead('edgeToEdge', 'leanBack');
+      const int hideMask = _kFlagFullscreen | _kFlagHideNavigation;
+      expect(flags & hideMask, hideMask);
+      expect(flags & (_kFlagImmersive | _kFlagImmersiveSticky), 0);
+    }, timeout: Timeout.none);
+  });
+}


### PR DESCRIPTION
## Summary

Adds a Flutter Driver integration test under `dev/integration_tests/android_engine_test/` covering `SystemUiMode` transitions on Android. The test exposes a `requestData` handler that applies modes via `SystemChrome.setEnabledSystemUIMode` and reads the resulting decor-view `systemUiVisibility` flags via a new `get_system_ui_visibility` method on the existing `native_driver` method channel.

Closes #187265.

## Why

#186723 was a P1 regression introduced by #183072 and fixed by #187207. The Mockito-based `PlatformPluginTest` unit tests verify which APIs are called on a mocked `Window`/`View` but cannot observe residual `decorView` state that bleeds across mode switches — which is the exact bug class the regression was. A device-level integration test closes that gap.

## What the tests cover

| Transition | Assertion |
|------------|-----------|
| `immersiveSticky → edgeToEdge` (regression case for #186723) | `FLAG_FULLSCREEN` and `FLAG_HIDE_NAVIGATION` are cleared |
| `immersive → edgeToEdge` | Same |
| `leanBack → edgeToEdge` | Same |
| `edgeToEdge → immersive` | `IMMERSIVE \| FULLSCREEN \| HIDE_NAVIGATION` set |
| `edgeToEdge → immersiveSticky` | `IMMERSIVE_STICKY \| FULLSCREEN \| HIDE_NAVIGATION` set |
| `edgeToEdge → leanBack` | `FULLSCREEN \| HIDE_NAVIGATION` set, no immersive flags |

All tests skip on API < 29 since `edgeToEdge` requires Android 10+.

## Files

- New: `lib/system_ui_mode_transitions_main.dart` — Flutter Driver entrypoint with mode-applying handler.
- New: `test_driver/system_ui_mode_transitions_main_test.dart` — assertion suite.
- Modified: `NativeDriverSupportPlugin.kt` — adds `get_system_ui_visibility` method that returns the decor view's `systemUiVisibility` int. Reading the deprecated field is the most direct signal of the regression class (#186723 was specifically about flag bleed-through on this field).
- Modified: `README.md` — adds the new entrypoint to the test list.

CI auto-discovery is via `Glob('dev/integration_tests/android_engine_test/lib/**_main.dart')` in `dev/bots/suite_runners/run_android_engine_tests.dart` — no separate registration needed.

## Pre-launch Checklist

- [x] I read the [Contributor Guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview).
- [x] I read the [Tree Hygiene](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) wiki page.
- [x] I read and followed the [Flutter Style Guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md).
- [x] I signed the [CLA](https://cla.developers.google.com/).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.

## Notes for reviewers

- Marked as draft because I do not have a local Android emulator set up — `flutter analyze` is clean but I have not run the test end-to-end. CI is the source of truth.
- The reason for reading the deprecated `systemUiVisibility` field on the native side (rather than `WindowInsetsCompat.isVisible(...)`) is that the regression was specifically about bit flags persisting on the decor view; the deprecated read gives a deterministic, version-independent signal. The production code still migrates to non-deprecated APIs for *setting* state per #183072.
- `SystemUiMode.manual` is out of scope here (different API surface — takes a `List<SystemUiOverlay>`) and can follow up.
