### PR TITLE
Keep macOS Flutter xcconfigs on Runner target

### DIFF
--- a/packages/flutter_tools/templates/app/macos.tmpl/Runner.xcodeproj/project.pbxproj.tmpl
+++ b/packages/flutter_tools/templates/app/macos.tmpl/Runner.xcodeproj/project.pbxproj.tmpl
@@ -452,7 +452,6 @@
 		};
 		338D0CE9231458BD00FA5F75 /* Profile */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -501,7 +500,7 @@
 		};
 		338D0CEA231458BD00FA5F75 /* Profile */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 33E5194F232828860026EE4D /* AppInfo.xcconfig */;
+			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -528,7 +527,6 @@
 		};
 		33CC10F92044A3C60003C045 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -584,7 +582,6 @@
 		};
 		33CC10FA2044A3C60003C045 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -633,7 +630,7 @@
 		};
 		33CC10FC2044A3C60003C045 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 33E5194F232828860026EE4D /* AppInfo.xcconfig */;
+			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -653,7 +650,7 @@
 		};
 		33CC10FD2044A3C60003C045 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 33E5194F232828860026EE4D /* AppInfo.xcconfig */;
+			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;

--- a/packages/flutter_tools/templates/app/macos.tmpl/Runner/Configs/Debug.xcconfig
+++ b/packages/flutter_tools/templates/app/macos.tmpl/Runner/Configs/Debug.xcconfig
@@ -1,2 +1,3 @@
+#include "AppInfo.xcconfig"
 #include "../../Flutter/Flutter-Debug.xcconfig"
 #include "Warnings.xcconfig"

--- a/packages/flutter_tools/templates/app/macos.tmpl/Runner/Configs/Release.xcconfig
+++ b/packages/flutter_tools/templates/app/macos.tmpl/Runner/Configs/Release.xcconfig
@@ -1,2 +1,3 @@
+#include "AppInfo.xcconfig"
 #include "../../Flutter/Flutter-Release.xcconfig"
 #include "Warnings.xcconfig"

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -1744,6 +1744,12 @@ void main() {
       expect(macosXcodeConfig, contains('PRODUCT_NAME = flutter_project'));
       expect(macosXcodeConfig, contains('PRODUCT_BUNDLE_IDENTIFIER = com.foo.bar.flutterProject'));
       expect(macosXcodeConfig, contains('PRODUCT_COPYRIGHT ='));
+      for (final configName in ['Debug.xcconfig', 'Release.xcconfig']) {
+        final File configFile = globals.fs.file(
+          globals.fs.path.join(projectDir.path, 'macos', 'Runner', 'Configs', configName),
+        );
+        expect(configFile.readAsStringSync(), contains('#include "AppInfo.xcconfig"'));
+      }
 
       // Xcode project
       final String xcodeProjectPath = globals.fs.path.join(
@@ -1758,6 +1764,48 @@ void main() {
       final String xcodeProject = xcodeProjectFile.readAsStringSync();
       expect(xcodeProject, contains('path = "flutter_project.app";'));
       expect(xcodeProject, contains('LastUpgradeCheck = 1510;'));
+      String xcodeBuildConfiguration(String identifier) {
+        final RegExpMatch? match = RegExp(
+          '\\t\\t$identifier /\\* [^*]+ \\*/ = \\{\\r?\\n([\\s\\S]*?)\\r?\\n\\t\\t\\};',
+        ).firstMatch(xcodeProject);
+        expect(match, isNotNull);
+        return match!.group(1)!;
+      }
+
+      Map<String, String> xcodeBuildConfigurationsFor(String ownerComment) {
+        final int start = xcodeProject.indexOf(
+          '/* Build configuration list for $ownerComment */ = {',
+        );
+        expect(start, isNot(-1));
+        final int end = xcodeProject.indexOf(RegExp(r'\r?\n\t\t};'), start);
+        expect(end, isNot(-1));
+        final String configurationList = xcodeProject.substring(start, end);
+        return <String, String>{
+          for (final RegExpMatch match in RegExp(
+            r'\t\t\t\t([A-Z0-9]+) /\* (Debug|Release|Profile) \*/,',
+          ).allMatches(configurationList))
+            match.group(2)!: xcodeBuildConfiguration(match.group(1)!),
+        };
+      }
+
+      final Map<String, String> projectConfigurations = xcodeBuildConfigurationsFor(
+        'PBXProject "Runner"',
+      );
+      expect(projectConfigurations.keys, unorderedEquals(<String>['Debug', 'Release', 'Profile']));
+      for (final String configuration in projectConfigurations.values) {
+        expect(configuration, isNot(contains('baseConfigurationReference')));
+      }
+
+      final Map<String, String> runnerTargetConfigurations = xcodeBuildConfigurationsFor(
+        'PBXNativeTarget "Runner"',
+      );
+      expect(
+        runnerTargetConfigurations.keys,
+        unorderedEquals(<String>['Debug', 'Release', 'Profile']),
+      );
+      expect(runnerTargetConfigurations['Debug'], contains('/* Debug.xcconfig */'));
+      expect(runnerTargetConfigurations['Release'], contains('/* Release.xcconfig */'));
+      expect(runnerTargetConfigurations['Profile'], contains('/* Release.xcconfig */'));
 
       // Xcode workspace shared data
       final Directory workspaceSharedData = globals.fs.directory(


### PR DESCRIPTION
## Issue

Fixes https://github.com/flutter/flutter/issues/167644.

The macOS app template attached `Debug.xcconfig` and `Release.xcconfig` to the Xcode project build configurations. Those files include Flutter's generated xcconfigs, and CocoaPods adds the Pods includes through those Flutter xcconfigs. As a result, unrelated targets added to the same macOS Xcode project could inherit Runner's Flutter/Pods linker settings.

## Fix

Keep the project build configurations generic and attach the Flutter xcconfigs to the Runner target build configurations instead, matching the iOS template shape. `Debug.xcconfig` and `Release.xcconfig` now include `AppInfo.xcconfig` so the Runner target keeps the existing app metadata settings.

## Tests

- `../../bin/dart run test -j1 --timeout=120s test/commands.shard/permeable/create_test.dart -n "has correct content and formatting with macOS app template"`
- `../../bin/dart analyze test/commands.shard/permeable/create_test.dart`
- `git diff --check`

## Risk

This is limited to the generated macOS app template and its create-template test. Existing macOS projects are not migrated by this change.
