### PR TITLE
[flutter_tools, devicelab] Fix filesystem safety guard for symlinked temp directories

### DIFF
--- a/dev/devicelab/lib/framework/fs_safety.dart
+++ b/dev/devicelab/lib/framework/fs_safety.dart
@@ -41,7 +41,14 @@ bool _isAllowedPath(String entityPath) {
   final String canonicalEntity = path.canonicalize(entityPath);
 
   // Allow system temp
-  final String canonicalTemp = path.canonicalize(io.Directory.systemTemp.path);
+  String canonicalTemp;
+  final io.IOOverrides? currentOverrides = io.IOOverrides.current;
+  if (currentOverrides is FSGuardIOOverrides) {
+    canonicalTemp = currentOverrides._canonicalSystemTemp;
+  } else {
+    canonicalTemp = path.canonicalize(io.Directory.systemTemp.path);
+  }
+
   if (path.isWithin(canonicalTemp, canonicalEntity) || canonicalEntity == canonicalTemp) {
     return true;
   }
@@ -565,6 +572,17 @@ final class FSGuardIOOverrides extends io.IOOverrides {
   FSGuardIOOverrides() : _parent = io.IOOverrides.current;
 
   final io.IOOverrides? _parent;
+
+  late final String _canonicalSystemTemp = () {
+    final io.Directory rawTemp = _parent != null
+        ? _parent.getSystemTempDirectory()
+        : super.getSystemTempDirectory();
+    try {
+      return path.canonicalize(rawTemp.resolveSymbolicLinksSync());
+    } on Object catch (_) {
+      return path.canonicalize(rawTemp.path);
+    }
+  }();
 
   @override
   io.File createFile(String path) {

--- a/packages/flutter_tools/test/general.shard/base/io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/io_test.dart
@@ -149,6 +149,30 @@ void main() {
       }, FSGuardIOOverrides());
     },
   );
+
+  testWithoutContext('FSGuardIOOverrides resolves symlinks for temp directory', () {
+    final io.Directory baseDir = io.Directory.systemTemp.createTempSync('fs_guard_symlink_test_');
+    addTearDown(() => baseDir.deleteSync(recursive: true));
+
+    final io.Directory targetDir = baseDir.createTempSync('target_');
+    final link = io.Link(path.join(baseDir.path, 'link_to_target'));
+    link.createSync(targetDir.path);
+
+    final mockTemp = io.Directory(link.path);
+    final mockOverrides = MockSystemTempOverrides(mockTemp);
+
+    io.IOOverrides.runWithIOOverrides(() {
+      io.IOOverrides.runWithIOOverrides(() {
+        final resolvedFile = io.File(path.join(targetDir.path, 'test.txt'));
+
+        // This should NOT throw if the guard resolves symlinks.
+        resolvedFile.writeAsStringSync('hello');
+        expect(resolvedFile.readAsStringSync(), 'hello');
+
+        resolvedFile.deleteSync();
+      }, FSGuardIOOverrides());
+    }, mockOverrides);
+  });
 }
 
 class FakeProcessSignal extends Fake implements io.ProcessSignal {
@@ -156,4 +180,11 @@ class FakeProcessSignal extends Fake implements io.ProcessSignal {
 
   @override
   Stream<io.ProcessSignal> watch() => controller.stream;
+}
+
+final class MockSystemTempOverrides extends io.IOOverrides {
+  MockSystemTempOverrides(this.mockTemp);
+  final io.Directory mockTemp;
+  @override
+  io.Directory getSystemTempDirectory() => mockTemp;
 }

--- a/packages/flutter_tools/test/src/fs_safety.dart
+++ b/packages/flutter_tools/test/src/fs_safety.dart
@@ -41,7 +41,14 @@ bool _isAllowedPath(String entityPath) {
   final String canonicalEntity = path.canonicalize(entityPath);
 
   // Allow system temp
-  final String canonicalTemp = path.canonicalize(io.Directory.systemTemp.path);
+  String canonicalTemp;
+  final io.IOOverrides? currentOverrides = io.IOOverrides.current;
+  if (currentOverrides is FSGuardIOOverrides) {
+    canonicalTemp = currentOverrides._canonicalSystemTemp;
+  } else {
+    canonicalTemp = path.canonicalize(io.Directory.systemTemp.path);
+  }
+
   if (path.isWithin(canonicalTemp, canonicalEntity) || canonicalEntity == canonicalTemp) {
     return true;
   }
@@ -565,6 +572,17 @@ final class FSGuardIOOverrides extends io.IOOverrides {
   FSGuardIOOverrides() : _parent = io.IOOverrides.current;
 
   final io.IOOverrides? _parent;
+
+  late final String _canonicalSystemTemp = () {
+    final io.Directory rawTemp = _parent != null
+        ? _parent.getSystemTempDirectory()
+        : super.getSystemTempDirectory();
+    try {
+      return path.canonicalize(rawTemp.resolveSymbolicLinksSync());
+    } on Object catch (_) {
+      return path.canonicalize(rawTemp.path);
+    }
+  }();
 
   @override
   io.File createFile(String path) {


### PR DESCRIPTION
Resolve symbolic links of the system temporary directory before canonicalizing it in `FSGuardIOOverrides`.

On macOS, the system temp directory `/var/folders/...` is a symlink to `/private/var/folders/...`. Tests using `createResolvedTempDirectorySync` use the resolved path, causing the filesystem guard to mistakenly block modifications because they string-wise do not match the unresolved temp path.

Also:
* Cache the resolved canonical temp path inside `FSGuardIOOverrides` to avoid costly I/O operations on every filesystem check.
* Add a regression test in `io_test.dart` to verify symlinked temp directory support.
* Use `addTearDown` in the new test for robust resource cleanup.