### PR TITLE
Discrete range slider has no floating-point rounding errors

### DIFF
--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -581,7 +581,13 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
 
   // Returns a number between min and max, proportional to value, which must
   // be between 0.0 and 1.0.
-  double _lerp(double value) => ui.lerpDouble(widget.min, widget.max, value)!;
+  double _lerp(double value) {
+    if (widget.divisions != null) {
+      return widget.min +
+          (value * widget.divisions!).round() * (widget.max - widget.min) / widget.divisions!;
+    }
+    return ui.lerpDouble(widget.min, widget.max, value)!;
+  }
 
   // Returns a new range value with the start and end lerped.
   RangeValues _lerpRangeValues(RangeValues values) {

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -776,6 +776,10 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
   double _lerp(double value) {
     assert(value >= 0.0);
     assert(value <= 1.0);
+    if (widget.divisions != null) {
+      return widget.min +
+          (value * widget.divisions!).round() * (widget.max - widget.min) / widget.divisions!;
+    }
     return value * (widget.max - widget.min) + widget.min;
   }
 

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -839,6 +839,49 @@ void main() {
     },
   );
 
+  testWidgets('Discrete range slider has no floating-point rounding errors', (
+    WidgetTester tester,
+  ) async {
+    final valuesList = <RangeValues>[];
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Material(
+            child: Center(
+              child: SizedBox(
+                width: 200.0,
+                child: RangeSlider(
+                  max: 35.0,
+                  divisions: 35,
+                  values: const RangeValues(0.0, 35.0),
+                  onChanged: (RangeValues newValues) {
+                    valuesList.add(newValues);
+                  },
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Offset topLeft = tester.getTopLeft(find.byType(RangeSlider)).translate(24, 0);
+    final Offset bottomRight = tester.getBottomRight(find.byType(RangeSlider)).translate(-24, 0);
+    final double activeTrackWidth = bottomRight.dx - topLeft.dx;
+
+    final startThumb = topLeft;
+    final TestGesture gesture = await tester.startGesture(startThumb);
+    await gesture.moveTo(topLeft + Offset(activeTrackWidth * 15.0 / 35.0, 0.0));
+    await gesture.up();
+
+    expect(valuesList.isNotEmpty, isTrue);
+    for (final val in valuesList) {
+      expect(val.start, equals(val.start.roundToDouble()));
+      expect(val.end, equals(val.end.roundToDouble()));
+    }
+  });
+
   testWidgets(
     'Range Slider thumbs can be dragged together and the end thumb can be dragged apart (continuous LTR)',
     (WidgetTester tester) async {

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -680,6 +680,46 @@ void main() {
     expect(SchedulerBinding.instance.transientCallbackCount, equals(0));
   });
 
+  testWidgets('Discrete slider has no floating-point rounding errors', (WidgetTester tester) async {
+    final values = <double>[];
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Material(
+            child: Center(
+              child: SizedBox(
+                width: 180.0,
+                child: Slider(
+                  max: 35.0,
+                  divisions: 35,
+                  value: 0.0,
+                  onChanged: (double newValue) {
+                    values.add(newValue);
+                  },
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Offset topLeft = tester.getTopLeft(find.byType(Slider));
+    final Offset bottomRight = tester.getBottomRight(find.byType(Slider));
+    final double width = bottomRight.dx - topLeft.dx;
+    final double activeTrackWidth = width - 48.0;
+    final Offset start = topLeft + Offset(24.0, (bottomRight.dy - topLeft.dy) / 2);
+    final TestGesture gesture = await tester.startGesture(start);
+    await gesture.moveTo(start + Offset(activeTrackWidth * 29.0 / 35.0, 0.0));
+    await gesture.up();
+
+    expect(values.isNotEmpty, isTrue);
+    for (final val in values) {
+      expect(val, equals(val.roundToDouble()));
+    }
+  });
+
   testWidgets('Slider can be given zero values', (WidgetTester tester) async {
     final log = <double>[];
     await tester.pumpWidget(


### PR DESCRIPTION
fix: https://github.com/flutter/flutter/issues/39510 

Before:
value1 =29.0/35.0;
value2 =value1* 35.0;

we will get value1 = 29.000000000000004 

After: value = 29.0 *35.0/ 35.0

we will get value =29.0; no more floating-point rounding errors;



## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
