### PR TITLE
[Impeller] Use glVertexAttribDivisor on GLES3 and glVertexAttribDivisorEXT on GLES2 with the extension

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -248,7 +248,9 @@ bool BufferBindingsGLES::BindVertexAttributes(const ProcTableGLES& gl,
     // which is the default. Setting it for every attribute (including
     // divisor 0) also clears any stale divisor left by a prior pipeline,
     // which matters on ES, where there is no vertex array object.
-    if (gl.VertexAttribDivisorEXT.IsAvailable()) {
+    if (gl.VertexAttribDivisor.IsAvailable()) {
+      gl.VertexAttribDivisor(array.index, array.vertex_attrib_divisor);
+    } else if (gl.VertexAttribDivisorEXT.IsAvailable()) {
       gl.VertexAttribDivisorEXT(array.index, array.vertex_attrib_divisor);
     }
   }

--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -248,10 +248,11 @@ bool BufferBindingsGLES::BindVertexAttributes(const ProcTableGLES& gl,
     // which is the default. Setting it for every attribute (including
     // divisor 0) also clears any stale divisor left by a prior pipeline,
     // which matters on ES, where there is no vertex array object.
-    const auto& gl_vertex_attrib_divisor = gl.VertexAttribDivisor.IsAvailable()
-                                               ? gl.VertexAttribDivisor
-                                               : gl.VertexAttribDivisorEXT;
-    gl_vertex_attrib_divisor(array.index, array.vertex_attrib_divisor);
+    if (gl.VertexAttribDivisor.IsAvailable()) {
+      gl.VertexAttribDivisor(array.index, array.vertex_attrib_divisor);
+    } else if (gl.VertexAttribDivisorEXT.IsAvailable()) {
+      gl.VertexAttribDivisorEXT(array.index, array.vertex_attrib_divisor);
+    }
   }
 
   return true;

--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -248,11 +248,10 @@ bool BufferBindingsGLES::BindVertexAttributes(const ProcTableGLES& gl,
     // which is the default. Setting it for every attribute (including
     // divisor 0) also clears any stale divisor left by a prior pipeline,
     // which matters on ES, where there is no vertex array object.
-    if (gl.VertexAttribDivisor.IsAvailable()) {
-      gl.VertexAttribDivisor(array.index, array.vertex_attrib_divisor);
-    } else if (gl.VertexAttribDivisorEXT.IsAvailable()) {
-      gl.VertexAttribDivisorEXT(array.index, array.vertex_attrib_divisor);
-    }
+    const auto& gl_vertex_attrib_divisor = gl.VertexAttribDivisor.IsAvailable()
+                                               ? gl.VertexAttribDivisor
+                                               : gl.VertexAttribDivisorEXT;
+    gl_vertex_attrib_divisor(array.index, array.vertex_attrib_divisor);
   }
 
   return true;

--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles_unittests.cc
@@ -190,8 +190,8 @@ TEST(BufferBindingsGLESTest, BindUniformFailsWithoutFloatType) {
 // per-vertex binding keeps a divisor of 0.
 TEST(BufferBindingsGLESTest, BindVertexAttributesSetsInstanceRateDivisor) {
   auto mock_gles_impl = std::make_unique<::testing::NiceMock<MockGLESImpl>>();
-  EXPECT_CALL(*mock_gles_impl, VertexAttribDivisorEXT(0, 0)).Times(1);
-  EXPECT_CALL(*mock_gles_impl, VertexAttribDivisorEXT(1, 1)).Times(1);
+  EXPECT_CALL(*mock_gles_impl, VertexAttribDivisor(0, 0)).Times(1);
+  EXPECT_CALL(*mock_gles_impl, VertexAttribDivisor(1, 1)).Times(1);
   std::shared_ptr<MockGLES> mock_gl = MockGLES::Init(std::move(mock_gles_impl));
 
   BufferBindingsGLES bindings;

--- a/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.cc
@@ -150,6 +150,11 @@ ProcTableGLES::ProcTableGLES(  // NOLINT(google-readability-function-size)
     VertexAttribDivisorEXT.Reset();
   }
 
+  if (!description_->HasExtension("GL_EXT_draw_instanced")) {
+    DrawArraysInstancedEXT.Reset();
+    DrawElementsInstancedEXT.Reset();
+  }
+
   capabilities_ = std::make_shared<CapabilitiesGLES>(*this);
 
   is_valid_ = true;

--- a/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.cc
@@ -146,6 +146,10 @@ ProcTableGLES::ProcTableGLES(  // NOLINT(google-readability-function-size)
     BlitFramebufferANGLE.Reset();
   }
 
+  if (!description_->HasExtension("GL_EXT_instanced_arrays")) {
+    VertexAttribDivisorEXT.Reset();
+  }
+
   capabilities_ = std::make_shared<CapabilitiesGLES>(*this);
 
   is_valid_ = true;

--- a/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
@@ -289,7 +289,9 @@ void(glDepthRange)(GLdouble n, GLdouble f);
   PROC(BlitFramebufferANGLE);               \
   PROC(VertexAttribDivisor);                \
   PROC(VertexAttribDivisorEXT);             \
+  PROC(DrawArraysInstanced);                \
   PROC(DrawArraysInstancedEXT);             \
+  PROC(DrawElementsInstanced);              \
   PROC(DrawElementsInstancedEXT);
 
 enum class DebugResourceType {

--- a/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
@@ -287,6 +287,7 @@ void(glDepthRange)(GLdouble n, GLdouble f);
   PROC(EndQueryEXT);                        \
   PROC(GetQueryObjectuivEXT);               \
   PROC(BlitFramebufferANGLE);               \
+  PROC(VertexAttribDivisor);                \
   PROC(VertexAttribDivisorEXT);             \
   PROC(DrawArraysInstancedEXT);             \
   PROC(DrawElementsInstancedEXT);

--- a/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -528,10 +528,14 @@ static void EncodeViewport(const ProcTableGLES& gl,
     /// instance in between.
     ///
     const bool instanced = command.instance_count > 1u;
-    const bool hardware_instanced = instanced &&  //
-                                    gl.DrawArraysInstancedEXT.IsAvailable() &&
-                                    gl.DrawElementsInstancedEXT.IsAvailable() &&
-                                    gl.VertexAttribDivisorEXT.IsAvailable();
+    const bool hardware_instanced =
+        instanced &&
+        (gl.DrawArraysInstanced.IsAvailable() ||
+         gl.DrawArraysInstancedEXT.IsAvailable()) &&
+        (gl.DrawElementsInstanced.IsAvailable() ||
+         gl.DrawElementsInstancedEXT.IsAvailable()) &&
+        (gl.VertexAttribDivisor.IsAvailable() ||
+         gl.VertexAttribDivisorEXT.IsAvailable());
     const bool emulate_instanced = instanced && !hardware_instanced;
     const GLsizei instance_count = static_cast<GLsizei>(command.instance_count);
 
@@ -590,12 +594,19 @@ static void EncodeViewport(const ProcTableGLES& gl,
     } else if (hardware_instanced) {
       // A single instanced call covers every instance.
       if (!is_indexed) {
-        gl.DrawArraysInstancedEXT(mode, command.base_vertex,
-                                  command.element_count, instance_count);
+        const auto& gl_draw_arrays_instanced =
+            gl.DrawArraysInstanced.IsAvailable() ? gl.DrawArraysInstanced
+                                                 : gl.DrawArraysInstancedEXT;
+        gl_draw_arrays_instanced(mode, command.base_vertex,
+                                 command.element_count, instance_count);
       } else {
-        gl.DrawElementsInstancedEXT(mode, command.element_count,
-                                    ToIndexType(command.index_type),
-                                    index_offset, instance_count);
+        const auto& gl_draw_elements_instanced =
+            gl.DrawElementsInstanced.IsAvailable()
+                ? gl.DrawElementsInstanced
+                : gl.DrawElementsInstancedEXT;
+        gl_draw_elements_instanced(mode, command.element_count,
+                                   ToIndexType(command.index_type),
+                                   index_offset, instance_count);
       }
     } else {
       draw_geometry();

--- a/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles_unittests.cc
@@ -399,8 +399,8 @@ TEST_F(RenderPassGLESCommandTest, HardwareInstancedArrayDraw) {
   EXPECT_TRUE(render_pass->Draw().ok());
 
   EXPECT_CALL(mock_gl_impl_ref,
-              DrawArraysInstancedEXT(/*mode=*/_, /*first=*/0, /*count=*/3,
-                                     /*instancecount=*/4))
+              DrawArraysInstanced(/*mode=*/_, /*first=*/0, /*count=*/3,
+                                  /*instancecount=*/4))
       .Times(1);
   EXPECT_CALL(mock_gl_impl_ref, DrawArrays(_, _, _)).Times(0);
 
@@ -433,8 +433,8 @@ TEST_F(RenderPassGLESCommandTest, HardwareInstancedElementsDraw) {
   EXPECT_TRUE(render_pass->Draw().ok());
 
   EXPECT_CALL(mock_gl_impl_ref,
-              DrawElementsInstancedEXT(/*mode=*/_, /*count=*/6, /*type=*/_,
-                                       /*indices=*/_, /*instancecount=*/4))
+              DrawElementsInstanced(/*mode=*/_, /*count=*/6, /*type=*/_,
+                                    /*indices=*/_, /*instancecount=*/4))
       .Times(1);
   EXPECT_CALL(mock_gl_impl_ref, DrawElements(_, _, _, _)).Times(0);
 
@@ -461,7 +461,7 @@ TEST_F(RenderPassGLESCommandTest, EmulatedInstancedArrayDraw) {
   EXPECT_CALL(mock_gl_impl_ref,
               DrawArrays(/*mode=*/_, /*first=*/0, /*count=*/3))
       .Times(4);
-  EXPECT_CALL(mock_gl_impl_ref, DrawArraysInstancedEXT(_, _, _, _)).Times(0);
+  EXPECT_CALL(mock_gl_impl_ref, DrawArraysInstanced(_, _, _, _)).Times(0);
 
   EXPECT_TRUE(render_pass->EncodeCommands());
   EXPECT_TRUE(reactor->React());
@@ -494,8 +494,7 @@ TEST_F(RenderPassGLESCommandTest, EmulatedInstancedElementsDraw) {
   EXPECT_CALL(mock_gl_impl_ref,
               DrawElements(/*mode=*/_, /*count=*/6, /*type=*/_, /*indices=*/_))
       .Times(4);
-  EXPECT_CALL(mock_gl_impl_ref, DrawElementsInstancedEXT(_, _, _, _, _))
-      .Times(0);
+  EXPECT_CALL(mock_gl_impl_ref, DrawElementsInstanced(_, _, _, _, _)).Times(0);
 
   EXPECT_TRUE(render_pass->EncodeCommands());
   EXPECT_TRUE(reactor->React());
@@ -518,7 +517,7 @@ TEST_F(RenderPassGLESCommandTest, NonInstancedDrawIssuesSingleDrawArrays) {
   EXPECT_CALL(mock_gl_impl_ref,
               DrawArrays(/*mode=*/_, /*first=*/0, /*count=*/3))
       .Times(1);
-  EXPECT_CALL(mock_gl_impl_ref, DrawArraysInstancedEXT(_, _, _, _)).Times(0);
+  EXPECT_CALL(mock_gl_impl_ref, DrawArraysInstanced(_, _, _, _)).Times(0);
 
   EXPECT_TRUE(render_pass->EncodeCommands());
   EXPECT_TRUE(reactor->React());
@@ -540,7 +539,7 @@ TEST_F(RenderPassGLESCommandTest, ZeroInstanceCountIssuesNoDraw) {
   EXPECT_TRUE(render_pass->Draw().ok());
 
   EXPECT_CALL(mock_gl_impl_ref, DrawArrays(_, _, _)).Times(0);
-  EXPECT_CALL(mock_gl_impl_ref, DrawArraysInstancedEXT(_, _, _, _)).Times(0);
+  EXPECT_CALL(mock_gl_impl_ref, DrawArraysInstanced(_, _, _, _)).Times(0);
 
   EXPECT_TRUE(render_pass->EncodeCommands());
   EXPECT_TRUE(reactor->React());

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.cc
@@ -373,35 +373,35 @@ void mockDrawElements(GLenum mode,
 static_assert(CheckSameSignature<decltype(mockDrawElements),  //
                                  decltype(glDrawElements)>::value);
 
-void mockDrawArraysInstancedEXT(GLenum mode,
-                                GLint first,
-                                GLsizei count,
-                                GLsizei instancecount) {
-  CallMockMethod(&IMockGLESImpl::DrawArraysInstancedEXT, mode, first, count,
+void mockDrawArraysInstanced(GLenum mode,
+                             GLint first,
+                             GLsizei count,
+                             GLsizei instancecount) {
+  CallMockMethod(&IMockGLESImpl::DrawArraysInstanced, mode, first, count,
                  instancecount);
 }
 
-static_assert(CheckSameSignature<decltype(mockDrawArraysInstancedEXT),  //
-                                 decltype(glDrawArraysInstancedEXT)>::value);
+static_assert(CheckSameSignature<decltype(mockDrawArraysInstanced),  //
+                                 decltype(glDrawArraysInstanced)>::value);
 
-void mockDrawElementsInstancedEXT(GLenum mode,
-                                  GLsizei count,
-                                  GLenum type,
-                                  const void* indices,
-                                  GLsizei instancecount) {
-  CallMockMethod(&IMockGLESImpl::DrawElementsInstancedEXT, mode, count, type,
+void mockDrawElementsInstanced(GLenum mode,
+                               GLsizei count,
+                               GLenum type,
+                               const void* indices,
+                               GLsizei instancecount) {
+  CallMockMethod(&IMockGLESImpl::DrawElementsInstanced, mode, count, type,
                  indices, instancecount);
 }
 
-static_assert(CheckSameSignature<decltype(mockDrawElementsInstancedEXT),  //
-                                 decltype(glDrawElementsInstancedEXT)>::value);
+static_assert(CheckSameSignature<decltype(mockDrawElementsInstanced),  //
+                                 decltype(glDrawElementsInstanced)>::value);
 
-void mockVertexAttribDivisorEXT(GLuint index, GLuint divisor) {
-  CallMockMethod(&IMockGLESImpl::VertexAttribDivisorEXT, index, divisor);
+void mockVertexAttribDivisor(GLuint index, GLuint divisor) {
+  CallMockMethod(&IMockGLESImpl::VertexAttribDivisor, index, divisor);
 }
 
-static_assert(CheckSameSignature<decltype(mockVertexAttribDivisorEXT),  //
-                                 decltype(glVertexAttribDivisorEXT)>::value);
+static_assert(CheckSameSignature<decltype(mockVertexAttribDivisor),  //
+                                 decltype(glVertexAttribDivisor)>::value);
 
 // static
 std::shared_ptr<MockGLES> MockGLES::Init(
@@ -519,12 +519,12 @@ const ProcTableGLES::Resolver kMockResolverGLES = [](const char* name) {
     return reinterpret_cast<void*>(mockDrawArrays);
   } else if (strcmp(name, "glDrawElements") == 0) {
     return reinterpret_cast<void*>(mockDrawElements);
-  } else if (strcmp(name, "glDrawArraysInstancedEXT") == 0) {
-    return reinterpret_cast<void*>(mockDrawArraysInstancedEXT);
-  } else if (strcmp(name, "glDrawElementsInstancedEXT") == 0) {
-    return reinterpret_cast<void*>(mockDrawElementsInstancedEXT);
-  } else if (strcmp(name, "glVertexAttribDivisorEXT") == 0) {
-    return reinterpret_cast<void*>(mockVertexAttribDivisorEXT);
+  } else if (strcmp(name, "glDrawArraysInstanced") == 0) {
+    return reinterpret_cast<void*>(mockDrawArraysInstanced);
+  } else if (strcmp(name, "glDrawElementsInstanced") == 0) {
+    return reinterpret_cast<void*>(mockDrawElementsInstanced);
+  } else if (strcmp(name, "glVertexAttribDivisor") == 0) {
+    return reinterpret_cast<void*>(mockVertexAttribDivisor);
   } else {
     return reinterpret_cast<void*>(&doNothing);
   }

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.h
@@ -111,16 +111,16 @@ class IMockGLESImpl {
                             GLsizei count,
                             GLenum type,
                             const void* indices) {}
-  virtual void DrawArraysInstancedEXT(GLenum mode,
-                                      GLint first,
-                                      GLsizei count,
-                                      GLsizei instancecount) {}
-  virtual void DrawElementsInstancedEXT(GLenum mode,
-                                        GLsizei count,
-                                        GLenum type,
-                                        const void* indices,
-                                        GLsizei instancecount) {}
-  virtual void VertexAttribDivisorEXT(GLuint index, GLuint divisor) {}
+  virtual void DrawArraysInstanced(GLenum mode,
+                                   GLint first,
+                                   GLsizei count,
+                                   GLsizei instancecount) {}
+  virtual void DrawElementsInstanced(GLenum mode,
+                                     GLsizei count,
+                                     GLenum type,
+                                     const void* indices,
+                                     GLsizei instancecount) {}
+  virtual void VertexAttribDivisor(GLuint index, GLuint divisor) {}
 };
 
 class MockGLESImpl : public IMockGLESImpl {
@@ -275,11 +275,11 @@ class MockGLESImpl : public IMockGLESImpl {
               (GLenum mode, GLsizei count, GLenum type, const void* indices),
               (override));
   MOCK_METHOD(void,
-              DrawArraysInstancedEXT,
+              DrawArraysInstanced,
               (GLenum mode, GLint first, GLsizei count, GLsizei instancecount),
               (override));
   MOCK_METHOD(void,
-              DrawElementsInstancedEXT,
+              DrawElementsInstanced,
               (GLenum mode,
                GLsizei count,
                GLenum type,
@@ -287,7 +287,7 @@ class MockGLESImpl : public IMockGLESImpl {
                GLsizei instancecount),
               (override));
   MOCK_METHOD(void,
-              VertexAttribDivisorEXT,
+              VertexAttribDivisor,
               (GLuint index, GLuint divisor),
               (override));
 };

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/proc_table_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/proc_table_gles_unittests.cc
@@ -47,6 +47,18 @@ TEST(ProcTableGLES, CheckFrameBufferStatusDebugOnly) {
   mock_gles->GetProcTable().CheckFramebufferStatusDebug(0);
 }
 
+TEST(ProcTableGLES, GLES2VertexAttribDivisor) {
+  const auto extensions = std::vector<const char*>{"GL_EXT_instanced_arrays"};
+  auto mock_gles = MockGLES::Init(extensions);
+  EXPECT_TRUE(mock_gles->GetProcTable().VertexAttribDivisorEXT.IsAvailable());
+}
+
+TEST(ProcTableGLES, GLES3VertexAttribDivisor) {
+  auto mock_gles = MockGLES::Init();
+  EXPECT_FALSE(mock_gles->GetProcTable().VertexAttribDivisorEXT.IsAvailable());
+  EXPECT_TRUE(mock_gles->GetProcTable().VertexAttribDivisor.IsAvailable());
+}
+
 TEST(GLErrorToString, ReturnsCorrectStringForKnownErrors) {
   EXPECT_EQ(GLErrorToString(GL_NO_ERROR), "GL_NO_ERROR");
   EXPECT_EQ(GLErrorToString(GL_INVALID_ENUM), "GL_INVALID_ENUM");


### PR DESCRIPTION
OpenGL ES 3.0 includes support for glVertexAttribDivisor. The glVertexAttribDivisorEXT API is available on OpenGL ES 2.0 devices with the GL_EXT_instanced_arrays extension.

GLES3 devices may be able to resolve a glVertexAttribDivisorEXT function that is not actually implemented.  This PR uses the glVertexAttribDivisor API if available and otherwise falls back to glVertexAttribDivisorEXT.

See https://github.com/flutter/flutter/pull/186653