### PR TITLE
[web] Fix iOS autofill of non-focused grouped fields

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/text_field.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/text_field.dart
@@ -122,10 +122,6 @@ class SemanticsTextEditingStrategy extends DefaultTextEditingStrategy {
 
   @override
   void addEventHandlers() {
-    if (inputConfiguration.autofillGroup != null) {
-      subscriptions.addAll(inputConfiguration.autofillGroup!.addInputEventListeners());
-    }
-
     // Subscribe to text and selection changes.
     subscriptions.add(
       DomSubscription(activeDomElement, 'input', createDomEventListener(handleChange)),

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -145,6 +145,22 @@ void _styleAutofillElements(
   elementStyle.setProperty('caret-color', 'transparent');
 }
 
+/// Whether [element] currently holds non-empty text, for example a value the
+/// browser autofilled into it.
+bool _domElementHasValue(DomHTMLElement element) {
+  if (element.isA<DomHTMLInputElement>()) {
+    return (element as DomHTMLInputElement).value.isNotEmpty;
+  }
+  if (element.isA<DomHTMLTextAreaElement>()) {
+    return (element as DomHTMLTextAreaElement).value.isNotEmpty;
+  }
+  return false;
+}
+
+/// Marks a form field that already has an autofill `input` listener, so
+/// [EngineAutofillForm.wakeUp] does not attach a second one to it.
+const String _autofillListenerAttribute = 'flt-autofill-listener';
+
 void _ensureEditingElementInView(DomElement element, int viewId) {
   final bool isAlreadyAppended = element.isConnected ?? false;
   if (!isAlreadyAppended) {
@@ -335,6 +351,7 @@ class EngineAutofillForm {
       oldFocusedElement.replaceWith(focusedElement);
     }
 
+    _attachAutofillListenersToNonFocusedFields();
     _updateFieldValues();
   }
 
@@ -416,6 +433,16 @@ class EngineAutofillForm {
       final AutofillInfo autofill = items[key]!.autofillInfo;
       // Focused elements are updated directly through `setEditingState`.
       if (key != focusedElementId) {
+        // Don't overwrite a value the browser autofilled into this non-focused
+        // field with our stale, empty editing state. Autofilled values for
+        // non-focused fields are forwarded to the framework and never stored
+        // back here, so re-applying the empty state would erase the autofill
+        // and, on iOS Chrome, drive a repeated fill/clear loop.
+        // See https://github.com/flutter/flutter/issues/185327.
+        final String storedText = autofill.editingState.text;
+        if (storedText.isEmpty && _domElementHasValue(element)) {
+          continue;
+        }
         // Non-focused elements do not have selection, and applying selection on them may cause them
         // to gain focus unexpectedly.
         autofill.editingState.applyTextToDomElement(element);
@@ -423,41 +450,37 @@ class EngineAutofillForm {
     }
   }
 
-  /// Listens to `onInput` event on the form fields.
+  /// Attaches an `input` listener to every field that is not currently focused,
+  /// so the browser's autofill of that field is forwarded to the framework.
   ///
-  /// Registering to the listeners could have been done in the constructor.
-  /// On the other hand, overall for text editing there is already a lifecycle
-  /// for subscriptions: All the subscriptions of the DOM elements are to the
-  /// `subscriptions` property of [DefaultTextEditingStrategy].
-  /// [TextEditingStrategy] manages all subscription lifecyle. All
-  /// listeners with no exceptions are added during
-  /// [TextEditingStrategy.addEventHandlers] method call and all
-  /// listeners are removed during [TextEditingStrategy.disable] method call.
-  List<DomSubscription> addInputEventListeners() {
-    final Iterable<String> keys = elements.keys;
-    final subscriptions = <DomSubscription>[];
-
-    void addSubscriptionForKey(String key) {
+  /// The listener is attached directly to the element rather than through the
+  /// text editing strategy's `subscriptions`, so it survives the strategy being
+  /// disabled and re-enabled around autofill on iOS, where a strategy-scoped
+  /// listener would be torn down before the browser fills the field.
+  ///
+  /// This runs on every [wakeUp] rather than once at form creation, because a
+  /// field can become non-focused later when focus moves to another field in
+  /// the group; that field must forward its autofill too. The marker attribute
+  /// keeps the attachment idempotent so a field never gets two listeners.
+  /// See https://github.com/flutter/flutter/issues/185327.
+  void _attachAutofillListenersToNonFocusedFields() {
+    for (final String key in elements.keys) {
+      if (key == focusedElementId) {
+        continue;
+      }
       final DomHTMLElement element = elements[key]!;
-      subscriptions.add(
-        DomSubscription(
-          element,
-          'input',
-          createDomEventListener((DomEvent e) {
-            if (items[key] == null) {
-              throw StateError('AutofillInfo must have a valid uniqueIdentifier.');
-            } else if (key != focusedElementId) {
-              // `input` events on the focused element are handled elsewhere.
-              final AutofillInfo autofillInfo = items[key]!.autofillInfo;
-              _handleChange(element, autofillInfo);
-            }
-          }),
-        ),
+      if (element.hasAttribute(_autofillListenerAttribute)) {
+        continue;
+      }
+      element.setAttribute(_autofillListenerAttribute, '');
+      final AutofillInfo autofillInfo = items[key]!.autofillInfo;
+      element.addEventListener(
+        'input',
+        createDomEventListener((DomEvent _) {
+          _handleChange(element, autofillInfo);
+        }),
       );
     }
-
-    keys.forEach(addSubscriptionForKey);
-    return subscriptions;
   }
 
   void _handleChange(DomHTMLElement domElement, AutofillInfo autofillInfo) {
@@ -1456,10 +1479,6 @@ abstract class DefaultTextEditingStrategy
 
   @override
   void addEventHandlers() {
-    if (inputConfiguration.autofillGroup != null) {
-      subscriptions.addAll(inputConfiguration.autofillGroup!.addInputEventListeners());
-    }
-
     // Subscribe to text and selection changes.
     subscriptions.add(
       DomSubscription(activeDomElement, 'input', createDomEventListener(handleChange)),
@@ -1858,10 +1877,6 @@ class IOSTextEditingStrategy extends GloballyPositionedTextEditingStrategy {
 
   @override
   void addEventHandlers() {
-    if (inputConfiguration.autofillGroup != null) {
-      subscriptions.addAll(inputConfiguration.autofillGroup!.addInputEventListeners());
-    }
-
     // Subscribe to text and selection changes.
     subscriptions.add(
       DomSubscription(activeDomElement, 'input', createDomEventListener(handleChange)),
@@ -2005,10 +2020,6 @@ class AndroidTextEditingStrategy extends GloballyPositionedTextEditingStrategy {
 
   @override
   void addEventHandlers() {
-    if (inputConfiguration.autofillGroup != null) {
-      subscriptions.addAll(inputConfiguration.autofillGroup!.addInputEventListeners());
-    }
-
     // Subscribe to text and selection changes.
     subscriptions.add(
       DomSubscription(activeDomElement, 'input', createDomEventListener(handleChange)),
@@ -2071,10 +2082,6 @@ class FirefoxTextEditingStrategy extends GloballyPositionedTextEditingStrategy {
 
   @override
   void addEventHandlers() {
-    if (inputConfiguration.autofillGroup != null) {
-      subscriptions.addAll(inputConfiguration.autofillGroup!.addInputEventListeners());
-    }
-
     // Subscribe to text and selection changes.
     subscriptions.add(
       DomSubscription(activeDomElement, 'input', createDomEventListener(handleChange)),

--- a/engine/src/flutter/lib/web_ui/test/engine/text_editing_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/text_editing_test.dart
@@ -3273,6 +3273,148 @@ Future<void> testMain() async {
       }
     });
 
+    test('does not erase a browser-autofilled value from a non-focused field', () {
+      // Regression test for https://github.com/flutter/flutter/issues/185327.
+      // The browser autofills the synthetic (non-focused) password field. A
+      // later form update must not overwrite that value with the engine's
+      // stale, empty editing state. On iOS Chrome that overwrite caused a
+      // fill/clear loop that left the password blank.
+      Map<String, Object?> emptyField(String hint, String id) => <String, Object?>{
+        'inputType': <String, Object?>{
+          'name': 'TextInputType.text',
+          'signed': null,
+          'decimal': null,
+        },
+        'textCapitalization': 'TextCapitalization.none',
+        'autofill': <String, dynamic>{
+          'uniqueIdentifier': id,
+          'hints': <String>[hint],
+          'editingValue': <String, dynamic>{
+            'text': '',
+            'selectionBase': 0,
+            'selectionExtent': 0,
+            'selectionAffinity': 'TextAffinity.downstream',
+            'selectionIsDirectional': false,
+            'composingBase': -1,
+            'composingExtent': -1,
+          },
+        },
+      };
+
+      final fields = <Map<String, Object?>>[
+        emptyField('username', 'field1'),
+        emptyField('password', 'field2'),
+      ];
+      final focusedAutofillMap = fields.first['autofill']! as Map<String, Object?>;
+      final EngineAutofillForm autofillForm = EngineAutofillForm.fromFrameworkMessage(
+        kImplicitViewId,
+        focusedAutofillMap,
+        fields,
+      )!;
+
+      final focusedAutofill = AutofillInfo.fromFrameworkMessage(focusedAutofillMap);
+      final DomHTMLInputElement focusedElement = createDomHTMLInputElement();
+      autofillForm.wakeUp(focusedElement, focusedAutofill);
+
+      final passwordElement = autofillForm.elements['field2']! as DomHTMLInputElement;
+      // The field starts empty: nothing has been autofilled yet.
+      expect(passwordElement.value, isEmpty);
+
+      // Simulate the browser autofilling the synthetic password field.
+      passwordElement.value = 'secret123';
+
+      // A later form update (e.g. a geometry change wakes the form again) must
+      // keep the autofilled value instead of clearing it back to empty.
+      autofillForm.wakeUp(focusedElement, focusedAutofill);
+
+      expect(passwordElement.value, 'secret123');
+    });
+
+    test('forwards a browser-autofilled value from a non-focused field', () {
+      // Regression test for https://github.com/flutter/flutter/issues/185327.
+      // The browser fills the synthetic (non-focused) field; the engine must
+      // forward that value to the framework as an updateEditingStateWithTag.
+      final spy = PlatformMessagesSpy();
+      spy.setUp();
+      try {
+        final List<Map<String, Object?>> fields = createFieldValues(
+          <String>['username', 'password'],
+          <String>['field1', 'field2'],
+        );
+        final focusedAutofillMap = fields.first['autofill']! as Map<String, Object?>;
+        final EngineAutofillForm autofillForm = EngineAutofillForm.fromFrameworkMessage(
+          kImplicitViewId,
+          focusedAutofillMap,
+          fields,
+        )!;
+        autofillForm.wakeUp(
+          createDomHTMLInputElement(),
+          AutofillInfo.fromFrameworkMessage(focusedAutofillMap),
+        );
+
+        final passwordElement = autofillForm.elements['field2']! as DomHTMLInputElement;
+        spy.messages.clear();
+        passwordElement.value = 'secret123';
+        passwordElement.dispatchEvent(createDomEvent('Event', 'input'));
+
+        expect(
+          spy.messages.where((m) => m.methodName == 'TextInputClient.updateEditingStateWithTag'),
+          isNotEmpty,
+        );
+      } finally {
+        spy.tearDown();
+        clearForms();
+      }
+    });
+
+    test('forwards autofill from a field that lost focus to another group field', () {
+      // Regression test for https://github.com/flutter/flutter/issues/185327.
+      // A field that was focused when the form was created, then lost focus to
+      // another field in the same group, must still forward a later autofill of
+      // itself. The listener is re-attached on every wakeUp for this reason.
+      final spy = PlatformMessagesSpy();
+      spy.setUp();
+      try {
+        final List<Map<String, Object?>> fields = createFieldValues(
+          <String>['username', 'password'],
+          <String>['field1', 'field2'],
+        );
+        final field1Map = fields[0]['autofill']! as Map<String, Object?>;
+        final field2Map = fields[1]['autofill']! as Map<String, Object?>;
+
+        // The username field is focused when the form is first created.
+        final EngineAutofillForm form1 = EngineAutofillForm.fromFrameworkMessage(
+          kImplicitViewId,
+          field1Map,
+          fields,
+        )!;
+        form1.wakeUp(createDomHTMLInputElement(), AutofillInfo.fromFrameworkMessage(field1Map));
+        form1.goDormant();
+
+        // Focus moves to the password field: a new form for the same group
+        // reuses the dormant one, and the username field is now non-focused.
+        final EngineAutofillForm form2 = EngineAutofillForm.fromFrameworkMessage(
+          kImplicitViewId,
+          field2Map,
+          fields,
+        )!;
+        form2.wakeUp(createDomHTMLInputElement(), AutofillInfo.fromFrameworkMessage(field2Map));
+
+        final nonFocusedUsername = form2.elements['field1']! as DomHTMLInputElement;
+        spy.messages.clear();
+        nonFocusedUsername.value = 'autofilled_user';
+        nonFocusedUsername.dispatchEvent(createDomEvent('Event', 'input'));
+
+        expect(
+          spy.messages.where((m) => m.methodName == 'TextInputClient.updateEditingStateWithTag'),
+          isNotEmpty,
+        );
+      } finally {
+        spy.tearDown();
+        clearForms();
+      }
+    });
+
     test('validate multi element form ids sorted for form id', () {
       final List<dynamic> fields = createFieldValues(
         <String>['username', 'password', 'newPassword'],

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -2201,7 +2201,12 @@ class TextInput {
         }
         return false;
     }
-    if (_currentConnection == null) {
+    // An autofill (updateEditingStateWithTag) message can arrive when there is
+    // no current connection. On iOS the connection is closed when focus moves
+    // to the browser's autofill UI, just before the autofilled values arrive.
+    // Let it through so it can be routed via the most recent connection below.
+    // See https://github.com/flutter/flutter/issues/185327.
+    if (_currentConnection == null && method != 'TextInputClient.updateEditingStateWithTag') {
       return;
     }
 
@@ -2219,10 +2224,13 @@ class TextInput {
     final args = methodCall.arguments as List<dynamic>;
 
     // The updateEditingStateWithTag request (autofill) can come up even to a
-    // text field that doesn't have a connection.
+    // text field that doesn't have a connection. Fall back to the most recent
+    // connection when the current one was closed (e.g. by the autofill UI
+    // taking focus on iOS) so the autofilled value still routes to its
+    // AutofillScope. See https://github.com/flutter/flutter/issues/185327.
     if (method == 'TextInputClient.updateEditingStateWithTag') {
-      final TextInputClient client = _currentConnection!._client;
-      final AutofillScope? scope = client.currentAutofillScope;
+      final TextInputConnection? connection = _currentConnection ?? _lastConnection;
+      final AutofillScope? scope = connection?._client.currentAutofillScope;
       final editingValue = args[1] as Map<String, dynamic>;
       for (final String tag in editingValue.keys) {
         final textEditingValue = TextEditingValue.fromJSON(
@@ -2928,6 +2936,7 @@ class SystemContextMenuController with SystemContextMenuClient, Diagnosticable {
     );
     callback?.call();
   }
+
   // End SystemContextMenuClient.
 
   /// Shows the system context menu anchored on the given [Rect].

--- a/packages/flutter/test/services/autofill_test.dart
+++ b/packages/flutter/test/services/autofill_test.dart
@@ -90,6 +90,57 @@ void main() {
         expect(client2.currentTextEditingValue, text2);
       },
     );
+
+    test(
+      'updateEditingStateWithTag routes via the last connection after the current one is closed',
+      () async {
+        // Regression test for https://github.com/flutter/flutter/issues/185327.
+        // On iOS the active connection is closed when focus moves to the
+        // browser's autofill UI, just before the autofilled values arrive. The
+        // tagged value must still route to the non-focused field's client.
+        final client1 = FakeAutofillClient(const TextEditingValue(text: 'test1'));
+        final client2 = FakeAutofillClient(const TextEditingValue(text: 'test2'));
+
+        client1.textInputConfiguration = TextInputConfiguration(
+          autofillConfiguration: AutofillConfiguration(
+            uniqueIdentifier: client1.autofillId,
+            autofillHints: const <String>['client1'],
+            currentEditingValue: client1.currentTextEditingValue,
+          ),
+        );
+        client2.textInputConfiguration = TextInputConfiguration(
+          autofillConfiguration: AutofillConfiguration(
+            uniqueIdentifier: client2.autofillId,
+            autofillHints: const <String>['client2'],
+            currentEditingValue: client2.currentTextEditingValue,
+          ),
+        );
+
+        scope.register(client1);
+        scope.register(client2);
+        client1.currentAutofillScope = scope;
+        client2.currentAutofillScope = scope;
+
+        final TextInputConnection connection = scope.attach(
+          client1,
+          client1.textInputConfiguration,
+        );
+
+        // Close the active connection, as the autofill UI does on iOS, before the
+        // autofilled value for the non-focused field arrives.
+        connection.close();
+
+        const text2 = TextEditingValue(text: 'Text 2');
+        fakeTextChannel.incoming?.call(
+          MethodCall('TextInputClient.updateEditingStateWithTag', <dynamic>[
+            0,
+            <String, dynamic>{client2.autofillId: text2.toJSON()},
+          ]),
+        );
+
+        expect(client2.currentTextEditingValue, text2);
+      },
+    );
   });
 
   group('AutoFillConfiguration', () {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
