### PR TITLE
Fix 3 typos in TestSemantics semantics_tester.dart

### DIFF
--- a/packages/flutter/test/material/semantics_tester.dart
+++ b/packages/flutter/test/material/semantics_tester.dart
@@ -508,7 +508,7 @@ class TestSemantics {
       );
     }
 
-    if (controlsNodes != controlsNodes && !setEquals(controlsNodes, node.controlsNodes)) {
+    if (controlsNodes != null && !setEquals(controlsNodes, node.controlsNodes)) {
       return fail(
         'expected node id $id to controls nodes $controlsNodes but found controlling nodes ${node.controlsNodes}',
       );
@@ -716,7 +716,7 @@ class SemanticsTester {
           (second[i] is! LocaleStringAttribute ||
               second[i].range != first[i].range ||
               (second[i] as LocaleStringAttribute).locale !=
-                  (second[i] as LocaleStringAttribute).locale)) {
+                  (first[i] as LocaleStringAttribute).locale)) {
         return false;
       }
     }
@@ -1180,8 +1180,8 @@ class _IncludesNodeWith extends Matcher {
              scrollExtentMin != null ||
              maxValueLength != null ||
              currentValueLength != null ||
-             inputType != null,
-         minValue != null || maxValue != null,
+             inputType != null ||
+             minValue != null || maxValue != null,
        );
   final AttributedString? attributedLabel;
   final AttributedString? attributedValue;

--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -508,7 +508,7 @@ class TestSemantics {
       );
     }
 
-    if (controlsNodes != controlsNodes && !setEquals(controlsNodes, node.controlsNodes)) {
+    if (controlsNodes != null && !setEquals(controlsNodes, node.controlsNodes)) {
       return fail(
         'expected node id $id to controls nodes $controlsNodes but found controlling nodes ${node.controlsNodes}',
       );
@@ -716,7 +716,7 @@ class SemanticsTester {
           (second[i] is! LocaleStringAttribute ||
               second[i].range != first[i].range ||
               (second[i] as LocaleStringAttribute).locale !=
-                  (second[i] as LocaleStringAttribute).locale)) {
+                  (first[i] as LocaleStringAttribute).locale)) {
         return false;
       }
     }
@@ -1180,8 +1180,8 @@ class _IncludesNodeWith extends Matcher {
              scrollExtentMin != null ||
              maxValueLength != null ||
              currentValueLength != null ||
-             inputType != null,
-         minValue != null || maxValue != null,
+             inputType != null ||
+             minValue != null || maxValue != null,
        );
   final AttributedString? attributedLabel;
   final AttributedString? attributedValue;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/185900

Three bugs fixed across both `packages/flutter/test/widgets/semantics_tester.dart` and `packages/flutter/test/material/semantics_tester.dart`:

1. **Locale compare-to-self**: `(second[i] as LocaleStringAttribute).locale` was compared to itself instead of `(first[i] as LocaleStringAttribute).locale`
2. **controlsNodes compare-to-self**: `controlsNodes != controlsNodes` was always false, should be `controlsNodes != null`
3. **Stray comma in assert**: A comma after `inputType != null` turned `minValue != null || maxValue != null` into the error message string instead of part of the assert condition