### PR TITLE
[Flutter GPU] Add block-compressed texture format support (BC, ETC2, ASTC LDR)

### DIFF
--- a/engine/src/flutter/lib/gpu/context.cc
+++ b/engine/src/flutter/lib/gpu/context.cc
@@ -9,6 +9,9 @@
 #include "flutter/lib/gpu/formats.h"
 #include "flutter/lib/ui/ui_dart_state.h"
 #include "fml/make_copyable.h"
+#include "impeller/core/allocator.h"
+#include "impeller/core/formats.h"
+#include "impeller/core/texture_descriptor.h"
 #include "impeller/renderer/context.h"
 #include "tonic/converter/dart_converter.h"
 
@@ -135,4 +138,38 @@ extern int InternalFlutterGpu_Context_GetMinimumUniformByteAlignment(
 extern bool InternalFlutterGpu_Context_GetSupportsOffscreenMSAA(
     flutter::gpu::Context* wrapper) {
   return flutter::gpu::SupportsNormalOffscreenMSAA(wrapper->GetContext());
+}
+
+extern bool InternalFlutterGpu_Context_SupportsTextureCompression(
+    flutter::gpu::Context* wrapper,
+    int family) {
+  return wrapper->GetContext().GetCapabilities()->SupportsTextureCompression(
+      flutter::gpu::ToImpellerCompressedTextureFamily(family));
+}
+
+extern bool InternalFlutterGpu_Context_SupportsTextureFormat(
+    flutter::gpu::Context* wrapper,
+    int format,
+    bool render_target,
+    bool shader_read,
+    bool shader_write) {
+  const impeller::PixelFormat impeller_format =
+      flutter::gpu::ToImpellerPixelFormat(format);
+  if (impeller_format == impeller::PixelFormat::kUnknown) {
+    return false;
+  }
+  // Compressed formats are sample-only: shader_read must be true, and
+  // render-target or shader-write usage is never available.
+  if (impeller::IsCompressed(impeller_format)) {
+    if (render_target || shader_write || !shader_read) {
+      return false;
+    }
+    return wrapper->GetContext().GetCapabilities()->SupportsTextureCompression(
+        impeller::CompressedTextureFamilyForFormat(impeller_format));
+  }
+  // For uncompressed formats, today's Impeller capability surface does not
+  // expose a per-format usage query, so this returns true. As that surface
+  // grows it should be wired in here.
+  (void)shader_read;
+  return true;
 }

--- a/engine/src/flutter/lib/gpu/context.cc
+++ b/engine/src/flutter/lib/gpu/context.cc
@@ -170,6 +170,5 @@ extern bool InternalFlutterGpu_Context_SupportsTextureFormat(
   // For uncompressed formats, today's Impeller capability surface does not
   // expose a per-format usage query, so this returns true. As that surface
   // grows it should be wired in here.
-  (void)shader_read;
   return true;
 }

--- a/engine/src/flutter/lib/gpu/context.h
+++ b/engine/src/flutter/lib/gpu/context.h
@@ -82,6 +82,19 @@ FLUTTER_GPU_EXPORT
 extern bool InternalFlutterGpu_Context_GetSupportsOffscreenMSAA(
     flutter::gpu::Context* wrapper);
 
+FLUTTER_GPU_EXPORT
+extern bool InternalFlutterGpu_Context_SupportsTextureCompression(
+    flutter::gpu::Context* wrapper,
+    int family);
+
+FLUTTER_GPU_EXPORT
+extern bool InternalFlutterGpu_Context_SupportsTextureFormat(
+    flutter::gpu::Context* wrapper,
+    int format,
+    bool render_target,
+    bool shader_read,
+    bool shader_write);
+
 }  // extern "C"
 
 #endif  // FLUTTER_LIB_GPU_CONTEXT_H_

--- a/engine/src/flutter/lib/gpu/formats.h
+++ b/engine/src/flutter/lib/gpu/formats.h
@@ -53,7 +53,47 @@ enum class FlutterGPUPixelFormat {
   kS8UInt,
   kD24UnormS8Uint,
   kD32FloatS8UInt,
+  // Block-compressed formats. Sample-only; support is per-family.
+  kBC1RGBAUNormInt,
+  kBC1RGBAUNormIntSRGB,
+  kBC3RGBAUNormInt,
+  kBC3RGBAUNormIntSRGB,
+  kBC5RGUNormInt,
+  kBC7RGBAUNormInt,
+  kBC7RGBAUNormIntSRGB,
+  kETC2RGB8UNormInt,
+  kETC2RGB8UNormIntSRGB,
+  kETC2RGBA8UNormInt,
+  kETC2RGBA8UNormIntSRGB,
+  kASTC4x4LDR,
+  kASTC4x4LDRSRGB,
+  kASTC8x8LDR,
+  kASTC8x8LDRSRGB,
 };
+
+enum class FlutterGPUTextureCompressionFamily {
+  kBC,
+  kETC2,
+  kASTC,
+};
+
+constexpr impeller::CompressedTextureFamily ToImpellerCompressedTextureFamily(
+    FlutterGPUTextureCompressionFamily value) {
+  switch (value) {
+    case FlutterGPUTextureCompressionFamily::kBC:
+      return impeller::CompressedTextureFamily::kBC;
+    case FlutterGPUTextureCompressionFamily::kETC2:
+      return impeller::CompressedTextureFamily::kETC2;
+    case FlutterGPUTextureCompressionFamily::kASTC:
+      return impeller::CompressedTextureFamily::kASTC;
+  }
+}
+
+constexpr impeller::CompressedTextureFamily ToImpellerCompressedTextureFamily(
+    int value) {
+  return ToImpellerCompressedTextureFamily(
+      static_cast<FlutterGPUTextureCompressionFamily>(value));
+}
 
 constexpr impeller::PixelFormat ToImpellerPixelFormat(
     FlutterGPUPixelFormat value) {
@@ -86,6 +126,36 @@ constexpr impeller::PixelFormat ToImpellerPixelFormat(
       return impeller::PixelFormat::kD24UnormS8Uint;
     case FlutterGPUPixelFormat::kD32FloatS8UInt:
       return impeller::PixelFormat::kD32FloatS8UInt;
+    case FlutterGPUPixelFormat::kBC1RGBAUNormInt:
+      return impeller::PixelFormat::kBC1RGBAUNormInt;
+    case FlutterGPUPixelFormat::kBC1RGBAUNormIntSRGB:
+      return impeller::PixelFormat::kBC1RGBAUNormIntSRGB;
+    case FlutterGPUPixelFormat::kBC3RGBAUNormInt:
+      return impeller::PixelFormat::kBC3RGBAUNormInt;
+    case FlutterGPUPixelFormat::kBC3RGBAUNormIntSRGB:
+      return impeller::PixelFormat::kBC3RGBAUNormIntSRGB;
+    case FlutterGPUPixelFormat::kBC5RGUNormInt:
+      return impeller::PixelFormat::kBC5RGUNormInt;
+    case FlutterGPUPixelFormat::kBC7RGBAUNormInt:
+      return impeller::PixelFormat::kBC7RGBAUNormInt;
+    case FlutterGPUPixelFormat::kBC7RGBAUNormIntSRGB:
+      return impeller::PixelFormat::kBC7RGBAUNormIntSRGB;
+    case FlutterGPUPixelFormat::kETC2RGB8UNormInt:
+      return impeller::PixelFormat::kETC2RGB8UNormInt;
+    case FlutterGPUPixelFormat::kETC2RGB8UNormIntSRGB:
+      return impeller::PixelFormat::kETC2RGB8UNormIntSRGB;
+    case FlutterGPUPixelFormat::kETC2RGBA8UNormInt:
+      return impeller::PixelFormat::kETC2RGBA8UNormInt;
+    case FlutterGPUPixelFormat::kETC2RGBA8UNormIntSRGB:
+      return impeller::PixelFormat::kETC2RGBA8UNormIntSRGB;
+    case FlutterGPUPixelFormat::kASTC4x4LDR:
+      return impeller::PixelFormat::kASTC4x4LDR;
+    case FlutterGPUPixelFormat::kASTC4x4LDRSRGB:
+      return impeller::PixelFormat::kASTC4x4LDRSRGB;
+    case FlutterGPUPixelFormat::kASTC8x8LDR:
+      return impeller::PixelFormat::kASTC8x8LDR;
+    case FlutterGPUPixelFormat::kASTC8x8LDRSRGB:
+      return impeller::PixelFormat::kASTC8x8LDRSRGB;
   }
 }
 
@@ -129,24 +199,39 @@ constexpr FlutterGPUPixelFormat FromImpellerPixelFormat(
       return FlutterGPUPixelFormat::kD24UnormS8Uint;
     case impeller::PixelFormat::kD32FloatS8UInt:
       return FlutterGPUPixelFormat::kD32FloatS8UInt;
-    // Block-compressed formats are not yet exposed by the Flutter GPU API.
     case impeller::PixelFormat::kBC1RGBAUNormInt:
+      return FlutterGPUPixelFormat::kBC1RGBAUNormInt;
     case impeller::PixelFormat::kBC1RGBAUNormIntSRGB:
+      return FlutterGPUPixelFormat::kBC1RGBAUNormIntSRGB;
     case impeller::PixelFormat::kBC3RGBAUNormInt:
+      return FlutterGPUPixelFormat::kBC3RGBAUNormInt;
     case impeller::PixelFormat::kBC3RGBAUNormIntSRGB:
+      return FlutterGPUPixelFormat::kBC3RGBAUNormIntSRGB;
     case impeller::PixelFormat::kBC5RGUNormInt:
+      return FlutterGPUPixelFormat::kBC5RGUNormInt;
     case impeller::PixelFormat::kBC7RGBAUNormInt:
+      return FlutterGPUPixelFormat::kBC7RGBAUNormInt;
     case impeller::PixelFormat::kBC7RGBAUNormIntSRGB:
+      return FlutterGPUPixelFormat::kBC7RGBAUNormIntSRGB;
     case impeller::PixelFormat::kETC2RGB8UNormInt:
+      return FlutterGPUPixelFormat::kETC2RGB8UNormInt;
     case impeller::PixelFormat::kETC2RGB8UNormIntSRGB:
+      return FlutterGPUPixelFormat::kETC2RGB8UNormIntSRGB;
     case impeller::PixelFormat::kETC2RGBA8UNormInt:
+      return FlutterGPUPixelFormat::kETC2RGBA8UNormInt;
     case impeller::PixelFormat::kETC2RGBA8UNormIntSRGB:
+      return FlutterGPUPixelFormat::kETC2RGBA8UNormIntSRGB;
     case impeller::PixelFormat::kASTC4x4LDR:
+      return FlutterGPUPixelFormat::kASTC4x4LDR;
     case impeller::PixelFormat::kASTC4x4LDRSRGB:
+      return FlutterGPUPixelFormat::kASTC4x4LDRSRGB;
     case impeller::PixelFormat::kASTC8x8LDR:
+      return FlutterGPUPixelFormat::kASTC8x8LDR;
     case impeller::PixelFormat::kASTC8x8LDRSRGB:
+      return FlutterGPUPixelFormat::kASTC8x8LDRSRGB;
     case impeller::PixelFormat::kASTC4x4HDR:
     case impeller::PixelFormat::kASTC8x8HDR:
+      // HDR variants are not yet exposed by the Flutter GPU API.
       return FlutterGPUPixelFormat::kUnknown;
   }
 }

--- a/engine/src/flutter/lib/gpu/lib/src/context.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/context.dart
@@ -58,6 +58,37 @@ base class GpuContext extends NativeFieldWrapperClass1 {
     return _getSupportsOffscreenMSAA();
   }
 
+  /// Whether this device supports the given family of block-compressed
+  /// texture formats. Hardware support is granted on a per-family basis.
+  ///
+  /// Compressed textures are always sample-only (no render target, no shader
+  /// write, no multisampling, and dimensions must be a multiple of the format
+  /// block size). [supportsTextureFormat] can be used for a per-format check.
+  bool supportsTextureCompression(TextureCompressionFamily family) {
+    return _supportsTextureCompression(family.index);
+  }
+
+  /// Whether this device can allocate a texture of the given [format] with
+  /// the requested usage flags.
+  ///
+  /// For block-compressed formats this returns false if either [renderTarget]
+  /// or [shaderWrite] is true, since compressed formats are sample-only.
+  /// For uncompressed formats this currently returns true: today the
+  /// underlying capability surface does not vary by per-format usage.
+  bool supportsTextureFormat(
+    PixelFormat format, {
+    bool renderTarget = false,
+    bool shaderRead = true,
+    bool shaderWrite = false,
+  }) {
+    return _supportsTextureFormat(
+      format.index,
+      renderTarget,
+      shaderRead,
+      shaderWrite,
+    );
+  }
+
   /// Allocates a new region of GPU-resident memory.
   ///
   /// The [storageMode] must be either [StorageMode.hostVisible] or
@@ -144,6 +175,27 @@ base class GpuContext extends NativeFieldWrapperClass1 {
         'for a ${width}x$height texture',
       );
     }
+    if (format.isCompressed) {
+      if (enableRenderTargetUsage ||
+          enableShaderWriteUsage ||
+          !enableShaderReadUsage ||
+          sampleCount != 1 ||
+          storageMode == StorageMode.deviceTransient) {
+        throw Exception(
+          'Compressed pixel format $format can only be used as a sample-only '
+          'texture (sampleCount=1, enableShaderReadUsage=true, no render '
+          'target, no shader write, and storageMode != deviceTransient)',
+        );
+      }
+      final int bw = format.blockWidth;
+      final int bh = format.blockHeight;
+      if (width % bw != 0 || height % bh != 0) {
+        throw Exception(
+          'Compressed pixel format $format requires width and height to be a '
+          'multiple of the block size (${bw}x$bh), got ${width}x$height',
+        );
+      }
+    }
     Texture result = Texture._initialize(
       this,
       storageMode,
@@ -210,6 +262,21 @@ base class GpuContext extends NativeFieldWrapperClass1 {
     symbol: 'InternalFlutterGpu_Context_GetSupportsOffscreenMSAA',
   )
   external bool _getSupportsOffscreenMSAA();
+
+  @Native<Bool Function(Pointer<Void>, Int)>(
+    symbol: 'InternalFlutterGpu_Context_SupportsTextureCompression',
+  )
+  external bool _supportsTextureCompression(int family);
+
+  @Native<Bool Function(Pointer<Void>, Int, Bool, Bool, Bool)>(
+    symbol: 'InternalFlutterGpu_Context_SupportsTextureFormat',
+  )
+  external bool _supportsTextureFormat(
+    int format,
+    bool renderTarget,
+    bool shaderRead,
+    bool shaderWrite,
+  );
 }
 
 /// The default graphics context.

--- a/engine/src/flutter/lib/gpu/lib/src/context.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/context.dart
@@ -181,7 +181,7 @@ base class GpuContext extends NativeFieldWrapperClass1 {
           !enableShaderReadUsage ||
           sampleCount != 1 ||
           storageMode == StorageMode.deviceTransient) {
-        throw Exception(
+        throw ArgumentError(
           'Compressed pixel format $format can only be used as a sample-only '
           'texture (sampleCount=1, enableShaderReadUsage=true, no render '
           'target, no shader write, and storageMode != deviceTransient)',
@@ -190,7 +190,7 @@ base class GpuContext extends NativeFieldWrapperClass1 {
       final int bw = format.blockWidth;
       final int bh = format.blockHeight;
       if (width % bw != 0 || height % bh != 0) {
-        throw Exception(
+        throw ArgumentError(
           'Compressed pixel format $format requires width and height to be a '
           'multiple of the block size (${bw}x$bh), got ${width}x$height',
         );

--- a/engine/src/flutter/lib/gpu/lib/src/formats.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/formats.dart
@@ -51,6 +51,200 @@ enum PixelFormat {
   s8UInt,
   d24UnormS8Uint,
   d32FloatS8UInt,
+  // Block-compressed formats. These are sample-only: they cannot be used as
+  // render targets, with storage modes other than `hostVisible`/`devicePrivate`,
+  // for shader writes, or with multisampling. Hardware support varies by
+  // family; check [GpuContext.supportsTextureCompression] before allocating.
+  /// BC1 RGBA, 4x4 blocks, 8 bytes per block. Desktop BC family.
+  bc1RGBAUNormInt,
+
+  /// BC1 RGBA sRGB, 4x4 blocks, 8 bytes per block. Desktop BC family.
+  bc1RGBAUNormIntSRGB,
+
+  /// BC3 RGBA, 4x4 blocks, 16 bytes per block. Desktop BC family.
+  bc3RGBAUNormInt,
+
+  /// BC3 RGBA sRGB, 4x4 blocks, 16 bytes per block. Desktop BC family.
+  bc3RGBAUNormIntSRGB,
+
+  /// BC5 RG, 4x4 blocks, 16 bytes per block. Desktop BC family.
+  bc5RGUNormInt,
+
+  /// BC7 RGBA, 4x4 blocks, 16 bytes per block. Desktop BC family.
+  bc7RGBAUNormInt,
+
+  /// BC7 RGBA sRGB, 4x4 blocks, 16 bytes per block. Desktop BC family.
+  bc7RGBAUNormIntSRGB,
+
+  /// ETC2 RGB8, 4x4 blocks, 8 bytes per block. Mobile ETC2 family.
+  etc2RGB8UNormInt,
+
+  /// ETC2 RGB8 sRGB, 4x4 blocks, 8 bytes per block. Mobile ETC2 family.
+  etc2RGB8UNormIntSRGB,
+
+  /// ETC2 RGBA8, 4x4 blocks, 16 bytes per block. Mobile ETC2 family.
+  etc2RGBA8UNormInt,
+
+  /// ETC2 RGBA8 sRGB, 4x4 blocks, 16 bytes per block. Mobile ETC2 family.
+  etc2RGBA8UNormIntSRGB,
+
+  /// ASTC LDR, 4x4 blocks, 16 bytes per block. Modern mobile ASTC family.
+  astc4x4LDR,
+
+  /// ASTC LDR sRGB, 4x4 blocks, 16 bytes per block. Modern mobile ASTC family.
+  astc4x4LDRSRGB,
+
+  /// ASTC LDR, 8x8 blocks, 16 bytes per block. Modern mobile ASTC family.
+  astc8x8LDR,
+
+  /// ASTC LDR sRGB, 8x8 blocks, 16 bytes per block. Modern mobile ASTC family.
+  astc8x8LDRSRGB,
+}
+
+/// The family of a block-compressed pixel format. Hardware support for
+/// compressed formats is granted on a per-family basis.
+enum TextureCompressionFamily {
+  /// BC1 through BC7. Typical on desktop GPUs.
+  bc,
+
+  /// ETC2 and EAC. Typical on mobile, OpenGL ES 3.0, and WebGL2.
+  etc2,
+
+  /// ASTC LDR. Typical on modern mobile and some desktop GPUs.
+  astc,
+}
+
+/// Block-geometry and family queries for [PixelFormat].
+extension PixelFormatProperties on PixelFormat {
+  /// Whether this is a block-compressed pixel format.
+  bool get isCompressed {
+    return blockWidth > 1 || blockHeight > 1;
+  }
+
+  /// The width, in texels, of a single block. Uncompressed formats return 1.
+  int get blockWidth {
+    switch (this) {
+      case PixelFormat.astc8x8LDR:
+      case PixelFormat.astc8x8LDRSRGB:
+        return 8;
+      case PixelFormat.bc1RGBAUNormInt:
+      case PixelFormat.bc1RGBAUNormIntSRGB:
+      case PixelFormat.bc3RGBAUNormInt:
+      case PixelFormat.bc3RGBAUNormIntSRGB:
+      case PixelFormat.bc5RGUNormInt:
+      case PixelFormat.bc7RGBAUNormInt:
+      case PixelFormat.bc7RGBAUNormIntSRGB:
+      case PixelFormat.etc2RGB8UNormInt:
+      case PixelFormat.etc2RGB8UNormIntSRGB:
+      case PixelFormat.etc2RGBA8UNormInt:
+      case PixelFormat.etc2RGBA8UNormIntSRGB:
+      case PixelFormat.astc4x4LDR:
+      case PixelFormat.astc4x4LDRSRGB:
+        return 4;
+      // ignore: no_default_cases
+      default:
+        return 1;
+    }
+  }
+
+  /// The height, in texels, of a single block. Uncompressed formats return 1.
+  int get blockHeight {
+    switch (this) {
+      case PixelFormat.astc8x8LDR:
+      case PixelFormat.astc8x8LDRSRGB:
+        return 8;
+      case PixelFormat.bc1RGBAUNormInt:
+      case PixelFormat.bc1RGBAUNormIntSRGB:
+      case PixelFormat.bc3RGBAUNormInt:
+      case PixelFormat.bc3RGBAUNormIntSRGB:
+      case PixelFormat.bc5RGUNormInt:
+      case PixelFormat.bc7RGBAUNormInt:
+      case PixelFormat.bc7RGBAUNormIntSRGB:
+      case PixelFormat.etc2RGB8UNormInt:
+      case PixelFormat.etc2RGB8UNormIntSRGB:
+      case PixelFormat.etc2RGBA8UNormInt:
+      case PixelFormat.etc2RGBA8UNormIntSRGB:
+      case PixelFormat.astc4x4LDR:
+      case PixelFormat.astc4x4LDRSRGB:
+        return 4;
+      // ignore: no_default_cases
+      default:
+        return 1;
+    }
+  }
+
+  /// The number of bytes used to store one block. For uncompressed formats a
+  /// block is a single texel, so this matches the bytes per texel.
+  int get bytesPerBlock {
+    switch (this) {
+      case PixelFormat.unknown:
+        return 0;
+      case PixelFormat.a8UNormInt:
+      case PixelFormat.r8UNormInt:
+      case PixelFormat.s8UInt:
+        return 1;
+      case PixelFormat.r8g8UNormInt:
+        return 2;
+      case PixelFormat.r8g8b8a8UNormInt:
+      case PixelFormat.r8g8b8a8UNormIntSRGB:
+      case PixelFormat.b8g8r8a8UNormInt:
+      case PixelFormat.b8g8r8a8UNormIntSRGB:
+      case PixelFormat.r32Float:
+      case PixelFormat.d24UnormS8Uint:
+        return 4;
+      case PixelFormat.d32FloatS8UInt:
+        return 5;
+      case PixelFormat.r16g16b16a16Float:
+        return 8;
+      case PixelFormat.r32g32b32a32Float:
+        return 16;
+      case PixelFormat.bc1RGBAUNormInt:
+      case PixelFormat.bc1RGBAUNormIntSRGB:
+      case PixelFormat.etc2RGB8UNormInt:
+      case PixelFormat.etc2RGB8UNormIntSRGB:
+        return 8;
+      case PixelFormat.bc3RGBAUNormInt:
+      case PixelFormat.bc3RGBAUNormIntSRGB:
+      case PixelFormat.bc5RGUNormInt:
+      case PixelFormat.bc7RGBAUNormInt:
+      case PixelFormat.bc7RGBAUNormIntSRGB:
+      case PixelFormat.etc2RGBA8UNormInt:
+      case PixelFormat.etc2RGBA8UNormIntSRGB:
+      case PixelFormat.astc4x4LDR:
+      case PixelFormat.astc4x4LDRSRGB:
+      case PixelFormat.astc8x8LDR:
+      case PixelFormat.astc8x8LDRSRGB:
+        return 16;
+    }
+  }
+
+  /// The compression family this format belongs to. Returns null for
+  /// uncompressed formats.
+  TextureCompressionFamily? get compressionFamily {
+    switch (this) {
+      case PixelFormat.bc1RGBAUNormInt:
+      case PixelFormat.bc1RGBAUNormIntSRGB:
+      case PixelFormat.bc3RGBAUNormInt:
+      case PixelFormat.bc3RGBAUNormIntSRGB:
+      case PixelFormat.bc5RGUNormInt:
+      case PixelFormat.bc7RGBAUNormInt:
+      case PixelFormat.bc7RGBAUNormIntSRGB:
+        return TextureCompressionFamily.bc;
+      case PixelFormat.etc2RGB8UNormInt:
+      case PixelFormat.etc2RGB8UNormIntSRGB:
+      case PixelFormat.etc2RGBA8UNormInt:
+      case PixelFormat.etc2RGBA8UNormIntSRGB:
+        return TextureCompressionFamily.etc2;
+      case PixelFormat.astc4x4LDR:
+      case PixelFormat.astc4x4LDRSRGB:
+      case PixelFormat.astc8x8LDR:
+      case PixelFormat.astc8x8LDRSRGB:
+        return TextureCompressionFamily.astc;
+      // ignore: no_default_cases
+      default:
+        return null;
+    }
+  }
 }
 
 enum TextureCoordinateSystem {

--- a/engine/src/flutter/lib/gpu/lib/src/texture.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/texture.dart
@@ -113,18 +113,19 @@ base class Texture extends NativeFieldWrapperClass1 {
     _setCoordinateSystem(value.index);
   }
 
-  int get bytesPerTexel {
-    return _bytesPerTexel();
-  }
-
   /// Returns the size in bytes of the [mipLevel] mip level (one slice). Mip
-  /// dimensions are clamped at 1, matching standard mip chain semantics.
+  /// dimensions are clamped at 1, matching standard mip chain semantics. For
+  /// block-compressed formats the dimensions are rounded up to whole blocks.
   int getMipLevelSizeInBytes(int mipLevel) {
     final int mipWidth = width >> mipLevel;
     final int mipHeight = height >> mipLevel;
     final int w = mipWidth > 0 ? mipWidth : 1;
     final int h = mipHeight > 0 ? mipHeight : 1;
-    return bytesPerTexel * w * h;
+    final int bw = format.blockWidth;
+    final int bh = format.blockHeight;
+    final int blocksWide = (w + bw - 1) ~/ bw;
+    final int blocksHigh = (h + bh - 1) ~/ bh;
+    return blocksWide * blocksHigh * format.bytesPerBlock;
   }
 
   /// Returns the size in bytes of the base mip level (one slice). Equivalent
@@ -143,10 +144,10 @@ base class Texture extends NativeFieldWrapperClass1 {
   /// each face is a separate slice in the order
   /// `+X, -X, +Y, -Y, +Z, -Z`. Must be 0 for non-cubemap textures.
   ///
-  /// The length of [sourceBytes] must exactly match the size of the
-  /// requested mip level, which is `mipWidth * mipHeight * bytesPerTexel`
-  /// (where `mipWidth` and `mipHeight` are the base dimensions right-shifted
-  /// by [mipLevel], floored at 1).
+  /// The length of [sourceBytes] must exactly match the size returned by
+  /// [getMipLevelSizeInBytes] for the requested [mipLevel]. For
+  /// block-compressed formats, this is the number of whole-block-rounded
+  /// blocks times the bytes per block.
   ///
   /// Throws an exception if the write fails due to an internal error or if
   /// any of the parameters are out of range.
@@ -220,11 +221,6 @@ base class Texture extends NativeFieldWrapperClass1 {
     symbol: 'InternalFlutterGpu_Texture_SetCoordinateSystem',
   )
   external void _setCoordinateSystem(int coordinateSystem);
-
-  @Native<Int Function(Pointer<Void>)>(
-    symbol: 'InternalFlutterGpu_Texture_BytesPerTexel',
-  )
-  external int _bytesPerTexel();
 
   @Native<Bool Function(Pointer<Void>, Pointer<Void>, Handle, Int, Int)>(
     symbol: 'InternalFlutterGpu_Texture_Overwrite',

--- a/engine/src/flutter/lib/gpu/texture.cc
+++ b/engine/src/flutter/lib/gpu/texture.cc
@@ -145,11 +145,6 @@ bool Texture::Overwrite(Context& gpu_context,
   return true;
 }
 
-size_t Texture::GetBytesPerTexel() {
-  return impeller::BytesPerPixelForPixelFormat(
-      texture_->GetTextureDescriptor().format);
-}
-
 Dart_Handle Texture::AsImage() const {
   // DlImageImpeller isn't compiled in builds with Impeller disabled. If
   // Impeller is disabled, it's impossible to get here anyhow, so just ifdef it
@@ -254,11 +249,6 @@ bool InternalFlutterGpu_Texture_Overwrite(flutter::gpu::Texture* texture,
   return texture->Overwrite(*gpu_context, tonic::DartByteData(source_byte_data),
                             static_cast<uint32_t>(mip_level),
                             static_cast<uint32_t>(slice));
-}
-
-extern int InternalFlutterGpu_Texture_BytesPerTexel(
-    flutter::gpu::Texture* wrapper) {
-  return wrapper->GetBytesPerTexel();
 }
 
 Dart_Handle InternalFlutterGpu_Texture_AsImage(flutter::gpu::Texture* wrapper) {

--- a/engine/src/flutter/lib/gpu/texture.h
+++ b/engine/src/flutter/lib/gpu/texture.h
@@ -32,8 +32,6 @@ class Texture : public RefCountedDartWrappable<Texture> {
                  uint32_t mip_level,
                  uint32_t slice);
 
-  size_t GetBytesPerTexel();
-
   Dart_Handle AsImage() const;
 
  private:
@@ -79,10 +77,6 @@ extern bool InternalFlutterGpu_Texture_Overwrite(
     Dart_Handle source_byte_data,
     int mip_level,
     int slice);
-
-FLUTTER_GPU_EXPORT
-extern int InternalFlutterGpu_Texture_BytesPerTexel(
-    flutter::gpu::Texture* wrapper);
 
 FLUTTER_GPU_EXPORT
 extern Dart_Handle InternalFlutterGpu_Texture_AsImage(

--- a/engine/src/flutter/testing/dart/gpu_test.dart
+++ b/engine/src/flutter/testing/dart/gpu_test.dart
@@ -320,14 +320,13 @@ void main() async {
     expect(texture.enableRenderTargetUsage, true);
     expect(texture.enableShaderReadUsage, true);
     expect(!texture.enableShaderWriteUsage, true);
-    expect(texture.bytesPerTexel, 4);
+    expect(texture.format.bytesPerBlock, 4);
     expect(texture.getBaseMipLevelSizeInBytes(), 40000);
     expect(texture.mipLevelCount, 1);
     expect(texture.sliceCount, 1);
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   test('GpuContext.createTexture allocates an r32Float texture', () async {
-    // Verifies the single-channel float format round-trips through allocation.
     final gpu.Texture texture = gpu.gpuContext.createTexture(
       gpu.StorageMode.hostVisible,
       4,
@@ -335,8 +334,204 @@ void main() async {
       format: gpu.PixelFormat.r32Float,
     );
     expect(texture.format, gpu.PixelFormat.r32Float);
-    expect(texture.bytesPerTexel, 4);
+    expect(texture.format.bytesPerBlock, 4);
     expect(texture.getBaseMipLevelSizeInBytes(), 4 * 4 * 4);
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  test('PixelFormat block introspection matches the format table', () async {
+    // Uncompressed formats report block dims of 1.
+    expect(gpu.PixelFormat.r8g8b8a8UNormInt.isCompressed, false);
+    expect(gpu.PixelFormat.r8g8b8a8UNormInt.blockWidth, 1);
+    expect(gpu.PixelFormat.r8g8b8a8UNormInt.blockHeight, 1);
+    expect(gpu.PixelFormat.r8g8b8a8UNormInt.bytesPerBlock, 4);
+    expect(gpu.PixelFormat.r8g8b8a8UNormInt.compressionFamily, isNull);
+    expect(gpu.PixelFormat.r32Float.bytesPerBlock, 4);
+
+    // BC1 / ETC2 RGB8: 4x4 blocks, 8 bytes per block.
+    expect(gpu.PixelFormat.bc1RGBAUNormInt.isCompressed, true);
+    expect(gpu.PixelFormat.bc1RGBAUNormInt.blockWidth, 4);
+    expect(gpu.PixelFormat.bc1RGBAUNormInt.blockHeight, 4);
+    expect(gpu.PixelFormat.bc1RGBAUNormInt.bytesPerBlock, 8);
+    expect(gpu.PixelFormat.bc1RGBAUNormInt.compressionFamily, gpu.TextureCompressionFamily.bc);
+    expect(gpu.PixelFormat.etc2RGB8UNormInt.bytesPerBlock, 8);
+    expect(gpu.PixelFormat.etc2RGB8UNormInt.compressionFamily, gpu.TextureCompressionFamily.etc2);
+
+    // BC7 / ETC2 RGBA / ASTC 4x4: 4x4 blocks, 16 bytes per block.
+    expect(gpu.PixelFormat.bc7RGBAUNormInt.bytesPerBlock, 16);
+    expect(gpu.PixelFormat.etc2RGBA8UNormInt.bytesPerBlock, 16);
+    expect(gpu.PixelFormat.astc4x4LDR.bytesPerBlock, 16);
+    expect(gpu.PixelFormat.astc4x4LDR.compressionFamily, gpu.TextureCompressionFamily.astc);
+
+    // ASTC 8x8: 8x8 blocks, 16 bytes per block.
+    expect(gpu.PixelFormat.astc8x8LDR.blockWidth, 8);
+    expect(gpu.PixelFormat.astc8x8LDR.blockHeight, 8);
+    expect(gpu.PixelFormat.astc8x8LDR.bytesPerBlock, 16);
+  });
+
+  test('GpuContext.supportsTextureCompression returns a bool per family', () async {
+    // The exact answer depends on the device, but each query must return.
+    expect(gpu.gpuContext.supportsTextureCompression(gpu.TextureCompressionFamily.bc), isA<bool>());
+    expect(
+      gpu.gpuContext.supportsTextureCompression(gpu.TextureCompressionFamily.etc2),
+      isA<bool>(),
+    );
+    expect(
+      gpu.gpuContext.supportsTextureCompression(gpu.TextureCompressionFamily.astc),
+      isA<bool>(),
+    );
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  test('GpuContext.supportsTextureFormat rejects render-target on compressed', () async {
+    // Sample-only is always permitted to be queried (subject to the family
+    // capability); render-target and shader-write are always rejected for
+    // compressed formats.
+    expect(
+      gpu.gpuContext.supportsTextureFormat(gpu.PixelFormat.bc7RGBAUNormInt, renderTarget: true),
+      false,
+    );
+    expect(
+      gpu.gpuContext.supportsTextureFormat(gpu.PixelFormat.bc7RGBAUNormInt, shaderWrite: true),
+      false,
+    );
+    // Uncompressed formats are not gated by per-format usage today.
+    expect(
+      gpu.gpuContext.supportsTextureFormat(gpu.PixelFormat.r8g8b8a8UNormInt, renderTarget: true),
+      true,
+    );
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  test('Texture.getMipLevelSizeInBytes is block-aware for compressed formats', () async {
+    if (!gpu.gpuContext.supportsTextureCompression(gpu.TextureCompressionFamily.bc)) {
+      return;
+    }
+    final gpu.Texture texture = gpu.gpuContext.createTexture(
+      gpu.StorageMode.hostVisible,
+      16,
+      16,
+      format: gpu.PixelFormat.bc1RGBAUNormInt,
+      enableRenderTargetUsage: false,
+      mipLevelCount: 3,
+    );
+    // 16x16 -> 4x4 blocks * 8 bytes = 128.
+    expect(texture.getMipLevelSizeInBytes(0), 128);
+    // 8x8 -> 2x2 blocks * 8 bytes = 32.
+    expect(texture.getMipLevelSizeInBytes(1), 32);
+    // 4x4 -> 1x1 block * 8 bytes = 8.
+    expect(texture.getMipLevelSizeInBytes(2), 8);
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  test('GpuContext.createTexture allocates a compressed texture when supported', () async {
+    if (!gpu.gpuContext.supportsTextureCompression(gpu.TextureCompressionFamily.bc)) {
+      return;
+    }
+    final gpu.Texture texture = gpu.gpuContext.createTexture(
+      gpu.StorageMode.hostVisible,
+      8,
+      8,
+      format: gpu.PixelFormat.bc1RGBAUNormInt,
+      enableRenderTargetUsage: false,
+    );
+    expect(texture.format, gpu.PixelFormat.bc1RGBAUNormInt);
+    expect(texture.format.isCompressed, true);
+    // 8x8 -> 2x2 blocks * 8 bytes = 32.
+    expect(texture.getBaseMipLevelSizeInBytes(), 32);
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  test('Texture.overwrite uploads block-aligned compressed data', () async {
+    if (!gpu.gpuContext.supportsTextureCompression(gpu.TextureCompressionFamily.bc)) {
+      return;
+    }
+    final gpu.Texture texture = gpu.gpuContext.createTexture(
+      gpu.StorageMode.hostVisible,
+      8,
+      8,
+      format: gpu.PixelFormat.bc1RGBAUNormInt,
+      enableRenderTargetUsage: false,
+    );
+    final ByteData bytes = Uint8List(32).buffer.asByteData();
+    texture.overwrite(bytes);
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  test('Texture.overwrite rejects wrong size for compressed format', () async {
+    if (!gpu.gpuContext.supportsTextureCompression(gpu.TextureCompressionFamily.bc)) {
+      return;
+    }
+    final gpu.Texture texture = gpu.gpuContext.createTexture(
+      gpu.StorageMode.hostVisible,
+      8,
+      8,
+      format: gpu.PixelFormat.bc1RGBAUNormInt,
+      enableRenderTargetUsage: false,
+    );
+    try {
+      // 8x8 BC1 needs 32 bytes; 16 is wrong.
+      texture.overwrite(Uint8List(16).buffer.asByteData());
+      fail('Exception not thrown for wrong compressed buffer size.');
+    } catch (e) {
+      expect(e.toString(), contains('must exactly match the size of mip level 0'));
+    }
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  test('GpuContext.createTexture rejects compressed format as render target', () async {
+    try {
+      gpu.gpuContext.createTexture(
+        gpu.StorageMode.hostVisible,
+        8,
+        8,
+        format: gpu.PixelFormat.bc1RGBAUNormInt,
+      );
+      fail('Exception not thrown for compressed render target.');
+    } catch (e) {
+      expect(e.toString(), contains('sample-only'));
+    }
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  test('GpuContext.createTexture rejects compressed format with shader write', () async {
+    try {
+      gpu.gpuContext.createTexture(
+        gpu.StorageMode.hostVisible,
+        8,
+        8,
+        format: gpu.PixelFormat.bc1RGBAUNormInt,
+        enableRenderTargetUsage: false,
+        enableShaderWriteUsage: true,
+      );
+      fail('Exception not thrown for compressed shader write.');
+    } catch (e) {
+      expect(e.toString(), contains('sample-only'));
+    }
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  test('GpuContext.createTexture rejects compressed format with MSAA', () async {
+    try {
+      gpu.gpuContext.createTexture(
+        gpu.StorageMode.hostVisible,
+        8,
+        8,
+        format: gpu.PixelFormat.bc1RGBAUNormInt,
+        enableRenderTargetUsage: false,
+        sampleCount: 4,
+      );
+      fail('Exception not thrown for compressed MSAA.');
+    } catch (e) {
+      expect(e.toString(), contains('sample-only'));
+    }
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  test('GpuContext.createTexture rejects non-block-aligned compressed dimensions', () async {
+    try {
+      // 5 is not a multiple of the 4x4 BC1 block.
+      gpu.gpuContext.createTexture(
+        gpu.StorageMode.hostVisible,
+        5,
+        8,
+        format: gpu.PixelFormat.bc1RGBAUNormInt,
+        enableRenderTargetUsage: false,
+      );
+      fail('Exception not thrown for non-block-aligned compressed dimensions.');
+    } catch (e) {
+      expect(e.toString(), contains('multiple of the block size'));
+    }
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   test('Texture.fullMipCount', () async {

--- a/engine/src/flutter/testing/dart/gpu_test.dart
+++ b/engine/src/flutter/testing/dart/gpu_test.dart
@@ -402,6 +402,7 @@ void main() async {
 
   test('Texture.getMipLevelSizeInBytes is block-aware for compressed formats', () async {
     if (!gpu.gpuContext.supportsTextureCompression(gpu.TextureCompressionFamily.bc)) {
+      markTestSkipped('BC texture compression is not supported on this device.');
       return;
     }
     final gpu.Texture texture = gpu.gpuContext.createTexture(
@@ -422,6 +423,7 @@ void main() async {
 
   test('GpuContext.createTexture allocates a compressed texture when supported', () async {
     if (!gpu.gpuContext.supportsTextureCompression(gpu.TextureCompressionFamily.bc)) {
+      markTestSkipped('BC texture compression is not supported on this device.');
       return;
     }
     final gpu.Texture texture = gpu.gpuContext.createTexture(
@@ -439,6 +441,7 @@ void main() async {
 
   test('Texture.overwrite uploads block-aligned compressed data', () async {
     if (!gpu.gpuContext.supportsTextureCompression(gpu.TextureCompressionFamily.bc)) {
+      markTestSkipped('BC texture compression is not supported on this device.');
       return;
     }
     final gpu.Texture texture = gpu.gpuContext.createTexture(
@@ -454,6 +457,7 @@ void main() async {
 
   test('Texture.overwrite rejects wrong size for compressed format', () async {
     if (!gpu.gpuContext.supportsTextureCompression(gpu.TextureCompressionFamily.bc)) {
+      markTestSkipped('BC texture compression is not supported on this device.');
       return;
     }
     final gpu.Texture texture = gpu.gpuContext.createTexture(


### PR DESCRIPTION
Addresses https://github.com/flutter/flutter/issues/187073. Builds on the Impeller-side support landed in https://github.com/flutter/flutter/pull/187077 and the `PixelFormat` cleanup in https://github.com/flutter/flutter/pull/187069.

Adds BC, ETC2, and ASTC LDR pixel formats to the Flutter GPU public API along with capability queries for selecting a hardware-supported family at runtime.

KTX2 / Basis transcoding is intentionally above Flutter GPU. Flutter Scene or a companion package picks a hardware target via the capability query, transcodes on the CPU, and uploads opaque block bytes via `Texture.overwrite`.

This is a small breaking change to an experimental API: callers using `texture.bytesPerTexel` should switch to `texture.format.bytesPerBlock`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md