### PR TITLE
[Impeller][Windows] fix black screen on OpenGL fallback

### DIFF
--- a/engine/src/flutter/shell/platform/windows/compositor_opengl.cc
+++ b/engine/src/flutter/shell/platform/windows/compositor_opengl.cc
@@ -66,28 +66,32 @@ bool CompositorOpenGL::CreateBackingStore(
   gl_->BindTexture(GL_TEXTURE_2D, 0);
 
   if (enable_impeller_) {
-    // Impeller requries that its onscreen surface is Multisampled and already
-    // has depth/stencil attached in order for anti-aliasing to work.
-    gl_->FramebufferTexture2DMultisampleEXT(GL_FRAMEBUFFER,
-                                            GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
-                                            store->texture_id, 0, 4);
+    if (supports_implicit_msaa_) {
+      // MSAA color attachment
+      gl_->FramebufferTexture2DMultisampleEXT(
+          GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+          store->texture_id, 0, 4);
+    } else {
+      gl_->FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                                GL_TEXTURE_2D, store->texture_id, 0);
+    }
 
-    // Set up depth/stencil attachment for impeller renderer.
-    GLuint depth_stencil;
+    // Impeller always requires depth/stencil attachment.
+    GLuint depth_stencil = 0;
     gl_->GenRenderbuffers(1, &depth_stencil);
     gl_->BindRenderbuffer(GL_RENDERBUFFER, depth_stencil);
-    gl_->RenderbufferStorageMultisampleEXT(
-        GL_RENDERBUFFER,      // target
-        4,                    // samples
-        GL_DEPTH24_STENCIL8,  // internal format
-        config.size.width,    // width
-        config.size.height    // height
-    );
+    if (supports_implicit_msaa_) {
+      gl_->RenderbufferStorageMultisampleEXT(
+          GL_RENDERBUFFER, 4, GL_DEPTH24_STENCIL8, config.size.width,
+          config.size.height);
+    } else {
+      gl_->RenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8,
+                               config.size.width, config.size.height);
+    }
     gl_->FramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
                                  GL_RENDERBUFFER, depth_stencil);
     gl_->FramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT,
                                  GL_RENDERBUFFER, depth_stencil);
-
   } else {
     gl_->FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
                               GL_TEXTURE_2D, store->texture_id, 0);
@@ -226,6 +230,9 @@ bool CompositorOpenGL::Initialize() {
     FML_LOG(ERROR) << "Unable to find OpenGL blit framebuffer procedure.";
     return false;
   }
+
+  supports_implicit_msaa_ =
+      gl_->GetCapabilities()->SupportsImplicitResolvingMSAA();
 
   is_initialized_ = true;
   return true;

--- a/engine/src/flutter/shell/platform/windows/compositor_opengl.cc
+++ b/engine/src/flutter/shell/platform/windows/compositor_opengl.cc
@@ -16,8 +16,9 @@ constexpr uint32_t kWindowFrameBufferId = 0;
 
 // The metadata for an OpenGL framebuffer backing store.
 struct FramebufferBackingStore {
-  uint32_t framebuffer_id;
-  uint32_t texture_id;
+  uint32_t framebuffer_id = 0;
+  uint32_t texture_id = 0;
+  uint32_t depth_stencil_id = 0;
 };
 
 typedef const impeller::GLProc<decltype(glBlitFramebuffer)> BlitFramebufferProc;
@@ -77,9 +78,8 @@ bool CompositorOpenGL::CreateBackingStore(
     }
 
     // Impeller always requires depth/stencil attachment.
-    GLuint depth_stencil = 0;
-    gl_->GenRenderbuffers(1, &depth_stencil);
-    gl_->BindRenderbuffer(GL_RENDERBUFFER, depth_stencil);
+    gl_->GenRenderbuffers(1, &store->depth_stencil_id);
+    gl_->BindRenderbuffer(GL_RENDERBUFFER, store->depth_stencil_id);
     if (supports_implicit_msaa_) {
       gl_->RenderbufferStorageMultisampleEXT(
           GL_RENDERBUFFER, 4, GL_DEPTH24_STENCIL8, config.size.width,
@@ -89,9 +89,9 @@ bool CompositorOpenGL::CreateBackingStore(
                                config.size.width, config.size.height);
     }
     gl_->FramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
-                                 GL_RENDERBUFFER, depth_stencil);
+                                 GL_RENDERBUFFER, store->depth_stencil_id);
     gl_->FramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT,
-                                 GL_RENDERBUFFER, depth_stencil);
+                                 GL_RENDERBUFFER, store->depth_stencil_id);
   } else {
     gl_->FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
                               GL_TEXTURE_2D, store->texture_id, 0);
@@ -119,6 +119,10 @@ bool CompositorOpenGL::CollectBackingStore(const FlutterBackingStore* store) {
 
   gl_->DeleteFramebuffers(1, &user_data->framebuffer_id);
   gl_->DeleteTextures(1, &user_data->texture_id);
+
+  if (user_data->depth_stencil_id != 0) {
+    gl_->DeleteRenderbuffers(1, &user_data->depth_stencil_id);
+  }
 
   delete user_data;
   return true;

--- a/engine/src/flutter/shell/platform/windows/compositor_opengl.h
+++ b/engine/src/flutter/shell/platform/windows/compositor_opengl.h
@@ -63,6 +63,9 @@ class CompositorOpenGL : public Compositor {
   // Whether the Impeller rendering backend is enabled.
   bool enable_impeller_ = false;
 
+  // Whether the OpenGL context supports implicit MSAA.
+  bool supports_implicit_msaa_ = false;
+
   // Initialize the compositor. This must run on the raster thread.
   bool Initialize();
 

--- a/engine/src/flutter/shell/platform/windows/compositor_opengl_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/compositor_opengl_unittests.cc
@@ -57,6 +57,23 @@ GLenum MockGetError() {
   return GL_NO_ERROR;
 }
 
+void MockGetIntegervWithMSAA(GLenum name, int* value) {
+  if (name == GL_NUM_EXTENSIONS) {
+    *value = 2;
+  } else {
+    *value = 0;
+  }
+}
+
+const unsigned char* MockGetStringiWithMSAA(GLenum name, int index) {
+  static constexpr const char* extensions[] = {
+      "GL_ANGLE_framebuffer_blit", "GL_EXT_multisampled_render_to_texture"};
+  if (name == GL_EXTENSIONS && index < 2) {
+    return reinterpret_cast<const unsigned char*>(extensions[index]);
+  }
+  return reinterpret_cast<const unsigned char*>("");
+}
+
 void DoNothing() {}
 
 const impeller::ProcTableGLES::Resolver kMockResolver = [](const char* name) {
@@ -74,6 +91,18 @@ const impeller::ProcTableGLES::Resolver kMockResolver = [](const char* name) {
     return reinterpret_cast<void*>(&DoNothing);
   }
 };
+
+const impeller::ProcTableGLES::Resolver kMockResolverWithMSAA =
+    [](const char* name) {
+      std::string_view function_name{name};
+
+      if (function_name == "glGetStringi") {
+        return reinterpret_cast<void*>(&MockGetStringiWithMSAA);
+      } else if (function_name == "glGetIntegerv") {
+        return reinterpret_cast<void*>(&MockGetIntegervWithMSAA);
+      }
+      return kMockResolver(name);
+    };
 
 class CompositorOpenGLTest : public WindowsTest {
  public:
@@ -151,17 +180,77 @@ TEST_F(CompositorOpenGLTest, CreateBackingStore) {
   ASSERT_TRUE(compositor.CollectBackingStore(&backing_store));
 }
 
-TEST_F(CompositorOpenGLTest, CreateBackingStoreImpeller) {
+TEST_F(CompositorOpenGLTest, CreateBackingStoreImpellerNoMSAA) {
   UseHeadlessEngine();
 
-  auto compositor =
-      CompositorOpenGL{engine(), kMockResolver, /*enable_impeller=*/true};
+  static int framebuffer_texture2d_calls = 0;
+  static int framebuffer_texture2d_multisample_calls = 0;
+  framebuffer_texture2d_calls = 0;
+  framebuffer_texture2d_multisample_calls = 0;
 
+  const impeller::ProcTableGLES::Resolver resolver =
+      [](const char* name) -> void* {
+    std::string_view function_name{name};
+    if (function_name == "glFramebufferTexture2D") {
+      return reinterpret_cast<void*>(
+          +[](GLenum, GLenum, GLenum, GLuint, GLint) {
+            framebuffer_texture2d_calls++;
+          });
+    } else if (function_name == "glFramebufferTexture2DMultisampleEXT") {
+      return reinterpret_cast<void*>(
+          +[](GLenum, GLenum, GLenum, GLuint, GLint, GLsizei) {
+            framebuffer_texture2d_multisample_calls++;
+          });
+    }
+    return kMockResolver(name);
+  };
+
+  auto compositor =
+      CompositorOpenGL{engine(), resolver, /*enable_impeller=*/true};
   FlutterBackingStoreConfig config = {};
   FlutterBackingStore backing_store = {};
 
   EXPECT_CALL(*render_context(), MakeCurrent).WillOnce(Return(true));
   ASSERT_TRUE(compositor.CreateBackingStore(config, &backing_store));
+  EXPECT_EQ(framebuffer_texture2d_calls, 1);
+  EXPECT_EQ(framebuffer_texture2d_multisample_calls, 0);
+  ASSERT_TRUE(compositor.CollectBackingStore(&backing_store));
+}
+
+TEST_F(CompositorOpenGLTest, CreateBackingStoreImpellerMSAA) {
+  UseHeadlessEngine();
+
+  static int framebuffer_texture2d_calls = 0;
+  static int framebuffer_texture2d_multisample_calls = 0;
+  framebuffer_texture2d_calls = 0;
+  framebuffer_texture2d_multisample_calls = 0;
+
+  const impeller::ProcTableGLES::Resolver resolver =
+      [](const char* name) -> void* {
+    std::string_view function_name{name};
+    if (function_name == "glFramebufferTexture2D") {
+      return reinterpret_cast<void*>(
+          +[](GLenum, GLenum, GLenum, GLuint, GLint) {
+            framebuffer_texture2d_calls++;
+          });
+    } else if (function_name == "glFramebufferTexture2DMultisampleEXT") {
+      return reinterpret_cast<void*>(
+          +[](GLenum, GLenum, GLenum, GLuint, GLint, GLsizei) {
+            framebuffer_texture2d_multisample_calls++;
+          });
+    }
+    return kMockResolverWithMSAA(name);
+  };
+
+  auto compositor =
+      CompositorOpenGL{engine(), resolver, /*enable_impeller=*/true};
+  FlutterBackingStoreConfig config = {};
+  FlutterBackingStore backing_store = {};
+
+  EXPECT_CALL(*render_context(), MakeCurrent).WillOnce(Return(true));
+  ASSERT_TRUE(compositor.CreateBackingStore(config, &backing_store));
+  EXPECT_EQ(framebuffer_texture2d_calls, 0);
+  EXPECT_EQ(framebuffer_texture2d_multisample_calls, 1);
   ASSERT_TRUE(compositor.CollectBackingStore(&backing_store));
 }
 


### PR DESCRIPTION
When Impeller is enabled on Windows without Vulkan support, it falls back to OpenGL via ANGLE/D3D11. In this case, `compositor_opengl.cc` unconditionally called `FramebufferTexture2DMultisampleEXT` regardless of whether implicit MSAA is supported, causing a fatal `GL_INVALID_OPERATION` error and a black screen.

`embedder.cc` already correctly checks `SupportsImplicitResolvingMSAA()` and creates a non-multisampled texture when implicit MSAA is unavailable. This PR mirrors that check in `compositor_opengl.cc`, falling back to plain `FramebufferTexture2D` + `RenderbufferStorage` while still providing the depth/stencil attachment that Impeller requires.

Fixes #187287

## Testing
Manually verified on Windows with ANGLE/D3D11 (no Vulkan, Impeller OpenGL fallback).
Unit tests for this change are not practical because the existing GL mocks in `compositor_opengl_unittests.cc` map all GL calls to `DoNothing`, making it impossible to verify correct GL call selection at the driver level.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.