### PR TITLE
Make shape border lerp symmetric

### DIFF
--- a/packages/flutter/lib/src/painting/borders.dart
+++ b/packages/flutter/lib/src/painting/borders.dart
@@ -440,8 +440,9 @@ abstract class ShapeBorder {
   /// class) to `this`.
   ///
   /// When implementing this method in subclasses, return null if this class
-  /// cannot interpolate from `a`. In that case, [lerp] will try `a`'s [lerpTo]
-  /// method instead. If `a` is null, this must not return null.
+  /// cannot interpolate from `a`. In that case, [lerp] will try other ways to
+  /// interpolate between the two borders before applying a default behavior. If
+  /// `a` is null, this must not return null.
   ///
   /// The base class implementation handles the case of `a` being null by
   /// deferring to [scale].
@@ -471,11 +472,10 @@ abstract class ShapeBorder {
   /// Linearly interpolates from `this` to another [ShapeBorder] (possibly of
   /// another class).
   ///
-  /// This is called if `b`'s [lerpTo] did not know how to handle this class.
-  ///
   /// When implementing this method in subclasses, return null if this class
-  /// cannot interpolate from `b`. In that case, [lerp] will apply a default
-  /// behavior instead. If `b` is null, this must not return null.
+  /// cannot interpolate to `b`. In that case, [lerp] will try other ways to
+  /// interpolate between the two borders before applying a default behavior. If
+  /// `b` is null, this must not return null.
   ///
   /// The base class implementation handles the case of `b` being null by
   /// deferring to [scale].
@@ -503,17 +503,20 @@ abstract class ShapeBorder {
 
   /// Linearly interpolates between two [ShapeBorder]s.
   ///
-  /// This defers to `b`'s [lerpTo] function if `b` is not null. If `b` is
-  /// null or if its [lerpTo] returns null, it uses `a`'s [lerpFrom]
-  /// function instead. If both return null, it returns `a` before `t=0.5`
-  /// and `b` after `t=0.5`.
+  /// This first tries the forward interpolation, by calling `b.lerpFrom(a, t)`
+  /// and then `a.lerpTo(b, t)`. If both return null, this tries the same
+  /// interpolation on the reversed timeline, by calling
+  /// `b.lerpTo(a, 1.0 - t)` and then `a.lerpFrom(b, 1.0 - t)`. If all of
+  /// these methods return null, this returns `a` before `t=0.5` and `b` after
+  /// `t=0.5`.
   ///
   /// {@macro dart.ui.shadow.lerp}
   static ShapeBorder? lerp(ShapeBorder? a, ShapeBorder? b, double t) {
     if (identical(a, b)) {
       return a;
     }
-    final ShapeBorder? result = b?.lerpFrom(a, t) ?? a?.lerpTo(b, t);
+    final ShapeBorder? result =
+        b?.lerpFrom(a, t) ?? a?.lerpTo(b, t) ?? b?.lerpTo(a, 1.0 - t) ?? a?.lerpFrom(b, 1.0 - t);
     return result ?? (t < 0.5 ? a : b);
   }
 
@@ -693,17 +696,20 @@ abstract class OutlinedBorder extends ShapeBorder {
 
   /// Linearly interpolates between two [OutlinedBorder]s.
   ///
-  /// This defers to `b`'s [lerpTo] function if `b` is not null. If `b` is
-  /// null or if its [lerpTo] returns null, it uses `a`'s [lerpFrom]
-  /// function instead. If both return null, it returns `a` before `t=0.5`
-  /// and `b` after `t=0.5`.
+  /// This first tries the forward interpolation, by calling `b.lerpFrom(a, t)`
+  /// and then `a.lerpTo(b, t)`. If both return null, this tries the same
+  /// interpolation on the reversed timeline, by calling
+  /// `b.lerpTo(a, 1.0 - t)` and then `a.lerpFrom(b, 1.0 - t)`. If all of
+  /// these methods return null, this returns `a` before `t=0.5` and `b` after
+  /// `t=0.5`.
   ///
   /// {@macro dart.ui.shadow.lerp}
   static OutlinedBorder? lerp(OutlinedBorder? a, OutlinedBorder? b, double t) {
     if (identical(a, b)) {
       return a;
     }
-    final ShapeBorder? result = b?.lerpFrom(a, t) ?? a?.lerpTo(b, t);
+    final ShapeBorder? result =
+        b?.lerpFrom(a, t) ?? a?.lerpTo(b, t) ?? b?.lerpTo(a, 1.0 - t) ?? a?.lerpFrom(b, 1.0 - t);
     return result as OutlinedBorder? ?? (t < 0.5 ? a : b);
   }
 }

--- a/packages/flutter/test/painting/shape_border_test.dart
+++ b/packages/flutter/test/painting/shape_border_test.dart
@@ -36,6 +36,60 @@ void main() {
     expect(identical(ShapeBorder.lerp(border, border, 0.5), border), true);
   });
 
+  test('ShapeBorder.lerp tries equivalent reverse interpolation', () {
+    final ShapeBorder reverseLerpToResult = ShapeBorder.lerp(
+      const _LerpShapeBorder(),
+      const _ReverseLerpToShapeBorder(),
+      0.25,
+    )!;
+    expect(reverseLerpToResult, isA<_LerpShapeBorder>());
+    expect((reverseLerpToResult as _LerpShapeBorder).t, 0.75);
+
+    final ShapeBorder reverseLerpFromResult = ShapeBorder.lerp(
+      const _ReverseLerpFromShapeBorder(),
+      const _LerpShapeBorder(),
+      0.25,
+    )!;
+    expect(reverseLerpFromResult, isA<_LerpShapeBorder>());
+    expect((reverseLerpFromResult as _LerpShapeBorder).t, 0.75);
+  });
+
+  test('OutlinedBorder.lerp tries equivalent reverse interpolation', () {
+    final OutlinedBorder reverseLerpToResult = OutlinedBorder.lerp(
+      const _LerpOutlinedBorder(),
+      const _ReverseLerpToOutlinedBorder(),
+      0.25,
+    )!;
+    expect(reverseLerpToResult, isA<_LerpOutlinedBorder>());
+    expect((reverseLerpToResult as _LerpOutlinedBorder).t, 0.75);
+
+    final OutlinedBorder reverseLerpFromResult = OutlinedBorder.lerp(
+      const _ReverseLerpFromOutlinedBorder(),
+      const _LerpOutlinedBorder(),
+      0.25,
+    )!;
+    expect(reverseLerpFromResult, isA<_LerpOutlinedBorder>());
+    expect((reverseLerpFromResult as _LerpOutlinedBorder).t, 0.75);
+  });
+
+  test('Outlined shape borders interpolate symmetrically through ShapeBorder.lerp', () {
+    const borders = <OutlinedBorder>[
+      RoundedRectangleBorder(),
+      StadiumBorder(),
+      CircleBorder(),
+      OvalBorder(),
+      StarBorder(),
+    ];
+
+    for (final a in borders) {
+      for (final b in borders) {
+        final ShapeBorder forward = ShapeBorder.lerp(a, b, 0.25)!;
+        final ShapeBorder reverse = ShapeBorder.lerp(b, a, 0.75)!;
+        expect(forward.runtimeType, reverse.runtimeType, reason: 'ShapeBorder.lerp($a, $b, 0.25)');
+      }
+    }
+  });
+
   test('Compound borders', () {
     final b1 = Border.all(color: const Color(0xFF00FF00));
     final b2 = Border.all(color: const Color(0xFF0000FF));
@@ -171,4 +225,84 @@ void main() {
         ..rect(rect: rect.deflate(2.5), color: b1.top.color),
     );
   });
+}
+
+class _LerpShapeBorder extends ShapeBorder {
+  const _LerpShapeBorder([this.t]);
+
+  final double? t;
+
+  @override
+  EdgeInsetsGeometry get dimensions => EdgeInsets.zero;
+
+  @override
+  Path getInnerPath(Rect rect, {TextDirection? textDirection}) => Path()..addRect(rect);
+
+  @override
+  Path getOuterPath(Rect rect, {TextDirection? textDirection}) => Path()..addRect(rect);
+
+  @override
+  void paint(Canvas canvas, Rect rect, {TextDirection? textDirection}) {}
+
+  @override
+  ShapeBorder scale(double t) => _LerpShapeBorder(t);
+}
+
+class _ReverseLerpToShapeBorder extends _LerpShapeBorder {
+  const _ReverseLerpToShapeBorder();
+
+  @override
+  ShapeBorder? lerpTo(ShapeBorder? b, double t) {
+    return b is _LerpShapeBorder ? _LerpShapeBorder(t) : super.lerpTo(b, t);
+  }
+}
+
+class _ReverseLerpFromShapeBorder extends _LerpShapeBorder {
+  const _ReverseLerpFromShapeBorder();
+
+  @override
+  ShapeBorder? lerpFrom(ShapeBorder? a, double t) {
+    return a is _LerpShapeBorder ? _LerpShapeBorder(t) : super.lerpFrom(a, t);
+  }
+}
+
+class _LerpOutlinedBorder extends OutlinedBorder {
+  const _LerpOutlinedBorder([this.t, BorderSide side = BorderSide.none]) : super(side: side);
+
+  final double? t;
+
+  @override
+  _LerpOutlinedBorder copyWith({BorderSide? side}) {
+    return _LerpOutlinedBorder(t, side ?? this.side);
+  }
+
+  @override
+  Path getInnerPath(Rect rect, {TextDirection? textDirection}) => Path()..addRect(rect);
+
+  @override
+  Path getOuterPath(Rect rect, {TextDirection? textDirection}) => Path()..addRect(rect);
+
+  @override
+  void paint(Canvas canvas, Rect rect, {TextDirection? textDirection}) {}
+
+  @override
+  ShapeBorder scale(double t) => _LerpOutlinedBorder(t, side.scale(t));
+}
+
+class _ReverseLerpToOutlinedBorder extends _LerpOutlinedBorder {
+  const _ReverseLerpToOutlinedBorder();
+
+  @override
+  ShapeBorder? lerpTo(ShapeBorder? b, double t) {
+    return b is _LerpOutlinedBorder ? _LerpOutlinedBorder(t) : super.lerpTo(b, t);
+  }
+}
+
+class _ReverseLerpFromOutlinedBorder extends _LerpOutlinedBorder {
+  const _ReverseLerpFromOutlinedBorder();
+
+  @override
+  ShapeBorder? lerpFrom(ShapeBorder? a, double t) {
+    return a is _LerpOutlinedBorder ? _LerpOutlinedBorder(t) : super.lerpFrom(a, t);
+  }
 }

--- a/packages/flutter/test/painting/shape_border_test.dart
+++ b/packages/flutter/test/painting/shape_border_test.dart
@@ -42,16 +42,14 @@ void main() {
       const _ReverseLerpToShapeBorder(),
       0.25,
     )!;
-    expect(reverseLerpToResult, isA<_LerpShapeBorder>());
-    expect((reverseLerpToResult as _LerpShapeBorder).t, 0.75);
+    expect(reverseLerpToResult, const _LerpShapeBorder(0.75));
 
     final ShapeBorder reverseLerpFromResult = ShapeBorder.lerp(
       const _ReverseLerpFromShapeBorder(),
       const _LerpShapeBorder(),
       0.25,
     )!;
-    expect(reverseLerpFromResult, isA<_LerpShapeBorder>());
-    expect((reverseLerpFromResult as _LerpShapeBorder).t, 0.75);
+    expect(reverseLerpFromResult, const _LerpShapeBorder(0.75));
   });
 
   test('OutlinedBorder.lerp tries equivalent reverse interpolation', () {
@@ -60,16 +58,14 @@ void main() {
       const _ReverseLerpToOutlinedBorder(),
       0.25,
     )!;
-    expect(reverseLerpToResult, isA<_LerpOutlinedBorder>());
-    expect((reverseLerpToResult as _LerpOutlinedBorder).t, 0.75);
+    expect(reverseLerpToResult, const _LerpOutlinedBorder(0.75));
 
     final OutlinedBorder reverseLerpFromResult = OutlinedBorder.lerp(
       const _ReverseLerpFromOutlinedBorder(),
       const _LerpOutlinedBorder(),
       0.25,
     )!;
-    expect(reverseLerpFromResult, isA<_LerpOutlinedBorder>());
-    expect((reverseLerpFromResult as _LerpOutlinedBorder).t, 0.75);
+    expect(reverseLerpFromResult, const _LerpOutlinedBorder(0.75));
   });
 
   test('Outlined shape borders interpolate symmetrically through ShapeBorder.lerp', () {
@@ -246,6 +242,17 @@ class _LerpShapeBorder extends ShapeBorder {
 
   @override
   ShapeBorder scale(double t) => _LerpShapeBorder(t);
+
+  @override
+  bool operator ==(Object other) {
+    return other is _LerpShapeBorder && other.runtimeType == runtimeType && other.t == t;
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, t);
+
+  @override
+  String toString() => '_LerpShapeBorder(t: $t)';
 }
 
 class _ReverseLerpToShapeBorder extends _LerpShapeBorder {
@@ -287,6 +294,20 @@ class _LerpOutlinedBorder extends OutlinedBorder {
 
   @override
   ShapeBorder scale(double t) => _LerpOutlinedBorder(t, side.scale(t));
+
+  @override
+  bool operator ==(Object other) {
+    return other is _LerpOutlinedBorder &&
+        other.runtimeType == runtimeType &&
+        other.t == t &&
+        other.side == side;
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, t, side);
+
+  @override
+  String toString() => '_LerpOutlinedBorder(t: $t, side: $side)';
 }
 
 class _ReverseLerpToOutlinedBorder extends _LerpOutlinedBorder {

--- a/packages/flutter/test/painting/shape_border_test.dart
+++ b/packages/flutter/test/painting/shape_border_test.dart
@@ -37,38 +37,28 @@ void main() {
   });
 
   test('ShapeBorder.lerp tries equivalent reverse interpolation', () {
-    final ShapeBorder reverseLerpToResult = ShapeBorder.lerp(
-      const _LerpShapeBorder(),
-      const _ReverseLerpToShapeBorder(),
-      0.25,
-    )!;
-    expect(reverseLerpToResult, const _LerpShapeBorder(0.75));
-
-    final ShapeBorder reverseLerpFromResult = ShapeBorder.lerp(
-      const _ReverseLerpFromShapeBorder(),
-      const _LerpShapeBorder(),
-      0.25,
-    )!;
-    expect(reverseLerpFromResult, const _LerpShapeBorder(0.75));
+    expect(
+      ShapeBorder.lerp(const _LerpBorder(), const _ReverseLerpToBorder(), 0.25),
+      const _LerpBorder(0.75),
+    );
+    expect(
+      ShapeBorder.lerp(const _ReverseLerpFromBorder(), const _LerpBorder(), 0.25),
+      const _LerpBorder(0.75),
+    );
   });
 
   test('OutlinedBorder.lerp tries equivalent reverse interpolation', () {
-    final OutlinedBorder reverseLerpToResult = OutlinedBorder.lerp(
-      const _LerpOutlinedBorder(),
-      const _ReverseLerpToOutlinedBorder(),
-      0.25,
-    )!;
-    expect(reverseLerpToResult, const _LerpOutlinedBorder(0.75));
-
-    final OutlinedBorder reverseLerpFromResult = OutlinedBorder.lerp(
-      const _ReverseLerpFromOutlinedBorder(),
-      const _LerpOutlinedBorder(),
-      0.25,
-    )!;
-    expect(reverseLerpFromResult, const _LerpOutlinedBorder(0.75));
+    expect(
+      OutlinedBorder.lerp(const _LerpBorder(), const _ReverseLerpToBorder(), 0.25),
+      const _LerpBorder(0.75),
+    );
+    expect(
+      OutlinedBorder.lerp(const _ReverseLerpFromBorder(), const _LerpBorder(), 0.25),
+      const _LerpBorder(0.75),
+    );
   });
 
-  test('Outlined shape borders interpolate symmetrically through ShapeBorder.lerp', () {
+  test('Outlined shape borders interpolate symmetrically', () {
     const borders = <OutlinedBorder>[
       RoundedRectangleBorder(),
       StadiumBorder(),
@@ -79,9 +69,16 @@ void main() {
 
     for (final a in borders) {
       for (final b in borders) {
-        final ShapeBorder forward = ShapeBorder.lerp(a, b, 0.25)!;
-        final ShapeBorder reverse = ShapeBorder.lerp(b, a, 0.75)!;
-        expect(forward.runtimeType, reverse.runtimeType, reason: 'ShapeBorder.lerp($a, $b, 0.25)');
+        expect(
+          ShapeBorder.lerp(a, b, 0.25).runtimeType,
+          ShapeBorder.lerp(b, a, 0.75).runtimeType,
+          reason: 'ShapeBorder.lerp($a, $b, 0.25)',
+        );
+        expect(
+          OutlinedBorder.lerp(a, b, 0.25).runtimeType,
+          OutlinedBorder.lerp(b, a, 0.75).runtimeType,
+          reason: 'OutlinedBorder.lerp($a, $b, 0.25)',
+        );
       }
     }
   });
@@ -223,13 +220,16 @@ void main() {
   });
 }
 
-class _LerpShapeBorder extends ShapeBorder {
-  const _LerpShapeBorder([this.t]);
+// A border that does not know how to interpolate with any other class, used
+// both as the lerp partner of the borders below and as their result, recording
+// through value equality the `t` value that the lerp method received.
+class _LerpBorder extends OutlinedBorder {
+  const _LerpBorder([this.t, BorderSide side = BorderSide.none]) : super(side: side);
 
   final double? t;
 
   @override
-  EdgeInsetsGeometry get dimensions => EdgeInsets.zero;
+  _LerpBorder copyWith({BorderSide? side}) => _LerpBorder(t, side ?? this.side);
 
   @override
   Path getInnerPath(Rect rect, {TextDirection? textDirection}) => Path()..addRect(rect);
@@ -241,63 +241,11 @@ class _LerpShapeBorder extends ShapeBorder {
   void paint(Canvas canvas, Rect rect, {TextDirection? textDirection}) {}
 
   @override
-  ShapeBorder scale(double t) => _LerpShapeBorder(t);
+  ShapeBorder scale(double t) => _LerpBorder(t, side.scale(t));
 
   @override
   bool operator ==(Object other) {
-    return other is _LerpShapeBorder && other.runtimeType == runtimeType && other.t == t;
-  }
-
-  @override
-  int get hashCode => Object.hash(runtimeType, t);
-
-  @override
-  String toString() => '_LerpShapeBorder(t: $t)';
-}
-
-class _ReverseLerpToShapeBorder extends _LerpShapeBorder {
-  const _ReverseLerpToShapeBorder();
-
-  @override
-  ShapeBorder? lerpTo(ShapeBorder? b, double t) {
-    return b is _LerpShapeBorder ? _LerpShapeBorder(t) : super.lerpTo(b, t);
-  }
-}
-
-class _ReverseLerpFromShapeBorder extends _LerpShapeBorder {
-  const _ReverseLerpFromShapeBorder();
-
-  @override
-  ShapeBorder? lerpFrom(ShapeBorder? a, double t) {
-    return a is _LerpShapeBorder ? _LerpShapeBorder(t) : super.lerpFrom(a, t);
-  }
-}
-
-class _LerpOutlinedBorder extends OutlinedBorder {
-  const _LerpOutlinedBorder([this.t, BorderSide side = BorderSide.none]) : super(side: side);
-
-  final double? t;
-
-  @override
-  _LerpOutlinedBorder copyWith({BorderSide? side}) {
-    return _LerpOutlinedBorder(t, side ?? this.side);
-  }
-
-  @override
-  Path getInnerPath(Rect rect, {TextDirection? textDirection}) => Path()..addRect(rect);
-
-  @override
-  Path getOuterPath(Rect rect, {TextDirection? textDirection}) => Path()..addRect(rect);
-
-  @override
-  void paint(Canvas canvas, Rect rect, {TextDirection? textDirection}) {}
-
-  @override
-  ShapeBorder scale(double t) => _LerpOutlinedBorder(t, side.scale(t));
-
-  @override
-  bool operator ==(Object other) {
-    return other is _LerpOutlinedBorder &&
+    return other is _LerpBorder &&
         other.runtimeType == runtimeType &&
         other.t == t &&
         other.side == side;
@@ -307,23 +255,28 @@ class _LerpOutlinedBorder extends OutlinedBorder {
   int get hashCode => Object.hash(runtimeType, t, side);
 
   @override
-  String toString() => '_LerpOutlinedBorder(t: $t, side: $side)';
+  String toString() => '_LerpBorder(t: $t)';
 }
 
-class _ReverseLerpToOutlinedBorder extends _LerpOutlinedBorder {
-  const _ReverseLerpToOutlinedBorder();
+// A border that can interpolate with [_LerpBorder] only through its own
+// [lerpTo], so that lerping it with a [_LerpBorder] succeeds only through the
+// reversed `b.lerpTo(a, 1.0 - t)` call.
+class _ReverseLerpToBorder extends _LerpBorder {
+  const _ReverseLerpToBorder();
 
   @override
   ShapeBorder? lerpTo(ShapeBorder? b, double t) {
-    return b is _LerpOutlinedBorder ? _LerpOutlinedBorder(t) : super.lerpTo(b, t);
+    return b is _LerpBorder ? _LerpBorder(t) : super.lerpTo(b, t);
   }
 }
 
-class _ReverseLerpFromOutlinedBorder extends _LerpOutlinedBorder {
-  const _ReverseLerpFromOutlinedBorder();
+// Same as [_ReverseLerpToBorder], but exercising the reversed
+// `a.lerpFrom(b, 1.0 - t)` call instead.
+class _ReverseLerpFromBorder extends _LerpBorder {
+  const _ReverseLerpFromBorder();
 
   @override
   ShapeBorder? lerpFrom(ShapeBorder? a, double t) {
-    return a is _LerpOutlinedBorder ? _LerpOutlinedBorder(t) : super.lerpFrom(a, t);
+    return a is _LerpBorder ? _LerpBorder(t) : super.lerpFrom(a, t);
   }
 }


### PR DESCRIPTION

<img width="1536" height="1024" alt="ChatGPT Image May 29, 2026, 01_48_49 AM" src="https://github.com/user-attachments/assets/1a48077b-6687-47de-820a-3171b8bde84b" />

<img width="1568" height="656" alt="image" src="https://github.com/user-attachments/assets/83c0b20f-25c8-49af-b1e7-c57ac5ab4ec4" />


Fix https://github.com/flutter/flutter/issues/110634 (took 4 years to think on this solution!)

Make ShapeBorder.lerp use reverse interpolation before fallback

Some border pairs can already lerp with each other, but only one side knows how to do it. For example, `StarBorder` knows how to lerp to `RoundedRectangleBorder`, but `RoundedRectangleBorder` does not need to know about `StarBorder`.

Instead of adding more pair-specific checks like `if (b is RoundedRectangleBorder)` across shapes (at a certain point I even considered sealed classes), we can make the central lerp smarter. After trying the existing direction:

`b.lerpFrom(a, t) ?? a.lerpTo(b, t)`

also try the same animation from the opposite direction:

`b.lerpTo(a, 1.0 - t) ?? a.lerpFrom(b, 1.0 - t)`

So if `ShapeBorder.lerp(star, roundedRectangle, t)` works, `ShapeBorder.lerp(roundedRectangle, star, t)` can reuse that same logic on the reversed timeline instead of falling back to the hard switch at `t = 0.5`.

This keeps the cross-shape behavior centralized in `ShapeBorder.lerp` and `OutlinedBorder.lerp`, without changing direct `lerpFrom` or `lerpTo` calls.