### PR TITLE
Adds macro for fragment shaders to support flutter <= 3.44

### DIFF
--- a/engine/src/flutter/impeller/compiler/compiler.cc
+++ b/engine/src/flutter/impeller/compiler/compiler.cc
@@ -478,6 +478,10 @@ Compiler::Compiler(const std::shared_ptr<const fml::Mapping>& source_mapping,
           source_options.target_platform ==
               TargetPlatform::kRuntimeStageGLES3) {
         spirv_options.macro_definitions.push_back("IMPELLER_TARGET_OPENGLES");
+        // A temporary macro that allows fragment shader authors to target
+        // Flutter <= 3.44 before the OpenGLES flip was removed.
+        spirv_options.macro_definitions.push_back(
+            "IMPELLER_OPENGLES_UNFLIPPED_DEPRECATED");
       }
     } break;
     case TargetPlatform::kSkSL: {

--- a/engine/src/flutter/impeller/compiler/compiler_unittests.cc
+++ b/engine/src/flutter/impeller/compiler/compiler_unittests.cc
@@ -79,6 +79,47 @@ TEST(CompilerTest, Defines) {
   EXPECT_NE(compiler_2.GetSPIRVAssembly(), nullptr);
 }
 
+TEST(CompilerTest, DeprecatedUnflippedDefines) {
+  std::shared_ptr<const fml::Mapping> fixture =
+      flutter::testing::OpenFixtureAsMapping(
+          "check_gles_unflipped_definition.frag");
+
+  SourceOptions options;
+  options.source_language = SourceLanguage::kGLSL;
+  options.entry_point_name = "main";
+  options.type = SourceType::kFragmentShader;
+
+  Reflector::Options reflector_options;
+
+  // Test that IMPELLER_OPENGLES_UNFLIPPED_DEPRECATED is defined on
+  // TargetPlatform::kRuntimeStageGLES.
+  {
+    options.target_platform = TargetPlatform::kRuntimeStageGLES;
+    reflector_options.target_platform = TargetPlatform::kRuntimeStageGLES;
+    Compiler compiler = Compiler(fixture, options, reflector_options);
+    // Should fail as the shader has a compilation error in it.
+    EXPECT_EQ(compiler.GetSPIRVAssembly(), nullptr);
+  }
+
+  // Test that IMPELLER_OPENGLES_UNFLIPPED_DEPRECATED is defined on
+  // TargetPlatform::kRuntimeStageGLES3.
+  {
+    options.target_platform = TargetPlatform::kRuntimeStageGLES3;
+    reflector_options.target_platform = TargetPlatform::kRuntimeStageGLES3;
+    Compiler compiler = Compiler(fixture, options, reflector_options);
+    // Should fail as the shader has a compilation error in it.
+    EXPECT_EQ(compiler.GetSPIRVAssembly(), nullptr);
+  }
+
+  // Should succeed as the compilation error is ifdef'd out.
+  {
+    options.target_platform = TargetPlatform::kRuntimeStageVulkan;
+    reflector_options.target_platform = TargetPlatform::kRuntimeStageVulkan;
+    Compiler compiler = Compiler(fixture, options, reflector_options);
+    EXPECT_NE(compiler.GetSPIRVAssembly(), nullptr);
+  }
+}
+
 TEST(CompilerTest, YFlipInjectionForGLESVertexShaders) {
   // Compiles `fixture_name` for `platform` and returns the generated SL
   // source. See https://github.com/flutter/flutter/issues/186554.

--- a/engine/src/flutter/impeller/fixtures/BUILD.gn
+++ b/engine/src/flutter/impeller/fixtures/BUILD.gn
@@ -165,6 +165,7 @@ test_fixtures("file_fixtures") {
     "sample.frag",
     "sample.vert",
     "check_gles_definition.frag",
+    "check_gles_unflipped_definition.frag",
     "sample_with_binding.vert",
     "sample_with_positioned_uniforms.frag",
     "sample_with_uniforms.frag",

--- a/engine/src/flutter/impeller/fixtures/check_gles_unflipped_definition.frag
+++ b/engine/src/flutter/impeller/fixtures/check_gles_unflipped_definition.frag
@@ -1,0 +1,13 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+out vec4 out_color;
+
+void main() {
+#ifdef IMPELLER_OPENGLES_UNFLIPPED_DEPRECATED
+  fail
+#else
+  out_color = vec4(1, 0, 0, 0);
+#endif
+}


### PR DESCRIPTION
https://github.com/flutter/flutter/pull/186556 was a breaking change that removed the necessity of flipping y coordinates when sampling in opengles.  This was a good improvement but it left fragment shader api users in a prediciment where they had to bump their required flutter SDK.  This was particularly unfortunate timing for the framework team's releases.  This new temporary macro allows people to author shaders that support flutter 3.44.0 and above.

## before
```glsl
void main() {
  vec2 uv = FlutterFragCoord().xy / u_size;
#ifdef IMPELLER_TARGET_OPENGLES
  uv.y = 1.0 - uv.y;
#endif
  fragColor = texture(u_texture, uv);
}
```

## after (support > 3.44.0)
```glsl
void main() {
  vec2 uv = FlutterFragCoord().xy / u_size;
  fragColor = texture(u_texture, uv);
}
```

## after (support >= 3.44.0)
```glsl
void main() {
  vec2 uv = FlutterFragCoord().xy / u_size;
#if defined(IMPELLER_TARGET_OPENGLES) && !defined(IMPELLER_OPENGLES_UNFLIPPED_DEPRECATED)
  uv.y = 1.0 - uv.y;
#endif
  fragColor = texture(u_texture, uv);
}
```
## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
