### PR TITLE
[flutter_tools] Improve performance of version checking

### DIFF
--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -92,8 +92,29 @@ abstract class FlutterVersion {
         }
         // If the cached version looks suspicious, we fall back to git detection.
         // This handles cases where the cache was poisoned by an app repo's git environment.
-        final bool isSuspicious =
-            version.frameworkVersion == kUnknownFrameworkVersion || version.channel == kUserBranch;
+        var isSuspicious = version.frameworkVersion == kUnknownFrameworkVersion;
+        if (!isSuspicious && version.channel == kUserBranch) {
+          // Under a detached HEAD state (extremely common in CI/LUCI environments),
+          // git's branch detection fails and defaults the channel to '[user-branch]'.
+          //
+          // To avoid considering all detached HEAD checkouts as suspicious (which
+          // completely invalidates the version cache and inflicts a heavy startup
+          // latency by forcing slow, synchronous git subprocess spawns on startup),
+          // we inspect the local `.git/HEAD` file directly. If it contains a raw
+          // commit SHA (indicating a detached HEAD state) instead of a branch
+          // pointer (starting with `ref:`), we know the `[user-branch]` channel is
+          // expected and the cache is valid.
+          final File headFile = fs.file(fs.path.join(flutterRoot, '.git', 'HEAD'));
+          if (headFile.existsSync()) {
+            final String headContent = headFile.readAsStringSync().trim();
+            final bool isDetachedStr = !headContent.startsWith('ref:');
+            if (!isDetachedStr) {
+              isSuspicious = true;
+            }
+          } else {
+            isSuspicious = true;
+          }
+        }
         if (!isSuspicious) {
           return version;
         }

--- a/packages/flutter_tools/test/general.shard/version_test.dart
+++ b/packages/flutter_tools/test/general.shard/version_test.dart
@@ -1704,6 +1704,47 @@ void main() {
     );
 
     testUsingContext(
+      'FlutterVersion stays with cache if channel is [user-branch] and git is in detached HEAD state',
+      () async {
+        final Directory cacheDir =
+            fs.directory(flutterRoot).childDirectory('bin').childDirectory('cache')
+              ..createSync(recursive: true);
+        final File versionFile = cacheDir.childFile('flutter.version.json');
+
+        final Directory gitDir = fs.directory(flutterRoot).childDirectory('.git')..createSync();
+        final File headFile = gitDir.childFile('HEAD');
+        headFile.writeAsStringSync('3ac51d8ee8960cac3fe806b4bb1c38684df055a1\n');
+
+        // Cache says [user-branch]
+        versionFile.writeAsStringSync(
+          jsonEncode(<String, String>{
+            'frameworkVersion': '1.0.0',
+            'channel': '[user-branch]',
+            'repositoryUrl': 'https://github.com/flutter/flutter.git',
+            'frameworkRevision': 'REVISION_A',
+            'frameworkCommitDate': '2021-01-01',
+            'engineRevision': 'abc',
+            'dartSdkVersion': '1.0.0',
+            'devToolsVersion': '1.0.0',
+            'flutterVersion': '1.0.0',
+          }),
+        );
+
+        // No git commands should be run because we are detached and cache expects [user-branch]
+        final version = FlutterVersion(fs: fs, git: git, flutterRoot: flutterRoot);
+
+        expect(version.channel, '[user-branch]');
+        expect(version.frameworkRevision, 'REVISION_A');
+        expect(processManager, hasNoRemainingExpectations);
+      },
+      overrides: <Type, Generator>{
+        Git: () => git,
+        ProcessManager: () => processManager,
+        Cache: () => cache,
+      },
+    );
+
+    testUsingContext(
       'FlutterVersion stays with cache if git revision and channel matches',
       () async {
         final Directory cacheDir =


### PR DESCRIPTION
Checks `.git/HEAD` file before marking a state as "suspicious"
Avoid invalidating a LOT of stuff that causes cascading, slow git invokes

Follow-up to

https://github.com/flutter/flutter/pull/186595
https://github.com/flutter/flutter/commit/3ac51d8ee8960cac3fe806b4bb1c38684df055a1
