### PR TITLE
Fix markdown typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,8 @@ docs/releases/Hotfix-Documentation-Best-Practices.md
 ## Flutter 3.44 Changes
 
 ### [3.44.1](https://github.com/flutter/flutter/releases/tag/3.44.1)
-- [flutter/186962]((https://github.com/flutter/flutter/issues/186962) When the analysis server exits unexpectedly, the `flutter` tool can crash instead of outputting a descriptive error message.
-- [flutter/186963]((https://github.com/flutter/flutter/issues/186963) When failing to connect to a Chrome instance on Windows, the `flutter` tool can crash instead of outputting a descriptive error message.
+- [flutter/186962](https://github.com/flutter/flutter/issues/186962) When the analysis server exits unexpectedly, the `flutter` tool can crash instead of outputting a descriptive error message.
+- [flutter/186963](https://github.com/flutter/flutter/issues/186963) When failing to connect to a Chrome instance on Windows, the `flutter` tool can crash instead of outputting a descriptive error message.
 
 ### [3.44.0](https://github.com/flutter/flutter/releases/tag/3.44.0)
 


### PR DESCRIPTION
There was a typo in the markdown made in https://github.com/flutter/flutter/pull/187258, and this PR corrects it. On master this is being fixed in https://github.com/flutter/flutter/pull/187380.