### PR TITLE
Opts mediatek devices on android 10 and earlier into SurfaceTextures

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -88,7 +88,8 @@ public class FlutterRenderer implements TextureRegistry {
       if ("HUAWEI".equalsIgnoreCase(Build.MANUFACTURER)) {
         return true;
       }
-      String hardware = Build.HARDWARE != null ? Build.HARDWARE.toLowerCase(java.util.Locale.ENGLISH) : "";
+      String hardware =
+          Build.HARDWARE != null ? Build.HARDWARE.toLowerCase(java.util.Locale.ENGLISH) : "";
       String board = Build.BOARD != null ? Build.BOARD.toLowerCase(java.util.Locale.ENGLISH) : "";
       if (hardware.startsWith("mt6762")
           || hardware.startsWith("mt6765")

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -88,8 +88,8 @@ public class FlutterRenderer implements TextureRegistry {
       if ("HUAWEI".equalsIgnoreCase(Build.MANUFACTURER)) {
         return true;
       }
-      String hardware = Build.HARDWARE.toLowerCase(java.util.Locale.ENGLISH);
-      String board = Build.BOARD.toLowerCase(java.util.Locale.ENGLISH);
+      String hardware = Build.HARDWARE != null ? Build.HARDWARE.toLowerCase(java.util.Locale.ENGLISH) : "";
+      String board = Build.BOARD != null ? Build.BOARD.toLowerCase(java.util.Locale.ENGLISH) : "";
       if (hardware.startsWith("mt6762")
           || hardware.startsWith("mt6765")
           || board.startsWith("mt6762")

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -84,8 +84,20 @@ public class FlutterRenderer implements TextureRegistry {
     // app.
     /// If the video plays then that is a strong signal that this method should be updated to
     // include the tested device.
-    return Build.VERSION.SDK_INT <= API_LEVELS.API_29
-        && "HUAWEI".equalsIgnoreCase(Build.MANUFACTURER);
+    if (Build.VERSION.SDK_INT <= API_LEVELS.API_29) {
+      if ("HUAWEI".equalsIgnoreCase(Build.MANUFACTURER)) {
+        return true;
+      }
+      String hardware = Build.HARDWARE.toLowerCase(java.util.Locale.ENGLISH);
+      String board = Build.BOARD.toLowerCase(java.util.Locale.ENGLISH);
+      if (hardware.startsWith("mt6762")
+          || hardware.startsWith("mt6765")
+          || board.startsWith("mt6762")
+          || board.startsWith("mt6765")) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /** Whether to disable clearing of the Surface used to render platform views. */


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/166248

The makes old mediatek devices running on Android 10 or older use SurfaceTexture platform views to avoid driver bugs.

Tested manually with an LG K8.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
