### PR TITLE
Fix TestSemantics typo checks

### DIFF
--- a/packages/flutter/test/material/semantics_tester.dart
+++ b/packages/flutter/test/material/semantics_tester.dart
@@ -508,7 +508,7 @@ class TestSemantics {
       );
     }
 
-    if (controlsNodes != controlsNodes && !setEquals(controlsNodes, node.controlsNodes)) {
+    if (controlsNodes != null && !setEquals(controlsNodes, node.controlsNodes)) {
       return fail(
         'expected node id $id to controls nodes $controlsNodes but found controlling nodes ${node.controlsNodes}',
       );
@@ -716,7 +716,7 @@ class SemanticsTester {
           (second[i] is! LocaleStringAttribute ||
               second[i].range != first[i].range ||
               (second[i] as LocaleStringAttribute).locale !=
-                  (second[i] as LocaleStringAttribute).locale)) {
+                  (first[i] as LocaleStringAttribute).locale)) {
         return false;
       }
     }
@@ -1168,7 +1168,10 @@ class _IncludesNodeWith extends Matcher {
     this.maxValue,
   }) : assert(
          label != null ||
+             attributedLabel != null ||
              value != null ||
+             attributedValue != null ||
+             attributedHint != null ||
              actions != null ||
              flags != null ||
              flagsCollection != null ||
@@ -1180,8 +1183,9 @@ class _IncludesNodeWith extends Matcher {
              scrollExtentMin != null ||
              maxValueLength != null ||
              currentValueLength != null ||
-             inputType != null,
-         minValue != null || maxValue != null,
+             inputType != null ||
+             minValue != null ||
+             maxValue != null,
        );
   final AttributedString? attributedLabel;
   final AttributedString? attributedValue;

--- a/packages/flutter/test/widgets/semantics_test.dart
+++ b/packages/flutter/test/widgets/semantics_test.dart
@@ -222,6 +222,77 @@ void main() {
     semantics.dispose();
   });
 
+  testWidgets('hasSemantics compares controlsNodes', (WidgetTester tester) async {
+    final semantics = SemanticsTester(tester);
+
+    await tester.pumpWidget(
+      Semantics(
+        controlsNodes: const <String>{'actual'},
+        child: const SizedBox(width: 10, height: 10),
+      ),
+    );
+
+    expect(
+      semantics,
+      isNot(
+        hasSemantics(
+          TestSemantics.root(
+            children: <TestSemantics>[
+              TestSemantics.rootChild(controlsNodes: const <String>{'expected'}),
+            ],
+          ),
+          ignoreId: true,
+          ignoreRect: true,
+          ignoreTransform: true,
+        ),
+      ),
+    );
+    semantics.dispose();
+  });
+
+  testWidgets('includesNodeWith compares attributed label locale', (WidgetTester tester) async {
+    final semantics = SemanticsTester(tester);
+
+    await tester.pumpWidget(
+      Semantics(
+        attributedLabel: AttributedString(
+          'label',
+          attributes: <StringAttribute>[
+            LocaleStringAttribute(
+              range: const TextRange(start: 0, end: 5),
+              locale: const Locale('en', 'US'),
+            ),
+          ],
+        ),
+        textDirection: TextDirection.ltr,
+        child: const SizedBox(width: 10, height: 10),
+      ),
+    );
+
+    expect(
+      semantics,
+      isNot(
+        includesNodeWith(
+          attributedLabel: AttributedString(
+            'label',
+            attributes: <StringAttribute>[
+              LocaleStringAttribute(
+                range: const TextRange(start: 0, end: 5),
+                locale: const Locale('fr', 'FR'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    semantics.dispose();
+  });
+
+  test('includesNodeWith can match minValue and maxValue', () {
+    expect(() => includesNodeWith(minValue: '0'), returnsNormally);
+    expect(() => includesNodeWith(maxValue: '100'), returnsNormally);
+  });
+
   testWidgets('Semantics and Directionality - RTL', (WidgetTester tester) async {
     final semantics = SemanticsTester(tester);
 

--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -508,7 +508,7 @@ class TestSemantics {
       );
     }
 
-    if (controlsNodes != controlsNodes && !setEquals(controlsNodes, node.controlsNodes)) {
+    if (controlsNodes != null && !setEquals(controlsNodes, node.controlsNodes)) {
       return fail(
         'expected node id $id to controls nodes $controlsNodes but found controlling nodes ${node.controlsNodes}',
       );
@@ -716,7 +716,7 @@ class SemanticsTester {
           (second[i] is! LocaleStringAttribute ||
               second[i].range != first[i].range ||
               (second[i] as LocaleStringAttribute).locale !=
-                  (second[i] as LocaleStringAttribute).locale)) {
+                  (first[i] as LocaleStringAttribute).locale)) {
         return false;
       }
     }
@@ -1168,7 +1168,10 @@ class _IncludesNodeWith extends Matcher {
     this.maxValue,
   }) : assert(
          label != null ||
+             attributedLabel != null ||
              value != null ||
+             attributedValue != null ||
+             attributedHint != null ||
              actions != null ||
              flags != null ||
              flagsCollection != null ||
@@ -1180,8 +1183,9 @@ class _IncludesNodeWith extends Matcher {
              scrollExtentMin != null ||
              maxValueLength != null ||
              currentValueLength != null ||
-             inputType != null,
-         minValue != null || maxValue != null,
+             inputType != null ||
+             minValue != null ||
+             maxValue != null,
        );
   final AttributedString? attributedLabel;
   final AttributedString? attributedValue;


### PR DESCRIPTION
﻿Fixes flutter/flutter#185900.

This PR fixes typo-level checks in the copied TestSemantics helpers:

- compare expected controlsNodes against the actual semantics node controlsNodes
- compare LocaleStringAttribute locale against the expected attribute instead of itself
- allow includesNodeWith to be constructed for minValue, maxValue, and attributed string matchers
- add widget semantics regression coverage for controlsNodes, attributed label locale matching, and min/max matcher construction

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`). This change does not require documentation updates.
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported. This is not a breaking change.
- [x] All existing and new tests are passing.

Tests:

- `bin/cache/dart-sdk/bin/dart.exe analyze packages/flutter/test/widgets/semantics_tester.dart packages/flutter/test/material/semantics_tester.dart packages/flutter/test/widgets/semantics_test.dart`
- `bin/flutter.bat test packages/flutter/test/widgets/semantics_test.dart`

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
