### PR TITLE
Adopt null-aware elements in NavigationRail

### DIFF
--- a/packages/flutter/lib/src/material/navigation_rail.dart
+++ b/packages/flutter/lib/src/material/navigation_rail.dart
@@ -536,7 +536,7 @@ class _NavigationRailState extends State<NavigationRail> with TickerProviderStat
             ),
             disabled: widget.destinations[i].disabled,
           ),
-        if (!widget.trailingAtBottom && widget.trailing != null) widget.trailing!,
+        if (!widget.trailingAtBottom) ?widget.trailing,
       ],
     );
 
@@ -566,7 +566,7 @@ class _NavigationRailState extends State<NavigationRail> with TickerProviderStat
                   Flexible(
                     child: Align(alignment: Alignment(0, groupAlignment), child: mainGroup),
                   ),
-                  if (widget.trailingAtBottom && widget.trailing != null) widget.trailing!,
+                  if (widget.trailingAtBottom) ?widget.trailing,
                 ],
               ),
             ),


### PR DESCRIPTION
Fixes #172188

## Summary
- Adopt null-aware collection elements for `NavigationRail.trailing` placement.
- Remove explicit null checks and force unwraps while preserving `trailingAtBottom` behavior.

## Validation
- `dart format packages\flutter\lib\src\material\navigation_rail.dart` (passed before final equivalent edit; no formatting-sensitive changes)
- `git diff --check` (passed)
- Attempted `flutter analyze --no-pub --flutter-repo packages\flutter\lib\src\material\navigation_rail.dart`, but local validation was blocked by the checkout device running out of disk space while writing `bin\cache\flutter.version.json`.