### PR TITLE
[Impeller] Fix GLES command submission status before context is current

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/gles/BUILD.gn
+++ b/engine/src/flutter/impeller/renderer/backend/gles/BUILD.gn
@@ -16,6 +16,7 @@ impeller_component("gles_unittests") {
   sources = [
     "blit_command_gles_unittests.cc",
     "buffer_bindings_gles_unittests.cc",
+    "command_buffer_gles_unittests.cc",
     "device_buffer_gles_unittests.cc",
     "render_pass_gles_unittests.cc",
     "test/capabilities_unittests.cc",

--- a/engine/src/flutter/impeller/renderer/backend/gles/command_buffer_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/command_buffer_gles.cc
@@ -4,11 +4,52 @@
 
 #include "impeller/renderer/backend/gles/command_buffer_gles.h"
 
+#include <memory>
+#include <utility>
+
 #include "impeller/base/config.h"
 #include "impeller/renderer/backend/gles/blit_pass_gles.h"
 #include "impeller/renderer/backend/gles/render_pass_gles.h"
 
 namespace impeller {
+namespace {
+
+/// Invokes a deferred command buffer completion callback exactly once.
+///
+/// The callback is completed with `kCompleted` when the deferred reactor
+/// operation runs. If the operation is discarded before it runs, such as during
+/// reactor teardown, the callback is completed with `kError`.
+class DeferredCompletionCallback {
+ public:
+  explicit DeferredCompletionCallback(
+      CommandBuffer::CompletionCallback callback)
+      : callback_(std::move(callback)) {}
+
+  /// Completes with `kError` unless the callback was already invoked.
+  ~DeferredCompletionCallback() { Invoke(CommandBuffer::Status::kError); }
+
+  DeferredCompletionCallback(const DeferredCompletionCallback&) = delete;
+  DeferredCompletionCallback& operator=(const DeferredCompletionCallback&) =
+      delete;
+  DeferredCompletionCallback(DeferredCompletionCallback&&) = delete;
+  DeferredCompletionCallback& operator=(DeferredCompletionCallback&&) = delete;
+
+  /// Completes with `kCompleted` when the deferred reactor operation runs.
+  void Complete() { Invoke(CommandBuffer::Status::kCompleted); }
+
+ private:
+  void Invoke(CommandBuffer::Status status) {
+    if (!callback_) {
+      return;
+    }
+    auto callback = std::exchange(callback_, nullptr);
+    callback(status);
+  }
+
+  CommandBuffer::CompletionCallback callback_;
+};
+
+}  // namespace
 
 CommandBufferGLES::CommandBufferGLES(std::weak_ptr<const Context> context,
                                      std::shared_ptr<ReactorGLES> reactor)
@@ -31,12 +72,31 @@ bool CommandBufferGLES::IsValid() const {
 // |CommandBuffer|
 bool CommandBufferGLES::OnSubmitCommands(bool block_on_schedule,
                                          CompletionCallback callback) {
-  const auto result = reactor_->React();
-  if (callback) {
-    callback(result ? CommandBuffer::Status::kCompleted
-                    : CommandBuffer::Status::kError);
+  if (reactor_->CanReactOnCurrentThread()) {
+    const auto result = reactor_->React();
+    if (callback) {
+      callback(result ? CommandBuffer::Status::kCompleted
+                      : CommandBuffer::Status::kError);
+    }
+    return result;
   }
-  return result;
+
+  // Submission is accepted even when no GL context is current yet. The
+  // reactor keeps previously encoded operations queued on this thread.
+  if (!callback) {
+    return true;
+  }
+
+  auto deferred_callback =
+      std::make_shared<DeferredCompletionCallback>(std::move(callback));
+  if (!reactor_->AddOperation(
+          [deferred_callback](const ReactorGLES& reactor) {
+            deferred_callback->Complete();
+          },
+          /*defer=*/true)) {
+    return false;
+  }
+  return true;
 }
 
 // |CommandBuffer|

--- a/engine/src/flutter/impeller/renderer/backend/gles/command_buffer_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/command_buffer_gles_unittests.cc
@@ -1,0 +1,236 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <atomic>
+#include <memory>
+#include <vector>
+
+#include "flutter/fml/mapping.h"
+#include "flutter/testing/testing.h"  // IWYU pragma: keep
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "impeller/core/formats.h"
+#include "impeller/renderer/backend/gles/context_gles.h"
+#include "impeller/renderer/backend/gles/reactor_gles.h"
+#include "impeller/renderer/backend/gles/test/mock_gles.h"
+#include "impeller/renderer/backend/gles/texture_gles.h"
+#include "impeller/renderer/blit_pass.h"
+#include "impeller/renderer/command_queue.h"
+#include "impeller/renderer/context.h"
+
+namespace impeller {
+namespace testing {
+namespace {
+
+using ::testing::_;
+using ::testing::NiceMock;
+
+class ToggleWorker final : public ReactorGLES::Worker {
+ public:
+  explicit ToggleWorker(bool allowed) : allowed_(allowed) {}
+
+  bool CanReactorReactOnCurrentThreadNow(
+      const ReactorGLES& reactor) const override {
+    return allowed_.load();
+  }
+
+  void SetAllowed(bool allowed) { allowed_.store(allowed); }
+
+ private:
+  std::atomic<bool> allowed_;
+};
+
+std::shared_ptr<ContextGLES> CreateFakeGLESContext() {
+  auto gl = std::make_unique<ProcTableGLES>(kMockResolverGLES);
+  return ContextGLES::Create(Flags{}, std::move(gl),
+                             std::vector<std::shared_ptr<fml::Mapping>>{},
+                             /*enable_gpu_tracing=*/false);
+}
+
+}  // namespace
+
+TEST(CommandBufferGLES,
+     SubmitWithoutCurrentContextIsAcceptedAndCompletesAfterReaction) {
+  auto mock_gles = MockGLES::Init();
+  auto context = CreateFakeGLESContext();
+  auto context_base = std::static_pointer_cast<Context>(context);
+  auto worker = std::make_shared<ToggleWorker>(false);
+  context->AddReactorWorker(worker);
+
+  auto command_buffer = context_base->CreateCommandBuffer();
+  ASSERT_TRUE(command_buffer);
+
+  bool callback_called = false;
+  CommandBuffer::Status callback_status = CommandBuffer::Status::kError;
+  auto status = context_base->GetCommandQueue()->Submit(
+      {command_buffer}, [&](CommandBuffer::Status status) {
+        callback_called = true;
+        callback_status = status;
+      });
+
+  EXPECT_TRUE(status.ok());
+  EXPECT_FALSE(callback_called);
+
+  worker->SetAllowed(true);
+  EXPECT_TRUE(context->GetReactor()->React());
+  EXPECT_TRUE(callback_called);
+  EXPECT_EQ(callback_status, CommandBuffer::Status::kCompleted);
+}
+
+TEST(CommandBufferGLES, SubmitWithoutCallbackIsAcceptedWithoutCurrentContext) {
+  auto mock_gles = MockGLES::Init();
+  auto context = CreateFakeGLESContext();
+  auto context_base = std::static_pointer_cast<Context>(context);
+  auto worker = std::make_shared<ToggleWorker>(false);
+  context->AddReactorWorker(worker);
+
+  auto command_buffer = context_base->CreateCommandBuffer();
+  ASSERT_TRUE(command_buffer);
+
+  EXPECT_TRUE(context_base->GetCommandQueue()->Submit({command_buffer}).ok());
+}
+
+TEST(CommandBufferGLES, DeferredSubmitCallbackErrorsIfReactorIsDestroyed) {
+  bool callback_called = false;
+  CommandBuffer::Status callback_status = CommandBuffer::Status::kCompleted;
+
+  {
+    auto mock_gles = MockGLES::Init();
+    auto context = CreateFakeGLESContext();
+    auto context_base = std::static_pointer_cast<Context>(context);
+    auto worker = std::make_shared<ToggleWorker>(false);
+    context->AddReactorWorker(worker);
+
+    auto command_buffer = context_base->CreateCommandBuffer();
+    ASSERT_TRUE(command_buffer);
+    auto status = context_base->GetCommandQueue()->Submit(
+        {command_buffer}, [&](CommandBuffer::Status status) {
+          callback_called = true;
+          callback_status = status;
+        });
+
+    EXPECT_TRUE(status.ok());
+    EXPECT_FALSE(callback_called);
+  }
+
+  EXPECT_TRUE(callback_called);
+  EXPECT_EQ(callback_status, CommandBuffer::Status::kError);
+}
+
+TEST(CommandBufferGLES, DeferredSubmitCompletesAfterPreviouslyQueuedWork) {
+  auto mock_gles = MockGLES::Init();
+  auto context = CreateFakeGLESContext();
+  auto context_base = std::static_pointer_cast<Context>(context);
+  auto worker = std::make_shared<ToggleWorker>(false);
+  context->AddReactorWorker(worker);
+
+  std::vector<int> order;
+  ASSERT_TRUE(context->GetReactor()->AddOperation(
+      [&](const ReactorGLES& reactor) { order.push_back(1); },
+      /*defer=*/true));
+
+  auto command_buffer = context_base->CreateCommandBuffer();
+  ASSERT_TRUE(command_buffer);
+  auto status = context_base->GetCommandQueue()->Submit(
+      {command_buffer},
+      [&](CommandBuffer::Status status) { order.push_back(2); });
+
+  EXPECT_TRUE(status.ok());
+  EXPECT_TRUE(order.empty());
+
+  worker->SetAllowed(true);
+  EXPECT_TRUE(context->GetReactor()->React());
+  EXPECT_THAT(order, ::testing::ElementsAre(1, 2));
+}
+
+TEST(CommandBufferGLES, LaterCurrentSubmitDrainsPreviouslyDeferredWork) {
+  auto mock_gles = MockGLES::Init();
+  auto context = CreateFakeGLESContext();
+  auto context_base = std::static_pointer_cast<Context>(context);
+  auto worker = std::make_shared<ToggleWorker>(false);
+  context->AddReactorWorker(worker);
+
+  std::vector<int> order;
+  ASSERT_TRUE(context->GetReactor()->AddOperation(
+      [&](const ReactorGLES& reactor) { order.push_back(1); },
+      /*defer=*/true));
+
+  auto deferred_command_buffer = context_base->CreateCommandBuffer();
+  ASSERT_TRUE(deferred_command_buffer);
+  EXPECT_TRUE(
+      context_base->GetCommandQueue()->Submit({deferred_command_buffer}).ok());
+  EXPECT_TRUE(order.empty());
+
+  worker->SetAllowed(true);
+  auto current_command_buffer = context_base->CreateCommandBuffer();
+  ASSERT_TRUE(current_command_buffer);
+  EXPECT_TRUE(
+      context_base->GetCommandQueue()
+          ->Submit({current_command_buffer},
+                   [&](CommandBuffer::Status status) { order.push_back(2); })
+          .ok());
+  EXPECT_THAT(order, ::testing::ElementsAre(1, 2));
+}
+
+TEST(CommandBufferGLES, BufferToTextureBlitCanBeSubmittedBeforeContextCurrent) {
+  auto mock_gles_impl = std::make_unique<NiceMock<MockGLESImpl>>();
+  auto& mock_gles_impl_ref = *mock_gles_impl;
+  auto mock_gles = MockGLES::Init(std::move(mock_gles_impl));
+  auto context = CreateFakeGLESContext();
+  auto context_base = std::static_pointer_cast<Context>(context);
+  auto worker = std::make_shared<ToggleWorker>(false);
+  context->AddReactorWorker(worker);
+
+  constexpr GLuint kTextureHandle = 1234;
+  bool texture_generated = false;
+  bool texture_uploaded = false;
+  EXPECT_CALL(mock_gles_impl_ref, GenTextures(1, _))
+      .WillOnce([&](GLsizei size, GLuint* textures) {
+        texture_generated = true;
+        textures[0] = kTextureHandle;
+      });
+  EXPECT_CALL(mock_gles_impl_ref, BindTexture(GL_TEXTURE_2D, kTextureHandle))
+      .Times(::testing::AtLeast(1));
+  EXPECT_CALL(mock_gles_impl_ref,
+              TexImage2D(GL_TEXTURE_2D, 0, _, 2, 2, 0, _, _, nullptr))
+      .Times(1);
+  EXPECT_CALL(mock_gles_impl_ref,
+              TexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 2, 2, _, _, _))
+      .WillOnce([&](GLenum target, GLint level, GLint xoffset, GLint yoffset,
+                    GLsizei width, GLsizei height, GLenum format, GLenum type,
+                    const void* pixels) { texture_uploaded = true; });
+
+  TextureDescriptor texture_descriptor;
+  texture_descriptor.size = {2, 2};
+  texture_descriptor.format = PixelFormat::kR8G8B8A8UNormInt;
+  auto texture = context_base->GetResourceAllocator()->CreateTexture(
+      texture_descriptor, /*threadsafe=*/true);
+  ASSERT_TRUE(texture);
+
+  const uint8_t pixels[16] = {};
+  auto buffer =
+      context_base->GetResourceAllocator()->CreateBufferWithCopy(pixels, 16);
+  ASSERT_TRUE(buffer);
+
+  auto command_buffer = context_base->CreateCommandBuffer();
+  ASSERT_TRUE(command_buffer);
+  auto blit_pass = command_buffer->CreateBlitPass();
+  ASSERT_TRUE(blit_pass);
+
+  EXPECT_TRUE(blit_pass->AddCopy(BufferView(buffer, Range(0, 16)), texture,
+                                 IRect::MakeXYWH(0, 0, 2, 2),
+                                 "Deferred texture overwrite"));
+  EXPECT_TRUE(blit_pass->EncodeCommands());
+  EXPECT_TRUE(context_base->GetCommandQueue()->Submit({command_buffer}).ok());
+  EXPECT_FALSE(texture_generated);
+  EXPECT_FALSE(texture_uploaded);
+
+  worker->SetAllowed(true);
+  EXPECT_TRUE(context->GetReactor()->React());
+  EXPECT_TRUE(texture_generated);
+  EXPECT_TRUE(texture_uploaded);
+}
+
+}  // namespace testing
+}  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/gles/reactor_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/reactor_gles.h
@@ -231,6 +231,15 @@ class ReactorGLES {
   [[nodiscard]] bool AddOperation(Operation operation, bool defer = false);
 
   //----------------------------------------------------------------------------
+  /// @brief      Whether a reaction can be performed on the current thread.
+  ///
+  ///             If this returns false, queued operations remain valid but
+  ///             cannot be flushed until a worker with a current OpenGL context
+  ///             is available on this thread.
+  ///
+  [[nodiscard]] bool CanReactOnCurrentThread() const;
+
+  //----------------------------------------------------------------------------
   /// @brief      Register a cleanup callback that will be invokved with the
   ///             provided user data when the handle is destroyed.
   ///
@@ -305,8 +314,6 @@ class ReactorGLES {
   bool ReactOnce();
 
   bool HasPendingOperations() const;
-
-  bool CanReactOnCurrentThread() const;
 
   bool ConsolidateHandles();
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/187290

This fixes another issue that makes the GLES backend behave quite differently from Metal/Vulkan.

This makes GLES command submission accept work when no reactor worker can currently react. Previously, that path returned failure even though encoded reactor operations remained queued, which made stuff like Flutter GPU `Texture.overwrite` erroneously fail if used before the first frame on GLES.

The GLES completion callback is now queued behind existing reactor work and fires after the deferred work drains. If a GL context is current and the reaction fails, submission still reports an error.

Adds GLES unit coverage for deferred submit acceptance, callback ordering, later draining by a current submit, and a buffer-to-texture blit submitted before a context is current.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
