### PR TITLE
Fix DropdownButton crash on orientation change while menu is open

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -15,6 +15,7 @@ import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
@@ -1576,14 +1577,18 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
       // The open menu's layout is computed for the previous orientation, so it
       // must be dismissed. Removing the route mutates the Navigator, which is
       // not allowed during build, so defer the dismissal until after the
-      // current frame.
+      // current frame when we are in the persistent callbacks phase.
       // See https://github.com/flutter/flutter/issues/171011
       if (_dropdownRoute != null) {
-        WidgetsBinding.instance.addPostFrameCallback((Duration timeStamp) {
-          if (mounted) {
-            _removeDropdownRoute();
-          }
-        }, debugLabel: 'DropdownButton.dismissOnOrientationChange');
+        if (SchedulerBinding.instance.schedulerPhase == SchedulerPhase.persistentCallbacks) {
+          WidgetsBinding.instance.addPostFrameCallback((Duration timeStamp) {
+            if (mounted) {
+              _removeDropdownRoute();
+            }
+          }, debugLabel: 'DropdownButton.dismissOnOrientationChange');
+        } else {
+          _removeDropdownRoute();
+        }
       }
     }
 

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1572,8 +1572,19 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     final Orientation newOrientation = _getOrientation(context);
     _lastOrientation ??= newOrientation;
     if (newOrientation != _lastOrientation) {
-      _removeDropdownRoute();
       _lastOrientation = newOrientation;
+      // The open menu's layout is computed for the previous orientation, so it
+      // must be dismissed. Removing the route mutates the Navigator, which is
+      // not allowed during build, so defer the dismissal until after the
+      // current frame.
+      // See https://github.com/flutter/flutter/issues/171011
+      if (_dropdownRoute != null) {
+        WidgetsBinding.instance.addPostFrameCallback((Duration timeStamp) {
+          if (mounted) {
+            _removeDropdownRoute();
+          }
+        }, debugLabel: 'DropdownButton.dismissOnOrientationChange');
+      }
     }
 
     // The width of the button and the menu are defined by the widest

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -1380,6 +1380,63 @@ void main() {
     },
   );
 
+  testWidgets('Dropdown menu opened inside a dialog is dismissed on orientation change without '
+      'throwing', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/171011
+    addTearDown(tester.view.reset);
+    tester.view.devicePixelRatio = 1.0;
+    tester.view.physicalSize = const Size(800, 600);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (BuildContext context) {
+              return Center(
+                child: ElevatedButton(
+                  onPressed: () {
+                    showDialog<void>(
+                      context: context,
+                      builder: (BuildContext context) {
+                        return AlertDialog(
+                          content: DropdownButton<int>(
+                            value: 1,
+                            onChanged: (int? value) {},
+                            items: const <DropdownMenuItem<int>>[
+                              DropdownMenuItem<int>(value: 1, child: Text('1')),
+                              DropdownMenuItem<int>(value: 2, child: Text('2')),
+                              DropdownMenuItem<int>(value: 3, child: Text('3')),
+                            ],
+                          ),
+                        );
+                      },
+                    );
+                  },
+                  child: const Text('Open dialog'),
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    // Open the dialog, then open the dropdown menu inside it.
+    await tester.tap(find.text('Open dialog'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byType(DropdownButton<int>));
+    await tester.pumpAndSettle();
+    expect(find.byType(ListView), findsOneWidget);
+
+    // Rotate the device (simulate by swapping the physical size dimensions).
+    tester.view.physicalSize = const Size(600, 800);
+    await tester.pumpAndSettle();
+
+    // The route should be dismissed without mutating the Navigator during build.
+    expect(tester.takeException(), isNull);
+    expect(find.byType(ListView), findsNothing);
+  });
+
   testWidgets('Semantics Tree contains only selected element', (WidgetTester tester) async {
     final semantics = SemanticsTester(tester);
     await tester.pumpWidget(buildFrame(onChanged: onChanged));


### PR DESCRIPTION
## Description

When a `DropdownButton`'s menu is open and the device **orientation changes**, the framework throws:

```
setState() or markNeedsBuild() called during build.
```

`_DropdownButtonState.build()` detects the orientation change and dismisses the open menu by calling `_removeDropdownRoute()` → `_DropdownRoute._dismiss()` → `Navigator.removeRoute()`. Mutating the `Navigator` **synchronously during build** marks route-transition listeners (`ListenableBuilder`) dirty mid-build, which trips the assertion. It is especially reproducible when the dropdown is hosted inside a dialog (the dialog route's transition builder is merged with the dropdown's secondary animation), as in the linked issue.

### Fix

Defer the dismissal to a post-frame callback so the `Navigator` is mutated *after* the current frame completes. This preserves the existing behavior — the menu still closes on orientation change — but no longer mutates the `Navigator` during build. A `mounted` guard avoids touching a disposed `State`, and the callback is only scheduled when a route is actually open.

### Tests

- Added a regression test (`Dropdown menu opened inside a dialog is dismissed on orientation change without throwing`) that opens a `DropdownButton` menu inside an `AlertDialog`, rotates the view, and asserts no exception is thrown and the menu is dismissed. It fails on `master` and passes with this change.
- The existing test `Dropdown menus are dismissed on screen orientation changes, but not on keyboard hide` continues to pass unmodified.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/171011

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
