### PR TITLE
[CP-stable][Impeller] Ensure that the TextureGLES destructor cleans up all objects that it holds including the sync fence

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/gles/test/texture_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/texture_gles_unittests.cc
@@ -67,6 +67,38 @@ TEST_P(TextureGLESTest, CanSetSyncFence) {
   ASSERT_FALSE(sync_fence.has_value());
 }
 
+TEST_P(TextureGLESTest, TextureDtorDeletesFence) {
+  ContextGLES& context_gles = ContextGLES::Cast(*GetContext());
+  if (!context_gles.GetReactor()
+           ->GetProcTable()
+           .GetDescription()
+           ->GetGlVersion()
+           .IsAtLeast(Version{3, 0, 0})) {
+    GTEST_SKIP() << "GL Version too low to test sync fence.";
+  }
+
+  TextureDescriptor desc;
+  desc.storage_mode = StorageMode::kDevicePrivate;
+  desc.size = {100, 100};
+  desc.format = PixelFormat::kR8G8B8A8UNormInt;
+
+  auto texture = GetContext()->GetResourceAllocator()->CreateTexture(desc);
+  ASSERT_TRUE(!!texture);
+
+  HandleGLES fence =
+      context_gles.GetReactor()->CreateHandle(HandleType::kFence);
+  bool fence_collected = false;
+  context_gles.GetReactor()->RegisterCleanupCallback(
+      fence, [&]() { fence_collected = true; });
+  TextureGLES::Cast(*texture).SetFence(fence);
+
+  texture.reset();
+  ASSERT_TRUE(context_gles.GetReactor()->AddOperation(
+      [](const ReactorGLES& reactor) {}));
+  ASSERT_TRUE(context_gles.GetReactor()->React());
+  EXPECT_TRUE(fence_collected);
+}
+
 TEST_P(TextureGLESTest, Binds2DTexture) {
   TextureDescriptor desc;
   desc.storage_mode = StorageMode::kDevicePrivate;

--- a/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.cc
@@ -133,11 +133,13 @@ TextureGLES::TextureGLES(std::shared_ptr<ReactorGLES> reactor,
       type_(GetTextureTypeFromDescriptor(
           GetTextureDescriptor(),
           reactor_->GetProcTable().GetCapabilities())),
-      handle_(external_handle.has_value()
-                  ? external_handle.value()
-                  : (threadsafe ? reactor_->CreateHandle(ToHandleType(type_))
-                                : reactor_->CreateUntrackedHandle(
-                                      ToHandleType(type_)))),
+      handle_(
+          external_handle.has_value()
+              ? UniqueHandleGLES(reactor_, external_handle.value())
+              : (threadsafe
+                     ? UniqueHandleGLES(reactor_, ToHandleType(type_))
+                     : UniqueHandleGLES::MakeUntracked(reactor_,
+                                                       ToHandleType(type_)))),
       is_wrapped_(fbo.has_value() || external_handle.has_value()),
       wrapped_fbo_(fbo) {
   // Ensure the texture descriptor itself is valid.
@@ -157,16 +159,8 @@ TextureGLES::TextureGLES(std::shared_ptr<ReactorGLES> reactor,
   is_valid_ = true;
 }
 
-// |Texture|
-TextureGLES::~TextureGLES() {
-  reactor_->CollectHandle(handle_);
-  if (!cached_fbo_.IsDead()) {
-    reactor_->CollectHandle(cached_fbo_);
-  }
-}
-
 void TextureGLES::Leak() {
-  handle_ = HandleGLES::DeadHandle();
+  handle_.Release();
 }
 
 // |Texture|
@@ -177,7 +171,7 @@ bool TextureGLES::IsValid() const {
 // |Texture|
 void TextureGLES::SetLabel(std::string_view label) {
 #ifdef IMPELLER_DEBUG
-  reactor_->SetDebugLabel(handle_, label);
+  reactor_->SetDebugLabel(handle_.Get(), label);
 #endif  // IMPELLER_DEBUG
 }
 
@@ -185,7 +179,8 @@ void TextureGLES::SetLabel(std::string_view label) {
 void TextureGLES::SetLabel(std::string_view label, std::string_view trailing) {
 #ifdef IMPELLER_DEBUG
   if (reactor_->CanSetDebugLabels()) {
-    reactor_->SetDebugLabel(handle_, std::format("{} {}", label, trailing));
+    reactor_->SetDebugLabel(handle_.Get(),
+                            std::format("{} {}", label, trailing));
   }
 #endif  // IMPELLER_DEBUG
 }
@@ -265,7 +260,7 @@ bool TextureGLES::OnSetContents(std::shared_ptr<const fml::Mapping> mapping,
     return false;
   }
 
-  ReactorGLES::Operation texture_upload = [handle = handle_,              //
+  ReactorGLES::Operation texture_upload = [handle = handle_.Get(),        //
                                            mapping,                       //
                                            format = gles_format.value(),  //
                                            size = tex_descriptor.size,    //
@@ -366,7 +361,7 @@ void TextureGLES::InitializeContentsIfNecessary() const {
   }
 
   const auto& gl = reactor_->GetProcTable();
-  std::optional<GLuint> handle = reactor_->GetGLHandle(handle_);
+  std::optional<GLuint> handle = reactor_->GetGLHandle(handle_.Get());
   if (!handle.has_value()) {
     VALIDATION_LOG << "Could not initialize the contents of texture.";
     return;
@@ -447,7 +442,7 @@ std::optional<GLuint> TextureGLES::GetGLHandle() const {
   if (!IsValid()) {
     return std::nullopt;
   }
-  return reactor_->GetGLHandle(handle_);
+  return reactor_->GetGLHandle(handle_.Get());
 }
 
 bool TextureGLES::Bind() const {
@@ -457,13 +452,12 @@ bool TextureGLES::Bind() const {
   }
   const auto& gl = reactor_->GetProcTable();
 
-  if (fence_.has_value()) {
-    std::optional<GLsync> fence = reactor_->GetGLFence(fence_.value());
+  if (fence_.IsValid()) {
+    std::optional<GLsync> fence = reactor_->GetGLFence(fence_.Get());
     if (fence.has_value()) {
       gl.WaitSync(fence.value(), 0, GL_TIMEOUT_IGNORED);
     }
-    reactor_->CollectHandle(fence_.value());
-    fence_ = std::nullopt;
+    fence_.Reset();
   }
 
   switch (type_) {
@@ -614,21 +608,21 @@ std::optional<GLuint> TextureGLES::GetFBO() const {
 }
 
 void TextureGLES::SetFence(HandleGLES fence) {
-  FML_DCHECK(!fence_.has_value());
-  fence_ = fence;
+  FML_DCHECK(!fence_.IsValid());
+  fence_ = UniqueHandleGLES(reactor_, fence);
 }
 
 // Visible for testing.
 std::optional<HandleGLES> TextureGLES::GetSyncFence() const {
-  return fence_;
+  return fence_.IsValid() ? std::optional(fence_.Get()) : std::nullopt;
 }
 
 void TextureGLES::SetCachedFBO(HandleGLES fbo) {
-  cached_fbo_ = fbo;
+  cached_fbo_ = UniqueHandleGLES(reactor_, fbo);
 }
 
 const HandleGLES& TextureGLES::GetCachedFBO() const {
-  return cached_fbo_;
+  return cached_fbo_.Get();
 }
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.h
@@ -12,6 +12,7 @@
 #include "impeller/core/texture.h"
 #include "impeller/renderer/backend/gles/handle_gles.h"
 #include "impeller/renderer/backend/gles/reactor_gles.h"
+#include "impeller/renderer/backend/gles/unique_handle_gles.h"
 
 namespace impeller {
 
@@ -78,9 +79,6 @@ class TextureGLES final : public Texture,
   TextureGLES(std::shared_ptr<ReactorGLES> reactor,
               TextureDescriptor desc,
               bool threadsafe = false);
-
-  // |Texture|
-  ~TextureGLES() override;
 
   // |Texture|
   bool IsValid() const override;
@@ -156,12 +154,12 @@ class TextureGLES final : public Texture,
  private:
   std::shared_ptr<ReactorGLES> reactor_;
   const Type type_;
-  HandleGLES handle_;
-  mutable std::optional<HandleGLES> fence_ = std::nullopt;
+  UniqueHandleGLES handle_;
+  mutable UniqueHandleGLES fence_;
   mutable std::bitset<6> slices_initialized_ = 0;
   const bool is_wrapped_;
   const std::optional<GLuint> wrapped_fbo_;
-  HandleGLES cached_fbo_ = HandleGLES::DeadHandle();
+  UniqueHandleGLES cached_fbo_;
   bool is_valid_ = false;
 
   TextureGLES(std::shared_ptr<ReactorGLES> reactor,

--- a/engine/src/flutter/impeller/renderer/backend/gles/unique_handle_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/unique_handle_gles.cc
@@ -30,6 +30,10 @@ UniqueHandleGLES::UniqueHandleGLES(std::shared_ptr<ReactorGLES> reactor,
     : reactor_(std::move(reactor)), handle_(handle) {}
 
 UniqueHandleGLES::~UniqueHandleGLES() {
+  CollectHandle();
+}
+
+void UniqueHandleGLES::CollectHandle() {
   if (!handle_.IsDead() && reactor_) {
     reactor_->CollectHandle(handle_);
   }
@@ -43,9 +47,31 @@ bool UniqueHandleGLES::IsValid() const {
   return !handle_.IsDead();
 }
 
+void UniqueHandleGLES::Reset() {
+  CollectHandle();
+  reactor_.reset();
+  handle_ = HandleGLES::DeadHandle();
+}
+
+HandleGLES UniqueHandleGLES::Release() {
+  reactor_.reset();
+  HandleGLES old_handle = handle_;
+  handle_ = HandleGLES::DeadHandle();
+  return old_handle;
+}
+
 UniqueHandleGLES::UniqueHandleGLES(UniqueHandleGLES&& other) {
   std::swap(reactor_, other.reactor_);
   std::swap(handle_, other.handle_);
+}
+
+UniqueHandleGLES& UniqueHandleGLES::operator=(UniqueHandleGLES&& other) {
+  if (this != &other) {
+    Reset();
+    std::swap(reactor_, other.reactor_);
+    std::swap(handle_, other.handle_);
+  }
+  return *this;
 }
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/gles/unique_handle_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/unique_handle_gles.h
@@ -17,6 +17,8 @@ namespace impeller {
 ///
 class UniqueHandleGLES {
  public:
+  UniqueHandleGLES() = default;
+
   UniqueHandleGLES(std::shared_ptr<ReactorGLES> reactor, HandleType type);
 
   static UniqueHandleGLES MakeUntracked(std::shared_ptr<ReactorGLES> reactor,
@@ -27,18 +29,26 @@ class UniqueHandleGLES {
   ~UniqueHandleGLES();
 
   UniqueHandleGLES(UniqueHandleGLES&&);
+  UniqueHandleGLES& operator=(UniqueHandleGLES&&);
 
   UniqueHandleGLES(const UniqueHandleGLES&) = delete;
-
   UniqueHandleGLES& operator=(const UniqueHandleGLES&) = delete;
 
   const HandleGLES& Get() const;
 
   bool IsValid() const;
 
+  /// Collect the managed handle and replace it with a dead handle.
+  void Reset();
+
+  /// Release ownership of the handle.
+  HandleGLES Release();
+
  private:
   std::shared_ptr<ReactorGLES> reactor_ = nullptr;
   HandleGLES handle_ = HandleGLES::DeadHandle();
+
+  void CollectHandle();
 };
 
 }  // namespace impeller


### PR DESCRIPTION
TextureGLES owns a texture and may be given ownership of cached FBO and sync fence objects. Use UniqueHandleGLES to manage the lifecycle of these objects.

Fixes https://github.com/flutter/flutter/issues/186899

### Issue Link:

https://github.com/flutter/flutter/issues/186899

### Impact Description:

This can cause a resource leak in some scenarios (particularly animated images).

### Changelog Description:

The PR ensures that a GLES fence sync object held by a texture will be deleted if the texture is destructed before the fence was used.

### Workaround:

No workaround.

### Risk:

What is the risk level of this cherry-pick?

  - [x] Low
  - [ ] Medium
  - [ ] High

### Test Coverage:

Are you confident that your fix is well-tested by automated tests?

  - [x] Yes
  - [ ] No

### Validation Steps:

Run the sample app in https://github.com/flutter/flutter/issues/186899#issuecomment-4521805530 using Impeller/GLES.

Look at the count of file descriptors in `/proc/[pid]/fd` for the app process.  Without the fix, the count will increase quickly.  With the fix, the count will be stable.

The exact behavior of the resource leak may vary across devices, and some devices may not show it as a leak of file descriptors.  I was able to reproduce the file descriptor leak on a Pixel 3 with an Adreno GPU.